### PR TITLE
fix(velvet): contain boundary-fallback and exit-callback exceptions

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -79,6 +79,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Layer and world-space hosts re-copy the declaring panel's configuration when it changes at
   runtime (theme swaps, scale changes, the ConstantPhysicalSize DPI pair) and survive a scene
   unload killing a host: patches skip dead records instead of throwing out of the pass.
+- An error boundary whose own fallback content throws while rendering no longer escapes
+  uncaught or recurses into itself — it declines and propagation continues to the next
+  ancestor boundary, the same as a fallback factory that throws.
+- `AnimatePresence`'s `onExitComplete` no longer escapes into UI Toolkit's scheduler update
+  when it throws: the exception is contained and routed to the nearest error boundary, and the
+  ghost-drop re-render it sits beside still runs.
 
 ## [1.2.0] - 2026-07-12
 

--- a/Packages/com.velvet.core/Runtime/Component/ComponentBoundarySearch.cs
+++ b/Packages/com.velvet.core/Runtime/Component/ComponentBoundarySearch.cs
@@ -35,7 +35,9 @@ namespace Velvet
         // Propagates an exception to the fiber's ancestor Error Boundary.
         // If a boundary that can catch the exception is found, processing completes there.
         // Otherwise, falls back to logging via Debug.LogException.
-        internal static void PropagateException(ComponentFiber fiber, Exception exception)
+        // fiber is nullable: a caller with no owning component fiber (e.g. AnimatePresence reconciled onto
+        // a bare element) has nothing to walk from and falls straight through to the log.
+        internal static void PropagateException(ComponentFiber? fiber, Exception exception)
         {
             for (var current = fiber?.Parent; current != null; current = current.Parent)
             {

--- a/Packages/com.velvet.core/Runtime/Component/ComponentFiber.cs
+++ b/Packages/com.velvet.core/Runtime/Component/ComponentFiber.cs
@@ -395,6 +395,16 @@ namespace Velvet
         internal Func<Exception, ErrorInfo, VNode>? FallbackFactory { get; set; }
 
         /// <summary>
+        /// True while this boundary is in the middle of rendering/reconciling its own fallback UI. An
+        /// exception raised by that fallback content (rather than the original throw it is responding to)
+        /// re-enters <see cref="FiberErrorBoundary.TryCatch"/> for this SAME fiber via the normal
+        /// per-fiber render catch; the guard makes that re-entrant call decline immediately instead of
+        /// attempting to show the (already failing) fallback again, so propagation continues to the next
+        /// ancestor boundary instead of recursing without bound.
+        /// </summary>
+        internal bool IsShowingFallback { get; set; }
+
+        /// <summary>
         /// Calls <c>Set(null)</c> on every ref registered by <see cref="UseImperativeHandle"/>.
         /// Responsible for resetting the parent-side <c>Ref&lt;T&gt;.Current</c> to null.
         /// </summary>

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/AnimatePresenceAnimationTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/AnimatePresenceAnimationTests.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
 using UnityEngine.UIElements;
 
 using Velvet;
@@ -41,6 +43,8 @@ namespace Velvet.Tests
             s_exitVariantShow = null;
             s_waitConfig = null;
             s_waitKey = null;
+            s_throwingExitConfig = null;
+            s_throwingExitShow = null;
         }
 
         protected override void OnTearDown() => _reconciler?.Dispose();
@@ -306,6 +310,43 @@ namespace Velvet.Tests
             // Assert — the exit was cancelled and the same element retained (not dropped and recreated).
             Assert.That(Root.ElementAt(0), Is.SameAs(original),
                 "Re-adding a key mid-exit cancels the exit and retains the same element rather than dropping and recreating it");
+        }
+
+        // By design onExitComplete is a user-supplied callback; it must not be able to block the ghost-drop
+        // re-render it sits beside by throwing. Reuses ExitRemovalHostRender's component-owned shape so the
+        // drop re-render has a fiber to run on.
+        private static StyleTransitionConfig s_throwingExitConfig;
+        private static Action<bool> s_throwingExitShow;
+
+        [Component]
+        private static VNode ThrowingOnExitCompleteHostRender()
+        {
+            var (show, setShow) = Hooks.UseState(true);
+            s_throwingExitShow = setShow;
+            return V.AnimatePresence(
+                onExitComplete: () => throw new InvalidOperationException("Test onExitComplete error"),
+                children: show
+                    ? new VNode[] { V.Motion(key: "a", transition: s_throwingExitConfig, children: new VNode[] { V.Label(text: "A") }) }
+                    : Array.Empty<VNode>());
+        }
+
+        [Test]
+        public void Given_OnExitCompleteThrows_When_ExitTransitionCompletes_Then_TheElementIsStillRemovedFromTheDom()
+        {
+            // Arrange
+            s_throwingExitConfig = NewConfig();
+            using var mounted = V.Mount(Root, V.Component(ThrowingOnExitCompleteHostRender, key: "throwing-exit-host"));
+            AdvancePast(s_throwingExitConfig.DurationSec);
+            Assume.That(LabelTexts(), Is.EqualTo(new[] { "A" }), "Precondition: the child entered and is present");
+            LogAssert.Expect(LogType.Exception, "InvalidOperationException: Test onExitComplete error");
+
+            // Act — hide the child; its exit completes and onExitComplete throws.
+            s_throwingExitShow.Invoke(false);
+            AdvancePast(s_throwingExitConfig.DurationSec);
+
+            // Assert — the ghost-drop re-render still ran despite the throw.
+            Assert.That(LabelTexts(), Is.Empty,
+                "The exited element is still removed from the DOM even though onExitComplete threw");
         }
 
         #endregion

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberErrorBoundary.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberErrorBoundary.cs
@@ -45,6 +45,13 @@ namespace Velvet
             return sb.ToString();
         }
 
+        // Known limitation: when the fallback's OWN content throws and IsShowingFallback declines the
+        // resulting re-entrant TryCatch (see below), that inner exception is resolved entirely inside the
+        // Reconcile call below via the ordinary per-fiber render catch + ComponentBoundarySearch — it never
+        // surfaces as a raw exception here. Reconcile returns normally either way, so this method reports
+        // success (and the caller marks the ORIGINAL exception caught) even on the sub-path where the
+        // fallback content itself failed and nothing meaningful ended up on screen for it. Verifying that
+        // sub-path's own success/failure would need a signal this method doesn't have — tracked separately.
         private static bool TryShowFallback(ComponentFiber fiber, ComponentFiber? throwingFiber, Exception originalException)
         {
             if (fiber.Reconciler == null) return false;
@@ -52,6 +59,12 @@ namespace Velvet
             try
             {
                 fallback = RenderFallback(fiber, throwingFiber, originalException);
+            }
+            catch (FiberSuspendSignal)
+            {
+                // Not a fallback failure: the factory suspended on a pending async resource and must reach
+                // a real Suspense boundary via the ordinary ambient path, the same as any other render.
+                throw;
             }
             catch (Exception fallbackEx)
             {
@@ -62,9 +75,25 @@ namespace Velvet
             }
             if (fallback == null) return false;
             var fallbackTree = new[] { fallback };
-            fiber.Reconciler.Reconcile(fiber.MountPoint, fiber.PreviousTree ?? Array.Empty<VNode>(), fallbackTree);
-            FiberTreeReturn.ReturnPooledObjects(fiber.PreviousTree);
-            fiber.PreviousTree = fallbackTree;
+            try
+            {
+                fiber.Reconciler.Reconcile(fiber.MountPoint, fiber.PreviousTree ?? Array.Empty<VNode>(), fallbackTree);
+                FiberTreeReturn.ReturnPooledObjects(fiber.PreviousTree);
+                fiber.PreviousTree = fallbackTree;
+            }
+            catch (FiberSuspendSignal)
+            {
+                // Same as above: a suspend raised while rendering the fallback's own content must keep
+                // unwinding toward a real Suspense boundary, not be treated as a fallback failure.
+                throw;
+            }
+            catch (Exception reconcileEx)
+            {
+                FiberLogger.LogError("ErrorBoundary",
+                    "FiberRenderer: reconciling the fallback UI threw an exception. The original exception is preserved.");
+                FiberLogger.LogException("ErrorBoundary", reconcileEx);
+                return false;
+            }
             return true;
         }
 
@@ -81,7 +110,13 @@ namespace Velvet
             // Opt-in contract: even if a Fiber returning IsErrorBoundary=false has TryCatch invoked through some
             // path, it does not catch.
             if (!fiber.IsErrorBoundary || fiber.Reconciler == null) return false;
+            // A fiber whose own fallback content throws re-enters here (the content's per-fiber render
+            // catch routes back to this same boundary via ComponentBoundarySearch.PropagateException).
+            // Decline immediately rather than attempting to show the already-failing fallback again — the
+            // caller's propagation loop then continues to the next ancestor boundary on its own.
+            if (fiber.IsShowingFallback) return false;
             var fiberPushed = FiberRenderer.PushFiber(fiber);
+            fiber.IsShowingFallback = true;
             bool result;
             try
             {
@@ -89,6 +124,7 @@ namespace Velvet
             }
             finally
             {
+                fiber.IsShowingFallback = false;
                 FiberRenderer.PopFiber(fiber, fiberPushed);
             }
             if (result)

--- a/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
@@ -1114,12 +1114,30 @@ namespace Velvet
                                 capturedState.ExitComplete.Add(capturedKey);
                                 // onExitComplete fires once the exiting set drains (the last
                                 // in-flight exit finished). Cancelled exits (key re-entered) remove from Exiting
-                                // elsewhere and do not reach here, so they never trigger it.
+                                // elsewhere and do not reach here, so they never trigger it. Contained: a
+                                // throwing callback must not skip the ghost-drop re-render scheduled below,
+                                // mirroring HookEffectExecutor's effect-exception containment.
                                 if (capturedState.Exiting.Count == 0)
                                 {
-                                    capturedOnExitComplete?.Invoke();
+                                    try
+                                    {
+                                        capturedOnExitComplete?.Invoke();
+                                    }
+                                    catch (Exception ex)
+                                    {
+                                        ComponentBoundarySearch.PropagateException(capturedBoundary, ex);
+                                    }
                                 }
-                                if (capturedBoundary != null)
+                                if (capturedBoundary != null && capturedBoundary.IsDisposed)
+                                {
+                                    // The callback above threw and an ancestor boundary's fallback already
+                                    // replaced capturedBoundary's whole subtree while handling it — there is no
+                                    // ghost left to drop a re-render for, and ScheduleRerender has no disposed
+                                    // guard of its own (unlike the public RequestRenderFromHook/
+                                    // RequestTransitionRerender), so scheduling here would just pin a disposed
+                                    // fiber dirty in the batch scheduler forever.
+                                }
+                                else if (capturedBoundary != null)
                                 {
                                     // The boundary's own hook inputs are unchanged (the exit finished out of band,
                                     // not via a state update), so an auto-memoized boundary would return its cached
@@ -1263,9 +1281,19 @@ namespace Velvet
                 // onExitComplete fires once the exiting children are gone. When every removed child
                 // had NO exit animation (all instant-removed above) no PlayExit callback runs to fire it, so fire it
                 // here — but only when no animated exit is still in flight (those fire it when the Exiting set drains).
+                // Contained the same way as RunExitComplete's animated-exit path above: a throwing callback
+                // must not skip the state.Committed/passSettled bookkeeping that follows, or the next render
+                // reproduces a stale old side.
                 if (commit != null && removedInstantThisRender && state.Exiting.Count == 0)
                 {
-                    presence.OnExitComplete?.Invoke();
+                    try
+                    {
+                        presence.OnExitComplete?.Invoke();
+                    }
+                    catch (Exception ex)
+                    {
+                        ComponentBoundarySearch.PropagateException(boundaryFiber, ex);
+                    }
                 }
 
                 // 3) Commit the new composition for the next old-side reproduction. Exit-complete keys were

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ErrorBoundaryTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ErrorBoundaryTests.cs
@@ -41,6 +41,7 @@ namespace Velvet.Tests
             ResetBoundary();
             ResetMultiChild();
             ResetEffectBoundary();
+            ResetBrokenFallback();
         }
 
         #region No boundary
@@ -448,6 +449,53 @@ namespace Velvet.Tests
                 throw new InvalidOperationException("Test cleanup error");
             }), new object[] { tick });
             return V.Label(text: "ok");
+        }
+
+        #endregion
+
+        #region A boundary's own fallback content throws (self re-catch guard)
+
+        private static int s_brokenFallbackContentRenderCount;
+
+        private static void ResetBrokenFallback()
+        {
+            s_brokenFallbackContentRenderCount = 0;
+        }
+
+        [Test]
+        public void Given_ABoundarysOwnFallbackContentThrows_When_TheOriginalExceptionTriggersIt_Then_TheFallbackContentRendersExactlyOnce()
+        {
+            // A component nested inside the fallback VNode throws when rendered. Its exception routes back to
+            // this SAME boundary through the ordinary per-fiber render catch (the boundary is the nested
+            // fiber's parent). Without a re-entrant guard, the boundary would attempt to show its own (still
+            // broken) fallback again, recursing without bound. The guard makes it decline immediately instead.
+            // Arrange
+            using var mounted = V.Mount(_root, V.Component(BoundaryWithBrokenFallbackRender, key: "broken-fallback-boundary"));
+            Assume.That(s_brokenFallbackContentRenderCount, Is.EqualTo(0), "Precondition: nothing has thrown yet");
+            s_trackingShouldThrow = true;
+            LogAssert.Expect(LogType.Exception, "InvalidOperationException: Test fallback content error");
+
+            // Act
+            s_trackingSetTick.Invoke(1);
+            mounted.FlushStateForTest();
+
+            // Assert
+            Assert.That(s_brokenFallbackContentRenderCount, Is.EqualTo(1),
+                "The broken fallback content renders exactly once, not recursively");
+        }
+
+        [Component(IsErrorBoundary = true)]
+        private static VNode BoundaryWithBrokenFallbackRender()
+        {
+            Hooks.UseFallback(_ => V.Component(BrokenFallbackContentRender, key: "broken-fallback-content"));
+            return V.Component(TrackingRender, key: "tracking");
+        }
+
+        [Component]
+        private static VNode BrokenFallbackContentRender()
+        {
+            s_brokenFallbackContentRenderCount++;
+            throw new InvalidOperationException("Test fallback content error");
         }
 
         #endregion


### PR DESCRIPTION
## Summary

Two pre-existing exception-containment gaps found during the post-merge audit of the six recently-shipped features, left for a follow-up pass:

- An error boundary showing its own fallback (`FiberErrorBoundary.TryShowFallback`) had no guard against the fallback content itself throwing during reconcile — a boundary whose fallback content always throws could recurse into re-catching itself without bound.
- `AnimatePresence`'s `onExitComplete` callback ran unguarded at both sites it can fire from, so a throwing callback could escape into UI Toolkit's scheduler update, or skip the ghost-drop re-render / bookkeeping that follows it.

## Changes

- `FiberErrorBoundary.TryShowFallback` wraps the fallback reconcile the same way it already wrapped the fallback factory call. `TryCatch` declines a re-entrant call for a boundary already showing its own fallback (via a new `ComponentFiber.IsShowingFallback` flag) — a throwing fallback now propagates to the next ancestor boundary instead of escaping uncaught or recursing into itself. Both of `TryShowFallback`'s catches re-throw `FiberSuspendSignal` instead of treating a pending-resource suspend as a fallback failure, matching every other catch site in the reconciler.
- `GeneralPathReconciler` contains `onExitComplete` at both sites it can fire from (an animated exit draining, and an instant no-animation removal): a throwing callback is routed to the nearest error boundary instead of skipping the ghost-drop re-render or the pass's own bookkeeping, mirroring `HookEffectExecutor`'s effect-exception containment. The animated-exit path also skips scheduling a re-render for a boundary an ancestor's fallback already disposed while handling the callback's exception, since `ScheduleRerender` has no disposed guard of its own.
- `ComponentBoundarySearch.PropagateException`'s `fiber` parameter is now annotated nullable, matching how it's actually called.
- CHANGELOG updated.

A deeper, related question (whether `TryShowFallback` can report false success when the fallback's own content fails, and whether a mid-mutation `Reconcile` throw can desync `PreviousTree` from the live VisualElement tree) was investigated but is architecturally larger than this fix — it's tracked separately rather than rushed in here.

## Test plan

- [x] 2 new specs (one per gap), each verified red before the fix and green after
- [x] Full EditMode suite: 2750/0
- [x] Full PlayMode suite: 42/0

🤖 Generated with [Claude Code](https://claude.com/claude-code)