### PR TITLE
docs(velvet): state the all-English convention and PR-content rule in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,4 +68,5 @@ Tests are **colocated** with the code: `Runtime/<Area>/Tests/Editor/` and `.../T
 
 ## Conventions
 
-- Commits use Conventional Commits with the `velvet` scope, frequently written in Japanese (e.g. `fix(velvet): …`, `feat(velvet): …`, `refactor(velvet): …`).
+- Commits use Conventional Commits with the `velvet` scope (e.g. `fix(velvet): …`, `feat(velvet): …`, `refactor(velvet): …`).
+- Everything in this repo is written in English: code, comments, commit messages, and PR titles/bodies. PR descriptions state what changed and why — never the local workflow that produced the change (audit/review process, agent tooling, session details).


### PR DESCRIPTION
CLAUDE.md said commits are "frequently written in Japanese", which no longer matches the repo: everything here — code, comments, commit messages, and PR titles/bodies — is written in English. The conventions section now states that explicitly, and adds that PR descriptions should state what changed and why rather than the local workflow that produced the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)