### PR TITLE
docs(velvet): scrub private-project references from two guides

### DIFF
--- a/Packages/com.velvet.core/Documentation~/react-migration.md
+++ b/Packages/com.velvet.core/Documentation~/react-migration.md
@@ -49,12 +49,13 @@ In C#, methods conventionally use PascalCase, so the names always differ from Re
 The Velvet core is independent of any DI framework, and receives an **`IHookServiceResolver`** abstraction (a minimal interface with a single method) via a Provider to bridge to the host DI container (e.g. VContainer). The canonical hook for obtaining short-lived services (UseCase / Factory / Logger, etc.) directly from a functional component is `Hooks.UseService<T>()`.
 
 ```csharp
+// For example, services your host container registers:
 [Component]
-public static VNode UserCardRender()
+public static VNode UserCard()
 {
-    var avatarLifecycle = Hooks.UseService<IAvatarLifecycleUseCase>();
-    var logger          = Hooks.UseService<ILog>();
-    // ... use avatarLifecycle / logger directly
+    var profiles = Hooks.UseService<IProfileUseCase>();
+    var logger   = Hooks.UseService<ILogger>();
+    // ... use profiles / logger directly
     return V.Div(/* ... */);
 }
 ```
@@ -64,16 +65,19 @@ public static VNode UserCardRender()
 | Use case | React canonical | Velvet |
 |------|----------------|--------|
 | Direct access to renderer / scene | R3F `useThree()` | `Hooks.UseService<IFoo>()` |
-| Obtaining a store via a store provider | react-redux `useStore()` | (same shape as above, though the Store itself is best obtained via `<PageContext>.UseRequired()`) |
+| Obtaining a store via a store provider | react-redux `useStore()` | share the `Store` through a `V.Provider` context and read it with `UseContext` |
 | Arbitrary DI container service | (no standard in the React community) | `Hooks.UseService<IFoo>()` |
 
 **Rationale and rules**:
 
-- The host bridge is written once in **`Composition/Bridges/VContainerServiceResolver.cs`**, and the Velvet core never references any VContainer type
+- The host bridge is one small class on the app side — an `IHookServiceResolver` implementation
+  wrapping your container (VContainer, Zenject, a hand-rolled locator, …); the Velvet core never
+  references any DI framework type
 - At the root `V.Mount`, you must wire `V.Provider(HookServiceContext.Ref, value: serviceResolver, children: ...)`
-- For **Page-specific view-state** (Store / Color / Navigation, etc.), continue to use `<PageContext>.UseRequired()` (separation of responsibilities)
+- For **page-scoped view state** (a store, theme, navigation context, …), prefer a typed context
+  published with `V.Provider` and read with `UseContext` over resolving services ad hoc
+  (separation of responsibilities)
 - `UseService<T>()` cannot be called **from within a Store's async lifecycle methods** (hook discipline). A Store obtains its UseCase via constructor injection
-- The three `*Operations` files are **retained as Store-driven static helpers** and are not targets for hook-ification
 
 ### 1-3. State Management (React + Zustand)
 

--- a/Packages/com.velvet.core/Documentation~/styling-flexbox-and-gap.md
+++ b/Packages/com.velvet.core/Documentation~/styling-flexbox-and-gap.md
@@ -150,5 +150,3 @@ A native `gap` and a configurable default direction depend on UI Toolkit feature
 available (USS `gap`, and broader Flexbox parity, are on Unity's roadmap beyond 6.7 LTS). When native
 `gap` lands, the polyfill can be replaced and the residual edge cases above go away. Until then, the
 framework-level manipulator is the supported approach and matches CSS `gap` for the common cases.
-
-See also: the related discussion in issues #7 (gap implementation) and #9 (flex default direction).


### PR DESCRIPTION
Follow-up to #23 — a full docs sweep found two more pages of the same leakage class (content citing a private project's code as established fact, unverifiable in this repository):

- **react-migration.md (DI section)**: cited an avatar-lifecycle service, a `Composition/Bridges/VContainerServiceResolver.cs` file, a `<PageContext>.UseRequired()` convention, and an `*Operations` migration-status note — none exist here. The example now uses clearly illustrative names, and the bridge / page-scope guidance is stated in library-neutral terms (context published with `V.Provider`, read with `UseContext`).
- **styling-flexbox-and-gap.md**: dropped a see-also line whose issue numbers came from the private tracker — in this repository they resolve to unrelated pull requests.

The sweep also verified: all relative markdown links resolve, no Japanese text in package sources/docs, no demo terms, no stray assets, and every other guide's cited identifiers exist in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)