### PR TITLE
fix: ChildReconciler abort handling stops the scan and keeps the replacement

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `ChildReconciler`'s same-key/same-index type-flip replacement path now checks for an
+  error-boundary abort (and leaves the old element in place) before removing it, instead of after
+  — a descendant render failure caught during the replacement's construction no longer strands the
+  slot empty. Applies to the Common-phase indexed loop and both keyed Pass-1 linear scans (sync and
+  time-sliced); the fully-synchronous keyed scan additionally now stops scanning the remaining
+  siblings once an abort is observed, matching every other CanPatch-gated call site.
+
 ### Changed
 
 - `V.SceneView`: the owned RenderTexture's backing resolution now rounds its larger axis up to the

--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -9,12 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `ChildReconciler`'s same-key/same-index type-flip replacement path now checks for an
-  error-boundary abort (and leaves the old element in place) before removing it, instead of after
-  — a descendant render failure caught during the replacement's construction no longer strands the
-  slot empty. Applies to the Common-phase indexed loop and both keyed Pass-1 linear scans (sync and
-  time-sliced); the fully-synchronous keyed scan additionally now stops scanning the remaining
-  siblings once an abort is observed, matching every other CanPatch-gated call site.
+- `ChildReconciler`'s fully-synchronous keyed diff now stops scanning the remaining siblings once a
+  descendant render failure aborts the reconcile mid-replacement, instead of continuing to
+  patch/replace later slots — matching every other `CanPatch`-gated call site (the Common-phase
+  indexed loop and the time-sliced keyed scan already did).
 
 ### Changed
 

--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -9,10 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `ChildReconciler`'s fully-synchronous keyed diff now stops scanning the remaining siblings once a
-  descendant render failure aborts the reconcile mid-replacement, instead of continuing to
-  patch/replace later slots — matching every other `CanPatch`-gated call site (the Common-phase
-  indexed loop and the time-sliced keyed scan already did).
+- `ChildReconciler`'s same-key type-flip replacement (the Common-phase indexed loop, and both keyed
+  Pass-1 linear scans — sync and time-sliced) now always inserts the newly built replacement element
+  even when building it triggers an error-boundary abort, instead of discarding it and leaving the
+  slot empty — the abort only fires once the boundary's fallback has already rendered successfully,
+  so the replacement being discarded was always holding valid content. The fully-synchronous keyed
+  diff also now stops scanning the remaining siblings once such an abort is observed, instead of
+  continuing to patch/replace later slots — matching every other `CanPatch`-gated call site (the
+  Common-phase indexed loop and the time-sliced keyed scan already did).
 
 ### Changed
 

--- a/Packages/com.velvet.core/Runtime/Reconciler/ChildReconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ChildReconciler.cs
@@ -78,8 +78,8 @@ namespace Velvet
         //     parent.childCount on a desync-shortened range; the keyed scan's slotStart + i is always
         //     in range on its own and must NOT be clamped (clamping would silently misplace an insert
         //     once slotStart + i legitimately reaches parent.childCount, i.e. a tail slot).
-        //   checkAbortAfterCreate: whether to bail before inserting when CreateElement's descendant
-        //     render triggered an error-boundary abort.
+        //   checkAbortAfterCreate: whether to stop the caller's scan (return true) after CreateElement
+        //     observes an error-boundary abort. Does NOT discard newElement either way — see below.
         //   Removal deliberately stays BEFORE CreateElement (remove-then-create), not
         //     create-then-remove: an inline-mounted component fiber is keyed by
         //     (parentFiber, positionKey, identity) — NOT by which VisualElement currently hosts it
@@ -92,12 +92,23 @@ namespace Velvet
         //     was tried. FiberElementCleaner.CleanupElement's own comment on DisposeFibersUnder
         //     explains why: an inline fiber under a torn-down host is otherwise invisible to the
         //     normal orphan sweep and "would survive to be re-paired as a zombie on a same-key
-        //     re-entry" — which is exactly what create-then-remove reintroduces. This means an abort
-        //     during CreateElement can still strand this slot empty (tracked as #48, left open) —
-        //     fixing that safely needs decoupling "unregister the old fiber" from "remove the old DOM
-        //     element", which is a deeper change than this consolidation's scope.
-        // Returns true when the caller must stop (an abort was observed and the caller opted in via
-        // checkAbortAfterCreate).
+        //     re-entry" — which is exactly what create-then-remove reintroduces.
+        //   newElement is ALWAYS inserted, abort or not (#48): _ctx.IsAborted only ever becomes true
+        //     via FiberErrorBoundary.TryCatch -> SetAborted, which fires exclusively on TryShowFallback's
+        //     SUCCESS path (fiber.Reconciler.Reconcile(fiber.MountPoint, ..., fallbackTree) returned
+        //     without throwing and FallbackContentFailed is false) — i.e. by the time CreateElement
+        //     returns, newElement already holds a fully, successfully rendered subtree (the boundary's
+        //     fallback content in place of whatever threw beneath it), not a half-built one. Discarding
+        //     it and leaving the slot empty was strictly worse than what React does: an error boundary
+        //     that catches never leaves the DOM with nothing where its fallback should be (render never
+        //     touches the committed tree — see ReactFiberThrow.js's throwException, which only tags
+        //     fibers for the commit phase to later process; Velvet has no such phase split, so the
+        //     nearest equivalent is "don't throw away content the boundary already finished building").
+        //     checkAbortAfterCreate's true meaning is narrower: stop scanning further siblings in THIS
+        //     pass, because the boundary already resolved the failure and any later slot's patch/replace
+        //     would be racing a reconcile the caller no longer owns end-to-end.
+        // Returns true when the caller must stop scanning further siblings (an abort was observed and
+        // the caller opted in via checkAbortAfterCreate); newElement has already been inserted either way.
         private bool PatchOrReplaceAtSlot(
             VisualElement parent, int slotStart, int i, VNode? oldNode, VNode? newNode,
             bool slotExists, bool clampInsertIndex, bool checkAbortAfterCreate)
@@ -115,13 +126,9 @@ namespace Velvet
                 _cleaner.RemoveElement(parent, slotStart + i);
             }
             var newElement = _factory.CreateElement(newNode);
-            if (checkAbortAfterCreate && _ctx.IsAborted)
-            {
-                return true;
-            }
             var insertIndex = clampInsertIndex ? Math.Min(slotStart + i, parent.childCount) : slotStart + i;
             parent.Insert(insertIndex, newElement);
-            return false;
+            return checkAbortAfterCreate && _ctx.IsAborted;
         }
 
         public void Reconcile(VisualElement? parent, VNode?[] oldChildren, VNode?[] newChildren,

--- a/Packages/com.velvet.core/Runtime/Reconciler/ChildReconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ChildReconciler.cs
@@ -64,10 +64,10 @@ namespace Velvet
         }
 
         // Applies the CanPatch-gated patch-or-replace decision at one DOM slot: patches the existing
-        // element in place when the pair is patch-compatible, otherwise removes the existing element
-        // (when slotExists) and inserts a freshly created one at the same slot. Shared by the
-        // Common-phase indexed loop and both keyed Pass-1 linear-scan implementations (sync and
-        // time-sliced) so this eager remove-then-create sequence cannot independently drift the way
+        // element in place when the pair is patch-compatible, otherwise creates a replacement and
+        // (when slotExists) removes the existing element before inserting the new one at the same
+        // slot. Shared by the Common-phase indexed loop and both keyed Pass-1 linear-scan
+        // implementations (sync and time-sliced) so this sequence cannot independently drift the way
         // FiberVirtualListController's own separately hand-rolled copy did — it skipped the CanPatch
         // gate entirely, patching a same-key type flip onto a stale element.
         //   slotExists: false only for the indexed diff's DOM-desync recovery, where a transient
@@ -77,11 +77,14 @@ namespace Velvet
         //   clampInsertIndex: the indexed diff inserts at an absolute position that must clamp to
         //     parent.childCount on a desync-shortened range; the keyed scan's slotStart + i is always
         //     in range on its own and must NOT be clamped (clamping would silently misplace an insert
-        //     once slotStart + i legitimately reaches parent.childCount, i.e. a tail slot).
-        //   checkAbortAfterCreate: whether to bail before inserting when CreateElement's descendant
-        //     render triggered an error-boundary abort. ReconcileKeyedSync (the fully-synchronous
-        //     keyed caller) does not check this today; preserved as-is here rather than folded in,
-        //     since flipping it would be a behavior change out of scope for this consolidation.
+        //     once slotStart + i legitimately reaches parent.childCount, i.e. a tail slot). The clamp
+        //     reads parent.childCount AFTER the old element (if any) is removed below, matching the
+        //     original per-site behavior this helper consolidates.
+        //   checkAbortAfterCreate: whether to bail before removing the old element / inserting the new
+        //     one when CreateElement's descendant render triggered an error-boundary abort. Create
+        //     runs before the old element is touched (create-before-dispose, mirroring the ordering
+        //     FiberVirtualListController's own replace branch already uses) so an abort here always
+        //     leaves the old element in place instead of stranding the slot empty.
         // Returns true when the caller must stop (an abort was observed and the caller opted in via
         // checkAbortAfterCreate).
         private bool PatchOrReplaceAtSlot(
@@ -96,14 +99,14 @@ namespace Velvet
                 return false;
             }
 
-            if (slotExists)
-            {
-                _cleaner.RemoveElement(parent, slotStart + i);
-            }
             var newElement = _factory.CreateElement(newNode);
             if (checkAbortAfterCreate && _ctx.IsAborted)
             {
                 return true;
+            }
+            if (slotExists)
+            {
+                _cleaner.RemoveElement(parent, slotStart + i);
             }
             var insertIndex = clampInsertIndex ? Math.Min(slotStart + i, parent.childCount) : slotStart + i;
             parent.Insert(insertIndex, newElement);
@@ -677,8 +680,11 @@ namespace Velvet
                     var newKey = _keying.EffectiveKey(newNodes[i]);
                     if (oldKey != newKey) break;
 
-                    PatchOrReplaceAtSlot(parent, slotStart, i, oldNodes[i], newNodes[i],
-                        slotExists: true, clampInsertIndex: false, checkAbortAfterCreate: false);
+                    if (PatchOrReplaceAtSlot(parent, slotStart, i, oldNodes[i], newNodes[i],
+                            slotExists: true, clampInsertIndex: false, checkAbortAfterCreate: true))
+                    {
+                        return;
+                    }
                 }
                 // Update only when an operation succeeded; left unchanged on break.
                 linearEnd = i + 1;

--- a/Packages/com.velvet.core/Runtime/Reconciler/ChildReconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ChildReconciler.cs
@@ -64,10 +64,10 @@ namespace Velvet
         }
 
         // Applies the CanPatch-gated patch-or-replace decision at one DOM slot: patches the existing
-        // element in place when the pair is patch-compatible, otherwise creates a replacement and
-        // (when slotExists) removes the existing element before inserting the new one at the same
-        // slot. Shared by the Common-phase indexed loop and both keyed Pass-1 linear-scan
-        // implementations (sync and time-sliced) so this sequence cannot independently drift the way
+        // element in place when the pair is patch-compatible, otherwise removes the existing element
+        // (when slotExists) and inserts a freshly created one at the same slot. Shared by the
+        // Common-phase indexed loop and both keyed Pass-1 linear-scan implementations (sync and
+        // time-sliced) so this eager remove-then-create sequence cannot independently drift the way
         // FiberVirtualListController's own separately hand-rolled copy did — it skipped the CanPatch
         // gate entirely, patching a same-key type flip onto a stale element.
         //   slotExists: false only for the indexed diff's DOM-desync recovery, where a transient
@@ -77,14 +77,25 @@ namespace Velvet
         //   clampInsertIndex: the indexed diff inserts at an absolute position that must clamp to
         //     parent.childCount on a desync-shortened range; the keyed scan's slotStart + i is always
         //     in range on its own and must NOT be clamped (clamping would silently misplace an insert
-        //     once slotStart + i legitimately reaches parent.childCount, i.e. a tail slot). The clamp
-        //     reads parent.childCount AFTER the old element (if any) is removed below, matching the
-        //     original per-site behavior this helper consolidates.
-        //   checkAbortAfterCreate: whether to bail before removing the old element / inserting the new
-        //     one when CreateElement's descendant render triggered an error-boundary abort. Create
-        //     runs before the old element is touched (create-before-dispose, mirroring the ordering
-        //     FiberVirtualListController's own replace branch already uses) so an abort here always
-        //     leaves the old element in place instead of stranding the slot empty.
+        //     once slotStart + i legitimately reaches parent.childCount, i.e. a tail slot).
+        //   checkAbortAfterCreate: whether to bail before inserting when CreateElement's descendant
+        //     render triggered an error-boundary abort.
+        //   Removal deliberately stays BEFORE CreateElement (remove-then-create), not
+        //     create-then-remove: an inline-mounted component fiber is keyed by
+        //     (parentFiber, positionKey, identity) — NOT by which VisualElement currently hosts it
+        //     (FiberRenderer.SetupMount's comment on the registry key; ComponentRegistry.cs). If the
+        //     OLD element (and the same-keyed nested fiber ComponentRegistry still has registered
+        //     under it) is still present when CreateElement builds the NEW element's same-keyed
+        //     child, the registry hands back the OLD, still-live fiber instead of mounting fresh —
+        //     confirmed by a regression in ComponentStateReparityTests
+        //     (Given_ANestedComponentWithAdvancedState_When_TheHostElementTypeChanges_...) when this
+        //     was tried. FiberElementCleaner.CleanupElement's own comment on DisposeFibersUnder
+        //     explains why: an inline fiber under a torn-down host is otherwise invisible to the
+        //     normal orphan sweep and "would survive to be re-paired as a zombie on a same-key
+        //     re-entry" — which is exactly what create-then-remove reintroduces. This means an abort
+        //     during CreateElement can still strand this slot empty (tracked as #48, left open) —
+        //     fixing that safely needs decoupling "unregister the old fiber" from "remove the old DOM
+        //     element", which is a deeper change than this consolidation's scope.
         // Returns true when the caller must stop (an abort was observed and the caller opted in via
         // checkAbortAfterCreate).
         private bool PatchOrReplaceAtSlot(
@@ -99,14 +110,14 @@ namespace Velvet
                 return false;
             }
 
+            if (slotExists)
+            {
+                _cleaner.RemoveElement(parent, slotStart + i);
+            }
             var newElement = _factory.CreateElement(newNode);
             if (checkAbortAfterCreate && _ctx.IsAborted)
             {
                 return true;
-            }
-            if (slotExists)
-            {
-                _cleaner.RemoveElement(parent, slotStart + i);
             }
             var insertIndex = clampInsertIndex ? Math.Min(slotStart + i, parent.childCount) : slotStart + i;
             parent.Insert(insertIndex, newElement);

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ChildReconcilerAbortSafetyTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ChildReconcilerAbortSafetyTests.cs
@@ -6,15 +6,19 @@ using UnityEngine.UIElements;
 namespace Velvet.Tests
 {
     /// <summary>
-    /// Specifies that a same-key/same-index type flip whose replacement element construction triggers
-    /// an error-boundary abort (<see cref="ReconcilerContext.IsAborted"/>) stops the same scan from
-    /// processing any later sibling, across every <c>ChildReconciler.PatchOrReplaceAtSlot</c> call
-    /// site (the Common-phase indexed loop, and both keyed Pass-1 linear-scan implementations — sync
-    /// and time-sliced): a later sibling is left untouched instead of being patched while the
-    /// reconcile is aborted. (The replaced slot's old element is NOT expected to survive the abort —
-    /// see #48, tracked open: removal deliberately stays before CreateElement so an inline-mounted
-    /// same-keyed child fiber isn't handed back stale by ComponentRegistry, per the comment on
-    /// PatchOrReplaceAtSlot.)
+    /// Specifies two properties of a same-key/same-index type flip whose replacement element
+    /// construction triggers an error-boundary abort (<see cref="ReconcilerContext.IsAborted"/>),
+    /// across every <c>ChildReconciler.PatchOrReplaceAtSlot</c> call site (the Common-phase indexed
+    /// loop, and both keyed Pass-1 linear-scan implementations — sync and time-sliced):
+    /// (1) the replacement element is still inserted at the slot — <see cref="ReconcilerContext.IsAborted"/>
+    /// only ever becomes true via a boundary's SUCCESSFUL fallback render (FiberErrorBoundary.TryCatch
+    /// calls SetAborted only after TryShowFallback's own Reconcile call returns without throwing), so by
+    /// the time the abort is observed the newly built element already holds the boundary's fully
+    /// rendered fallback content, not a half-built one — discarding it would strand the slot with
+    /// nothing where the fallback should be, which React's render/commit split never does (an error
+    /// boundary's fallback only ever replaces committed DOM, never leaves it empty mid-render); and
+    /// (2) the same abort stops the scan from processing any LATER sibling — it is left untouched
+    /// instead of being patched while the reconcile is aborted.
     /// </summary>
     [TestFixture]
     internal sealed class ChildReconcilerAbortSafetyTests : ReconcilerTestFixture
@@ -48,17 +52,15 @@ namespace Velvet.Tests
         }
 
         [Test]
-        public void Given_ErrorBoundaryAbortsDuringIndexedReplace_When_Reconciled_Then_TheLaterSiblingIsUntouched()
+        public void Given_ErrorBoundaryAbortsDuringIndexedReplace_When_Reconciled_Then_TheFallbackIsInsertedAndLaterSiblingIsUntouched()
         {
             // Arrange — unkeyed siblings select the Common-phase indexed diff. The first sibling flips
             // from a Label to a Div wrapping an error boundary whose child throws; the flip's CanPatch
             // decision is false, so building the replacement recurses into the boundary before the
-            // abort can be observed. Remove-then-create means the aborted slot's OLD element is
-            // already gone by the time the abort is observed (see #48) and no new element is
-            // inserted in its place, so the container shrinks by one and the untouched second
-            // sibling's ORIGINAL text shifts down to index 0 — that shift, plus the original text
-            // surviving instead of being patched to "b-updated", is the proof the abort stopped the
-            // scan rather than letting it keep patching later slots.
+            // abort is observed. The boundary catches successfully, so the built Div (containing the
+            // "caught" fallback Label) is inserted at slot 0 despite the abort; the abort then stops
+            // the scan before the second sibling is reached, so its ORIGINAL text survives instead of
+            // being patched to "b-updated".
             using var mounted = V.Mount(Root, V.Component(IndexedListHost, key: "host"));
             var container = Root.ElementAt(0);
 
@@ -67,8 +69,10 @@ namespace Velvet.Tests
             mounted.FlushStateForTest();
 
             // Assert
-            Assert.That((s_fallbackShown, container.childCount, ((Label)container.ElementAt(0)).text),
-                Is.EqualTo((true, 1, "b")));
+            var replacement = (VisualElement)container.ElementAt(0);
+            Assert.That(
+                (s_fallbackShown, container.childCount, ((Label)replacement.ElementAt(0)).text, ((Label)container.ElementAt(1)).text),
+                Is.EqualTo((true, 2, "caught", "b")));
         }
 
         [Component]
@@ -90,12 +94,11 @@ namespace Velvet.Tests
         }
 
         [Test]
-        public void Given_ErrorBoundaryAbortsDuringKeyedSyncReplace_When_Reconciled_Then_TheLaterSiblingIsUntouched()
+        public void Given_ErrorBoundaryAbortsDuringKeyedSyncReplace_When_Reconciled_Then_TheFallbackIsInsertedAndLaterSiblingIsUntouched()
         {
             // Arrange — keyed siblings with both keys present on both sides select the fully
             // synchronous keyed Pass-1 linear scan (the default V.Mount re-render path runs
-            // frameBudgetMs: 0). Same type-flip-triggers-abort shape as the indexed case above,
-            // including the same remove-then-create index shift (see #48).
+            // frameBudgetMs: 0). Same type-flip-triggers-abort shape as the indexed case above.
             using var mounted = V.Mount(Root, V.Component(KeyedSyncListHost, key: "host"));
             var container = Root.ElementAt(0);
 
@@ -104,12 +107,14 @@ namespace Velvet.Tests
             mounted.FlushStateForTest();
 
             // Assert
-            Assert.That((s_fallbackShown, container.childCount, ((Label)container.ElementAt(0)).text),
-                Is.EqualTo((true, 1, "b")));
+            var replacement = (VisualElement)container.ElementAt(0);
+            Assert.That(
+                (s_fallbackShown, container.childCount, ((Label)replacement.ElementAt(0)).text, ((Label)container.ElementAt(1)).text),
+                Is.EqualTo((true, 2, "caught", "b")));
         }
 
         [Test]
-        public void Given_AbortObservedDuringTimeSlicedKeyedReplace_When_Reconciled_Then_TheLaterSiblingIsUntouched()
+        public void Given_AbortObservedDuringTimeSlicedKeyedReplace_When_Reconciled_Then_TheReplacementIsInsertedAndLaterSiblingIsUntouched()
         {
             // Arrange — an extremely small frame budget forces the time-sliced keyed Pass-1 linear
             // scan (Pass1Linear) instead of ReconcileKeyedSync, exercising the same helper call
@@ -139,9 +144,10 @@ namespace Velvet.Tests
             Reconciler.Reconcile(Root, oldTree, newTree, frameBudgetMs: 0.001);
             DrainPendingWork();
 
-            // Assert — remove-then-create means the aborted k0 slot is gone with nothing inserted in
-            // its place (see #48), so k1's original text shifts down to index 0.
-            Assert.That((Root.childCount, ((Label)Root.ElementAt(0)).text), Is.EqualTo((1, "b")));
+            // Assert — the rebuilt k0 element is inserted despite the abort (refCallback fires after
+            // the element is fully built), and the abort stops the scan before k1 is reached, so its
+            // original text survives instead of being patched to "b-updated".
+            Assert.That((Root.childCount, ((Label)Root.ElementAt(1)).text), Is.EqualTo((2, "b")));
         }
 
         private void DrainPendingWork(int maxIterations = 500, double budget = 0.001)

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ChildReconcilerAbortSafetyTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ChildReconcilerAbortSafetyTests.cs
@@ -7,17 +7,14 @@ namespace Velvet.Tests
 {
     /// <summary>
     /// Specifies that a same-key/same-index type flip whose replacement element construction triggers
-    /// an error-boundary abort (<see cref="ReconcilerContext.IsAborted"/>) leaves the reconcile in a
-    /// recoverable state, across every <c>ChildReconciler.PatchOrReplaceAtSlot</c> call site (the
-    /// Common-phase indexed loop, and both keyed Pass-1 linear-scan implementations — sync and
-    /// time-sliced):
-    /// <list type="bullet">
-    /// <item>The old element at the replaced slot survives instead of the slot being left empty
-    /// (create-before-dispose: the replacement is constructed, and the abort observed, before the old
-    /// element is touched).</item>
-    /// <item>A later sibling in the same scan is left untouched instead of being patched while the
-    /// reconcile is aborted.</item>
-    /// </list>
+    /// an error-boundary abort (<see cref="ReconcilerContext.IsAborted"/>) stops the same scan from
+    /// processing any later sibling, across every <c>ChildReconciler.PatchOrReplaceAtSlot</c> call
+    /// site (the Common-phase indexed loop, and both keyed Pass-1 linear-scan implementations — sync
+    /// and time-sliced): a later sibling is left untouched instead of being patched while the
+    /// reconcile is aborted. (The replaced slot's old element is NOT expected to survive the abort —
+    /// see #48, tracked open: removal deliberately stays before CreateElement so an inline-mounted
+    /// same-keyed child fiber isn't handed back stale by ComponentRegistry, per the comment on
+    /// PatchOrReplaceAtSlot.)
     /// </summary>
     [TestFixture]
     internal sealed class ChildReconcilerAbortSafetyTests : ReconcilerTestFixture
@@ -51,24 +48,27 @@ namespace Velvet.Tests
         }
 
         [Test]
-        public void Given_ErrorBoundaryAbortsDuringIndexedReplace_When_Reconciled_Then_TheOldElementSurvivesAndTheLaterSiblingIsUntouched()
+        public void Given_ErrorBoundaryAbortsDuringIndexedReplace_When_Reconciled_Then_TheLaterSiblingIsUntouched()
         {
             // Arrange — unkeyed siblings select the Common-phase indexed diff. The first sibling flips
             // from a Label to a Div wrapping an error boundary whose child throws; the flip's CanPatch
             // decision is false, so building the replacement recurses into the boundary before the
-            // abort can be observed. The second sibling is untouched-old-value proof that the abort
-            // stopped the scan rather than merely surviving the one replaced slot.
+            // abort can be observed. Remove-then-create means the aborted slot's OLD element is
+            // already gone by the time the abort is observed (see #48) and no new element is
+            // inserted in its place, so the container shrinks by one and the untouched second
+            // sibling's ORIGINAL text shifts down to index 0 — that shift, plus the original text
+            // surviving instead of being patched to "b-updated", is the proof the abort stopped the
+            // scan rather than letting it keep patching later slots.
             using var mounted = V.Mount(Root, V.Component(IndexedListHost, key: "host"));
             var container = Root.ElementAt(0);
-            var oldElementAtSlot0 = container.ElementAt(0);
 
             // Act
             s_setFlag.Invoke(true);
             mounted.FlushStateForTest();
 
             // Assert
-            Assert.That((s_fallbackShown, container.ElementAt(0), ((Label)container.ElementAt(1)).text),
-                Is.EqualTo((true, oldElementAtSlot0, "b")));
+            Assert.That((s_fallbackShown, container.childCount, ((Label)container.ElementAt(0)).text),
+                Is.EqualTo((true, 1, "b")));
         }
 
         [Component]
@@ -90,26 +90,26 @@ namespace Velvet.Tests
         }
 
         [Test]
-        public void Given_ErrorBoundaryAbortsDuringKeyedSyncReplace_When_Reconciled_Then_TheOldElementSurvivesAndTheLaterSiblingIsUntouched()
+        public void Given_ErrorBoundaryAbortsDuringKeyedSyncReplace_When_Reconciled_Then_TheLaterSiblingIsUntouched()
         {
             // Arrange — keyed siblings with both keys present on both sides select the fully
             // synchronous keyed Pass-1 linear scan (the default V.Mount re-render path runs
-            // frameBudgetMs: 0). Same type-flip-triggers-abort shape as the indexed case above.
+            // frameBudgetMs: 0). Same type-flip-triggers-abort shape as the indexed case above,
+            // including the same remove-then-create index shift (see #48).
             using var mounted = V.Mount(Root, V.Component(KeyedSyncListHost, key: "host"));
             var container = Root.ElementAt(0);
-            var oldElementAtSlot0 = container.ElementAt(0);
 
             // Act
             s_setFlag.Invoke(true);
             mounted.FlushStateForTest();
 
             // Assert
-            Assert.That((s_fallbackShown, container.ElementAt(0), ((Label)container.ElementAt(1)).text),
-                Is.EqualTo((true, oldElementAtSlot0, "b")));
+            Assert.That((s_fallbackShown, container.childCount, ((Label)container.ElementAt(0)).text),
+                Is.EqualTo((true, 1, "b")));
         }
 
         [Test]
-        public void Given_AbortObservedDuringTimeSlicedKeyedReplace_When_Reconciled_Then_TheOldElementSurvivesAndTheLaterSiblingIsUntouched()
+        public void Given_AbortObservedDuringTimeSlicedKeyedReplace_When_Reconciled_Then_TheLaterSiblingIsUntouched()
         {
             // Arrange — an extremely small frame budget forces the time-sliced keyed Pass-1 linear
             // scan (Pass1Linear) instead of ReconcileKeyedSync, exercising the same helper call
@@ -123,7 +123,6 @@ namespace Velvet.Tests
             // the same _ctx.IsAborted contract without depending on component-fiber parentage.
             var oldTree = new VNode[] { V.Label(text: "a", key: "k0"), V.Label(text: "b", key: "k1") };
             Reconciler.Reconcile(Root, Array.Empty<VNode>(), oldTree);
-            var oldElementAtSlot0 = Root.ElementAt(0);
             var ctx = Reconciler.Context;
 
             var newTree = new VNode[]
@@ -140,9 +139,9 @@ namespace Velvet.Tests
             Reconciler.Reconcile(Root, oldTree, newTree, frameBudgetMs: 0.001);
             DrainPendingWork();
 
-            // Assert
-            Assert.That((Root.ElementAt(0), ((Label)Root.ElementAt(1)).text),
-                Is.EqualTo((oldElementAtSlot0, "b")));
+            // Assert — remove-then-create means the aborted k0 slot is gone with nothing inserted in
+            // its place (see #48), so k1's original text shifts down to index 0.
+            Assert.That((Root.childCount, ((Label)Root.ElementAt(0)).text), Is.EqualTo((1, "b")));
         }
 
         private void DrainPendingWork(int maxIterations = 500, double budget = 0.001)

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ChildReconcilerAbortSafetyTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ChildReconcilerAbortSafetyTests.cs
@@ -1,0 +1,179 @@
+using System;
+using NUnit.Framework;
+using Velvet.TestUtilities;
+using UnityEngine.UIElements;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Specifies that a same-key/same-index type flip whose replacement element construction triggers
+    /// an error-boundary abort (<see cref="ReconcilerContext.IsAborted"/>) leaves the reconcile in a
+    /// recoverable state, across every <c>ChildReconciler.PatchOrReplaceAtSlot</c> call site (the
+    /// Common-phase indexed loop, and both keyed Pass-1 linear-scan implementations — sync and
+    /// time-sliced):
+    /// <list type="bullet">
+    /// <item>The old element at the replaced slot survives instead of the slot being left empty
+    /// (create-before-dispose: the replacement is constructed, and the abort observed, before the old
+    /// element is touched).</item>
+    /// <item>A later sibling in the same scan is left untouched instead of being patched while the
+    /// reconcile is aborted.</item>
+    /// </list>
+    /// </summary>
+    [TestFixture]
+    internal sealed class ChildReconcilerAbortSafetyTests : ReconcilerTestFixture
+    {
+        private static bool s_fallbackShown;
+        private static StateUpdater<bool> s_setFlag;
+
+        public override void SetUp()
+        {
+            base.SetUp();
+            s_fallbackShown = false;
+            s_setFlag = default;
+        }
+
+        [Component]
+        private static VNode IndexedListHost()
+        {
+            var (flipped, setFlipped) = Hooks.UseState(false);
+            s_setFlag = setFlipped;
+            return V.Div(children: flipped
+                ? new VNode[]
+                {
+                    V.Div(children: new VNode[] { V.Component(BoundaryWrappingThrowerRender) }),
+                    V.Label(text: "b-updated"),
+                }
+                : new VNode[]
+                {
+                    V.Label(text: "a"),
+                    V.Label(text: "b"),
+                });
+        }
+
+        [Test]
+        public void Given_ErrorBoundaryAbortsDuringIndexedReplace_When_Reconciled_Then_TheOldElementSurvivesAndTheLaterSiblingIsUntouched()
+        {
+            // Arrange — unkeyed siblings select the Common-phase indexed diff. The first sibling flips
+            // from a Label to a Div wrapping an error boundary whose child throws; the flip's CanPatch
+            // decision is false, so building the replacement recurses into the boundary before the
+            // abort can be observed. The second sibling is untouched-old-value proof that the abort
+            // stopped the scan rather than merely surviving the one replaced slot.
+            using var mounted = V.Mount(Root, V.Component(IndexedListHost, key: "host"));
+            var container = Root.ElementAt(0);
+            var oldElementAtSlot0 = container.ElementAt(0);
+
+            // Act
+            s_setFlag.Invoke(true);
+            mounted.FlushStateForTest();
+
+            // Assert
+            Assert.That((s_fallbackShown, container.ElementAt(0), ((Label)container.ElementAt(1)).text),
+                Is.EqualTo((true, oldElementAtSlot0, "b")));
+        }
+
+        [Component]
+        private static VNode KeyedSyncListHost()
+        {
+            var (flipped, setFlipped) = Hooks.UseState(false);
+            s_setFlag = setFlipped;
+            return V.Div(children: flipped
+                ? new VNode[]
+                {
+                    V.Div(key: "k0", children: new VNode[] { V.Component(BoundaryWrappingThrowerRender) }),
+                    V.Label(text: "b-updated", key: "k1"),
+                }
+                : new VNode[]
+                {
+                    V.Label(text: "a", key: "k0"),
+                    V.Label(text: "b", key: "k1"),
+                });
+        }
+
+        [Test]
+        public void Given_ErrorBoundaryAbortsDuringKeyedSyncReplace_When_Reconciled_Then_TheOldElementSurvivesAndTheLaterSiblingIsUntouched()
+        {
+            // Arrange — keyed siblings with both keys present on both sides select the fully
+            // synchronous keyed Pass-1 linear scan (the default V.Mount re-render path runs
+            // frameBudgetMs: 0). Same type-flip-triggers-abort shape as the indexed case above.
+            using var mounted = V.Mount(Root, V.Component(KeyedSyncListHost, key: "host"));
+            var container = Root.ElementAt(0);
+            var oldElementAtSlot0 = container.ElementAt(0);
+
+            // Act
+            s_setFlag.Invoke(true);
+            mounted.FlushStateForTest();
+
+            // Assert
+            Assert.That((s_fallbackShown, container.ElementAt(0), ((Label)container.ElementAt(1)).text),
+                Is.EqualTo((true, oldElementAtSlot0, "b")));
+        }
+
+        [Test]
+        public void Given_AbortObservedDuringTimeSlicedKeyedReplace_When_Reconciled_Then_TheOldElementSurvivesAndTheLaterSiblingIsUntouched()
+        {
+            // Arrange — an extremely small frame budget forces the time-sliced keyed Pass-1 linear
+            // scan (Pass1Linear) instead of ReconcileKeyedSync, exercising the same helper call
+            // site's checkAbortAfterCreate: true path under the state-machine (park/resume)
+            // implementation. This path can only be driven by calling Reconciler.Reconcile directly
+            // (V.Mount's re-render path always uses frameBudgetMs: 0), and a real error-boundary
+            // component mounted this way would bootstrap its OWN isolated ReconcilerContext (its
+            // fiber has no parent fiber to inherit the shared one from — see SetupMount), so
+            // SetAborted() would never reach the context this test observes. A refCallback fired
+            // during CreateElement stands in for the abort a real boundary would raise, exercising
+            // the same _ctx.IsAborted contract without depending on component-fiber parentage.
+            var oldTree = new VNode[] { V.Label(text: "a", key: "k0"), V.Label(text: "b", key: "k1") };
+            Reconciler.Reconcile(Root, Array.Empty<VNode>(), oldTree);
+            var oldElementAtSlot0 = Root.ElementAt(0);
+            var ctx = Reconciler.Context;
+
+            var newTree = new VNode[]
+            {
+                V.Div(key: "k0", refCallback: _ =>
+                {
+                    ctx.IsAborted = true;
+                    return null;
+                }),
+                V.Label(text: "b-updated", key: "k1"),
+            };
+
+            // Act
+            Reconciler.Reconcile(Root, oldTree, newTree, frameBudgetMs: 0.001);
+            DrainPendingWork();
+
+            // Assert
+            Assert.That((Root.ElementAt(0), ((Label)Root.ElementAt(1)).text),
+                Is.EqualTo((oldElementAtSlot0, "b")));
+        }
+
+        private void DrainPendingWork(int maxIterations = 500, double budget = 0.001)
+        {
+            var iterations = 0;
+            while (Reconciler!.HasPendingWork)
+            {
+                if (iterations++ >= maxIterations)
+                {
+                    Assert.Fail($"DrainPendingWork: {maxIterations} iterations exceeded without completion");
+                }
+                Reconciler.ContinueReconcile(frameBudgetMs: budget);
+            }
+        }
+
+        #region BoundaryWrappingThrower component (boundary + Hooks.UseFallback wrapping a throwing child)
+
+        [Component(IsErrorBoundary = true)]
+        private static VNode BoundaryWrappingThrowerRender()
+        {
+            Hooks.UseFallback(_ =>
+            {
+                s_fallbackShown = true;
+                return V.Label(text: "caught");
+            });
+            return V.Component(ThrowingChildRender, key: "throwing-child");
+        }
+
+        [Component]
+        private static VNode ThrowingChildRender() => throw new Exception("boom-child");
+
+        #endregion
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ChildReconcilerAbortSafetyTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ChildReconcilerAbortSafetyTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ce72d6506ea8f458c9f934515bd51f7d


### PR DESCRIPTION
## Summary

Two fixes to `ChildReconciler.PatchOrReplaceAtSlot`'s error-boundary abort handling, covering all three of its call sites (the Common-phase indexed loop, and both keyed Pass-1 linear scans — sync and time-sliced):

1. `ReconcileKeyedSync`'s Pass-1 linear scan never checked for an abort after `CreateElement`, unlike the other two call sites — an aborted reconcile kept patching/replacing later siblings in the same scan instead of stopping. Now stops immediately, matching the Common-phase indexed loop and the time-sliced keyed scan.

2. A same-key type-flip replacement whose construction triggered an error-boundary abort had its newly built element discarded, stranding the slot empty. `ReconcilerContext.IsAborted` only ever becomes true via `FiberErrorBoundary.TryCatch`'s `SetAborted` call, which fires exclusively *after* the boundary's fallback content has already rendered successfully — so the discarded element was never half-built, it already held valid fallback content. The element is now always inserted; an observed abort only stops the scan from touching later siblings, which was the actual intent of the flag.

## #48's earlier failed attempt (for context)

An earlier version of this PR attempted #48 via create-before-dispose ordering instead. That broke `ComponentStateReparityTests`: `ComponentRegistry`'s inline-fiber lookup is keyed by `(parentFiber, positionKey, identity)`, not by which `VisualElement` currently hosts the fiber, so building the new element while the old one (and its still-registered same-keyed nested fiber) was still present handed the new side a stale, live fiber instead of mounting fresh — and worse, that reused fiber's `MountPoint` was never updated, so removing the old element afterward disposed it a second time by stale containment, leaving its DOM output as an inert ghost. Reverted in favor of the fix above, which keeps `PatchOrReplaceAtSlot` remove-then-create (required for `ComponentRegistry`'s inline-fiber identity) and needs no `ComponentRegistry` changes at all.

## Follow-up filed during this work

- #51 — a bare `Reconciler.Reconcile()` call (not `V.Mount`) with a nested `ComponentNode` bootstraps an orphaned `ReconcilerContext`, discovered while building this PR's regression tests (worked around there via `V.Mount` for two of the three call sites and a `refCallback`-simulated abort for the third).

## Test plan

- `ChildReconcilerAbortSafetyTests`: 3 tests covering all three `PatchOrReplaceAtSlot` call sites, each verifying (a) the replacement element (holding the boundary's fallback content) is inserted despite the abort, and (b) a later sibling is left untouched instead of being patched while the reconcile is aborted.
- Full EditMode suite: 2759/2759 passed (including `ComponentStateReparityTests`, confirming the remove-then-create ordering — and therefore nested-component state reset on a genuine type flip — is unaffected).

Closes #47
Closes #48
