### PR TITLE
fix(velvet): element pool lifecycle and ownership guards

### DIFF
--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/VNodePoolOwnershipTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/VNodePoolOwnershipTests.cs
@@ -1,0 +1,86 @@
+using NUnit.Framework;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins ownership tracking for the props-bag and single-event-array pools, mirroring the
+    /// identity set the VNode?[] pool already keeps. The V.* factories accept caller-supplied
+    /// <see cref="FiberElementProps"/> / event arrays that a component may cache and reuse across
+    /// renders; retiring an old tree unconditionally returned them, wiping every field of an object
+    /// the caller still holds and pushing it into the shared pool where an unrelated mount could
+    /// rent and overwrite it. Only instances the pool itself created may be cleared and recycled.
+    /// </summary>
+    [TestFixture]
+    internal sealed class VNodePoolOwnershipTests
+    {
+        [Test]
+        public void Given_UserPropsNotRentedFromPool_When_ReturnProps_Then_ItIsNotCleared()
+        {
+            // Arrange — a caller-owned props bag, as a component caching props across renders holds.
+            var props = new FiberElementProps { Tooltip = "Save" };
+
+            // Act
+            VNodePool.ReturnProps(props);
+
+            // Assert — the caller's instance is left untouched.
+            Assert.That(props.Tooltip, Is.EqualTo("Save"));
+        }
+
+        [Test]
+        public void Given_UserPropsWasPassedToReturn_When_AnotherRentFollows_Then_TheUserInstanceIsNotHandedOut()
+        {
+            // Arrange
+            var props = new FiberElementProps { Tooltip = "Save" };
+            VNodePool.ReturnProps(props);
+
+            // Act — an unrelated factory call rents from the pool.
+            var rented = VNodePool.RentProps();
+
+            // Assert — the caller-owned instance never entered the shared pool.
+            Assert.That(ReferenceEquals(rented, props), Is.False);
+        }
+
+        [Test]
+        public void Given_RentedProps_When_ReturnedAndRentedAgain_Then_ThePoolStillRecyclesIt()
+        {
+            // Arrange — a genuinely pool-owned props bag with a stale field.
+            var rented = VNodePool.RentProps();
+            rented.Tooltip = "stale";
+            VNodePool.ReturnProps(rented);
+
+            // Act
+            var again = VNodePool.RentProps();
+
+            // Assert — the pooled instance round-trips and comes back scrubbed.
+            Assert.That((ReferenceEquals(again, rented), again.Tooltip),
+                Is.EqualTo((true, (string)null)));
+        }
+
+        [Test]
+        public void Given_UserEventArrayNotRentedFromPool_When_ReturnEventArray_Then_ItIsNotCleared()
+        {
+            // Arrange — a caller-owned single-event array, as a component caching events would hold.
+            var events = new FiberEventBinding[] { new ClickedBinding { Handler = () => { } } };
+
+            // Act
+            VNodePool.ReturnEventArray(events);
+
+            // Assert — the caller's binding survives.
+            Assert.That(events[0], Is.Not.Null);
+        }
+
+        [Test]
+        public void Given_UserEventArrayWasPassedToReturn_When_AnotherRentFollows_Then_TheUserArrayIsNotHandedOut()
+        {
+            // Arrange
+            var events = new FiberEventBinding[] { new ClickedBinding { Handler = () => { } } };
+            VNodePool.ReturnEventArray(events);
+
+            // Act
+            var rented = VNodePool.RentSingleEventArray();
+
+            // Assert — the caller-owned array never entered the shared pool.
+            Assert.That(ReferenceEquals(rented, events), Is.False);
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/VNodePoolOwnershipTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/VNodePoolOwnershipTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 84c7365bc60a64bf0899ccb96231503d

--- a/Packages/com.velvet.core/Runtime/Component/VNodePool.cs
+++ b/Packages/com.velvet.core/Runtime/Component/VNodePool.cs
@@ -21,15 +21,36 @@ namespace Velvet
 
         private static readonly Stack<FiberElementProps> s_propsPool = new();
 
+        // Identity set of props bags this pool created (via RentProps). ReturnProps clears + recycles
+        // ONLY these — never a caller-supplied instance: the V.* factories accept a raw `props:`
+        // argument a consumer may cache and reuse across renders, and clearing it would wipe an object
+        // the caller still holds and alias it into the shared pool. Mirrors s_ownedNodeArrays.
+        private static readonly HashSet<FiberElementProps> s_ownedProps = new();
+
         public static FiberElementProps RentProps()
         {
-            return s_propsPool.Count > 0 ? s_propsPool.Pop() : new FiberElementProps();
+            if (s_propsPool.Count > 0)
+            {
+                // A pooled bag is already owned (recorded when first created); no set op on this hot path.
+                return s_propsPool.Pop();
+            }
+
+            var created = new FiberElementProps();
+            s_ownedProps.Add(created);
+            return created;
         }
 
         public static void ReturnProps(FiberElementProps? props)
         {
             if (props == null || ReferenceEquals(props, FiberElementProps.Empty)) return;
-            if (s_propsPool.Count >= MaxPoolSize) return;
+            // Only recycle bags the pool owns; a caller-owned bag is left untouched (not cleared, not pooled).
+            if (!s_ownedProps.Contains(props)) return;
+            if (s_propsPool.Count >= MaxPoolSize)
+            {
+                // Pool is full: drop this owned bag (let it be GC'd) and stop tracking it so the set does not leak.
+                s_ownedProps.Remove(props);
+                return;
+            }
 
             props.Text = null;
             props.Tooltip = null;
@@ -53,16 +74,33 @@ namespace Velvet
 
         private static readonly Stack<FiberEventBinding[]> s_singleEventPool = new();
 
+        // Identity set mirroring s_ownedProps: only arrays RentSingleEventArray created may be
+        // cleared and recycled — V.Motion accepts a raw `events:` array a consumer may cache and
+        // reuse across renders, and clearing slot 0 would sever the caller's handler in place.
+        private static readonly HashSet<FiberEventBinding[]> s_ownedSingleEventArrays = new();
+
         public static FiberEventBinding[] RentSingleEventArray()
         {
-            return s_singleEventPool.Count > 0 ? s_singleEventPool.Pop() : new FiberEventBinding[1];
+            if (s_singleEventPool.Count > 0)
+            {
+                return s_singleEventPool.Pop();
+            }
+
+            var created = new FiberEventBinding[1];
+            s_ownedSingleEventArrays.Add(created);
+            return created;
         }
 
         public static void ReturnEventArray(FiberEventBinding[] array)
         {
-            if (array == null || array.Length == 0) return;
-            if (array.Length != 1) return;
-            if (s_singleEventPool.Count >= MaxPoolSize) return;
+            if (array == null || array.Length != 1) return;
+            // Only recycle arrays the pool owns; a caller-owned array is left untouched.
+            if (!s_ownedSingleEventArrays.Contains(array)) return;
+            if (s_singleEventPool.Count >= MaxPoolSize)
+            {
+                s_ownedSingleEventArrays.Remove(array);
+                return;
+            }
 
             array[0] = null!;
             s_singleEventPool.Push(array);

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberElementCleaner.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberElementCleaner.cs
@@ -301,6 +301,10 @@ namespace Velvet
                 routeScope.Dispose();
                 _ctx.OutletScopes.Remove(element);
             }
+            // Identity-side registration added on every Outlet mount; without this per-element
+            // removal the set would pin every unmounted Outlet's dead container element until the
+            // whole reconciler disposes. No-op for non-Outlet elements.
+            _ctx.OutletContainers.Remove(element);
         }
 
         // Removes only this Portal's slot range from the target's children

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberElementCleaner.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberElementCleaner.cs
@@ -81,47 +81,53 @@ namespace Velvet
                 return;
             }
 
-            switch (element)
+            var exactType = element.GetType();
+            if (exactType == typeof(Label) || exactType == typeof(Toggle)
+                || exactType == typeof(Slider) || exactType == typeof(TextField)
+                || (exactType == typeof(Button) && ((Button)element).childCount == 0))
             {
-                case Label or Toggle or Slider or TextField:
-                    CleanupElementResources(element);
-                    ReturnToPool(element);
-                    break;
-                case Button button when button.childCount == 0:
-                    CleanupElementResources(button);
-                    ReturnToPool(button);
-                    break;
-                default:
-                    // A plain container orphan (Div) or a Button declared with children. Release the
-                    // orphan subtree's element-keyed resources without disposing its fibers and
-                    // without pooling the non-poolable container.
-                    CleanupElementCore(element);
-                    break;
+                CleanupElementResources(element);
+                ReturnToPool(element);
+            }
+            else
+            {
+                // A plain container orphan (Div), a Button declared with children, or a user
+                // subclass of a poolable primitive (never pooled — see ReturnToPool). Release the
+                // orphan subtree's element-keyed resources without disposing its fibers and
+                // without pooling the non-poolable container.
+                CleanupElementCore(element);
             }
         }
 
         // Returns the element to the VNodePool when the type supports pooling.
         // Called after the element has been detached from the DOM hierarchy and Velvet-managed
-        // resources have been released.
+        // resources have been released. Dispatches on the EXACT runtime type, mirroring the
+        // factory's exact-type rent checks: a user subclass of a poolable primitive (mounted via
+        // V.Custom<T>) must never enter the shared pool — its own fields and constructor-registered
+        // callbacks survive the base-type reset, so a later plain rent would resurrect them on an
+        // unrelated mount.
         private static void ReturnToPool(VisualElement element)
         {
-            switch (element)
+            var type = element.GetType();
+            if (type == typeof(TextField))
             {
-                case TextField textField:
-                    VNodePool.ReturnTextField(textField);
-                    break;
-                case Toggle toggle:
-                    VNodePool.ReturnToggle(toggle);
-                    break;
-                case Slider slider:
-                    VNodePool.ReturnSlider(slider);
-                    break;
-                case Button button:
-                    VNodePool.ReturnButton(button);
-                    break;
-                case Label label:
-                    VNodePool.ReturnLabel(label);
-                    break;
+                VNodePool.ReturnTextField((TextField)element);
+            }
+            else if (type == typeof(Toggle))
+            {
+                VNodePool.ReturnToggle((Toggle)element);
+            }
+            else if (type == typeof(Slider))
+            {
+                VNodePool.ReturnSlider((Slider)element);
+            }
+            else if (type == typeof(Button))
+            {
+                VNodePool.ReturnButton((Button)element);
+            }
+            else if (type == typeof(Label))
+            {
+                VNodePool.ReturnLabel((Label)element);
             }
         }
 

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberElementCleaner.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberElementCleaner.cs
@@ -32,9 +32,10 @@ namespace Velvet
             }
 
             var element = parent.ElementAt(index);
+            var poolable = PoolableOccupantOf(element);
             CleanupElement(element);
             parent.RemoveAt(index);
-            ReturnToPool(element);
+            ReturnOccupantToPool(element, poolable);
         }
 
         // Removes an element from its parent directly (by element reference, not index).
@@ -45,9 +46,28 @@ namespace Velvet
                 return;
             }
 
+            var poolable = PoolableOccupantOf(element);
             CleanupElement(element);
             element.RemoveFromHierarchy();
-            ReturnToPool(element);
+            ReturnOccupantToPool(element, poolable);
+        }
+
+        // Resolves the poolable occupant of a slot: a ring-*/clip-path-* leaf sits inside a
+        // structural wrapper, and the wrapper — not the widget — is the slot's element. Must run
+        // BEFORE CleanupElement, which consumes the wrapper map entry.
+        private VisualElement PoolableOccupantOf(VisualElement element)
+            => _ctx.WrapperToInnerMap.TryGetValue(element, out var inner) ? inner : element;
+
+        // Reclaims the slot's poolable occupant after cleanup. A wrapped inner is detached from its
+        // wrapper first so a pooled widget never carries the dead wrapper as its parent — mirroring
+        // the rollback-orphan path, which already unwraps before reclaiming.
+        private static void ReturnOccupantToPool(VisualElement removed, VisualElement poolable)
+        {
+            if (!ReferenceEquals(poolable, removed))
+            {
+                poolable.RemoveFromHierarchy();
+            }
+            ReturnToPool(poolable);
         }
 
         // Returns a created-but-never-placed orphan element to the pool. Used by the speculative
@@ -308,9 +328,10 @@ namespace Velvet
             for (var i = slotEnd - 1; i >= portalInfo.SlotStart; i--)
             {
                 var child = target.ElementAt(i);
+                var poolable = PoolableOccupantOf(child);
                 CleanupElement(child);
                 target.RemoveAt(i);
-                ReturnToPool(child);
+                ReturnOccupantToPool(child, poolable);
             }
 
             // Surviving Portals on the same target whose slot starts after the removed range

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/CustomSubclassPoolExactTypeTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/CustomSubclassPoolExactTypeTests.cs
@@ -1,0 +1,78 @@
+using System;
+using NUnit.Framework;
+using UnityEngine.UIElements;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins pool-return dispatch to the exact runtime type, mirroring the exact-type checks the
+    /// factory uses to rent. V.Custom&lt;T&gt; legitimately mounts user subclasses of the poolable
+    /// primitives; the return side's type-pattern switch subtype-matched them into the shared pools,
+    /// so an unrelated later V.Button could rent the subclass instance back — with its own fields and
+    /// constructor-registered callbacks still live, since the base-type reset cannot know about them.
+    /// A subclass must simply fall through un-pooled.
+    /// </summary>
+    [TestFixture]
+    internal sealed class CustomSubclassPoolExactTypeTests
+    {
+        private sealed class ProbeButton : Button
+        {
+        }
+
+        private readonly record struct PhaseState(int Phase);
+
+        private sealed class PhaseStore : Store<PhaseState>
+        {
+            public PhaseStore() : base(new PhaseState(0)) { }
+            public void Set(int phase) => SetState(_ => new PhaseState(phase));
+            protected override void ResetCore() => SetState(_ => new PhaseState(0));
+        }
+
+        private static PhaseStore s_store;
+
+        private VisualElement _root;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _root = new VisualElement();
+            s_store = null;
+        }
+
+        // Phase 0 mounts the subclass; phase 1 unmounts it (its only pooling opportunity);
+        // phase 2 mounts a plain button that rents from the pool.
+        [Component]
+        private static VNode Screen()
+        {
+            var phase = Hooks.UseStore(s_store, s => s.Phase);
+            return V.Div(name: "screen", children: phase switch
+            {
+                0 => new VNode[] { V.Custom<ProbeButton>(name: "probe") },
+                1 => Array.Empty<VNode>(),
+                _ => new VNode[] { V.Button(name: "plain", text: "plain") },
+            });
+        }
+
+        [Test]
+        public void Given_ACustomButtonSubclassWasUnmounted_When_APlainButtonMounts_Then_ItIsNotTheSubclassInstance()
+        {
+            // Arrange — mount the subclass, then unmount it so it hits the pool-return path.
+            using var store = new PhaseStore();
+            s_store = store;
+            using var mounted = V.Mount(_root, V.Component(Screen, key: "screen"));
+            var scheduler = mounted.Root.Reconciler.Context.BatchScheduler;
+            var probe = _root.Q<ProbeButton>();
+            Assume.That(probe, Is.Not.Null, "Precondition: the subclass instance is mounted");
+            store.Set(1);
+            scheduler.DrainImmediateForTest();
+
+            // Act — a plain button mounts, renting from the shared pool.
+            store.Set(2);
+            scheduler.DrainImmediateForTest();
+
+            // Assert — the plain button is a real Button, never the recycled subclass instance.
+            Assert.That(ReferenceEquals(_root.Q<VisualElement>("plain"), probe), Is.False);
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/CustomSubclassPoolExactTypeTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/CustomSubclassPoolExactTypeTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5d13b10a661274f63a6ac3125ace12fa

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/OutletContainerReleaseTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/OutletContainerReleaseTests.cs
@@ -1,0 +1,68 @@
+using System;
+using NUnit.Framework;
+using UnityEngine.UIElements;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins per-element release of the Outlet-container identity set. Every Outlet mount registers
+    /// its layout-passthrough container so the context spine can identify Outlet hosts, but unlike
+    /// every other element-keyed side table the set had no per-element removal — only the
+    /// whole-reconciler dispose cleared it. Each route change that destroys and recreates an Outlet
+    /// then pinned the dead container element for the remaining lifetime of the mount, growing
+    /// without bound over a long session.
+    /// </summary>
+    [TestFixture]
+    internal sealed class OutletContainerReleaseTests
+    {
+        private readonly record struct ToggleState(bool Show);
+
+        private sealed class ToggleStore : Store<ToggleState>
+        {
+            public ToggleStore() : base(new ToggleState(true)) { }
+            public void Set(bool show) => SetState(_ => new ToggleState(show));
+            protected override void ResetCore() => SetState(_ => new ToggleState(true));
+        }
+
+        private static ToggleStore s_store;
+
+        private VisualElement _root;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _root = new VisualElement();
+            s_store = null;
+        }
+
+        [Component]
+        private static VNode App()
+        {
+            var show = Hooks.UseStore(s_store, s => s.Show);
+            return V.Div(name: "app", children: show
+                ? new VNode[] { V.Outlet() }
+                : Array.Empty<VNode>());
+        }
+
+        [Test]
+        public void Given_AMountedOutlet_When_ItUnmounts_Then_ItsContainerRegistrationIsReleased()
+        {
+            // Arrange — a mounted Outlet registers its container in the identity set.
+            using var store = new ToggleStore();
+            s_store = store;
+            using var mounted = V.Mount(_root, V.Component(App, key: "app"));
+            var context = mounted.Root.Reconciler.Context;
+            var scheduler = context.BatchScheduler;
+            Assume.That(context.OutletContainers.Count, Is.EqualTo(1),
+                "Precondition: the mounted Outlet's container is registered");
+
+            // Act — the Outlet unmounts.
+            store.Set(false);
+            scheduler.DrainImmediateForTest();
+
+            // Assert — the registration is gone, so dead containers cannot accumulate across route changes.
+            Assert.AreEqual(0, context.OutletContainers.Count);
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/OutletContainerReleaseTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/OutletContainerReleaseTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 62f0db2f17978473cbb4daf0343cf4ed

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/WrappedWidgetPoolReclaimTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/WrappedWidgetPoolReclaimTests.cs
@@ -1,0 +1,67 @@
+using System;
+using NUnit.Framework;
+using UnityEngine.UIElements;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins pool reclamation for a poolable widget that occupies its slot through a structural
+    /// wrapper (ring-*/clip-path-* classes wrap the widget in a passthrough element). The ordinary
+    /// removal paths returned the WRAPPER to the pool switch — a plain container that matches no
+    /// pooled type — so the inner widget was silently dropped for GC instead of recycled, unlike the
+    /// rollback-orphan path which already resolves the wrapper to its inner. Removal must reclaim
+    /// the inner widget so pooling keeps working for the wrapped combination.
+    /// </summary>
+    [TestFixture]
+    internal sealed class WrappedWidgetPoolReclaimTests
+    {
+        private readonly record struct ToggleState(bool Show);
+
+        private sealed class ToggleStore : Store<ToggleState>
+        {
+            public ToggleStore() : base(new ToggleState(true)) { }
+            public void Set(bool show) => SetState(_ => new ToggleState(show));
+            protected override void ResetCore() => SetState(_ => new ToggleState(true));
+        }
+
+        private static ToggleStore s_store;
+
+        private VisualElement _root;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _root = new VisualElement();
+            s_store = null;
+        }
+
+        [Component]
+        private static VNode Avatar()
+        {
+            var show = Hooks.UseStore(s_store, s => s.Show);
+            return V.Div(name: "host", children: show
+                ? new VNode[] { V.Button(name: "avatar", className: "ring-2", text: "a") }
+                : Array.Empty<VNode>());
+        }
+
+        [Test]
+        public void Given_ARingWrappedButton_When_ItsSlotUnmounts_Then_TheInnerButtonIsReclaimedToThePool()
+        {
+            // Arrange — a mounted ring-wrapped button (the wrapper occupies the parent slot).
+            using var store = new ToggleStore();
+            s_store = store;
+            using var mounted = V.Mount(_root, V.Component(Avatar, key: "avatar"));
+            var scheduler = mounted.Root.Reconciler.Context.BatchScheduler;
+            Assume.That(_root.Q<Button>("avatar"), Is.Not.Null, "Precondition: the wrapped button is mounted");
+            var before = VNodePool.ButtonPoolCountForTesting;
+
+            // Act — remove the wrapped slot through the ordinary unmount path.
+            store.Set(false);
+            scheduler.DrainImmediateForTest();
+
+            // Assert — the inner button reached the pool (not the wrapper, not GC).
+            Assert.AreEqual(before + 1, VNodePool.ButtonPoolCountForTesting);
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/WrappedWidgetPoolReclaimTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/WrappedWidgetPoolReclaimTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 84d17414bf11845fcb46bce00783331c


### PR DESCRIPTION
## Summary

Four pooling/cleanup fixes in the state-ghosting bug class, each with a RED→GREEN regression test:

- **Pool returns dispatched on subtype matches.** The factory rents with exact-type checks, but ReturnToPool/ReturnRolledBackOrphan used type-pattern switches — an is-style subtype match — so a V.Custom<T> subclass of Button/Label/Toggle/Slider/TextField was absorbed into the shared base-type pool on unmount, and a later plain V.Button anywhere in the app could rent that instance back with its subclass fields and constructor-registered callbacks still live. Returns now dispatch on GetType() equality; subclasses fall through un-pooled (resources still released).
- **Wrapped widgets were never reclaimed.** A ring-*/clip-path-* leaf occupies its slot through a structural wrapper, and the ordinary removal paths ran the pool switch against the wrapper (matching nothing), silently dropping the inner widget for GC. The rollback-orphan path already unwraps; the ordinary paths now capture the inner before cleanup consumes the wrapper map entry, detach it, and reclaim it.
- **Outlet container registrations leaked.** Every Outlet mount adds its layout-passthrough container to an identity set, but unlike every other element-keyed side table the set had no per-element removal — only whole-reconciler dispose cleared it, pinning one dead element per navigation that recreates an Outlet. CleanupElementResources now removes the entry alongside the Outlet scope teardown.
- **Caller-owned props bags and event arrays were cleared and recycled.** ReturnProps/ReturnEventArray nulled every field of whatever instance the retiring tree carried and pushed it into the shared pool — but the V.* factories accept caller-supplied props/events that a component may cache across renders, so retiring a tree wiped an object the caller still holds and the next unrelated rent handed it out for another mount to overwrite. Both pools now track ownership with an identity set, exactly as the VNode?[] pool already does.

## Testing

- New fixtures: CustomSubclassPoolExactTypeTests, WrappedWidgetPoolReclaimTests, OutletContainerReleaseTests, VNodePoolOwnershipTests.
- Full EditMode suite green (2589 tests).

Independent of the other fix PRs from the same series; mergeable in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)