### PR TITLE
fix(velvet): correctness, perf, and API-consistency fixes across the runtime and weaver

### DIFF
--- a/Packages/com.velvet.core/CodeGen/CompilerWeaver.cs
+++ b/Packages/com.velvet.core/CodeGen/CompilerWeaver.cs
@@ -19,7 +19,8 @@ namespace Velvet.CodeGen
     //   The allow-list is the safety contract: a hook is admitted only when its re-render trigger is soundly
     //   represented by an Object.is comparison of a value captured into the deps array, or when it
     //   returns nothing reactive at all.
-    //   At least one hook call, with every return placed after the last hook call (Rules of Hooks).
+    //   At least one hook call, with every return placed after the last hook call, every hook reached
+    //   unconditionally, and no hook inside a loop (Rules of Hooks).
     //   Each value-returning hook result captured via var x = Hooks.UseXxx(...) (IL
     //   call → stloc) or a single-element deconstruction var (x, _, _) = Hooks.UseXxx(...)
     //   (IL call → ldfld → stloc). A void hook (UseEffect and friends) captures no dep but still
@@ -30,10 +31,17 @@ namespace Velvet.CodeGen
     // so a fresh record prop or a changed context value is treated as a miss rather than a stale hit.
     // Any shape the weaver cannot prove correct — a discarded hook result, a deconstruction that drops the
     // value element, a body that reaches a non-allow-listed hook, a call whose hook safety cannot be confirmed
-    // because Resolve() fails, a return before the hook section, a hook return consumed by an
-    // unsupported pattern, or a protected region overlapping the hook section — is left byte-for-byte unchanged
+    // (Resolve() fails, or the call is an open virtual / interface dispatch outside the known BCL / Unity /
+    // UniTask carve-out — an override composing a hook can live in an assembly this scan never sees, regardless
+    // of whether the statically declared base/interface's own assembly references Velvet), a return before the
+    // hook section, a hook skipped or repeated by a branch, a hook return consumed by an unsupported pattern, or
+    // a protected region overlapping the hook section — is left byte-for-byte unchanged
     // (graceful bailout). The allow-list defaults unknown hooks to bail, so correctness is never traded for
-    // coverage; no diagnostic is emitted for a bailout. The goal is "memoize less but never wrong".
+    // coverage; no diagnostic is emitted for a bailout. The goal is "memoize less but never wrong". The one
+    // dispatch this static model still cannot see through is an override of a BCL / Unity virtual signature
+    // (e.g. object.ToString) that itself calls a hook: the carve-out treats the base signature as hook-free
+    // because the BCL/Unity type declaring it cannot itself compose a hook, but a user override of it can —
+    // that stays outside this static model and is a rules-of-hooks violation the analyzer layer reports.
     // A body that already contains a Velvet.Hooks.TryGetMemoizedVNode call (a hand-written memoization,
     // e.g. in a test fixture) is skipped so the weaver does not memoize it a second time.
     internal static class CompilerWeaver
@@ -58,6 +66,8 @@ namespace Velvet.CodeGen
         //   UseTransition — the (startTransition, isPending) tuple flows out; isPending changes drive a re-render.
         //   UseId — a stable id; constant across renders, never hides a change.
         //   UseCallback — a memoized delegate whose identity is itself the dep; a fresh identity is a miss.
+        //   UseMemo — the memoized value flows out and changes only when its deps change; any change is an
+        //     Object.is difference in the captured value (the same soundness argument as UseCallback).
         //   UseRef / UseMutableRef / UseService — a stable reference that does NOT self-trigger a re-render.
         //     Reading through the ref is non-reactive by design, so capturing the stable
         //     reference as a constant dep never produces a stale VNode: a change that must repaint flows through
@@ -73,6 +83,7 @@ namespace Velvet.CodeGen
             nameof(Velvet.Hooks.UseOptimistic),
             nameof(Velvet.Hooks.UseTransition),
             nameof(Velvet.Hooks.UseCallback),
+            nameof(Velvet.Hooks.UseMemo),
             nameof(Velvet.Hooks.UseService),
             nameof(Velvet.Hooks.UseRef),
             nameof(Velvet.Hooks.UseMutableRef),
@@ -105,11 +116,22 @@ namespace Velvet.CodeGen
 
         public static bool Weave(ModuleDefinition module, List<DiagnosticMessage> diagnostics)
         {
-            _ = diagnostics;
-
-            var context = WeaverContext.TryResolve(module);
+            var context = WeaverContext.TryResolve(module, out var resolutionFailure);
             if (context == null)
             {
+                // A silent return here would leave every [Component] in the assembly permanently unwoven,
+                // indistinguishable from "nothing needed weaving" — auto-memoization is default-on, so the
+                // opt-out must be visible. Resolution can genuinely fail in ordinary workflows (e.g. a stale
+                // or duplicate assembly copy that defeats the post-processor's resolver), so surface it.
+                diagnostics.Add(new DiagnosticMessage
+                {
+                    DiagnosticType = DiagnosticType.Warning,
+                    MessageData = WeaverDiagnostics.FormatResolutionFailureWarning(
+                        module,
+                        "auto-memoization",
+                        resolutionFailure,
+                        "Every [Component] method in this assembly is left unwoven."),
+                });
                 return false;
             }
 
@@ -492,8 +514,9 @@ namespace Velvet.CodeGen
             if (cache.TryGetValue(key, out var cached)) return cached;
 
             // Resolve() requires the referenced assembly to be reachable from the IL post-processor.
-            // Cross-assembly failures (or methods without bodies — abstract / pinvoke / runtime impls)
-            // are treated as "does not call hooks" and never block weaving.
+            // Cross-assembly failures (or body-less non-virtual methods — pinvoke / runtime impls) are
+            // treated as "does not call hooks" and never block weaving on their own; the safety gate
+            // (ReachesNonSafeHook) is what bails a method on an unverifiable callee.
             MethodDefinition? def;
             try
             {
@@ -504,7 +527,25 @@ namespace Velvet.CodeGen
                 cache[key] = false;
                 return false;
             }
-            if (def == null || !def.HasBody)
+            if (def == null)
+            {
+                cache[key] = false;
+                return false;
+            }
+            if (IsDispatchOpen(def))
+            {
+                // An open virtual / interface dispatch resolves only to the statically declared method — the
+                // runtime override's body is not the one below, and that override can be declared in an
+                // assembly that references Velvet even when the statically declared base/interface's own
+                // assembly does not — checking the DECLARING assembly for a Velvet reference proves nothing
+                // about where an override can live. The CannotReachVelvetHook check above already excluded the
+                // only case this method can rule out (a BCL / Unity / UniTask namespace root); every other
+                // open dispatch reached this far is treated as reaching a hook, consistent with the safety
+                // gate below, which applies the identical rule.
+                cache[key] = true;
+                return true;
+            }
+            if (!def.HasBody)
             {
                 cache[key] = false;
                 return false;
@@ -567,6 +608,18 @@ namespace Velvet.CodeGen
             return false;
         }
 
+        // True when a call to this definition may dispatch to an override the static resolution does not
+        // reveal: the method is virtual (interface members are virtual in metadata) and still overridable —
+        // neither sealed itself nor declared on a sealed class, where no further override can exist. The
+        // sealed-type carve-out is what keeps delegate invocations out of the bail: a delegate's Invoke is
+        // virtual in metadata but declared on a sealed type. A hook reached only through delegate
+        // indirection stays outside this static model (as it always has), which is a rules-of-hooks
+        // violation the analyzer layer reports.
+        private static bool IsDispatchOpen(MethodDefinition def)
+            => def.IsVirtual
+                && !def.IsFinal
+                && !(def.DeclaringType.IsSealed && !def.DeclaringType.IsInterface);
+
         // Returns true when method reaches a non-SAFE hook, directly or transitively across
         // plain method calls. A hook is non-SAFE when it is a positional hook absent from both allow-lists
         // (known memo-unsafe or unknown / future), or when hook safety cannot be confirmed because
@@ -614,10 +667,40 @@ namespace Velvet.CodeGen
                 cache[key] = true;
                 return true;
             }
+            if (IsDispatchOpen(def))
+            {
+                // Resolve() on a virtual / abstract / interface target returns only the statically declared
+                // method; the runtime dispatch may land on an override whose body the weaver cannot
+                // enumerate, and that override can be declared in an assembly that references Velvet even
+                // when the statically declared base/interface's own assembly does not — checking the
+                // DECLARING assembly for a Velvet reference proves nothing about where an override can live.
+                // The only case this weaver can rule out is the CannotReachVelvetHook namespace carve-out
+                // checked above (a BCL / Unity / UniTask virtual signature — e.g. ToString — cannot itself
+                // declare a hook call, though a user override of one still could, which stays outside this
+                // static model and is a rules-of-hooks violation the analyzer layer reports). Every other
+                // open dispatch reached this far is unverifiable and folds into the non-SAFE bucket like a
+                // Resolve() failure.
+                //
+                // This also bails the common `var svc = Hooks.UseService<IFoo>(); svc.Method()` pattern even
+                // when IFoo is an internal interface implemented only inside this same module — a case that
+                // could in principle be proven hook-free from Cecil metadata alone (enumerate every type in
+                // the module implementing IFoo, require the interface to lack an InternalsVisibleTo friend,
+                // and verify every implementer's body reaches no hook). That proof was judged too fragile to
+                // add here: it would have to separately rule out an implementation inherited through a base
+                // class this module also declares, a further override of a non-sealed public implementer
+                // from outside the module, generic interfaces/methods, and explicit interface
+                // implementations, while reconciling two different recursive predicates (CallsHookTransitively's
+                // "reaches any hook" and this method's "reaches a non-SAFE hook") over the same implementer
+                // set without the two walkers disagreeing. Getting any one of those wrong would silently
+                // reopen the exact soundness hole this bail exists to close, so the pattern stays bailed;
+                // wrap the interface call in UseMemo/UseCallback to capture it as an explicit dep instead.
+                cache[key] = true;
+                return true;
+            }
             if (!def.HasBody)
             {
-                // A body-less method (abstract / pinvoke / runtime-implemented / interface) composes no hooks the
-                // weaver could miss: it has no IL that could call a Velvet.Hooks member. Treat as SAFE.
+                // A body-less non-virtual method (pinvoke / extern / runtime-implemented) composes no hooks
+                // the weaver could miss: it has no IL that could call a Velvet.Hooks member. Treat as SAFE.
                 cache[key] = false;
                 return false;
             }
@@ -669,11 +752,19 @@ namespace Velvet.CodeGen
                 || op == OpCodes.Stsfld;
         }
 
-        // True when some (forward) branch can jump OVER a hook call, i.e. a hook is reached only conditionally
-        // (`if (cond) { UseXxx(); }`, a hook inside a loop, a hook in one arm of a branch). Such a component
-        // violates the rules of hooks and must not be woven. A branch whose target lands strictly AFTER a hook
-        // while the branch itself is strictly BEFORE that hook can skip it; a benign branch (ternary in/around a
-        // hook arg) converges before the next hook, so its target never lands past a hook.
+        // True when some branch can skip or repeat a hook call, i.e. a hook does not execute exactly once per
+        // render (`if (cond) { UseXxx(); }`, a hook inside a loop, a hook in one arm of a branch). Such a
+        // component violates the rules of hooks and must not be woven. Two shapes are detected:
+        //   A forward branch whose target lands strictly AFTER a hook while the branch itself is strictly
+        //   BEFORE it can skip the hook (`if`, and the head-tested loops, which enter through a forward jump
+        //   past the body).
+        //   A backward branch that jumps from AFTER a hook to AT-OR-BEFORE it re-enters the hook — the hook
+        //   sits inside a loop body. A `do { UseXxx(); } while (cond)` is lowered with only this back-edge
+        //   (no forward jump precedes the body), so forward-skip detection alone cannot see it; weaving it
+        //   would also anchor the cache gate inside the loop, where its early return on a hit would abandon
+        //   the remaining iterations and everything after the loop.
+        // A benign branch (ternary in/around a hook arg, a loop that does not contain a hook) converges before
+        // the next hook / never crosses one, so neither test fires.
         private static bool HasConditionallySkippedHook(MethodBody body, List<Instruction> hookCalls)
         {
             if (hookCalls.Count == 0) return false;
@@ -699,7 +790,10 @@ namespace Velvet.CodeGen
             {
                 foreach (var h in hooks)
                 {
+                    // Forward jump over the hook: the hook can be skipped entirely.
                     if (branch.Offset < h.Offset && h.Offset < target.Offset) return true;
+                    // Backward jump across the hook: the hook sits inside a loop body and can repeat.
+                    if (branch.Offset > h.Offset && target.Offset <= h.Offset) return true;
                 }
                 return false;
             }
@@ -824,19 +918,38 @@ namespace Velvet.CodeGen
         public required MethodReference TryGetMemoizedVNode { get; init; }
         public required MethodReference StoreMemoizedVNode { get; init; }
 
-        public static WeaverContext? TryResolve(ModuleDefinition module)
+        // Resolves the Velvet runtime members the weaver injects calls to. On failure, returns null and
+        // reports what could not be resolved through failure so the caller can emit a diagnostic
+        // instead of silently skipping the assembly.
+        public static WeaverContext? TryResolve(ModuleDefinition module, out string failure)
         {
+            failure = string.Empty;
+
             var hooksType = module.GetType("Velvet.Hooks")
-                ?? ResolveExternal(module, "Velvet.Hooks");
-            if (hooksType == null) return null;
+                ?? WeaverDiagnostics.ResolveExternal(module, "Velvet.Hooks");
+            if (hooksType == null)
+            {
+                failure = "the type 'Velvet.Hooks' could not be resolved from the assembly's references.";
+                return null;
+            }
 
             var vnodeType = module.GetType("Velvet.VNode")
-                ?? ResolveExternal(module, "Velvet.VNode");
-            if (vnodeType == null) return null;
+                ?? WeaverDiagnostics.ResolveExternal(module, "Velvet.VNode");
+            if (vnodeType == null)
+            {
+                failure = "the type 'Velvet.VNode' could not be resolved from the assembly's references.";
+                return null;
+            }
 
             var tryGet = ResolveHookMethod(hooksType, "TryGetMemoizedVNode");
             var store = ResolveHookMethod(hooksType, "StoreMemoizedVNode");
-            if (tryGet == null || store == null) return null;
+            if (tryGet == null || store == null)
+            {
+                failure = "the memoization methods 'Velvet.Hooks.TryGetMemoizedVNode' /"
+                    + " 'Velvet.Hooks.StoreMemoizedVNode' could not be resolved on the referenced"
+                    + " Velvet assembly.";
+                return null;
+            }
 
             return new WeaverContext
             {
@@ -844,18 +957,6 @@ namespace Velvet.CodeGen
                 TryGetMemoizedVNode = module.ImportReference(tryGet),
                 StoreMemoizedVNode = module.ImportReference(store),
             };
-        }
-
-        private static TypeDefinition? ResolveExternal(ModuleDefinition module, string fullName)
-        {
-            foreach (var asmRef in module.AssemblyReferences)
-            {
-                var asm = module.AssemblyResolver.Resolve(asmRef);
-                if (asm == null) continue;
-                var t = asm.MainModule.GetType(fullName);
-                if (t != null) return t;
-            }
-            return null;
         }
 
         private static MethodDefinition? ResolveHookMethod(TypeDefinition hooks, string name)

--- a/Packages/com.velvet.core/CodeGen/MetadataRegistrationWeaver.cs
+++ b/Packages/com.velvet.core/CodeGen/MetadataRegistrationWeaver.cs
@@ -29,17 +29,29 @@ namespace Velvet.CodeGen
 
         public static bool Weave(ModuleDefinition module, List<DiagnosticMessage> diagnostics)
         {
-            _ = diagnostics;
-
             var entries = CollectEntries(module);
             if (entries.Count == 0)
             {
                 return false;
             }
 
-            var context = RegistryContext.TryResolve(module);
+            var context = RegistryContext.TryResolve(module, out var resolutionFailure);
             if (context == null)
             {
+                // The assembly carries [Component] metadata that must be registered (Error Boundary /
+                // props-bail / DisplayName all silently stop working without it), so a resolution failure
+                // must be visible rather than indistinguishable from "nothing to register".
+                diagnostics.Add(new DiagnosticMessage
+                {
+                    DiagnosticType = DiagnosticType.Warning,
+                    MessageData = WeaverDiagnostics.FormatResolutionFailureWarning(
+                        module,
+                        "component metadata registration",
+                        resolutionFailure,
+                        $"{entries.Count} [Component] method(s) declaring IsErrorBoundary / Memoize /"
+                        + " DisplayName are not registered, so those settings will not take effect at"
+                        + " runtime."),
+                });
                 return false;
             }
 
@@ -235,17 +247,28 @@ namespace Velvet.CodeGen
         public required MethodReference RegisterMemoize { get; init; }
         public required MethodReference RegisterDisplayName { get; init; }
 
-        public static RegistryContext? TryResolve(ModuleDefinition module)
+        // Resolves the registry members the weaver injects calls to. On failure, returns null and reports
+        // what could not be resolved through failure so the caller can emit a diagnostic instead of
+        // silently skipping the assembly.
+        public static RegistryContext? TryResolve(ModuleDefinition module, out string failure)
         {
+            failure = string.Empty;
+
             var registryType = module.GetType(RegistryTypeFullName)
-                ?? ResolveExternal(module, RegistryTypeFullName);
-            if (registryType == null) return null;
+                ?? WeaverDiagnostics.ResolveExternal(module, RegistryTypeFullName);
+            if (registryType == null)
+            {
+                failure = $"the type '{RegistryTypeFullName}' could not be resolved from the assembly's references.";
+                return null;
+            }
 
             var registerErrorBoundary = ResolveRegisterMethod(registryType, "RegisterErrorBoundary", 2);
             var registerMemoize = ResolveRegisterMethod(registryType, "RegisterMemoize", 2);
             var registerDisplayName = ResolveRegisterMethod(registryType, "RegisterComponentDisplayName", 3);
             if (registerErrorBoundary == null || registerMemoize == null || registerDisplayName == null)
             {
+                failure = $"the registration methods on '{RegistryTypeFullName}' could not be resolved on the"
+                    + " referenced Velvet assembly.";
                 return null;
             }
 
@@ -258,18 +281,6 @@ namespace Velvet.CodeGen
         }
 
         private const string RegistryTypeFullName = "Velvet.ComponentMethodRegistry";
-
-        private static TypeDefinition? ResolveExternal(ModuleDefinition module, string fullName)
-        {
-            foreach (var asmRef in module.AssemblyReferences)
-            {
-                var asm = module.AssemblyResolver.Resolve(asmRef);
-                if (asm == null) continue;
-                var t = asm.MainModule.GetType(fullName);
-                if (t != null) return t;
-            }
-            return null;
-        }
 
         private static MethodDefinition? ResolveRegisterMethod(TypeDefinition registry, string name, int parameterCount)
         {

--- a/Packages/com.velvet.core/CodeGen/WeaverDiagnostics.cs
+++ b/Packages/com.velvet.core/CodeGen/WeaverDiagnostics.cs
@@ -1,0 +1,42 @@
+using Mono.Cecil;
+
+namespace Velvet.CodeGen
+{
+    // Shared support for the two ILPP weavers (CompilerWeaver, MetadataRegistrationWeaver). Both hit the
+    // identical resolution-failure shape when the Velvet runtime members they inject calls to cannot be
+    // resolved from the processed module — a stale or duplicate copy of the Velvet assembly defeating the
+    // post-processor's resolver — and both fell back to the same remediation sentence and the same
+    // referenced-assembly type lookup before this was factored out.
+    internal static class WeaverDiagnostics
+    {
+        // Formats the warning a weaver emits when its TryResolve fails: the assembly name (so the outcome
+        // is distinguishable from "nothing needed weaving/registering"), featureLabel names what is
+        // disabled (e.g. "auto-memoization"), resolutionFailure is the specific type/method that could not
+        // be resolved, and whatBreaks is the weaver-specific consequence sentence (what silently stops
+        // working as a result). The trailing remediation sentence is identical for every weaver.
+        public static string FormatResolutionFailureWarning(
+            ModuleDefinition module, string featureLabel, string resolutionFailure, string whatBreaks)
+        {
+            return $"Velvet {featureLabel} is disabled for assembly '{module.Assembly.Name.Name}': "
+                + resolutionFailure
+                + " " + whatBreaks
+                + " Check for stale or duplicate copies of the Velvet assembly that prevent the IL"
+                + " post-processor from resolving it, then recompile.";
+        }
+
+        // Resolves fullName from one of module's referenced assemblies. Used when the type is not declared
+        // in module itself (the case for every assembly except Velvet, which declares its own runtime
+        // types directly). Returns null when no referenced assembly resolves or none declares the type.
+        public static TypeDefinition? ResolveExternal(ModuleDefinition module, string fullName)
+        {
+            foreach (var asmRef in module.AssemblyReferences)
+            {
+                var asm = module.AssemblyResolver.Resolve(asmRef);
+                if (asm == null) continue;
+                var t = asm.MainModule.GetType(fullName);
+                if (t != null) return t;
+            }
+            return null;
+        }
+    }
+}

--- a/Packages/com.velvet.core/CodeGen/WeaverDiagnostics.cs.meta
+++ b/Packages/com.velvet.core/CodeGen/WeaverDiagnostics.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f3bee6c01cb64475946c675d23c57585

--- a/Packages/com.velvet.core/Runtime/Component/V.cs
+++ b/Packages/com.velvet.core/Runtime/Component/V.cs
@@ -70,6 +70,8 @@ namespace Velvet
         /// <param name="whileHoverClass">USS class toggled while the pointer hovers the element.</param>
         /// <param name="whileTapClass">USS class toggled while the pointer is pressed on the element.</param>
         /// <param name="whileFocusClass">USS class toggled while the element holds keyboard/UI focus.</param>
+        /// <param name="data">data-* attribute map matched by <c>data-[...]</c> variants.</param>
+        /// <param name="aria">aria-* attribute map matched by <c>aria-[...]</c> variants.</param>
         /// <returns>The created <see cref="ElementNode"/> representing this element.</returns>
         public static ElementNode Div(
             string? className = null,
@@ -81,7 +83,9 @@ namespace Velvet
             VNode?[]? children = null,
             string? whileHoverClass = null,
             string? whileTapClass = null,
-            string? whileFocusClass = null)
+            string? whileFocusClass = null,
+            IReadOnlyDictionary<string, string>? data = null,
+            IReadOnlyDictionary<string, string>? aria = null)
         {
             return new ElementNode
             {
@@ -89,7 +93,7 @@ namespace Velvet
                 ElementType = typeof(VisualElement),
                 Name = name,
                 ClassNames = ParseClassNames(className),
-                Props = props,
+                Props = WithAttributes(props, data, aria),
                 Styles = styles,
                 Children = children ?? EmptyChildren,
                 Events = EmptyEvents,
@@ -128,15 +132,27 @@ namespace Velvet
         /// <param name="className">CSS-like utility class string. Multiple classes separated by spaces.</param>
         /// <param name="key">Key used to disambiguate siblings at the same position.</param>
         /// <param name="name">Element name assigned to <see cref="VisualElement.name"/> for query/debug.</param>
+        /// <param name="props">Optional FiberElementProps (text / tooltip / enabled / etc.) bag.</param>
         /// <param name="refCallback">Callback invoked on mount with the created VisualElement; returned Action runs on unmount.</param>
         /// <param name="children">Child VNodes rendered inside this element.</param>
+        /// <param name="whileHoverClass">USS class toggled while the pointer hovers the element.</param>
+        /// <param name="whileTapClass">USS class toggled while the pointer is pressed on the element.</param>
+        /// <param name="whileFocusClass">USS class toggled while the element holds keyboard/UI focus.</param>
+        /// <param name="data">data-* attribute map matched by <c>data-[...]</c> variants.</param>
+        /// <param name="aria">aria-* attribute map matched by <c>aria-[...]</c> variants.</param>
         /// <returns>The created <see cref="ElementNode"/> representing this element.</returns>
         public static ElementNode Custom<T>(
             string? className = null,
             string? key = null,
             string? name = null,
+            FiberElementProps? props = null,
             Func<VisualElement, Action>? refCallback = null,
-            VNode?[]? children = null) where T : VisualElement
+            VNode?[]? children = null,
+            string? whileHoverClass = null,
+            string? whileTapClass = null,
+            string? whileFocusClass = null,
+            IReadOnlyDictionary<string, string>? data = null,
+            IReadOnlyDictionary<string, string>? aria = null) where T : VisualElement
         {
             return new ElementNode
             {
@@ -144,9 +160,13 @@ namespace Velvet
                 ElementType = typeof(T),
                 Name = name,
                 ClassNames = ParseClassNames(className),
+                Props = WithAttributes(props, data, aria),
                 Children = children ?? EmptyChildren,
                 Events = EmptyEvents,
                 RefCallback = refCallback,
+                WhileHoverClass = whileHoverClass,
+                WhileTapClass = whileTapClass,
+                WhileFocusClass = whileFocusClass,
             };
         }
 
@@ -184,6 +204,9 @@ namespace Velvet
         /// <param name="onCreated">Callback invoked once when the ScrollView VisualElement is first created.</param>
         /// <param name="refCallback">Callback invoked on mount with the created VisualElement; returned Action runs on unmount.</param>
         /// <param name="children">Child VNodes placed inside the scroll content container.</param>
+        /// <param name="whileHoverClass">USS class toggled while the pointer hovers the element.</param>
+        /// <param name="whileTapClass">USS class toggled while the pointer is pressed on the element.</param>
+        /// <param name="whileFocusClass">USS class toggled while the element holds keyboard/UI focus.</param>
         /// <param name="data">data-* attribute map matched by <c>data-[...]</c> variants.</param>
         /// <param name="aria">aria-* attribute map matched by <c>aria-[...]</c> variants.</param>
         /// <returns>The created <see cref="ElementNode"/> representing the ScrollView.</returns>
@@ -197,6 +220,9 @@ namespace Velvet
             Action<VisualElement>? onCreated = null,
             Func<VisualElement, Action>? refCallback = null,
             VNode?[]? children = null,
+            string? whileHoverClass = null,
+            string? whileTapClass = null,
+            string? whileFocusClass = null,
             IReadOnlyDictionary<string, string>? data = null,
             IReadOnlyDictionary<string, string>? aria = null)
         {
@@ -220,6 +246,9 @@ namespace Velvet
                 Events = EmptyEvents,
                 OnCreated = onCreated,
                 RefCallback = refCallback,
+                WhileHoverClass = whileHoverClass,
+                WhileTapClass = whileTapClass,
+                WhileFocusClass = whileFocusClass,
             };
         }
 
@@ -393,6 +422,9 @@ namespace Velvet
         /// <param name="enabled">When false, disables the slider input.</param>
         /// <param name="refCallback">Callback invoked on mount with the created VisualElement; returned Action runs on unmount.</param>
         /// <param name="onCreated">Callback invoked once when the Slider VisualElement is first created.</param>
+        /// <param name="whileHoverClass">USS class toggled while the pointer hovers the element.</param>
+        /// <param name="whileTapClass">USS class toggled while the pointer is pressed on the element.</param>
+        /// <param name="whileFocusClass">USS class toggled while the element holds keyboard/UI focus.</param>
         /// <param name="data">data-* attribute map matched by <c>data-[...]</c> variants.</param>
         /// <param name="aria">aria-* attribute map matched by <c>aria-[...]</c> variants.</param>
         /// <returns>The created <see cref="ElementNode"/> representing this slider.</returns>
@@ -407,6 +439,9 @@ namespace Velvet
             bool? enabled = null,
             Func<VisualElement, Action>? refCallback = null,
             Action<VisualElement>? onCreated = null,
+            string? whileHoverClass = null,
+            string? whileTapClass = null,
+            string? whileFocusClass = null,
             IReadOnlyDictionary<string, string>? data = null,
             IReadOnlyDictionary<string, string>? aria = null)
         {
@@ -435,6 +470,9 @@ namespace Velvet
                 Events = events,
                 RefCallback = refCallback,
                 OnCreated = onCreated,
+                WhileHoverClass = whileHoverClass,
+                WhileTapClass = whileTapClass,
+                WhileFocusClass = whileFocusClass,
             };
         }
 
@@ -449,6 +487,9 @@ namespace Velvet
         /// <param name="label">Label text shown next to the toggle.</param>
         /// <param name="enabled">When false, disables user interaction with the toggle.</param>
         /// <param name="refCallback">Callback invoked on mount with the created VisualElement; returned Action runs on unmount.</param>
+        /// <param name="whileHoverClass">USS class toggled while the pointer hovers the element.</param>
+        /// <param name="whileTapClass">USS class toggled while the pointer is pressed on the element.</param>
+        /// <param name="whileFocusClass">USS class toggled while the element holds keyboard/UI focus.</param>
         /// <param name="data">data-* attribute map matched by <c>data-[...]</c> variants.</param>
         /// <param name="aria">aria-* attribute map matched by <c>aria-[...]</c> variants.</param>
         /// <returns>The created <see cref="ElementNode"/> representing this toggle.</returns>
@@ -461,6 +502,9 @@ namespace Velvet
             string? label = null,
             bool? enabled = null,
             Func<VisualElement, Action>? refCallback = null,
+            string? whileHoverClass = null,
+            string? whileTapClass = null,
+            string? whileFocusClass = null,
             IReadOnlyDictionary<string, string>? data = null,
             IReadOnlyDictionary<string, string>? aria = null)
         {
@@ -486,6 +530,9 @@ namespace Velvet
                 Children = EmptyChildren,
                 Events = events,
                 RefCallback = refCallback,
+                WhileHoverClass = whileHoverClass,
+                WhileTapClass = whileTapClass,
+                WhileFocusClass = whileFocusClass,
             };
         }
 
@@ -501,6 +548,9 @@ namespace Velvet
         /// <param name="isPasswordField">When true, masks the input as a password field.</param>
         /// <param name="enabled">When false, disables user input.</param>
         /// <param name="refCallback">Callback invoked on mount with the created VisualElement; returned Action runs on unmount.</param>
+        /// <param name="whileHoverClass">USS class toggled while the pointer hovers the element.</param>
+        /// <param name="whileTapClass">USS class toggled while the pointer is pressed on the element.</param>
+        /// <param name="whileFocusClass">USS class toggled while the element holds keyboard/UI focus.</param>
         /// <param name="data">data-* attribute map matched by <c>data-[...]</c> variants.</param>
         /// <param name="aria">aria-* attribute map matched by <c>aria-[...]</c> variants.</param>
         /// <returns>The created <see cref="ElementNode"/> representing this text field.</returns>
@@ -514,6 +564,9 @@ namespace Velvet
             bool? isPasswordField = null,
             bool? enabled = null,
             Func<VisualElement, Action>? refCallback = null,
+            string? whileHoverClass = null,
+            string? whileTapClass = null,
+            string? whileFocusClass = null,
             IReadOnlyDictionary<string, string>? data = null,
             IReadOnlyDictionary<string, string>? aria = null)
         {
@@ -542,6 +595,9 @@ namespace Velvet
                 Children = EmptyChildren,
                 Events = events,
                 RefCallback = refCallback,
+                WhileHoverClass = whileHoverClass,
+                WhileTapClass = whileTapClass,
+                WhileFocusClass = whileFocusClass,
             };
         }
 
@@ -600,6 +656,9 @@ namespace Velvet
         /// <param name="label">Label text shown next to the dropdown.</param>
         /// <param name="enabled">When false, disables user interaction with the dropdown.</param>
         /// <param name="refCallback">Callback invoked on mount with the created VisualElement; returned Action runs on unmount.</param>
+        /// <param name="whileHoverClass">USS class toggled while the pointer hovers the element.</param>
+        /// <param name="whileTapClass">USS class toggled while the pointer is pressed on the element.</param>
+        /// <param name="whileFocusClass">USS class toggled while the element holds keyboard/UI focus.</param>
         /// <param name="data">data-* attribute map matched by <c>data-[...]</c> variants.</param>
         /// <param name="aria">aria-* attribute map matched by <c>aria-[...]</c> variants.</param>
         /// <returns>The created <see cref="ElementNode"/> representing this dropdown.</returns>
@@ -613,6 +672,9 @@ namespace Velvet
             string? label = null,
             bool? enabled = null,
             Func<VisualElement, Action>? refCallback = null,
+            string? whileHoverClass = null,
+            string? whileTapClass = null,
+            string? whileFocusClass = null,
             IReadOnlyDictionary<string, string>? data = null,
             IReadOnlyDictionary<string, string>? aria = null)
         {
@@ -639,6 +701,9 @@ namespace Velvet
                 Children = EmptyChildren,
                 Events = events,
                 RefCallback = refCallback,
+                WhileHoverClass = whileHoverClass,
+                WhileTapClass = whileTapClass,
+                WhileFocusClass = whileFocusClass,
             };
         }
 
@@ -651,6 +716,11 @@ namespace Velvet
         /// <param name="enabled">When false, disables user interaction with the list.</param>
         /// <param name="styles">Inline style overrides applied on top of USS classes.</param>
         /// <param name="refCallback">Callback invoked on mount with the created VisualElement; returned Action runs on unmount.</param>
+        /// <param name="whileHoverClass">USS class toggled while the pointer hovers the element.</param>
+        /// <param name="whileTapClass">USS class toggled while the pointer is pressed on the element.</param>
+        /// <param name="whileFocusClass">USS class toggled while the element holds keyboard/UI focus.</param>
+        /// <param name="data">data-* attribute map matched by <c>data-[...]</c> variants.</param>
+        /// <param name="aria">aria-* attribute map matched by <c>aria-[...]</c> variants.</param>
         /// <returns>The created <see cref="ElementNode"/> representing this list view.</returns>
         public static ElementNode ListView(
             string? className = null,
@@ -658,7 +728,12 @@ namespace Velvet
             string? name = null,
             bool? enabled = null,
             StyleOverrides? styles = null,
-            Func<VisualElement, Action>? refCallback = null)
+            Func<VisualElement, Action>? refCallback = null,
+            string? whileHoverClass = null,
+            string? whileTapClass = null,
+            string? whileFocusClass = null,
+            IReadOnlyDictionary<string, string>? data = null,
+            IReadOnlyDictionary<string, string>? aria = null)
         {
             FiberElementProps? props = null;
             if (enabled.HasValue)
@@ -666,6 +741,7 @@ namespace Velvet
                 props = VNodePool.RentProps();
                 props.Enabled = enabled;
             }
+            props = WithAttributes(props, data, aria);
 
             return new ElementNode
             {
@@ -678,6 +754,9 @@ namespace Velvet
                 Children = EmptyChildren,
                 Events = EmptyEvents,
                 RefCallback = refCallback,
+                WhileHoverClass = whileHoverClass,
+                WhileTapClass = whileTapClass,
+                WhileFocusClass = whileFocusClass,
             };
         }
 
@@ -692,6 +771,11 @@ namespace Velvet
         /// <param name="label">Label text shown next to the radio button.</param>
         /// <param name="enabled">When false, disables user interaction with the radio button.</param>
         /// <param name="refCallback">Callback invoked on mount with the created VisualElement; returned Action runs on unmount.</param>
+        /// <param name="whileHoverClass">USS class toggled while the pointer hovers the element.</param>
+        /// <param name="whileTapClass">USS class toggled while the pointer is pressed on the element.</param>
+        /// <param name="whileFocusClass">USS class toggled while the element holds keyboard/UI focus.</param>
+        /// <param name="data">data-* attribute map matched by <c>data-[...]</c> variants.</param>
+        /// <param name="aria">aria-* attribute map matched by <c>aria-[...]</c> variants.</param>
         /// <returns>The created <see cref="ElementNode"/> representing this radio button.</returns>
         public static ElementNode RadioButton(
             string? className = null,
@@ -701,7 +785,12 @@ namespace Velvet
             string? name = null,
             string? label = null,
             bool? enabled = null,
-            Func<VisualElement, Action>? refCallback = null)
+            Func<VisualElement, Action>? refCallback = null,
+            string? whileHoverClass = null,
+            string? whileTapClass = null,
+            string? whileFocusClass = null,
+            IReadOnlyDictionary<string, string>? data = null,
+            IReadOnlyDictionary<string, string>? aria = null)
         {
             var events = SingleEvent(onValueChanged != null ? new ChangeEventBinding<bool> { Handler = onValueChanged } : null);
 
@@ -713,6 +802,7 @@ namespace Velvet
                 props.Text = label;
                 props.Enabled = enabled;
             }
+            props = WithAttributes(props, data, aria);
 
             return new ElementNode
             {
@@ -724,6 +814,9 @@ namespace Velvet
                 Children = EmptyChildren,
                 Events = events,
                 RefCallback = refCallback,
+                WhileHoverClass = whileHoverClass,
+                WhileTapClass = whileTapClass,
+                WhileFocusClass = whileFocusClass,
             };
         }
 
@@ -739,6 +832,11 @@ namespace Velvet
         /// <param name="label">Group-level label text.</param>
         /// <param name="enabled">When false, disables user interaction with the entire group.</param>
         /// <param name="refCallback">Callback invoked on mount with the created VisualElement; returned Action runs on unmount.</param>
+        /// <param name="whileHoverClass">USS class toggled while the pointer hovers the element.</param>
+        /// <param name="whileTapClass">USS class toggled while the pointer is pressed on the element.</param>
+        /// <param name="whileFocusClass">USS class toggled while the element holds keyboard/UI focus.</param>
+        /// <param name="data">data-* attribute map matched by <c>data-[...]</c> variants.</param>
+        /// <param name="aria">aria-* attribute map matched by <c>aria-[...]</c> variants.</param>
         /// <returns>The created <see cref="ElementNode"/> representing this radio button group.</returns>
         public static ElementNode RadioButtonGroup(
             string? className = null,
@@ -749,7 +847,12 @@ namespace Velvet
             string? name = null,
             string? label = null,
             bool? enabled = null,
-            Func<VisualElement, Action>? refCallback = null)
+            Func<VisualElement, Action>? refCallback = null,
+            string? whileHoverClass = null,
+            string? whileTapClass = null,
+            string? whileFocusClass = null,
+            IReadOnlyDictionary<string, string>? data = null,
+            IReadOnlyDictionary<string, string>? aria = null)
         {
             var events = SingleEvent(onValueChanged != null ? new ChangeEventBinding<int> { Handler = onValueChanged } : null);
 
@@ -762,6 +865,7 @@ namespace Velvet
                 props.Enabled = enabled;
                 props.Choices = choices != null ? new ChoicesSettings(choices) : null;
             }
+            props = WithAttributes(props, data, aria);
 
             return new ElementNode
             {
@@ -773,6 +877,9 @@ namespace Velvet
                 Children = EmptyChildren,
                 Events = events,
                 RefCallback = refCallback,
+                WhileHoverClass = whileHoverClass,
+                WhileTapClass = whileTapClass,
+                WhileFocusClass = whileFocusClass,
             };
         }
 
@@ -787,6 +894,11 @@ namespace Velvet
         /// <param name="label">Label text shown next to the field.</param>
         /// <param name="enabled">When false, disables user input.</param>
         /// <param name="refCallback">Callback invoked on mount with the created VisualElement; returned Action runs on unmount.</param>
+        /// <param name="whileHoverClass">USS class toggled while the pointer hovers the element.</param>
+        /// <param name="whileTapClass">USS class toggled while the pointer is pressed on the element.</param>
+        /// <param name="whileFocusClass">USS class toggled while the element holds keyboard/UI focus.</param>
+        /// <param name="data">data-* attribute map matched by <c>data-[...]</c> variants.</param>
+        /// <param name="aria">aria-* attribute map matched by <c>aria-[...]</c> variants.</param>
         /// <returns>The created <see cref="ElementNode"/> representing this integer field.</returns>
         public static ElementNode IntegerField(
             string? className = null,
@@ -796,7 +908,12 @@ namespace Velvet
             string? name = null,
             string? label = null,
             bool? enabled = null,
-            Func<VisualElement, Action>? refCallback = null)
+            Func<VisualElement, Action>? refCallback = null,
+            string? whileHoverClass = null,
+            string? whileTapClass = null,
+            string? whileFocusClass = null,
+            IReadOnlyDictionary<string, string>? data = null,
+            IReadOnlyDictionary<string, string>? aria = null)
         {
             var events = SingleEvent(onValueChanged != null ? new ChangeEventBinding<int> { Handler = onValueChanged } : null);
 
@@ -808,6 +925,7 @@ namespace Velvet
                 props.Text = label;
                 props.Enabled = enabled;
             }
+            props = WithAttributes(props, data, aria);
 
             return new ElementNode
             {
@@ -819,6 +937,9 @@ namespace Velvet
                 Children = EmptyChildren,
                 Events = events,
                 RefCallback = refCallback,
+                WhileHoverClass = whileHoverClass,
+                WhileTapClass = whileTapClass,
+                WhileFocusClass = whileFocusClass,
             };
         }
 

--- a/Packages/com.velvet.core/Runtime/Hooks/PositionalHookNames.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/PositionalHookNames.cs
@@ -14,6 +14,7 @@ namespace Velvet
             nameof(Hooks.UseLayoutEffect),
             nameof(Hooks.UseInsertionEffect),
             nameof(Hooks.UseCallback),
+            nameof(Hooks.UseMemo),
             nameof(Hooks.UseBlocker),
             nameof(Hooks.UseState),
             nameof(Hooks.UseReducer),

--- a/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/CompilerILPostProcessorE2ETests.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/CompilerILPostProcessorE2ETests.cs
@@ -15,14 +15,20 @@ namespace Velvet.Tests
     /// <c>StoreMemoizedVNode</c> commit; an unwoven body has neither.</item>
     /// <item>An analyzable body — one with a hook whose captured value keys the cache — is woven independently
     /// of the props-bail flag. Single-element deconstruction of a hook result, multiple returns after the hook
-    /// section, props prepended to the deps array, a captured <c>UseContext</c> value, a safe void effect hook
-    /// alongside a value hook, and the stable references from <c>UseRef</c> / <c>UseService</c> are all
-    /// analyzable shapes.</item>
+    /// section, props prepended to the deps array, a captured <c>UseContext</c> value, a captured
+    /// <c>UseMemo</c> value, a safe void effect hook alongside a value hook, and the stable references from
+    /// <c>UseRef</c> / <c>UseService</c> are all analyzable shapes. The cache gate is injected after the whole
+    /// hook section, so no hook call is skipped on a cache hit.</item>
     /// <item>A body the weaver cannot prove correct is left unwoven (graceful bailout): no hook to key a cache
     /// on, a props-only body, a discarded hook value, a whole-tuple capture (compared structurally, not by
     /// reference, so a fresh-but-equal record would be a stale hit), a void-only body (empty deps would freeze
-    /// it on an unconditional hit), and a body that reaches the suspend-unsafe <c>Use</c> hook or
-    /// <c>UseMutation</c> — directly or transitively through a custom hook.</item>
+    /// it on an unconditional hit), a body that reaches the suspend-unsafe <c>Use</c> hook or
+    /// <c>UseMutation</c> — directly or transitively through a custom hook — a hook inside a loop (head-tested
+    /// or do-while), a hook section overlapping a try/catch region, and an open virtual / interface dispatch
+    /// outside the BCL / Unity / UniTask carve-out (the runtime override could compose a hook the static
+    /// target does not show, regardless of whether the declaring assembly itself references Velvet — an
+    /// override can live in a third assembly that does). A delegate invocation (virtual Invoke on a sealed
+    /// type) is not an open dispatch and does not bail.</item>
     /// <item>A body opting out with <c>[Component(Compiler = false)]</c> is left unwoven even when it is provably
     /// analyzable; the opt-out is honored ahead of analysis.</item>
     /// <item>Every component — woven, opted-out, or bailed — still renders normally and produces visible output
@@ -185,12 +191,15 @@ namespace Velvet.Tests
         }
 
         // UseService returns a stable service reference (DI-resolved) that does not self-trigger a re-render. It
-        // is on the value allow-list, so the body is woven.
+        // is on the value allow-list, so the body is woven. The body deliberately does not CALL a member
+        // through the interface-typed reference: an open interface dispatch in a Velvet-referencing assembly
+        // is unverifiable and would bail (see InterfaceDispatchComponent) — the stable reference itself is
+        // the captured dep.
         [Component]
         public static VNode UseServiceComponent()
         {
             var service = Hooks.UseService<IWovenService>();
-            return V.Label(text: service.Name());
+            return V.Label(text: service != null ? "resolved" : "missing");
         }
 
         // Custom hook that transitively reaches the suspend-unsafe Use hook. A component calling it must bail.
@@ -216,6 +225,131 @@ namespace Velvet.Tests
         {
             var mutation = UseDoubler();
             return V.Label(text: mutation.Status.ToString());
+        }
+
+        // UseMemo's captured return value changes only when its deps change, so it is on the value
+        // allow-list; a body whose ONLY hook is UseMemo is analyzable and must be woven.
+        [Component]
+        public static VNode UseMemoOnlyComponent()
+        {
+            var memoized = Hooks.UseMemo(() => "memo", "stable");
+            return V.Label(text: memoized);
+        }
+
+        // UseMemo placed after another value hook. The whole hook section — including the UseMemo call —
+        // must run on every render, so the injected cache gate has to land after the UseMemo call; a gate
+        // anchored between UseState and UseMemo would skip the UseMemo call outright on a cache hit and
+        // leave its changing value out of the deps array.
+        [Component]
+        public static VNode UseMemoAfterStateComponent()
+        {
+            var (count, _) = Hooks.UseState(3);
+            var memoized = Hooks.UseMemo(() => "value", "key");
+            return V.Label(text: memoized + count.ToString());
+        }
+
+        public interface IDispatchService
+        {
+            string Value();
+        }
+
+        // Deliberately never assigned: analysis is static, so the bail happens regardless of the runtime
+        // value, and the null-propagated call keeps the render test NPE-free.
+        private static readonly IDispatchService? s_dispatchService = null;
+
+        // A call through an interface declared in a Velvet-referencing assembly: the statically resolved
+        // target has no body, but the runtime implementation could compose any hook, so the weaver must
+        // treat the call as unverifiable and bail rather than weave against the declared (empty) target.
+        [Component]
+        public static VNode InterfaceDispatchComponent()
+        {
+            var (count, _) = Hooks.UseState(0);
+            var extra = s_dispatchService?.Value() ?? "none";
+            return V.Label(text: extra + count.ToString());
+        }
+
+        public class OverridableFormatter
+        {
+            public virtual string Format(int value) => value.ToString();
+        }
+
+        private static readonly OverridableFormatter s_formatter = new();
+
+        // A virtual method on a non-sealed class in a Velvet-referencing assembly: an override could call a
+        // hook the statically resolved body does not show, so the call is unverifiable and the weaver bails.
+        [Component]
+        public static VNode VirtualDispatchComponent()
+        {
+            var (count, _) = Hooks.UseState(0);
+            return V.Label(text: s_formatter.Format(count));
+        }
+
+        public delegate string TextProvider();
+
+        private static readonly TextProvider s_textProvider = static () => "delegate";
+
+        // Invoking a delegate declared in a Velvet-referencing assembly: a delegate type is sealed and its
+        // runtime-implemented Invoke cannot be overridden by user code, so the call is not an open dispatch
+        // and must not bail the component. Pins that the open-dispatch bail does not over-reach into
+        // delegate invocations — the callback pattern component bodies use everywhere.
+        [Component]
+        public static VNode DelegateInvokeComponent()
+        {
+            var (count, _) = Hooks.UseState(0);
+            return V.Label(text: s_textProvider() + count.ToString());
+        }
+
+        // A hook inside a head-tested loop: the loop is entered through a forward jump over the body, so the
+        // hook can be skipped entirely (zero iterations) or repeated. The weaver must bail. The loop runs
+        // exactly once at runtime so mounting still satisfies the rules of hooks.
+        [Component]
+        public static VNode WhileLoopHookComponent()
+        {
+            var text = "";
+            var i = 0;
+            while (i < 1)
+            {
+                var (count, _) = Hooks.UseState(11);
+                text = count.ToString();
+                i++;
+            }
+            return V.Label(text: text);
+        }
+
+        // A hook inside a do-while loop: the body is entered without any forward jump — only a backward
+        // conditional branch closes the loop — so forward-skip detection alone cannot see it. The hook can
+        // repeat within one render, and a cache gate anchored after it would sit inside the loop, returning
+        // from mid-loop on a hit. The weaver must bail. The loop runs exactly once at runtime so mounting
+        // still satisfies the rules of hooks.
+        [Component]
+        public static VNode DoWhileLoopHookComponent()
+        {
+            var text = "";
+            var i = 0;
+            do
+            {
+                var (count, _) = Hooks.UseState(13);
+                text = count.ToString();
+                i++;
+            } while (i < 1);
+            return V.Label(text: text);
+        }
+
+        // A hook and a hook-derived return inside a try region: the injected early return (cache hit) and
+        // the commit before the real returns would need the Leave protocol required for protected regions,
+        // which the weaver does not emit. The weaver must bail.
+        [Component]
+        public static VNode TryCatchHookComponent()
+        {
+            try
+            {
+                var (count, _) = Hooks.UseState(17);
+                return V.Label(text: count.ToString());
+            }
+            catch (System.Exception)
+            {
+                return V.Label(text: "error");
+            }
         }
 
         #region Woven shapes (gate + commit injected)
@@ -282,6 +416,41 @@ namespace Velvet.Tests
             // Act + Assert
             Assert.That(IsWoven(LoadMethod(nameof(UseServiceComponent))), Is.True,
                 "UseService returns a stable DI reference captured as a constant dep; the body is woven");
+        }
+
+        [Test]
+        public void Given_UseMemoOnlyComponent_When_Woven_Then_InjectsBothMemoCalls()
+        {
+            // Act + Assert
+            Assert.That(IsWoven(LoadMethod(nameof(UseMemoOnlyComponent))), Is.True,
+                "UseMemo is a value hook whose captured result changes only when its deps change; a body whose"
+                + " only hook is UseMemo is analyzable and woven");
+        }
+
+        [Test]
+        public void Given_UseMemoAfterValueHook_When_Woven_Then_GateIsInjectedAfterTheUseMemoCall()
+        {
+            // Arrange
+            var method = LoadMethod(nameof(UseMemoAfterStateComponent));
+            Assume.That(IsWoven(method), Is.True, "Precondition: the UseState + UseMemo body is woven");
+
+            // Act
+            var useMemoIndex = IndexOfHookCall(method, nameof(Hooks.UseMemo));
+            var gateIndex = IndexOfHookCall(method, nameof(Hooks.TryGetMemoizedVNode));
+
+            // Assert — a gate before the UseMemo call would skip the hook outright on a cache hit,
+            // violating the invariant that hooks run on every render.
+            Assert.That(gateIndex, Is.GreaterThan(useMemoIndex),
+                "The cache gate must land after the whole hook section, including the trailing UseMemo call");
+        }
+
+        [Test]
+        public void Given_DelegateInvokeComponent_When_Woven_Then_InjectsBothMemoCalls()
+        {
+            // Act + Assert
+            Assert.That(IsWoven(LoadMethod(nameof(DelegateInvokeComponent))), Is.True,
+                "A delegate's Invoke is virtual on a sealed type — not an open dispatch — so invoking a"
+                + " user-declared delegate does not bail the component");
         }
 
         #endregion
@@ -358,6 +527,50 @@ namespace Velvet.Tests
             // Act + Assert
             Assert.That(IsWoven(LoadMethod(nameof(TransitiveUseMutationComponent))), Is.False,
                 "A custom hook that transitively reaches UseMutation forces the component to bail");
+        }
+
+        [Test]
+        public void Given_InterfaceDispatchComponent_When_Analyzed_Then_IsLeftUnwoven()
+        {
+            // Act + Assert
+            Assert.That(IsWoven(LoadMethod(nameof(InterfaceDispatchComponent))), Is.False,
+                "An interface dispatch in a Velvet-referencing assembly resolves only to the body-less"
+                + " declaration; the runtime implementation could compose a hook, so the weaver bails");
+        }
+
+        [Test]
+        public void Given_VirtualDispatchComponent_When_Analyzed_Then_IsLeftUnwoven()
+        {
+            // Act + Assert
+            Assert.That(IsWoven(LoadMethod(nameof(VirtualDispatchComponent))), Is.False,
+                "A virtual call on a non-sealed class in a Velvet-referencing assembly may dispatch to an"
+                + " override that composes a hook, so the weaver bails");
+        }
+
+        [Test]
+        public void Given_HookInsideWhileLoop_When_Analyzed_Then_IsLeftUnwoven()
+        {
+            // Act + Assert
+            Assert.That(IsWoven(LoadMethod(nameof(WhileLoopHookComponent))), Is.False,
+                "A hook inside a head-tested loop can be skipped or repeated within a render, so the weaver bails");
+        }
+
+        [Test]
+        public void Given_HookInsideDoWhileLoop_When_Analyzed_Then_IsLeftUnwoven()
+        {
+            // Act + Assert
+            Assert.That(IsWoven(LoadMethod(nameof(DoWhileLoopHookComponent))), Is.False,
+                "A do-while loop closes with only a backward branch across the hook; weaving it would anchor"
+                + " the cache gate inside the loop, so the weaver bails");
+        }
+
+        [Test]
+        public void Given_HookInsideTryCatch_When_Analyzed_Then_IsLeftUnwoven()
+        {
+            // Act + Assert
+            Assert.That(IsWoven(LoadMethod(nameof(TryCatchHookComponent))), Is.False,
+                "A hook section overlapping a protected region would require the Leave protocol the weaver"
+                + " does not emit, so the weaver bails");
         }
 
         #endregion
@@ -442,6 +655,61 @@ namespace Velvet.Tests
                 "The captured context value drives the output; the woven gate misses on first render");
         }
 
+        [Test]
+        public void Given_WovenUseMemoOnlyComponent_When_FirstRender_Then_ProducesVisibleOutput()
+        {
+            // Act
+            using var mounted = V.Mount(_root, V.Component(UseMemoOnlyComponent, key: "use-memo"));
+
+            // Assert
+            Assert.That(_root.Q<Label>()?.text, Is.EqualTo("memo"),
+                "A woven UseMemo-only component renders normally on first render");
+        }
+
+        [Test]
+        public void Given_BailedWhileLoopHookComponent_When_FirstRender_Then_ProducesVisibleOutput()
+        {
+            // Act
+            using var mounted = V.Mount(_root, V.Component(WhileLoopHookComponent, key: "while-loop"));
+
+            // Assert
+            Assert.That(_root.Q<Label>()?.text, Is.EqualTo("11"),
+                "A bailed loop component still renders normally (the loop body runs exactly once)");
+        }
+
+        [Test]
+        public void Given_BailedDoWhileLoopHookComponent_When_FirstRender_Then_ProducesVisibleOutput()
+        {
+            // Act
+            using var mounted = V.Mount(_root, V.Component(DoWhileLoopHookComponent, key: "do-while-loop"));
+
+            // Assert
+            Assert.That(_root.Q<Label>()?.text, Is.EqualTo("13"),
+                "A bailed do-while component still renders normally (the loop body runs exactly once)");
+        }
+
+        [Test]
+        public void Given_BailedTryCatchHookComponent_When_FirstRender_Then_ProducesVisibleOutput()
+        {
+            // Act
+            using var mounted = V.Mount(_root, V.Component(TryCatchHookComponent, key: "try-catch"));
+
+            // Assert
+            Assert.That(_root.Q<Label>()?.text, Is.EqualTo("17"),
+                "A bailed try/catch component still renders normally through the non-throwing path");
+        }
+
+        [Test]
+        public void Given_BailedInterfaceDispatchComponent_When_FirstRender_Then_ProducesVisibleOutput()
+        {
+            // Act — the service field is left null, so the null-propagated call yields the fallback text.
+            using var mounted = V.Mount(_root, V.Component(InterfaceDispatchComponent, key: "iface"));
+
+            // Assert
+            Assert.That(_root.Q<Label>()?.text, Is.EqualTo("none0"),
+                "A bailed interface-dispatch component still renders normally");
+        }
+
         #endregion
 
         #region Helpers
@@ -463,6 +731,19 @@ namespace Velvet.Tests
 
         private static bool InjectsHookCall(MethodDefinition method, string hookMethodName) =>
             method.Body.Instructions.Any(IsHookCallTo(hookMethodName));
+
+        // Index (in instruction order) of the first call to the given Velvet.Hooks method, or -1 when absent.
+        // Instruction order is what places the injected cache gate relative to the hook section.
+        private static int IndexOfHookCall(MethodDefinition method, string hookMethodName)
+        {
+            var instructions = method.Body.Instructions;
+            var isHookCall = IsHookCallTo(hookMethodName);
+            for (var i = 0; i < instructions.Count; i++)
+            {
+                if (isHookCall(instructions[i])) return i;
+            }
+            return -1;
+        }
 
         private static System.Func<Instruction, bool> IsHookCallTo(string methodName) => instr =>
             instr.OpCode == OpCodes.Call

--- a/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/OpenDispatchHookSafetyTests.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/OpenDispatchHookSafetyTests.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using NUnit.Framework;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Specifies how the CompilerWeaver ILPP classifies an open virtual / interface dispatch whose declaring
+    /// type is outside the BCL/Unity/UniTask carve-out (<c>CannotReachVelvetHook</c>). The classifier must not
+    /// use "does the declaring assembly reference Velvet" as a proxy for "could an override reach a hook": an
+    /// override can be declared in a third assembly that references Velvet even when the statically declared
+    /// base/interface's own assembly never does, so the only sound classification for such a dispatch is
+    /// unverifiable / non-SAFE regardless of the declaring assembly's own references.
+    /// <para>
+    /// The E2E weaving tests (<see cref="CompilerILPostProcessorE2ETests"/>) compile a single test assembly, so
+    /// a callee declared in a genuinely separate, non-Velvet-referencing assembly cannot be produced that way.
+    /// This fixture instead invokes the two private classifier methods
+    /// (<c>ReachesNonSafeHook</c>/<c>CallsHookTransitively</c>) directly through reflection, against a callee
+    /// synthesized with Cecil in a module whose reference list never includes Velvet at all.
+    /// </para>
+    /// </summary>
+    [TestFixture]
+    internal sealed class OpenDispatchHookSafetyTests
+    {
+        private const string CodeGenAssemblyName = "Unity.Velvet.CodeGen";
+        private const string CompilerWeaverTypeFullName = "Velvet.CodeGen.CompilerWeaver";
+
+        [Test]
+        public void Given_OpenVirtualOutsideCarveOutInNonVelvetReferencingAssembly_When_ReachesNonSafeHookClassifies_Then_TreatsCalleeAsNonSafe()
+        {
+            // Arrange
+            using var module = BuildNonVelvetReferencingModuleWithOpenVirtual(out var handler);
+            Assume.That(module.AssemblyReferences.Any(r => r.Name == "Velvet"), Is.False,
+                "Precondition: the synthetic module never references Velvet");
+
+            // Act
+            var isNonSafe = (bool)InvokeClassifier("ReachesNonSafeHook", handler);
+
+            // Assert
+            Assert.That(isNonSafe, Is.True,
+                "An open dispatch outside the BCL/Unity/UniTask carve-out is unverifiable regardless of whether"
+                + " its declaring assembly references Velvet, because an override composing a hook can live in"
+                + " a third assembly that does");
+        }
+
+        [Test]
+        public void Given_OpenVirtualOutsideCarveOutInNonVelvetReferencingAssembly_When_CallsHookTransitivelyClassifies_Then_TreatsCalleeAsMayReachHook()
+        {
+            // Arrange
+            using var module = BuildNonVelvetReferencingModuleWithOpenVirtual(out var handler);
+
+            // Act
+            var mayReachHook = (bool)InvokeClassifier("CallsHookTransitively", handler);
+
+            // Assert
+            Assert.That(mayReachHook, Is.True,
+                "CallsHookTransitively must classify the same open dispatch identically to ReachesNonSafeHook,"
+                + " or the two walkers would disagree about whether the call is a hook call");
+        }
+
+        // Builds a module with no reference to Velvet, declaring a public, non-sealed class with an
+        // overridable (virtual, non-final) method — an open dispatch whose declaring type is outside every
+        // BCL/Unity/UniTask namespace root. Returns the MethodDefinition for that method via handler.
+        private static ModuleDefinition BuildNonVelvetReferencingModuleWithOpenVirtual(out MethodDefinition handler)
+        {
+            var module = ModuleDefinition.CreateModule("NonVelvetReferencingProbe", ModuleKind.Dll);
+            var baseType = new TypeDefinition("Probe", "Base",
+                Mono.Cecil.TypeAttributes.Public | Mono.Cecil.TypeAttributes.Class,
+                module.TypeSystem.Object);
+            handler = new MethodDefinition("Handler",
+                Mono.Cecil.MethodAttributes.Public | Mono.Cecil.MethodAttributes.Virtual
+                    | Mono.Cecil.MethodAttributes.NewSlot | Mono.Cecil.MethodAttributes.HideBySig,
+                module.TypeSystem.Void);
+            handler.Body = new Mono.Cecil.Cil.MethodBody(handler);
+            handler.Body.GetILProcessor().Append(Instruction.Create(OpCodes.Ret));
+            baseType.Methods.Add(handler);
+            module.Types.Add(baseType);
+            return module;
+        }
+
+        // Invokes CompilerWeaver's private static bool <name>(MethodReference, Dictionary<string, bool>)
+        // through reflection (the CodeGen assembly is editor-only and not referenced by this test asmdef).
+        private static object InvokeClassifier(string methodName, MethodReference callee)
+        {
+            var codeGenAssembly = AppDomain.CurrentDomain.GetAssemblies()
+                .FirstOrDefault(a => a.GetName().Name == CodeGenAssemblyName);
+            Assume.That(codeGenAssembly, Is.Not.Null,
+                "Precondition: the Unity.Velvet.CodeGen assembly is loaded in the editor domain");
+            var weaverType = codeGenAssembly!.GetType(CompilerWeaverTypeFullName, throwOnError: true);
+            var method = weaverType!.GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Static);
+            Assume.That(method, Is.Not.Null,
+                $"Precondition: {CompilerWeaverTypeFullName} exposes a private static {methodName} method");
+            var cache = new Dictionary<string, bool>();
+            return method!.Invoke(null, new object[] { callee, cache })!;
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/OpenDispatchHookSafetyTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/OpenDispatchHookSafetyTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 66c51bc16fad4dce84687d5df466136f

--- a/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/PositionalHookNamesLockstepTests.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/PositionalHookNamesLockstepTests.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using Mono.Cecil;
 using NUnit.Framework;
 
 namespace Velvet.Tests
@@ -10,6 +12,10 @@ namespace Velvet.Tests
     /// list directly to decide which calls must stay in the hook section, so a positional-slot hook missing
     /// from it is silently dropped from that set.</item>
     /// <item>The set contains no duplicate names.</item>
+    /// <item>Structurally: every public <c>Use*</c> hook whose implementation allocates a positional slot
+    /// (touches a <c>HookIndexTable</c> cursor or advances the async resource slot cursor) is present in the
+    /// list, so a newly added positional hook that is forgotten here fails this fixture instead of being
+    /// silently invisible to the weaver.</item>
     /// </list>
     /// </summary>
     [TestFixture]
@@ -21,6 +27,7 @@ namespace Velvet.Tests
             "UseLayoutEffect",
             "UseInsertionEffect",
             "UseCallback",
+            "UseMemo",
             "UseBlocker",
             "UseState",
             "UseReducer",
@@ -53,6 +60,79 @@ namespace Velvet.Tests
         {
             // Act + Assert
             Assert.That(PositionalHookNames.All, Is.Unique);
+        }
+
+        [Test]
+        public void Given_HooksAssembly_When_PositionalSlotConsumersAreEnumerated_Then_EveryOneIsInTheCanonicalList()
+        {
+            // Arrange
+            using var assembly = AssemblyDefinition.ReadAssembly(typeof(Hooks).Assembly.Location);
+            var hooksType = assembly.MainModule.GetType(typeof(Hooks).FullName);
+            Assume.That(hooksType, Is.Not.Null, "Precondition: Velvet.Hooks is present in the Velvet assembly");
+
+            // Act
+            var slotConsumers = EnumeratePositionalSlotConsumers(hooksType);
+
+            // Assert
+            Assert.That(slotConsumers, Is.SubsetOf(PositionalHookNames.All),
+                "Every public hook that allocates a positional slot (a HookIndexTable cursor or an async" +
+                " resource slot) must be listed in PositionalHookNames.All, or the ILPP weaver silently" +
+                " treats its calls as non-hook plumbing and may skip or mis-anchor them.");
+        }
+
+        // Enumerates the public Use* hooks whose implementation allocates a positional slot: the method's
+        // body — or the body of a non-hook Hooks helper it calls, transitively — touches a HookIndexTable
+        // cursor field or advances the fiber's async resource slot cursor. Descent deliberately stops at
+        // other public Use* hooks: those allocate their own slot and are enumerated independently, while a
+        // hook that merely composes them (e.g. UseNavigation over UseState) is tracked transitively by the
+        // weaver and does not need a list entry of its own.
+        private static IReadOnlyCollection<string> EnumeratePositionalSlotConsumers(TypeDefinition hooksType)
+        {
+            var consumers = new SortedSet<string>(System.StringComparer.Ordinal);
+            foreach (var method in hooksType.Methods)
+            {
+                if (!IsPublicHookMethod(method)) continue;
+                if (AllocatesPositionalSlot(method, hooksType, new HashSet<string>()))
+                {
+                    consumers.Add(method.Name);
+                }
+            }
+            return consumers;
+        }
+
+        private static bool IsPublicHookMethod(MethodDefinition method)
+            => method.IsPublic
+                && method.IsStatic
+                && method.Name.StartsWith("Use", System.StringComparison.Ordinal);
+
+        private static bool AllocatesPositionalSlot(
+            MethodDefinition method, TypeDefinition hooksType, HashSet<string> visited)
+        {
+            if (!method.HasBody || !visited.Add(method.FullName)) return false;
+            foreach (var instruction in method.Body.Instructions)
+            {
+                if (instruction.Operand is FieldReference field
+                    && field.DeclaringType.FullName == "Velvet.HookIndexTable")
+                {
+                    return true;
+                }
+                if (instruction.Operand is not MethodReference callee) continue;
+                if (callee.Name == "NextAsyncSlotIndex")
+                {
+                    return true;
+                }
+                // Only same-type helpers are followed, so resolution never leaves the already-loaded
+                // module (resolving foreign references would require an assembly resolver).
+                if (callee.DeclaringType.FullName != hooksType.FullName) continue;
+                var calleeDefinition = callee.Resolve();
+                if (calleeDefinition == null) continue;
+                if (IsPublicHookMethod(calleeDefinition)) continue;
+                if (AllocatesPositionalSlot(calleeDefinition, hooksType, visited))
+                {
+                    return true;
+                }
+            }
+            return false;
         }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/WeaverResolutionDiagnosticsTests.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/WeaverResolutionDiagnosticsTests.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Mono.Cecil;
+using NUnit.Framework;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Specifies that the ILPP weavers surface a diagnostic warning instead of failing silently when the
+    /// Velvet runtime types they inject calls to cannot be resolved from the processed module.
+    /// <list type="bullet">
+    /// <item>CompilerWeaver: when <c>Velvet.Hooks</c> / <c>Velvet.VNode</c> cannot be resolved, every
+    /// <c>[Component]</c> in the assembly is left unwoven — the warning names the assembly so that outcome is
+    /// distinguishable from "nothing needed weaving".</item>
+    /// <item>MetadataRegistrationWeaver: same contract when the module carries <c>[Component]</c> metadata to
+    /// register but <c>Velvet.ComponentMethodRegistry</c> cannot be resolved.</item>
+    /// </list>
+    /// The weavers live in the <c>Unity.Velvet.CodeGen</c> editor assembly and are internal, so they are
+    /// invoked through reflection; the probe modules are synthesized with Cecil and stripped of every
+    /// assembly reference so resolution deterministically fails without consulting an assembly resolver.
+    /// </summary>
+    [TestFixture]
+    internal sealed class WeaverResolutionDiagnosticsTests
+    {
+        private const string CodeGenAssemblyName = "Unity.Velvet.CodeGen";
+
+        [Test]
+        public void Given_ModuleWithoutVelvetReference_When_CompilerWeaverRuns_Then_WarnsNamingTheAssembly()
+        {
+            // Arrange
+            using var module = ModuleDefinition.CreateModule("VelvetWeaverProbe", ModuleKind.Dll);
+            module.AssemblyReferences.Clear();
+
+            // Act
+            var messages = InvokeWeave("Velvet.CodeGen.CompilerWeaver", module);
+
+            // Assert
+            Assert.That(messages, Has.Some.Contains("VelvetWeaverProbe"),
+                "A resolution failure must produce a diagnostic naming the assembly instead of silently"
+                + " disabling auto-memoization for it");
+        }
+
+        [Test]
+        public void Given_ModuleWithComponentMetadataButNoVelvetReference_When_MetadataWeaverRuns_Then_WarnsNamingTheAssembly()
+        {
+            // Arrange
+            using var module = CreateModuleWithMemoizedComponent("VelvetRegistryProbe");
+
+            // Act
+            var messages = InvokeWeave("Velvet.CodeGen.MetadataRegistrationWeaver", module);
+
+            // Assert
+            Assert.That(messages, Has.Some.Contains("VelvetRegistryProbe"),
+                "A resolution failure must produce a diagnostic naming the assembly instead of silently"
+                + " dropping the [Component] metadata registrations");
+        }
+
+        // Synthesizes a module carrying one method with [Component(Memoize = true)] so the metadata weaver
+        // has an entry to register, then strips every assembly reference so RegistryContext resolution
+        // deterministically fails. The attribute type is scoped to the module itself: the weaver matches the
+        // attribute by full name only and never resolves it.
+        private static ModuleDefinition CreateModuleWithMemoizedComponent(string name)
+        {
+            var module = ModuleDefinition.CreateModule(name, ModuleKind.Dll);
+            var type = new TypeDefinition("Probe", "Fixture",
+                Mono.Cecil.TypeAttributes.Public | Mono.Cecil.TypeAttributes.Class
+                | Mono.Cecil.TypeAttributes.Abstract | Mono.Cecil.TypeAttributes.Sealed,
+                module.TypeSystem.Object);
+            var method = new MethodDefinition("Component",
+                Mono.Cecil.MethodAttributes.Public | Mono.Cecil.MethodAttributes.Static,
+                module.TypeSystem.Object);
+            var attributeType = new TypeReference("Velvet", "ComponentAttribute", module, module);
+            var attributeCtor = new MethodReference(".ctor", module.TypeSystem.Void, attributeType)
+            {
+                HasThis = true,
+            };
+            var attribute = new CustomAttribute(attributeCtor);
+            attribute.Properties.Add(new CustomAttributeNamedArgument(
+                "Memoize", new CustomAttributeArgument(module.TypeSystem.Boolean, true)));
+            method.CustomAttributes.Add(attribute);
+            type.Methods.Add(method);
+            module.Types.Add(type);
+            // Strip the references the TypeSystem lazily added (corlib for Object / Boolean / Void) AFTER
+            // building the shape, so the weaver's external resolution has nothing to consult and fails
+            // without touching an assembly resolver.
+            module.AssemblyReferences.Clear();
+            return module;
+        }
+
+        // Invokes the internal static Weave(ModuleDefinition, List<DiagnosticMessage>) through reflection
+        // (the CodeGen assembly is editor-only and not referenced by this test asmdef) and returns the
+        // MessageData of every emitted diagnostic.
+        private static List<string> InvokeWeave(string weaverTypeFullName, ModuleDefinition module)
+        {
+            var codeGenAssembly = AppDomain.CurrentDomain.GetAssemblies()
+                .FirstOrDefault(a => a.GetName().Name == CodeGenAssemblyName);
+            Assume.That(codeGenAssembly, Is.Not.Null,
+                "Precondition: the Unity.Velvet.CodeGen assembly is loaded in the editor domain");
+            var weaverType = codeGenAssembly!.GetType(weaverTypeFullName, throwOnError: true);
+            var weaveMethod = weaverType!.GetMethod("Weave",
+                System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);
+            Assume.That(weaveMethod, Is.Not.Null,
+                "Precondition: the weaver exposes a public static Weave method");
+
+            var diagnostics = Activator.CreateInstance(weaveMethod!.GetParameters()[1].ParameterType)!;
+            weaveMethod.Invoke(null, new[] { (object)module, diagnostics });
+
+            var messages = new List<string>();
+            foreach (var diagnostic in (IEnumerable)diagnostics)
+            {
+                var messageData = diagnostic.GetType().GetProperty("MessageData")?.GetValue(diagnostic);
+                messages.Add(messageData as string ?? string.Empty);
+            }
+            return messages;
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/WeaverResolutionDiagnosticsTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/WeaverResolutionDiagnosticsTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9ef9d68ca65c48f7b05bfd19a191248c

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberEffects.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberEffects.cs
@@ -133,72 +133,34 @@ namespace Velvet
                 }
                 deduped.Reverse();
 
-                // Group entries by their nearest pushed ancestor. Non-pushed intermediates are
-                // skipped so wrapper-mount subtrees whose middle ancestors did not defer collapse
-                // naturally.
-                Dictionary<ComponentFiber, List<(ComponentFiber Fiber, bool IsMount)>>? childrenByParent = null;
-                var roots = new List<(ComponentFiber Fiber, bool IsMount)>();
-                for (var i = 0; i < deduped.Count; i++)
-                {
-                    var entry = deduped[i];
-                    var ancestor = entry.Fiber.Parent;
-                    while (ancestor != null && !pushedSet.Contains(ancestor)) ancestor = ancestor.Parent;
-                    if (ancestor == null)
-                    {
-                        roots.Add(entry);
-                    }
-                    else
-                    {
-                        childrenByParent ??= new Dictionary<ComponentFiber, List<(ComponentFiber Fiber, bool IsMount)>>();
-                        if (!childrenByParent.TryGetValue(ancestor, out var list))
-                        {
-                            list = new List<(ComponentFiber Fiber, bool IsMount)>();
-                            childrenByParent[ancestor] = list;
-                        }
-                        list.Add(entry);
-                    }
-                }
-
-                for (var i = 0; i < roots.Count; i++) DrainPostOrderIterative(roots[i], childrenByParent);
-
+                // Reconstruct the post-order sequence over the deduped snapshot (nearest-staged-ancestor
+                // grouping — see OrderByNearestStagedAncestorPostOrder), then commit each fiber's deferred
+                // effects in that order. The traversal reads only the snapshot built above, so ordering
+                // first and running after is equivalent to running mid-walk; an effect that synchronously
+                // pushes MORE deferred fibers lands on the stack and is picked up by the outer re-drain
+                // loop, exactly as before.
+                var ordered = new List<(ComponentFiber Fiber, bool IsMount)>(deduped.Count);
+                OrderByNearestStagedAncestorPostOrder(deduped, pushedSet, static e => e.Fiber, ordered);
                 bufferPool.ReturnFiberSet(pushedSet);
-            }
-        }
 
-        // Iterative post-order DFS drain. Recursion-free to prevent .NET stack overflow on deep
-        // inline-mount chains (1k+ nested Provider / Memo subtrees); the same iterative pattern
-        // that FiberTreeTraversal.Visit documented away.
-        private static void DrainPostOrderIterative(
-            (ComponentFiber Fiber, bool IsMount) root,
-            Dictionary<ComponentFiber, List<(ComponentFiber Fiber, bool IsMount)>>? childrenByParent)
-        {
-            var workStack = new Stack<(int ChildIndex, (ComponentFiber Fiber, bool IsMount) Entry)>();
-            workStack.Push((0, root));
-            while (workStack.Count > 0)
-            {
-                var (childIndex, entry) = workStack.Pop();
-                if (childrenByParent != null && childrenByParent.TryGetValue(entry.Fiber, out var children) && childIndex < children.Count)
+                for (var i = 0; i < ordered.Count; i++)
                 {
-                    // Resume parent after this child completes, then descend into the next child.
-                    workStack.Push((childIndex + 1, entry));
-                    workStack.Push((0, children[childIndex]));
-                    continue;
+                    // Children already committed (post-order) — commit this fiber's deferred effects.
+                    // Mount commits run the Editor-only double-invoke; re-expansion commits (parent
+                    // re-render reaching an existing inline child) only run prior cleanup + new setup
+                    // for deps-changed slots. Insertion effects fire before layout effects.
+                    // UseImperativeHandle commits between insertion and layout effects so a
+                    // parent layout effect / handle factory observes the child's handle already
+                    // written into its parent ref (imperative handles are part of the
+                    // layout-effect phase). 2-phase separation (all-insertion → all-layout across the
+                    // subtree, splitting DOM mutation from layout-effect commit) is tracked
+                    // separately for the broader CommitSubtreeEffects refactor.
+                    var (deferred, isMount) = ordered[i];
+                    if (deferred == null || deferred.IsDisposed) continue;
+                    RunInsertionEffects(deferred, mountDoubleInvoke: isMount);
+                    FiberHookCommit.RunImperativeHandleSlots(deferred);
+                    RunLayoutEffects(deferred, mountDoubleInvoke: isMount);
                 }
-                // All children visited (or none) — commit this fiber's deferred effects.
-                // Mount commits run the Editor-only double-invoke; re-expansion commits (parent
-                // re-render reaching an existing inline child) only run prior cleanup + new setup
-                // for deps-changed slots. Insertion effects fire before layout effects.
-                // UseImperativeHandle commits between insertion and layout effects so a
-                // parent layout effect / handle factory observes the child's handle already
-                // written into its parent ref (imperative handles are part of the
-                // layout-effect phase). 2-phase separation (all-insertion → all-layout across the
-                // subtree, splitting DOM mutation from layout-effect commit) is tracked
-                // separately for the broader CommitSubtreeEffects refactor.
-                var deferred = entry.Fiber;
-                if (deferred == null || deferred.IsDisposed) continue;
-                RunInsertionEffects(deferred, mountDoubleInvoke: entry.IsMount);
-                FiberHookCommit.RunImperativeHandleSlots(deferred);
-                RunLayoutEffects(deferred, mountDoubleInvoke: entry.IsMount);
             }
         }
 
@@ -336,52 +298,64 @@ namespace Velvet
         private static List<ComponentFiber> OrderFibersPostOrder(List<ComponentFiber> staged)
         {
             var stagedSet = new HashSet<ComponentFiber>(staged);
-            Dictionary<ComponentFiber, List<ComponentFiber>>? childrenByParent = null;
-            var roots = new List<ComponentFiber>();
-            for (var i = 0; i < staged.Count; i++)
-            {
-                var fiber = staged[i];
-                var ancestor = fiber.Parent;
-                while (ancestor != null && !stagedSet.Contains(ancestor)) ancestor = ancestor.Parent;
-                if (ancestor == null)
-                {
-                    roots.Add(fiber);
-                }
-                else
-                {
-                    childrenByParent ??= new Dictionary<ComponentFiber, List<ComponentFiber>>();
-                    if (!childrenByParent.TryGetValue(ancestor, out var list))
-                    {
-                        list = new List<ComponentFiber>();
-                        childrenByParent[ancestor] = list;
-                    }
-                    list.Add(fiber);
-                }
-            }
-
             var result = new List<ComponentFiber>(staged.Count);
-            for (var i = 0; i < roots.Count; i++) EmitPostOrder(roots[i], childrenByParent, result);
+            OrderByNearestStagedAncestorPostOrder(staged, stagedSet, static f => f, result);
             return result;
         }
 
-        private static void EmitPostOrder(
-            ComponentFiber root,
-            Dictionary<ComponentFiber, List<ComponentFiber>>? childrenByParent,
-            List<ComponentFiber> result)
+        // The one post-order-by-nearest-staged-ancestor implementation shared by the layout-effect drain
+        // (entries carry an IsMount flag) and the passive-effect drain (plain fibers): each staged entry is
+        // grouped under its NEAREST staged ancestor — non-staged intermediates are skipped, so wrapper-mount
+        // subtrees whose middle ancestors did not stage collapse naturally — then an iterative post-order
+        // DFS over the resulting forest emits children before their parent into result, roots in their
+        // relative staging order. Iterative (stack-based, recursion-free) to prevent .NET stack overflow on
+        // deep inline-mount chains (1k+ nested Provider / Memo subtrees); the same iterative pattern that
+        // FiberTreeTraversal.Visit documented away. fiberOf must be a compiler-cached static lambda so this
+        // stays allocation-free per call beyond the grouping collections themselves.
+        private static void OrderByNearestStagedAncestorPostOrder<T>(
+            List<T> staged, HashSet<ComponentFiber> stagedSet, Func<T, ComponentFiber> fiberOf, List<T> result)
         {
-            // Iterative post-order DFS (recursion-free) to avoid .NET stack overflow on deep chains.
-            var workStack = new Stack<(int ChildIndex, ComponentFiber Fiber)>();
-            workStack.Push((0, root));
-            while (workStack.Count > 0)
+            Dictionary<ComponentFiber, List<T>>? childrenByParent = null;
+            var roots = new List<T>();
+            for (var i = 0; i < staged.Count; i++)
             {
-                var (childIndex, fiber) = workStack.Pop();
-                if (childrenByParent != null && childrenByParent.TryGetValue(fiber, out var children) && childIndex < children.Count)
+                var entry = staged[i];
+                var ancestor = fiberOf(entry).Parent;
+                while (ancestor != null && !stagedSet.Contains(ancestor)) ancestor = ancestor.Parent;
+                if (ancestor == null)
                 {
-                    workStack.Push((childIndex + 1, fiber));
-                    workStack.Push((0, children[childIndex]));
-                    continue;
+                    roots.Add(entry);
                 }
-                result.Add(fiber);
+                else
+                {
+                    childrenByParent ??= new Dictionary<ComponentFiber, List<T>>();
+                    if (!childrenByParent.TryGetValue(ancestor, out var list))
+                    {
+                        list = new List<T>();
+                        childrenByParent[ancestor] = list;
+                    }
+                    list.Add(entry);
+                }
+            }
+
+            var workStack = new Stack<(int ChildIndex, T Entry)>();
+            for (var r = 0; r < roots.Count; r++)
+            {
+                workStack.Push((0, roots[r]));
+                while (workStack.Count > 0)
+                {
+                    var (childIndex, entry) = workStack.Pop();
+                    if (childrenByParent != null
+                        && childrenByParent.TryGetValue(fiberOf(entry), out var children)
+                        && childIndex < children.Count)
+                    {
+                        // Resume the parent after this child's subtree completes, then descend.
+                        workStack.Push((childIndex + 1, entry));
+                        workStack.Push((0, children[childIndex]));
+                        continue;
+                    }
+                    result.Add(entry);
+                }
             }
         }
 

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberElementPoolReset.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberElementPoolReset.cs
@@ -150,6 +150,12 @@ namespace Velvet
             style.aspectRatio = StyleKeyword.Null;
             // blur-/grayscale-/etc. write inline filter (StyleArbitraryValueResolver); same pool-ghost reason.
             style.filter = StyleKeyword.Null;
+            // This editor's inline-filter setter clears the wrong internal has-inline flag on a Null
+            // assignment, so the stored filter list survives the line above and would still ghost onto the
+            // next consumer. Empty the surviving list in place: an empty inline filter computes to "no
+            // filter", a consumer's filter classes replace the list wholesale, and on editors where the
+            // Null assignment works the getter already reads back a null list, making this a no-op.
+            style.filter.value?.Clear();
             style.transformOrigin = StyleKeyword.Null;
             style.transitionDuration = StyleKeyword.Null;
             style.transitionDelay = StyleKeyword.Null;

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
@@ -203,12 +203,17 @@ namespace Velvet
         // so the full set of class-driven mechanisms lives in one place and the two paths cannot drift.
         // Gap is intentionally excluded: it is re-applied separately by the per-node patch methods
         // (PatchElement / PatchMotion) AFTER children reconcile, so it sees the
-        // final child list. The variant/font work is gated on an actual class-list change; DiffClassList
-        // has its own ReferenceEquals/SequenceEqual early-outs.
+        // final child list. The variant/font work is gated on DiffClassList's own verdict of whether the
+        // class list actually changed CONTENT (not merely array identity) — every variant manipulator this
+        // derives from (ApplyVariantManipulators and its callees) reads ONLY the classNames array, so a
+        // freshly-allocated array with the same tokens carries no new information and re-deriving from it
+        // would just rebuild the same payloads. A component that rebuilds its VNode tree every render
+        // (no ILPP memoization, or a Motion resolving the same active variant label — MotionVariantResolver
+        // .ResolveApplied always concatenates a fresh array) hits this path on every patch.
         internal void SyncClassDrivenStyling(VisualElement element, string[] oldClasses, string[] newClasses)
         {
-            DiffClassList(element, oldClasses, newClasses);
-            if (!ReferenceEquals(oldClasses, newClasses))
+            var changed = DiffClassList(element, oldClasses, newClasses);
+            if (changed)
             {
                 ApplyVariantManipulators(element, newClasses);
                 // Font family / weight / italic are resolved together (so font-bold + italic compose)
@@ -221,35 +226,14 @@ namespace Velvet
         {
             PatchBaseElement(element, oldNode, newNode);
             DiffStyles(element, oldNode.Styles, newNode.Styles);
-            // Run gap LAST — after PatchCommon (which reconciles children) AND DiffStyles — so the
-            // manipulator's margin writes are the final word on the element. The wrap path writes the
-            // container's OWN margins (-gap/2); keeping gap after DiffStyles preserves the ordering
-            // invariant that the manipulator's container-margin writes are never clobbered by a later
-            // inline-style diff on the same element. (Today DiffStyles only touches color properties, but
-            // the invariant must hold if a margin-writing StyleOverride is ever added.) Running after
-            // PatchCommon also re-applies against the current child set so a child add / remove re-spaces
-            // even when the className did not change.
-            ApplyGapManipulator(element, newNode.ClassNames);
-            ApplyDivideManipulator(element, newNode.ClassNames);
-            ApplyGridManipulator(element, newNode.ClassNames);
-            ApplyStructuralVariants(element);
-            // has-[.class]: re-evaluated with the element AS subject (its descendants drive its own payload),
-            // at the same post-children timing — a child added / removed re-derives the match.
-            ApplyHasClassVariants(element);
-            // has-[:checked]: / has-[:focus]: re-scanned at the same timing — a checked / focused descendant
-            // added or removed fires no event, so the manipulator must re-derive from the live subtree.
-            ApplyHasVariantManipulators(element);
-            // text-transform / -decoration cascade (post-children so it reaches descendant text leaves).
-            StyleTextEffectResolver.Apply(_ctx, element, newNode.ClassNames);
-            // Gradient runs after DiffStyles (PatchCommon) so its background-image is the last word on
-            // this element — DiffStyles only writes background-image on an actual node-style change, which
-            // a gradient element never carries, so the two never fight.
-            _appliers.ApplyGradientOnPatch(element, newNode.ClassNames, skewable: true);
-            // animate-* motion runs after the gradient (a pan mode reads the live gradient) and reconciles
-            // its own restart/attach/detach against the new class list.
-            _appliers.ApplyAnimateOnPatch(element, newNode.ClassNames);
-            // After gap (and the child reconcile it follows): reconcile the paint + wrapper effect layers
-            // against the new class list. They run last so each is the final word on this element. Skew and
+            // The shared post-children passes run after PatchCommon (which reconciles children) AND
+            // DiffStyles — keeping gap after DiffStyles preserves the ordering invariant that the
+            // manipulator's container-margin writes are never clobbered by a later inline-style diff on
+            // the same element. (Today DiffStyles only touches color properties, but the invariant must
+            // hold if a margin-writing StyleOverride is ever added.)
+            ApplyPostChildrenClassPasses(element, newNode.ClassNames, gradientSkewable: true);
+            // After the shared passes: reconcile the paint + wrapper effect layers against the new class
+            // list. They run last so each is the final word on this element. Skew and
             // shadow are wrapper-less paints (the silhouette / shadow are the element's own
             // generateVisualContent); their stash / spec sync must observe this patch's freshly-applied class
             // styling. clip-path runs BEFORE shadow: a clip clips the box-shadow too (CSS), so the shadow
@@ -262,6 +246,42 @@ namespace Velvet
             // are mutually exclusive — one wrapper per element). The shadow is now a paint, so a ring composes
             // with it rather than competing for the wrapper.
             _appliers.ApplyRingOnPatch(element, newNode.ClassNames, suppress: clipActive, allowWrap: true);
+        }
+
+        // The ordered post-children effect-pass sequence shared by PatchElement and PatchMotion, kept in
+        // one place so the two patch paths cannot drift (a pass added here reaches both). The ORDER is
+        // load-bearing:
+        // - Gap runs first but still AFTER PatchCommon (which reconciles children) so the manipulator's
+        //   margin writes are the final word on the element — the wrap path writes the container's OWN
+        //   margins (-gap/2) — and so it re-applies against the current child set (a child add / remove
+        //   re-spaces even when the className did not change). Divide / grid follow at the same timing
+        //   for the same child-set reason.
+        // - Structural variants (first:/last:/nth) re-derive every child's position-based match from the
+        //   final sibling order.
+        // - has-[.class]: re-evaluated with the element AS subject (its descendants drive its own payload),
+        //   at the same post-children timing — a child added / removed re-derives the match.
+        // - has-[:checked]: / has-[:focus]: re-scanned at the same timing — a checked / focused descendant
+        //   added or removed fires no event, so the manipulator must re-derive from the live subtree.
+        // - text-transform / -decoration cascade (post-children so it reaches descendant text leaves).
+        // - Gradient runs after the node-style diff so its background-image is the last word on this
+        //   element — DiffStyles only writes background-image on an actual node-style change, which a
+        //   gradient element never carries, so the two never fight. gradientSkewable is the one per-path
+        //   knob: an ElementNode may render a sheared silhouette, a Motion never does (see PatchMotion).
+        // - animate-* motion runs after the gradient (a pan mode reads the live gradient) and reconciles
+        //   its own restart/attach/detach against the new class list.
+        // The element-only paint/wrapper tail (skew / clip-path / shadow, then ring) stays with the
+        // callers: PatchMotion intentionally omits the trio and passes different ring flags.
+        private void ApplyPostChildrenClassPasses(VisualElement element, string[] classNames, bool gradientSkewable)
+        {
+            ApplyGapManipulator(element, classNames);
+            ApplyDivideManipulator(element, classNames);
+            ApplyGridManipulator(element, classNames);
+            ApplyStructuralVariants(element);
+            ApplyHasClassVariants(element);
+            ApplyHasVariantManipulators(element);
+            StyleTextEffectResolver.Apply(_ctx, element, classNames);
+            _appliers.ApplyGradientOnPatch(element, classNames, skewable: gradientSkewable);
+            _appliers.ApplyAnimateOnPatch(element, classNames);
         }
 
         private void PatchText(Label label, TextNode oldNode, TextNode newNode)
@@ -359,19 +379,11 @@ namespace Velvet
                 PatchBaseElement(element, oldNode, newNode, appliedOld, appliedNew);
             }
 
-            // MotionNode has no Styles diff, but keep the gap / divide manipulators last (after PatchCommon
-            // reconciles children) for the same child-set re-spacing reason as PatchElement.
-            ApplyGapManipulator(element, appliedNew);
-            ApplyDivideManipulator(element, appliedNew);
-            ApplyGridManipulator(element, appliedNew);
-            ApplyStructuralVariants(element);
-            ApplyHasClassVariants(element);
-            ApplyHasVariantManipulators(element);
-            StyleTextEffectResolver.Apply(_ctx, element, appliedNew);
-            // A Motion never renders skew (the animation node never attaches a sheared silhouette), so its
-            // gradient always takes the straight background-image path even with skew classes present.
-            _appliers.ApplyGradientOnPatch(element, appliedNew, skewable: false);
-            _appliers.ApplyAnimateOnPatch(element, appliedNew);
+            // MotionNode has no Styles diff, so the shared passes follow PatchCommon (which reconciles
+            // children) directly. A Motion never renders skew (the animation node never attaches a sheared
+            // silhouette), so its gradient always takes the straight background-image path even with skew
+            // classes present (gradientSkewable: false).
+            ApplyPostChildrenClassPasses(element, appliedNew, gradientSkewable: false);
             // A Motion carries no shadow paint: the create path warns and skips a shadow-* on a Motion (the
             // animation node owns its transition; a shadow belongs on a wrapped Div), so there is never a
             // binding to update — and the patch must not start attaching one. Ring likewise never wraps a
@@ -459,18 +471,21 @@ namespace Velvet
 
         // ClassList diff. Skips work via fast paths using ReferenceEquals and SequenceEqual.
         // Uses linear comparison for sizes ≤ 8 and a HashSet otherwise.
-        internal void DiffClassList(VisualElement element, string[] oldClasses, string[] newClasses)
+        // Returns whether the class list changed content (false when either fast path hit), so the caller
+        // can gate variant/font re-derivation on real change rather than array identity — a
+        // content-identical but freshly-allocated array must not re-derive anything.
+        internal bool DiffClassList(VisualElement element, string[] oldClasses, string[] newClasses)
         {
             oldClasses ??= Array.Empty<string>();
             newClasses ??= Array.Empty<string>();
             if (ReferenceEquals(oldClasses, newClasses))
             {
-                return;
+                return false;
             }
 
             if (SequenceEqual(oldClasses, newClasses))
             {
-                return;
+                return false;
             }
 
             const int linearThreshold = 8;
@@ -485,6 +500,7 @@ namespace Velvet
             {
                 ReapplyArbitraryValues(element, newClasses);
             }
+            return true;
         }
 
         // Re-asserts the class list's inline-resolved (arbitrary / preset) values. Shared with the

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberPropApplier.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberPropApplier.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using UnityEngine.UIElements;
 
 namespace Velvet
@@ -91,21 +92,19 @@ namespace Velvet
             tfEl.isPasswordField = settings?.IsPassword ?? false;
         }
 
-        // Applies choices to DropdownField / RadioButtonGroup.
+        // Applies choices to DropdownField / RadioButtonGroup. A null Choices prop (or no settings at
+        // all) resets the widget to an empty choice list instead of stranding a prior render's options,
+        // mirroring ApplyFieldValue's null-clears-to-default contract.
         public static void ApplyChoices(VisualElement element, ChoicesSettings? settings)
         {
-            if (settings?.Choices == null)
-            {
-                return;
-            }
-
+            var choices = settings?.Choices ?? new List<string>();
             switch (element)
             {
                 case DropdownField dd:
-                    dd.choices = settings.Choices;
+                    dd.choices = choices;
                     break;
                 case RadioButtonGroup rbg:
-                    rbg.choices = settings.Choices;
+                    rbg.choices = choices;
                     break;
             }
         }

--- a/Packages/com.velvet.core/Runtime/Reconciler/Reconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Reconciler.cs
@@ -503,6 +503,16 @@ namespace Velvet
             }
 
             _ctx.VirtualListControllers.Clear();
+            // Outlet route scopes are user-supplied DI scopes (IRouteScope extends IDisposable):
+            // dispose each so an Outlet still mounted at whole-reconciler teardown does not leak the
+            // scope's resources, mirroring FiberElementCleaner's per-element Outlet-scope-dispose.
+            foreach (var scope in _ctx.OutletScopes.Values)
+            {
+                scope.Dispose();
+            }
+
+            _ctx.OutletScopes.Clear();
+            _ctx.OutletContainers.Clear();
             _ctx.PresenceStates.Clear();
         }
     }

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/AttributeVariantTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/AttributeVariantTests.cs
@@ -211,5 +211,21 @@ namespace Velvet.Tests
             // Assert
             Assert.IsTrue(El(scope).ClassListContains("bg-mark"));
         }
+
+        [Test]
+        public void Given_Div_When_DataSuppliedViaParam_Then_PayloadApplied()
+        {
+            // Arrange/Act — V.Div supplies a data-* attribute via its own data: convenience parameter
+            // (rather than an explicit props: bag) and matches its data-[...] variant.
+            using var scope = new ReconcilerScope();
+            scope.Reconciler.Reconcile(scope.Root, Array.Empty<VNode>(), new VNode[]
+            {
+                V.Div(className: "data-[state=open]:bg-mark", name: "el",
+                    data: new Dictionary<string, string> { ["state"] = "open" }),
+            });
+
+            // Assert — the data: parameter reaches Div, not just typed widget factories.
+            Assert.IsTrue(El(scope).ClassListContains("bg-mark"));
+        }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ClassContentEqualityVariantSkipTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ClassContentEqualityVariantSkipTests.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Reflection;
+using NUnit.Framework;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins the class-content fast-path in <c>SyncClassDrivenStyling</c>: a re-render that supplies a
+    /// content-identical but FRESHLY ALLOCATED ClassNames array — the shape any component that rebuilds
+    /// its VNode tree each render produces (and the Motion variant path produces unconditionally, since
+    /// resolving an unchanged active label still merges a new array) — must NOT re-derive the variant
+    /// manipulators. Re-derivation is observed through the <c>StyleVariantManipulator</c>'s private
+    /// hover-payload array: a re-derivation always installs a freshly extracted array via
+    /// <c>UpdatePayloads</c>, so the array instance surviving the patch proves the whole
+    /// <c>ApplyVariantManipulators</c> cascade was skipped. The payload store is a private field, hence
+    /// reflection inside the test. GWT, one assert.
+    /// </summary>
+    [TestFixture]
+    internal sealed class ClassContentEqualityVariantSkipTests
+    {
+        // Builds the leaf with a FRESH ClassNames array per call. Deliberately bypasses V.Div: its
+        // ParseClassNames cache returns a reference-stable array for a constant className string, which
+        // would hit the ReferenceEquals fast-path and mask the content-equality case under test.
+        private static VNode[] Tree() => new VNode[]
+        {
+            new ElementNode
+            {
+                Name = "leaf",
+                ClassNames = new[] { "p-4", "hover:bg-red-500" },
+            },
+        };
+
+        // Reads the manipulator's derived hover-payload array. A private field is the only observation
+        // point: the manipulator instance itself is reused by design, so instance identity cannot
+        // distinguish "derivation skipped" from "derivation re-ran and updated the same instance".
+        private static string[] HoverPayloadsOf(StyleVariantManipulator manipulator)
+        {
+            var field = typeof(StyleVariantManipulator).GetField("_hover", BindingFlags.Instance | BindingFlags.NonPublic)
+                ?? throw new InvalidOperationException(
+                    "Could not find StyleVariantManipulator._hover. The payload field may have been renamed.");
+            return (string[])field.GetValue(manipulator);
+        }
+
+        [Test]
+        public void Given_AMountedHoverVariantLeaf_When_RepatchedWithAContentIdenticalFreshClassArray_Then_TheVariantManipulatorIsNotRederived()
+        {
+            // Arrange — mount the leaf, then capture the manipulator's derived hover-payload array.
+            using var scope = new ReconcilerScope();
+            var oldTree = Tree();
+            var newTree = Tree();
+            Assume.That(
+                ReferenceEquals(((ElementNode)oldTree[0]).ClassNames, ((ElementNode)newTree[0]).ClassNames),
+                Is.False,
+                "Precondition: the two renders carry distinct (content-identical) class array instances");
+            scope.Reconciler.Reconcile(scope.Root, Array.Empty<VNode>(), oldTree);
+            var leaf = scope.Root[0];
+            Assume.That(scope.Reconciler.Context.VariantManipulators.ContainsKey(leaf), Is.True,
+                "Precondition: the hover: leaf is tracked while mounted");
+            var manipulator = scope.Reconciler.Context.VariantManipulators[leaf];
+            var payloadsBefore = HoverPayloadsOf(manipulator);
+
+            // Act — patch with the content-identical, freshly allocated class array.
+            scope.Reconciler.Reconcile(scope.Root, oldTree, newTree);
+            Assume.That(scope.Root[0], Is.SameAs(leaf),
+                "Premise guard: the leaf was patched in place — a replacement would trivially keep the " +
+                "captured manipulator's payloads and mask a broken fast-path");
+
+            // Assert — the derivation was skipped: a re-derivation would have installed a freshly
+            // extracted payload array, so the surviving instance proves the content fast-path held.
+            Assert.That(ReferenceEquals(payloadsBefore, HoverPayloadsOf(manipulator)), Is.True,
+                "A content-identical class array must not re-derive the variant manipulator payloads");
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ClassContentEqualityVariantSkipTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ClassContentEqualityVariantSkipTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 430ee640dea34d01a85121f723c10784

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/OutletNodeTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/OutletNodeTests.cs
@@ -265,6 +265,35 @@ namespace Velvet.Tests
 
         #endregion
 
+        #region Root disposal
+
+        [Test]
+        public void Given_RoutedOutletWithScope_When_ReconcilerDisposed_Then_ScopeIsDisposed()
+        {
+            // A whole-Reconciler/root teardown (e.g. closing a mounted UI tree) never reconciles the
+            // Outlet away element-by-element, so the scope must be released by Dispose itself, not by
+            // FiberElementCleaner's per-element path.
+            // Arrange
+            var scopeFactory = new TestRouteScopeFactory();
+            var routes = V.Routes(V.Route(path: "/", element: V.Component(SimpleRender, key: "simple")));
+            var router = new Router(routes, scopeFactory);
+            router.NavigateAsync("/").GetAwaiter().GetResult();
+            var tree = OutletUnderRouter(router.CurrentLocation!, depth: 0);
+            _reconciler.Reconcile(_root, Array.Empty<VNode>(), tree);
+            Assume.That(scopeFactory.LastScope, Is.Not.Null, "Precondition: the Outlet created a route scope");
+
+            // Act — dispose the whole Reconciler, not the individual Outlet element
+            _reconciler.Dispose();
+            _reconciler = new Reconciler();
+
+            // Assert
+            Assert.That(scopeFactory.LastScope!.IsDisposed, Is.True);
+
+            router.Dispose();
+        }
+
+        #endregion
+
         #region Helpers
 
         private static RouterLocation LocationWithSingleMatch(ComponentNode element)

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/PooledElementStyleGhostTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/PooledElementStyleGhostTests.cs
@@ -1,4 +1,7 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
 using NUnit.Framework;
 using UnityEngine.UIElements;
 using Velvet.TestUtilities;
@@ -13,6 +16,9 @@ namespace Velvet.Tests
     /// label therefore kept its previous letter spacing and ghosted it onto the next consumer whose node declared no
     /// <c>tracking-*</c> (the fresh node's empty oldClasses diff never clears it) — the same pooled-reuse ghosting
     /// class as the Button-children bug. GWT, one assert per case.
+    /// The structural cases pin the FULL reset surface: every inline style property the reset scrubs is compared
+    /// against a freshly constructed element, in both directions, so dropping a scrubbed property from the helper
+    /// (reintroducing a ghost) or scrubbing a new one without extending the pinned contract list fails a test.
     /// </summary>
     [TestFixture]
     internal sealed class PooledElementStyleGhostTests : VariantCleanupTestsBase
@@ -104,6 +110,212 @@ namespace Velvet.Tests
 
             // Assert — the recycled label carries no leftover inline width (arbitrary values do not ghost across reuse).
             Assert.AreEqual(StyleKeyword.Null, _root.Q<Label>("text").style.width.keyword);
+        }
+
+        // Structural: the full inline-style scrub surface, compared against a fresh element
+
+        // Every inline style property FiberElementPoolReset.ResetInlineStyle scrubs. This list is the
+        // pinned reset contract: the structural test below fails when the helper stops scrubbing a
+        // listed property (a pool-reuse ghost) AND when it starts scrubbing an unlisted one (the new
+        // property would otherwise have no regression coverage), so the two cannot drift silently.
+        private static readonly string[] ScrubbedInlineStyleProperties =
+        {
+            nameof(IStyle.color),
+            nameof(IStyle.backgroundColor),
+            nameof(IStyle.backgroundImage),
+            nameof(IStyle.backgroundSize),
+            nameof(IStyle.backgroundPositionX),
+            nameof(IStyle.backgroundPositionY),
+            nameof(IStyle.backgroundRepeat),
+            nameof(IStyle.opacity),
+            nameof(IStyle.display),
+            nameof(IStyle.visibility),
+            nameof(IStyle.overflow),
+            nameof(IStyle.width),
+            nameof(IStyle.height),
+            nameof(IStyle.minWidth),
+            nameof(IStyle.minHeight),
+            nameof(IStyle.maxWidth),
+            nameof(IStyle.maxHeight),
+            nameof(IStyle.marginLeft),
+            nameof(IStyle.marginRight),
+            nameof(IStyle.marginTop),
+            nameof(IStyle.marginBottom),
+            nameof(IStyle.paddingLeft),
+            nameof(IStyle.paddingRight),
+            nameof(IStyle.paddingTop),
+            nameof(IStyle.paddingBottom),
+            nameof(IStyle.borderLeftWidth),
+            nameof(IStyle.borderRightWidth),
+            nameof(IStyle.borderTopWidth),
+            nameof(IStyle.borderBottomWidth),
+            nameof(IStyle.borderLeftColor),
+            nameof(IStyle.borderRightColor),
+            nameof(IStyle.borderTopColor),
+            nameof(IStyle.borderBottomColor),
+            nameof(IStyle.borderTopLeftRadius),
+            nameof(IStyle.borderTopRightRadius),
+            nameof(IStyle.borderBottomLeftRadius),
+            nameof(IStyle.borderBottomRightRadius),
+            nameof(IStyle.flexGrow),
+            nameof(IStyle.flexShrink),
+            nameof(IStyle.flexBasis),
+            nameof(IStyle.flexDirection),
+            nameof(IStyle.flexWrap),
+            nameof(IStyle.alignSelf),
+            nameof(IStyle.alignItems),
+            nameof(IStyle.alignContent),
+            nameof(IStyle.justifyContent),
+            nameof(IStyle.position),
+            nameof(IStyle.left),
+            nameof(IStyle.right),
+            nameof(IStyle.top),
+            nameof(IStyle.bottom),
+            nameof(IStyle.fontSize),
+            nameof(IStyle.letterSpacing),
+            nameof(IStyle.unityFontDefinition),
+            nameof(IStyle.unityFontStyleAndWeight),
+            nameof(IStyle.unityTextAlign),
+            nameof(IStyle.whiteSpace),
+            nameof(IStyle.translate),
+            nameof(IStyle.rotate),
+            nameof(IStyle.scale),
+            nameof(IStyle.aspectRatio),
+            nameof(IStyle.filter),
+            nameof(IStyle.transformOrigin),
+            nameof(IStyle.transitionDuration),
+            nameof(IStyle.transitionDelay),
+            nameof(IStyle.transitionProperty),
+            nameof(IStyle.transitionTimingFunction),
+        };
+
+        [Test]
+        public void Given_EveryInlineStylePropertyWritten_When_ResetForReuse_Then_ScrubbedPropertiesMatchTheContractList()
+        {
+            // Arrange — write EVERY settable IStyle property as a real inline entry. StyleKeyword.Initial is
+            // the sentinel because it is distinguishable from the unset state (which reads back as
+            // StyleKeyword.Null), so "reads equal to a fresh element" after the reset means exactly "scrubbed".
+            // Obsolete properties are excluded: they are synthetic shims whose getters derive from the real
+            // background properties instead of owning storage, so they would always read equal to fresh.
+            var element = new VisualElement();
+            var fresh = new VisualElement();
+            // unityMaterial is also excluded: its inline getter returns StyleKeyword.Null whenever the
+            // stored material object is null, so a keyword-only sentinel cannot round-trip and the
+            // property is indistinguishable from fresh without a live Material. Velvet's styling layer
+            // never writes it inline.
+            var properties = typeof(IStyle).GetProperties()
+                .Where(p => p.CanWrite && !p.IsDefined(typeof(ObsoleteAttribute))
+                    && p.Name != nameof(IStyle.unityMaterial))
+                .ToArray();
+            var unsettable = new List<string>();
+            foreach (var property in properties)
+            {
+                var sentinel = MakeStyleValue(property.PropertyType, StyleKeyword.Initial);
+                if (sentinel == null)
+                {
+                    unsettable.Add(property.Name);
+                    continue;
+                }
+                property.SetValue(element.style, sentinel);
+            }
+            Assume.That(unsettable, Is.Empty, "Precondition: every IStyle property type accepts a StyleKeyword value");
+
+            // Act — the shared pool reset runs.
+            FiberElementPoolReset.ResetCommonState(element);
+
+            // Assert — the set of properties that read back indistinguishable from a fresh element equals the
+            // pinned contract list, in both directions.
+            // filter cannot read back equal to fresh on this editor: its setter clears the wrong internal
+            // has-inline flag on a Null assignment, so the reset instead empties the surviving list in
+            // place. An empty inline filter list computes to "no filter", so it counts as scrubbed.
+            var observedScrubbed = properties
+                .Where(p => Equals(p.GetValue(element.style), p.GetValue(fresh.style))
+                    || (p.Name == nameof(IStyle.filter)
+                        && element.style.filter.value is { Count: 0 }))
+                .Select(p => p.Name)
+                .ToArray();
+            var mismatches = ScrubbedInlineStyleProperties.Except(observedScrubbed)
+                .Select(name => $"not scrubbed by the reset (pool-reuse ghost): {name}")
+                .Concat(observedScrubbed.Except(ScrubbedInlineStyleProperties)
+                    .Select(name => $"scrubbed by the reset but missing from the contract list: {name}"))
+                .ToList();
+            Assert.That(mismatches, Is.Empty);
+        }
+
+        // Structural: the non-style common state ResetCommonState restores
+
+        private static readonly (string Name, Func<VisualElement, object> Read)[] CommonStateProbes =
+        {
+            ("userData", e => e.userData),
+            ("name", e => e.name),
+            ("tooltip", e => e.tooltip),
+            ("focusable", e => e.focusable),
+            ("pickingMode", e => e.pickingMode),
+            ("viewDataKey", e => e.viewDataKey),
+            ("enabledSelf", e => e.enabledSelf),
+        };
+
+        [Test]
+        public void Given_EveryCommonStateFieldMutated_When_ResetForReuse_Then_ElementMatchesAFreshInstance()
+        {
+            // Arrange — mutate every non-style field ResetCommonState claims to restore.
+            var element = new VisualElement
+            {
+                userData = new object(),
+                name = "stale-name",
+                tooltip = "stale-tooltip",
+                focusable = true,
+                pickingMode = PickingMode.Ignore,
+                viewDataKey = "stale-view-data",
+            };
+            element.SetEnabled(false);
+            var fresh = new VisualElement();
+
+            // Act
+            FiberElementPoolReset.ResetCommonState(element);
+
+            // Assert — every probed field reads identically to a freshly constructed element.
+            var mismatches = CommonStateProbes
+                .Where(probe => !Equals(probe.Read(element), probe.Read(fresh)))
+                .Select(probe => probe.Name)
+                .ToList();
+            Assert.That(mismatches, Is.Empty);
+        }
+
+        // Resolves a boxed style value carrying the given keyword for any IStyle property type. Every
+        // Unity style struct exposes either a StyleKeyword constructor or an implicit conversion from
+        // StyleKeyword; returns null when a (future) type exposes neither, surfacing it as unsettable.
+        //
+        // List-typed properties (StyleList<T>: filter, transition*) are the one exception: their
+        // StyleKeyword-only constructor stores a null backing List<T>. Unity's inline-style write path
+        // only reads that list when it is non-null (it clears/appends into it in place); when it is
+        // null it stores null on the underlying StyleValueManaged and defers to a copy-from-initial-style
+        // step that dereferences a per-element destination list which is not guaranteed to be allocated
+        // yet on a fresh, panel-less element — a NullReferenceException. Building a real (non-null)
+        // List<T> instead keeps the value in the safe, direct-store path while still reading back as
+        // "set" (distinguishable from a fresh element), so it still exercises the same reset contract.
+        private static object MakeStyleValue(Type styleType, StyleKeyword keyword)
+        {
+            if (styleType.IsGenericType && styleType.GetGenericTypeDefinition() == typeof(StyleList<>))
+            {
+                var elementType = styleType.GetGenericArguments()[0];
+                var listType = typeof(List<>).MakeGenericType(elementType);
+                var list = Activator.CreateInstance(listType);
+                listType.GetMethod("Add")!.Invoke(list, new[] { Activator.CreateInstance(elementType) });
+                var listCtor = styleType.GetConstructor(new[] { listType });
+                return listCtor?.Invoke(new[] { list });
+            }
+
+            var ctor = styleType.GetConstructor(new[] { typeof(StyleKeyword) });
+            if (ctor != null)
+            {
+                return ctor.Invoke(new object[] { keyword });
+            }
+
+            var implicitOperator = styleType.GetMethod(
+                "op_Implicit", BindingFlags.Public | BindingFlags.Static, binder: null,
+                new[] { typeof(StyleKeyword) }, modifiers: null);
+            return implicitOperator?.Invoke(null, new object[] { keyword });
         }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/PropsDiffTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/PropsDiffTests.cs
@@ -228,6 +228,36 @@ namespace Velvet.Tests
         }
 
         [Test]
+        public void Given_ChoicesClearedToNull_When_Patched_Then_DropdownChoicesEmptied()
+        {
+            // Arrange
+            var oldTree = new VNode[] { V.DropdownField(choices: new List<string> { "A", "B" }) };
+            var newTree = new VNode[] { V.DropdownField(choices: null) };
+            Reconciler.Reconcile(Root, Array.Empty<VNode>(), oldTree);
+
+            // Act
+            Reconciler.Reconcile(Root, oldTree, newTree);
+
+            // Assert
+            Assert.That(((DropdownField)Root.ElementAt(0)).choices, Is.Empty);
+        }
+
+        [Test]
+        public void Given_ChoicesClearedToNull_When_Patched_Then_RadioButtonGroupChoicesEmptied()
+        {
+            // Arrange
+            var oldTree = new VNode[] { V.RadioButtonGroup(choices: new List<string> { "A", "B" }) };
+            var newTree = new VNode[] { V.RadioButtonGroup(choices: null) };
+            Reconciler.Reconcile(Root, Array.Empty<VNode>(), oldTree);
+
+            // Act
+            Reconciler.Reconcile(Root, oldTree, newTree);
+
+            // Assert
+            Assert.That(((RadioButtonGroup)Root.ElementAt(0)).choices, Is.Empty);
+        }
+
+        [Test]
         public void Given_VerticalScrollerVisibilityChanged_When_Patched_Then_Applied()
         {
             // Arrange

--- a/Packages/com.velvet.core/Runtime/Routing/RouteLink.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/RouteLink.cs
@@ -47,7 +47,6 @@ namespace Velvet
         [Component]
         public static VNode Render(Props p)
         {
-            var navigate = Hooks.UseNavigate(p.Replace);
             var location = Hooks.UseLocation();
             var currentPath = location?.Path ?? string.Empty;
             var isActive = IsActive(currentPath, p.To, p.End, p.CaseSensitive);
@@ -56,16 +55,12 @@ namespace Velvet
                 ? string.IsNullOrEmpty(p.ClassName) ? p.ActiveClass : p.ClassName + " " + p.ActiveClass
                 : p.ClassName;
 
-            var onClick = Hooks.UseCallback<Action>(
-                () => navigate(p.To).Forget(),
-                p.To, navigate);
-
-            return V.Button(
-                className: className,
-                text: p.Text,
-                onClick: onClick,
-                name: p.Name,
-                children: p.Children);
+            // NavLink is Link plus active-state styling: derive the effective class from the current
+            // location, then delegate the click/navigate wiring to the Link component so the two can
+            // never drift.
+            return V.Component(
+                RouteLink.Render,
+                new RouteLink.Props(p.To, p.Text, className, p.Name, p.Children, p.Replace));
         }
 
         private static bool IsActive(string currentPath, string to, bool end, bool caseSensitive)
@@ -95,8 +90,7 @@ namespace Velvet
             {
                 return "/";
             }
-            var qIndex = path.IndexOf('?');
-            var stripped = qIndex < 0 ? path : path.Substring(0, qIndex);
+            var stripped = RouteQuery.StripQuery(path);
             if (stripped.Length > 1)
             {
                 stripped = stripped.TrimEnd('/');

--- a/Packages/com.velvet.core/Runtime/Routing/RouteQuery.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/RouteQuery.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Velvet
 {
@@ -49,6 +50,7 @@ namespace Velvet
         private static string DecodeQueryComponent(string component) =>
             Uri.UnescapeDataString(component.Replace('+', ' '));
 
+        [return: NotNullIfNotNull(nameof(path))]
         internal static string? StripQuery(string? path)
         {
             if (path == null)

--- a/Packages/com.velvet.core/Runtime/Routing/RouteTree.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/RouteTree.cs
@@ -145,7 +145,7 @@ namespace Velvet
                 yield break;
             }
 
-            var trimmed = path.TrimStart('/').TrimEnd('/');
+            var trimmed = TrimSlashes(path);
             if (trimmed.Length == 0)
             {
                 yield break;
@@ -239,14 +239,20 @@ namespace Velvet
         private static bool TryMatchBranch(RouteBranch branch, string[] segments, out List<RouteMatch>? matches)
         {
             matches = null;
-            var captured = new Dictionary<string, string>();
 
-            if (!TryConsume(branch.Pattern, 0, segments, 0, captured))
+            // The params dictionary is created lazily on the first param/splat capture: Match() probes
+            // every ranked branch until one succeeds, and most probes fail on a static segment before
+            // capturing anything, so an eager allocation per attempted branch would be pure waste.
+            Dictionary<string, string>? captured = null;
+
+            if (!TryConsume(branch.Pattern, 0, segments, 0, ref captured))
             {
                 return false;
             }
 
-            matches = BuildMatches(branch.Chain, captured);
+            // A paramless successful match still exposes a (shared, empty) dictionary at every level,
+            // preserving the pre-lazy contract that RouteMatch.Params is never null.
+            matches = BuildMatches(branch.Chain, captured ?? new Dictionary<string, string>());
             return true;
         }
 
@@ -256,7 +262,7 @@ namespace Velvet
         /// the remaining path tail.
         /// </summary>
         private static bool TryConsume(
-            List<RouteSegment>? pattern, int pi, string[] segments, int si, Dictionary<string, string> captured)
+            List<RouteSegment>? pattern, int pi, string[] segments, int si, ref Dictionary<string, string>? captured)
         {
             if (pattern == null) return false;
             while (pi < pattern.Count)
@@ -269,6 +275,7 @@ namespace Velvet
                     var rest = si >= segments.Length
                         ? string.Empty
                         : string.Join("/", segments, si, segments.Length - si);
+                    captured ??= new Dictionary<string, string>();
                     captured["*"] = rest;
                     return true;
                 }
@@ -282,18 +289,20 @@ namespace Velvet
                     {
                         var keyExisted = false;
                         string snap = "";
-                        if (seg.IsParam)
+                        if (seg.IsParam && captured != null)
                         {
                             keyExisted = captured.TryGetValue(seg.Value, out snap);
                         }
 
-                        if (TryMatchSingle(seg, segments[si], captured) &&
-                            TryConsume(pattern, pi + 1, segments, si + 1, captured))
+                        if (TryMatchSingle(seg, segments[si], ref captured) &&
+                            TryConsume(pattern, pi + 1, segments, si + 1, ref captured))
                         {
                             return true;
                         }
 
-                        if (seg.IsParam)
+                        // The failed "present" attempt may have been what created the dictionary, so
+                        // it can be non-null here even when the snapshot above saw null.
+                        if (seg.IsParam && captured != null)
                         {
                             if (keyExisted)
                             {
@@ -307,10 +316,10 @@ namespace Velvet
                     }
 
                     // Skip the optional segment without consuming a path segment.
-                    return TryConsume(pattern, pi + 1, segments, si, captured);
+                    return TryConsume(pattern, pi + 1, segments, si, ref captured);
                 }
 
-                if (si >= segments.Length || !TryMatchSingle(seg, segments[si], captured))
+                if (si >= segments.Length || !TryMatchSingle(seg, segments[si], ref captured))
                 {
                     return false;
                 }
@@ -323,10 +332,11 @@ namespace Velvet
             return si == segments.Length;
         }
 
-        private static bool TryMatchSingle(RouteSegment seg, string pathSeg, Dictionary<string, string> captured)
+        private static bool TryMatchSingle(RouteSegment seg, string pathSeg, ref Dictionary<string, string>? captured)
         {
             if (seg.IsParam)
             {
+                captured ??= new Dictionary<string, string>();
                 captured[seg.Value] = pathSeg;
                 return true;
             }
@@ -385,7 +395,7 @@ namespace Velvet
                 return string.Empty;
             }
 
-            var pattern = route.Path.TrimStart('/').TrimEnd('/');
+            var pattern = TrimSlashes(route.Path);
             var parts = pattern.Split('/', StringSplitOptions.RemoveEmptyEntries);
             var resolved = new List<string>(parts.Length);
 
@@ -442,7 +452,7 @@ namespace Velvet
                 return "/";
             }
 
-            var segment = route.Path?.TrimStart('/').TrimEnd('/') ?? string.Empty;
+            var segment = TrimSlashes(route.Path ?? string.Empty);
             if (parentId.Length == 0 || parentId == "/")
             {
                 return "/" + segment;
@@ -463,7 +473,7 @@ namespace Velvet
                 return "";
             }
 
-            return route.Path?.TrimStart('/').TrimEnd('/') ?? string.Empty;
+            return TrimSlashes(route.Path ?? string.Empty);
         }
 
         #endregion
@@ -475,8 +485,14 @@ namespace Velvet
                 return Array.Empty<string>();
             }
 
-            var trimmed = path.TrimStart('/').TrimEnd('/');
+            var trimmed = TrimSlashes(path);
             return trimmed.Length == 0 ? Array.Empty<string>() : trimmed.Split('/');
         }
+
+        /// <summary>
+        /// Canonical leading/trailing slash normalization shared by every pattern/path consumer in
+        /// this class. Interior slashes are preserved; segment splitting stays with each caller.
+        /// </summary>
+        private static string TrimSlashes(string path) => path.TrimStart('/').TrimEnd('/');
     }
 }

--- a/Packages/com.velvet.core/Runtime/Routing/Router.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/Router.cs
@@ -248,11 +248,7 @@ namespace Velvet
 
             // CurrentLocation.Path retains the query string; strip it before splitting so a "?..."
             // tail does not fold into a path segment and corrupt relative resolution.
-            var queryIndex = basePath.IndexOf('?');
-            if (queryIndex >= 0)
-            {
-                basePath = basePath.Substring(0, queryIndex);
-            }
+            basePath = RouteQuery.StripQuery(basePath);
 
             var baseSegments = new List<string>(
                 basePath.Trim('/').Split('/', StringSplitOptions.RemoveEmptyEntries));
@@ -328,8 +324,7 @@ namespace Velvet
             Status = RouterStatus.Matching;
             // Match against the path only; the query string (?key=value) is not part of route matching but
             // is preserved on CurrentLocation.Path so UseSearchParams can read it.
-            var queryIndex = path.IndexOf('?');
-            var pathForMatch = queryIndex < 0 ? path : path.Substring(0, queryIndex);
+            var pathForMatch = RouteQuery.StripQuery(path);
             var matches = _routeTree.Match(pathForMatch);
 
             if (matches == null)

--- a/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouteLinkTests.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouteLinkTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using NUnit.Framework;
 using UnityEngine.UIElements;
 using Velvet;
+using Velvet.TestUtilities;
 using static Velvet.Tests.RouteTestStubs;
 
 namespace Velvet.Tests
@@ -17,11 +18,13 @@ namespace Velvet.Tests
     /// <item>Active matching is case-insensitive by default (including the non-end sub-path form);
     /// <c>caseSensitive: true</c> opts into ordinal comparison so a different-case target is inactive while the
     /// same-case target stays active.</item>
+    /// <item>Clicking a <c>V.Link</c> or <c>V.NavLink</c> navigates via the active router.</item>
     /// </list>
     /// </summary>
     /// <remarks>
-    /// Click dispatch through a real panel is unreliable in EditMode, so these assert on the rendered structure
-    /// (button text and applied classes derived from the current location) rather than on navigation.
+    /// Click dispatch through a real panel is unreliable in EditMode, so structure tests assert on the rendered
+    /// output (button text and applied classes derived from the current location), and click tests drive the
+    /// button's callback registry directly via the synthetic-event helper instead of a panel.
     /// </remarks>
     [TestFixture]
     internal sealed class RouteLinkTests
@@ -60,6 +63,43 @@ namespace Velvet.Tests
             var button = FindButton(_root);
             Assume.That(button, Is.Not.Null, "Precondition: the link rendered a button");
             Assert.That(button!.text, Is.EqualTo("About"));
+        }
+
+        [Test]
+        public void Given_Link_When_Clicked_Then_NavigatesToTarget()
+        {
+            // Arrange — SimulateClick drives the button's callback registry directly, so the click
+            // path is exercisable without a live panel.
+            using var mounted = MountAt("/home", V.Link(to: "/home", text: "Home"));
+            var button = FindButton(_root);
+            Assume.That(button, Is.Not.Null, "Precondition: the link rendered a button");
+            var navigated = false;
+            Router.Current!.OnLocationChanged += _ => navigated = true;
+
+            // Act
+            button!.SimulateClick();
+
+            // Assert
+            Assert.That(navigated, Is.True, "A Link click navigates via the active router");
+        }
+
+        [Test]
+        public void Given_NavLink_When_Clicked_Then_NavigatesToTarget()
+        {
+            // NavLink delegates its click/navigate wiring to Link; a click must still navigate.
+            // Arrange
+            using var mounted = MountAt("/home",
+                V.NavLink(to: "/home", activeClass: "is-active", text: "Home"));
+            var button = FindButton(_root);
+            Assume.That(button, Is.Not.Null, "Precondition: the nav link rendered a button");
+            var navigated = false;
+            Router.Current!.OnLocationChanged += _ => navigated = true;
+
+            // Act
+            button!.SimulateClick();
+
+            // Assert
+            Assert.That(navigated, Is.True, "A NavLink click navigates via the active router");
         }
 
         [Test]

--- a/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouterTests.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouterTests.cs
@@ -1,10 +1,12 @@
 using System;
 using System.Collections;
+using System.Reflection;
 using System.Threading;
 using Cysharp.Threading.Tasks;
 using NUnit.Framework;
 using UnityEngine.TestTools;
 using Velvet;
+using Velvet.TestUtilities;
 using static Velvet.Tests.RouteTestStubs;
 
 namespace Velvet.Tests
@@ -18,6 +20,8 @@ namespace Velvet.Tests
     /// <see cref="RouteMatch.RouteId"/>.</item>
     /// <item>Each successful navigation pushes a history entry; GoBack/GoForward restore the previous/next
     /// location, and stepping past either end returns <see cref="NavigationResult.Cancelled"/>.</item>
+    /// <item>The history stack is FIFO-capped: pushing beyond the cap evicts the oldest entry while the
+    /// Back/Forward index keeps pointing at the same locations.</item>
     /// <item>GoBack/GoForward serve loader data and loader errors from the history cache without re-running the
     /// loader.</item>
     /// <item>A Suspend loader commits navigation immediately and resolves later; on resolution or failure the
@@ -252,6 +256,84 @@ namespace Velvet.Tests
 
             // Assert
             Assert.That(result, Is.EqualTo(NavigationResult.Cancelled));
+        }
+
+        #endregion
+
+        #region History FIFO cap
+
+        // The history cap is a private constant; read it via reflection so these tests stay in
+        // lockstep with the production value instead of hard-coding it.
+        private static int HistoryCap => (int)typeof(Router)
+            .GetField("MaxHistoryEntries", BindingFlags.NonPublic | BindingFlags.Static)
+            .GetRawConstantValue();
+
+        /// <summary>
+        /// Pushes one navigation more than the history cap ("/p1" .. "/p{cap+1}"), so the head
+        /// entry ("/p1") has been evicted and the router sits on the latest entry.
+        /// </summary>
+        private static Router BuildRouterAtCapOverflow(out string lastPath)
+        {
+            var router = new Router(new[] { Route(":page") });
+            var total = HistoryCap + 1;
+            for (var i = 1; i <= total; i++)
+            {
+                router.NavigateSync($"/p{i}");
+            }
+            lastPath = $"/p{total}";
+            return router;
+        }
+
+        [Test]
+        public void Given_PushesBeyondHistoryCap_When_GoBack_Then_LandsOnEntryBeforeLatest()
+        {
+            // Evicting the head shifts every entry down by one, so the history index must shift with
+            // it for a Back step to still land on the entry pushed immediately before the latest.
+            // Arrange
+            var router = BuildRouterAtCapOverflow(out var lastPath);
+            Assume.That(router.CurrentLocation.Path, Is.EqualTo(lastPath), "Precondition: the latest push committed");
+
+            // Act
+            router.GoBackSync();
+
+            // Assert
+            Assert.That(router.CurrentLocation.Path, Is.EqualTo($"/p{HistoryCap}"));
+        }
+
+        [Test]
+        public void Given_PushesBeyondHistoryCap_When_WalkingBackToStart_Then_OldestEntryWasEvicted()
+        {
+            // Arrange
+            var router = BuildRouterAtCapOverflow(out _);
+
+            // Act: walk to the oldest reachable entry (bounded so a broken CanGoBack cannot hang).
+            var steps = 0;
+            while (router.CanGoBack && steps++ < HistoryCap * 2)
+            {
+                router.GoBackSync();
+            }
+
+            // Assert: "/p1" was dropped by the FIFO cap, so the walk bottoms out on "/p2".
+            Assert.That(router.CurrentLocation.Path, Is.EqualTo("/p2"));
+        }
+
+        [Test]
+        public void Given_PushesBeyondHistoryCap_When_WalkingBackToStart_Then_HistoryCountIsCapped()
+        {
+            // Arrange
+            var router = BuildRouterAtCapOverflow(out _);
+
+            // Act: the number of possible Back steps observably measures the history length
+            // (bounded so a broken CanGoBack cannot hang).
+            var backSteps = 0;
+            while (router.CanGoBack && backSteps < HistoryCap * 2)
+            {
+                router.GoBackSync();
+                backSteps++;
+            }
+
+            // Assert: a capped history holds exactly the cap's worth of entries.
+            Assert.That(backSteps, Is.EqualTo(HistoryCap - 1));
         }
 
         #endregion
@@ -942,25 +1024,5 @@ namespace Velvet.Tests
         }
 
         #endregion
-
-        private sealed class TestRouteScopeFactory : IRouteScopeFactory
-        {
-            public int CreateScopeCount { get; private set; }
-
-            public IRouteScope CreateScope(RouteDefinition? route, IRouteScope? parent)
-            {
-                CreateScopeCount++;
-                return new TestRouteScope();
-            }
-        }
-
-        private sealed class TestRouteScope : IRouteScope
-        {
-            public bool IsDisposed { get; private set; }
-
-            public T Resolve<T>() => throw new NotImplementedException();
-
-            public void Dispose() => IsDisposed = true;
-        }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Store/Tests/Editor/StoreTests.cs
+++ b/Packages/com.velvet.core/Runtime/Store/Tests/Editor/StoreTests.cs
@@ -20,8 +20,6 @@ namespace Velvet.Tests.Editor
     /// <item><c>Subscribe</c> delivers each subsequent state, optionally firing immediately with the current value;
     /// its (current, previous) overload pairs each state with the one before it. A null listener is rejected.</item>
     /// <item>Disposing runs subclass dispose logic exactly once and cancels the store's cancellation token.</item>
-    /// <item>A keyed async operation under the Drop policy ignores a concurrent same-key call; under the Switch
-    /// policy it cancels the running same-key call. Distinct keys run independently.</item>
     /// <item><c>Reset</c> returns the state to its initial value.</item>
     /// </list>
     /// </summary>

--- a/Packages/com.velvet.core/Runtime/Styling/DropShadowBaker.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/DropShadowBaker.cs
@@ -203,7 +203,7 @@ namespace Velvet
             {
                 if (existing != null && existing != tex)
                 {
-                    Object.DestroyImmediate(existing);
+                    VelvetObjectUtil.Destroy(existing);
                 }
                 s_silhouetteCache[key] = tex;
                 TouchSilhouette(key);
@@ -221,7 +221,7 @@ namespace Velvet
                     s_silhouetteCache.Remove(oldest);
                     if (evicted != null)
                     {
-                        Object.DestroyImmediate(evicted);
+                        VelvetObjectUtil.Destroy(evicted);
                     }
                 }
             }

--- a/Packages/com.velvet.core/Runtime/Styling/StyleCompoundVariantMatcher.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleCompoundVariantMatcher.cs
@@ -5,22 +5,9 @@ namespace Velvet
     // Shared matching logic for StyleRecipe.CompoundVariant / StyleSlotRecipe.SlotCompoundVariant.
     internal static class StyleCompoundVariantMatcher
     {
-        // Returns whether every entry in conditions matches the corresponding entry in selected.
-        public static bool Matches(Dictionary<string, string> conditions, Dictionary<string, string> selected)
-        {
-            foreach (var (axis, value) in conditions)
-            {
-                if (!selected.TryGetValue(axis, out var selectedValue) || selectedValue != value)
-                {
-                    return false;
-                }
-            }
-
-            return true;
-        }
-
-        // Array-based matching (allocation-free variant for reducing GC pressure).
-        public static bool MatchesArray(Dictionary<string, string> conditions, (string axis, string value)[] selections, int count)
+        // Returns whether every entry in conditions matches the corresponding selection
+        // (allocation-free: selections is a deduped array scanned linearly).
+        public static bool Matches(Dictionary<string, string> conditions, (string axis, string value)[] selections, int count)
         {
             foreach (var (axis, value) in conditions)
             {

--- a/Packages/com.velvet.core/Runtime/Styling/StyleGestureClassManipulator.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleGestureClassManipulator.cs
@@ -5,13 +5,13 @@ namespace Velvet
 {
     // Manipulator that toggles CSS classes dynamically in response to pointer / focus events,
     // driving the whileHover / whileTap / whileFocus gesture classes.
-    // whileFocus uses the element's own FocusEvent / BlurEvent
-    // (only focusable elements — buttons, fields — ever fire them).
-    // Note: in multi-touch environments, only the first pointer is tracked (single-pointer assumption).
-    // Hover uses the bubbling PointerOverEvent/PointerOutEvent pair (which trickle
-    // down and bubble up) so a pointer over a descendant still counts as hovering this element, matching CSS
-    // :hover; the non-bubbling PointerEnter/PointerLeave only fire on the element itself.
-    // PointerOut clears hover only once the pointer leaves this element's bounds.
+    // Mirrors StyleVariantManipulator's lifecycle: element-local interaction detection (the bubbling
+    // PointerOut worldBound check, the hover/active/focus edge bookkeeping, the single-pointer assumption)
+    // is owned by ElementLocalVariantSignals so this manipulator and StyleVariantManipulator cannot drift on
+    // that detection logic; this class only maps each signal edge to its gesture class array.
+    // whileFocus uses the element's own Focus signal (backed by FocusEvent / BlurEvent — only focusable
+    // elements — buttons, fields — ever trigger it). whileTap maps to the Active signal (pointer-down /
+    // pointer-up / pointer-cancel / release-outside-bounds).
     internal sealed class StyleGestureClassManipulator : Manipulator
     {
         private string[] _hoverClasses;
@@ -20,6 +20,10 @@ namespace Velvet
         private bool _isHovered;
         private bool _isTapped;
         private bool _isFocused;
+
+        // Owns the element-local signal detection (pointer/focus edges, worldBound bubbling); this
+        // manipulator keeps only the per-state gesture-class bookkeeping below.
+        private ElementLocalVariantSignals _signals = null!;
 
         public StyleGestureClassManipulator(string[] hoverClasses, string[] tapClasses, string[] focusClasses)
         {
@@ -63,13 +67,10 @@ namespace Velvet
 
         protected override void RegisterCallbacksOnTarget()
         {
-            target.RegisterCallback<PointerOverEvent>(OnPointerOver);
-            target.RegisterCallback<PointerOutEvent>(OnPointerOut);
-            target.RegisterCallback<PointerDownEvent>(OnPointerDown);
-            target.RegisterCallback<PointerUpEvent>(OnPointerUp);
-            target.RegisterCallback<PointerCancelEvent>(OnPointerCancel);
-            target.RegisterCallback<FocusEvent>(OnFocus);
-            target.RegisterCallback<BlurEvent>(OnBlur);
+            _signals ??= new ElementLocalVariantSignals(OnSignal);
+            // No checked: signal here — gesture classes have no while-checked concept, so the ChangeEvent
+            // registration stays off (matching the original hand-rolled wiring's event set).
+            _signals.Hook(target, seedChecked: false, registerChecked: false);
         }
 
         protected override void UnregisterCallbacksFromTarget()
@@ -93,99 +94,52 @@ namespace Velvet
             _isTapped = false;
             _isFocused = false;
 
-            target.UnregisterCallback<PointerOverEvent>(OnPointerOver);
-            target.UnregisterCallback<PointerOutEvent>(OnPointerOut);
-            target.UnregisterCallback<PointerDownEvent>(OnPointerDown);
-            target.UnregisterCallback<PointerUpEvent>(OnPointerUp);
-            target.UnregisterCallback<PointerCancelEvent>(OnPointerCancel);
-            target.UnregisterCallback<FocusEvent>(OnFocus);
-            target.UnregisterCallback<BlurEvent>(OnBlur);
+            _signals?.Unhook();
         }
 
-        private void OnPointerOver(PointerOverEvent evt)
+        // Maps a detected element-local signal edge to its gesture class array, deduping on the per-state
+        // bookkeeping (the source does not dedup) so a repeated edge does not churn the class list. Active
+        // maps to whileTap (pointer-down/-up/-cancel/release-outside-bounds) and Focus maps to whileFocus
+        // (plain FocusEvent/BlurEvent, not the focus-visible distinction); FocusVisible/Checked are not used
+        // by gesture classes and fall through the switch untouched.
+        private void OnSignal(VariantSignal signal, bool on)
         {
-            if (_isHovered)
+            switch (signal)
             {
-                return;
-            }
-
-            _isHovered = true;
-            StyleAnimationClassUtils.AddClasses(target, _hoverClasses);
-        }
-
-        private void OnPointerOut(PointerOutEvent evt)
-        {
-            // PointerOut bubbles; while the pointer merely crosses between descendants it is still inside us,
-            // so only treat it as a real leave once the pointer is outside our bounds.
-            if (target.worldBound.Contains(evt.position))
-            {
-                return;
-            }
-
-            if (_isHovered)
-            {
-                _isHovered = false;
-                StyleAnimationClassUtils.RemoveClasses(target, _hoverClasses);
-            }
-
-            if (_isTapped)
-            {
-                _isTapped = false;
-                StyleAnimationClassUtils.RemoveClasses(target, _tapClasses);
+                case VariantSignal.Hover:
+                    if (on != _isHovered)
+                    {
+                        _isHovered = on;
+                        ToggleClasses(_hoverClasses, on);
+                    }
+                    break;
+                case VariantSignal.Active:
+                    if (on != _isTapped)
+                    {
+                        _isTapped = on;
+                        ToggleClasses(_tapClasses, on);
+                    }
+                    break;
+                case VariantSignal.Focus:
+                    if (on != _isFocused)
+                    {
+                        _isFocused = on;
+                        ToggleClasses(_focusClasses, on);
+                    }
+                    break;
             }
         }
 
-        private void OnPointerDown(PointerDownEvent evt)
+        private void ToggleClasses(string[] classes, bool on)
         {
-            if (_isTapped)
+            if (on)
             {
-                return;
+                StyleAnimationClassUtils.AddClasses(target, classes);
             }
-
-            _isTapped = true;
-            StyleAnimationClassUtils.AddClasses(target, _tapClasses);
-        }
-
-        private void OnPointerUp(PointerUpEvent evt)
-        {
-            if (!_isTapped)
+            else
             {
-                return;
+                StyleAnimationClassUtils.RemoveClasses(target, classes);
             }
-
-            _isTapped = false;
-            StyleAnimationClassUtils.RemoveClasses(target, _tapClasses);
-        }
-
-        private void OnPointerCancel(PointerCancelEvent evt)
-        {
-            if (_isTapped)
-            {
-                _isTapped = false;
-                StyleAnimationClassUtils.RemoveClasses(target, _tapClasses);
-            }
-        }
-
-        private void OnFocus(FocusEvent evt)
-        {
-            if (_isFocused)
-            {
-                return;
-            }
-
-            _isFocused = true;
-            StyleAnimationClassUtils.AddClasses(target, _focusClasses);
-        }
-
-        private void OnBlur(BlurEvent evt)
-        {
-            if (!_isFocused)
-            {
-                return;
-            }
-
-            _isFocused = false;
-            StyleAnimationClassUtils.RemoveClasses(target, _focusClasses);
         }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Styling/StyleGradientClass.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleGradientClass.cs
@@ -148,8 +148,35 @@ namespace Velvet
         private const string ViaPrefix = "via-";
         private const string ToPrefix = "to-";
 
-        // Cheap early-out gate: true when ANY class is a gradient shape activator. No allocation — used to
-        // skip the full TryExtract on the ~99% of elements with no gradient.
+        // The one activator shape that accepts a leading '-' for a negative numeric angle
+        // (TryParseAngle strips it before matching LinearActivator; the -to- alias never accepts it).
+        private const string NegativeLinearActivator = "-" + LinearActivator;
+        private const string RadialArbitraryActivator = RadialActivator + "-[";
+        private const string ConicSuffixActivator = ConicActivator + "-";
+
+        // Cheap prefix/equality table for gradient shape activators, shared by the gate and the parser
+        // so the two can never drift apart: TryParseActivator consults this SAME table as its first
+        // check, which makes "parser-accepts implies gate-accepts" hold by construction rather than by
+        // the two being kept in sync by hand. Radial/conic must stay plain StartsWith: the bare
+        // activator may carry a trailing /interp modifier ("bg-radial/oklab"), which an equality check
+        // would miss.
+        private static bool MatchesActivatorPrefix(string cls)
+        {
+            return cls.StartsWith(DirActivator, StringComparison.Ordinal)
+                || cls.StartsWith(LinearActivator, StringComparison.Ordinal)
+                || cls.StartsWith(NegativeLinearActivator, StringComparison.Ordinal)
+                || cls.StartsWith(RadialActivator, StringComparison.Ordinal)
+                || cls.StartsWith(ConicActivator, StringComparison.Ordinal);
+        }
+
+        // Cheap early-out gate: true when ANY class LOOKS LIKE a gradient shape activator. A pure
+        // prefix scan — no substring allocation, no angle/position parsing — so it never
+        // duplicates TryExtract's parse cost. May false-positive on a malformed activator (e.g. an
+        // unrecognized /modifier or an out-of-range value), which TryExtract then correctly rejects.
+        // It never false-negatives on anything TryExtract can actually resolve BY CONSTRUCTION:
+        // TryParseActivator's first check is this same MatchesActivatorPrefix, so a class TryExtract
+        // can parse always already looked like an activator here. Used to skip the full TryExtract on
+        // the ~99% of elements with no gradient.
         public static bool HasGradientClass(string[] classNames)
         {
             if (classNames == null)
@@ -158,7 +185,11 @@ namespace Velvet
             }
             foreach (var cls in classNames)
             {
-                if (!string.IsNullOrEmpty(cls) && TryParseActivator(cls, out _, out _, out _, out _, out _))
+                if (string.IsNullOrEmpty(cls))
+                {
+                    continue;
+                }
+                if (MatchesActivatorPrefix(cls))
                 {
                     return true;
                 }
@@ -247,6 +278,15 @@ namespace Velvet
             centerY = 0.5f;
             interp = GradientInterp.Srgb;
 
+            // Must pass the gate's own prefix table before any parsing: this is what makes the shapes
+            // this method accepts a structural SUBSET of what HasGradientClass matches, so a shape added
+            // here without also widening MatchesActivatorPrefix simply cannot parse (loud), instead of
+            // parsing while the gate silently skips it (the false-negative this guards against).
+            if (!MatchesActivatorPrefix(cls))
+            {
+                return false;
+            }
+
             // Split off a trailing /interp modifier (the gradient interpolation modifier).
             var baseTok = cls;
             var slash = cls.IndexOf('/');
@@ -267,7 +307,7 @@ namespace Velvet
                 type = GradientType.Radial;
                 return true;
             }
-            if (baseTok.StartsWith(RadialActivator + "-[", StringComparison.Ordinal) && baseTok[baseTok.Length - 1] == ']')
+            if (baseTok.StartsWith(RadialArbitraryActivator, StringComparison.Ordinal) && baseTok[baseTok.Length - 1] == ']')
             {
                 type = GradientType.Radial;
                 ParseRadialPosition(baseTok.Substring(RadialActivator.Length + 2, baseTok.Length - RadialActivator.Length - 3),
@@ -279,7 +319,7 @@ namespace Velvet
                 type = GradientType.Conic;
                 return true;
             }
-            if (baseTok.StartsWith(ConicActivator + "-", StringComparison.Ordinal))
+            if (baseTok.StartsWith(ConicSuffixActivator, StringComparison.Ordinal))
             {
                 type = GradientType.Conic;
                 return TryParseConicStart(baseTok.Substring(ConicActivator.Length + 1), out angle);

--- a/Packages/com.velvet.core/Runtime/Styling/StyleRecipe.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleRecipe.cs
@@ -154,7 +154,7 @@ namespace Velvet
 
             /// <summary>Linear-scan matching against a deduped selections array (no per-call allocation).</summary>
             public bool Matches((string axis, string value)[] selections, int count)
-                => StyleCompoundVariantMatcher.MatchesArray(Conditions, selections, count);
+                => StyleCompoundVariantMatcher.Matches(Conditions, selections, count);
         }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Styling/StyleSlotRecipe.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleSlotRecipe.cs
@@ -40,34 +40,58 @@ namespace Velvet
 
         private StyleSlotClasses ApplyInternal((string axis, string value)[] selections)
         {
-            var selected = new Dictionary<string, string>(selections.Length);
+            // Dedup selections to last-write-wins per axis, keeping each axis at its FIRST-occurrence
+            // position (matching what the previous `selected[axis] = value` Dictionary-assignment loop
+            // produced), then fill in defaultVariants for any axis still unselected. A linear scan over a
+            // small array avoids the Dictionary allocation, mirroring StyleRecipe's deduped-array approach.
+            var defaultCount = _defaultVariants?.Count ?? 0;
+            var selected = new (string axis, string value)[selections.Length + defaultCount];
+            var selectedCount = 0;
+
             foreach (var (axis, value) in selections)
             {
-                selected[axis] = value;
+                var existing = IndexOfAxis(selected, selectedCount, axis);
+                if (existing >= 0)
+                {
+                    selected[existing] = (axis, value);
+                }
+                else
+                {
+                    selected[selectedCount++] = (axis, value);
+                }
             }
 
             if (_defaultVariants != null)
             {
                 foreach (var (axis, defaultValue) in _defaultVariants)
                 {
-                    selected.TryAdd(axis, defaultValue);
+                    if (IndexOfAxis(selected, selectedCount, axis) < 0)
+                    {
+                        selected[selectedCount++] = (axis, defaultValue);
+                    }
                 }
             }
 
-            // Build class names per slot (precompute loop-invariant values).
-            var variantCount = _variants != null ? selected.Count : 0;
+            // Build class names per slot (precompute loop-invariant values). parts is sized once to the
+            // shared upper bound and reused across slots instead of allocating a fresh array per slot; a
+            // slot that fills fewer entries than a previous one has its unused tail cleared before
+            // StyleClassNames.Class (which reads the whole array) runs, so no stale entry from an earlier
+            // slot can leak into a later one.
+            var variantCount = _variants != null ? selectedCount : 0;
             var compoundCount = _compoundVariants?.Length ?? 0;
+            var capacity = 1 + variantCount + compoundCount;
+            var parts = new string?[capacity];
             var result = new Dictionary<string, string>(_baseSlots.Count);
             foreach (var (slot, baseClass) in _baseSlots)
             {
-                var parts = new string?[1 + variantCount + compoundCount];
                 var idx = 0;
                 parts[idx++] = baseClass;
 
                 if (_variants != null)
                 {
-                    foreach (var (axis, value) in selected)
+                    for (var i = 0; i < selectedCount; i++)
                     {
+                        var (axis, value) = selected[i];
                         if (_variants.TryGetValue(axis, out var axisSlots) &&
                             axisSlots.TryGetValue(value, out var slotOverrides) &&
                             slotOverrides.TryGetValue(slot, out var classes))
@@ -81,7 +105,7 @@ namespace Velvet
                 {
                     foreach (var compound in _compoundVariants)
                     {
-                        if (compound.Matches(selected) &&
+                        if (compound.Matches(selected, selectedCount) &&
                             compound.SlotClasses.TryGetValue(slot, out var compoundClass))
                         {
                             parts[idx++] = compoundClass;
@@ -89,10 +113,29 @@ namespace Velvet
                     }
                 }
 
+                if (idx < capacity)
+                {
+                    System.Array.Clear(parts, idx, capacity - idx);
+                }
+
                 result[slot] = StyleClassNames.Class(parts) ?? "";
             }
 
             return new StyleSlotClasses(result);
+        }
+
+        // Linear scan for the first `count` entries of selected — small enough (bounded by the number of
+        // axes a single Apply() call selects) that this stays cheaper than a Dictionary for the dedup pass.
+        private static int IndexOfAxis((string axis, string value)[] selected, int count, string axis)
+        {
+            for (var i = 0; i < count; i++)
+            {
+                if (selected[i].axis == axis)
+                {
+                    return i;
+                }
+            }
+            return -1;
         }
 
         /// <summary>Adds classes to slots when a compound condition matches.</summary>
@@ -113,8 +156,9 @@ namespace Velvet
                 SlotClasses = slotClasses;
             }
 
-            public bool Matches(Dictionary<string, string> selected)
-                => StyleCompoundVariantMatcher.Matches(Conditions, selected);
+            /// <summary>Linear-scan matching against a deduped selections array (no per-call allocation).</summary>
+            public bool Matches((string axis, string value)[] selected, int count)
+                => StyleCompoundVariantMatcher.Matches(Conditions, selected, count);
         }
     }
 

--- a/Packages/com.velvet.core/Runtime/Styling/StyleVariantPayload.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleVariantPayload.cs
@@ -47,9 +47,7 @@ namespace Velvet
                 }
                 var effectivePriority = important ? StyleLayerPriority.Important : priority;
 
-                if ((core.IndexOf('[') >= 0
-                        || StyleColorValueParser.HasColorOpacityModifier(core)
-                        || StyleArbitraryValueResolver.MayBeStaticScale(core))
+                if (StyleArbitraryValueResolver.IsInlineResolved(core)
                     && StyleArbitraryValueResolver.TryParse(core, out var style))
                 {
                     if (on)

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/DropShadowSilhouetteCacheTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/DropShadowSilhouetteCacheTests.cs
@@ -55,5 +55,37 @@ namespace Velvet.Tests
             Assert.That((CacheCount <= cap, CacheCount == LruCount, LruCount == NodesCount),
                 Is.EqualTo((true, true, true)));
         }
+
+        [Test]
+        public void Given_OverwritingAnExistingKey_When_Stored_Then_ThePreviousTextureIsDestroyed()
+        {
+            // Arrange — store a texture at a key, keeping the reference to check its lifetime.
+            var previous = new Texture2D(2, 2);
+            Store(0, previous);
+
+            // Act — re-store the same key with a different texture (StoreSilhouette's overwrite path).
+            Store(0, new Texture2D(2, 2));
+
+            // Assert — the overwritten texture was destroyed (Unity's fake-null on a destroyed Object).
+            Assert.That(previous == null, Is.True);
+        }
+
+        [Test]
+        public void Given_TheLeastRecentlyUsedEntry_When_EvictedPastTheCap_Then_ItsTextureIsDestroyed()
+        {
+            // Arrange — the first-stored key becomes least-recently-used and is the first evicted past the cap.
+            var cap = Cap;
+            var oldest = new Texture2D(2, 2);
+            Store(0, oldest);
+
+            // Act — store past the cap so the oldest entry is evicted (StoreSilhouette's LRU-eviction path).
+            for (var i = 1; i <= cap; i++)
+            {
+                Store(i, new Texture2D(2, 2));
+            }
+
+            // Assert — the evicted texture was destroyed (Unity's fake-null on a destroyed Object).
+            Assert.That(oldest == null, Is.True);
+        }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/GestureClassManipulatorTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/GestureClassManipulatorTests.cs
@@ -233,6 +233,120 @@ namespace Velvet.Tests
 
         #endregion
 
+        #region Signal-Driven Edge Detection (ElementLocalVariantSignals wiring)
+
+        [Test]
+        public void Given_UnhoveredElement_When_PointerOverFires_Then_HoverClassIsApplied()
+        {
+            // Arrange
+            var manipulator = new StyleGestureClassManipulator(new[] { "hover-glow" }, Array.Empty<string>(), Array.Empty<string>());
+            _element.AddManipulator(manipulator);
+            Assume.That(_element.ClassListContains("hover-glow"), Is.False, "Precondition: hover class not yet applied");
+
+            // Act
+            using (var evt = PointerOverEvent.GetPooled()) _element.SimulateEvent(evt);
+
+            // Assert
+            Assert.That(_element.ClassListContains("hover-glow"), Is.True);
+        }
+
+        [Test]
+        public void Given_HoveredElement_When_PointerLeavesItsBounds_Then_HoverClassIsRemoved()
+        {
+            // Arrange — a detached element's worldBound is Rect.zero, so a default-position PointerOut never
+            // reads as "still inside" and is treated as a real leave.
+            var manipulator = new StyleGestureClassManipulator(new[] { "hover-glow" }, Array.Empty<string>(), Array.Empty<string>());
+            _element.AddManipulator(manipulator);
+            using (var over = PointerOverEvent.GetPooled()) _element.SimulateEvent(over);
+            Assume.That(_element.ClassListContains("hover-glow"), Is.True, "Precondition: hover class applied while hovered");
+
+            // Act
+            using (var evt = PointerOutEvent.GetPooled()) _element.SimulateEvent(evt);
+
+            // Assert
+            Assert.That(_element.ClassListContains("hover-glow"), Is.False);
+        }
+
+        [Test]
+        public void Given_UntappedElement_When_PointerDownFires_Then_TapClassIsApplied()
+        {
+            // Arrange
+            var manipulator = new StyleGestureClassManipulator(Array.Empty<string>(), new[] { "tap-shrink" }, Array.Empty<string>());
+            _element.AddManipulator(manipulator);
+            Assume.That(_element.ClassListContains("tap-shrink"), Is.False, "Precondition: tap class not yet applied");
+
+            // Act
+            using (var evt = PointerDownEvent.GetPooled()) _element.SimulateEvent(evt);
+
+            // Assert
+            Assert.That(_element.ClassListContains("tap-shrink"), Is.True);
+        }
+
+        [Test]
+        public void Given_TappedElement_When_PointerUpFires_Then_TapClassIsRemoved()
+        {
+            // Arrange
+            var manipulator = new StyleGestureClassManipulator(Array.Empty<string>(), new[] { "tap-shrink" }, Array.Empty<string>());
+            _element.AddManipulator(manipulator);
+            using (var down = PointerDownEvent.GetPooled()) _element.SimulateEvent(down);
+            Assume.That(_element.ClassListContains("tap-shrink"), Is.True, "Precondition: tap class applied while pressed");
+
+            // Act
+            using (var evt = PointerUpEvent.GetPooled()) _element.SimulateEvent(evt);
+
+            // Assert
+            Assert.That(_element.ClassListContains("tap-shrink"), Is.False);
+        }
+
+        [Test]
+        public void Given_TappedElement_When_PointerIsCancelled_Then_TapClassIsRemoved()
+        {
+            // Arrange — a cancelled gesture (e.g. an OS-level interruption) ends the tap state just like a release.
+            var manipulator = new StyleGestureClassManipulator(Array.Empty<string>(), new[] { "tap-shrink" }, Array.Empty<string>());
+            _element.AddManipulator(manipulator);
+            using (var down = PointerDownEvent.GetPooled()) _element.SimulateEvent(down);
+            Assume.That(_element.ClassListContains("tap-shrink"), Is.True, "Precondition: tap class applied while pressed");
+
+            // Act
+            using (var evt = PointerCancelEvent.GetPooled()) _element.SimulateEvent(evt);
+
+            // Assert
+            Assert.That(_element.ClassListContains("tap-shrink"), Is.False);
+        }
+
+        [Test]
+        public void Given_UnfocusedElement_When_FocusEventFires_Then_FocusClassIsApplied()
+        {
+            // Arrange
+            var manipulator = new StyleGestureClassManipulator(Array.Empty<string>(), Array.Empty<string>(), new[] { "focus-ring" });
+            _element.AddManipulator(manipulator);
+            Assume.That(_element.ClassListContains("focus-ring"), Is.False, "Precondition: focus class not yet applied");
+
+            // Act
+            using (var evt = FocusEvent.GetPooled()) _element.SimulateEvent(evt);
+
+            // Assert
+            Assert.That(_element.ClassListContains("focus-ring"), Is.True);
+        }
+
+        [Test]
+        public void Given_FocusedElement_When_BlurEventFires_Then_FocusClassIsRemoved()
+        {
+            // Arrange
+            var manipulator = new StyleGestureClassManipulator(Array.Empty<string>(), Array.Empty<string>(), new[] { "focus-ring" });
+            _element.AddManipulator(manipulator);
+            using (var focus = FocusEvent.GetPooled()) _element.SimulateEvent(focus);
+            Assume.That(_element.ClassListContains("focus-ring"), Is.True, "Precondition: focus class applied while focused");
+
+            // Act
+            using (var evt = BlurEvent.GetPooled()) _element.SimulateEvent(evt);
+
+            // Assert
+            Assert.That(_element.ClassListContains("focus-ring"), Is.False);
+        }
+
+        #endregion
+
         #region ParseClassNames
 
         [Test]

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/GradientClassParityTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/GradientClassParityTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using NUnit.Framework;
 using UnityEngine;
 
@@ -290,11 +291,60 @@ namespace Velvet.Tests
         }
 
         [Test]
-        public void Given_UnknownInterpModifier_When_Gated_Then_NotAGradient()
+        public void Given_UnknownInterpModifier_When_GatedThenExtracted_Then_NotAGradient()
         {
-            // An unknown /modifier makes the activator unrecognized (no valid utility would emit it).
-            var has = StyleGradientClass.HasGradientClass(new[] { "bg-linear-to-r/bogus", "from-[#ff0000]" });
-            Assert.That(has, Is.False);
+            // An unknown /modifier makes the activator unrecognized (no valid utility would emit it). The
+            // cheap gate is a prefix scan and may false-positive on this (it does not parse the /modifier),
+            // so the real contract — mirroring every call site's `Has(...) && TryExtract(...)` — is that the
+            // combination still resolves to "not a gradient".
+            var classNames = new[] { "bg-linear-to-r/bogus", "from-[#ff0000]" };
+            var resolved = StyleGradientClass.HasGradientClass(classNames)
+                && StyleGradientClass.TryExtract(classNames, out _);
+            Assert.That(resolved, Is.False);
+        }
+
+        [Test]
+        public void Given_NegativeBgLinearArbitrary_When_Gated_Then_HasGradientIsTrue()
+        {
+            // -bg-linear-[30deg] is a valid negative-angle activator (TryExtract parses it, see the
+            // "TheAngleIsNegative" test above). The cheap gate must not false-negative on it just because
+            // the class starts with '-' rather than the plain "bg-linear-" prefix.
+            var has = StyleGradientClass.HasGradientClass(
+                new[] { "-bg-linear-[30deg]", "from-[#ff0000]", "to-[#0000ff]" });
+            Assert.That(has, Is.True);
+        }
+
+        [Test]
+        public void Given_BareRadialWithInterpModifier_When_Gated_Then_HasGradientIsTrue()
+        {
+            // bg-radial/oklab is a valid activator: the /interp modifier rides on the bare radial
+            // token, so a gate comparing the whole class for equality with "bg-radial" would
+            // false-negative and silently skip the gradient.
+            var has = StyleGradientClass.HasGradientClass(
+                new[] { "bg-radial/oklab", "from-[#ff0000]", "to-[#0000ff]" });
+            Assert.That(has, Is.True);
+        }
+
+        [Test]
+        public void Given_AClassRejectedByTheSharedPrefixTable_When_Extracted_Then_TryExtractAlsoRejectsIt()
+        {
+            // Arrange — reach the private shared prefix table by reflection (the repo's pattern for pinning
+            // a private internal). TryParseActivator's first line is a hard call to this exact predicate, so
+            // a class it rejects can never reach TryExtract as a shape axis — this is what keeps the gate
+            // (HasGradientClass) and the parser (TryParseActivator) from drifting into two independently
+            // maintained enumerations of accepted shapes.
+            var matchesActivatorPrefix = typeof(StyleGradientClass).GetMethod(
+                "MatchesActivatorPrefix", BindingFlags.NonPublic | BindingFlags.Static);
+            const string notAShapeActivator = "bg-not-a-real-shape";
+            Assume.That((bool)matchesActivatorPrefix.Invoke(null, new object[] { notAShapeActivator }), Is.False,
+                "Precondition: the crafted class fails the shared prefix table");
+
+            // Act — the same class, alongside a from/to stop, through the public extraction path.
+            var ok = StyleGradientClass.TryExtract(
+                new[] { notAShapeActivator, "from-[#ff0000]", "to-[#0000ff]" }, out _);
+
+            // Assert
+            Assert.That(ok, Is.False);
         }
 
         [Test]

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/StyleSlotRecipeTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/StyleSlotRecipeTests.cs
@@ -247,5 +247,57 @@ namespace Velvet.Tests
             // Act + Assert
             Assert.That(s["anything"], Is.EqualTo(""));
         }
+
+        [Test]
+        public void Given_AnEarlierSlotWithMoreOverrides_When_ALaterSlotFillsFewer_Then_TheLaterSlotDoesNotInheritTheEarlierSlotsClasses()
+        {
+            // Arrange — the root slot is targeted by both axes while the title slot is targeted by neither,
+            // so a per-slot class buffer reused across slots would carry root's overrides into title unless
+            // its unused tail is scrubbed between slots.
+            var sut = new StyleSlotRecipe(
+                new Dictionary<string, string>
+                {
+                    ["root"] = "base-root",
+                    ["title"] = "base-title",
+                },
+                new Dictionary<string, Dictionary<string, Dictionary<string, string>>>
+                {
+                    ["size"] = new() { ["lg"] = new() { ["root"] = "p-8" } },
+                    ["color"] = new() { ["red"] = new() { ["root"] = "bg-red" } },
+                });
+
+            // Act
+            var s = sut.Apply(("size", "lg"), ("color", "red"));
+
+            // Assert — title resolves to its base class only, with no ghost of root's p-8 / bg-red.
+            Assert.That(s["title"], Is.EqualTo("base-title"));
+        }
+
+        [Test]
+        public void Given_ADefaultForASelectedAxis_When_Applied_Then_TheExplicitSelectionWinsOverTheDefault()
+        {
+            // Arrange — the theme axis is both explicitly selected AND carries a default, so the default
+            // must be skipped rather than appended as a second value for the same axis.
+            var sut = new StyleSlotRecipe(
+                new Dictionary<string, string>
+                {
+                    ["root"] = "base",
+                },
+                new Dictionary<string, Dictionary<string, Dictionary<string, string>>>
+                {
+                    ["theme"] = new()
+                    {
+                        ["dark"] = new() { ["root"] = "bg-black" },
+                        ["light"] = new() { ["root"] = "bg-white" },
+                    }
+                },
+                defaultVariants: new Dictionary<string, string> { ["theme"] = "dark" });
+
+            // Act
+            var s = sut.Apply(("theme", "light"));
+
+            // Assert — only the selected value's classes appear; the default's bg-black does not.
+            Assert.That(s["root"], Is.EqualTo("base bg-white"));
+        }
     }
 }

--- a/Packages/com.velvet.core/TestUtilities/TestRouteScopeFactory.cs
+++ b/Packages/com.velvet.core/TestUtilities/TestRouteScopeFactory.cs
@@ -1,0 +1,37 @@
+using System;
+
+namespace Velvet.TestUtilities
+{
+    /// <summary>
+    /// Test double for <see cref="IRouteScopeFactory"/>. Records both the last scope it created and
+    /// how many times it was invoked, so a single fixture can assert on either probe without needing
+    /// its own copy of the double.
+    /// </summary>
+    public sealed class TestRouteScopeFactory : IRouteScopeFactory
+    {
+        public int CreateScopeCount { get; private set; }
+
+        public TestRouteScope? LastScope { get; private set; }
+
+        public IRouteScope CreateScope(RouteDefinition? route, IRouteScope? parent)
+        {
+            CreateScopeCount++;
+            LastScope = new TestRouteScope();
+            return LastScope;
+        }
+    }
+
+    /// <summary>
+    /// Test double for <see cref="IRouteScope"/>. Resolve always throws since no fixture exercises
+    /// DI resolution through this scope; Dispose flips <see cref="IsDisposed"/> so tests can assert
+    /// the scope was torn down.
+    /// </summary>
+    public sealed class TestRouteScope : IRouteScope
+    {
+        public bool IsDisposed { get; private set; }
+
+        public T Resolve<T>() => throw new NotImplementedException();
+
+        public void Dispose() => IsDisposed = true;
+    }
+}

--- a/Packages/com.velvet.core/TestUtilities/TestRouteScopeFactory.cs.meta
+++ b/Packages/com.velvet.core/TestUtilities/TestRouteScopeFactory.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: dae34f6c45354ffab9fb09a466f44c5c


### PR DESCRIPTION
## Bug fixes

- **Weaver**: add the missing `UseMemo` entry to `PositionalHookNames.All` (the lockstep test now structurally enumerates positional-slot-consuming hooks via Cecil, so the next omission fails the suite). Bail on open virtual/interface dispatch outside the BCL/Unity/UniTask carve-out — the statically resolved callee proves nothing about where an override lives, so weaving through one could memoize a component that reaches a hook at runtime. Bail on do-while-wrapped hooks (only forward skips were detected before). Report assembly-resolution failures as diagnostics instead of silently leaving every `[Component]` in the assembly unwoven.
- **Reconciler**: dispose the `IRouteScope` instances held in `OutletScopes` on whole-reconciler teardown (previously only element-level cleanup was wired). Reset `DropdownField`/`RadioButtonGroup` choices when the prop transitions back to null instead of keeping the previous render's options.
- **Styling**: route `DropShadowBaker`'s texture eviction through the play-mode-aware destroy helper instead of a raw `DestroyImmediate`.
- **Pool reuse**: on Unity 6000.3.11f1, assigning `StyleKeyword.Null` to `style.filter` clears the wrong internal has-inline flag, so the inline filter list survives the pool reset and ghosts onto the next consumer. The reset now empties the surviving list in place (a no-op on editors where the assignment works).

## Parity / API

- Expose `data`/`aria` and the gesture-class parameters (`whileHoverClass`/`whileTapClass`/`whileFocusClass`) uniformly across every `V.*` element factory. The reconciler supported these attributes end-to-end, but `Div`, `Custom<T>`, `ListView`, `RadioButton(Group)`, and `IntegerField` could not reach them.

## Performance

- Skip variant-manipulator re-derivation when the class list is content-identical (previously gated on array identity, so unwoven components re-derived every manipulator each render).
- Drop per-call allocations from `StyleSlotRecipe.Apply` (pooled parts buffer, dictionary-free axis dedup) and `RouteTree` matching (params dictionary allocated only once a branch actually captures).
- Make `HasGradientClass` a pure prefix scan, and route `TryParseActivator` through the same prefix table so the gate can never false-negative on a parser-accepted shape.

## Deduplication and tests

- Unify the duplicated post-children effect passes, nearest-staged-ancestor post-order DFS, query stripping, slash trimming, NavLink/Link wiring, gesture edge detection, weaver diagnostics/`ResolveExternal`, and route-scope test doubles into single owners.
- Pin the full pool-reset scrub surface structurally against a freshly constructed element, and cover the previously untested history FIFO eviction and weaver bail paths.

## Verification

EditMode: 2542 passed. PlayMode: 20 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)