### PR TITLE
fix(velvet): patch-compatibility gate on VirtualList's same-key fast path

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `V.VirtualList`: a same-key item whose node type changes across a re-render (e.g. a slot
+  swapping from `V.Label` to `V.SceneView` while keeping the same key) is now created fresh
+  instead of patched onto the old element — the fast path was missing the type-compatibility
+  check the general keyed reconcile path already applies before reusing an element.
+
 ## [1.3.0] - 2026-07-13
 
 ### Added

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/VirtualListTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/VirtualListTests.cs
@@ -197,6 +197,38 @@ namespace Velvet.Tests
             Assert.That(Reconciler.Context.ClipPathBindings.Count, Is.EqualTo(visibleContainer.childCount));
         }
 
+        [Test]
+        public void Given_MountedVirtualListItem_When_SameKeyRendersADifferentNodeType_Then_TheNewTypeIsCreatedInstead()
+        {
+            // Arrange: item 0 first renders as a Label under key "item-0".
+            var node1 = V.VirtualList(
+                items: CreateItems(10),
+                keySelector: item => item.Id,
+                itemHeight: 50f,
+                renderer: item => V.Label(text: item.Name, key: item.Id),
+                overscan: 0);
+            var scrollView = new ScrollView(ScrollViewMode.Vertical);
+            using var controller = new FiberVirtualListController(scrollView, node1, Reconciler);
+            controller.UpdateVisibleRange(scrollY: 0f, viewportHeight: 200f);
+            var visibleContainer = scrollView.contentContainer.ElementAt(1);
+            Assume.That(visibleContainer.ElementAt(0), Is.InstanceOf<Label>(), "Precondition: item 0 first renders as a Label");
+
+            // Act: the same key now renders as a Div — a same-key type flip, applied via Update (not a fresh mount).
+            // ForceRefresh resets the tracked range but only re-renders once _viewportHeight is known (normally
+            // set by a live GeometryChangedEvent), so re-supply the range directly, as the other tests do.
+            var node2 = V.VirtualList(
+                items: CreateItems(10),
+                keySelector: item => item.Id,
+                itemHeight: 50f,
+                renderer: item => V.Div(key: item.Id),
+                overscan: 0);
+            controller.Update(node2);
+            controller.UpdateVisibleRange(scrollY: 0f, viewportHeight: 200f);
+
+            // Assert: item 0 is a fresh VisualElement, not the old Label patched in place.
+            Assert.That(visibleContainer.ElementAt(0).GetType(), Is.EqualTo(typeof(VisualElement)));
+        }
+
         #endregion
 
         #region Context inheritance

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberVirtualListController.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberVirtualListController.cs
@@ -230,7 +230,8 @@ namespace Velvet
                     vnode.Key ??= key;
                     newNodes[i] = vnode;
 
-                    if (_oldNodesByKey.TryGetValue(key, out var existing))
+                    var hasExisting = _oldNodesByKey.TryGetValue(key, out var existing);
+                    if (hasExisting && ReconcileKeying.CanPatch(existing.node, vnode))
                     {
                         // Store the patch's RETURN: a class-driven wrap/unwrap (shadow-*/clip-path-*)
                         // swaps the slot's top-level element, and re-mounting a stale reference would
@@ -239,7 +240,16 @@ namespace Velvet
                     }
                     else
                     {
-                        newElements[i] = _reconciler.CreateElementForController(vnode);
+                        // A same-key type flip (CanPatch=false) is a replacement, not a patch — mirroring
+                        // the general keyed diff path's create-before-dispose ordering: a throw while
+                        // constructing the replacement element leaves the old one intact instead of the
+                        // slot holding nothing recoverable.
+                        var replacement = _reconciler.CreateElementForController(vnode);
+                        if (hasExisting)
+                        {
+                            _reconciler.CleanupElementForController(existing.element);
+                        }
+                        newElements[i] = replacement;
                     }
 
                     // Stamp this item's newly created fibers with its own vnode so an isolated re-render can


### PR DESCRIPTION
## Summary
- `VirtualList`'s item reuse fast path now checks `ReconcileKeying.CanPatch` before patching a same-key item in place, matching the general keyed reconcile path's contract — a slot whose renderer swaps node type across a re-render (e.g. `V.Label` to `V.SceneView`) while keeping the same key is now created fresh instead of patched onto the stale element
- Orders the replacement path as create-then-dispose (matching the general path's own ordering), so a throw while constructing the replacement leaves the old element intact instead of losing both

Closes #29.

## Test plan
- [x] RED confirmed without the fix, GREEN with it
- [x] Full EditMode: 2750/2750, full PlayMode: 42/42