### PR TITLE
chore(velvet): prepare v1.2.0 release

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-07-12
+
 ### Added
 
 - Standalone mount enters: a `V.Motion` outside `AnimatePresence` now plays its `initial` →

--- a/Packages/com.velvet.core/package.json
+++ b/Packages/com.velvet.core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.velvet.core",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "displayName": "Velvet",
   "description": "React-style declarative UI framework for Unity UI Toolkit. Provides virtual DOM, reconciliation engine, hooks, and component model.",
   "license": "MIT",


### PR DESCRIPTION
Promotes the CHANGELOG's Unreleased notes to a dated 1.2.0 section and bumps `package.json` to 1.2.0 so the upm release dispatch's version check passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)