### PR TITLE
fix: a nested ComponentNode joins its creator's ReconcilerContext

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A `ComponentNode` nested inside a tree reconciled via a direct `Reconciler.Reconcile()` call
+  (rather than `V.Mount`) no longer bootstraps its own isolated `ReconcilerContext`. Its fiber now
+  always joins the context of the `ComponentRegistry` that created it, instead of deriving one from
+  `fiber.Parent?.Reconciler?.Context` — which resolved to nothing whenever nothing had yet been
+  pushed onto the shared `FiberStack` (any hand-authored tree that reconciles directly instead of
+  through `V.Mount`). The gap silently detached the nested fiber from the caller's own registries
+  and `IsAborted` flag, so an error boundary nested this way could catch its child's exception and
+  render a fallback, but the caller's own reconcile pass never observed the abort and kept
+  processing later siblings as if nothing had failed.
 - `ChildReconciler`'s same-key type-flip replacement (the Common-phase indexed loop, and both keyed
   Pass-1 linear scans — sync and time-sliced) now always inserts the newly built replacement element
   even when building it triggers an error-boundary abort, instead of discarding it and leaving the

--- a/Packages/com.velvet.core/Runtime/Component/ComponentRegistry.cs
+++ b/Packages/com.velvet.core/Runtime/Component/ComponentRegistry.cs
@@ -171,11 +171,11 @@ namespace Velvet
             {
                 if (isInline)
                 {
-                    FiberRenderer.MountInline(fiber, mountPoint, slotStart);
+                    FiberRenderer.MountInline(fiber, mountPoint, slotStart, _ctx);
                 }
                 else
                 {
-                    FiberRenderer.Mount(fiber, mountPoint);
+                    FiberRenderer.Mount(fiber, mountPoint, _ctx);
                 }
             }
             catch (FiberSuspendSignal)

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberRenderer.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberRenderer.cs
@@ -60,9 +60,10 @@ namespace Velvet
         // Attaches the fiber to mountPoint and runs the initial render + layout effects.
         // fiber: Fiber to mount. Must not already be mounted.
         // mountPoint: VisualElement that hosts the rendered tree. Must not be null.
-        public static void Mount(ComponentFiber fiber, VisualElement? mountPoint)
+        // sharedContext: see SetupMount.
+        public static void Mount(ComponentFiber fiber, VisualElement? mountPoint, ReconcilerContext? sharedContext = null)
         {
-            SetupMount(fiber, mountPoint);
+            SetupMount(fiber, mountPoint, sharedContext);
             RenderAndReconcile(fiber);
             FiberEffects.CommitSubtreeEffects(fiber, mountDoubleInvoke: true);
         }
@@ -74,9 +75,10 @@ namespace Velvet
         // output VEs into parent.children at slotStart.
         // Subsequent setState-triggered re-renders use the fiber's own Reconciler with slot-range
         // addressing (the deferReconcile flag is only honored on this initial mount path).
-        public static void MountInline(ComponentFiber fiber, VisualElement? parent, int slotStart)
+        // sharedContext: see SetupMount.
+        public static void MountInline(ComponentFiber fiber, VisualElement? parent, int slotStart, ReconcilerContext? sharedContext = null)
         {
-            SetupMount(fiber, parent);
+            SetupMount(fiber, parent, sharedContext);
             fiber.IsInlineMounted = true;
             fiber.MountSlotStart = slotStart;
             RenderAndReconcile(fiber, deferReconcile: true);
@@ -129,7 +131,20 @@ namespace Velvet
             fiber.Reconciler?.Context.BatchScheduler.Remove(fiber);
         }
 
-        private static void SetupMount(ComponentFiber fiber, VisualElement? mountPoint)
+        // sharedContext: the ReconcilerContext this fiber must join, when its creator already knows
+        // one authoritatively — ComponentRegistry passes its own _ctx here (both its inline and
+        // wrapper-mounted GetOrCreate paths), since a fiber it creates always belongs to that
+        // context regardless of tree position. Deriving the context from fiber.Parent?.Reconciler?.Context
+        // instead is unreliable: fiber.Parent is only set when _ctx.FiberStack.Current was non-null at
+        // AppendChild time, which requires an ancestor fiber's render to already be in progress
+        // (RenderAndReconcile / TryCatch push it). A bare Reconciler.Reconcile() call — not driven
+        // through V.Mount, e.g. a hand-authored tree in a test — has nothing on FiberStack, so a nested
+        // ComponentNode's fiber.Parent stays null even though ComponentRegistry itself is unambiguously
+        // running inside a real, non-orphaned context. Falling back to bootstrapping a fresh, unrelated
+        // Reconciler+ReconcilerContext there silently detaches the fiber from the caller's registries /
+        // FiberStack / IsAborted flag (see #51). Left null only by V.Mount's direct root-fiber path,
+        // which has no context to join and must bootstrap its own (this fiber becomes the owner).
+        private static void SetupMount(ComponentFiber fiber, VisualElement? mountPoint, ReconcilerContext? sharedContext = null)
         {
             if (fiber.IsMounted)
             {
@@ -142,7 +157,7 @@ namespace Velvet
             // by (anchor, slotKey, identity) resolve to the same fiber instance regardless of
             // which fiber's Reconciler is currently running. Wrapper-mounted fibers without a
             // parent fiber (root mount path) bootstrap a fresh Reconciler that owns its ctx.
-            var parentCtx = fiber.Parent?.Reconciler?.Context;
+            var parentCtx = sharedContext ?? fiber.Parent?.Reconciler?.Context;
             fiber.Reconciler = parentCtx != null
                 ? new Reconciler(parentCtx)
                 : new Reconciler();

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/BareReconcileContextSharingTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/BareReconcileContextSharingTests.cs
@@ -1,0 +1,63 @@
+#nullable enable
+using System;
+using NUnit.Framework;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Specifies that a ComponentNode nested inside a tree reconciled via a bare
+    /// Reconciler.Reconcile() call (not V.Mount) shares the caller's own ReconcilerContext instead
+    /// of its fiber bootstrapping an orphaned, unrelated one — verified via an error boundary's
+    /// SetAborted() call reaching the SAME context the caller reads IsAborted from. A bare
+    /// Reconcile() call leaves FiberStack empty before the nested ComponentNode is registered, so
+    /// its fiber.Parent stays null; ComponentRegistry must hand it the context it is itself running
+    /// inside of rather than deriving one from that null parent.
+    /// </summary>
+    [TestFixture]
+    internal sealed class BareReconcileContextSharingTests : ReconcilerTestFixture
+    {
+        private static bool s_fallbackShown;
+
+        public override void SetUp()
+        {
+            base.SetUp();
+            s_fallbackShown = false;
+        }
+
+        [Test]
+        public void Given_ABareReconcileWithNestedErrorBoundary_When_ItsChildThrows_Then_TheAbortIsObservedOnTheCallersOwnContext()
+        {
+            // Arrange — Reconciler.Reconcile is called directly (not via V.Mount), so nothing is
+            // pushed onto FiberStack before the nested ComponentNode is expanded during Reconcile.
+            var newTree = new VNode[] { V.Component(BoundaryWrappingThrowerRender) };
+
+            // Act
+            Reconciler.Reconcile(Root, Array.Empty<VNode>(), newTree);
+
+            // Assert — LastTopLevelWasAborted snapshots the caller's OWN _ctx.IsAborted right before
+            // Reconciler.Reconcile's top-level pass resets it for the next call (Reconciler.cs), so
+            // this observes whether the boundary's SetAborted() reached the SAME context the caller's
+            // Reconcile() is running under, instead of an orphaned one silently absorbing it.
+            Assert.That((s_fallbackShown, Reconciler.LastTopLevelWasAborted), Is.EqualTo((true, true)));
+        }
+
+        #region BoundaryWrappingThrower component (boundary + Hooks.UseFallback wrapping a throwing child)
+
+        [Component(IsErrorBoundary = true)]
+        private static VNode BoundaryWrappingThrowerRender()
+        {
+            Hooks.UseFallback(_ =>
+            {
+                s_fallbackShown = true;
+                return V.Label(text: "caught");
+            });
+            return V.Component(ThrowingChildRender, key: "throwing-child");
+        }
+
+        [Component]
+        private static VNode ThrowingChildRender() => throw new Exception("boom-child");
+
+        #endregion
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/BareReconcileContextSharingTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/BareReconcileContextSharingTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b5e497bfb63144bc78e65c2d27abfc49


### PR DESCRIPTION
## Summary

A `ComponentNode` nested inside a tree reconciled via a bare `Reconciler.Reconcile()` call (not `V.Mount`) bootstrapped its own isolated `ReconcilerContext` instead of sharing the caller's.

`FiberRenderer.SetupMount` derived the context to share via `fiber.Parent?.Reconciler?.Context`, which resolves to nothing when `fiber.Parent` is null. `fiber.Parent` is only set when something was pushed onto the shared `FiberStack` before the fiber was created — that requires an ancestor fiber's render to already be in progress (`RenderAndReconcile` / `TryCatch` push it). A bare `Reconcile()` call has nothing on `FiberStack`, so a directly nested `ComponentNode`'s `fiber.Parent` stays null even though the `ComponentRegistry` creating it is unambiguously running inside a real, non-orphaned context.

An error boundary nested this way still caught its child's exception and rendered a fallback correctly, but `SetAborted()` landed on the orphaned context — so the caller's own reconcile pass never observed the abort and kept processing later siblings as if nothing had failed.

## Fix

`ComponentRegistry` already knows the context it runs inside of (`_ctx`, passed to its constructor). `GetOrCreateCore` now passes that context explicitly to `FiberRenderer.Mount`/`MountInline` instead of relying on `fiber.Parent` to derive it. `V.Mount`'s direct root-fiber path (which never goes through `ComponentRegistry`) is unaffected — it still bootstraps its own context, since it has none to join.

## Test plan

- New `BareReconcileContextSharingTests`: a `Reconciler.Reconcile()` call with a directly nested error-boundary `ComponentNode` whose child throws — verifies `Reconciler.LastTopLevelWasAborted` (which snapshots the caller's own `_ctx.IsAborted` right before the top-level pass resets it) reflects the boundary's successful catch. RED-verified against the pre-fix orphaned-context derivation, GREEN with the fix.
- Full EditMode suite: 2760/2760 passed.
- Full PlayMode suite: 42/42 passed.

Closes #51
