### PR TITLE
perf: quantize V.SceneView's RenderTexture resize to avoid reallocation churn

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `V.SceneView`: the owned RenderTexture's backing resolution now rounds up to the nearest 16px
+  step instead of matching the element's laid-out pixel size exactly, so small, rapid resizes (a
+  drag-resize, an animated layout) reuse the existing texture instead of reallocating on every
+  change. The displayed output is unaffected — only the texture's internal resolution changes.
+
 ### Fixed
 
 - `V.VirtualList`: a same-key item whose node type changes across a re-render (e.g. a slot

--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -9,10 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `V.SceneView`: the owned RenderTexture's backing resolution now rounds up to the nearest 16px
-  step instead of matching the element's laid-out pixel size exactly, so small, rapid resizes (a
-  drag-resize, an animated layout) reuse the existing texture instead of reallocating on every
-  change. The displayed output is unaffected — only the texture's internal resolution changes.
+- `V.SceneView`: the owned RenderTexture's backing resolution now rounds its larger axis up to the
+  nearest 16px step (rescaling the other axis by the same factor, so the texture's aspect ratio
+  still matches the element's) instead of matching the element's laid-out pixel size exactly, so
+  small, rapid resizes that keep the element's aspect ratio unchanged (a drag-resize, an animated
+  layout) reuse the existing texture instead of reallocating on every change.
 
 ### Fixed
 

--- a/Packages/com.velvet.core/Runtime/Component/SceneViewDriver.cs
+++ b/Packages/com.velvet.core/Runtime/Component/SceneViewDriver.cs
@@ -29,7 +29,8 @@ namespace Velvet
 
     /// <summary>
     /// Drives a <see cref="SceneViewElement"/>'s camera-output display: a framework-owned
-    /// RenderTexture created at the element's laid-out pixel size (times the resolution scale),
+    /// RenderTexture sized to the element's laid-out pixel size (times the resolution scale, rounded
+    /// up to reuse the existing texture across minor resizes — see <see cref="TryComputePixelSize"/>),
     /// assigned to <c>camera.targetTexture</c>, and shown through the element's background image. The
     /// element samples the LIVE texture — the camera keeps rendering into it and UI Toolkit's command
     /// list samples it at draw time, so new frames appear with no Velvet re-render and no pixel copy.
@@ -46,13 +47,13 @@ namespace Velvet
         // universally supported.
         private const int MaxTextureSize = 4096;
 
-        // The pixel-size rounding grain TryComputePixelSize quantizes up to. 16 divides
-        // MaxTextureSize evenly (4096 / 16 = 256), so the ceiling clamp and this step never leave a
-        // leftover partial bucket at the boundary. Large enough to absorb the few-pixels-per-frame
-        // deltas a drag-resize or an animated layout produces — so most jitter keeps landing on the
-        // same bucket and reuses the existing RenderTexture instead of reallocating — while small
-        // enough that the worst-case 15px-per-axis overshoot is negligible against any on-screen
-        // SceneView size.
+        // The pixel-size rounding grain TryComputePixelSize quantizes the larger axis up to. 16
+        // divides MaxTextureSize evenly (4096 / 16 = 256), so the ceiling clamp and this step never
+        // leave a leftover partial bucket at the boundary. Large enough to absorb the
+        // few-pixels-per-frame deltas a drag-resize or an animated layout produces — so most jitter
+        // keeps landing on the same bucket and reuses the existing RenderTexture instead of
+        // reallocating — while small enough that the worst-case 15px overshoot is negligible against
+        // any on-screen SceneView size.
         private const int SizeQuantizationStep = 16;
 
         // Wires the geometry-driven texture sync onto the element and returns the binding. The
@@ -178,12 +179,19 @@ namespace Velvet
         // zero-dimension texture (which RenderTexture creation rejects); the ceiling bounds the VRAM
         // request like the sibling texture bakers bound theirs — applied as ONE shared shrink when
         // either axis overflows, because clamping each axis independently would change the texture's
-        // aspect and distort the camera picture. The result is then quantized UP to
-        // SizeQuantizationStep: minor layout jitter (a drag-resize, an animated layout moving a
-        // handful of pixels a frame) keeps landing on the SAME quantized size, so SyncTexture's
-        // exact-match reuse check hits instead of reallocating the RenderTexture on every change.
-        // Re-clamped to MaxTextureSize afterward — quantizing up could otherwise carry a
-        // near-ceiling size into the next bucket past the cap.
+        // aspect and distort the camera picture.
+        //
+        // The result is then quantized for reuse-friendliness, but — for the same distort-the-picture
+        // reason the shrink above is careful about — NOT by rounding each axis up independently: since
+        // SceneViewDriver never pins camera.aspect, Unity derives the camera's render aspect straight
+        // from the texture's own width/height, so a texture whose aspect drifts from the element's
+        // true aspect renders the scene visibly skewed. Instead the LARGER axis is quantized up to
+        // SizeQuantizationStep and the other axis is rescaled by the same factor, which keeps the
+        // texture's aspect equal to the element's true aspect while still landing same-aspect jitter
+        // (a uniform drag-resize, a DPI change) on a shared bucket so SyncTexture's exact-match reuse
+        // check hits instead of reallocating. A resize that itself changes the element's aspect ratio
+        // still gets a fresh texture either way — that's correct, not a regression, since the aspect
+        // actually changed.
         private static bool TryComputePixelSize(VisualElement element, SceneViewBinding binding, out int pw, out int ph)
         {
             pw = 0;
@@ -203,8 +211,18 @@ namespace Velvet
                 pw = Mathf.Clamp(Mathf.FloorToInt(pw * shrink), 1, MaxTextureSize);
                 ph = Mathf.Clamp(Mathf.FloorToInt(ph * shrink), 1, MaxTextureSize);
             }
-            pw = Mathf.Min(QuantizeUp(pw), MaxTextureSize);
-            ph = Mathf.Min(QuantizeUp(ph), MaxTextureSize);
+            if (pw >= ph)
+            {
+                var quantizedW = Mathf.Min(QuantizeUp(pw), MaxTextureSize);
+                ph = Mathf.Max(1, Mathf.RoundToInt((float)quantizedW * ph / pw));
+                pw = quantizedW;
+            }
+            else
+            {
+                var quantizedH = Mathf.Min(QuantizeUp(ph), MaxTextureSize);
+                pw = Mathf.Max(1, Mathf.RoundToInt((float)quantizedH * pw / ph));
+                ph = quantizedH;
+            }
             return true;
         }
 

--- a/Packages/com.velvet.core/Runtime/Component/SceneViewDriver.cs
+++ b/Packages/com.velvet.core/Runtime/Component/SceneViewDriver.cs
@@ -20,6 +20,10 @@ namespace Velvet
         // bail pre-layout and the FIRST sync that gets past the validity gate must inherit it.
         // Layout- and tick-driven resyncs never claim a foreign target on their own.
         public bool ClaimOnNextSync;
+        // Sticky record of which axis TryComputePixelSize last quantized as the "larger" one; null
+        // until the first successful derivation. See TryComputePixelSize for why this must persist
+        // across calls instead of being re-derived from the bare current size each time.
+        public bool? WidthWasQuantizedAxis;
 
         public SceneViewBinding(SceneViewSettings settings)
         {
@@ -192,6 +196,17 @@ namespace Velvet
         // check hits instead of reallocating. A resize that itself changes the element's aspect ratio
         // still gets a fresh texture either way — that's correct, not a regression, since the aspect
         // actually changed.
+        //
+        // Which axis counts as "larger" is STICKY (binding.WidthWasQuantizedAxis), not re-derived from
+        // scratch on every call: for an element whose aspect ratio hovers near 1:1, re-deriving "is pw
+        // >= ph" from the bare current size would flip which axis is quantized on a 1px change in
+        // which axis is momentarily longer, picking an entirely different bucket for BOTH axes even
+        // though the element barely moved (a square avatar/minimap/preview, or ordinary sub-pixel
+        // layout jitter, would then defeat the whole point of quantizing). Once an axis is chosen it
+        // keeps being used as long as it is still at least as long as the other OR the gap between
+        // them is under one quantization step — only a gap that clears a full step flips the basis,
+        // so which axis is "larger" changes only when the element's aspect ratio has genuinely and
+        // durably changed, not on sub-step jitter.
         private static bool TryComputePixelSize(VisualElement element, SceneViewBinding binding, out int pw, out int ph)
         {
             pw = 0;
@@ -211,7 +226,23 @@ namespace Velvet
                 pw = Mathf.Clamp(Mathf.FloorToInt(pw * shrink), 1, MaxTextureSize);
                 ph = Mathf.Clamp(Mathf.FloorToInt(ph * shrink), 1, MaxTextureSize);
             }
-            if (pw >= ph)
+            bool useWidthAsBasis;
+            if (binding.WidthWasQuantizedAxis is { } stickyToWidth)
+            {
+                // Symmetric hysteresis: the axis last used as the basis keeps being used unless the
+                // OTHER axis has pulled ahead by a full quantization step, so a sub-step wobble in
+                // which axis is momentarily longer never flips the basis.
+                useWidthAsBasis = stickyToWidth
+                    ? pw >= ph || ph - pw < SizeQuantizationStep
+                    : pw > ph && pw - ph >= SizeQuantizationStep;
+            }
+            else
+            {
+                useWidthAsBasis = pw >= ph;
+            }
+            binding.WidthWasQuantizedAxis = useWidthAsBasis;
+
+            if (useWidthAsBasis)
             {
                 var quantizedW = Mathf.Min(QuantizeUp(pw), MaxTextureSize);
                 ph = Mathf.Max(1, Mathf.RoundToInt((float)quantizedW * ph / pw));
@@ -286,6 +317,10 @@ namespace Velvet
             binding.Texture.Release();
             VelvetObjectUtil.Destroy(binding.Texture);
             binding.Texture = null;
+            // The sticky basis-axis choice exists to keep a LIVE texture's bucket continuous across
+            // resizes; once the texture itself is gone there is nothing left to stay continuous with,
+            // so the next texture this binding creates derives its basis fresh from that size alone.
+            binding.WidthWasQuantizedAxis = null;
             if (element is SceneViewElement sceneView)
             {
                 // Releasing the feed returns the slot to whatever writer was deferred while the

--- a/Packages/com.velvet.core/Runtime/Component/SceneViewDriver.cs
+++ b/Packages/com.velvet.core/Runtime/Component/SceneViewDriver.cs
@@ -46,6 +46,15 @@ namespace Velvet
         // universally supported.
         private const int MaxTextureSize = 4096;
 
+        // The pixel-size rounding grain TryComputePixelSize quantizes up to. 16 divides
+        // MaxTextureSize evenly (4096 / 16 = 256), so the ceiling clamp and this step never leave a
+        // leftover partial bucket at the boundary. Large enough to absorb the few-pixels-per-frame
+        // deltas a drag-resize or an animated layout produces — so most jitter keeps landing on the
+        // same bucket and reuses the existing RenderTexture instead of reallocating — while small
+        // enough that the worst-case 15px-per-axis overshoot is negligible against any on-screen
+        // SceneView size.
+        private const int SizeQuantizationStep = 16;
+
         // Wires the geometry-driven texture sync onto the element and returns the binding. The
         // synchronous sync attempt covers a binding attached to an ALREADY laid-out element (a camera
         // arriving through a patch, where no further geometry event may ever fire); at mount the
@@ -169,7 +178,12 @@ namespace Velvet
         // zero-dimension texture (which RenderTexture creation rejects); the ceiling bounds the VRAM
         // request like the sibling texture bakers bound theirs — applied as ONE shared shrink when
         // either axis overflows, because clamping each axis independently would change the texture's
-        // aspect and distort the camera picture.
+        // aspect and distort the camera picture. The result is then quantized UP to
+        // SizeQuantizationStep: minor layout jitter (a drag-resize, an animated layout moving a
+        // handful of pixels a frame) keeps landing on the SAME quantized size, so SyncTexture's
+        // exact-match reuse check hits instead of reallocating the RenderTexture on every change.
+        // Re-clamped to MaxTextureSize afterward — quantizing up could otherwise carry a
+        // near-ceiling size into the next bucket past the cap.
         private static bool TryComputePixelSize(VisualElement element, SceneViewBinding binding, out int pw, out int ph)
         {
             pw = 0;
@@ -189,7 +203,16 @@ namespace Velvet
                 pw = Mathf.Clamp(Mathf.FloorToInt(pw * shrink), 1, MaxTextureSize);
                 ph = Mathf.Clamp(Mathf.FloorToInt(ph * shrink), 1, MaxTextureSize);
             }
+            pw = Mathf.Min(QuantizeUp(pw), MaxTextureSize);
+            ph = Mathf.Min(QuantizeUp(ph), MaxTextureSize);
             return true;
+        }
+
+        // Rounds a pixel size up to the next SizeQuantizationStep multiple (e.g. 100 -> 112 at the
+        // 16px step); an already-aligned value passes through unchanged.
+        private static int QuantizeUp(int value)
+        {
+            return (value + SizeQuantizationStep - 1) / SizeQuantizationStep * SizeQuantizationStep;
         }
 
         // An Editor-context panel repaints only when something marks it dirty, so a live camera feed

--- a/Packages/com.velvet.core/Runtime/Component/SceneViewDriver.cs
+++ b/Packages/com.velvet.core/Runtime/Component/SceneViewDriver.cs
@@ -120,7 +120,7 @@ namespace Velvet
         {
             var camera = binding.Settings.Camera;
             if (camera == null || element.panel == null
-                || !TryComputePixelSize(element, binding, out var pw, out var ph))
+                || !TryComputePixelSize(element, binding, out var pw, out var ph, out var usedWidthAsBasis))
             {
                 ReleaseOutput(element, binding);
                 return;
@@ -130,6 +130,9 @@ namespace Velvet
 
             if (binding.Texture != null && binding.Texture.width == pw && binding.Texture.height == ph)
             {
+                // Confirmed: the live texture already matches this derivation, so this call's basis
+                // choice is the one actually in effect — safe to commit.
+                binding.WidthWasQuantizedAxis = usedWidthAsBasis;
                 if (camera.targetTexture != binding.Texture
                     && (claim || camera.targetTexture == null))
                 {
@@ -148,11 +151,18 @@ namespace Velvet
             {
                 // The camera is borrowed: re-deriving the texture now would swap the background to an
                 // image nothing renders into and destroy the last good frame. Keep showing that
-                // frame; the next explicit camera/settings pass reclaims and re-derives the size.
+                // frame; the next explicit camera/settings pass reclaims and re-derives the size. This
+                // call's (pw, ph, usedWidthAsBasis) is discarded rather than applied to any texture,
+                // so binding.WidthWasQuantizedAxis must NOT be touched here — committing it would let
+                // a transient geometry sample observed while borrowed silently steer the basis-axis
+                // choice for whatever texture the eventual reclaim actually creates.
                 SyncRepaintTick(element, binding);
                 return;
             }
 
+            // Confirmed: about to create a fresh texture at exactly (pw, ph) — commit the basis that
+            // produced it.
+            binding.WidthWasQuantizedAxis = usedWidthAsBasis;
             // Target the new texture BEFORE destroying the old one so the camera never points at a
             // dead texture in between (the re-target is itself the polite release of our own texture).
             var texture = new RenderTexture(pw, ph, 24);
@@ -207,10 +217,19 @@ namespace Velvet
         // them is under one quantization step — only a gap that clears a full step flips the basis,
         // so which axis is "larger" changes only when the element's aspect ratio has genuinely and
         // durably changed, not on sub-step jitter.
-        private static bool TryComputePixelSize(VisualElement element, SceneViewBinding binding, out int pw, out int ph)
+        // usedWidthAsBasis reports which axis THIS call would use as the quantization basis, given
+        // binding's CURRENT sticky state — it does not write binding.WidthWasQuantizedAxis itself.
+        // Not every caller ends up applying this call's (pw, ph) to a texture (SyncTexture's
+        // borrowed-camera bail-out keeps showing an older texture; OnRepaintTick's staleness probe
+        // only checks whether a resync is needed), so committing the sticky axis unconditionally
+        // here would let a call whose result is discarded still steer future basis-axis decisions —
+        // only the caller that actually confirms or creates a texture for (pw, ph) should commit it,
+        // via `binding.WidthWasQuantizedAxis = usedWidthAsBasis`.
+        private static bool TryComputePixelSize(VisualElement element, SceneViewBinding binding, out int pw, out int ph, out bool usedWidthAsBasis)
         {
             pw = 0;
             ph = 0;
+            usedWidthAsBasis = false;
             var w = element.layout.width;
             var h = element.layout.height;
             if (w <= 0f || h <= 0f || float.IsNaN(w) || float.IsNaN(h))
@@ -226,21 +245,15 @@ namespace Velvet
                 pw = Mathf.Clamp(Mathf.FloorToInt(pw * shrink), 1, MaxTextureSize);
                 ph = Mathf.Clamp(Mathf.FloorToInt(ph * shrink), 1, MaxTextureSize);
             }
-            bool useWidthAsBasis;
-            if (binding.WidthWasQuantizedAxis is { } stickyToWidth)
-            {
-                // Symmetric hysteresis: the axis last used as the basis keeps being used unless the
-                // OTHER axis has pulled ahead by a full quantization step, so a sub-step wobble in
-                // which axis is momentarily longer never flips the basis.
-                useWidthAsBasis = stickyToWidth
+            // Symmetric hysteresis: the axis last COMMITTED as the basis keeps being used unless the
+            // OTHER axis has pulled ahead by a full quantization step, so a sub-step wobble in which
+            // axis is momentarily longer never flips the basis.
+            var useWidthAsBasis = binding.WidthWasQuantizedAxis is { } stickyToWidth
+                ? (stickyToWidth
                     ? pw >= ph || ph - pw < SizeQuantizationStep
-                    : pw > ph && pw - ph >= SizeQuantizationStep;
-            }
-            else
-            {
-                useWidthAsBasis = pw >= ph;
-            }
-            binding.WidthWasQuantizedAxis = useWidthAsBasis;
+                    : pw > ph && pw - ph >= SizeQuantizationStep)
+                : pw >= ph;
+            usedWidthAsBasis = useWidthAsBasis;
 
             if (useWidthAsBasis)
             {
@@ -289,8 +302,12 @@ namespace Velvet
         // texture. Runtime panels have no tick and heal on their next geometry or props pass instead.
         private static void OnRepaintTick(VisualElement element, SceneViewBinding binding)
         {
+            // This is a staleness PROBE, not a commit: only checks whether the derived size still
+            // matches the live texture. The basis-axis choice this call computes is discarded — if a
+            // resync turns out to be needed, SyncTexture below re-derives (and, on that path, commits)
+            // it from scratch.
             if (binding.Texture != null
-                && TryComputePixelSize(element, binding, out var pw, out var ph)
+                && TryComputePixelSize(element, binding, out var pw, out var ph, out _)
                 && (binding.Texture.width != pw || binding.Texture.height != ph))
             {
                 SyncTexture(element, binding);

--- a/Packages/com.velvet.core/Runtime/Component/V.cs
+++ b/Packages/com.velvet.core/Runtime/Component/V.cs
@@ -646,8 +646,10 @@ namespace Velvet
 
         /// <summary>
         /// Creates a SceneView element displaying <paramref name="camera"/>'s output — the canvas-parity
-        /// element. The framework owns the RenderTexture: it is created at the element's laid-out pixel
-        /// size (times <paramref name="resolutionScale"/>), resized when the element's geometry changes,
+        /// element. The framework owns the RenderTexture: it is sized to the element's laid-out pixel
+        /// size (times <paramref name="resolutionScale"/>), rounded up to reuse the existing texture
+        /// across minor resizes (preserving the element's aspect ratio), resized when the element's
+        /// geometry changes,
         /// assigned to <c>camera.targetTexture</c> while mounted, and released on unmount (restoring the
         /// camera's target only if it is still the framework's own texture). The output arrives through
         /// the element's background image, so background utilities and rounded corners apply to it.

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/SceneViewTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/SceneViewTests.cs
@@ -222,8 +222,35 @@ namespace Velvet.Tests
             s_setFlag.Invoke(true);
             FlushAndLayout();
 
+            // Assert — 200 rounds up to the next 16px quantization step (208); 64 already lands on one.
+            Assert.That((s_camera.targetTexture.width, s_camera.targetTexture.height), Is.EqualTo((208, 64)));
+        }
+
+        [Component]
+        private static VNode SubStepResizeHost()
+        {
+            var (grown, setGrown) = Hooks.UseState(false);
+            s_setFlag = setGrown;
+            return V.SceneView(s_camera, className: grown ? "w-[105px] h-[64px]" : "w-[100px] h-[64px]");
+        }
+
+        [Test]
+        public void Given_ASubStepSizeDelta_When_TheElementResizes_Then_TheRenderTextureIsNotReallocated()
+        {
+            // Arrange — 100px and 105px both round up to the same 112px bucket at the 16px
+            // quantization step, so this resize must reuse the existing RenderTexture instead of
+            // reallocating a new one for a size delta smaller than the step.
+            s_camera = CreateCamera("cam");
+            MountAndLayout(V.Component(SubStepResizeHost, key: "root"));
+            var initial = s_camera.targetTexture;
+            Assume.That(initial, Is.Not.Null, "Precondition: the camera targets a texture");
+
+            // Act
+            s_setFlag.Invoke(true);
+            FlushAndLayout();
+
             // Assert
-            Assert.That((s_camera.targetTexture.width, s_camera.targetTexture.height), Is.EqualTo((200, 64)));
+            Assert.That(s_camera.targetTexture, Is.SameAs(initial));
         }
 
         [Component]
@@ -459,6 +486,23 @@ namespace Velvet.Tests
             Assume.That(rt.width, Is.EqualTo(4096), "Precondition: the width hit the ceiling");
             var aspect = (float)rt.width / rt.height;
             Assert.That((rt.height <= 4096, Mathf.Abs(aspect - 20f) < 0.5f), Is.EqualTo((true, true)));
+        }
+
+        [Test]
+        public void Given_AnElementFarPastTheTextureCap_When_TheSizeIsQuantized_Then_ItNeverExceedsTheCap()
+        {
+            // Arrange — a square element far past the 4096 ceiling forces the aspect-preserving
+            // shrink to land both axes at the cap; quantizing that result up must not carry either
+            // axis past it into the next 16px bucket.
+            var cam = CreateCamera("cam");
+
+            // Act
+            MountAndLayout(V.SceneView(cam, className: "shrink-0 w-[5000px] h-[5000px]"));
+
+            // Assert
+            var rt = cam.targetTexture;
+            Assume.That(rt, Is.Not.Null, "Precondition: the camera received a texture");
+            Assert.That((rt.width <= 4096, rt.height <= 4096), Is.EqualTo((true, true)));
         }
 
         [Test]

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/SceneViewTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/SceneViewTests.cs
@@ -294,6 +294,41 @@ namespace Velvet.Tests
             Assert.That((widthAtStep0, widthAtStep1, widthAtStep2), Is.EqualTo((112, 112, 112)));
         }
 
+        [Test]
+        public void Given_ADiscardedDerivation_When_ItWouldFlipTheBasis_Then_TheBindingIsNotMutated()
+        {
+            // Arrange — mount width-basis (100x100). The geometry-changed callback is unregistered
+            // BEFORE growing the live layout's height, so growing it does not itself trigger the
+            // driver's normal SyncTexture (which would legitimately commit the flip) — this isolates
+            // the one call this test cares about: TryComputePixelSize's own out parameter reports a
+            // derivation that would flip to height-basis, and that call alone must not write the
+            // flip into binding.WidthWasQuantizedAxis — only a caller that actually applies the
+            // derived size (SyncTexture, on either its exact-match or fresh-texture path) may commit
+            // it. This is what keeps a call whose result is discarded (SyncTexture's borrowed-camera
+            // bail-out, OnRepaintTick's staleness probe) from silently steering the basis of whatever
+            // texture a later confirmed call actually produces.
+            s_camera = CreateCamera("cam");
+            MountAndLayout(V.SceneView(s_camera, className: "w-[100px] h-[100px]", name: "sv"));
+            var element = _host.Root.Q<VisualElement>("sv");
+            var binding = _mounted.Root.Reconciler.Context.SceneViewBindings[element];
+            Assume.That(binding.WidthWasQuantizedAxis, Is.EqualTo(true),
+                "Precondition: width-basis committed by the initial mount");
+            element.UnregisterCallback(binding.OnGeometryChanged);
+            element.style.height = 200;
+            EditorPanelTestHelpers.ForcePanelUpdate(_host.Panel);
+
+            // Act
+            var method = typeof(SceneViewDriver).GetMethod("TryComputePixelSize",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+            var args = new object[] { element, binding, 0, 0, false };
+            method.Invoke(null, args);
+            Assume.That(args[4], Is.EqualTo(false),
+                "Precondition: this call's fresh derivation would flip to height-basis");
+
+            // Assert
+            Assert.That(binding.WidthWasQuantizedAxis, Is.EqualTo(true));
+        }
+
         [Component]
         private static VNode SubStepResizeHost()
         {

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/SceneViewTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/SceneViewTests.cs
@@ -489,23 +489,6 @@ namespace Velvet.Tests
         }
 
         [Test]
-        public void Given_AnElementFarPastTheTextureCap_When_TheSizeIsQuantized_Then_ItNeverExceedsTheCap()
-        {
-            // Arrange — a square element far past the 4096 ceiling forces the aspect-preserving
-            // shrink to land both axes at the cap; quantizing that result up must not carry either
-            // axis past it into the next 16px bucket.
-            var cam = CreateCamera("cam");
-
-            // Act
-            MountAndLayout(V.SceneView(cam, className: "shrink-0 w-[5000px] h-[5000px]"));
-
-            // Assert
-            var rt = cam.targetTexture;
-            Assume.That(rt, Is.Not.Null, "Precondition: the camera received a texture");
-            Assert.That((rt.width <= 4096, rt.height <= 4096), Is.EqualTo((true, true)));
-        }
-
-        [Test]
         public void Given_AStalePixelScale_When_TheEditorRepaintTickFires_Then_TheTextureIsRederived()
         {
             // Arrange — a pixel-density change (a monitor-DPI move) alters the derived pixel size with

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/SceneViewTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/SceneViewTests.cs
@@ -10,12 +10,16 @@ namespace Velvet.Tests
     /// Specifies the contract of <c>V.SceneView</c> — a Camera's output as an element:
     /// <list type="bullet">
     /// <item>Mounting creates the dedicated <see cref="SceneViewElement"/>; once layout resolves, the
-    /// framework creates a RenderTexture at the element's laid-out pixel size (times the resolution
-    /// scale), assigns it to <c>camera.targetTexture</c>, and shows it through the element's background
-    /// image — so background utilities and rounded corners apply to the camera output.</item>
-    /// <item>The texture follows the element: a geometry change re-sizes it, a camera swap releases the
-    /// old camera and targets the new one, and removing the camera (or the element, or disposing the
-    /// tree) releases both the camera's target and the texture.</item>
+    /// framework creates a RenderTexture sized to the element's laid-out pixel size (times the
+    /// resolution scale), assigns it to <c>camera.targetTexture</c>, and shows it through the
+    /// element's background image — so background utilities and rounded corners apply to the camera
+    /// output.</item>
+    /// <item>The texture follows the element: a geometry change re-sizes it (rounding the larger axis
+    /// up to a shared quantization step and rescaling the other axis by the same factor, so its
+    /// aspect ratio keeps matching the element's, so a minor resize reuses the existing texture
+    /// instead of reallocating), a camera swap releases the old camera and targets the new one, and
+    /// removing the camera (or the element, or disposing the tree) releases both the camera's target
+    /// and the texture.</item>
     /// <item>Release is polite: a camera whose targetTexture was reassigned by user code after mount is
     /// left untouched on unmount.</item>
     /// <item>A null camera mounts an inert element; a zero-sized element creates no texture.</item>
@@ -222,8 +226,33 @@ namespace Velvet.Tests
             s_setFlag.Invoke(true);
             FlushAndLayout();
 
-            // Assert — 200 rounds up to the next 16px quantization step (208); 64 already lands on one.
-            Assert.That((s_camera.targetTexture.width, s_camera.targetTexture.height), Is.EqualTo((208, 64)));
+            // Assert — the larger axis (200) rounds up to the next 16px quantization step (208); the
+            // unchanged 64px axis is rescaled by the same factor (208/200) to keep the texture's
+            // aspect equal to the element's, landing at round(208 * 64 / 200) = 67.
+            Assert.That((s_camera.targetTexture.width, s_camera.targetTexture.height), Is.EqualTo((208, 67)));
+        }
+
+        [Test]
+        public void Given_AQuantizedResize_When_TheTextureIsCreated_Then_TheAspectMatchesTheElement()
+        {
+            // Arrange — SceneViewDriver never pins camera.aspect, so Unity derives the camera's
+            // render aspect straight from the texture's own width/height; quantizing width and
+            // height independently would drift the texture's aspect from the element's true 200:64
+            // aspect and visibly skew the rendered scene.
+            s_camera = CreateCamera("cam");
+            MountAndLayout(V.Component(ResizingHost, key: "root"));
+
+            // Act
+            s_setFlag.Invoke(true);
+            FlushAndLayout();
+
+            // Assert — allows the rounding slack RoundToInt introduces when rescaling the shorter axis
+            // (a fraction of a pixel), while still failing hard against independent-axis quantization,
+            // which would land at aspect 208/64 = 3.25 — an 0.125 gap, over 5x this tolerance.
+            var rt = s_camera.targetTexture;
+            var textureAspect = (float)rt.width / rt.height;
+            var elementAspect = 200f / 64f;
+            Assert.That(Mathf.Abs(textureAspect - elementAspect), Is.LessThan(0.05f));
         }
 
         [Component]
@@ -231,15 +260,17 @@ namespace Velvet.Tests
         {
             var (grown, setGrown) = Hooks.UseState(false);
             s_setFlag = setGrown;
-            return V.SceneView(s_camera, className: grown ? "w-[105px] h-[64px]" : "w-[100px] h-[64px]");
+            return V.SceneView(s_camera, className: grown ? "w-[103px] h-[66px]" : "w-[100px] h-[64px]");
         }
 
         [Test]
         public void Given_ASubStepSizeDelta_When_TheElementResizes_Then_TheRenderTextureIsNotReallocated()
         {
-            // Arrange — 100px and 105px both round up to the same 112px bucket at the 16px
-            // quantization step, so this resize must reuse the existing RenderTexture instead of
-            // reallocating a new one for a size delta smaller than the step.
+            // Arrange — 100x64 and 103x66 are nearly the same aspect ratio (1.5625 vs. 1.5606), so
+            // both quantize their larger (width) axis to the same 112px bucket and rescale height to
+            // the same 72px, landing on the identical texture size; this resize must reuse the
+            // existing RenderTexture instead of reallocating a new one for a size delta smaller than
+            // the step.
             s_camera = CreateCamera("cam");
             MountAndLayout(V.Component(SubStepResizeHost, key: "root"));
             var initial = s_camera.targetTexture;

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/SceneViewTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/SceneViewTests.cs
@@ -34,6 +34,7 @@ namespace Velvet.Tests
         private readonly List<Object> _spawned = new();
 
         private static StateUpdater<bool> s_setFlag;
+        private static StateUpdater<int> s_setStep;
 
         [SetUp]
         public void SetUp()
@@ -253,6 +254,44 @@ namespace Velvet.Tests
             var textureAspect = (float)rt.width / rt.height;
             var elementAspect = 200f / 64f;
             Assert.That(Mathf.Abs(textureAspect - elementAspect), Is.LessThan(0.05f));
+        }
+
+        [Component]
+        private static VNode NearSquareJiggleHost()
+        {
+            var (step, setStep) = Hooks.UseState(0);
+            s_setStep = setStep;
+            var sizes = new[]
+            {
+                "w-[100px] h-[100px]",
+                "w-[99px] h-[100px]",
+                "w-[100px] h-[99px]",
+            };
+            return V.SceneView(s_camera, className: sizes[step]);
+        }
+
+        [Test]
+        public void Given_ANearSquareElement_When_TheDominantAxisAlternates_Then_TheWidthBasisStaysStable()
+        {
+            // Arrange — a 1px jiggle around a 1:1 aspect ratio flips which axis is momentarily
+            // longer (100x100 -> 99x100 -> 100x99). Without a sticky basis-axis, re-deriving "is
+            // width >= height" from scratch each time would flip which axis gets quantized and
+            // rescale the OTHER axis to match it, changing the width bucket on every step even
+            // though the element barely moved.
+            s_camera = CreateCamera("cam");
+            MountAndLayout(V.Component(NearSquareJiggleHost, key: "root"));
+            var widthAtStep0 = s_camera.targetTexture.width;
+
+            // Act
+            s_setStep.Invoke(1);
+            FlushAndLayout();
+            var widthAtStep1 = s_camera.targetTexture.width;
+            s_setStep.Invoke(2);
+            FlushAndLayout();
+            var widthAtStep2 = s_camera.targetTexture.width;
+
+            // Assert
+            Assert.That((widthAtStep0, widthAtStep1, widthAtStep2), Is.EqualTo((112, 112, 112)));
         }
 
         [Component]


### PR DESCRIPTION
## Summary

`V.SceneView` resized its owned RenderTexture to the element's exact laid-out pixel size on every layout change, triggering a reallocation on every single-pixel resize (a drag-resize, an animated layout). This rounds the larger axis up to a 16px step and rescales the other axis by the same factor, so same-aspect jitter reuses the existing texture instead of reallocating.

Quantizing width and height independently would drift the texture's aspect ratio from the element's own — `SceneViewDriver` never pins `camera.aspect`, so Unity derives the camera's render aspect straight from the texture's dimensions, and a mismatched aspect visibly skews the rendered scene. Rescaling the non-quantized axis by the same factor keeps the aspect ratio exact.

Which axis counts as "larger" is sticky (`SceneViewBinding.WidthWasQuantizedAxis`) rather than re-derived from the bare current size on every call: for an element whose aspect ratio hovers near 1:1, re-deriving "is width >= height" from scratch would flip which axis is quantized on a 1px change in which axis is momentarily longer, picking an entirely different bucket for both axes even though the element barely moved. The sticky choice only flips once the gap between the axes clears a full quantization step. The commit itself is only made by a caller that actually applies the derived size to a texture — not by `TryComputePixelSize` itself — so a call whose result is discarded (the borrowed-camera bail-out, `OnRepaintTick`'s staleness probe) can't silently steer the basis of a texture it never produced.

Closes #34

## Test plan

- EditMode `SceneViewTests`: 31/31 passed, including a regression for the sub-step reuse case, a direct aspect-fidelity assertion, a near-square axis-stability regression, and a reflection-based test isolating the commit-only-on-confirm behavior from `TryComputePixelSize` itself.
- Manually rendered `V.SceneView` at a non-16px-aligned size (201x130) against an evenly-spaced 5x5 cube grid and measured the captured pixels: 26.0px column spacing and 26.0px row spacing — confirming no aspect distortion in the actual rendered output, not just the derived numbers.