### PR TITLE
refactor(velvet): consolidate registry Register/Unregister/reset pattern

### DIFF
--- a/Packages/com.velvet.core/Runtime/NameKeyedRegistry.cs
+++ b/Packages/com.velvet.core/Runtime/NameKeyedRegistry.cs
@@ -1,5 +1,4 @@
 #nullable enable
-using System;
 using System.Collections.Generic;
 
 namespace Velvet
@@ -16,30 +15,21 @@ namespace Velvet
     {
         /// <summary>
         /// Inserts <paramref name="value"/> under <paramref name="key"/> in <paramref name="store"/>,
-        /// overwriting any existing entry. Returns <c>false</c> for a fresh key. For a key that is already
-        /// registered, returns <c>false</c> when <paramref name="isSameRegistration"/> is supplied and
-        /// reports the existing entry as the same registration restated (a no-op: the store is left
-        /// untouched), and <c>true</c> otherwise — a genuine overwrite the caller can warn about.
+        /// overwriting any existing entry. Returns <c>false</c> for a fresh key (single-probe fast path)
+        /// and <c>true</c> when a key already registered was overwritten, so the caller can warn about it.
+        /// A registry that needs to recognize a re-registration as a no-op (e.g. the same reference
+        /// restated) checks that itself before calling <see cref="Set{TValue}"/>, per this type's own
+        /// principle that per-registry validation stays in the registry.
         /// </summary>
-        public static bool Set<TValue>(
-            string key,
-            TValue value,
-            Dictionary<string, TValue> store,
-            Func<TValue, TValue, bool>? isSameRegistration = null)
+        public static bool Set<TValue>(string key, TValue value, Dictionary<string, TValue> store)
         {
-            if (store.TryGetValue(key, out var existing))
+            if (store.TryAdd(key, value))
             {
-                if (isSameRegistration != null && isSameRegistration(existing, value))
-                {
-                    return false;
-                }
-
-                store[key] = value;
-                return true;
+                return false;
             }
 
             store[key] = value;
-            return false;
+            return true;
         }
 
         /// <summary>

--- a/Packages/com.velvet.core/Runtime/NameKeyedRegistry.cs
+++ b/Packages/com.velvet.core/Runtime/NameKeyedRegistry.cs
@@ -1,0 +1,59 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+
+namespace Velvet
+{
+    /// <summary>
+    /// Mechanics shared by the name-keyed static registries (<see cref="VelvetFilters"/>,
+    /// <see cref="VelvetFonts"/>, <see cref="FiberPortalRegistry"/>): each owns its own
+    /// <see cref="Dictionary{TKey,TValue}"/> and value type, and calls into these helpers for the parts
+    /// of Register/Unregister that are identical no matter what the registry stores. Validation that
+    /// differs per registry — name character rules, reserved names, value-shape checks, and whether a
+    /// re-registration warns at all — stays in the registry itself.
+    /// </summary>
+    internal static class NameKeyedRegistry
+    {
+        /// <summary>
+        /// Inserts <paramref name="value"/> under <paramref name="key"/> in <paramref name="store"/>,
+        /// overwriting any existing entry. Returns <c>false</c> for a fresh key. For a key that is already
+        /// registered, returns <c>false</c> when <paramref name="isSameRegistration"/> is supplied and
+        /// reports the existing entry as the same registration restated (a no-op: the store is left
+        /// untouched), and <c>true</c> otherwise — a genuine overwrite the caller can warn about.
+        /// </summary>
+        public static bool Set<TValue>(
+            string key,
+            TValue value,
+            Dictionary<string, TValue> store,
+            Func<TValue, TValue, bool>? isSameRegistration = null)
+        {
+            if (store.TryGetValue(key, out var existing))
+            {
+                if (isSameRegistration != null && isSameRegistration(existing, value))
+                {
+                    return false;
+                }
+
+                store[key] = value;
+                return true;
+            }
+
+            store[key] = value;
+            return false;
+        }
+
+        /// <summary>
+        /// Removes <paramref name="key"/> from <paramref name="store"/>. A null/empty key, or a key that
+        /// is not registered, is a no-op. Returns whether an entry was actually removed.
+        /// </summary>
+        public static bool Unregister<TValue>(string? key, Dictionary<string, TValue> store) =>
+            !string.IsNullOrEmpty(key) && store.Remove(key);
+
+        /// <summary>
+        /// Returns whether <paramref name="key"/> is currently registered in <paramref name="store"/>. A
+        /// null/empty key always returns <c>false</c>.
+        /// </summary>
+        public static bool IsRegistered<TValue>(string? key, Dictionary<string, TValue> store) =>
+            !string.IsNullOrEmpty(key) && store.ContainsKey(key);
+    }
+}

--- a/Packages/com.velvet.core/Runtime/NameKeyedRegistry.cs.meta
+++ b/Packages/com.velvet.core/Runtime/NameKeyedRegistry.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a2fe94cdd73e3413e8bf105edc94dff1

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberPortalRegistry.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberPortalRegistry.cs
@@ -39,10 +39,9 @@ namespace Velvet
                 return;
             }
 
-            if (!_targets.TryAdd(id, target))
+            if (NameKeyedRegistry.Set(id, target, _targets))
             {
                 Debug.LogWarning($"[FiberPortalRegistry] Id \"{id}\" is already registered. Overwriting.");
-                _targets[id] = target;
             }
         }
 
@@ -50,15 +49,7 @@ namespace Velvet
         /// Unregisters a Portal mount target.
         /// </summary>
         /// <param name="id">Identifier previously passed to <see cref="Register"/>. Null or empty values are no-ops.</param>
-        public static void Unregister(string id)
-        {
-            if (string.IsNullOrEmpty(id))
-            {
-                return;
-            }
-
-            _targets.Remove(id);
-        }
+        public static void Unregister(string id) => NameKeyedRegistry.Unregister(id, _targets);
 
         /// <summary>
         /// Gets a Portal mount target. Returns null if not registered.
@@ -80,15 +71,7 @@ namespace Velvet
         /// </summary>
         /// <param name="id">Identifier to test. Null or empty values always return <c>false</c>.</param>
         /// <returns><c>true</c> when a target is currently registered for <paramref name="id"/>; otherwise <c>false</c>.</returns>
-        public static bool IsRegistered(string id)
-        {
-            if (string.IsNullOrEmpty(id))
-            {
-                return false;
-            }
-
-            return _targets.ContainsKey(id);
-        }
+        public static bool IsRegistered(string id) => NameKeyedRegistry.IsRegistered(id, _targets);
 
         /// <summary>
         /// Test-only: clears all registrations.

--- a/Packages/com.velvet.core/Runtime/Styling/VelvetFilters.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/VelvetFilters.cs
@@ -80,7 +80,12 @@ namespace Velvet
             }
 
             // The exact same registration again is a true no-op, not a conflict worth a warning.
-            if (NameKeyedRegistry.Set(name, definition!, s_definitions, ReferenceEquals))
+            if (s_definitions.TryGetValue(name, out var existingDefinition) && ReferenceEquals(existingDefinition, definition))
+            {
+                return;
+            }
+
+            if (NameKeyedRegistry.Set(name, definition!, s_definitions))
             {
                 Debug.LogWarning($"[VelvetFilters] \"{name}\" is already registered; overwriting.");
             }

--- a/Packages/com.velvet.core/Runtime/Styling/VelvetFilters.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/VelvetFilters.cs
@@ -79,23 +79,15 @@ namespace Velvet
                 return;
             }
 
-            if (s_definitions.TryGetValue(name, out var existing))
+            // The exact same registration again is a true no-op, not a conflict worth a warning.
+            if (NameKeyedRegistry.Set(name, definition!, s_definitions, ReferenceEquals))
             {
-                if (ReferenceEquals(existing, definition))
-                {
-                    // The exact same registration again is a true no-op, not a conflict worth a warning.
-                    return;
-                }
                 Debug.LogWarning($"[VelvetFilters] \"{name}\" is already registered; overwriting.");
             }
-            s_definitions[name] = definition!;
         }
 
         /// <summary>Removes a registration. Returns true when the name was registered.</summary>
-        public static bool Unregister(string name)
-        {
-            return !string.IsNullOrEmpty(name) && s_definitions.Remove(name);
-        }
+        public static bool Unregister(string name) => NameKeyedRegistry.Unregister(name, s_definitions);
 
         // Parse-time lookup for the filter-[name:args] resolver branch. A destroyed (fake-null) asset
         // fails the lookup so the token falls through instead of applying a dead definition.

--- a/Packages/com.velvet.core/Runtime/Styling/VelvetFonts.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/VelvetFonts.cs
@@ -126,7 +126,7 @@ namespace Velvet
         /// <summary>Removes a family by name. No-op when it is not registered.</summary>
         public static void Unregister(string? familyName)
         {
-            if (string.IsNullOrEmpty(familyName) || !_families.Remove(familyName))
+            if (!NameKeyedRegistry.Unregister(familyName, _families))
             {
                 return;
             }
@@ -148,8 +148,7 @@ namespace Velvet
         }
 
         /// <summary>True when a family with the given name is registered.</summary>
-        public static bool IsRegistered(string? familyName) =>
-            !string.IsNullOrEmpty(familyName) && _families.ContainsKey(familyName);
+        public static bool IsRegistered(string? familyName) => NameKeyedRegistry.IsRegistered(familyName, _families);
 
         /// <summary>
         /// Resolves a font request to a <see cref="ResolvedFont"/>. When <paramref name="family"/> is null

--- a/Packages/com.velvet.core/Runtime/Styling/VelvetFonts.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/VelvetFonts.cs
@@ -86,7 +86,7 @@ namespace Velvet
                 return;
             }
 
-            _families[family.name] = family;
+            NameKeyedRegistry.Set(family.name, family, _families);
             FontsChanged?.Invoke();
         }
 
@@ -110,7 +110,7 @@ namespace Velvet
                 {
                     if (family != null && !string.IsNullOrEmpty(family.name))
                     {
-                        _families[family.name] = family;
+                        NameKeyedRegistry.Set(family.name, family, _families);
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Extract a shared `NameKeyedRegistry` helper (`Set`/`Unregister`/`IsRegistered`) mirroring the existing `AddressableAssetCache` pattern
- `VelvetFilters`, `VelvetFonts`, and `FiberPortalRegistry` delegate to it, keeping their own domain-specific validation and behavior (reserved-name rejection, identical-re-registration no-op, etc.) as thin call-site logic

Closes #31.

## Test plan
- [x] Existing fixtures for all three registries pass unchanged (`CustomFilterRegistryTests`, `StyleFontTests`, `PortalTests`): 98/0
- [x] Full EditMode: 2749/0, full PlayMode: 42/0