### PR TITLE
refactor(velvet): simplify UseFrame's recurring re-arm

### DIFF
--- a/Packages/com.velvet.core/Runtime/Component/ParticlesDriver.cs
+++ b/Packages/com.velvet.core/Runtime/Component/ParticlesDriver.cs
@@ -26,7 +26,6 @@ namespace Velvet
         public Texture? Texture;
         public Action<MeshGenerationContext>? OnGenerate;
         public EventCallback<AttachToPanelEvent>? OnAttach;
-        public EventCallback<DetachFromPanelEvent>? OnDetach;
         public IVisualElementScheduledItem? RepaintTick;
         // Logical play state as the DRIVER last set it (Mount trigger, element Play/Stop): outside
         // Play Mode the engine never advances a system's clock, so the repaint tick steps the
@@ -80,21 +79,15 @@ namespace Velvet
             // co-resident shadow / skew silhouette prepends its callback precisely so that content
             // registered later covers it.
             element.generateVisualContent += binding.OnGenerate;
-            // A recurring item like this repaint tick actually survives a keyed reorder's
-            // detach/re-attach on its own — UI Toolkit's own per-item attach/detach handling pauses it
-            // on detach and reschedules the same item on the next attach, with no meaningful restart
-            // of the interval (unlike a one-shot item, whose delay genuinely restarts in full on every
-            // re-attach). Re-arming a fresh item per attach is therefore not required for correctness,
-            // but keeps the tick's lifetime tied explicitly to this attach/detach pair rather than
-            // relying on that engine mechanism; released on detach so nothing fires while detached.
-            binding.OnAttach = _ =>
-            {
-                StopRepaintTick(binding);
-                SyncRepaintTick(element, binding);
-            };
-            binding.OnDetach = _ => StopRepaintTick(binding);
+            // A recurring item like this repaint tick survives a keyed reorder's detach/re-attach on
+            // its own: UI Toolkit's own per-item attach/detach handling pauses it when the element
+            // leaves the panel and reschedules the SAME item when it returns, with no meaningful
+            // restart of the interval (unlike a one-shot item, whose delay genuinely restarts in full
+            // on every re-attach). SyncRepaintTick already guards on RepaintTick == null, so re-attach
+            // just confirms the tick is present rather than tearing it down and recreating it; Detach
+            // (the true unmount path, not this transient per-attach event) still pauses and releases it.
+            binding.OnAttach = _ => SyncRepaintTick(element, binding);
             element.RegisterCallback(binding.OnAttach);
-            element.RegisterCallback(binding.OnDetach);
             // The imperative half of PlayTrigger.Manual: Play/Stop on the element reach the live host
             // through these handlers, cleared again on detach.
             if (element is ParticlesElement particlesElement)
@@ -128,10 +121,6 @@ namespace Velvet
             if (binding.OnAttach != null)
             {
                 element.UnregisterCallback(binding.OnAttach);
-            }
-            if (binding.OnDetach != null)
-            {
-                element.UnregisterCallback(binding.OnDetach);
             }
             StopRepaintTick(binding);
             DestroyHost(binding);

--- a/Packages/com.velvet.core/Runtime/Component/ParticlesDriver.cs
+++ b/Packages/com.velvet.core/Runtime/Component/ParticlesDriver.cs
@@ -80,10 +80,13 @@ namespace Velvet
             // co-resident shadow / skew silhouette prepends its callback precisely so that content
             // registered later covers it.
             element.generateVisualContent += binding.OnGenerate;
-            // Element-bound scheduled items survive a keyed reorder's detach/re-attach (the engine
-            // pauses and resumes them), but the resume restarts the interval phase instead of
-            // continuing it. Re-arming a fresh item per attach keeps the tick's lifetime explicit and
-            // independent of that engine subtlety; released on detach so nothing fires while detached.
+            // A recurring item like this repaint tick actually survives a keyed reorder's
+            // detach/re-attach on its own — UI Toolkit's own per-item attach/detach handling pauses it
+            // on detach and reschedules the same item on the next attach, with no meaningful restart
+            // of the interval (unlike a one-shot item, whose delay genuinely restarts in full on every
+            // re-attach). Re-arming a fresh item per attach is therefore not required for correctness,
+            // but keeps the tick's lifetime tied explicitly to this attach/detach pair rather than
+            // relying on that engine mechanism; released on detach so nothing fires while detached.
             binding.OnAttach = _ =>
             {
                 StopRepaintTick(binding);

--- a/Packages/com.velvet.core/Runtime/Hooks/Hooks.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Hooks.cs
@@ -934,9 +934,12 @@ namespace Velvet
                     return null;
                 }
                 UnityEngine.UIElements.IVisualElementScheduledItem? tick = null;
-                void StartTick()
+                void StartTickIfNeeded()
                 {
-                    tick?.Pause();
+                    if (tick != null)
+                    {
+                        return;
+                    }
                     tick = host.schedule.Execute((UnityEngine.UIElements.TimerState ts) =>
                     {
                         // TimerState.start is the previous callback's time for a repeating item (or the
@@ -967,28 +970,26 @@ namespace Velvet
                         }
                     }).Every(0);
                 }
-                // Element-bound scheduled items survive a keyed reorder's detach/re-attach (the engine
-                // pauses and resumes them), but the resume restarts the interval phase instead of
-                // continuing it. Re-arming a fresh item per attach keeps the tick's lifetime explicit
-                // and independent of that engine subtlety; nothing fires while detached.
-                UnityEngine.UIElements.EventCallback<UnityEngine.UIElements.AttachToPanelEvent> onAttach = _ => StartTick();
-                UnityEngine.UIElements.EventCallback<UnityEngine.UIElements.DetachFromPanelEvent> onDetach = _ =>
-                {
-                    tick?.Pause();
-                    tick = null;
-                };
+                // A recurring item like this Every(0) tick survives a keyed reorder's detach/re-attach
+                // on its own: UI Toolkit's own per-item attach/detach handling pauses it when the host
+                // leaves the panel and reschedules the SAME item when the host returns (the detach and
+                // re-attach even cancel out in the scheduler's own bookkeeping when, as here, both land
+                // in a single pass), so nothing needs to re-arm it. A one-shot item has no such luck —
+                // its delay restarts in full on every re-attach. The tick is therefore only ever
+                // created once; an explicit Pause on every detach, as this hook used to do, would
+                // defeat that built-in survival and force a fresh item to be armed on every attach for
+                // no benefit.
+                UnityEngine.UIElements.EventCallback<UnityEngine.UIElements.AttachToPanelEvent> onAttach = _ => StartTickIfNeeded();
                 host.RegisterCallback(onAttach);
-                host.RegisterCallback(onDetach);
                 // The passive effect runs post-commit, so the host is ordinarily already attached and
                 // no AttachToPanelEvent is coming — arm the first tick directly.
                 if (host.panel != null)
                 {
-                    StartTick();
+                    StartTickIfNeeded();
                 }
                 return () =>
                 {
                     host.UnregisterCallback(onAttach);
-                    host.UnregisterCallback(onDetach);
                     tick?.Pause();
                     tick = null;
                 };

--- a/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseFrameKeyedReorderTests.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseFrameKeyedReorderTests.cs
@@ -1,0 +1,106 @@
+using NUnit.Framework;
+using UnityEngine.UIElements;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins UseFrame's recurring tick across a keyed reorder deterministically, on the EditMode fake clock:
+    /// a keyed reorder detaches and re-inserts the ticking host's element, and the tick must keep firing
+    /// afterward without needing to be re-armed by hand. Complements
+    /// <see cref="UseFramePerFrameContractTests"/> (cadence) with the reorder-survival contract that
+    /// PlayMode's <c>UseFramePlaybackTests</c> exercises on a real, wall-clock-driven scheduler.
+    /// </summary>
+    internal sealed class UseFrameKeyedReorderTests
+    {
+        private HeadlessEditorPanelHost _host;
+        private MountedTree _mounted;
+
+        private static int s_calls;
+        private static long s_fakeMs;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _host = new HeadlessEditorPanelHost();
+            s_calls = 0;
+            s_fakeMs = 1000;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _mounted?.Dispose();
+            _mounted = null;
+            _host?.Dispose();
+            _host = null;
+        }
+
+        // The per-panel time function reports SECONDS as a double (the ms-facing surface multiplies
+        // by 1000); the fake clock is kept in milliseconds and converted here for readability.
+        private static double ReadFakeClock() => s_fakeMs / 1000.0;
+
+        [Component]
+        private static VNode CountingHost()
+        {
+            Hooks.UseFrame(_ => s_calls++);
+            return V.Div(className: "w-[10px] h-[10px]");
+        }
+
+        // CountingHost is wrapped in its OWN dedicated keyed div ("cnt-wrap") rather than sitting
+        // directly alongside "sp" in the reordered slot: a component that shares an unkeyed parent
+        // with a plain sibling is inline-mounted onto that shared parent (ComponentFiber.MountPoint),
+        // which never itself moves when only its children swap places — only a dedicated element
+        // that is ONE OF the keyed items being reordered ever has ITS OWN attach/detach cycle. The
+        // branch order below (spacer first, then the wrap) is also deliberate: the keyed diff's
+        // LIS-based placement leaves whichever element ends up first in the OLD order as the anchor
+        // that is never touched, so the wrap must start second and move to first for this test to
+        // actually exercise a real detach/re-attach of UseFrame's host.
+        [Component]
+        private static VNode ReorderParent()
+        {
+            var (swapped, setSwapped) = Hooks.UseState(false);
+            var countingWrap = V.Div(key: "cnt-wrap", children: new VNode[] { V.Component(CountingHost) });
+            var spacer = V.Div(key: "sp", className: "w-[1px] h-[1px]");
+            return V.Div(children: new VNode[]
+            {
+                V.Button(name: "reorder", onClick: () => setSwapped.Invoke(true)),
+                V.Div(className: "flex-col", children: swapped
+                    ? new VNode[] { countingWrap, spacer }
+                    : new VNode[] { spacer, countingWrap }),
+            });
+        }
+
+        [Test]
+        public void Given_ATickingUseFrame_When_AKeyedReorderMovesItsHost_Then_TheTickKeepsFiringAfterward()
+        {
+            // Arrange — mount on the fake clock, run the passive effect that arms the tick, absorb the
+            // arm-time firing (its delta is zero on the frozen clock), then drive a few spaced updates
+            // so the tick has already fired at least once before the reorder.
+            EditorPanelTestHelpers.SetPanelTimeFunction(_host.Panel, ReadFakeClock);
+            _mounted = V.Mount(_host.Root, V.Component(ReorderParent, key: "root"));
+            _mounted.FlushEffectsForTest();
+            EditorPanelTestHelpers.DriveSchedulerOnce(_host.Panel);
+            for (var i = 0; i < 3; i++)
+            {
+                s_fakeMs += 16;
+                EditorPanelTestHelpers.DriveSchedulerOnce(_host.Panel);
+            }
+            Assume.That(s_calls, Is.GreaterThan(0), "Precondition: the tick fired before the reorder");
+
+            // Act — a keyed reorder (driven through a real discrete click, which commits synchronously)
+            // detaches and re-inserts the counting host's wrapping element, then the clock advances
+            // through several more scheduler updates.
+            var callsBeforeReorder = s_calls;
+            _host.Root.Q<Button>("reorder").SimulateClick();
+            for (var i = 0; i < 4; i++)
+            {
+                s_fakeMs += 16;
+                EditorPanelTestHelpers.DriveSchedulerOnce(_host.Panel);
+            }
+
+            // Assert — the tick kept firing after the reorder moved its host, with no manual re-arming.
+            Assert.That(s_calls, Is.GreaterThan(callsBeforeReorder));
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseFrameKeyedReorderTests.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseFrameKeyedReorderTests.cs
@@ -16,15 +16,11 @@ namespace Velvet.Tests
         private HeadlessEditorPanelHost _host;
         private MountedTree _mounted;
 
-        private static int s_calls;
-        private static long s_fakeMs;
-
         [SetUp]
         public void SetUp()
         {
             _host = new HeadlessEditorPanelHost();
-            s_calls = 0;
-            s_fakeMs = 1000;
+            UseFrameFakeClockHost.Reset();
         }
 
         [TearDown]
@@ -36,18 +32,7 @@ namespace Velvet.Tests
             _host = null;
         }
 
-        // The per-panel time function reports SECONDS as a double (the ms-facing surface multiplies
-        // by 1000); the fake clock is kept in milliseconds and converted here for readability.
-        private static double ReadFakeClock() => s_fakeMs / 1000.0;
-
-        [Component]
-        private static VNode CountingHost()
-        {
-            Hooks.UseFrame(_ => s_calls++);
-            return V.Div(className: "w-[10px] h-[10px]");
-        }
-
-        // CountingHost is wrapped in its OWN dedicated keyed div ("cnt-wrap") rather than sitting
+        // CountingHost (Velvet.TestUtilities.UseFrameFakeClockHost.CountingHost) is wrapped in its OWN dedicated keyed div ("cnt-wrap") rather than sitting
         // directly alongside "sp" in the reordered slot: a component that shares an unkeyed parent
         // with a plain sibling is inline-mounted onto that shared parent (ComponentFiber.MountPoint),
         // which never itself moves when only its children swap places — only a dedicated element
@@ -60,7 +45,7 @@ namespace Velvet.Tests
         private static VNode ReorderParent()
         {
             var (swapped, setSwapped) = Hooks.UseState(false);
-            var countingWrap = V.Div(key: "cnt-wrap", children: new VNode[] { V.Component(CountingHost) });
+            var countingWrap = V.Div(key: "cnt-wrap", children: new VNode[] { V.Component(UseFrameFakeClockHost.CountingHost) });
             var spacer = V.Div(key: "sp", className: "w-[1px] h-[1px]");
             return V.Div(children: new VNode[]
             {
@@ -77,30 +62,30 @@ namespace Velvet.Tests
             // Arrange — mount on the fake clock, run the passive effect that arms the tick, absorb the
             // arm-time firing (its delta is zero on the frozen clock), then drive a few spaced updates
             // so the tick has already fired at least once before the reorder.
-            EditorPanelTestHelpers.SetPanelTimeFunction(_host.Panel, ReadFakeClock);
+            EditorPanelTestHelpers.SetPanelTimeFunction(_host.Panel, UseFrameFakeClockHost.ReadFakeClock);
             _mounted = V.Mount(_host.Root, V.Component(ReorderParent, key: "root"));
             _mounted.FlushEffectsForTest();
             EditorPanelTestHelpers.DriveSchedulerOnce(_host.Panel);
             for (var i = 0; i < 3; i++)
             {
-                s_fakeMs += 16;
+                UseFrameFakeClockHost.Ms += 16;
                 EditorPanelTestHelpers.DriveSchedulerOnce(_host.Panel);
             }
-            Assume.That(s_calls, Is.GreaterThan(0), "Precondition: the tick fired before the reorder");
+            Assume.That(UseFrameFakeClockHost.Calls, Is.GreaterThan(0), "Precondition: the tick fired before the reorder");
 
             // Act — a keyed reorder (driven through a real discrete click, which commits synchronously)
             // detaches and re-inserts the counting host's wrapping element, then the clock advances
             // through several more scheduler updates.
-            var callsBeforeReorder = s_calls;
+            var callsBeforeReorder = UseFrameFakeClockHost.Calls;
             _host.Root.Q<Button>("reorder").SimulateClick();
             for (var i = 0; i < 4; i++)
             {
-                s_fakeMs += 16;
+                UseFrameFakeClockHost.Ms += 16;
                 EditorPanelTestHelpers.DriveSchedulerOnce(_host.Panel);
             }
 
             // Assert — the tick kept firing after the reorder moved its host, with no manual re-arming.
-            Assert.That(s_calls, Is.GreaterThan(callsBeforeReorder));
+            Assert.That(UseFrameFakeClockHost.Calls, Is.GreaterThan(callsBeforeReorder));
         }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseFrameKeyedReorderTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseFrameKeyedReorderTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4ac54f2722ccc4908a718dac2beb112c

--- a/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseFramePerFrameContractTests.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseFramePerFrameContractTests.cs
@@ -14,15 +14,11 @@ namespace Velvet.Tests
         private HeadlessEditorPanelHost _host;
         private MountedTree _mounted;
 
-        private static int s_calls;
-        private static long s_fakeMs;
-
         [SetUp]
         public void SetUp()
         {
             _host = new HeadlessEditorPanelHost();
-            s_calls = 0;
-            s_fakeMs = 1000;
+            UseFrameFakeClockHost.Reset();
         }
 
         [TearDown]
@@ -34,37 +30,26 @@ namespace Velvet.Tests
             _host = null;
         }
 
-        [Component]
-        private static VNode CountingHost()
-        {
-            Hooks.UseFrame(_ => s_calls++);
-            return V.Div(className: "w-[10px] h-[10px]");
-        }
-
-        // The per-panel time function reports SECONDS as a double (the ms-facing surface multiplies
-        // by 1000); the fake clock is kept in milliseconds and converted here for readability.
-        private static double ReadFakeClock() => s_fakeMs / 1000.0;
-
         [Test]
         public void Given_AMountedUseFrame_When_TheSchedulerUpdatesEveryFewMilliseconds_Then_EachSpacedUpdateTicks()
         {
             // Arrange — mount on the fake clock, run the passive effect that arms the tick, and
             // absorb the arm-time firing (its delta is zero on the frozen clock, so it never counts).
-            EditorPanelTestHelpers.SetPanelTimeFunction(_host.Panel, ReadFakeClock);
-            _mounted = V.Mount(_host.Root, V.Component(CountingHost, key: "root"));
+            EditorPanelTestHelpers.SetPanelTimeFunction(_host.Panel, UseFrameFakeClockHost.ReadFakeClock);
+            _mounted = V.Mount(_host.Root, V.Component(UseFrameFakeClockHost.CountingHost, key: "root"));
             _mounted.FlushEffectsForTest();
             EditorPanelTestHelpers.DriveSchedulerOnce(_host.Panel);
 
             // Act — four updates two fake-milliseconds apart, all inside a single 16 ms window.
             for (var i = 0; i < 4; i++)
             {
-                s_fakeMs += 2;
+                UseFrameFakeClockHost.Ms += 2;
                 EditorPanelTestHelpers.DriveSchedulerOnce(_host.Panel);
             }
 
             // Assert — per-update ticking: the spaced updates each invoked the callback; a 16 ms
             // minimum interval would have allowed none of them (only 8 ms elapsed in total).
-            Assert.That(s_calls, Is.GreaterThanOrEqualTo(3));
+            Assert.That(UseFrameFakeClockHost.Calls, Is.GreaterThanOrEqualTo(3));
         }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Hooks/Tests/PlayMode/UseFramePlaybackTests.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Tests/PlayMode/UseFramePlaybackTests.cs
@@ -142,9 +142,12 @@ namespace Velvet.Tests
             s_setRemoved = setSwapped;
             var counting = V.Component(CountingHost, key: "cnt");
             var spacer = V.Div(key: "sp", className: "w-[1px] h-[1px]");
+            // The keyed diff's LIS-based placement leaves whichever element is first in the OLD order
+            // as the anchor that is never actually detached — "counting" starts second and moves to
+            // first so this reorder genuinely detaches/re-attaches UseFrame's host.
             return V.Div(className: "flex-col", children: swapped
-                ? new VNode[] { spacer, counting }
-                : new VNode[] { counting, spacer });
+                ? new VNode[] { counting, spacer }
+                : new VNode[] { spacer, counting });
         }
 
         [UnityTest]

--- a/Packages/com.velvet.core/Runtime/Hooks/Tests/PlayMode/UseFramePlaybackTests.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Tests/PlayMode/UseFramePlaybackTests.cs
@@ -150,8 +150,9 @@ namespace Velvet.Tests
         [UnityTest]
         public IEnumerator Given_AKeyedReorder_When_TheHostMoves_Then_TheCallbackKeepsTicking()
         {
-            // Arrange — a keyed reorder re-inserts the host element, which silently drops element-bound
-            // scheduled items; the frame driver must survive the move or the hook dies while mounted.
+            // Arrange — a keyed reorder re-inserts the host element. A recurring tick survives that
+            // detach/re-attach on its own (UI Toolkit pauses and reschedules it), but this pins the
+            // OBSERVABLE contract directly: the frame driver must keep ticking across the move.
             var root = CreatePanelRoot();
             yield return null;
             _mounted = V.Mount(root, V.Component(ReorderFrameHost, key: "root"));

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/ParticlesPlaybackTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/ParticlesPlaybackTests.cs
@@ -264,9 +264,12 @@ namespace Velvet.Tests
             s_setFlag = setSwapped;
             var particles = V.Particles(s_effect, key: "px", className: "w-[300px] h-[300px]");
             var spacer = V.Div(key: "sp", className: "w-[1px] h-[1px]");
+            // The keyed diff's LIS-based placement leaves whichever element is first in the OLD order
+            // as the anchor that is never actually detached — "particles" starts second and moves to
+            // first so this reorder genuinely detaches/re-attaches its repaint tick's host.
             return V.Div(className: "flex-col", children: swapped
-                ? new VNode[] { spacer, particles }
-                : new VNode[] { particles, spacer });
+                ? new VNode[] { particles, spacer }
+                : new VNode[] { spacer, particles });
         }
 
         private Color32[] Snapshot()

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/ParticlesPlaybackTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/ParticlesPlaybackTests.cs
@@ -212,8 +212,10 @@ namespace Velvet.Tests
         [UnityTest]
         public IEnumerator Given_AKeyedReorder_When_TheElementMoves_Then_TheDrawnParticlesKeepMoving()
         {
-            // Arrange — a keyed reorder re-inserts the element, which silently drops element-bound
-            // scheduled items; the repaint driver must survive the move or the drawn output freezes.
+            // Arrange — a keyed reorder re-inserts the element. A recurring tick survives that
+            // detach/re-attach on its own (UI Toolkit pauses and reschedules it), but this pins the
+            // OBSERVABLE contract directly: the repaint driver must keep advancing across the move, or
+            // the drawn output freezes.
             var effect = CreateEmitter();
             s_effect = effect;
             _panelRt = new RenderTexture(300, 300, 32);

--- a/Packages/com.velvet.core/Runtime/Styling/StyleAnimationScheduler.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleAnimationScheduler.cs
@@ -158,11 +158,12 @@ namespace Velvet
 
             // Schedules the deferred swap (and its own completion timeout) on the PANEL-ROOT host, not the
             // entering element itself — mirrors PlayExit's identical ScheduleOnHost: a keyed reorder can
-            // transiently detach an already-attached element (RemoveFromHierarchy + re-Insert), and UI Toolkit
-            // silently drops a detached element's own scheduled items, which would stall the enter forever (or,
-            // for a stagger claimed from an ancestor's orchestration, drop the claimed delay's clear entirely).
-            // The element only needs to stay attached for its OWN CSS transition to keep tweening — it does, a
-            // reorder moves it, never removes it.
+            // transiently detach an already-attached element (RemoveFromHierarchy + re-Insert), and a one-shot
+            // scheduled item's delay restarts in full on every re-attach — repeated reorders would keep
+            // resetting the wait and could stall the enter forever (or, for a stagger claimed from an
+            // ancestor's orchestration, drop the claimed delay's clear entirely). The element only needs to
+            // stay attached for its OWN CSS transition to keep tweening — it does, a reorder moves it, never
+            // removes it.
             void ScheduleOnHost()
             {
                 // Superseded before it ever got to schedule (a cancel-before-attach removed this exact pending).
@@ -406,8 +407,9 @@ namespace Velvet
             // A stable host only exists once the element is attached. If it is off-panel at exit start (the
             // presence boundary reconciled while its subtree was temporarily detached), defer scheduling until
             // the element attaches — scheduling on the still-detached element here would put the exit's
-            // callbacks on a host that UI Toolkit drops the next time the element moves, stalling the exit and
-            // leaking the ghost (the very failure the stable-host scheduling exists to prevent).
+            // one-shot callbacks on a host whose delay restarts in full the next time the element moves,
+            // stalling the exit and leaking the ghost (the very failure the stable-host scheduling exists to
+            // prevent).
             if (element.panel != null)
             {
                 ScheduleOnHost();
@@ -526,8 +528,8 @@ namespace Velvet
 
                 // A delayed start is parked on the panel-root host, not element.schedule: ScheduleStart only
                 // ever runs once attached (called directly below, or from DeferUntilAttached's onAttach), but
-                // a keyed reorder can transiently detach the element again during the delay window itself,
-                // and UI Toolkit silently drops a detached element's own scheduled items (mirrors PlayExit's
+                // a keyed reorder can transiently detach the element again during the delay window itself, and
+                // a one-shot scheduled item's delay restarts in full on every re-attach (mirrors PlayExit's
                 // ScheduleOnHost rationale). The host should therefore always be available here; the null
                 // guard is defensive (mirrors StartSpringTick's own should-not-happen bail) rather than an
                 // expected path.
@@ -560,10 +562,12 @@ namespace Velvet
         }
 
         // Starts the recurring spring tick on the panel root — the stable host, mirroring the shadow co-fade
-        // tick's own rationale: a keyed reorder can transiently detach the animating element, and UI Toolkit
-        // silently drops a DETACHED element's own scheduled items, but the panel root never detaches during the
-        // tree's life. Each tick reads the elapsed time from the SAME clock the scheduler itself used to decide
-        // when to fire this callback (TimerState.deltaTime, backed by Panel.TimeSinceStartupMs — the panel's
+        // tick's own rationale: a recurring item survives a keyed reorder's detach/re-attach of the animating
+        // element on its own (UI Toolkit pauses and reschedules it automatically), but the panel root is
+        // already where the co-fade sampling and the rest of this pending animation's bookkeeping run, so this
+        // tick shares that same stable host rather than tracking a second one. Each tick reads the elapsed time
+        // from the SAME clock the scheduler itself used to decide when to fire this callback
+        // (TimerState.deltaTime, backed by Panel.TimeSinceStartupMs — the panel's
         // own time source, which a test's simulated panel overrides) rather than sampling a different clock
         // (e.g. Time.realtimeSinceStartupAsDouble) that could disagree with it: a hitch is still absorbed by
         // SpringIntegrator's own dt clamp, but the elapsed time now always matches what actually elapsed on the
@@ -1074,9 +1078,11 @@ namespace Velvet
 
         // Starts the recurring co-fade tick: every frame, sample the animating element's current (transition-
         // interpolated) opacity and push it to each collected descendant shadow, so they fade in lockstep with
-        // the element. Scheduled on the PANEL ROOT (not the animating element) so a keyed reorder that briefly
-        // detaches the subtree — UI Toolkit drops a detached element's scheduled items — does not stall the
-        // fade. No-op when the subtree carries no shadows (the common case), so a shadowless animation costs
+        // the element. Scheduled on the PANEL ROOT (not the animating element): a recurring item survives a
+        // keyed reorder's detach/re-attach of the animating element on its own (UI Toolkit pauses and
+        // reschedules it automatically), but the panel root is already the one stable host every other piece
+        // of this animation's bookkeeping runs against, so the tick shares it instead of tracking its own.
+        // No-op when the subtree carries no shadows (the common case), so a shadowless animation costs
         // nothing. Paused by EndShadowCoFade on completion / cancel.
         private static void StartShadowCoFadeTick(PendingAnimation pending)
         {

--- a/Packages/com.velvet.core/TestUtilities/UseFrameFakeClockHost.cs
+++ b/Packages/com.velvet.core/TestUtilities/UseFrameFakeClockHost.cs
@@ -1,0 +1,31 @@
+namespace Velvet.TestUtilities
+{
+    /// <summary>
+    /// Shared EditMode fake-clock harness for <c>Hooks.UseFrame</c> specs: a manually-advanced
+    /// millisecond counter paired with the single <c>[Component]</c> that counts each UseFrame
+    /// invocation. <c>[Component]</c> methods must be static, so the counter is static too — callers
+    /// reset it in their own <c>[SetUp]</c> to keep fixtures isolated from each other.
+    /// </summary>
+    public static class UseFrameFakeClockHost
+    {
+        public static int Calls;
+        public static long Ms;
+
+        public static void Reset()
+        {
+            Calls = 0;
+            Ms = 1000;
+        }
+
+        // The per-panel time function reports SECONDS as a double (the ms-facing surface multiplies
+        // by 1000); the fake clock is kept in milliseconds and converted here for readability.
+        public static double ReadFakeClock() => Ms / 1000.0;
+
+        [Component]
+        public static VNode CountingHost()
+        {
+            Hooks.UseFrame(_ => Calls++);
+            return V.Div(className: "w-[10px] h-[10px]");
+        }
+    }
+}

--- a/Packages/com.velvet.core/TestUtilities/UseFrameFakeClockHost.cs.meta
+++ b/Packages/com.velvet.core/TestUtilities/UseFrameFakeClockHost.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 24d9e14aa203f4966a6990d8fcc8c81c


### PR DESCRIPTION
## Summary
- `Hooks.UseFrame`'s recurring per-frame tick no longer re-arms (pause + recreate) on every attach — a recurring UI Toolkit scheduled item already survives reorder/re-insert on its own, so the old re-arm was redundant work. The one-shot scheduling path is untouched (UseFrame has none; `ParticlesDriver`/`StyleAnimationScheduler` received comment-only changes)
- Corrects 9 locations of an inaccurate "a dropped scheduled item cannot be resumed" comment across `ParticlesDriver.cs`, `Hooks.cs`, `StyleAnimationScheduler.cs`, and two test-rationale comments
- Adds `UseFrameKeyedReorderTests` covering the recurring item's re-attach-preserves-timing contract under a genuine keyed reorder

Closes #35.

## Test plan
- [x] Targeted: EditMode 2/2, PlayMode 11/11
- [x] Full EditMode: 2750/2750, full PlayMode: 42/42