### PR TITLE
feat(velvet): Framer Motion parity (standalone enter, PopLayout, per-property, orchestration, springs, runtime swaps)

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -7,6 +7,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Standalone mount enters: a `V.Motion` outside `AnimatePresence` now plays its `initial` →
+  `animate` variant enter on mount (Framer parity: `initial` / `animate` work on any `motion.*`
+  element).
+- `V.AnimatePresence(mode: AnimatePresenceMode.PopLayout)`: an exiting child is pinned out of
+  flow at its last laid-out rect so siblings reflow immediately (Framer's `mode="popLayout"`);
+  the `gap-*` / `grid-cols-*` / `divide-*` emulations skip the pinned ghost in their index math.
+- Per-property transition overrides: `StyleTransitionConfig.PropertyOverrides` gives individual
+  USS properties their own duration / easing / delay within one variant transition, with
+  completion sized off the slowest overridden property.
+- Orchestration for plain variant propagation: `StaggerChildrenSec` / `DelayChildrenSec` /
+  `When` on a parent Motion's transition stagger its inheriting children without an
+  `AnimatePresence` boundary (`When = AfterChildren` warns and falls back to `Together`).
+- Opt-in spring physics: `StyleTransitionConfig { Type = TransitionType.Spring, Stiffness,
+  Damping, Mass }` drives variant enters / exits with a velocity-preserving integrator — an
+  interrupted spring retargets from its current value and velocity instead of restarting.
+- Runtime variant swaps ride the Motion's own transition config: a mounted Motion whose
+  `animate` label changes — directly or through label inheritance, including every orchestrated
+  stagger child — now tweens (or springs) on its `StyleTransitionConfig`, with no `transition-*`
+  utilities required (Framer parity: `transition` applies to every animate update). Pass
+  `transition: StyleTransitionConfig.None` for an instant swap.
+- A Motion & AnimatePresence guide (`Documentation~/motion.md`): variants and label
+  inheritance, enters / exits, `PopLayout`, orchestration, per-property overrides, springs, and
+  the one-config-every-update transition semantics.
+
+### Changed
+
+- Orchestrated stagger slots now delay the child's class swap itself instead of pre-swapping the
+  classes behind an inline `transition-delay`: the target classes land when the slot elapses,
+  and the swap then plays on the child's own config.
+
+### Fixed
+
+- A classic (tween) enter could snap straight to its end pose on a runtime panel: the class
+  swap now defers one nominal frame so the from-state survives a style pass and the transition
+  actually fires.
+- `gap-*` / `grid-cols-*` / `divide-*` spacing no longer counts absolutely-positioned children:
+  an out-of-flow child neither receives inter-child margins nor shifts its siblings' spacing.
+
 ## [1.1.0] - 2026-07-11
 
 ### Added

--- a/Packages/com.velvet.core/Documentation~/README.md
+++ b/Packages/com.velvet.core/Documentation~/README.md
@@ -12,6 +12,7 @@ For the package overview and installation instructions, see the repository root 
 | [deep-nest-mitigation.md](deep-nest-mitigation.md) | DX patterns for deeply nested `V.*` trees (component splitting + `StyleSlotClasses` typo prevention) |
 | [styling-flexbox-and-gap.md](styling-flexbox-and-gap.md) | Flexbox direction (`flex` defaults to column, not row) and `gap-*` gotchas (single-axis, trailing margin) vs Tailwind |
 | [styling-variants.md](styling-variants.md) | The variant set (state / theme `dark:` / responsive `sm:`…`2xl:` / relational `group-`·`peer-` / stacked) and container queries (`@container`, the `container-type: inline-size` equivalent) |
+| [motion.md](motion.md) | `V.Motion` / `V.AnimatePresence` Framer Motion parity: variants & label inheritance, mount enters, exits & `PopLayout`, `staggerChildren` / `delayChildren` / `when` orchestration, per-property overrides, springs, and the one-config-every-update transition semantics |
 | [preview-tooling.md](preview-tooling.md) | Editor-time preview suite (the Storybook equivalent): `[VelvetPreview]` stories, `[VelvetPreviewSetup]` environments, the Controls / Viewport / Theme / Backgrounds / Zoom / Outline / Measure addons, and registry-driven screenshot capture |
 | [fonts.md](fonts.md) | Font utilities (`font-<family>` / weight scale / `italic`), the `VelvetFonts` registry (representation-agnostic), Addressables fonts, and CJK fallback |
 

--- a/Packages/com.velvet.core/Documentation~/motion.md
+++ b/Packages/com.velvet.core/Documentation~/motion.md
@@ -1,0 +1,183 @@
+# Motion & AnimatePresence: the Framer Motion parity guide
+
+`V.Motion` and `V.AnimatePresence` model [Framer Motion](https://www.framer.com/motion/)'s
+declarative animation API on Unity UI Toolkit. This guide covers the variant-driven feature set:
+labels and inheritance, mount enters, exits and `PopLayout`, orchestration
+(`staggerChildren` / `delayChildren` / `when`), per-property transition overrides, and spring
+physics — plus the transition semantics that tie them together: **one config, every update**
+(and the instant opt-out; see the last section).
+
+The `StyleTransition` presets (`Fade`, `SlideUp`, `ScaleIn`, `FadeSlideUp`, …) and
+`whileHoverClass` / `whileTapClass` gestures are covered in the README; everything below uses
+**variants**.
+
+## Variants & labels
+
+A variant map names poses as utility-class strings; `initial` / `animate` / `exit` select them by
+label, exactly like Framer's `variants` / `initial` / `animate` / `exit`:
+
+```csharp
+static readonly Dictionary<string, string> s_fade = new()
+{
+    ["hidden"]  = "opacity-0 translate-y-8",
+    ["visible"] = "opacity-100",
+};
+
+V.Motion(key: "card", className: "w-24 h-24 rounded-xl bg-sky-500",
+    variants: s_fade, initial: "hidden", animate: "visible",
+    transition: new StyleTransitionConfig { DurationSec = 0.4f });
+```
+
+A pose is a *class delta*: classes present in the resting variant and absent from another are
+removed/added on swap, and anything not mentioned falls back to the element's base `className`.
+
+**Label inheritance (Framer's variant propagation):** a Motion with no `animate` of its own
+follows the nearest ancestor Motion's active label. A coordinator can therefore flip one label
+and drive a whole subtree of inheriting children — that is also what orchestration staggers
+(below).
+
+## Enter on mount (`initial` → `animate`)
+
+Any Motion that declares its own `animate` plus a resolvable `initial` label plays a mount
+enter — **standalone, no `AnimatePresence` required** (Framer parity: `initial` / `animate` work
+on any `motion.*` element). The element mounts showing `variants[initial]`, then transitions to
+`variants[animate]` and rests there.
+
+- An *inherited* label does not drive a standalone enter: the Motion needs its own `animate`
+  (a warning explains this at mount time otherwise).
+- Inside `AnimatePresence`, first-mount enters are controlled by the presence instead:
+  `V.AnimatePresence(initial: false, …)` suppresses them on the initial mount, like Framer's
+  `<AnimatePresence initial={false}>`.
+
+## Exits (`AnimatePresence`)
+
+`V.AnimatePresence` keeps a removed keyed child mounted as a *ghost* until its `exit` variant
+finishes, then removes it and fires `onExitComplete` (once, cancelled exits excluded):
+
+```csharp
+V.Div(name: "row", className: "flex flex-row gap-x-2", children: new VNode[]
+{
+    V.AnimatePresence(key: "presence", onExitComplete: OnRowSettled, children: items),
+});
+```
+
+- **DOM-less:** the presence emits no wrapper element — children expand directly into the
+  parent, so put `flex` / `gap-*` / wrapping on the parent.
+- **Framer's splice semantics:** while a ghost exits, surviving siblings keep their positions;
+  the ghost holds its slot until the exit completes (the default `Sync` mode).
+- Re-adding a key mid-exit cancels the exit and returns the element to its resting variant —
+  including inline geometry the pose had overwritten.
+
+### `PopLayout` mode
+
+```csharp
+V.AnimatePresence(mode: AnimatePresenceMode.PopLayout, children: items);
+```
+
+Framer's `mode="popLayout"`: the exiting child is pinned **out of flow** (absolute, at its last
+laid-out rect, margins accounted for) so surviving siblings reflow *immediately* while the ghost
+plays its exit in place. The `gap-*` / `grid-cols-*` / `divide-*` emulations skip pinned ghosts
+in their index math, so spacing recomputes as if the child were already gone. Note the ghost
+keeps its original paint order: a survivor that reflows into the ghost's rect draws over it.
+
+## Orchestration (`staggerChildren` / `delayChildren` / `when`)
+
+A parent Motion whose transition declares orchestration knobs staggers its **inheriting**
+children (children with no `animate` of their own) whenever its propagated label changes — no
+`AnimatePresence` boundary required:
+
+```csharp
+V.Motion(key: "list", animate: label, className: "flex flex-col gap-2",
+    transition: new StyleTransitionConfig
+    {
+        DurationSec = 0.2f,          // the parent's own swap
+        StaggerChildrenSec = 0.25f,  // +0.25s per child, in tree order
+        DelayChildrenSec = 0.1f,     // base offset for every child
+        When = TransitionWhen.BeforeChildren,
+    },
+    children: cards);
+```
+
+- `When = Together` (default): children start at `DelayChildrenSec` + their stagger slot.
+- `When = BeforeChildren`: children additionally wait out the parent's own
+  `DelaySec + DurationSec` span.
+- `When = AfterChildren` is not orchestratable under label propagation; it warns once and falls
+  back to `Together`.
+- The stagger counter runs in **tree order across the orchestrator's whole subtree** (a
+  documented deviation from Framer, which numbers each parent's children independently).
+- `V.AnimatePresence(staggerSec: …, delayChildrenSec: …, staggerDirection: …)` provides the
+  presence-side equivalent for enter/exit plays, including `V.AnimatedList`'s `staggerSec`.
+
+Orchestration delays each child's **swap itself**: once a child's slot elapses, the swap fires
+and tweens (or springs) on that child's own `StyleTransitionConfig`.
+
+## Per-property transition overrides
+
+`PropertyOverrides` gives individual USS properties their own timing inside one variant
+transition, like Framer's per-value `transition` maps:
+
+```csharp
+new StyleTransitionConfig
+{
+    DurationSec = 0.3f,   // the default for every animated property
+    PropertyOverrides = new[]
+    {
+        new StylePropertyTransition("opacity",   durationSec: 0.15f),
+        new StylePropertyTransition("translate", durationSec: 0.5f, easing: EasingMode.EaseOutBounce),
+    },
+}
+```
+
+Property names are UI Toolkit `transition-property` spellings (`"opacity"`, `"translate"`,
+`"scale"`, `"rotate"`, `"background-color"`, …). Null fields fall back to the enclosing config.
+Completion is sized off the **slowest** overridden property, so a long override finishes instead
+of being snapped when the top-level duration elapses. Overrides apply on the scheduler-driven
+paths (enters / exits); they are not read by plain label-swap patches.
+
+## Springs
+
+```csharp
+new StyleTransitionConfig
+{
+    Type = TransitionType.Spring,
+    Stiffness = 170f,   // default 100
+    Damping   = 10f,    // default 10 — this pair overshoots visibly
+    Mass      = 1f,     // default 1
+}
+```
+
+- Springs drive the numeric channels of a variant delta — `opacity`, `translate`, `scale`,
+  `rotate` — with a velocity-preserving integrator: **interrupting a spring retargets from the
+  current value *and velocity***, Framer's signature interruptible feel. An exit whose delta has
+  no spring channel (e.g. colors only) completes immediately.
+- `DurationSec` is ignored for springs — settling time comes from the physics.
+- Springs drive mount enters, presence exits, and runtime `animate` label swaps alike — flipping
+  a label mid-spring retargets from the current value and velocity.
+- Non-finite / non-positive `Stiffness` / `Damping` / `Mass` log a warning and complete
+  immediately rather than freezing the element mid-pose.
+
+## Transition semantics: one config, every update
+
+Every variant update rides the Motion's own `StyleTransitionConfig` — mount enters
+(`initial` → `animate`), presence enters and exits, and runtime `animate` label changes, whether
+the label is the Motion's own or inherited from an ancestor (orchestrated stagger children
+included). Tweens write the config's timing as an inline transition for the swap and release it
+on completion; spring configs integrate physically instead. This matches Framer, where
+`transition` applies to every animate update:
+
+```csharp
+// Tweens on its own config — no transition-* utilities anywhere.
+V.Motion(key: "card", className: "w-24 h-24 bg-sky-500",
+    variants: s_fade, animate: isOpen ? "visible" : "hidden",
+    transition: new StyleTransitionConfig { DurationSec = 0.3f });
+```
+
+Two consequences worth knowing:
+
+- **Every Motion animates by default.** `V.Motion` without an explicit `transition` falls back
+  to the `Fade` preset's timing, so even a bare Motion tweens its label swaps. Pass
+  `transition: StyleTransitionConfig.None` for an instant, non-animated swap.
+- **`transition-*` utilities are optional for variant swaps.** They still govern property
+  changes outside the variant system (a `hover:` state flipping, an arbitrary class toggle); a
+  variant swap's inline transition simply takes precedence while it plays and is released
+  afterwards.

--- a/Packages/com.velvet.core/README.md
+++ b/Packages/com.velvet.core/README.md
@@ -53,7 +53,7 @@ The UI is described as the pure-function output of state. The VNode tree may be 
 - **Functional components**: `V.Component(() => ...)` mirrors React Function Components
 - **Reconciler**: diff patching plus Lane-based priority scheduling
 - **Hooks**: React's primary hooks exposed in C# PascalCase (see [Documentation~/](./Documentation~/) for details)
-- **Animation**: `V.Motion` / `V.AnimatePresence` model Framer Motion's enter / exit / gesture animations; `AnimatePresence` is DOM-less (it emits no wrapper, mirroring React/Framer). Lists are `V.AnimatePresence(children: V.List(items, key, (x, i) => V.Motion(...)))` — author the animated cell directly, exactly like Framer's `motion.div`
+- **Animation**: `V.Motion` / `V.AnimatePresence` model Framer Motion — variants with `initial` / `animate` / `exit` labels, standalone mount enters, `PopLayout` exits, `staggerChildren` / `delayChildren` orchestration, per-property transition overrides, and opt-in spring physics (see [Documentation~/motion.md](./Documentation~/motion.md)); `AnimatePresence` is DOM-less (it emits no wrapper, mirroring React/Framer). Lists are `V.AnimatePresence(children: V.List(items, key, (x, i) => V.Motion(...)))` — author the animated cell directly, exactly like Framer's `motion.div`
 - **Source Generator memoization**: `[Memoize]` for partial-method-level memoization, `[Component(Memoize = true)]` for whole-component `React.memo`-equivalent caching
 
 #### 2. Utility-first styling

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/AnimatePresenceTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/AnimatePresenceTests.cs
@@ -457,19 +457,21 @@ namespace Velvet.Tests
         [Test]
         public void Given_AVariantMotion_When_AnimateLabelChanges_Then_TheVariantClassesSwapInPlace()
         {
-            // Arrange — a Motion driven by a named variant, mounted in the hidden state.
+            // Arrange — a Motion driven by a named variant, mounted in the hidden state. transition: None
+            // opts out of the runtime-swap tween (see MotionRuntimeSwapTests) so the class list itself is
+            // checked deterministically right after the patch, independent of animation timing.
             var variants = new Dictionary<string, string>
             {
                 { "hidden", "opacity-0" },
                 { "visible", "opacity-100" },
             };
-            var old = new VNode[] { V.Motion("base", key: "x", variants: variants, animate: "hidden") };
-            var @new = new VNode[] { V.Motion("base", key: "x", variants: variants, animate: "visible") };
+            var old = new VNode[] { V.Motion("base", key: "x", variants: variants, animate: "hidden", transition: StyleTransitionConfig.None) };
+            var @new = new VNode[] { V.Motion("base", key: "x", variants: variants, animate: "visible", transition: StyleTransitionConfig.None) };
             Reconciler.Reconcile(Root, Array.Empty<VNode>(), old);
             Assume.That(Root.ElementAt(0).ClassListContains("opacity-0"), Is.True,
                 "Precondition: starts in the hidden variant");
 
-            // Act — switch the active variant label (a USS transition-* utility would tween this swap).
+            // Act — switch the active variant label.
             Reconciler.Reconcile(Root, old, @new);
 
             // Assert — the old variant's classes are gone and the new variant's classes are applied in place.

--- a/Packages/com.velvet.core/Runtime/Component/V.cs
+++ b/Packages/com.velvet.core/Runtime/Component/V.cs
@@ -1419,7 +1419,8 @@ namespace Velvet
         /// <param name="staggerSec">Delay (seconds) staggered between sequential children.</param>
         /// <param name="mode">Exit / enter sequencing. <see cref="AnimatePresenceMode.Sync"/> (default) overlaps
         /// exit and enter; <see cref="AnimatePresenceMode.Wait"/> holds a brand-new child back until in-flight
-        /// exits finish (suited to single-child route / screen swaps).</param>
+        /// exits finish (suited to single-child route / screen swaps); <see cref="AnimatePresenceMode.PopLayout"/>
+        /// pulls an exiting child out of layout flow so still-present siblings reflow immediately.</param>
         /// <param name="onExitComplete">Invoked once when every in-flight exit animation has finished;
         /// not fired for cancelled exits or animation-less removals.</param>
         /// <returns>The created <see cref="AnimatePresenceNode"/>.</returns>

--- a/Packages/com.velvet.core/Runtime/Component/V.cs
+++ b/Packages/com.velvet.core/Runtime/Component/V.cs
@@ -1455,6 +1455,8 @@ namespace Velvet
         /// <summary>
         /// Element targeted by an animation.
         /// Used inside AnimatePresence; toggles CSS classes on mount / unmount according to <paramref name="transition"/>.
+        /// The one exception is a variant <paramref name="initial"/>/<paramref name="animate"/> pair (see
+        /// <paramref name="initial"/>), which plays its mount enter on any Motion, standalone or not.
         /// When <paramref name="transition"/> is null, <c>StyleTransition.Fade</c> is applied as the default.
         /// <paramref name="duration"/> / <paramref name="easing"/> can override individual fields of the
         /// transition preset (e.g. setting only the duration while keeping the preset's other fields).
@@ -1490,14 +1492,16 @@ namespace Velvet
         /// on a parent drives the whole subtree.</param>
         /// <param name="animate">The active variant label (a key of <paramref name="variants"/>). When null, the
         /// nearest ancestor Motion's active label is inherited; when set, it overrides any inherited label.</param>
-        /// <param name="initial">Mount-time starting variant label. When this Motion is the
-        /// DIRECT child of an AnimatePresence and also sets <paramref name="animate"/> + <paramref name="variants"/>,
-        /// the enter starts at <c>variants[initial]</c> and transitions to <c>variants[animate]</c> (its persistent
-        /// resting state) using this Motion's transition timing.</param>
+        /// <param name="initial">Mount-time starting variant label. When this Motion also sets
+        /// <paramref name="animate"/> + <paramref name="variants"/>, the enter starts at <c>variants[initial]</c>
+        /// and transitions to <c>variants[animate]</c> (its persistent resting state) using this Motion's
+        /// transition timing — whether this Motion is the DIRECT child of an AnimatePresence or mounts standalone
+        /// (Framer parity: <c>initial</c>/<c>animate</c> apply to any motion.* component).</param>
         /// <param name="exit">Exit variant label. When this Motion is the DIRECT child of an
         /// AnimatePresence and also sets <paramref name="animate"/> + <paramref name="variants"/>, removal animates
         /// from <c>variants[animate]</c> to <c>variants[exit]</c> (using this Motion's transition timing) before the
-        /// element unmounts.</param>
+        /// element unmounts. Unlike <paramref name="initial"/>, this needs AnimatePresence to defer the unmount —
+        /// set outside one, it is inert and logs a warning.</param>
         /// <returns>The created <see cref="MotionNode"/>.</returns>
         /// <remarks>
         /// Equivalent to Framer Motion's <c>motion.&lt;tag&gt;</c> component (with its <c>variants</c>,

--- a/Packages/com.velvet.core/Runtime/Component/VNodeTypes.cs
+++ b/Packages/com.velvet.core/Runtime/Component/VNodeTypes.cs
@@ -298,6 +298,14 @@ namespace Velvet
         /// is in flight, a brand-new key is withheld; the exit-completion re-render then mounts and enters it.
         /// </summary>
         Wait,
+
+        /// <summary>
+        /// The instant a child starts exiting, it is pulled out of layout flow and pinned via absolute
+        /// positioning at the last rect it occupied, so still-present siblings reflow immediately into its
+        /// place while its exit animation finishes on top of them. Cancelling the exit (its key re-added
+        /// before the animation finishes) restores the child into flow.
+        /// </summary>
+        PopLayout,
     }
 
     /// <summary>
@@ -357,6 +365,8 @@ namespace Velvet
         /// <summary>
         /// Exit / enter sequencing. Defaults to <see cref="AnimatePresenceMode.Sync"/> (exit and enter overlap).
         /// <see cref="AnimatePresenceMode.Wait"/> holds a brand-new child back until in-flight exits finish.
+        /// <see cref="AnimatePresenceMode.PopLayout"/> pulls an exiting child out of flow so siblings reflow
+        /// around it immediately.
         /// </summary>
         public AnimatePresenceMode Mode { get; init; } = AnimatePresenceMode.Sync;
 

--- a/Packages/com.velvet.core/Runtime/Component/VNodeTypes.cs
+++ b/Packages/com.velvet.core/Runtime/Component/VNodeTypes.cs
@@ -80,7 +80,9 @@ namespace Velvet
 
     /// <summary>
     /// Element node that participates in animations.
-    /// Used inside AnimatePresence; switches CSS classes on mount / unmount based on the transition definition.
+    /// A variant <see cref="Initial"/>/<see cref="Animate"/> pair plays its mount enter on ANY Motion, standalone
+    /// or under AnimatePresence; <see cref="Exit"/> requires AnimatePresence (something must defer the unmount
+    /// for the removal to animate against) and switches CSS classes on unmount based on the transition definition.
     /// Inline styles (StyleOverrides) are intentionally not supported. Apply styles via USS classes.
     /// </summary>
     public sealed class MotionNode : BaseElementNode
@@ -90,7 +92,8 @@ namespace Velvet
 
         /// <summary>
         /// Callback invoked when the enter animation completes.
-        /// Effective only inside AnimatePresence. Invoked immediately when StyleTransitionConfig.None.
+        /// Fires for a variant <see cref="Initial"/>/<see cref="Animate"/> enter whether this Motion sits under
+        /// AnimatePresence or mounts standalone. Invoked immediately when StyleTransitionConfig.None.
         /// When initial=false, fires synchronously inside CreateElement.
         /// On asynchronous animation completion via schedule.Execute, called outside of Reconcile, so SetState()
         /// is safe.
@@ -110,10 +113,12 @@ namespace Velvet
         public string? Animate { get; init; }
 
         /// <summary>
-        /// Mount-time starting variant label. When this Motion is the direct child of an
-        /// AnimatePresence and sets <see cref="Initial"/> + <see cref="Animate"/> + <see cref="Variants"/>, the
-        /// enter starts the element at <c>variants[Initial]</c> and transitions to <c>variants[Animate]</c> (which
-        /// it then rests at, persistently) using the <see cref="Transition"/> timing. Null = no variant initial state.
+        /// Mount-time starting variant label. When this Motion sets <see cref="Initial"/> + <see cref="Animate"/> +
+        /// <see cref="Variants"/>, the enter starts the element at <c>variants[Initial]</c> and transitions to
+        /// <c>variants[Animate]</c> (which it then rests at, persistently) using the <see cref="Transition"/>
+        /// timing. Works the same whether this Motion is the direct child of an AnimatePresence or mounts
+        /// standalone — Framer parity: <c>initial</c>/<c>animate</c> apply to any motion.* component; AnimatePresence
+        /// is only required for <see cref="Exit"/>. Null = no variant initial state.
         /// </summary>
         public string? Initial { get; init; }
 
@@ -121,7 +126,9 @@ namespace Velvet
         /// Exit variant label. When this Motion is the direct child of an AnimatePresence and
         /// sets <see cref="Exit"/> + <see cref="Animate"/> + <see cref="Variants"/>, removal animates from the resting
         /// <c>variants[Animate]</c> to <c>variants[Exit]</c> (using the <see cref="Transition"/> timing) before the
-        /// element unmounts. Null = use the transition's own ExitFrom/ExitTo classes.
+        /// element unmounts. Unlike <see cref="Initial"/>, this genuinely needs AnimatePresence — something must
+        /// defer the unmount for the removal to animate against — so it is inert (and logs a warning) outside one.
+        /// Null = use the transition's own ExitFrom/ExitTo classes.
         /// </summary>
         public string? Exit { get; init; }
     }

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberElementCleaner.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberElementCleaner.cs
@@ -198,7 +198,6 @@ namespace Velvet
             // living) must not run even though it can still be attached at this point — DOM detachment is the
             // caller's own job, performed after this cleanup.
             _ctx.StyleAnimationScheduler.CancelExitForTeardown(element);
-            _ctx.StyleAnimationScheduler.CancelDelayedVariantSwap(element);
             _ctx.EventManager.UnbindAll(element);
             _ctx.ComponentRegistry.Remove(element);
             DetachManipulator(element, _ctx.GestureManipulators);

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberElementCleaner.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberElementCleaner.cs
@@ -194,6 +194,7 @@ namespace Velvet
             }
             _ctx.StyleAnimationScheduler.CancelEnter(element);
             _ctx.StyleAnimationScheduler.CancelExit(element);
+            _ctx.StyleAnimationScheduler.CancelDelayedVariantSwap(element);
             _ctx.EventManager.UnbindAll(element);
             _ctx.ComponentRegistry.Remove(element);
             DetachManipulator(element, _ctx.GestureManipulators);

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberElementCleaner.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberElementCleaner.cs
@@ -193,7 +193,11 @@ namespace Velvet
                 refCleanup?.Invoke();
             }
             _ctx.StyleAnimationScheduler.CancelEnter(element);
-            _ctx.StyleAnimationScheduler.CancelExit(element);
+            // Teardown-flavored: this element is being released for good (pool return / disposal), not merely
+            // interrupted, so an ordinary CancelExit's reversal hand-off (which assumes the element keeps
+            // living) must not run even though it can still be attached at this point — DOM detachment is the
+            // caller's own job, performed after this cleanup.
+            _ctx.StyleAnimationScheduler.CancelExitForTeardown(element);
             _ctx.StyleAnimationScheduler.CancelDelayedVariantSwap(element);
             _ctx.EventManager.UnbindAll(element);
             _ctx.ComponentRegistry.Remove(element);

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodeFactory.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodeFactory.cs
@@ -248,15 +248,35 @@ namespace Velvet
                     // recorded against that resting state, so PlayVariantEnter's synchronous strip-to-`initial` is
                     // purely a transient visual state: a later patch (PatchMotion) always diffs against the
                     // resting baseline and never replays this entrance.
-                    if (_ctx.PresenceExpansionDepth == 0 && motionNode.Initial != null && motionNode.Transition != null
-                        && GeneralPathReconciler.TryResolveVariantInitial(
-                            motionNode, out var standaloneFromClasses, out var standaloneToClasses))
+                    // Gated on IDENTITY, not PresenceExpansionDepth: the presence expansion drives an enter for
+                    // only its ONE resolved anchor Motion (PresenceAnchorMotion, set by GeneralPathReconciler
+                    // around the exact EmitPresenceChild call whose enter/exit it dispatches explicitly) — every
+                    // OTHER Motion created while that expansion is on the stack (nested deeper, sitting under a
+                    // non-anchor wrapper — e.g. a plain Div — or simply a sibling keyed child) is not presence-
+                    // managed at all and must keep this mount enter, or wrapping unrelated content in
+                    // AnimatePresence would silently disable it.
+                    if (!ReferenceEquals(motionNode, _ctx.PresenceAnchorMotion) && motionNode.Initial != null)
                     {
-                        var t = motionNode.Transition;
-                        _ctx.StyleAnimationScheduler.PlayVariantEnter(element, standaloneFromClasses, standaloneToClasses,
-                            t.DurationSec, t.Easing, t.DelaySec, motionNode.OnEnterComplete,
-                            propertyOverrides: t.PropertyOverrides,
-                            type: t.Type, stiffness: t.Stiffness, damping: t.Damping, mass: t.Mass);
+                        if (motionNode.Transition != null && GeneralPathReconciler.TryResolveVariantInitial(
+                                motionNode, out var standaloneFromClasses, out var standaloneToClasses))
+                        {
+                            var t = motionNode.Transition;
+                            _ctx.StyleAnimationScheduler.PlayVariantEnter(element, standaloneFromClasses, standaloneToClasses,
+                                t.DurationSec, t.Easing, t.DelaySec, motionNode.OnEnterComplete,
+                                propertyOverrides: t.PropertyOverrides,
+                                type: t.Type, stiffness: t.Stiffness, damping: t.Damping, mass: t.Mass);
+                        }
+                        else
+                        {
+                            // Initial declared but unresolvable: no own Animate (an inherited-label
+                            // configuration is not yet driven by the standalone enter), or the label is missing
+                            // from Variants / maps to an empty class. Warn instead of silently mounting inert,
+                            // matching the Exit gate's own inert-configuration diagnostic above.
+                            FiberLogger.LogWarning("Motion",
+                                "initial is set but has no resolvable enter: this Motion needs its own animate + "
+                                + "variants (with initial mapping to a non-empty class) for a standalone mount "
+                                + "enter. An inherited animate label does not yet drive one.");
+                        }
                     }
                     return element;
                 }

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodeFactory.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodeFactory.cs
@@ -213,18 +213,33 @@ namespace Velvet
                             "A clip-path-* utility on a Motion is ignored: it would break AnimatePresence enter/exit "
                             + "(same constraint as shadow-*). Wrap the Motion around a clipped Div instead.");
                     }
-                    // Enter/exit tweens are scheduled by the AnimatePresence expansion, so on a
-                    // standalone Motion these props are silently inert: the element mounts already
-                    // at its animate/resting classes and the declared initial never plays. Warn like
-                    // the shadow-*/clip-path-* gates above so a Framer-style initial/animate pair
-                    // does not just fail to animate without a trace.
-                    if (_ctx.PresenceExpansionDepth == 0
-                        && (motionNode.Initial != null || motionNode.Exit != null))
+                    // Exit tweens are scheduled only by the AnimatePresence expansion — something has to defer
+                    // the unmount for a removal to animate against, and AnimatePresence is what does that — so
+                    // exit outside one is genuinely inert. Warn like the shadow-*/clip-path-* gates above. Initial
+                    // is NOT warned here (see the standalone enter below): unlike exit, a mount-time enter needs
+                    // no deferred unmount to play against, so it works on any Motion, matching Framer parity
+                    // (initial/animate apply to any motion.* component; only AnimatePresence is exit-only).
+                    if (_ctx.PresenceExpansionDepth == 0 && motionNode.Exit != null)
                     {
                         FiberLogger.LogWarning("Motion",
-                            "initial/exit on a Motion outside AnimatePresence is inert: enter/exit tweens are "
-                            + "driven by the AnimatePresence expansion. Wrap the Motion in V.AnimatePresence "
-                            + "(or drop initial/exit).");
+                            "exit on a Motion outside AnimatePresence is inert: exit tweens are driven by the "
+                            + "AnimatePresence expansion. Wrap the Motion in V.AnimatePresence (or drop exit).");
+                    }
+                    // Standalone `initial` enter: outside AnimatePresence this Motion still plays its own
+                    // mount animation, the same variant enter the presence expansion drives
+                    // (GeneralPathReconciler.ExpandAnimatePresenceInline) — just with no stagger (there is no
+                    // AnimatePresence boundary to stagger against). The element above was created carrying the
+                    // resting variants[animate] classes (appliedClasses), with MotionAppliedClasses already
+                    // recorded against that resting state, so PlayVariantEnter's synchronous strip-to-`initial` is
+                    // purely a transient visual state: a later patch (PatchMotion) always diffs against the
+                    // resting baseline and never replays this entrance.
+                    if (_ctx.PresenceExpansionDepth == 0 && motionNode.Initial != null && motionNode.Transition != null
+                        && GeneralPathReconciler.TryResolveVariantInitial(
+                            motionNode, out var standaloneFromClasses, out var standaloneToClasses))
+                    {
+                        var t = motionNode.Transition;
+                        _ctx.StyleAnimationScheduler.PlayVariantEnter(element, standaloneFromClasses, standaloneToClasses,
+                            t.DurationSec, t.Easing, t.DelaySec, motionNode.OnEnterComplete);
                     }
                     return element;
                 }

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodeFactory.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodeFactory.cs
@@ -239,7 +239,8 @@ namespace Velvet
                     {
                         var t = motionNode.Transition;
                         _ctx.StyleAnimationScheduler.PlayVariantEnter(element, standaloneFromClasses, standaloneToClasses,
-                            t.DurationSec, t.Easing, t.DelaySec, motionNode.OnEnterComplete);
+                            t.DurationSec, t.Easing, t.DelaySec, motionNode.OnEnterComplete,
+                            propertyOverrides: t.PropertyOverrides);
                     }
                     return element;
                 }

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodeFactory.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodeFactory.cs
@@ -144,13 +144,13 @@ namespace Velvet
                     // Resolve the applied classes against the effective label (own Animate, else the nearest
                     // ancestor Motion's label read from MotionContext) — the variant-inheritance model.
                     var motionAmbient = _ctx.ComponentContextStack.Get(MotionContext.ActiveLabel);
-                    var appliedClasses = MotionVariantResolver.ResolveApplied(motionNode, motionAmbient, out var variantApplied);
+                    var appliedClasses = MotionVariantResolver.ResolveApplied(motionNode, motionAmbient, out var variantClasses);
                     var element = _ctx.FiberElementFactory.CreateMotion(motionNode, appliedClasses);
                     // Only record applied-class bookkeeping when a variant actually merged; the variant-less
                     // majority needs no entry (patch falls back to oldNode.ClassNames for the diff baseline).
-                    if (variantApplied)
+                    if (variantClasses.Length > 0)
                     {
-                        _ctx.MotionAppliedClasses[element] = appliedClasses;
+                        _ctx.MotionAppliedClasses[element] = new MotionAppliedClassSet(appliedClasses, variantClasses);
                     }
                     // Record the label propagated to children now (regardless of whether this Motion currently
                     // has any) so the FIRST patch on this element has an accurate baseline: PatchMotion diffs

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodeFactory.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodeFactory.cs
@@ -255,7 +255,8 @@ namespace Velvet
                         var t = motionNode.Transition;
                         _ctx.StyleAnimationScheduler.PlayVariantEnter(element, standaloneFromClasses, standaloneToClasses,
                             t.DurationSec, t.Easing, t.DelaySec, motionNode.OnEnterComplete,
-                            propertyOverrides: t.PropertyOverrides);
+                            propertyOverrides: t.PropertyOverrides,
+                            type: t.Type, stiffness: t.Stiffness, damping: t.Damping, mass: t.Mass);
                     }
                     return element;
                 }

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodeFactory.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodeFactory.cs
@@ -158,15 +158,14 @@ namespace Velvet
                     // staggerChildren/delayChildren orchestration — without seeding it here, that first patch
                     // would see no previous entry and could misfire even when the label held steady across
                     // mount and the first re-render. Orchestration itself only ever starts from a PATCH-time
-                    // label change (see FiberNodePatcher.PatchMotion), never on mount.
+                    // label change (see FiberNodePatcher.PatchMotion), never on mount. A null childLabel needs no
+                    // removal here: a brand-new element was never in this map, and a pooled one already had its
+                    // entry cleared by ReconcilerContext.ClearElementSideTables when it was returned (see
+                    // MotionChildLabel's own doc).
                     var childLabel = MotionVariantResolver.LabelForChildren(motionNode, motionAmbient);
                     if (childLabel != null)
                     {
                         _ctx.MotionChildLabel[element] = childLabel;
-                    }
-                    else
-                    {
-                        _ctx.MotionChildLabel.Remove(element);
                     }
                     if (motionNode.Children != null)
                     {

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodeFactory.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodeFactory.cs
@@ -262,9 +262,7 @@ namespace Velvet
                         {
                             var t = motionNode.Transition;
                             _ctx.StyleAnimationScheduler.PlayVariantEnter(element, standaloneFromClasses, standaloneToClasses,
-                                t.DurationSec, t.Easing, t.DelaySec, motionNode.OnEnterComplete,
-                                propertyOverrides: t.PropertyOverrides,
-                                type: t.Type, stiffness: t.Stiffness, damping: t.Damping, mass: t.Mass);
+                                t, motionNode.OnEnterComplete);
                         }
                         else
                         {

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodeFactory.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodeFactory.cs
@@ -152,13 +152,28 @@ namespace Velvet
                     {
                         _ctx.MotionAppliedClasses[element] = appliedClasses;
                     }
+                    // Record the label propagated to children now (regardless of whether this Motion currently
+                    // has any) so the FIRST patch on this element has an accurate baseline: PatchMotion diffs
+                    // against this stored value to detect an ACTUAL label change before it (re-)triggers
+                    // staggerChildren/delayChildren orchestration — without seeding it here, that first patch
+                    // would see no previous entry and could misfire even when the label held steady across
+                    // mount and the first re-render. Orchestration itself only ever starts from a PATCH-time
+                    // label change (see FiberNodePatcher.PatchMotion), never on mount.
+                    var childLabel = MotionVariantResolver.LabelForChildren(motionNode, motionAmbient);
+                    if (childLabel != null)
+                    {
+                        _ctx.MotionChildLabel[element] = childLabel;
+                    }
+                    else
+                    {
+                        _ctx.MotionChildLabel.Remove(element);
+                    }
                     if (motionNode.Children != null)
                     {
                         var childContainer = FiberNodePatcher.GetChildContainer(element);
                         // Provide this Motion's active label to its descendants while their subtree reconciles
                         // (same ComponentContextStack the Router/Outlet ambient values ride on). Skip the
                         // stack round-trip entirely when there is no label to propagate (the common case).
-                        var childLabel = MotionVariantResolver.LabelForChildren(motionNode, motionAmbient);
                         if (childLabel != null)
                         {
                             _ctx.ComponentContextStack.Push(MotionContext.ActiveLabel, childLabel);

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
@@ -368,10 +368,15 @@ namespace Velvet
             // Transition declared the knobs) — claim the next sequential slot and delay this element's class
             // swap by it, on top of whatever this node's own Transition.DelaySec already declares. Applied
             // BEFORE PatchBaseElement performs the actual class diff below, so the inline transition-delay is
-            // already in place when the swapped classes change the resolved style.
+            // already in place when the swapped classes change the resolved style. Declared OUTSIDE the `if`
+            // (0f when this node claims nothing) so it can be folded into a fresh orchestration frame THIS node
+            // establishes below for its OWN children (see ResolveChildOrchestration): this node's own swap does
+            // not start until extraDelaySec has elapsed, so a child frame it establishes must measure its
+            // claims from that same origin, not from render-commit time as if this node's swap were immediate.
+            var extraDelaySec = 0f;
             if (newNode.Animate == null && variantApplied && ambientOrchestration != null)
             {
-                var extraDelaySec = ambientOrchestration.ClaimNextChildDelaySec();
+                extraDelaySec = ambientOrchestration.ClaimNextChildDelaySec();
                 ApplyOrchestratedDelay(element, newNode.Transition, extraDelaySec);
             }
 
@@ -393,7 +398,7 @@ namespace Velvet
 
             if (childLabel != null)
             {
-                var childOrchestration = ResolveChildOrchestration(newNode, childLabelChanged, ambientOrchestration);
+                var childOrchestration = ResolveChildOrchestration(newNode, childLabelChanged, ambientOrchestration, extraDelaySec);
                 _ctx.ComponentContextStack.Push(MotionContext.ActiveLabel, childLabel);
                 _ctx.ComponentContextStack.Push(MotionContext.Orchestration, childOrchestration);
                 try
@@ -428,7 +433,14 @@ namespace Velvet
         // - A FRESH frame when this node's propagated label just changed AND its own Transition declares
         //   StaggerChildrenSec / DelayChildrenSec / a non-Together When — establishing a new stagger sequence
         //   (When == AfterChildren is not orchestrated; it warns once here and falls back to Together's
-        //   no-extra-delay semantics for the parent's own swap — see TransitionWhen.AfterChildren).
+        //   no-extra-delay semantics for the parent's own swap — see TransitionWhen.AfterChildren). The frame's
+        //   base offset is this node's own [DelaySec, DelaySec + DurationSec] span when When == BeforeChildren
+        //   (children wait for the delay AND the swap, not just the swap), PLUS extraDelaySec — the delay THIS
+        //   node itself claimed a moment ago in PatchMotion when it is, itself, an inheriting descendant of a
+        //   FURTHER-OUT orchestration. Folding extraDelaySec in regardless of When matters because this node's
+        //   own swap does not start at render-commit time when extraDelaySec > 0 — without it, a claim from the
+        //   fresh frame below would be measured as if this node's (already-delayed) swap started immediately,
+        //   letting a grandchild start animating before its own parent does.
         // - null when this node drives its children via its OWN explicit Animate: an ambient orchestration
         //   meant for a sibling branch must not leak through a node that is no longer inheriting (it computes
         //   its own child label independently of the ambient one, so it is a natural cut point).
@@ -436,7 +448,7 @@ namespace Velvet
         //   passed through UNCHANGED, so a non-orchestrating intermediate layer does not interrupt an outer
         //   ancestor's stagger sequence reaching its own grandchildren.
         private static MotionOrchestrationFrame? ResolveChildOrchestration(
-            MotionNode newNode, bool childLabelChanged, MotionOrchestrationFrame? ambientOrchestration)
+            MotionNode newNode, bool childLabelChanged, MotionOrchestrationFrame? ambientOrchestration, float extraDelaySec)
         {
             var transition = newNode.Transition;
             var hasOwnOrchestration = transition != null
@@ -450,8 +462,11 @@ namespace Velvet
                         "transition.When = AfterChildren is not yet orchestrated for label propagation; "
                         + "children animate as if When = Together (no wait for the parent's own transition).");
                 }
-                var extraBeforeChildrenSec = transition.When == TransitionWhen.BeforeChildren ? transition.DurationSec : 0f;
-                return new MotionOrchestrationFrame(transition.DelayChildrenSec, transition.StaggerChildrenSec, extraBeforeChildrenSec);
+                var extraBeforeChildrenSec = transition.When == TransitionWhen.BeforeChildren
+                    ? transition.DelaySec + transition.DurationSec
+                    : 0f;
+                return new MotionOrchestrationFrame(transition.DelayChildrenSec, transition.StaggerChildrenSec,
+                    extraBeforeChildrenSec + extraDelaySec);
             }
             return newNode.Animate != null ? null : ambientOrchestration;
         }

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
@@ -346,16 +346,21 @@ namespace Velvet
             // node's label for its own children).
             var motionAmbient = _ctx.ComponentContextStack.Get(MotionContext.ActiveLabel);
             var ambientOrchestration = _ctx.ComponentContextStack.Get(MotionContext.Orchestration);
-            var appliedNew = MotionVariantResolver.ResolveApplied(newNode, motionAmbient, out var variantApplied);
+            var appliedNew = MotionVariantResolver.ResolveApplied(newNode, motionAmbient, out var newVariantClasses);
             // Diff against the previously-APPLIED set (base + resolved variant), not the raw ClassNames — so a
             // changed effective label swaps the variant classes even when this node's base classes are equal.
-            // When no entry exists (variant-less, never stored) the baseline is the node's base classes.
-            var appliedOld = _ctx.MotionAppliedClasses.TryGetValue(element, out var prev) ? prev : oldNode.ClassNames;
+            // When no entry exists (variant-less, never stored) the baseline is the node's base classes with no
+            // variant classes — an explicit pair (MotionAppliedClassSet), not something re-derived from the
+            // merged array's tail by position (see ResolveApplied's own doc for why that would be fragile).
+            var hasPreviousApplied = _ctx.MotionAppliedClasses.TryGetValue(element, out var previousApplied);
+            var appliedOld = hasPreviousApplied ? previousApplied.Merged : oldNode.ClassNames;
+            var oldVariantClasses = hasPreviousApplied ? previousApplied.VariantClasses : Array.Empty<string>();
+            var variantApplied = newVariantClasses.Length > 0;
             // Keep an entry only while a variant is applied; drop it when a variant→no-variant transition happens
             // (the diff above still uses the stored old classes to REMOVE the now-stale variant utilities).
             if (variantApplied)
             {
-                _ctx.MotionAppliedClasses[element] = appliedNew;
+                _ctx.MotionAppliedClasses[element] = new MotionAppliedClassSet(appliedNew, newVariantClasses);
             }
             else
             {
@@ -365,19 +370,18 @@ namespace Velvet
             // staggerChildren/delayChildren propagation (plain variant-tree orchestration — no AnimatePresence
             // required): this node FOLLOWS the ambient label (no own Animate opting it out) and an ancestor
             // Motion is currently orchestrating THIS render (its own active label just changed and its
-            // Transition declared the knobs) — claim the next sequential slot and delay this element's class
-            // swap by it, on top of whatever this node's own Transition.DelaySec already declares. Applied
-            // BEFORE PatchBaseElement performs the actual class diff below, so the inline transition-delay is
-            // already in place when the swapped classes change the resolved style. Declared OUTSIDE the `if`
-            // (0f when this node claims nothing) so it can be folded into a fresh orchestration frame THIS node
-            // establishes below for its OWN children (see ResolveChildOrchestration): this node's own swap does
-            // not start until extraDelaySec has elapsed, so a child frame it establishes must measure its
+            // Transition declared the knobs) — claim the next sequential slot. The claim rides along as the
+            // runtime-swap play's additionalDelaySec further below (delaying the SWAP itself, not a parked CSS
+            // transition-delay for utilities this element may not even declare), layered on top of whatever
+            // this node's own Transition.DelaySec the play's own config already carries. Declared OUTSIDE the
+            // `if` (0f when this node claims nothing) so it can be folded into a fresh orchestration frame THIS
+            // node establishes below for its OWN children (see ResolveChildOrchestration): this node's own swap
+            // does not start until extraDelaySec has elapsed, so a child frame it establishes must measure its
             // claims from that same origin, not from render-commit time as if this node's swap were immediate.
             var extraDelaySec = 0f;
             if (newNode.Animate == null && variantApplied && ambientOrchestration != null)
             {
                 extraDelaySec = ambientOrchestration.ClaimNextChildDelaySec();
-                ApplyOrchestratedDelay(element, newNode.Transition, extraDelaySec);
             }
 
             var childLabel = MotionVariantResolver.LabelForChildren(newNode, motionAmbient);
@@ -434,6 +438,30 @@ namespace Velvet
                 PatchBaseElement(element, oldNode, newNode, appliedOld, appliedNew);
             }
 
+            // Runtime variant swap: PatchBaseElement above already synced the class list to the final resting
+            // state (appliedNew) via a plain, instant diff. When the effective label actually changed WHICH
+            // variant classes are applied AND this Motion declares a Transition, replay that same swap as a
+            // VISUAL tween on the scheduler instead — Framer applies `transition` to every animate update, not
+            // just the first. A null Transition keeps today's plain, instant diff (Velvet does not imitate
+            // Framer's implicit default transition).
+            // Gated off an element the scheduler already treats as EXITING (not off PresenceAnchorMotion
+            // identity — that field is set for every current AnimatePresence child, including a plain
+            // PERSISTING one this swap must still drive when its ambient label changes, e.g. a coordinator
+            // orchestrating a presence-managed child). A Motion's own resolved variant only actually changes
+            // (the precondition above) while ReferenceEquals(node, motion) && Variants != null, which is
+            // exactly GeneralPathReconciler's own isVariantMotion — and its explicit enter dispatch for that
+            // shape either runs on a fresh CREATE (never reaches PatchMotion) or, for a still-exiting /
+            // cancelled-exit reproduction, plays no competing animation of its own (CancelExit's reversal, or
+            // no-op) — so the one real overlap is a GHOST re-patched on a LATER render while still exiting
+            // (skipping the ghost dispatch's own CancelEnter, which only runs the FIRST time
+            // state.Exiting.Add(key) succeeds): IsExiting catches exactly that window.
+            if (newNode.Transition != null && !_ctx.StyleAnimationScheduler.IsExiting(element)
+                && !SequenceEqual(oldVariantClasses, newVariantClasses))
+            {
+                _ctx.StyleAnimationScheduler.PlayVariantEnter(element, oldVariantClasses, newVariantClasses,
+                    newNode.Transition, onComplete: null, additionalDelaySec: extraDelaySec);
+            }
+
             // MotionNode has no Styles diff, so the shared passes follow PatchCommon (which reconciles
             // children) directly. A Motion never renders skew (the animation node never attaches a sheared
             // silhouette), so its gradient always takes the straight background-image path even with skew
@@ -487,22 +515,6 @@ namespace Velvet
                     extraBeforeChildrenSec + extraDelaySec);
             }
             return newNode.Animate != null ? null : ambientOrchestration;
-        }
-
-        // Adds the orchestrated extra delay (staggerChildren/delayChildren, computed by the ancestor's
-        // MotionOrchestrationFrame) on top of this Motion's OWN configured DelaySec, and applies the total as
-        // this element's inline transition-delay for the class-diff swap PatchBaseElement is about to perform —
-        // a plain class add/remove, not a scheduler-driven enter/exit, so whatever CSS transition actually
-        // tweens the changed properties is whichever the element's OWN utility classes declare (e.g.
-        // transition-opacity duration-300); this only shifts when it starts. PropertyOverrides' own per-property
-        // delays are not read here: that mechanism is currently wired only through StyleAnimationScheduler's
-        // enter/exit plays (an AnimatePresence-driven or standalone initial->animate enter), never through this
-        // plain class-diff swap, so there is nothing to layer the extra delay onto for that path yet.
-        private void ApplyOrchestratedDelay(VisualElement element, StyleTransitionConfig? transition, float extraDelaySec)
-        {
-            var totalDelaySec = (transition?.DelaySec ?? 0f) + extraDelaySec;
-            var durationSec = transition?.DurationSec ?? 0f;
-            _ctx.StyleAnimationScheduler.PlayDelayedVariantSwap(element, totalDelaySec, durationSec);
         }
 
         // Applies the diff for a PortalNode. Reconciles only this Portal's own slot range

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
@@ -345,6 +345,7 @@ namespace Velvet
             // Effective label = own Animate, else the inherited MotionContext label (read BEFORE we push this
             // node's label for its own children).
             var motionAmbient = _ctx.ComponentContextStack.Get(MotionContext.ActiveLabel);
+            var ambientOrchestration = _ctx.ComponentContextStack.Get(MotionContext.Orchestration);
             var appliedNew = MotionVariantResolver.ResolveApplied(newNode, motionAmbient, out var variantApplied);
             // Diff against the previously-APPLIED set (base + resolved variant), not the raw ClassNames — so a
             // changed effective label swaps the variant classes even when this node's base classes are equal.
@@ -361,16 +362,47 @@ namespace Velvet
                 _ctx.MotionAppliedClasses.Remove(element);
             }
 
+            // staggerChildren/delayChildren propagation (plain variant-tree orchestration — no AnimatePresence
+            // required): this node FOLLOWS the ambient label (no own Animate opting it out) and an ancestor
+            // Motion is currently orchestrating THIS render (its own active label just changed and its
+            // Transition declared the knobs) — claim the next sequential slot and delay this element's class
+            // swap by it, on top of whatever this node's own Transition.DelaySec already declares. Applied
+            // BEFORE PatchBaseElement performs the actual class diff below, so the inline transition-delay is
+            // already in place when the swapped classes change the resolved style.
+            if (newNode.Animate == null && variantApplied && ambientOrchestration != null)
+            {
+                var extraDelaySec = ambientOrchestration.ClaimNextChildDelaySec();
+                ApplyOrchestratedDelay(element, newNode.Transition, extraDelaySec);
+            }
+
             var childLabel = MotionVariantResolver.LabelForChildren(newNode, motionAmbient);
+            // Compare against the label THIS element propagated to children last time (not merely whether ITS
+            // OWN classes changed — a "coordinator" Motion may propagate a label while carrying no Variants of
+            // its own) to detect an ACTUAL change before (re-)establishing a fresh orchestration frame: a
+            // re-render that keeps the same label must not re-trigger the stagger.
+            var previousChildLabel = _ctx.MotionChildLabel.TryGetValue(element, out var prevChildLabel) ? prevChildLabel : null;
+            var childLabelChanged = childLabel != previousChildLabel;
             if (childLabel != null)
             {
+                _ctx.MotionChildLabel[element] = childLabel;
+            }
+            else
+            {
+                _ctx.MotionChildLabel.Remove(element);
+            }
+
+            if (childLabel != null)
+            {
+                var childOrchestration = ResolveChildOrchestration(newNode, childLabelChanged, ambientOrchestration);
                 _ctx.ComponentContextStack.Push(MotionContext.ActiveLabel, childLabel);
+                _ctx.ComponentContextStack.Push(MotionContext.Orchestration, childOrchestration);
                 try
                 {
                     PatchBaseElement(element, oldNode, newNode, appliedOld, appliedNew);
                 }
                 finally
                 {
+                    _ctx.ComponentContextStack.Pop(MotionContext.Orchestration);
                     _ctx.ComponentContextStack.Pop(MotionContext.ActiveLabel);
                 }
             }
@@ -390,6 +422,54 @@ namespace Velvet
             // Motion (allowWrap false); a Motion thus carries no ring binding, so this only updates/unwraps an
             // (absent by this rule) binding.
             _appliers.ApplyRingOnPatch(element, appliedNew, suppress: false, allowWrap: false);
+        }
+
+        // Resolves the MotionOrchestrationFrame this node exposes to its OWN inheriting children:
+        // - A FRESH frame when this node's propagated label just changed AND its own Transition declares
+        //   StaggerChildrenSec / DelayChildrenSec / a non-Together When — establishing a new stagger sequence
+        //   (When == AfterChildren is not orchestrated; it warns once here and falls back to Together's
+        //   no-extra-delay semantics for the parent's own swap — see TransitionWhen.AfterChildren).
+        // - null when this node drives its children via its OWN explicit Animate: an ambient orchestration
+        //   meant for a sibling branch must not leak through a node that is no longer inheriting (it computes
+        //   its own child label independently of the ambient one, so it is a natural cut point).
+        // - Otherwise (a pure pass-through inheritor with no orchestration of its own) the ambient frame is
+        //   passed through UNCHANGED, so a non-orchestrating intermediate layer does not interrupt an outer
+        //   ancestor's stagger sequence reaching its own grandchildren.
+        private static MotionOrchestrationFrame? ResolveChildOrchestration(
+            MotionNode newNode, bool childLabelChanged, MotionOrchestrationFrame? ambientOrchestration)
+        {
+            var transition = newNode.Transition;
+            var hasOwnOrchestration = transition != null
+                && (transition.StaggerChildrenSec > 0f || transition.DelayChildrenSec > 0f
+                    || transition.When != TransitionWhen.Together);
+            if (childLabelChanged && hasOwnOrchestration)
+            {
+                if (transition.When == TransitionWhen.AfterChildren)
+                {
+                    FiberLogger.LogWarning("Motion",
+                        "transition.When = AfterChildren is not yet orchestrated for label propagation; "
+                        + "children animate as if When = Together (no wait for the parent's own transition).");
+                }
+                var extraBeforeChildrenSec = transition.When == TransitionWhen.BeforeChildren ? transition.DurationSec : 0f;
+                return new MotionOrchestrationFrame(transition.DelayChildrenSec, transition.StaggerChildrenSec, extraBeforeChildrenSec);
+            }
+            return newNode.Animate != null ? null : ambientOrchestration;
+        }
+
+        // Adds the orchestrated extra delay (staggerChildren/delayChildren, computed by the ancestor's
+        // MotionOrchestrationFrame) on top of this Motion's OWN configured DelaySec, and applies the total as
+        // this element's inline transition-delay for the class-diff swap PatchBaseElement is about to perform —
+        // a plain class add/remove, not a scheduler-driven enter/exit, so whatever CSS transition actually
+        // tweens the changed properties is whichever the element's OWN utility classes declare (e.g.
+        // transition-opacity duration-300); this only shifts when it starts. PropertyOverrides' own per-property
+        // delays are not read here: that mechanism is currently wired only through StyleAnimationScheduler's
+        // enter/exit plays (an AnimatePresence-driven or standalone initial->animate enter), never through this
+        // plain class-diff swap, so there is nothing to layer the extra delay onto for that path yet.
+        private void ApplyOrchestratedDelay(VisualElement element, StyleTransitionConfig? transition, float extraDelaySec)
+        {
+            var totalDelaySec = (transition?.DelaySec ?? 0f) + extraDelaySec;
+            var durationSec = transition?.DurationSec ?? 0f;
+            _ctx.StyleAnimationScheduler.PlayDelayedVariantSwap(element, totalDelaySec, durationSec);
         }
 
         // Applies the diff for a PortalNode. Reconciles only this Portal's own slot range

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
@@ -387,27 +387,45 @@ namespace Velvet
             // re-render that keeps the same label must not re-trigger the stagger.
             var previousChildLabel = _ctx.MotionChildLabel.TryGetValue(element, out var prevChildLabel) ? prevChildLabel : null;
             var childLabelChanged = childLabel != previousChildLabel;
-            if (childLabel != null)
+            // Only touch the map when the label actually changed: an unchanged null already has no entry (the
+            // else branch below already removed it last time), and an unchanged non-null value is already
+            // stored under this exact key — re-writing/re-removing it every render would just be a wasted
+            // Dictionary op on the (overwhelming) common "same label" re-render.
+            if (childLabelChanged)
             {
-                _ctx.MotionChildLabel[element] = childLabel;
-            }
-            else
-            {
-                _ctx.MotionChildLabel.Remove(element);
+                if (childLabel != null)
+                {
+                    _ctx.MotionChildLabel[element] = childLabel;
+                }
+                else
+                {
+                    _ctx.MotionChildLabel.Remove(element);
+                }
             }
 
             if (childLabel != null)
             {
                 var childOrchestration = ResolveChildOrchestration(newNode, childLabelChanged, ambientOrchestration, extraDelaySec);
+                // Skip the Orchestration round-trip when this node passes the ambient frame through UNCHANGED
+                // (including the common "no orchestration anywhere in this subtree" case, both null): a
+                // descendant's Get already sees exactly ambientOrchestration without anything new pushed, so
+                // pushing then popping the identical reference back off is pure overhead.
+                var pushOrchestration = !ReferenceEquals(childOrchestration, ambientOrchestration);
                 _ctx.ComponentContextStack.Push(MotionContext.ActiveLabel, childLabel);
-                _ctx.ComponentContextStack.Push(MotionContext.Orchestration, childOrchestration);
+                if (pushOrchestration)
+                {
+                    _ctx.ComponentContextStack.Push(MotionContext.Orchestration, childOrchestration);
+                }
                 try
                 {
                     PatchBaseElement(element, oldNode, newNode, appliedOld, appliedNew);
                 }
                 finally
                 {
-                    _ctx.ComponentContextStack.Pop(MotionContext.Orchestration);
+                    if (pushOrchestration)
+                    {
+                        _ctx.ComponentContextStack.Pop(MotionContext.Orchestration);
+                    }
                     _ctx.ComponentContextStack.Pop(MotionContext.ActiveLabel);
                 }
             }

--- a/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
@@ -1206,7 +1206,8 @@ namespace Velvet
                                         var t = motion.Transition;
                                         _ctx.StyleAnimationScheduler.PlayVariantEnter(anchor, fromClasses, toClasses,
                                             t.DurationSec, t.Easing, t.DelaySec,
-                                            motion.OnEnterComplete, presence.StaggerDelaySec(visualIndex, newKeyed.Count));
+                                            motion.OnEnterComplete, presence.StaggerDelaySec(visualIndex, newKeyed.Count),
+                                            propertyOverrides: t.PropertyOverrides);
                                     }
                                     else if (isVariantMotion)
                                     {
@@ -1407,6 +1408,7 @@ namespace Velvet
                 Easing = timing.Easing,
                 ExitEasing = timing.ExitEasing,
                 DelaySec = timing.DelaySec,
+                PropertyOverrides = timing.PropertyOverrides,
             };
         }
 

--- a/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
@@ -1073,6 +1073,10 @@ namespace Velvet
                         if (commit != null && ghostAnchor != null && state.Exiting.Add(key))
                         {
                             _ctx.StyleAnimationScheduler.CancelEnter(ghostAnchor);
+                            if (presence.Mode == AnimatePresenceMode.PopLayout)
+                            {
+                                PinExitingChildOutOfFlow(ghostAnchor);
+                            }
                             var capturedKey = key;
                             var capturedState = state;
                             var capturedBoundary = boundaryFiber;
@@ -1161,7 +1165,14 @@ namespace Velvet
                         {
                             state.ExitAnchors.Remove(key!);
                         }
-                        if (wasExiting) _ctx.StyleAnimationScheduler.CancelExit(anchor);
+                        if (wasExiting)
+                        {
+                            _ctx.StyleAnimationScheduler.CancelExit(anchor);
+                            if (presence.Mode == AnimatePresenceMode.PopLayout)
+                            {
+                                RestorePopLayoutChildToFlow(anchor);
+                            }
+                        }
 
                         var isEnter = wasExiting || wasExitComplete || !PresenceContainsKey(prevCommitted, key);
                         if (isEnter)
@@ -1252,6 +1263,41 @@ namespace Velvet
                 if (list[i].key == key) return true;
             }
             return false;
+        }
+
+        // AnimatePresenceMode.PopLayout: the instant a child's exit starts, pull it out of layout flow and pin
+        // it via absolute positioning at the last rect Yoga resolved for it in-flow (anchor.layout is parent-
+        // relative), so still-present siblings reflow into its place immediately while the exit animation
+        // finishes on top. Skipped when any component is non-finite (an EditMode pass with no forced layout
+        // leaves `.layout` at NaN) — the child then degrades to a normal in-flow exit rather than being pinned
+        // to garbage coordinates.
+        private static void PinExitingChildOutOfFlow(VisualElement anchor)
+        {
+            var rect = anchor.layout;
+            if (!float.IsFinite(rect.x) || !float.IsFinite(rect.y)
+                || !float.IsFinite(rect.width) || !float.IsFinite(rect.height))
+            {
+                return;
+            }
+
+            anchor.style.position = Position.Absolute;
+            anchor.style.left = rect.x;
+            anchor.style.top = rect.y;
+            anchor.style.width = rect.width;
+            anchor.style.height = rect.height;
+        }
+
+        // Reverses PinExitingChildOutOfFlow when a PopLayout exit is cancelled (its key re-added before the
+        // exit finished): clears the same five inline styles back to StyleKeyword.Null so the child rejoins
+        // its parent's normal layout flow. A no-op (harmless) when the exit was never pinned (non-finite
+        // layout at exit-start), since clearing an already-null style is idempotent.
+        private static void RestorePopLayoutChildToFlow(VisualElement anchor)
+        {
+            anchor.style.position = StyleKeyword.Null;
+            anchor.style.left = StyleKeyword.Null;
+            anchor.style.top = StyleKeyword.Null;
+            anchor.style.width = StyleKeyword.Null;
+            anchor.style.height = StyleKeyword.Null;
         }
 
         // Disposes the inline/wrapper fibers mounted under an exit-completed ghost's anchor element. Needed

--- a/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
@@ -957,7 +957,8 @@ namespace Velvet
                 {
                     foreach (var (key, node) in oldState.Committed)
                     {
-                        EmitPresenceChild(node, key, presenceKey, result, isNewSide: false, parent, slotStart,
+                        EmitPresenceChildAsAnchor(node, FiberNodeFactory.FindFirstMotionDescendant(node),
+                            key, presenceKey, result, isNewSide: false, parent, slotStart,
                             oldFibers, newFibers, providers, oldProvidersForPairing, ref newProviderIndex, commit);
                     }
                 }
@@ -1078,7 +1079,8 @@ namespace Velvet
                             continue;
                         }
 
-                        var ghostAnchor = EmitPresenceChild(node, key, presenceKey, result, isNewSide: true, parent, slotStart,
+                        var ghostAnchor = EmitPresenceChildAsAnchor(node, ghostMotionNode, key, presenceKey, result,
+                            isNewSide: true, parent, slotStart,
                             oldFibers, newFibers, providers, oldProvidersForPairing, ref newProviderIndex, commit);
 
                         // Track the live ghost anchor so the drop path (exit complete) can dispose the subtree
@@ -1166,8 +1168,15 @@ namespace Velvet
                         continue;
                     }
 
-                    var anchor = EmitPresenceChild(node, key, presenceKey, result, isNewSide: true, parent, slotStart,
-                        oldFibers, newFibers, providers, oldProvidersForPairing, ref newProviderIndex, commit);
+                    // Resolved BEFORE emission (not just once): shared by the PopLayout restore below (it needs
+                    // the re-added node's OWN class list, not the ghost's pre-pin one), the enter dispatch
+                    // further down, and — via EmitPresenceChildAsAnchor — FiberNodeFactory's standalone-enter
+                    // gate, so CreateElement can tell this SAME node (which the dispatch below is about to
+                    // explicitly animate) apart from every OTHER Motion the emission below might create.
+                    var motion = FiberNodeFactory.FindFirstMotionDescendant(node);
+                    var anchor = EmitPresenceChildAsAnchor(node, motion, key, presenceKey, result, isNewSide: true,
+                        parent, slotStart, oldFibers, newFibers, providers, oldProvidersForPairing,
+                        ref newProviderIndex, commit);
 
                     if (commit != null && anchor != null)
                     {
@@ -1187,10 +1196,6 @@ namespace Velvet
                         {
                             state.ExitAnchors.Remove(key!);
                         }
-                        // Resolved once and shared by the PopLayout restore below (it needs the re-added
-                        // node's OWN class list, not the ghost's pre-pin one) and the enter dispatch further
-                        // down, which already read the same descendant on every render before this change.
-                        var motion = FiberNodeFactory.FindFirstMotionDescendant(node);
                         if (wasExiting)
                         {
                             _ctx.StyleAnimationScheduler.CancelExit(anchor);
@@ -1445,6 +1450,45 @@ namespace Velvet
                 return commit.NewElements[startIdx].element;
             }
             return null;
+        }
+
+        // Wraps EmitPresenceChild with ReconcilerContext.PresenceAnchorMotion bookkeeping: anchorMotion is
+        // whichever MotionNode this keyed child's enter/exit is dispatched against (this method's caller's own
+        // FindFirstMotionDescendant resolution — null when the child has none, e.g. a plain Div wrapper), and
+        // recording it for the exact dynamic extent of the expansion below lets FiberNodeFactory.CreateElement
+        // tell that ONE node apart from every OTHER Motion the expansion creates (nested deeper, sitting under
+        // a non-anchor wrapper, or a later sibling keyed child) — only the anchor must skip its own standalone
+        // enter (this class already plays it explicitly), everything else keeps its normal mount behavior.
+        // Saved and RESTORED (not just cleared) around the call so a nested AnimatePresence inside this keyed
+        // child's own subtree — which sets its own anchor for ITS keyed children — does not leave the outer
+        // anchor cleared once its own expansion returns and this child's subtree keeps unwinding.
+        private VisualElement? EmitPresenceChildAsAnchor(
+            VNode? node,
+            MotionNode? anchorMotion,
+            string? key,
+            string? presenceScope,
+            List<VNode>? result,
+            bool isNewSide,
+            VisualElement? parent,
+            int slotStart,
+            List<ComponentFiber> oldFibers,
+            HashSet<ComponentFiber> newFibers,
+            List<ContextProviderNode>? providers,
+            List<ContextProviderNode>? oldProvidersForPairing,
+            ref int newProviderIndex,
+            GeneralCommitState? commit)
+        {
+            var previousAnchor = _ctx.PresenceAnchorMotion;
+            _ctx.PresenceAnchorMotion = anchorMotion;
+            try
+            {
+                return EmitPresenceChild(node, key, presenceScope, result, isNewSide, parent, slotStart,
+                    oldFibers, newFibers, providers, oldProvidersForPairing, ref newProviderIndex, commit);
+            }
+            finally
+            {
+                _ctx.PresenceAnchorMotion = previousAnchor;
+            }
         }
 
         // Resolves the from/to class arrays for an `initial` variant enter: fromClasses =

--- a/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
@@ -1187,19 +1187,22 @@ namespace Velvet
                         {
                             state.ExitAnchors.Remove(key!);
                         }
+                        // Resolved once and shared by the PopLayout restore below (it needs the re-added
+                        // node's OWN class list, not the ghost's pre-pin one) and the enter dispatch further
+                        // down, which already read the same descendant on every render before this change.
+                        var motion = FiberNodeFactory.FindFirstMotionDescendant(node);
                         if (wasExiting)
                         {
                             _ctx.StyleAnimationScheduler.CancelExit(anchor);
                             if (presence.Mode == AnimatePresenceMode.PopLayout)
                             {
-                                RestorePopLayoutChildToFlow(anchor);
+                                RestorePopLayoutChildToFlow(anchor, motion?.ClassNames);
                             }
                         }
 
                         var isEnter = wasExiting || wasExitComplete || !PresenceContainsKey(prevCommitted, key);
                         if (isEnter)
                         {
-                            var motion = FiberNodeFactory.FindFirstMotionDescendant(node);
                             if (motion?.Transition != null)
                             {
                                 // The Initial flag only suppresses the enter animation on the AnimatePresence's
@@ -1304,6 +1307,14 @@ namespace Velvet
         // finishes on top. Skipped when any component is non-finite (an EditMode pass with no forced layout
         // leaves `.layout` at NaN) — the child then degrades to a normal in-flow exit rather than being pinned
         // to garbage coordinates.
+        //
+        // layout.x/y is a flow-resolved position that already bakes in the child's own leading margin (an
+        // explicit m-* utility, or the inter-child margin StyleGapManipulator writes for gap-*) — the box
+        // simply renders shifted by that margin. Absolute positioning keeps the margin active too (UI Toolkit
+        // offsets the border box by left/top AND the still-set margin, matching CSS), so pinning at the raw
+        // layout rect would apply the same margin twice and jump the child by it the instant the exit starts.
+        // Subtracting the resolved margin back out of left/top cancels exactly that double count, so the
+        // pinned rect reproduces the in-flow position pixel for pixel.
         private static void PinExitingChildOutOfFlow(VisualElement anchor)
         {
             var rect = anchor.layout;
@@ -1313,9 +1324,13 @@ namespace Velvet
                 return;
             }
 
+            var resolved = anchor.resolvedStyle;
+            var marginLeft = resolved.marginLeft;
+            var marginTop = resolved.marginTop;
+
             anchor.style.position = Position.Absolute;
-            anchor.style.left = rect.x;
-            anchor.style.top = rect.y;
+            anchor.style.left = rect.x - marginLeft;
+            anchor.style.top = rect.y - marginTop;
             anchor.style.width = rect.width;
             anchor.style.height = rect.height;
         }
@@ -1324,13 +1339,50 @@ namespace Velvet
         // exit finished): clears the same five inline styles back to StyleKeyword.Null so the child rejoins
         // its parent's normal layout flow. A no-op (harmless) when the exit was never pinned (non-finite
         // layout at exit-start), since clearing an already-null style is idempotent.
-        private static void RestorePopLayoutChildToFlow(VisualElement anchor)
+        //
+        // Nulling width/height erases whatever geometry a resolver-applied arbitrary-value class (w-[..],
+        // h-[..]) owns — those live in the SAME inline slots this method clears and have no USS rule to fall
+        // back to, unlike a named utility (w-full) whose class rule keeps applying underneath. classNames is
+        // the re-added Motion's OWN class array (not anchor.GetClasses(): arbitrary-value tokens resolve
+        // straight to inline style and are deliberately never added to the USS class list, so the element's
+        // class list itself never contains them). The caller resolves it from the CURRENT node — already
+        // patched by EmitPresenceChild, which runs before this restore — so a re-add that also changed props
+        // re-applies the new value rather than a stale pre-pin one.
+        //
+        // CancelExit (the caller's previous statement) deliberately leaves transition-property: all /
+        // transition-duration active on this exact element so the variant's OWN reversal (e.g. opacity
+        // fading back toward its resting value) keeps interpolating instead of popping. This geometry fixup
+        // is bookkeeping, not an animated property, but with that transition still live any value it passes
+        // through — including the Null this method itself writes before re-asserting the resting one — is
+        // just as eligible to animate, so the position/left/top/width/height correction would visibly tween
+        // in on top of the resting geometry instead of landing on it immediately. Suspending the transition
+        // for exactly this method's writes and restoring it immediately after keeps the reversal (which never
+        // touches these five properties) running untouched while the geometry itself snaps.
+        private static void RestorePopLayoutChildToFlow(VisualElement anchor, string[]? classNames)
         {
+            var savedProperty = anchor.style.transitionProperty;
+            var savedDuration = anchor.style.transitionDuration;
+            var savedTimingFunction = anchor.style.transitionTimingFunction;
+            var savedDelay = anchor.style.transitionDelay;
+            anchor.style.transitionProperty = StyleKeyword.Null;
+            anchor.style.transitionDuration = StyleKeyword.Null;
+            anchor.style.transitionTimingFunction = StyleKeyword.Null;
+            anchor.style.transitionDelay = StyleKeyword.Null;
+
             anchor.style.position = StyleKeyword.Null;
             anchor.style.left = StyleKeyword.Null;
             anchor.style.top = StyleKeyword.Null;
             anchor.style.width = StyleKeyword.Null;
             anchor.style.height = StyleKeyword.Null;
+            if (classNames != null)
+            {
+                FiberNodePatcher.ReapplyArbitraryValues(anchor, classNames);
+            }
+
+            anchor.style.transitionProperty = savedProperty;
+            anchor.style.transitionDuration = savedDuration;
+            anchor.style.transitionTimingFunction = savedTimingFunction;
+            anchor.style.transitionDelay = savedDelay;
         }
 
         // Disposes the inline/wrapper fibers mounted under an exit-completed ghost's anchor element. Needed

--- a/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
@@ -1319,8 +1319,10 @@ namespace Velvet
         // Resolves the from/to class arrays for an `initial` variant enter: fromClasses =
         // variants[Initial], toClasses = variants[Animate]. Returns false (no
         // variant-initial enter; caller falls back to the classic transition) unless the Motion sets its own
-        // Initial + Animate + Variants and the initial label maps to a non-empty class string.
-        private static bool TryResolveVariantInitial(MotionNode? motion, out string[]? fromClasses, out string[]? toClasses)
+        // Initial + Animate + Variants and the initial label maps to a non-empty class string. Internal (not
+        // private): FiberNodeFactory calls this too, to play the same variant enter on a standalone Motion
+        // (outside any AnimatePresence) at element-creation time.
+        internal static bool TryResolveVariantInitial(MotionNode? motion, out string[]? fromClasses, out string[]? toClasses)
         {
             fromClasses = null;
             toClasses = null;

--- a/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
@@ -1207,7 +1207,8 @@ namespace Velvet
                                         _ctx.StyleAnimationScheduler.PlayVariantEnter(anchor, fromClasses, toClasses,
                                             t.DurationSec, t.Easing, t.DelaySec,
                                             motion.OnEnterComplete, presence.StaggerDelaySec(visualIndex, newKeyed.Count),
-                                            propertyOverrides: t.PropertyOverrides);
+                                            propertyOverrides: t.PropertyOverrides,
+                                            type: t.Type, stiffness: t.Stiffness, damping: t.Damping, mass: t.Mass);
                                     }
                                     else if (isVariantMotion)
                                     {
@@ -1409,6 +1410,14 @@ namespace Velvet
                 ExitEasing = timing.ExitEasing,
                 DelaySec = timing.DelaySec,
                 PropertyOverrides = timing.PropertyOverrides,
+                // Carried through so a spring-configured Motion's variant EXIT is also spring-driven (and
+                // therefore hands off to a reversal spring on an exit-cancel) instead of silently falling back
+                // to a tween — this builds a FRESH config rather than reusing `timing`, so every knob timing
+                // carries has to be copied explicitly here.
+                Type = timing.Type,
+                Stiffness = timing.Stiffness,
+                Damping = timing.Damping,
+                Mass = timing.Mass,
             };
         }
 

--- a/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
@@ -994,7 +994,7 @@ namespace Velvet
                         if (newKeySet.Contains(key)) continue;
                         if (state.ExitComplete.Contains(key)) continue;
                         var ghostMotion = FiberNodeFactory.FindFirstMotionDescendant(node);
-                        if (ghostMotion?.Transition is { DurationSec: > 0f })
+                        if (ghostMotion?.Transition?.HasExitAnimation == true)
                         {
                             blockEnters = true;
                             break;
@@ -1026,8 +1026,23 @@ namespace Velvet
                 foreach (var (key, node) in prevCommitted)
                 {
                     if (newKeySet.Contains(key) || state.ExitComplete.Contains(key)) continue;
-                    if (FiberNodeFactory.FindFirstMotionDescendant(node)?.Transition is { DurationSec: > 0f }) exitCount++;
+                    if (FiberNodeFactory.FindFirstMotionDescendant(node)?.Transition?.HasExitAnimation == true) exitCount++;
                 }
+
+                // An exit's completion callback normally runs long after this method has returned (a tween's
+                // scheduled timeout, a spring's settled tick). A spring exit whose variant pair touches no
+                // spring-animatable channel (MotionSpringDriver.Create returns null — e.g. a color-only exit
+                // variant) is the one case that completes SYNCHRONOUSLY, from inside the PlayExit call below,
+                // before this pass has finished building nextCommitted for every other key and before this
+                // pass's own state.ExitComplete.Clear() further down. Running such a completion's bookkeeping
+                // immediately would have that same Clear() wipe the ExitComplete entry it just added, so the
+                // re-render it schedules finds the ghost "not complete" again, replays PlayExit, and repeats
+                // forever. passSettled tracks whether this pass's own bookkeeping (below) has already run; a
+                // completion that fires before then is queued and drained once it has, so its ExitComplete.Add
+                // survives into the render it schedules — a genuinely async completion always finds passSettled
+                // already true (this method returned long before it fires) and runs immediately, unchanged.
+                var passSettled = false;
+                List<Action>? deferredExitCompletions = null;
 
                 var visualIndex = 0;
                 var exitIndex = 0;
@@ -1055,7 +1070,7 @@ namespace Velvet
 
                         var ghostMotionNode = FiberNodeFactory.FindFirstMotionDescendant(node);
                         var ghostTransition = ghostMotionNode?.Transition;
-                        if (ghostTransition is not { DurationSec: > 0f })
+                        if (ghostTransition?.HasExitAnimation != true)
                         {
                             // No exit animation → immediate removal (skip emitting; the diff reaps the leaves).
                             state.Exiting.Remove(key);
@@ -1088,7 +1103,7 @@ namespace Velvet
                             // For a variant exit the From classes ARE the resting variants[animate]; if this exit is
                             // cancelled (the key is re-added before it finishes) the element must return to that resting
                             // variant rather than be left without it (interrupt handling).
-                            _ctx.StyleAnimationScheduler.PlayExit(ghostAnchor, exitTransition, () =>
+                            void RunExitComplete()
                             {
                                 if (_ctx.IsDisposed) return;
                                 // Reconcile-driven removal: flag the finished exit and re-render the boundary;
@@ -1127,6 +1142,13 @@ namespace Velvet
                                         + "so the exited child cannot be removed. Mount AnimatePresence inside a "
                                         + "component (e.g. via V.Mount) rather than reconciling it onto a bare element.");
                                 }
+                            }
+                            _ctx.StyleAnimationScheduler.PlayExit(ghostAnchor, exitTransition, () =>
+                            {
+                                // See passSettled's own comment above the loop: a synchronous completion (fired
+                                // from inside this very PlayExit call) is queued instead of run inline.
+                                if (passSettled) RunExitComplete();
+                                else (deferredExitCompletions ??= new List<Action>()).Add(RunExitComplete);
                             }, restoreFromOnCancel: variantExit != null,
                                 additionalDelaySec: presence.StaggerDelaySec(exitIndex, exitCount));
                             exitIndex++;
@@ -1246,6 +1268,15 @@ namespace Velvet
                 state.Committed.Clear();
                 foreach (var entry in nextCommitted) state.Committed.Add(entry);
                 state.ExitComplete.Clear();
+
+                // This pass's own bookkeeping has settled — a synchronous exit completion queued above can now
+                // run safely (see passSettled's declaration comment): its ExitComplete.Add survives past this
+                // point instead of being wiped by the Clear() just above.
+                passSettled = true;
+                if (deferredExitCompletions != null)
+                {
+                    foreach (var completion in deferredExitCompletions) completion();
+                }
             }
             finally
             {

--- a/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
@@ -1235,10 +1235,7 @@ namespace Velvet
                                         // (kept as the persistent resting state).
                                         var t = motion.Transition;
                                         _ctx.StyleAnimationScheduler.PlayVariantEnter(anchor, fromClasses, toClasses,
-                                            t.DurationSec, t.Easing, t.DelaySec,
-                                            motion.OnEnterComplete, presence.StaggerDelaySec(visualIndex, newKeyed.Count),
-                                            propertyOverrides: t.PropertyOverrides,
-                                            type: t.Type, stiffness: t.Stiffness, damping: t.Damping, mass: t.Mass);
+                                            t, motion.OnEnterComplete, presence.StaggerDelaySec(visualIndex, newKeyed.Count));
                                     }
                                     else if (isVariantMotion)
                                     {
@@ -1527,25 +1524,11 @@ namespace Velvet
             }
 
             motion.Variants.TryGetValue(motion.Animate, out var restingClass);
-            var timing = motion.Transition!;
-            return new StyleTransitionConfig
-            {
-                ExitFromClass = restingClass ?? string.Empty,
-                ExitToClass = exitClass,
-                DurationSec = timing.DurationSec,
-                Easing = timing.Easing,
-                ExitEasing = timing.ExitEasing,
-                DelaySec = timing.DelaySec,
-                PropertyOverrides = timing.PropertyOverrides,
-                // Carried through so a spring-configured Motion's variant EXIT is also spring-driven (and
-                // therefore hands off to a reversal spring on an exit-cancel) instead of silently falling back
-                // to a tween — this builds a FRESH config rather than reusing `timing`, so every knob timing
-                // carries has to be copied explicitly here.
-                Type = timing.Type,
-                Stiffness = timing.Stiffness,
-                Damping = timing.Damping,
-                Mass = timing.Mass,
-            };
+            // WithExitClasses copies every timing/spring/per-property-override knob (including Type/Stiffness/
+            // Damping/Mass, so a spring-configured Motion's variant EXIT is also spring-driven and hands off to
+            // a reversal spring on an exit-cancel instead of silently falling back to a tween) and replaces
+            // only the exit class pair — a single source for that knob list instead of hand-copying it here.
+            return motion.Transition!.WithExitClasses(restingClass ?? string.Empty, exitClass);
         }
 
         #endregion

--- a/Packages/com.velvet.core/Runtime/Reconciler/MotionContext.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/MotionContext.cs
@@ -15,5 +15,50 @@ namespace Velvet
     internal static class MotionContext
     {
         public static readonly ComponentContext<string> ActiveLabel = ComponentContext<string>.Create(null);
+
+        // The active staggerChildren/delayChildren orchestration for the current label-propagation subtree,
+        // established by the nearest ancestor Motion whose active label just changed THIS render and whose own
+        // Transition declares StaggerChildrenSec / DelayChildrenSec / a non-Together When. Pushed alongside
+        // ActiveLabel by FiberNodePatcher.PatchMotion. Null (the default, and the overwhelming common case) means
+        // no orchestration is active — a Motion that declares none of those knobs costs nothing beyond the
+        // ordinary label push. Flows THROUGH an inheriting descendant (no own Animate) that declares no
+        // orchestration of its own, so a grandchild keeps claiming from the SAME ancestor sequence; a descendant
+        // with its own explicit Animate breaks the chain (pushes null) since it is no longer driven by this
+        // propagation. See MotionOrchestrationFrame for the per-child delay computation.
+        public static readonly ComponentContext<MotionOrchestrationFrame> Orchestration =
+            ComponentContext<MotionOrchestrationFrame>.Create(null);
+    }
+
+    // Mutable per-subtree stagger state pushed onto MotionContext.Orchestration when a Motion's active label
+    // just changed and its own Transition declares StaggerChildrenSec / DelayChildrenSec / a non-Together When.
+    // A reference type (not a struct) so the child-index counter mutates in place as siblings are visited, in
+    // document order, during the same reconcile pass — ComponentContextStack.Get unboxes a COPY of a struct on
+    // every read, which would reset the counter for each sibling instead of advancing it. Pushed once per
+    // label-changing render and popped when that render's subtree walk unwinds (see FiberNodePatcher.PatchMotion),
+    // so an instance never survives past the render that created it.
+    internal sealed class MotionOrchestrationFrame
+    {
+        private readonly float _delayChildrenSec;
+        private readonly float _staggerChildrenSec;
+        // This Motion's own DurationSec when When == BeforeChildren (inheriting descendants wait for the
+        // parent's own swap to finish first), else 0.
+        private readonly float _extraBeforeChildrenSec;
+        private int _nextChildIndex;
+
+        public MotionOrchestrationFrame(float delayChildrenSec, float staggerChildrenSec, float extraBeforeChildrenSec)
+        {
+            _delayChildrenSec = delayChildrenSec;
+            _staggerChildrenSec = staggerChildrenSec;
+            _extraBeforeChildrenSec = extraBeforeChildrenSec;
+        }
+
+        // Claims the next sequential slot (document order) and returns the claiming descendant's total extra
+        // delay (seconds): delayChildren + index * staggerChildren, plus the parent's own duration when
+        // When == BeforeChildren.
+        public float ClaimNextChildDelaySec()
+        {
+            var index = _nextChildIndex++;
+            return _delayChildrenSec + index * _staggerChildrenSec + _extraBeforeChildrenSec;
+        }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Reconciler/MotionContext.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/MotionContext.cs
@@ -40,25 +40,30 @@ namespace Velvet
     {
         private readonly float _delayChildrenSec;
         private readonly float _staggerChildrenSec;
-        // This Motion's own DurationSec when When == BeforeChildren (inheriting descendants wait for the
-        // parent's own swap to finish first), else 0.
-        private readonly float _extraBeforeChildrenSec;
+        // Extra delay (seconds) folded into EVERY claim from this frame, on top of delayChildren +
+        // index*staggerChildren — see FiberNodePatcher.ResolveChildOrchestration for the two contributions:
+        // this Motion's own [DelaySec, DelaySec + DurationSec] span when When == BeforeChildren (inheriting
+        // descendants wait for the parent's own swap to finish, not just start), PLUS — when this Motion is
+        // itself an inheriting descendant claiming a delay from a FURTHER-OUT orchestration — that claimed
+        // delay, so a claim from this frame is measured from render-commit time (when the whole chain actually
+        // started), not from when this Motion's own already-delayed swap begins.
+        private readonly float _baseDelaySec;
         private int _nextChildIndex;
 
-        public MotionOrchestrationFrame(float delayChildrenSec, float staggerChildrenSec, float extraBeforeChildrenSec)
+        public MotionOrchestrationFrame(float delayChildrenSec, float staggerChildrenSec, float baseDelaySec)
         {
             _delayChildrenSec = delayChildrenSec;
             _staggerChildrenSec = staggerChildrenSec;
-            _extraBeforeChildrenSec = extraBeforeChildrenSec;
+            _baseDelaySec = baseDelaySec;
         }
 
         // Claims the next sequential slot (document order) and returns the claiming descendant's total extra
-        // delay (seconds): delayChildren + index * staggerChildren, plus the parent's own duration when
-        // When == BeforeChildren.
+        // delay (seconds): delayChildren + index * staggerChildren, plus this frame's base delay (see
+        // _baseDelaySec).
         public float ClaimNextChildDelaySec()
         {
             var index = _nextChildIndex++;
-            return _delayChildrenSec + index * _staggerChildrenSec + _extraBeforeChildrenSec;
+            return _delayChildrenSec + index * _staggerChildrenSec + _baseDelaySec;
         }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Reconciler/MotionVariantResolver.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/MotionVariantResolver.cs
@@ -12,46 +12,68 @@ namespace Velvet
     {
         // Returns base ClassNames augmented with the variant classes for the effective label
         // (Animate ?? ambientLabel) when this node has variants and the label is one
-        // of its keys. Otherwise returns the base ClassNames unchanged. variantApplied is
-        // true only when a variant actually merged — callers use it to skip the per-element applied-class
-        // bookkeeping for the variant-less majority.
-        public static string[] ResolveApplied(MotionNode node, string ambientLabel, out bool variantApplied)
+        // of its keys. Otherwise returns the base ClassNames unchanged. variantClasses is the variant-only
+        // tail that was concatenated on — Array.Empty when nothing merged. Callers use its Length both to
+        // skip the per-element applied-class bookkeeping for the variant-less majority AND, as an explicit
+        // value rather than something re-derived from the merged array's tail by POSITION, as the from/to
+        // input to a runtime variant swap (see FiberNodePatcher.PatchMotion) — deriving it positionally would
+        // silently assume the base portion never changes length between renders.
+        public static string[] ResolveApplied(MotionNode node, string ambientLabel, out string[] variantClasses)
         {
-            variantApplied = false;
             var baseClasses = node.ClassNames ?? Array.Empty<string>();
 
             var label = node.Animate ?? ambientLabel;
             if (label == null || node.Variants == null)
             {
+                variantClasses = Array.Empty<string>();
                 return baseClasses;
             }
 
             if (!node.Variants.TryGetValue(label, out var variantClassString)
                 || string.IsNullOrEmpty(variantClassString))
             {
+                variantClasses = Array.Empty<string>();
                 return baseClasses;
             }
 
-            var variantClasses = V.ParseClassNames(variantClassString);
-            if (variantClasses.Length == 0)
+            var parsed = V.ParseClassNames(variantClassString);
+            if (parsed.Length == 0)
             {
+                variantClasses = Array.Empty<string>();
                 return baseClasses;
             }
 
-            variantApplied = true;
+            variantClasses = parsed;
             if (baseClasses.Length == 0)
             {
-                return variantClasses;
+                return parsed;
             }
 
-            var merged = new string[baseClasses.Length + variantClasses.Length];
+            var merged = new string[baseClasses.Length + parsed.Length];
             Array.Copy(baseClasses, merged, baseClasses.Length);
-            Array.Copy(variantClasses, 0, merged, baseClasses.Length, variantClasses.Length);
+            Array.Copy(parsed, 0, merged, baseClasses.Length, parsed.Length);
             return merged;
         }
 
         // The label a Motion exposes to its descendants: its own Animate when set, else the
         // inherited ambientLabel (so the nearest-ancestor label keeps flowing down).
         public static string LabelForChildren(MotionNode node, string ambientLabel) => node.Animate ?? ambientLabel;
+    }
+
+    // Per-Motion-element applied-class bookkeeping pair: the full merged array (base + variant classes, used
+    // for the ordinary class-driven styling diff via PatchBaseElement) alongside the variant-only classes that
+    // were concatenated onto it (used as the explicit from/to input to a runtime variant swap — see
+    // FiberNodePatcher.PatchMotion). Kept together so a caller never has to re-derive the variant tail from the
+    // merged array by POSITION, which would silently assume the base portion's length never changes.
+    internal readonly struct MotionAppliedClassSet
+    {
+        public readonly string[] Merged;
+        public readonly string[] VariantClasses;
+
+        public MotionAppliedClassSet(string[] merged, string[] variantClasses)
+        {
+            Merged = merged;
+            VariantClasses = variantClasses;
+        }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
@@ -243,6 +243,17 @@ namespace Velvet
         // in _pureElementSideTables and cleared on element cleanup / reconciler dispose through that mechanism.
         public Dictionary<VisualElement, string[]> MotionAppliedClasses { get; } = new();
 
+        // Per-Motion-element bookkeeping of the label last propagated to CHILDREN (Animate ?? ambient) —
+        // independent of MotionAppliedClasses above, because a "coordinator" Motion may propagate a label to
+        // descendants (for staggerChildren/delayChildren orchestration) while carrying no Variants of its own,
+        // and so never gets a MotionAppliedClasses entry at all. FiberNodePatcher.PatchMotion compares the
+        // freshly-resolved child label against this stored one to detect an ACTUAL change (not merely an
+        // unrelated re-render that happens to re-propagate the same label) before establishing a fresh
+        // MotionOrchestrationFrame — a re-render that keeps the same label must not re-trigger the stagger.
+        // A pure side-table (bare Remove on teardown), so it is enrolled in _pureElementSideTables and cleared
+        // on element cleanup / reconciler dispose through that mechanism.
+        public Dictionary<VisualElement, string> MotionChildLabel { get; } = new();
+
         // Per-element drop-shadow bookkeeping for the shadow-* className layer, keyed by the element
         // itself — the shadow needs NO structural wrapper. Like skew and gradient, the shadow is painted
         // by the element's own generateVisualContent (DropShadowSilhouette draws the baked shadow texture
@@ -624,6 +635,7 @@ namespace Velvet
                 DataAttributes,
                 SupportsVariants,
                 MotionAppliedClasses,
+                MotionChildLabel,
                 TextEffects,
                 TextRawText,
             };

--- a/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
@@ -236,12 +236,15 @@ namespace Velvet
         public Dictionary<VisualElement, StyleDivideManipulator> DivideManipulators { get; } = new();
         public Dictionary<VisualElement, StyleGridManipulator> GridManipulators { get; } = new();
 
-        // Per-Motion-element bookkeeping of the class array actually APPLIED (base ClassNames plus any
-        // variant classes propagated from an ancestor Motion's active label). The patch path diffs the new
-        // applied set against this stored one so a label change swaps the propagated classes even though the
-        // node's base ClassNames are unchanged. A pure side-table (bare Remove on teardown), so it is enrolled
-        // in _pureElementSideTables and cleared on element cleanup / reconciler dispose through that mechanism.
-        public Dictionary<VisualElement, string[]> MotionAppliedClasses { get; } = new();
+        // Per-Motion-element bookkeeping of the class set actually APPLIED (base ClassNames plus any
+        // variant classes propagated from an ancestor Motion's active label, PLUS the variant-only classes
+        // alone — see MotionAppliedClassSet). The patch path diffs the new applied set against this stored one
+        // so a label change swaps the propagated classes even though the node's base ClassNames are unchanged,
+        // and replays that swap as a runtime variant transition when the variant-only classes actually
+        // changed and the node declares a Transition (see FiberNodePatcher.PatchMotion). A pure side-table
+        // (bare Remove on teardown), so it is enrolled in _pureElementSideTables and cleared on element
+        // cleanup / reconciler dispose through that mechanism.
+        public Dictionary<VisualElement, MotionAppliedClassSet> MotionAppliedClasses { get; } = new();
 
         // Per-Motion-element bookkeeping of the label last propagated to CHILDREN (Animate ?? ambient) —
         // independent of MotionAppliedClasses above, because a "coordinator" Motion may propagate a label to

--- a/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
@@ -495,6 +495,19 @@ namespace Velvet
         // created at depth 0 mounts standalone, where those props are inert and warn.
         internal int PresenceExpansionDepth;
 
+        // The MotionNode a presence expansion is CURRENTLY dispatching enter/exit for — the one
+        // FindFirstMotionDescendant resolved for whichever keyed child GeneralPathReconciler is expanding right
+        // now (set/restored around each EmitPresenceChild call, not just cleared, so a nested AnimatePresence
+        // inside that child's own subtree does not lose the OUTER anchor once its own expansion returns). Null
+        // outside any presence expansion, and also null for a keyed child whose FindFirstMotionDescendant walk
+        // found no Motion (e.g. a plain Div wrapper). FiberNodeFactory's standalone-enter gate compares a
+        // freshly created MotionNode against this BY REFERENCE — not PresenceExpansionDepth — so only the ONE
+        // node the presence itself already plays an enter for (via PlayVariantEnter/PlayEnter) skips its
+        // redundant standalone enter; every OTHER Motion created while the expansion is on the stack (nested
+        // deeper, sitting under a non-anchor wrapper, or a sibling keyed child) is not presence-managed at all
+        // and must keep its own mount enter.
+        internal MotionNode? PresenceAnchorMotion;
+
         // Removes all DOM-less AnimatePresence state keyed by boundary. Invoked from
         // ComponentRegistry when the boundary fiber is unregistered, so a boundary that
         // unmounts while a child is exiting leaves no dangling fiber reference in PresenceStates.

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/AnimatePresencePopLayoutFlowTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/AnimatePresencePopLayoutFlowTests.cs
@@ -1,0 +1,158 @@
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.UIElements;
+using UnityEngine.UIElements.TestFramework;
+using UnityEditor.UIElements.TestFramework;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins PopLayout's geometry against a laid-out (simulated) panel. The pin must reproduce the
+    /// child's last visual rect exactly: layout.x/y already include margins, and absolute
+    /// positioning applies margins again, so pinning at the raw layout rect makes a margined child
+    /// (explicit m-* or the child margins the gap-* emulation writes) jump the instant its exit
+    /// starts. Cancelling the exit must restore what the pin overwrote without destroying
+    /// arbitrary-value geometry (w-[..]/h-[..] live in those same inline slots and a re-add with an
+    /// unchanged class list never re-applies them). And the whole point of the mode — siblings
+    /// reflowing immediately — requires the index-driven gap manipulator to stop counting a pinned
+    /// (absolute) ghost as an in-flow child.
+    /// </summary>
+    [TestFixture]
+    internal sealed class AnimatePresencePopLayoutFlowTests
+    {
+        private static readonly Dictionary<string, string> s_fade = new()
+        {
+            ["hidden"] = "opacity-0",
+            ["visible"] = "opacity-100",
+        };
+
+        private readonly record struct SetState(string Keys);
+
+        private sealed class SetStore : Store<SetState>
+        {
+            public SetStore(string initial) : base(new SetState(initial)) { }
+            public void Set(string keys) => SetState(_ => new SetState(keys));
+            protected override void ResetCore() => SetState(_ => new SetState("ab"));
+        }
+
+        private static SetStore s_store;
+        private static Dictionary<char, string> s_itemClasses;
+
+        private EditorPanelSimulator _sim;
+
+        [SetUp]
+        public void SetUp()
+        {
+            PanelSimulator.ResetCurrentTime();
+            _sim = new EditorPanelSimulator { panelSize = new Vector2(800, 600) };
+            _sim.ResetTimePerSimulatedFrameToDefault();
+            s_store = null;
+            s_itemClasses = null;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _sim?.Dispose();
+            _sim = null;
+        }
+
+        private VisualElement Root => _sim.rootVisualElement;
+
+        private void Tick() => _sim.FrameUpdateMs(16);
+
+        [Component]
+        private static VNode PopRow()
+        {
+            var keys = Hooks.UseStore(s_store, s => s.Keys);
+            var children = new List<VNode>();
+            foreach (var key in keys)
+            {
+                var extra = s_itemClasses != null && s_itemClasses.TryGetValue(key, out var cls) ? " " + cls : "";
+                children.Add(V.Motion(name: "item-" + key, key: key.ToString(),
+                    className: "h-[20px] w-[40px]" + extra,
+                    variants: s_fade, animate: "visible", exit: "hidden",
+                    transition: new StyleTransitionConfig { DurationSec = 0.3f }));
+            }
+            return V.Div(name: "row", className: "flex flex-row gap-x-2", children: new VNode[]
+            {
+                V.AnimatePresence(key: "presence", initial: false,
+                    mode: AnimatePresenceMode.PopLayout, children: children.ToArray()),
+            });
+        }
+
+        [Test]
+        public void Given_AGapMarginedChild_When_ItsPopLayoutExitStarts_Then_ItStaysAtItsLastLaidOutPosition()
+        {
+            // Arrange — [a,b] under gap-x-2: b carries the gap emulation's leading margin, so its
+            // laid-out x already includes it.
+            using var store = new SetStore("ab");
+            s_store = store;
+            using var mounted = V.Mount(Root, V.Component(PopRow, key: "row"));
+            var scheduler = mounted.Root.Reconciler.Context.BatchScheduler;
+            Tick();
+            var b = Root.Q<VisualElement>("item-b");
+            var xBefore = b.layout.x;
+            Assume.That(xBefore, Is.GreaterThan(0f), "Precondition: b sits after a with the gap margin applied");
+
+            // Act — remove b; PopLayout pins it out of flow at its last rect.
+            store.Set("a");
+            scheduler.DrainImmediateForTest();
+            Tick();
+
+            // Assert — the pinned ghost has not moved (no margin double-application jump).
+            Assert.That(b.layout.x, Is.EqualTo(xBefore).Within(0.5f));
+        }
+
+        [Test]
+        public void Given_AnArbitraryWidthChild_When_ItsPopLayoutExitIsCancelled_Then_TheWidthSurvives()
+        {
+            // Arrange — b's width lives ONLY as the resolver-applied inline style of w-[60px].
+            s_itemClasses = new Dictionary<char, string> { ['b'] = "w-[60px]" };
+            using var store = new SetStore("ab");
+            s_store = store;
+            using var mounted = V.Mount(Root, V.Component(PopRow, key: "row"));
+            var scheduler = mounted.Root.Reconciler.Context.BatchScheduler;
+            Tick();
+            var b = Root.Q<VisualElement>("item-b");
+            Assume.That(b.resolvedStyle.width, Is.EqualTo(60f).Within(0.5f),
+                "Precondition: the arbitrary width applied");
+
+            // Act — start the exit (pin overwrites the inline slots), then cancel by re-adding.
+            store.Set("a");
+            scheduler.DrainImmediateForTest();
+            store.Set("ab");
+            scheduler.DrainImmediateForTest();
+            Tick();
+
+            // Assert — restoring to flow must not destroy the class-owned inline width.
+            Assert.That(Root.Q<VisualElement>("item-b").resolvedStyle.width, Is.EqualTo(60f).Within(0.5f));
+        }
+
+        [Test]
+        public void Given_TheFirstChildExitsUnderPopLayout_When_TheGhostIsPinned_Then_TheSurvivorReflowsToTheFront()
+        {
+            // Arrange — [a,b]: while a exits under PopLayout, b must reflow into a's place
+            // immediately (that is the mode's purpose), which requires the gap manipulator to stop
+            // counting the pinned ghost as an in-flow child.
+            using var store = new SetStore("ab");
+            s_store = store;
+            using var mounted = V.Mount(Root, V.Component(PopRow, key: "row"));
+            var scheduler = mounted.Root.Reconciler.Context.BatchScheduler;
+            Tick();
+            Assume.That(Root.Q<VisualElement>("item-b").layout.x, Is.GreaterThan(0f),
+                "Precondition: b starts behind a");
+
+            // Act — remove a (the FIRST child) and let layout settle while the ghost is pinned.
+            store.Set("b");
+            scheduler.DrainImmediateForTest();
+            Tick();
+
+            // Assert — the survivor now leads the row (no leading gap margin, no reserved slot).
+            Assert.That(Root.Q<VisualElement>("item-b").layout.x, Is.EqualTo(0f).Within(0.5f));
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/AnimatePresencePopLayoutFlowTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/AnimatePresencePopLayoutFlowTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0fcb539b3752440b2b1726cada6920e8

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/AnimatePresencePopLayoutTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/AnimatePresencePopLayoutTests.cs
@@ -1,0 +1,187 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.UIElements;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins <see cref="AnimatePresenceMode.PopLayout"/>: the instant a keyed child starts exiting, it is pulled
+    /// out of layout flow and pinned via inline absolute positioning (position/left/top/width/height) at the
+    /// last rect it occupied, so still-present siblings are free to reflow into its place while its exit
+    /// animation finishes on top of them. The pin is captured from the child's own last resolved layout, so a
+    /// cancelled exit (the key re-added before the animation finishes) can simply clear those five inline
+    /// styles to rejoin normal flow. Under <see cref="AnimatePresenceMode.Sync"/> (the default) none of this
+    /// applies — an exiting child keeps participating in flow exactly as it did before this mode existed.
+    /// Mounted in a real <see cref="EditorWindow"/> panel with a forced layout pass, because the pin only
+    /// applies when the child's resolved rect is already finite (an un-laid-out panel leaves it NaN).
+    /// </summary>
+    [TestFixture]
+    internal sealed class AnimatePresencePopLayoutTests
+    {
+        private readonly record struct SetState(string Keys);
+
+        private sealed class SetStore : Store<SetState>
+        {
+            public SetStore() : base(new SetState("abc")) { }
+            public void Set(string keys) => SetState(_ => new SetState(keys));
+            protected override void ResetCore() => SetState(_ => new SetState("abc"));
+        }
+
+        private static SetStore s_store;
+        private static AnimatePresenceMode s_mode;
+        private static readonly Dictionary<string, string> s_fade = new()
+        {
+            ["visible"] = "opacity-100",
+            ["hidden"] = "opacity-0",
+        };
+
+        private EditorWindow _window;
+
+        [SetUp]
+        public void SetUp()
+        {
+            TestGraphics.IgnoreIfHeadless("an EditorWindow panel");
+            _window = ScriptableObject.CreateInstance<TestHostWindow>();
+            _window.Show();
+            s_store = null;
+            s_mode = AnimatePresenceMode.PopLayout;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (_window != null)
+            {
+                _window.Close();
+                Object.DestroyImmediate(_window);
+                _window = null;
+            }
+        }
+
+        [Component]
+        private static VNode PresenceList()
+        {
+            var keys = Hooks.UseStore(s_store, s => s.Keys);
+            var children = new List<VNode>();
+            foreach (var key in keys)
+            {
+                children.Add(V.Motion(name: "item-" + key, key: key.ToString(),
+                    className: "w-[60px] h-[24px]",
+                    variants: s_fade, animate: "visible", exit: "hidden",
+                    transition: new StyleTransitionConfig { DurationSec = 0.3f }));
+            }
+            return V.Div(name: "presence-host", children: new VNode[]
+            {
+                V.AnimatePresence(key: "presence", mode: s_mode, children: children.ToArray()),
+            });
+        }
+
+        // Mounts the list and forces a real layout pass so every child's `.layout` is finite BEFORE any exit
+        // starts: the reconciler reads that pre-exit rect to pin a ghost, and by design skips pinning
+        // altogether when it is not finite (an un-forced EditMode layout pass leaves it NaN).
+        private MountedTree MountLaidOut()
+        {
+            var mounted = V.Mount(_window.rootVisualElement, V.Component(PresenceList, key: "list"));
+            EditorPanelTestHelpers.ForcePanelUpdate(_window.rootVisualElement.panel);
+            return mounted;
+        }
+
+        [Test]
+        public void Given_APopLayoutModeChild_When_ItStartsExiting_Then_ItsInlinePositionBecomesAbsolute()
+        {
+            // Arrange — three keyed children laid out in a real panel, so item-b already has a finite
+            // resolved rect before its exit starts.
+            using var store = new SetStore();
+            s_store = store;
+            using var mounted = MountLaidOut();
+            var scheduler = mounted.Root.Reconciler.Context.BatchScheduler;
+            var item = _window.rootVisualElement.Q<VisualElement>("item-b");
+            Assume.That(float.IsFinite(item.layout.width), Is.True,
+                "Precondition: the panel already laid out item-b (finite rect) before the exit starts");
+
+            // Act — remove the middle child; PopLayout pins its ghost out of flow the instant its exit starts.
+            store.Set("ac");
+            scheduler.DrainImmediateForTest();
+
+            // Assert — the exiting ghost is pinned via inline absolute positioning.
+            Assert.That(_window.rootVisualElement.Q<VisualElement>("item-b").style.position.value,
+                Is.EqualTo(Position.Absolute));
+        }
+
+        [Test]
+        public void Given_APopLayoutModeChild_When_Pinned_Then_ItsInlineRectMatchesItsLastLaidOutBox()
+        {
+            // Arrange — capture item-b's last resolved (parent-relative) rect before removing it, so the
+            // pinned inline rect can be checked against the box it actually occupied in flow.
+            using var store = new SetStore();
+            s_store = store;
+            using var mounted = MountLaidOut();
+            var scheduler = mounted.Root.Reconciler.Context.BatchScheduler;
+            var item = _window.rootVisualElement.Q<VisualElement>("item-b");
+            var lastLayout = item.layout;
+            Assume.That(float.IsFinite(lastLayout.height), Is.True,
+                "Precondition: item-b's pre-exit rect is finite");
+
+            // Act — remove the middle child, pinning its ghost out of flow at that captured rect.
+            store.Set("ac");
+            scheduler.DrainImmediateForTest();
+
+            // Assert — the pinned inline box (left/top/width/height) matches the rect it held in flow, so
+            // still-present siblings are freed to reflow into exactly the space it no longer occupies.
+            var pinned = _window.rootVisualElement.Q<VisualElement>("item-b");
+            Assert.That(
+                (pinned.style.left.value.value, pinned.style.top.value.value,
+                    pinned.style.width.value.value, pinned.style.height.value.value),
+                Is.EqualTo((lastLayout.x, lastLayout.y, lastLayout.width, lastLayout.height)));
+        }
+
+        [Test]
+        public void Given_APopLayoutExitInFlight_When_TheKeyReturnsBeforeItFinishes_Then_ItsInlinePositionClearsToNull()
+        {
+            // Arrange — item-b's exit has started (and is pinned out of flow); its 0.3s duration has not
+            // elapsed (the EditMode scheduler never ticks a scheduled swap on its own), so it is still exiting.
+            using var store = new SetStore();
+            s_store = store;
+            using var mounted = MountLaidOut();
+            var scheduler = mounted.Root.Reconciler.Context.BatchScheduler;
+            store.Set("ac");
+            scheduler.DrainImmediateForTest();
+            var pinnedBeforeCancel = _window.rootVisualElement.Q<VisualElement>("item-b");
+            Assume.That(pinnedBeforeCancel.style.position.value, Is.EqualTo(Position.Absolute),
+                "Precondition: the exiting ghost is pinned out of flow");
+
+            // Act — re-add the key before the exit finishes, cancelling it.
+            store.Set("abc");
+            scheduler.DrainImmediateForTest();
+
+            // Assert — the cancel clears the inline position back to Null, rejoining normal flow.
+            Assert.That(_window.rootVisualElement.Q<VisualElement>("item-b").style.position.keyword,
+                Is.EqualTo(StyleKeyword.Null));
+        }
+
+        [Test]
+        public void Given_ASyncModeChild_When_ItIsExiting_Then_ItsInlinePositionStaysNull()
+        {
+            // Arrange — same three-child list, but under the default Sync mode.
+            s_mode = AnimatePresenceMode.Sync;
+            using var store = new SetStore();
+            s_store = store;
+            using var mounted = MountLaidOut();
+            var scheduler = mounted.Root.Reconciler.Context.BatchScheduler;
+
+            // Act — remove the middle child; Sync mode keeps its exit in flow (no pinning).
+            store.Set("ac");
+            scheduler.DrainImmediateForTest();
+
+            // Assert — no PopLayout pinning applies under Sync mode.
+            Assert.That(_window.rootVisualElement.Q<VisualElement>("item-b").style.position.keyword,
+                Is.EqualTo(StyleKeyword.Null));
+        }
+
+        /// <summary>Minimal EditorWindow host that supplies a real panel so layout resolves.</summary>
+        private sealed class TestHostWindow : EditorWindow { }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/AnimatePresencePopLayoutTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/AnimatePresencePopLayoutTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9be9e636c03c4403a2877fa5a714042a

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/MotionDelayedSwapOwnershipTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/MotionDelayedSwapOwnershipTests.cs
@@ -1,0 +1,207 @@
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.UIElements;
+using UnityEngine.UIElements.TestFramework;
+using UnityEditor.UIElements.TestFramework;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins ownership of the single inline <c>transition-delay</c> slot that orchestrated
+    /// (staggered) variant swaps park on an element. An enter/exit play starting on the same
+    /// element must take the slot over — cancelling the parked swap — or a DelaySec=0 exit
+    /// silently inherits the stale orchestration delay while its completion timeout is sized
+    /// without it, and the ghost is dropped before any visible exit plays. And the parked clear
+    /// must survive a transient keyed-reorder detach (the panel-root-host discipline every other
+    /// must-fire timer in the scheduler follows), or the stale delay postpones every later
+    /// transition on that element indefinitely.
+    /// </summary>
+    [TestFixture]
+    internal sealed class MotionDelayedSwapOwnershipTests
+    {
+        private static readonly Dictionary<string, string> s_fade = new()
+        {
+            ["hidden"] = "opacity-0",
+            ["visible"] = "opacity-100",
+        };
+
+        private readonly record struct LabelState(string Label);
+
+        private sealed class LabelStore : Store<LabelState>
+        {
+            public LabelStore() : base(new LabelState("hidden")) { }
+            public void Set(string label) => SetState(_ => new LabelState(label));
+            protected override void ResetCore() => SetState(_ => new LabelState("hidden"));
+        }
+
+        private readonly record struct SetState(string Keys);
+
+        private sealed class SetStore : Store<SetState>
+        {
+            public SetStore(string initial) : base(new SetState(initial)) { }
+            public void Set(string keys) => SetState(_ => new SetState(keys));
+            protected override void ResetCore() => SetState(_ => new SetState("x"));
+        }
+
+        private static LabelStore s_labelStore;
+        private static SetStore s_keyStore;
+
+        private EditorPanelSimulator _sim;
+        private Reconciler _reconciler;
+
+        [SetUp]
+        public void SetUp()
+        {
+            PanelSimulator.ResetCurrentTime();
+            _sim = new EditorPanelSimulator { panelSize = new Vector2(800, 600) };
+            _sim.ResetTimePerSimulatedFrameToDefault();
+            _reconciler = new Reconciler();
+            s_labelStore = null;
+            s_keyStore = null;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _reconciler?.Dispose();
+            _sim?.Dispose();
+            _sim = null;
+        }
+
+        private VisualElement Root => _sim.rootVisualElement;
+
+        private void Tick() => _sim.FrameUpdateMs(16);
+
+        private void AdvancePast(float seconds)
+        {
+            var steps = (int)((seconds + 0.2f) * 1000f / 16f) + 1;
+            for (var i = 0; i < steps; i++) Tick();
+        }
+
+        private static float InlineDelayMs(VisualElement element)
+        {
+            var delay = element.style.transitionDelay;
+            return delay.keyword == StyleKeyword.Null || delay.value == null || delay.value.Count == 0
+                ? 0f
+                : delay.value[0].value;
+        }
+
+        // A coordinator whose label flip orchestrates ONE inheriting presence child: the child both
+        // claims a stagger delay (it has no own animate) and is a keyed AnimatePresence child whose
+        // removal takes the classic preset exit.
+        [Component]
+        private static VNode OrchestratedPresence()
+        {
+            var label = Hooks.UseStore(s_labelStore, s => s.Label);
+            var keys = Hooks.UseStore(s_keyStore, s => s.Keys);
+            var children = new List<VNode>();
+            foreach (var key in keys)
+            {
+                children.Add(V.Motion(name: "item-" + key, key: key.ToString(),
+                    variants: s_fade,
+                    transition: new StyleTransitionConfig { DurationSec = 0.3f }));
+            }
+            return V.Motion(key: "coord", name: "coord", animate: label,
+                transition: new StyleTransitionConfig { DurationSec = 0.2f, DelayChildrenSec = 0.5f },
+                children: new VNode[]
+                {
+                    V.AnimatePresence(key: "presence", initial: false, children: children.ToArray()),
+                });
+        }
+
+        [Test]
+        public void Given_AParkedOrchestrationDelay_When_TheChildStartsAPresenceExit_Then_TheStaleDelayDoesNotApply()
+        {
+            // Arrange — flip the coordinator's label so the inheriting child parks a 500ms delay.
+            using var labels = new LabelStore();
+            s_labelStore = labels;
+            using var keys = new SetStore("x");
+            s_keyStore = keys;
+            using var mounted = V.Mount(Root, V.Component(OrchestratedPresence, key: "root"));
+            var scheduler = mounted.Root.Reconciler.Context.BatchScheduler;
+            Tick();
+            labels.Set("visible");
+            scheduler.DrainImmediateForTest();
+            var item = Root.Q<VisualElement>("item-x");
+            Assume.That(InlineDelayMs(item), Is.EqualTo(500f).Within(1e-3f),
+                "Precondition: the orchestrated delay is parked on the child");
+
+            // Act — remove the key inside the parked window; the exit (DelaySec 0) starts.
+            keys.Set("");
+            scheduler.DrainImmediateForTest();
+
+            // Assert — the exit owns the delay slot now: the stale 500ms must not postpone it
+            // (otherwise the completion timeout, sized without it, drops the ghost before any
+            // visible exit plays).
+            Assert.That(InlineDelayMs(Root.Q<VisualElement>("item-x")), Is.EqualTo(0f).Within(1e-3f));
+        }
+
+        // Plain (non-presence) orchestration for the reorder case: two inheriting keyed children.
+        private static VNode[] StaggerTree(string label, params string[] order)
+        {
+            var children = new VNode[order.Length];
+            for (var i = 0; i < order.Length; i++)
+            {
+                children[i] = V.Motion(key: order[i], name: order[i], variants: s_fade,
+                    transition: new StyleTransitionConfig { DurationSec = 0.15f });
+            }
+            return new VNode[]
+            {
+                V.Motion(key: "p", name: "p", animate: label,
+                    transition: new StyleTransitionConfig { DurationSec = 0.1f, StaggerChildrenSec = 0.3f },
+                    children: children),
+            };
+        }
+
+        [Test]
+        public void Given_AParkedDelayClear_When_TheChildIsReorderedDuringTheWindow_Then_TheDelayIsStillClearedEventually()
+        {
+            // Arrange — flip the label so c1 parks a 300ms delay with its clear scheduled out past
+            // delay + duration.
+            _reconciler.Reconcile(Root, Array.Empty<VNode>(), StaggerTree("hidden", "c0", "c1"));
+            _reconciler.Reconcile(Root, StaggerTree("hidden", "c0", "c1"), StaggerTree("visible", "c0", "c1"));
+            var c1 = Root.Q<VisualElement>("c1");
+            Assume.That(InlineDelayMs(c1), Is.GreaterThan(0f), "Precondition: the stagger delay is parked");
+
+            // Act — a keyed reorder transiently detaches/re-inserts the children inside the parked
+            // window, then time advances well past the whole window.
+            _reconciler.Reconcile(Root, StaggerTree("visible", "c0", "c1"), StaggerTree("visible", "c1", "c0"));
+            AdvancePast(1.5f);
+
+            // Assert — the inline delay is released; a dropped element-scheduled clear would leave
+            // every later transition on this element starting 300ms late.
+            Assert.That(InlineDelayMs(Root.Q<VisualElement>("c1")), Is.EqualTo(0f).Within(1e-3f));
+        }
+
+        [Test]
+        public void Given_AParkedDelayClear_When_TheReorderTransientlyDetachesTheDelayedChild_Then_TheDelayIsStillClearedEventually()
+        {
+            // Arrange — three inheriting children so the rotation below is FORCED to move the one that
+            // actually parked a delay. The sibling test above swaps only two children, and the reconciler's
+            // own LIS-based placement happens to keep ITS delayed child (c1) anchored in place — nothing
+            // there ever transiently detaches it (see that test's own comment). c2 (index 2) claims the
+            // largest stagger delay (600ms) and is the one non-anchor element this 3-way rotation moves via
+            // RemoveFromHierarchy + re-Insert.
+            _reconciler.Reconcile(Root, Array.Empty<VNode>(), StaggerTree("hidden", "c0", "c1", "c2"));
+            _reconciler.Reconcile(Root, StaggerTree("hidden", "c0", "c1", "c2"), StaggerTree("visible", "c0", "c1", "c2"));
+            Assume.That(InlineDelayMs(Root.Q<VisualElement>("c2")), Is.GreaterThan(0f),
+                "Precondition: c2's stagger delay is parked");
+
+            var c2Detached = false;
+            Root.Q<VisualElement>("c2").RegisterCallback<DetachFromPanelEvent>(_ => c2Detached = true);
+
+            // Act — a keyed rotation inside the parked window.
+            _reconciler.Reconcile(Root, StaggerTree("visible", "c0", "c1", "c2"), StaggerTree("visible", "c2", "c0", "c1"));
+            Assume.That(c2Detached, Is.True, "Precondition: the rotation transiently detached the delayed child");
+            AdvancePast(0.6f + 0.15f);
+
+            // Assert — the delay is still released; a clear timer parked on the detached element itself
+            // (rather than the panel-root host) would have been silently dropped by the transient detach,
+            // leaving this element's transition-delay stuck 600ms late on every later transition.
+            Assert.That(InlineDelayMs(Root.Q<VisualElement>("c2")), Is.EqualTo(0f).Within(1e-3f));
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/MotionDelayedSwapOwnershipTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/MotionDelayedSwapOwnershipTests.cs
@@ -10,14 +10,15 @@ using Velvet.TestUtilities;
 namespace Velvet.Tests
 {
     /// <summary>
-    /// Pins ownership of the single inline <c>transition-delay</c> slot that orchestrated
-    /// (staggered) variant swaps park on an element. An enter/exit play starting on the same
-    /// element must take the slot over — cancelling the parked swap — or a DelaySec=0 exit
-    /// silently inherits the stale orchestration delay while its completion timeout is sized
-    /// without it, and the ghost is dropped before any visible exit plays. And the parked clear
-    /// must survive a transient keyed-reorder detach (the panel-root-host discipline every other
-    /// must-fire timer in the scheduler follows), or the stale delay postpones every later
-    /// transition on that element indefinitely.
+    /// Pins ownership of a pending runtime variant-swap play (an orchestrated staggerChildren/delayChildren
+    /// claim — see <c>MotionRuntimeSwapTests</c>) against a presence exit starting on the SAME element. The
+    /// swap is scheduled as an ordinary pending ENTER (<c>StyleAnimationScheduler</c>'s own bookkeeping), so
+    /// the existing enter/exit self-cancel discipline — <c>CancelEnter</c>, already called before
+    /// <c>PlayExit</c> in <c>GeneralPathReconciler</c> — is the whole ownership mechanism: an exit starting
+    /// while a stagger-parked swap is still scheduled must cancel it and play on its OWN schedule, with no
+    /// stale delay of any kind postponing it. Unlike the parked-inline-transition-delay mechanism this
+    /// superseded, there is no separate inline style left to race here at all — the claimed delay is purely a
+    /// scheduler-side timing offset on the deferred swap, never written to the element.
     /// </summary>
     [TestFixture]
     internal sealed class MotionDelayedSwapOwnershipTests
@@ -81,12 +82,12 @@ namespace Velvet.Tests
             for (var i = 0; i < steps; i++) Tick();
         }
 
-        private static float InlineDelayMs(VisualElement element)
+        // Whether the element's inline transition-duration is currently set — the runtime-swap play's own
+        // tell (see MotionRuntimeSwapTests), used here to confirm the claimed swap actually started.
+        private static bool InlineDurationIsSet(VisualElement element)
         {
-            var delay = element.style.transitionDelay;
-            return delay.keyword == StyleKeyword.Null || delay.value == null || delay.value.Count == 0
-                ? 0f
-                : delay.value[0].value;
+            var duration = element.style.transitionDuration;
+            return duration.keyword != StyleKeyword.Null && duration.value != null && duration.value.Count > 0;
         }
 
         // A coordinator whose label flip orchestrates ONE inheriting presence child: the child both
@@ -113,9 +114,10 @@ namespace Velvet.Tests
         }
 
         [Test]
-        public void Given_AParkedOrchestrationDelay_When_TheChildStartsAPresenceExit_Then_TheStaleDelayDoesNotApply()
+        public void Given_AParkedOrchestrationSwap_When_TheChildStartsAPresenceExit_Then_TheExitCompletesOnItsOwnScheduleWithoutTheStaleClaim()
         {
-            // Arrange — flip the coordinator's label so the inheriting child parks a 500ms delay.
+            // Arrange — flip the coordinator's label so the inheriting child's runtime-swap play is claimed
+            // behind a 500ms stagger slot (its own deferred swap has not fired yet).
             using var labels = new LabelStore();
             s_labelStore = labels;
             using var keys = new SetStore("x");
@@ -125,83 +127,19 @@ namespace Velvet.Tests
             Tick();
             labels.Set("visible");
             scheduler.DrainImmediateForTest();
-            var item = Root.Q<VisualElement>("item-x");
-            Assume.That(InlineDelayMs(item), Is.EqualTo(500f).Within(1e-3f),
-                "Precondition: the orchestrated delay is parked on the child");
+            Assume.That(InlineDurationIsSet(Root.Q<VisualElement>("item-x")), Is.True,
+                "Precondition: the child's runtime-swap play started, claimed behind its 500ms stagger slot");
 
-            // Act — remove the key inside the parked window; the exit (DelaySec 0) starts.
+            // Act — remove the key inside the parked window; the exit (its own 0.3s duration, no delay of
+            // its own) must cancel the parked swap and start immediately.
             keys.Set("");
             scheduler.DrainImmediateForTest();
+            AdvancePast(0.3f);
+            scheduler.DrainImmediateForTest();
 
-            // Assert — the exit owns the delay slot now: the stale 500ms must not postpone it
-            // (otherwise the completion timeout, sized without it, drops the ghost before any
-            // visible exit plays).
-            Assert.That(InlineDelayMs(Root.Q<VisualElement>("item-x")), Is.EqualTo(0f).Within(1e-3f));
-        }
-
-        // Plain (non-presence) orchestration for the reorder case: two inheriting keyed children.
-        private static VNode[] StaggerTree(string label, params string[] order)
-        {
-            var children = new VNode[order.Length];
-            for (var i = 0; i < order.Length; i++)
-            {
-                children[i] = V.Motion(key: order[i], name: order[i], variants: s_fade,
-                    transition: new StyleTransitionConfig { DurationSec = 0.15f });
-            }
-            return new VNode[]
-            {
-                V.Motion(key: "p", name: "p", animate: label,
-                    transition: new StyleTransitionConfig { DurationSec = 0.1f, StaggerChildrenSec = 0.3f },
-                    children: children),
-            };
-        }
-
-        [Test]
-        public void Given_AParkedDelayClear_When_TheChildIsReorderedDuringTheWindow_Then_TheDelayIsStillClearedEventually()
-        {
-            // Arrange — flip the label so c1 parks a 300ms delay with its clear scheduled out past
-            // delay + duration.
-            _reconciler.Reconcile(Root, Array.Empty<VNode>(), StaggerTree("hidden", "c0", "c1"));
-            _reconciler.Reconcile(Root, StaggerTree("hidden", "c0", "c1"), StaggerTree("visible", "c0", "c1"));
-            var c1 = Root.Q<VisualElement>("c1");
-            Assume.That(InlineDelayMs(c1), Is.GreaterThan(0f), "Precondition: the stagger delay is parked");
-
-            // Act — a keyed reorder transiently detaches/re-inserts the children inside the parked
-            // window, then time advances well past the whole window.
-            _reconciler.Reconcile(Root, StaggerTree("visible", "c0", "c1"), StaggerTree("visible", "c1", "c0"));
-            AdvancePast(1.5f);
-
-            // Assert — the inline delay is released; a dropped element-scheduled clear would leave
-            // every later transition on this element starting 300ms late.
-            Assert.That(InlineDelayMs(Root.Q<VisualElement>("c1")), Is.EqualTo(0f).Within(1e-3f));
-        }
-
-        [Test]
-        public void Given_AParkedDelayClear_When_TheReorderTransientlyDetachesTheDelayedChild_Then_TheDelayIsStillClearedEventually()
-        {
-            // Arrange — three inheriting children so the rotation below is FORCED to move the one that
-            // actually parked a delay. The sibling test above swaps only two children, and the reconciler's
-            // own LIS-based placement happens to keep ITS delayed child (c1) anchored in place — nothing
-            // there ever transiently detaches it (see that test's own comment). c2 (index 2) claims the
-            // largest stagger delay (600ms) and is the one non-anchor element this 3-way rotation moves via
-            // RemoveFromHierarchy + re-Insert.
-            _reconciler.Reconcile(Root, Array.Empty<VNode>(), StaggerTree("hidden", "c0", "c1", "c2"));
-            _reconciler.Reconcile(Root, StaggerTree("hidden", "c0", "c1", "c2"), StaggerTree("visible", "c0", "c1", "c2"));
-            Assume.That(InlineDelayMs(Root.Q<VisualElement>("c2")), Is.GreaterThan(0f),
-                "Precondition: c2's stagger delay is parked");
-
-            var c2Detached = false;
-            Root.Q<VisualElement>("c2").RegisterCallback<DetachFromPanelEvent>(_ => c2Detached = true);
-
-            // Act — a keyed rotation inside the parked window.
-            _reconciler.Reconcile(Root, StaggerTree("visible", "c0", "c1", "c2"), StaggerTree("visible", "c2", "c0", "c1"));
-            Assume.That(c2Detached, Is.True, "Precondition: the rotation transiently detached the delayed child");
-            AdvancePast(0.6f + 0.15f);
-
-            // Assert — the delay is still released; a clear timer parked on the detached element itself
-            // (rather than the panel-root host) would have been silently dropped by the transient detach,
-            // leaving this element's transition-delay stuck 600ms late on every later transition.
-            Assert.That(InlineDelayMs(Root.Q<VisualElement>("c2")), Is.EqualTo(0f).Within(1e-3f));
+            // Assert — the ghost is already gone well before the original 500ms claim would have elapsed:
+            // the exit ran on its own schedule instead of being postponed by the cancelled swap.
+            Assert.That(Root.Q<VisualElement>("item-x"), Is.Null);
         }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/MotionDelayedSwapOwnershipTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/MotionDelayedSwapOwnershipTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: fde60f19cad0144f2ae3d2343d2251c5

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/MotionEnterSwapTimingTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/MotionEnterSwapTimingTests.cs
@@ -1,0 +1,149 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.UIElements;
+using UnityEngine.UIElements.TestFramework;
+using UnityEditor.UIElements.TestFramework;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins the frame discipline of a classic (tween) variant enter's class swap: the from-state
+    /// must survive the tick that started the enter, because the panel computes styles only after
+    /// the timer queue drains — a swap that runs before the from-state's first style pass leaves
+    /// the CSS transition with no property change to animate, degenerating the whole enter into an
+    /// instant jump. The dangerous shape is production's own: the mount runs inside the panel's
+    /// timer tick (the batch scheduler's drain is itself a scheduled item), the enter's swap is
+    /// registered on a freshly attached element, and a zero-delay swap item then becomes runnable
+    /// in the very tick that mounted the element.
+    /// </summary>
+    [TestFixture]
+    internal sealed class MotionEnterSwapTimingTests
+    {
+        private static readonly Dictionary<string, string> s_fade = new()
+        {
+            ["hidden"] = "opacity-0",
+            ["visible"] = "opacity-100",
+        };
+
+        private readonly record struct SetState(string Keys);
+
+        private sealed class SetStore : Store<SetState>
+        {
+            public SetStore(string initial) : base(new SetState(initial)) { }
+            public void Set(string keys) => SetState(_ => new SetState(keys));
+            protected override void ResetCore() => SetState(_ => new SetState(""));
+        }
+
+        private static SetStore s_store;
+
+        private EditorPanelSimulator _sim;
+
+        [SetUp]
+        public void SetUp()
+        {
+            PanelSimulator.ResetCurrentTime();
+            _sim = new EditorPanelSimulator { panelSize = new Vector2(800, 600) };
+            _sim.ResetTimePerSimulatedFrameToDefault();
+            s_store = null;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _sim?.Dispose();
+            _sim = null;
+        }
+
+        private VisualElement Root => _sim.rootVisualElement;
+
+        private void Tick() => _sim.FrameUpdateMs(16);
+
+        private VisualElement StartEnterInsideATimerTick(StyleAnimationScheduler scheduler)
+        {
+            var element = new VisualElement();
+            Root.Add(element);
+            element.AddToClassList("opacity-100");
+            Tick();
+            element.schedule.Execute(() =>
+            {
+                scheduler.PlayVariantEnter(element, new[] { "opacity-0" }, new[] { "opacity-100" },
+                    durationSec: 0.3f, easing: EasingMode.EaseInOut, delaySec: 0f);
+            });
+            return element;
+        }
+
+        [Test]
+        public void Given_AVariantEnterStartedInsideATimerTick_When_ThatTickEnds_Then_TheFromStateIsStillApplied()
+        {
+            // Arrange — mirror production: the enter's step 1 (strip to-classes, apply from-classes,
+            // schedule the swap) runs inside the panel's own timer tick.
+            var scheduler = new StyleAnimationScheduler();
+            var element = StartEnterInsideATimerTick(scheduler);
+
+            // Act — the single tick that both starts the enter and drains the timer queue.
+            Tick();
+
+            // Assert — the from-state must survive the tick that started the enter; a swap that ran
+            // in the same tick strips it before the panel computes it once, so the transition sees
+            // no change and the enter degenerates to an instant jump.
+            Assert.That(element.ClassListContains("opacity-0"), Is.True);
+        }
+
+        [Test]
+        public void Given_AVariantEnterStartedInsideATimerTick_When_TheNextTickRuns_Then_TheSwapReachesTheAnimateState()
+        {
+            // Arrange — same production shape as above.
+            var scheduler = new StyleAnimationScheduler();
+            var element = StartEnterInsideATimerTick(scheduler);
+            Tick();
+            Assume.That(element.ClassListContains("opacity-0"), Is.True,
+                "Precondition: the from-state survived the starting tick");
+
+            // Act — the next tick is where the deferred swap belongs.
+            Tick();
+
+            // Assert — the swap did fire on the following tick (the enter must still make progress,
+            // not park the from-state forever).
+            Assert.That(element.ClassListContains("opacity-0"), Is.False);
+        }
+
+        [Component]
+        private static VNode LateMountHost()
+        {
+            var keys = Hooks.UseStore(s_store, s => s.Keys);
+            var children = new List<VNode>();
+            foreach (var key in keys)
+            {
+                children.Add(V.Motion(name: "late-" + key, key: key.ToString(), variants: s_fade,
+                    initial: "hidden", animate: "visible",
+                    transition: new StyleTransitionConfig { DurationSec = 0.3f }));
+            }
+            return V.Div(name: "host", children: children.ToArray());
+        }
+
+        [Test]
+        public void Given_AMotionMountedByATimerTickDrain_When_ThatTickEnds_Then_TheFromStateIsStillApplied()
+        {
+            // Arrange — mount the host and settle, then dirty the store WITHOUT a manual drain, so
+            // the new Motion's whole mount (create detached -> play enter -> attach) happens inside
+            // the panel's own timer tick via the batch scheduler's scheduled drain, exactly like
+            // production. The enter's zero-delay swap item is attached mid-tick with its deadline
+            // already reached.
+            using var store = new SetStore("");
+            s_store = store;
+            using var mounted = V.Mount(Root, V.Component(LateMountHost, key: "root"));
+            Tick();
+            store.Set("a");
+
+            // Act — the single tick that both drains the batch (mounting the Motion) and the timer
+            // queue (where the just-scheduled swap must NOT yet run).
+            Tick();
+
+            // Assert — the from-state survived its mounting tick; swapping in the same tick would
+            // strip it before its first style pass and the enter would play as an instant jump.
+            Assert.That(Root.Q<VisualElement>("late-a").ClassListContains("opacity-0"), Is.True);
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/MotionEnterSwapTimingTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/MotionEnterSwapTimingTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e3459561cb7bc4f8e93a699ad13224d3

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/MotionInertPresencePropsWarningTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/MotionInertPresencePropsWarningTests.cs
@@ -7,12 +7,11 @@ using UnityEngine.UIElements;
 namespace Velvet.Tests
 {
     /// <summary>
-    /// Pins the diagnostic for presence-scoped Motion props used outside AnimatePresence. Enter and
-    /// exit tweens are scheduled by the AnimatePresence expansion, so a standalone
-    /// <c>V.Motion(initial:, animate:)</c> mounts already at its animate/resting classes and the
-    /// declared initial never plays — previously with no trace, which is surprising for a
-    /// Framer-style entrance-animation pair. The factory already warns for other silently-inert
-    /// Motion configurations (shadow-*, clip-path-*); initial/exit must warn the same way.
+    /// Pins the diagnostic for the one Motion prop that is still genuinely inert outside AnimatePresence:
+    /// <c>exit</c> requires AnimatePresence to defer the unmount a removal animates against, so it warns like the
+    /// factory's other silently-inert configurations (shadow-*, clip-path-*). <c>initial</c> is NOT presence-scoped
+    /// — a standalone <c>V.Motion(initial:, animate:)</c> plays its own mount enter (Framer parity: initial/animate
+    /// apply to any motion.* component) — so it must NOT warn.
     /// </summary>
     [TestFixture]
     internal sealed class MotionInertPresencePropsWarningTests
@@ -32,19 +31,46 @@ namespace Velvet.Tests
         }
 
         [Test]
-        public void Given_AMotionWithInitialOutsideAnimatePresence_When_Mounted_Then_ItWarnsThatInitialIsInert()
+        public void Given_AMotionWithExitOutsideAnimatePresence_When_Mounted_Then_ItWarnsThatExitIsInert()
         {
             // Arrange — the warning is expected (LogAssert fails the test if it never fires).
             LogAssert.Expect(LogType.Warning,
-                new System.Text.RegularExpressions.Regex("initial/exit on a Motion outside AnimatePresence"));
+                new System.Text.RegularExpressions.Regex("exit on a Motion outside AnimatePresence"));
 
-            // Act — an idiomatic Framer-style entrance pair, mounted with no AnimatePresence.
+            // Act — an `exit` variant declared with no AnimatePresence to defer the unmount for.
             using var mounted = V.Mount(_root,
-                V.Motion(name: "m", variants: s_fade, initial: "hidden", animate: "visible"));
+                V.Motion(name: "m", variants: s_fade, animate: "visible", exit: "hidden"));
 
             // Assert — the element mounted; the expected warning is enforced by LogAssert at test
             // end (an Assert.Pass would bypass that unmatched-expectation check).
             Assert.That(_root.Q<VisualElement>("m"), Is.Not.Null);
+        }
+
+        [Test]
+        public void Given_AMotionWithOnlyInitialAndAnimateOutsideAnimatePresence_When_Mounted_Then_ItDoesNotWarn()
+        {
+            // Arrange — capture log messages directly rather than relying on LogAssert's implicit
+            // unmatched-message behavior: a Warning with no LogAssert.Expect does NOT fail a Unity test on
+            // its own (only Error/Exception/Assert do), so the negative case needs a real assertion instead.
+            var warned = false;
+            void OnLog(string condition, string stackTrace, LogType type)
+            {
+                if (type == LogType.Warning) warned = true;
+            }
+            Application.logMessageReceived += OnLog;
+            try
+            {
+                // Act — a standalone entrance pair (no `exit`, no AnimatePresence).
+                using var mounted = V.Mount(_root,
+                    V.Motion(name: "m", variants: s_fade, initial: "hidden", animate: "visible"));
+            }
+            finally
+            {
+                Application.logMessageReceived -= OnLog;
+            }
+
+            // Assert — initial/animate work standalone, so nothing is inert and nothing warns.
+            Assert.That(warned, Is.False);
         }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/MotionOrchestrationTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/MotionOrchestrationTests.cs
@@ -159,6 +159,62 @@ namespace Velvet.Tests
         }
 
         [Test]
+        public void Given_BeforeChildrenWithAParentDelay_When_TheLabelFlips_Then_ChildrenWaitForTheDelayAndTheDuration()
+        {
+            // Arrange — the parent's own swap spans [DelaySec, DelaySec + DurationSec]; BeforeChildren
+            // means children start after it ENDS, so the parent's DelaySec must be part of the wait.
+            var transition = new StyleTransitionConfig
+            {
+                DurationSec = 0.4f,
+                DelaySec = 0.2f,
+                When = TransitionWhen.BeforeChildren,
+            };
+            _reconciler.Reconcile(Root, Array.Empty<VNode>(), Tree("hidden", transition));
+
+            // Act
+            _reconciler.Reconcile(Root, Tree("hidden", transition), Tree("visible", transition));
+
+            // Assert — 600ms = the parent's DelaySec (200) plus its DurationSec (400).
+            Assert.That(InlineDelayMs(Root.Q<VisualElement>("c0")), Is.EqualTo(600f).Within(1e-3f));
+        }
+
+        [Test]
+        public void Given_AnInheritingOrchestratorWithItsOwnChildStagger_When_TheAncestorLabelFlips_Then_TheGrandchildWaitsForBothDelays()
+        {
+            // Arrange — "mid" both CLAIMS a delay from "gp"'s orchestration (it inherits gp's label and
+            // declares its own Variants, so it actually claims a stagger slot) and ESTABLISHES a fresh
+            // orchestration frame for "gc" (its own Transition declares DelayChildrenSec). "gc"'s total delay
+            // must be measured from render-commit time, not from when "mid"'s own already-delayed swap starts,
+            // or the grandchild would start animating before its own parent's swap even begins.
+            var midVariants = new Dictionary<string, string> { ["hidden"] = "translate-x-0", ["visible"] = "translate-x-4" };
+            VNode[] NestedTree(string label) => new VNode[]
+            {
+                V.Motion(key: "gp", name: "gp", animate: label,
+                    transition: new StyleTransitionConfig { DurationSec = 0.1f, DelayChildrenSec = 0.5f },
+                    children: new VNode[]
+                    {
+                        V.Motion(key: "mid", name: "mid", variants: midVariants,
+                            transition: new StyleTransitionConfig { DurationSec = 0.1f, DelayChildrenSec = 0.25f },
+                            children: new VNode[]
+                            {
+                                V.Motion(key: "gc", name: "gc", variants: s_fade,
+                                    transition: new StyleTransitionConfig { DurationSec = 0.05f }),
+                            }),
+                    }),
+            };
+            _reconciler.Reconcile(Root, Array.Empty<VNode>(), NestedTree("hidden"));
+            Assume.That(InlineDelayMs(Root.Q<VisualElement>("mid")), Is.EqualTo(0f),
+                "Precondition: no orchestrated delay is applied on mount");
+
+            // Act — flip the top ancestor's label.
+            _reconciler.Reconcile(Root, NestedTree("hidden"), NestedTree("visible"));
+
+            // Assert — 750ms = gp's delayChildren (500ms, claimed by "mid") + mid's OWN delayChildren (250ms),
+            // folded together rather than measuring mid's fresh frame from zero.
+            Assert.That(InlineDelayMs(Root.Q<VisualElement>("gc")), Is.EqualTo(750f).Within(1e-3f));
+        }
+
+        [Test]
         public void Given_AChildWithItsOwnExplicitAnimate_When_TheParentLabelFlips_Then_ItIsNotDelayedButItsSiblingIs()
         {
             // Arrange — c0 declares its OWN explicit animate ("visible", fixed across both trees below),

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/MotionOrchestrationTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/MotionOrchestrationTests.cs
@@ -1,10 +1,7 @@
 using System;
 using System.Collections.Generic;
 using NUnit.Framework;
-using UnityEngine;
 using UnityEngine.UIElements;
-using UnityEngine.UIElements.TestFramework;
-using UnityEditor.UIElements.TestFramework;
 
 namespace Velvet.Tests
 {
@@ -23,57 +20,18 @@ namespace Velvet.Tests
     /// later, unrelated patch on the same element does not inherit a stale delay.
     /// </summary>
     /// <remarks>
-    /// Needs a REAL (simulated) panel: the orchestrated delay clears via <c>schedule.Execute().ExecuteLater(ms)</c>,
-    /// which only fires once a panel ticks its scheduler against its clock (the batchmode EditMode PlayerLoop
-    /// never does) — off-panel, the same clear fires IMMEDIATELY instead (mirroring
-    /// <c>StyleAnimationScheduler.CancelExit</c>'s own off-panel-immediate-clear contract for a reversal
-    /// cleanup), which would make the delay unobservable synchronously. <see cref="EditorPanelSimulator"/> ticks
-    /// the panel deterministically instead (see <see cref="Tick"/> / <see cref="AdvancePast"/>).
+    /// Needs a REAL (simulated) panel — see <see cref="MotionSimulatedPanelTestsBase"/> — for the orchestrated
+    /// delay's clear, which only fires once a panel ticks its scheduler against its clock (the batchmode
+    /// EditMode PlayerLoop never does).
     /// </remarks>
     [TestFixture]
-    internal sealed class MotionOrchestrationTests
+    internal sealed class MotionOrchestrationTests : MotionSimulatedPanelTestsBase
     {
         private static readonly Dictionary<string, string> s_fade = new()
         {
             ["hidden"] = "opacity-0",
             ["visible"] = "opacity-100",
         };
-
-        private EditorPanelSimulator _sim;
-        private Reconciler _reconciler;
-
-        [SetUp]
-        public void SetUp()
-        {
-            // Simulated time (and the per-frame step) are process-static and not auto-reset between tests;
-            // reset both so this fixture's frame accounting starts from a known clock regardless of what a
-            // sibling simulator-based fixture left behind.
-            PanelSimulator.ResetCurrentTime();
-            _sim = new EditorPanelSimulator { panelSize = new Vector2(800, 600) };
-            _sim.ResetTimePerSimulatedFrameToDefault();
-            _reconciler = new Reconciler();
-        }
-
-        [TearDown]
-        public void TearDown()
-        {
-            _reconciler?.Dispose();
-            _sim?.Dispose();
-            _sim = null;
-        }
-
-        private VisualElement Root => _sim.rootVisualElement;
-
-        // One frame (a real-frame-sized scheduler tick).
-        private void Tick() => _sim.FrameUpdateMs(16);
-
-        // Advances well past the given duration so any scheduled callback due by then fires; the +0.2s margin
-        // absorbs the scheduler's internal grace period without coupling to its exact value.
-        private void AdvancePast(float seconds)
-        {
-            var steps = (int)((seconds + 0.2f) * 1000f / 16f) + 1;
-            for (var i = 0; i < steps; i++) Tick();
-        }
 
         // Builds a parent Motion (a PURE COORDINATOR: it declares no `variants` of its own, only `animate` +
         // `transition` — the orchestration must key off the label it PROPAGATES, not off its own resolved

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/MotionOrchestrationTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/MotionOrchestrationTests.cs
@@ -1,0 +1,201 @@
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.UIElements;
+using UnityEngine.UIElements.TestFramework;
+using UnityEditor.UIElements.TestFramework;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins <c>StyleTransitionConfig.StaggerChildrenSec</c> / <c>DelayChildrenSec</c> / <c>When</c>: PLAIN
+    /// parent → child variant-tree orchestration — no AnimatePresence involved, just a Motion's <c>animate</c>
+    /// label flipping while descendants inherit it via <c>variants</c> (see
+    /// <c>MotionVariantPropagationTests.Given_AChildInheritingHidden_...</c>). A descendant that follows the
+    /// ambient label (no own <c>animate</c>) claims a sequential slot and gets an inline
+    /// <c>transition-delay</c> of <c>DelayChildrenSec + StaggerChildrenSec * index</c> (plus the parent's own
+    /// <c>DurationSec</c> when <c>When == BeforeChildren</c>), ADDED on top of whatever it already declares via
+    /// its own <c>Transition.DelaySec</c>. A descendant with its OWN explicit <c>animate</c> opts out entirely
+    /// (Framer parity: an explicit override disconnects a component from its parent's variant propagation).
+    /// The delay is delivered as a plain inline style (the class swap itself is a synchronous class diff, not a
+    /// scheduler-driven enter/exit) and is cleared once its own swap's transition would have finished, so a
+    /// later, unrelated patch on the same element does not inherit a stale delay.
+    /// </summary>
+    /// <remarks>
+    /// Needs a REAL (simulated) panel: the orchestrated delay clears via <c>schedule.Execute().ExecuteLater(ms)</c>,
+    /// which only fires once a panel ticks its scheduler against its clock (the batchmode EditMode PlayerLoop
+    /// never does) — off-panel, the same clear fires IMMEDIATELY instead (mirroring
+    /// <c>StyleAnimationScheduler.CancelExit</c>'s own off-panel-immediate-clear contract for a reversal
+    /// cleanup), which would make the delay unobservable synchronously. <see cref="EditorPanelSimulator"/> ticks
+    /// the panel deterministically instead (see <see cref="Tick"/> / <see cref="AdvancePast"/>).
+    /// </remarks>
+    [TestFixture]
+    internal sealed class MotionOrchestrationTests
+    {
+        private static readonly Dictionary<string, string> s_fade = new()
+        {
+            ["hidden"] = "opacity-0",
+            ["visible"] = "opacity-100",
+        };
+
+        private EditorPanelSimulator _sim;
+        private Reconciler _reconciler;
+
+        [SetUp]
+        public void SetUp()
+        {
+            // Simulated time (and the per-frame step) are process-static and not auto-reset between tests;
+            // reset both so this fixture's frame accounting starts from a known clock regardless of what a
+            // sibling simulator-based fixture left behind.
+            PanelSimulator.ResetCurrentTime();
+            _sim = new EditorPanelSimulator { panelSize = new Vector2(800, 600) };
+            _sim.ResetTimePerSimulatedFrameToDefault();
+            _reconciler = new Reconciler();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _reconciler?.Dispose();
+            _sim?.Dispose();
+            _sim = null;
+        }
+
+        private VisualElement Root => _sim.rootVisualElement;
+
+        // One frame (a real-frame-sized scheduler tick).
+        private void Tick() => _sim.FrameUpdateMs(16);
+
+        // Advances well past the given duration so any scheduled callback due by then fires; the +0.2s margin
+        // absorbs the scheduler's internal grace period without coupling to its exact value.
+        private void AdvancePast(float seconds)
+        {
+            var steps = (int)((seconds + 0.2f) * 1000f / 16f) + 1;
+            for (var i = 0; i < steps; i++) Tick();
+        }
+
+        // Builds a parent Motion (a PURE COORDINATOR: it declares no `variants` of its own, only `animate` +
+        // `transition` — the orchestration must key off the label it PROPAGATES, not off its own resolved
+        // class, since a coordinator like this never gets a MotionAppliedClasses entry) with two inheriting
+        // children. child0Animate, when non-null, gives c0 its OWN explicit `animate` (opting it out of
+        // inheriting the parent's label, and so out of this stagger — see test (d)).
+        private static VNode[] Tree(
+            string parentLabel, StyleTransitionConfig parentTransition,
+            string child0Animate = null, StyleTransitionConfig childTransition = null)
+        {
+            childTransition ??= new StyleTransitionConfig { DurationSec = 0.15f };
+            return new VNode[]
+            {
+                V.Motion(key: "p", name: "p", animate: parentLabel, transition: parentTransition,
+                    children: new VNode[]
+                    {
+                        V.Motion(key: "c0", name: "c0", variants: s_fade, animate: child0Animate, transition: childTransition),
+                        V.Motion(key: "c1", name: "c1", variants: s_fade, transition: childTransition),
+                    }),
+            };
+        }
+
+        // Reads the element's inline transition-delay as milliseconds; unset (StyleKeyword.Null, or an empty
+        // list) reads as 0, matching CSS's own "no delay" default.
+        private static float InlineDelayMs(VisualElement element)
+        {
+            var delay = element.style.transitionDelay;
+            return delay.keyword == StyleKeyword.Null || delay.value == null || delay.value.Count == 0
+                ? 0f
+                : delay.value[0].value;
+        }
+
+        [Test]
+        public void Given_AParentLabelFlipWithStaggerChildren_When_TheChildrenInheritTheNewLabel_Then_EachGetsAnIncreasingDelay()
+        {
+            // Arrange — mount with the parent hidden (orchestration only ever starts from a PATCH-time label
+            // change, never on mount — see FiberNodePatcher.PatchMotion), so nothing carries a delay yet.
+            var transition = new StyleTransitionConfig { DurationSec = 0.2f, DelayChildrenSec = 0.2f, StaggerChildrenSec = 0.1f };
+            _reconciler.Reconcile(Root, Array.Empty<VNode>(), Tree("hidden", transition));
+            Assume.That(InlineDelayMs(Root.Q<VisualElement>("c1")), Is.EqualTo(0f),
+                "Precondition: no orchestrated delay is applied on mount");
+
+            // Act — flip the parent's label (the render that actually triggers orchestration).
+            _reconciler.Reconcile(Root, Tree("hidden", transition), Tree("visible", transition));
+
+            // Assert — child 0 claims index 0 (200ms = delayChildren + 0*stagger), child 1 claims index 1
+            // (300ms = delayChildren + 1*stagger), each ADDED on top of the child's own (unset, 0) DelaySec.
+            var c0 = InlineDelayMs(Root.Q<VisualElement>("c0"));
+            var c1 = InlineDelayMs(Root.Q<VisualElement>("c1"));
+            Assert.That((c0, c1), Is.EqualTo((200f, 300f)).Within(1e-3f));
+        }
+
+        [Test]
+        public void Given_DelayChildrenSecWithNoStagger_When_TheParentLabelFlips_Then_BothChildrenGetTheSameFixedDelay()
+        {
+            // Arrange — isolate delayChildren's own contribution (StaggerChildrenSec = 0, so the per-index term
+            // vanishes and every inheriting child should be delayed by exactly the same fixed amount).
+            var transition = new StyleTransitionConfig { DurationSec = 0.2f, DelayChildrenSec = 0.5f, StaggerChildrenSec = 0f };
+            _reconciler.Reconcile(Root, Array.Empty<VNode>(), Tree("hidden", transition));
+
+            // Act
+            _reconciler.Reconcile(Root, Tree("hidden", transition), Tree("visible", transition));
+
+            // Assert — both children are delayed by the same fixed 500ms, regardless of stagger index.
+            var c0 = InlineDelayMs(Root.Q<VisualElement>("c0"));
+            var c1 = InlineDelayMs(Root.Q<VisualElement>("c1"));
+            Assert.That((c0, c1), Is.EqualTo((500f, 500f)).Within(1e-3f));
+        }
+
+        [Test]
+        public void Given_WhenIsBeforeChildren_When_TheParentLabelFlips_Then_TheParentsOwnDurationIsAddedToTheChildDelay()
+        {
+            // Arrange — no delayChildren/staggerChildren, isolating BeforeChildren's own contribution: children
+            // wait for the parent's own 400ms swap to finish before starting theirs.
+            var transition = new StyleTransitionConfig { DurationSec = 0.4f, When = TransitionWhen.BeforeChildren };
+            _reconciler.Reconcile(Root, Array.Empty<VNode>(), Tree("hidden", transition));
+
+            // Act
+            _reconciler.Reconcile(Root, Tree("hidden", transition), Tree("visible", transition));
+
+            // Assert — the inheriting child is delayed by exactly the parent's own DurationSec.
+            Assert.That(InlineDelayMs(Root.Q<VisualElement>("c0")), Is.EqualTo(400f).Within(1e-3f));
+        }
+
+        [Test]
+        public void Given_AChildWithItsOwnExplicitAnimate_When_TheParentLabelFlips_Then_ItIsNotDelayedButItsSiblingIs()
+        {
+            // Arrange — c0 declares its OWN explicit animate ("visible", fixed across both trees below),
+            // opting it out of inheriting the parent's ambient label and so out of this stagger; c1 declares no
+            // own animate and inherits normally, so it MUST still be delayed regardless of which stagger index
+            // it claims (c0 never calls into the shared counter at all, since it never satisfies the ambient-
+            // following gate) — DelayChildrenSec alone (no stagger) makes that unambiguous.
+            var transition = new StyleTransitionConfig { DurationSec = 0.2f, DelayChildrenSec = 0.2f };
+            _reconciler.Reconcile(Root, Array.Empty<VNode>(), Tree("hidden", transition, child0Animate: "visible"));
+
+            // Act
+            _reconciler.Reconcile(Root, Tree("hidden", transition, child0Animate: "visible"),
+                Tree("visible", transition, child0Animate: "visible"));
+
+            // Assert — c0 (own explicit animate) carries no delay; c1 (ambient-inheriting) does.
+            var c0HasNoDelay = InlineDelayMs(Root.Q<VisualElement>("c0")) == 0f;
+            var c1IsDelayed = InlineDelayMs(Root.Q<VisualElement>("c1")) > 0f;
+            Assert.That((c0HasNoDelay, c1IsDelayed), Is.EqualTo((true, true)));
+        }
+
+        [Test]
+        public void Given_AnOrchestratedDelayOnAPanel_When_TheSwapsTransitionWouldHaveFinished_Then_TheInlineDelayClearsAutomatically()
+        {
+            // Arrange — the same parent-flip scenario as the tests above, applying a non-zero inline delay to c0.
+            var transition = new StyleTransitionConfig { DurationSec = 0.2f, DelayChildrenSec = 0.2f, StaggerChildrenSec = 0.1f };
+            var childTransition = new StyleTransitionConfig { DurationSec = 0.1f };
+            _reconciler.Reconcile(Root, Array.Empty<VNode>(), Tree("hidden", transition, childTransition: childTransition));
+            _reconciler.Reconcile(Root, Tree("hidden", transition, childTransition: childTransition),
+                Tree("visible", transition, childTransition: childTransition));
+            var c0 = Root.Q<VisualElement>("c0");
+            Assume.That(InlineDelayMs(c0), Is.GreaterThan(0f), "Precondition: the swap applied a non-zero inline delay");
+
+            // Act — advance the simulated clock well past this child's delay (200ms) + its own duration (100ms).
+            AdvancePast(0.2f + 0.1f);
+
+            // Assert — the deferred clear fired and removed the inline transition-delay.
+            Assert.That(c0.style.transitionDelay.keyword, Is.EqualTo(StyleKeyword.Null));
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/MotionOrchestrationTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/MotionOrchestrationTests.cs
@@ -10,19 +10,21 @@ namespace Velvet.Tests
     /// parent → child variant-tree orchestration — no AnimatePresence involved, just a Motion's <c>animate</c>
     /// label flipping while descendants inherit it via <c>variants</c> (see
     /// <c>MotionVariantPropagationTests.Given_AChildInheritingHidden_...</c>). A descendant that follows the
-    /// ambient label (no own <c>animate</c>) claims a sequential slot and gets an inline
-    /// <c>transition-delay</c> of <c>DelayChildrenSec + StaggerChildrenSec * index</c> (plus the parent's own
-    /// <c>DurationSec</c> when <c>When == BeforeChildren</c>), ADDED on top of whatever it already declares via
-    /// its own <c>Transition.DelaySec</c>. A descendant with its OWN explicit <c>animate</c> opts out entirely
-    /// (Framer parity: an explicit override disconnects a component from its parent's variant propagation).
-    /// The delay is delivered as a plain inline style (the class swap itself is a synchronous class diff, not a
-    /// scheduler-driven enter/exit) and is cleared once its own swap's transition would have finished, so a
-    /// later, unrelated patch on the same element does not inherit a stale delay.
+    /// ambient label (no own <c>animate</c>) claims a sequential slot — <c>DelayChildrenSec + StaggerChildrenSec
+    /// * index</c> (plus the parent's own <c>DurationSec</c> when <c>When == BeforeChildren</c>) — ADDED on top
+    /// of whatever it already declares via its own <c>Transition.DelaySec</c>. That claim rides as the
+    /// <c>StyleAnimationScheduler</c> runtime-swap play's <c>additionalDelaySec</c> (see
+    /// <c>FiberNodePatcher.PatchMotion</c> / <c>MotionRuntimeSwapTests</c>): the claim delays the SWAP itself —
+    /// the target classes land only once the slot elapses — rather than parking an inline
+    /// <c>transition-delay</c> for utility classes that may not even declare a transition. A descendant with
+    /// its OWN explicit <c>animate</c> opts out entirely (Framer parity: an explicit override disconnects a
+    /// component from its parent's variant propagation) — and, since its own resolved variant never changes
+    /// as a result, never plays a swap at all.
     /// </summary>
     /// <remarks>
     /// Needs a REAL (simulated) panel — see <see cref="MotionSimulatedPanelTestsBase"/> — for the orchestrated
-    /// delay's clear, which only fires once a panel ticks its scheduler against its clock (the batchmode
-    /// EditMode PlayerLoop never does).
+    /// swap, which only fires once a panel ticks its scheduler against its own clock (the batchmode EditMode
+    /// PlayerLoop never does).
     /// </remarks>
     [TestFixture]
     internal sealed class MotionOrchestrationTests : MotionSimulatedPanelTestsBase
@@ -37,7 +39,7 @@ namespace Velvet.Tests
         // `transition` — the orchestration must key off the label it PROPAGATES, not off its own resolved
         // class, since a coordinator like this never gets a MotionAppliedClasses entry) with two inheriting
         // children. child0Animate, when non-null, gives c0 its OWN explicit `animate` (opting it out of
-        // inheriting the parent's label, and so out of this stagger — see test (d)).
+        // inheriting the parent's label, and so out of this stagger — see test (f)).
         private static VNode[] Tree(
             string parentLabel, StyleTransitionConfig parentTransition,
             string child0Animate = null, StyleTransitionConfig childTransition = null)
@@ -54,70 +56,85 @@ namespace Velvet.Tests
             };
         }
 
-        // Reads the element's inline transition-delay as milliseconds; unset (StyleKeyword.Null, or an empty
-        // list) reads as 0, matching CSS's own "no delay" default.
-        private static float InlineDelayMs(VisualElement element)
+        // Whether the element's inline transition-duration is currently set — the runtime-swap play's own
+        // tell (see MotionRuntimeSwapTests), used here to confirm a claimed swap actually started/settled.
+        private static bool InlineDurationIsSet(VisualElement element)
         {
-            var delay = element.style.transitionDelay;
-            return delay.keyword == StyleKeyword.Null || delay.value == null || delay.value.Count == 0
-                ? 0f
-                : delay.value[0].value;
+            var duration = element.style.transitionDuration;
+            return duration.keyword != StyleKeyword.Null && duration.value != null && duration.value.Count > 0;
         }
 
         [Test]
-        public void Given_AParentLabelFlipWithStaggerChildren_When_TheChildrenInheritTheNewLabel_Then_EachGetsAnIncreasingDelay()
+        public void Given_AParentLabelFlipWithStaggerChildren_When_TheChildrenInheritTheNewLabel_Then_EachSwapsOnItsOwnIncreasingSlot()
         {
             // Arrange — mount with the parent hidden (orchestration only ever starts from a PATCH-time label
-            // change, never on mount — see FiberNodePatcher.PatchMotion), so nothing carries a delay yet.
+            // change, never on mount — see FiberNodePatcher.PatchMotion), so nothing has swapped yet.
             var transition = new StyleTransitionConfig { DurationSec = 0.2f, DelayChildrenSec = 0.2f, StaggerChildrenSec = 0.1f };
             _reconciler.Reconcile(Root, Array.Empty<VNode>(), Tree("hidden", transition));
-            Assume.That(InlineDelayMs(Root.Q<VisualElement>("c1")), Is.EqualTo(0f),
-                "Precondition: no orchestrated delay is applied on mount");
+            Assume.That(Root.Q<VisualElement>("c1").ClassListContains("opacity-100"), Is.False,
+                "Precondition: no orchestrated swap has fired on mount");
 
-            // Act — flip the parent's label (the render that actually triggers orchestration).
+            // Act — flip the parent's label (the render that actually triggers orchestration). Sample at
+            // 256ms (past child 0's 200ms slot, short of child 1's 300ms one), then again once both have
+            // elapsed.
             _reconciler.Reconcile(Root, Tree("hidden", transition), Tree("visible", transition));
+            for (var i = 0; i < 16; i++) Tick();
+            var c0SwappedAtMidpoint = Root.Q<VisualElement>("c0").ClassListContains("opacity-100");
+            var c1SwappedAtMidpoint = Root.Q<VisualElement>("c1").ClassListContains("opacity-100");
+            AdvancePast(0.3f);
+            var c1SwappedLate = Root.Q<VisualElement>("c1").ClassListContains("opacity-100");
 
-            // Assert — child 0 claims index 0 (200ms = delayChildren + 0*stagger), child 1 claims index 1
-            // (300ms = delayChildren + 1*stagger), each ADDED on top of the child's own (unset, 0) DelaySec.
-            var c0 = InlineDelayMs(Root.Q<VisualElement>("c0"));
-            var c1 = InlineDelayMs(Root.Q<VisualElement>("c1"));
-            Assert.That((c0, c1), Is.EqualTo((200f, 300f)).Within(1e-3f));
+            // Assert — child 0 claims index 0 (200ms = delayChildren + 0*stagger) and has already swapped
+            // by 256ms; child 1 claims index 1 (300ms = delayChildren + 1*stagger) and has not yet, only
+            // swapping once its own later slot elapses.
+            Assert.That((c0SwappedAtMidpoint, c1SwappedAtMidpoint, c1SwappedLate), Is.EqualTo((true, false, true)));
         }
 
         [Test]
-        public void Given_DelayChildrenSecWithNoStagger_When_TheParentLabelFlips_Then_BothChildrenGetTheSameFixedDelay()
+        public void Given_DelayChildrenSecWithNoStagger_When_TheParentLabelFlips_Then_BothChildrenSwapAtTheSameFixedSlot()
         {
-            // Arrange — isolate delayChildren's own contribution (StaggerChildrenSec = 0, so the per-index term
-            // vanishes and every inheriting child should be delayed by exactly the same fixed amount).
+            // Arrange — isolate delayChildren's own contribution (StaggerChildrenSec = 0, so the per-index
+            // term vanishes and every inheriting child should swap at exactly the same fixed slot).
             var transition = new StyleTransitionConfig { DurationSec = 0.2f, DelayChildrenSec = 0.5f, StaggerChildrenSec = 0f };
             _reconciler.Reconcile(Root, Array.Empty<VNode>(), Tree("hidden", transition));
 
-            // Act
+            // Act — flip the parent's label. Sample shortly before the shared 500ms slot (neither should
+            // have swapped) and again once it has elapsed.
             _reconciler.Reconcile(Root, Tree("hidden", transition), Tree("visible", transition));
+            for (var i = 0; i < 28; i++) Tick();
+            var beforeSlot = (Root.Q<VisualElement>("c0").ClassListContains("opacity-100"),
+                Root.Q<VisualElement>("c1").ClassListContains("opacity-100"));
+            AdvancePast(0.2f);
+            var afterSlot = (Root.Q<VisualElement>("c0").ClassListContains("opacity-100"),
+                Root.Q<VisualElement>("c1").ClassListContains("opacity-100"));
 
-            // Assert — both children are delayed by the same fixed 500ms, regardless of stagger index.
-            var c0 = InlineDelayMs(Root.Q<VisualElement>("c0"));
-            var c1 = InlineDelayMs(Root.Q<VisualElement>("c1"));
-            Assert.That((c0, c1), Is.EqualTo((500f, 500f)).Within(1e-3f));
+            // Assert — both children are still un-swapped right up to the shared 500ms slot, then both
+            // have swapped once it elapses: the same fixed delay regardless of stagger index.
+            Assert.That((beforeSlot, afterSlot), Is.EqualTo(((false, false), (true, true))));
         }
 
         [Test]
-        public void Given_WhenIsBeforeChildren_When_TheParentLabelFlips_Then_TheParentsOwnDurationIsAddedToTheChildDelay()
+        public void Given_WhenIsBeforeChildren_When_TheParentLabelFlips_Then_TheChildDoesNotSwapUntilTheParentsOwnDurationElapses()
         {
-            // Arrange — no delayChildren/staggerChildren, isolating BeforeChildren's own contribution: children
-            // wait for the parent's own 400ms swap to finish before starting theirs.
+            // Arrange — no delayChildren/staggerChildren, isolating BeforeChildren's own contribution:
+            // children wait for the parent's own 400ms swap to finish before starting theirs.
             var transition = new StyleTransitionConfig { DurationSec = 0.4f, When = TransitionWhen.BeforeChildren };
             _reconciler.Reconcile(Root, Array.Empty<VNode>(), Tree("hidden", transition));
 
-            // Act
+            // Act — flip the parent's label. Sample shortly before the 400ms slot and again once it elapses.
             _reconciler.Reconcile(Root, Tree("hidden", transition), Tree("visible", transition));
+            for (var i = 0; i < 23; i++) Tick();
+            var beforeSlot = Root.Q<VisualElement>("c0").ClassListContains("opacity-100");
+            AdvancePast(0.2f);
+            var afterSlot = Root.Q<VisualElement>("c0").ClassListContains("opacity-100");
 
-            // Assert — the inheriting child is delayed by exactly the parent's own DurationSec.
-            Assert.That(InlineDelayMs(Root.Q<VisualElement>("c0")), Is.EqualTo(400f).Within(1e-3f));
+            // Assert — the inheriting child does not swap until exactly the parent's own DurationSec has
+            // elapsed.
+            Assert.That((beforeSlot, afterSlot), Is.EqualTo((false, true)));
         }
 
         [Test]
-        public void Given_BeforeChildrenWithAParentDelay_When_TheLabelFlips_Then_ChildrenWaitForTheDelayAndTheDuration()
+        public void Given_BeforeChildrenWithAParentDelay_When_TheLabelFlips_Then_TheChildWaitsForTheDelayAndTheDuration()
         {
             // Arrange — the parent's own swap spans [DelaySec, DelaySec + DurationSec]; BeforeChildren
             // means children start after it ENDS, so the parent's DelaySec must be part of the wait.
@@ -129,11 +146,17 @@ namespace Velvet.Tests
             };
             _reconciler.Reconcile(Root, Array.Empty<VNode>(), Tree("hidden", transition));
 
-            // Act
+            // Act — flip the parent's label. Sample shortly before the 600ms slot (DelaySec + DurationSec)
+            // and again once it elapses.
             _reconciler.Reconcile(Root, Tree("hidden", transition), Tree("visible", transition));
+            for (var i = 0; i < 35; i++) Tick();
+            var beforeSlot = Root.Q<VisualElement>("c0").ClassListContains("opacity-100");
+            AdvancePast(0.2f);
+            var afterSlot = Root.Q<VisualElement>("c0").ClassListContains("opacity-100");
 
-            // Assert — 600ms = the parent's DelaySec (200) plus its DurationSec (400).
-            Assert.That(InlineDelayMs(Root.Q<VisualElement>("c0")), Is.EqualTo(600f).Within(1e-3f));
+            // Assert — 600ms = the parent's DelaySec (200) plus its DurationSec (400); the child does not
+            // swap until both have elapsed.
+            Assert.That((beforeSlot, afterSlot), Is.EqualTo((false, true)));
         }
 
         [Test]
@@ -161,19 +184,25 @@ namespace Velvet.Tests
                     }),
             };
             _reconciler.Reconcile(Root, Array.Empty<VNode>(), NestedTree("hidden"));
-            Assume.That(InlineDelayMs(Root.Q<VisualElement>("mid")), Is.EqualTo(0f),
-                "Precondition: no orchestrated delay is applied on mount");
+            Assume.That(Root.Q<VisualElement>("gc").ClassListContains("opacity-100"), Is.False,
+                "Precondition: no orchestrated swap has fired on mount");
 
-            // Act — flip the top ancestor's label.
+            // Act — flip the top ancestor's label. Sample shortly before the 750ms slot and again once it
+            // elapses.
             _reconciler.Reconcile(Root, NestedTree("hidden"), NestedTree("visible"));
+            for (var i = 0; i < 45; i++) Tick();
+            var beforeSlot = Root.Q<VisualElement>("gc").ClassListContains("opacity-100");
+            AdvancePast(0.2f);
+            var afterSlot = Root.Q<VisualElement>("gc").ClassListContains("opacity-100");
 
-            // Assert — 750ms = gp's delayChildren (500ms, claimed by "mid") + mid's OWN delayChildren (250ms),
-            // folded together rather than measuring mid's fresh frame from zero.
-            Assert.That(InlineDelayMs(Root.Q<VisualElement>("gc")), Is.EqualTo(750f).Within(1e-3f));
+            // Assert — 750ms = gp's delayChildren (500ms, claimed by "mid") + mid's OWN delayChildren
+            // (250ms), folded together rather than measuring mid's fresh frame from zero; the grandchild
+            // does not swap until both have elapsed.
+            Assert.That((beforeSlot, afterSlot), Is.EqualTo((false, true)));
         }
 
         [Test]
-        public void Given_AChildWithItsOwnExplicitAnimate_When_TheParentLabelFlips_Then_ItIsNotDelayedButItsSiblingIs()
+        public void Given_AChildWithItsOwnExplicitAnimate_When_TheParentLabelFlips_Then_ItNeverPlaysButItsSiblingIsDelayed()
         {
             // Arrange — c0 declares its OWN explicit animate ("visible", fixed across both trees below),
             // opting it out of inheriting the parent's ambient label and so out of this stagger; c1 declares no
@@ -183,33 +212,40 @@ namespace Velvet.Tests
             var transition = new StyleTransitionConfig { DurationSec = 0.2f, DelayChildrenSec = 0.2f };
             _reconciler.Reconcile(Root, Array.Empty<VNode>(), Tree("hidden", transition, child0Animate: "visible"));
 
-            // Act
+            // Act — flip the parent's label. c1's own resolved variant changes (hidden -> visible) and must
+            // wait for its claimed 200ms slot; c0's never changes (fixed at "visible" throughout), so no
+            // runtime-swap play is ever triggered for it at all.
             _reconciler.Reconcile(Root, Tree("hidden", transition, child0Animate: "visible"),
                 Tree("visible", transition, child0Animate: "visible"));
+            var c1SwappedImmediately = Root.Q<VisualElement>("c1").ClassListContains("opacity-100");
+            AdvancePast(0.2f);
+            var c0NeverPlayed = !InlineDurationIsSet(Root.Q<VisualElement>("c0"));
+            var c1SwappedAfterItsSlot = Root.Q<VisualElement>("c1").ClassListContains("opacity-100");
 
-            // Assert — c0 (own explicit animate) carries no delay; c1 (ambient-inheriting) does.
-            var c0HasNoDelay = InlineDelayMs(Root.Q<VisualElement>("c0")) == 0f;
-            var c1IsDelayed = InlineDelayMs(Root.Q<VisualElement>("c1")) > 0f;
-            Assert.That((c0HasNoDelay, c1IsDelayed), Is.EqualTo((true, true)));
+            // Assert — c0 (own explicit animate) never got a runtime-swap play at all; c1 (ambient-inheriting)
+            // did not swap immediately and only reached its target once its claimed delay elapsed.
+            Assert.That((c0NeverPlayed, c1SwappedImmediately, c1SwappedAfterItsSlot), Is.EqualTo((true, false, true)));
         }
 
         [Test]
-        public void Given_AnOrchestratedDelayOnAPanel_When_TheSwapsTransitionWouldHaveFinished_Then_TheInlineDelayClearsAutomatically()
+        public void Given_AnOrchestratedSwapOnAPanel_When_ItsTransitionWouldHaveFinished_Then_TheInlineTransitionStylesClearAutomatically()
         {
-            // Arrange — the same parent-flip scenario as the tests above, applying a non-zero inline delay to c0.
+            // Arrange — the same parent-flip scenario as the tests above; c0's runtime-swap play is claimed
+            // behind a non-zero orchestrated delay.
             var transition = new StyleTransitionConfig { DurationSec = 0.2f, DelayChildrenSec = 0.2f, StaggerChildrenSec = 0.1f };
             var childTransition = new StyleTransitionConfig { DurationSec = 0.1f };
             _reconciler.Reconcile(Root, Array.Empty<VNode>(), Tree("hidden", transition, childTransition: childTransition));
             _reconciler.Reconcile(Root, Tree("hidden", transition, childTransition: childTransition),
                 Tree("visible", transition, childTransition: childTransition));
             var c0 = Root.Q<VisualElement>("c0");
-            Assume.That(InlineDelayMs(c0), Is.GreaterThan(0f), "Precondition: the swap applied a non-zero inline delay");
+            Assume.That(InlineDurationIsSet(c0), Is.True, "Precondition: the runtime-swap play set its inline transition");
 
-            // Act — advance the simulated clock well past this child's delay (200ms) + its own duration (100ms).
+            // Act — advance the simulated clock well past this child's claimed delay (200ms) + its own swap
+            // duration (100ms).
             AdvancePast(0.2f + 0.1f);
 
-            // Assert — the deferred clear fired and removed the inline transition-delay.
-            Assert.That(c0.style.transitionDelay.keyword, Is.EqualTo(StyleKeyword.Null));
+            // Assert — the completion cleanup fired and released the inline transition styles.
+            Assert.That(InlineDurationIsSet(c0), Is.False);
         }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/MotionOrchestrationTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/MotionOrchestrationTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a69d5b62d7a724ff48b2786d92e4e011

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/MotionPresenceEnterGateTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/MotionPresenceEnterGateTests.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using UnityEngine.UIElements;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins the standalone-enter gate against AnimatePresence subtrees. The presence expansion
+    /// animates only its first-found anchor Motion, so a Motion that is NOT the anchor (e.g. nested
+    /// under a keyed wrapper Div) must keep its own mount enter — the ambient expansion-depth
+    /// counter must not blanket-suppress it, or wrapping content in AnimatePresence silently
+    /// disables unrelated Motions' documented initial→animate behavior. And an <c>initial</c> the
+    /// enter machinery cannot resolve (no own <c>animate</c>, or a label missing from the variants)
+    /// must warn instead of being silently inert, matching the factory's other inert-configuration
+    /// diagnostics.
+    /// </summary>
+    [TestFixture]
+    internal sealed class MotionPresenceEnterGateTests
+    {
+        private static readonly Dictionary<string, string> s_fade = new()
+        {
+            ["hidden"] = "opacity-0",
+            ["visible"] = "opacity-100",
+        };
+
+        private VisualElement _root;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _root = new VisualElement();
+        }
+
+        [Component]
+        private static VNode WrappedPresence()
+        {
+            return V.Div(name: "host", children: new VNode[]
+            {
+                V.AnimatePresence(key: "presence", children: new VNode[]
+                {
+                    // The keyed child is a plain Div, so the presence has no anchor Motion to
+                    // animate; the nested Motion below is on its own.
+                    V.Div(key: "card", name: "card", children: new VNode[]
+                    {
+                        V.Motion(name: "inner", variants: s_fade,
+                            initial: "hidden", animate: "visible",
+                            transition: new StyleTransitionConfig { DurationSec = 0.3f }),
+                    }),
+                }),
+            });
+        }
+
+        [Test]
+        public void Given_ANonAnchorMotionInsideAPresenceChild_When_Mounted_Then_ItStartsAtItsInitialVariant()
+        {
+            // Arrange / Act — mount the presence subtree; the nested Motion is not the presence's
+            // anchor, so its own initial→animate enter must play (it starts at the initial classes;
+            // the EditMode scheduler never fires the swap, mirroring MotionStandaloneEnterTests).
+            using var mounted = V.Mount(_root, V.Component(WrappedPresence, key: "host"));
+
+            // Assert — the enter was scheduled: the element carries variants[initial]'s classes
+            // instead of mounting directly at rest.
+            Assert.That(_root.Q<VisualElement>("inner").ClassListContains("opacity-0"), Is.True);
+        }
+
+        [Test]
+        public void Given_AnInitialTheEnterCannotResolve_When_Mounted_Then_ItWarnsInsteadOfStayingSilentlyInert()
+        {
+            // Arrange — initial with NO own animate (inherited-label configurations are not yet
+            // driven by the standalone enter), which previously warned and now must again.
+            LogAssert.Expect(LogType.Warning, new System.Text.RegularExpressions.Regex("initial"));
+
+            // Act
+            using var mounted = V.Mount(_root,
+                V.Motion(name: "m", variants: s_fade, initial: "hidden"));
+
+            // Assert — the element mounted; the warning expectation is enforced at test end.
+            Assert.That(_root.Q<VisualElement>("m"), Is.Not.Null);
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/MotionPresenceEnterGateTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/MotionPresenceEnterGateTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: db0d1df32b79c48b7ab5a02c07e74ec7

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/MotionRuntimeSwapTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/MotionRuntimeSwapTests.cs
@@ -1,0 +1,281 @@
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.UIElements;
+using UnityEngine.UIElements.TestFramework;
+using UnityEditor.UIElements.TestFramework;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins the runtime variant-swap path — a mounted Motion whose effective animate label changes,
+    /// directly or through label inheritance — to the SAME transition semantics as mount enters and
+    /// presence exits: the swap must ride the Motion's own <see cref="StyleTransitionConfig"/>
+    /// (inline duration/easing plus any orchestrated stagger delay for tweens; the spring integrator
+    /// for spring configs) instead of applying the class diff instantly and relying on whatever
+    /// transition utilities the element happens to declare. Framer applies <c>transition</c> to
+    /// every animate update, so a config-carrying label flip that snaps is a parity break. Because
+    /// the swap is deferred (not applied inside the patch), an interrupted flip must still settle at
+    /// the latest resting variant with the inline slots released, and a stagger-parked swap must
+    /// survive a keyed reorder's transient detach (the panel-root-host discipline every other
+    /// must-fire timer follows).
+    /// </summary>
+    [TestFixture]
+    internal sealed class MotionRuntimeSwapTests
+    {
+        private static readonly Dictionary<string, string> s_fade = new()
+        {
+            ["hidden"] = "opacity-0",
+            ["visible"] = "opacity-100",
+        };
+
+        private readonly record struct LabelState(string Label);
+
+        private sealed class LabelStore : Store<LabelState>
+        {
+            public LabelStore() : base(new LabelState("hidden")) { }
+            public void Set(string label) => SetState(_ => new LabelState(label));
+            protected override void ResetCore() => SetState(_ => new LabelState("hidden"));
+        }
+
+        private static LabelStore s_labelStore;
+
+        private EditorPanelSimulator _sim;
+        private Reconciler _reconciler;
+
+        [SetUp]
+        public void SetUp()
+        {
+            PanelSimulator.ResetCurrentTime();
+            _sim = new EditorPanelSimulator { panelSize = new Vector2(800, 600) };
+            _sim.ResetTimePerSimulatedFrameToDefault();
+            // The spring case reads resolvedStyle across the swap, so the utility classes the
+            // variants name must actually resolve (opacity-0 -> 0); the inline-slot and class-list
+            // assertions elsewhere don't care, and no element here declares transition utilities.
+            var sheet = AssetDatabase.LoadAssetAtPath<StyleSheet>(
+                "Packages/com.velvet.core/Runtime/Styles/StyleUtilities.uss");
+            Assume.That(sheet, Is.Not.Null, "Precondition: the bundled StyleUtilities.uss loads");
+            _sim.rootVisualElement.styleSheets.Add(sheet);
+            _reconciler = new Reconciler();
+            s_labelStore = null;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _reconciler?.Dispose();
+            _sim?.Dispose();
+            _sim = null;
+        }
+
+        private VisualElement Root => _sim.rootVisualElement;
+
+        private void Tick() => _sim.FrameUpdateMs(16);
+
+        private void AdvancePast(float seconds)
+        {
+            var steps = (int)((seconds + 0.2f) * 1000f / 16f) + 1;
+            for (var i = 0; i < steps; i++) Tick();
+        }
+
+        private static bool InlineDurationIsSet(VisualElement element)
+        {
+            var duration = element.style.transitionDuration;
+            return duration.keyword != StyleKeyword.Null && duration.value != null && duration.value.Count > 0;
+        }
+
+        [Component]
+        private static VNode LabeledBox()
+        {
+            var label = Hooks.UseStore(s_labelStore, s => s.Label);
+            return V.Div(name: "wrap", children: new VNode[]
+            {
+                V.Motion(key: "m", name: "m", variants: s_fade, animate: label,
+                    transition: new StyleTransitionConfig { DurationSec = 0.35f }),
+            });
+        }
+
+        [Component]
+        private static VNode SpringBox()
+        {
+            var label = Hooks.UseStore(s_labelStore, s => s.Label);
+            return V.Div(name: "wrap", children: new VNode[]
+            {
+                V.Motion(key: "m", name: "m", variants: s_fade, animate: label,
+                    transition: new StyleTransitionConfig
+                    {
+                        Type = TransitionType.Spring,
+                        Stiffness = 170f,
+                        Damping = 26f,
+                    }),
+            });
+        }
+
+        [Component]
+        private static VNode StaggeredRow()
+        {
+            var label = Hooks.UseStore(s_labelStore, s => s.Label);
+            return V.Motion(key: "p", name: "p", animate: label,
+                transition: new StyleTransitionConfig { DurationSec = 0.2f, StaggerChildrenSec = 0.5f },
+                children: new VNode[]
+                {
+                    V.Motion(key: "c0", name: "c0", variants: s_fade,
+                        transition: new StyleTransitionConfig { DurationSec = 0.3f }),
+                    V.Motion(key: "c1", name: "c1", variants: s_fade,
+                        transition: new StyleTransitionConfig { DurationSec = 0.3f }),
+                });
+        }
+
+        [Test]
+        public void Given_AMountedMotionWithAConfigDuration_When_ItsAnimateLabelFlips_Then_TheSwapCarriesTheConfigsInlineTransition()
+        {
+            // Arrange — no transition utilities anywhere: the config alone must drive the tween.
+            using var labels = new LabelStore();
+            s_labelStore = labels;
+            using var mounted = V.Mount(Root, V.Component(LabeledBox, key: "root"));
+            var scheduler = mounted.Root.Reconciler.Context.BatchScheduler;
+            Tick();
+
+            // Act — flip the label at runtime.
+            labels.Set("visible");
+            scheduler.DrainImmediateForTest();
+
+            // Assert — the swap rides an inline transition written from the config (Framer applies
+            // `transition` to every animate update); a bare class diff would leave the slot null and
+            // the flip would snap instantly.
+            Assert.That(InlineDurationIsSet(Root.Q<VisualElement>("m")), Is.True);
+        }
+
+        [Test]
+        public void Given_ARuntimeFlipInFlight_When_TheLabelFlipsBack_Then_TheElementSettlesAtTheOriginalVariantWithInlineSlotsReleased()
+        {
+            // Arrange — start hidden -> visible, then reverse before it finishes.
+            using var labels = new LabelStore();
+            s_labelStore = labels;
+            using var mounted = V.Mount(Root, V.Component(LabeledBox, key: "root"));
+            var scheduler = mounted.Root.Reconciler.Context.BatchScheduler;
+            Tick();
+            labels.Set("visible");
+            scheduler.DrainImmediateForTest();
+            Tick();
+
+            // Act — interrupt with the reverse flip, then let everything play out.
+            labels.Set("hidden");
+            scheduler.DrainImmediateForTest();
+            AdvancePast(1.0f);
+
+            // Assert — the element rests at the latest variant (hidden), carries no leftover class
+            // from the interrupted target pose, and the swap's inline transition is released so later
+            // unrelated class changes don't inherit it.
+            var m = Root.Q<VisualElement>("m");
+            Assert.That(
+                (m.ClassListContains("opacity-0"), m.ClassListContains("opacity-100"), InlineDurationIsSet(m)),
+                Is.EqualTo((true, false, false)));
+        }
+
+        [Test]
+        public void Given_AnOrchestratedChildSwap_When_TheCoordinatorFlips_Then_TheSwapTweensOnTheConfigAndFiresOnItsStaggerSlot()
+        {
+            // Arrange — two inheriting children under a staggering coordinator; no transition
+            // utilities, so the children's own configs must drive their tweens.
+            using var labels = new LabelStore();
+            s_labelStore = labels;
+            using var mounted = V.Mount(Root, V.Component(StaggeredRow, key: "root"));
+            var scheduler = mounted.Root.Reconciler.Context.BatchScheduler;
+            Tick();
+
+            // Act — flip the coordinator's label; c0 claims slot 0, c1 claims the 0.5s slot. Sample
+            // between the two slots (128ms) and after both (past 0.5s).
+            labels.Set("visible");
+            scheduler.DrainImmediateForTest();
+            var c1 = Root.Q<VisualElement>("c1");
+            var durationSetAtStart = InlineDurationIsSet(c1);
+            for (var i = 0; i < 8; i++) Tick();
+            var c0SwappedEarly = Root.Q<VisualElement>("c0").ClassListContains("opacity-100");
+            var c1SwappedEarly = c1.ClassListContains("opacity-100");
+            AdvancePast(0.5f);
+            var c1SwappedLate = c1.ClassListContains("opacity-100");
+
+            // Assert — the child's swap rides its config's inline transition, and the stagger delays
+            // the SWAP itself (the target classes land only when the slot elapses) instead of
+            // pre-swapping the classes and parking a CSS delay for utilities that may not exist.
+            Assert.That((durationSetAtStart, c0SwappedEarly, c1SwappedEarly, c1SwappedLate),
+                Is.EqualTo((true, true, false, true)));
+        }
+
+        [Test]
+        public void Given_ASpringConfiguredMotion_When_ItsAnimateLabelFlipsAtRuntime_Then_TheSwapPassesThroughIntermediateOpacity()
+        {
+            // Arrange — a spring config on a mounted Motion; Framer springs every animate update.
+            using var labels = new LabelStore();
+            s_labelStore = labels;
+            using var mounted = V.Mount(Root, V.Component(SpringBox, key: "root"));
+            var scheduler = mounted.Root.Reconciler.Context.BatchScheduler;
+            Tick();
+            var m = Root.Q<VisualElement>("m");
+            Assume.That(m.resolvedStyle.opacity, Is.LessThan(0.05f),
+                "Precondition: the motion rests at the hidden variant");
+
+            // Act — flip the label and tick the panel while the spring integrates.
+            labels.Set("visible");
+            scheduler.DrainImmediateForTest();
+            var sawIntermediate = false;
+            for (var i = 0; i < 60 && !sawIntermediate; i++)
+            {
+                Tick();
+                var opacity = m.resolvedStyle.opacity;
+                if (opacity > 0.05f && opacity < 0.95f)
+                {
+                    sawIntermediate = true;
+                }
+            }
+
+            // Assert — the runtime swap is spring-driven (an instant class diff never shows an
+            // intermediate value).
+            Assert.That(sawIntermediate, Is.True);
+        }
+
+        // Plain (reconciler-driven) orchestration tree for the reorder case, mirroring the keyed
+        // 3-way rotation that transiently detaches the child with the largest parked stagger slot.
+        private static VNode[] StaggerTree(string label, params string[] order)
+        {
+            var children = new VNode[order.Length];
+            for (var i = 0; i < order.Length; i++)
+            {
+                children[i] = V.Motion(key: order[i], name: order[i], variants: s_fade,
+                    transition: new StyleTransitionConfig { DurationSec = 0.15f });
+            }
+            return new VNode[]
+            {
+                V.Motion(key: "p", name: "p", animate: label,
+                    transition: new StyleTransitionConfig { DurationSec = 0.1f, StaggerChildrenSec = 0.3f },
+                    children: children),
+            };
+        }
+
+        [Test]
+        public void Given_AnOrchestratedSwapParkedBehindItsStagger_When_AKeyedReorderTransientlyDetachesTheChild_Then_TheSwapStillReachesTheTargetVariant()
+        {
+            // Arrange — flip the label so c2 (index 2) parks the largest stagger slot (600ms); its
+            // swap has not fired yet when the rotation below transiently detaches it.
+            _reconciler.Reconcile(Root, Array.Empty<VNode>(), StaggerTree("hidden", "c0", "c1", "c2"));
+            _reconciler.Reconcile(Root, StaggerTree("hidden", "c0", "c1", "c2"), StaggerTree("visible", "c0", "c1", "c2"));
+            var c2Detached = false;
+            Root.Q<VisualElement>("c2").RegisterCallback<DetachFromPanelEvent>(_ => c2Detached = true);
+
+            // Act — a keyed rotation inside the parked window, then time advances past the whole
+            // stagger + duration span.
+            _reconciler.Reconcile(Root, StaggerTree("visible", "c0", "c1", "c2"), StaggerTree("visible", "c2", "c0", "c1"));
+            Assume.That(c2Detached, Is.True, "Precondition: the rotation transiently detached the delayed child");
+            AdvancePast(0.6f + 0.15f + 0.5f);
+
+            // Assert — the deferred swap still fired: a swap timer parked on the detached element
+            // itself (rather than the panel-root host) would be silently dropped, freezing the child
+            // at its stale variant forever.
+            Assert.That(Root.Q<VisualElement>("c2").ClassListContains("opacity-100"), Is.True);
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/MotionRuntimeSwapTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/MotionRuntimeSwapTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a213d6c94882e458bb548b7bd3c146cc

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/MotionSimulatedPanelTestsBase.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/MotionSimulatedPanelTestsBase.cs
@@ -1,0 +1,62 @@
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.UIElements;
+using UnityEngine.UIElements.TestFramework;
+using UnityEditor.UIElements.TestFramework;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Shared harness for the Motion enter/orchestration fixtures that need a REAL (simulated) panel: their
+    /// scheduled swap-to-animate and deferred inline-style clears run through
+    /// <c>schedule.Execute().ExecuteLater(ms)</c>, which only fires once a panel ticks its scheduler against its
+    /// own clock — the batchmode EditMode PlayerLoop never does. Owns the simulated panel and a fresh Reconciler
+    /// per test, plus the deterministic frame-advance helpers every such fixture needs, so each one only has to
+    /// declare its own component tree and assertions.
+    /// </summary>
+    /// <remarks>
+    /// Lifecycle methods are <c>virtual</c>; a subclass that needs its own additional per-test reset overrides
+    /// and calls <c>base</c> (see <see cref="MotionStandaloneEnterTests"/>), mirroring
+    /// <c>Velvet.TestUtilities.ReconcilerScope</c>'s <c>ReconcilerTestFixture</c> base. A separate, in-asmdef
+    /// base (rather than extending that one, or the Component-test assembly's own internal simulated-panel
+    /// base) because neither exposes a panel-backed <c>Root</c> a Motion-enter fixture can attach to.
+    /// </remarks>
+    internal abstract class MotionSimulatedPanelTestsBase
+    {
+        private EditorPanelSimulator _sim;
+        protected Reconciler _reconciler;
+
+        [SetUp]
+        public virtual void SetUp()
+        {
+            // Simulated time (and the per-frame step) are process-static and not auto-reset between tests;
+            // reset both so this fixture's frame accounting starts from a known clock regardless of what a
+            // sibling simulator-based fixture left behind.
+            PanelSimulator.ResetCurrentTime();
+            _sim = new EditorPanelSimulator { panelSize = new Vector2(800, 600) };
+            _sim.ResetTimePerSimulatedFrameToDefault();
+            _reconciler = new Reconciler();
+        }
+
+        [TearDown]
+        public virtual void TearDown()
+        {
+            _reconciler?.Dispose();
+            _sim?.Dispose();
+            _sim = null;
+        }
+
+        protected VisualElement Root => _sim.rootVisualElement;
+
+        // One frame (a real-frame-sized scheduler tick).
+        protected void Tick() => _sim.FrameUpdateMs(16);
+
+        // Advances well past the given duration so any scheduled callback due by then fires; the +0.2s margin
+        // absorbs the scheduler's internal grace period without coupling to its exact value.
+        protected void AdvancePast(float seconds)
+        {
+            var steps = (int)((seconds + 0.2f) * 1000f / 16f) + 1;
+            for (var i = 0; i < steps; i++) Tick();
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/MotionSimulatedPanelTestsBase.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/MotionSimulatedPanelTestsBase.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5ff295676d0874137a385c357e139880

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/MotionSpringLifecycleTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/MotionSpringLifecycleTests.cs
@@ -1,0 +1,341 @@
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.UIElements;
+using UnityEngine.UIElements.TestFramework;
+using UnityEditor.UIElements.TestFramework;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins the spring driver's lifecycle against a live (simulated) panel — the coverage the
+    /// panel-free driver units cannot give. A spring must: start once its element is attached (both
+    /// production call sites play the enter BEFORE insertion); play a presence exit regardless of
+    /// <c>DurationSec</c> (documented as ignored for springs, so the exit gate must not key on it);
+    /// leave a resolver-backed resting value (e.g. <c>translate-x-4</c>, inline-only, no USS rule)
+    /// intact after settling; finish its reversal after a cancel that landed before the first tick;
+    /// scrub its inline pose when its subtree is torn down mid-exit (a pooled element must not keep
+    /// receiving tick writes); and complete an exit whose variants animate no spring channel exactly
+    /// once instead of replaying forever against the boundary's per-pass exit bookkeeping.
+    /// </summary>
+    [TestFixture]
+    internal sealed class MotionSpringLifecycleTests
+    {
+        private static readonly Dictionary<string, string> s_fade = new()
+        {
+            ["hidden"] = "opacity-0",
+            ["visible"] = "opacity-100",
+        };
+
+        private static readonly Dictionary<string, string> s_slide = new()
+        {
+            ["hidden"] = "opacity-0",
+            ["visible"] = "opacity-100 translate-x-4",
+        };
+
+        // Colors are not a spring channel: an exit between these labels resolves to an empty plan.
+        private static readonly Dictionary<string, string> s_paint = new()
+        {
+            ["visible"] = "bg-white",
+            ["hidden"] = "bg-black",
+        };
+
+        private readonly record struct SetState(string Keys);
+
+        private sealed class SetStore : Store<SetState>
+        {
+            public SetStore(string initial) : base(new SetState(initial)) { }
+            public void Set(string keys) => SetState(_ => new SetState(keys));
+            protected override void ResetCore() => SetState(_ => new SetState("a"));
+        }
+
+        private readonly record struct ToggleState(bool Show);
+
+        private sealed class ToggleStore : Store<ToggleState>
+        {
+            public ToggleStore() : base(new ToggleState(true)) { }
+            public void Set(bool show) => SetState(_ => new ToggleState(show));
+            protected override void ResetCore() => SetState(_ => new ToggleState(true));
+        }
+
+        private static SetStore s_store;
+        private static ToggleStore s_outerStore;
+        private static Dictionary<string, string> s_hostVariants;
+        private static StyleTransitionConfig s_hostTransition;
+        private static Action s_onExitComplete;
+
+        private EditorPanelSimulator _sim;
+        private Reconciler _reconciler;
+
+        [SetUp]
+        public void SetUp()
+        {
+            PanelSimulator.ResetCurrentTime();
+            _sim = new EditorPanelSimulator { panelSize = new Vector2(800, 600) };
+            _sim.ResetTimePerSimulatedFrameToDefault();
+            _reconciler = new Reconciler();
+            s_store = null;
+            s_outerStore = null;
+            s_hostVariants = null;
+            s_hostTransition = null;
+            s_onExitComplete = null;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _reconciler?.Dispose();
+            _sim?.Dispose();
+            _sim = null;
+        }
+
+        private VisualElement Root => _sim.rootVisualElement;
+
+        private void Tick() => _sim.FrameUpdateMs(16);
+
+        private void AdvancePast(float seconds)
+        {
+            var steps = (int)((seconds + 0.2f) * 1000f / 16f) + 1;
+            for (var i = 0; i < steps; i++) Tick();
+        }
+
+        private static StyleTransitionConfig Spring(float delaySec = 0f) => new()
+        {
+            Type = TransitionType.Spring,
+            Stiffness = 200f,
+            Damping = 26f,
+            DelaySec = delaySec,
+        };
+
+        [Component]
+        private static VNode PresenceHost()
+        {
+            var keys = Hooks.UseStore(s_store, s => s.Keys);
+            var children = new List<VNode>();
+            foreach (var key in keys)
+            {
+                children.Add(V.Motion(name: "item-" + key, key: key.ToString(),
+                    variants: s_hostVariants, animate: "visible", exit: "hidden",
+                    transition: s_hostTransition));
+            }
+            return V.Div(name: "host", children: new VNode[]
+            {
+                V.AnimatePresence(key: "presence", initial: false,
+                    onExitComplete: s_onExitComplete, children: children.ToArray()),
+            });
+        }
+
+        [Component]
+        private static VNode OuterGate()
+        {
+            var show = Hooks.UseStore(s_outerStore, s => s.Show);
+            return V.Div(name: "outer", children: show
+                ? new VNode[] { V.Component(PresenceHost, key: "host") }
+                : Array.Empty<VNode>());
+        }
+
+        [Test]
+        public void Given_AStandaloneSpringEnter_When_ThePanelTicks_Then_TheElementSettlesAtItsAnimatePose()
+        {
+            // Arrange / Act — the enter plays inside CreateElement (detached); the panel then attaches
+            // the element and ticks. The spring must start once attached, not silently give up.
+            _reconciler.Reconcile(Root, Array.Empty<VNode>(), new VNode[]
+            {
+                V.Motion(key: "m", name: "m", variants: s_fade,
+                    initial: "hidden", animate: "visible", transition: Spring()),
+            });
+            var m = Root.Q<VisualElement>("m");
+            Assume.That(m, Is.Not.Null, "Precondition: the motion mounted");
+            AdvancePast(1.5f);
+
+            // Assert — the spring ran to rest instead of freezing at the pinned from-pose.
+            Assert.That(m.resolvedStyle.opacity, Is.EqualTo(1f).Within(1e-2f));
+        }
+
+        [Test]
+        public void Given_ASpringConfigWithDefaultDuration_When_APresenceChildExits_Then_TheGhostStaysWhileTheSpringPlays()
+        {
+            // Arrange — DurationSec is left at its default (documented as ignored for springs).
+            s_hostVariants = s_fade;
+            s_hostTransition = Spring();
+            using var store = new SetStore("a");
+            s_store = store;
+            using var mounted = V.Mount(Root, V.Component(PresenceHost, key: "host"));
+            var scheduler = mounted.Root.Reconciler.Context.BatchScheduler;
+            Tick();
+
+            // Act — remove the key; a spring exit must play, so the ghost stays mounted.
+            store.Set("");
+            scheduler.DrainImmediateForTest();
+
+            // Assert — the child is still present as an exiting ghost, not instant-removed.
+            Assert.AreEqual(1, Root.Q<VisualElement>("host").childCount);
+        }
+
+        [Test]
+        public void Given_ASpringWhoseRestingVariantUsesAResolverValue_When_ItSettles_Then_TheValueIsKept()
+        {
+            // Arrange / Act — translate-x-4 exists only as a resolver-applied inline style (no USS
+            // rule), so the settle path must leave the element at 16px, not clear it to identity.
+            _reconciler.Reconcile(Root, Array.Empty<VNode>(), new VNode[]
+            {
+                V.Motion(key: "m", name: "m", variants: s_slide,
+                    initial: "hidden", animate: "visible", transition: Spring()),
+            });
+            var m = Root.Q<VisualElement>("m");
+            AdvancePast(2f);
+
+            // Assert — the resolver-owned resting translate survives the spring's completion.
+            Assert.That(m.resolvedStyle.translate.x, Is.EqualTo(16f).Within(0.5f));
+        }
+
+        [Test]
+        public void Given_ASpringExitCancelledDuringItsDelay_When_TimeAdvances_Then_TheInlinePoseIsReleased()
+        {
+            // Arrange — the exit parks behind a 0.4s delay; the cancel lands before the first tick.
+            s_hostVariants = s_fade;
+            s_hostTransition = Spring(delaySec: 0.4f);
+            using var store = new SetStore("a");
+            s_store = store;
+            using var mounted = V.Mount(Root, V.Component(PresenceHost, key: "host"));
+            var scheduler = mounted.Root.Reconciler.Context.BatchScheduler;
+            Tick();
+            store.Set("");
+            scheduler.DrainImmediateForTest();
+            Tick();
+
+            // Act — re-add the key inside the delay window, then let any reversal run its course.
+            store.Set("a");
+            scheduler.DrainImmediateForTest();
+            AdvancePast(1.5f);
+
+            // Assert — the cancelled exit's inline pose is fully released (no dead pending entry
+            // pinning stale inline opacity that would mask later class-driven changes).
+            Assert.That(Root.Q<VisualElement>("item-a").style.opacity.keyword,
+                Is.EqualTo(StyleKeyword.Null));
+        }
+
+        [Test]
+        public void Given_AMidExitSpringSubtree_When_ItIsTornDown_Then_TheDetachedElementCarriesNoInlinePose()
+        {
+            // Arrange — a spring exit is in flight when the whole presence subtree unmounts.
+            s_hostVariants = s_fade;
+            s_hostTransition = Spring();
+            using var store = new SetStore("a");
+            s_store = store;
+            using var outer = new ToggleStore();
+            s_outerStore = outer;
+            using var mounted = V.Mount(Root, V.Component(OuterGate, key: "outer"));
+            var scheduler = mounted.Root.Reconciler.Context.BatchScheduler;
+            Tick();
+            store.Set("");
+            scheduler.DrainImmediateForTest();
+            Tick();
+            var item = Root.Q<VisualElement>("item-a");
+            Assume.That(item, Is.Not.Null, "Precondition: the ghost is exiting");
+
+            // Act — tear the subtree down mid-exit (the element heads back to the pool).
+            outer.Set(false);
+            scheduler.DrainImmediateForTest();
+
+            // Assert — teardown scrubs the spring's inline pose immediately; no reversal may keep
+            // ticking styles onto (and eventually null-clearing) a pooled element.
+            Assert.That(item.style.opacity.keyword, Is.EqualTo(StyleKeyword.Null));
+        }
+
+        [Test]
+        public void Given_ASpringExitWithNoAnimatableChannel_When_TheKeyIsRemoved_Then_TheGhostDropsAndExitCompleteFiresOnce()
+        {
+            // Arrange — the exit variant only changes colors (not a spring channel), so the spring
+            // plan is empty and the exit must complete once, not replay against the per-pass
+            // exit bookkeeping forever.
+            s_hostVariants = s_paint;
+            s_hostTransition = new StyleTransitionConfig { Type = TransitionType.Spring, DurationSec = 0.5f };
+            var exitCompleteCalls = 0;
+            s_onExitComplete = () => exitCompleteCalls++;
+            using var store = new SetStore("a");
+            s_store = store;
+            using var mounted = V.Mount(Root, V.Component(PresenceHost, key: "host"));
+            var scheduler = mounted.Root.Reconciler.Context.BatchScheduler;
+            Tick();
+
+            // Act — remove the key and drain several times (the completion re-render included).
+            store.Set("");
+            for (var i = 0; i < 6; i++)
+            {
+                scheduler.DrainImmediateForTest();
+            }
+
+            // Assert — the ghost is gone and onExitComplete fired exactly once (no re-render loop).
+            Assert.That((Root.Q<VisualElement>("host").childCount, exitCompleteCalls),
+                Is.EqualTo((0, 1)));
+        }
+
+        [Test]
+        public void Given_ASpringExitCancelledBeforeItsDelayedTickEverStarted_When_TimeAdvances_Then_NoDeadRetargetLingersForever()
+        {
+            // Arrange — drives StyleAnimationScheduler directly (bypassing AnimatePresence) so this
+            // exercises the scheduler's own cancel discipline on a REAL attached element, independent
+            // of any presence-level exit gating. A 0.4s delay means the recurring tick has not started
+            // (Spring.Tick is still null) by the time the cancel below lands.
+            var scheduler = new StyleAnimationScheduler();
+            var element = new VisualElement();
+            Root.Add(element);
+            element.AddToClassList("opacity-100");
+            var config = new StyleTransitionConfig
+            {
+                Type = TransitionType.Spring,
+                Stiffness = 200f,
+                Damping = 26f,
+                DelaySec = 0.4f,
+                ExitFromClass = "opacity-100",
+                ExitToClass = "opacity-0",
+            };
+            scheduler.PlayExit(element, config, onComplete: null, restoreFromOnCancel: true);
+            Tick();
+            Assume.That(element.style.opacity.keyword, Is.Not.EqualTo(StyleKeyword.Null),
+                "Precondition: the exit's ApplyCurrentValues wrote an inline opacity override");
+
+            // Act — cancel while still parked behind the delay, then let plenty of time pass.
+            scheduler.CancelExit(element);
+            AdvancePast(1.5f);
+
+            // Assert — no dead retarget was parked in the enter map forever: the inline opacity
+            // override the exit's ApplyCurrentValues wrote is released immediately by the cancel
+            // instead of waiting on a tick that nothing would ever start.
+            Assert.That(element.style.opacity.keyword, Is.EqualTo(StyleKeyword.Null));
+        }
+
+        [Test]
+        public void Given_AnActivelyTickingSpringExit_When_CancelledForTeardown_Then_ItNeverHandsOffToAReversal()
+        {
+            // Arrange — no delay, so the panel-root tick is already running (mirrors FiberElementCleaner
+            // tearing an element down mid-exit, before the caller physically detaches it).
+            var scheduler = new StyleAnimationScheduler();
+            var element = new VisualElement();
+            Root.Add(element);
+            element.AddToClassList("opacity-100");
+            var config = new StyleTransitionConfig
+            {
+                Type = TransitionType.Spring,
+                Stiffness = 200f,
+                Damping = 26f,
+                ExitFromClass = "opacity-100",
+                ExitToClass = "opacity-0",
+            };
+            scheduler.PlayExit(element, config, onComplete: null, restoreFromOnCancel: true);
+            Tick();
+            Assume.That(element.style.opacity.keyword, Is.Not.EqualTo(StyleKeyword.Null),
+                "Precondition: the exit's tick is actively writing an inline opacity override");
+
+            // Act — the element is being torn down for good, not merely interrupted.
+            scheduler.CancelExitForTeardown(element);
+
+            // Assert — the teardown cancel finalized immediately instead of parking a reversal whose
+            // recurring tick would keep writing inline styles onto this (about to be pooled) element.
+            Assert.That(element.style.opacity.keyword, Is.EqualTo(StyleKeyword.Null));
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/MotionSpringLifecycleTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/MotionSpringLifecycleTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6775d7b736620427abbc718f18ac4890

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/MotionStandaloneEnterTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/MotionStandaloneEnterTests.cs
@@ -1,10 +1,7 @@
 using System;
 using System.Collections.Generic;
 using NUnit.Framework;
-using UnityEngine;
 using UnityEngine.UIElements;
-using UnityEngine.UIElements.TestFramework;
-using UnityEditor.UIElements.TestFramework;
 
 namespace Velvet.Tests
 {
@@ -19,16 +16,12 @@ namespace Velvet.Tests
     /// state — fires on the next tick and stays afterwards.
     /// </summary>
     /// <remarks>
-    /// Needs a REAL (simulated) panel: the swap-to-animate is driven by
-    /// <c>schedule.Execute().ExecuteLater(ms)</c>, which only fires once a panel ticks its scheduler against its
-    /// clock, and the batchmode EditMode PlayerLoop never does. <see cref="EditorPanelSimulator"/> ticks it
-    /// deterministically instead (see <see cref="Tick"/> / <see cref="AdvancePast"/>). This duplicates the small
-    /// setup Component.Editor's own simulated-panel base wraps, rather than sharing it, because that base is
-    /// internal to a sibling test assembly this fixture's asmdef has no visibility into (Motion enter is a
-    /// Reconciler-owned concern, so this fixture lives alongside the Reconciler test suite instead).
+    /// Needs a REAL (simulated) panel — see <see cref="MotionSimulatedPanelTestsBase"/> — for the scheduled
+    /// swap-to-animate, which only fires once a panel ticks its scheduler against its clock (the batchmode
+    /// EditMode PlayerLoop never does).
     /// </remarks>
     [TestFixture]
-    internal sealed class MotionStandaloneEnterTests
+    internal sealed class MotionStandaloneEnterTests : MotionSimulatedPanelTestsBase
     {
         private const float DurationSec = 0.1f;
 
@@ -38,41 +31,11 @@ namespace Velvet.Tests
             ["visible"] = "opacity-100",
         };
 
-        private EditorPanelSimulator _sim;
-        private Reconciler _reconciler;
-
         [SetUp]
-        public void SetUp()
+        public override void SetUp()
         {
-            // Simulated time (and the per-frame step) are process-static and not auto-reset between tests;
-            // reset both so this fixture's frame accounting starts from a known clock regardless of what a
-            // sibling simulator-based fixture left behind.
-            PanelSimulator.ResetCurrentTime();
-            _sim = new EditorPanelSimulator { panelSize = new Vector2(800, 600) };
-            _sim.ResetTimePerSimulatedFrameToDefault();
-            _reconciler = new Reconciler();
+            base.SetUp();
             s_bump = null;
-        }
-
-        [TearDown]
-        public void TearDown()
-        {
-            _reconciler?.Dispose();
-            _sim?.Dispose();
-            _sim = null;
-        }
-
-        private VisualElement Root => _sim.rootVisualElement;
-
-        // One frame (a real-frame-sized scheduler tick).
-        private void Tick() => _sim.FrameUpdateMs(16);
-
-        // Advances well past the given duration so the scheduled swap-to-animate and its completion timer both
-        // fire; the +0.2s margin absorbs the scheduler's internal grace period without coupling to its exact value.
-        private void AdvancePast(float seconds)
-        {
-            var steps = (int)((seconds + 0.2f) * 1000f / 16f) + 1;
-            for (var i = 0; i < steps; i++) Tick();
         }
 
         [Test]

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/MotionStandaloneEnterTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/MotionStandaloneEnterTests.cs
@@ -1,0 +1,148 @@
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.UIElements;
+using UnityEngine.UIElements.TestFramework;
+using UnityEditor.UIElements.TestFramework;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins Framer parity for a standalone <c>V.Motion(variants:, initial:, animate:)</c> mounted with NO
+    /// AnimatePresence: in Framer Motion, <c>initial</c>/<c>animate</c> drive the mount enter on any
+    /// <c>motion.*</c> component — AnimatePresence is only required to defer an unmount so <c>exit</c> can play
+    /// against it. The standalone enter plays the same variant enter the AnimatePresence expansion drives (compare
+    /// <c>MotionVariantPropagationTests.Given_AMotionWithInitial_When_MountedUnderAnimatePresence_...</c> and
+    /// <c>AnimatePresenceAnimationTests</c>'s "Variant initial" region): the element mounts carrying
+    /// <c>variants[initial]</c>, then the scheduled swap to <c>variants[animate]</c> — its persistent resting
+    /// state — fires on the next tick and stays afterwards.
+    /// </summary>
+    /// <remarks>
+    /// Needs a REAL (simulated) panel: the swap-to-animate is driven by
+    /// <c>schedule.Execute().ExecuteLater(ms)</c>, which only fires once a panel ticks its scheduler against its
+    /// clock, and the batchmode EditMode PlayerLoop never does. <see cref="EditorPanelSimulator"/> ticks it
+    /// deterministically instead (see <see cref="Tick"/> / <see cref="AdvancePast"/>). This duplicates the small
+    /// setup Component.Editor's own simulated-panel base wraps, rather than sharing it, because that base is
+    /// internal to a sibling test assembly this fixture's asmdef has no visibility into (Motion enter is a
+    /// Reconciler-owned concern, so this fixture lives alongside the Reconciler test suite instead).
+    /// </remarks>
+    [TestFixture]
+    internal sealed class MotionStandaloneEnterTests
+    {
+        private const float DurationSec = 0.1f;
+
+        private static readonly Dictionary<string, string> s_fade = new()
+        {
+            ["hidden"] = "opacity-0",
+            ["visible"] = "opacity-100",
+        };
+
+        private EditorPanelSimulator _sim;
+        private Reconciler _reconciler;
+
+        [SetUp]
+        public void SetUp()
+        {
+            // Simulated time (and the per-frame step) are process-static and not auto-reset between tests;
+            // reset both so this fixture's frame accounting starts from a known clock regardless of what a
+            // sibling simulator-based fixture left behind.
+            PanelSimulator.ResetCurrentTime();
+            _sim = new EditorPanelSimulator { panelSize = new Vector2(800, 600) };
+            _sim.ResetTimePerSimulatedFrameToDefault();
+            _reconciler = new Reconciler();
+            s_bump = null;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _reconciler?.Dispose();
+            _sim?.Dispose();
+            _sim = null;
+        }
+
+        private VisualElement Root => _sim.rootVisualElement;
+
+        // One frame (a real-frame-sized scheduler tick).
+        private void Tick() => _sim.FrameUpdateMs(16);
+
+        // Advances well past the given duration so the scheduled swap-to-animate and its completion timer both
+        // fire; the +0.2s margin absorbs the scheduler's internal grace period without coupling to its exact value.
+        private void AdvancePast(float seconds)
+        {
+            var steps = (int)((seconds + 0.2f) * 1000f / 16f) + 1;
+            for (var i = 0; i < steps; i++) Tick();
+        }
+
+        [Test]
+        public void Given_AStandaloneMotionWithInitial_When_Mounted_Then_ItStartsAtTheInitialVariant()
+        {
+            // Arrange / Act — no AnimatePresence anywhere: initial/animate must still drive the mount enter.
+            _reconciler.Reconcile(Root, Array.Empty<VNode>(), new VNode[]
+            {
+                V.Motion(name: "m", variants: s_fade, initial: "hidden", animate: "visible",
+                    transition: new StyleTransitionConfig { DurationSec = DurationSec }),
+            });
+
+            // Assert — starts at variants[initial]=opacity-0; variants[animate]=opacity-100 is stripped during
+            // the from-frame (swapped back in, and kept on completion — see the next two tests).
+            var element = Root.Q<VisualElement>("m");
+            Assert.That((element.ClassListContains("opacity-0"), element.ClassListContains("opacity-100")),
+                Is.EqualTo((true, false)));
+        }
+
+        [Test]
+        public void Given_AStandaloneMotionWithoutInitial_When_Mounted_Then_ItStartsAtTheAnimateVariantWithNoTweenScheduled()
+        {
+            // Arrange / Act — no `initial` declared, so there is no starting pose to enter FROM.
+            _reconciler.Reconcile(Root, Array.Empty<VNode>(), new VNode[]
+            {
+                V.Motion(name: "m", variants: s_fade, animate: "visible",
+                    transition: new StyleTransitionConfig { DurationSec = DurationSec }),
+            });
+
+            // Assert — rests directly at variants[animate], and (unlike the `initial` case above) no transition
+            // was scheduled: no inline transition-duration was ever applied.
+            var element = Root.Q<VisualElement>("m");
+            Assert.That(
+                (element.ClassListContains("opacity-100"), element.style.transitionDuration.keyword),
+                Is.EqualTo((true, StyleKeyword.Null)));
+        }
+
+        private static Action<int> s_bump;
+
+        [Component]
+        private static VNode StandaloneHostRender()
+        {
+            var (_, bump) = Hooks.UseState(0);
+            s_bump = bump;
+            return V.Motion(name: "m", variants: s_fade, initial: "hidden", animate: "visible",
+                transition: new StyleTransitionConfig { DurationSec = DurationSec });
+        }
+
+        [Test]
+        public void Given_AStandaloneMotionThatFinishedEntering_When_AnUnrelatedStateChangeReRenders_Then_ItKeepsTheAnimateVariant()
+        {
+            // Arrange — mount under a component (so a self-contained state update can re-render it), and let
+            // the enter complete: it rests at variants[animate], persistently.
+            using var mounted = V.Mount(Root, V.Component(StandaloneHostRender, key: "host"));
+            AdvancePast(DurationSec);
+            var element = Root.Q<VisualElement>("m");
+            Assume.That(
+                (element.ClassListContains("opacity-100"), element.ClassListContains("opacity-0")),
+                Is.EqualTo((true, false)),
+                "Precondition: the enter completed and rests at variants[animate]");
+
+            // Act — an UNRELATED state change re-renders the same Motion node through PatchMotion (not
+            // CreateElement again), which resolves the applied classes from Animate/ambient only.
+            s_bump.Invoke(1);
+            Tick();
+
+            // Assert — the patch never replays `initial`: the element keeps resting at variants[animate].
+            Assert.That(
+                (element.ClassListContains("opacity-100"), element.ClassListContains("opacity-0")),
+                Is.EqualTo((true, false)));
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/MotionStandaloneEnterTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/MotionStandaloneEnterTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e04dcf20c081945588283958c9499a2a

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/MotionVariantPropagationTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/MotionVariantPropagationTests.cs
@@ -59,7 +59,9 @@ namespace Velvet.Tests
         private static VNode MemoizedIntermediateRender()
         {
             s_memoRenderCount++;
-            return V.Motion(name: "memo-leaf", key: "c", variants: Fade);
+            // transition: None opts out of the runtime-swap tween (see MotionRuntimeSwapTests) so the
+            // class list is checked deterministically right after the flush, independent of animation timing.
+            return V.Motion(name: "memo-leaf", key: "c", variants: Fade, transition: StyleTransitionConfig.None);
         }
 
         // A stateful intermediate component under an animated Motion that renders a child Motion. Its
@@ -334,15 +336,23 @@ namespace Velvet.Tests
         [Test]
         public void Given_AChildInheritingHidden_When_TheParentAnimateChangesToVisible_Then_TheChildVariantClassSwitches()
         {
-            // Arrange — mounted with the parent showing "hidden".
+            // Arrange — mounted with the parent showing "hidden". transition: None opts the child out of the
+            // runtime-swap tween (see MotionRuntimeSwapTests) so the class list is checked deterministically
+            // right after the patch, independent of animation timing.
             using var scope = new ReconcilerScope();
             var hidden = new VNode[]
             {
-                V.Motion(key: "p", animate: "hidden", children: new VNode[] { V.Motion(key: "c", variants: Fade) }),
+                V.Motion(key: "p", animate: "hidden", children: new VNode[]
+                {
+                    V.Motion(key: "c", variants: Fade, transition: StyleTransitionConfig.None),
+                }),
             };
             var visible = new VNode[]
             {
-                V.Motion(key: "p", animate: "visible", children: new VNode[] { V.Motion(key: "c", variants: Fade) }),
+                V.Motion(key: "p", animate: "visible", children: new VNode[]
+                {
+                    V.Motion(key: "c", variants: Fade, transition: StyleTransitionConfig.None),
+                }),
             };
             scope.Reconciler.Reconcile(scope.Root, Array.Empty<VNode>(), hidden);
             Assume.That(scope.Root[0][0].ClassListContains("opacity-0"), Is.True);

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/Velvet.Tests.Reconciler.Editor.asmdef
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/Velvet.Tests.Reconciler.Editor.asmdef
@@ -6,7 +6,9 @@
         "UnityEditor.TestRunner",
         "Velvet",
         "Velvet.TestUtilities",
-        "UniTask"
+        "UniTask",
+        "Unity.UI.TestFramework.Runtime",
+        "Unity.UI.TestFramework.Editor"
     ],
     "includePlatforms": [
         "Editor"

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/MotionEnterPlaybackTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/MotionEnterPlaybackTests.cs
@@ -1,0 +1,101 @@
+#if UNITY_EDITOR
+using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.TestTools;
+using UnityEngine.UIElements;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins that a standalone variant enter (initial -> animate) actually PLAYS on a real runtime
+    /// panel — coverage the EditMode simulator suites cannot give, because their manual batch
+    /// drains run outside the panel's timer tick, which always lands the "next frame" class swap
+    /// one tick after the from-state was computed. On a runtime panel the mount itself runs inside
+    /// (or right before) a timer tick, so a zero-delay swap fires before the panel has computed
+    /// the from-state even once; the transition then sees no property change and the whole enter
+    /// degenerates to an instant jump. A playing enter must pass through intermediate opacity.
+    /// </summary>
+    internal sealed class MotionEnterPlaybackTests
+    {
+        private static readonly Dictionary<string, string> s_fade = new()
+        {
+            ["hidden"] = "opacity-0",
+            ["visible"] = "opacity-100",
+        };
+
+        private GameObject _go;
+        private PanelSettings _settings;
+        private MountedTree _mounted;
+        private int _savedTargetFrameRate;
+
+        [UnitySetUp]
+        public IEnumerator UnitySetUp()
+        {
+            _savedTargetFrameRate = Application.targetFrameRate;
+            Application.targetFrameRate = 120;
+            yield break;
+        }
+
+        [UnityTearDown]
+        public IEnumerator UnityTearDown()
+        {
+            Application.targetFrameRate = _savedTargetFrameRate;
+            _mounted?.Dispose();
+            _mounted = null;
+            if (_go != null) Object.Destroy(_go);
+            if (_settings != null) Object.Destroy(_settings);
+            yield return null;
+        }
+
+        [Component]
+        private static VNode EnterHost()
+        {
+            return V.Div(name: "wrap", children: new VNode[]
+            {
+                V.Motion(key: "m", name: "m", variants: s_fade,
+                    initial: "hidden", animate: "visible",
+                    transition: new StyleTransitionConfig { DurationSec = 0.4f }),
+            });
+        }
+
+        [UnityTest]
+        public IEnumerator Given_AStandaloneVariantEnterOnARuntimePanel_When_FramesAdvance_Then_OpacityPassesThroughAnIntermediateValue()
+        {
+            // Arrange — a real UIDocument panel with the bundled utilities so opacity-0/100 resolve.
+            _go = new GameObject("EnterPlayback");
+            var doc = _go.AddComponent<UIDocument>();
+            _settings = ScriptableObject.CreateInstance<PanelSettings>();
+            _settings.scaleMode = PanelScaleMode.ConstantPixelSize;
+            doc.panelSettings = _settings;
+            yield return null;
+            var sheet = AssetDatabase.LoadAssetAtPath<StyleSheet>(
+                "Packages/com.velvet.core/Runtime/Styles/StyleUtilities.uss");
+            Assume.That(sheet, Is.Not.Null, "Precondition: the bundled StyleUtilities.uss loads");
+            doc.rootVisualElement.styleSheets.Add(sheet);
+
+            // Act — mount, then let the panel run past the whole 0.4s enter while sampling.
+            _mounted = V.Mount(doc.rootVisualElement, V.Component(EnterHost, key: "root"));
+            var m = doc.rootVisualElement.Q<VisualElement>("m");
+            Assume.That(m, Is.Not.Null, "Precondition: the motion mounted");
+            var sawIntermediate = false;
+            var deadline = Time.realtimeSinceStartupAsDouble + 1.0;
+            while (Time.realtimeSinceStartupAsDouble < deadline)
+            {
+                var opacity = m.resolvedStyle.opacity;
+                if (opacity > 0.05f && opacity < 0.95f)
+                {
+                    sawIntermediate = true;
+                }
+                yield return null;
+            }
+
+            // Assert — the enter tweened through the middle instead of snapping straight to the
+            // animate pose (the from-state must survive one style pass so the transition can fire).
+            Assert.That(sawIntermediate, Is.True);
+        }
+    }
+}
+#endif

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/MotionEnterPlaybackTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/MotionEnterPlaybackTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: aece3d97c9e40405cb09a71684aedb60

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/MotionRuntimeSwapPlaybackTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/MotionRuntimeSwapPlaybackTests.cs
@@ -1,0 +1,121 @@
+#if UNITY_EDITOR
+using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.TestTools;
+using UnityEngine.UIElements;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins that a runtime animate-label flip on a mounted Motion actually TWEENS on a real runtime
+    /// panel when only its <see cref="StyleTransitionConfig"/> declares the timing (no transition
+    /// utilities in the class list). Framer applies <c>transition</c> to every animate update; a
+    /// label flip whose class diff lands instantly — because nothing wrote the config's timing to
+    /// the element — snaps to the end pose without ever showing an intermediate value.
+    /// </summary>
+    internal sealed class MotionRuntimeSwapPlaybackTests
+    {
+        private static readonly Dictionary<string, string> s_fade = new()
+        {
+            ["hidden"] = "opacity-0",
+            ["visible"] = "opacity-100",
+        };
+
+        private readonly record struct LabelState(string Label);
+
+        private sealed class LabelStore : Store<LabelState>
+        {
+            public LabelStore() : base(new LabelState("hidden")) { }
+            public void Set(string label) => SetState(_ => new LabelState(label));
+            protected override void ResetCore() => SetState(_ => new LabelState("hidden"));
+        }
+
+        private static LabelStore s_labelStore;
+
+        private GameObject _go;
+        private PanelSettings _settings;
+        private MountedTree _mounted;
+        private LabelStore _store;
+        private int _savedTargetFrameRate;
+
+        [UnitySetUp]
+        public IEnumerator UnitySetUp()
+        {
+            _savedTargetFrameRate = Application.targetFrameRate;
+            Application.targetFrameRate = 120;
+            s_labelStore = null;
+            yield break;
+        }
+
+        [UnityTearDown]
+        public IEnumerator UnityTearDown()
+        {
+            Application.targetFrameRate = _savedTargetFrameRate;
+            _mounted?.Dispose();
+            _mounted = null;
+            _store?.Dispose();
+            _store = null;
+            if (_go != null) Object.Destroy(_go);
+            if (_settings != null) Object.Destroy(_settings);
+            yield return null;
+        }
+
+        [Component]
+        private static VNode SwapHost()
+        {
+            var label = Hooks.UseStore(s_labelStore, s => s.Label);
+            return V.Div(name: "wrap", children: new VNode[]
+            {
+                V.Motion(key: "m", name: "m", variants: s_fade, animate: label,
+                    transition: new StyleTransitionConfig { DurationSec = 0.4f }),
+            });
+        }
+
+        [UnityTest]
+        public IEnumerator Given_ARuntimeAnimateFlipOnARuntimePanel_When_FramesAdvance_Then_OpacityPassesThroughAnIntermediateValue()
+        {
+            // Arrange — a real UIDocument panel with the bundled utilities so opacity-0/100 resolve;
+            // the Motion mounts resting at the hidden variant.
+            _go = new GameObject("RuntimeSwapPlayback");
+            var doc = _go.AddComponent<UIDocument>();
+            _settings = ScriptableObject.CreateInstance<PanelSettings>();
+            _settings.scaleMode = PanelScaleMode.ConstantPixelSize;
+            doc.panelSettings = _settings;
+            yield return null;
+            var sheet = AssetDatabase.LoadAssetAtPath<StyleSheet>(
+                "Packages/com.velvet.core/Runtime/Styles/StyleUtilities.uss");
+            Assume.That(sheet, Is.Not.Null, "Precondition: the bundled StyleUtilities.uss loads");
+            doc.rootVisualElement.styleSheets.Add(sheet);
+            _store = new LabelStore();
+            s_labelStore = _store;
+            _mounted = V.Mount(doc.rootVisualElement, V.Component(SwapHost, key: "root"));
+            var m = doc.rootVisualElement.Q<VisualElement>("m");
+            Assume.That(m, Is.Not.Null, "Precondition: the motion mounted");
+            yield return null;
+            Assume.That(m.resolvedStyle.opacity, Is.LessThan(0.05f),
+                "Precondition: the motion rests at the hidden variant");
+
+            // Act — flip the label at runtime and sample past the whole 0.4s swap.
+            _store.Set("visible");
+            var sawIntermediate = false;
+            var deadline = Time.realtimeSinceStartupAsDouble + 1.0;
+            while (Time.realtimeSinceStartupAsDouble < deadline)
+            {
+                var opacity = m.resolvedStyle.opacity;
+                if (opacity > 0.05f && opacity < 0.95f)
+                {
+                    sawIntermediate = true;
+                }
+                yield return null;
+            }
+
+            // Assert — the flip tweened through the middle on the config's own timing instead of
+            // snapping straight to the animate pose.
+            Assert.That(sawIntermediate, Is.True);
+        }
+    }
+}
+#endif

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/MotionRuntimeSwapPlaybackTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/MotionRuntimeSwapPlaybackTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b9dadeb307370490589f4e6611ac992e

--- a/Packages/com.velvet.core/Runtime/Styling/MotionSpringClassParser.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/MotionSpringClassParser.cs
@@ -1,0 +1,214 @@
+using System.Collections.Generic;
+using UnityEngine.UIElements;
+
+namespace Velvet
+{
+    /// <summary>The style channel a spring transition can drive — see <see cref="MotionSpringClassParser"/>.</summary>
+    internal enum SpringAxis
+    {
+        Opacity,
+        TranslateX,
+        TranslateY,
+        Scale,
+        Rotate,
+    }
+
+    /// <summary>
+    /// Resolves the numeric value a single utility class contributes to a spring-animated channel, and combines
+    /// a variant's from/to class arrays into a <see cref="SpringPlan"/> — WITHOUT reading <c>resolvedStyle</c> or
+    /// touching a panel: <c>StyleAnimationScheduler</c>'s from/to class swap for a spring lands the classes at
+    /// rest immediately (see <see cref="MotionSpringDriver"/>), so there is no "before/after" style-resolution
+    /// window to read values from even if a panel were available — the numeric values have to come from the
+    /// classes' own known definitions instead.
+    /// </summary>
+    /// <remarks>
+    /// Scope: only <see cref="SpringAxis.Opacity"/> and the transform trio (translate x/y in PIXELS, uniform
+    /// scale, rotate degrees) are recognized — matching the utilities <c>_effects.uss</c> / <c>_transforms.uss</c>
+    /// define plus their arbitrary-value/spacing-scale equivalents in <see cref="StyleArbitraryValueResolver"/>.
+    /// A class the parser does not recognize (a color, an arbitrary length on an unrelated property, a
+    /// percentage-based translate like <c>translate-x-1/2</c>/<c>translate-x-full</c>, or a per-axis
+    /// <c>scale-x-</c>/<c>scale-y-</c>) is simply skipped: it still applies as a plain class (untouched by the
+    /// class-swap step), it just is not animated by the spring.
+    /// </remarks>
+    internal static class MotionSpringClassParser
+    {
+        /// <summary>
+        /// A resolved (from, to) pair per channel; null when neither side of the swap named that channel (out of
+        /// scope for this play, or simply unchanged).
+        /// </summary>
+        internal struct SpringPlan
+        {
+            public (float from, float to)? Opacity;
+            public (float from, float to)? TranslateX;
+            public (float from, float to)? TranslateY;
+            public (float from, float to)? Scale;
+            public (float from, float to)? Rotate;
+
+            public bool IsEmpty => Opacity == null && TranslateX == null && TranslateY == null
+                && Scale == null && Rotate == null;
+        }
+
+        // Mirrors _effects.uss's fixed opacity scale exactly (a class outside this exact set has no matching
+        // USS rule, so accepting it here would let the spring settle on a value the cleared inline style would
+        // then NOT reproduce from the cascade).
+        private static readonly Dictionary<string, float> s_opacity = new()
+        {
+            ["opacity-0"] = 0f, ["opacity-5"] = 0.05f, ["opacity-10"] = 0.1f, ["opacity-15"] = 0.15f,
+            ["opacity-20"] = 0.2f, ["opacity-25"] = 0.25f, ["opacity-30"] = 0.3f, ["opacity-35"] = 0.35f,
+            ["opacity-40"] = 0.4f, ["opacity-45"] = 0.45f, ["opacity-50"] = 0.5f, ["opacity-55"] = 0.55f,
+            ["opacity-60"] = 0.6f, ["opacity-65"] = 0.65f, ["opacity-70"] = 0.7f, ["opacity-75"] = 0.75f,
+            ["opacity-80"] = 0.8f, ["opacity-85"] = 0.85f, ["opacity-90"] = 0.9f, ["opacity-95"] = 0.95f,
+            ["opacity-100"] = 1f,
+        };
+
+        // Mirrors _transforms.uss's uniform (non-per-axis) scale scale exactly.
+        private static readonly Dictionary<string, float> s_uniformScale = new()
+        {
+            ["scale-0"] = 0f, ["scale-50"] = 0.5f, ["scale-75"] = 0.75f, ["scale-90"] = 0.9f,
+            ["scale-95"] = 0.95f, ["scale-100"] = 1f, ["scale-105"] = 1.05f, ["scale-110"] = 1.1f,
+            ["scale-125"] = 1.25f, ["scale-150"] = 1.5f,
+        };
+
+        // Mirrors _transforms.uss's positive rotate-N and negative rotate-nN classes exactly.
+        private static readonly Dictionary<string, float> s_rotate = new()
+        {
+            ["rotate-0"] = 0f, ["rotate-1"] = 1f, ["rotate-2"] = 2f, ["rotate-3"] = 3f, ["rotate-6"] = 6f,
+            ["rotate-12"] = 12f, ["rotate-45"] = 45f, ["rotate-90"] = 90f, ["rotate-180"] = 180f,
+            ["rotate-n1"] = -1f, ["rotate-n2"] = -2f, ["rotate-n3"] = -3f, ["rotate-n6"] = -6f,
+            ["rotate-n12"] = -12f, ["rotate-n45"] = -45f, ["rotate-n90"] = -90f, ["rotate-n180"] = -180f,
+        };
+
+        /// <summary>
+        /// Resolves a single class token to the spring channel it touches. Tries the static literal tables
+        /// above first (classes with a REAL static USS rule, so <see cref="StyleArbitraryValueResolver"/>
+        /// deliberately does not parse them), then falls back to
+        /// <see cref="StyleArbitraryValueResolver.TryParse"/> for the bracket/spacing-scale forms that have no
+        /// USS class at all (<c>translate-x-4</c>, <c>-rotate-6</c>, <c>opacity-[.5]</c>, …). Percentage-based
+        /// translate and per-axis scale-x-/scale-y- are recognized by that resolver but rejected here (out of
+        /// scope — see the type doc).
+        /// </summary>
+        internal static bool TryParseAxisValue(string className, out SpringAxis axis, out float value)
+        {
+            axis = default;
+            value = 0f;
+            if (string.IsNullOrEmpty(className))
+            {
+                return false;
+            }
+
+            var core = StyleArbitraryValueResolver.StripImportant(className, out _);
+
+            if (s_opacity.TryGetValue(core, out value))
+            {
+                axis = SpringAxis.Opacity;
+                return true;
+            }
+            if (s_uniformScale.TryGetValue(core, out value))
+            {
+                axis = SpringAxis.Scale;
+                return true;
+            }
+            if (s_rotate.TryGetValue(core, out value))
+            {
+                axis = SpringAxis.Rotate;
+                return true;
+            }
+
+            if (StyleArbitraryValueResolver.TryParse(core, out var arbitrary))
+            {
+                switch (arbitrary.Property)
+                {
+                    case ArbitraryProperty.Opacity:
+                        axis = SpringAxis.Opacity;
+                        value = arbitrary.Value;
+                        return true;
+                    case ArbitraryProperty.Scale:
+                        axis = SpringAxis.Scale;
+                        value = arbitrary.Value;
+                        return true;
+                    case ArbitraryProperty.Rotate:
+                        axis = SpringAxis.Rotate;
+                        value = arbitrary.Value;
+                        return true;
+                    case ArbitraryProperty.TranslateX when arbitrary.Unit == LengthUnit.Pixel:
+                        axis = SpringAxis.TranslateX;
+                        value = arbitrary.Value;
+                        return true;
+                    case ArbitraryProperty.TranslateY when arbitrary.Unit == LengthUnit.Pixel:
+                        axis = SpringAxis.TranslateY;
+                        value = arbitrary.Value;
+                        return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Builds the spring plan for a from/to class-array swap: each channel named by EITHER side is in
+        /// scope, with the un-naming side falling back to that channel's identity value (opacity 1, translate 0,
+        /// scale 1, rotate 0deg) — the common "declare only what changes" authoring style (e.g. a `visible`
+        /// variant that only sets `opacity-100` and relies on the default scale/rotate/position). A resting
+        /// baseline set by some OTHER, unrelated class on the element is not accounted for (undocumented — see
+        /// the type doc's scope note).
+        /// </summary>
+        internal static SpringPlan Resolve(string[]? fromClasses, string[]? toClasses)
+        {
+            float? fromOpacity = null, toOpacity = null;
+            float? fromX = null, toX = null;
+            float? fromY = null, toY = null;
+            float? fromScale = null, toScale = null;
+            float? fromRotate = null, toRotate = null;
+
+            Scan(fromClasses, ref fromOpacity, ref fromX, ref fromY, ref fromScale, ref fromRotate);
+            Scan(toClasses, ref toOpacity, ref toX, ref toY, ref toScale, ref toRotate);
+
+            var plan = new SpringPlan();
+            if (fromOpacity.HasValue || toOpacity.HasValue)
+            {
+                plan.Opacity = (fromOpacity ?? 1f, toOpacity ?? 1f);
+            }
+            if (fromX.HasValue || toX.HasValue || fromY.HasValue || toY.HasValue)
+            {
+                // Translate x/y are independent springs but always compose onto ONE inline `translate`
+                // (UI Toolkit has no separate translateX/translateY style), so once either axis is in scope the
+                // other gets a channel too, pinned at its own identity (0) if it was never named.
+                plan.TranslateX = (fromX ?? 0f, toX ?? 0f);
+                plan.TranslateY = (fromY ?? 0f, toY ?? 0f);
+            }
+            if (fromScale.HasValue || toScale.HasValue)
+            {
+                plan.Scale = (fromScale ?? 1f, toScale ?? 1f);
+            }
+            if (fromRotate.HasValue || toRotate.HasValue)
+            {
+                plan.Rotate = (fromRotate ?? 0f, toRotate ?? 0f);
+            }
+            return plan;
+        }
+
+        private static void Scan(string[]? classes, ref float? opacity, ref float? translateX, ref float? translateY,
+            ref float? scale, ref float? rotate)
+        {
+            if (classes == null)
+            {
+                return;
+            }
+            foreach (var cls in classes)
+            {
+                if (!TryParseAxisValue(cls, out var axis, out var value))
+                {
+                    continue;
+                }
+                switch (axis)
+                {
+                    case SpringAxis.Opacity: opacity = value; break;
+                    case SpringAxis.TranslateX: translateX = value; break;
+                    case SpringAxis.TranslateY: translateY = value; break;
+                    case SpringAxis.Scale: scale = value; break;
+                    case SpringAxis.Rotate: rotate = value; break;
+                }
+            }
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Styling/MotionSpringClassParser.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/MotionSpringClassParser.cs
@@ -150,9 +150,14 @@ namespace Velvet
         /// scale 1, rotate 0deg) — the common "declare only what changes" authoring style (e.g. a `visible`
         /// variant that only sets `opacity-100` and relies on the default scale/rotate/position). A resting
         /// baseline set by some OTHER, unrelated class on the element is not accounted for (undocumented — see
-        /// the type doc's scope note).
+        /// the type doc's scope note), EXCEPT for translate: since translate x/y always compose onto one inline
+        /// style (see below), naming only one axis still forces a channel for the other, and <paramref
+        /// name="restingTranslateX"/> / <paramref name="restingTranslateY"/> — the element's own current inline
+        /// translate, read by the caller before the swap lands — let that forced channel sit at wherever the
+        /// element's OWN (unrelated) classes already put it instead of snapping it to identity.
         /// </summary>
-        internal static SpringPlan Resolve(string[]? fromClasses, string[]? toClasses)
+        internal static SpringPlan Resolve(string[]? fromClasses, string[]? toClasses,
+            float restingTranslateX = 0f, float restingTranslateY = 0f)
         {
             float? fromOpacity = null, toOpacity = null;
             float? fromX = null, toX = null;
@@ -172,9 +177,15 @@ namespace Velvet
             {
                 // Translate x/y are independent springs but always compose onto ONE inline `translate`
                 // (UI Toolkit has no separate translateX/translateY style), so once either axis is in scope the
-                // other gets a channel too, pinned at its own identity (0) if it was never named.
-                plan.TranslateX = (fromX ?? 0f, toX ?? 0f);
-                plan.TranslateY = (fromY ?? 0f, toY ?? 0f);
+                // other gets a channel too. An axis actually named by either side still falls back to identity
+                // on its own un-naming side (the "declare only what changes" rule above); an axis named by
+                // NEITHER side — forced into the plan only because its sibling needed one — pins at the
+                // element's own resting value instead, so a base translate-y-* class the swap never touches
+                // does not get stomped to 0 for the swap's duration.
+                var xNamed = fromX.HasValue || toX.HasValue;
+                plan.TranslateX = xNamed ? (fromX ?? 0f, toX ?? 0f) : (restingTranslateX, restingTranslateX);
+                var yNamed = fromY.HasValue || toY.HasValue;
+                plan.TranslateY = yNamed ? (fromY ?? 0f, toY ?? 0f) : (restingTranslateY, restingTranslateY);
             }
             if (fromScale.HasValue || toScale.HasValue)
             {

--- a/Packages/com.velvet.core/Runtime/Styling/MotionSpringClassParser.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/MotionSpringClassParser.cs
@@ -61,27 +61,12 @@ namespace Velvet
             ["opacity-100"] = 1f,
         };
 
-        // Mirrors _transforms.uss's uniform (non-per-axis) scale scale exactly.
-        private static readonly Dictionary<string, float> s_uniformScale = new()
-        {
-            ["scale-0"] = 0f, ["scale-50"] = 0.5f, ["scale-75"] = 0.75f, ["scale-90"] = 0.9f,
-            ["scale-95"] = 0.95f, ["scale-100"] = 1f, ["scale-105"] = 1.05f, ["scale-110"] = 1.1f,
-            ["scale-125"] = 1.25f, ["scale-150"] = 1.5f,
-        };
-
-        // Mirrors _transforms.uss's positive rotate-N and negative rotate-nN classes exactly.
-        private static readonly Dictionary<string, float> s_rotate = new()
-        {
-            ["rotate-0"] = 0f, ["rotate-1"] = 1f, ["rotate-2"] = 2f, ["rotate-3"] = 3f, ["rotate-6"] = 6f,
-            ["rotate-12"] = 12f, ["rotate-45"] = 45f, ["rotate-90"] = 90f, ["rotate-180"] = 180f,
-            ["rotate-n1"] = -1f, ["rotate-n2"] = -2f, ["rotate-n3"] = -3f, ["rotate-n6"] = -6f,
-            ["rotate-n12"] = -12f, ["rotate-n45"] = -45f, ["rotate-n90"] = -90f, ["rotate-n180"] = -180f,
-        };
-
         /// <summary>
         /// Resolves a single class token to the spring channel it touches. Tries the static literal tables
-        /// above first (classes with a REAL static USS rule, so <see cref="StyleArbitraryValueResolver"/>
-        /// deliberately does not parse them), then falls back to
+        /// first (classes with a REAL static USS rule, so <see cref="StyleArbitraryValueResolver"/>
+        /// deliberately does not parse them) — the opacity scale here, and the uniform scale / rotate
+        /// magnitude shared from <see cref="StyleArbitraryValueResolver"/>'s own preset tables (single-sourced
+        /// rather than a second hand-copied dictionary) — then falls back to
         /// <see cref="StyleArbitraryValueResolver.TryParse"/> for the bracket/spacing-scale forms that have no
         /// USS class at all (<c>translate-x-4</c>, <c>-rotate-6</c>, <c>opacity-[.5]</c>, …). Percentage-based
         /// translate and per-axis scale-x-/scale-y- are recognized by that resolver but rejected here (out of
@@ -103,15 +88,28 @@ namespace Velvet
                 axis = SpringAxis.Opacity;
                 return true;
             }
-            if (s_uniformScale.TryGetValue(core, out value))
+            // Uniform scale-N: the bare suffix mirrors the per-axis scale-x-/scale-y- preset's own numeric
+            // scale exactly, so it is looked up in that same table rather than a duplicate one.
+            if (core.StartsWith("scale-", System.StringComparison.Ordinal)
+                && StyleArbitraryValueResolver.TryGetAxisScale(core.Substring("scale-".Length), out value))
             {
                 axis = SpringAxis.Scale;
                 return true;
             }
-            if (s_rotate.TryGetValue(core, out value))
+            // rotate-N / rotate-nN: the magnitude table is shared with the resolver's own negative-rotate
+            // preset (which only ever stores the unsigned form, negating the negative "-rotate-N" spelling
+            // itself); the sign here is decided by which of the two class spellings this token used.
+            if (core.StartsWith("rotate-", System.StringComparison.Ordinal))
             {
-                axis = SpringAxis.Rotate;
-                return true;
+                var suffix = core.Substring("rotate-".Length);
+                var negated = suffix.StartsWith("n", System.StringComparison.Ordinal);
+                var magnitude = negated ? suffix.Substring(1) : suffix;
+                if (StyleArbitraryValueResolver.TryGetRotateScale(magnitude, out var degrees))
+                {
+                    axis = SpringAxis.Rotate;
+                    value = negated ? -degrees : degrees;
+                    return true;
+                }
             }
 
             if (StyleArbitraryValueResolver.TryParse(core, out var arbitrary))

--- a/Packages/com.velvet.core/Runtime/Styling/MotionSpringClassParser.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Styling/MotionSpringClassParser.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: dd777e1dd676d47aa8965c5904660969

--- a/Packages/com.velvet.core/Runtime/Styling/MotionSpringDriver.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/MotionSpringDriver.cs
@@ -49,9 +49,6 @@ namespace Velvet
         // StyleAnimationScheduler.CancelPending) clears it to null — a reversal settling is not "finishing"
         // anything the original caller asked for.
         public System.Action? OnSettled;
-
-        public bool HasAnyChannel => Opacity != null || TranslateX != null || TranslateY != null
-            || Scale != null || Rotate != null;
     }
 
     /// <summary>
@@ -132,46 +129,37 @@ namespace Velvet
             {
                 var c = state.Opacity;
                 c.Integrator.Step(dtSec, c.Target, state.Stiffness, state.Damping, state.Mass);
-                element.style.opacity = c.Integrator.Value;
                 settled &= c.Integrator.IsSettled(c.Target, NormalizedRestDelta, NormalizedRestSpeed);
             }
-
-            if (state.TranslateX != null || state.TranslateY != null)
+            if (state.TranslateX != null)
             {
-                if (state.TranslateX != null)
-                {
-                    var c = state.TranslateX;
-                    c.Integrator.Step(dtSec, c.Target, state.Stiffness, state.Damping, state.Mass);
-                    settled &= c.Integrator.IsSettled(c.Target, PixelRestDelta, PixelRestSpeed);
-                }
-                if (state.TranslateY != null)
-                {
-                    var c = state.TranslateY;
-                    c.Integrator.Step(dtSec, c.Target, state.Stiffness, state.Damping, state.Mass);
-                    settled &= c.Integrator.IsSettled(c.Target, PixelRestDelta, PixelRestSpeed);
-                }
-                element.style.translate = new Translate(
-                    new Length(state.TranslateX?.Integrator.Value ?? 0f),
-                    new Length(state.TranslateY?.Integrator.Value ?? 0f));
+                var c = state.TranslateX;
+                c.Integrator.Step(dtSec, c.Target, state.Stiffness, state.Damping, state.Mass);
+                settled &= c.Integrator.IsSettled(c.Target, PixelRestDelta, PixelRestSpeed);
             }
-
+            if (state.TranslateY != null)
+            {
+                var c = state.TranslateY;
+                c.Integrator.Step(dtSec, c.Target, state.Stiffness, state.Damping, state.Mass);
+                settled &= c.Integrator.IsSettled(c.Target, PixelRestDelta, PixelRestSpeed);
+            }
             if (state.Scale != null)
             {
                 var c = state.Scale;
                 c.Integrator.Step(dtSec, c.Target, state.Stiffness, state.Damping, state.Mass);
-                var v = c.Integrator.Value;
-                element.style.scale = new Scale(new Vector2(v, v));
                 settled &= c.Integrator.IsSettled(c.Target, NormalizedRestDelta, NormalizedRestSpeed);
             }
-
             if (state.Rotate != null)
             {
                 var c = state.Rotate;
                 c.Integrator.Step(dtSec, c.Target, state.Stiffness, state.Damping, state.Mass);
-                element.style.rotate = new Rotate(Angle.Degrees(c.Integrator.Value));
                 settled &= c.Integrator.IsSettled(c.Target, DegreeRestDelta, DegreeRestSpeed);
             }
 
+            // Every channel's Integrator.Value was just advanced above; re-applying them is exactly what
+            // ApplyCurrentValues already does for the initial (pre-tick) write, so the four style writes live
+            // in exactly one place instead of being duplicated here.
+            ApplyCurrentValues(element, state);
             return settled;
         }
 
@@ -190,13 +178,23 @@ namespace Velvet
         /// <see cref="SpringIntegrator"/> instance is untouched, so its current value/velocity carry over
         /// unbroken; only the goal it steps toward next changes.
         /// </summary>
-        public static void Retarget(MotionSpringState state)
+        public static void Retarget(MotionSpringState state) => ForEachActiveChannel(state, static c => c.Target = c.RestingTarget);
+
+        /// <summary>
+        /// Runs <paramref name="action"/> against whichever of the five optional channels on <paramref
+        /// name="state"/> are active (non-null) — the single place that walks the fixed channel set for the
+        /// callers (like <see cref="Retarget"/>) whose per-channel action does not otherwise depend on WHICH
+        /// channel it is. Not used by <see cref="ApplyCurrentValues"/> / <see cref="Step"/> (each element.style
+        /// write is channel-specific, and translate x/y compose onto one shared inline style) or
+        /// <see cref="ClearInlineOverrides"/> (same translate composition), which stay hand-written.
+        /// </summary>
+        private static void ForEachActiveChannel(MotionSpringState state, System.Action<SpringChannel> action)
         {
-            if (state.Opacity != null) state.Opacity.Target = state.Opacity.RestingTarget;
-            if (state.TranslateX != null) state.TranslateX.Target = state.TranslateX.RestingTarget;
-            if (state.TranslateY != null) state.TranslateY.Target = state.TranslateY.RestingTarget;
-            if (state.Scale != null) state.Scale.Target = state.Scale.RestingTarget;
-            if (state.Rotate != null) state.Rotate.Target = state.Rotate.RestingTarget;
+            if (state.Opacity != null) action(state.Opacity);
+            if (state.TranslateX != null) action(state.TranslateX);
+            if (state.TranslateY != null) action(state.TranslateY);
+            if (state.Scale != null) action(state.Scale);
+            if (state.Rotate != null) action(state.Rotate);
         }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Styling/MotionSpringDriver.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/MotionSpringDriver.cs
@@ -1,0 +1,207 @@
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace Velvet
+{
+    /// <summary>
+    /// One spring-animated channel: an integrator plus the value it is currently heading toward, and the value
+    /// it started from (its resting/pre-animation value, used only by <see cref="MotionSpringDriver.Retarget"/>
+    /// on an exit-cancel hand-off — see <see cref="StyleAnimationScheduler"/>).
+    /// </summary>
+    internal sealed class SpringChannel
+    {
+        public readonly SpringIntegrator Integrator;
+        public float Target;
+        public readonly float RestingTarget;
+
+        public SpringChannel(float initialValue, float target)
+        {
+            Integrator = new SpringIntegrator(initialValue);
+            Target = target;
+            RestingTarget = initialValue;
+        }
+    }
+
+    /// <summary>
+    /// Running state for one spring-driven Motion variant enter/exit: up to five channels (see
+    /// <see cref="SpringAxis"/>; translate x/y are always present together, never alone — see
+    /// <see cref="MotionSpringClassParser.Resolve"/>), the shared stiffness/damping/mass, the recurring tick
+    /// handle, and the completion callback. Owned by <c>StyleAnimationScheduler</c>'s <c>PendingAnimation</c>.
+    /// </summary>
+    internal sealed class MotionSpringState
+    {
+        public SpringChannel? Opacity;
+        public SpringChannel? TranslateX;
+        public SpringChannel? TranslateY;
+        public SpringChannel? Scale;
+        public SpringChannel? Rotate;
+
+        public float Stiffness;
+        public float Damping;
+        public float Mass;
+
+        // Wall-clock time (Time.realtimeSinceStartupAsDouble) as of the previous tick, so each Step call gets
+        // the REAL elapsed interval rather than the scheduler's nominal cadence (see StyleAnimationScheduler's
+        // tick, which mirrors StyleAnimateDriver's own elapsed-time approach).
+        public double LastTickTime;
+
+        // The recurring tick, scheduled on the panel root. Paused (and nulled) once every channel has settled,
+        // or on cancel.
+        public IVisualElementScheduledItem? Tick;
+
+        // Runs once every channel has settled (after the driver has already cleared the inline overrides).
+        // The natural-completion caller sets this to its onComplete; an exit-cancel hand-off (see
+        // StyleAnimationScheduler.CancelPending) clears it to null — a reversal settling is not "finishing"
+        // anything the original caller asked for.
+        public System.Action? OnSettled;
+
+        public bool HasAnyChannel => Opacity != null || TranslateX != null || TranslateY != null
+            || Scale != null || Rotate != null;
+    }
+
+    /// <summary>
+    /// Pure(ish) mechanics for a spring-driven Motion variant enter/exit: builds the per-channel state from a
+    /// resolved <see cref="MotionSpringClassParser.SpringPlan"/>, applies/steps/clears the inline styles a
+    /// channel owns, and retargets on a cancel hand-off. Takes no dependency on scheduling, panels, or the
+    /// enter/exit bookkeeping maps — see <see cref="StyleAnimationScheduler"/> for the piece that decides WHEN to
+    /// start/stop/retarget one of these and owns the actual recurring <c>schedule.Execute</c> tick.
+    /// </summary>
+    internal static class MotionSpringDriver
+    {
+        // Rest epsilons, chosen per channel's natural scale (Framer Motion's own defaults — 0.01 — are tuned for
+        // a roughly 0..1 range; a channel in pixels or degrees needs a proportionally larger pair or it would
+        // spend many extra (imperceptible) ticks converging on a threshold far tighter than the value's scale).
+        private const float NormalizedRestDelta = 0.001f; // opacity / uniform scale (~0..1 / ~1 range)
+        private const float NormalizedRestSpeed = 0.001f;
+        private const float PixelRestDelta = 0.1f; // translate x/y (pixels)
+        private const float PixelRestSpeed = 0.1f;
+        private const float DegreeRestDelta = 0.1f; // rotate (degrees)
+        private const float DegreeRestSpeed = 0.1f;
+
+        /// <summary>
+        /// Builds the running state from a resolved plan, or null when the plan animates nothing (the caller
+        /// should treat this exactly like a zero-duration tween: land the classes and complete immediately).
+        /// </summary>
+        public static MotionSpringState? Create(MotionSpringClassParser.SpringPlan plan, float stiffness, float damping, float mass)
+        {
+            if (plan.IsEmpty)
+            {
+                return null;
+            }
+            var state = new MotionSpringState { Stiffness = stiffness, Damping = damping, Mass = mass };
+            if (plan.Opacity is { } o) state.Opacity = new SpringChannel(o.from, o.to);
+            if (plan.TranslateX is { } tx) state.TranslateX = new SpringChannel(tx.from, tx.to);
+            if (plan.TranslateY is { } ty) state.TranslateY = new SpringChannel(ty.from, ty.to);
+            if (plan.Scale is { } s) state.Scale = new SpringChannel(s.from, s.to);
+            if (plan.Rotate is { } r) state.Rotate = new SpringChannel(r.from, r.to);
+            return state;
+        }
+
+        /// <summary>
+        /// Writes each channel's CURRENT integrator value as an inline style, synchronously — so the element
+        /// shows the from-pose on the very first rendered frame instead of flashing at the (already-applied)
+        /// resting classes' value until the first tick runs.
+        /// </summary>
+        public static void ApplyCurrentValues(VisualElement element, MotionSpringState state)
+        {
+            if (state.Opacity != null)
+            {
+                element.style.opacity = state.Opacity.Integrator.Value;
+            }
+            if (state.TranslateX != null || state.TranslateY != null)
+            {
+                element.style.translate = new Translate(
+                    new Length(state.TranslateX?.Integrator.Value ?? 0f),
+                    new Length(state.TranslateY?.Integrator.Value ?? 0f));
+            }
+            if (state.Scale != null)
+            {
+                var v = state.Scale.Integrator.Value;
+                element.style.scale = new Scale(new Vector2(v, v));
+            }
+            if (state.Rotate != null)
+            {
+                element.style.rotate = new Rotate(Angle.Degrees(state.Rotate.Integrator.Value));
+            }
+        }
+
+        /// <summary>
+        /// Steps every active channel by <paramref name="dtSec"/> and re-applies the inline styles. Returns true
+        /// once EVERY channel has settled at its (possibly retargeted) target.
+        /// </summary>
+        public static bool Step(VisualElement element, MotionSpringState state, float dtSec)
+        {
+            var settled = true;
+
+            if (state.Opacity != null)
+            {
+                var c = state.Opacity;
+                c.Integrator.Step(dtSec, c.Target, state.Stiffness, state.Damping, state.Mass);
+                element.style.opacity = c.Integrator.Value;
+                settled &= c.Integrator.IsSettled(c.Target, NormalizedRestDelta, NormalizedRestSpeed);
+            }
+
+            if (state.TranslateX != null || state.TranslateY != null)
+            {
+                if (state.TranslateX != null)
+                {
+                    var c = state.TranslateX;
+                    c.Integrator.Step(dtSec, c.Target, state.Stiffness, state.Damping, state.Mass);
+                    settled &= c.Integrator.IsSettled(c.Target, PixelRestDelta, PixelRestSpeed);
+                }
+                if (state.TranslateY != null)
+                {
+                    var c = state.TranslateY;
+                    c.Integrator.Step(dtSec, c.Target, state.Stiffness, state.Damping, state.Mass);
+                    settled &= c.Integrator.IsSettled(c.Target, PixelRestDelta, PixelRestSpeed);
+                }
+                element.style.translate = new Translate(
+                    new Length(state.TranslateX?.Integrator.Value ?? 0f),
+                    new Length(state.TranslateY?.Integrator.Value ?? 0f));
+            }
+
+            if (state.Scale != null)
+            {
+                var c = state.Scale;
+                c.Integrator.Step(dtSec, c.Target, state.Stiffness, state.Damping, state.Mass);
+                var v = c.Integrator.Value;
+                element.style.scale = new Scale(new Vector2(v, v));
+                settled &= c.Integrator.IsSettled(c.Target, NormalizedRestDelta, NormalizedRestSpeed);
+            }
+
+            if (state.Rotate != null)
+            {
+                var c = state.Rotate;
+                c.Integrator.Step(dtSec, c.Target, state.Stiffness, state.Damping, state.Mass);
+                element.style.rotate = new Rotate(Angle.Degrees(c.Integrator.Value));
+                settled &= c.Integrator.IsSettled(c.Target, DegreeRestDelta, DegreeRestSpeed);
+            }
+
+            return settled;
+        }
+
+        /// <summary>Clears every inline override this state ever wrote, letting the (already-resting) classes take back over.</summary>
+        public static void ClearInlineOverrides(VisualElement element, MotionSpringState state)
+        {
+            if (state.Opacity != null) element.style.opacity = StyleKeyword.Null;
+            if (state.TranslateX != null || state.TranslateY != null) element.style.translate = StyleKeyword.Null;
+            if (state.Scale != null) element.style.scale = StyleKeyword.Null;
+            if (state.Rotate != null) element.style.rotate = StyleKeyword.Null;
+        }
+
+        /// <summary>
+        /// Re-targets every active channel toward the value it STARTED from (see
+        /// <see cref="SpringChannel.RestingTarget"/>) — the exit-cancel hand-off. Each channel's
+        /// <see cref="SpringIntegrator"/> instance is untouched, so its current value/velocity carry over
+        /// unbroken; only the goal it steps toward next changes.
+        /// </summary>
+        public static void Retarget(MotionSpringState state)
+        {
+            if (state.Opacity != null) state.Opacity.Target = state.Opacity.RestingTarget;
+            if (state.TranslateX != null) state.TranslateX.Target = state.TranslateX.RestingTarget;
+            if (state.TranslateY != null) state.TranslateY.Target = state.TranslateY.RestingTarget;
+            if (state.Scale != null) state.Scale.Target = state.Scale.RestingTarget;
+            if (state.Rotate != null) state.Rotate.Target = state.Rotate.RestingTarget;
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Styling/MotionSpringDriver.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/MotionSpringDriver.cs
@@ -40,11 +40,6 @@ namespace Velvet
         public float Damping;
         public float Mass;
 
-        // Wall-clock time (Time.realtimeSinceStartupAsDouble) as of the previous tick, so each Step call gets
-        // the REAL elapsed interval rather than the scheduler's nominal cadence (see StyleAnimationScheduler's
-        // tick, which mirrors StyleAnimateDriver's own elapsed-time approach).
-        public double LastTickTime;
-
         // The recurring tick, scheduled on the panel root. Paused (and nulled) once every channel has settled,
         // or on cancel.
         public IVisualElementScheduledItem? Tick;

--- a/Packages/com.velvet.core/Runtime/Styling/MotionSpringDriver.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/MotionSpringDriver.cs
@@ -10,7 +10,11 @@ namespace Velvet
     /// </summary>
     internal sealed class SpringChannel
     {
-        public readonly SpringIntegrator Integrator;
+        // Deliberately NOT readonly: SpringIntegrator is a mutable struct embedded inline (see its own doc), and
+        // every Step call mutates it in place through this field. Marking the field readonly would make the
+        // compiler silently invoke Step on a defensive COPY instead — the spring would never advance, only
+        // ever reporting its initial value forever.
+        public SpringIntegrator Integrator;
         public float Target;
         public readonly float RestingTarget;
 

--- a/Packages/com.velvet.core/Runtime/Styling/MotionSpringDriver.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Styling/MotionSpringDriver.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6a71a2a10e15b461abf8da7c77c174db

--- a/Packages/com.velvet.core/Runtime/Styling/SpringIntegrator.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/SpringIntegrator.cs
@@ -17,8 +17,16 @@ namespace Velvet
     /// between calls, so the SAME instance keeps its current value and velocity — the physical continuity an
     /// interrupted spring needs (e.g. an AnimatePresence exit that gets cancelled hands off to a reversal
     /// spring built from wherever the exit currently was, not from a fresh rest state).
+    /// <para>
+    /// A mutable struct, not a class: <see cref="SpringChannel"/> embeds one inline (as a plain, non-readonly
+    /// field — see its own doc) instead of holding a separate heap reference, so a spring channel costs one
+    /// allocation instead of two. <see cref="Step"/> mutates <see cref="Value"/>/<see cref="Velocity"/> in
+    /// place, so every caller must reach an instance through an addressable field/variable (never through a
+    /// property or a <c>readonly</c> field of this type) or the mutation lands on a silent defensive copy
+    /// instead of the real one.
+    /// </para>
     /// </remarks>
-    internal sealed class SpringIntegrator
+    internal struct SpringIntegrator
     {
         // A single large hitch (a dropped frame, a GC pause, the editor regaining focus) must not make the
         // spring "jump": integrating a huge dt in one step can overshoot wildly or numerically blow up. Capping

--- a/Packages/com.velvet.core/Runtime/Styling/SpringIntegrator.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/SpringIntegrator.cs
@@ -1,0 +1,73 @@
+using UnityEngine;
+
+namespace Velvet
+{
+    /// <summary>
+    /// A single damped-harmonic-oscillator spring, integrated one step at a time via semi-implicit Euler
+    /// (velocity is updated from the current acceleration FIRST, then position is advanced using the
+    /// already-updated velocity — unconditionally stable for the stiffness/damping ranges a UI transition
+    /// uses, unlike explicit Euler). Pure math: holds only <see cref="Value"/> / <see cref="Velocity"/>, takes
+    /// every other input (target, stiffness, damping, mass) per <see cref="Step"/> call, and has no dependency
+    /// on a <c>VisualElement</c> or panel — see <see cref="MotionSpringDriver"/> for the piece that applies a
+    /// per-channel instance of this to a Motion's animated style properties.
+    /// </summary>
+    /// <remarks>
+    /// Retargeting mid-flight (calling <see cref="Step"/> with a different <c>target</c> than the previous
+    /// call) is intentionally just a normal call: <see cref="Value"/> / <see cref="Velocity"/> are never reset
+    /// between calls, so the SAME instance keeps its current value and velocity — the physical continuity an
+    /// interrupted spring needs (e.g. an AnimatePresence exit that gets cancelled hands off to a reversal
+    /// spring built from wherever the exit currently was, not from a fresh rest state).
+    /// </remarks>
+    internal sealed class SpringIntegrator
+    {
+        // A single large hitch (a dropped frame, a GC pause, the editor regaining focus) must not make the
+        // spring "jump": integrating a huge dt in one step can overshoot wildly or numerically blow up. Capping
+        // dt means a hitch just looks like a few frames of slightly slower motion instead.
+        private const float MaxDtSec = 1f / 30f;
+
+        // A non-positive mass would divide by zero (or flip the sign of the restoring force); clamp to a tiny
+        // positive epsilon so a misconfigured Mass degrades to "very heavy" instead of producing NaN/Infinity.
+        private const float MinMass = 1e-4f;
+
+        /// <summary>The spring's current value.</summary>
+        public float Value { get; private set; }
+
+        /// <summary>The spring's current velocity (units of <see cref="Value"/> per second).</summary>
+        public float Velocity { get; private set; }
+
+        public SpringIntegrator(float initialValue, float initialVelocity = 0f)
+        {
+            Value = initialValue;
+            Velocity = initialVelocity;
+        }
+
+        /// <summary>
+        /// Advances the spring by one tick toward <paramref name="target"/>. <paramref name="dtSec"/> is clamped
+        /// to <see cref="MaxDtSec"/> (a no-op or negative dt does nothing). Semi-implicit Euler:
+        /// <c>velocity += ((-stiffness*(value-target) - damping*velocity) / mass) * dt; value += velocity * dt;</c>
+        /// </summary>
+        public void Step(float dtSec, float target, float stiffness, float damping, float mass)
+        {
+            if (dtSec <= 0f)
+            {
+                return;
+            }
+            var dt = Mathf.Min(dtSec, MaxDtSec);
+            var safeMass = Mathf.Max(mass, MinMass);
+            var acceleration = (-stiffness * (Value - target) - (damping * Velocity)) / safeMass;
+            Velocity += acceleration * dt;
+            Value += Velocity * dt;
+        }
+
+        /// <summary>
+        /// True once the spring is close enough to <paramref name="target"/>, in both position and speed, to
+        /// treat as settled. The default epsilons (Framer Motion's own defaults) suit a roughly 0..1-scale value
+        /// (opacity, a uniform scale factor); a caller animating a pixel or degree-scale channel should pass a
+        /// larger, scale-appropriate pair (see <see cref="MotionSpringDriver"/>'s per-channel epsilons).
+        /// </summary>
+        public bool IsSettled(float target, float restDelta = 0.01f, float restSpeed = 0.01f)
+        {
+            return Mathf.Abs(Value - target) <= restDelta && Mathf.Abs(Velocity) <= restSpeed;
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Styling/SpringIntegrator.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Styling/SpringIntegrator.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 533f2f2d776ae4dd0bbbc727400f9ae1

--- a/Packages/com.velvet.core/Runtime/Styling/StyleAnimateDriver.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleAnimateDriver.cs
@@ -33,7 +33,9 @@ namespace Velvet
     internal static class StyleAnimateDriver
     {
         // Tick interval (~60fps). The phase is time-derived, so the exact cadence only affects smoothness.
-        private const long TickMs = 16;
+        // Internal: shared with StyleAnimationScheduler's spring tick and shadow co-fade tick, which want the
+        // SAME ~60fps cadence rather than a second (or third) hand-copied literal.
+        internal const long TickMs = 16;
         // Oversize factor for the Gradient pan: the background is twice the box along the pan axis, so the
         // box window slides across the full gradient (offset range [-box, 0]) without revealing an edge.
         private const float GradientOversize = 200f;

--- a/Packages/com.velvet.core/Runtime/Styling/StyleAnimationScheduler.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleAnimationScheduler.cs
@@ -30,6 +30,12 @@ namespace Velvet
 
         private readonly Dictionary<VisualElement, PendingAnimation> _pendingExits = new();
         private readonly Dictionary<VisualElement, PendingAnimation> _pendingEnters = new();
+        // Plain class-diff variant swaps (parent→child label propagation, staggerChildren/delayChildren — see
+        // PlayDelayedVariantSwap) awaiting their deferred inline transition-delay clear. Separate from the
+        // enter/exit maps above: a delayed swap has no from/to class lifecycle of its own (the class diff
+        // already happened via SyncClassDrivenStyling before this is called), so PendingAnimation's
+        // enter/exit-only fields would all sit unused.
+        private readonly Dictionary<VisualElement, PendingDelayedSwap> _pendingDelayedSwaps = new();
         private readonly Stack<List<TimeValue>> _durationPool = new();
         private readonly Stack<List<TimeValue>> _delayPool = new();
 
@@ -334,11 +340,90 @@ namespace Velvet
         // Whether the given element is currently exiting.
         public bool IsExiting(VisualElement element) => _pendingExits.ContainsKey(element);
 
+        // Applies an ADDITIONAL inline transition-delay to a plain class-diff variant swap — the parent→child
+        // label-propagation path (FiberNodePatcher.PatchMotion's staggerChildren/delayChildren orchestration),
+        // which swaps classes directly with no enter/exit lifecycle of its own and no transition-property:all
+        // override, relying on the element's OWN utility classes (e.g. transition-opacity duration-300) to
+        // declare whatever is to be delayed. totalDelaySec is this swap's FULL transition-delay (the Motion's
+        // own configured DelaySec plus any staggerChildren/delayChildren orchestration offset — the caller
+        // already added them); durationSec is that swap's own transition duration, used only to size the
+        // deferred clear below. A non-positive totalDelaySec is a no-op.
+        // The delay is cleared once the swap's transition would have finished, so a LATER, unrelated patch on
+        // the same element does not inherit a stale delay. On a real panel the clear is deferred via
+        // schedule.Execute (mirrors PlayEnter/PlayExit's own completion timing); off-panel there is nothing to
+        // interpolate against, and schedule.Execute never fires for a detached element, so the delay is never
+        // applied in the first place instead of setting up a schedule that would never run — net-equivalent to
+        // CancelExit's reversal cleanup, which clears an already-applied delay immediately off-panel for the
+        // same reason.
+        public void PlayDelayedVariantSwap(VisualElement? element, float totalDelaySec, float durationSec)
+        {
+            if (element == null || totalDelaySec <= 0f)
+            {
+                return;
+            }
+
+            // Cancel any previous still-parked delay on this element first, so an interrupted stagger (a second
+            // label flip before the first swap's grace period elapsed) does not leave a stale timer racing
+            // this one's clear (also covers a rare case where an ON-panel schedule was parked and the element
+            // has since gone off-panel: schedule.Execute never fires for a detached element, so that stale
+            // entry would otherwise leak).
+            CancelDelayedVariantSwap(element);
+
+            if (element.panel == null)
+            {
+                // Nothing to interpolate without a panel, and schedule.Execute never fires for a detached
+                // element, so there is nothing worth setting in the first place — mirrors CancelExit's
+                // off-panel-immediate-clear rule for a reversal cleanup.
+                return;
+            }
+
+            var delayMs = (int)(totalDelaySec * 1000);
+            var delayList = RentDelayList(delayMs);
+            element.style.transitionDelay = delayList;
+            var pending = new PendingDelayedSwap { DelayList = delayList };
+            var timeoutMs = (long)(totalDelaySec * 1000) + (long)(durationSec * 1000) + AnimationGraceMs;
+            var timeout = element.schedule.Execute(() =>
+            {
+                if (_pendingDelayedSwaps.Remove(element, out var completed))
+                {
+                    element.style.transitionDelay = StyleKeyword.Null;
+                    ReturnDelayList(completed.DelayList);
+                }
+            });
+            timeout.ExecuteLater(timeoutMs);
+            pending.TimeoutItem = timeout;
+            _pendingDelayedSwaps[element] = pending;
+        }
+
+        // Cancels a still-parked delayed-swap clear (superseded by a follow-up swap, or the element being torn
+        // down) and clears the inline transition-delay immediately. Safe to call when none is pending (no-op).
+        public void CancelDelayedVariantSwap(VisualElement element)
+        {
+            if (_pendingDelayedSwaps.Remove(element, out var pending))
+            {
+                pending.TimeoutItem?.Pause();
+                element.style.transitionDelay = StyleKeyword.Null;
+                ReturnDelayList(pending.DelayList);
+            }
+        }
+
         // Cancels every animation and removes the applied CSS classes and inline styles.
         public void CancelAll()
         {
             CancelAllInMap(_pendingExits);
             CancelAllInMap(_pendingEnters);
+            CancelAllDelayedSwaps();
+        }
+
+        private void CancelAllDelayedSwaps()
+        {
+            foreach (var (element, pending) in _pendingDelayedSwaps)
+            {
+                pending.TimeoutItem?.Pause();
+                element.style.transitionDelay = StyleKeyword.Null;
+                ReturnDelayList(pending.DelayList);
+            }
+            _pendingDelayedSwaps.Clear();
         }
 
         private static bool ValidateDuration(float durationSec, Action? onComplete)
@@ -784,6 +869,16 @@ namespace Velvet
             // never fires it, so it must be unregistered on cancel — otherwise it (and the closure pinning this
             // PendingAnimation) lingers on the element, surviving even pool reuse. Null for on-panel exits.
             public EventCallback<AttachToPanelEvent>? PendingAttach;
+        }
+
+        // State for a delayed variant swap's pending inline transition-delay clear (see
+        // PlayDelayedVariantSwap). Deliberately separate from PendingAnimation, which carries enter/exit-only
+        // fields (FromClasses/ToClasses/Shadows/PendingAttach/…) that a plain class-diff swap — having no
+        // lifecycle of its own beyond "clear this one inline style later" — never needs.
+        private sealed class PendingDelayedSwap
+        {
+            public IVisualElementScheduledItem? TimeoutItem;
+            public List<TimeValue>? DelayList;
         }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Styling/StyleAnimationScheduler.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleAnimationScheduler.cs
@@ -396,7 +396,13 @@ namespace Velvet
             float delaySec, float stiffness, float damping, float mass, Action? onComplete, float additionalDelaySec,
             Dictionary<VisualElement, PendingAnimation> map, string[]? restingClasses, bool isExit)
         {
-            var plan = MotionSpringClassParser.Resolve(fromClasses, toClasses);
+            // Read BEFORE the class swap below lands: the element's own current inline translate is whatever
+            // its UNRELATED (non-swapped) classes rested it at — e.g. a base translate-y-8 alongside a
+            // variant pair that only touches translate-x. Used as the resting value for a translate axis the
+            // swap names on neither side (see Resolve's own doc).
+            var restingTranslate = element.style.translate.value;
+            var plan = MotionSpringClassParser.Resolve(fromClasses, toClasses,
+                restingTranslate.x.value, restingTranslate.y.value);
             // An invalid configuration (see ValidateSpringParameters) degrades exactly like an empty plan
             // below: no state is built, so the shared "land the classes, complete immediately" branch handles
             // it without a separate code path.
@@ -430,6 +436,16 @@ namespace Velvet
                 AnimatingElement = element,
                 Spring = state,
             };
+            // Co-fade drop-shadows with the spring exactly like the tween paths (PlayEnterInternal / PlayExit):
+            // register this play as a shadow driver at the from-value NOW (synchronously, before the spring
+            // ever ticks) so there is no first-frame flash, then the recurring tick — started alongside the
+            // spring's own tick in StartSpringTick — samples the caster's opacity each frame so descendant
+            // shadows track it exactly as they do a tween. isExit selects the same start value PlayExit uses (1
+            // = opaque, the resting state before fading out); a standalone enter always starts invisible (0),
+            // mirroring PlayEnterInternal — matching those hardcoded values (rather than reading the spring's
+            // own opacity channel, which may not even exist for a translate/scale/rotate-only play) keeps a
+            // spring's shadow behavior identical to a tween's for the same enter/exit direction.
+            pending.Shadows = CollectShadowsForCoFade(element, pending, isExit ? 1f : 0f);
             state.OnSettled = onComplete;
             map[element] = pending;
             pending.OwningMap = map;
@@ -506,6 +522,11 @@ namespace Velvet
                 return;
             }
 
+            // The spring's own physics tick is now live — start sampling the caster's opacity each frame
+            // (StartShadowCoFadeTick) so co-faded descendant shadows track it exactly like a tween's, from the
+            // same moment its CSS transition would have started firing.
+            StartShadowCoFadeTick(pending);
+
             state.Tick = host.schedule.Execute((TimerState ts) =>
             {
                 // TimerState.start is the previous callback's time for a repeating item (or the schedule time
@@ -530,10 +551,36 @@ namespace Velvet
                 {
                     pending.OwningMap.Remove(element);
                 }
-                EndShadowCoFade(pending); // No-op: a spring-driven entry never registers a shadow co-fade driver.
+                // Target is at rest now — stop the co-fade and restore the shadows to full strength (a no-op
+                // when this subtree carries none, the common case).
+                EndShadowCoFade(pending);
                 MotionSpringDriver.ClearInlineOverrides(element, state);
+                ReapplySpringOwnedInlineValues(element);
                 state.OnSettled?.Invoke();
             }).Every(SpringTickMs);
+        }
+
+        // MotionSpringDriver.ClearInlineOverrides nulls whichever style slots the spring wrote (opacity /
+        // translate / scale / rotate), letting the cascade take back over — but a class the element still
+        // carries can OWN one of those same slots as a resolver-applied inline value with no USS rule behind
+        // it at all (translate-x-4, translate-x-[100px], opacity-[.5] — see MotionSpringClassParser's own scope
+        // note: translate has no USS form whatsoever), so clearing the slot loses that value instead of letting
+        // it fall back to a cascade rule that does not exist. DiffClassList only re-applies such a value when a
+        // class REMOVAL triggers it; nothing removes a class here (the swap already landed its classes back
+        // when the spring started), so nobody else re-asserts it. Re-read the element's OWN current class list
+        // and re-apply whatever inline-resolved values it still names, mirroring
+        // FiberWrapperElementAppliers.RestoreSharedInlineSlot's identical problem for the animate-* motions.
+        private static void ReapplySpringOwnedInlineValues(VisualElement element)
+        {
+            List<string>? classes = null;
+            foreach (var cls in element.GetClasses())
+            {
+                (classes ??= new List<string>()).Add(cls);
+            }
+            if (classes != null)
+            {
+                FiberNodePatcher.ReapplyArbitraryValues(element, classes.ToArray());
+            }
         }
 
         // Cancels the exit animation on the given element and removes the applied CSS classes; the
@@ -852,6 +899,7 @@ namespace Velvet
                         spring.Tick?.Pause();
                         spring.Tick = null;
                         MotionSpringDriver.ClearInlineOverrides(element, spring);
+                        ReapplySpringOwnedInlineValues(element);
                     }
                     return;
                 }
@@ -951,6 +999,7 @@ namespace Velvet
                     // a spring entry, which never touches transition-* styles or rents a TimeValue list).
                     pending.Spring.Tick?.Pause();
                     MotionSpringDriver.ClearInlineOverrides(element, pending.Spring);
+                    ReapplySpringOwnedInlineValues(element);
                 }
                 ClearTransitionStyles(element);
                 ReturnDurationList(pending.DurationList);

--- a/Packages/com.velvet.core/Runtime/Styling/StyleAnimationScheduler.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleAnimationScheduler.cs
@@ -167,8 +167,13 @@ namespace Velvet
                 StartShadowCoFadeTick(pending);
 
                 // Step 3: after the duration, clear inline styles. Classic enter also removes the transient
-                // to-classes; variantMode KEEPS them (they are the persistent resting variant).
-                var durationMs = (long)(durationSec * 1000) + (long)(delaySec * 1000) + AnimationGraceMs;
+                // to-classes; variantMode KEEPS them (they are the persistent resting variant). Sized from the
+                // SLOWEST animating property (SlowestPropertyTimeoutMs) rather than just the top-level
+                // durationSec/delaySec: PropertyOverrides can give one property a longer duration than the
+                // top-level value, and completing on the top-level timing alone would clear the inline
+                // transition-duration (snapping the still-mid-tween slower property to its resting value) before
+                // it actually finishes.
+                var durationMs = (long)SlowestPropertyTimeoutMs(durationList, delayList) + AnimationGraceMs;
                 var timeout = element.schedule.Execute(() =>
                 {
                     if (_pendingEnters.Remove(element, out var completed))
@@ -314,8 +319,12 @@ namespace Velvet
                     // reconcile-reorder detach of the exiting ghost, which is why the host is the panel root).
                     StartShadowCoFadeTick(pending);
 
-                    // Step 3: invoke onComplete after the duration.
-                    var durationMs = (long)(config.DurationSec * 1000) + (long)(config.DelaySec * 1000) + AnimationGraceMs;
+                    // Step 3: invoke onComplete after the duration. Sized from the SLOWEST animating property
+                    // (SlowestPropertyTimeoutMs) rather than just the top-level DurationSec/DelaySec: a variant
+                    // exit's PropertyOverrides can give one property a longer duration than the top-level value,
+                    // and completing on the top-level timing alone would drop the ghost — removing its element —
+                    // while that slower property is still mid-tween.
+                    var durationMs = (long)SlowestPropertyTimeoutMs(durationList, delayList) + AnimationGraceMs;
                     var timeout = host.schedule.Execute(() =>
                     {
                         if (_pendingExits.Remove(element, out var completed))
@@ -939,7 +948,7 @@ namespace Velvet
                 DurationList = pending.DurationList,
                 DelayList = pending.DelayList,
             };
-            var timeoutMs = MaxReversalTimeoutMs(pending.DurationList, pending.DelayList);
+            var timeoutMs = SlowestPropertyTimeoutMs(pending.DurationList, pending.DelayList);
             var timeout = element.schedule.Execute(() =>
             {
                 if (_pendingEnters.Remove(element))
@@ -954,13 +963,17 @@ namespace Velvet
             _pendingEnters[element] = reversal;
         }
 
-        // How long the reversal must stay alive before it is safe to clear the inline transition styles: the
-        // SLOWEST animating property's delay + duration. For the single-entry case (no PropertyOverrides) that
-        // is just duration[0] + delay[0], same as before; PropertyOverrides can give each property its own
-        // duration / delay, so an interrupted variant exit's reversal must wait for whichever one finishes
-        // last, not just the first, or a slower property's transition-duration would be cleared (snapping it to
-        // the resting value) while it is still mid-tween.
-        private static float MaxReversalTimeoutMs(List<TimeValue>? durationList, List<TimeValue>? delayList)
+        // How long a tween must stay alive before it is safe to clear the inline transition styles / fire
+        // completion: the SLOWEST animating property's delay + duration. For the single-entry case (no
+        // PropertyOverrides) that is just duration[0] + delay[0], same as a plain top-level DurationSec/DelaySec;
+        // PropertyOverrides can give each property its own duration / delay, so an interrupted reversal, and an
+        // enter/exit's own completion, must both wait for whichever property finishes last, not just the first
+        // (or the first-declared) one — otherwise a slower property's transition-duration gets cleared (snapping
+        // it to the resting value, or dropping the ghost) while it is still mid-tween. Shared by
+        // ScheduleReversalCleanup (a cancelled exit's reversal) and PlayEnterInternal / PlayExit's own
+        // completion timeout, all three of which already hold the exact duration/delay lists ApplyTransitionStyles
+        // built for this play, so the slowest-property computation only has to live here once.
+        private static float SlowestPropertyTimeoutMs(List<TimeValue>? durationList, List<TimeValue>? delayList)
         {
             if (durationList is not { Count: > 0 })
             {

--- a/Packages/com.velvet.core/Runtime/Styling/StyleAnimationScheduler.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleAnimationScheduler.cs
@@ -31,12 +31,6 @@ namespace Velvet
 
         private readonly Dictionary<VisualElement, PendingAnimation> _pendingExits = new();
         private readonly Dictionary<VisualElement, PendingAnimation> _pendingEnters = new();
-        // Plain class-diff variant swaps (parent→child label propagation, staggerChildren/delayChildren — see
-        // PlayDelayedVariantSwap) awaiting their deferred inline transition-delay clear. Separate from the
-        // enter/exit maps above: a delayed swap has no from/to class lifecycle of its own (the class diff
-        // already happened via SyncClassDrivenStyling before this is called), so PendingAnimation's
-        // enter/exit-only fields would all sit unused.
-        private readonly Dictionary<VisualElement, PendingDelayedSwap> _pendingDelayedSwaps = new();
         private readonly Stack<List<TimeValue>> _durationPool = new();
         private readonly Stack<List<TimeValue>> _delayPool = new();
 
@@ -133,13 +127,6 @@ namespace Velvet
 
             // Cancel any existing enter animation.
             CancelEnter(element);
-            // Take ownership of the inline transition-delay slot: a parked orchestration swap (plain
-            // parent→child staggerChildren/delayChildren propagation — see PlayDelayedVariantSwap) may have
-            // left a stale delay sitting on this SAME element. This enter is about to become the sole owner of
-            // that slot (ApplyTransitionStyles below only WRITES it when its own delaySec > 0, so a zero-delay
-            // enter would otherwise silently inherit the stale value instead of starting immediately), and the
-            // parked clear must not fire later and null a delay this enter itself goes on to set.
-            CancelDelayedVariantSwap(element);
 
             var staggerDelayMs = (long)(additionalDelaySec * 1000);
 
@@ -169,71 +156,105 @@ namespace Velvet
             pending.Shadows = CollectShadowsForCoFade(element, pending, 0f);
             _pendingEnters[element] = pending;
 
-            // schedule.Execute does not fire when the panel is disconnected, but CancelEnter is invoked
-            // via Reconciler.RemoveElement / CleanupDescendants, so the dictionary does not leak.
-            var startAction = new Action(() =>
+            // Schedules the deferred swap (and its own completion timeout) on the PANEL-ROOT host, not the
+            // entering element itself — mirrors PlayExit's identical ScheduleOnHost: a keyed reorder can
+            // transiently detach an already-attached element (RemoveFromHierarchy + re-Insert), and UI Toolkit
+            // silently drops a detached element's own scheduled items, which would stall the enter forever (or,
+            // for a stagger claimed from an ancestor's orchestration, drop the claimed delay's clear entirely).
+            // The element only needs to stay attached for its OWN CSS transition to keep tweening — it does, a
+            // reorder moves it, never removes it.
+            void ScheduleOnHost()
             {
-                if (!_pendingEnters.ContainsKey(element))
+                // Superseded before it ever got to schedule (a cancel-before-attach removed this exact pending).
+                if (!_pendingEnters.TryGetValue(element, out var cur) || !ReferenceEquals(cur, pending))
                 {
                     return;
                 }
 
-                StyleAnimationClassUtils.RemoveClasses(element, fromClasses);
-                StyleAnimationClassUtils.AddClasses(element, toClasses);
-                // The CSS opacity transition is now firing — start sampling the caster's opacity each frame so
-                // descendant shadows fade in lockstep with it.
-                StartShadowCoFadeTick(pending);
-
-                // Step 3: after the duration, clear inline styles. Classic enter also removes the transient
-                // to-classes; variantMode KEEPS them (they are the persistent resting variant). Sized from the
-                // SLOWEST animating property (SlowestPropertyTimeoutMs) rather than just the top-level
-                // durationSec/delaySec: PropertyOverrides can give one property a longer duration than the
-                // top-level value, and completing on the top-level timing alone would clear the inline
-                // transition-duration (snapping the still-mid-tween slower property to its resting value) before
-                // it actually finishes.
-                var durationMs = (long)SlowestPropertyTimeoutMs(durationList, delayList) + AnimationGraceMs;
-                var timeout = element.schedule.Execute(() =>
+                var panel = element.panel;
+                if (panel == null)
                 {
-                    if (_pendingEnters.Remove(element, out var completed))
-                    {
-                        if (!variantMode)
-                        {
-                            StyleAnimationClassUtils.RemoveClasses(element, toClasses);
-                        }
-                        // Target is opaque now — stop the co-fade and restore the shadows to full strength.
-                        EndShadowCoFade(completed);
-                        ClearTransitionStyles(element);
-                        ReturnDurationList(completed.DurationList);
-                        ReturnDelayList(completed.DelayList);
-                        onComplete?.Invoke();
-                    }
-                });
-                timeout.ExecuteLater(durationMs);
-                pending.TimeoutItem = timeout;
-            });
+                    return;
+                }
+                var host = panel.visualTree;
 
-            if (staggerDelayMs > 0)
+                var startAction = new Action(() =>
+                {
+                    if (!_pendingEnters.ContainsKey(element))
+                    {
+                        return;
+                    }
+
+                    StyleAnimationClassUtils.RemoveClasses(element, fromClasses);
+                    StyleAnimationClassUtils.AddClasses(element, toClasses);
+                    // The CSS opacity transition is now firing — start sampling the caster's opacity each frame so
+                    // descendant shadows fade in lockstep with it.
+                    StartShadowCoFadeTick(pending);
+
+                    // Step 3: after the duration, clear inline styles. Classic enter also removes the transient
+                    // to-classes; variantMode KEEPS them (they are the persistent resting variant). Sized from the
+                    // SLOWEST animating property (SlowestPropertyTimeoutMs) rather than just the top-level
+                    // durationSec/delaySec: PropertyOverrides can give one property a longer duration than the
+                    // top-level value, and completing on the top-level timing alone would clear the inline
+                    // transition-duration (snapping the still-mid-tween slower property to its resting value) before
+                    // it actually finishes.
+                    var durationMs = (long)SlowestPropertyTimeoutMs(durationList, delayList) + AnimationGraceMs;
+                    var timeout = host.schedule.Execute(() =>
+                    {
+                        if (_pendingEnters.Remove(element, out var completed))
+                        {
+                            if (!variantMode)
+                            {
+                                StyleAnimationClassUtils.RemoveClasses(element, toClasses);
+                            }
+                            // Target is opaque now — stop the co-fade and restore the shadows to full strength.
+                            EndShadowCoFade(completed);
+                            ClearTransitionStyles(element);
+                            ReturnDurationList(completed.DurationList);
+                            ReturnDelayList(completed.DelayList);
+                            onComplete?.Invoke();
+                        }
+                    });
+                    timeout.ExecuteLater(durationMs);
+                    pending.TimeoutItem = timeout;
+                });
+
+                if (staggerDelayMs > 0)
+                {
+                    // With extra delay: start after staggerDelayMs.
+                    var scheduled = host.schedule.Execute(startAction);
+                    scheduled.ExecuteLater(staggerDelayMs);
+                    pending.ScheduledItem = scheduled;
+                }
+                else
+                {
+                    // No extra delay: still deferred by one nominal frame (StyleAnimateDriver.TickMs)
+                    // rather than a zero-delay schedule.Execute. This call runs from inside the same
+                    // timer tick that mounts the element (a standalone Motion's create, or an
+                    // AnimatePresence-driven enter), and a zero-delay item becomes runnable within that
+                    // very tick — before the panel has resolved the from-state's style even once. With
+                    // nothing to compare against, the CSS transition sees no property change and the
+                    // whole enter snaps straight to the end pose instead of tweening. A same-tick swap is
+                    // possible with any deferral shorter than roughly a frame, so a full nominal frame is
+                    // used instead of a token 1ms: it reliably survives the from-state's first style pass
+                    // at any practical frame rate while still landing on (about) the very next update.
+                    var scheduled = host.schedule.Execute(startAction);
+                    scheduled.ExecuteLater(StyleAnimateDriver.TickMs);
+                    pending.ScheduledItem = scheduled;
+                }
+            }
+
+            // A stable host only exists once the element is attached. Off-panel at call time is the COMMON
+            // case here — a standalone Motion's mount enter plays inside CreateElement, before the element is
+            // inserted into the tree — so defer scheduling until attach, exactly like PlayExit's own off-panel
+            // branch below.
+            if (element.panel != null)
             {
-                // With extra delay: start after staggerDelayMs.
-                var scheduled = element.schedule.Execute(startAction);
-                scheduled.ExecuteLater(staggerDelayMs);
-                pending.ScheduledItem = scheduled;
+                ScheduleOnHost();
             }
             else
             {
-                // No extra delay: still deferred by one nominal frame (StyleAnimateDriver.TickMs)
-                // rather than a zero-delay schedule.Execute. This call runs from inside the same
-                // timer tick that mounts the element (a standalone Motion's create, or an
-                // AnimatePresence-driven enter), and a zero-delay item becomes runnable within that
-                // very tick — before the panel has resolved the from-state's style even once. With
-                // nothing to compare against, the CSS transition sees no property change and the
-                // whole enter snaps straight to the end pose instead of tweening. A same-tick swap is
-                // possible with any deferral shorter than roughly a frame, so a full nominal frame is
-                // used instead of a token 1ms: it reliably survives the from-state's first style pass
-                // at any practical frame rate while still landing on (about) the very next update.
-                var scheduled = element.schedule.Execute(startAction);
-                scheduled.ExecuteLater(StyleAnimateDriver.TickMs);
-                pending.ScheduledItem = scheduled;
+                DeferUntilAttached(element, pending, ScheduleOnHost);
             }
         }
 
@@ -278,13 +299,6 @@ namespace Velvet
 
             // Cancel any existing exit animation.
             CancelExit(element);
-            // Take ownership of the inline transition-delay slot: see PlayEnterInternal's identical call
-            // above for the failure this prevents. Concretely, a DelaySec=0 variant exit racing a just-parked
-            // orchestration delay would otherwise inherit it invisibly (ApplyTransitionStyles below never
-            // WRITES transition-delay when this exit's own delaySec is <= 0, so the stale value would survive
-            // untouched) while the completion timeout below is sized from THIS exit's own (unaware) duration —
-            // dropping the ghost before the actually-delayed CSS transition ever visibly starts.
-            CancelDelayedVariantSwap(element);
 
             var fromClasses = config.ExitFromClasses;
             var toClasses = config.ExitToClasses;
@@ -459,12 +473,6 @@ namespace Velvet
             // Cancel any existing animation of this SAME flavor first (mirrors PlayEnterInternal's
             // CancelEnter(element) / PlayExit's CancelExit(element) self-cancel).
             CancelPending(map, element, animateReversal: isExit);
-            // Take ownership of the inline transition-delay slot exactly like the tween paths above: a spring
-            // never reads transition-delay itself (delaySec below only offsets ScheduleStart's own timer), but
-            // a stale parked swap sharing this element would otherwise clear out from under this play whenever
-            // its own timeout happens to fire, and the element should not carry a transition-delay left over
-            // from a class swap this new play has nothing to do with.
-            CancelDelayedVariantSwap(element);
 
             // Land the classes at rest either way — nothing recognized to animate (or invalid spring
             // parameters) degrades to a plain, instantaneous class swap (the spring equivalent of a
@@ -674,96 +682,11 @@ namespace Velvet
         // Whether the given element is currently exiting.
         public bool IsExiting(VisualElement element) => _pendingExits.ContainsKey(element);
 
-        // Applies an ADDITIONAL inline transition-delay to a plain class-diff variant swap — the parent→child
-        // label-propagation path (FiberNodePatcher.PatchMotion's staggerChildren/delayChildren orchestration),
-        // which swaps classes directly with no enter/exit lifecycle of its own and no transition-property:all
-        // override, relying on the element's OWN utility classes (e.g. transition-opacity duration-300) to
-        // declare whatever is to be delayed. totalDelaySec is this swap's FULL transition-delay (the Motion's
-        // own configured DelaySec plus any staggerChildren/delayChildren orchestration offset — the caller
-        // already added them); durationSec is that swap's own transition duration, used only to size the
-        // deferred clear below. A non-positive totalDelaySec is a no-op.
-        // The delay is cleared once the swap's transition would have finished, so a LATER, unrelated patch on
-        // the same element does not inherit a stale delay. On a real panel the clear is scheduled on the
-        // PANEL-ROOT host, not the element itself (mirrors PlayExit's own ScheduleOnHost rationale): a keyed
-        // reorder can transiently detach this element (RemoveFromHierarchy + re-Insert) while the delay is
-        // still parked, and UI Toolkit silently drops a detached element's own scheduled items, which would
-        // strand the inline transition-delay on it forever. Off-panel there is nothing to interpolate against,
-        // and schedule.Execute never fires for a detached element, so the delay is never applied in the first
-        // place instead of setting up a schedule that would never run — net-equivalent to CancelExit's
-        // reversal cleanup, which clears an already-applied delay immediately off-panel for the same reason.
-        public void PlayDelayedVariantSwap(VisualElement? element, float totalDelaySec, float durationSec)
-        {
-            if (element == null || totalDelaySec <= 0f)
-            {
-                return;
-            }
-
-            // Cancel any previous still-parked delay on this element first, so an interrupted stagger (a second
-            // label flip before the first swap's grace period elapsed) does not leave a stale timer racing
-            // this one's clear (also covers a rare case where an ON-panel schedule was parked and the element
-            // has since gone off-panel: schedule.Execute never fires for a detached element, so that stale
-            // entry would otherwise leak).
-            CancelDelayedVariantSwap(element);
-
-            if (element.panel == null)
-            {
-                // Nothing to interpolate without a panel, and schedule.Execute never fires for a detached
-                // element, so there is nothing worth setting in the first place — mirrors CancelExit's
-                // off-panel-immediate-clear rule for a reversal cleanup.
-                return;
-            }
-
-            var delayMs = (int)(totalDelaySec * 1000);
-            var delayList = RentDelayList(delayMs);
-            element.style.transitionDelay = delayList;
-            var pending = new PendingDelayedSwap { DelayList = delayList };
-            var timeoutMs = (long)(totalDelaySec * 1000) + (long)(durationSec * 1000) + AnimationGraceMs;
-            // The panel root never detaches during the tree's life, so its scheduled items always fire; the
-            // element being delayed only needs to stay attached for its OWN CSS transition (it does — a keyed
-            // reorder moves it, never removes it), matching PlayExit's stable-host argument exactly.
-            var host = element.panel.visualTree;
-            var timeout = host.schedule.Execute(() =>
-            {
-                if (_pendingDelayedSwaps.Remove(element, out var completed))
-                {
-                    element.style.transitionDelay = StyleKeyword.Null;
-                    ReturnDelayList(completed.DelayList);
-                }
-            });
-            timeout.ExecuteLater(timeoutMs);
-            pending.TimeoutItem = timeout;
-            _pendingDelayedSwaps[element] = pending;
-        }
-
-        // Cancels a still-parked delayed-swap clear (superseded by a follow-up swap, or the element being torn
-        // down) and clears the inline transition-delay immediately. Safe to call when none is pending (no-op).
-        public void CancelDelayedVariantSwap(VisualElement element)
-        {
-            if (_pendingDelayedSwaps.Remove(element, out var pending))
-            {
-                pending.TimeoutItem?.Pause();
-                element.style.transitionDelay = StyleKeyword.Null;
-                ReturnDelayList(pending.DelayList);
-            }
-        }
-
         // Cancels every animation and removes the applied CSS classes and inline styles.
         public void CancelAll()
         {
             CancelAllInMap(_pendingExits);
             CancelAllInMap(_pendingEnters);
-            CancelAllDelayedSwaps();
-        }
-
-        private void CancelAllDelayedSwaps()
-        {
-            foreach (var (element, pending) in _pendingDelayedSwaps)
-            {
-                pending.TimeoutItem?.Pause();
-                element.style.transitionDelay = StyleKeyword.Null;
-                ReturnDelayList(pending.DelayList);
-            }
-            _pendingDelayedSwaps.Clear();
         }
 
         private static bool ValidateDuration(float durationSec, Action? onComplete)
@@ -1306,14 +1229,5 @@ namespace Velvet
             public MotionSpringState? Spring;
         }
 
-        // State for a delayed variant swap's pending inline transition-delay clear (see
-        // PlayDelayedVariantSwap). Deliberately separate from PendingAnimation, which carries enter/exit-only
-        // fields (FromClasses/ToClasses/Shadows/PendingAttach/…) that a plain class-diff swap — having no
-        // lifecycle of its own beyond "clear this one inline style later" — never needs.
-        private sealed class PendingDelayedSwap
-        {
-            public IVisualElementScheduledItem? TimeoutItem;
-            public List<TimeValue>? DelayList;
-        }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Styling/StyleAnimationScheduler.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleAnimationScheduler.cs
@@ -122,6 +122,13 @@ namespace Velvet
 
             // Cancel any existing enter animation.
             CancelEnter(element);
+            // Take ownership of the inline transition-delay slot: a parked orchestration swap (plain
+            // parent→child staggerChildren/delayChildren propagation — see PlayDelayedVariantSwap) may have
+            // left a stale delay sitting on this SAME element. This enter is about to become the sole owner of
+            // that slot (ApplyTransitionStyles below only WRITES it when its own delaySec > 0, so a zero-delay
+            // enter would otherwise silently inherit the stale value instead of starting immediately), and the
+            // parked clear must not fire later and null a delay this enter itself goes on to set.
+            CancelDelayedVariantSwap(element);
 
             var staggerDelayMs = (long)(additionalDelaySec * 1000);
 
@@ -249,6 +256,13 @@ namespace Velvet
 
             // Cancel any existing exit animation.
             CancelExit(element);
+            // Take ownership of the inline transition-delay slot: see PlayEnterInternal's identical call
+            // above for the failure this prevents. Concretely, a DelaySec=0 variant exit racing a just-parked
+            // orchestration delay would otherwise inherit it invisibly (ApplyTransitionStyles below never
+            // WRITES transition-delay when this exit's own delaySec is <= 0, so the stale value would survive
+            // untouched) while the completion timeout below is sized from THIS exit's own (unaware) duration —
+            // dropping the ghost before the actually-delayed CSS transition ever visibly starts.
+            CancelDelayedVariantSwap(element);
 
             var fromClasses = config.ExitFromClasses;
             var toClasses = config.ExitToClasses;
@@ -422,6 +436,12 @@ namespace Velvet
             // Cancel any existing animation of this SAME flavor first (mirrors PlayEnterInternal's
             // CancelEnter(element) / PlayExit's CancelExit(element) self-cancel).
             CancelPending(map, element, animateReversal: isExit);
+            // Take ownership of the inline transition-delay slot exactly like the tween paths above: a spring
+            // never reads transition-delay itself (delaySec below only offsets ScheduleStart's own timer), but
+            // a stale parked swap sharing this element would otherwise clear out from under this play whenever
+            // its own timeout happens to fire, and the element should not carry a transition-delay left over
+            // from a class swap this new play has nothing to do with.
+            CancelDelayedVariantSwap(element);
 
             // Land the classes at rest either way — nothing recognized to animate (or invalid spring
             // parameters) degrades to a plain, instantaneous class swap (the spring equivalent of a
@@ -624,12 +644,14 @@ namespace Velvet
         // already added them); durationSec is that swap's own transition duration, used only to size the
         // deferred clear below. A non-positive totalDelaySec is a no-op.
         // The delay is cleared once the swap's transition would have finished, so a LATER, unrelated patch on
-        // the same element does not inherit a stale delay. On a real panel the clear is deferred via
-        // schedule.Execute (mirrors PlayEnter/PlayExit's own completion timing); off-panel there is nothing to
-        // interpolate against, and schedule.Execute never fires for a detached element, so the delay is never
-        // applied in the first place instead of setting up a schedule that would never run — net-equivalent to
-        // CancelExit's reversal cleanup, which clears an already-applied delay immediately off-panel for the
-        // same reason.
+        // the same element does not inherit a stale delay. On a real panel the clear is scheduled on the
+        // PANEL-ROOT host, not the element itself (mirrors PlayExit's own ScheduleOnHost rationale): a keyed
+        // reorder can transiently detach this element (RemoveFromHierarchy + re-Insert) while the delay is
+        // still parked, and UI Toolkit silently drops a detached element's own scheduled items, which would
+        // strand the inline transition-delay on it forever. Off-panel there is nothing to interpolate against,
+        // and schedule.Execute never fires for a detached element, so the delay is never applied in the first
+        // place instead of setting up a schedule that would never run — net-equivalent to CancelExit's
+        // reversal cleanup, which clears an already-applied delay immediately off-panel for the same reason.
         public void PlayDelayedVariantSwap(VisualElement? element, float totalDelaySec, float durationSec)
         {
             if (element == null || totalDelaySec <= 0f)
@@ -657,7 +679,11 @@ namespace Velvet
             element.style.transitionDelay = delayList;
             var pending = new PendingDelayedSwap { DelayList = delayList };
             var timeoutMs = (long)(totalDelaySec * 1000) + (long)(durationSec * 1000) + AnimationGraceMs;
-            var timeout = element.schedule.Execute(() =>
+            // The panel root never detaches during the tree's life, so its scheduled items always fire; the
+            // element being delayed only needs to stay attached for its OWN CSS transition (it does — a keyed
+            // reorder moves it, never removes it), matching PlayExit's stable-host argument exactly.
+            var host = element.panel.visualTree;
+            var timeout = host.schedule.Execute(() =>
             {
                 if (_pendingDelayedSwaps.Remove(element, out var completed))
                 {

--- a/Packages/com.velvet.core/Runtime/Styling/StyleAnimationScheduler.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleAnimationScheduler.cs
@@ -221,8 +221,19 @@ namespace Velvet
             }
             else
             {
-                // No extra delay: run on the next frame (matches existing behavior).
-                pending.ScheduledItem = element.schedule.Execute(startAction);
+                // No extra delay: still deferred by one nominal frame (StyleAnimateDriver.TickMs)
+                // rather than a zero-delay schedule.Execute. This call runs from inside the same
+                // timer tick that mounts the element (a standalone Motion's create, or an
+                // AnimatePresence-driven enter), and a zero-delay item becomes runnable within that
+                // very tick — before the panel has resolved the from-state's style even once. With
+                // nothing to compare against, the CSS transition sees no property change and the
+                // whole enter snaps straight to the end pose instead of tweening. A same-tick swap is
+                // possible with any deferral shorter than roughly a frame, so a full nominal frame is
+                // used instead of a token 1ms: it reliably survives the from-state's first style pass
+                // at any practical frame rate while still landing on (about) the very next update.
+                var scheduled = element.schedule.Execute(startAction);
+                scheduled.ExecuteLater(StyleAnimateDriver.TickMs);
+                pending.ScheduledItem = scheduled;
             }
         }
 

--- a/Packages/com.velvet.core/Runtime/Styling/StyleAnimationScheduler.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleAnimationScheduler.cs
@@ -1,6 +1,7 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
+using UnityEngine;
 using UnityEngine.UIElements;
 
 namespace Velvet
@@ -17,6 +18,8 @@ namespace Velvet
         private const long AnimationGraceMs = 50;
         private const float MaxDurationSec = 10f;
         private const int MaxPoolSize = 16;
+        // Spring tick interval (~60fps), matching the shadow co-fade tick and StyleAnimateDriver's own cadence.
+        private const long SpringTickMs = 16;
 
         // Static cache from EasingMode to List<EasingFunction>. EasingMode values are finite, so caching is safe.
         private static readonly Dictionary<EasingMode, List<EasingFunction>> s_easingCache = new();
@@ -54,6 +57,18 @@ namespace Velvet
                 return;
             }
 
+            if (config.Type == TransitionType.Spring)
+            {
+                // Reachable only in principle: a classic (non-variant) transition's EnterFromClass/EnterToClass
+                // are internal-setter-only, so a caller-authored spring config passed here has none set and this
+                // no-ops to an immediate complete (see StartSpringVariant) — kept for completeness/symmetry with
+                // PlayVariantEnter / PlayExit rather than silently ignoring Type on this call path.
+                StartSpringVariant(element, config.EnterFromClasses, config.EnterToClasses, config.DelaySec,
+                    config.Stiffness, config.Damping, config.Mass, onComplete, additionalDelaySec,
+                    _pendingEnters, restingClasses: null, isExit: false);
+                return;
+            }
+
             // Classic transition enter: the to-classes are a TRANSIENT overlay (resting state = the element's
             // base classes), so they are removed on completion (variantMode: false). Per-property overrides are
             // wired only where a variant swap sets transition-property: all (see PlayVariantEnter / PlayExit); a
@@ -70,12 +85,24 @@ namespace Velvet
         // difference — the to-classes are KEPT after completion, since they ARE the persistent resting state
         // (the animate target persists). A zero/invalid duration leaves the element at its
         // already-applied resting state (no strip, mounts directly at animate).
+        // type/stiffness/damping/mass: the enclosing StyleTransitionConfig's spring knobs (Tween/100/10/1 by
+        // default — the caller passes the config's own values through, since this overload takes the
+        // already-unpacked timing primitives rather than the config itself).
         public void PlayVariantEnter(VisualElement? element, string[]? fromClasses, string[]? toClasses,
             float durationSec, EasingMode easing, float delaySec, Action? onComplete = null, float additionalDelaySec = 0f,
-            IReadOnlyList<StylePropertyTransition>? propertyOverrides = null)
+            IReadOnlyList<StylePropertyTransition>? propertyOverrides = null,
+            TransitionType type = TransitionType.Tween, float stiffness = 100f, float damping = 10f, float mass = 1f)
         {
             if (element == null)
             {
+                return;
+            }
+
+            if (type == TransitionType.Spring)
+            {
+                StartSpringVariant(element, fromClasses ?? System.Array.Empty<string>(), toClasses ?? System.Array.Empty<string>(),
+                    delaySec, stiffness, damping, mass, onComplete, additionalDelaySec,
+                    _pendingEnters, restingClasses: null, isExit: false);
                 return;
             }
 
@@ -195,6 +222,18 @@ namespace Velvet
             if (element == null || config == null)
             {
                 onComplete?.Invoke();
+                return;
+            }
+
+            if (config.Type == TransitionType.Spring)
+            {
+                // Deferred to attach when off-panel: a presence exit can start while its subtree is transiently
+                // detached by a keyed reorder (see the tween exit's own ScheduleOnHost below) and this exit must
+                // still eventually complete so the reconciler's ghost-removal re-render fires.
+                StartSpringVariant(element, config.ExitFromClasses, config.ExitToClasses, config.DelaySec,
+                    config.Stiffness, config.Damping, config.Mass, onComplete, additionalDelaySec,
+                    _pendingExits, restingClasses: restoreFromOnCancel ? config.ExitFromClasses : null,
+                    isExit: true);
                 return;
             }
 
@@ -327,6 +366,145 @@ namespace Velvet
                 // Track it on the pending so a cancel-before-attach can remove the dangling callback.
                 pending.PendingAttach = onAttach;
             }
+        }
+
+        // Starts a spring-driven variant enter/exit (StyleTransitionConfig.Type == Spring). Unlike the tween
+        // path, a spring needs no CSS-transition-triggering frame boundary, so the from→to class swap lands
+        // IMMEDIATELY at rest; MotionSpringClassParser then resolves whatever numeric channels that swap
+        // touches (opacity / translate / scale / rotate) into a from/to pair each, and a per-frame physics tick
+        // (StartSpringTick) drives them via inline styles until they settle — replacing the tween's fixed-
+        // duration completion timeout with a dynamic settle check.
+        // map: the caller's own map (_pendingEnters for an enter, _pendingExits for an exit) so a later
+        // CancelEnter/CancelExit/CancelAll finds this entry exactly like a tween one.
+        // restingClasses: non-null only for a variant exit (restoreFromOnCancel) — see PendingAnimation.RestingClasses.
+        // isExit: selects the exit-shaped behavior — self-cancel-with-reversal (mirrors calling the PUBLIC
+        // CancelExit rather than CancelEnter for the self-cancel below) and deferring the tick start until
+        // attach when off-panel (a presence exit can start mid-reorder while its subtree is transiently
+        // detached — see PlayExit's own ScheduleOnHost/AttachToPanelEvent for why). False for an enter: an
+        // entering element is freshly created/reused and inserted as part of the SAME reconcile, so it is
+        // already on-panel by the time this runs (PlayEnterInternal has no off-panel handling either).
+        private void StartSpringVariant(VisualElement element, string[] fromClasses, string[] toClasses,
+            float delaySec, float stiffness, float damping, float mass, Action? onComplete, float additionalDelaySec,
+            Dictionary<VisualElement, PendingAnimation> map, string[]? restingClasses, bool isExit)
+        {
+            var plan = MotionSpringClassParser.Resolve(fromClasses, toClasses);
+            var state = MotionSpringDriver.Create(plan, stiffness, damping, mass);
+
+            // Cancel any existing animation of this SAME flavor first (mirrors PlayEnterInternal's
+            // CancelEnter(element) / PlayExit's CancelExit(element) self-cancel).
+            CancelPending(map, element, animateReversal: isExit);
+
+            // Land the classes at rest either way — nothing recognized to animate degrades to a plain,
+            // instantaneous class swap (the spring equivalent of a zero-duration tween).
+            StyleAnimationClassUtils.RemoveClasses(element, fromClasses);
+            StyleAnimationClassUtils.AddClasses(element, toClasses);
+
+            if (state == null)
+            {
+                onComplete?.Invoke();
+                return;
+            }
+
+            MotionSpringDriver.ApplyCurrentValues(element, state);
+
+            var pending = new PendingAnimation
+            {
+                FromClasses = fromClasses,
+                ToClasses = toClasses,
+                RestingClasses = restingClasses,
+                AnimatingElement = element,
+                Spring = state,
+            };
+            state.OnSettled = onComplete;
+            map[element] = pending;
+            pending.OwningMap = map;
+
+            void ScheduleStart()
+            {
+                // Superseded before it ever got to start (a cancel-before-attach removed this exact pending).
+                if (!map.TryGetValue(element, out var current) || !ReferenceEquals(current, pending))
+                {
+                    return;
+                }
+                var totalDelayMs = (long)((delaySec + additionalDelaySec) * 1000);
+                if (totalDelayMs > 0)
+                {
+                    var scheduled = element.schedule.Execute(() => StartSpringTick(element, pending));
+                    scheduled.ExecuteLater(totalDelayMs);
+                    pending.ScheduledItem = scheduled;
+                }
+                else
+                {
+                    StartSpringTick(element, pending);
+                }
+            }
+
+            if (!isExit || element.panel != null)
+            {
+                ScheduleStart();
+            }
+            else
+            {
+                EventCallback<AttachToPanelEvent>? onAttach = null;
+                onAttach = _ =>
+                {
+                    element.UnregisterCallback(onAttach);
+                    pending.PendingAttach = null;
+                    ScheduleStart();
+                };
+                element.RegisterCallback(onAttach);
+                pending.PendingAttach = onAttach;
+            }
+        }
+
+        // Starts the recurring spring tick on the panel root — the stable host, mirroring the shadow co-fade
+        // tick's own rationale: a keyed reorder can transiently detach the animating element, and UI Toolkit
+        // silently drops a DETACHED element's own scheduled items, but the panel root never detaches during the
+        // tree's life. Each tick measures its OWN real elapsed time (Time.realtimeSinceStartupAsDouble) rather
+        // than assuming the nominal 16ms cadence, so a hitch is absorbed by SpringIntegrator's internal dt clamp
+        // instead of silently under-integrating. No-op if there is no host (should not happen for the on-panel /
+        // already-deferred-to-attach cases this is called from, but this guards rather than throws).
+        private void StartSpringTick(VisualElement element, PendingAnimation pending)
+        {
+            var state = pending.Spring;
+            if (state == null)
+            {
+                return;
+            }
+            var host = element.panel?.visualTree;
+            if (host == null)
+            {
+                return;
+            }
+
+            state.LastTickTime = Time.realtimeSinceStartupAsDouble;
+            state.Tick = host.schedule.Execute(() =>
+            {
+                var now = Time.realtimeSinceStartupAsDouble;
+                var dt = (float)(now - state.LastTickTime);
+                state.LastTickTime = now;
+                if (dt <= 0f)
+                {
+                    return;
+                }
+
+                var settled = MotionSpringDriver.Step(element, state, dt);
+                if (!settled)
+                {
+                    return;
+                }
+
+                state.Tick?.Pause();
+                state.Tick = null;
+                if (pending.OwningMap != null && pending.OwningMap.TryGetValue(element, out var current)
+                    && ReferenceEquals(current, pending))
+                {
+                    pending.OwningMap.Remove(element);
+                }
+                EndShadowCoFade(pending); // No-op: a spring-driven entry never registers a shadow co-fade driver.
+                MotionSpringDriver.ClearInlineOverrides(element, state);
+                state.OnSettled?.Invoke();
+            }).Every(SpringTickMs);
         }
 
         // Cancels the exit animation on the given element and removes the applied CSS classes; the
@@ -573,6 +751,36 @@ namespace Velvet
                 // tween's co-fade and drop its driver — the shadow snaps back to full (product collapses to 1)
                 // unless an enclosing fade still drives it.
                 EndShadowCoFade(pending);
+
+                if (pending.Spring != null)
+                {
+                    var spring = pending.Spring;
+                    if (animateReversal && element.panel != null)
+                    {
+                        // Hand off to a reversal spring: retarget every channel toward the value it STARTED
+                        // from (continuity — each channel's SpringIntegrator instance, and therefore its
+                        // current value/velocity, is untouched by this), drop the original completion (a
+                        // reversal settling is not "finishing" anything the original caller asked for), and
+                        // move ownership into the enter map — mirroring the tween reversal's own move into
+                        // _pendingEnters below. The recurring tick keeps running uninterrupted throughout;
+                        // only its targets and its eventual finalize action change.
+                        MotionSpringDriver.Retarget(spring);
+                        spring.OnSettled = null;
+                        CancelPending(_pendingEnters, element);
+                        _pendingEnters[element] = pending;
+                        pending.OwningMap = _pendingEnters;
+                    }
+                    else
+                    {
+                        // No reversal (a plain CancelEnter, or an off-panel exit with nothing left to
+                        // interpolate against): stop the tick now and drop the inline overrides immediately.
+                        spring.Tick?.Pause();
+                        spring.Tick = null;
+                        MotionSpringDriver.ClearInlineOverrides(element, spring);
+                    }
+                    return;
+                }
+
                 if (animateReversal && element.panel != null && pending.DurationList is { Count: > 0 })
                 {
                     // A cancelled exit retargets a still-attached element back to its resting
@@ -661,6 +869,14 @@ namespace Velvet
                 StyleAnimationClassUtils.RemoveClasses(element, pending.FromClasses);
                 StyleAnimationClassUtils.RemoveClasses(element, pending.ToClasses);
                 EndShadowCoFade(pending);
+                if (pending.Spring != null)
+                {
+                    // A hard stop, no reversal: pause the tick and drop the inline overrides it owns (the
+                    // tween-only ClearTransitionStyles/ReturnDurationList/ReturnDelayList below are no-ops for
+                    // a spring entry, which never touches transition-* styles or rents a TimeValue list).
+                    pending.Spring.Tick?.Pause();
+                    MotionSpringDriver.ClearInlineOverrides(element, pending.Spring);
+                }
                 ClearTransitionStyles(element);
                 ReturnDurationList(pending.DurationList);
                 ReturnDelayList(pending.DelayList);
@@ -869,6 +1085,16 @@ namespace Velvet
             // never fires it, so it must be unregistered on cancel — otherwise it (and the closure pinning this
             // PendingAnimation) lingers on the element, surviving even pool reuse. Null for on-panel exits.
             public EventCallback<AttachToPanelEvent>? PendingAttach;
+            // Non-null for a spring-driven entry (StyleAnimationScheduler.StartSpringVariant) — the per-channel
+            // integrators/targets and the recurring tick. Null for a tween entry, which never touches this
+            // (DurationList/DelayList/ScheduledItem/TimeoutItem are the tween's own equivalents).
+            public MotionSpringState? Spring;
+            // The map this entry currently lives in (_pendingEnters or _pendingExits) — kept in sync on a
+            // spring's exit-cancel hand-off (which MOVES the entry from _pendingExits into _pendingEnters so the
+            // reversal keeps ticking uninterrupted). Only the spring tick reads this (to remove itself from
+            // whichever map currently owns it once it settles); a tween entry's own completion timeout already
+            // closes over its own map directly and never needs this.
+            public Dictionary<VisualElement, PendingAnimation>? OwningMap;
         }
 
         // State for a delayed variant swap's pending inline transition-delay clear (see

--- a/Packages/com.velvet.core/Runtime/Styling/StyleAnimationScheduler.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleAnimationScheduler.cs
@@ -1,7 +1,6 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
-using UnityEngine;
 using UnityEngine.UIElements;
 
 namespace Velvet
@@ -355,17 +354,27 @@ namespace Velvet
             }
             else
             {
-                EventCallback<AttachToPanelEvent>? onAttach = null;
-                onAttach = _ =>
-                {
-                    element.UnregisterCallback(onAttach);
-                    pending.PendingAttach = null;
-                    ScheduleOnHost();
-                };
-                element.RegisterCallback(onAttach);
-                // Track it on the pending so a cancel-before-attach can remove the dangling callback.
-                pending.PendingAttach = onAttach;
+                DeferUntilAttached(element, pending, ScheduleOnHost);
             }
+        }
+
+        // Defers an action until the element attaches to a panel — shared by any animation that can start
+        // while its element is off-panel (freshly created but not yet inserted, or transiently detached by a
+        // keyed reorder) and therefore has no working schedule / panel-root host to run on yet. The callback
+        // unregisters itself once it fires; pending.PendingAttach is tracked so a cancel-before-attach (see
+        // CancelPending) can remove the still-dangling registration instead of leaking it — and the closure
+        // pinning the caller's PendingAnimation — on the element across pool reuse.
+        private static void DeferUntilAttached(VisualElement element, PendingAnimation pending, Action onAttach)
+        {
+            EventCallback<AttachToPanelEvent>? handler = null;
+            handler = _ =>
+            {
+                element.UnregisterCallback(handler);
+                pending.PendingAttach = null;
+                onAttach();
+            };
+            element.RegisterCallback(handler);
+            pending.PendingAttach = handler;
         }
 
         // Starts a spring-driven variant enter/exit (StyleTransitionConfig.Type == Spring). Unlike the tween
@@ -377,25 +386,31 @@ namespace Velvet
         // map: the caller's own map (_pendingEnters for an enter, _pendingExits for an exit) so a later
         // CancelEnter/CancelExit/CancelAll finds this entry exactly like a tween one.
         // restingClasses: non-null only for a variant exit (restoreFromOnCancel) — see PendingAnimation.RestingClasses.
-        // isExit: selects the exit-shaped behavior — self-cancel-with-reversal (mirrors calling the PUBLIC
-        // CancelExit rather than CancelEnter for the self-cancel below) and deferring the tick start until
-        // attach when off-panel (a presence exit can start mid-reorder while its subtree is transiently
-        // detached — see PlayExit's own ScheduleOnHost/AttachToPanelEvent for why). False for an enter: an
-        // entering element is freshly created/reused and inserted as part of the SAME reconcile, so it is
-        // already on-panel by the time this runs (PlayEnterInternal has no off-panel handling either).
+        // isExit: selects the exit-shaped self-cancel (mirrors calling the PUBLIC CancelExit rather than
+        // CancelEnter below). Both directions defer the tick start until attach when off-panel: a standalone
+        // Motion's enter plays during element creation (FiberNodeFactory), and a presence enter plays before
+        // the entering element is placed into the tree (GeneralPathReconciler) — so BOTH, like a presence
+        // exit, can start while still detached (see PlayExit's own ScheduleOnHost/AttachToPanelEvent for the
+        // same rationale on the exit side).
         private void StartSpringVariant(VisualElement element, string[] fromClasses, string[] toClasses,
             float delaySec, float stiffness, float damping, float mass, Action? onComplete, float additionalDelaySec,
             Dictionary<VisualElement, PendingAnimation> map, string[]? restingClasses, bool isExit)
         {
             var plan = MotionSpringClassParser.Resolve(fromClasses, toClasses);
-            var state = MotionSpringDriver.Create(plan, stiffness, damping, mass);
+            // An invalid configuration (see ValidateSpringParameters) degrades exactly like an empty plan
+            // below: no state is built, so the shared "land the classes, complete immediately" branch handles
+            // it without a separate code path.
+            var state = ValidateSpringParameters(stiffness, damping, mass)
+                ? MotionSpringDriver.Create(plan, stiffness, damping, mass)
+                : null;
 
             // Cancel any existing animation of this SAME flavor first (mirrors PlayEnterInternal's
             // CancelEnter(element) / PlayExit's CancelExit(element) self-cancel).
             CancelPending(map, element, animateReversal: isExit);
 
-            // Land the classes at rest either way — nothing recognized to animate degrades to a plain,
-            // instantaneous class swap (the spring equivalent of a zero-duration tween).
+            // Land the classes at rest either way — nothing recognized to animate (or invalid spring
+            // parameters) degrades to a plain, instantaneous class swap (the spring equivalent of a
+            // zero-duration tween).
             StyleAnimationClassUtils.RemoveClasses(element, fromClasses);
             StyleAnimationClassUtils.AddClasses(element, toClasses);
 
@@ -427,42 +442,56 @@ namespace Velvet
                     return;
                 }
                 var totalDelayMs = (long)((delaySec + additionalDelaySec) * 1000);
-                if (totalDelayMs > 0)
-                {
-                    var scheduled = element.schedule.Execute(() => StartSpringTick(element, pending));
-                    scheduled.ExecuteLater(totalDelayMs);
-                    pending.ScheduledItem = scheduled;
-                }
-                else
+                if (totalDelayMs <= 0)
                 {
                     StartSpringTick(element, pending);
+                    return;
                 }
+
+                // A delayed start is parked on the panel-root host, not element.schedule: ScheduleStart only
+                // ever runs once attached (called directly below, or from DeferUntilAttached's onAttach), but
+                // a keyed reorder can transiently detach the element again during the delay window itself,
+                // and UI Toolkit silently drops a detached element's own scheduled items (mirrors PlayExit's
+                // ScheduleOnHost rationale). The host should therefore always be available here; the null
+                // guard is defensive (mirrors StartSpringTick's own should-not-happen bail) rather than an
+                // expected path.
+                var host = element.panel?.visualTree;
+                if (host == null)
+                {
+                    return;
+                }
+                var scheduled = host.schedule.Execute(() =>
+                {
+                    // Re-check on fire, not just on schedule: the host outlives a transient detach, so this
+                    // closure can still run after a later cancel/supersede replaced this exact pending.
+                    if (map.TryGetValue(element, out var stillCurrent) && ReferenceEquals(stillCurrent, pending))
+                    {
+                        StartSpringTick(element, pending);
+                    }
+                });
+                scheduled.ExecuteLater(totalDelayMs);
+                pending.ScheduledItem = scheduled;
             }
 
-            if (!isExit || element.panel != null)
+            if (element.panel != null)
             {
                 ScheduleStart();
             }
             else
             {
-                EventCallback<AttachToPanelEvent>? onAttach = null;
-                onAttach = _ =>
-                {
-                    element.UnregisterCallback(onAttach);
-                    pending.PendingAttach = null;
-                    ScheduleStart();
-                };
-                element.RegisterCallback(onAttach);
-                pending.PendingAttach = onAttach;
+                DeferUntilAttached(element, pending, ScheduleStart);
             }
         }
 
         // Starts the recurring spring tick on the panel root — the stable host, mirroring the shadow co-fade
         // tick's own rationale: a keyed reorder can transiently detach the animating element, and UI Toolkit
         // silently drops a DETACHED element's own scheduled items, but the panel root never detaches during the
-        // tree's life. Each tick measures its OWN real elapsed time (Time.realtimeSinceStartupAsDouble) rather
-        // than assuming the nominal 16ms cadence, so a hitch is absorbed by SpringIntegrator's internal dt clamp
-        // instead of silently under-integrating. No-op if there is no host (should not happen for the on-panel /
+        // tree's life. Each tick reads the elapsed time from the SAME clock the scheduler itself used to decide
+        // when to fire this callback (TimerState.deltaTime, backed by Panel.TimeSinceStartupMs — the panel's
+        // own time source, which a test's simulated panel overrides) rather than sampling a different clock
+        // (e.g. Time.realtimeSinceStartupAsDouble) that could disagree with it: a hitch is still absorbed by
+        // SpringIntegrator's own dt clamp, but the elapsed time now always matches what actually elapsed on the
+        // clock this tick is scheduled against. No-op if there is no host (should not happen for the on-panel /
         // already-deferred-to-attach cases this is called from, but this guards rather than throws).
         private void StartSpringTick(VisualElement element, PendingAnimation pending)
         {
@@ -477,12 +506,12 @@ namespace Velvet
                 return;
             }
 
-            state.LastTickTime = Time.realtimeSinceStartupAsDouble;
-            state.Tick = host.schedule.Execute(() =>
+            state.Tick = host.schedule.Execute((TimerState ts) =>
             {
-                var now = Time.realtimeSinceStartupAsDouble;
-                var dt = (float)(now - state.LastTickTime);
-                state.LastTickTime = now;
+                // TimerState.start is the previous callback's time for a repeating item (or the schedule time
+                // for the first firing), so deltaTime is already exactly the elapsed interval this tick needs
+                // — no separate "last tick" bookkeeping to maintain.
+                var dt = ts.deltaTime / 1000f;
                 if (dt <= 0f)
                 {
                     return;
@@ -511,6 +540,18 @@ namespace Velvet
         // element reverses toward its resting classes with the transition kept alive (the inline
         // transition styles are cleared only after the reversal has run its course).
         public void CancelExit(VisualElement element) => CancelPending(_pendingExits, element, animateReversal: true);
+
+        // Cancels the exit animation on an element being torn down for good (pool return / disposal) — never
+        // hands off to a reversal, regardless of whether the element is still attached at the moment this
+        // runs. FiberElementCleaner releases scheduler resources BEFORE the caller physically detaches the
+        // element (DOM operations are the caller's own job), so element.panel can still be non-null here even
+        // though the element is on its way to the pool. An ordinary CancelExit's reversal hand-off assumes the
+        // element keeps living: for a spring, it re-adds a live entry into the enter map whose recurring,
+        // panel-root-scheduled tick keeps calling MotionSpringDriver.Step and writing inline styles — nothing
+        // ever calls CancelEnter on this element again to catch that re-added entry, so it would otherwise
+        // keep corrupting whatever the pooled element is reused for next.
+        public void CancelExitForTeardown(VisualElement element) =>
+            CancelPending(_pendingExits, element, animateReversal: true, forTeardown: true);
 
         // Cancels the enter animation on the given element and removes the applied CSS classes and inline styles.
         public void CancelEnter(VisualElement element) => CancelPending(_pendingEnters, element);
@@ -621,6 +662,30 @@ namespace Velvet
             return true;
         }
 
+        // Mirrors ValidateDuration's guard, for the spring path: a non-finite or non-positive stiffness/damping
+        // makes SpringIntegrator.Step's settle predicate unsatisfiable forever — zero/negative stiffness never
+        // pulls the value toward its target, zero/negative damping never dissipates velocity, and NaN
+        // propagates into every inline style write and never compares equal to anything (including itself), so
+        // IsSettled never returns true. Left unvalidated, the panel-root tick this drives would run
+        // indefinitely and its completion callback — the ONLY thing that removes a presence exit's ghost —
+        // would never fire. Mass gets its own numeric safety clamp inside SpringIntegrator.Step (a non-positive
+        // mass would otherwise divide by zero or flip the restoring force's sign), but that clamp has no way to
+        // warn the caller, so it is still validated here for the same failure modes.
+        private static bool ValidateSpringParameters(float stiffness, float damping, float mass)
+        {
+            if (float.IsFinite(stiffness) && stiffness > 0f
+                && float.IsFinite(damping) && damping > 0f
+                && float.IsFinite(mass) && mass > 0f)
+            {
+                return true;
+            }
+
+            FiberLogger.LogWarning("Spring",
+                $"Invalid spring parameters (stiffness={stiffness}, damping={damping}, mass={mass}). " +
+                "Expected finite, positive values for all three. Completing immediately instead of ticking forever.");
+            return false;
+        }
+
         // Sets transition-duration and transition-timing-function as inline styles.
         // C# becomes the Single Source of Truth, so they need not be defined in USS.
         // GC tuning: the EasingFunction list is cached statically per EasingMode; TimeValue lists are
@@ -724,8 +789,12 @@ namespace Velvet
 
         // If the timeout callback already ran, map.Remove returns false and the cancellation is skipped.
         // This is safe because the classes have already been cleaned up in that case.
+        // forTeardown: true only from CancelExitForTeardown — the element is being torn down for good (pool
+        // return / disposal), not merely interrupted, so a reversal (tween or spring) is never appropriate
+        // even when animateReversal is requested and the element still happens to be attached: see
+        // CancelExitForTeardown for why handing off to one would corrupt the element after it is pooled.
         private void CancelPending(Dictionary<VisualElement, PendingAnimation> map, VisualElement element,
-            bool animateReversal = false)
+            bool animateReversal = false, bool forTeardown = false)
         {
             if (map.Remove(element, out var pending))
             {
@@ -755,7 +824,7 @@ namespace Velvet
                 if (pending.Spring != null)
                 {
                     var spring = pending.Spring;
-                    if (animateReversal && element.panel != null)
+                    if (!forTeardown && animateReversal && element.panel != null && spring.Tick != null)
                     {
                         // Hand off to a reversal spring: retarget every channel toward the value it STARTED
                         // from (continuity — each channel's SpringIntegrator instance, and therefore its
@@ -763,7 +832,12 @@ namespace Velvet
                         // reversal settling is not "finishing" anything the original caller asked for), and
                         // move ownership into the enter map — mirroring the tween reversal's own move into
                         // _pendingEnters below. The recurring tick keeps running uninterrupted throughout;
-                        // only its targets and its eventual finalize action change.
+                        // only its targets and its eventual finalize action change. Requires a tick that has
+                        // actually started (spring.Tick != null): a cancel that lands before then — still
+                        // parked behind its delay — has no running tick to keep alive, and nothing would ever
+                        // start one for it (its ScheduledItem was already paused above, and a still-off-panel
+                        // PendingAttach was already unregistered), so handing off here would just park a dead
+                        // entry in _pendingEnters forever instead of finalizing below.
                         MotionSpringDriver.Retarget(spring);
                         spring.OnSettled = null;
                         CancelPending(_pendingEnters, element);
@@ -772,8 +846,9 @@ namespace Velvet
                     }
                     else
                     {
-                        // No reversal (a plain CancelEnter, or an off-panel exit with nothing left to
-                        // interpolate against): stop the tick now and drop the inline overrides immediately.
+                        // No reversal (a plain CancelEnter, an off-panel exit with nothing left to interpolate
+                        // against, a cancel before the tick ever started, or a teardown cancel that must never
+                        // hand off regardless): stop the tick now and drop the inline overrides immediately.
                         spring.Tick?.Pause();
                         spring.Tick = null;
                         MotionSpringDriver.ClearInlineOverrides(element, spring);
@@ -781,7 +856,7 @@ namespace Velvet
                     return;
                 }
 
-                if (animateReversal && element.panel != null && pending.DurationList is { Count: > 0 })
+                if (!forTeardown && animateReversal && element.panel != null && pending.DurationList is { Count: > 0 })
                 {
                     // A cancelled exit retargets a still-attached element back to its resting
                     // classes. Clearing the inline transition styles in this same call would make

--- a/Packages/com.velvet.core/Runtime/Styling/StyleAnimationScheduler.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleAnimationScheduler.cs
@@ -17,8 +17,6 @@ namespace Velvet
         private const long AnimationGraceMs = 50;
         private const float MaxDurationSec = 10f;
         private const int MaxPoolSize = 16;
-        // Spring tick interval (~60fps), matching the shadow co-fade tick and StyleAnimateDriver's own cadence.
-        private const long SpringTickMs = 16;
 
         // Static cache from EasingMode to List<EasingFunction>. EasingMode values are finite, so caching is safe.
         private static readonly Dictionary<EasingMode, List<EasingFunction>> s_easingCache = new();
@@ -64,7 +62,7 @@ namespace Velvet
                 // PlayVariantEnter / PlayExit rather than silently ignoring Type on this call path.
                 StartSpringVariant(element, config.EnterFromClasses, config.EnterToClasses, config.DelaySec,
                     config.Stiffness, config.Damping, config.Mass, onComplete, additionalDelaySec,
-                    _pendingEnters, restingClasses: null, isExit: false);
+                    restingClasses: null, isExit: false);
                 return;
             }
 
@@ -75,6 +73,18 @@ namespace Velvet
             PlayEnterInternal(element, config.EnterFromClasses, config.EnterToClasses,
                 config.DurationSec, config.Easing, config.DelaySec, onComplete, additionalDelaySec,
                 variantMode: false, propertyOverrides: null);
+        }
+
+        // Config-taking overload: every production call site (a standalone Motion's mount enter, and an
+        // AnimatePresence-driven variant enter) reads its timing/spring knobs straight off the enclosing
+        // Motion's OWN StyleTransitionConfig, so this unpacks it once here instead of each call site repeating
+        // the same eight-argument unpack of the same object.
+        public void PlayVariantEnter(VisualElement? element, string[]? fromClasses, string[]? toClasses,
+            StyleTransitionConfig config, Action? onComplete = null, float additionalDelaySec = 0f)
+        {
+            PlayVariantEnter(element, fromClasses, toClasses, config.DurationSec, config.Easing, config.DelaySec,
+                onComplete, additionalDelaySec, config.PropertyOverrides,
+                config.Type, config.Stiffness, config.Damping, config.Mass);
         }
 
         // Variant-driven enter (initial → animate). Unlike PlayEnter, the
@@ -101,7 +111,7 @@ namespace Velvet
             {
                 StartSpringVariant(element, fromClasses ?? System.Array.Empty<string>(), toClasses ?? System.Array.Empty<string>(),
                     delaySec, stiffness, damping, mass, onComplete, additionalDelaySec,
-                    _pendingEnters, restingClasses: null, isExit: false);
+                    restingClasses: null, isExit: false);
                 return;
             }
 
@@ -243,7 +253,7 @@ namespace Velvet
                 // still eventually complete so the reconciler's ghost-removal re-render fires.
                 StartSpringVariant(element, config.ExitFromClasses, config.ExitToClasses, config.DelaySec,
                     config.Stiffness, config.Damping, config.Mass, onComplete, additionalDelaySec,
-                    _pendingExits, restingClasses: restoreFromOnCancel ? config.ExitFromClasses : null,
+                    restingClasses: restoreFromOnCancel ? config.ExitFromClasses : null,
                     isExit: true);
                 return;
             }
@@ -406,19 +416,20 @@ namespace Velvet
         // touches (opacity / translate / scale / rotate) into a from/to pair each, and a per-frame physics tick
         // (StartSpringTick) drives them via inline styles until they settle — replacing the tween's fixed-
         // duration completion timeout with a dynamic settle check.
-        // map: the caller's own map (_pendingEnters for an enter, _pendingExits for an exit) so a later
-        // CancelEnter/CancelExit/CancelAll finds this entry exactly like a tween one.
         // restingClasses: non-null only for a variant exit (restoreFromOnCancel) — see PendingAnimation.RestingClasses.
-        // isExit: selects the exit-shaped self-cancel (mirrors calling the PUBLIC CancelExit rather than
-        // CancelEnter below). Both directions defer the tick start until attach when off-panel: a standalone
-        // Motion's enter plays during element creation (FiberNodeFactory), and a presence enter plays before
-        // the entering element is placed into the tree (GeneralPathReconciler) — so BOTH, like a presence
-        // exit, can start while still detached (see PlayExit's own ScheduleOnHost/AttachToPanelEvent for the
-        // same rationale on the exit side).
+        // isExit: selects both the exit-shaped self-cancel (mirrors calling the PUBLIC CancelExit rather than
+        // CancelEnter below) and which bookkeeping map (_pendingExits / _pendingEnters) this play registers
+        // into — a separate map parameter would only ever repeat that same choice, so isExit alone decides it.
+        // Both directions defer the tick start until attach when off-panel: a standalone Motion's enter plays
+        // during element creation (FiberNodeFactory), and a presence enter plays before the entering element is
+        // placed into the tree (GeneralPathReconciler) — so BOTH, like a presence exit, can start while still
+        // detached (see PlayExit's own ScheduleOnHost/AttachToPanelEvent for the same rationale on the exit side).
         private void StartSpringVariant(VisualElement element, string[] fromClasses, string[] toClasses,
             float delaySec, float stiffness, float damping, float mass, Action? onComplete, float additionalDelaySec,
-            Dictionary<VisualElement, PendingAnimation> map, string[]? restingClasses, bool isExit)
+            string[]? restingClasses, bool isExit)
         {
+            var map = isExit ? _pendingExits : _pendingEnters;
+
             // Read BEFORE the class swap below lands: the element's own current inline translate is whatever
             // its UNRELATED (non-swapped) classes rested it at — e.g. a base translate-y-8 alongside a
             // variant pair that only touches translate-x. Used as the resting value for a translate axis the
@@ -477,7 +488,6 @@ namespace Velvet
             pending.Shadows = CollectShadowsForCoFade(element, pending, isExit ? 1f : 0f);
             state.OnSettled = onComplete;
             map[element] = pending;
-            pending.OwningMap = map;
 
             void ScheduleStart()
             {
@@ -575,10 +585,13 @@ namespace Velvet
 
                 state.Tick?.Pause();
                 state.Tick = null;
-                if (pending.OwningMap != null && pending.OwningMap.TryGetValue(element, out var current)
-                    && ReferenceEquals(current, pending))
+                // Removes this entry from whichever of the two bookkeeping maps currently owns it — ordinarily
+                // the map this play was started into, but an exit-cancel reversal hand-off (CancelPending) can
+                // have MOVED it into _pendingEnters since then, so both are probed rather than assuming the
+                // original one still holds it.
+                if (!RemoveIfCurrent(_pendingExits, element, pending))
                 {
-                    pending.OwningMap.Remove(element);
+                    RemoveIfCurrent(_pendingEnters, element, pending);
                 }
                 // Target is at rest now — stop the co-fade and restore the shadows to full strength (a no-op
                 // when this subtree carries none, the common case).
@@ -586,7 +599,21 @@ namespace Velvet
                 MotionSpringDriver.ClearInlineOverrides(element, state);
                 ReapplySpringOwnedInlineValues(element);
                 state.OnSettled?.Invoke();
-            }).Every(SpringTickMs);
+            }).Every(StyleAnimateDriver.TickMs);
+        }
+
+        // Removes element's entry from map, but only when it is STILL exactly pending (a later cancel/supersede
+        // may have already replaced or removed it) — the identity check a settled tick and a cancelled play both
+        // need before touching a map entry that might no longer be theirs. Returns whether it removed anything,
+        // so a caller checking more than one candidate map (see StartSpringTick) can stop at the first hit.
+        private static bool RemoveIfCurrent(Dictionary<VisualElement, PendingAnimation> map, VisualElement element, PendingAnimation pending)
+        {
+            if (map.TryGetValue(element, out var current) && ReferenceEquals(current, pending))
+            {
+                map.Remove(element);
+                return true;
+            }
+            return false;
         }
 
         // MotionSpringDriver.ClearInlineOverrides nulls whichever style slots the spring wrote (opacity /
@@ -924,7 +951,6 @@ namespace Velvet
                         spring.OnSettled = null;
                         CancelPending(_pendingEnters, element);
                         _pendingEnters[element] = pending;
-                        pending.OwningMap = _pendingEnters;
                     }
                     else
                     {
@@ -1122,7 +1148,7 @@ namespace Velvet
                 {
                     DropShadowSilhouette.SetCoFade(binding, el, pending, factor);
                 }
-            }).Every(16);
+            }).Every(StyleAnimateDriver.TickMs);
         }
 
         // Stops the co-fade tick and drops this animation's driver from each shadow (null-safe; balanced
@@ -1250,14 +1276,11 @@ namespace Velvet
             public EventCallback<AttachToPanelEvent>? PendingAttach;
             // Non-null for a spring-driven entry (StyleAnimationScheduler.StartSpringVariant) — the per-channel
             // integrators/targets and the recurring tick. Null for a tween entry, which never touches this
-            // (DurationList/DelayList/ScheduledItem/TimeoutItem are the tween's own equivalents).
+            // (DurationList/DelayList/ScheduledItem/TimeoutItem are the tween's own equivalents). Which of the
+            // two bookkeeping maps (_pendingEnters / _pendingExits) currently holds this entry is NOT tracked
+            // as a field here — a spring's exit-cancel hand-off can MOVE it from one to the other, and the
+            // settled tick just probes both (see RemoveIfCurrent) rather than keeping that choice in sync.
             public MotionSpringState? Spring;
-            // The map this entry currently lives in (_pendingEnters or _pendingExits) — kept in sync on a
-            // spring's exit-cancel hand-off (which MOVES the entry from _pendingExits into _pendingEnters so the
-            // reversal keeps ticking uninterrupted). Only the spring tick reads this (to remove itself from
-            // whichever map currently owns it once it settles); a tween entry's own completion timeout already
-            // closes over its own map directly and never needs this.
-            public Dictionary<VisualElement, PendingAnimation>? OwningMap;
         }
 
         // State for a delayed variant swap's pending inline transition-delay clear (see

--- a/Packages/com.velvet.core/Runtime/Styling/StyleAnimationScheduler.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleAnimationScheduler.cs
@@ -49,10 +49,12 @@ namespace Velvet
             }
 
             // Classic transition enter: the to-classes are a TRANSIENT overlay (resting state = the element's
-            // base classes), so they are removed on completion (variantMode: false).
+            // base classes), so they are removed on completion (variantMode: false). Per-property overrides are
+            // wired only where a variant swap sets transition-property: all (see PlayVariantEnter / PlayExit); a
+            // preset's own USS-declared transition-property is untouched, so PropertyOverrides is not read here.
             PlayEnterInternal(element, config.EnterFromClasses, config.EnterToClasses,
                 config.DurationSec, config.Easing, config.DelaySec, onComplete, additionalDelaySec,
-                variantMode: false);
+                variantMode: false, propertyOverrides: null);
         }
 
         // Variant-driven enter (initial → animate). Unlike PlayEnter, the
@@ -63,7 +65,8 @@ namespace Velvet
         // (the animate target persists). A zero/invalid duration leaves the element at its
         // already-applied resting state (no strip, mounts directly at animate).
         public void PlayVariantEnter(VisualElement? element, string[]? fromClasses, string[]? toClasses,
-            float durationSec, EasingMode easing, float delaySec, Action? onComplete = null, float additionalDelaySec = 0f)
+            float durationSec, EasingMode easing, float delaySec, Action? onComplete = null, float additionalDelaySec = 0f,
+            IReadOnlyList<StylePropertyTransition>? propertyOverrides = null)
         {
             if (element == null)
             {
@@ -71,11 +74,12 @@ namespace Velvet
             }
 
             PlayEnterInternal(element, fromClasses ?? System.Array.Empty<string>(), toClasses ?? System.Array.Empty<string>(),
-                durationSec, easing, delaySec, onComplete, additionalDelaySec, variantMode: true);
+                durationSec, easing, delaySec, onComplete, additionalDelaySec, variantMode: true, propertyOverrides);
         }
 
         private void PlayEnterInternal(VisualElement element, string[] fromClasses, string[] toClasses,
-            float durationSec, EasingMode easing, float delaySec, Action? onComplete, float additionalDelaySec, bool variantMode)
+            float durationSec, EasingMode easing, float delaySec, Action? onComplete, float additionalDelaySec, bool variantMode,
+            IReadOnlyList<StylePropertyTransition>? propertyOverrides)
         {
             // DurationSec=0 / invalid: complete immediately. For variantMode this happens BEFORE any strip, so
             // the element keeps its already-applied resting (to) classes and mounts directly at animate.
@@ -92,7 +96,7 @@ namespace Velvet
             // Step 1: set duration / easing as inline styles, then show the from-state. In variantMode the
             // element already carries the resting to-classes, so strip them first so they don't fight the from-state.
             var (durationList, delayList) = ApplyTransitionStyles(element, durationSec, easing, delaySec,
-                allProperties: variantMode);
+                allProperties: variantMode, propertyOverrides: propertyOverrides);
             if (variantMode)
             {
                 StyleAnimationClassUtils.RemoveClasses(element, toClasses);
@@ -202,9 +206,12 @@ namespace Velvet
             var exitEasing = config.ExitEasing ?? config.Easing;
 
             // Step 1: add the exit initial-state class and set duration / easing as inline styles. A variant exit
-            // (restoreFromOnCancel) swaps variant utility classes, so it needs transition-property: all to tween.
+            // (restoreFromOnCancel) swaps variant utility classes, so it needs transition-property: all to tween
+            // — the same condition that gates reading PropertyOverrides (a preset exit's own USS-declared
+            // transition-property is untouched).
             var (durationList, delayList) = ApplyTransitionStyles(element, config.DurationSec, exitEasing,
-                config.DelaySec, allProperties: restoreFromOnCancel);
+                config.DelaySec, allProperties: restoreFromOnCancel,
+                propertyOverrides: restoreFromOnCancel ? config.PropertyOverrides : null);
             StyleAnimationClassUtils.AddClasses(element, fromClasses);
 
             // Step 2: swap classes on the next frame.
@@ -361,8 +368,18 @@ namespace Velvet
             new() { new UnityEngine.UIElements.StylePropertyName("all") };
 
         private (List<TimeValue> durationList, List<TimeValue>? delayList) ApplyTransitionStyles(
-            VisualElement element, float durationSec, EasingMode easing, float delaySec = 0f, bool allProperties = false)
+            VisualElement element, float durationSec, EasingMode easing, float delaySec = 0f, bool allProperties = false,
+            IReadOnlyList<StylePropertyTransition>? propertyOverrides = null)
         {
+            // Per-property overrides replace the "all" catch-all with an explicit property list — reachable only
+            // where a variant swap would otherwise set transition-property: all (allProperties), matching the
+            // contract documented on StyleTransitionConfig.PropertyOverrides. Every other combination (no
+            // overrides, or a preset transition that never sets allProperties) falls through unchanged below.
+            if (allProperties && propertyOverrides is { Count: > 0 })
+            {
+                return ApplyPropertyOverrideTransitionStyles(element, durationSec, easing, delaySec, propertyOverrides);
+            }
+
             var durationMs = (int)(durationSec * 1000);
             var durationList = RentDurationList(durationMs);
             element.style.transitionDuration = durationList;
@@ -382,6 +399,59 @@ namespace Velvet
             if (delaySec > 0f)
             {
                 var delayMs = (int)(delaySec * 1000);
+                delayList = RentDelayList(delayMs);
+                element.style.transitionDelay = delayList;
+            }
+
+            return (durationList, delayList);
+        }
+
+        // Per-property override path: transition-property becomes EXACTLY the overridden properties (in
+        // declaration order) instead of "all" — matching CSS semantics where an explicit transition-property list
+        // transitions only what it names. Duration / delay are positionally-matched n-entry lists rented from the
+        // SAME pools the single-entry path above uses (RentDurationList / RentDelayList n-entry overloads), so
+        // they are returned through the existing PendingAnimation.DurationList / DelayList bookkeeping unchanged.
+        // A null override field falls back to the value the caller already resolved for this direction
+        // (durationSec / easing / delaySec — for an exit, easing here is already ExitEasing ?? Easing, so the
+        // fallback stays direction-correct without this method needing to know enter from exit).
+        // The property-name and easing lists are rebuilt each call instead of pooled: PropertyOverrides is a
+        // handful of entries fixed at config-authoring time, so the allocation is bounded and one-shot per
+        // animation start (never per-frame) — but the per-mode EasingFunction INSTANCES are still reused via the
+        // existing static cache (GetOrCreateEasingList) rather than reallocated, mirroring its intent.
+        private (List<TimeValue> durationList, List<TimeValue>? delayList) ApplyPropertyOverrideTransitionStyles(
+            VisualElement element, float defaultDurationSec, EasingMode defaultEasing, float defaultDelaySec,
+            IReadOnlyList<StylePropertyTransition> overrides)
+        {
+            var count = overrides.Count;
+            var propertyNames = new List<StylePropertyName>(count);
+            var easingList = new List<EasingFunction>(count);
+            var durationMs = new int[count];
+            var delayMs = new int[count];
+            var hasDelay = false;
+            for (var i = 0; i < count; i++)
+            {
+                var o = overrides[i];
+                propertyNames.Add(new StylePropertyName(o.Property));
+                easingList.Add(GetOrCreateEasingList(o.Easing ?? defaultEasing)[0]);
+                durationMs[i] = (int)((o.DurationSec ?? defaultDurationSec) * 1000);
+                var delaySec = o.DelaySec ?? defaultDelaySec;
+                if (delaySec > 0f)
+                {
+                    hasDelay = true;
+                    delayMs[i] = (int)(delaySec * 1000);
+                }
+            }
+
+            var durationList = RentDurationList(durationMs);
+            element.style.transitionProperty = propertyNames;
+            element.style.transitionDuration = durationList;
+            element.style.transitionTimingFunction = easingList;
+
+            // Mirrors the single-entry path: transition-delay is set only when at least one property actually
+            // needs one (an all-zero delay list is behaviorally identical to leaving it unset).
+            List<TimeValue>? delayList = null;
+            if (hasDelay)
+            {
                 delayList = RentDelayList(delayMs);
                 element.style.transitionDelay = delayList;
             }
@@ -453,9 +523,7 @@ namespace Velvet
                 DurationList = pending.DurationList,
                 DelayList = pending.DelayList,
             };
-            var timeoutMs = 0f;
-            if (pending.DurationList is { Count: > 0 }) timeoutMs += pending.DurationList[0].value;
-            if (pending.DelayList is { Count: > 0 }) timeoutMs += pending.DelayList[0].value;
+            var timeoutMs = MaxReversalTimeoutMs(pending.DurationList, pending.DelayList);
             var timeout = element.schedule.Execute(() =>
             {
                 if (_pendingEnters.Remove(element))
@@ -468,6 +536,34 @@ namespace Velvet
             timeout.ExecuteLater((long)timeoutMs);
             reversal.TimeoutItem = timeout;
             _pendingEnters[element] = reversal;
+        }
+
+        // How long the reversal must stay alive before it is safe to clear the inline transition styles: the
+        // SLOWEST animating property's delay + duration. For the single-entry case (no PropertyOverrides) that
+        // is just duration[0] + delay[0], same as before; PropertyOverrides can give each property its own
+        // duration / delay, so an interrupted variant exit's reversal must wait for whichever one finishes
+        // last, not just the first, or a slower property's transition-duration would be cleared (snapping it to
+        // the resting value) while it is still mid-tween.
+        private static float MaxReversalTimeoutMs(List<TimeValue>? durationList, List<TimeValue>? delayList)
+        {
+            if (durationList is not { Count: > 0 })
+            {
+                return 0f;
+            }
+            var maxMs = 0f;
+            for (var i = 0; i < durationList.Count; i++)
+            {
+                var ms = durationList[i].value;
+                if (delayList is { Count: > 0 })
+                {
+                    ms += delayList[Math.Min(i, delayList.Count - 1)].value;
+                }
+                if (ms > maxMs)
+                {
+                    maxMs = ms;
+                }
+            }
+            return maxMs;
         }
 
         private void CancelAllInMap(Dictionary<VisualElement, PendingAnimation> map)
@@ -607,10 +703,14 @@ namespace Velvet
         }
 
         private List<TimeValue> RentDurationList(int ms) => RentTimeValueList(_durationPool, ms);
+        private List<TimeValue> RentDurationList(IReadOnlyList<int> msValues) => RentTimeValueList(_durationPool, msValues);
         private void ReturnDurationList(List<TimeValue>? list) => ReturnTimeValueList(_durationPool, list);
         private List<TimeValue> RentDelayList(int ms) => RentTimeValueList(_delayPool, ms);
+        private List<TimeValue> RentDelayList(IReadOnlyList<int> msValues) => RentTimeValueList(_delayPool, msValues);
         private void ReturnDelayList(List<TimeValue>? list) => ReturnTimeValueList(_delayPool, list);
 
+        // Single-entry hot path (unchanged): every enter / exit without PropertyOverrides rents exactly one of
+        // these per animation.
         private static List<TimeValue> RentTimeValueList(Stack<List<TimeValue>> pool, int ms)
         {
             if (!pool.TryPop(out var list))
@@ -622,6 +722,27 @@ namespace Velvet
                 list.Clear();
             }
             list.Add(new TimeValue(ms, TimeUnit.Millisecond));
+            return list;
+        }
+
+        // n-entry sibling for PropertyOverrides: builds a positionally-matched TimeValue per override, reusing
+        // the SAME pool as the single-entry path above (a rented list's capacity just grows to whatever size it
+        // was last asked for; Clear()+Add() reuse is agnostic to entry count) — so ReturnTimeValueList below
+        // already handles returning either shape without change.
+        private static List<TimeValue> RentTimeValueList(Stack<List<TimeValue>> pool, IReadOnlyList<int> msValues)
+        {
+            if (!pool.TryPop(out var list))
+            {
+                list = new List<TimeValue>(msValues.Count);
+            }
+            else
+            {
+                list.Clear();
+            }
+            for (var i = 0; i < msValues.Count; i++)
+            {
+                list.Add(new TimeValue(msValues[i], TimeUnit.Millisecond));
+            }
             return list;
         }
 

--- a/Packages/com.velvet.core/Runtime/Styling/StyleAnimationScheduler.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleAnimationScheduler.cs
@@ -1,6 +1,7 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using UnityEngine.UIElements;
 
 namespace Velvet
@@ -843,56 +844,74 @@ namespace Velvet
             return (durationList, delayList);
         }
 
+        // Per-overrides-list cache of the property-name list transition-property is set to: WHICH properties
+        // are named never depends on the enter/exit direction (unlike the easing list below, an override's own
+        // Property is never direction-dependent), and PropertyOverrides is fixed at config-authoring time and
+        // typically shared across every element/render a given Motion plays — so building this once per
+        // distinct overrides list (auto-evicted when that list itself is collected, mirroring
+        // StyleArbitraryValueResolver's per-element layer cache) avoids repeating an identical List<T> on every
+        // single enter/exit that reuses the same config.
+        private static readonly ConditionalWeakTable<IReadOnlyList<StylePropertyTransition>, List<StylePropertyName>> s_propertyNameListCache = new();
+
         // Per-property override path: transition-property becomes EXACTLY the overridden properties (in
         // declaration order) instead of "all" — matching CSS semantics where an explicit transition-property list
-        // transitions only what it names. Duration / delay are positionally-matched n-entry lists rented from the
-        // SAME pools the single-entry path above uses (RentDurationList / RentDelayList n-entry overloads), so
-        // they are returned through the existing PendingAnimation.DurationList / DelayList bookkeeping unchanged.
-        // A null override field falls back to the value the caller already resolved for this direction
-        // (durationSec / easing / delaySec — for an exit, easing here is already ExitEasing ?? Easing, so the
-        // fallback stays direction-correct without this method needing to know enter from exit).
-        // The property-name and easing lists are rebuilt each call instead of pooled: PropertyOverrides is a
-        // handful of entries fixed at config-authoring time, so the allocation is bounded and one-shot per
-        // animation start (never per-frame) — but the per-mode EasingFunction INSTANCES are still reused via the
-        // existing static cache (GetOrCreateEasingList) rather than reallocated, mirroring its intent.
+        // transitions only what it names. Duration / delay are positionally-matched n-entry lists, rented EMPTY
+        // and filled directly in the loop below (rather than staged through an intermediary int[] first) from
+        // the SAME pools the single-entry path above uses, so they are returned through the existing
+        // PendingAnimation.DurationList / DelayList bookkeeping unchanged. A null override field falls back to
+        // the value the caller already resolved for this direction (durationSec / easing / delaySec — for an
+        // exit, easing here is already ExitEasing ?? Easing, so the fallback stays direction-correct without
+        // this method needing to know enter from exit).
+        // The easing list IS direction-dependent (an override's null Easing falls back to defaultEasing, which
+        // differs between an enter and an exit) and is rebuilt each call rather than cached: PropertyOverrides
+        // is a handful of entries, so the allocation is bounded and one-shot per animation start (never
+        // per-frame) — the per-mode EasingFunction INSTANCES it holds are still reused via the existing static
+        // cache (GetOrCreateEasingList) rather than reallocated.
         private (List<TimeValue> durationList, List<TimeValue>? delayList) ApplyPropertyOverrideTransitionStyles(
             VisualElement element, float defaultDurationSec, EasingMode defaultEasing, float defaultDelaySec,
             IReadOnlyList<StylePropertyTransition> overrides)
         {
             var count = overrides.Count;
-            var propertyNames = new List<StylePropertyName>(count);
+            var propertyNames = s_propertyNameListCache.GetValue(overrides, static ov =>
+            {
+                var names = new List<StylePropertyName>(ov.Count);
+                for (var i = 0; i < ov.Count; i++)
+                {
+                    names.Add(new StylePropertyName(ov[i].Property));
+                }
+                return names;
+            });
             var easingList = new List<EasingFunction>(count);
-            var durationMs = new int[count];
-            var delayMs = new int[count];
+            var durationList = RentEmptyDurationList(count);
+            var delayList = RentEmptyDelayList(count);
             var hasDelay = false;
             for (var i = 0; i < count; i++)
             {
                 var o = overrides[i];
-                propertyNames.Add(new StylePropertyName(o.Property));
                 easingList.Add(GetOrCreateEasingList(o.Easing ?? defaultEasing)[0]);
-                durationMs[i] = (int)((o.DurationSec ?? defaultDurationSec) * 1000);
+                durationList.Add(new TimeValue((int)((o.DurationSec ?? defaultDurationSec) * 1000), TimeUnit.Millisecond));
                 var delaySec = o.DelaySec ?? defaultDelaySec;
                 if (delaySec > 0f)
                 {
                     hasDelay = true;
-                    delayMs[i] = (int)(delaySec * 1000);
                 }
+                delayList.Add(new TimeValue((int)(delaySec * 1000), TimeUnit.Millisecond));
             }
 
-            var durationList = RentDurationList(durationMs);
             element.style.transitionProperty = propertyNames;
             element.style.transitionDuration = durationList;
             element.style.transitionTimingFunction = easingList;
 
             // Mirrors the single-entry path: transition-delay is set only when at least one property actually
-            // needs one (an all-zero delay list is behaviorally identical to leaving it unset).
-            List<TimeValue>? delayList = null;
-            if (hasDelay)
+            // needs one (an all-zero delay list is behaviorally identical to leaving it unset) — the rented list
+            // is returned immediately rather than handed to the caller for a later ReturnDelayList that would
+            // never come (this play's own bookkeeping only tracks a DelayList when it set one).
+            if (!hasDelay)
             {
-                delayList = RentDelayList(delayMs);
-                element.style.transitionDelay = delayList;
+                ReturnDelayList(delayList);
+                return (durationList, null);
             }
-
+            element.style.transitionDelay = delayList;
             return (durationList, delayList);
         }
 
@@ -1193,45 +1212,38 @@ namespace Velvet
         }
 
         private List<TimeValue> RentDurationList(int ms) => RentTimeValueList(_durationPool, ms);
-        private List<TimeValue> RentDurationList(IReadOnlyList<int> msValues) => RentTimeValueList(_durationPool, msValues);
         private void ReturnDurationList(List<TimeValue>? list) => ReturnTimeValueList(_durationPool, list);
         private List<TimeValue> RentDelayList(int ms) => RentTimeValueList(_delayPool, ms);
-        private List<TimeValue> RentDelayList(IReadOnlyList<int> msValues) => RentTimeValueList(_delayPool, msValues);
         private void ReturnDelayList(List<TimeValue>? list) => ReturnTimeValueList(_delayPool, list);
+        // n-entry siblings for PropertyOverrides: rented EMPTY (the caller fills them directly, positionally
+        // matching each override — see ApplyPropertyOverrideTransitionStyles) rather than pre-filled from an
+        // intermediary int[], but drawn from the SAME pools the single-entry methods above use (a rented list's
+        // capacity just grows to whatever size it was last asked for, so ReturnTimeValueList already handles
+        // returning either shape without change).
+        private List<TimeValue> RentEmptyDurationList(int capacity) => RentEmptyTimeValueList(_durationPool, capacity);
+        private List<TimeValue> RentEmptyDelayList(int capacity) => RentEmptyTimeValueList(_delayPool, capacity);
 
-        // Single-entry hot path (unchanged): every enter / exit without PropertyOverrides rents exactly one of
-        // these per animation.
+        // Single-entry hot path: every enter / exit without PropertyOverrides rents exactly one of these per
+        // animation.
         private static List<TimeValue> RentTimeValueList(Stack<List<TimeValue>> pool, int ms)
         {
-            if (!pool.TryPop(out var list))
-            {
-                list = new List<TimeValue>(1);
-            }
-            else
-            {
-                list.Clear();
-            }
+            var list = RentEmptyTimeValueList(pool, capacity: 1);
             list.Add(new TimeValue(ms, TimeUnit.Millisecond));
             return list;
         }
 
-        // n-entry sibling for PropertyOverrides: builds a positionally-matched TimeValue per override, reusing
-        // the SAME pool as the single-entry path above (a rented list's capacity just grows to whatever size it
-        // was last asked for; Clear()+Add() reuse is agnostic to entry count) — so ReturnTimeValueList below
-        // already handles returning either shape without change.
-        private static List<TimeValue> RentTimeValueList(Stack<List<TimeValue>> pool, IReadOnlyList<int> msValues)
+        // Rents a list with no entries — either a fresh one sized to capacity, or a pooled one cleared of
+        // whatever it held last. Shared by the single-entry rent above (which adds its one TimeValue itself)
+        // and the PropertyOverrides path (which fills several, positionally, in its own loop).
+        private static List<TimeValue> RentEmptyTimeValueList(Stack<List<TimeValue>> pool, int capacity)
         {
             if (!pool.TryPop(out var list))
             {
-                list = new List<TimeValue>(msValues.Count);
+                list = new List<TimeValue>(capacity);
             }
             else
             {
                 list.Clear();
-            }
-            for (var i = 0; i < msValues.Count; i++)
-            {
-                list.Add(new TimeValue(msValues[i], TimeUnit.Millisecond));
             }
             return list;
         }

--- a/Packages/com.velvet.core/Runtime/Styling/StyleArbitraryValueResolver.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleArbitraryValueResolver.cs
@@ -229,6 +229,18 @@ namespace Velvet
             ["100"] = 1f, ["105"] = 1.05f, ["110"] = 1.1f, ["125"] = 1.25f, ["150"] = 1.5f,
         };
 
+        // Single source for the uniform .scale-N USS class's own numeric scale (identical mapping to
+        // s_axisScale above, just keyed by the bare suffix rather than the "scale-x-"/"scale-y-" prefixed
+        // form) — shared so MotionSpringClassParser's uniform-scale recognition resolves the SAME table
+        // instead of holding a second copy that could drift, mirroring TryGetSpacingPx's precedent.
+        internal static bool TryGetAxisScale(string suffix, out float scale) => s_axisScale.TryGetValue(suffix, out scale);
+
+        // Single source for the rotate preset's magnitude (degrees), keyed by the UNSIGNED suffix — shared so
+        // MotionSpringClassParser's rotate-N / rotate-nN recognition resolves the SAME magnitude table instead
+        // of hand-expanding a second ±copy, mirroring TryGetSpacingPx's precedent. The caller negates the
+        // result itself for the "-n"-suffixed (negative) form.
+        internal static bool TryGetRotateScale(string suffix, out float degrees) => s_rotateScale.TryGetValue(suffix, out degrees);
+
         // Maps a margin utility prefix (without the leading '-') to its shorthand ArbitraryProperty.
         private static readonly Dictionary<string, ArbitraryProperty> s_marginPrefix = new()
         {

--- a/Packages/com.velvet.core/Runtime/Styling/StyleDivideManipulator.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleDivideManipulator.cs
@@ -29,6 +29,11 @@ namespace Velvet
     // (divide-dashed / divide-dotted are unsupported, handled by StyleDivideClass). An explicit per-child
     // border on the SAME edge the divider draws on (e.g. border-l on a child of a divide-x row) is
     // OVERWRITTEN — this manipulator owns that edge, exactly as the gap manipulator owns its margin edge.
+    //
+    // Out-of-flow children (position: absolute) are excluded from the index walk — see
+    // StyleOutOfFlowChild — the same way StyleGapManipulator excludes them: an out-of-flow child (a
+    // PopLayout-pinned ghost, or an app-authored .absolute child) is not a layout sibling, so it neither
+    // draws a divider nor counts toward which of the remaining children is "first".
     internal sealed class StyleDivideManipulator : Manipulator
     {
         private DivideSpec _spec;
@@ -114,11 +119,18 @@ namespace Velvet
             _bordered.Clear();
 
             var count = container.childCount;
+            var logicalIndex = 0;
             for (var i = 0; i < count; i++)
             {
                 var child = container[i];
+                // An out-of-flow child is not a layout sibling, so it draws no divider and does not
+                // consume the "first child" slot for whichever in-flow child follows it.
+                if (StyleOutOfFlowChild.IsOutOfFlow(child))
+                {
+                    continue;
+                }
                 // The first child has no leading divider (the `> * + *` rule starts at the second child).
-                var isDivider = i != 0;
+                var isDivider = logicalIndex != 0;
                 var width = isDivider ? new StyleFloat(_spec.Width) : new StyleFloat(StyleKeyword.Null);
                 // Own the edge's color channel on EVERY pass (like the gap manipulator owns its margin):
                 // write the divider color only on a colored divider, else reset to Null. Without the reset a
@@ -136,6 +148,7 @@ namespace Velvet
                     child.style.borderTopColor = color;
                 }
                 _bordered.Add(child);
+                logicalIndex++;
             }
 
             _lastSignature = signature;
@@ -226,7 +239,11 @@ namespace Velvet
                 hash = hash * 31 + count;
                 for (var i = 0; i < count; i++)
                 {
-                    hash = hash * 31 + System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(container[i]);
+                    var child = container[i];
+                    hash = hash * 31 + System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(child);
+                    // A child's in-flow / out-of-flow transition changes which children the divider walk
+                    // counts even though neither its identity nor the container's total count changed.
+                    hash = hash * 31 + (StyleOutOfFlowChild.IsOutOfFlow(child) ? 1 : 0);
                 }
                 return hash;
             }

--- a/Packages/com.velvet.core/Runtime/Styling/StyleGapManipulator.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleGapManipulator.cs
@@ -45,6 +45,14 @@ namespace Velvet
     // (_margined); on each Apply / Clear any tracked element
     // that is no longer a current child has its gap margins reset first, so a child moved out of (or
     // removed from) a gap container carries no residual inline margin.
+    // Out-of-flow children (position: absolute) are excluded from the index walk entirely — see
+    // StyleOutOfFlowChild — matching CSS gap, which never spaces a child that has been taken out of
+    // flow. This is not a PopLayout-only carve-out: any app-authored .absolute child under a gap
+    // container was already exempt from occupying a flex slot, so it must not consume or shift a gap
+    // margin either. It is also what lets AnimatePresenceMode.PopLayout deliver its purpose — a
+    // GeneralPathReconciler.PinExitingChildOutOfFlow ghost must stop being counted the instant it is
+    // pinned so its still-present siblings reflow into its slot immediately, and the ghost's own frozen
+    // margin (folded into its pinned left/top) is left untouched rather than being reset or reassigned.
     // Wrap (flex-wrap) hybrid. CSS gap under wrapping spaces BOTH axes
     // (between items in a line AND between wrapped lines), but a single leading-edge margin can only
     // space the main axis. So this manipulator switches strategy by container mode:
@@ -206,10 +214,20 @@ namespace Velvet
             _margined.Clear();
 
             var count = container.childCount;
+            var logicalIndex = 0;
             for (var i = 0; i < count; i++)
             {
                 var child = container[i];
-                var value = i == 0 ? new StyleLength(StyleKeyword.Null) : new StyleLength(_gap);
+                // Out-of-flow children (a PopLayout-pinned exiting ghost, or an app-authored .absolute
+                // child) hold no slot in the flex line — see StyleOutOfFlowChild. Skip them entirely rather
+                // than resetting their margin: a pinned ghost's own margin is frozen into the compensated
+                // left/top PinExitingChildOutOfFlow already computed for it, and touching it here would
+                // reintroduce the same double-application it was pinned to avoid.
+                if (StyleOutOfFlowChild.IsOutOfFlow(child))
+                {
+                    continue;
+                }
+                var value = logicalIndex == 0 ? new StyleLength(StyleKeyword.Null) : new StyleLength(_gap);
                 if (edge == Edge.Left)
                 {
                     child.style.marginLeft = value;
@@ -219,6 +237,7 @@ namespace Velvet
                     child.style.marginTop = value;
                 }
                 _margined.Add(child);
+                logicalIndex++;
             }
         }
 
@@ -245,6 +264,12 @@ namespace Velvet
             for (var i = 0; i < count; i++)
             {
                 var child = container[i];
+                // See ApplyLeading: an out-of-flow child takes no line slot, so it gets no half-margin
+                // either — the wrap polyfill only spaces children that actually wrap.
+                if (StyleOutOfFlowChild.IsOutOfFlow(child))
+                {
+                    continue;
+                }
                 child.style.marginLeft = half;
                 child.style.marginRight = half;
                 child.style.marginTop = half;
@@ -377,7 +402,12 @@ namespace Velvet
                 hash = hash * 31 + count;
                 for (var i = 0; i < count; i++)
                 {
-                    hash = hash * 31 + System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(container[i]);
+                    var child = container[i];
+                    hash = hash * 31 + System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(child);
+                    // A child's in-flow / out-of-flow transition (a PopLayout pin or its cancel) changes
+                    // which children the margin walk counts even though neither its identity nor the
+                    // container's total count changed, so it must also flip the signature.
+                    hash = hash * 31 + (StyleOutOfFlowChild.IsOutOfFlow(child) ? 1 : 0);
                 }
                 return hash;
             }

--- a/Packages/com.velvet.core/Runtime/Styling/StyleGridManipulator.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleGridManipulator.cs
@@ -42,6 +42,11 @@ namespace Velvet
     // UnregisterCallbacksFromTarget clears the widths + margins it wrote so removing the grid class (or
     // unmounting) leaves no residue. Like the gap manipulator it iterates FiberNodePatcher.GetChildContainer,
     // so the sizing lands on the reconciled content and never on a ScrollView's internal hierarchy.
+    //
+    // Out-of-flow children (position: absolute) are excluded from the column/row walk — see
+    // StyleOutOfFlowChild — matching CSS Grid, whose auto-placement never assigns a cell to an
+    // out-of-flow item. This also keeps a PopLayout-pinned ghost's frozen geometry untouched instead of
+    // being reassigned a column width and margin as if it still occupied a cell.
     internal sealed class StyleGridManipulator : Manipulator
     {
         // A sub-pixel shave off each column so that N*colWidth + (N-1)*gap never exceeds the row width through
@@ -124,11 +129,18 @@ namespace Velvet
                 : 0f;
 
             var count = container.childCount;
+            var logicalIndex = 0;
             for (var i = 0; i < count; i++)
             {
                 var child = container[i];
-                var col = i % n;
-                var row = i / n;
+                // An out-of-flow child (a PopLayout-pinned ghost, or an app-authored .absolute child)
+                // takes no grid cell, so it is skipped rather than assigned a column/row and sized.
+                if (StyleOutOfFlowChild.IsOutOfFlow(child))
+                {
+                    continue;
+                }
+                var col = logicalIndex % n;
+                var row = logicalIndex / n;
                 // The column owns the box: width + all four margins. Width is deferred (Null) until a real
                 // row width resolves on panel.
                 child.style.width = hasWidth ? new StyleLength(colWidth) : new StyleLength(StyleKeyword.Null);
@@ -137,6 +149,7 @@ namespace Velvet
                 child.style.marginRight = new StyleLength(0f);
                 child.style.marginBottom = new StyleLength(0f);
                 _sized.Add(child);
+                logicalIndex++;
             }
 
             // Only lock the signature once a real width resolved, so the deferred (off-panel) pass re-runs
@@ -213,7 +226,11 @@ namespace Velvet
                 hash = hash * 31 + count;
                 for (var i = 0; i < count; i++)
                 {
-                    hash = hash * 31 + System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(container[i]);
+                    var child = container[i];
+                    hash = hash * 31 + System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(child);
+                    // A child's in-flow / out-of-flow transition changes which children the column/row
+                    // walk counts even though neither its identity nor the container's total count changed.
+                    hash = hash * 31 + (StyleOutOfFlowChild.IsOutOfFlow(child) ? 1 : 0);
                 }
                 return hash;
             }

--- a/Packages/com.velvet.core/Runtime/Styling/StyleOutOfFlowChild.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleOutOfFlowChild.cs
@@ -1,0 +1,30 @@
+using UnityEngine.UIElements;
+
+namespace Velvet
+{
+    // Shared out-of-flow test for the index-driven child manipulators (StyleGapManipulator,
+    // StyleGridManipulator, StyleDivideManipulator). Each of them walks a container's children by raw
+    // DOM index to decide "is this the first child" / "which column or row does this child fall into", and
+    // writes margins / borders / widths on that basis. A child pulled out of layout flow via
+    // position: absolute — a PopLayout ghost pinned by GeneralPathReconciler.PinExitingChildOutOfFlow, or an
+    // app-authored .absolute utility child — holds no slot in the flex line, so counting it would both waste
+    // spacing on a sibling that no longer occupies one and, for a pinned ghost, disturb the compensated
+    // inline position PinExitingChildOutOfFlow computed for it. CSS itself excludes out-of-flow children from
+    // gap / grid placement the same way, so this is a correctness fix for the ordinary (non-PopLayout) case
+    // too, not a PopLayout-only carve-out.
+    internal static class StyleOutOfFlowChild
+    {
+        // On a panel this reads the resolved position (reflects both an inline override — the way a PopLayout
+        // pin sets it — and a class-driven one). Off-panel (EditMode, pre-attach) resolvedStyle is not yet
+        // meaningful, so this falls back to the .absolute utility class marker, mirroring the off-panel idiom
+        // StyleGapManipulator.IsRow/IsWrap already use for flex-direction / flex-wrap.
+        internal static bool IsOutOfFlow(VisualElement child)
+        {
+            if (child.panel != null)
+            {
+                return child.resolvedStyle.position == Position.Absolute;
+            }
+            return child.ClassListContains("absolute");
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Styling/StyleOutOfFlowChild.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleOutOfFlowChild.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e28a4902a94e42d1b8de7d78af95cac5

--- a/Packages/com.velvet.core/Runtime/Styling/StyleTransitionConfig.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleTransitionConfig.cs
@@ -143,6 +143,17 @@ namespace Velvet
         /// <remarks>Equivalent to Framer Motion's <c>transition.when</c> for users migrating from Framer Motion.</remarks>
         public TransitionWhen When { get; init; } = TransitionWhen.Together;
 
+        /// <summary>
+        /// Whether an AnimatePresence exit gated by this config should be treated as animated (kept mounted as
+        /// an exiting ghost) rather than removed instantly. A spring's settle time is decided by
+        /// <see cref="Stiffness"/> / <see cref="Damping"/> / <see cref="Mass"/>, not <see cref="DurationSec"/>
+        /// (documented as ignored for <see cref="TransitionType.Spring"/>), so a spring counts as animated
+        /// regardless of DurationSec — including the degenerate case where the exit's variant pair touches no
+        /// spring-animatable channel at all, which still plays through the spring machinery (completing on its
+        /// own, deferred, rather than being pre-empted by an instant-removal gate keyed on this flag).
+        /// </summary>
+        internal bool HasExitAnimation => Type == TransitionType.Spring || DurationSec > 0f;
+
         // Parsed class-name array caches (lazily initialized).
         private string[]? _enterFromClasses;
         private string[]? _enterToClasses;

--- a/Packages/com.velvet.core/Runtime/Styling/StyleTransitionConfig.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleTransitionConfig.cs
@@ -295,7 +295,10 @@ namespace Velvet
 
         /// <summary>
         /// Inheriting descendants wait for this Motion's OWN transition to finish before starting: every
-        /// descendant's computed delay additionally includes this Motion's <see cref="StyleTransitionConfig.DurationSec"/>.
+        /// descendant's computed delay additionally includes this Motion's own
+        /// <see cref="StyleTransitionConfig.DelaySec"/> + <see cref="StyleTransitionConfig.DurationSec"/> — the
+        /// full span of its swap, not just the duration, since the swap does not even START until DelaySec has
+        /// elapsed.
         /// </summary>
         BeforeChildren,
 

--- a/Packages/com.velvet.core/Runtime/Styling/StyleTransitionConfig.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleTransitionConfig.cs
@@ -34,13 +34,46 @@ namespace Velvet
         internal string? ExitToClass { get; init; }
 
         /// <summary>
+        /// Selects the animation model: a USS <c>transition-*</c> class swap (<see cref="TransitionType.Tween"/>,
+        /// the default) or a physics-integrated spring (<see cref="TransitionType.Spring"/>). See
+        /// <see cref="TransitionType"/> for the full contract, including what a spring does and does not animate.
+        /// </summary>
+        /// <remarks>Equivalent to setting Framer Motion's <c>transition.type</c> to <c>"tween"</c> / <c>"spring"</c>
+        /// for users migrating from Framer Motion — except Velvet defaults to <c>Tween</c> where Framer defaults
+        /// transform-like values to a spring; spring is opt-in here.</remarks>
+        public TransitionType Type { get; init; } = TransitionType.Tween;
+
+        /// <summary>
+        /// Spring stiffness (only meaningful when <see cref="Type"/> is <see cref="TransitionType.Spring"/>).
+        /// Higher values snap toward the target faster. Framer Motion's default (100).
+        /// </summary>
+        public float Stiffness { get; init; } = 100f;
+
+        /// <summary>
+        /// Spring damping (only meaningful when <see cref="Type"/> is <see cref="TransitionType.Spring"/>).
+        /// Higher values settle with less oscillation. Framer Motion's default (10).
+        /// </summary>
+        public float Damping { get; init; } = 10f;
+
+        /// <summary>
+        /// Spring mass (only meaningful when <see cref="Type"/> is <see cref="TransitionType.Spring"/>).
+        /// Higher values feel heavier / slower to accelerate. Framer Motion's default (1).
+        /// </summary>
+        public float Mass { get; init; } = 1f;
+
+        /// <summary>
         /// Animation duration (seconds). Applied as the inline transition-duration style.
+        /// Ignored when <see cref="Type"/> is <see cref="TransitionType.Spring"/>: a spring's settle time is
+        /// decided entirely by <see cref="Stiffness"/> / <see cref="Damping"/> / <see cref="Mass"/>, not a fixed
+        /// duration.
         /// </summary>
         public float DurationSec { get; init; }
 
         /// <summary>
         /// Easing mode. Applied as the inline transition-timing-function style.
         /// Defaults to EaseOut (for enter). Presets in StyleTransition.cs configure enter/exit easing separately.
+        /// Ignored when <see cref="Type"/> is <see cref="TransitionType.Spring"/>: the physics integration IS the
+        /// curve.
         /// </summary>
         public EasingMode Easing { get; init; } = EasingMode.EaseOut;
 
@@ -70,6 +103,10 @@ namespace Velvet
         /// all (a variant-driven enter, or an exit driven by a <c>variants</c> + <c>exit</c> label) — a preset
         /// transition's own USS-declared transition-property is untouched. Null (default) preserves today's
         /// behavior unchanged.
+        /// Not read when <see cref="Type"/> is <see cref="TransitionType.Spring"/>: a spring drives every animated
+        /// channel with the SAME <see cref="Stiffness"/> / <see cref="Damping"/> / <see cref="Mass"/> — there is no
+        /// per-property override of the spring model itself (only <see cref="TransitionType.Tween"/>'s per-property
+        /// duration/easing/delay can be overridden this way).
         /// </summary>
         public IReadOnlyList<StylePropertyTransition>? PropertyOverrides { get; init; }
 
@@ -147,12 +184,16 @@ namespace Velvet
                 Easing = easing ?? Easing,
                 ExitEasing = exitEasing ?? ExitEasing,
                 DelaySec = delaySec ?? DelaySec,
-                // Passed through unchanged: With() only tunes the top-level timing, not per-property overrides
-                // or the child-orchestration knobs.
+                // Passed through unchanged: With() only tunes the top-level timing, not per-property overrides,
+                // the child-orchestration knobs, or the spring model.
                 PropertyOverrides = PropertyOverrides,
                 StaggerChildrenSec = StaggerChildrenSec,
                 DelayChildrenSec = DelayChildrenSec,
                 When = When,
+                Type = Type,
+                Stiffness = Stiffness,
+                Damping = Damping,
+                Mass = Mass,
                 // Class names are identical, so share the parsed arrays (avoids re-parsing).
                 _enterFromClasses = _enterFromClasses,
                 _enterToClasses = _enterToClasses,
@@ -194,6 +235,37 @@ namespace Velvet
             Easing = easing;
             DelaySec = delaySec;
         }
+    }
+
+    /// <summary>
+    /// Selects the animation model a <see cref="StyleTransitionConfig"/> plays with — see
+    /// <see cref="StyleTransitionConfig.Type"/>.
+    /// </summary>
+    public enum TransitionType
+    {
+        /// <summary>
+        /// A USS <c>transition-*</c> class swap: <see cref="StyleTransitionConfig.DurationSec"/> /
+        /// <see cref="StyleTransitionConfig.Easing"/> drive a fixed-duration tween between the from/to classes.
+        /// The default.
+        /// </summary>
+        Tween,
+
+        /// <summary>
+        /// A physics-integrated spring (see the internal SpringIntegrator): <see cref="StyleTransitionConfig.Stiffness"/>
+        /// / <see cref="StyleTransitionConfig.Damping"/> / <see cref="StyleTransitionConfig.Mass"/> decide the
+        /// curve and settle time instead of a fixed duration — CSS/USS transitions cannot express a spring, so
+        /// this is driven by a per-frame tick that writes inline styles directly (like the drop-shadow co-fade
+        /// tick), not <c>transition-duration</c>/<c>transition-timing-function</c>.
+        /// Only <see cref="Velvet.MotionNode"/>'s variant enter/exit (<c>variants</c> + <c>initial</c>/<c>animate</c>/
+        /// <c>exit</c>) plays a spring — the classic preset transitions (<see cref="StyleTransition"/>) are always
+        /// tweens, since their enter/exit classes are internal to the package.
+        /// Only OPACITY and the transform trio — translate x/y (pixels only; percentage-based translate such as
+        /// <c>translate-x-1/2</c> or <c>translate-x-full</c> is out of scope), uniform scale, and rotate (degrees)
+        /// — are spring-animated; colors, arbitrary lengths (width/height/margin/…), and per-axis
+        /// <c>scale-x-</c>/<c>scale-y-</c> are out of scope and are NOT animated by a spring (they still apply as
+        /// plain classes, just without a tween/spring transition on them).
+        /// </summary>
+        Spring,
     }
 
     /// <summary>

--- a/Packages/com.velvet.core/Runtime/Styling/StyleTransitionConfig.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleTransitionConfig.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using UnityEngine.UIElements;
 
 namespace Velvet
@@ -58,6 +59,20 @@ namespace Velvet
         /// </summary>
         public float DelaySec { get; init; }
 
+        /// <summary>
+        /// Optional per-property transition overrides layered on top of the top-level <see cref="DurationSec"/> /
+        /// <see cref="Easing"/> / <see cref="DelaySec"/> (e.g. opacity tweening in 0.15s while scale takes 0.5s).
+        /// When set, transition-property switches from the implicit "all" catch-all — used for a variant class
+        /// swap, which carries no transition-* of its own — to EXACTLY these properties, in declaration order:
+        /// overrides REPLACE transition-property: all rather than layering on top of it, matching CSS semantics
+        /// where an explicit transition-property list transitions only what it names. Name every property that
+        /// should animate. Currently wired only where a variant swap would otherwise set transition-property:
+        /// all (a variant-driven enter, or an exit driven by a <c>variants</c> + <c>exit</c> label) — a preset
+        /// transition's own USS-declared transition-property is untouched. Null (default) preserves today's
+        /// behavior unchanged.
+        /// </summary>
+        public IReadOnlyList<StylePropertyTransition>? PropertyOverrides { get; init; }
+
         // Parsed class-name array caches (lazily initialized).
         private string[]? _enterFromClasses;
         private string[]? _enterToClasses;
@@ -99,6 +114,8 @@ namespace Velvet
                 Easing = easing ?? Easing,
                 ExitEasing = exitEasing ?? ExitEasing,
                 DelaySec = delaySec ?? DelaySec,
+                // Passed through unchanged: With() only tunes the top-level timing, not per-property overrides.
+                PropertyOverrides = PropertyOverrides,
                 // Class names are identical, so share the parsed arrays (avoids re-parsing).
                 _enterFromClasses = _enterFromClasses,
                 _enterToClasses = _enterToClasses,
@@ -108,5 +125,37 @@ namespace Velvet
         }
 
         private static string[] ParseClasses(string? classNames) => Velvet.V.ParseClassNames(classNames);
+    }
+
+    /// <summary>
+    /// A single property's transition override inside <see cref="StyleTransitionConfig.PropertyOverrides"/>.
+    /// Any null field falls back to the enclosing config's corresponding top-level value — <see cref="Easing"/>
+    /// falls back to the config's EFFECTIVE easing for the direction being played (<c>Easing</c> for an enter,
+    /// <c>ExitEasing ?? Easing</c> for an exit), matching how the top-level fields already resolve per direction.
+    /// </summary>
+    public readonly struct StylePropertyTransition
+    {
+        /// <summary>
+        /// The USS property name UI Toolkit animates, e.g. <c>"opacity"</c>, <c>"scale"</c>, <c>"translate"</c>,
+        /// <c>"rotate"</c>, <c>"background-color"</c> — spelled exactly as UI Toolkit's transition-property expects.
+        /// </summary>
+        public string Property { get; }
+
+        /// <summary>Duration override (seconds). Null falls back to <see cref="StyleTransitionConfig.DurationSec"/>.</summary>
+        public float? DurationSec { get; }
+
+        /// <summary>Easing override. Null falls back to the enclosing config's effective easing for the direction being played.</summary>
+        public EasingMode? Easing { get; }
+
+        /// <summary>Delay override (seconds). Null falls back to <see cref="StyleTransitionConfig.DelaySec"/>.</summary>
+        public float? DelaySec { get; }
+
+        public StylePropertyTransition(string property, float? durationSec = null, EasingMode? easing = null, float? delaySec = null)
+        {
+            Property = property;
+            DurationSec = durationSec;
+            Easing = easing;
+            DelaySec = delaySec;
+        }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Styling/StyleTransitionConfig.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleTransitionConfig.cs
@@ -73,6 +73,39 @@ namespace Velvet
         /// </summary>
         public IReadOnlyList<StylePropertyTransition>? PropertyOverrides { get; init; }
 
+        /// <summary>
+        /// Delay interval (seconds) applied sequentially to each DESCENDANT Motion that inherits its active
+        /// label from this Motion (it declares <c>variants</c> but no own <c>animate</c> — see
+        /// <see cref="Velvet.MotionNode.Animate"/>) when that ambient label changes: the i-th such inheriting
+        /// descendant, visited in document order, is delayed an additional <c>DelayChildrenSec + StaggerChildrenSec
+        /// * i</c> on top of its OWN <see cref="DelaySec"/>. 0 (default) means no stagger (every inheriting
+        /// descendant responds at the same time). Unlike AnimatePresence's own per-child enter/exit stagger
+        /// (<c>V.AnimatePresence(staggerSec:)</c>), this orchestrates a PLAIN parent → child label propagation —
+        /// no AnimatePresence boundary is required; toggling this Motion's <c>animate</c> prop is enough. A
+        /// descendant with its OWN explicit <c>animate</c> opts out of both the label inheritance and this
+        /// stagger — it is driven by its own render, not this propagation (matching Framer Motion, where an
+        /// explicit <c>animate</c> override disconnects a component from its parent's variant propagation). The
+        /// stagger index is transitive: an inheriting descendant with no stagger config of its own passes this
+        /// orchestration through to ITS OWN inheriting children, who continue claiming from the SAME sequence.
+        /// </summary>
+        /// <remarks>Equivalent to Framer Motion's <c>transition.staggerChildren</c> for users migrating from Framer Motion.</remarks>
+        public float StaggerChildrenSec { get; init; }
+
+        /// <summary>
+        /// A fixed delay (seconds) added before any inheriting descendant's staggered delay — see
+        /// <see cref="StaggerChildrenSec"/> for the full propagation contract. 0 (default) means no fixed delay.
+        /// </summary>
+        /// <remarks>Equivalent to Framer Motion's <c>transition.delayChildren</c> for users migrating from Framer Motion.</remarks>
+        public float DelayChildrenSec { get; init; }
+
+        /// <summary>
+        /// Sequences this Motion's own class swap against its inheriting descendants' swaps (see
+        /// <see cref="StaggerChildrenSec"/>) when its active label changes. Defaults to
+        /// <see cref="TransitionWhen.Together"/>.
+        /// </summary>
+        /// <remarks>Equivalent to Framer Motion's <c>transition.when</c> for users migrating from Framer Motion.</remarks>
+        public TransitionWhen When { get; init; } = TransitionWhen.Together;
+
         // Parsed class-name array caches (lazily initialized).
         private string[]? _enterFromClasses;
         private string[]? _enterToClasses;
@@ -114,8 +147,12 @@ namespace Velvet
                 Easing = easing ?? Easing,
                 ExitEasing = exitEasing ?? ExitEasing,
                 DelaySec = delaySec ?? DelaySec,
-                // Passed through unchanged: With() only tunes the top-level timing, not per-property overrides.
+                // Passed through unchanged: With() only tunes the top-level timing, not per-property overrides
+                // or the child-orchestration knobs.
                 PropertyOverrides = PropertyOverrides,
+                StaggerChildrenSec = StaggerChildrenSec,
+                DelayChildrenSec = DelayChildrenSec,
+                When = When,
                 // Class names are identical, so share the parsed arrays (avoids re-parsing).
                 _enterFromClasses = _enterFromClasses,
                 _enterToClasses = _enterToClasses,
@@ -157,5 +194,35 @@ namespace Velvet
             Easing = easing;
             DelaySec = delaySec;
         }
+    }
+
+    /// <summary>
+    /// Sequences a Motion's own class swap against its inheriting descendants' swaps — see
+    /// <see cref="StyleTransitionConfig.When"/> and <see cref="StyleTransitionConfig.StaggerChildrenSec"/>.
+    /// </summary>
+    /// <remarks>Equivalent to Framer Motion's <c>transition.when</c> for users migrating from Framer Motion.</remarks>
+    public enum TransitionWhen
+    {
+        /// <summary>
+        /// This Motion and its inheriting descendants animate at the same time, offset only by
+        /// <see cref="StyleTransitionConfig.StaggerChildrenSec"/> / <see cref="StyleTransitionConfig.DelayChildrenSec"/>.
+        /// The default.
+        /// </summary>
+        Together,
+
+        /// <summary>
+        /// Inheriting descendants wait for this Motion's OWN transition to finish before starting: every
+        /// descendant's computed delay additionally includes this Motion's <see cref="StyleTransitionConfig.DurationSec"/>.
+        /// </summary>
+        BeforeChildren,
+
+        /// <summary>
+        /// In Framer Motion, this Motion's own transition would wait for every inheriting descendant to finish
+        /// first. Not implemented: Velvet applies this Motion's own class swap before its descendants are even
+        /// visited during the reconcile walk, so the descendant count / durations needed to delay THIS swap are
+        /// not known in time. Setting this value logs a warning and behaves like <see cref="Together"/> (no
+        /// parent/child sequencing) rather than silently applying the wrong delay.
+        /// </summary>
+        AfterChildren,
     }
 }

--- a/Packages/com.velvet.core/Runtime/Styling/StyleTransitionConfig.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleTransitionConfig.cs
@@ -213,6 +213,35 @@ namespace Velvet
             };
         }
 
+        /// <summary>
+        /// Builds a new StyleTransitionConfig for a variant `exit` (see
+        /// <see cref="Velvet.MotionNode.Exit"/>): copies every timing / spring / per-property-override knob
+        /// unchanged from this config — the enclosing Motion's own <c>transition</c> — but replaces the exit
+        /// class pair with the resolved variant classes. Sibling to <see cref="With"/> (which tunes a preset's
+        /// timing while keeping its class names): this keeps the timing/spring knobs fixed while replacing the
+        /// classes, so the two together cover both directions a caller needs to override without repeating the
+        /// growing knob list at each call site.
+        /// </summary>
+        /// <param name="exitFromClass">The resting variant's own class string (variants[Animate]).</param>
+        /// <param name="exitToClass">The exit variant's class string (variants[Exit]).</param>
+        internal StyleTransitionConfig WithExitClasses(string exitFromClass, string exitToClass)
+        {
+            return new StyleTransitionConfig
+            {
+                ExitFromClass = exitFromClass,
+                ExitToClass = exitToClass,
+                DurationSec = DurationSec,
+                Easing = Easing,
+                ExitEasing = ExitEasing,
+                DelaySec = DelaySec,
+                PropertyOverrides = PropertyOverrides,
+                Type = Type,
+                Stiffness = Stiffness,
+                Damping = Damping,
+                Mass = Mass,
+            };
+        }
+
         private static string[] ParseClasses(string? classNames) => Velvet.V.ParseClassNames(classNames);
     }
 

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/MotionCompletionTimeoutTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/MotionCompletionTimeoutTests.cs
@@ -1,0 +1,141 @@
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.UIElements;
+using UnityEngine.UIElements.TestFramework;
+using UnityEditor.UIElements.TestFramework;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins the enter/exit completion timeout against <see cref="StyleTransitionConfig.PropertyOverrides"/>: a
+    /// variant swap's completion (the timer that clears the inline transition styles for an enter, or drops the
+    /// ghost for an exit) must wait for the SLOWEST overridden property, not just the top-level DurationSec —
+    /// sharing the same slowest-property computation an interrupted reversal already uses
+    /// (StyleAnimationScheduler.SlowestPropertyTimeoutMs). Needs a real (simulated, time-driven) panel: the
+    /// timeout is a scheduled item, so observing whether it has fired yet requires actually advancing the
+    /// panel's clock, which <c>MotionPerPropertyTransitionTests</c>' ForcePanelUpdate-based harness (a
+    /// synchronous style-resolution pass, not a clock) cannot do.
+    /// </summary>
+    [TestFixture]
+    internal sealed class MotionCompletionTimeoutTests
+    {
+        private EditorPanelSimulator _sim;
+
+        [SetUp]
+        public void SetUp()
+        {
+            PanelSimulator.ResetCurrentTime();
+            _sim = new EditorPanelSimulator { panelSize = new Vector2(800, 600) };
+            _sim.ResetTimePerSimulatedFrameToDefault();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _sim?.Dispose();
+            _sim = null;
+        }
+
+        private VisualElement Root => _sim.rootVisualElement;
+
+        private void AdvancePastMs(long ms)
+        {
+            var steps = (int)(ms / 16) + 1;
+            for (var i = 0; i < steps; i++) _sim.FrameUpdateMs(16);
+        }
+
+        private static StylePropertyTransition[] SlowScaleOverrides() => new[]
+        {
+            new StylePropertyTransition("opacity", durationSec: 0.15f),
+            new StylePropertyTransition("scale", durationSec: 0.5f),
+        };
+
+        [Test]
+        public void Given_AVariantEnterWithASlowerPropertyOverride_When_OnlyTheTopLevelDurationHasElapsed_Then_OnCompleteHasNotFiredYet()
+        {
+            // Arrange — the top-level DurationSec (0.3s) is FASTER than the "scale" override (0.5s); sizing the
+            // completion off the top-level value alone would fire while scale is still mid-tween.
+            var element = new VisualElement();
+            Root.Add(element);
+            var scheduler = new StyleAnimationScheduler();
+            var completed = false;
+
+            // Act
+            scheduler.PlayVariantEnter(element, System.Array.Empty<string>(), System.Array.Empty<string>(),
+                durationSec: 0.3f, easing: EasingMode.EaseOut, delaySec: 0f,
+                onComplete: () => completed = true, propertyOverrides: SlowScaleOverrides());
+            AdvancePastMs(400);
+
+            // Assert — 400ms has cleared the top-level 0.3s (plus grace) but not the slowest override (0.5s).
+            Assert.That(completed, Is.False);
+        }
+
+        [Test]
+        public void Given_AVariantEnterWithASlowerPropertyOverride_When_TheSlowestOverrideDurationPlusGraceHasElapsed_Then_OnCompleteFires()
+        {
+            // Arrange — same config as above; this time advance well past the slowest override.
+            var element = new VisualElement();
+            Root.Add(element);
+            var scheduler = new StyleAnimationScheduler();
+            var completed = false;
+
+            // Act
+            scheduler.PlayVariantEnter(element, System.Array.Empty<string>(), System.Array.Empty<string>(),
+                durationSec: 0.3f, easing: EasingMode.EaseOut, delaySec: 0f,
+                onComplete: () => completed = true, propertyOverrides: SlowScaleOverrides());
+            AdvancePastMs(700);
+
+            // Assert — the completion still fires once the slowest override has genuinely elapsed.
+            Assert.That(completed, Is.True);
+        }
+
+        [Test]
+        public void Given_AVariantExitWithASlowerPropertyOverride_When_OnlyTheTopLevelDurationHasElapsed_Then_OnCompleteHasNotFiredYet()
+        {
+            // Arrange — a variant exit (restoreFromOnCancel) whose PropertyOverrides carries the same
+            // faster-top-level / slower-scale-override shape.
+            var element = new VisualElement();
+            Root.Add(element);
+            var scheduler = new StyleAnimationScheduler();
+            var completed = false;
+            var config = new StyleTransitionConfig
+            {
+                ExitFromClass = "opacity-100",
+                ExitToClass = "opacity-0",
+                DurationSec = 0.3f,
+                PropertyOverrides = SlowScaleOverrides(),
+            };
+
+            // Act
+            scheduler.PlayExit(element, config, onComplete: () => completed = true, restoreFromOnCancel: true);
+            AdvancePastMs(400);
+
+            // Assert — completing here would drop the ghost while the slower "scale" override is still animating.
+            Assert.That(completed, Is.False);
+        }
+
+        [Test]
+        public void Given_AVariantExitWithASlowerPropertyOverride_When_TheSlowestOverrideDurationPlusGraceHasElapsed_Then_OnCompleteFires()
+        {
+            // Arrange
+            var element = new VisualElement();
+            Root.Add(element);
+            var scheduler = new StyleAnimationScheduler();
+            var completed = false;
+            var config = new StyleTransitionConfig
+            {
+                ExitFromClass = "opacity-100",
+                ExitToClass = "opacity-0",
+                DurationSec = 0.3f,
+                PropertyOverrides = SlowScaleOverrides(),
+            };
+
+            // Act
+            scheduler.PlayExit(element, config, onComplete: () => completed = true, restoreFromOnCancel: true);
+            AdvancePastMs(700);
+
+            // Assert
+            Assert.That(completed, Is.True);
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/MotionCompletionTimeoutTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/MotionCompletionTimeoutTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 97ea7e1ac95c4dbcb661c6ae86aeb78f

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/MotionPerPropertyTransitionTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/MotionPerPropertyTransitionTests.cs
@@ -1,0 +1,132 @@
+using System.Linq;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.UIElements;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins <see cref="StyleTransitionConfig.PropertyOverrides"/>: a variant-swap transition (the only place the
+    /// scheduler sets transition-property: all — PlayVariantEnter / a variant-driven PlayExit) with per-property
+    /// overrides switches transition-property from that implicit "all" catch-all to EXACTLY the overridden
+    /// properties, in declaration order, with duration / easing / delay built as positionally-matched lists — a
+    /// null override field falls back to the top-level DurationSec / Easing / DelaySec. The resolving cases use a
+    /// real EditorWindow panel so resolvedStyle reflects the scheduler's inline styles; the cancel case is
+    /// deliberately off-panel (mirrors the existing off-panel-cancel contract, so no panel is needed there).
+    /// </summary>
+    [TestFixture]
+    internal sealed class MotionPerPropertyTransitionTests
+    {
+        private EditorWindow _window;
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (_window != null)
+            {
+                _window.Close();
+                Object.DestroyImmediate(_window);
+                _window = null;
+            }
+        }
+
+        private VisualElement MountOnRealPanel()
+        {
+            TestGraphics.IgnoreIfHeadless("an EditorWindow panel");
+            _window = ScriptableObject.CreateInstance<EditorWindow>();
+            _window.Show();
+            var element = new VisualElement();
+            _window.rootVisualElement.Add(element);
+            return element;
+        }
+
+        [Test]
+        public void Given_AVariantEnterWithTwoPropertyOverrides_When_Resolved_Then_TransitionPropertyIsExactlyThoseTwoWithMatchingDurations()
+        {
+            // Arrange — a variant enter (the allProperties path) whose transition carries two per-property
+            // overrides with different durations.
+            var element = MountOnRealPanel();
+            var scheduler = new StyleAnimationScheduler();
+            var overrides = new[]
+            {
+                new StylePropertyTransition("opacity", durationSec: 0.15f),
+                new StylePropertyTransition("scale", durationSec: 0.5f),
+            };
+            Assume.That(element.panel, Is.Not.Null, "Precondition: the element is on a real panel");
+
+            // Act
+            scheduler.PlayVariantEnter(element, System.Array.Empty<string>(), System.Array.Empty<string>(),
+                durationSec: 0.3f, easing: EasingMode.EaseOut, delaySec: 0f, propertyOverrides: overrides);
+            EditorPanelTestHelpers.ForcePanelUpdate(element.panel);
+
+            // Assert — transition-property is exactly [opacity, scale] (not the implicit "all"), each POSITIONALLY
+            // paired with its OWN override duration instead of the shared top-level 0.3f. The scheduler authors
+            // TimeValue entries in milliseconds (TimeUnit.Millisecond), and resolvedStyle reports them back in
+            // that same unit (unlike a USS duration-* utility, which is parsed straight to seconds). Zipped into
+            // an array of (property, durationMs) pairs so the array-of-scalar-tuples compares deep-equal instead
+            // of a tuple-of-arrays (which NUnit does not expand element-wise).
+            var props = element.resolvedStyle.transitionProperty.Select(p => p.ToString());
+            var durationsMs = element.resolvedStyle.transitionDuration.Select(t => t.value);
+            var resolved = props.Zip(durationsMs, (property, durationMs) => (property, durationMs)).ToArray();
+            Assert.That(resolved, Is.EqualTo(new[] { ("opacity", 150f), ("scale", 500f) }).Within(1e-3f));
+        }
+
+        [Test]
+        public void Given_APropertyOverrideWithNoDurationField_When_Resolved_Then_ItFallsBackToTheTopLevelDurationSec()
+        {
+            // Arrange — one override sets its own duration; the other omits it (null DurationSec).
+            var element = MountOnRealPanel();
+            var scheduler = new StyleAnimationScheduler();
+            var overrides = new[]
+            {
+                new StylePropertyTransition("opacity", durationSec: 0.15f),
+                new StylePropertyTransition("scale"),
+            };
+            Assume.That(element.panel, Is.Not.Null, "Precondition: the element is on a real panel");
+
+            // Act
+            scheduler.PlayVariantEnter(element, System.Array.Empty<string>(), System.Array.Empty<string>(),
+                durationSec: 0.4f, easing: EasingMode.EaseOut, delaySec: 0f, propertyOverrides: overrides);
+            EditorPanelTestHelpers.ForcePanelUpdate(element.panel);
+
+            // Assert — the un-overridden "scale" duration falls back to the top-level DurationSec (0.4f = 400ms).
+            var durationsMs = element.resolvedStyle.transitionDuration.Select(t => t.value).ToArray();
+            Assert.That(durationsMs, Is.EqualTo(new[] { 150f, 400f }).Within(1e-3f));
+        }
+
+        [Test]
+        public void Given_AnOffPanelVariantExitWithPropertyOverrides_When_Cancelled_Then_TheInlineTransitionStylesClearImmediately()
+        {
+            // Arrange — an off-panel variant exit (restoreFromOnCancel) whose config carries property
+            // overrides. Off-panel mirrors the existing contract: nothing to interpolate, so a cancel clears
+            // synchronously instead of deferring (which would also plant a stale deferred-attach callback).
+            var scheduler = new StyleAnimationScheduler();
+            var element = new VisualElement();
+            Assume.That(element.panel, Is.Null, "Precondition: the element is off-panel");
+            var config = new StyleTransitionConfig
+            {
+                ExitFromClass = "opacity-100",
+                ExitToClass = "opacity-0",
+                DurationSec = 0.2f,
+                Easing = EasingMode.EaseOut,
+                PropertyOverrides = new[]
+                {
+                    new StylePropertyTransition("opacity", durationSec: 0.1f),
+                    new StylePropertyTransition("scale", durationSec: 0.3f),
+                },
+            };
+            scheduler.PlayExit(element, config, onComplete: null, restoreFromOnCancel: true);
+            Assume.That(element.style.transitionDuration.keyword, Is.Not.EqualTo(StyleKeyword.Null),
+                "Precondition: PlayExit applied the per-property inline transition styles");
+
+            // Act — cancel before the element ever attaches.
+            scheduler.CancelExit(element);
+
+            // Assert — cleared immediately (no panel to interpolate against): the n-entry lists rented for the
+            // overrides are returned rather than left applied.
+            Assert.That(element.style.transitionDuration.keyword, Is.EqualTo(StyleKeyword.Null));
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/MotionPerPropertyTransitionTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/MotionPerPropertyTransitionTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 361e92da79c1948769a1c5053fdf45ef

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/MotionSpringDriverTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/MotionSpringDriverTests.cs
@@ -15,11 +15,10 @@ namespace Velvet.Tests
     /// numeric from/to values come from <see cref="MotionSpringClassParser"/>'s class-name parsing, not a style
     /// resolution pass), and the recurring tick this scheduler registers (<c>schedule.Execute(...).Every(16)</c>)
     /// needs a live panel clock to FIRE automatically, which the EditMode batchmode PlayerLoop never drives. So,
-    /// mirroring <c>ShadowAnimationVisibilityTests</c>' own panel-free approach and the assignment's documented
-    /// fallback: the scheduler's synchronous setup is asserted directly (no tick needed to observe it), and the
-    /// recurring tick's own math is exercised by calling <see cref="MotionSpringDriver.Step"/> directly in a loop
-    /// instead of trying to pump a real/simulated scheduler clock. GWT, one assert per case (Assume for
-    /// preconditions).
+    /// mirroring <c>ShadowAnimationVisibilityTests</c>' own panel-free approach: the scheduler's synchronous
+    /// setup is asserted directly (no tick needed to observe it), and the recurring tick's own math is exercised
+    /// by calling <see cref="MotionSpringDriver.Step"/> directly in a loop instead of trying to pump a
+    /// real/simulated scheduler clock. GWT, one assert per case (Assume for preconditions).
     /// </remarks>
     [TestFixture]
     internal sealed class MotionSpringDriverTests

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/MotionSpringDriverTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/MotionSpringDriverTests.cs
@@ -1,0 +1,151 @@
+using NUnit.Framework;
+using UnityEngine.UIElements;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins the spring-driven variant enter/exit (<c>StyleTransitionConfig.Type == Spring</c>): the from→to class
+    /// swap lands at rest IMMEDIATELY (no CSS-transition-triggering frame boundary the tween path needs), the
+    /// per-frame physics tick (<see cref="MotionSpringDriver.Step"/>) moves the inline style toward the target
+    /// and reports settled once it arrives, and an exit-cancel retarget (<see cref="MotionSpringDriver.Retarget"/>)
+    /// redirects a channel toward its resting value without resetting its integrator.
+    /// </summary>
+    /// <remarks>
+    /// Panel-free by design: <c>StyleAnimationScheduler</c>'s spring path never reads <c>resolvedStyle</c> (the
+    /// numeric from/to values come from <see cref="MotionSpringClassParser"/>'s class-name parsing, not a style
+    /// resolution pass), and the recurring tick this scheduler registers (<c>schedule.Execute(...).Every(16)</c>)
+    /// needs a live panel clock to FIRE automatically, which the EditMode batchmode PlayerLoop never drives. So,
+    /// mirroring <c>ShadowAnimationVisibilityTests</c>' own panel-free approach and the assignment's documented
+    /// fallback: the scheduler's synchronous setup is asserted directly (no tick needed to observe it), and the
+    /// recurring tick's own math is exercised by calling <see cref="MotionSpringDriver.Step"/> directly in a loop
+    /// instead of trying to pump a real/simulated scheduler clock. GWT, one assert per case (Assume for
+    /// preconditions).
+    /// </remarks>
+    [TestFixture]
+    internal sealed class MotionSpringDriverTests
+    {
+        private const float FixedDeltaSec = 1f / 60f;
+
+        [Test]
+        public void Given_ASpringVariantEnter_When_Started_Then_ClassesLandAtRestWithInlineOpacityAtTheFromValue()
+        {
+            // Arrange — the element already carries the resting (to) class, matching PlayVariantEnter's
+            // precondition (FiberNodeFactory / GeneralPathReconciler create it with variants[animate] applied
+            // before ever calling this).
+            var scheduler = new StyleAnimationScheduler();
+            var element = new VisualElement();
+            element.AddToClassList("opacity-100");
+
+            // Act — a spring enter from "hidden" (opacity-0) to the already-applied "visible" (opacity-100).
+            scheduler.PlayVariantEnter(element, fromClasses: new[] { "opacity-0" }, toClasses: new[] { "opacity-100" },
+                durationSec: 0.3f, easing: EasingMode.EaseOut, delaySec: 0f,
+                type: TransitionType.Spring, stiffness: 100f, damping: 20f, mass: 1f);
+
+            // Assert — the class swap resolved immediately (opacity-100 present, opacity-0 never added), and the
+            // inline style shows the FROM pose synchronously so the element does not flash at the (already-
+            // applied) resting classes' value before the first tick runs.
+            Assert.That(
+                (element.ClassListContains("opacity-100"), element.ClassListContains("opacity-0"), element.style.opacity.value),
+                Is.EqualTo((true, false, 0f)));
+        }
+
+        [Test]
+        public void Given_ASpringDrivenOpacityChannel_When_SteppedRepeatedly_Then_TheInlineOpacityMovesTowardTheTarget()
+        {
+            // Arrange — a critically damped opacity spring (no overshoot, so progress toward the target is
+            // strictly monotonic) starting at 0, heading to 1.
+            var element = new VisualElement();
+            var plan = MotionSpringClassParser.Resolve(new[] { "opacity-0" }, new[] { "opacity-100" });
+            var state = MotionSpringDriver.Create(plan, stiffness: 100f, damping: 20f, mass: 1f);
+            Assume.That(state, Is.Not.Null, "Precondition: the plan resolves an opacity channel");
+            MotionSpringDriver.ApplyCurrentValues(element, state!);
+            Assume.That(element.style.opacity.value, Is.EqualTo(0f), "Precondition: starts at the from-value");
+
+            // Act — a handful of early ticks, then many more later ticks.
+            for (var i = 0; i < 5; i++)
+            {
+                MotionSpringDriver.Step(element, state!, FixedDeltaSec);
+            }
+            var earlyOpacity = element.style.opacity.value;
+            for (var i = 0; i < 40; i++)
+            {
+                MotionSpringDriver.Step(element, state!, FixedDeltaSec);
+            }
+            var laterOpacity = element.style.opacity.value;
+
+            // Assert — opacity has moved further toward the target (1) as more ticks run.
+            Assert.That(laterOpacity, Is.GreaterThan(earlyOpacity));
+        }
+
+        [Test]
+        public void Given_ASpringDrivenOpacityChannel_When_SteppedUntilSettled_Then_TheOpacityRestsAtTheTarget()
+        {
+            // Arrange
+            var element = new VisualElement();
+            var plan = MotionSpringClassParser.Resolve(new[] { "opacity-0" }, new[] { "opacity-100" });
+            var state = MotionSpringDriver.Create(plan, stiffness: 100f, damping: 20f, mass: 1f);
+            Assume.That(state, Is.Not.Null, "Precondition: the plan resolves an opacity channel");
+            MotionSpringDriver.ApplyCurrentValues(element, state!);
+
+            // Act — step until settled (a critically damped spring at this stiffness settles well inside this
+            // budget; the cap just guards against an infinite loop if a regression stops it from ever settling).
+            var settled = false;
+            for (var i = 0; i < 600 && !settled; i++)
+            {
+                settled = MotionSpringDriver.Step(element, state!, FixedDeltaSec);
+            }
+            Assume.That(settled, Is.True, "Precondition: the spring settled within the tick budget");
+
+            // Assert
+            Assert.That(element.style.opacity.value, Is.EqualTo(1f).Within(0.01f));
+        }
+
+        [Test]
+        public void Given_ASettledSpringChannel_When_InlineOverridesCleared_Then_TheOpacityStyleIsRemoved()
+        {
+            // Arrange — settle the spring first (Assume guards the precondition, mirroring the test above).
+            var element = new VisualElement();
+            var plan = MotionSpringClassParser.Resolve(new[] { "opacity-0" }, new[] { "opacity-100" });
+            var state = MotionSpringDriver.Create(plan, stiffness: 100f, damping: 20f, mass: 1f);
+            Assume.That(state, Is.Not.Null, "Precondition: the plan resolves an opacity channel");
+            MotionSpringDriver.ApplyCurrentValues(element, state!);
+            var settled = false;
+            for (var i = 0; i < 600 && !settled; i++)
+            {
+                settled = MotionSpringDriver.Step(element, state!, FixedDeltaSec);
+            }
+            Assume.That(settled, Is.True, "Precondition: the spring settled within the tick budget");
+
+            // Act — the scheduler calls this once every channel has settled, so the (already-applied) resting
+            // classes' own opacity takes back over instead of the driver's inline value.
+            MotionSpringDriver.ClearInlineOverrides(element, state!);
+
+            // Assert
+            Assert.That(element.style.opacity.keyword, Is.EqualTo(StyleKeyword.Null));
+        }
+
+        [Test]
+        public void Given_ASpringChannelMidExit_When_Retargeted_Then_ItHeadsBackTowardTheValueItStartedFrom()
+        {
+            // Arrange — an exit-shaped channel: starts at the resting value (1, opaque) and heads to the exit
+            // value (0). A few ticks in, it is partway there but not yet settled.
+            var element = new VisualElement();
+            var plan = MotionSpringClassParser.Resolve(new[] { "opacity-100" }, new[] { "opacity-0" });
+            var state = MotionSpringDriver.Create(plan, stiffness: 100f, damping: 20f, mass: 1f);
+            Assume.That(state, Is.Not.Null, "Precondition: the plan resolves an opacity channel");
+            MotionSpringDriver.ApplyCurrentValues(element, state!);
+            for (var i = 0; i < 5; i++)
+            {
+                MotionSpringDriver.Step(element, state!, FixedDeltaSec);
+            }
+            Assume.That(state!.Opacity!.Target, Is.EqualTo(0f), "Precondition: heading toward the exit value");
+
+            // Act — an exit-cancel (the key re-entered mid-exit): retarget back toward the resting value.
+            MotionSpringDriver.Retarget(state!);
+
+            // Assert — the channel's goal flipped to the value it originally started from (its RestingTarget),
+            // not a fresh 0/1 default or the exit value it was still short of.
+            Assert.That(state!.Opacity!.Target, Is.EqualTo(1f));
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/MotionSpringDriverTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/MotionSpringDriverTests.cs
@@ -125,6 +125,33 @@ namespace Velvet.Tests
         }
 
         [Test]
+        public void Given_AUniformScaleClassPair_When_Resolved_Then_TheScaleChannelMatchesTheAxisScalePreset()
+        {
+            // Arrange / Act — scale-50 -> scale-100 mirrors the uniform (non-per-axis) .scale-N USS classes;
+            // the parser reads this magnitude from StyleArbitraryValueResolver's own per-axis scale table
+            // (shared, not a second hand-copied dictionary), so this pins that the shared table still resolves
+            // the same 0.5 / 1.0 pair.
+            var plan = MotionSpringClassParser.Resolve(new[] { "scale-50" }, new[] { "scale-100" });
+            Assume.That(plan.Scale, Is.Not.Null, "Precondition: the pair resolves a scale channel");
+
+            // Assert
+            Assert.That((plan.Scale!.Value.from, plan.Scale.Value.to), Is.EqualTo((0.5f, 1f)));
+        }
+
+        [Test]
+        public void Given_ANegativeRotateClassPair_When_Resolved_Then_TheRotateChannelMatchesTheSharedMagnitudeTable()
+        {
+            // Arrange / Act — rotate-45 -> rotate-n45 mirrors the static .rotate-45 / .rotate-n45 USS classes;
+            // the parser now reads the magnitude from StyleArbitraryValueResolver's own rotate-preset table
+            // (negating it itself for the "n"-suffixed spelling) instead of a duplicate hand-expanded ± table.
+            var plan = MotionSpringClassParser.Resolve(new[] { "rotate-45" }, new[] { "rotate-n45" });
+            Assume.That(plan.Rotate, Is.Not.Null, "Precondition: the pair resolves a rotate channel");
+
+            // Assert
+            Assert.That((plan.Rotate!.Value.from, plan.Rotate.Value.to), Is.EqualTo((45f, -45f)));
+        }
+
+        [Test]
         public void Given_ASpringChannelMidExit_When_Retargeted_Then_ItHeadsBackTowardTheValueItStartedFrom()
         {
             // Arrange — an exit-shaped channel: starts at the resting value (1, opaque) and heads to the exit

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/MotionSpringDriverTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/MotionSpringDriverTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 60949547364f74a0490c6c26a2ed5cc4

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/MotionSpringShadowCoFadeTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/MotionSpringShadowCoFadeTests.cs
@@ -1,0 +1,114 @@
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.UIElements;
+using UnityEngine.UIElements.TestFramework;
+using UnityEditor.UIElements.TestFramework;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Extends <c>ShadowAnimationVisibilityTests</c>' co-fade coverage to the spring path. A spring-driven
+    /// Motion enter/exit writes its animated opacity as a per-frame inline style tick (StartSpringTick), not a
+    /// CSS transition, but the drop-shadow paint is still opacity-blind either way, so it still needs the SAME
+    /// co-fade (CollectShadowsForCoFade + StartShadowCoFadeTick) the tween paths already get — the tick samples
+    /// resolvedStyle.opacity and does not care what is driving it. Needs a real (simulated) panel: the co-fade
+    /// tick's sampling requires resolvedStyle, which <c>ShadowAnimationVisibilityTests</c>' panel-free setup
+    /// cannot resolve — exactly why a missing co-fade wire on the spring path was invisible to that suite.
+    /// </summary>
+    [TestFixture]
+    internal sealed class MotionSpringShadowCoFadeTests
+    {
+        private static readonly ShadowSpec Spec =
+            new(new Color(0f, 0f, 0f, 0.3f), blur: 20f, offsetY: 4f, spread: 0f);
+
+        private EditorPanelSimulator _sim;
+        private StyleAnimationScheduler _scheduler;
+
+        [SetUp]
+        public void SetUp()
+        {
+            PanelSimulator.ResetCurrentTime();
+            _sim = new EditorPanelSimulator { panelSize = new Vector2(800, 600) };
+            _sim.ResetTimePerSimulatedFrameToDefault();
+            _scheduler = new StyleAnimationScheduler();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _sim?.Dispose();
+            _sim = null;
+        }
+
+        private VisualElement Root => _sim.rootVisualElement;
+
+        private void Tick() => _sim.FrameUpdateMs(16);
+
+        // Attaches a shadow paint to a child of target and returns the child's binding, mirroring
+        // ShadowAnimationVisibilityTests' own helper.
+        private DropShadowBinding AttachShadowChild(VisualElement target)
+        {
+            var child = new VisualElement();
+            target.Add(child);
+            return DropShadowSilhouette.Attach(child, Spec, System.Array.Empty<string>(), skewXDeg: 0f);
+        }
+
+        [Test]
+        public void Given_AShadowedSpringEnter_When_APanelTickRunsMidFlight_Then_TheDescendantShadowIsCoFading()
+        {
+            // Arrange — a spring-driven enter (opacity 0 -> 100) on a target carrying a shadow-painted child.
+            var target = new VisualElement();
+            Root.Add(target);
+            var binding = AttachShadowChild(target);
+            var config = new StyleTransitionConfig
+            {
+                Type = TransitionType.Spring,
+                Stiffness = 200f,
+                Damping = 26f,
+                EnterFromClass = "opacity-0",
+                EnterToClass = "opacity-100",
+            };
+
+            // Act — a few ticks start the spring and let it climb without fully settling.
+            _scheduler.PlayEnter(target, config);
+            Tick();
+            Tick();
+            Tick();
+            Assume.That(target.resolvedStyle.opacity, Is.LessThan(1f),
+                "Precondition: the caster is still mid-climb, not yet settled at full opacity");
+
+            // Assert — an un-cofaded shadow would sit stuck at its resting full strength; the co-fade tick must
+            // have already pulled it down alongside the still-translucent caster.
+            Assert.That(binding.ShadowOpacity, Is.LessThan(1f));
+        }
+
+        [Test]
+        public void Given_AShadowedSpringExit_When_APanelTickRunsMidFlight_Then_TheDescendantShadowIsCoFading()
+        {
+            // Arrange — a spring-driven exit (opacity 100 -> 0) on a target carrying a shadow-painted child.
+            var target = new VisualElement();
+            Root.Add(target);
+            var binding = AttachShadowChild(target);
+            target.AddToClassList("opacity-100");
+            var config = new StyleTransitionConfig
+            {
+                Type = TransitionType.Spring,
+                Stiffness = 200f,
+                Damping = 26f,
+                ExitFromClass = "opacity-100",
+                ExitToClass = "opacity-0",
+            };
+
+            // Act
+            _scheduler.PlayExit(target, config, onComplete: null);
+            Tick();
+            Tick();
+            Tick();
+            Assume.That(target.resolvedStyle.opacity, Is.GreaterThan(0f),
+                "Precondition: the caster is still mid-fade, not yet settled at zero opacity");
+
+            // Assert — the shadow must be following the caster's fade down, not sitting untouched at full.
+            Assert.That(binding.ShadowOpacity, Is.LessThan(1f));
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/MotionSpringShadowCoFadeTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/MotionSpringShadowCoFadeTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8cc80e0006924ab180d13d0f3a5bf172

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/SpringConfigValidationTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/SpringConfigValidationTests.cs
@@ -1,0 +1,58 @@
+using System.Text.RegularExpressions;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using UnityEngine.UIElements;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins validation of user-supplied spring parameters, mirroring the tween path's
+    /// duration guard: a spring that can never satisfy its settle predicate (zero or negative
+    /// stiffness never approaches the target; NaN diverges into the styles it writes; zero damping
+    /// never drops below rest speed) must warn and complete immediately instead of scheduling a
+    /// 16ms panel tick that runs forever and a completion callback that never fires — on a
+    /// presence exit that callback is the only thing that ever removes the ghost.
+    /// </summary>
+    [TestFixture]
+    internal sealed class SpringConfigValidationTests
+    {
+        [Test]
+        public void Given_AZeroStiffnessSpring_When_AVariantEnterPlays_Then_ItWarnsAndCompletesImmediately()
+        {
+            // Arrange
+            var scheduler = new StyleAnimationScheduler();
+            var element = new VisualElement();
+            var completed = false;
+            LogAssert.Expect(LogType.Warning, new Regex("[Ss]pring"));
+
+            // Act — stiffness 0 can never move the value toward its target.
+            scheduler.PlayVariantEnter(element, new[] { "opacity-0" }, new[] { "opacity-100" },
+                0f, EasingMode.Linear, 0f, onComplete: () => completed = true,
+                additionalDelaySec: 0f, propertyOverrides: null,
+                type: TransitionType.Spring, stiffness: 0f, damping: 10f, mass: 1f);
+
+            // Assert — the play degrades to an immediate completion instead of a forever-tick.
+            Assert.That(completed, Is.True);
+        }
+
+        [Test]
+        public void Given_ANaNSpringParameter_When_AVariantEnterPlays_Then_ItWarnsAndCompletesImmediately()
+        {
+            // Arrange
+            var scheduler = new StyleAnimationScheduler();
+            var element = new VisualElement();
+            var completed = false;
+            LogAssert.Expect(LogType.Warning, new Regex("[Ss]pring"));
+
+            // Act — NaN stiffness would propagate NaN into every style write.
+            scheduler.PlayVariantEnter(element, new[] { "opacity-0" }, new[] { "opacity-100" },
+                0f, EasingMode.Linear, 0f, onComplete: () => completed = true,
+                additionalDelaySec: 0f, propertyOverrides: null,
+                type: TransitionType.Spring, stiffness: float.NaN, damping: 10f, mass: 1f);
+
+            // Assert
+            Assert.That(completed, Is.True);
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/SpringConfigValidationTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/SpringConfigValidationTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8ba8f657c35f64554a6a95dd5fee03e3

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/SpringIntegratorTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/SpringIntegratorTests.cs
@@ -1,0 +1,84 @@
+using NUnit.Framework;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins <see cref="SpringIntegrator"/>'s pure physics: it converges to its target given enough time, an
+    /// underdamped configuration overshoots before settling (Framer Motion's spring is underdamped by default),
+    /// and retargeting an in-flight spring carries its CURRENT value/velocity forward instead of resetting them
+    /// (the continuity an interrupted AnimatePresence exit/enter needs). No panel or VisualElement involved —
+    /// this is deterministic math, driven directly. GWT, one assert per case.
+    /// </summary>
+    [TestFixture]
+    internal sealed class SpringIntegratorTests
+    {
+        private const float FixedDeltaSec = 1f / 60f;
+
+        [Test]
+        public void Given_ACriticallyDampedSpring_When_SteppedForEnoughTime_Then_ItSettlesAtTheTarget()
+        {
+            // Arrange — stiffness 100 / mass 1 critically damps at damping = 2*sqrt(stiffness*mass) = 20 (no
+            // ringing, the fastest non-oscillating approach).
+            var spring = new SpringIntegrator(initialValue: 0f);
+            const float target = 100f;
+
+            // Act — 180 ticks (3 simulated seconds) is comfortably past this spring's settle time.
+            for (var i = 0; i < 180; i++)
+            {
+                spring.Step(FixedDeltaSec, target, stiffness: 100f, damping: 20f, mass: 1f);
+            }
+
+            // Assert
+            Assert.That(spring.Value, Is.EqualTo(target).Within(0.5f));
+        }
+
+        [Test]
+        public void Given_AnUnderdampedSpring_When_SteppedTowardATarget_Then_ItOvershootsBeforeSettling()
+        {
+            // Arrange — damping (2) sits well below critical (20 for this stiffness/mass), so the spring rings
+            // past its target before settling instead of approaching it monotonically.
+            var spring = new SpringIntegrator(initialValue: 0f);
+            const float target = 100f;
+            var peakValue = float.NegativeInfinity;
+
+            // Act — step long enough to pass through and beyond the target at least once.
+            for (var i = 0; i < 180; i++)
+            {
+                spring.Step(FixedDeltaSec, target, stiffness: 100f, damping: 2f, mass: 1f);
+                if (spring.Value > peakValue)
+                {
+                    peakValue = spring.Value;
+                }
+            }
+
+            // Assert
+            Assert.That(peakValue, Is.GreaterThan(target));
+        }
+
+        [Test]
+        public void Given_ASpringMidFlightTowardOneTarget_When_RetargetedToADifferentValue_Then_TheNextStepContinuesFromItsCurrentValueAndVelocity()
+        {
+            // Arrange — run partway toward 100 so the spring has accumulated a nonzero value/velocity, then
+            // capture that state right before retargeting.
+            var spring = new SpringIntegrator(initialValue: 0f);
+            for (var i = 0; i < 10; i++)
+            {
+                spring.Step(FixedDeltaSec, 100f, stiffness: 100f, damping: 10f, mass: 1f);
+            }
+            var capturedValue = spring.Value;
+            var capturedVelocity = spring.Velocity;
+            Assume.That(capturedVelocity, Is.Not.EqualTo(0f), "Precondition: the spring has built up velocity heading toward the first target");
+
+            // Act — retarget to a wildly different value (mirrors an exit-cancel reversing back toward the
+            // resting value) and take one more step; a FRESH spring seeded with the exact captured state is the
+            // reference for what one step from "here" should produce with nothing reset.
+            spring.Step(FixedDeltaSec, -50f, stiffness: 100f, damping: 10f, mass: 1f);
+            var reference = new SpringIntegrator(capturedValue, capturedVelocity);
+            reference.Step(FixedDeltaSec, -50f, stiffness: 100f, damping: 10f, mass: 1f);
+
+            // Assert — the retargeted spring's value matches the reference exactly: the retarget carried the
+            // SAME value/velocity forward (no discontinuity) rather than resetting either.
+            Assert.That(spring.Value, Is.EqualTo(reference.Value).Within(1e-6f));
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/SpringIntegratorTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/SpringIntegratorTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 51260e112aa0c4691a73bcc29f3b5bc0

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/Velvet.Tests.Styling.Editor.asmdef
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/Velvet.Tests.Styling.Editor.asmdef
@@ -6,7 +6,9 @@
         "UnityEditor.TestRunner",
         "Velvet",
         "Velvet.TestUtilities",
-        "UniTask"
+        "UniTask",
+        "Unity.UI.TestFramework.Runtime",
+        "Unity.UI.TestFramework.Editor"
     ],
     "includePlatforms": [
         "Editor"

--- a/README.md
+++ b/README.md
@@ -194,9 +194,12 @@ Styling is composed entirely from utility classes — no per-component USS files
 
 Mount / unmount and gesture animations, modeled on Framer Motion:
 
-- **`V.Motion`** — an animated element with `StyleTransition` presets (`Fade`, `SlideUp`, `ScaleIn`, `FadeSlideUp`, …) and `whileHoverClass` / `whileTapClass` gestures.
-- **`V.AnimatePresence`** — keyed enter / exit, keeping a removed child mounted until its exit finishes. **DOM-less** (React/Framer parity): it emits no wrapper, so its children flow directly into the parent's layout.
+- **`V.Motion`** — an animated element with `StyleTransition` presets (`Fade`, `SlideUp`, `ScaleIn`, `FadeSlideUp`, …), Framer-style **variants** (`variants:` + `initial:` / `animate:` / `exit:` labels, with label inheritance down the tree), and `whileHoverClass` / `whileTapClass` gestures. A Motion outside `AnimatePresence` plays its `initial` → `animate` enter on mount, like any `motion.*` element.
+- **`V.AnimatePresence`** — keyed enter / exit, keeping a removed child mounted until its exit finishes. **DOM-less** (React/Framer parity): it emits no wrapper, so its children flow directly into the parent's layout. `mode: AnimatePresenceMode.PopLayout` pins an exiting child out of flow so siblings reflow immediately (Framer's `mode="popLayout"`).
+- **`StyleTransitionConfig`** — tween timing (`DurationSec` / `Easing` / `DelaySec`), per-property overrides (`PropertyOverrides`), `staggerChildren` / `delayChildren` / `when` orchestration for variant propagation, and opt-in **spring physics** (`Type = TransitionType.Spring` + `Stiffness` / `Damping` / `Mass`) with velocity-preserving interruption.
 - **`V.AnimatedList`** — sugar combining `AnimatePresence` + `List` + `Motion` for animated collections, with `staggerSec`.
+
+See [motion.md](Packages/com.velvet.core/Documentation~/motion.md) for the full guide (variants, orchestration, springs, and the one-config-every-update transition semantics).
 
 ### Source Generator memoization
 


### PR DESCRIPTION
## What

Closes the six Framer Motion behavioral gaps in `V.Motion` / `V.AnimatePresence`:

- **Standalone enter** — a Motion outside AnimatePresence now plays its `initial` → `animate` variant enter on mount (Framer: `initial`/`animate` work on any `motion.*` element).
- **PopLayout mode** — `V.AnimatePresence(mode: AnimatePresenceMode.PopLayout)` pins an exiting child out of flow at its last laid-out rect so siblings reflow immediately (Framer: `mode="popLayout"`).
- **Per-property transition overrides** — `StyleTransitionConfig.PropertyOverrides` gives individual properties their own duration/easing/delay within one variant transition (Framer: per-value `transition` maps).
- **Orchestration** — `staggerChildren` / `delayChildren` / `when` propagate through plain variant-label inheritance, staggering inheriting children without needing an AnimatePresence boundary (`when: AfterChildren` is not orchestratable and falls back to `Together` with a warning).
- **Spring physics** — `StyleTransitionConfig { Type = TransitionType.Spring, Stiffness, Damping, Mass }` drives variant transitions with a velocity-preserving integrator, so interruptions retarget from the current value and velocity instead of restarting.
- **One config, every update** — a mounted Motion whose `animate` label changes at runtime (directly or through label inheritance, including every orchestrated stagger child) now tweens or springs on its own `StyleTransitionConfig`, with no `transition-*` utilities required (Framer applies `transition` to every animate update). `StyleTransitionConfig.None` opts out for an instant swap.

## Behavioral changes

- Orchestrated stagger slots delay the child's class swap itself instead of pre-swapping the classes behind an inline `transition-delay`: the target classes land when the slot elapses, and the swap then plays on the child's own config.
- A bare `V.Motion`'s label swap now animates: the default `transition` falls back to the `Fade` preset, which previously only governed presence enters/exits, so runtime swaps that used to apply instantly now tween unless `StyleTransitionConfig.None` is passed.

## Hardening on top of the features

- Spring lifecycle: panel-safe scheduling and cancellation (attach deferral, panel-root host ticking, teardown cancel), the settle path keeps resolver-owned resting values, empty-plan exits complete exactly once, and invalid spring parameters warn instead of freezing the element.
- PopLayout: the pin no longer double-applies margins or destroys arbitrary-value geometry on cancel; gap/grid/divide index math skips out-of-flow ghosts.
- Scheduling correctness: enter/exit completion is sized off the slowest overridden property; enter/exit/spring plays take ownership of the inline transition-delay slot; a parent's own delay span folds into `BeforeChildren` orchestration; standalone enters gate on presence-anchor identity (and runtime swaps on exit state) so presence-managed elements don't double-play.
- Classic enters defer their class swap by one nominal frame so the from-state survives a style pass on a real runtime panel (previously the transition could observe no change and snap straight to the end pose).
- The enter path's deferred work (stagger slots, the class swap, completion timeouts) schedules on the panel-root host, so a keyed reorder's transient detach can no longer drop a pending swap.

## Docs

- New `Documentation~/motion.md` guide: variants and label inheritance, enters/exits, PopLayout, orchestration, per-property overrides, springs, and the one-config-every-update transition semantics (including the `StyleTransitionConfig.None` opt-out). Both READMEs' animation sections expanded; release notes recorded under CHANGELOG `[Unreleased]`.

## Tests

- New EditMode coverage across spring lifecycle, PopLayout geometry, enter swap timing, runtime-swap semantics (config-driven tween/spring, interruption, stagger firing times, reorder survival), and orchestration timing (simulated-panel, time-driven).
- New PlayMode tests pin that a standalone enter and a runtime label flip actually tween on a real `UIDocument` panel (timings the EditMode simulator structurally cannot reproduce).
- The stagger ownership/distribution suites are respecified against the scheduler-driven swap (the parked inline-delay mechanism is gone).
- Full EditMode suite: 2644 passed / 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)