### PR TITLE
fix(velvet): keyed-diff and fiber bookkeeping correctness

### DIFF
--- a/Packages/com.velvet.core/Runtime/Component/ComponentFiber.cs
+++ b/Packages/com.velvet.core/Runtime/Component/ComponentFiber.cs
@@ -85,7 +85,14 @@ namespace Velvet
         /// </summary>
         internal bool IsOffscreen { get; set; }
 
-        internal List<ContextDependency> Dependencies { get; } = new();
+        internal List<ContextDependency> Dependencies { get; private set; } = new();
+
+        // Staging list for the render in progress: context reads land here and are swapped into
+        // Dependencies only when the render settles, so a render that throws partway cannot leave
+        // the committed list empty/partial (which would silently detach the fiber from future
+        // Provider-change notifications). Swapped by reference — no per-render allocation.
+        private List<ContextDependency> _stagedDependencies = new();
+        private bool _isStagingDependencies;
 
         internal List<IFiberAsyncResource> AsyncSlots { get; } = new();
         private int _asyncSlotCursor;
@@ -461,11 +468,12 @@ namespace Velvet
 
         internal void RegisterContextDependency(object context)
         {
-            for (var i = 0; i < Dependencies.Count; i++)
+            var target = _isStagingDependencies ? _stagedDependencies : Dependencies;
+            for (var i = 0; i < target.Count; i++)
             {
-                if (Dependencies[i].Context == context) return;
+                if (target[i].Context == context) return;
             }
-            Dependencies.Add(new ContextDependency { Context = context });
+            target.Add(new ContextDependency { Context = context });
         }
 
         internal bool HasDependencyOn(object context)
@@ -477,7 +485,30 @@ namespace Velvet
             return false;
         }
 
-        internal void ClearDependencies() => Dependencies.Clear();
+        // Starts collecting this render attempt's context reads into the staging list, leaving the
+        // committed Dependencies untouched until the attempt settles.
+        internal void BeginDependencyStaging()
+        {
+            _stagedDependencies.Clear();
+            _isStagingDependencies = true;
+        }
+
+        // Promotes the settled attempt's reads to the committed list by swapping the two lists.
+        internal void CommitStagedDependencies()
+        {
+            if (!_isStagingDependencies) return;
+            (Dependencies, _stagedDependencies) = (_stagedDependencies, Dependencies);
+            _isStagingDependencies = false;
+        }
+
+        // Drops an unsettled attempt's reads (throw / suspend / diagnostic pass), keeping the
+        // committed list exactly as the last successful render left it.
+        internal void DiscardStagedDependencies()
+        {
+            if (!_isStagingDependencies) return;
+            _isStagingDependencies = false;
+            _stagedDependencies.Clear();
+        }
 
         public object? Ref { get; set; }
 

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/ComponentFiberTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/ComponentFiberTests.cs
@@ -350,18 +350,38 @@ namespace Velvet.Tests
         }
 
         [Test]
-        public void Given_FiberWithDependencies_When_Cleared_Then_DependencySetIsEmpty()
+        public void Given_AStagedRenderAttempt_When_Committed_Then_ItsReadsBecomeTheDependencies()
         {
-            // Arrange
+            // Arrange — a committed dependency from an earlier render, then a new staged attempt
+            // reading a different context.
             var fiber = new ComponentFiber();
             fiber.RegisterContextDependency(new object());
-            fiber.RegisterContextDependency(new object());
+            var next = new object();
+            fiber.BeginDependencyStaging();
+            fiber.RegisterContextDependency(next);
 
             // Act
-            fiber.ClearDependencies();
+            fiber.CommitStagedDependencies();
 
-            // Assert
-            Assert.That(fiber.Dependencies, Is.Empty, "Clearing removes every dependency entry");
+            // Assert — the settled attempt's reads replace the previous committed set.
+            Assert.That((fiber.Dependencies.Count, fiber.HasDependencyOn(next)), Is.EqualTo((1, true)));
+        }
+
+        [Test]
+        public void Given_AStagedRenderAttempt_When_Discarded_Then_TheCommittedDependenciesSurvive()
+        {
+            // Arrange — a committed dependency, then a staged attempt that would have dropped it
+            // (the shape of a render throwing before it reaches a UseContext call).
+            var committed = new object();
+            var fiber = new ComponentFiber();
+            fiber.RegisterContextDependency(committed);
+            fiber.BeginDependencyStaging();
+
+            // Act
+            fiber.DiscardStagedDependencies();
+
+            // Assert — the failed attempt leaves the committed set untouched.
+            Assert.That(fiber.HasDependencyOn(committed), Is.True);
         }
 
         #endregion

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/StrictModeDirectTreeMountTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/StrictModeDirectTreeMountTests.cs
@@ -1,0 +1,72 @@
+using NUnit.Framework;
+using UnityEngine.UIElements;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins the StrictMode double-invoke diagnostic against a directly-built mount tree. V.Mount
+    /// documents plain element trees ("V.Provider, V.Component, V.Div, etc."), wiring the root
+    /// fiber's Body to a constant passthrough closure — a second invocation returns the SAME node
+    /// graph the commit owns. The diagnostic recycled its second pass's output unconditionally, so
+    /// it wiped the committed tree's props/events in place and pushed them into the shared pools
+    /// where any unrelated mount could rent and overwrite them — exactly the state-ghosting class
+    /// the diagnostic exists to catch. A constant Body has no render purity to validate; real
+    /// coverage comes from the nested component fibers, which each run their own diagnostic.
+    /// </summary>
+    [TestFixture]
+    internal sealed class StrictModeDirectTreeMountTests
+    {
+        private VisualElement _root;
+        private bool _strictModeBefore;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _root = new VisualElement();
+            _strictModeBefore = FiberStrictMode.Enabled;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            FiberStrictMode.Enabled = _strictModeBefore;
+        }
+
+        [Test]
+        public void Given_StrictMode_When_ADirectlyBuiltTreeIsMounted_Then_TheCommittedTreeKeepsItsPropsAndEvents()
+        {
+            // Arrange
+            FiberStrictMode.Enabled = true;
+
+            // Act — mount a plain element tree (no component wrapper), the documented pattern.
+            using var mounted = V.Mount(_root, V.Div(name: "app", children: new VNode[]
+            {
+                V.Button(name: "b", text: "Click me", onClick: () => { }),
+            }));
+
+            // Assert — the committed VNode tree still carries its text and click binding.
+            var app = (ElementNode)mounted.Root.PreviousTree[0];
+            var button = (ElementNode)app.Children[0];
+            Assert.That((button.Props?.Text, button.Events != null && button.Events[0] != null),
+                Is.EqualTo(("Click me", true)));
+        }
+
+        [Test]
+        public void Given_StrictMode_When_ADirectlyBuiltTreeIsMounted_Then_ItsPropsDoNotLeakIntoThePool()
+        {
+            // Arrange
+            FiberStrictMode.Enabled = true;
+            using var mounted = V.Mount(_root, V.Div(name: "app", children: new VNode[]
+            {
+                V.Button(name: "b", text: "Click me", onClick: () => { }),
+            }));
+            var committedProps = ((ElementNode)((ElementNode)mounted.Root.PreviousTree[0]).Children[0]).Props;
+
+            // Act — an unrelated factory call rents from the shared pool.
+            var rented = VNodePool.RentProps();
+
+            // Assert — the committed tree's live props bag was never recycled into the pool.
+            Assert.That(ReferenceEquals(rented, committedProps), Is.False);
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/StrictModeDirectTreeMountTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/StrictModeDirectTreeMountTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9732f63eb15b24aa887a250c3a5b36be

--- a/Packages/com.velvet.core/Runtime/Reconciler/ChildReconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ChildReconciler.cs
@@ -1243,7 +1243,23 @@ namespace Velvet
 
             if (oldKeyMap.TryGetValue(key, out var old))
             {
-                usedKeys.Add(key);
+                if (!usedKeys.Add(key))
+                {
+                    // A second new-side sibling resolved the same old entry. Re-matching would alias
+                    // two logical rows onto one element (the reorder pass then collapses them,
+                    // silently dropping a row) or, on a type swap, retroactively remove the element
+                    // the first occurrence patched. Mirror the old-side duplicate guard: warn and
+                    // mount a fresh element so every declared row commits.
+                    FiberLogger.LogWarning("ChildReconciler",
+                        $"Duplicate key detected among new siblings: {key}. " +
+                        "The repeated sibling mounts a fresh element; give each sibling a unique key.");
+                    var duplicateElement = _factory.CreateElement(newNode);
+                    if (_ctx.IsAborted) return true;
+                    UnityEngine.Debug.Assert(duplicateElement.parent == null,
+                        "[ChildReconciler] _factory.CreateElement must return an orphaned VisualElement (no parent).");
+                    newElements.Add((duplicateElement, false));
+                    return false;
+                }
                 AssertDomIndexInvariant(slotStart, old.index, parent);
                 var existingDomElement = parent.ElementAt(slotStart + old.index);
 

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberBeginWork.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberBeginWork.cs
@@ -65,7 +65,10 @@ namespace Velvet
             while (true)
             {
                 ResetHookIndex(fiber);
-                fiber.ClearDependencies();
+                // Context reads are staged per attempt and swapped into the committed list only by
+                // CommitSettledHookDeps: a render that throws partway must not leave the committed
+                // list empty/partial, or the Provider-change walk would skip this fiber forever.
+                fiber.BeginDependencyStaging();
                 rendered = Render(fiber);
                 if (!fiber.HasRenderPhaseUpdate)
                 {
@@ -94,6 +97,8 @@ namespace Velvet
         // discarded attempt cannot break callback referential stability or force a memo rebuild.
         internal static void CommitSettledHookDeps(ComponentFiber fiber)
         {
+            // The settled attempt's context reads become the committed dependency list (list swap).
+            fiber.CommitStagedDependencies();
             HookEffectExecutor.CommitEffectDeps(fiber.LayoutEffects);
             HookEffectExecutor.CommitEffectDeps(fiber.InsertionEffects);
             HookEffectExecutor.CommitEffectDeps(fiber.Effects);

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberCommitWork.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberCommitWork.cs
@@ -9,19 +9,31 @@ namespace Velvet
     // the orchestrator (FiberRenderer.RenderAndReconcile) hands in after FiberBeginWork produced them.
     internal static class FiberCommitWork
     {
-        // The slot index at which this inline fiber's range ENDS within its shared MountPoint — the next
-        // inline-mount sibling's MountSlotStart, or int.MaxValue when this fiber is the last/only tenant. Used to
-        // bound the keyed desync-recovery rebuild so it cannot reach past this fiber's rows into a sibling's.
+        // The slot index at which this inline fiber's range ENDS within its shared MountPoint — the
+        // nearest co-located tenant's MountSlotStart beyond this fiber's own, or int.MaxValue when
+        // this fiber is the last/only tenant. Used to bound the keyed desync-recovery rebuild so it
+        // cannot reach past this fiber's rows into a sibling's. The sibling chain is fiber-CREATION
+        // order and a keyed reorder does not resync it, so the first co-located entry can sit
+        // visually BEFORE this fiber; bounding by it would make slotLimit < slotStart — every slot
+        // in this fiber's own range would look missing, and an independent re-render of the
+        // displaced fiber would insert a permanent duplicate instead of patching in place. Walk the
+        // parent's whole co-located chain instead and take the minimum start strictly beyond ours.
         private static int NextInlineSiblingSlotStart(ComponentFiber fiber)
         {
-            for (var sibling = fiber.Sibling; sibling != null; sibling = sibling.Sibling)
+            var limit = int.MaxValue;
+            var first = fiber.Parent?.Child ?? fiber.Sibling;
+            for (var sibling = first; sibling != null; sibling = sibling.Sibling)
             {
-                if (sibling.IsInlineMounted && sibling.MountPoint == fiber.MountPoint)
+                if (!ReferenceEquals(sibling, fiber)
+                    && sibling.IsInlineMounted
+                    && sibling.MountPoint == fiber.MountPoint
+                    && sibling.MountSlotStart > fiber.MountSlotStart
+                    && sibling.MountSlotStart < limit)
                 {
-                    return sibling.MountSlotStart;
+                    limit = sibling.MountSlotStart;
                 }
             }
-            return int.MaxValue;
+            return limit;
         }
 
         // Propagates an inline-mount fiber's committed child-count change to the siblings that share its

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberHookCommit.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberHookCommit.cs
@@ -30,7 +30,7 @@ namespace Velvet
             TruncateTo(fiber.PendingEffects, committedPendingEffectCount);
         }
 
-        private static void TruncateTo(List<HookEffectSlot>? list, int count)
+        internal static void TruncateTo(List<HookEffectSlot>? list, int count)
         {
             if (list != null && list.Count > count)
             {

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberRenderer.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberRenderer.cs
@@ -497,6 +497,13 @@ namespace Velvet
         private static void DoubleInvokeRenderForStrictMode(ComponentFiber fiber, VNode?[] committedTree)
         {
             if (!FiberStrictMode.Enabled || fiber.IsDisposed || fiber.Reconciler == null) return;
+            // The mount root's Body is a constant passthrough closure over the caller-built tree
+            // (V.Mount wires `() => tree` — the only CreateRoot caller), so a second invocation
+            // returns the SAME node graph the commit owns: there is no render purity to validate,
+            // and recycling the diagnostic output would wipe the committed tree's props/events in
+            // place and alias them into the shared pools. Nested component fibers still run the
+            // diagnostic individually, which is where the real coverage lives.
+            if (fiber.Parent == null) return;
 
             var committedSignature = FiberStrictMode.ComputeSignature(committedTree);
 

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberRenderer.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberRenderer.cs
@@ -308,6 +308,10 @@ namespace Velvet
 #endif
             VNode?[]? prevPendingOldTree = null;
             VNode?[]? oldTree = null;
+            // Committed baseline of the passive-effect list: entries staged by EARLIER renders and
+            // not yet flushed (the flush is deferred to the frame boundary) must survive an
+            // exception thrown by THIS render — see the catch block.
+            var committedPendingEffectCount = fiber.PendingEffects?.Count ?? 0;
             var fiberPushed = PushFiber(fiber);
             // Spine-rewalk-with-bailout: an isolated re-render (a standalone entry, not a
             // nested expansion render) starts with an empty live context cursor, so reconstruct the
@@ -395,7 +399,13 @@ namespace Velvet
                 }
                 fiber.PendingLayoutEffects?.Clear();
                 fiber.PendingInsertionEffects?.Clear();
-                fiber.PendingEffects?.Clear();
+                // Unlike the two lists above (rebuilt every render and flushed synchronously),
+                // PendingEffects intentionally persists across renders until the deferred flush
+                // runs it — and the settled deps of an already-committed entry were promoted at its
+                // commit, so no later successful render would ever re-stage a wiped stable-deps
+                // mount effect. Truncate this render's additions only, mirroring the render-phase
+                // retry discipline, instead of discarding earlier commits' still-pending work.
+                FiberHookCommit.TruncateTo(fiber.PendingEffects, committedPendingEffectCount);
                 if (ex is FiberSuspendSignal)
                 {
                     if (fiber.Parent != null)
@@ -422,6 +432,10 @@ namespace Velvet
                 // Runs after Render + Reconcile (descendants re-rendered during the expansion needed the
                 // spine as their base) and is a no-op for nested / root renders (default handle).
                 contextSpine.Unwind();
+                // A throw/suspend exits with this render's context reads still staged; drop them so
+                // the committed dependency list stays exactly as the last successful render left it
+                // (no-op on the success path, where CommitSettledHookDeps already swapped).
+                fiber.DiscardStagedDependencies();
                 PopFiber(fiber, fiberPushed);
                 fiber.IsRendering = false;
                 // Any setState arriving after IsRendering clears belongs to the regular next-frame
@@ -501,7 +515,9 @@ namespace Velvet
             try
             {
                 FiberBeginWork.ResetHookIndex(fiber);
-                fiber.ClearDependencies();
+                // The diagnostic's context reads are staged and later discarded, so the committed
+                // dependency list (matching the real committed render) stays intact.
+                fiber.BeginDependencyStaging();
                 fiber.HasRenderPhaseUpdate = false;
                 diagnosticTree = FiberTreeReturn.NormalizeToArray(FiberBeginWork.Render(fiber));
 
@@ -543,6 +559,9 @@ namespace Velvet
                 // pool drain that the committed (owned) tree would not cause.
                 FiberTreeReturn.ReturnPooledTreeRecursive(diagnosticTree);
                 contextSpine.Unwind();
+                // Discard the diagnostic's staged context reads; the committed list stays as the
+                // real render left it.
+                fiber.DiscardStagedDependencies();
                 PopFiber(fiber, fiberPushed);
                 FiberAmbientStack.Pop();
                 fiber.IsRendering = false;

--- a/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
@@ -182,8 +182,20 @@ namespace Velvet
             // (e.g. after a prior aborted/suspended commit) to a fresh create instead of throwing
             // IndexOutOfRange — the time-sliced keyed path asserts this invariant; the general path
             // can be re-entered mid-suspend so it guards defensively.
-            if (commit.OldKeyMap.TryGetValue(key, out var old)
-                && slotStart + old.index < parent.childCount)
+            var oldMatched = commit.OldKeyMap.TryGetValue(key, out var old)
+                && slotStart + old.index < parent.childCount;
+            if (oldMatched && commit.UsedKeys.Contains(key))
+            {
+                // A second new-side sibling resolved the same old entry its first occurrence already
+                // claimed: re-matching would alias two rows onto one element or retroactively remove
+                // the patched one via ReplacedKeys. Mirror the old-side duplicate guard: warn and
+                // fall through to a fresh create so every declared row commits.
+                FiberLogger.LogWarning("GeneralPathReconciler",
+                    $"Duplicate key detected among new siblings: {key}. " +
+                    "The repeated sibling mounts a fresh element; give each sibling a unique key.");
+                oldMatched = false;
+            }
+            if (oldMatched)
             {
                 var existingDom = parent.ElementAt(slotStart + old.index);
                 if (ReconcileKeying.CanPatch(old.node, node))
@@ -569,7 +581,6 @@ namespace Velvet
                             var fiber = _ctx.ComponentRegistry.TryGetFiberForInlineKey(_ctx.FiberStack.Current, slotKey, identity);
                             if (fiber != null)
                             {
-                                oldFibers.Add(fiber);
                                 if (fiber.PreviousTree != null && fiber.PreviousTree.Length > 0)
                                 {
                                     var childCounters = _ctx.BufferPool.RentPositionCounter();
@@ -586,6 +597,7 @@ namespace Velvet
                                         _ctx.BufferPool.ReturnPositionCounter(childCounters);
                                     }
                                 }
+                                oldFibers.Add(fiber);
                             }
                         }
                         break;

--- a/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
@@ -597,6 +597,10 @@ namespace Velvet
                                         _ctx.BufferPool.ReturnPositionCounter(childCounters);
                                     }
                                 }
+                                // Post-order add: a directly-nested component must precede its
+                                // parent in oldFibers so the orphan sweep's forward walk tears the
+                                // subtree down bottom-up — a descendant's effect cleanups complete
+                                // before an ancestor's, matching the commit-phase deletion order.
                                 oldFibers.Add(fiber);
                             }
                         }

--- a/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
@@ -545,6 +545,20 @@ namespace Velvet
                             // path accumulates them in result.
                             var emittedCount = commit != null ? commit.NewElements.Count : result!.Count;
                             var currentSlotStart = slotStart + emittedCount;
+                            // Two same-identity siblings sharing one explicit key resolve to the
+                            // SAME registry fiber; expanding it once per sibling would emit one
+                            // component's DOM twice while its slot bookkeeping tracks only the last
+                            // position (with hook state shared across both copies). Mirror the
+                            // leaf-level duplicate guard: warn and skip the repeat before
+                            // GetOrCreate can clobber the first occurrence's slot.
+                            var priorFiber = _ctx.ComponentRegistry.TryGetFiberForInlineKey(parentFiber, slotKey, identity);
+                            if (priorFiber != null && newFibers.Contains(priorFiber))
+                            {
+                                FiberLogger.LogWarning("GeneralPathReconciler",
+                                    $"Duplicate component key detected among siblings: '{slotKey}'. " +
+                                    "The repeated sibling is skipped; give each sibling a unique key.");
+                                break;
+                            }
                             var fiber = _ctx.ComponentRegistry.GetOrCreateInline(
                                 component, parentFiber, slotKey, parent, currentSlotStart);
                             newFibers.Add(fiber);

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/DuplicateInlineComponentKeyTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/DuplicateInlineComponentKeyTests.cs
@@ -1,0 +1,60 @@
+using System;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using UnityEngine.UIElements;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins the duplicate sibling-key guard for inline component nodes. Two same-identity siblings
+    /// sharing one explicit key resolve to the SAME registry fiber — the leaf-level keyed diff warns
+    /// on duplicates, but the component path silently expanded the one fiber once per sibling: its
+    /// DOM output was emitted twice while the fiber's slot bookkeeping tracked only the last
+    /// position (and both copies shared one hook state), so a later re-render patched one copy and
+    /// stranded the other. The repeat must warn and be skipped; two independent instances require
+    /// unique keys, exactly as the reachable V.List keySelector documentation implies.
+    /// </summary>
+    [TestFixture]
+    internal sealed class DuplicateInlineComponentKeyTests
+    {
+        private VisualElement _root;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _root = new VisualElement();
+        }
+
+        [Component]
+        private static VNode FooRow()
+        {
+            return V.Label(text: "foo");
+        }
+
+        [Component]
+        private static VNode DupHost()
+        {
+            return V.Div(name: "dup-host", children: new VNode[]
+            {
+                V.Component(FooRow, key: "x"),
+                V.Component(FooRow, key: "x"),
+            });
+        }
+
+        [Test]
+        public void Given_TwoSiblingComponentsWithTheSameKey_When_Mounted_Then_OnlyOneInstanceCommits()
+        {
+            // Arrange — the duplicate is reported (LogAssert also fails if no warning fires).
+            LogAssert.Expect(LogType.Warning,
+                new System.Text.RegularExpressions.Regex("Duplicate component key"));
+
+            // Act
+            using var mounted = V.Mount(_root, V.Component(DupHost, key: "host"));
+
+            // Assert — one fiber, one committed copy; the repeat did not double-emit its DOM.
+            Assert.AreEqual(1, _root.Q<VisualElement>("dup-host").childCount);
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/DuplicateInlineComponentKeyTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/DuplicateInlineComponentKeyTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 364b36e4828bc4560add67fc5e0a500d

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/InlineSiblingReorderRerenderTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/InlineSiblingReorderRerenderTests.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine.UIElements;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins slot-bound resolution for an inline fiber that a keyed reorder displaced. The fiber
+    /// sibling chain is creation order and a reorder does not resync it, so the chain-next sibling
+    /// can sit visually BEFORE the fiber; bounding the fiber's own reconcile by that sibling's slot
+    /// start produced slotLimit &lt; slotStart, every slot in the fiber's range looked missing, and an
+    /// independent re-render (its own setState — not a parent-driven render) inserted a brand-new
+    /// element while the stale one stayed: a permanent duplicate no future reconcile removes. The
+    /// bound must come from the nearest co-located slot start beyond the fiber's own, regardless of
+    /// chain position.
+    /// </summary>
+    [TestFixture]
+    internal sealed class InlineSiblingReorderRerenderTests
+    {
+        private readonly record struct OrderState(string Order);
+
+        private sealed class OrderStore : Store<OrderState>
+        {
+            public OrderStore() : base(new OrderState("abc")) { }
+            public void Set(string order) => SetState(_ => new OrderState(order));
+            protected override void ResetCore() => SetState(_ => new OrderState("abc"));
+        }
+
+        private static OrderStore s_store;
+
+        private VisualElement _root;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _root = new VisualElement();
+            s_store = null;
+        }
+
+        [Component]
+        private static VNode RowA()
+        {
+            var (count, setCount) = Hooks.UseState(0);
+            return V.Button(name: "btn-a", text: "a" + count, onClick: () => setCount.Invoke(c => c + 1));
+        }
+
+        [Component]
+        private static VNode RowB()
+        {
+            var (count, setCount) = Hooks.UseState(0);
+            return V.Button(name: "btn-b", text: "b" + count, onClick: () => setCount.Invoke(c => c + 1));
+        }
+
+        [Component]
+        private static VNode RowC()
+        {
+            var (count, setCount) = Hooks.UseState(0);
+            return V.Button(name: "btn-c", text: "c" + count, onClick: () => setCount.Invoke(c => c + 1));
+        }
+
+        [Component]
+        private static VNode ReorderList()
+        {
+            var order = Hooks.UseStore(s_store, s => s.Order);
+            var rows = new List<VNode>();
+            foreach (var id in order)
+            {
+                rows.Add(id switch
+                {
+                    'a' => V.Component(RowA, key: "a"),
+                    'b' => V.Component(RowB, key: "b"),
+                    _ => V.Component(RowC, key: "c"),
+                });
+            }
+            return V.Div(name: "container", children: rows.ToArray());
+        }
+
+        [Test]
+        public void Given_KeyedInlineComponentsWereReordered_When_TheDisplacedFiberRerendersOnItsOwn_Then_NoDuplicateElementAppears()
+        {
+            // Arrange — mount [a,b,c], then reorder to [b,c,a] so fiber a's creation-order successor
+            // (b) now sits visually before it.
+            using var store = new OrderStore();
+            s_store = store;
+            using var mounted = V.Mount(_root, V.Component(ReorderList, key: "list"));
+            var scheduler = mounted.Root.Reconciler.Context.BatchScheduler;
+            store.Set("bca");
+            scheduler.DrainImmediateForTest();
+            var container = _root.Q<VisualElement>("container");
+            Assume.That(container.childCount, Is.EqualTo(3), "Precondition: the reorder itself commits cleanly");
+
+            // Act — fiber a re-renders on its own via its click handler (a discrete-event flush,
+            // bypassing the parent).
+            _root.Q<Button>("btn-a").SimulateClick();
+
+            // Assert — the displaced fiber patched its own slot; no ghost duplicate was inserted.
+            Assert.AreEqual(3, container.childCount);
+        }
+
+        [Test]
+        public void Given_KeyedInlineComponentsWereReordered_When_TheDisplacedFiberRerendersOnItsOwn_Then_ItsOwnRowIsUpdatedInPlace()
+        {
+            // Arrange
+            using var store = new OrderStore();
+            s_store = store;
+            using var mounted = V.Mount(_root, V.Component(ReorderList, key: "list"));
+            var scheduler = mounted.Root.Reconciler.Context.BatchScheduler;
+            store.Set("bca");
+            scheduler.DrainImmediateForTest();
+
+            // Act
+            _root.Q<Button>("btn-a").SimulateClick();
+
+            // Assert — exactly one btn-a exists and it carries the bumped state.
+            var buttons = _root.Query<Button>(name: "btn-a").ToList();
+            Assert.That((buttons.Count, buttons[0].text), Is.EqualTo((1, "a1")));
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/InlineSiblingReorderRerenderTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/InlineSiblingReorderRerenderTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 843db16dba82a402dbf09e94478f43f0

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/KeyedNewSideDuplicateKeyTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/KeyedNewSideDuplicateKeyTests.cs
@@ -1,0 +1,163 @@
+using System;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using UnityEngine.UIElements;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins the keyed diff against a NEW-side duplicate key. The old→(index,node) map lookup never
+    /// marked an entry consumed, so a second new sibling with the same key re-resolved the entry the
+    /// first occurrence had already claimed: two logical rows aliased one physical element and the
+    /// reorder pass collapsed them into a single DOM slot — a row silently vanished and childCount no
+    /// longer matched the declared child array. The old-side duplicate guard warns loudly; the
+    /// new-side case must do the same and mount a fresh element for the repeated key so every
+    /// declared row commits. Covered on both the flat keyed fast path and the general expansion path
+    /// (forced by a Fragment sibling), which mirrored the same unguarded lookup.
+    /// </summary>
+    [TestFixture]
+    internal sealed class KeyedNewSideDuplicateKeyTests
+    {
+        private readonly record struct PhaseState(int Phase);
+
+        private sealed class PhaseStore : Store<PhaseState>
+        {
+            public PhaseStore() : base(new PhaseState(0)) { }
+            public void Set(int phase) => SetState(_ => new PhaseState(phase));
+            protected override void ResetCore() => SetState(_ => new PhaseState(0));
+        }
+
+        private static PhaseStore s_store;
+
+        private VisualElement _root;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _root = new VisualElement();
+            s_store = null;
+        }
+
+        [Component]
+        private static VNode DupList()
+        {
+            var phase = Hooks.UseStore(s_store, s => s.Phase);
+            return V.Div(name: "list", children: phase == 0
+                ? new VNode[] { V.Label(key: "x", text: "X") }
+                : new VNode[]
+                {
+                    V.Label(key: "y", text: "Y1"),
+                    V.Label(key: "x", text: "DupA"),
+                    V.Label(key: "x", text: "DupB"),
+                });
+        }
+
+        // The Fragment sibling forces the general expansion path instead of the flat keyed fast path.
+        [Component]
+        private static VNode DupListBesideFragment()
+        {
+            var phase = Hooks.UseStore(s_store, s => s.Phase);
+            return V.Div(name: "glist", children: phase == 0
+                ? new VNode[]
+                {
+                    V.Fragment(new VNode?[] { V.Label(key: "f", text: "F") }),
+                    V.Label(key: "x", text: "X"),
+                }
+                : new VNode[]
+                {
+                    V.Fragment(new VNode?[] { V.Label(key: "f", text: "F") }),
+                    V.Label(key: "y", text: "Y1"),
+                    V.Label(key: "x", text: "DupA"),
+                    V.Label(key: "x", text: "DupB"),
+                });
+        }
+
+        private static string[] LabelTextsOf(VisualElement root, string containerName)
+        {
+            var container = root.Q<VisualElement>(containerName);
+            var texts = new string[container.childCount];
+            for (var i = 0; i < container.childCount; i++)
+            {
+                texts[i] = ((Label)container.ElementAt(i)).text;
+            }
+            return texts;
+        }
+
+        [Test]
+        public void Given_ANewSideDuplicateKey_When_Reconciled_Then_EveryDeclaredRowCommits()
+        {
+            // Arrange — one keyed row, then a new tree whose tail repeats a key.
+            using var store = new PhaseStore();
+            s_store = store;
+            using var mounted = V.Mount(_root, V.Component(DupList, key: "list"));
+            var scheduler = mounted.Root.Reconciler.Context.BatchScheduler;
+            Assume.That(_root.Q<VisualElement>("list").childCount, Is.EqualTo(1),
+                "Precondition: the single keyed row is mounted");
+
+            // Act
+            store.Set(1);
+            scheduler.DrainImmediateForTest();
+
+            // Assert — three declared rows produce three committed children; none is silently dropped.
+            Assert.AreEqual(3, _root.Q<VisualElement>("list").childCount);
+        }
+
+        [Test]
+        public void Given_ANewSideDuplicateKey_When_Reconciled_Then_RowsCommitInDeclaredOrder()
+        {
+            // Arrange
+            using var store = new PhaseStore();
+            s_store = store;
+            using var mounted = V.Mount(_root, V.Component(DupList, key: "list"));
+            var scheduler = mounted.Root.Reconciler.Context.BatchScheduler;
+
+            // Act
+            store.Set(1);
+            scheduler.DrainImmediateForTest();
+
+            // Assert — the first occurrence keeps the matched element, the repeat mounts fresh after it.
+            Assert.That(LabelTextsOf(_root, "list"), Is.EqualTo(new[] { "Y1", "DupA", "DupB" }));
+        }
+
+        [Test]
+        public void Given_ANewSideDuplicateKey_When_Reconciled_Then_ItWarnsLikeTheOldSideGuard()
+        {
+            // Arrange
+            using var store = new PhaseStore();
+            s_store = store;
+            using var mounted = V.Mount(_root, V.Component(DupList, key: "list"));
+            var scheduler = mounted.Root.Reconciler.Context.BatchScheduler;
+            LogAssert.Expect(LogType.Warning,
+                new System.Text.RegularExpressions.Regex("Duplicate key detected among new siblings"));
+
+            // Act
+            store.Set(1);
+            scheduler.DrainImmediateForTest();
+
+            // Assert — the new-side warning was observed (LogAssert fails the test otherwise). The
+            // message is distinct from the old-side guard's, so a later unmount diff cannot satisfy it.
+            Assert.Pass("New-side duplicate-key warning observed");
+        }
+
+        [Test]
+        public void Given_ANewSideDuplicateKeyOnTheGeneralPath_When_Reconciled_Then_EveryDeclaredRowCommits()
+        {
+            // Arrange — a Fragment sibling routes the reconcile through the general expansion path.
+            using var store = new PhaseStore();
+            s_store = store;
+            using var mounted = V.Mount(_root, V.Component(DupListBesideFragment, key: "glist"));
+            var scheduler = mounted.Root.Reconciler.Context.BatchScheduler;
+            Assume.That(_root.Q<VisualElement>("glist").childCount, Is.EqualTo(2),
+                "Precondition: the fragment row and the keyed row are mounted");
+
+            // Act
+            store.Set(1);
+            scheduler.DrainImmediateForTest();
+
+            // Assert — the fragment row plus three declared rows; the duplicate is not dropped.
+            Assert.AreEqual(4, _root.Q<VisualElement>("glist").childCount);
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/KeyedNewSideDuplicateKeyTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/KeyedNewSideDuplicateKeyTests.cs
@@ -136,9 +136,11 @@ namespace Velvet.Tests
             store.Set(1);
             scheduler.DrainImmediateForTest();
 
-            // Assert — the new-side warning was observed (LogAssert fails the test otherwise). The
-            // message is distinct from the old-side guard's, so a later unmount diff cannot satisfy it.
-            Assert.Pass("New-side duplicate-key warning observed");
+            // Assert — every row still committed; the new-side warning itself is enforced by
+            // LogAssert at test end (an Assert.Pass would bypass that unmatched-expectation check),
+            // and its message is distinct from the old-side guard's so a later unmount diff cannot
+            // satisfy it.
+            Assert.AreEqual(3, _root.Q<VisualElement>("list").childCount);
         }
 
         [Test]

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/KeyedNewSideDuplicateKeyTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/KeyedNewSideDuplicateKeyTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c14e58a3006a34ec183d7249592c6db0

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/OrphanCleanupOrderTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/OrphanCleanupOrderTests.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine.UIElements;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins bottom-up effect-cleanup order when a subtree of directly-nested inline components is
+    /// orphaned in one reconcile (a conditional unmount of a component that itself returns another
+    /// component, with no host element in between — the shape of a link wrapper or a functional
+    /// error boundary). The old-side expansion appended the parent fiber before recursing into its
+    /// body output, so the orphan sweep's forward walk ran the PARENT's cleanups while the child was
+    /// still fully mounted, inverting unmount order: a descendant's cleanups must complete before an
+    /// ancestor's, exactly as the commit-phase deletion path already guarantees.
+    /// </summary>
+    [TestFixture]
+    internal sealed class OrphanCleanupOrderTests
+    {
+        private readonly record struct ToggleState(bool Show);
+
+        private sealed class ToggleStore : Store<ToggleState>
+        {
+            public ToggleStore() : base(new ToggleState(true)) { }
+            public void Set(bool show) => SetState(_ => new ToggleState(show));
+            protected override void ResetCore() => SetState(_ => new ToggleState(true));
+        }
+
+        private static ToggleStore s_store;
+        private static readonly List<string> s_log = new();
+
+        private VisualElement _root;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _root = new VisualElement();
+            s_store = null;
+            s_log.Clear();
+        }
+
+        [Component]
+        private static VNode OrderProbeInner()
+        {
+            Hooks.UseLayoutEffect(() => () => s_log.Add("cleanup:Inner"), Array.Empty<object>());
+            return V.Div(name: "inner");
+        }
+
+        // Directly returns another component — no host element in between, so both fibers are
+        // collected by the same old-side expansion walk when the subtree is orphaned.
+        [Component]
+        private static VNode OrderProbeOuter()
+        {
+            Hooks.UseLayoutEffect(() => () => s_log.Add("cleanup:Outer"), Array.Empty<object>());
+            return V.Component(OrderProbeInner, key: "inner");
+        }
+
+        [Component]
+        private static VNode OrderProbeRoot()
+        {
+            var visible = Hooks.UseStore(s_store, s => s.Show);
+            return V.Div(name: "root", children: visible
+                ? new VNode[] { V.Component(OrderProbeOuter, key: "outer") }
+                : Array.Empty<VNode>());
+        }
+
+        [Test]
+        public void Given_NestedInlineComponentsAreOrphanedTogether_When_CleanupsRun_Then_TheChildCleansUpBeforeTheParent()
+        {
+            // Arrange — a mounted parent→child inline chain with one layout-effect cleanup each.
+            using var store = new ToggleStore();
+            s_store = store;
+            using var mounted = V.Mount(_root, V.Component(OrderProbeRoot, key: "probe-root"));
+            var scheduler = mounted.Root.Reconciler.Context.BatchScheduler;
+            mounted.FlushEffectsForTest();
+            Assume.That(s_log, Is.Empty, "Precondition: no cleanup has run while mounted");
+
+            // Act — orphan the whole chain in one reconcile.
+            store.Set(false);
+            scheduler.DrainImmediateForTest();
+
+            // Assert — bottom-up: the child's cleanup completes before the parent's.
+            Assert.That(s_log, Is.EqualTo(new[] { "cleanup:Inner", "cleanup:Outer" }));
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/OrphanCleanupOrderTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/OrphanCleanupOrderTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 94c063592a8e84213b5e268f17df8397

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/RenderExceptionContextDependencyTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/RenderExceptionContextDependencyTests.cs
@@ -1,0 +1,102 @@
+using System;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using UnityEngine.UIElements;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins context-dependency retention across a failing render. The dependency list was cleared
+    /// in place at the top of every render attempt and rebuilt by the UseContext calls that attempt
+    /// reached — so a render that threw partway left the committed list empty or partial, and the
+    /// Provider-change walk (which skips fibers without a recorded dependency) never re-rendered the
+    /// consumer again: it was stuck on a stale context value forever, with no error. A memoized
+    /// consumer has no other re-render path, so the reads of each attempt must be staged and swapped
+    /// in only when the attempt settles, like the hook-slot machinery already does.
+    /// </summary>
+    [TestFixture]
+    internal sealed class RenderExceptionContextDependencyTests
+    {
+        private static readonly ComponentContext<int> NumberContext = ComponentContext<int>.Create(0);
+        private static readonly ComponentContext<string> LetterContext = ComponentContext<string>.Create("-");
+
+        private readonly record struct ProviderState(int Number, string Letter);
+
+        private sealed class ProviderStore : Store<ProviderState>
+        {
+            public ProviderStore() : base(new ProviderState(1, "a")) { }
+            public void SetNumber(int n) => SetState(s => s with { Number = n });
+            public void SetLetter(string l) => SetState(s => s with { Letter = l });
+            protected override void ResetCore() => SetState(_ => new ProviderState(1, "a"));
+        }
+
+        private static ProviderStore s_store;
+        private static bool s_throwOnce;
+
+        private VisualElement _root;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _root = new VisualElement();
+            s_store = null;
+            s_throwOnce = false;
+        }
+
+        // Memoized: with stable (absent) props, a parent-driven render bails, so a later re-render
+        // can arrive only through the Provider-change walk — the exact gate under test. The one-shot
+        // throw fires after the first UseContext but before the second, leaving the second context's
+        // dependency to the staging discipline.
+        [Component(Memoize = true)]
+        private static VNode TwoContextConsumer()
+        {
+            var number = Hooks.UseContext(NumberContext);
+            if (s_throwOnce)
+            {
+                s_throwOnce = false;
+                throw new InvalidOperationException("boom");
+            }
+            var letter = Hooks.UseContext(LetterContext);
+            return V.Label(name: "ctx-out", text: number + "-" + letter);
+        }
+
+        [Component]
+        private static VNode ProviderHost()
+        {
+            var state = Hooks.UseStore(s_store, s => s);
+            return V.Provider(NumberContext, state.Number, new VNode[]
+            {
+                V.Provider(LetterContext, state.Letter, new VNode[]
+                {
+                    V.Component(TwoContextConsumer, key: "consumer"),
+                }),
+            });
+        }
+
+        [Test]
+        public void Given_ARenderThrewBeforeItsSecondContextRead_When_ThatContextChanges_Then_TheConsumerStillRerenders()
+        {
+            // Arrange — a successful mount records both context reads; a later render throws between
+            // the first and the second read (no error boundary above).
+            using var store = new ProviderStore();
+            s_store = store;
+            using var mounted = V.Mount(_root, V.Component(ProviderHost, key: "host"));
+            var scheduler = mounted.Root.Reconciler.Context.BatchScheduler;
+            Assume.That(_root.Q<Label>("ctx-out").text, Is.EqualTo("1-a"), "Precondition: both contexts render");
+            LogAssert.Expect(LogType.Exception, new System.Text.RegularExpressions.Regex("boom"));
+            s_throwOnce = true;
+            store.SetNumber(2);
+            scheduler.DrainImmediateForTest();
+
+            // Act — only the SECOND context's value changes afterwards.
+            store.SetLetter("b");
+            scheduler.DrainImmediateForTest();
+
+            // Assert — the consumer still re-rendered for it (the failed render did not drop the
+            // committed dependency), showing both current values.
+            Assert.AreEqual("2-b", _root.Q<Label>("ctx-out").text);
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/RenderExceptionContextDependencyTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/RenderExceptionContextDependencyTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8c8e8d0d0fd3f476c9a924c4dce68098

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/RenderExceptionPendingEffectTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/RenderExceptionPendingEffectTests.cs
@@ -1,0 +1,81 @@
+using System;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using UnityEngine.UIElements;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins that a passive effect committed by an earlier, successful render survives a later render
+    /// of the same fiber throwing. The render-exception handler blanket-cleared PendingEffects — but
+    /// unlike the layout/insertion lists (rebuilt every render), PendingEffects intentionally
+    /// persists across renders until the deferred frame-boundary flush runs it. Because the settled
+    /// deps were already promoted at commit time, a wiped mount effect (stable deps) was never
+    /// re-staged by any later successful render either: it silently never ran, with no error, while
+    /// the component kept rendering normally. The handler must truncate back to the committed
+    /// baseline instead of clearing, exactly as the render-phase retry path already does.
+    /// </summary>
+    [TestFixture]
+    internal sealed class RenderExceptionPendingEffectTests
+    {
+        private readonly record struct ThrowState(bool Throw);
+
+        private sealed class ThrowStore : Store<ThrowState>
+        {
+            public ThrowStore() : base(new ThrowState(false)) { }
+            public void Set(bool value) => SetState(_ => new ThrowState(value));
+            protected override void ResetCore() => SetState(_ => new ThrowState(false));
+        }
+
+        private static ThrowStore s_store;
+        private static bool s_mountEffectRan;
+
+        private VisualElement _root;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _root = new VisualElement();
+            s_store = null;
+            s_mountEffectRan = false;
+        }
+
+        [Component]
+        private static VNode EffectThenThrow()
+        {
+            var shouldThrow = Hooks.UseStore(s_store, s => s.Throw);
+            Hooks.UseEffect(() =>
+            {
+                s_mountEffectRan = true;
+                return (Action)null;
+            }, Array.Empty<object>());
+            if (shouldThrow)
+            {
+                throw new InvalidOperationException("boom");
+            }
+            return V.Div(name: "etr");
+        }
+
+        [Test]
+        public void Given_ACommittedMountEffectNotYetFlushed_When_ALaterRenderThrows_Then_TheEffectStillRuns()
+        {
+            // Arrange — mount commits the effect into the pending list; the deferred flush has not
+            // run yet when a second render of the same fiber throws (no error boundary above).
+            using var store = new ThrowStore();
+            s_store = store;
+            using var mounted = V.Mount(_root, V.Component(EffectThenThrow, key: "etr"));
+            var scheduler = mounted.Root.Reconciler.Context.BatchScheduler;
+            LogAssert.Expect(LogType.Exception, new System.Text.RegularExpressions.Regex("boom"));
+            store.Set(true);
+            scheduler.DrainImmediateForTest();
+
+            // Act — the deferred passive-effect flush finally runs.
+            mounted.FlushEffectsForTest();
+
+            // Assert — the already-committed mount effect was not discarded by the failing render.
+            Assert.That(s_mountEffectRan, Is.True);
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/RenderExceptionPendingEffectTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/RenderExceptionPendingEffectTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: cb85d323be0674fc6b2e8a3c7c647d93


### PR DESCRIPTION
## Summary

Six reconciler correctness fixes, each landing with a regression test that fails before the fix and passes after:

- **New-side duplicate keys silently dropped a row.** The keyed diff never marked an old-map entry consumed, so a second sibling with the same key aliased the first occurrence's element and the reorder pass collapsed them into one slot — childCount desynced from the declared child array. Both the flat fast path and the general expansion path now warn (mirroring the existing old-side guard) and mount a fresh element for the repeat.
- **A keyed reorder plus an independent re-render inserted a permanent duplicate.** The fiber sibling chain is creation order and a reorder does not resync it, so the slot bound for a displaced inline fiber's own re-render could fall below its slot start; every slot looked missing and a ghost element was inserted that no future reconcile removes. The bound now comes from the nearest co-located slot start beyond the fiber's own, regardless of chain position.
- **Duplicate sibling keys on inline components double-emitted one fiber's DOM.** Two same-identity siblings sharing a key resolve to the same registry fiber; it was expanded once per sibling (sharing hook state across both copies). The repeat now warns and is skipped before it can clobber the first occurrence's slot bookkeeping.
- **A failing render corrupted committed fiber state.** The exception handler blanket-cleared passive effects that an earlier commit had staged but not yet flushed (their settled deps were already promoted, so they would never be re-staged — a mount effect silently never ran), and the context-dependency list was cleared in place at the top of every attempt, so a partway throw detached the fiber from Provider-change notifications forever. Effects are truncated back to the committed baseline and context reads are staged and swapped in only when the attempt settles.
- **StrictMode's double-invoke corrupted a directly-built mount tree.** V.Mount documents plain element trees; the root Body is a constant passthrough closure, so the diagnostic's second pass returned the same node graph the commit owns and recycling it wiped the live tree's props/events into the shared pools. The constant mount root is now exempt; nested component fibers keep the diagnostic.
- **Orphaned nested components tore down top-down.** The old-side expansion appended the parent fiber before recursing into its body output, so the orphan sweep ran parent cleanups while the child was still mounted. Post-order collection restores bottom-up teardown, matching the commit-phase deletion order.

## Testing

- New fixtures: KeyedNewSideDuplicateKeyTests, InlineSiblingReorderRerenderTests, DuplicateInlineComponentKeyTests, RenderExceptionPendingEffectTests, RenderExceptionContextDependencyTests, StrictModeDirectTreeMountTests, OrphanCleanupOrderTests (+ staging-discipline units in ComponentFiberTests).
- Full EditMode suite green (2589 tests).

Independent of the other fix PRs from the same series; mergeable in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)