### PR TITLE
chore(velvet): prepare v1.3.0 release

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-07-13
+
 ### Added
 
 - `V.Portal(layer:)`: framework-managed screen-space layer panels (`UILayer.Background` /

--- a/Packages/com.velvet.core/package.json
+++ b/Packages/com.velvet.core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.velvet.core",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "displayName": "Velvet",
   "description": "React-style declarative UI framework for Unity UI Toolkit. Provides virtual DOM, reconciliation engine, hooks, and component model.",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Move `[Unreleased]` to `[1.3.0] - 2026-07-13` in CHANGELOG.md
- Bump `package.json` version to 1.3.0

## Release contents
- `V.Portal(layer:)` and `V.WorldSpace(...)` screen/world-space portals
- `Hooks.UseFrame` per-frame hook
- `V.Particles` ParticleSystem rendering
- `V.SceneView` camera-to-element rendering
- Custom filter registry (`VelvetFilters.Register`)
- Hardening fixes from the post-merge audit and error-boundary/exit-callback containment work

## Test plan
- [x] Full EditMode + PlayMode suites green prior to this branch (carried over from #26/#27/#28)
- [x] No source changes in this PR — CHANGELOG/package.json only