### PR TITLE
fix(velvet): store notification, nullable equality, and blocker liveness

### DIFF
--- a/Packages/com.velvet.core/Runtime/Component/ObjectIs.cs
+++ b/Packages/com.velvet.core/Runtime/Component/ObjectIs.cs
@@ -40,7 +40,11 @@ namespace Velvet
                 return string.Equals((string?)(object?)a, (string?)(object?)b, System.StringComparison.Ordinal);
             }
 
-            if (default(T) == null)
+            // Route by IsValueType, not by a null-test: Nullable<T> satisfies a lifted
+            // `default(T) == null` (boxing an empty nullable yields a true null reference), which
+            // would send it to the reference branch — where boxing each operand afresh makes equal
+            // values never compare equal. Nullable<T> must fall through to the value comparison.
+            if (!typeof(T).IsValueType)
             {
                 return ReferenceEquals(a, b);
             }

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/ObjectIsNullableValueTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/ObjectIsNullableValueTests.cs
@@ -1,0 +1,99 @@
+using NUnit.Framework;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Specifies <see cref="ObjectIs.AreEqual{T}"/> for nullable value types — the comparer behind the
+    /// UseState setter bail, the Store SetState no-op check, and the default UseStore / Select comparer.
+    /// A <c>Nullable&lt;T&gt;</c> is a value type, but its lifted <c>default(T) == null</c> comparison is
+    /// true, so a null-test misrouted it to the reference-identity branch — where boxing each operand
+    /// yields a fresh object every call, making two equal values never compare equal. Every store
+    /// notification then looked like a change to an <c>int?</c>-selected slice, re-rendering subscribers
+    /// on unrelated updates. Nullable values must compare by value, like every other value type.
+    /// </summary>
+    [TestFixture]
+    internal sealed class ObjectIsNullableValueTests
+    {
+        [Test]
+        public void Given_EqualNullableInts_When_AreEqualGeneric_Then_AreEqual()
+        {
+            // Arrange — two independently boxed but numerically equal nullable ints.
+            int? a = 5;
+            int? b = 5;
+
+            // Act
+            var equal = ObjectIs.AreEqual(a, b);
+
+            // Assert — equal values bail, so an unchanged int?-selected store slice does not re-render.
+            Assert.That(equal, Is.True);
+        }
+
+        [Test]
+        public void Given_BothNullNullableInts_When_AreEqualGeneric_Then_AreEqual()
+        {
+            // Arrange
+            int? a = null;
+            int? b = null;
+
+            // Act
+            var equal = ObjectIs.AreEqual(a, b);
+
+            // Assert
+            Assert.That(equal, Is.True);
+        }
+
+        [Test]
+        public void Given_NullAndValuedNullableInt_When_AreEqualGeneric_Then_AreNotEqual()
+        {
+            // Arrange
+            int? a = null;
+            int? b = 5;
+
+            // Act
+            var equal = ObjectIs.AreEqual(a, b);
+
+            // Assert
+            Assert.That(equal, Is.False);
+        }
+
+        [Test]
+        public void Given_DifferentNullableInts_When_AreEqualGeneric_Then_AreNotEqual()
+        {
+            // Arrange
+            int? a = 5;
+            int? b = 6;
+
+            // Act
+            var equal = ObjectIs.AreEqual(a, b);
+
+            // Assert
+            Assert.That(equal, Is.False);
+        }
+
+        [Test]
+        public void Given_EqualNullableUserStructs_When_AreEqualGeneric_Then_AreEqual()
+        {
+            // Arrange — a plain struct with no custom Equals, wrapped in Nullable.
+            Point? a = new Point(1, 2);
+            Point? b = new Point(1, 2);
+
+            // Act
+            var equal = ObjectIs.AreEqual(a, b);
+
+            // Assert
+            Assert.That(equal, Is.True);
+        }
+
+        private readonly struct Point
+        {
+            public Point(int x, int y)
+            {
+                X = x;
+                Y = y;
+            }
+
+            public int X { get; }
+            public int Y { get; }
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/ObjectIsNullableValueTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/ObjectIsNullableValueTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 71fbed80c43c04bdab77451c11252e7e

--- a/Packages/com.velvet.core/Runtime/Routing/RouteBlockerManager.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/RouteBlockerManager.cs
@@ -71,7 +71,19 @@ namespace Velvet
                     continue;
                 }
 
-                if (blocked)
+                // A superseded attempt must not flip any state: the token is the navigation's own,
+                // cancelled when a newer navigation takes over, and the caller is about to discard
+                // this result as Cancelled — a Blocked state would strand a confirm-UI until some
+                // unrelated future navigation resets it.
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return anyBlocked;
+                }
+
+                // Skip entries whose registration died during this pass (the snapshot keeps them
+                // iterable, but their owner unmounted or an earlier blocker's decision tore them
+                // down): nothing live is waiting on their state.
+                if (blocked && _blockers.Contains(entry))
                 {
                     entry.State.Block(attempt);
                     anyBlocked = true;

--- a/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/BlockerLivenessTests.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/BlockerLivenessTests.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Threading;
+using NUnit.Framework;
+using static Velvet.Tests.RouteTestStubs;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins that a blocker's Block() side effect lands only for live registrations on a live
+    /// attempt. CheckAsync snapshots the registration list (so an unregister during the pass cannot
+    /// corrupt iteration) but then applied Block() unconditionally: an entry disposed during the
+    /// pass (its owner unmounted, or an earlier blocker's decision tore it down) still flipped its
+    /// state to Blocked, and a superseded attempt (its token already cancelled by a newer
+    /// navigation) still flipped states the caller was about to discard — stranding a
+    /// confirm-before-leaving UI on a navigation nobody was waiting on until some unrelated future
+    /// navigation reset it.
+    /// </summary>
+    [TestFixture]
+    internal sealed class BlockerLivenessTests
+    {
+        [Test]
+        public void Given_ABlockerThatUnregistersItselfWhileBlocking_When_ThePassCompletes_Then_ItsStateStaysIdle()
+        {
+            // Arrange — the blocker's own check disposes its registration before answering true,
+            // the synchronous shape of an owner unmounting mid-check.
+            var manager = new RouteBlockerManager();
+            var state = new RouteBlockerState();
+            IDisposable registration = null;
+            registration = manager.Register(_ =>
+            {
+                registration.Dispose();
+                return true;
+            }, state);
+
+            // Act
+            var blocked = manager.CheckAsync(Attempt()).GetAwaiter().GetResult();
+
+            // Assert — a dead registration neither blocks the navigation nor strands its state.
+            Assert.That((blocked, state.Status), Is.EqualTo((false, RouteBlockerStatus.Idle)));
+        }
+
+        [Test]
+        public void Given_AnEarlierBlockerUnregistersALaterOne_When_ThePassContinues_Then_TheLaterStateStaysIdle()
+        {
+            // Arrange — the first blocker's decision tears down the second's registration (e.g. it
+            // unmounts the subtree owning it) before the snapshot loop reaches it.
+            var manager = new RouteBlockerManager();
+            var laterState = new RouteBlockerState();
+            IDisposable laterRegistration = null;
+            using var earlier = manager.Register(_ =>
+            {
+                laterRegistration.Dispose();
+                return false;
+            }, new RouteBlockerState());
+            laterRegistration = manager.Register(_ => true, laterState);
+
+            // Act
+            var blocked = manager.CheckAsync(Attempt()).GetAwaiter().GetResult();
+
+            // Assert
+            Assert.That((blocked, laterState.Status), Is.EqualTo((false, RouteBlockerStatus.Idle)));
+        }
+
+        [Test]
+        public void Given_AnAlreadySupersededAttempt_When_ABlockerWouldBlock_Then_NoStateIsFlipped()
+        {
+            // Arrange — the attempt's token is already cancelled (a newer navigation took over);
+            // the caller is about to discard this result as Cancelled.
+            var manager = new RouteBlockerManager();
+            var state = new RouteBlockerState();
+            using var registration = manager.Register(_ => true, state);
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            // Act
+            manager.CheckAsync(Attempt(), cts.Token).GetAwaiter().GetResult();
+
+            // Assert — the abandoned attempt leaves no Blocked state behind.
+            Assert.That(state.Status, Is.EqualTo(RouteBlockerStatus.Idle));
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/BlockerLivenessTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/BlockerLivenessTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 27cbd63b3aaa04ec3b691269d45cf125

--- a/Packages/com.velvet.core/Runtime/Store/StoreStateNotifier.cs
+++ b/Packages/com.velvet.core/Runtime/Store/StoreStateNotifier.cs
@@ -10,9 +10,11 @@ namespace Velvet
     // immediate delivery invoke their listener themselves before subscribing.
     // Notification iterates an immutable snapshot of the listener set, rebuilt only when the set
     // changes (copy-on-write), so Notify allocates nothing in the steady state. A
-    // listener that subscribes, unsubscribes, or pushes re-entrantly during a notification does not
-    // affect the in-flight pass: it observes the snapshot captured when that pass began, and a
-    // listener removed mid-pass still receives the value already being delivered.
+    // listener that subscribes or unsubscribes re-entrantly during a notification does not
+    // affect the in-flight pass: it observes the listener set captured when that pass began, and a
+    // listener removed mid-pass still receives the delivery already in flight. Each delivery reads
+    // the value that is current at call time, so a listener that re-entrantly pushes a newer value
+    // supersedes the in-flight value for the listeners that follow it.
     // Single-threaded: no internal locking. All calls (Notify / Subscribe /
     // Dispose) must occur on the owning Store<TState>'s thread (the Unity
     // main thread).
@@ -39,7 +41,10 @@ namespace Velvet
             var snapshot = _snapshot ??= _listeners.ToArray();
             foreach (var listener in snapshot)
             {
-                listener(value);
+                // Deliver the live field, not the captured parameter: a listener that re-entrantly
+                // pushes a newer value must not leave the listeners after it holding the superseded
+                // one as their final observation.
+                listener(Value);
             }
         }
 

--- a/Packages/com.velvet.core/Runtime/Store/Tests/Editor/StoreReentrantNotifyTests.cs
+++ b/Packages/com.velvet.core/Runtime/Store/Tests/Editor/StoreReentrantNotifyTests.cs
@@ -1,0 +1,70 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace Velvet.Tests.Editor
+{
+    /// <summary>
+    /// Pins value freshness across a re-entrant notification. Delivering the value captured when the
+    /// pass began let a listener that re-entrantly pushes a newer value leave every listener AFTER it
+    /// holding the superseded value as its FINAL observation — silently diverging from
+    /// <see cref="Store{TState}.Current"/> until some unrelated future mutation. Each delivery must
+    /// instead read the value current at call time, so the last call any listener receives in a
+    /// cascade carries the store's true state.
+    /// </summary>
+    [TestFixture]
+    internal sealed class StoreReentrantNotifyTests
+    {
+        private readonly record struct CounterState(int Value);
+
+        private sealed class CounterStore : Store<CounterState>
+        {
+            public CounterStore() : base(new CounterState(0)) { }
+            public void Set(int value) => SetState(_ => new CounterState(value));
+            protected override void ResetCore() => SetState(_ => new CounterState(0));
+        }
+
+        [Test]
+        public void Given_AnEarlierListenerReentrantlySetsState_When_Notified_Then_ALaterListenersFinalValueIsCurrent()
+        {
+            // Arrange — the first listener supersedes value 1 with 2 mid-pass; a later listener records.
+            using var store = new CounterStore();
+            var lastSeenByLater = -1;
+            using var reentrant = store.Subscribe(s =>
+            {
+                if (s.Value == 1)
+                {
+                    store.Set(2);
+                }
+            });
+            using var later = store.Subscribe(s => lastSeenByLater = s.Value);
+
+            // Act
+            store.Set(1);
+
+            // Assert — the later listener's final delivery matches Current, not the superseded 1.
+            Assert.AreEqual(store.Current.Value, lastSeenByLater);
+        }
+
+        [Test]
+        public void Given_AListenerReentrantlyNotifies_When_TheOuterPassResumes_Then_ItDeliversTheLiveValue()
+        {
+            // Arrange — listener one pushes 2 upon seeing 1; listener two records every delivery.
+            using var notifier = new StoreStateNotifier<int>(0);
+            var seenByTwo = new List<int>();
+            notifier.Subscribe(v =>
+            {
+                if (v == 1)
+                {
+                    notifier.Notify(2);
+                }
+            });
+            notifier.Subscribe(seenByTwo.Add);
+
+            // Act
+            notifier.Notify(1);
+
+            // Assert — the outer pass's resumed delivery carries the live value, not its stale parameter.
+            Assert.That(seenByTwo, Is.EqualTo(new[] { 2, 2 }));
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Store/Tests/Editor/StoreReentrantNotifyTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Store/Tests/Editor/StoreReentrantNotifyTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 468d60c62542c49d290a08fb5e3f09fe


### PR DESCRIPTION
## Summary

Three correctness fixes in core runtime services, each with a RED→GREEN regression test:

- **Equal Nullable<T> values always compared as changed.** ObjectIs.AreEqual<T> routed by a lifted `default(T) == null` test, which is true for every Nullable<T> — boxing each operand afresh made numerically equal values never reference-equal. Every store notification then looked like a change to an int?-selected slice (the default UseStore/Select comparer), and a UseState setter holding an equal nullable never bailed. Routing by typeof(T).IsValueType sends Nullable<T> through the value comparison like every other value type.
- **A re-entrant notify left later listeners on a stale value.** Notify delivered the value captured when the pass began, so a listener that re-entrantly pushed a newer value left every listener after it holding the superseded value as its final observation — silently diverging from Store.Current until some unrelated future mutation. Each delivery now reads the live field at call time.
- **Route blockers flipped state for dead registrations and superseded attempts.** CheckAsync snapshots the registration list but applied Block() unconditionally: an entry disposed during the pass, or an attempt whose token a newer navigation had already cancelled, still flipped its RouteBlockerState — stranding a confirm-before-leaving UI on a navigation nobody was waiting on. The pass now stops once the attempt's token is cancelled and skips entries no longer registered.

## Testing

- New fixtures: ObjectIsNullableValueTests, StoreReentrantNotifyTests, BlockerLivenessTests.
- Full EditMode suite green (2589 tests).

Independent of the other fix PRs from the same series; mergeable in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)