### PR TITLE
chore(velvet): prepare v1.1.0 release

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -7,6 +7,72 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-07-11
+
+### Added
+
+- `data:` / `aria:` parameters on every element factory that takes a class string (and
+  gesture-class parameters where they were missing), so `data-[...]:` / `aria-[...]:` styling no
+  longer requires a hand-built `FiberElementProps`.
+
+### Changed
+
+- Reworked the preview window's zoom / resolution handling (device-resolution viewport and
+  fit-to-window no longer break layout).
+- The `transition-all` / `transition-opacity` / `transition-colors` / `transition-colors-scale` /
+  `transition-colors-scale-opacity` utilities now bundle a default `transition-duration`
+  (`var(--duration-normal)`, 0.15s) and `ease-out` timing, matching Tailwind's standalone-utility
+  contract. Property changes that previously snapped (no `duration-*` class alongside) now
+  animate; explicit `duration-*` / `ease-*` classes still override.
+
+### Fixed
+
+- Keyed reconciliation: a duplicate key among new siblings warns and mounts a fresh element
+  instead of silently dropping a row and desyncing the committed child count; duplicate sibling
+  keys on inline components warn and skip instead of double-emitting one fiber's DOM with shared
+  hook state.
+- An inline component displaced by a keyed reorder no longer inserts a permanent duplicate element
+  when it later re-renders from its own state.
+- A render that throws (including a routine Suspense re-suspend) no longer discards an earlier
+  commit's still-pending `UseEffect` work, and no longer drops the fiber's recorded context
+  dependencies — a memoized consumer could stay detached from Provider updates forever.
+- The StrictMode double-invoke diagnostic no longer corrupts the committed tree of a
+  directly-built `V.Mount(root, V.Div(...))`.
+- Orphaned nested components run their effect cleanups bottom-up (child before parent), matching
+  the commit-phase deletion order.
+- Element pools: returns dispatch on the exact runtime type, so a `V.Custom<T>` subclass of a
+  poolable primitive can no longer be recycled into the shared pool with its constructor-wired
+  callbacks still live; a ring-*/clip-path-wrapped widget is reclaimed on ordinary removal; Outlet
+  container registrations are released per element instead of accumulating until dispose; and
+  caller-supplied `props:` bags / event arrays are never cleared and recycled (pool-ownership
+  tracking, mirroring the children-array pool).
+- `Nullable<T>` values compare by value in the identity comparer, so an unchanged `int?`-selected
+  store slice no longer re-renders its subscribers on every unrelated update, and equal-value
+  `UseState` sets bail as intended.
+- A store listener that re-entrantly pushes a newer value no longer leaves the remaining
+  listeners' final delivery on the superseded value.
+- Route blockers no longer transition to Blocked for a registration disposed mid-check or for a
+  navigation attempt already superseded by a newer one.
+- Stacked variants (`dark:hover:` and friends) keep a continuously-held hover / focus / active
+  across the outer condition closing and reopening — a theme or breakpoint toggle no longer
+  requires a physical re-hover.
+- Arbitrary `rgb()` / `rgba()` color values honor the underscore-for-space convention
+  (`bg-[rgb(0,_0,_0)]` parses like `rgb(0, 0, 0)`).
+- AnimatePresence: an exiting non-last child holds its slot for the whole exit instead of jumping
+  behind its later siblings; cancelling an exit blends back from the element's current value (the
+  transition survives the cancel, and a declared `initial` is never replayed on re-entry); and
+  `initial` / `exit` on a Motion outside AnimatePresence warns instead of being silently inert.
+- Auto-memo weaver soundness: `UseMemo` participates in positional-slot accounting, open
+  virtual / interface dispatch outside the BCL/Unity carve-out bails instead of caching unsoundly,
+  hooks inside do-while loops are detected, and assembly-resolution failures surface as
+  diagnostics instead of silently leaving every `[Component]` unwoven.
+- Reconciler teardown: outlet route scopes are disposed on whole-reconciler teardown,
+  dropdown / radio choices reset when the prop returns to null, and the inline filter list that
+  survives a Null reset is emptied.
+- Styling: drop-shadow texture eviction routes through the play-mode-aware destroy helper, the
+  gradient class gate can no longer false-negative on parser-accepted shapes, and
+  `StyleSlotRecipe.Apply` no longer allocates per call.
+
 ## [1.0.0] - 2026-07-05
 
 ### Changed

--- a/Packages/com.velvet.core/package.json
+++ b/Packages/com.velvet.core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.velvet.core",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "displayName": "Velvet",
   "description": "React-style declarative UI framework for Unity UI Toolkit. Provides virtual DOM, reconciliation engine, hooks, and component model.",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- Bump `com.velvet.core` to **1.1.0** and add the changelog entry.
- Since v1.0.0, main carries API additions (data/aria parameters on every element factory, the preview-window zoom/resolution rework) alongside the correctness fixes from #4 and #7–#11, so the next release is a minor per SemVer.
- The changelog calls out the one visible behavior change explicitly: the `transition-*` property utilities now bundle a default duration/curve (previously they snapped without a `duration-*` class).

After merge: run the UPM workflow (workflow_dispatch, version `1.1.0`) to tag `v1.1.0` on the upm branch, then publish the GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)