### PR TITLE
test(velvet): dedup PlayMode panel/camera/RenderTexture harness setup

### DIFF
--- a/Packages/com.velvet.core/Runtime/Hooks/Tests/PlayMode/UseFramePlaybackTests.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Tests/PlayMode/UseFramePlaybackTests.cs
@@ -3,6 +3,8 @@ using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
 using UnityEngine.UIElements;
+using Velvet.TestUtilities;
+using static Velvet.TestUtilities.PlayModeRealtimeTestHelpers;
 
 namespace Velvet.Tests
 {
@@ -17,7 +19,7 @@ namespace Velvet.Tests
         private GameObject _docGo;
         private PanelSettings _settings;
         private MountedTree _mounted;
-        private int _savedTargetFrameRate;
+        private TargetFrameRateScope _frameRateScope;
 
         private static int s_calls;
         private static float s_minDt;
@@ -29,8 +31,7 @@ namespace Velvet.Tests
         [UnitySetUp]
         public IEnumerator UnitySetUp()
         {
-            _savedTargetFrameRate = Application.targetFrameRate;
-            Application.targetFrameRate = 120;
+            _frameRateScope = new TargetFrameRateScope(120);
             s_calls = 0;
             s_minDt = float.MaxValue;
             s_maxDt = 0f;
@@ -42,7 +43,7 @@ namespace Velvet.Tests
         [UnityTearDown]
         public IEnumerator UnityTearDown()
         {
-            Application.targetFrameRate = _savedTargetFrameRate;
+            _frameRateScope.Dispose();
             _mounted?.Dispose();
             _mounted = null;
             if (_docGo != null) Object.Destroy(_docGo);
@@ -58,15 +59,6 @@ namespace Velvet.Tests
             _settings.scaleMode = PanelScaleMode.ConstantPixelSize;
             doc.panelSettings = _settings;
             return doc.rootVisualElement;
-        }
-
-        private static IEnumerator WaitRealtime(double seconds)
-        {
-            var deadline = Time.realtimeSinceStartupAsDouble + seconds;
-            while (Time.realtimeSinceStartupAsDouble < deadline)
-            {
-                yield return null;
-            }
         }
 
         [Component]

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/MotionEnterPlaybackTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/MotionEnterPlaybackTests.cs
@@ -6,6 +6,7 @@ using UnityEditor;
 using UnityEngine;
 using UnityEngine.TestTools;
 using UnityEngine.UIElements;
+using Velvet.TestUtilities;
 
 namespace Velvet.Tests
 {
@@ -29,20 +30,19 @@ namespace Velvet.Tests
         private GameObject _go;
         private PanelSettings _settings;
         private MountedTree _mounted;
-        private int _savedTargetFrameRate;
+        private TargetFrameRateScope _frameRateScope;
 
         [UnitySetUp]
         public IEnumerator UnitySetUp()
         {
-            _savedTargetFrameRate = Application.targetFrameRate;
-            Application.targetFrameRate = 120;
+            _frameRateScope = new TargetFrameRateScope(120);
             yield break;
         }
 
         [UnityTearDown]
         public IEnumerator UnityTearDown()
         {
-            Application.targetFrameRate = _savedTargetFrameRate;
+            _frameRateScope.Dispose();
             _mounted?.Dispose();
             _mounted = null;
             if (_go != null) Object.Destroy(_go);

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/MotionRuntimeSwapPlaybackTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/MotionRuntimeSwapPlaybackTests.cs
@@ -6,6 +6,7 @@ using UnityEditor;
 using UnityEngine;
 using UnityEngine.TestTools;
 using UnityEngine.UIElements;
+using Velvet.TestUtilities;
 
 namespace Velvet.Tests
 {
@@ -39,13 +40,12 @@ namespace Velvet.Tests
         private PanelSettings _settings;
         private MountedTree _mounted;
         private LabelStore _store;
-        private int _savedTargetFrameRate;
+        private TargetFrameRateScope _frameRateScope;
 
         [UnitySetUp]
         public IEnumerator UnitySetUp()
         {
-            _savedTargetFrameRate = Application.targetFrameRate;
-            Application.targetFrameRate = 120;
+            _frameRateScope = new TargetFrameRateScope(120);
             s_labelStore = null;
             yield break;
         }
@@ -53,7 +53,7 @@ namespace Velvet.Tests
         [UnityTearDown]
         public IEnumerator UnityTearDown()
         {
-            Application.targetFrameRate = _savedTargetFrameRate;
+            _frameRateScope.Dispose();
             _mounted?.Dispose();
             _mounted = null;
             _store?.Dispose();

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/ParticlesPlaybackTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/ParticlesPlaybackTests.cs
@@ -3,6 +3,8 @@ using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
 using UnityEngine.UIElements;
+using Velvet.TestUtilities;
+using static Velvet.TestUtilities.PlayModeRealtimeTestHelpers;
 
 namespace Velvet.Tests
 {
@@ -24,30 +26,26 @@ namespace Velvet.Tests
     internal sealed class ParticlesPlaybackTests
     {
         private GameObject _effectGo;
-        private GameObject _docGo;
-        private PanelSettings _settings;
-        private RenderTexture _panelRt;
+        private RenderTexturePanelHost _host;
         private MountedTree _mounted;
-        private int _savedTargetFrameRate;
+        private TargetFrameRateScope _frameRateScope;
 
         [UnitySetUp]
         public IEnumerator UnitySetUp()
         {
-            _savedTargetFrameRate = Application.targetFrameRate;
-            Application.targetFrameRate = 120;
+            _frameRateScope = new TargetFrameRateScope(120);
             yield break;
         }
 
         [UnityTearDown]
         public IEnumerator UnityTearDown()
         {
-            Application.targetFrameRate = _savedTargetFrameRate;
+            _frameRateScope.Dispose();
             _mounted?.Dispose();
             _mounted = null;
-            if (_docGo != null) Object.Destroy(_docGo);
             if (_effectGo != null) Object.Destroy(_effectGo);
-            if (_settings != null) Object.Destroy(_settings);
-            if (_panelRt != null) { _panelRt.Release(); Object.Destroy(_panelRt); }
+            _host?.Dispose();
+            _host = null;
             yield return null;
         }
 
@@ -74,43 +72,21 @@ namespace Velvet.Tests
 
         private void MountPanel(ParticleSystem effect, PlayTrigger playOn)
         {
-            _panelRt = new RenderTexture(300, 300, 32);
-            _docGo = new GameObject("ParticlesPanel");
-            var doc = _docGo.AddComponent<UIDocument>();
-            _settings = ScriptableObject.CreateInstance<PanelSettings>();
-            _settings.scaleMode = PanelScaleMode.ConstantPixelSize;
-            _settings.targetTexture = _panelRt;
-            doc.panelSettings = _settings;
-            _mounted = V.Mount(doc.rootVisualElement,
+            _host = new RenderTexturePanelHost("ParticlesPanel", 300, 300);
+            _mounted = V.Mount(_host.Root,
                 V.Particles(effect, className: "w-[300px] h-[300px]", playOn: playOn));
         }
 
         // Counts red-dominant pixels in the panel's center region (bottom-origin irrelevant: centered).
         private int CountParticlePixels()
         {
-            var prev = RenderTexture.active;
-            RenderTexture.active = _panelRt;
-            var tex = new Texture2D(100, 100, TextureFormat.RGBA32, false);
-            tex.ReadPixels(new Rect(100, 100, 100, 100), 0, 0);
-            tex.Apply();
-            RenderTexture.active = prev;
+            var pixels = RenderTexturePixelReader.ReadPixels(_host.TargetTexture, new RectInt(100, 100, 100, 100));
             var count = 0;
-            var pixels = tex.GetPixels32();
             foreach (var p in pixels)
             {
                 if (p.r > 140 && p.g < 90 && p.b < 90) count++;
             }
-            Object.Destroy(tex);
             return count;
-        }
-
-        private static IEnumerator WaitRealtime(double seconds)
-        {
-            var deadline = Time.realtimeSinceStartupAsDouble + seconds;
-            while (Time.realtimeSinceStartupAsDouble < deadline)
-            {
-                yield return null;
-            }
         }
 
         [UnityTest]
@@ -172,7 +148,7 @@ namespace Velvet.Tests
             MountPanel(effect, PlayTrigger.Manual);
             yield return WaitRealtime(0.3);
             Assume.That(CountParticlePixels(), Is.EqualTo(0), "Precondition: nothing draws before Play");
-            var element = _docGo.GetComponent<UIDocument>().rootVisualElement.Q<ParticlesElement>();
+            var element = _host.Root.Q<ParticlesElement>();
             Assume.That(element, Is.Not.Null, "Precondition: the particles element mounted");
 
             // Act
@@ -190,14 +166,8 @@ namespace Velvet.Tests
             // state on effect identity alone would make the flip a silent no-op.
             var effect = CreateEmitter();
             s_effect = effect;
-            _panelRt = new RenderTexture(300, 300, 32);
-            _docGo = new GameObject("ParticlesPanel");
-            var doc = _docGo.AddComponent<UIDocument>();
-            _settings = ScriptableObject.CreateInstance<PanelSettings>();
-            _settings.scaleMode = PanelScaleMode.ConstantPixelSize;
-            _settings.targetTexture = _panelRt;
-            doc.panelSettings = _settings;
-            _mounted = V.Mount(doc.rootVisualElement, V.Component(TriggerFlipHost, key: "root"));
+            _host = new RenderTexturePanelHost("ParticlesPanel", 300, 300);
+            _mounted = V.Mount(_host.Root, V.Component(TriggerFlipHost, key: "root"));
             yield return WaitRealtime(0.3);
             Assume.That(CountParticlePixels(), Is.EqualTo(0), "Precondition: Manual draws nothing");
 
@@ -216,14 +186,8 @@ namespace Velvet.Tests
             // scheduled items; the repaint driver must survive the move or the drawn output freezes.
             var effect = CreateEmitter();
             s_effect = effect;
-            _panelRt = new RenderTexture(300, 300, 32);
-            _docGo = new GameObject("ParticlesPanel");
-            var doc = _docGo.AddComponent<UIDocument>();
-            _settings = ScriptableObject.CreateInstance<PanelSettings>();
-            _settings.scaleMode = PanelScaleMode.ConstantPixelSize;
-            _settings.targetTexture = _panelRt;
-            doc.panelSettings = _settings;
-            _mounted = V.Mount(doc.rootVisualElement, V.Component(ReorderHost, key: "root"));
+            _host = new RenderTexturePanelHost("ParticlesPanel", 300, 300);
+            _mounted = V.Mount(_host.Root, V.Component(ReorderHost, key: "root"));
             yield return WaitRealtime(0.5);
             Assume.That(CountParticlePixels(), Is.GreaterThan(20), "Precondition: particles are visible");
 
@@ -269,15 +233,7 @@ namespace Velvet.Tests
 
         private Color32[] Snapshot()
         {
-            var prev = RenderTexture.active;
-            RenderTexture.active = _panelRt;
-            var tex = new Texture2D(300, 300, TextureFormat.RGBA32, false);
-            tex.ReadPixels(new Rect(0, 0, 300, 300), 0, 0);
-            tex.Apply();
-            RenderTexture.active = prev;
-            var pixels = tex.GetPixels32();
-            Object.Destroy(tex);
-            return pixels;
+            return RenderTexturePixelReader.ReadPixels(_host.TargetTexture, new RectInt(0, 0, 300, 300));
         }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/ParticlesPlaybackTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/ParticlesPlaybackTests.cs
@@ -84,7 +84,7 @@ namespace Velvet.Tests
             var count = 0;
             foreach (var p in pixels)
             {
-                if (p.r > 140 && p.g < 90 && p.b < 90) count++;
+                if (RenderTexturePixelReader.IsRedPixel(p)) count++;
             }
             return count;
         }

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/PortalLayersPlaybackTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/PortalLayersPlaybackTests.cs
@@ -130,7 +130,7 @@ namespace Velvet.Tests
             var redPixels = 0;
             foreach (var p in pixels)
             {
-                if (p.r > 140 && p.g < 90 && p.b < 90) redPixels++;
+                if (RenderTexturePixelReader.IsRedPixel(p)) redPixels++;
             }
             Assert.That(redPixels, Is.GreaterThan(50));
         }

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/PortalLayersPlaybackTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/PortalLayersPlaybackTests.cs
@@ -3,6 +3,8 @@ using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
 using UnityEngine.UIElements;
+using Velvet.TestUtilities;
+using static Velvet.TestUtilities.PlayModeRealtimeTestHelpers;
 
 namespace Velvet.Tests
 {
@@ -20,22 +22,21 @@ namespace Velvet.Tests
         private ThemeStyleSheet _themeB;
         private RenderTexture _cameraRt;
         private MountedTree _mounted;
-        private int _savedTargetFrameRate;
+        private TargetFrameRateScope _frameRateScope;
 
         private static StateUpdater<int> s_bump;
 
         [UnitySetUp]
         public IEnumerator UnitySetUp()
         {
-            _savedTargetFrameRate = Application.targetFrameRate;
-            Application.targetFrameRate = 120;
+            _frameRateScope = new TargetFrameRateScope(120);
             yield break;
         }
 
         [UnityTearDown]
         public IEnumerator UnityTearDown()
         {
-            Application.targetFrameRate = _savedTargetFrameRate;
+            _frameRateScope.Dispose();
             _mounted?.Dispose();
             _mounted = null;
             if (_docGo != null) Object.Destroy(_docGo);
@@ -60,15 +61,6 @@ namespace Velvet.Tests
             }
             doc.panelSettings = _settings;
             return doc.rootVisualElement;
-        }
-
-        private static IEnumerator WaitRealtime(double seconds)
-        {
-            var deadline = Time.realtimeSinceStartupAsDouble + seconds;
-            while (Time.realtimeSinceStartupAsDouble < deadline)
-            {
-                yield return null;
-            }
         }
 
         // The framework host is whichever live UIDocument's tree contains the marker element.
@@ -134,18 +126,12 @@ namespace Velvet.Tests
             yield return WaitRealtime(0.6);
 
             // Assert — the camera's output carries the panel's red pixels.
-            var prev = RenderTexture.active;
-            RenderTexture.active = _cameraRt;
-            var tex = new Texture2D(200, 200, TextureFormat.RGBA32, false);
-            tex.ReadPixels(new Rect(0, 0, 200, 200), 0, 0);
-            tex.Apply();
-            RenderTexture.active = prev;
+            var pixels = RenderTexturePixelReader.ReadPixels(_cameraRt, new RectInt(0, 0, 200, 200));
             var redPixels = 0;
-            foreach (var p in tex.GetPixels32())
+            foreach (var p in pixels)
             {
                 if (p.r > 140 && p.g < 90 && p.b < 90) redPixels++;
             }
-            Object.Destroy(tex);
             Assert.That(redPixels, Is.GreaterThan(50));
         }
 

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/SceneViewPlaybackTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/SceneViewPlaybackTests.cs
@@ -3,6 +3,8 @@ using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
 using UnityEngine.UIElements;
+using Velvet.TestUtilities;
+using static Velvet.TestUtilities.PlayModeRealtimeTestHelpers;
 
 namespace Velvet.Tests
 {
@@ -15,30 +17,26 @@ namespace Velvet.Tests
     internal sealed class SceneViewPlaybackTests
     {
         private GameObject _cameraGo;
-        private GameObject _docGo;
-        private PanelSettings _settings;
-        private RenderTexture _panelRt;
+        private RenderTexturePanelHost _host;
         private MountedTree _mounted;
-        private int _savedTargetFrameRate;
+        private TargetFrameRateScope _frameRateScope;
 
         [UnitySetUp]
         public IEnumerator UnitySetUp()
         {
-            _savedTargetFrameRate = Application.targetFrameRate;
-            Application.targetFrameRate = 120;
+            _frameRateScope = new TargetFrameRateScope(120);
             yield break;
         }
 
         [UnityTearDown]
         public IEnumerator UnityTearDown()
         {
-            Application.targetFrameRate = _savedTargetFrameRate;
+            _frameRateScope.Dispose();
             _mounted?.Dispose();
             _mounted = null;
-            if (_docGo != null) Object.Destroy(_docGo);
             if (_cameraGo != null) Object.Destroy(_cameraGo);
-            if (_settings != null) Object.Destroy(_settings);
-            if (_panelRt != null) { _panelRt.Release(); Object.Destroy(_panelRt); }
+            _host?.Dispose();
+            _host = null;
             yield return null;
         }
 
@@ -54,39 +52,17 @@ namespace Velvet.Tests
 
         private VisualElement MountPanelWithSceneView(Camera cam)
         {
-            _panelRt = new RenderTexture(400, 300, 32);
-            _docGo = new GameObject("SceneViewPanel");
-            var doc = _docGo.AddComponent<UIDocument>();
-            _settings = ScriptableObject.CreateInstance<PanelSettings>();
-            _settings.scaleMode = PanelScaleMode.ConstantPixelSize;
-            _settings.targetTexture = _panelRt;
-            doc.panelSettings = _settings;
-            _mounted = V.Mount(doc.rootVisualElement,
+            _host = new RenderTexturePanelHost("SceneViewPanel", 400, 300);
+            _mounted = V.Mount(_host.Root,
                 V.SceneView(cam, className: "w-[200px] h-[150px]", name: "sv"));
-            return doc.rootVisualElement;
+            return _host.Root;
         }
 
         private Color32 SamplePanelCenterOfElement()
         {
-            var prev = RenderTexture.active;
-            RenderTexture.active = _panelRt;
-            var tex = new Texture2D(1, 1, TextureFormat.RGBA32, false);
             // The element sits at the panel's top-left; sample its center (ReadPixels is bottom-origin).
-            tex.ReadPixels(new Rect(100, 300 - 75, 1, 1), 0, 0);
-            tex.Apply();
-            RenderTexture.active = prev;
-            var c = tex.GetPixel(0, 0);
-            Object.Destroy(tex);
-            return c;
-        }
-
-        private static IEnumerator WaitRealtime(double seconds)
-        {
-            var deadline = Time.realtimeSinceStartupAsDouble + seconds;
-            while (Time.realtimeSinceStartupAsDouble < deadline)
-            {
-                yield return null;
-            }
+            var pixels = RenderTexturePixelReader.ReadPixels(_host.TargetTexture, new RectInt(100, 300 - 75, 1, 1));
+            return pixels[0];
         }
 
         [UnityTest]

--- a/Packages/com.velvet.core/TestUtilities/RenderTexturePanelHost.cs
+++ b/Packages/com.velvet.core/TestUtilities/RenderTexturePanelHost.cs
@@ -13,31 +13,28 @@ namespace Velvet.TestUtilities
     /// </summary>
     public sealed class RenderTexturePanelHost : IDisposable
     {
-        private readonly GameObject _gameObject;
+        private readonly UIDocument _document;
         private readonly PanelSettings _settings;
-
-        public UIDocument Document { get; }
 
         /// <summary>The RenderTexture the panel's PanelSettings renders into.</summary>
         public RenderTexture TargetTexture { get; }
 
         /// <summary>The panel's root, ready to V.Mount a VNode tree onto.</summary>
-        public VisualElement Root => Document.rootVisualElement;
+        public VisualElement Root => _document.rootVisualElement;
 
         public RenderTexturePanelHost(string name, int width, int height, int depth = 32)
         {
             TargetTexture = new RenderTexture(width, height, depth);
-            _gameObject = new GameObject(name);
-            Document = _gameObject.AddComponent<UIDocument>();
+            _document = new GameObject(name).AddComponent<UIDocument>();
             _settings = ScriptableObject.CreateInstance<PanelSettings>();
             _settings.scaleMode = PanelScaleMode.ConstantPixelSize;
             _settings.targetTexture = TargetTexture;
-            Document.panelSettings = _settings;
+            _document.panelSettings = _settings;
         }
 
         public void Dispose()
         {
-            if (_gameObject != null) UnityEngine.Object.Destroy(_gameObject);
+            if (_document != null) UnityEngine.Object.Destroy(_document.gameObject);
             if (_settings != null) UnityEngine.Object.Destroy(_settings);
             if (TargetTexture != null)
             {
@@ -58,16 +55,25 @@ namespace Velvet.TestUtilities
         public static Color32[] ReadPixels(RenderTexture renderTexture, RectInt region)
         {
             var previouslyActive = RenderTexture.active;
-            RenderTexture.active = renderTexture;
-
             var texture = new Texture2D(region.width, region.height, TextureFormat.RGBA32, false);
-            texture.ReadPixels(new Rect(region.x, region.y, region.width, region.height), 0, 0);
-            texture.Apply();
-            RenderTexture.active = previouslyActive;
-
-            var pixels = texture.GetPixels32();
-            UnityEngine.Object.Destroy(texture);
-            return pixels;
+            try
+            {
+                RenderTexture.active = renderTexture;
+                texture.ReadPixels(new Rect(region.x, region.y, region.width, region.height), 0, 0);
+                texture.Apply();
+                return texture.GetPixels32();
+            }
+            finally
+            {
+                RenderTexture.active = previouslyActive;
+                UnityEngine.Object.Destroy(texture);
+            }
         }
+
+        /// <summary>
+        /// Whether a sampled pixel reads as the saturated red used by the SceneView/Particles playback
+        /// specs' test materials — a fixed threshold wide enough to absorb sRGB/anti-aliasing drift.
+        /// </summary>
+        public static bool IsRedPixel(Color32 pixel) => pixel.r > 140 && pixel.g < 90 && pixel.b < 90;
     }
 }

--- a/Packages/com.velvet.core/TestUtilities/RenderTexturePanelHost.cs
+++ b/Packages/com.velvet.core/TestUtilities/RenderTexturePanelHost.cs
@@ -1,0 +1,73 @@
+using System;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace Velvet.TestUtilities
+{
+    /// <summary>
+    /// Builds a UIDocument-backed runtime panel whose PanelSettings targets a RenderTexture, so a
+    /// PlayMode fixture can read back what the panel actually drew. Previously hand-rolled per fixture
+    /// across the SceneView and Particles playback specs: a GameObject + UIDocument + PanelSettings +
+    /// RenderTexture, wired up and torn down the same way each time.
+    /// Test-only. Must not be used from production code.
+    /// </summary>
+    public sealed class RenderTexturePanelHost : IDisposable
+    {
+        private readonly GameObject _gameObject;
+        private readonly PanelSettings _settings;
+
+        public UIDocument Document { get; }
+
+        /// <summary>The RenderTexture the panel's PanelSettings renders into.</summary>
+        public RenderTexture TargetTexture { get; }
+
+        /// <summary>The panel's root, ready to V.Mount a VNode tree onto.</summary>
+        public VisualElement Root => Document.rootVisualElement;
+
+        public RenderTexturePanelHost(string name, int width, int height, int depth = 32)
+        {
+            TargetTexture = new RenderTexture(width, height, depth);
+            _gameObject = new GameObject(name);
+            Document = _gameObject.AddComponent<UIDocument>();
+            _settings = ScriptableObject.CreateInstance<PanelSettings>();
+            _settings.scaleMode = PanelScaleMode.ConstantPixelSize;
+            _settings.targetTexture = TargetTexture;
+            Document.panelSettings = _settings;
+        }
+
+        public void Dispose()
+        {
+            if (_gameObject != null) UnityEngine.Object.Destroy(_gameObject);
+            if (_settings != null) UnityEngine.Object.Destroy(_settings);
+            if (TargetTexture != null)
+            {
+                TargetTexture.Release();
+                UnityEngine.Object.Destroy(TargetTexture);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Reads pixels back from a RenderTexture via a throwaway Texture2D, saving and restoring
+    /// RenderTexture.active around the read. Previously hand-rolled per fixture across the
+    /// SceneView/Particles/Portal playback specs.
+    /// Test-only. Must not be used from production code.
+    /// </summary>
+    public static class RenderTexturePixelReader
+    {
+        public static Color32[] ReadPixels(RenderTexture renderTexture, RectInt region)
+        {
+            var previouslyActive = RenderTexture.active;
+            RenderTexture.active = renderTexture;
+
+            var texture = new Texture2D(region.width, region.height, TextureFormat.RGBA32, false);
+            texture.ReadPixels(new Rect(region.x, region.y, region.width, region.height), 0, 0);
+            texture.Apply();
+            RenderTexture.active = previouslyActive;
+
+            var pixels = texture.GetPixels32();
+            UnityEngine.Object.Destroy(texture);
+            return pixels;
+        }
+    }
+}

--- a/Packages/com.velvet.core/TestUtilities/RenderTexturePanelHost.cs.meta
+++ b/Packages/com.velvet.core/TestUtilities/RenderTexturePanelHost.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 442f7d0e37889401c95712a9afa079e5

--- a/Packages/com.velvet.core/TestUtilities/TargetFrameRateScope.cs
+++ b/Packages/com.velvet.core/TestUtilities/TargetFrameRateScope.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections;
+using UnityEngine;
+
+namespace Velvet.TestUtilities
+{
+    /// <summary>
+    /// Raises Application.targetFrameRate for the scope's lifetime and restores the previous value on
+    /// Dispose. PlayMode fixtures that assert on real elapsed time (camera/particle playback) bump the
+    /// frame rate so their realtime waits resolve in fewer, more predictable frames; previously each
+    /// fixture saved and restored the value by hand in UnitySetUp/UnityTearDown.
+    /// Test-only. Must not be used from production code.
+    /// </summary>
+    public readonly struct TargetFrameRateScope : IDisposable
+    {
+        private readonly int _previous;
+
+        public TargetFrameRateScope(int frameRate)
+        {
+            _previous = Application.targetFrameRate;
+            Application.targetFrameRate = frameRate;
+        }
+
+        public void Dispose()
+        {
+            Application.targetFrameRate = _previous;
+        }
+    }
+
+    /// <summary>
+    /// Shared realtime wait for PlayMode fixtures that assert on actual rendered/simulated output
+    /// rather than a fixed frame count. Previously duplicated verbatim across the SceneView/Particles/
+    /// Portal playback specs.
+    /// Test-only. Must not be used from production code.
+    /// </summary>
+    public static class PlayModeRealtimeTestHelpers
+    {
+        /// <summary>Yields until at least <paramref name="seconds"/> of realtime have elapsed.</summary>
+        public static IEnumerator WaitRealtime(double seconds)
+        {
+            var deadline = Time.realtimeSinceStartupAsDouble + seconds;
+            while (Time.realtimeSinceStartupAsDouble < deadline)
+            {
+                yield return null;
+            }
+        }
+    }
+}

--- a/Packages/com.velvet.core/TestUtilities/TargetFrameRateScope.cs.meta
+++ b/Packages/com.velvet.core/TestUtilities/TargetFrameRateScope.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e2e863f07126446299414706044bea98


### PR DESCRIPTION
## Summary
- Extract `RenderTexturePanelHost` and `TargetFrameRateScope` shared PlayMode test helpers into `Packages/com.velvet.core/TestUtilities/`
- Migrate `SceneViewPlaybackTests`, `ParticlesPlaybackTests`, and the RT-driven part of `PortalLayersPlaybackTests` onto them

Test-only change, no production behavior touched. Closes #33.

## Test plan
- [x] Migrated fixtures: 15/15
- [x] Full EditMode: 2748/2749 (1 known environment-sensitive failure in `VNodePoolZeroAllocTests`, which the fixture itself documents as CI-skipped and local-only-sensitive; unrelated to this diff — reproduced independently both in isolation and across two full-suite runs)
- [x] Full PlayMode: 42/42