### PR TITLE
feat(velvet): rework preview window zoom/resolution and fix layout breakage

### DIFF
--- a/.github/workflows/upm.yml
+++ b/.github/workflows/upm.yml
@@ -57,13 +57,15 @@ jobs:
         run: |
           SPLIT=$(git subtree split --prefix="$PREFIX")
           git checkout --quiet "$SPLIT"
-          # Strip developer-only sources from the published artifact. None of these are used by a
-          # consumer's build: test asmdefs are gated by UNITY_INCLUDE_TESTS (off for installed
-          # packages), and the source generators ship as prebuilt DLLs under Runtime/Plugins — their
-          # Roslyn source in Generators~ (a Unity-ignored '~' folder) is needed only to rebuild them.
-          # So this removes pure disk noise, not anything a consumer compiles. Matches every Tests/
-          # folder (+ sibling Tests.meta), the test-only TestUtilities assembly, and Generators~.
-          REMOVE=$(git ls-files | grep -E '(^|/)Tests(/|\.meta$)|(^|/)TestUtilities(/|\.meta$)|(^|/)Generators~(/|\.meta$)' || true)
+          # Strip developer-only sources from the published artifact. Test asmdefs are gated by
+          # UNITY_INCLUDE_TESTS (off for installed packages); the source generators ship as prebuilt
+          # DLLs under Runtime/Plugins, so their Roslyn source in Generators~ (a Unity-ignored '~'
+          # folder) is needed only to rebuild them; and the Preview example stories are this repo's own
+          # verification fixtures — shipping them would inject "Examples/*" entries into every consumer's
+          # Preview window, so they stay in the dev project but not the package. Matches every Tests/
+          # folder (+ sibling Tests.meta), the test-only TestUtilities assembly, Generators~, and
+          # Editor/Preview/Examples (+ sibling Examples.meta).
+          REMOVE=$(git ls-files | grep -E '(^|/)Tests(/|\.meta$)|(^|/)TestUtilities(/|\.meta$)|(^|/)Generators~(/|\.meta$)|(^|/)Preview/Examples(/|\.meta$)' || true)
           if [ -n "$REMOVE" ]; then
             printf '%s\n' "$REMOVE" | tr '\n' '\0' | xargs -0 git rm --quiet
             git commit --quiet --amend --no-edit

--- a/Packages/com.velvet.core/Editor/Preview/Examples.meta
+++ b/Packages/com.velvet.core/Editor/Preview/Examples.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ef169a2631cf46929ae0c8ab19c5764d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Packages/com.velvet.core/Editor/Preview/Examples/PreviewExampleStories.cs
+++ b/Packages/com.velvet.core/Editor/Preview/Examples/PreviewExampleStories.cs
@@ -1,0 +1,82 @@
+#if UNITY_EDITOR
+using System.Collections.Generic;
+
+namespace Velvet.Editor.Preview
+{
+    /// <summary>
+    /// Verification <c>[VelvetPreview]</c> stories used while developing Velvet's own Preview window: they give
+    /// this repo's otherwise-empty story list something to render so the window's viewport / centering /
+    /// zoom-and-scroll behavior can be eyeballed live. They are developer-only — the package publish strips this
+    /// folder, so an installed Velvet never injects these <c>Examples/*</c> entries into a consumer's Preview
+    /// window; they exist only in this development project. Each is also a minimal example of authoring a
+    /// <c>[VelvetPreview]</c> story: a static, parameterless method returning a <see cref="VNode"/>, discovered
+    /// automatically with no further registration.
+    /// </summary>
+    internal static class PreviewExampleStories
+    {
+        private const int TallListRowCount = 30;
+
+        /// <summary>
+        /// No explicit Width/Height, so the canvas fills the stage (the Full viewport) or a simulated reference
+        /// size (a custom viewport), becoming a responsive scope in the latter case. Background color and flex
+        /// direction shift at the sm/md/lg breakpoints, and one caption only shows below the sm breakpoint —
+        /// editing the toolbar's W field (or switching between Full and a custom size) makes the shift visible
+        /// immediately.
+        /// </summary>
+        [VelvetPreview(Group = "Examples", Name = "Responsive")]
+        private static VNode Responsive()
+        {
+            return V.Div(
+                "flex-col sm:flex-row items-center justify-center gap-4 p-6 w-full h-full " +
+                "bg-danger sm:bg-highlight md:bg-primary-soft lg:bg-success",
+                V.Label(
+                    className: "text-white font-bold text-center",
+                    text: "Resize the viewport width to see sm/md/lg flip"),
+                V.Label(
+                    className: "text-white text-center",
+                    text: "sm 640px: row layout + highlight background. md 768px: primary background. " +
+                        "lg 1024px: success background."),
+                V.Label(
+                    className: "sm:hidden text-white text-center",
+                    text: "Below 640px only - this note disappears once sm: takes over."));
+        }
+
+        /// <summary>
+        /// Explicit Width/Height: the canvas is sized to exactly 320x200 regardless of the stage or viewport, and
+        /// is NOT a responsive scope. At this footprint the story is smaller than the stage, so mounting it also
+        /// confirms the stage centers a small explicit-size story (rather than pinning it to a corner) and that
+        /// it scales with the zoom toolbar.
+        /// </summary>
+        [VelvetPreview(Group = "Examples", Name = "Card", Width = 320, Height = 200)]
+        private static VNode Card()
+        {
+            return V.Div(
+                "w-full h-full flex-col justify-center gap-2 p-4 bg-surface border border-default rounded-2xl",
+                V.Label(className: "text-lg font-bold text-strong", text: "Fixed-size Card"),
+                V.Label(
+                    className: "text-sm text-subtle",
+                    text: "Authored at 320x200. Stays centered in the stage and scales with zoom."));
+        }
+
+        /// <summary>
+        /// An explicit-size story taller than any reasonable stage (360x1400). Each row carries <c>shrink-0</c>
+        /// so the flex column never squeezes them to fit — at 100%/200% zoom or a short window the stage's
+        /// ScrollView must pan to reach the lower rows, and the Outline/Measure overlay should keep tracking a
+        /// row while it scrolls.
+        /// </summary>
+        [VelvetPreview(Group = "Examples", Name = "Tall List", Width = 360, Height = 1400)]
+        private static VNode TallList()
+        {
+            var rows = new List<int>(TallListRowCount);
+            for (var i = 0; i < TallListRowCount; i++) rows.Add(i);
+
+            return V.Div(
+                "flex-col w-full h-full bg-neutral",
+                V.List(rows, i => $"row-{i}", i => V.Div(
+                    "shrink-0 flex-row items-center justify-between p-3 border-b border-default bg-surface",
+                    V.Label(className: "text-sm text-strong", text: $"Row {i + 1}"),
+                    V.Label(className: "text-xs text-subtle", text: "flexShrink: 0"))));
+        }
+    }
+}
+#endif

--- a/Packages/com.velvet.core/Editor/Preview/Examples/PreviewExampleStories.cs.meta
+++ b/Packages/com.velvet.core/Editor/Preview/Examples/PreviewExampleStories.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4a5941eadbf445078daa8d1486a3843d

--- a/Packages/com.velvet.core/Editor/Preview/Tests/Editor/VelvetPreviewWindowInspectTests.cs
+++ b/Packages/com.velvet.core/Editor/Preview/Tests/Editor/VelvetPreviewWindowInspectTests.cs
@@ -23,8 +23,24 @@ namespace Velvet.Tests
             TestGraphics.IgnoreIfHeadless("an EditorWindow panel");
             // Start from a known default so the toggle's starting value is deterministic.
             EditorPrefs.SetBool("Velvet.Preview.Outline", false);
+            // Cleared before the window is created so CreateGUI's RefreshStories cannot restore a persisted
+            // selection (e.g. a developer having clicked an example story in the live window).
+            EditorPrefs.DeleteKey("Velvet.Preview.LastStoryId");
             _window = EditorWindow.GetWindow<VelvetPreviewWindow>();
             _window.Show();
+            // The window instance can be reused across tests (GetWindow finds the existing one), so its own
+            // auto-selection from a previous run could still be sitting in _selected — null it explicitly.
+            ResetSelection();
+        }
+
+        // Restores the pre-example baseline: no story selected. This fixture's assertions do not depend on canvas
+        // sizing, but a null selection keeps it consistent with the other preview-window fixtures and out of the
+        // way of whatever the registry happens to discover.
+        private void ResetSelection()
+        {
+            var select = typeof(VelvetPreviewWindow).GetMethod("Select", BindingFlags.Instance | BindingFlags.NonPublic);
+            Assume.That(select, Is.Not.Null, "VelvetPreviewWindow.Select must exist");
+            select.Invoke(_window, new object[] { null });
         }
 
         [TearDown]

--- a/Packages/com.velvet.core/Editor/Preview/Tests/Editor/VelvetPreviewWindowThemeTests.cs
+++ b/Packages/com.velvet.core/Editor/Preview/Tests/Editor/VelvetPreviewWindowThemeTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using NUnit.Framework;
 using UnityEditor;
 using UnityEditor.UIElements;
@@ -24,6 +25,10 @@ namespace Velvet.Tests
             _originalIsDark = VelvetTheme.IsDark;
             // Start from a known editor-side default so the toggle's restore target is deterministic.
             EditorPrefs.SetBool("Velvet.Preview.Dark", false);
+            // Cleared before the window is created (in ShowWindowAndGetDarkToggle) so CreateGUI's RefreshStories
+            // cannot restore a persisted selection (e.g. a developer having clicked an example story in the live
+            // window).
+            EditorPrefs.DeleteKey("Velvet.Preview.LastStoryId");
         }
 
         [TearDown]
@@ -42,6 +47,11 @@ namespace Velvet.Tests
         {
             _window = EditorWindow.GetWindow<VelvetPreviewWindow>();
             _window.Show();
+            // The window instance can be reused across tests (GetWindow finds the existing one), so its own
+            // auto-selection from a previous run could still be sitting in _selected — null it explicitly. These
+            // tests only assert on VelvetTheme.IsDark, but a null selection keeps this fixture consistent with the
+            // other preview-window fixtures and out of the way of whatever the registry happens to discover.
+            ResetSelection();
             // CreateGUI builds the toolbar lazily; force the visual tree to exist before querying it.
             _window.rootVisualElement.Q<ToolbarToggle>();
             foreach (var toggle in _window.rootVisualElement.Query<ToolbarToggle>().ToList())
@@ -50,6 +60,13 @@ namespace Velvet.Tests
             }
 
             return null;
+        }
+
+        private void ResetSelection()
+        {
+            var select = typeof(VelvetPreviewWindow).GetMethod("Select", BindingFlags.Instance | BindingFlags.NonPublic);
+            Assume.That(select, Is.Not.Null, "VelvetPreviewWindow.Select must exist");
+            select.Invoke(_window, new object[] { null });
         }
 
         [Test]

--- a/Packages/com.velvet.core/Editor/Preview/Tests/Editor/VelvetPreviewWindowViewportTests.cs
+++ b/Packages/com.velvet.core/Editor/Preview/Tests/Editor/VelvetPreviewWindowViewportTests.cs
@@ -9,20 +9,23 @@ using Velvet.TestUtilities;
 namespace Velvet.Tests
 {
     /// <summary>
-    /// The preview window's Viewport addon: selecting a fixed viewport sizes the mount canvas to that reference
-    /// width and marks it a responsive scope (<c>@container</c>) so a mounted story's <c>sm:</c>/<c>md:</c>…
-    /// evaluate against the simulated width; <b>Full</b> removes the marker and restores the fill behavior.
+    /// The preview window's Viewport addon: selecting a custom W/H pair (via the toolbar fields) sizes the mount
+    /// canvas to that reference size and marks it a responsive scope (<c>@container</c>) so a mounted story's
+    /// <c>sm:</c>/<c>md:</c>… evaluate against the simulated width; <b>Full</b> (the only remaining menu preset —
+    /// device presets were removed in favor of free-form W/H entry) removes the marker and restores the fill
+    /// behavior.
     /// </summary>
     /// <remarks>
-    /// The viewport selection handler (<c>SetViewport</c>) and the mount canvas are private to the window; the
-    /// tests reach them by reflection (the repo convention for verifying internals from a test assembly that
-    /// lacks InternalsVisibleTo).
+    /// The viewport selection handlers (<c>SetViewport</c>/<c>OnViewportFieldChanged</c>) and the mount canvas
+    /// are private to the window; the tests reach them by reflection (the repo convention for verifying internals
+    /// from a test assembly that lacks InternalsVisibleTo).
     /// </remarks>
     internal sealed class VelvetPreviewWindowViewportTests
     {
-        private const string MobileViewport = "Mobile (375)";
-        private const float MobileWidth = 375f;
+        private const float CustomWidth = 500f;
+        private const float CustomHeight = 900f;
         private const string FullViewport = "Full";
+        private const string CustomViewport = "Custom";
 
         private VelvetPreviewWindow _window;
 
@@ -30,9 +33,26 @@ namespace Velvet.Tests
         public void SetUp()
         {
             TestGraphics.IgnoreIfHeadless("an EditorWindow panel");
+            // Cleared before the window is created so CreateGUI's RefreshStories cannot restore a persisted
+            // selection (e.g. a developer having clicked an example story in the live window) that would land on
+            // an explicit-size story and defeat every assertion below that assumes the viewport drives the canvas.
+            EditorPrefs.DeleteKey("Velvet.Preview.LastStoryId");
             EditorPrefs.SetString("Velvet.Preview.Viewport", FullViewport);
             _window = EditorWindow.GetWindow<VelvetPreviewWindow>();
             _window.Show();
+            // The window instance can be reused across tests (GetWindow finds the existing one), so its own
+            // auto-selection from a previous run could still be sitting in _selected — null it explicitly rather
+            // than relying on the cleared EditorPrefs key alone.
+            ResetSelection();
+        }
+
+        // Restores the pre-example baseline: no story selected, so ApplyCanvasSize lets the viewport drive the
+        // canvas instead of an explicit-size story's own Width/Height.
+        private void ResetSelection()
+        {
+            var select = typeof(VelvetPreviewWindow).GetMethod("Select", BindingFlags.Instance | BindingFlags.NonPublic);
+            Assume.That(select, Is.Not.Null, "VelvetPreviewWindow.Select must exist");
+            select.Invoke(_window, new object[] { null });
         }
 
         [TearDown]
@@ -51,6 +71,32 @@ namespace Velvet.Tests
             method.Invoke(_window, new object[] { viewport });
         }
 
+        // Drives the same path the W/H toolbar fields use: set the actual IntegerField widgets' values (as a user
+        // typing in them would) via reflection, then invoke the field-changed handler so the viewport switches to
+        // Custom using those values. OnViewportFieldChanged reads the live widgets, not a settable backing field,
+        // so the widgets themselves — not some intermediate int — are what must be driven here.
+        private void SetCustomViewport(int width, int height)
+        {
+            SetPrivateFieldWidgetValue("_viewportWidthField", width);
+            SetPrivateFieldWidgetValue("_viewportHeightField", height);
+            var method = typeof(VelvetPreviewWindow).GetMethod(
+                "OnViewportFieldChanged", BindingFlags.Instance | BindingFlags.NonPublic);
+            Assume.That(method, Is.Not.Null, "VelvetPreviewWindow.OnViewportFieldChanged must exist");
+            method.Invoke(_window, null);
+        }
+
+        private void SetPrivateFieldWidgetValue(string fieldName, int value)
+        {
+            var field = typeof(VelvetPreviewWindow).GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic);
+            Assume.That(field, Is.Not.Null, $"VelvetPreviewWindow.{fieldName} must exist");
+            var widget = (IntegerField)field.GetValue(_window);
+            Assume.That(widget, Is.Not.Null, $"VelvetPreviewWindow.{fieldName} must be built by the time the test runs");
+            // WithoutNotify: setting both fields must not itself raise the change callback (which would remount
+            // once per field, before both values are actually in place) — SetCustomViewport invokes the handler
+            // itself exactly once, after both widgets already hold their new values.
+            widget.SetValueWithoutNotify(value);
+        }
+
         private VisualElement Canvas()
         {
             var field = typeof(VelvetPreviewWindow).GetField(
@@ -59,39 +105,153 @@ namespace Velvet.Tests
             return (VisualElement)field.GetValue(_window);
         }
 
-        [Test]
-        public void Given_AFixedViewport_When_Selected_Then_TheCanvasWidthBecomesThePresetWidth()
+        private VisualElement ZoomBox()
         {
-            // Arrange / Act
-            SetViewport(MobileViewport);
+            var field = typeof(VelvetPreviewWindow).GetField(
+                "_zoomBox", BindingFlags.Instance | BindingFlags.NonPublic);
+            Assume.That(field, Is.Not.Null, "VelvetPreviewWindow._zoomBox must exist");
+            return (VisualElement)field.GetValue(_window);
+        }
 
-            // Assert
-            Assert.That(Canvas().style.width.value.value, Is.EqualTo(MobileWidth));
+        private IntegerField ViewportField(string fieldName)
+        {
+            var field = typeof(VelvetPreviewWindow).GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic);
+            Assume.That(field, Is.Not.Null, $"VelvetPreviewWindow.{fieldName} must exist");
+            var widget = (IntegerField)field.GetValue(_window);
+            Assume.That(widget, Is.Not.Null, $"VelvetPreviewWindow.{fieldName} must be built by the time the test runs");
+            return widget;
+        }
+
+        private int PrivateInt(string fieldName)
+        {
+            var field = typeof(VelvetPreviewWindow).GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic);
+            Assume.That(field, Is.Not.Null, $"VelvetPreviewWindow.{fieldName} must exist");
+            return (int)field.GetValue(_window);
+        }
+
+        // Drives the same path the preset dropdown uses (SetViewportPreset), rather than SetViewport, so the
+        // Full-preset-clobbers-custom-size regression is exercised through its real entry point.
+        private void SetViewportPreset(string label, float width, float height)
+        {
+            var method = typeof(VelvetPreviewWindow).GetMethod(
+                "SetViewportPreset", BindingFlags.Instance | BindingFlags.NonPublic);
+            Assume.That(method, Is.Not.Null, "VelvetPreviewWindow.SetViewportPreset must exist");
+            method.Invoke(_window, new object[] { label, width, height });
         }
 
         [Test]
-        public void Given_AFixedViewport_When_Selected_Then_TheCanvasIsMarkedAsAResponsiveScope()
+        public void Given_ACustomWidthAndHeight_When_TheFieldsChange_Then_TheCanvasWidthMatches()
+        {
+            // Arrange / Act — simulates editing the W/H toolbar fields to an arbitrary resolution.
+            SetCustomViewport((int)CustomWidth, (int)CustomHeight);
+
+            // Assert
+            Assert.That(Canvas().style.width.value.value, Is.EqualTo(CustomWidth));
+        }
+
+        [Test]
+        public void Given_ACustomWidthAndHeight_When_TheFieldsChange_Then_TheCanvasHeightMatches()
         {
             // Arrange / Act
-            SetViewport(MobileViewport);
+            SetCustomViewport((int)CustomWidth, (int)CustomHeight);
+
+            // Assert
+            Assert.That(Canvas().style.height.value.value, Is.EqualTo(CustomHeight));
+        }
+
+        [Test]
+        public void Given_ACustomViewport_When_Selected_Then_TheCanvasIsMarkedAsAResponsiveScope()
+        {
+            // Arrange / Act
+            SetCustomViewport((int)CustomWidth, (int)CustomHeight);
 
             // Assert
             Assert.That(Canvas().ClassListContains(VelvetResponsive.ContainerClass), Is.True);
         }
 
         [Test]
-        public void Given_AFixedViewport_When_SwitchedBackToFull_Then_TheScopeMarkerIsRemoved()
+        public void Given_ACustomViewport_When_SwitchedBackToFull_Then_TheScopeMarkerIsRemoved()
         {
-            // Arrange — a fixed viewport first marks the canvas.
-            SetViewport(MobileViewport);
+            // Arrange — a custom viewport first marks the canvas.
+            SetCustomViewport((int)CustomWidth, (int)CustomHeight);
             Assume.That(Canvas().ClassListContains(VelvetResponsive.ContainerClass), Is.True,
-                "Precondition: the fixed viewport marked the canvas");
+                "Precondition: the custom viewport marked the canvas");
 
             // Act
             SetViewport(FullViewport);
 
             // Assert
             Assert.That(Canvas().ClassListContains(VelvetResponsive.ContainerClass), Is.False);
+        }
+
+        [Test]
+        public void Given_ACustomWidthAndHeight_When_TheFieldsChange_Then_TheViewportModeBecomesCustom()
+        {
+            // Arrange / Act
+            SetCustomViewport((int)CustomWidth, (int)CustomHeight);
+
+            // Assert
+            var field = typeof(VelvetPreviewWindow).GetField("_viewport", BindingFlags.Instance | BindingFlags.NonPublic);
+            Assume.That(field, Is.Not.Null, "VelvetPreviewWindow._viewport must exist");
+            Assert.That((string)field.GetValue(_window), Is.EqualTo(CustomViewport));
+        }
+
+        [Test]
+        public void Given_AZoomFactorOf200Percent_When_Applied_Then_TheZoomBoxWidthIsTwiceTheReferenceWidth()
+        {
+            // Arrange — a known reference width via a custom viewport, then zoom to 200%.
+            SetCustomViewport((int)CustomWidth, (int)CustomHeight);
+            var setZoom = typeof(VelvetPreviewWindow).GetMethod("SetZoom", BindingFlags.Instance | BindingFlags.NonPublic);
+            Assume.That(setZoom, Is.Not.Null, "VelvetPreviewWindow.SetZoom must exist");
+
+            // Act
+            setZoom.Invoke(_window, new object[] { "200%" });
+
+            // Assert
+            Assert.That(ZoomBox().style.width.value.value, Is.EqualTo(CustomWidth * 2f));
+        }
+
+        [Test]
+        public void Given_TheViewportToolbar_When_Built_Then_BothWidthAndHeightFieldsAreDelayed()
+        {
+            // Arrange / Act — the fields are built during window creation (SetUp); nothing further to drive.
+
+            // Assert — isDelayed so the change event (and the remount it triggers) commits once on Enter/blur
+            // rather than firing per keystroke while typing a multi-digit value.
+            Assert.That((ViewportField("_viewportWidthField").isDelayed, ViewportField("_viewportHeightField").isDelayed),
+                Is.EqualTo((true, true)));
+        }
+
+        [Test]
+        public void Given_ACustomViewportSize_When_TheFullPresetIsSelected_Then_TheRememberedCustomSizeIsPreserved()
+        {
+            // Arrange — a custom size stored via the toolbar fields.
+            SetCustomViewport((int)CustomWidth, (int)CustomHeight);
+            Assume.That(PrivateInt("_viewportWidth"), Is.EqualTo((int)CustomWidth), "Precondition: the custom width was stored");
+
+            // Act — Full is (0, 0): it must not clamp through and clobber the remembered custom size.
+            SetViewportPreset(FullViewport, 0f, 0f);
+
+            // Assert
+            Assert.That((PrivateInt("_viewportWidth"), PrivateInt("_viewportHeight")), Is.EqualTo(((int)CustomWidth, (int)CustomHeight)));
+        }
+
+        [Test]
+        public void Given_AnUnrecognizedPersistedViewportLabel_When_TheWindowOpens_Then_TheViewportResetsToFull()
+        {
+            // Arrange — a label a pre-rework session could have persisted, matching neither the current preset
+            // table nor Custom.
+            _window.Close();
+            EditorPrefs.SetString("Velvet.Preview.Viewport", "Mobile (375)");
+
+            // Act
+            _window = EditorWindow.GetWindow<VelvetPreviewWindow>();
+            _window.Show();
+
+            // Assert
+            var field = typeof(VelvetPreviewWindow).GetField("_viewport", BindingFlags.Instance | BindingFlags.NonPublic);
+            Assume.That(field, Is.Not.Null, "VelvetPreviewWindow._viewport must exist");
+            Assert.That((string)field.GetValue(_window), Is.EqualTo(FullViewport));
         }
     }
 }

--- a/Packages/com.velvet.core/Editor/Preview/Tests/Editor/VelvetPreviewWindowZoomLayoutTests.cs
+++ b/Packages/com.velvet.core/Editor/Preview/Tests/Editor/VelvetPreviewWindowZoomLayoutTests.cs
@@ -1,0 +1,188 @@
+using System.Reflection;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.UIElements;
+using Velvet.Editor.Preview;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// The preview window's zoom/layout rework: the mount canvas and its zoom box never shrink under flex
+    /// pressure (a fixed-size story taller than the stage keeps its declared height instead of being squeezed to
+    /// fit), and the zoom box's LAYOUT size tracks the zoom factor (not just the canvas's paint scale), so the
+    /// stage's ScrollView has the correct scrollable extent at any zoom.
+    /// </summary>
+    /// <remarks>
+    /// The canvas, zoom box, and story selection are private to the window; reached by reflection (the repo
+    /// convention for verifying internals from a test assembly that lacks InternalsVisibleTo). A story is built
+    /// directly via <see cref="VelvetPreviewStory"/>'s internal constructor (as <c>VelvetPreviewHostTests</c>
+    /// does) so this fixture does not depend on story discovery scanning any particular assembly.
+    /// </remarks>
+    internal sealed class VelvetPreviewWindowZoomLayoutTests
+    {
+        // Taller than any reasonable test-stage height, so a squeeze bug (flex-shrink compressing the canvas to
+        // fit) is unambiguous: the resolved height would land far below this if the bug were present.
+        private const int TallStoryWidth = 400;
+        private const int TallStoryHeight = 2000;
+        private const string Marker = "zoom-layout-marker";
+
+        private static VNode TallStory() => V.Div(name: Marker, className: "box");
+
+        private VelvetPreviewWindow _window;
+
+        [SetUp]
+        public void SetUp()
+        {
+            TestGraphics.IgnoreIfHeadless("an EditorWindow panel");
+            // Cleared before the window is created so CreateGUI's RefreshStories cannot restore a persisted
+            // selection (e.g. a developer having clicked an example story in the live window) that would land on
+            // an explicit-size story and defeat the viewport-driven assertions below.
+            EditorPrefs.DeleteKey("Velvet.Preview.LastStoryId");
+            EditorPrefs.SetString("Velvet.Preview.Viewport", "Full");
+            EditorPrefs.SetString("Velvet.Preview.Zoom", "100%");
+            _window = EditorWindow.GetWindow<VelvetPreviewWindow>();
+            // Small enough that a story taller than this would be squeezed by a naive flex column if flexShrink
+            // were left at its UI Toolkit default of 1.
+            _window.position = new Rect(0, 0, 500, 300);
+            _window.Show();
+            // The window instance can be reused across tests (GetWindow finds the existing one), so its own
+            // auto-selection from a previous run could still be sitting in _selected — null it explicitly, via the
+            // same Select path the individual tests use to pick their own story afterward.
+            SelectStory(null);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (_window == null) return;
+            _window.Close();
+            _window = null;
+        }
+
+        private static VelvetPreviewStory BuildStory(int width, int height)
+        {
+            var method = typeof(VelvetPreviewWindowZoomLayoutTests).GetMethod(
+                nameof(TallStory), BindingFlags.Static | BindingFlags.NonPublic);
+            Assume.That(method, Is.Not.Null, "fixture method 'TallStory' must exist");
+            var attribute = new VelvetPreviewAttribute { Name = "TallStory", Group = "ZoomLayoutFixture", Width = width, Height = height };
+            return PreviewStoryTestFactory.Build(method, attribute);
+        }
+
+        // Selects the story through the window's private Select method — the same path the sidebar list uses —
+        // so ApplyCanvasSize, the mount, and the post-mount reapply all run exactly as they would interactively.
+        private void SelectStory(VelvetPreviewStory story)
+        {
+            var select = typeof(VelvetPreviewWindow).GetMethod("Select", BindingFlags.Instance | BindingFlags.NonPublic);
+            Assume.That(select, Is.Not.Null, "VelvetPreviewWindow.Select must exist");
+            select.Invoke(_window, new object[] { story });
+        }
+
+        private void InvokePrivate(string name, params object[] args)
+        {
+            var method = typeof(VelvetPreviewWindow).GetMethod(name, BindingFlags.Instance | BindingFlags.NonPublic);
+            Assume.That(method, Is.Not.Null, $"VelvetPreviewWindow.{name} must exist");
+            method.Invoke(_window, args);
+        }
+
+        private VisualElement PrivateElement(string fieldName)
+        {
+            var field = typeof(VelvetPreviewWindow).GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic);
+            Assume.That(field, Is.Not.Null, $"VelvetPreviewWindow.{fieldName} must exist");
+            return (VisualElement)field.GetValue(_window);
+        }
+
+        // Forces the window's panel through a layout pass so resolvedStyle is populated; the EditMode batch
+        // player loop does not tick layout on its own.
+        private void ForceLayout()
+        {
+            var panel = _window.rootVisualElement.panel;
+            Assume.That(panel, Is.Not.Null, "the window must have a live panel");
+            EditorPanelTestHelpers.ForcePanelUpdate(panel);
+        }
+
+        [Test]
+        public void Given_AFixedSizeStoryTallerThanTheStage_When_Selected_Then_TheCanvasKeepsItsDeclaredHeight()
+        {
+            // Arrange
+            var story = BuildStory(TallStoryWidth, TallStoryHeight);
+
+            // Act
+            SelectStory(story);
+            ForceLayout();
+
+            // Assert — flexShrink: 0 on the canvas means the stage (300px tall) does not compress it down.
+            Assert.That(PrivateElement("_canvas").resolvedStyle.height, Is.EqualTo(TallStoryHeight));
+        }
+
+        [Test]
+        public void Given_ACustomViewport_When_Applied_Then_TheCanvasReferenceSizeMatchesBothAxes()
+        {
+            // Arrange — set the W/H toolbar widgets' values, as a user typing in them would. The change handler
+            // reads the live widgets (not a plain backing field), so the widgets are what must be driven here.
+            var widthField = (IntegerField)typeof(VelvetPreviewWindow)
+                .GetField("_viewportWidthField", BindingFlags.Instance | BindingFlags.NonPublic)?.GetValue(_window);
+            var heightField = (IntegerField)typeof(VelvetPreviewWindow)
+                .GetField("_viewportHeightField", BindingFlags.Instance | BindingFlags.NonPublic)?.GetValue(_window);
+            Assume.That(widthField, Is.Not.Null, "VelvetPreviewWindow._viewportWidthField must exist and be built");
+            Assume.That(heightField, Is.Not.Null, "VelvetPreviewWindow._viewportHeightField must exist and be built");
+            // SetValueWithoutNotify so setting both fields does not itself trigger two premature (and, since the
+            // fields disagree mid-setup, wrong) remounts before the explicit invoke below runs the handler once
+            // with both values already in place.
+            widthField.SetValueWithoutNotify(620);
+            heightField.SetValueWithoutNotify(410);
+
+            // Act
+            InvokePrivate("OnViewportFieldChanged");
+
+            // Assert
+            var canvas = PrivateElement("_canvas");
+            Assert.That((canvas.style.width.value.value, canvas.style.height.value.value), Is.EqualTo((620f, 410f)));
+        }
+
+        [Test]
+        public void Given_AZoomFactorOf200Percent_When_Applied_Then_TheZoomBoxLayoutSizeDoublesTheReferenceSize()
+        {
+            // Arrange — a fixed-size story gives a known, stable reference size to multiply.
+            var story = BuildStory(TallStoryWidth, TallStoryHeight);
+            SelectStory(story);
+            ForceLayout();
+
+            // Act
+            InvokePrivate("SetZoom", "200%");
+
+            // Assert
+            Assert.That(PrivateElement("_zoomBox").style.width.value.value, Is.EqualTo(TallStoryWidth * 2f));
+        }
+
+        [Test]
+        public void Given_TheStageScrollView_When_Built_Then_TheContentContainerHasAFullPercentMinHeight()
+        {
+            // Arrange / Act — the scroll view is built during window creation (SetUp); nothing further to drive.
+
+            // Assert — Unity's default USS gives a VerticalAndHorizontal ScrollView's content container an
+            // align-self: flex-start that shrink-wraps it vertically, leaving justifyContent: Center with no
+            // vertical space to center within (a small story pinned to the top). A Percent(100) min-height is a
+            // proxy for the fix here — asserting the true vertical centering needs a live layout pass.
+            var minHeight = PrivateElement("_stageScroll").contentContainer.style.minHeight.value;
+            Assert.That((minHeight.value, minHeight.unit), Is.EqualTo((100f, LengthUnit.Percent)));
+        }
+
+        [Test]
+        public void Given_TheZoomBoxFrame_When_TheBackgroundSwitchesBetweenDarkAndLight_Then_TheFrameColorDiffers()
+        {
+            // Arrange — a single fixed frame color would read against one backdrop and nearly vanish against the
+            // other, so the frame must be re-derived per background rather than staying constant.
+            InvokePrivate("SetBackground", "Dark");
+            var darkFrame = PrivateElement("_zoomBox").style.borderTopColor.value;
+
+            // Act
+            InvokePrivate("SetBackground", "Light");
+            var lightFrame = PrivateElement("_zoomBox").style.borderTopColor.value;
+
+            // Assert
+            Assert.That(lightFrame, Is.Not.EqualTo(darkFrame));
+        }
+    }
+}

--- a/Packages/com.velvet.core/Editor/Preview/Tests/Editor/VelvetPreviewWindowZoomLayoutTests.cs.meta
+++ b/Packages/com.velvet.core/Editor/Preview/Tests/Editor/VelvetPreviewWindowZoomLayoutTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d52965a1ea8e544d3827f527c35c2604

--- a/Packages/com.velvet.core/Editor/Preview/VelvetPreviewWindow.cs
+++ b/Packages/com.velvet.core/Editor/Preview/VelvetPreviewWindow.cs
@@ -36,11 +36,32 @@ namespace Velvet.Editor.Preview
         private const string OutlineKey = "Velvet.Preview.Outline";
         private const string MeasureKey = "Velvet.Preview.Measure";
         private const string ViewportKey = "Velvet.Preview.Viewport";
+        private const string ViewportWidthKey = "Velvet.Preview.ViewportW";
+        private const string ViewportHeightKey = "Velvet.Preview.ViewportH";
+
+        // Custom viewport W/H fields are clamped to this range — 1 keeps a story from collapsing to nothing, 8192
+        // is generously above any real device or monitor so it never blocks an intentionally huge reference size.
+        private const int MinCustomViewportSize = 1;
+        private const int MaxCustomViewportSize = 8192;
+
+        // Default custom W/H shown the first time the window opens (no remembered custom size yet) — full HD
+        // landscape, just a starting point for the free-form fields.
+        private const int DefaultCustomViewportWidth = 1920;
+        private const int DefaultCustomViewportHeight = 1080;
 
         // Stage backdrops. Dark is the default — a near-black so light UI stays legible
         // and the mounted tree's own bounds read against it; Light is a neutral gray for dark UI.
         private static readonly Color DarkBackdrop = new(0.09f, 0.10f, 0.13f, 1f);
         private static readonly Color LightBackdrop = new(0.92f, 0.92f, 0.92f, 1f);
+
+        // A thin frame drawn around the simulated viewport so its rectangle — and therefore the active resolution
+        // and aspect ratio — is always visible against the stage, even when the story is transparent or smaller
+        // than its canvas. The color adapts to the active backdrop (set from ApplyBackground) rather than being a
+        // single fixed color — a light frame that reads on Dark is nearly invisible against Light, and vice versa.
+        // Kept subtle so it reads as a bezel, not part of the story.
+        private static readonly Color DarkBgViewportFrame = new(1f, 1f, 1f, 0.35f);
+        private static readonly Color LightBgViewportFrame = new(0f, 0f, 0f, 0.35f);
+        private static readonly Color CheckerboardViewportFrame = new(0.5f, 0.5f, 0.5f, 0.6f);
 
         private const string BgDark = "Dark";
         private const string BgLight = "Light";
@@ -53,13 +74,16 @@ namespace Velvet.Editor.Preview
             (ZoomFit, 0f), ("50%", 0.5f), ("100%", 1f), ("200%", 2f),
         };
 
-        // Simulated viewports. "Full" lets the canvas fill the stage (no scope); a fixed
-        // preset sizes the canvas to that reference width and makes it a responsive scope so the mounted story's
-        // sm:/md:/... evaluate against the simulated width. Reference px mirror common device breakpoints.
+        // Simulated viewports. "Full" lets the canvas fill the stage (no scope) and is the menu's only entry —
+        // the fixed device presets (Mobile/Tablet/Desktop) were removed in favor of free-form entry: any reference
+        // size, including the old preset sizes, is reachable by typing into the W/H fields below. "Custom" is not
+        // in this list — it is entered via those fields and stores its size under
+        // ViewportWidthKey/ViewportHeightKey instead of a table entry.
         private const string ViewportFull = "Full";
-        private static readonly (string Label, float Width)[] Viewports =
+        private const string ViewportCustom = "Custom";
+        private static readonly (string Label, float Width, float Height)[] Viewports =
         {
-            (ViewportFull, 0f), ("Mobile (375)", 375f), ("Tablet (768)", 768f), ("Desktop (1280)", 1280f),
+            (ViewportFull, 0f, 0f),
         };
 
         private readonly List<VelvetPreviewStory> _stories = new();
@@ -67,7 +91,9 @@ namespace Velvet.Editor.Preview
         private VelvetPreviewHost _host;
 
         private ListView _list;
-        private VisualElement _stage;     // fixed backdrop the canvas centers within
+        private VisualElement _stage;     // fixed backdrop the scroll view / zoom box center within
+        private ScrollView _stageScroll;  // pans/scrolls when the zoom box exceeds the stage viewport
+        private VisualElement _zoomBox;   // layout-sized box (reference * zoom) that makes zoom affect layout, not just paint
         private VisualElement _canvas;    // the element the story actually mounts onto
         private CheckerboardBackground _checkerboard;
         private PreviewInspectOverlay _overlay;
@@ -76,6 +102,8 @@ namespace Velvet.Editor.Preview
         private ToolbarMenu _backgroundMenu;
         private ToolbarMenu _zoomMenu;
         private ToolbarMenu _viewportMenu;
+        private IntegerField _viewportWidthField;
+        private IntegerField _viewportHeightField;
 
         // View-addon state, persisted in EditorPrefs so it survives remounts / domain reloads.
         private bool _dark;
@@ -84,6 +112,8 @@ namespace Velvet.Editor.Preview
         private bool _outline;
         private bool _measure;
         private string _viewport = ViewportFull;
+        private int _viewportWidth;
+        private int _viewportHeight;
 
         // The IsDark value the editor (or a running game) had before this window first applied its own, captured
         // once and restored on close so toggling Dark in preview never leaks to whatever else uses the theme.
@@ -134,6 +164,29 @@ namespace Velvet.Editor.Preview
             _outline = EditorPrefs.GetBool(OutlineKey, false);
             _measure = EditorPrefs.GetBool(MeasureKey, false);
             _viewport = EditorPrefs.GetString(ViewportKey, ViewportFull);
+            _viewportWidth = ClampCustomViewportSize(EditorPrefs.GetInt(ViewportWidthKey, DefaultCustomViewportWidth));
+            _viewportHeight = ClampCustomViewportSize(EditorPrefs.GetInt(ViewportHeightKey, DefaultCustomViewportHeight));
+
+            if (!IsKnownViewportLabel(_viewport))
+            {
+                // A label persisted by a pre-rework session (e.g. an old preset that no longer exists) matches
+                // neither the current Viewports table nor Custom. Left as-is, ViewportSize() would silently fall
+                // back to (0, 0) while the toolbar kept showing the stale label — reset to Full so the label and
+                // the actual reference size agree again.
+                _viewport = ViewportFull;
+                EditorPrefs.SetString(ViewportKey, _viewport);
+            }
+        }
+
+        private static bool IsKnownViewportLabel(string label)
+        {
+            if (label == ViewportCustom) return true;
+            foreach (var (presetLabel, _, _) in Viewports)
+            {
+                if (presetLabel == label) return true;
+            }
+
+            return false;
         }
 
         #region Sidebar
@@ -194,18 +247,18 @@ namespace Velvet.Editor.Preview
             var vertical = new TwoPaneSplitView(1, 160f, TwoPaneSplitViewOrientation.Vertical) { style = { flexGrow = 1f } };
             column.Add(vertical);
 
+            // The stage is the fixed backdrop; it never shrinks or grows to match the canvas — instead a
+            // ScrollView inside it pans/scrolls to reach a zoom box larger than the stage. overflow: Hidden here
+            // only clips the checkerboard/overlay to the stage bounds; the scroll view supplies the real clip +
+            // scroll behavior for the zoomed content.
             _stage = new VisualElement
             {
                 style =
                 {
                     flexGrow = 1f,
-                    alignItems = Align.Center,
-                    justifyContent = Justify.Center,
                     overflow = Overflow.Hidden,
                 },
             };
-            // Fit recomputes against the stage's measured size, so it must re-run whenever the stage resizes.
-            _stage.RegisterCallback<GeometryChangedEvent>(_ => ApplyZoom());
             vertical.Add(_stage);
 
             _controls = new PreviewControlsPanel();
@@ -216,20 +269,73 @@ namespace Velvet.Editor.Preview
             _checkerboard = new CheckerboardBackground { style = { display = DisplayStyle.None } };
             _stage.Add(_checkerboard);
 
+            // Both scrollers are Auto: a zoom box that fits the stage shows no scroller (the common case), and one
+            // larger than the stage in either axis becomes pannable in that axis instead of clipping silently.
+            _stageScroll = new ScrollView(ScrollViewMode.VerticalAndHorizontal)
+            {
+                style = { flexGrow = 1f },
+                horizontalScrollerVisibility = ScrollerVisibility.Auto,
+                verticalScrollerVisibility = ScrollerVisibility.Auto,
+            };
+            _stage.Add(_stageScroll);
+
+            // Center the zoom box inside the scroll view's content container. A ScrollView's content container
+            // does not center by default (it is sized to its content, like a normal document flow), so this
+            // wrapper opts in explicitly: flexGrow fills the viewport when the zoom box is smaller than it, and
+            // alignItems/justifyContent center the box within that filled space. When the zoom box is larger than
+            // the viewport in an axis, centering has no visible effect there (there is no extra space to center
+            // within) and the ScrollView's scrollers take over for that axis instead.
+            _stageScroll.contentContainer.style.flexGrow = 1f;
+            _stageScroll.contentContainer.style.alignItems = Align.Center;
+            _stageScroll.contentContainer.style.justifyContent = Justify.Center;
+            // Unity's default USS gives a VerticalAndHorizontal ScrollView's content container align-self:
+            // flex-start, which overrides flexGrow along the cross axis and lets it shrink-wrap vertically — so
+            // justifyContent: Center above had no vertical space to center within and a small story pinned to the
+            // top. A percentage min-size (not a fixed size, so the container still grows past 100% when the zoom
+            // box is larger than the stage) forces it to fill the viewport in both axes while still growing to fit.
+            _stageScroll.contentContainer.style.minHeight = Length.Percent(100);
+            _stageScroll.contentContainer.style.minWidth = Length.Percent(100);
+
+            // The zoom box: its LAYOUT size is the reference size times the zoom factor, so the scroll view's
+            // scrollable extent matches what is actually painted. flexShrink 0 keeps it from being compressed by
+            // the flex column above it (the original squeeze bug for a fixed-size story taller than the stage).
+            // The frame hugs the painted story at any zoom because the zoom box carries the post-zoom layout size
+            // (reference * factor) in unscaled px, so its border is a crisp 1px bezel around the simulated viewport.
+            // Border colors are left at their default here and set by ApplyBackground (called once from CreateGUI
+            // right after this element tree is built, and again on every background change) so the frame always
+            // matches the active backdrop.
+            _zoomBox = new VisualElement
+            {
+                style =
+                {
+                    flexShrink = 0f,
+                    borderTopWidth = 1f, borderRightWidth = 1f, borderBottomWidth = 1f, borderLeftWidth = 1f,
+                },
+            };
+            _stageScroll.Add(_zoomBox);
+
             _canvas = new VisualElement
             {
                 style =
                 {
-                    flexGrow = 1f, width = Length.Percent(100f), height = Length.Percent(100f),
-                    // Scale about the top-center so zooming grows the canvas downward from a stable anchor.
-                    transformOrigin = new TransformOrigin(Length.Percent(50f), Length.Percent(0f)),
+                    // flexGrow 0 + flexShrink 0: the canvas is never stretched or compressed by the flex
+                    // containers around it, so its declared reference size (written by ApplyCanvasSize) is always
+                    // what actually lays out — the fix for a fixed-size story taller than the stage getting
+                    // silently squeezed. Constant for the canvas's lifetime, so set once here rather than rewritten
+                    // on every ApplyCanvasSize call.
+                    flexGrow = 0f,
+                    flexShrink = 0f,
+                    // Scale about the top-left: the zoom box already carries the post-zoom layout size, so the
+                    // canvas's own paint transform must grow from the box's origin, not re-center over it (top-center
+                    // origin was the old fill-canvas convention and only made sense when zoom was paint-only).
+                    transformOrigin = new TransformOrigin(0f, 0f),
                 },
             };
             var utilities = AssetDatabase.LoadAssetAtPath<StyleSheet>(UtilitiesUssPath);
             if (utilities != null) _canvas.styleSheets.Add(utilities);
-            _stage.Add(_canvas);
+            _zoomBox.Add(_canvas);
 
-            // Inspection overlay (outline / measure) drawn above the canvas; non-interactive so it never steals
+            // Inspection overlay (outline / measure) drawn above everything; non-interactive so it never steals
             // the story's pointer events. It tracks the canvas subtree and re-draws when the stage resizes.
             _overlay = new PreviewInspectOverlay(_canvas)
             {
@@ -237,16 +343,28 @@ namespace Velvet.Editor.Preview
                 MeasureEnabled = _measure,
             };
             _stage.Add(_overlay);
-            // Re-draw the overlay when the stage resizes OR the canvas relayouts (a story laying out after mount,
-            // or a zoom change altering the canvas transform) so outlines track the current geometry. The canvas
-            // also re-runs Fit: a viewport-driven canvas WIDTH change (not a stage resize) must recompute the fit
-            // scale, which only the canvas's own geometry change reports.
-            _stage.RegisterCallback<GeometryChangedEvent>(_ => _overlay?.Refresh());
-            _canvas.RegisterCallback<GeometryChangedEvent>(_ =>
+            // The scroll view pans by writing contentContainer.style.translate directly (a paint-time transform),
+            // which fires no GeometryChangedEvent — so without this, scrolling a zoomed-in story left the outline
+            // / measure overlay frozen at its pre-scroll position until some unrelated geometry event happened to
+            // fire. Subscribing to the scrollers' own valueChanged covers both drag-scrolling and programmatic
+            // scrolling.
+            _stageScroll.horizontalScroller.valueChanged += _ => _overlay?.Refresh();
+            _stageScroll.verticalScroller.valueChanged += _ => _overlay?.Refresh();
+            // The stage resize is the only geometry source that can change a Full/fill story's reference size (the
+            // measured stage size); re-derive the reference and zoom box from it. ApplyCanvasSize now early-outs
+            // whenever the reference size is not yet resolved (NaN before the first layout pass, or a collapsed
+            // stage), so a resize tick that does not actually make the reference size resolvable simply writes
+            // nothing and cannot retrigger this handler in a loop.
+            _stage.RegisterCallback<GeometryChangedEvent>(_ =>
             {
+                ApplyCanvasSize(_selected);
                 ApplyZoom();
                 _overlay?.Refresh();
             });
+            // The canvas's own geometry change (a story laying out after mount) does not affect sizing decisions
+            // here — the reference size is derived from the story metadata / viewport / stage, never from the
+            // canvas's own resolved size — but the overlay still needs to redraw to track it.
+            _canvas.RegisterCallback<GeometryChangedEvent>(_ => _overlay?.Refresh());
 
             return column;
         }
@@ -287,15 +405,30 @@ namespace Velvet.Editor.Preview
             toolbar.Add(_zoomMenu);
 
             _viewportMenu = new ToolbarMenu { text = ViewportLabel() };
-            foreach (var (label, _) in Viewports)
+            foreach (var (label, width, height) in Viewports)
             {
                 var captured = label;
+                var capturedWidth = width;
+                var capturedHeight = height;
                 _viewportMenu.menu.AppendAction(
                     captured,
-                    _ => SetViewport(captured),
+                    _ => SetViewportPreset(captured, capturedWidth, capturedHeight),
                     _ => _viewport == captured ? DropdownMenuAction.Status.Checked : DropdownMenuAction.Status.Normal);
             }
             toolbar.Add(_viewportMenu);
+
+            // Free-form W/H entry: picking a preset above writes its values in here (read-only feedback), and
+            // editing either field switches the viewport to Custom using both fields' current values — so the
+            // fields are always "what the viewport reference size currently is," regardless of how it was set.
+            // isDelayed: the change event (and the remount it triggers) commits once on Enter/blur instead of
+            // firing — and remounting — on every keystroke while typing a multi-digit value.
+            _viewportWidthField = new IntegerField { value = _viewportWidth, style = { width = 50f }, isDelayed = true };
+            _viewportWidthField.RegisterValueChangedCallback(_ => OnViewportFieldChanged());
+            toolbar.Add(_viewportWidthField);
+
+            _viewportHeightField = new IntegerField { value = _viewportHeight, style = { width = 50f }, isDelayed = true };
+            _viewportHeightField.RegisterValueChangedCallback(_ => OnViewportFieldChanged());
+            toolbar.Add(_viewportHeightField);
 
             var outlineToggle = new ToolbarToggle { text = "Outline", value = _outline };
             outlineToggle.RegisterValueChangedCallback(evt =>
@@ -363,6 +496,23 @@ namespace Velvet.Editor.Preview
                 BgCheckerboard => new StyleColor(StyleKeyword.Initial),
                 _ => DarkBackdrop,
             };
+
+            // The frame's color must track the backdrop it is drawn over, or a fixed color reads on one background
+            // and nearly vanishes on another (the bug this addresses: a single white@0.28 frame was invisible over
+            // the Light backdrop's near-white gray).
+            var frame = _background switch
+            {
+                BgLight => LightBgViewportFrame,
+                BgCheckerboard => CheckerboardViewportFrame,
+                _ => DarkBgViewportFrame,
+            };
+            if (_zoomBox != null)
+            {
+                _zoomBox.style.borderTopColor = frame;
+                _zoomBox.style.borderRightColor = frame;
+                _zoomBox.style.borderBottomColor = frame;
+                _zoomBox.style.borderLeftColor = frame;
+            }
         }
 
         private void SetZoom(string zoom)
@@ -373,28 +523,60 @@ namespace Velvet.Editor.Preview
             ApplyZoom();
         }
 
+        // Applies the current zoom factor to BOTH the zoom box's layout size and the canvas's paint scale. Scale
+        // alone (the pre-rework behavior) only repaints the canvas larger without changing the space it occupies,
+        // so the stage always centered the UNSCALED box: at 200% the painted content overflowed the stage's
+        // Hidden clip with nothing to scroll to, and at 50%/Fit the centered (but unscaled) box left dead space
+        // below a top-anchored paint. Driving the zoom box's layout size in step with the canvas's paint scale
+        // makes the two agree, so centering is correct at any factor and the ScrollView's scrollable extent
+        // matches what is actually painted.
         private void ApplyZoom()
         {
-            if (_canvas == null) return;
+            if (_canvas == null || _zoomBox == null) return;
             var factor = _zoom == ZoomFit ? ComputeFitFactor() : ZoomFactor(_zoom);
-            _canvas.style.scale = new Scale(new Vector3(factor, factor, 1f));
+            var (refW, refH, _) = ComputeReferenceSize(_selected);
+
+            if (IsResolved(refW) && IsResolved(refH))
+            {
+                _canvas.style.scale = new Scale(new Vector3(factor, factor, 1f));
+
+                var boxWidth = refW * factor;
+                var boxHeight = refH * factor;
+                // Only write when the value actually changed — this handler also runs from the stage's
+                // GeometryChangedEvent, so writing unconditionally could retrigger layout every resize tick even
+                // when nothing here actually moved.
+                if (!Mathf.Approximately(_zoomBox.style.width.value.value, boxWidth)) _zoomBox.style.width = boxWidth;
+                if (!Mathf.Approximately(_zoomBox.style.height.value.value, boxHeight)) _zoomBox.style.height = boxHeight;
+            }
+            // Else: the reference size is not yet resolved (NaN before the first layout pass, or a collapsed
+            // stage). Leave the canvas's scale and the zoom box's size untouched rather than writing a scale/size
+            // computed from NaN — that would paint the canvas at a NaN scale (effectively invisible) and, unlike a
+            // wrong-but-finite value, nothing would ever compare unequal to NaN to trigger a corrective rewrite
+            // once the size resolves. The stage's GeometryChangedEvent re-runs this once resolution is available.
+
+            _overlay?.Refresh();
+            // Keep the status line's resolution/zoom readout in step with the applied factor and stage size, so a
+            // zoom step or a Fit recompute (e.g. the window being resized) is reflected as text, not only as layout.
+            // Passes the factor/reference size already computed above instead of letting UpdateStatus recompute
+            // them a second time — this runs on every stage GeometryChangedEvent tick, so recomputation was pure
+            // waste.
+            UpdateStatus(factor, refW, refH);
         }
 
-        // Fit: the largest scale at which the canvas's reference size fits inside the stage. Uses the story's
-        // explicit Width/Height when set, else the canvas's measured layout; returns 1 until the stage and
-        // canvas have a resolved size (the GeometryChangedEvent re-runs this once they do).
+        // Fit: the largest scale at which the canvas's reference size fits inside the stage, capped at 1 so Fit
+        // never upscales a small story. Returns 1 until the stage has a resolved size or the reference size is not
+        // yet known (the stage's GeometryChangedEvent re-runs this once both are available).
         private float ComputeFitFactor()
         {
-            if (_stage == null || _canvas == null) return 1f;
+            if (_stage == null) return 1f;
             var stageW = _stage.resolvedStyle.width;
             var stageH = _stage.resolvedStyle.height;
-            if (stageW <= 0f || stageH <= 0f) return 1f;
+            if (!IsResolved(stageW) || !IsResolved(stageH)) return 1f;
 
-            var canvasW = _selected is { Width: > 0 } ? _selected.Width : _canvas.resolvedStyle.width;
-            var canvasH = _selected is { Height: > 0 } ? _selected.Height : _canvas.resolvedStyle.height;
-            if (canvasW <= 0f || canvasH <= 0f) return 1f;
+            var (refW, refH, _) = ComputeReferenceSize(_selected);
+            if (!IsResolved(refW) || !IsResolved(refH)) return 1f;
 
-            return Mathf.Min(1f, Mathf.Min(stageW / canvasW, stageH / canvasH));
+            return Mathf.Min(1f, Mathf.Min(stageW / refW, stageH / refH));
         }
 
         private static float ZoomFactor(string label)
@@ -405,6 +587,41 @@ namespace Velvet.Editor.Preview
             }
 
             return 1f;
+        }
+
+        // Selecting a preset from the dropdown: store its label (so ViewportLabel/menu-check reflect it) and, for
+        // a sized preset, its W/H as the "custom" numbers too, so the W/H fields immediately show the preset's
+        // values rather than stale custom ones from a previous session. Full is (0, 0) — it has no size of its
+        // own, so storing it would clamp to 1x1 and destroy whatever custom size was remembered; Full leaves the
+        // remembered custom size and fields untouched and only changes which viewport is active.
+        private void SetViewportPreset(string label, float width, float height)
+        {
+            if (width > 0f && height > 0f) StoreViewportSize((int)width, (int)height);
+
+            SetViewport(label);
+        }
+
+        // Editing either W/H field: the viewport becomes Custom using both fields' current (clamped) values. A
+        // non-positive or out-of-range entry is clamped rather than rejected, so the field never gets stuck showing
+        // a value that cannot produce a usable canvas.
+        private void OnViewportFieldChanged()
+        {
+            StoreViewportSize(_viewportWidthField?.value ?? _viewportWidth, _viewportHeightField?.value ?? _viewportHeight);
+
+            SetViewport(ViewportCustom);
+        }
+
+        // Clamps and persists a custom viewport size, then reflects it into both W/H fields without re-raising
+        // their change callback (which would recurse back into OnViewportFieldChanged). Shared by the preset
+        // handler (a sized preset also becomes the remembered custom size) and the field-change handler.
+        private void StoreViewportSize(int width, int height)
+        {
+            _viewportWidth = ClampCustomViewportSize(width);
+            _viewportHeight = ClampCustomViewportSize(height);
+            EditorPrefs.SetInt(ViewportWidthKey, _viewportWidth);
+            EditorPrefs.SetInt(ViewportHeightKey, _viewportHeight);
+            if (_viewportWidthField != null) _viewportWidthField.SetValueWithoutNotify(_viewportWidth);
+            if (_viewportHeightField != null) _viewportHeightField.SetValueWithoutNotify(_viewportHeight);
         }
 
         private void SetViewport(string viewport)
@@ -420,15 +637,20 @@ namespace Velvet.Editor.Preview
             MountWithCurrentArgs(_selected);
         }
 
-        // The fixed viewport width in reference px, or 0 for Full.
-        private float ViewportWidth()
+        private static int ClampCustomViewportSize(int value) =>
+            Mathf.Clamp(value, MinCustomViewportSize, MaxCustomViewportSize);
+
+        // The active viewport's reference W/H in px, or (0, 0) for Full. A known preset label returns its table
+        // entry; Custom (or any unrecognized persisted label — no migration of old labels, just fall back to
+        // Full-like zero) returns the W/H fields' current values only when actually in Custom mode.
+        private (float Width, float Height) ViewportSize()
         {
-            foreach (var (label, width) in Viewports)
+            foreach (var (label, width, height) in Viewports)
             {
-                if (label == _viewport) return width;
+                if (label == _viewport) return (width, height);
             }
 
-            return 0f;
+            return _viewport == ViewportCustom ? (_viewportWidth, _viewportHeight) : (0f, 0f);
         }
 
         private string BackgroundLabel() => "BG: " + _background;
@@ -504,53 +726,90 @@ namespace Velvet.Editor.Preview
         }
 
         // The single post-(re)mount step: re-apply the theme (so a remounted tree picks up dark:), recompute zoom
-        // (Fit depends on the current story / viewport size), refresh the overlay (track the new subtree), and
-        // refresh the status line. Called from every mount path so they cannot diverge.
+        // (Fit depends on the current story / viewport size), and refresh the overlay (track the new subtree).
+        // ApplyZoom already refreshes the status line itself at the end, so this does not call UpdateStatus again.
+        // Called from every mount path so they cannot diverge.
         private void ReapplyAfterMount()
         {
             ApplyTheme();
             ApplyZoom();
             _overlay?.Refresh();
-            UpdateStatus();
         }
 
-        // Sizes the mount canvas. A story's explicit Width/Height ALWAYS wins: an authored card footprint is
-        // shown at its real size and is NOT treated as a responsive container (the viewport simulation does not
-        // apply to a fixed-size story, so no @container marker). Only a fill-canvas story (no explicit size)
-        // honors a fixed viewport: the canvas takes the simulated width and becomes a responsive scope
-        // (@container) so the mounted story's sm:/md:/... evaluate against that width. With Full viewport and no
-        // explicit size, the canvas fills the stage (the original behavior).
-        private void ApplyCanvasSize(VelvetPreviewStory story)
+        // A stage/reference dimension is only usable once it is a positive, non-NaN number. resolvedStyle.width/
+        // height IS NaN before the panel's first layout pass, and NaN <= 0f is false — so a plain "<= 0" guard lets
+        // NaN slip through into a scale or an explicit size write, silently corrupting the canvas until the next
+        // resize happens to overwrite it. Every read of a stage/reference size below must go through this guard.
+        private static bool IsResolved(float v) => v > 0f && !float.IsNaN(v);
+
+        // Computes the canvas's reference size (pre-zoom, in px) purely from the story metadata / viewport /
+        // stage — no field is written here, so callers can probe "what would the reference size be" without
+        // mutating state. Matches the pre-rework rule exactly:
+        // <list type="bullet">
+        // <item>A story's explicit Width/Height ALWAYS wins: an authored card footprint is shown at its real size
+        // and is NOT treated as a responsive container. If only one axis is authored, the OTHER axis falls back to
+        // the measured stage size (so e.g. a Width-only story still gets a sensible height instead of 0).</item>
+        // <item>Else a fixed viewport (preset or custom) sizes the canvas to that reference W x H and marks it a
+        // responsive scope so the mounted story's sm:/md:/... evaluate against the simulated size.</item>
+        // <item>Else ("Full", no explicit size): the canvas fills the stage — its reference size IS the measured
+        // stage size, and it is not a responsive scope (matches the panel root instead).</item>
+        // </list>
+        private (float Width, float Height, bool IsResponsiveScope) ComputeReferenceSize(VelvetPreviewStory story)
         {
-            if (_canvas == null) return;
+            var stageW = _stage?.resolvedStyle.width ?? 0f;
+            var stageH = _stage?.resolvedStyle.height ?? 0f;
 
             var hasExplicitSize = story != null && (story.Width > 0 || story.Height > 0);
             if (hasExplicitSize)
             {
-                _canvas.EnableInClassList(VelvetResponsive.ContainerClass, false);
-                _canvas.style.width = story.Width > 0 ? (StyleLength)story.Width : Length.Percent(100f);
-                _canvas.style.height = story.Height > 0 ? (StyleLength)story.Height : Length.Percent(100f);
-                _canvas.style.flexGrow = 0f;
-                return;
+                var refW = story.Width > 0 ? story.Width : stageW;
+                var refH = story.Height > 0 ? story.Height : stageH;
+                return (refW, refH, false);
             }
 
-            var viewportWidth = ViewportWidth();
-            if (viewportWidth > 0f)
-            {
-                _canvas.style.width = viewportWidth;
-                _canvas.style.height = Length.Percent(100f);
-                _canvas.style.flexGrow = 0f;
-                _canvas.EnableInClassList(VelvetResponsive.ContainerClass, true);
-                return;
-            }
+            var (viewportW, viewportH) = ViewportSize();
+            if (viewportW > 0f && viewportH > 0f) return (viewportW, viewportH, true);
 
-            _canvas.EnableInClassList(VelvetResponsive.ContainerClass, false);
-            _canvas.style.width = Length.Percent(100f);
-            _canvas.style.height = Length.Percent(100f);
-            _canvas.style.flexGrow = 1f;
+            return (stageW, stageH, false);
         }
 
-        private void UpdateStatus()
+        // Writes the canvas's reference size (pre-zoom, in px) as an EXPLICIT pixel size — never a percentage. A
+        // percentage reference was the root of the old zoom-box-less design's problems: it made the canvas's
+        // layout size a function of its unscaled parent, so there was no stable "100%" to multiply by a zoom
+        // factor. Also toggles the @container responsive-scope marker per ComputeReferenceSize's rule.
+        private void ApplyCanvasSize(VelvetPreviewStory story)
+        {
+            if (_canvas == null || _zoomBox == null) return;
+
+            var (refW, refH, isResponsiveScope) = ComputeReferenceSize(story);
+            // The scope marker never depends on whether the stage has actually resolved a size — it only depends
+            // on story metadata / viewport mode, both known regardless of layout — so it is always safe to apply,
+            // unlike the pixel size below. Toggling it unconditionally also keeps a Full selection able to clear
+            // the marker even before the first layout pass.
+            _canvas.EnableInClassList(VelvetResponsive.ContainerClass, isResponsiveScope);
+
+            // Unresolved (NaN pre-layout, or a collapsed stage with no explicit/viewport size to fall back to):
+            // skip the size write rather than corrupt the canvas with a NaN or 0x0 size. The stage's
+            // GeometryChangedEvent re-runs this once the stage actually has a resolved size.
+            if (!IsResolved(refW) || !IsResolved(refH)) return;
+
+            _canvas.style.width = refW;
+            _canvas.style.height = refH;
+        }
+
+        private void UpdateStatus() => UpdateStatus(null);
+
+        // Overload for a caller (ApplyZoom) that already computed the zoom factor and reference size for its own
+        // purposes — passing them through lets DescribeViewport skip re-deriving both (ComputeFitFactor itself
+        // re-calls ComputeReferenceSize), which matters because ApplyZoom runs on every stage GeometryChangedEvent
+        // tick.
+        private void UpdateStatus(float factor, float refW, float refH)
+        {
+            (float Factor, float RefW, float RefH)? precomputed = (factor, refW, refH);
+            UpdateStatus(precomputed);
+        }
+
+        private void UpdateStatus((float Factor, float RefW, float RefH)? precomputed)
         {
             if (_statusLabel == null) return;
             if (_selected == null)
@@ -563,8 +822,38 @@ namespace Velvet.Editor.Preview
 
             var error = _host?.MountError;
             _statusLabel.text = error == null
-                ? $"{_selected.Group} / {_selected.Name}"
+                ? $"{_selected.Group} / {_selected.Name}      {DescribeViewport(precomputed)}"
                 : $"{_selected.Name} failed to mount: {error.Message}";
+        }
+
+        // A short human-readable summary of what actually drives the canvas size right now — shown in the status
+        // line so a resolution or zoom change is visible as text, not only as a (sometimes subtle) layout change.
+        // Mode is "Story" when the selected story's own Width/Height wins, else the viewport mode ("Full"/"Custom");
+        // in Full mode the reported size is the stage the canvas fills, which is why Full always looks window-wide.
+        // Accepts an optional precomputed (factor, refW, refH) so a caller that already derived these values (e.g.
+        // ApplyZoom) does not force a second computation here; a caller without them (the parameterless UpdateStatus
+        // path) falls back to deriving both itself.
+        private string DescribeViewport((float Factor, float RefW, float RefH)? precomputed)
+        {
+            float factor, refW, refH;
+            if (precomputed.HasValue)
+            {
+                (factor, refW, refH) = precomputed.Value;
+            }
+            else
+            {
+                (refW, refH, _) = ComputeReferenceSize(_selected);
+                factor = _zoom == ZoomFit ? ComputeFitFactor() : ZoomFactor(_zoom);
+            }
+
+            if (!IsResolved(refW) || !IsResolved(refH)) return "sizing…";
+
+            var pct = Mathf.RoundToInt(factor * 100f);
+            var size = $"{Mathf.RoundToInt(refW)}×{Mathf.RoundToInt(refH)}";
+
+            var hasExplicitSize = _selected != null && (_selected.Width > 0 || _selected.Height > 0);
+            var mode = hasExplicitSize ? "Story" : _viewport;
+            return $"{mode}  {size} · {pct}%";
         }
         #endregion
     }

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/FocusLossDuringCommitTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/FocusLossDuringCommitTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Reflection;
 using NUnit.Framework;
 using UnityEditor;
 using UnityEngine;
@@ -72,21 +71,8 @@ namespace Velvet.Tests
             var btn = _window.rootVisualElement.Q<Button>("focusable");
             _window.Focus();
             btn.Focus();
-            ForcePanelUpdate(btn.panel);
+            EditorPanelTestHelpers.ForcePanelUpdate(btn.panel);
             return btn;
-        }
-
-        private static void ForcePanelUpdate(IPanel panel)
-        {
-            var t = panel.GetType();
-            foreach (var name in new[] { "UpdateForRepaint", "ValidateLayout", "ApplyStyles" })
-            {
-                var m = t.GetMethod(name, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
-                if (m != null && m.GetParameters().Length == 0)
-                {
-                    m.Invoke(panel, null);
-                }
-            }
         }
 
         [Test]

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/PanelTestBase.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/PanelTestBase.cs
@@ -1,4 +1,3 @@
-using System.Reflection;
 using NUnit.Framework;
 using UnityEditor;
 using UnityEngine;
@@ -81,21 +80,11 @@ namespace Velvet.Tests
 
         /// <summary>
         /// Forces the panel through a layout/styles pass via reflection so <c>resolvedStyle</c> is populated; the
-        /// EditMode batch player loop does not tick layout on its own. Invokes whichever of
-        /// <c>UpdateForRepaint</c>/<c>ValidateLayout</c>/<c>ApplyStyles</c> the panel exposes.
+        /// EditMode batch player loop does not tick layout on its own. Delegates to the shared TestUtilities
+        /// helper (kept as a protected member here so existing subclasses calling <c>ForcePanelUpdate(...)</c>
+        /// unqualified keep compiling).
         /// </summary>
-        protected static void ForcePanelUpdate(IPanel panel)
-        {
-            var t = panel.GetType();
-            foreach (var name in new[] { "UpdateForRepaint", "ValidateLayout", "ApplyStyles" })
-            {
-                var m = t.GetMethod(name, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
-                if (m != null && m.GetParameters().Length == 0)
-                {
-                    m.Invoke(panel, null);
-                }
-            }
-        }
+        protected static void ForcePanelUpdate(IPanel panel) => EditorPanelTestHelpers.ForcePanelUpdate(panel);
 
         /// <summary>
         /// Mounts a single named leaf, forces a layout pass, and returns it resolved. Convenience for USS

--- a/Packages/com.velvet.core/TestUtilities/EditorPanelTestHelpers.cs
+++ b/Packages/com.velvet.core/TestUtilities/EditorPanelTestHelpers.cs
@@ -1,0 +1,46 @@
+using System.Reflection;
+using UnityEngine.UIElements;
+
+namespace Velvet.TestUtilities
+{
+    /// <summary>
+    /// Shared reflection helper for EditMode fixtures that mount onto a real editor panel: the batchmode
+    /// PlayerLoop never ticks layout on its own, so a fixture that reads <c>resolvedStyle</c> must force a
+    /// layout/styles pass first. Previously duplicated across <c>PanelTestBase</c>,
+    /// <c>FocusLossDuringCommitTests</c>, and the preview window's zoom/layout fixture.
+    /// </summary>
+    public static class EditorPanelTestHelpers
+    {
+        /// <summary>
+        /// Invokes whichever of <c>UpdateForRepaint</c>/<c>ValidateLayout</c>/<c>ApplyStyles</c> the panel
+        /// implementation exposes (the parameterless overload of each), so <c>resolvedStyle</c> reflects the
+        /// current styles/layout without waiting for a PlayerLoop tick that batchmode never delivers.
+        /// </summary>
+        public static void ForcePanelUpdate(IPanel panel)
+        {
+            var t = panel.GetType();
+            foreach (var name in new[] { "UpdateForRepaint", "ValidateLayout", "ApplyStyles" })
+            {
+                var m = t.GetMethod(name, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+                if (m != null && m.GetParameters().Length == 0)
+                {
+                    m.Invoke(panel, null);
+                }
+            }
+        }
+    }
+
+#if UNITY_EDITOR
+    /// <summary>
+    /// Builds a <see cref="VelvetPreviewStory"/> directly via its internal constructor instead of through
+    /// reflection — TestUtilities has <c>InternalsVisibleTo</c> from the Runtime assembly (where the story type
+    /// lives), so a fixture that needs a story without going through <c>[VelvetPreview]</c> discovery can
+    /// construct one plainly.
+    /// </summary>
+    public static class PreviewStoryTestFactory
+    {
+        public static VelvetPreviewStory Build(MethodInfo method, VelvetPreviewAttribute attribute) =>
+            new(method, attribute);
+    }
+#endif
+}

--- a/Packages/com.velvet.core/TestUtilities/EditorPanelTestHelpers.cs.meta
+++ b/Packages/com.velvet.core/TestUtilities/EditorPanelTestHelpers.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c5d0621901534801be930ac6e6c1cb0a

--- a/Packages/com.velvet.core/TestUtilities/HeadlessEditorPanelHost.cs
+++ b/Packages/com.velvet.core/TestUtilities/HeadlessEditorPanelHost.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Reflection;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace Velvet.TestUtilities
+{
+    /// <summary>
+    /// Supplies a real editor <see cref="IPanel"/> without <see cref="UnityEditor.EditorWindow.Show"/>,
+    /// which requires a graphics device and fails under <c>-batchmode -nographics</c>.
+    /// Uses Unity's internal <c>Panel.CreateEditorPanel</c> via reflection — the concrete <c>Panel</c> class is
+    /// internal to the UIElements module, so it cannot be named directly from this assembly; only its
+    /// public <see cref="IPanel"/> surface is referenced by name here.
+    /// </summary>
+    public sealed class HeadlessEditorPanelHost : IDisposable
+    {
+        private readonly ScriptableObject _owner;
+        private IPanel _panel;
+
+        public HeadlessEditorPanelHost()
+        {
+            _owner = ScriptableObject.CreateInstance<ScriptableObject>();
+            _panel = CreateEditorPanel(_owner);
+            Root = _panel.visualTree;
+        }
+
+        public VisualElement Root { get; }
+
+        public IPanel Panel => _panel;
+
+        public void Dispose()
+        {
+            // The concrete Panel implements IDisposable even though the internal type itself cannot be named
+            // here; a runtime pattern match reaches it without a compile-time reference to that type.
+            if (_panel is IDisposable disposablePanel)
+            {
+                disposablePanel.Dispose();
+            }
+            _panel = null;
+
+            if (_owner != null)
+            {
+                UnityEngine.Object.DestroyImmediate(_owner);
+            }
+        }
+
+        private static IPanel CreateEditorPanel(ScriptableObject owner)
+        {
+            var panelType = typeof(IPanel).Assembly.GetType("UnityEngine.UIElements.Panel");
+            if (panelType == null)
+            {
+                throw new TypeLoadException("UnityEngine.UIElements.Panel");
+            }
+
+            var method = panelType.GetMethod(
+                "CreateEditorPanel",
+                BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public);
+            if (method == null)
+            {
+                throw new MissingMethodException(panelType.FullName, "CreateEditorPanel");
+            }
+
+            return (IPanel)method.Invoke(null, new object[] { owner });
+        }
+    }
+}

--- a/Packages/com.velvet.core/TestUtilities/HeadlessEditorPanelHost.cs.meta
+++ b/Packages/com.velvet.core/TestUtilities/HeadlessEditorPanelHost.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e40a08d240909400fbf7ddf002c86e72


### PR DESCRIPTION
## Summary
Fixes the preview window's "layout breaks" and "cannot freely set the resolution" problems and rounds out the related behavior.

## Changes
- **Zoom/layout rework**: paint-only scale → a layout-sized `zoomBox` (reference × factor) inside a `ScrollView`; the canvas is `flexShrink 0` with an explicit px size. Fixes fixed-size stories being squeezed, drifting off-center, and overflowing the stage at 200%.
- **Resolution**: viewport reduced to Full plus free-form W/H entry (Custom); the Mobile/Tablet/Desktop device presets are removed. Default custom resolution is Full HD (1920×1080).
- **Robustness**: pre-layout NaN guarded via `IsResolved` and the reference-size computation made a pure function; the inspect overlay refreshes on scroll/zoom; an unknown persisted viewport label is normalized back to Full.
- **Visibility**: the current resolution/mode/zoom is shown in the status line and a backdrop-adaptive frame is drawn around the simulated viewport.
- **Centering**: vertical centering (defeated by the ScrollView content container's default `align-self: flex-start`) is fixed with a full-percent `minHeight`.

## Tests / dev aids
- Three verification `[VelvetPreview]` example stories (**developer-only**: `Editor/Preview/Examples` is stripped by the upm split at publish).
- Preview-window test `SetUp`s made deterministic (clear `LastStoryId` + reset selection) so an auto-selected explicit-size story cannot break the viewport assertions; shared panel-layout helpers hoisted into `TestUtilities`.

## Verification
- Preview EditMode suite **33/33 green** (headless, no `-nographics`), 0 compile errors.
- Ran `/code-review max` twice; confirmed findings (including a deterministic test breakage and the frame being invisible on the light backdrop) are addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
