### PR TITLE
fix(velvet): harden the six new features after a post-merge audit

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -12,7 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `V.Portal(layer:)`: framework-managed screen-space layer panels (`UILayer.Background` /
   `Overlay` / `Topmost`) sorted around the app's main panel — one host per layer per mounted
   tree, created lazily, copying the declaring panel's theme and scale when resolvable,
-  destroyed with the tree. Portal semantics unchanged: context and state cross the logical boundary; events,
+  destroyed with the tree, and kept in sync with the declaring panel's settings. The shared
+  portal semantics apply: context and state cross the logical boundary; events,
   relational variants and focus-within do not, and responsive breakpoints evaluate per panel.
 - `V.WorldSpace(position, rotation, panelSize)`: children rendered into a framework-owned
   world-space panel positioned by a scene transform — depth-tested against scene geometry (the
@@ -50,6 +51,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`hover:filter-[dissolve:0.9]` restores the base arguments on hover-off) and the same
   transition behavior as any other filter change. A filters guide
   (`Documentation~/styling-filters.md`) documents the built-in utilities and the registry.
+
+### Fixed
+
+- `V.Portal(targetId:)` target lifecycle: a live portal keeps the target its children mounted
+  into when the id is re-registered (re-registration routes future portals only), and a portal
+  mounted before its target registered heals on its next patch and records the healed target —
+  previously a re-registration could diff one portal's slot range against another element's
+  children, and a healed mount could leak its cleanup.
+- Deferred portal mounts whose subtree rolled back before the drain (a suspended Suspense
+  primary, an interrupted pass) are skipped instead of mounting content for a subtree that no
+  longer exists.
+- An error boundary's abort no longer discards the layer/world-space portal mounts its own
+  fallback enqueued in the same pass — an error toast rendered by a fallback now reaches its
+  layer — while the failed subtree's pending portals still never mount.
+- `Hooks.UseFrame` ticks once per frame (a fixed 16 ms interval previously skipped frames above
+  ~60 FPS) and contains callback exceptions the way effects do: routed to the nearest error
+  boundary instead of escaping into the panel's scheduler update.
+- `V.SceneView`: class-driven backgrounds (gradients, `bg-[addr:…]`) and `styles:` posters no
+  longer clobber a live camera feed — the camera owns the background while its texture is
+  live, other writers defer and are restored on release; a `camera.targetTexture` reassigned
+  by user code survives layout-driven resyncs, not just unmount; the texture-size ceiling
+  preserves the aspect; and a pixel-density change re-derives the texture on editor panels.
+- `V.Particles` simulates outside Play Mode (editor preview panels previously repainted one
+  frozen frame), parks its repaint tick on the drawn root's own liveness, and rate-limits its
+  advisories per source name so an unstable effect reference cannot repeat them per rebuild.
+- Layer and world-space hosts re-copy the declaring panel's configuration when it changes at
+  runtime (theme swaps, scale changes, the ConstantPhysicalSize DPI pair) and survive a scene
+  unload killing a host: patches skip dead records instead of throwing out of the pass.
 
 ## [1.2.0] - 2026-07-12
 

--- a/Packages/com.velvet.core/Documentation~/particles.md
+++ b/Packages/com.velvet.core/Documentation~/particles.md
@@ -41,6 +41,10 @@ System is the right tool for UI-scale effects:
 - ❌ Renderer-module features: trails, mesh particles, texture-sheet animation, sub-emitter
   rendering, stretched billboards. One texture per system; up to 2048 particles drawn.
 
+The simulation runs anywhere the element does — including **outside Play Mode**: on
+editor-hosted panels (preview tooling) the repaint tick steps the hidden host itself, so
+effects play live without entering Play Mode.
+
 ## What about VFX Graph?
 
 VFX Graph is GPU-resident — there is no supported per-particle CPU readback, so the

--- a/Packages/com.velvet.core/Documentation~/portals.md
+++ b/Packages/com.velvet.core/Documentation~/portals.md
@@ -30,8 +30,10 @@ all three forms:
 
 The framework owns one host panel per `UILayer` per mounted tree, created lazily on first use
 and destroyed with the tree. When the declaring panel's settings are resolvable (a runtime
-`UIDocument` panel), the host copies its theme, scaling and text settings and sorts around it;
-a declaring panel without resolvable settings (an editor-hosted or headless root) gets an
+`UIDocument` panel), the host copies its theme, scaling (the DPI pair included) and text
+settings and sorts around it — and keeps them in sync: a runtime change on the declaring
+panel (a theme swap, a scale flip) re-copies on the next pass that touches the portal. A
+declaring panel without resolvable settings (an editor-hosted or headless root) gets an
 empty runtime theme instead — native-control default visuals come from a theme, so declare
 layers from a themed panel when those matter. The host object itself is hidden from the
 Hierarchy (a framework-owned `UIDocument` host, like every other framework host):
@@ -45,7 +47,14 @@ Hierarchy (a framework-owned `UIDocument` host, like every other framework host)
 One engine fact bounds this feature: **a screen-space panel always composites over the 3D
 scene** — the compositor draws overlay panels after cameras, and `sortingOrder` only orders
 panels among themselves. UI that must sit *among or behind scene geometry* is world-space
-territory:
+territory.
+
+Two operational notes: layer order anchors to the **declaring panel's** `sortingOrder`
+(base −100 / +100 / +200), so two mounted trees whose main panels share a `sortingOrder`
+produce layers that tie across the apps — give each main panel its own base when several run
+side by side. And a host panel killed externally (a scene unload tearing down framework
+objects) is replaced the next time a portal mounts on that layer; portals already mounted
+into the dead host need a remount.
 
 ## World space: `V.WorldSpace`
 
@@ -62,3 +71,7 @@ host; `panelSize` is the panel's virtual resolution in pixels.
 
 **Display-only for now**: world-space input routing (picking, focus) is not wired — treat
 these panels as output. Interactive world-space UI is a separate milestone.
+
+A world-space host follows the same declaring-panel sync as the layers, and a host destroyed
+externally (a scene unload) is skipped safely on later patches — remount the `V.WorldSpace`
+node to rebuild it.

--- a/Packages/com.velvet.core/Documentation~/scene-view.md
+++ b/Packages/com.velvet.core/Documentation~/scene-view.md
@@ -12,16 +12,21 @@ V.SceneView(previewCamera, className: "w-64 h-64 rounded-lg border border-neutra
 There is no RenderTexture in the API — the framework owns it:
 
 - On layout, a RenderTexture is created at the element's **laid-out size in device pixels**
-  (the panel's scale factor is included, times `resolutionScale`, capped at 4096 per axis) and
-  assigned to `camera.targetTexture`; the element shows it as its background image.
+  (the panel's scale factor is included, times `resolutionScale`, capped at 4096 — one shared
+  shrink when either axis overflows, so the aspect is preserved) and assigned to
+  `camera.targetTexture`; the element shows it as its background image.
 - A geometry change (the element resizes) recreates the texture at the new size and re-targets
-  the camera. A zero-sized or unattached element holds no texture.
+  the camera. A zero-sized or unattached element holds no texture. A pixel-density change (a
+  monitor DPI move) fires no geometry event: editor panels re-derive the texture on their
+  repaint tick, runtime panels on their next layout or props change.
 - Swapping the `camera:` prop releases the old camera and targets the new one; passing `null`
   releases everything and leaves an inert box.
 - Unmounting (including a conditional `cond ? V.SceneView(...) : null` removal and whole-tree
   disposal) releases the camera's target and destroys the texture.
-- Release is **polite**: if user code reassigned `camera.targetTexture` after mount, unmount
-  leaves that assignment intact.
+- Release is **polite in both directions**: if user code reassigned `camera.targetTexture`
+  after mount, unmount leaves that assignment intact — and a layout- or tick-driven resync
+  never claws it back either (only an explicit camera/settings pass claims the camera; a bare
+  resync reclaims it from `null` alone).
 
 ## Styling composes
 
@@ -34,9 +39,10 @@ camera at half the element's pixel size (the background scales it up). A non-pos
 scale throws at the factory.
 
 One property is spoken for: **the element's background image belongs to the camera output
-while a camera is bound**. A `BackgroundImage` passed through `styles:` (or a `bg-[...]`
-utility) shows only until the camera texture arrives — use a sibling/overlay element for
-poster or overlay imagery.
+while its texture is live**. A `BackgroundImage` passed through `styles:` (or a gradient /
+`bg-[...]` utility) shows until the camera texture arrives, keeps receiving updates in a
+deferred slot while the feed is live, and returns when the camera releases (camera removed,
+element unmounting) — so a poster naturally brackets the feed's lifetime.
 
 ## Live output
 

--- a/Packages/com.velvet.core/Editor/DevTools/VNodeTreeRenderer.cs
+++ b/Packages/com.velvet.core/Editor/DevTools/VNodeTreeRenderer.cs
@@ -65,35 +65,17 @@ namespace Velvet.Editor.DevTools
 
                 case FragmentNode fragmentNode:
                     AppendLine(sb, "[Fragment]", depth);
-                    if (fragmentNode.Children != null)
-                    {
-                        foreach (var child in fragmentNode.Children)
-                        {
-                            AppendNode(sb, child, depth + 1);
-                        }
-                    }
+                    AppendChildren(sb, fragmentNode.Children, depth);
                     break;
 
                 case AnimatePresenceNode apNode:
                     AppendLine(sb, "[AnimatePresence]", depth);
-                    if (apNode.Children != null)
-                    {
-                        foreach (var child in apNode.Children)
-                        {
-                            AppendNode(sb, child, depth + 1);
-                        }
-                    }
+                    AppendChildren(sb, apNode.Children, depth);
                     break;
 
                 case ContextProviderNode contextNode:
                     AppendLine(sb, $"[ContextProvider<{GetGenericTypeName(contextNode)}>]", depth);
-                    if (contextNode.Children != null)
-                    {
-                        foreach (var child in contextNode.Children)
-                        {
-                            AppendNode(sb, child, depth + 1);
-                        }
-                    }
+                    AppendChildren(sb, contextNode.Children, depth);
                     break;
 
                 case PortalNode portalNode:
@@ -101,24 +83,12 @@ namespace Velvet.Editor.DevTools
                     // children live in the logical tree even though they attach elsewhere, so the
                     // dump walks them like every other container's.
                     AppendLine(sb, $"[Portal] target={portalNode.TargetId ?? portalNode.Layer?.ToString()}", depth);
-                    if (portalNode.Children != null)
-                    {
-                        foreach (var child in portalNode.Children)
-                        {
-                            AppendNode(sb, child, depth + 1);
-                        }
-                    }
+                    AppendChildren(sb, portalNode.Children, depth);
                     break;
 
                 case WorldSpaceNode worldSpaceNode:
                     AppendLine(sb, $"[WorldSpace] position={worldSpaceNode.Position} panelSize={worldSpaceNode.PanelSize}", depth);
-                    if (worldSpaceNode.Children != null)
-                    {
-                        foreach (var child in worldSpaceNode.Children)
-                        {
-                            AppendNode(sb, child, depth + 1);
-                        }
-                    }
+                    AppendChildren(sb, worldSpaceNode.Children, depth);
                     break;
 
                 case SuspenseNode:
@@ -153,13 +123,19 @@ namespace Velvet.Editor.DevTools
                 : string.Empty;
 
             AppendLine(sb, $"{prefix}<{typeName}{namePart}{keyPart}{classPart}>", depth);
+            AppendChildren(sb, node.Children, depth);
+        }
 
-            if (node.Children != null)
+        // The shared null-guarded child walk every container case uses.
+        private static void AppendChildren(StringBuilder sb, VNode[] children, int depth)
+        {
+            if (children == null)
             {
-                foreach (var child in node.Children)
-                {
-                    AppendNode(sb, child, depth + 1);
-                }
+                return;
+            }
+            foreach (var child in children)
+            {
+                AppendNode(sb, child, depth + 1);
             }
         }
 

--- a/Packages/com.velvet.core/Editor/DevTools/VNodeTreeRenderer.cs
+++ b/Packages/com.velvet.core/Editor/DevTools/VNodeTreeRenderer.cs
@@ -97,12 +97,28 @@ namespace Velvet.Editor.DevTools
                     break;
 
                 case PortalNode portalNode:
-                    // TargetId and Layer are a one-of pair; whichever is set names the target.
+                    // TargetId and Layer are a one-of pair; whichever is set names the target. The
+                    // children live in the logical tree even though they attach elsewhere, so the
+                    // dump walks them like every other container's.
                     AppendLine(sb, $"[Portal] target={portalNode.TargetId ?? portalNode.Layer?.ToString()}", depth);
+                    if (portalNode.Children != null)
+                    {
+                        foreach (var child in portalNode.Children)
+                        {
+                            AppendNode(sb, child, depth + 1);
+                        }
+                    }
                     break;
 
                 case WorldSpaceNode worldSpaceNode:
                     AppendLine(sb, $"[WorldSpace] position={worldSpaceNode.Position} panelSize={worldSpaceNode.PanelSize}", depth);
+                    if (worldSpaceNode.Children != null)
+                    {
+                        foreach (var child in worldSpaceNode.Children)
+                        {
+                            AppendNode(sb, child, depth + 1);
+                        }
+                    }
                     break;
 
                 case SuspenseNode:

--- a/Packages/com.velvet.core/Runtime/Component/ParticlesDriver.cs
+++ b/Packages/com.velvet.core/Runtime/Component/ParticlesDriver.cs
@@ -29,6 +29,11 @@ namespace Velvet
         public EventCallback<AttachToPanelEvent>? OnAttach;
         public EventCallback<DetachFromPanelEvent>? OnDetach;
         public IVisualElementScheduledItem? RepaintTick;
+        // Logical play state as the DRIVER last set it (Mount trigger, element Play/Stop): outside
+        // Play Mode the engine never advances a system's clock, so the repaint tick steps the
+        // simulation manually exactly while this is set — the native isPlaying flag cannot serve,
+        // because ParticleSystem.Simulate itself flips the system to paused.
+        public bool LogicallyPlaying;
 
         public ParticlesBinding(ParticlesSettings settings)
         {
@@ -54,11 +59,13 @@ namespace Velvet
         // lands on unusual setups.
         private static readonly Vector3 HostParkingPosition = new(0f, -10000f, 0f);
 
-        // Warn-once bookkeeping per SOURCE instance for the advisory mount warnings: an unstable
-        // effect reference (a component re-creating its source every render) rebuilds hosts
-        // repeatedly, and the same advice must not repeat once per rebuild.
-        private static readonly HashSet<int> s_warnedSimulationSpace = new();
-        private static readonly HashSet<int> s_warnedDrawCap = new();
+        // Warn-once bookkeeping per SOURCE NAME for the advisory mount warnings: an unstable effect
+        // reference (a component re-creating its source every render) rebuilds hosts repeatedly with
+        // a FRESH instance id each time — the exact case the debounce exists for — while the name
+        // stays put, and distinct names stay bounded by the project's effect inventory instead of
+        // growing one entry per mounted instance for the life of the session.
+        private static readonly HashSet<string> s_warnedSimulationSpace = new();
+        private static readonly HashSet<string> s_warnedDrawCap = new();
 
 #if UNITY_EDITOR
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
@@ -80,9 +87,10 @@ namespace Velvet
             // co-resident shadow / skew silhouette prepends its callback precisely so that content
             // registered later covers it.
             element.generateVisualContent += binding.OnGenerate;
-            // A keyed reorder re-inserts the element, which silently drops its element-bound scheduled
-            // items — so the repaint tick is re-armed from scratch on every attach (a dropped item
-            // cannot be resumed) and released on detach.
+            // Element-bound scheduled items survive a keyed reorder's detach/re-attach (the engine
+            // pauses and resumes them), but the resume restarts the interval phase instead of
+            // continuing it. Re-arming a fresh item per attach keeps the tick's lifetime explicit and
+            // independent of that engine subtlety; released on detach so nothing fires while detached.
             binding.OnAttach = _ =>
             {
                 StopRepaintTick(binding);
@@ -207,10 +215,12 @@ namespace Velvet
             if (binding.Settings.PlayOn == PlayTrigger.Mount)
             {
                 binding.Host!.Play();
+                binding.LogicallyPlaying = true;
             }
             else
             {
                 binding.Host!.Stop(true, ParticleSystemStopBehavior.StopEmittingAndClear);
+                binding.LogicallyPlaying = false;
             }
             binding.AppliedPlayOn = binding.Settings.PlayOn;
         }
@@ -225,6 +235,7 @@ namespace Velvet
             binding.SourceId = 0;
             binding.Buffer = null;
             binding.Texture = null;
+            binding.LogicallyPlaying = false;
         }
 
         // ParticlesElement.Play: the imperative half of PlayTrigger.Manual (and a replay for a
@@ -235,7 +246,14 @@ namespace Velvet
             {
                 return;
             }
+            // Editor-side replay: a Simulate()-driven clock clamps at a finished non-looping timeline
+            // and Play() merely resumes the pause there, so a drained host restarts from zero first.
+            if (EditorSimulationDrained(binding.Host))
+            {
+                binding.Host.Simulate(0f, withChildren: true, restart: true, fixedTimeStep: false);
+            }
             binding.Host.Play();
+            binding.LogicallyPlaying = true;
             // The idle tick parks itself while nothing simulates; a fresh play must resume dirtying.
             SyncRepaintTick(element, binding);
             element.MarkDirtyRepaint();
@@ -248,10 +266,11 @@ namespace Velvet
             if (binding.Host != null)
             {
                 binding.Host.Stop(true, ParticleSystemStopBehavior.StopEmittingAndClear);
+                binding.LogicallyPlaying = false;
             }
         }
 
-        // Advisory mount warnings, once per source instance (see the warn-once sets above).
+        // Advisory mount warnings, once per source name (see the warn-once sets above).
         private static void WarnOnceForSource(ParticleSystem source)
         {
             var main = source.main;
@@ -259,13 +278,13 @@ namespace Velvet
             // canvas); any other space draws at meaningless offsets, so say so up front instead of
             // rendering garbage silently. Advisory: the host still simulates.
             if (main.simulationSpace != ParticleSystemSimulationSpace.Local
-                && s_warnedSimulationSpace.Add(source.GetInstanceID()))
+                && s_warnedSimulationSpace.Add(source.name))
             {
                 Debug.LogWarning($"[Velvet] V.Particles: \"{source.name}\" does not use local simulation space; particle positions are read locally, so a world- or custom-space simulation will not match the drawn layout. Use local simulation space.");
             }
             // The draw path truncates at its particle cap; a denser effect must say so once instead of
             // silently thinning out compared to everywhere else the same source is used.
-            if (main.maxParticles > MaxDrawnParticles && s_warnedDrawCap.Add(source.GetInstanceID()))
+            if (main.maxParticles > MaxDrawnParticles && s_warnedDrawCap.Add(source.name))
             {
                 Debug.LogWarning($"[Velvet] V.Particles: \"{source.name}\" declares {main.maxParticles} max particles, above the {MaxDrawnParticles} the element draws; the densest frames will render truncated.");
             }
@@ -341,7 +360,7 @@ namespace Velvet
             if (binding.Host != null && binding.RepaintTick == null)
             {
                 binding.RepaintTick = element.schedule
-                    .Execute(() => OnRepaintTick(element, binding))
+                    .Execute((TimerState ts) => OnRepaintTick(element, binding, ts.deltaTime / 1000f))
                     .Every(SceneViewDriver.RepaintIntervalMs);
             }
             else if (binding.Host == null)
@@ -350,18 +369,44 @@ namespace Velvet
             }
         }
 
-        private static void OnRepaintTick(VisualElement element, ParticlesBinding binding)
+        private static void OnRepaintTick(VisualElement element, ParticlesBinding binding, float dt)
         {
             var host = binding.Host;
             // A drained simulation — a finished burst, a stopped Manual host, a host killed by a scene
             // unload — must not keep dirtying the element at tick rate forever: park the tick (Sync
             // and Play() re-arm it) after one final dirty, so the last live frame's quads are
-            // regenerated away instead of lingering.
-            if (host == null || !host.IsAlive(true))
+            // regenerated away instead of lingering. Root-only liveness: the draw samples only the
+            // root's particles, so a longer-lived child sub-emitter must not hold the tick open after
+            // the drawn output is already empty.
+            if (host == null || !host.IsAlive(false) || (binding.LogicallyPlaying && EditorSimulationDrained(host)))
             {
                 StopRepaintTick(binding);
             }
+            else if (!Application.isPlaying && binding.LogicallyPlaying && dt > 0f)
+            {
+                // Outside Play Mode the engine never steps a particle system's clock on its own, so an
+                // editor-context panel (preview tooling, EditMode fixtures) would repaint one frozen
+                // frame forever. Advance the hidden host by the tick's real elapsed time, clamped the
+                // way frame deltas are clamped; children advance in step for coherence even though
+                // only the root is drawn.
+                host.Simulate(Mathf.Min(dt, Time.maximumDeltaTime), withChildren: true, restart: false, fixedTimeStep: false);
+            }
             element.MarkDirtyRepaint();
+        }
+
+        // The editor-side twin of the IsAlive park above: a Simulate()-driven system is left PAUSED,
+        // and a paused system reads IsAlive forever (it never transitions to stopped on its own, and
+        // its clock clamps at the end of a non-looping timeline), so "drained" is derived directly —
+        // a non-looping root whose clock reached its end with no live particles has nothing left to
+        // draw or emit. Root-only on purpose, like the draw.
+        private static bool EditorSimulationDrained(ParticleSystem host)
+        {
+            if (Application.isPlaying)
+            {
+                return false;
+            }
+            var main = host.main;
+            return !main.loop && host.particleCount == 0 && host.time >= main.duration;
         }
 
         private static void StopRepaintTick(ParticlesBinding binding)

--- a/Packages/com.velvet.core/Runtime/Component/ParticlesDriver.cs
+++ b/Packages/com.velvet.core/Runtime/Component/ParticlesDriver.cs
@@ -1,6 +1,5 @@
 #nullable enable
 using System;
-using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UIElements;
 
@@ -34,6 +33,17 @@ namespace Velvet
         // simulation manually exactly while this is set — the native isPlaying flag cannot serve,
         // because ParticleSystem.Simulate itself flips the system to paused.
         public bool LogicallyPlaying;
+        // Advisory warn-once flags, per mounted element: an unstable effect reference that rebuilds
+        // its source every render must not repeat the advice per rebuild, while two elements whose
+        // sources merely share a name stay independent problems. Dying with the binding, the flags
+        // need no static registry and no domain-reload reset.
+        public bool WarnedSimulationSpace;
+        public bool WarnedDrawCap;
+        // The host's own loop flag and duration, captured at clone time (the framework owns the
+        // clone, so they cannot change underneath): the editor drained-probe reads them every tick
+        // and each ParticleSystem property access is a native call.
+        public bool HostLoops;
+        public float HostDuration;
 
         public ParticlesBinding(ParticlesSettings settings)
         {
@@ -58,23 +68,6 @@ namespace Velvet
         // (or the scene view) never composes the simulation twice even before the renderer disable
         // lands on unusual setups.
         private static readonly Vector3 HostParkingPosition = new(0f, -10000f, 0f);
-
-        // Warn-once bookkeeping per SOURCE NAME for the advisory mount warnings: an unstable effect
-        // reference (a component re-creating its source every render) rebuilds hosts repeatedly with
-        // a FRESH instance id each time — the exact case the debounce exists for — while the name
-        // stays put, and distinct names stay bounded by the project's effect inventory instead of
-        // growing one entry per mounted instance for the life of the session.
-        private static readonly HashSet<string> s_warnedSimulationSpace = new();
-        private static readonly HashSet<string> s_warnedDrawCap = new();
-
-#if UNITY_EDITOR
-        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
-        private static void ResetWarnOnceState()
-        {
-            s_warnedSimulationSpace.Clear();
-            s_warnedDrawCap.Clear();
-        }
-#endif
 
         // Wires the particle painter onto the element and returns the binding; a non-null effect gets
         // its hidden host immediately (the simulation needs no panel or layout — only the DRAW does,
@@ -183,7 +176,7 @@ namespace Velvet
         private static void CreateHost(ParticlesBinding binding)
         {
             var source = binding.Settings.Effect!;
-            WarnOnceForSource(source);
+            WarnOnceForSource(binding, source);
 
             var host = UnityEngine.Object.Instantiate(source);
             // Cloning preserves activeSelf, and an inactive host never simulates; a pooled prefab kept
@@ -196,6 +189,8 @@ namespace Velvet
             // output — the host must always simulate; only the element consumes it.
             var main = host.main;
             main.cullingMode = ParticleSystemCullingMode.AlwaysSimulate;
+            binding.HostLoops = main.loop;
+            binding.HostDuration = main.duration;
             var renderer = host.GetComponent<ParticleSystemRenderer>();
             if (renderer != null)
             {
@@ -248,7 +243,7 @@ namespace Velvet
             }
             // Editor-side replay: a Simulate()-driven clock clamps at a finished non-looping timeline
             // and Play() merely resumes the pause there, so a drained host restarts from zero first.
-            if (EditorSimulationDrained(binding.Host))
+            if (!Application.isPlaying && EditorSimulationDrained(binding.Host, binding))
             {
                 binding.Host.Simulate(0f, withChildren: true, restart: true, fixedTimeStep: false);
             }
@@ -270,22 +265,23 @@ namespace Velvet
             }
         }
 
-        // Advisory mount warnings, once per source name (see the warn-once sets above).
-        private static void WarnOnceForSource(ParticleSystem source)
+        // Advisory mount warnings, once per mounted element (see the binding's warn-once flags).
+        private static void WarnOnceForSource(ParticlesBinding binding, ParticleSystem source)
         {
             var main = source.main;
             // Particle positions are read in the simulation's LOCAL space (the element rect is the
             // canvas); any other space draws at meaningless offsets, so say so up front instead of
             // rendering garbage silently. Advisory: the host still simulates.
-            if (main.simulationSpace != ParticleSystemSimulationSpace.Local
-                && s_warnedSimulationSpace.Add(source.name))
+            if (main.simulationSpace != ParticleSystemSimulationSpace.Local && !binding.WarnedSimulationSpace)
             {
+                binding.WarnedSimulationSpace = true;
                 Debug.LogWarning($"[Velvet] V.Particles: \"{source.name}\" does not use local simulation space; particle positions are read locally, so a world- or custom-space simulation will not match the drawn layout. Use local simulation space.");
             }
             // The draw path truncates at its particle cap; a denser effect must say so once instead of
             // silently thinning out compared to everywhere else the same source is used.
-            if (main.maxParticles > MaxDrawnParticles && s_warnedDrawCap.Add(source.name))
+            if (main.maxParticles > MaxDrawnParticles && !binding.WarnedDrawCap)
             {
+                binding.WarnedDrawCap = true;
                 Debug.LogWarning($"[Velvet] V.Particles: \"{source.name}\" declares {main.maxParticles} max particles, above the {MaxDrawnParticles} the element draws; the densest frames will render truncated.");
             }
         }
@@ -372,17 +368,19 @@ namespace Velvet
         private static void OnRepaintTick(VisualElement element, ParticlesBinding binding, float dt)
         {
             var host = binding.Host;
+            var playing = Application.isPlaying;
             // A drained simulation — a finished burst, a stopped Manual host, a host killed by a scene
             // unload — must not keep dirtying the element at tick rate forever: park the tick (Sync
             // and Play() re-arm it) after one final dirty, so the last live frame's quads are
             // regenerated away instead of lingering. Root-only liveness: the draw samples only the
             // root's particles, so a longer-lived child sub-emitter must not hold the tick open after
             // the drawn output is already empty.
-            if (host == null || !host.IsAlive(false) || (binding.LogicallyPlaying && EditorSimulationDrained(host)))
+            if (host == null || !host.IsAlive(false)
+                || (!playing && binding.LogicallyPlaying && EditorSimulationDrained(host, binding)))
             {
                 StopRepaintTick(binding);
             }
-            else if (!Application.isPlaying && binding.LogicallyPlaying && dt > 0f)
+            else if (!playing && binding.LogicallyPlaying && dt > 0f)
             {
                 // Outside Play Mode the engine never steps a particle system's clock on its own, so an
                 // editor-context panel (preview tooling, EditMode fixtures) would repaint one frozen
@@ -398,15 +396,10 @@ namespace Velvet
         // and a paused system reads IsAlive forever (it never transitions to stopped on its own, and
         // its clock clamps at the end of a non-looping timeline), so "drained" is derived directly —
         // a non-looping root whose clock reached its end with no live particles has nothing left to
-        // draw or emit. Root-only on purpose, like the draw.
-        private static bool EditorSimulationDrained(ParticleSystem host)
+        // draw or emit. Root-only on purpose, like the draw. Callers gate on !Application.isPlaying.
+        private static bool EditorSimulationDrained(ParticleSystem host, ParticlesBinding binding)
         {
-            if (Application.isPlaying)
-            {
-                return false;
-            }
-            var main = host.main;
-            return !main.loop && host.particleCount == 0 && host.time >= main.duration;
+            return !binding.HostLoops && host.particleCount == 0 && host.time >= binding.HostDuration;
         }
 
         private static void StopRepaintTick(ParticlesBinding binding)

--- a/Packages/com.velvet.core/Runtime/Component/SceneViewDriver.cs
+++ b/Packages/com.velvet.core/Runtime/Component/SceneViewDriver.cs
@@ -49,9 +49,9 @@ namespace Velvet
         public static SceneViewBinding Attach(VisualElement element, SceneViewSettings settings)
         {
             var binding = new SceneViewBinding(settings);
-            binding.OnGeometryChanged = _ => SyncTexture(element, binding);
+            binding.OnGeometryChanged = _ => SyncTexture(element, binding, claimForeignTarget: false);
             element.RegisterCallback(binding.OnGeometryChanged);
-            SyncTexture(element, binding);
+            SyncTexture(element, binding, claimForeignTarget: true);
             return binding;
         }
 
@@ -71,7 +71,7 @@ namespace Velvet
             {
                 ReleaseCameraTarget(previousCamera, binding.Texture);
             }
-            SyncTexture(element, binding);
+            SyncTexture(element, binding, claimForeignTarget: true);
         }
 
         // Full teardown: unregisters the geometry callback and releases both ends of the output pair.
@@ -85,33 +85,29 @@ namespace Velvet
         }
 
         // (Re)creates or releases the texture to match the CURRENT layout and settings — the one sync
-        // point shared by attach, patch, and every geometry change. No camera, or no renderable size
-        // (pre-layout NaN, a zero-sized rect, a detached element), releases any existing output;
-        // otherwise the texture is re-created only when the effective pixel size actually changed
-        // (keyed on the live texture's own dimensions), and an unchanged-size texture is simply
-        // re-targeted (where a camera swap lands).
-        private static void SyncTexture(VisualElement element, SceneViewBinding binding)
+        // point shared by attach, patch, geometry changes and the editor tick's staleness probe. No
+        // camera, or no renderable size (pre-layout NaN, a zero-sized rect, a detached element),
+        // releases any existing output; otherwise the texture is re-created only when the effective
+        // pixel size actually changed (keyed on the live texture's own dimensions), and an
+        // unchanged-size texture is simply re-targeted (where a camera swap lands).
+        // claimForeignTarget separates the two kinds of caller: an explicit camera/settings pass
+        // (attach, props update) claims the camera outright, while a layout/tick resync reclaims it
+        // only from null or from the framework's own outgoing texture — a targetTexture user code
+        // pointed elsewhere stays theirs, mirroring the polite release on the way out.
+        private static void SyncTexture(VisualElement element, SceneViewBinding binding, bool claimForeignTarget)
         {
             var camera = binding.Settings.Camera;
-            var w = element.layout.width;
-            var h = element.layout.height;
-            if (camera == null || w <= 0f || h <= 0f || float.IsNaN(w) || float.IsNaN(h) || element.panel == null)
+            if (camera == null || element.panel == null
+                || !TryComputePixelSize(element, binding, out var pw, out var ph))
             {
                 ReleaseOutput(element, binding);
                 return;
             }
 
-            // Size in device pixels: layout points times the resolution scale times the panel's pixel
-            // density, so a scaled panel (HiDPI editor, runtime panel scaling) gets pixel-sharp output.
-            // The floor keeps a sub-pixel rect from rounding to a zero-dimension texture (which
-            // RenderTexture creation rejects); the ceiling bounds the VRAM request like the sibling
-            // texture bakers bound theirs.
-            var pixelScale = binding.Settings.ResolutionScale * element.scaledPixelsPerPoint;
-            var pw = Mathf.Clamp(Mathf.RoundToInt(w * pixelScale), 1, MaxTextureSize);
-            var ph = Mathf.Clamp(Mathf.RoundToInt(h * pixelScale), 1, MaxTextureSize);
             if (binding.Texture != null && binding.Texture.width == pw && binding.Texture.height == ph)
             {
-                if (camera.targetTexture != binding.Texture)
+                if (camera.targetTexture != binding.Texture
+                    && (claimForeignTarget || camera.targetTexture == null))
                 {
                     camera.targetTexture = binding.Texture;
                     // The texture object shown by the background is unchanged, so nothing else marks
@@ -128,7 +124,10 @@ namespace Velvet
             var previous = binding.Texture;
             var texture = new RenderTexture(pw, ph, 24);
             binding.Texture = texture;
-            camera.targetTexture = texture;
+            if (claimForeignTarget || camera.targetTexture == null || camera.targetTexture == previous)
+            {
+                camera.targetTexture = texture;
+            }
             element.style.backgroundImage = Background.FromRenderTexture(texture);
             element.MarkDirtyRepaint();
             if (previous != null)
@@ -137,6 +136,37 @@ namespace Velvet
                 VelvetObjectUtil.Destroy(previous);
             }
             SyncRepaintTick(element, binding);
+        }
+
+        // Derives the texture's target pixel size from the CURRENT layout, scale and pixel density —
+        // shared by the sync and the editor tick's staleness probe so the two can never disagree
+        // about what "current" means. Size in device pixels: layout points times the resolution
+        // scale times the panel's pixel density, so a scaled panel (HiDPI editor, runtime panel
+        // scaling) gets pixel-sharp output. The floor keeps a sub-pixel rect from rounding to a
+        // zero-dimension texture (which RenderTexture creation rejects); the ceiling bounds the VRAM
+        // request like the sibling texture bakers bound theirs — applied as ONE shared shrink when
+        // either axis overflows, because clamping each axis independently would change the texture's
+        // aspect and distort the camera picture.
+        private static bool TryComputePixelSize(VisualElement element, SceneViewBinding binding, out int pw, out int ph)
+        {
+            pw = 0;
+            ph = 0;
+            var w = element.layout.width;
+            var h = element.layout.height;
+            if (w <= 0f || h <= 0f || float.IsNaN(w) || float.IsNaN(h))
+            {
+                return false;
+            }
+            var pixelScale = binding.Settings.ResolutionScale * element.scaledPixelsPerPoint;
+            pw = Mathf.Max(1, Mathf.RoundToInt(w * pixelScale));
+            ph = Mathf.Max(1, Mathf.RoundToInt(h * pixelScale));
+            if (pw > MaxTextureSize || ph > MaxTextureSize)
+            {
+                var shrink = Mathf.Min((float)MaxTextureSize / pw, (float)MaxTextureSize / ph);
+                pw = Mathf.Clamp(Mathf.FloorToInt(pw * shrink), 1, MaxTextureSize);
+                ph = Mathf.Clamp(Mathf.FloorToInt(ph * shrink), 1, MaxTextureSize);
+            }
+            return true;
         }
 
         // An Editor-context panel repaints only when something marks it dirty, so a live camera feed
@@ -150,12 +180,27 @@ namespace Velvet
             var wantTick = binding.Texture != null && element.panel?.contextType == ContextType.Editor;
             if (wantTick && binding.RepaintTick == null)
             {
-                binding.RepaintTick = element.schedule.Execute(element.MarkDirtyRepaint).Every(RepaintIntervalMs);
+                binding.RepaintTick = element.schedule.Execute(() => OnRepaintTick(element, binding)).Every(RepaintIntervalMs);
             }
             else if (!wantTick)
             {
                 StopRepaintTick(binding);
             }
+        }
+
+        // Beyond dirtying the panel, the tick doubles as the staleness probe: a pixel-density change
+        // (a monitor-DPI move, a runtime panel-scale tweak) alters the derived pixel size with NO
+        // geometry event — points are unchanged — so no other signal would ever re-derive the
+        // texture. Runtime panels have no tick and heal on their next geometry or props pass instead.
+        private static void OnRepaintTick(VisualElement element, SceneViewBinding binding)
+        {
+            if (binding.Texture != null
+                && TryComputePixelSize(element, binding, out var pw, out var ph)
+                && (binding.Texture.width != pw || binding.Texture.height != ph))
+            {
+                SyncTexture(element, binding, claimForeignTarget: false);
+            }
+            element.MarkDirtyRepaint();
         }
 
         private static void StopRepaintTick(SceneViewBinding binding)

--- a/Packages/com.velvet.core/Runtime/Component/SceneViewDriver.cs
+++ b/Packages/com.velvet.core/Runtime/Component/SceneViewDriver.cs
@@ -15,6 +15,11 @@ namespace Velvet
         public RenderTexture? Texture;
         public EventCallback<GeometryChangedEvent>? OnGeometryChanged;
         public IVisualElementScheduledItem? RepaintTick;
+        // An explicit camera/settings pass (attach, props update) claims the camera even from a
+        // foreign targetTexture; the intent is recorded here because the claiming sync itself may
+        // bail pre-layout and the FIRST sync that gets past the validity gate must inherit it.
+        // Layout- and tick-driven resyncs never claim a foreign target on their own.
+        public bool ClaimOnNextSync;
 
         public SceneViewBinding(SceneViewSettings settings)
         {
@@ -49,9 +54,10 @@ namespace Velvet
         public static SceneViewBinding Attach(VisualElement element, SceneViewSettings settings)
         {
             var binding = new SceneViewBinding(settings);
-            binding.OnGeometryChanged = _ => SyncTexture(element, binding, claimForeignTarget: false);
+            binding.OnGeometryChanged = _ => SyncTexture(element, binding);
             element.RegisterCallback(binding.OnGeometryChanged);
-            SyncTexture(element, binding, claimForeignTarget: true);
+            binding.ClaimOnNextSync = true;
+            SyncTexture(element, binding);
             return binding;
         }
 
@@ -71,7 +77,8 @@ namespace Velvet
             {
                 ReleaseCameraTarget(previousCamera, binding.Texture);
             }
-            SyncTexture(element, binding, claimForeignTarget: true);
+            binding.ClaimOnNextSync = true;
+            SyncTexture(element, binding);
         }
 
         // Full teardown: unregisters the geometry callback and releases both ends of the output pair.
@@ -90,11 +97,12 @@ namespace Velvet
         // releases any existing output; otherwise the texture is re-created only when the effective
         // pixel size actually changed (keyed on the live texture's own dimensions), and an
         // unchanged-size texture is simply re-targeted (where a camera swap lands).
-        // claimForeignTarget separates the two kinds of caller: an explicit camera/settings pass
-        // (attach, props update) claims the camera outright, while a layout/tick resync reclaims it
-        // only from null or from the framework's own outgoing texture — a targetTexture user code
-        // pointed elsewhere stays theirs, mirroring the polite release on the way out.
-        private static void SyncTexture(VisualElement element, SceneViewBinding binding, bool claimForeignTarget)
+        // Claim intent: an explicit camera/settings pass sets ClaimOnNextSync and the first sync past
+        // the validity gate consumes it, claiming the camera even from a foreign targetTexture.
+        // Without it a resync reclaims only from null or from the framework's own outgoing texture;
+        // while user code holds the camera, the element keeps showing the last framework frame
+        // rather than re-deriving a texture nothing would render into.
+        private static void SyncTexture(VisualElement element, SceneViewBinding binding)
         {
             var camera = binding.Settings.Camera;
             if (camera == null || element.panel == null
@@ -103,11 +111,13 @@ namespace Velvet
                 ReleaseOutput(element, binding);
                 return;
             }
+            var claim = binding.ClaimOnNextSync;
+            binding.ClaimOnNextSync = false;
 
             if (binding.Texture != null && binding.Texture.width == pw && binding.Texture.height == ph)
             {
                 if (camera.targetTexture != binding.Texture
-                    && (claimForeignTarget || camera.targetTexture == null))
+                    && (claim || camera.targetTexture == null))
                 {
                     camera.targetTexture = binding.Texture;
                     // The texture object shown by the background is unchanged, so nothing else marks
@@ -119,15 +129,21 @@ namespace Velvet
                 return;
             }
 
+            var previous = binding.Texture;
+            if (!claim && camera.targetTexture != null && camera.targetTexture != previous)
+            {
+                // The camera is borrowed: re-deriving the texture now would swap the background to an
+                // image nothing renders into and destroy the last good frame. Keep showing that
+                // frame; the next explicit camera/settings pass reclaims and re-derives the size.
+                SyncRepaintTick(element, binding);
+                return;
+            }
+
             // Target the new texture BEFORE destroying the old one so the camera never points at a
             // dead texture in between (the re-target is itself the polite release of our own texture).
-            var previous = binding.Texture;
             var texture = new RenderTexture(pw, ph, 24);
             binding.Texture = texture;
-            if (claimForeignTarget || camera.targetTexture == null || camera.targetTexture == previous)
-            {
-                camera.targetTexture = texture;
-            }
+            camera.targetTexture = texture;
             if (element is SceneViewElement sceneView)
             {
                 // Taking the slot captures whatever the element was showing (a poster, a baked
@@ -205,7 +221,7 @@ namespace Velvet
                 && TryComputePixelSize(element, binding, out var pw, out var ph)
                 && (binding.Texture.width != pw || binding.Texture.height != ph))
             {
-                SyncTexture(element, binding, claimForeignTarget: false);
+                SyncTexture(element, binding);
             }
             element.MarkDirtyRepaint();
         }
@@ -232,12 +248,10 @@ namespace Velvet
             if (element is SceneViewElement sceneView)
             {
                 // Releasing the feed returns the slot to whatever writer was deferred while the
-                // camera owned it (a poster, a baked gradient) — or clears it when none was.
+                // camera owned it (a poster, a baked gradient) — or clears it when none was. Every
+                // binding is keyed by a SceneViewElement (the applier type-gates), so this is the
+                // only live branch.
                 sceneView.EndCameraOwnership();
-            }
-            else
-            {
-                element.style.backgroundImage = StyleKeyword.Null;
             }
             element.MarkDirtyRepaint();
         }

--- a/Packages/com.velvet.core/Runtime/Component/SceneViewDriver.cs
+++ b/Packages/com.velvet.core/Runtime/Component/SceneViewDriver.cs
@@ -128,6 +128,13 @@ namespace Velvet
             {
                 camera.targetTexture = texture;
             }
+            if (element is SceneViewElement sceneView)
+            {
+                // Taking the slot captures whatever the element was showing (a poster, a baked
+                // gradient) as the deferred restore target; class/style writers keep updating that
+                // deferred value through the ownership gate instead of clobbering the live feed.
+                sceneView.BeginCameraOwnership();
+            }
             element.style.backgroundImage = Background.FromRenderTexture(texture);
             element.MarkDirtyRepaint();
             if (previous != null)
@@ -222,7 +229,16 @@ namespace Velvet
             binding.Texture.Release();
             VelvetObjectUtil.Destroy(binding.Texture);
             binding.Texture = null;
-            element.style.backgroundImage = StyleKeyword.Null;
+            if (element is SceneViewElement sceneView)
+            {
+                // Releasing the feed returns the slot to whatever writer was deferred while the
+                // camera owned it (a poster, a baked gradient) — or clears it when none was.
+                sceneView.EndCameraOwnership();
+            }
+            else
+            {
+                element.style.backgroundImage = StyleKeyword.Null;
+            }
             element.MarkDirtyRepaint();
         }
 

--- a/Packages/com.velvet.core/Runtime/Component/SceneViewElement.cs
+++ b/Packages/com.velvet.core/Runtime/Component/SceneViewElement.cs
@@ -8,9 +8,53 @@ namespace Velvet
     /// image, from a framework-owned RenderTexture sized to the element's laid-out rect. A dedicated
     /// subclass (rather than reusing another element type) so a type change to or from any other
     /// element remounts instead of patching, and so the element is never recycled through the shared
-    /// primitive pools while it owns a live RenderTexture.
+    /// primitive pools while it owns a live RenderTexture. While the camera texture is live it owns
+    /// the element's <c>backgroundImage</c>: every other writer routes through
+    /// <see cref="WriteBackground"/>, which defers the value instead of clobbering the feed and
+    /// restores it when the camera releases.
     /// </summary>
     public sealed class SceneViewElement : VisualElement
     {
+        internal bool CameraOwnsBackground { get; private set; }
+        internal StyleBackground DeferredBackground { get; private set; }
+
+        // Called by the SceneView driver when the camera texture takes the slot: whatever the element
+        // was showing (a poster, a baked gradient) becomes the deferred restore target. Idempotent so
+        // a texture re-create on resize keeps the original capture.
+        internal void BeginCameraOwnership()
+        {
+            if (CameraOwnsBackground)
+            {
+                return;
+            }
+            CameraOwnsBackground = true;
+            DeferredBackground = style.backgroundImage;
+        }
+
+        // Called by the SceneView driver when the texture is released: the last deferred value (or
+        // the pre-camera capture) returns to the live style, and later writers land directly again.
+        internal void EndCameraOwnership()
+        {
+            if (!CameraOwnsBackground)
+            {
+                return;
+            }
+            CameraOwnsBackground = false;
+            style.backgroundImage = DeferredBackground;
+            DeferredBackground = default;
+        }
+
+        // The single seam every non-camera background writer goes through (the styles diff, the
+        // gradient bake, the bg-[addr:…] resolver): a write while the camera owns the slot lands in
+        // the deferred value instead of the live style, so the feed survives ordinary restyles.
+        internal static void WriteBackground(VisualElement element, StyleBackground value)
+        {
+            if (element is SceneViewElement { CameraOwnsBackground: true } sceneView)
+            {
+                sceneView.DeferredBackground = value;
+                return;
+            }
+            element.style.backgroundImage = value;
+        }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Component/V.cs
+++ b/Packages/com.velvet.core/Runtime/Component/V.cs
@@ -682,11 +682,13 @@ namespace Velvet
             IReadOnlyDictionary<string, string>? data = null,
             IReadOnlyDictionary<string, string>? aria = null)
         {
-            // Always carried (even with a null camera): the patcher needs the settings on BOTH sides of a
-            // diff to see a camera arriving or leaving as a settings change. The settings constructor
-            // fail-fasts on an invalid scale for every construction path, this factory included.
+            // Validated BEFORE renting pooled props so a throwing call leaks nothing (the settings
+            // constructor fail-fasts on an invalid scale for every construction path, this factory
+            // included). Always carried (even with a null camera): the patcher needs the settings on
+            // BOTH sides of a diff to see a camera arriving or leaving as a settings change.
+            var sceneView = new SceneViewSettings(camera, resolutionScale);
             var props = VNodePool.RentProps();
-            props.SceneView = new SceneViewSettings(camera, resolutionScale);
+            props.SceneView = sceneView;
 
             return new ElementNode
             {
@@ -744,11 +746,13 @@ namespace Velvet
             IReadOnlyDictionary<string, string>? data = null,
             IReadOnlyDictionary<string, string>? aria = null)
         {
-            // Always carried (even with a null effect): the patcher needs the settings on BOTH sides of
-            // a diff to see an effect arriving or leaving as a settings change. The settings constructor
-            // fail-fasts on an invalid mapping for every construction path, this factory included.
+            // Validated BEFORE renting pooled props so a throwing call leaks nothing (the settings
+            // constructor fail-fasts on an invalid mapping for every construction path, this factory
+            // included). Always carried (even with a null effect): the patcher needs the settings on
+            // BOTH sides of a diff to see an effect arriving or leaving as a settings change.
+            var particles = new ParticlesSettings(effect, playOn, pixelsPerUnit);
             var props = VNodePool.RentProps();
-            props.Particles = new ParticlesSettings(effect, playOn, pixelsPerUnit);
+            props.Particles = particles;
 
             return new ElementNode
             {

--- a/Packages/com.velvet.core/Runtime/Component/V.cs
+++ b/Packages/com.velvet.core/Runtime/Component/V.cs
@@ -682,15 +682,9 @@ namespace Velvet
             IReadOnlyDictionary<string, string>? data = null,
             IReadOnlyDictionary<string, string>? aria = null)
         {
-            // A non-positive (or NaN) scale could never size a texture; fail fast at the call site like
-            // the other factories with numeric preconditions. The negated > comparison catches NaN too.
-            if (!(resolutionScale > 0f))
-            {
-                throw new ArgumentOutOfRangeException(nameof(resolutionScale), "ResolutionScale must be greater than 0.");
-            }
-
             // Always carried (even with a null camera): the patcher needs the settings on BOTH sides of a
-            // diff to see a camera arriving or leaving as a settings change.
+            // diff to see a camera arriving or leaving as a settings change. The settings constructor
+            // fail-fasts on an invalid scale for every construction path, this factory included.
             var props = VNodePool.RentProps();
             props.SceneView = new SceneViewSettings(camera, resolutionScale);
 
@@ -750,14 +744,9 @@ namespace Velvet
             IReadOnlyDictionary<string, string>? data = null,
             IReadOnlyDictionary<string, string>? aria = null)
         {
-            if (!(pixelsPerUnit > 0f))
-            {
-                throw new ArgumentOutOfRangeException(nameof(pixelsPerUnit),
-                    "pixelsPerUnit must be positive; it maps particle world units to element pixels.");
-            }
-
             // Always carried (even with a null effect): the patcher needs the settings on BOTH sides of
-            // a diff to see an effect arriving or leaving as a settings change.
+            // a diff to see an effect arriving or leaving as a settings change. The settings constructor
+            // fail-fasts on an invalid mapping for every construction path, this factory included.
             var props = VNodePool.RentProps();
             props.Particles = new ParticlesSettings(effect, playOn, pixelsPerUnit);
 

--- a/Packages/com.velvet.core/Runtime/Hooks/Hooks.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Hooks.cs
@@ -944,19 +944,33 @@ namespace Velvet
                         // elapsed interval — no separate "last tick" bookkeeping. A zero delta
                         // (same-frame flush) is skipped so the callback only ever observes positive,
                         // frame-sized seconds; a hitch spike is clamped the way Time.deltaTime clamps
-                        // its own, so a stall cannot teleport a user simulation by one giant step.
+                        // its own, so a stall cannot teleport a user simulation by one giant step. The
+                        // zero interval fires on every scheduler update — once per frame — rather than
+                        // imposing a wall-clock floor that would skip frames on fast panels.
                         var dt = ts.deltaTime / 1000f;
                         if (dt <= 0f)
                         {
                             return;
                         }
                         dt = UnityEngine.Mathf.Min(dt, UnityEngine.Time.maximumDeltaTime);
-                        latest.Current?.Invoke(dt);
-                    }).Every(16);
+                        try
+                        {
+                            latest.Current?.Invoke(dt);
+                        }
+                        catch (Exception ex)
+                        {
+                            // Contained like an effect exception: an escaped throw would abort the rest
+                            // of this panel's scheduled updates for the frame and re-fire every frame
+                            // thereafter (the scheduler never unschedules a throwing item), and the
+                            // nearest error boundary must receive user-callback failures either way.
+                            ComponentBoundarySearch.PropagateException(fiber, ex);
+                        }
+                    }).Every(0);
                 }
-                // A keyed reorder re-inserts the host element, which silently drops its element-bound
-                // scheduled items — so the tick is re-armed from scratch on every attach (a dropped
-                // item cannot be resumed) and released on detach; nothing fires while detached.
+                // Element-bound scheduled items survive a keyed reorder's detach/re-attach (the engine
+                // pauses and resumes them), but the resume restarts the interval phase instead of
+                // continuing it. Re-arming a fresh item per attach keeps the tick's lifetime explicit
+                // and independent of that engine subtlety; nothing fires while detached.
                 UnityEngine.UIElements.EventCallback<UnityEngine.UIElements.AttachToPanelEvent> onAttach = _ => StartTick();
                 UnityEngine.UIElements.EventCallback<UnityEngine.UIElements.DetachFromPanelEvent> onDetach = _ =>
                 {

--- a/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseFramePerFrameContractTests.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseFramePerFrameContractTests.cs
@@ -1,7 +1,4 @@
-using System;
-using System.Reflection;
 using NUnit.Framework;
-using UnityEngine.UIElements;
 using Velvet.TestUtilities;
 
 namespace Velvet.Tests
@@ -48,31 +45,12 @@ namespace Velvet.Tests
         // by 1000); the fake clock is kept in milliseconds and converted here for readability.
         private static double ReadFakeClock() => s_fakeMs / 1000.0;
 
-        // Installs the fake clock: the scheduler and every scheduled item read time exclusively
-        // through the panel's own time function, which the engine exposes for exactly this kind of
-        // deterministic driving. Internal engine surface, reached by walking the panel's type chain.
-        private static void InstallFakeClock(IPanel panel)
-        {
-            PropertyInfo prop = null;
-            for (var t = panel.GetType(); t != null && prop == null; t = t.BaseType)
-            {
-                prop = t.GetProperty(
-                    "TimeSinceStartupFunc",
-                    BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly);
-            }
-            Assume.That(prop, Is.Not.Null, "Precondition: the panel exposes its time function");
-            var clock = Delegate.CreateDelegate(prop.PropertyType,
-                typeof(UseFramePerFrameContractTests).GetMethod(nameof(ReadFakeClock),
-                    BindingFlags.Static | BindingFlags.NonPublic));
-            prop.SetValue(panel, clock);
-        }
-
         [Test]
         public void Given_AMountedUseFrame_When_TheSchedulerUpdatesEveryFewMilliseconds_Then_EachSpacedUpdateTicks()
         {
             // Arrange — mount on the fake clock, run the passive effect that arms the tick, and
             // absorb the arm-time firing (its delta is zero on the frozen clock, so it never counts).
-            InstallFakeClock(_host.Panel);
+            EditorPanelTestHelpers.SetPanelTimeFunction(_host.Panel, ReadFakeClock);
             _mounted = V.Mount(_host.Root, V.Component(CountingHost, key: "root"));
             _mounted.FlushEffectsForTest();
             EditorPanelTestHelpers.DriveSchedulerOnce(_host.Panel);

--- a/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseFramePerFrameContractTests.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseFramePerFrameContractTests.cs
@@ -1,0 +1,93 @@
+using System.Diagnostics;
+using System.Reflection;
+using System.Threading;
+using NUnit.Framework;
+using UnityEngine.UIElements;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins UseFrame's cadence contract deterministically: the callback follows the panel's scheduler
+    /// update — once per update with a positive delta — rather than a fixed minimum wall-clock
+    /// interval, so several scheduler updates spaced a few milliseconds apart each tick the callback
+    /// (a 16 ms floor would swallow every firing after the first on any panel updating faster than it).
+    /// </summary>
+    internal sealed class UseFramePerFrameContractTests
+    {
+        private HeadlessEditorPanelHost _host;
+        private MountedTree _mounted;
+
+        private static int s_calls;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _host = new HeadlessEditorPanelHost();
+            s_calls = 0;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _mounted?.Dispose();
+            _mounted = null;
+            _host?.Dispose();
+            _host = null;
+        }
+
+        [Component]
+        private static VNode CountingHost()
+        {
+            Hooks.UseFrame(_ => s_calls++);
+            return V.Div(className: "w-[10px] h-[10px]");
+        }
+
+        // The timer scheduler is internal engine surface: walk the panel's type chain for its
+        // "scheduler" property and pump one update — the exact call a live panel issues once per frame.
+        private static void DriveSchedulerOnce(IPanel panel)
+        {
+            object scheduler = null;
+            for (var t = panel.GetType(); t != null && scheduler == null; t = t.BaseType)
+            {
+                var prop = t.GetProperty(
+                    "scheduler",
+                    BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly);
+                if (prop != null)
+                {
+                    scheduler = prop.GetValue(panel);
+                }
+            }
+            Assume.That(scheduler, Is.Not.Null, "Precondition: the panel exposes a timer scheduler");
+            var update = scheduler.GetType().GetMethod(
+                "UpdateScheduledEvents",
+                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            Assume.That(update, Is.Not.Null, "Precondition: the scheduler exposes UpdateScheduledEvents");
+            update.Invoke(scheduler, null);
+        }
+
+        [Test]
+        public void Given_AMountedUseFrame_When_TheSchedulerUpdatesEveryFewMilliseconds_Then_EachSpacedUpdateTicks()
+        {
+            // Arrange — mount, run the passive effect that arms the tick, and absorb the first firing
+            // (its delta spans the arm-to-now gap, not an update-to-update one).
+            _mounted = V.Mount(_host.Root, V.Component(CountingHost, key: "root"));
+            _mounted.FlushEffectsForTest();
+            DriveSchedulerOnce(_host.Panel);
+            var clock = Stopwatch.StartNew();
+
+            // Act — pump a handful of updates ~2 ms apart, all inside a single 16 ms window.
+            for (var i = 0; i < 4; i++)
+            {
+                Thread.Sleep(2);
+                DriveSchedulerOnce(_host.Panel);
+            }
+            Assume.That(clock.ElapsedMilliseconds, Is.LessThan(16),
+                "Precondition: every update landed inside one 16 ms window");
+
+            // Assert — per-update ticking: the spaced updates each invoked the callback; a 16 ms
+            // minimum interval would have allowed at most the window's first firing.
+            Assert.That(s_calls, Is.GreaterThanOrEqualTo(3));
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseFramePerFrameContractTests.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseFramePerFrameContractTests.cs
@@ -1,6 +1,7 @@
-using System.Diagnostics;
-using System.Threading;
+using System;
+using System.Reflection;
 using NUnit.Framework;
+using UnityEngine.UIElements;
 using Velvet.TestUtilities;
 
 namespace Velvet.Tests
@@ -8,8 +9,8 @@ namespace Velvet.Tests
     /// <summary>
     /// Pins UseFrame's cadence contract deterministically: the callback follows the panel's scheduler
     /// update — once per update with a positive delta — rather than a fixed minimum wall-clock
-    /// interval, so several scheduler updates spaced a few milliseconds apart each tick the callback
-    /// (a 16 ms floor would swallow every firing after the first on any panel updating faster than it).
+    /// interval (a 16 ms floor would swallow every firing after the first on any panel updating
+    /// faster than it). The panel runs on a fake clock, so machine load cannot skew the probe.
     /// </summary>
     internal sealed class UseFramePerFrameContractTests
     {
@@ -17,12 +18,14 @@ namespace Velvet.Tests
         private MountedTree _mounted;
 
         private static int s_calls;
+        private static long s_fakeMs;
 
         [SetUp]
         public void SetUp()
         {
             _host = new HeadlessEditorPanelHost();
             s_calls = 0;
+            s_fakeMs = 1000;
         }
 
         [TearDown]
@@ -41,27 +44,48 @@ namespace Velvet.Tests
             return V.Div(className: "w-[10px] h-[10px]");
         }
 
+        // The per-panel time function reports SECONDS as a double (the ms-facing surface multiplies
+        // by 1000); the fake clock is kept in milliseconds and converted here for readability.
+        private static double ReadFakeClock() => s_fakeMs / 1000.0;
+
+        // Installs the fake clock: the scheduler and every scheduled item read time exclusively
+        // through the panel's own time function, which the engine exposes for exactly this kind of
+        // deterministic driving. Internal engine surface, reached by walking the panel's type chain.
+        private static void InstallFakeClock(IPanel panel)
+        {
+            PropertyInfo prop = null;
+            for (var t = panel.GetType(); t != null && prop == null; t = t.BaseType)
+            {
+                prop = t.GetProperty(
+                    "TimeSinceStartupFunc",
+                    BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly);
+            }
+            Assume.That(prop, Is.Not.Null, "Precondition: the panel exposes its time function");
+            var clock = Delegate.CreateDelegate(prop.PropertyType,
+                typeof(UseFramePerFrameContractTests).GetMethod(nameof(ReadFakeClock),
+                    BindingFlags.Static | BindingFlags.NonPublic));
+            prop.SetValue(panel, clock);
+        }
+
         [Test]
         public void Given_AMountedUseFrame_When_TheSchedulerUpdatesEveryFewMilliseconds_Then_EachSpacedUpdateTicks()
         {
-            // Arrange — mount, run the passive effect that arms the tick, and absorb the first firing
-            // (its delta spans the arm-to-now gap, not an update-to-update one).
+            // Arrange — mount on the fake clock, run the passive effect that arms the tick, and
+            // absorb the arm-time firing (its delta is zero on the frozen clock, so it never counts).
+            InstallFakeClock(_host.Panel);
             _mounted = V.Mount(_host.Root, V.Component(CountingHost, key: "root"));
             _mounted.FlushEffectsForTest();
             EditorPanelTestHelpers.DriveSchedulerOnce(_host.Panel);
-            var clock = Stopwatch.StartNew();
 
-            // Act — pump a handful of updates ~2 ms apart, all inside a single 16 ms window.
+            // Act — four updates two fake-milliseconds apart, all inside a single 16 ms window.
             for (var i = 0; i < 4; i++)
             {
-                Thread.Sleep(2);
+                s_fakeMs += 2;
                 EditorPanelTestHelpers.DriveSchedulerOnce(_host.Panel);
             }
-            Assume.That(clock.ElapsedMilliseconds, Is.LessThan(16),
-                "Precondition: every update landed inside one 16 ms window");
 
             // Assert — per-update ticking: the spaced updates each invoked the callback; a 16 ms
-            // minimum interval would have allowed at most the window's first firing.
+            // minimum interval would have allowed none of them (only 8 ms elapsed in total).
             Assert.That(s_calls, Is.GreaterThanOrEqualTo(3));
         }
     }

--- a/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseFramePerFrameContractTests.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseFramePerFrameContractTests.cs
@@ -1,8 +1,6 @@
 using System.Diagnostics;
-using System.Reflection;
 using System.Threading;
 using NUnit.Framework;
-using UnityEngine.UIElements;
 using Velvet.TestUtilities;
 
 namespace Velvet.Tests
@@ -43,29 +41,6 @@ namespace Velvet.Tests
             return V.Div(className: "w-[10px] h-[10px]");
         }
 
-        // The timer scheduler is internal engine surface: walk the panel's type chain for its
-        // "scheduler" property and pump one update — the exact call a live panel issues once per frame.
-        private static void DriveSchedulerOnce(IPanel panel)
-        {
-            object scheduler = null;
-            for (var t = panel.GetType(); t != null && scheduler == null; t = t.BaseType)
-            {
-                var prop = t.GetProperty(
-                    "scheduler",
-                    BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly);
-                if (prop != null)
-                {
-                    scheduler = prop.GetValue(panel);
-                }
-            }
-            Assume.That(scheduler, Is.Not.Null, "Precondition: the panel exposes a timer scheduler");
-            var update = scheduler.GetType().GetMethod(
-                "UpdateScheduledEvents",
-                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
-            Assume.That(update, Is.Not.Null, "Precondition: the scheduler exposes UpdateScheduledEvents");
-            update.Invoke(scheduler, null);
-        }
-
         [Test]
         public void Given_AMountedUseFrame_When_TheSchedulerUpdatesEveryFewMilliseconds_Then_EachSpacedUpdateTicks()
         {
@@ -73,14 +48,14 @@ namespace Velvet.Tests
             // (its delta spans the arm-to-now gap, not an update-to-update one).
             _mounted = V.Mount(_host.Root, V.Component(CountingHost, key: "root"));
             _mounted.FlushEffectsForTest();
-            DriveSchedulerOnce(_host.Panel);
+            EditorPanelTestHelpers.DriveSchedulerOnce(_host.Panel);
             var clock = Stopwatch.StartNew();
 
             // Act — pump a handful of updates ~2 ms apart, all inside a single 16 ms window.
             for (var i = 0; i < 4; i++)
             {
                 Thread.Sleep(2);
-                DriveSchedulerOnce(_host.Panel);
+                EditorPanelTestHelpers.DriveSchedulerOnce(_host.Panel);
             }
             Assume.That(clock.ElapsedMilliseconds, Is.LessThan(16),
                 "Precondition: every update landed inside one 16 ms window");

--- a/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseFramePerFrameContractTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseFramePerFrameContractTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f89125f56e631407095c5c6eca71d565

--- a/Packages/com.velvet.core/Runtime/Hooks/Tests/PlayMode/UseFramePlaybackTests.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Tests/PlayMode/UseFramePlaybackTests.cs
@@ -35,6 +35,7 @@ namespace Velvet.Tests
             s_minDt = float.MaxValue;
             s_maxDt = 0f;
             s_observedValue = -1;
+            s_fallbackShown = false;
             yield break;
         }
 
@@ -187,6 +188,42 @@ namespace Velvet.Tests
 
             // Assert
             Assert.That(s_calls, Is.EqualTo(callsAtUnmount));
+        }
+
+        private static bool s_fallbackShown;
+
+        [Component]
+        private static VNode ThrowingFrameHost()
+        {
+            Hooks.UseFrame(_ => throw new System.InvalidOperationException("frame boom"));
+            return V.Div(className: "w-[10px] h-[10px]");
+        }
+
+        [Component(IsErrorBoundary = true)]
+        private static VNode FrameBoundary()
+        {
+            Hooks.UseFallback(_ =>
+            {
+                s_fallbackShown = true;
+                return V.Div(name: "frame-fallback");
+            });
+            return V.Component(ThrowingFrameHost, key: "thrower");
+        }
+
+        [UnityTest]
+        public IEnumerator Given_AThrowingFrameCallback_When_ABoundaryWraps_Then_TheFallbackRenders()
+        {
+            // Arrange
+            var root = CreatePanelRoot();
+            yield return null;
+
+            // Act
+            _mounted = V.Mount(root, V.Component(FrameBoundary, key: "root"));
+            yield return WaitRealtime(0.5);
+
+            // Assert — a frame-callback exception routes to the nearest error boundary the way effect
+            // exceptions do, instead of escaping into the panel's scheduler update.
+            Assert.That(s_fallbackShown, Is.True);
         }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Reconciler/ChildReconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ChildReconciler.cs
@@ -168,17 +168,20 @@ namespace Velvet
                 {
                     case PortalNode { Layer: { } layer } layerPortal:
                     {
-                        if (!_ctx.LayerHosts.TryGetValue(layer, out var layerHost))
+                        if (!_ctx.LayerHosts.TryGetValue(layer, out var layerHost)
+                            || layerHost.Document == null)
                         {
+                            // Also lands here when a scene unload killed a previously created host:
+                            // the dead record is replaced so new portals mount into a live panel.
                             layerHost = PanelHostFactory.CreateLayerHost(layer, placeholder.panel, _ctx);
                             _ctx.LayerHosts[layer] = layerHost;
                         }
-                        else if (!layerHost.DeclaringResolved)
+                        else
                         {
-                            // The host was configured from defaults because no declaring settings
-                            // were resolvable at creation; a later drain touching the layer is the
-                            // retry point (the declaring panel may have gained its document since).
-                            PanelHostFactory.TryUpgradeDeclaring(layerHost, layer, placeholder.panel, _ctx);
+                            // The copy of the declaring configuration is a snapshot: this drain is a
+                            // recurring touch point, so late resolution and runtime drift both
+                            // re-sync here.
+                            PanelHostFactory.SyncDeclaring(layerHost, layer, placeholder.panel, _ctx);
                         }
                         target = layerHost.Document.rootVisualElement;
                         children = layerPortal.Children ?? Array.Empty<VNode>();

--- a/Packages/com.velvet.core/Runtime/Reconciler/ChildReconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ChildReconciler.cs
@@ -261,7 +261,7 @@ namespace Velvet
                     }
                 }
                 var slotLength = resolvedTarget.childCount - slotStart;
-                _ctx.PortalState[placeholder] = new PortalSlotInfo(resolvedTarget, children, slotStart, slotLength);
+                _ctx.PortalState[placeholder] = new PortalSlotInfo(resolvedTarget, slotStart, slotLength);
             }
         }
 

--- a/Packages/com.velvet.core/Runtime/Reconciler/ChildReconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ChildReconciler.cs
@@ -178,9 +178,8 @@ namespace Velvet
                         }
                         else
                         {
-                            // The copy of the declaring configuration is a snapshot: this drain is a
-                            // recurring touch point, so late resolution and runtime drift both
-                            // re-sync here.
+                            // Recurring re-sync point for late declaring resolution and runtime
+                            // drift (see SyncDeclaring).
                             PanelHostFactory.SyncDeclaring(layerHost, layer, placeholder.panel, _ctx);
                         }
                         target = layerHost.Document.rootVisualElement;

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberElementProps.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberElementProps.cs
@@ -113,19 +113,60 @@ namespace Velvet
     /// <summary>
     /// The camera a SceneView element displays, plus its render-resolution policy. The framework owns
     /// the RenderTexture: it is created at the element's laid-out pixel size (times
-    /// <paramref name="ResolutionScale"/>), follows geometry changes, and is released on unmount.
+    /// <see cref="ResolutionScale"/>), follows geometry changes, and is released on unmount.
+    /// The constructor fail-fasts on a non-positive or NaN scale so every construction path (the
+    /// factory, wrapper hosts, direct construction) shares one guard; a <c>with</c> expression
+    /// bypasses it like any record init.
     /// </summary>
-    public sealed record SceneViewSettings(
-        Camera? Camera = null,
-        float ResolutionScale = 1f);
+    public sealed record SceneViewSettings
+    {
+        public Camera? Camera { get; init; }
+        public float ResolutionScale { get; init; } = 1f;
+
+        /// <exception cref="System.ArgumentOutOfRangeException"><paramref name="resolutionScale"/> is &lt;= 0 or NaN.</exception>
+        public SceneViewSettings(Camera? camera = null, float resolutionScale = 1f)
+        {
+            Camera = camera;
+            ResolutionScale = VelvetArgUtil.RequirePositiveFinite(resolutionScale, nameof(resolutionScale),
+                "resolutionScale must be greater than 0.");
+        }
+    }
 
     /// <summary>
     /// The particle effect a Particles element simulates and draws: the source effect (a prefab's
     /// ParticleSystem — the framework instantiates a hidden simulation host from it and owns that
     /// instance), the play trigger, and the world-unit → element-pixel mapping.
+    /// The constructor fail-fasts on a non-positive or NaN mapping so every construction path shares
+    /// one guard; a <c>with</c> expression bypasses it like any record init.
     /// </summary>
-    public sealed record ParticlesSettings(
-        ParticleSystem? Effect = null,
-        PlayTrigger PlayOn = PlayTrigger.Mount,
-        float PixelsPerUnit = 100f);
+    public sealed record ParticlesSettings
+    {
+        public ParticleSystem? Effect { get; init; }
+        public PlayTrigger PlayOn { get; init; } = PlayTrigger.Mount;
+        public float PixelsPerUnit { get; init; } = 100f;
+
+        /// <exception cref="System.ArgumentOutOfRangeException"><paramref name="pixelsPerUnit"/> is &lt;= 0 or NaN.</exception>
+        public ParticlesSettings(ParticleSystem? effect = null, PlayTrigger playOn = PlayTrigger.Mount, float pixelsPerUnit = 100f)
+        {
+            Effect = effect;
+            PlayOn = playOn;
+            PixelsPerUnit = VelvetArgUtil.RequirePositiveFinite(pixelsPerUnit, nameof(pixelsPerUnit),
+                "pixelsPerUnit must be positive; it maps particle world units to element pixels.");
+        }
+    }
+
+    // Shared numeric precondition for the settings records above: several element factories carry a
+    // positive-finite float knob, and each duplicating its own NaN-safe check invites drift.
+    internal static class VelvetArgUtil
+    {
+        internal static float RequirePositiveFinite(float value, string paramName, string message)
+        {
+            // The negated > comparison catches NaN too.
+            if (!(value > 0f))
+            {
+                throw new System.ArgumentOutOfRangeException(paramName, message);
+            }
+            return value;
+        }
+    }
 }

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodeFactory.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodeFactory.cs
@@ -335,7 +335,7 @@ namespace Velvet
                         {
                             FiberLogger.LogWarning("Portal", $"Target \"{portalNode.TargetId}\" is not registered. Children will not be rendered.");
                             var placeholder = CreateHiddenPlaceholder();
-                            _ctx.PortalState[placeholder] = new PortalSlotInfo(null, portalNode.Children ?? Array.Empty<VNode>(), 0, 0);
+                            _ctx.PortalState[placeholder] = new PortalSlotInfo(null, 0, 0);
                             return placeholder;
                         }
                     }

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
@@ -689,22 +689,28 @@ namespace Velvet
 
             const int linearThreshold = 8;
             var removedArbitrary = oldClasses.Length <= linearThreshold && newClasses.Length <= linearThreshold
-                ? DiffClassListLinear(element, oldClasses, newClasses)
-                : DiffClassListWithHashSet(element, oldClasses, newClasses);
+                ? DiffClassListLinear(element, oldClasses, newClasses, out var removedFilterFamily)
+                : DiffClassListWithHashSet(element, oldClasses, newClasses, out removedFilterFamily);
 
             // Arbitrary values are cleared per property, so removing a value of the same property
             // also clears any other values that should have remained.
-            // Reapply the arbitrary values from the new list only when a removal occurred to preserve consistency.
+            // Reapply the arbitrary values from the new list only when a removal occurred to preserve
+            // consistency. Filter-family survivors are exempt unless a filter-family token itself was
+            // removed: other properties' clears never touch their per-name layers and every real filter
+            // mutation recomposes inline during the diff, so re-resolving survivors here would only
+            // repeat registry lookups to rebuild an identical composed list.
             if (removedArbitrary)
             {
-                ReapplyArbitraryValues(element, newClasses);
+                ReapplyArbitraryValues(element, newClasses, skipFilterFamily: !removedFilterFamily);
             }
             return true;
         }
 
         // Re-asserts the class list's inline-resolved (arbitrary / preset) values. Shared with the
-        // wrapper element appliers, which call it after detaching a motion that owned a shared inline slot.
-        internal static void ReapplyArbitraryValues(VisualElement element, string[] classes)
+        // wrapper element appliers, which call it after detaching a motion that owned a shared inline
+        // slot. skipFilterFamily exempts composed-filter tokens for callers that know no filter layer
+        // was disturbed (the class-diff reapply); full-scrub callers keep the default full pass.
+        internal static void ReapplyArbitraryValues(VisualElement element, string[] classes, bool skipFilterFamily = false)
         {
             foreach (var rawCls in classes)
             {
@@ -720,6 +726,10 @@ namespace Velvet
                 // Strip the important bang so it reapplies on the same Important layer AddClass used.
                 var cls = StyleArbitraryValueResolver.StripImportant(rawCls, out var important);
                 if (!StyleArbitraryValueResolver.IsInlineResolved(cls))
+                {
+                    continue;
+                }
+                if (skipFilterFamily && StyleArbitraryValueResolver.IsFilterFamilyToken(cls))
                 {
                     continue;
                 }
@@ -748,9 +758,10 @@ namespace Velvet
             return true;
         }
 
-        private static bool DiffClassListLinear(VisualElement element, string[] oldClasses, string[] newClasses)
+        private static bool DiffClassListLinear(VisualElement element, string[] oldClasses, string[] newClasses, out bool removedFilterFamily)
         {
             var removedArbitrary = false;
+            removedFilterFamily = false;
             foreach (var cls in oldClasses)
             {
                 if (string.IsNullOrEmpty(cls))
@@ -769,6 +780,7 @@ namespace Velvet
                     if (StyleArbitraryValueResolver.IsInlineResolved(core))
                     {
                         removedArbitrary = true;
+                        removedFilterFamily |= StyleArbitraryValueResolver.IsFilterFamilyToken(core);
                     }
 
                     RemoveClass(element, cls);
@@ -794,9 +806,10 @@ namespace Velvet
             return removedArbitrary;
         }
 
-        private bool DiffClassListWithHashSet(VisualElement element, string[] oldClasses, string[] newClasses)
+        private bool DiffClassListWithHashSet(VisualElement element, string[] oldClasses, string[] newClasses, out bool removedFilterFamily)
         {
             var removedArbitrary = false;
+            removedFilterFamily = false;
 
             // Rent from the pool to make this re-entrant-safe.
             // Even along the path PatchElement → DiffClassList → PatchCommon → Reconcile (recursive)
@@ -816,6 +829,7 @@ namespace Velvet
                         if (StyleArbitraryValueResolver.IsInlineResolved(core))
                         {
                             removedArbitrary = true;
+                            removedFilterFamily |= StyleArbitraryValueResolver.IsFilterFamilyToken(core);
                         }
 
                         RemoveClass(element, cls);

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
@@ -1086,13 +1086,12 @@ namespace Velvet
             oldStyles ??= StyleOverrides.Empty;
             newStyles ??= StyleOverrides.Empty;
 
-            // The SceneView driver owns backgroundImage while a binding is live (the camera texture is
-            // shown through it), so a StyleOverrides change must not blank the running feed — a poster
-            // passed through styles shows only until the camera texture arrives.
-            if (!Equals(oldStyles.BackgroundImage, newStyles.BackgroundImage)
-                && !_ctx.SceneViewBindings.ContainsKey(element))
+            // Routed through the SceneView ownership gate: while a live camera texture owns the slot
+            // the poster is deferred (and restored on release); with no live texture — no camera yet,
+            // camera removed, plain elements — the write lands directly.
+            if (!Equals(oldStyles.BackgroundImage, newStyles.BackgroundImage))
             {
-                element.style.backgroundImage = newStyles.BackgroundImage ?? StyleKeyword.Null;
+                SceneViewElement.WriteBackground(element, newStyles.BackgroundImage ?? StyleKeyword.Null);
             }
 
             if (!Equals(oldStyles.BackgroundColor, newStyles.BackgroundColor))

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
@@ -649,7 +649,7 @@ namespace Velvet
             // grouping, the eventual cleanup, and the has-variant portal-target sweep all see where
             // the children actually live. For an already-recorded portal this rewrites the same
             // reference.
-            _ctx.PortalState[placeholder] = prevState with { Target = target, Children = newChildren, SlotLength = newSlotLength };
+            _ctx.PortalState[placeholder] = prevState with { Target = target, SlotLength = newSlotLength };
 
             PortalSlotTracker.ShiftSlotStartsAfter(_ctx.PortalState, target, prevState.SlotStart, delta, placeholder);
         }

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
@@ -543,8 +543,7 @@ namespace Velvet
                     FiberLogger.LogWarning("Portal", $"Layer host for \"{describe}\" is missing. Children will not be rendered.");
                     return;
                 }
-                // The copy of the declaring configuration is a snapshot: this patch is a recurring
-                // touch point, so late resolution and runtime drift both re-sync here.
+                // Recurring re-sync point for late declaring resolution and runtime drift.
                 PanelHostFactory.SyncDeclaring(layerHost, layer, placeholder.panel, _ctx);
                 target = layerHost.Document.rootVisualElement;
             }
@@ -589,15 +588,15 @@ namespace Velvet
             {
                 // A scene unload can kill the host GameObject while the owning fiber tree survives
                 // (a persistent root anchoring per-scene world-space UI). Patching a dead document
-                // would throw out of the whole reconcile pass; drop the record instead — the
-                // children need a remount of the world-space node to rebuild a host.
-                _ctx.WorldSpaceBindings.Remove(placeholder);
+                // would throw out of the whole reconcile pass, so every patch skips it on this same
+                // warning path — the record stays so later patches keep landing here rather than
+                // degrading into the missing-record corruption error (mirrors the layer flavor);
+                // remount the world-space node to rebuild its host.
                 FiberLogger.LogWarning("WorldSpace",
-                    "Host died externally (scene unload?). Patch skipped and the record dropped; remount the world-space node to rebuild its host.");
+                    "Host died externally (scene unload?). Patch skipped; remount the world-space node to rebuild its host.");
                 return;
             }
-            // The copy of the declaring configuration is a snapshot: this patch is the recurring
-            // touch point, so late resolution and runtime drift both re-sync here (null layer —
+            // Recurring re-sync point for late declaring resolution and runtime drift (null layer:
             // world-space panels depth-sort in the scene, not by sorting order).
             PanelHostFactory.SyncDeclaring(record, null, placeholder.panel, _ctx);
 

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
@@ -535,16 +535,18 @@ namespace Velvet
             if (newNode.Layer is { } layer)
             {
                 // The per-layer framework host was created when the mount drained and persists
-                // until reconciler disposal, so a patch resolves it from the table.
-                target = _ctx.LayerHosts.TryGetValue(layer, out var layerHost)
-                    ? layerHost.Document.rootVisualElement
-                    : null;
+                // until reconciler disposal, so a patch resolves it from the table. A record whose
+                // GameObject a scene unload killed reads as dead here and counts as missing.
                 describe = layer.ToString();
-                if (target == null)
+                if (!_ctx.LayerHosts.TryGetValue(layer, out var layerHost) || layerHost.Document == null)
                 {
                     FiberLogger.LogWarning("Portal", $"Layer host for \"{describe}\" is missing. Children will not be rendered.");
                     return;
                 }
+                // The copy of the declaring configuration is a snapshot: this patch is a recurring
+                // touch point, so late resolution and runtime drift both re-sync here.
+                PanelHostFactory.SyncDeclaring(layerHost, layer, placeholder.panel, _ctx);
+                target = layerHost.Document.rootVisualElement;
             }
             else
             {
@@ -583,6 +585,21 @@ namespace Velvet
                 FiberLogger.LogError("WorldSpace", "Host record missing for a world-space placeholder. Patch skipped.");
                 return;
             }
+            if (record.Document == null)
+            {
+                // A scene unload can kill the host GameObject while the owning fiber tree survives
+                // (a persistent root anchoring per-scene world-space UI). Patching a dead document
+                // would throw out of the whole reconcile pass; drop the record instead — the
+                // children need a remount of the world-space node to rebuild a host.
+                _ctx.WorldSpaceBindings.Remove(placeholder);
+                FiberLogger.LogWarning("WorldSpace",
+                    "Host died externally (scene unload?). Patch skipped and the record dropped; remount the world-space node to rebuild its host.");
+                return;
+            }
+            // The copy of the declaring configuration is a snapshot: this patch is the recurring
+            // touch point, so late resolution and runtime drift both re-sync here (null layer —
+            // world-space panels depth-sort in the scene, not by sorting order).
+            PanelHostFactory.SyncDeclaring(record, null, placeholder.panel, _ctx);
 
             if (oldNode.Position != newNode.Position || oldNode.Rotation != newNode.Rotation)
             {

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberWrapperElementAppliers.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberWrapperElementAppliers.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UIElements;
 
@@ -888,7 +890,7 @@ namespace Velvet
 
         #endregion
 
-        #region SceneView
+        #region Element bindings (SceneView / Particles)
 
         // Binds / re-binds / releases a SceneView element's camera-output machinery — the mount paths
         // (plain element AND Motion host) and the props diff all land here, beside the sibling binding
@@ -901,56 +903,56 @@ namespace Velvet
             {
                 return;
             }
-            if (_ctx.SceneViewBindings.TryGetValue(element, out var binding))
-            {
-                if (settings == null)
-                {
-                    // A vanished settings prop only happens on a hand-built ElementNode (V.SceneView
-                    // always carries settings, even for a null camera): release both ends and drop the
-                    // binding — the element stays mounted and inert.
-                    SceneViewDriver.Detach(element, binding);
-                    _ctx.SceneViewBindings.Remove(element);
-                    return;
-                }
-                SceneViewDriver.Update(element, binding, settings);
-            }
-            else if (settings != null)
-            {
-                _ctx.SceneViewBindings[element] = SceneViewDriver.Attach(element, settings);
-            }
+            ApplyElementBinding(element, settings, _ctx.SceneViewBindings,
+                s_sceneViewAttach, s_sceneViewUpdate, s_sceneViewDetach);
         }
 
-        #endregion
-
-        #region Particles
-
-        // Binds / re-binds / releases a Particles element's simulation-and-draw machinery — the mount
-        // paths (plain element AND Motion host) and the props diff all land here, beside the sibling
-        // binding lifecycles above, because the binding owns live resources (the hidden simulation host
-        // GameObject, a painter callback, a repaint tick) tracked per element for the cleaner and the
-        // reconciler dispose sweep to release.
+        // Binds / re-binds / releases a Particles element's simulation-and-draw machinery, on the same
+        // dispatch as the SceneView binding: live resources here are the hidden simulation host
+        // GameObject, the painter callback and the repaint tick.
         internal void ApplyParticles(VisualElement element, ParticlesSettings? settings)
         {
             if (element is not ParticlesElement)
             {
                 return;
             }
-            if (_ctx.ParticlesBindings.TryGetValue(element, out var binding))
+            ApplyElementBinding(element, settings, _ctx.ParticlesBindings,
+                s_particlesAttach, s_particlesUpdate, s_particlesDetach);
+        }
+
+        // Cached method-group delegates so the shared dispatch below adds no per-call allocation.
+        private static readonly Func<VisualElement, SceneViewSettings, SceneViewBinding> s_sceneViewAttach = SceneViewDriver.Attach;
+        private static readonly Action<VisualElement, SceneViewBinding, SceneViewSettings> s_sceneViewUpdate = SceneViewDriver.Update;
+        private static readonly Action<VisualElement, SceneViewBinding> s_sceneViewDetach = SceneViewDriver.Detach;
+        private static readonly Func<VisualElement, ParticlesSettings, ParticlesBinding> s_particlesAttach = ParticlesDriver.Attach;
+        private static readonly Action<VisualElement, ParticlesBinding, ParticlesSettings> s_particlesUpdate = ParticlesDriver.Update;
+        private static readonly Action<VisualElement, ParticlesBinding> s_particlesDetach = ParticlesDriver.Detach;
+
+        // The attach/update/detach dispatch both element bindings share. A vanished settings prop only
+        // happens on a hand-built ElementNode (the factories always carry settings, even for a null
+        // camera/effect): release everything and drop the binding — the element stays mounted, inert.
+        private static void ApplyElementBinding<TSettings, TBinding>(
+            VisualElement element,
+            TSettings? settings,
+            Dictionary<VisualElement, TBinding> bindings,
+            Func<VisualElement, TSettings, TBinding> attach,
+            Action<VisualElement, TBinding, TSettings> update,
+            Action<VisualElement, TBinding> detach)
+            where TSettings : class
+        {
+            if (bindings.TryGetValue(element, out var binding))
             {
                 if (settings == null)
                 {
-                    // A vanished settings prop only happens on a hand-built ElementNode (V.Particles
-                    // always carries settings, even for a null effect): release everything and drop the
-                    // binding — the element stays mounted and inert.
-                    ParticlesDriver.Detach(element, binding);
-                    _ctx.ParticlesBindings.Remove(element);
+                    detach(element, binding);
+                    bindings.Remove(element);
                     return;
                 }
-                ParticlesDriver.Update(element, binding, settings);
+                update(element, binding, settings);
             }
             else if (settings != null)
             {
-                _ctx.ParticlesBindings[element] = ParticlesDriver.Attach(element, settings);
+                bindings[element] = attach(element, settings);
             }
         }
 

--- a/Packages/com.velvet.core/Runtime/Reconciler/PanelHostFactory.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/PanelHostFactory.cs
@@ -118,35 +118,16 @@ namespace Velvet
             {
                 return;
             }
-            if (record.DeclaringResolved && !DeclaringDrifted(declaring, settings))
-            {
-                return;
-            }
-            CopyDeclaringSettings(declaring, settings);
+            // Compare-and-assign inside the copy: one field list serves both drift detection and the
+            // re-copy (twin lists would drift apart), and untouched fields never re-dirty the panel.
+            var copied = CopyDeclaringSettings(declaring, settings);
+            var rebased = !record.DeclaringResolved || record.BaseOrder != baseOrder;
             record.BaseOrder = baseOrder;
             record.DeclaringResolved = true;
-            if (layer is { } resolvedLayer)
+            if ((copied || rebased) && layer is { } resolvedLayer)
             {
                 settings.sortingOrder = baseOrder + SortingOffset(resolvedLayer);
             }
-        }
-
-        // The drift probe mirroring CopyDeclaringSettings field-for-field. The theme compares
-        // against the shared empty fallback when the declaring panel carries none, so a themeless
-        // declaring panel does not read as perpetually drifted.
-        private static bool DeclaringDrifted(PanelSettings from, PanelSettings to)
-        {
-            var expectedTheme = from.themeStyleSheet != null ? from.themeStyleSheet : s_sharedEmptyTheme;
-            return (expectedTheme != null && to.themeStyleSheet != expectedTheme)
-                || to.scaleMode != from.scaleMode
-                || to.scale != from.scale
-                || to.referenceResolution != from.referenceResolution
-                || to.screenMatchMode != from.screenMatchMode
-                || to.match != from.match
-                || to.referenceDpi != from.referenceDpi
-                || to.fallbackDpi != from.fallbackDpi
-                || to.textSettings != from.textSettings
-                || to.targetDisplay != from.targetDisplay;
         }
 
         // The shared skeleton: the hidden GameObject + document + a runtime PanelSettings carrying
@@ -178,21 +159,65 @@ namespace Velvet
         private static void AttachDocument(UIDocument document, PanelSettings settings)
             => document.panelSettings = settings;
 
-        // The base configuration a host copies from the panel its portal was declared on. The shared
-        // empty theme stands in when the declaring panel carries none — writing a null theme
-        // through would re-trigger the loud missing-theme warning on the live panel.
-        private static void CopyDeclaringSettings(PanelSettings from, PanelSettings to)
+        // The base configuration a host copies from the panel its portal was declared on, written
+        // compare-and-assign so the return value doubles as the drift signal. The shared empty theme
+        // stands in when the declaring panel carries none — writing a null theme through would
+        // re-trigger the loud missing-theme warning on the live panel.
+        private static bool CopyDeclaringSettings(PanelSettings from, PanelSettings to)
         {
-            to.themeStyleSheet = from.themeStyleSheet != null ? from.themeStyleSheet : SharedEmptyTheme;
-            to.scaleMode = from.scaleMode;
-            to.scale = from.scale;
-            to.referenceResolution = from.referenceResolution;
-            to.screenMatchMode = from.screenMatchMode;
-            to.match = from.match;
-            to.referenceDpi = from.referenceDpi;
-            to.fallbackDpi = from.fallbackDpi;
-            to.textSettings = from.textSettings;
-            to.targetDisplay = from.targetDisplay;
+            var changed = false;
+            var theme = from.themeStyleSheet != null ? from.themeStyleSheet : SharedEmptyTheme;
+            if (to.themeStyleSheet != theme)
+            {
+                to.themeStyleSheet = theme;
+                changed = true;
+            }
+            if (to.scaleMode != from.scaleMode)
+            {
+                to.scaleMode = from.scaleMode;
+                changed = true;
+            }
+            if (to.scale != from.scale)
+            {
+                to.scale = from.scale;
+                changed = true;
+            }
+            if (to.referenceResolution != from.referenceResolution)
+            {
+                to.referenceResolution = from.referenceResolution;
+                changed = true;
+            }
+            if (to.screenMatchMode != from.screenMatchMode)
+            {
+                to.screenMatchMode = from.screenMatchMode;
+                changed = true;
+            }
+            if (to.match != from.match)
+            {
+                to.match = from.match;
+                changed = true;
+            }
+            if (to.referenceDpi != from.referenceDpi)
+            {
+                to.referenceDpi = from.referenceDpi;
+                changed = true;
+            }
+            if (to.fallbackDpi != from.fallbackDpi)
+            {
+                to.fallbackDpi = from.fallbackDpi;
+                changed = true;
+            }
+            if (to.textSettings != from.textSettings)
+            {
+                to.textSettings = from.textSettings;
+                changed = true;
+            }
+            if (to.targetDisplay != from.targetDisplay)
+            {
+                to.targetDisplay = from.targetDisplay;
+                changed = true;
+            }
+            return changed;
         }
 
         // Resolves the declaring panel's own PanelSettings plus the sorting BASE that portals
@@ -210,9 +235,13 @@ namespace Velvet
             {
                 return (null, 0f);
             }
-            if (ctx.DeclaringSettingsCache.TryGetValue(declaringPanel, out var cached))
+            if (ctx.DeclaringSettingsCache.TryGetValue(declaringPanel, out var cachedDocument)
+                && cachedDocument != null && cachedDocument.panelSettings != null)
             {
-                return cached;
+                // Only the document lookup is cached; the settings and the sorting base are re-read
+                // live so a runtime sortingOrder change (or a nested host re-anchoring) reaches
+                // later syncs. A cached document killed externally falls through to a fresh scan.
+                return (cachedDocument.panelSettings, DeriveBaseOrder(cachedDocument, ctx));
             }
             if (ctx.DeclaringResolveMisses.Contains(declaringPanel))
             {
@@ -226,26 +255,34 @@ namespace Velvet
                 {
                     continue;
                 }
-                var result = (Settings: document.panelSettings, BaseOrder: document.panelSettings.sortingOrder);
-                foreach (var record in ctx.LayerHosts.Values)
-                {
-                    if (record.Document == document)
-                    {
-                        result.BaseOrder = record.BaseOrder;
-                    }
-                }
-                foreach (var record in ctx.WorldSpaceBindings.Values)
-                {
-                    if (record.Document == document)
-                    {
-                        result.BaseOrder = record.BaseOrder;
-                    }
-                }
-                ctx.DeclaringSettingsCache[declaringPanel] = result;
-                return result;
+                ctx.DeclaringSettingsCache[declaringPanel] = document;
+                return (document.panelSettings, DeriveBaseOrder(document, ctx));
             }
             ctx.DeclaringResolveMisses.Add(declaringPanel);
             return (null, 0f);
+        }
+
+        // The sorting base portals declared on this document anchor to: one of OUR host records
+        // anchors to that record's own live base (a Background portal declared inside a Topmost host
+        // must sort against the ORIGINAL panel rather than compound the Topmost offset), and a plain
+        // user panel anchors to its settings' current sortingOrder.
+        private static float DeriveBaseOrder(UIDocument document, ReconcilerContext ctx)
+        {
+            foreach (var record in ctx.LayerHosts.Values)
+            {
+                if (record.Document == document)
+                {
+                    return record.BaseOrder;
+                }
+            }
+            foreach (var record in ctx.WorldSpaceBindings.Values)
+            {
+                if (record.Document == document)
+                {
+                    return record.BaseOrder;
+                }
+            }
+            return document.panelSettings.sortingOrder;
         }
 
         // Destroys everything a record owns: the host GameObject (detaching the document from its

--- a/Packages/com.velvet.core/Runtime/Reconciler/PanelHostFactory.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/PanelHostFactory.cs
@@ -5,29 +5,26 @@ using UnityEngine.UIElements;
 namespace Velvet
 {
     // A framework-owned host panel backing a layer portal or a world-space node. The UIDocument is
-    // the one stored handle — the GameObject and PanelSettings derive from it — and CreatedTheme is
-    // the empty theme created when no declaring theme was resolvable (tracked so disposal destroys
-    // exactly what was created). BaseOrder is the sorting base the host was anchored to, recorded so
-    // a portal declared INSIDE this host anchors to the SAME base instead of compounding this host's
-    // own layer offset on top. DeclaringResolved is false while the host was configured from
-    // defaults because no declaring panel settings were resolvable yet; a later drain that touches
-    // the host retries the resolution and re-copies once. Held in ReconcilerContext.LayerHosts /
-    // WorldSpaceBindings; destroyed by FiberElementCleaner (world-space, with its placeholder) and
-    // the reconciler dispose sweep.
+    // the one stored handle — the GameObject and PanelSettings derive from it. BaseOrder is the
+    // sorting base the host was anchored to, recorded so a portal declared INSIDE this host anchors
+    // to the SAME base instead of compounding this host's own layer offset on top.
+    // DeclaringResolved is false while the host was configured from defaults because no declaring
+    // panel settings were resolvable yet; the passes that touch the host keep re-syncing through
+    // PanelHostFactory.SyncDeclaring (late resolution and runtime drift alike). Held in
+    // ReconcilerContext.LayerHosts / WorldSpaceBindings; destroyed by FiberElementCleaner
+    // (world-space, with its placeholder) and the reconciler dispose sweep.
     internal sealed class PanelHostRecord
     {
         public readonly UIDocument Document;
-        public readonly ThemeStyleSheet? CreatedTheme;
         public float BaseOrder;
         public bool DeclaringResolved;
 
         public GameObject? Host => Document != null ? Document.gameObject : null;
         public PanelSettings? Settings => Document != null ? Document.panelSettings : null;
 
-        public PanelHostRecord(UIDocument document, ThemeStyleSheet? createdTheme)
+        public PanelHostRecord(UIDocument document)
         {
             Document = document;
-            CreatedTheme = createdTheme;
         }
     }
 
@@ -49,6 +46,27 @@ namespace Velvet
             UILayer.Topmost => TopmostSortingOffset,
             _ => OverlaySortingOffset,
         };
+
+        // One empty theme shared by every host whose declaring panel resolves none: panel creation
+        // warns loudly about a missing theme, and per-host instances would pile up one
+        // ScriptableObject per host for identical default styling. Never destroyed (records do not
+        // own it); HideAndDontSave keeps it out of scenes and saves, and a domain reload simply
+        // recreates it on demand.
+        private static ThemeStyleSheet? s_sharedEmptyTheme;
+
+        private static ThemeStyleSheet SharedEmptyTheme
+        {
+            get
+            {
+                if (s_sharedEmptyTheme == null)
+                {
+                    s_sharedEmptyTheme = ScriptableObject.CreateInstance<ThemeStyleSheet>();
+                    s_sharedEmptyTheme.name = "VelvetSharedEmptyTheme";
+                    s_sharedEmptyTheme.hideFlags = HideFlags.HideAndDontSave;
+                }
+                return s_sharedEmptyTheme;
+            }
+        }
 
         // One screen-space host panel for a UILayer, sorted around the resolved base order.
         public static PanelHostRecord CreateLayerHost(UILayer layer, IPanel? declaringPanel, ReconcilerContext ctx)
@@ -85,12 +103,14 @@ namespace Velvet
             return record;
         }
 
-        // A host created while the declaring panel was unresolvable (a headless mount, a panel that
-        // gained settings later) keeps defaults and base 0 otherwise: retry the resolution and
-        // re-copy the declaring configuration — theme, scaling, text settings and sorting — the
-        // first time it resolves. The empty created theme is superseded on the settings but still
-        // destroyed with the record, so nothing leaks either way.
-        public static void TryUpgradeDeclaring(PanelHostRecord record, UILayer layer, IPanel? declaringPanel, ReconcilerContext ctx)
+        // Late resolution and runtime drift, handled at one recurring re-sync point: a host created
+        // while the declaring panel was unresolvable (a headless mount, a panel that gained settings
+        // later) keeps defaults until the first resolution lands here, and an already-resolved host
+        // re-copies whenever the declaring panel's settings were mutated at runtime (a theme swap, a
+        // scale change) — the copy is a snapshot, so the passes that touch the host re-check it.
+        // Layer hosts also re-anchor their sorting; world-space callers pass null (their panels
+        // depth-sort in the scene, not by sorting order).
+        public static void SyncDeclaring(PanelHostRecord record, UILayer? layer, IPanel? declaringPanel, ReconcilerContext ctx)
         {
             var (declaring, baseOrder) = ResolveDeclaring(declaringPanel, ctx);
             var settings = record.Settings;
@@ -98,10 +118,35 @@ namespace Velvet
             {
                 return;
             }
+            if (record.DeclaringResolved && !DeclaringDrifted(declaring, settings))
+            {
+                return;
+            }
             CopyDeclaringSettings(declaring, settings);
             record.BaseOrder = baseOrder;
             record.DeclaringResolved = true;
-            settings.sortingOrder = baseOrder + SortingOffset(layer);
+            if (layer is { } resolvedLayer)
+            {
+                settings.sortingOrder = baseOrder + SortingOffset(resolvedLayer);
+            }
+        }
+
+        // The drift probe mirroring CopyDeclaringSettings field-for-field. The theme compares
+        // against the shared empty fallback when the declaring panel carries none, so a themeless
+        // declaring panel does not read as perpetually drifted.
+        private static bool DeclaringDrifted(PanelSettings from, PanelSettings to)
+        {
+            var expectedTheme = from.themeStyleSheet != null ? from.themeStyleSheet : s_sharedEmptyTheme;
+            return (expectedTheme != null && to.themeStyleSheet != expectedTheme)
+                || to.scaleMode != from.scaleMode
+                || to.scale != from.scale
+                || to.referenceResolution != from.referenceResolution
+                || to.screenMatchMode != from.screenMatchMode
+                || to.match != from.match
+                || to.referenceDpi != from.referenceDpi
+                || to.fallbackDpi != from.fallbackDpi
+                || to.textSettings != from.textSettings
+                || to.targetDisplay != from.targetDisplay;
         }
 
         // The shared skeleton: the hidden GameObject + document + a runtime PanelSettings carrying
@@ -118,16 +163,14 @@ namespace Velvet
             {
                 CopyDeclaringSettings(declaring, settings);
             }
-            ThemeStyleSheet? createdTheme = null;
             if (settings.themeStyleSheet == null)
             {
                 // No resolvable theme (a headless declaring panel, or one whose settings carry
-                // none): panel creation warns loudly about a missing theme, so hand it an empty
-                // runtime-created one — default styling, quiet creation.
-                createdTheme = ScriptableObject.CreateInstance<ThemeStyleSheet>();
-                settings.themeStyleSheet = createdTheme;
+                // none): panel creation warns loudly about a missing theme, so hand it the shared
+                // empty one — default styling, quiet creation.
+                settings.themeStyleSheet = SharedEmptyTheme;
             }
-            return (new PanelHostRecord(document, createdTheme), settings);
+            return (new PanelHostRecord(document), settings);
         }
 
         // Assigning panelSettings is the attach: it inserts the document's root into the settings'
@@ -135,15 +178,19 @@ namespace Velvet
         private static void AttachDocument(UIDocument document, PanelSettings settings)
             => document.panelSettings = settings;
 
-        // The base configuration a host copies from the panel its portal was declared on.
+        // The base configuration a host copies from the panel its portal was declared on. The shared
+        // empty theme stands in when the declaring panel carries none — writing a null theme
+        // through would re-trigger the loud missing-theme warning on the live panel.
         private static void CopyDeclaringSettings(PanelSettings from, PanelSettings to)
         {
-            to.themeStyleSheet = from.themeStyleSheet;
+            to.themeStyleSheet = from.themeStyleSheet != null ? from.themeStyleSheet : SharedEmptyTheme;
             to.scaleMode = from.scaleMode;
             to.scale = from.scale;
             to.referenceResolution = from.referenceResolution;
             to.screenMatchMode = from.screenMatchMode;
             to.match = from.match;
+            to.referenceDpi = from.referenceDpi;
+            to.fallbackDpi = from.fallbackDpi;
             to.textSettings = from.textSettings;
             to.targetDisplay = from.targetDisplay;
         }
@@ -155,8 +202,8 @@ namespace Velvet
         // is reused as the base — a Background portal declared inside a Topmost host must still
         // sort against the ORIGINAL panel rather than compound the Topmost offset. Successful
         // resolutions are cached per declaring panel (one scan per distinct panel per reconciler);
-        // failures are NOT cached, so a panel that gains a driving document later resolves on retry
-        // (the late-declaring upgrade path).
+        // failures are remembered only for the current top-level pass, so a panel that gains a
+        // driving document later still resolves on a later pass (the late-declaring upgrade path).
         private static (PanelSettings? Settings, float BaseOrder) ResolveDeclaring(IPanel? declaringPanel, ReconcilerContext ctx)
         {
             if (declaringPanel == null)
@@ -166,6 +213,10 @@ namespace Velvet
             if (ctx.DeclaringSettingsCache.TryGetValue(declaringPanel, out var cached))
             {
                 return cached;
+            }
+            if (ctx.DeclaringResolveMisses.Contains(declaringPanel))
+            {
+                return (null, 0f);
             }
             foreach (var document in Resources.FindObjectsOfTypeAll<UIDocument>())
             {
@@ -193,6 +244,7 @@ namespace Velvet
                 ctx.DeclaringSettingsCache[declaringPanel] = result;
                 return result;
             }
+            ctx.DeclaringResolveMisses.Add(declaringPanel);
             return (null, 0f);
         }
 
@@ -211,10 +263,6 @@ namespace Velvet
             if (settings != null)
             {
                 VelvetObjectUtil.Destroy(settings);
-            }
-            if (record.CreatedTheme != null)
-            {
-                VelvetObjectUtil.Destroy(record.CreatedTheme);
             }
         }
     }

--- a/Packages/com.velvet.core/Runtime/Reconciler/Reconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Reconciler.cs
@@ -186,6 +186,9 @@ namespace Velvet
                         // the same way.
                         _ctx.PendingPortalMounts.Clear();
                         _ctx.IsAborted = false;
+                        // Declaring-resolution misses are scoped to one top-level pass: retrying the
+                        // scan next pass is what lets a late-arriving declaring panel resolve.
+                        _ctx.DeclaringResolveMisses.Clear();
                         // EffectiveKeys is scoped to one top-level pass. VNode references are fresh
                         // per render, so unconsumed entries would otherwise accumulate across renders.
                         _ctx.EffectiveKeys.Clear();

--- a/Packages/com.velvet.core/Runtime/Reconciler/Reconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Reconciler.cs
@@ -166,20 +166,24 @@ namespace Velvet
                 if (isTopLevel)
                 {
                     LastTopLevelWasAborted = _ctx.IsAborted;
+                    // The abort flag stops sibling work inside the pass that just ended; the deferred
+                    // host mounts below are commit work for placeholders that SURVIVED it. A boundary
+                    // rollback detaches its failed subtree's placeholders (the drain's per-entry
+                    // liveness check skips those), while the fallback the boundary swapped in may have
+                    // enqueued live portals of its own in this same pass — so the flag is consumed
+                    // here rather than used to discard the queue wholesale, and the drain's nested
+                    // reconciles run unimpeded.
+                    _ctx.IsAborted = false;
                     try
                     {
-                        // Drain deferred Portal mounts only on a clean top-level finish; on abort
-                        // the queue holds stale enqueues from the aborted subtree that must not
-                        // survive into the next top-level pass.
-                        if (!_ctx.IsAborted)
-                        {
-                            _childReconciler.DrainPendingPortalMounts();
-                        }
+                        _childReconciler.DrainPendingPortalMounts();
                     }
                     finally
                     {
-                        // Always clear the queue at top-level boundary so aborted or partially
-                        // drained passes do not leak placeholders into the next reconcile.
+                        // Always clear the queue at top-level boundary so partially drained passes do
+                        // not leak placeholders into the next reconcile; an abort raised DURING the
+                        // drain (a boundary inside a portal's children) is consumed at this boundary
+                        // the same way.
                         _ctx.PendingPortalMounts.Clear();
                         _ctx.IsAborted = false;
                         // EffectiveKeys is scoped to one top-level pass. VNode references are fresh

--- a/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
@@ -364,11 +364,13 @@ namespace Velvet
         // reconciler disposal.
         public Dictionary<VisualElement, PanelHostRecord> WorldSpaceBindings { get; } = new();
 
-        // Resolved (declaring PanelSettings, sorting base) per declaring panel, filled by
+        // The declaring panel's driving UIDocument per panel, filled by
         // PanelHostFactory.ResolveDeclaring so each distinct declaring panel costs one
-        // FindObjectsOfTypeAll scan per reconciler instead of one per host mount. Only successful
-        // resolutions land here — a miss must stay retryable for the late-declaring upgrade.
-        public Dictionary<IPanel, (PanelSettings Settings, float BaseOrder)> DeclaringSettingsCache { get; } = new();
+        // FindObjectsOfTypeAll scan per reconciler instead of one per host mount. Only the document
+        // lookup is cached — the settings and the sorting base are re-read live so runtime changes
+        // propagate — and only successful resolutions land here (a miss must stay retryable for the
+        // late-declaring upgrade).
+        public Dictionary<IPanel, UIDocument> DeclaringSettingsCache { get; } = new();
 
         // Declaring panels whose resolution MISSED during the current top-level pass. A miss means a
         // full FindObjectsOfTypeAll scan found nothing, and every further host mount in the same

--- a/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
@@ -12,7 +12,7 @@ namespace Velvet
     // portals whose ranges shift together — two layer portals on different layers must never
     // shift each other even though neither carries a registry id. Null only for the mount-time
     // path that found no registry target (nothing was mounted; SlotLength is 0).
-    internal readonly record struct PortalSlotInfo(VisualElement? Target, VNode?[] Children, int SlotStart, int SlotLength);
+    internal readonly record struct PortalSlotInfo(VisualElement? Target, int SlotStart, int SlotLength);
 
     // Captured on the top-level child fiber of a DETACHED mount — one whose children reconcile outside the
     // normal parent-walked reconcile, so FiberContextSpine's parent-walk cannot reach the host that carries

--- a/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
@@ -370,6 +370,13 @@ namespace Velvet
         // resolutions land here — a miss must stay retryable for the late-declaring upgrade.
         public Dictionary<IPanel, (PanelSettings Settings, float BaseOrder)> DeclaringSettingsCache { get; } = new();
 
+        // Declaring panels whose resolution MISSED during the current top-level pass. A miss means a
+        // full FindObjectsOfTypeAll scan found nothing, and every further host mount in the same
+        // pass would repeat that scan for the same answer; the set clears at the top-level boundary
+        // so a panel that gains a driving document later still resolves on the next pass (the
+        // late-declaring upgrade path).
+        public HashSet<IPanel> DeclaringResolveMisses { get; } = new();
+
         // Inline-mounted ComponentFiber whose insertion / layout effect commit is deferred to the
         // post-commit drain. The DOM mutation + ref attachment must complete before layout effect
         // setup runs. Velvet's inline-mount path defers child reconcile via

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ParticlesTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ParticlesTests.cs
@@ -381,12 +381,19 @@ namespace Velvet.Tests
 
         #region Editor simulation and advisories
 
+        // Fake panel clock for the editor-simulation specs: the repaint tick fires on a 16 ms
+        // interval read exclusively through the panel's time function, so fixed fake steps make the
+        // firing count and every simulated delta deterministic under any machine load.
+        private long _fakeMs;
+
         [Test]
         public void Given_AMountedEffectOutsidePlayMode_When_TheRepaintTickFires_Then_TheSimulationAdvances()
         {
             // Arrange — outside Play Mode the engine never steps a hidden host's clock on its own, so
             // the repaint tick must advance the simulation itself or an editor-context panel repaints
             // one frozen (typically empty) frame forever.
+            _fakeMs = 1000;
+            EditorPanelTestHelpers.SetPanelTimeFunction(_host.Panel, () => _fakeMs / 1000.0);
             var effect = CreateEffectSource("fx-edit-sim");
             var emission = effect.emission;
             emission.rateOverTime = 1000f;
@@ -394,15 +401,15 @@ namespace Velvet.Tests
             var host = FindHost(effect);
             Assume.That(host, Is.Not.Null, "Precondition: the hidden host clone exists");
 
-            // Act — pump the panel's scheduler with real time between firings: each firing advances the
-            // simulation by its elapsed delta.
+            // Act — each 20 fake-ms step crosses the tick interval, so every drive fires once and
+            // advances the simulation by exactly that delta.
             for (var i = 0; i < 6; i++)
             {
-                System.Threading.Thread.Sleep(5);
+                _fakeMs += 20;
                 EditorPanelTestHelpers.DriveSchedulerOnce(_host.Panel);
             }
 
-            // Assert — emission produced live particles (~30 ms at 1000/s).
+            // Assert — emission produced live particles (~100 fake-ms at 1000/s).
             Assert.That(host.particleCount, Is.GreaterThan(0));
         }
 
@@ -411,6 +418,8 @@ namespace Velvet.Tests
         {
             // Arrange — the draw samples only the ROOT's particles, so a longer-lived child system must
             // not keep the repaint tick dirtying the element after the drawn output is already empty.
+            _fakeMs = 1000;
+            EditorPanelTestHelpers.SetPanelTimeFunction(_host.Panel, () => _fakeMs / 1000.0);
             var effect = CreateEffectSource("fx-park-root");
             var rootMain = effect.main;
             rootMain.loop = false;
@@ -427,10 +436,11 @@ namespace Velvet.Tests
             Assume.That(binding.Host != null && binding.Host.IsAlive(false), Is.True,
                 "Precondition: the played root reads alive before any advance");
 
-            // Act — advance well past the root's whole lifetime, then let the tick observe the corpse.
-            for (var i = 0; i < 12; i++)
+            // Act — each 20 fake-ms step fires the tick once: the first firings advance the root past
+            // its whole timeline, and the next observes the drained corpse and parks.
+            for (var i = 0; i < 6; i++)
             {
-                System.Threading.Thread.Sleep(5);
+                _fakeMs += 20;
                 EditorPanelTestHelpers.DriveSchedulerOnce(_host.Panel);
             }
 

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ParticlesTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ParticlesTests.cs
@@ -136,8 +136,9 @@ namespace Velvet.Tests
         public void Given_AWorldSpaceSource_When_Mounted_Then_ItWarns()
         {
             // Arrange — particle positions are read in local space; a world-space source would misrender,
-            // so mounting one must say so instead of drawing garbage silently.
-            var effect = CreateEffectSource("fx");
+            // so mounting one must say so instead of drawing garbage silently. The advisory debounce is
+            // keyed by source name, so each advisory fixture uses its own name.
+            var effect = CreateEffectSource("fx-world-space");
             var main = effect.main;
             main.simulationSpace = ParticleSystemSimulationSpace.World;
             LogAssert.Expect(LogType.Warning, new Regex("world", RegexOptions.IgnoreCase));
@@ -186,7 +187,7 @@ namespace Velvet.Tests
         public void Given_ACustomSpaceSource_When_Mounted_Then_ItWarns()
         {
             // Arrange — Custom simulation space has the same local-space read mismatch as World.
-            var effect = CreateEffectSource("fx");
+            var effect = CreateEffectSource("fx-custom-space");
             var main = effect.main;
             main.simulationSpace = ParticleSystemSimulationSpace.Custom;
             LogAssert.Expect(LogType.Warning, new Regex("simulation space", RegexOptions.IgnoreCase));
@@ -203,7 +204,7 @@ namespace Velvet.Tests
         {
             // Arrange — the draw path truncates at its particle cap; a denser effect must say so once
             // instead of silently thinning out compared to everywhere else the prefab is used.
-            var effect = CreateEffectSource("fx");
+            var effect = CreateEffectSource("fx-draw-cap");
             var main = effect.main;
             main.maxParticles = 5000;
             LogAssert.Expect(LogType.Warning, new Regex("2048"));
@@ -374,6 +375,101 @@ namespace Velvet.Tests
 
             // Assert
             Assert.That(CountSystems(), Is.EqualTo(_baselineSystems));
+        }
+
+        #endregion
+
+        #region Editor simulation and advisories
+
+        [Test]
+        public void Given_AMountedEffectOutsidePlayMode_When_TheRepaintTickFires_Then_TheSimulationAdvances()
+        {
+            // Arrange — outside Play Mode the engine never steps a hidden host's clock on its own, so
+            // the repaint tick must advance the simulation itself or an editor-context panel repaints
+            // one frozen (typically empty) frame forever.
+            var effect = CreateEffectSource("fx-edit-sim");
+            var emission = effect.emission;
+            emission.rateOverTime = 1000f;
+            MountAndLayout(V.Particles(effect, className: "w-[128px] h-[128px]"));
+            var host = FindHost(effect);
+            Assume.That(host, Is.Not.Null, "Precondition: the hidden host clone exists");
+
+            // Act — pump the panel's scheduler with real time between firings: each firing advances the
+            // simulation by its elapsed delta.
+            for (var i = 0; i < 6; i++)
+            {
+                System.Threading.Thread.Sleep(5);
+                EditorPanelTestHelpers.DriveSchedulerOnce(_host.Panel);
+            }
+
+            // Assert — emission produced live particles (~30 ms at 1000/s).
+            Assert.That(host.particleCount, Is.GreaterThan(0));
+        }
+
+        [Test]
+        public void Given_AFinishedRootWithALiveChildSystem_When_TheTickObservesIt_Then_TheTickParks()
+        {
+            // Arrange — the draw samples only the ROOT's particles, so a longer-lived child system must
+            // not keep the repaint tick dirtying the element after the drawn output is already empty.
+            var effect = CreateEffectSource("fx-park-root");
+            var rootMain = effect.main;
+            rootMain.loop = false;
+            rootMain.duration = 0.02f;
+            rootMain.startLifetime = 0.01f;
+            var childGo = new GameObject("fx-park-child");
+            childGo.transform.SetParent(effect.transform);
+            var childMain = childGo.AddComponent<ParticleSystem>().main;
+            childMain.loop = true;
+            MountAndLayout(V.Particles(effect, name: "px-park", className: "w-[128px] h-[128px]"));
+            var element = _host.Root.Q<VisualElement>("px-park");
+            Assume.That(element, Is.Not.Null, "Precondition: the particles element mounted");
+            var binding = _mounted.Root.Reconciler.Context.ParticlesBindings[element];
+            Assume.That(binding.Host != null && binding.Host.IsAlive(false), Is.True,
+                "Precondition: the played root reads alive before any advance");
+
+            // Act — advance well past the root's whole lifetime, then let the tick observe the corpse.
+            for (var i = 0; i < 12; i++)
+            {
+                System.Threading.Thread.Sleep(5);
+                EditorPanelTestHelpers.DriveSchedulerOnce(_host.Panel);
+            }
+
+            // Assert — the tick parked itself even though the looping child system is still alive.
+            Assert.That(binding.RepaintTick, Is.Null);
+        }
+
+        [Test]
+        public void Given_ARecreatedSourceWithTheSameName_When_Remounted_Then_TheAdvisoryDoesNotRepeat()
+        {
+            // Arrange — an unstable effect reference re-creates its source every render with a fresh
+            // instance id; the advisory debounce must survive that, or the advice repeats per rebuild.
+            var first = CreateEffectSource("fx-warn-dedup");
+            var firstMain = first.main;
+            firstMain.simulationSpace = ParticleSystemSimulationSpace.World;
+            LogAssert.Expect(LogType.Warning, new Regex("simulation space", RegexOptions.IgnoreCase));
+            MountAndLayout(V.Particles(first, className: "w-[128px] h-[128px]"));
+            _mounted.Dispose();
+            _mounted = null;
+
+            // Act — a fresh instance under the same name, tripping the same advisory condition.
+            var second = CreateEffectSource("fx-warn-dedup");
+            var secondMain = second.main;
+            secondMain.simulationSpace = ParticleSystemSimulationSpace.World;
+            _mounted = V.Mount(_host.Root, V.Particles(second, className: "w-[128px] h-[128px]"));
+            LogAssert.NoUnexpectedReceived();
+
+            // Assert — the second mount still created its host; only the repeat advisory is suppressed.
+            Assert.That(CountSystems(), Is.EqualTo(_baselineSystems + 1));
+        }
+
+        [Test]
+        public void Given_ADirectlyConstructedSettings_When_PixelsPerUnitIsInvalid_Then_ItThrows()
+        {
+            // Arrange — the factory's fail-fast guard must hold for every construction path (fixtures
+            // and wrapper hosts build the settings record directly).
+            // Act & Assert
+            Assert.Throws<System.ArgumentOutOfRangeException>(
+                () => new ParticlesSettings(null, PlayTrigger.Mount, float.NaN));
         }
 
         #endregion

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ParticlesTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ParticlesTests.cs
@@ -439,27 +439,51 @@ namespace Velvet.Tests
         }
 
         [Test]
-        public void Given_ARecreatedSourceWithTheSameName_When_Remounted_Then_TheAdvisoryDoesNotRepeat()
+        public void Given_AnEffectSwapOnOneElement_When_BothSourcesAreMisconfigured_Then_TheAdvisoryFiresOnce()
         {
-            // Arrange — an unstable effect reference re-creates its source every render with a fresh
-            // instance id; the advisory debounce must survive that, or the advice repeats per rebuild.
-            var first = CreateEffectSource("fx-warn-dedup");
-            var firstMain = first.main;
-            firstMain.simulationSpace = ParticleSystemSimulationSpace.World;
+            // Arrange — the advisory is per mounted element: an unstable reference that rebuilds its
+            // source every render (fresh instance, any name) must not repeat the advice per rebuild.
+            s_effect = CreateEffectSource("fx-adv-a");
+            var mainA = s_effect.main;
+            mainA.simulationSpace = ParticleSystemSimulationSpace.World;
+            s_effectB = CreateEffectSource("fx-adv-b");
+            var mainB = s_effectB.main;
+            mainB.simulationSpace = ParticleSystemSimulationSpace.World;
             LogAssert.Expect(LogType.Warning, new Regex("simulation space", RegexOptions.IgnoreCase));
-            MountAndLayout(V.Particles(first, className: "w-[128px] h-[128px]"));
-            _mounted.Dispose();
-            _mounted = null;
+            MountAndLayout(V.Component(SwappingHost, key: "root"));
 
-            // Act — a fresh instance under the same name, tripping the same advisory condition.
-            var second = CreateEffectSource("fx-warn-dedup");
-            var secondMain = second.main;
-            secondMain.simulationSpace = ParticleSystemSimulationSpace.World;
-            _mounted = V.Mount(_host.Root, V.Particles(second, className: "w-[128px] h-[128px]"));
+            // Act — swap to a different (differently named) but equally misconfigured source.
+            s_setFlag.Invoke(true);
+            FlushAndLayout();
             LogAssert.NoUnexpectedReceived();
 
-            // Assert — the second mount still created its host; only the repeat advisory is suppressed.
+            // Assert — still exactly one live host after the swap.
             Assert.That(CountSystems(), Is.EqualTo(_baselineSystems + 1));
+        }
+
+        [Test]
+        public void Given_TwoElementsWithSameNamedSources_When_BothMisconfigured_Then_BothAdvisoriesFire()
+        {
+            // Arrange — two DIFFERENT effects that merely share a name are independent problems;
+            // each mounted element gets its own advisory.
+            var first = CreateEffectSource("fx-shared-name");
+            var m1 = first.main;
+            m1.simulationSpace = ParticleSystemSimulationSpace.World;
+            var second = CreateEffectSource("fx-shared-name");
+            var m2 = second.main;
+            m2.simulationSpace = ParticleSystemSimulationSpace.World;
+            LogAssert.Expect(LogType.Warning, new Regex("simulation space", RegexOptions.IgnoreCase));
+            LogAssert.Expect(LogType.Warning, new Regex("simulation space", RegexOptions.IgnoreCase));
+
+            // Act
+            MountAndLayout(V.Div(children: new VNode[]
+            {
+                V.Particles(first, className: "w-[64px] h-[64px]"),
+                V.Particles(second, className: "w-[64px] h-[64px]"),
+            }));
+
+            // Assert — both hosts exist (the two expectations pin both advisories firing).
+            Assert.That(CountSystems(), Is.EqualTo(_baselineSystems + 2));
         }
 
         [Test]

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/PortalLayersTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/PortalLayersTests.cs
@@ -430,6 +430,37 @@ namespace Velvet.Tests
             Assert.That(NewDocs().Count, Is.EqualTo(0));
         }
 
+        [Test]
+        public void Given_APanelSizeMatchingTheDocumentDefault_When_Mounted_Then_FixedSizingStillApplies()
+        {
+            // Arrange — the size settings are driven after the attach with a mode round-trip, so the
+            // fixed sizing derives even when the requested size equals the document's own default (a
+            // plain value write would read as no-change and never re-derive).
+            Vector2 documentDefault;
+            var probeGo = new GameObject("ws-default-probe");
+            try
+            {
+                documentDefault = probeGo.AddComponent<UIDocument>().worldSpaceSize;
+            }
+            finally
+            {
+                Object.DestroyImmediate(probeGo);
+            }
+
+            // Act
+            MountAndLayout(V.Div(children: new VNode[]
+            {
+                V.WorldSpace(Vector3.zero, panelSize: documentDefault,
+                    children: new VNode[] { V.Div(name: "ws1") }),
+            }));
+
+            // Assert — the mode landed on Fixed with the requested (default-equal) size.
+            var docs = NewDocs();
+            Assume.That(docs.Count, Is.EqualTo(1), "Precondition: the world-space host exists");
+            Assert.That((docs[0].worldSpaceSizeMode, docs[0].worldSpaceSize),
+                Is.EqualTo((UIDocument.WorldSpaceSizeMode.Fixed, documentDefault)));
+        }
+
         #endregion
 
         #region Host resilience

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/PortalLayersTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/PortalLayersTests.cs
@@ -430,5 +430,70 @@ namespace Velvet.Tests
         }
 
         #endregion
+
+        #region Error boundary interplay
+
+        [Component]
+        private static VNode ThrowingChild() =>
+            throw new System.InvalidOperationException("boundary portal boom");
+
+        [Component(IsErrorBoundary = true)]
+        private static VNode BoundaryWithPortalFallback()
+        {
+            Hooks.UseFallback(_ => V.Div(children: new VNode[]
+            {
+                V.Portal(UILayer.Topmost, children: new VNode[] { V.Div(name: "boundary-toast") }),
+                V.Div(name: "fallback-body"),
+            }));
+            return V.Component(ThrowingChild, key: "child");
+        }
+
+        [Test]
+        public void Given_AFallbackContainingALayerPortal_When_TheBoundaryCatches_Then_ThePortalMounts()
+        {
+            // Arrange — the abort that ends the failed pass must not also discard the deferred mount
+            // the boundary's own fallback just enqueued: that enqueue belongs to a LIVE placeholder.
+            // Act
+            MountAndLayout(V.Component(BoundaryWithPortalFallback, key: "root"));
+
+            // Assert — the fallback's toast reached the Topmost layer host.
+            VisualElement toast = null;
+            foreach (var doc in NewDocs())
+            {
+                toast ??= doc.rootVisualElement?.Q<VisualElement>("boundary-toast");
+            }
+            Assert.That(toast, Is.Not.Null);
+        }
+
+        [Component(IsErrorBoundary = true)]
+        private static VNode PortalThenThrowerBoundary()
+        {
+            Hooks.UseFallback(_ => V.Div(name: "plain-fallback"));
+            return V.Div(children: new VNode[]
+            {
+                V.Portal(UILayer.Overlay, children: new VNode[] { V.Div(name: "victim-content") }),
+                V.Component(ThrowingChild, key: "child"),
+            });
+        }
+
+        [Test]
+        public void Given_AFailedSubtreeWithALayerPortal_When_TheBoundaryCatches_Then_ThatPortalNeverMounts()
+        {
+            // Arrange — the failed subtree enqueued a portal before its sibling threw; the boundary's
+            // rollback detaches that placeholder, so the drain must skip the dead enqueue instead of
+            // mounting content for a subtree that no longer exists.
+            // Act
+            MountAndLayout(V.Component(PortalThenThrowerBoundary, key: "root"));
+
+            // Assert — no layer host carries the failed subtree's content.
+            VisualElement victim = null;
+            foreach (var doc in NewDocs())
+            {
+                victim ??= doc.rootVisualElement?.Q<VisualElement>("victim-content");
+            }
+            Assert.That(victim, Is.Null);
+        }
+
+        #endregion
     }
 }

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/PortalLayersTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/PortalLayersTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
@@ -427,6 +428,29 @@ namespace Velvet.Tests
 
             // Assert
             Assert.That(NewDocs().Count, Is.EqualTo(0));
+        }
+
+        #endregion
+
+        #region Host resilience
+
+        [Test]
+        public void Given_AHostKilledExternally_When_TheWorldSpacePatches_Then_TheReconcileSurvives()
+        {
+            // Arrange — a scene unload can destroy the host GameObject while the owning fiber tree
+            // survives; the next patch must skip the dead record instead of throwing out of the pass.
+            MountAndLayout(V.Component(MovingWorldSpaceHost, key: "root"));
+            var docs = NewDocs();
+            Assume.That(docs.Count, Is.EqualTo(1), "Precondition: the world-space host exists");
+            LogAssert.Expect(LogType.Warning, new Regex("died externally", RegexOptions.IgnoreCase));
+            Object.DestroyImmediate(docs[0].gameObject);
+
+            // Act & Assert
+            Assert.That(() =>
+            {
+                s_setFlag.Invoke(true);
+                FlushAndLayout();
+            }, Throws.Nothing);
         }
 
         #endregion

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/PortalLayersTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/PortalLayersTests.cs
@@ -465,21 +465,39 @@ namespace Velvet.Tests
 
         #region Host resilience
 
+        [Component]
+        private static VNode SlidingWorldSpaceHost()
+        {
+            var (step, setStep) = Hooks.UseState(0);
+            s_bumpStep = setStep;
+            return V.Div(children: new VNode[]
+            {
+                V.WorldSpace(new Vector3(step, 0f, 0f), key: "ws",
+                    children: new VNode[] { V.Div(name: "ws-live") }),
+            });
+        }
+
+        private static StateUpdater<int> s_bumpStep;
+
         [Test]
         public void Given_AHostKilledExternally_When_TheWorldSpacePatches_Then_TheReconcileSurvives()
         {
             // Arrange — a scene unload can destroy the host GameObject while the owning fiber tree
-            // survives; the next patch must skip the dead record instead of throwing out of the pass.
-            MountAndLayout(V.Component(MovingWorldSpaceHost, key: "root"));
+            // survives; EVERY later patch must skip the dead record on the same warning path instead
+            // of throwing or escalating to an error-level log.
+            MountAndLayout(V.Component(SlidingWorldSpaceHost, key: "root"));
             var docs = NewDocs();
             Assume.That(docs.Count, Is.EqualTo(1), "Precondition: the world-space host exists");
             LogAssert.Expect(LogType.Warning, new Regex("died externally", RegexOptions.IgnoreCase));
+            LogAssert.Expect(LogType.Warning, new Regex("died externally", RegexOptions.IgnoreCase));
             Object.DestroyImmediate(docs[0].gameObject);
 
-            // Act & Assert
+            // Act & Assert — two consecutive patches both survive on the warning path.
             Assert.That(() =>
             {
-                s_setFlag.Invoke(true);
+                s_bumpStep.Invoke(s => s + 1);
+                FlushAndLayout();
+                s_bumpStep.Invoke(s => s + 1);
                 FlushAndLayout();
             }, Throws.Nothing);
         }

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/SceneViewTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/SceneViewTests.cs
@@ -493,5 +493,102 @@ namespace Velvet.Tests
         }
 
         #endregion
+
+        #region Background ownership
+
+        private static Texture2D s_posterA;
+        private static Texture2D s_posterB;
+
+        [Component]
+        private static VNode GradientSwapHost()
+        {
+            var (alt, setAlt) = Hooks.UseState(false);
+            s_setFlag = setAlt;
+            return V.SceneView(s_camera, key: "sv", name: "sv", className: alt
+                ? "w-[128px] h-[64px] bg-gradient-to-r from-green-500 to-yellow-500"
+                : "w-[128px] h-[64px] bg-gradient-to-r from-red-500 to-blue-500");
+        }
+
+        [Test]
+        public void Given_ALiveCameraFeed_When_TheGradientClassChanges_Then_TheFeedIsNotClobbered()
+        {
+            // Arrange — a gradient class and a live camera compete for the one backgroundImage slot;
+            // while the camera texture is live it owns the slot, and class-driven writers defer.
+            s_camera = CreateCamera("cam");
+            MountAndLayout(V.Component(GradientSwapHost, key: "root"));
+            var el = _host.Root.Q<VisualElement>("sv");
+            Assume.That(el, Is.Not.Null, "Precondition: the element mounted");
+            Assume.That(s_camera.targetTexture, Is.Not.Null, "Precondition: the camera targets the texture");
+
+            // Act — an ordinary state-driven restyle changes the gradient spec.
+            s_setFlag.Invoke(true);
+            FlushAndLayout();
+
+            // Assert — the background still samples the live camera texture.
+            Assert.That(el.resolvedStyle.backgroundImage.renderTexture, Is.SameAs(s_camera.targetTexture));
+        }
+
+        [Component]
+        private static VNode PosterSwapHost()
+        {
+            var (alt, setAlt) = Hooks.UseState(false);
+            s_setFlag = setAlt;
+            return V.SceneView(null, key: "sv", name: "sv", className: "w-[128px] h-[64px]",
+                styles: new StyleOverrides
+                {
+                    BackgroundImage = new StyleBackground(alt ? s_posterB : s_posterA),
+                });
+        }
+
+        [Test]
+        public void Given_ACameraLessSceneView_When_ThePosterStyleChanges_Then_TheNewPosterShows()
+        {
+            // Arrange — no camera ever arrives, so styles.BackgroundImage owns the slot outright; the
+            // mere existence of a (textureless) binding must not freeze the poster forever.
+            s_posterA = new Texture2D(2, 2);
+            _spawned.Add(s_posterA);
+            s_posterB = new Texture2D(2, 2);
+            _spawned.Add(s_posterB);
+            MountAndLayout(V.Component(PosterSwapHost, key: "root"));
+            var el = _host.Root.Q<VisualElement>("sv");
+            Assume.That(el?.resolvedStyle.backgroundImage.texture, Is.SameAs(s_posterA),
+                "Precondition: the first poster shows");
+
+            // Act
+            s_setFlag.Invoke(true);
+            FlushAndLayout();
+
+            // Assert
+            Assert.That(el.resolvedStyle.backgroundImage.texture, Is.SameAs(s_posterB));
+        }
+
+        [Component]
+        private static VNode ReleasingGradientHost()
+        {
+            var (released, setReleased) = Hooks.UseState(false);
+            s_setFlag = setReleased;
+            return V.SceneView(released ? null : s_camera, key: "sv", name: "sv",
+                className: "w-[128px] h-[64px] bg-gradient-to-r from-red-500 to-blue-500");
+        }
+
+        [Test]
+        public void Given_ALiveFeedOverAGradient_When_TheCameraIsRemoved_Then_TheGradientIsRestored()
+        {
+            // Arrange
+            s_camera = CreateCamera("cam");
+            MountAndLayout(V.Component(ReleasingGradientHost, key: "root"));
+            var el = _host.Root.Q<VisualElement>("sv");
+            Assume.That(el?.resolvedStyle.backgroundImage.renderTexture, Is.Not.Null,
+                "Precondition: the camera feed owns the background");
+
+            // Act — removing the camera releases the texture; the deferred class background returns.
+            s_setFlag.Invoke(true);
+            FlushAndLayout();
+
+            // Assert — a baked gradient texture, not a blank slot, fills the element again.
+            Assert.That(el.resolvedStyle.backgroundImage.texture, Is.Not.Null);
+        }
+
+        #endregion
     }
 }

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/SceneViewTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/SceneViewTests.cs
@@ -492,6 +492,83 @@ namespace Velvet.Tests
             Assert.Throws<System.ArgumentOutOfRangeException>(() => new SceneViewSettings(null, 0f));
         }
 
+        [Test]
+        public void Given_AnInvalidScale_When_TheFactoryThrows_Then_NoPooledPropsLeak()
+        {
+            // Arrange — the factory rents a pooled props bag; a throwing validation must not leave
+            // it stranded in the pool's ownership ledger (each failing render would leak one).
+            var ledger = typeof(VNodePool).GetField("s_ownedProps",
+                System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic);
+            Assume.That(ledger, Is.Not.Null, "Precondition: the pool ownership ledger exists");
+            var set = ledger.GetValue(null);
+            var count = set.GetType().GetProperty("Count");
+            Assume.That(count, Is.Not.Null, "Precondition: the ledger exposes a count");
+            var before = (int)count.GetValue(set);
+
+            // Act
+            try
+            {
+                V.SceneView(null, resolutionScale: 0f);
+            }
+            catch (System.ArgumentOutOfRangeException)
+            {
+            }
+
+            // Assert
+            var after = (int)count.GetValue(set);
+            Assert.That(after, Is.EqualTo(before));
+        }
+
+        [Component]
+        private static VNode ResizingSceneHost()
+        {
+            var (wide, setWide) = Hooks.UseState(false);
+            s_setFlag = setWide;
+            return V.SceneView(s_camera, key: "sv", name: "sv",
+                className: wide ? "w-[256px] h-[64px]" : "w-[128px] h-[64px]");
+        }
+
+        [Test]
+        public void Given_AUserReassignedTarget_When_TheElementResizes_Then_TheLastFrameSurvives()
+        {
+            // Arrange — user code borrowed the camera; a later RESIZE must not swap the background
+            // to a fresh texture nothing renders into, nor destroy the frame being shown.
+            s_camera = CreateCamera("cam");
+            MountAndLayout(V.Component(ResizingSceneHost, key: "root"));
+            var el = _host.Root.Q<VisualElement>("sv");
+            var shown = s_camera.targetTexture;
+            Assume.That(shown, Is.Not.Null, "Precondition: the camera targets the texture");
+            var foreign = new RenderTexture(16, 16, 0);
+            _spawned.Add(foreign);
+            s_camera.targetTexture = foreign;
+
+            // Act
+            s_setFlag.Invoke(true);
+            FlushAndLayout();
+
+            // Assert — the background still shows the framework texture holding the last frame.
+            Assert.That(el.resolvedStyle.backgroundImage.renderTexture, Is.SameAs(shown));
+        }
+
+        [Test]
+        public void Given_ACameraAlreadyTargetingAUserTexture_When_Mounted_Then_TheExplicitPassClaimsIt()
+        {
+            // Arrange — passing a camera to V.SceneView is explicit intent: a target the user set
+            // BEFORE mounting must not stop the mount-time claim (only borrowing that happens after
+            // the claim is respected by layout-driven resyncs).
+            var cam = CreateCamera("cam");
+            var pre = new RenderTexture(16, 16, 0);
+            _spawned.Add(pre);
+            cam.targetTexture = pre;
+
+            // Act
+            MountAndLayout(V.SceneView(cam, className: "w-[128px] h-[64px]", name: "sv"));
+
+            // Assert — the camera renders into the framework texture the element shows.
+            var el = _host.Root.Q<VisualElement>("sv");
+            Assert.That(cam.targetTexture, Is.SameAs(el.resolvedStyle.backgroundImage.renderTexture));
+        }
+
         #endregion
 
         #region Background ownership

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/SceneViewTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/SceneViewTests.cs
@@ -407,5 +407,91 @@ namespace Velvet.Tests
         }
 
         #endregion
+
+        #region Driver hardening
+
+        [Component]
+        private static VNode ShiftingColumnHost()
+        {
+            var (shifted, setShifted) = Hooks.UseState(false);
+            s_setFlag = setShifted;
+            return V.Div(className: "flex-col", children: new VNode[]
+            {
+                V.Div(key: "spacer", className: shifted ? "w-[10px] h-[40px]" : "w-[10px] h-[10px]"),
+                V.SceneView(s_camera, key: "sv", className: "w-[128px] h-[64px]"),
+            });
+        }
+
+        [Test]
+        public void Given_AUserReassignedTarget_When_AnUnrelatedGeometryEventFires_Then_TheForeignTargetSurvives()
+        {
+            // Arrange — user code borrowed the camera while the element stays mounted; a sibling's
+            // resize then moves the element (same size, new position), which fires a geometry event.
+            s_camera = CreateCamera("cam");
+            MountAndLayout(V.Component(ShiftingColumnHost, key: "root"));
+            Assume.That(s_camera.targetTexture, Is.Not.Null, "Precondition: the camera targets the texture");
+            var foreign = new RenderTexture(16, 16, 0);
+            _spawned.Add(foreign);
+            s_camera.targetTexture = foreign;
+
+            // Act
+            s_setFlag.Invoke(true);
+            FlushAndLayout();
+
+            // Assert — a layout-driven resync must not claw the camera back from user code; only an
+            // explicit camera/settings change may claim a foreign target.
+            Assert.That(s_camera.targetTexture, Is.SameAs(foreign));
+        }
+
+        [Test]
+        public void Given_AnElementWiderThanTheTextureCap_When_TheTextureIsCreated_Then_TheAspectIsPreserved()
+        {
+            // Arrange — 6000×300 points is 20:1; clamping each axis independently to the 4096 ceiling
+            // would flatten the texture to ~13.7:1 and visibly distort the camera picture.
+            var cam = CreateCamera("cam");
+
+            // Act
+            MountAndLayout(V.SceneView(cam, className: "shrink-0 w-[6000px] h-[300px]"));
+
+            // Assert
+            var rt = cam.targetTexture;
+            Assume.That(rt, Is.Not.Null, "Precondition: the camera received a texture");
+            Assume.That(rt.width, Is.EqualTo(4096), "Precondition: the width hit the ceiling");
+            var aspect = (float)rt.width / rt.height;
+            Assert.That((rt.height <= 4096, Mathf.Abs(aspect - 20f) < 0.5f), Is.EqualTo((true, true)));
+        }
+
+        [Test]
+        public void Given_AStalePixelScale_When_TheEditorRepaintTickFires_Then_TheTextureIsRederived()
+        {
+            // Arrange — a pixel-density change (a monitor-DPI move) alters the derived pixel size with
+            // no geometry event (points are unchanged) and no props pass, so only the recurring editor
+            // repaint tick can notice. Staleness is simulated by doubling the scale on the live
+            // binding directly — the same derivation input a density change moves.
+            var cam = CreateCamera("cam");
+            MountAndLayout(V.SceneView(cam, className: "w-[128px] h-[64px]", name: "sv"));
+            Assume.That(cam.targetTexture, Is.Not.Null, "Precondition: the camera targets the texture");
+            var element = _host.Root.Q<VisualElement>("sv");
+            var binding = _mounted.Root.Reconciler.Context.SceneViewBindings[element];
+            binding.Settings = new SceneViewSettings(cam, 2f);
+
+            // Act
+            EditorPanelTestHelpers.DriveSchedulerOnce(_host.Panel);
+
+            // Assert
+            Assert.That((cam.targetTexture.width, cam.targetTexture.height), Is.EqualTo((256, 128)));
+        }
+
+        [Test]
+        public void Given_ADirectlyConstructedSettings_When_TheScaleIsInvalid_Then_ItThrows()
+        {
+            // Arrange — the factory's fail-fast guard must hold for every construction path (Motion
+            // hosts and fixtures build the settings record directly), or an invalid scale silently
+            // degrades to a degenerate near-1-pixel texture instead of the documented exception.
+            // Act & Assert
+            Assert.Throws<System.ArgumentOutOfRangeException>(() => new SceneViewSettings(null, 0f));
+        }
+
+        #endregion
     }
 }

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/PortalLayersPlaybackTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/PortalLayersPlaybackTests.cs
@@ -101,14 +101,7 @@ namespace Velvet.Tests
             yield return null;
 
             // Assert — the layer host resolves the same theme as the panel the portal was declared on.
-            PanelSettings hostSettings = null;
-            foreach (var doc in Resources.FindObjectsOfTypeAll<UIDocument>())
-            {
-                if (doc.rootVisualElement?.Q<VisualElement>("inside") != null)
-                {
-                    hostSettings = doc.panelSettings;
-                }
-            }
+            var hostSettings = FindHostSettingsContaining("inside");
             Assume.That(hostSettings, Is.Not.Null, "Precondition: the layer host exists");
             Assert.That(hostSettings.themeStyleSheet, Is.SameAs(_theme));
         }
@@ -231,6 +224,63 @@ namespace Velvet.Tests
 
             // Assert
             Assert.That(hostSettings.themeStyleSheet, Is.SameAs(_themeB));
+        }
+
+        [UnityTest]
+        public IEnumerator Given_ARuntimeThemeCleared_When_TheLayerPortalRerenders_Then_TheHostDropsTheStaleTheme()
+        {
+            // Arrange — clearing the declaring theme at runtime is drift like any other change: the
+            // host must stop referencing the stale theme (falling back to the shared empty one).
+            var root = CreateMainPanel(withTheme: true);
+            yield return null;
+            _mounted = V.Mount(root, V.Component(TogglingOverlayHost, key: "root"));
+            yield return null;
+            yield return null;
+            var hostSettings = FindHostSettingsContaining("inside");
+            Assume.That(hostSettings, Is.Not.Null, "Precondition: the layer host exists");
+            Assume.That(hostSettings.themeStyleSheet, Is.SameAs(_theme),
+                "Precondition: the host copied the initial theme");
+            // Simulate a session where no themeless declaring panel ever forced the shared empty
+            // theme into existence — the drift probe must not depend on that side effect (another
+            // fixture running first would otherwise mask the regression).
+            var sharedField = typeof(PanelHostFactory).GetField("s_sharedEmptyTheme",
+                System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic);
+            Assume.That(sharedField, Is.Not.Null, "Precondition: the shared-theme field exists");
+            sharedField.SetValue(null, null);
+            _settings.themeStyleSheet = null;
+
+            // Act
+            s_bump.Invoke(v => v + 1);
+            yield return null;
+            yield return null;
+
+            // Assert — the stale reference is gone.
+            Assert.That(hostSettings.themeStyleSheet, Is.Not.SameAs(_theme));
+        }
+
+        [UnityTest]
+        public IEnumerator Given_ARuntimeSortingOrderChange_When_TheLayerPortalRerenders_Then_TheHostReanchors()
+        {
+            // Arrange — layer order anchors to the declaring panel's sortingOrder; a runtime change
+            // there must re-anchor the host (base + layer offset), not stay frozen at first resolve.
+            var root = CreateMainPanel(withTheme: false);
+            yield return null;
+            _mounted = V.Mount(root, V.Component(TogglingOverlayHost, key: "root"));
+            yield return null;
+            yield return null;
+            var hostSettings = FindHostSettingsContaining("inside");
+            Assume.That(hostSettings, Is.Not.Null, "Precondition: the layer host exists");
+            Assume.That(hostSettings.sortingOrder, Is.EqualTo(100f),
+                "Precondition: anchored to base 0 plus the overlay offset");
+            _settings.sortingOrder = 7f;
+
+            // Act
+            s_bump.Invoke(v => v + 1);
+            yield return null;
+            yield return null;
+
+            // Assert
+            Assert.That(hostSettings.sortingOrder, Is.EqualTo(107f));
         }
 
         [UnityTest]

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/PortalLayersPlaybackTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/PortalLayersPlaybackTests.cs
@@ -17,9 +17,12 @@ namespace Velvet.Tests
         private GameObject _cameraGo;
         private PanelSettings _settings;
         private ThemeStyleSheet _theme;
+        private ThemeStyleSheet _themeB;
         private RenderTexture _cameraRt;
         private MountedTree _mounted;
         private int _savedTargetFrameRate;
+
+        private static StateUpdater<int> s_bump;
 
         [UnitySetUp]
         public IEnumerator UnitySetUp()
@@ -39,6 +42,7 @@ namespace Velvet.Tests
             if (_cameraGo != null) Object.Destroy(_cameraGo);
             if (_settings != null) Object.Destroy(_settings);
             if (_theme != null) Object.Destroy(_theme);
+            if (_themeB != null) Object.Destroy(_themeB);
             if (_cameraRt != null) { _cameraRt.Release(); Object.Destroy(_cameraRt); }
             yield return null;
         }
@@ -65,6 +69,20 @@ namespace Velvet.Tests
             {
                 yield return null;
             }
+        }
+
+        // The framework host is whichever live UIDocument's tree contains the marker element.
+        private static PanelSettings FindHostSettingsContaining(string elementName)
+        {
+            PanelSettings found = null;
+            foreach (var doc in Resources.FindObjectsOfTypeAll<UIDocument>())
+            {
+                if (doc.rootVisualElement?.Q<VisualElement>(elementName) != null)
+                {
+                    found = doc.panelSettings;
+                }
+            }
+            return found;
         }
 
         [UnityTest]
@@ -136,6 +154,108 @@ namespace Velvet.Tests
             }
             Object.Destroy(tex);
             Assert.That(redPixels, Is.GreaterThan(50));
+        }
+
+        [Component]
+        private static VNode TogglingOverlayHost()
+        {
+            var (_, bump) = Hooks.UseState(0);
+            s_bump = bump;
+            return V.Div(children: new VNode[]
+            {
+                V.Portal(UILayer.Overlay, children: new VNode[] { V.Div(name: "inside") }),
+            });
+        }
+
+        [UnityTest]
+        public IEnumerator Given_ARuntimeThemeSwap_When_TheLayerPortalRerenders_Then_TheHostFollowsIt()
+        {
+            // Arrange — the host copies the declaring panel's settings (a snapshot, not a reference),
+            // so a later runtime swap there must re-sync on the next pass that touches the portal.
+            var root = CreateMainPanel(withTheme: true);
+            yield return null;
+            _mounted = V.Mount(root, V.Component(TogglingOverlayHost, key: "root"));
+            yield return null;
+            yield return null;
+            var hostSettings = FindHostSettingsContaining("inside");
+            Assume.That(hostSettings, Is.Not.Null, "Precondition: the layer host exists");
+            Assume.That(hostSettings.themeStyleSheet, Is.SameAs(_theme),
+                "Precondition: the host copied the initial theme");
+            _themeB = ScriptableObject.CreateInstance<ThemeStyleSheet>();
+            _settings.themeStyleSheet = _themeB;
+
+            // Act
+            s_bump.Invoke(v => v + 1);
+            yield return null;
+            yield return null;
+
+            // Assert
+            Assert.That(hostSettings.themeStyleSheet, Is.SameAs(_themeB));
+        }
+
+        [Component]
+        private static VNode TogglingWorldSpaceHost()
+        {
+            var (_, bump) = Hooks.UseState(0);
+            s_bump = bump;
+            return V.Div(children: new VNode[]
+            {
+                V.WorldSpace(Vector3.zero, panelSize: new Vector2(400f, 400f), children: new VNode[]
+                {
+                    V.Div(name: "ws-inside"),
+                }),
+            });
+        }
+
+        [UnityTest]
+        public IEnumerator Given_ARuntimeThemeSwap_When_TheWorldSpaceRerenders_Then_TheHostFollowsIt()
+        {
+            // Arrange — same snapshot semantics as the layer host, re-synced through the world-space
+            // patch path.
+            var root = CreateMainPanel(withTheme: true);
+            yield return null;
+            _mounted = V.Mount(root, V.Component(TogglingWorldSpaceHost, key: "root"));
+            yield return null;
+            yield return null;
+            var hostSettings = FindHostSettingsContaining("ws-inside");
+            Assume.That(hostSettings, Is.Not.Null, "Precondition: the world-space host exists");
+            Assume.That(hostSettings.themeStyleSheet, Is.SameAs(_theme),
+                "Precondition: the host copied the initial theme");
+            _themeB = ScriptableObject.CreateInstance<ThemeStyleSheet>();
+            _settings.themeStyleSheet = _themeB;
+
+            // Act
+            s_bump.Invoke(v => v + 1);
+            yield return null;
+            yield return null;
+
+            // Assert
+            Assert.That(hostSettings.themeStyleSheet, Is.SameAs(_themeB));
+        }
+
+        [UnityTest]
+        public IEnumerator Given_APhysicalSizeDeclaringPanel_When_ALayerPortalMounts_Then_TheHostCopiesTheDpiPair()
+        {
+            // Arrange — ConstantPhysicalSize scaling is driven by the DPI pair, so a host that copies
+            // the scale mode without them scales differently than the panel it was declared on.
+            var root = CreateMainPanel(withTheme: false);
+            _settings.scaleMode = PanelScaleMode.ConstantPhysicalSize;
+            _settings.referenceDpi = 120f;
+            _settings.fallbackDpi = 72f;
+            yield return null;
+
+            // Act
+            _mounted = V.Mount(root, V.Div(children: new VNode[]
+            {
+                V.Portal(UILayer.Overlay, children: new VNode[] { V.Div(name: "dpi-inside") }),
+            }));
+            yield return null;
+            yield return null;
+
+            // Assert
+            var hostSettings = FindHostSettingsContaining("dpi-inside");
+            Assume.That(hostSettings, Is.Not.Null, "Precondition: the layer host exists");
+            Assert.That((hostSettings.referenceDpi, hostSettings.fallbackDpi), Is.EqualTo((120f, 72f)));
         }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Styling/GradientBackground.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/GradientBackground.cs
@@ -53,7 +53,9 @@ namespace Velvet
         public static void Apply(VisualElement element, GradientSpec spec)
         {
             var tex = GetOrBake(spec);
-            element.style.backgroundImage = new StyleBackground(tex);
+            // Through the SceneView ownership gate: a live camera feed keeps the slot and defers
+            // the gradient for its release; everywhere else this is a plain style write.
+            SceneViewElement.WriteBackground(element, new StyleBackground(tex));
             // Stretch the baked texture to the full element box (no 9-slice); border-radius clips it.
             element.style.backgroundSize = new StyleBackgroundSize(
                 new BackgroundSize(Length.Percent(100f), Length.Percent(100f)));
@@ -62,7 +64,7 @@ namespace Velvet
         // Full reset: clears the gradient's background-image AND the backgroundSize it set.
         public static void Clear(VisualElement element)
         {
-            element.style.backgroundImage = new StyleBackground(StyleKeyword.Null);
+            SceneViewElement.WriteBackground(element, new StyleBackground(StyleKeyword.Null));
             ClearSizeOnly(element);
         }
 

--- a/Packages/com.velvet.core/Runtime/Styling/StyleAnimationScheduler.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleAnimationScheduler.cs
@@ -332,9 +332,10 @@ namespace Velvet
             var staggerDelayMs = (long)(additionalDelaySec * 1000);
 
             // Schedule the exit's frame callbacks on a STABLE host (the panel root), not on the exiting
-            // element itself. UI Toolkit silently drops an element's scheduled items the moment it leaves the
-            // panel, and a reconcile reorder briefly detaches a still-exiting ghost (RemoveFromHierarchy +
-            // re-Insert) to move it — which would drop the startAction/timeout, stall the exit, and leak the
+            // element itself. An element-bound scheduled item pauses while its element is off the panel and
+            // its delay RESTARTS in full on re-attach, and a reconcile reorder briefly detaches a
+            // still-exiting ghost (RemoveFromHierarchy + re-Insert) to move it — repeated moves would keep
+            // restarting the startAction/timeout, stall the exit, and leak the
             // ghost (it never completes, so the diff never removes it). The panel root never detaches during
             // the presence's life, so its scheduled items always fire; the exiting child only needs to stay
             // attached for its CSS opacity tween (it does — a committed ghost stays in the DOM). Exit

--- a/Packages/com.velvet.core/Runtime/Styling/StyleArbitraryValueResolver.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleArbitraryValueResolver.cs
@@ -754,24 +754,34 @@ namespace Velvet
             {
                 Clear(element, in style, priority);
             }
-            else if (TryResolveUnregisteredFilterClear(core, out style))
+            else if (!TryClearUnregisteredFilterToken(element, core, priority))
             {
-                // A filter-[name:args] token whose name is not (or no longer) registered: the
-                // registry-gated parse above does not claim it, but a layer applied while the name WAS
-                // registered is still composed and must leave. The class removal mirrors the
-                // never-registered apply, which fell through to the class list; each action is a no-op
-                // in the other's scenario.
-                Clear(element, in style, priority);
-                element.RemoveFromClassList(core);
+                if (StyleBackgroundImageResolver.TryParse(core, out _))
+                {
+                    StyleBackgroundImageResolver.Clear(element);
+                }
+                else
+                {
+                    element.RemoveFromClassList(core);
+                }
             }
-            else if (StyleBackgroundImageResolver.TryParse(core, out _))
+        }
+
+        // Clears a filter-[name:args] token whose name is not (or no longer) registered. The
+        // registry-gated parse does not claim such a token, but a layer applied while the name WAS
+        // registered is still composed and must leave; the name alone identifies the layer, so it is
+        // resolved syntactically. The class-list removal mirrors the never-registered apply, which
+        // fell through to the class list — each action is a no-op in the other's scenario. Returns
+        // false when the token is not a custom-filter shape at all.
+        internal static bool TryClearUnregisteredFilterToken(VisualElement element, string core, int priority)
+        {
+            if (!TryResolveUnregisteredFilterClear(core, out var style))
             {
-                StyleBackgroundImageResolver.Clear(element);
+                return false;
             }
-            else
-            {
-                element.RemoveFromClassList(core);
-            }
+            Clear(element, in style, priority);
+            element.RemoveFromClassList(core);
+            return true;
         }
 
         // Fallback clear resolution for a filter-[name:args] token whose name is NOT (or no longer)
@@ -789,6 +799,37 @@ namespace Velvet
                 return true;
             }
             style = default;
+            return false;
+        }
+
+        // Prefixes classifying a core token as part of the composed filter family (the built-in filter
+        // utilities' bracket forms plus filter-[name:…] customs) without resolving it — the class-diff
+        // reapply's skip decision must not itself pay the parse it is avoiding.
+        private static readonly string[] s_filterFamilyTokenPrefixes = BuildFilterFamilyTokenPrefixes();
+
+        private static string[] BuildFilterFamilyTokenPrefixes()
+        {
+            var families = StyleFilterValueParser.BuiltInFamilyNames;
+            var prefixes = new string[families.Length + 1];
+            for (var i = 0; i < families.Length; i++)
+            {
+                prefixes[i] = families[i] + "-[";
+            }
+            prefixes[families.Length] = "filter-[";
+            return prefixes;
+        }
+
+        // True for tokens whose resolved property lands in the composed filter family. Purely
+        // syntactic on the bracket prefix: cheap enough to gate a skip without parsing the value.
+        internal static bool IsFilterFamilyToken(string core)
+        {
+            foreach (var prefix in s_filterFamilyTokenPrefixes)
+            {
+                if (core.StartsWith(prefix, System.StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
             return false;
         }
 

--- a/Packages/com.velvet.core/Runtime/Styling/StyleBackgroundImageResolver.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleBackgroundImageResolver.cs
@@ -67,17 +67,18 @@ namespace Velvet
         }
 
         /// <summary>
-        /// Sets the element's inline <c>backgroundImage</c> from the given Texture2D.
+        /// Sets the element's inline <c>backgroundImage</c> from the given Texture2D, through the
+        /// SceneView ownership gate (a live camera feed keeps the slot and defers this value).
         /// </summary>
         public static void Apply(VisualElement element, Texture2D? texture)
         {
-            element.style.backgroundImage = new StyleBackground(texture);
+            SceneViewElement.WriteBackground(element, new StyleBackground(texture));
         }
 
-        /// <summary>Reverts the inline background-image to the USS default.</summary>
+        /// <summary>Reverts the inline background-image to the USS default (same gate as Apply).</summary>
         public static void Clear(VisualElement element)
         {
-            element.style.backgroundImage = new StyleBackground(StyleKeyword.Null);
+            SceneViewElement.WriteBackground(element, new StyleBackground(StyleKeyword.Null));
         }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Styling/StyleVariantPayload.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleVariantPayload.cs
@@ -59,16 +59,11 @@ namespace Velvet
                         StyleArbitraryValueResolver.Clear(target, in style, effectivePriority);
                     }
                 }
-                else if (!on && StyleArbitraryValueResolver.TryResolveUnregisteredFilterClear(core, out style))
+                else if (!on && StyleArbitraryValueResolver.TryClearUnregisteredFilterToken(target, core, effectivePriority))
                 {
                     // The off-toggle of a filter-[name:args] payload whose name was unregistered while
-                    // the layer was active: the registry-gated parse above no longer claims the token,
-                    // but the layer the on-toggle applied is still composed, so resolve the NAME
-                    // syntactically and clear that. The class removal mirrors the never-registered
-                    // on-arm, which falls through to AddToClassList below; each action is a no-op in the
-                    // other's scenario.
-                    StyleArbitraryValueResolver.Clear(target, in style, effectivePriority);
-                    target.RemoveFromClassList(core);
+                    // the layer was active — the shared clear resolves the name syntactically and
+                    // removes the mirrored class (see TryClearUnregisteredFilterToken).
                 }
                 else if (on)
                 {

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/CustomFilterRegistryTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/CustomFilterRegistryTests.cs
@@ -561,6 +561,36 @@ namespace Velvet.Tests
             Assert.That(VelvetFilters.Unregister("bad:name"), Is.False);
         }
 
+        [Test]
+        public void Given_AReservedNameInUppercase_When_Registered_Then_TheWarningNamesTheCanonicalFamily()
+        {
+            // Arrange — the warning teaches which utility family owns the name, so it must spell the
+            // canonical lowercase family, not echo the caller's casing back as a nonexistent "BLUR-*".
+            LogAssert.Expect(LogType.Warning,
+                "[VelvetFilters] Cannot register \"BLUR\": the name is reserved by the built-in blur-* utilities.");
+
+            // Act
+            VelvetFilters.Register("BLUR", CreateDefinition());
+
+            // Assert — rejected: the reserved spelling never entered the registry.
+            Assert.That(VelvetFilters.Unregister("BLUR"), Is.False);
+        }
+
+        [Test]
+        public void Given_TheSameDefinitionReference_When_RegisteredAgain_Then_NoOverwriteWarningIsLogged()
+        {
+            // Arrange — re-registering the exact same name/definition pair is a true no-op, so the
+            // "overwriting" warning would be noise pointing at a conflict that does not exist.
+            RegisterForTestRun("pulse", _fadeDef);
+
+            // Act
+            VelvetFilters.Register("pulse", _fadeDef);
+            LogAssert.NoUnexpectedReceived();
+
+            // Assert — the registration is intact after the silent no-op.
+            Assert.That(VelvetFilters.Unregister("pulse"), Is.True);
+        }
+
         #endregion
     }
 }

--- a/Packages/com.velvet.core/Runtime/Styling/VelvetFilters.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/VelvetFilters.cs
@@ -41,7 +41,8 @@ namespace Velvet
 
         /// <summary>
         /// Registers <paramref name="definition"/> under <paramref name="name"/> for
-        /// <c>filter-[name:args]</c> resolution. Re-registering a live name logs a warning and overwrites.
+        /// <c>filter-[name:args]</c> resolution. Re-registering a live name logs a warning and
+        /// overwrites; re-registering the identical definition under the same name is a silent no-op.
         /// </summary>
         /// <param name="name">Filter name as written inside the class brackets. Must be non-empty and
         /// must not contain whitespace, <c>:</c>, <c>[</c> or <c>]</c> (they would break the class token);
@@ -50,7 +51,7 @@ namespace Velvet
         /// <param name="definition">The custom filter definition applied when the class resolves.
         /// Null (or a destroyed asset) is rejected with a warning, as is a definition declaring more than
         /// the 4 parameters a filter function can carry.</param>
-        public static void Register(string name, FilterFunctionDefinition definition)
+        public static void Register(string name, FilterFunctionDefinition? definition)
         {
             if (string.IsNullOrEmpty(name) || !HasValidNameChars(name))
             {
@@ -60,7 +61,7 @@ namespace Velvet
 
             if (s_reserved.Contains(name))
             {
-                Debug.LogWarning($"[VelvetFilters] Cannot register \"{name}\": the name is reserved by the built-in {name}-* utilities.");
+                Debug.LogWarning($"[VelvetFilters] Cannot register \"{name}\": the name is reserved by the built-in {name.ToLowerInvariant()}-* utilities.");
                 return;
             }
 
@@ -78,11 +79,16 @@ namespace Velvet
                 return;
             }
 
-            if (s_definitions.ContainsKey(name))
+            if (s_definitions.TryGetValue(name, out var existing))
             {
+                if (ReferenceEquals(existing, definition))
+                {
+                    // The exact same registration again is a true no-op, not a conflict worth a warning.
+                    return;
+                }
                 Debug.LogWarning($"[VelvetFilters] \"{name}\" is already registered; overwriting.");
             }
-            s_definitions[name] = definition;
+            s_definitions[name] = definition!;
         }
 
         /// <summary>Removes a registration. Returns true when the name was registered.</summary>

--- a/Packages/com.velvet.core/TestUtilities/EditorPanelTestHelpers.cs
+++ b/Packages/com.velvet.core/TestUtilities/EditorPanelTestHelpers.cs
@@ -28,6 +28,39 @@ namespace Velvet.TestUtilities
                 }
             }
         }
+
+        /// <summary>
+        /// Pumps the panel's internal timer scheduler once — the same call a live panel issues once per
+        /// frame — so an EditMode fixture can drive <c>schedule.Execute</c> items deterministically (the
+        /// batchmode PlayerLoop never ticks them). The scheduler is internal engine surface, reached by
+        /// walking the panel's type chain for its <c>scheduler</c> property.
+        /// </summary>
+        public static void DriveSchedulerOnce(IPanel panel)
+        {
+            object scheduler = null;
+            for (var t = panel.GetType(); t != null && scheduler == null; t = t.BaseType)
+            {
+                var prop = t.GetProperty(
+                    "scheduler",
+                    BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly);
+                if (prop != null)
+                {
+                    scheduler = prop.GetValue(panel);
+                }
+            }
+            if (scheduler == null)
+            {
+                throw new System.MissingMemberException(panel.GetType().FullName, "scheduler");
+            }
+            var update = scheduler.GetType().GetMethod(
+                "UpdateScheduledEvents",
+                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            if (update == null)
+            {
+                throw new System.MissingMethodException(scheduler.GetType().FullName, "UpdateScheduledEvents");
+            }
+            update.Invoke(scheduler, null);
+        }
     }
 
 #if UNITY_EDITOR

--- a/Packages/com.velvet.core/TestUtilities/EditorPanelTestHelpers.cs
+++ b/Packages/com.velvet.core/TestUtilities/EditorPanelTestHelpers.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Reflection;
 using UnityEngine.UIElements;
 
@@ -37,29 +38,53 @@ namespace Velvet.TestUtilities
         /// </summary>
         public static void DriveSchedulerOnce(IPanel panel)
         {
-            object scheduler = null;
-            for (var t = panel.GetType(); t != null && scheduler == null; t = t.BaseType)
-            {
-                var prop = t.GetProperty(
-                    "scheduler",
-                    BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly);
-                if (prop != null)
-                {
-                    scheduler = prop.GetValue(panel);
-                }
-            }
+            var scheduler = FindPanelProperty(panel, "scheduler")?.GetValue(panel);
             if (scheduler == null)
             {
-                throw new System.MissingMemberException(panel.GetType().FullName, "scheduler");
+                throw new MissingMemberException(panel.GetType().FullName, "scheduler");
             }
             var update = scheduler.GetType().GetMethod(
                 "UpdateScheduledEvents",
                 BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
             if (update == null)
             {
-                throw new System.MissingMethodException(scheduler.GetType().FullName, "UpdateScheduledEvents");
+                throw new MissingMethodException(scheduler.GetType().FullName, "UpdateScheduledEvents");
             }
             update.Invoke(scheduler, null);
+        }
+
+        /// <summary>
+        /// Installs a fake clock on the panel: the scheduler and every scheduled item read time
+        /// exclusively through the panel's own time function (double seconds), so an EditMode fixture
+        /// can drive cadence deterministically regardless of machine load. Internal engine surface,
+        /// like the scheduler above.
+        /// </summary>
+        public static void SetPanelTimeFunction(IPanel panel, Func<double> secondsClock)
+        {
+            var prop = FindPanelProperty(panel, "TimeSinceStartupFunc");
+            if (prop == null)
+            {
+                throw new MissingMemberException(panel.GetType().FullName, "TimeSinceStartupFunc");
+            }
+            var del = Delegate.CreateDelegate(prop.PropertyType, secondsClock.Target, secondsClock.Method);
+            prop.SetValue(panel, del);
+        }
+
+        // Walks the panel's type chain for an internal property: the engine members these helpers
+        // reach (scheduler, time function) are internal AND inherited, which a plain GetProperty on
+        // the concrete type misses.
+        private static PropertyInfo FindPanelProperty(IPanel panel, string name)
+        {
+            for (var t = panel.GetType(); t != null; t = t.BaseType)
+            {
+                var prop = t.GetProperty(name,
+                    BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly);
+                if (prop != null)
+                {
+                    return prop;
+                }
+            }
+            return null;
         }
     }
 


### PR DESCRIPTION
## What

A hardening pass over the six features shipped in v1.2.0's follow-up wave (custom filter registry, V.SceneView, UseFrame, V.Particles, layer portals, V.WorldSpace), fixing defects and waste found by a post-merge audit of the merged state plus a follow-up review of this branch itself.

### Correctness

- **UseFrame**: callback exceptions are contained like effect exceptions (routed to the nearest error boundary; an escaped throw aborted the panel's remaining scheduled updates for the frame and re-fired forever), and the tick now fires once per frame instead of at a fixed 16 ms floor that skipped frames above ~60 FPS.
- **SceneView**: class-driven backgrounds (gradients, `bg-[addr:…]`) and `styles:` posters no longer clobber a live camera feed — ownership lives on the element, other writers defer while the texture is live and are restored on release; a `camera.targetTexture` reassigned by user code survives layout/tick resyncs and element resizes (claim intent carries across the pre-layout bail); the texture-size ceiling preserves aspect; a pixel-density change re-derives the texture on editor panels; settings validate on every construction path without leaking pooled props on a throwing call.
- **Particles**: the hidden simulation advances outside Play Mode (editor preview panels previously repainted one frozen frame), `Play()` restarts a drained editor-side clock, idle parking follows the drawn root's own liveness, and the advisories are per mounted element (an unstable effect reference warns once; same-named distinct effects both warn; nothing persists across interactive test runs).
- **Portals/WorldSpace**: an error boundary's abort no longer discards the layer/world-space mounts its own fallback enqueued (an error toast in a fallback now reaches its layer) while a failed subtree's pending portals still never mount; hosts re-sync the declaring panel's configuration on runtime changes (theme swaps — including clearing to null — scale changes, the ConstantPhysicalSize DPI pair, `sortingOrder` re-anchoring); a host killed by a scene unload is skipped safely on every later patch (layers are replaced on the next mount); declaring-resolution misses stop re-scanning every UIDocument per host mount; themeless hosts share one empty theme.
- **Filter registry**: the reserved-name warning names the canonical family, identical re-registration is a silent no-op, the definition parameter is annotated nullable, and the class-diff reapply skips untouched filter survivors instead of re-resolving them through the registry.

### Docs and cleanup

- The changelog gains the Fixed section it was missing (including the pre-existing portal target-lifecycle changes that shipped with the layer-portal work), and the guides document the background-ownership contract, the host re-sync semantics with operational notes, and the editor-preview behavior.
- Dead weight removed (write-only `PortalSlotInfo.Children`, a dead release branch, stale engine-behavior comments corrected), duplication merged (copy/drift field lists, the DevTools child walk, the element-binding dispatch, panel-property reflection walks), and per-tick native calls trimmed.

## Tests

31 new/updated specs (all verified red before their fix, green after); full suites: EditMode 2745/0, PlayMode 42/0.