### PR TITLE
ci(velvet): scope test workflows to the paths that can affect them

### DIFF
--- a/.github/workflows/generators.yml
+++ b/.github/workflows/generators.yml
@@ -1,0 +1,47 @@
+name: Source generators
+
+# The Roslyn generators are a standalone dotnet solution: only changes under
+# Generators~ (or this workflow) can affect the result, so nothing else
+# triggers it. Generator changes reach the Unity side as committed DLLs under
+# Runtime/Plugins, which the Unity test workflow picks up on its own paths.
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'Packages/com.velvet.core/Generators~/**'
+      - '.github/workflows/generators.yml'
+      - '!**.md'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'Packages/com.velvet.core/Generators~/**'
+      - '.github/workflows/generators.yml'
+      - '!**.md'
+  workflow_dispatch:
+
+# Cancel superseded runs on the same ref.
+concurrency:
+  group: generators-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Source-generator tests (.NET / xUnit). No Unity license required.
+  # ---------------------------------------------------------------------------
+  source-generators:
+    name: Source generators (dotnet)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Setup .NET (pinned by Generators~/global.json)
+        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
+        with:
+          global-json-file: Packages/com.velvet.core/Generators~/global.json
+
+      - name: Test
+        working-directory: Packages/com.velvet.core/Generators~
+        run: dotnet test Velvet.SourceGenerators.sln -c Release --nologo

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,32 @@
 name: Test
 
+# Only changes that can affect what Unity compiles or imports trigger the
+# Unity jobs: the embedded package, project settings/assets, and this
+# workflow. Generators~ sources are excluded — the Unity side consumes their
+# committed DLLs under Runtime/Plugins, so a generator change reaches this
+# workflow when the redeployed DLLs are committed. Docs and markdown never
+# affect the tests.
 on:
   push:
     branches: [main]
+    paths:
+      - 'Assets/**'
+      - 'Packages/**'
+      - 'ProjectSettings/**'
+      - '.github/workflows/test.yml'
+      - '!Packages/com.velvet.core/Generators~/**'
+      - '!Packages/com.velvet.core/Documentation~/**'
+      - '!**.md'
   pull_request:
     branches: [main]
+    paths:
+      - 'Assets/**'
+      - 'Packages/**'
+      - 'ProjectSettings/**'
+      - '.github/workflows/test.yml'
+      - '!Packages/com.velvet.core/Generators~/**'
+      - '!Packages/com.velvet.core/Documentation~/**'
+      - '!**.md'
   workflow_dispatch:
 
 # Cancel superseded runs on the same ref.
@@ -19,24 +41,6 @@ permissions:
   checks: write
 
 jobs:
-  # ---------------------------------------------------------------------------
-  # Source-generator tests (.NET / xUnit). No Unity license required.
-  # ---------------------------------------------------------------------------
-  source-generators:
-    name: Source generators (dotnet)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Setup .NET (pinned by Generators~/global.json)
-        uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
-        with:
-          global-json-file: Packages/com.velvet.core/Generators~/global.json
-
-      - name: Test
-        working-directory: Packages/com.velvet.core/Generators~
-        run: dotnet test Velvet.SourceGenerators.sln -c Release --nologo
-
   # ---------------------------------------------------------------------------
   # Detect whether a Unity license secret is configured. Secrets cannot be
   # referenced directly in a job-level `if`, so expose it as an output here.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ dotnet test Velvet.SourceGenerators.sln -c Release   # generator unit tests (no 
 ./build.sh                                            # rebuild + redeploy DLLs to Runtime/Plugins, then commit them
 ```
 
-CI (`.github/workflows/test.yml`) runs `source-generators` (no license) and `unity-tests` (EditMode/PlayMode, **skipped unless a `UNITY_LICENSE` secret is set** — see CONTRIBUTING.md). Docs (`docs/`) are DocFX-generated from XML comments via `docs/build.sh`.
+CI is split by what a change can affect: `.github/workflows/generators.yml` runs `source-generators` (no license) only for `Generators~/**` changes, and `.github/workflows/test.yml` runs `unity-tests` (EditMode/PlayMode, **skipped unless a `UNITY_LICENSE` secret is set** — see CONTRIBUTING.md) only for package/project changes; docs and markdown trigger neither. Docs (`docs/`) are DocFX-generated from XML comments via `docs/build.sh`.
 
 ## Architecture (the parts that span many files)
 


### PR DESCRIPTION
Docs-only changes (e.g. a CLAUDE.md edit) previously triggered the full Test workflow. The triggers are now scoped by what a change can actually affect:

- `.github/workflows/generators.yml` (new) runs the dotnet source-generator tests only for `Packages/com.velvet.core/Generators~/**` changes. Generator changes reach the Unity side as committed DLLs under `Runtime/Plugins/`, which the Unity workflow watches on its own paths, so the two stay correctly decoupled.
- `.github/workflows/test.yml` runs the Unity EditMode/PlayMode jobs only for `Assets/`, `Packages/` (excluding `Generators~` and `Documentation~`), `ProjectSettings/`, or workflow changes.
- Markdown and docs changes trigger neither workflow.

Note: if any of these checks are ever made required in branch protection, path-filtered workflows report no status on skipped PRs and would block merging — at that point the filters should move to an in-job early exit instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)