### PR TITLE
ci(velvet): tag the main-side release point and link releases to it

### DIFF
--- a/.github/workflows/upm.yml
+++ b/.github/workflows/upm.yml
@@ -85,4 +85,18 @@ jobs:
           TAG="v${VERSION}"
           git tag "$TAG" "$SPLIT_SHA"
           git push origin "$TAG"
-          gh release create "$TAG" --title "$TAG" --generate-notes
+          # The split artifact is amended per release (test stripping), so vX.Y.Z tags are
+          # one-off snapshots with no ancestor relation between releases — they cannot anchor
+          # a "changes since the last release" compare link. Tag the main-side release point
+          # too (vX.Y.Z-main on the commit that triggered this dispatch) and link the release
+          # notes to the compare between consecutive -main tags instead.
+          MAIN_TAG="v${VERSION}-main"
+          git tag "$MAIN_TAG" "$GITHUB_SHA"
+          git push origin "$MAIN_TAG"
+          PREV_MAIN_TAG=$(git tag -l "v*-main" --sort=-v:refname | grep -vx "$MAIN_TAG" | head -1)
+          if [ -n "$PREV_MAIN_TAG" ]; then
+            gh release create "$TAG" --title "$TAG" \
+              --notes "**Full Changelog**: https://github.com/${GITHUB_REPOSITORY}/compare/${PREV_MAIN_TAG}...${MAIN_TAG}"
+          else
+            gh release create "$TAG" --title "$TAG" --generate-notes
+          fi


### PR DESCRIPTION
## Summary

- The release job amends the split artifact (test stripping), so the `vX.Y.Z` tags on the upm branch are one-off snapshots with no ancestor relation between releases: `compare/v1.0.0...v1.1.0` reports *diverged* and the auto-generated notes fall back to a full-history `commits/vX.Y.Z` link — neither shows "changes since the last release".
- The release dispatch now also tags the main-side release point as `vX.Y.Z-main` and writes the release's **Full Changelog** as the compare between consecutive `-main` tags, which is the real source diff between release points. The first release (no prior `-main` tag) keeps the auto-generated notes.
- Backfill for the two existing releases (`v1.0.0-main` → f55f4ca, `v1.1.0-main` → a40bea5) will be pushed once this merges, and the v1.1.0 release notes updated to use them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)