### PR TITLE
fix(velvet): styling utility and stacked-variant fixes

### DIFF
--- a/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
@@ -214,11 +214,21 @@ namespace Velvet
             }
             else if (StackedVariantManipulators.TryGetValue(key, out var m))
             {
-                // Outer gate closed: clear the leaf, then detach + drop so the inner-variant subscription (a
-                // stacked dark:'s process-wide DarkModeChanged) is released immediately, not left until unmount.
+                // Outer gate closed: clear the leaf. Level-based inners (dark, responsive) are then
+                // detached + dropped so their subscription (a stacked dark:'s process-wide
+                // DarkModeChanged) is released immediately, not left until unmount — safe because a
+                // re-created manipulator re-derives that ambient truth on attach. An EDGE-based
+                // inner (hover/focus/active, element-local or relational) must stay attached with
+                // just the gate closed: its pointer/focus signals fire only on state edges, so a
+                // fresh instance cannot re-seed "pointer already over" and a continuously-held
+                // hover would be lost across an outer close/reopen until a physical re-hover. Its
+                // hooks are per-element (no process-wide leak) and unmount still sweeps it.
                 m.SetOuterGate(false);
-                target.RemoveManipulator(m);
-                StackedVariantManipulators.Remove(key);
+                if (!m.RetainsAcrossOuterClose)
+                {
+                    target.RemoveManipulator(m);
+                    StackedVariantManipulators.Remove(key);
+                }
             }
         }
 

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/StackedVariantCleanupTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/StackedVariantCleanupTests.cs
@@ -63,20 +63,24 @@ namespace Velvet.Tests
         }
 
         [Test]
-        public void Given_AStackedManipulator_When_TheOuterGateCloses_Then_ItIsDetachedNotJustGatedOff()
+        public void Given_AStackedDarkInner_When_TheOuterGateCloses_Then_ItIsDetachedNotJustGatedOff()
         {
-            // Arrange — dark:hover: with dark on creates + tracks the stacked (hover) manipulator.
-            using var mounted = MountHost(_ => V.Label(name: "leaf", className: "dark:hover:bg-red-500", text: "x"),
+            // Arrange — hover:dark: with hover held creates + tracks the stacked (dark) manipulator,
+            // whose inner holds the process-wide DarkModeChanged subscription.
+            using var mounted = MountHost(_ => V.Label(name: "leaf", className: "hover:dark:bg-red-500", text: "x"),
                 out _, out var ctx);
             var leaf = _root.Q<Label>("leaf");
-            VelvetTheme.IsDark = true;
+            using (var evt = PointerOverEvent.GetPooled()) leaf.SimulateEvent(evt);
             Assume.That(ctx.StackedVariantManipulators.Keys.Any(k => k.target == leaf), Is.True,
-                "Precondition: created while the outer (dark) gate is open");
+                "Precondition: created while the outer (hover) gate is open");
 
             // Act — the outer gate closes (the element stays mounted).
-            VelvetTheme.IsDark = false;
+            using (var evt = PointerOutEvent.GetPooled()) leaf.SimulateEvent(evt);
 
-            // Assert — the stacked manipulator is detached + dropped, not left lingering until unmount.
+            // Assert — a LEVEL-based inner (dark) is detached + dropped so its process-wide
+            // subscription releases immediately, not left lingering until unmount. Edge-based
+            // inners (hover/focus/active) instead stay attached with the gate closed — they cannot
+            // re-seed a continuously-held state on re-attach (see StackedVariantOuterReopenTests).
             Assert.IsFalse(ctx.StackedVariantManipulators.Keys.Any(k => k.target == leaf));
         }
     }

--- a/Packages/com.velvet.core/Runtime/Styles/_state_variants.uss
+++ b/Packages/com.velvet.core/Runtime/Styles/_state_variants.uss
@@ -103,17 +103,35 @@
 /* Transition                    */
 /* ============================= */
 
-.transition-all { transition-property: all; }
+/* Each property utility bundles a default duration + curve (Tailwind ships
+ * transition-duration/timing-function inside every transition-* utility) so the class works
+ * standalone — UI Toolkit's initial transition-duration is 0s, which would otherwise snap.
+ * The explicit .duration-* / .ease-* classes below are declared later, so they still override. */
+.transition-all {
+    transition-property: all;
+    transition-duration: var(--duration-normal);
+    transition-timing-function: ease-out;
+}
 .transition-none { transition-property: none; }
-.transition-opacity { transition-property: opacity; }
+.transition-opacity {
+    transition-property: opacity;
+    transition-duration: var(--duration-normal);
+    transition-timing-function: ease-out;
+}
 .transition-colors {
     transition-property: background-color, border-color, color;
+    transition-duration: var(--duration-normal);
+    transition-timing-function: ease-out;
 }
 .transition-colors-scale {
     transition-property: background-color, border-color, color, scale;
+    transition-duration: var(--duration-normal);
+    transition-timing-function: ease-out;
 }
 .transition-colors-scale-opacity {
     transition-property: background-color, border-color, color, scale, opacity;
+    transition-duration: var(--duration-normal);
+    transition-timing-function: ease-out;
 }
 .duration-fast { transition-duration: var(--duration-fast); }
 .duration-normal { transition-duration: var(--duration-normal); }

--- a/Packages/com.velvet.core/Runtime/Styling/StyleColorValueParser.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleColorValueParser.cs
@@ -221,7 +221,10 @@ namespace Velvet
                 return false;
             }
             var open = s.IndexOf('(');
-            var parts = s.Substring(open + 1, s.Length - open - 2).Split(',');
+            // Underscores stand in for the spaces a class string cannot carry (the same
+            // arbitrary-value convention the shadow and clip-path grammars restore before parsing),
+            // so the underscore form of a copy-pasted "rgb(0, 0, 0)" parses like the spaced one.
+            var parts = s.Substring(open + 1, s.Length - open - 2).Replace('_', ' ').Split(',');
             if (parts.Length != (isRgba ? 4 : 3))
             {
                 return false;

--- a/Packages/com.velvet.core/Runtime/Styling/StyleStackedVariantManipulator.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleStackedVariantManipulator.cs
@@ -61,6 +61,12 @@ namespace Velvet
             _innerKind is StyleVariantKind.GroupHover or StyleVariantKind.GroupFocus or StyleVariantKind.GroupActive
                 or StyleVariantKind.PeerHover or StyleVariantKind.PeerFocus or StyleVariantKind.PeerActive;
 
+        // Edge-based inners survive an outer-gate close (see ReconcilerContext.GateStackedVariant):
+        // their pointer/focus signals fire only on state edges, so a re-created manipulator could
+        // not re-seed a continuously-held hover/focus. Level-based inners (dark, responsive)
+        // re-derive their truth on attach and are detached on close to release their subscriptions.
+        internal bool RetainsAcrossOuterClose => IsElementLocal || IsRelational;
+
         protected override void RegisterCallbacksOnTarget()
         {
             if (IsElementLocal)

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/StackedVariantOuterReopenTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/StackedVariantOuterReopenTests.cs
@@ -1,0 +1,83 @@
+using NUnit.Framework;
+using UnityEngine.UIElements;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins that an edge-based inner state (hover/focus/active) survives the outer condition of a
+    /// stacked variant closing and reopening. The outer-gate close used to detach and drop the
+    /// stacked manipulator for every inner kind; on reopen a fresh instance started with the inner
+    /// off, and pointer/focus signals fire only on state EDGES — so a pointer that never left the
+    /// element could not re-apply <c>dark:hover:*</c> until a physical re-hover. In real CSS the
+    /// oracle is a continuously-tracked :hover pseudo-class, unaffected by an ancestor class
+    /// toggling. Level-based inners (dark, responsive) still detach on close: they re-derive their
+    /// truth on re-attach and dark's process-wide theme subscription must release immediately.
+    /// </summary>
+    [TestFixture]
+    internal sealed class StackedVariantOuterReopenTests
+    {
+        private VisualElement _root;
+        private bool _darkBefore;
+        private MountedTree _mounted;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _root = new VisualElement();
+            _darkBefore = VelvetTheme.IsDark;
+            VelvetTheme.IsDark = false;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _mounted?.Dispose();
+            _mounted = null;
+            VelvetTheme.IsDark = _darkBefore;
+        }
+
+        private Label MountLeaf(string className)
+        {
+            _mounted = V.Mount(_root, V.Label(name: "leaf", className: className, text: "x"));
+            return _root.Q<Label>("leaf");
+        }
+
+        [Test]
+        public void Given_DarkHoverLeafApplied_When_DarkTogglesOffAndBackOnWithoutRehover_Then_PayloadReapplies()
+        {
+            // Arrange — applied while dark AND hovered, then the outer (dark) gate closes while the
+            // pointer never leaves the element.
+            var leaf = MountLeaf("dark:hover:bg-hot");
+            VelvetTheme.IsDark = true;
+            using (var evt = PointerOverEvent.GetPooled()) leaf.SimulateEvent(evt);
+            Assume.That(leaf.ClassListContains("bg-hot"), Is.True, "Precondition: applied while dark AND hovered");
+            VelvetTheme.IsDark = false;
+            Assume.That(leaf.ClassListContains("bg-hot"), Is.False, "Precondition: cleared while light");
+
+            // Act — dark returns; no new pointer event has fired.
+            VelvetTheme.IsDark = true;
+
+            // Assert — the continuously-held hover still counts, matching CSS's live :hover.
+            Assert.IsTrue(leaf.ClassListContains("bg-hot"));
+        }
+
+        [Test]
+        public void Given_DarkHoverLeafReopenedWhileHovered_When_ThePointerFinallyLeaves_Then_PayloadClears()
+        {
+            // Arrange — the close/reopen cycle above, payload re-applied via the retained hover.
+            var leaf = MountLeaf("dark:hover:bg-hot");
+            VelvetTheme.IsDark = true;
+            using (var evt = PointerOverEvent.GetPooled()) leaf.SimulateEvent(evt);
+            VelvetTheme.IsDark = false;
+            VelvetTheme.IsDark = true;
+            Assume.That(leaf.ClassListContains("bg-hot"), Is.True, "Precondition: re-applied after reopen");
+
+            // Act — the pointer leaves for real.
+            using (var evt = PointerOutEvent.GetPooled()) leaf.SimulateEvent(evt);
+
+            // Assert — the retained manipulator still tracks the live edge and clears.
+            Assert.IsFalse(leaf.ClassListContains("bg-hot"));
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/StackedVariantOuterReopenTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/StackedVariantOuterReopenTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 79433e9755dc7413d8b4d51b36012809

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/StyleColorUnderscoreConventionTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/StyleColorUnderscoreConventionTests.cs
@@ -1,0 +1,37 @@
+using NUnit.Framework;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins the underscore-for-space arbitrary-value convention for functional color notation.
+    /// A className string splits on spaces, so a bracketed value embeds its spaces as underscores —
+    /// shadow and clip-path arbitrary values already restore them before parsing. The rgb()/rgba()
+    /// grammar must do the same: without the substitution, the underscore form of a copy-pasted
+    /// "rgb(0, 128, 255)" fails byte parsing on its "_128"/"_255" channels, the class silently falls
+    /// back to a no-op USS class, and the color is never applied.
+    /// </summary>
+    [TestFixture]
+    internal sealed class StyleColorUnderscoreConventionTests
+    {
+        [Test]
+        public void Given_RgbWithUnderscoreSpacing_When_Parsed_Then_ResolvesChannels()
+        {
+            // Act — the underscore form of "rgb(0, 128, 255)".
+            var ok = StyleArbitraryValueResolver.TryParse("bg-[rgb(0,_128,_255)]", out var s);
+
+            // Assert — recognized as an arbitrary background color with the spaced channels resolved.
+            Assert.That((ok, s.Property, s.Color.g, s.Color.b),
+                Is.EqualTo((true, ArbitraryProperty.BackgroundColor, 128f / 255f, 1f)));
+        }
+
+        [Test]
+        public void Given_RgbaWithUnderscoreSpacing_When_Parsed_Then_ResolvesAlpha()
+        {
+            // Act — the underscore form of "rgba(255, 0, 0, 0.5)".
+            var ok = StyleArbitraryValueResolver.TryParse("bg-[rgba(255,_0,_0,_0.5)]", out var s);
+
+            // Assert — the alpha channel survives the underscore substitution.
+            Assert.That((ok, s.Color.r, s.Color.a), Is.EqualTo((true, 1f, 0.5f)));
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/StyleColorUnderscoreConventionTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/StyleColorUnderscoreConventionTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a784b846c26d54f71ab7b345b3de8c0a

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/TransitionUtilityDefaultDurationTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/TransitionUtilityDefaultDurationTests.cs
@@ -1,0 +1,80 @@
+using System.Linq;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins that the transition-* property utilities work standalone, like their Tailwind
+    /// counterparts: each bundles a default transition-duration and timing-function alongside its
+    /// transition-property. UI Toolkit's initial transition-duration is 0s, so a property-only
+    /// utility (e.g. <c>transition-opacity</c> plus a hover-driven value change) never visibly
+    /// animated until the developer also added a duration-* class — while the sibling
+    /// <c>transition-transform</c> already bundled its own duration, leaving one of six utilities
+    /// functional standalone. Explicit duration-*/ease-* classes still override (declared later in
+    /// the same sheet).
+    /// </summary>
+    [TestFixture]
+    internal sealed class TransitionUtilityDefaultDurationTests : PanelTestBase
+    {
+        private const string StyleSheetPath = "Packages/com.velvet.core/Runtime/Styles/StyleUtilities.uss";
+
+        protected override void LoadStyleSheets()
+        {
+            var sheet = AssetDatabase.LoadAssetAtPath<StyleSheet>(StyleSheetPath);
+            Assume.That(sheet, Is.Not.Null, "Precondition: the bundled StyleUtilities.uss loads");
+            _window.rootVisualElement.styleSheets.Add(sheet);
+        }
+
+        private VisualElement MountLeaf(string className)
+        {
+            _mounted = V.Mount(_window.rootVisualElement, V.Div(name: "leaf", className: className));
+            var leaf = _window.rootVisualElement.Q<VisualElement>("leaf");
+            ForcePanelUpdate(leaf.panel);
+            return leaf;
+        }
+
+        [Test]
+        public void Given_TransitionOpacityAlone_When_Resolved_Then_ItCarriesANonZeroDefaultDuration()
+        {
+            // Arrange / Act — the utility stands alone, with no duration-* class.
+            var leaf = MountLeaf("transition-opacity");
+
+            // Assert — the class animates by itself instead of resolving to the 0s initial value.
+            Assert.That(leaf.resolvedStyle.transitionDuration.First().value, Is.GreaterThan(0f));
+        }
+
+        [Test]
+        public void Given_TransitionColorsAlone_When_Resolved_Then_ItCarriesANonZeroDefaultDuration()
+        {
+            // Arrange / Act
+            var leaf = MountLeaf("transition-colors");
+
+            // Assert
+            Assert.That(leaf.resolvedStyle.transitionDuration.First().value, Is.GreaterThan(0f));
+        }
+
+        [Test]
+        public void Given_TransitionAllAlone_When_Resolved_Then_ItCarriesANonZeroDefaultDuration()
+        {
+            // Arrange / Act
+            var leaf = MountLeaf("transition-all");
+
+            // Assert
+            Assert.That(leaf.resolvedStyle.transitionDuration.First().value, Is.GreaterThan(0f));
+        }
+
+        [Test]
+        public void Given_TransitionOpacityWithExplicitDurationZero_When_Resolved_Then_TheExplicitClassWins()
+        {
+            // Arrange / Act — duration-* is declared after the transition-* utilities, so an
+            // explicit opt-out still overrides the bundled default.
+            var leaf = MountLeaf("transition-opacity duration-0");
+
+            // Assert
+            Assert.That(leaf.resolvedStyle.transitionDuration.First().value, Is.EqualTo(0f));
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/TransitionUtilityDefaultDurationTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/TransitionUtilityDefaultDurationTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 50c73638414054e3ea52342cb032cde5


### PR DESCRIPTION
## Summary

Three styling fixes, each with a RED→GREEN regression test:

- **transition-* utilities did not work standalone.** Tailwind ships transition-duration and timing-function inside every transition-* utility; Velvet's transition-all/-opacity/-colors/-colors-scale/-colors-scale-opacity set only transition-property, and UI Toolkit's initial duration is 0s — so a property-only utility plus a hover-driven change snapped instead of animating, while the sibling transition-transform already bundled its own duration. All five now bundle var(--duration-normal) (0.15s, matching Tailwind's 150ms) + ease-out; explicit duration-*/ease-* classes are declared later in the sheet and still override.
- **A continuously-held hover was lost across a theme toggle.** The outer-gate close of a stacked variant (dark:hover:) detached and dropped the stacked manipulator for every inner kind; on reopen a fresh instance started with the inner off, and pointer/focus signals fire only on state edges — so dark:hover:* could not re-apply until a physical re-hover, unlike CSS's continuously tracked :hover. Edge-based inners (hover/focus/active, element-local or relational) now stay attached with just the gate closed (per-element hooks, nothing process-wide to leak; unmount still sweeps them); level-based inners (dark, responsive) keep the immediate detach that releases the process-wide theme subscription.
- **Underscore-spaced rgb()/rgba() failed to parse.** Class strings split on spaces, so bracketed arbitrary values embed spaces as underscores — the shadow and clip-path grammars already restore them, but the color grammar did not: bg-[rgb(0,_0,_0)] failed byte parsing and silently fell back to a no-op USS class. Underscores are now restored before splitting the channel list.

## Testing

- New fixtures: TransitionUtilityDefaultDurationTests, StackedVariantOuterReopenTests, StyleColorUnderscoreConventionTests (plus StackedVariantCleanupTests re-pinned to the dark-inner detach contract).
- Full EditMode suite green (2589 tests).

Independent of the other fix PRs from the same series; mergeable in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)