### PR TITLE
fix(velvet): AnimatePresence exit ordering and interruption

### DIFF
--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodeFactory.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodeFactory.cs
@@ -213,6 +213,19 @@ namespace Velvet
                             "A clip-path-* utility on a Motion is ignored: it would break AnimatePresence enter/exit "
                             + "(same constraint as shadow-*). Wrap the Motion around a clipped Div instead.");
                     }
+                    // Enter/exit tweens are scheduled by the AnimatePresence expansion, so on a
+                    // standalone Motion these props are silently inert: the element mounts already
+                    // at its animate/resting classes and the declared initial never plays. Warn like
+                    // the shadow-*/clip-path-* gates above so a Framer-style initial/animate pair
+                    // does not just fail to animate without a trace.
+                    if (_ctx.PresenceExpansionDepth == 0
+                        && (motionNode.Initial != null || motionNode.Exit != null))
+                    {
+                        FiberLogger.LogWarning("Motion",
+                            "initial/exit on a Motion outside AnimatePresence is inert: enter/exit tweens are "
+                            + "driven by the AnimatePresence expansion. Wrap the Motion in V.AnimatePresence "
+                            + "(or drop initial/exit).");
+                    }
                     return element;
                 }
                 case AnimatePresenceNode:

--- a/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
@@ -1151,7 +1151,13 @@ namespace Velvet
                                     // resting variant on every add / interrupt.
                                     var isVariantMotion = ReferenceEquals(node, motion)
                                         && motion.Variants != null && motion.Animate != null;
-                                    if (isVariantMotion
+                                    // A cancelled exit reproduces the SAME still-attached element —
+                                    // not a first mount — so `initial` does not reapply: CancelExit
+                                    // already reverses the element toward its resting variant with
+                                    // the transition kept alive, and replaying initial→animate here
+                                    // would re-seed the declared initial pose (a jump) and restart
+                                    // the full enter duration from it.
+                                    if (isVariantMotion && !wasExiting
                                         && TryResolveVariantInitial(motion, out var fromClasses, out var toClasses))
                                     {
                                         // `initial`: enter from variants[initial] to variants[animate]

--- a/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
@@ -945,6 +945,7 @@ namespace Velvet
             var newKeySet = _ctx.BufferPool.RentPresenceKeySet();
             var prevCommitted = _ctx.BufferPool.RentKeyedList();
             var nextCommitted = _ctx.BufferPool.RentKeyedList();
+            var plan = _ctx.BufferPool.RentKeyedList();
             try
             {
                 foreach (var entry in state.Committed) prevCommitted.Add(entry);
@@ -971,11 +972,136 @@ namespace Velvet
                     }
                 }
 
-                // 1) Current children, in order. Each emits its leaves; the anchor (first element) drives
-                //    enter / cancel-exit animations.
-                var visualIndex = 0;
-                foreach (var (key, node) in newKeyed)
+                // Committed emission order: the current children in new order, with each previously
+                // committed key now absent spliced back at the index it held among its previous
+                // siblings. An exiting child must hold its slot among unchanged neighbors for the
+                // whole exit (only a popLayout-style mode pulls it out of flow); appending ghosts
+                // after every current child instead yanked a non-last exiting item behind its later
+                // siblings — and physically reordered the DOM — the instant its exit began.
+                // Finished / instant-removed ghosts are dropped during the walk below.
+                foreach (var entry in newKeyed) plan.Add(entry);
+                var previousIndex = 0;
+                foreach (var (key, node) in prevCommitted)
                 {
+                    if (!newKeySet.Contains(key))
+                    {
+                        plan.Insert(previousIndex < plan.Count ? previousIndex : plan.Count, (key, node));
+                    }
+                    previousIndex++;
+                }
+
+                // Count the children that will actually animate-exit this render, so staggerDirection can sweep
+                // last-to-first over them (a no-op for the default forward direction, but needed to reverse).
+                var exitCount = 0;
+                foreach (var (key, node) in prevCommitted)
+                {
+                    if (newKeySet.Contains(key) || state.ExitComplete.Contains(key)) continue;
+                    if (FiberNodeFactory.FindFirstMotionDescendant(node)?.Transition is { DurationSec: > 0f }) exitCount++;
+                }
+
+                var visualIndex = 0;
+                var exitIndex = 0;
+                var removedInstantThisRender = false;
+                foreach (var (key, node) in plan)
+                {
+                    if (!newKeySet.Contains(key))
+                    {
+                        // Ghost: a previously-committed key absent from the new children, spliced into
+                        // the plan at its old position. A finished exit is dropped (not emitted → the
+                        // diff removes its leaves); a child without an exit animation is removed
+                        // immediately; otherwise the child stays mounted in its old slot and its exit
+                        // is started once.
+                        if (state.ExitComplete.Contains(key))
+                        {
+                            state.Exiting.Remove(key);
+                            // Once the exit detached the ghost's element, the old-side reproduction can no longer
+                            // recurse into the ghost's subtree (the Motion's PreviousTree was cleared), so its
+                            // inline fibers escape the orphan sweep. Dispose them explicitly via the tracked anchor
+                            // before the diff removes the leaves — otherwise a same-key re-entry would re-pair the
+                            // undisposed fiber as a zombie whose local state updates no longer re-render.
+                            DisposeExitedGhostFibers(state, key);
+                            continue;
+                        }
+
+                        var ghostMotionNode = FiberNodeFactory.FindFirstMotionDescendant(node);
+                        var ghostTransition = ghostMotionNode?.Transition;
+                        if (ghostTransition is not { DurationSec: > 0f })
+                        {
+                            // No exit animation → immediate removal (skip emitting; the diff reaps the leaves).
+                            state.Exiting.Remove(key);
+                            removedInstantThisRender = true;
+                            continue;
+                        }
+
+                        var ghostAnchor = EmitPresenceChild(node, key, presenceKey, result, isNewSide: true, parent, slotStart,
+                            oldFibers, newFibers, providers, oldProvidersForPairing, ref newProviderIndex, commit);
+
+                        // Track the live ghost anchor so the drop path (exit complete) can dispose the subtree
+                        // fibers under it — see DisposeExitedGhostFibers.
+                        if (commit != null && ghostAnchor != null) state.ExitAnchors[key] = ghostAnchor;
+
+                        if (commit != null && ghostAnchor != null && state.Exiting.Add(key))
+                        {
+                            _ctx.StyleAnimationScheduler.CancelEnter(ghostAnchor);
+                            var capturedKey = key;
+                            var capturedState = state;
+                            var capturedBoundary = boundaryFiber;
+                            var capturedOnExitComplete = presence.OnExitComplete;
+                            // `exit`: when the direct Motion child declares an exit variant label, animate from the
+                            // resting variants[animate] to variants[exit]; otherwise use the transition's ExitFrom/ExitTo.
+                            var variantExit = TryResolveVariantExit(node, ghostMotionNode);
+                            var exitTransition = variantExit ?? ghostTransition;
+                            // For a variant exit the From classes ARE the resting variants[animate]; if this exit is
+                            // cancelled (the key is re-added before it finishes) the element must return to that resting
+                            // variant rather than be left without it (interrupt handling).
+                            _ctx.StyleAnimationScheduler.PlayExit(ghostAnchor, exitTransition, () =>
+                            {
+                                if (_ctx.IsDisposed) return;
+                                // Reconcile-driven removal: flag the finished exit and re-render the boundary;
+                                // the next render stops emitting this child and the diff removes its leaves.
+                                capturedState.Exiting.Remove(capturedKey);
+                                capturedState.ExitComplete.Add(capturedKey);
+                                // onExitComplete fires once the exiting set drains (the last
+                                // in-flight exit finished). Cancelled exits (key re-entered) remove from Exiting
+                                // elsewhere and do not reach here, so they never trigger it.
+                                if (capturedState.Exiting.Count == 0)
+                                {
+                                    capturedOnExitComplete?.Invoke();
+                                }
+                                if (capturedBoundary != null)
+                                {
+                                    // The boundary's own hook inputs are unchanged (the exit finished out of band,
+                                    // not via a state update), so an auto-memoized boundary would return its cached
+                                    // VNode and the reconciler would bail — the AnimatePresence would never re-expand
+                                    // and the finished ghost would linger forever. Invalidate the memo so the
+                                    // re-render re-walks the children and the ghost-drop runs, mirroring the Suspense
+                                    // reveal path (InvalidateMemoCache + FiberWorkLoop.RequestRenderFromHook).
+                                    capturedBoundary.InvalidateMemoCache();
+                                    FiberWorkLoop.ScheduleRerender(capturedBoundary, FiberUpdatePriority.Normal);
+                                }
+                                else
+                                {
+                                    // No owning component fiber to re-render (a top-level AnimatePresence reconciled
+                                    // straight onto a VisualElement). The exit animation finished but the reconcile
+                                    // that drops the ghost can't be scheduled, so the element would silently linger.
+                                    // Mount AnimatePresence inside a component (V.Mount establishes a root fiber) so
+                                    // exit completion can remove the child. Warn rather than leak in silence.
+                                    // Intentional: the supported path is V.Mount; reconciling straight onto a bare
+                                    // element leaves no owner to drive the ghost-removal re-render.
+                                    FiberLogger.LogWarning("AnimatePresence",
+                                        "Exit completed but the presence has no owning component fiber to re-render, "
+                                        + "so the exited child cannot be removed. Mount AnimatePresence inside a "
+                                        + "component (e.g. via V.Mount) rather than reconciling it onto a bare element.");
+                                }
+                            }, restoreFromOnCancel: variantExit != null,
+                                additionalDelaySec: presence.StaggerDelaySec(exitIndex, exitCount));
+                            exitIndex++;
+                        }
+
+                        nextCommitted.Add((key, node));
+                        continue;
+                    }
+
                     // Withhold a brand-new child under mode="wait" while exits are in flight (see above). The
                     // linear prevCommitted scan is bounded: this only runs when blockEnters is set, and wait-mode
                     // targets single-child swaps, so prevCommitted holds ~1 entry.
@@ -1058,113 +1184,6 @@ namespace Velvet
                     visualIndex++;
                 }
 
-                // 2) Ghosts: previously-committed keys absent from the new children. A finished exit is
-                //    dropped (not emitted → diff removes its leaves); a child without an exit animation is
-                //    removed immediately; otherwise the child is kept mounted and its exit started once.
-                // Count the children that will actually animate-exit this render, so staggerDirection can sweep
-                // last-to-first over them (a no-op for the default forward direction, but needed to reverse).
-                var exitCount = 0;
-                foreach (var (key, node) in prevCommitted)
-                {
-                    if (newKeySet.Contains(key) || state.ExitComplete.Contains(key)) continue;
-                    if (FiberNodeFactory.FindFirstMotionDescendant(node)?.Transition is { DurationSec: > 0f }) exitCount++;
-                }
-
-                var exitIndex = 0;
-                var removedInstantThisRender = false;
-                foreach (var (key, node) in prevCommitted)
-                {
-                    if (newKeySet.Contains(key)) continue;
-                    if (state.ExitComplete.Contains(key))
-                    {
-                        state.Exiting.Remove(key);
-                        // Once the exit detached the ghost's element, the old-side reproduction can no longer
-                        // recurse into the ghost's subtree (the Motion's PreviousTree was cleared), so its
-                        // inline fibers escape the orphan sweep. Dispose them explicitly via the tracked anchor
-                        // before the diff removes the leaves — otherwise a same-key re-entry would re-pair the
-                        // undisposed fiber as a zombie whose local state updates no longer re-render.
-                        DisposeExitedGhostFibers(state, key);
-                        continue;
-                    }
-
-                    var motion = FiberNodeFactory.FindFirstMotionDescendant(node);
-                    var transition = motion?.Transition;
-                    if (transition is not { DurationSec: > 0f })
-                    {
-                        // No exit animation → immediate removal (skip emitting; the diff reaps the leaves).
-                        state.Exiting.Remove(key);
-                        removedInstantThisRender = true;
-                        continue;
-                    }
-
-                    var anchor = EmitPresenceChild(node, key, presenceKey, result, isNewSide: true, parent, slotStart,
-                        oldFibers, newFibers, providers, oldProvidersForPairing, ref newProviderIndex, commit);
-
-                    // Track the live ghost anchor so the drop path (exit complete) can dispose the subtree
-                    // fibers under it — see DisposeExitedGhostFibers.
-                    if (commit != null && anchor != null) state.ExitAnchors[key] = anchor;
-
-                    if (commit != null && anchor != null && state.Exiting.Add(key))
-                    {
-                        _ctx.StyleAnimationScheduler.CancelEnter(anchor);
-                        var capturedKey = key;
-                        var capturedState = state;
-                        var capturedBoundary = boundaryFiber;
-                        var capturedOnExitComplete = presence.OnExitComplete;
-                        // `exit`: when the direct Motion child declares an exit variant label, animate from the
-                        // resting variants[animate] to variants[exit]; otherwise use the transition's ExitFrom/ExitTo.
-                        var variantExit = TryResolveVariantExit(node, motion);
-                        var exitTransition = variantExit ?? transition;
-                        // For a variant exit the From classes ARE the resting variants[animate]; if this exit is
-                        // cancelled (the key is re-added before it finishes) the element must return to that resting
-                        // variant rather than be left without it (interrupt handling).
-                        _ctx.StyleAnimationScheduler.PlayExit(anchor, exitTransition, () =>
-                        {
-                            if (_ctx.IsDisposed) return;
-                            // Reconcile-driven removal: flag the finished exit and re-render the boundary;
-                            // the next render stops emitting this child and the diff removes its leaves.
-                            capturedState.Exiting.Remove(capturedKey);
-                            capturedState.ExitComplete.Add(capturedKey);
-                            // onExitComplete fires once the exiting set drains (the last
-                            // in-flight exit finished). Cancelled exits (key re-entered) remove from Exiting
-                            // elsewhere and do not reach here, so they never trigger it.
-                            if (capturedState.Exiting.Count == 0)
-                            {
-                                capturedOnExitComplete?.Invoke();
-                            }
-                            if (capturedBoundary != null)
-                            {
-                                // The boundary's own hook inputs are unchanged (the exit finished out of band,
-                                // not via a state update), so an auto-memoized boundary would return its cached
-                                // VNode and the reconciler would bail — the AnimatePresence would never re-expand
-                                // and the finished ghost would linger forever. Invalidate the memo so the
-                                // re-render re-walks the children and the ghost-drop runs, mirroring the Suspense
-                                // reveal path (InvalidateMemoCache + FiberWorkLoop.RequestRenderFromHook).
-                                capturedBoundary.InvalidateMemoCache();
-                                FiberWorkLoop.ScheduleRerender(capturedBoundary, FiberUpdatePriority.Normal);
-                            }
-                            else
-                            {
-                                // No owning component fiber to re-render (a top-level AnimatePresence reconciled
-                                // straight onto a VisualElement). The exit animation finished but the reconcile
-                                // that drops the ghost can't be scheduled, so the element would silently linger.
-                                // Mount AnimatePresence inside a component (V.Mount establishes a root fiber) so
-                                // exit completion can remove the child. Warn rather than leak in silence.
-                                // Intentional: the supported path is V.Mount; reconciling straight onto a bare
-                                // element leaves no owner to drive the ghost-removal re-render.
-                                FiberLogger.LogWarning("AnimatePresence",
-                                    "Exit completed but the presence has no owning component fiber to re-render, "
-                                    + "so the exited child cannot be removed. Mount AnimatePresence inside a "
-                                    + "component (e.g. via V.Mount) rather than reconciling it onto a bare element.");
-                            }
-                        }, restoreFromOnCancel: variantExit != null,
-                            additionalDelaySec: presence.StaggerDelaySec(exitIndex, exitCount));
-                        exitIndex++;
-                    }
-
-                    nextCommitted.Add((key, node));
-                }
-
                 // onExitComplete fires once the exiting children are gone. When every removed child
                 // had NO exit animation (all instant-removed above) no PlayExit callback runs to fire it, so fire it
                 // here — but only when no animated exit is still in flight (those fire it when the Exiting set drains).
@@ -1185,6 +1204,7 @@ namespace Velvet
                 _ctx.BufferPool.ReturnPresenceKeySet(newKeySet);
                 _ctx.BufferPool.Return(prevCommitted);
                 _ctx.BufferPool.Return(nextCommitted);
+                _ctx.BufferPool.Return(plan);
             }
         }
 

--- a/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
@@ -618,9 +618,20 @@ namespace Velvet
                         // into the parent's slot range (so the parent's flex / wrap / gap reach them), with
                         // enter / exit / stagger played on each keyed child's anchor element. Old/new sides
                         // are reproduced from the per-boundary presence state, mirroring ExpandSuspenseInline.
-                        ExpandAnimatePresenceInline(presence, result, isNewSide, parent, slotStart,
-                            oldFibers, newFibers, providers, oldProvidersForPairing, ref newProviderIndex,
-                            fragmentKeyScope, nodeIndex, commit);
+                        // Depth marker: Motion nodes created while a presence expansion is on the
+                        // stack are presence-managed (initial/exit are live); a standalone Motion
+                        // mount sees depth 0 and warns that those props are inert.
+                        _ctx.PresenceExpansionDepth++;
+                        try
+                        {
+                            ExpandAnimatePresenceInline(presence, result, isNewSide, parent, slotStart,
+                                oldFibers, newFibers, providers, oldProvidersForPairing, ref newProviderIndex,
+                                fragmentKeyScope, nodeIndex, commit);
+                        }
+                        finally
+                        {
+                            _ctx.PresenceExpansionDepth--;
+                        }
                         break;
                     case BaseElementNode:
                         // Regular element: CreateElement / PatchNode reconciles its children via the

--- a/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
@@ -469,6 +469,11 @@ namespace Velvet
         // AnimatePresence's renders (the host element is reused), and disambiguates inner from outer.
         internal Dictionary<(ComponentFiber? boundary, VisualElement? parent, string presenceKey), PresenceBoundaryState> PresenceStates { get; } = new();
 
+        // Non-zero while an AnimatePresence expansion is on the stack. Motion nodes created inside
+        // it are presence-managed (initial/exit tweens are scheduled by the expansion); a Motion
+        // created at depth 0 mounts standalone, where those props are inert and warn.
+        internal int PresenceExpansionDepth;
+
         // Removes all DOM-less AnimatePresence state keyed by boundary. Invoked from
         // ComponentRegistry when the boundary fiber is unregistered, so a boundary that
         // unmounts while a child is exiting leaves no dangling fiber reference in PresenceStates.

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/AnimatePresenceExitCancelBlendTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/AnimatePresenceExitCancelBlendTests.cs
@@ -1,5 +1,7 @@
 using System.Collections.Generic;
 using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
 using UnityEngine.UIElements;
 using Velvet.TestUtilities;
 
@@ -36,6 +38,7 @@ namespace Velvet.Tests
         private static bool s_withInitial;
 
         private VisualElement _root;
+        private EditorWindow _window;
 
         [SetUp]
         public void SetUp()
@@ -43,6 +46,17 @@ namespace Velvet.Tests
             _root = new VisualElement();
             s_store = null;
             s_withInitial = false;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (_window != null)
+            {
+                _window.Close();
+                Object.DestroyImmediate(_window);
+                _window = null;
+            }
         }
 
         [Component]
@@ -68,14 +82,18 @@ namespace Velvet.Tests
         [Test]
         public void Given_AVariantExitWasCancelled_When_TheElementReverts_Then_TheTransitionStaysAliveForTheReversal()
         {
-            // Arrange — a settled child whose exit has started, then the key is re-added mid-exit.
+            // Arrange — a real panel (the reversal is panel-interpolated; off-panel cancels clear
+            // immediately), a settled child whose exit has started, then the key re-added mid-exit.
+            TestGraphics.IgnoreIfHeadless("an EditorWindow panel");
+            _window = ScriptableObject.CreateInstance<EditorWindow>();
+            _window.Show();
             using var store = new SetStore();
             s_store = store;
-            using var mounted = V.Mount(_root, V.Component(PresenceHost, key: "host"));
+            using var mounted = V.Mount(_window.rootVisualElement, V.Component(PresenceHost, key: "host"));
             var scheduler = mounted.Root.Reconciler.Context.BatchScheduler;
             store.Set("");
             scheduler.DrainImmediateForTest();
-            var item = _root.Q<VisualElement>("item-a");
+            var item = _window.rootVisualElement.Q<VisualElement>("item-a");
             Assume.That(item, Is.Not.Null, "Precondition: the exiting ghost is still mounted");
 
             // Act — cancel the exit by re-adding the key.
@@ -84,7 +102,7 @@ namespace Velvet.Tests
 
             // Assert — the transition styles survive the cancel, so the panel interpolates from the
             // currently-resolved value back to the resting classes instead of snapping.
-            Assert.That(_root.Q<VisualElement>("item-a").style.transitionDuration.keyword,
+            Assert.That(_window.rootVisualElement.Q<VisualElement>("item-a").style.transitionDuration.keyword,
                 Is.Not.EqualTo(StyleKeyword.Null));
         }
 

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/AnimatePresenceExitCancelBlendTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/AnimatePresenceExitCancelBlendTests.cs
@@ -1,0 +1,116 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine.UIElements;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins interruption continuity for a cancelled AnimatePresence exit. Cancelling used to revert
+    /// to the resting classes and null the transition styles in the SAME synchronous call, so the
+    /// next style resolve saw the resting target with no active transition and popped straight to it
+    /// instead of blending back from the mid-tween value; with an <c>initial</c> variant declared,
+    /// the cancel additionally replayed the full initial→animate enter from the declared initial
+    /// pose. The oracle starts every retarget — including an exit cancelled by re-adding the key —
+    /// from the value the element currently shows: the reversal must keep the transition alive
+    /// (deferring the style clear) and must not replay <c>initial</c> on a still-mounted element.
+    /// </summary>
+    [TestFixture]
+    internal sealed class AnimatePresenceExitCancelBlendTests
+    {
+        private readonly record struct SetState(string Keys);
+
+        private sealed class SetStore : Store<SetState>
+        {
+            public SetStore() : base(new SetState("a")) { }
+            public void Set(string keys) => SetState(_ => new SetState(keys));
+            protected override void ResetCore() => SetState(_ => new SetState("a"));
+        }
+
+        private static SetStore s_store;
+        private static readonly Dictionary<string, string> s_fade = new()
+        {
+            ["visible"] = "opacity-100",
+            ["hidden"] = "opacity-0",
+        };
+        private static bool s_withInitial;
+
+        private VisualElement _root;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _root = new VisualElement();
+            s_store = null;
+            s_withInitial = false;
+        }
+
+        [Component]
+        private static VNode PresenceHost()
+        {
+            var keys = Hooks.UseStore(s_store, s => s.Keys);
+            var children = new List<VNode>();
+            foreach (var key in keys)
+            {
+                children.Add(V.Motion(name: "item-" + key, key: key.ToString(),
+                    variants: s_fade,
+                    animate: "visible",
+                    initial: s_withInitial ? "hidden" : null,
+                    exit: "hidden",
+                    transition: new StyleTransitionConfig { DurationSec = 0.3f }));
+            }
+            return V.Div(name: "host", children: new VNode[]
+            {
+                V.AnimatePresence(key: "presence", initial: false, children: children.ToArray()),
+            });
+        }
+
+        [Test]
+        public void Given_AVariantExitWasCancelled_When_TheElementReverts_Then_TheTransitionStaysAliveForTheReversal()
+        {
+            // Arrange — a settled child whose exit has started, then the key is re-added mid-exit.
+            using var store = new SetStore();
+            s_store = store;
+            using var mounted = V.Mount(_root, V.Component(PresenceHost, key: "host"));
+            var scheduler = mounted.Root.Reconciler.Context.BatchScheduler;
+            store.Set("");
+            scheduler.DrainImmediateForTest();
+            var item = _root.Q<VisualElement>("item-a");
+            Assume.That(item, Is.Not.Null, "Precondition: the exiting ghost is still mounted");
+
+            // Act — cancel the exit by re-adding the key.
+            store.Set("a");
+            scheduler.DrainImmediateForTest();
+
+            // Assert — the transition styles survive the cancel, so the panel interpolates from the
+            // currently-resolved value back to the resting classes instead of snapping.
+            Assert.That(_root.Q<VisualElement>("item-a").style.transitionDuration.keyword,
+                Is.Not.EqualTo(StyleKeyword.Null));
+        }
+
+        [Test]
+        public void Given_AVariantMotionWithInitial_When_ItsExitIsCancelled_Then_TheInitialPoseIsNotReplayed()
+        {
+            // Arrange — the full initial+animate+exit pattern; exit starts, then the key returns.
+            s_withInitial = true;
+            using var store = new SetStore();
+            s_store = store;
+            using var mounted = V.Mount(_root, V.Component(PresenceHost, key: "host"));
+            var scheduler = mounted.Root.Reconciler.Context.BatchScheduler;
+            store.Set("");
+            scheduler.DrainImmediateForTest();
+            Assume.That(_root.Q<VisualElement>("item-a"), Is.Not.Null,
+                "Precondition: the exiting ghost is still mounted");
+
+            // Act — cancel the exit; the same still-attached element is reproduced (not a remount).
+            store.Set("a");
+            scheduler.DrainImmediateForTest();
+
+            // Assert — initial applies only on a genuine first mount: the cancel leaves the element
+            // at its resting variant instead of re-seeding the declared initial pose.
+            var item = _root.Q<VisualElement>("item-a");
+            Assert.That((item.ClassListContains("opacity-0"), item.ClassListContains("opacity-100")),
+                Is.EqualTo((false, true)));
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/AnimatePresenceExitCancelBlendTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/AnimatePresenceExitCancelBlendTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2cc6560384ea14bb091650b436ed7811

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/AnimatePresenceExitOrderTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/AnimatePresenceExitOrderTests.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine.UIElements;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins DOM order while a non-last AnimatePresence child exits. The boundary's committed order
+    /// was assembled in two unconditional passes — every current child first, every still-exiting
+    /// ghost appended after — so the instant a middle item started exiting it was yanked out of its
+    /// visual slot and dropped behind every later sibling: in a flex parent the layout visibly
+    /// jumped before the fade even began, and the committed set's own "in DOM order" invariant was
+    /// violated for the whole exit. The oracle re-inserts each exiting child at the position it held
+    /// among its previous siblings, so an in-place exit stays in place.
+    /// </summary>
+    [TestFixture]
+    internal sealed class AnimatePresenceExitOrderTests
+    {
+        private readonly record struct SetState(string Keys);
+
+        private sealed class SetStore : Store<SetState>
+        {
+            public SetStore() : base(new SetState("abc")) { }
+            public void Set(string keys) => SetState(_ => new SetState(keys));
+            protected override void ResetCore() => SetState(_ => new SetState("abc"));
+        }
+
+        private static SetStore s_store;
+        private static readonly Dictionary<string, string> s_fade = new()
+        {
+            ["visible"] = "opacity-100",
+            ["hidden"] = "opacity-0",
+        };
+
+        private VisualElement _root;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _root = new VisualElement();
+            s_store = null;
+        }
+
+        [Component]
+        private static VNode PresenceList()
+        {
+            var keys = Hooks.UseStore(s_store, s => s.Keys);
+            var children = new List<VNode>();
+            foreach (var key in keys)
+            {
+                children.Add(V.Motion(name: "item-" + key, key: key.ToString(),
+                    variants: s_fade, animate: "visible", exit: "hidden",
+                    transition: new StyleTransitionConfig { DurationSec = 0.3f }));
+            }
+            return V.Div(name: "presence-host", children: new VNode[]
+            {
+                V.AnimatePresence(key: "presence", children: children.ToArray()),
+            });
+        }
+
+        private static string OrderOf(VisualElement host)
+        {
+            var order = "";
+            for (var i = 0; i < host.childCount; i++)
+            {
+                var name = host.ElementAt(i).name;
+                order += name.Substring(name.Length - 1);
+            }
+            return order;
+        }
+
+        [Test]
+        public void Given_ThreeKeyedChildren_When_TheMiddleOneExits_Then_ItStaysInItsSlotWhileExiting()
+        {
+            // Arrange — [a,b,c] settled, then b (non-last) is removed with a real exit transition.
+            using var store = new SetStore();
+            s_store = store;
+            using var mounted = V.Mount(_root, V.Component(PresenceList, key: "list"));
+            var scheduler = mounted.Root.Reconciler.Context.BatchScheduler;
+            var host = _root.Q<VisualElement>("presence-host");
+            Assume.That(OrderOf(host), Is.EqualTo("abc"), "Precondition: three children in declared order");
+
+            // Act — remove the middle child; its exit keeps it mounted as a ghost.
+            store.Set("ac");
+            scheduler.DrainImmediateForTest();
+
+            // Assert — the exiting ghost holds its old slot between a and c, not the tail.
+            Assert.AreEqual("abc", OrderOf(host));
+        }
+
+        [Test]
+        public void Given_TwoMiddleChildrenExit_When_TheGhostsRemain_Then_TheWholeOldOrderIsPreserved()
+        {
+            // Arrange — [a,b,c,d] settled (via an initial add), then both middles are removed.
+            using var store = new SetStore();
+            s_store = store;
+            store.Set("abcd");
+            using var mounted = V.Mount(_root, V.Component(PresenceList, key: "list"));
+            var scheduler = mounted.Root.Reconciler.Context.BatchScheduler;
+            var host = _root.Q<VisualElement>("presence-host");
+            Assume.That(OrderOf(host), Is.EqualTo("abcd"), "Precondition: four children in declared order");
+
+            // Act
+            store.Set("ad");
+            scheduler.DrainImmediateForTest();
+
+            // Assert — both ghosts hold their old relative slots.
+            Assert.AreEqual("abcd", OrderOf(host));
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/AnimatePresenceExitOrderTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/AnimatePresenceExitOrderTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c2ce81a58115a47fc8979c28eac3d1d3

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/MotionInertPresencePropsWarningTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/MotionInertPresencePropsWarningTests.cs
@@ -1,0 +1,50 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using UnityEngine.UIElements;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins the diagnostic for presence-scoped Motion props used outside AnimatePresence. Enter and
+    /// exit tweens are scheduled by the AnimatePresence expansion, so a standalone
+    /// <c>V.Motion(initial:, animate:)</c> mounts already at its animate/resting classes and the
+    /// declared initial never plays — previously with no trace, which is surprising for a
+    /// Framer-style entrance-animation pair. The factory already warns for other silently-inert
+    /// Motion configurations (shadow-*, clip-path-*); initial/exit must warn the same way.
+    /// </summary>
+    [TestFixture]
+    internal sealed class MotionInertPresencePropsWarningTests
+    {
+        private static readonly Dictionary<string, string> s_fade = new()
+        {
+            ["hidden"] = "opacity-0",
+            ["visible"] = "opacity-100",
+        };
+
+        private VisualElement _root;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _root = new VisualElement();
+        }
+
+        [Test]
+        public void Given_AMotionWithInitialOutsideAnimatePresence_When_Mounted_Then_ItWarnsThatInitialIsInert()
+        {
+            // Arrange — the warning is expected (LogAssert fails the test if it never fires).
+            LogAssert.Expect(LogType.Warning,
+                new System.Text.RegularExpressions.Regex("initial/exit on a Motion outside AnimatePresence"));
+
+            // Act — an idiomatic Framer-style entrance pair, mounted with no AnimatePresence.
+            using var mounted = V.Mount(_root,
+                V.Motion(name: "m", variants: s_fade, initial: "hidden", animate: "visible"));
+
+            // Assert — the element mounted; the expected warning is enforced by LogAssert at test
+            // end (an Assert.Pass would bypass that unmatched-expectation check).
+            Assert.That(_root.Q<VisualElement>("m"), Is.Not.Null);
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/MotionInertPresencePropsWarningTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/MotionInertPresencePropsWarningTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9e18925663b47435d8789ef1df677ece

--- a/Packages/com.velvet.core/Runtime/Styling/StyleAnimationScheduler.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleAnimationScheduler.cs
@@ -418,14 +418,15 @@ namespace Velvet
                 // tween's co-fade and drop its driver — the shadow snaps back to full (product collapses to 1)
                 // unless an enclosing fade still drives it.
                 EndShadowCoFade(pending);
-                if (animateReversal && pending.DurationList is { Count: > 0 })
+                if (animateReversal && element.panel != null && pending.DurationList is { Count: > 0 })
                 {
                     // A cancelled exit retargets a still-attached element back to its resting
                     // classes. Clearing the inline transition styles in this same call would make
                     // the next style resolve snap straight to the resting values; keep the
                     // transition alive instead so the panel interpolates from the currently
                     // resolved value, and defer the clear (and list return) until the reversal has
-                    // run its course.
+                    // run its course. Off-panel there is nothing to interpolate (and scheduling
+                    // would plant a fresh deferred-attach callback), so clear immediately.
                     ScheduleReversalCleanup(element, pending);
                 }
                 else

--- a/Packages/com.velvet.core/Runtime/Styling/StyleAnimationScheduler.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleAnimationScheduler.cs
@@ -316,8 +316,10 @@ namespace Velvet
             }
         }
 
-        // Cancels the exit animation on the given element and removes the applied CSS classes and inline styles.
-        public void CancelExit(VisualElement element) => CancelPending(_pendingExits, element);
+        // Cancels the exit animation on the given element and removes the applied CSS classes; the
+        // element reverses toward its resting classes with the transition kept alive (the inline
+        // transition styles are cleared only after the reversal has run its course).
+        public void CancelExit(VisualElement element) => CancelPending(_pendingExits, element, animateReversal: true);
 
         // Cancels the enter animation on the given element and removes the applied CSS classes and inline styles.
         public void CancelEnter(VisualElement element) => CancelPending(_pendingEnters, element);
@@ -389,7 +391,8 @@ namespace Velvet
 
         // If the timeout callback already ran, map.Remove returns false and the cancellation is skipped.
         // This is safe because the classes have already been cleaned up in that case.
-        private void CancelPending(Dictionary<VisualElement, PendingAnimation> map, VisualElement element)
+        private void CancelPending(Dictionary<VisualElement, PendingAnimation> map, VisualElement element,
+            bool animateReversal = false)
         {
             if (map.Remove(element, out var pending))
             {
@@ -415,10 +418,55 @@ namespace Velvet
                 // tween's co-fade and drop its driver — the shadow snaps back to full (product collapses to 1)
                 // unless an enclosing fade still drives it.
                 EndShadowCoFade(pending);
-                ClearTransitionStyles(element);
-                ReturnDurationList(pending.DurationList);
-                ReturnDelayList(pending.DelayList);
+                if (animateReversal && pending.DurationList is { Count: > 0 })
+                {
+                    // A cancelled exit retargets a still-attached element back to its resting
+                    // classes. Clearing the inline transition styles in this same call would make
+                    // the next style resolve snap straight to the resting values; keep the
+                    // transition alive instead so the panel interpolates from the currently
+                    // resolved value, and defer the clear (and list return) until the reversal has
+                    // run its course.
+                    ScheduleReversalCleanup(element, pending);
+                }
+                else
+                {
+                    ClearTransitionStyles(element);
+                    ReturnDurationList(pending.DurationList);
+                    ReturnDelayList(pending.DelayList);
+                }
             }
+        }
+
+        // Parks the cancelled animation's transition styles until the reversal tween completes,
+        // then clears them and reclaims the lists. The parked entry lives in the ENTER map — the
+        // reversal is a motion toward the resting state — so a follow-up enter/exit on the same
+        // element cancels it like any other pending animation instead of racing its deferred
+        // cleanup (the recursive CancelPending call takes the non-reversal branch: the parked entry
+        // carries only RestingClasses, which re-adding is idempotent).
+        private void ScheduleReversalCleanup(VisualElement element, PendingAnimation pending)
+        {
+            CancelPending(_pendingEnters, element);
+            var reversal = new PendingAnimation
+            {
+                RestingClasses = pending.RestingClasses,
+                DurationList = pending.DurationList,
+                DelayList = pending.DelayList,
+            };
+            var timeoutMs = 0f;
+            if (pending.DurationList is { Count: > 0 }) timeoutMs += pending.DurationList[0].value;
+            if (pending.DelayList is { Count: > 0 }) timeoutMs += pending.DelayList[0].value;
+            var timeout = element.schedule.Execute(() =>
+            {
+                if (_pendingEnters.Remove(element))
+                {
+                    ClearTransitionStyles(element);
+                    ReturnDurationList(reversal.DurationList);
+                    ReturnDelayList(reversal.DelayList);
+                }
+            });
+            timeout.ExecuteLater((long)timeoutMs);
+            reversal.TimeoutItem = timeout;
+            _pendingEnters[element] = reversal;
         }
 
         private void CancelAllInMap(Dictionary<VisualElement, PendingAnimation> map)


### PR DESCRIPTION
## Summary

Exit-lifecycle fixes for AnimatePresence/Motion, each with a RED→GREEN regression test:

- **An exiting non-last child jumped behind its later siblings.** The boundary's committed order was assembled in two unconditional passes — current children first, every still-exiting ghost appended after — so removing a middle item yanked it out of its visual slot (and physically reordered the DOM) the instant its exit began. The emission order is now a single plan: current children in new order with each still-tracked absent key spliced back at the index it held among its previous siblings, so an in-place exit stays in place.
- **Cancelling an exit snapped instead of blending.** The cancel reverted to the resting classes and nulled the inline transition styles in the same synchronous call, so the next style resolve popped straight to the resting values; with an initial variant declared it additionally replayed the full initial→animate tween from the declared pose. Interruptions now continue from the current value: the cancelled exit's transition styles stay alive with the clear parked as a pending entry (a follow-up enter/exit cancels it like any other), and initial is never replayed on a cancel — it applies only to a genuine first mount.
- **Off-panel cancels clear immediately.** Scheduling the deferred clear on a detached element would plant a fresh deferred-attach callback (the exact dangling listener the off-panel cancel path exists to remove), and there is nothing to interpolate without a panel.
- **initial/exit on a Motion outside AnimatePresence now warns.** Enter/exit tweens are scheduled by the presence expansion, so on a standalone Motion those props were silently inert — surprising for a Framer-style entrance pair. The factory now warns, matching the existing shadow-*/clip-path-* inert-configuration warnings.

## Testing

- New fixtures: AnimatePresenceExitOrderTests, AnimatePresenceExitCancelBlendTests, MotionInertPresencePropsWarningTests.
- Full EditMode suite green (2589 tests).

Independent of the other fix PRs from the same series; mergeable in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)