### PR TITLE
feat: V.Motion(layoutId:) shared-element layout animation

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `V.Motion(layoutId:)`: Framer Motion's shared-element layout animation parity. When a Motion
+  carrying the same `layoutId` string patches at a resolved layout rect different from the rect
+  that id last settled at — including across a same-key type flip or a move to a different
+  parent — it tweens from the old rect to the new one (FLIP: capture, invert, spring back to
+  zero) instead of jump-cutting. Reuses the existing spring physics driver; scoped to uniform
+  scale (UI Toolkit's `scale` style has no independent X/Y factor).
 - Cross-panel input routing for `V.Portal(layer:)` and `V.WorldSpace`: a layer or world-space
   host panel is a wholly separate UI Toolkit `Panel` from the panel its content logically
   belongs to, so native input delivery, propagation, and focus were previously scoped entirely

--- a/Packages/com.velvet.core/Documentation~/motion.md
+++ b/Packages/com.velvet.core/Documentation~/motion.md
@@ -156,6 +156,34 @@ new StyleTransitionConfig
 - Non-finite / non-positive `Stiffness` / `Damping` / `Mass` log a warning and complete
   immediately rather than freezing the element mid-pose.
 
+## Shared-element layout animation (`layoutId`)
+
+```csharp
+V.Motion(layoutId: "card-3", className: expanded ? "absolute left-[0px] top-[0px] w-[600px] h-[400px]"
+                                                  : "absolute left-[40px] top-[120px] w-[120px] h-[80px]");
+```
+
+- Framer's `layoutId` parity. When a Motion carrying this same string patches at a resolved
+  layout rect (position and/or size) different from the rect the SAME id last settled at, it
+  tweens from the old rect to the new one — FLIP: the old rect is captured, layout settles at the
+  new one, an inverse inline transform is applied immediately, then it springs back to zero —
+  instead of jump-cutting.
+- Works across a same-key type flip or a move to a different parent, not just an in-place resize:
+  the id, not the physical element, is what's tracked. Two Motions in the same tree must never
+  share a live `layoutId` simultaneously — the second one to patch silently steals the
+  registration.
+- Independent of `Variants`/`Animate`: the tween runs from the ACTUAL rect delta captured off
+  `element.layout`, not a class-defined from/to pair, so it fires whether or not the same patch
+  also changed variants. Falls back to `StyleTransitionConfig`'s own spring defaults (Stiffness
+  100 / Damping 10 / Mass 1) when the Motion declares no `Transition`.
+- **Uniform scale only.** A non-uniform rect change (width and height scale by different factors)
+  averages the two axis scale factors rather than distorting the element on two independent axes
+  — UI Toolkit's `scale` style is a single uniform factor, not independent X/Y.
+- Position is captured synchronously before the patch (mirroring `PopLayout`'s own "read
+  `.layout` before the mutation that invalidates it" pattern); the new rect is captured on the
+  element's own next `GeometryChangedEvent`, since a reparented/freshly-created element's
+  `.layout` stays stale until the following layout pass.
+
 ## Transition semantics: one config, every update
 
 Every variant update rides the Motion's own `StyleTransitionConfig` — mount enters

--- a/Packages/com.velvet.core/Runtime/Component/V.cs
+++ b/Packages/com.velvet.core/Runtime/Component/V.cs
@@ -1714,7 +1714,8 @@ namespace Velvet
             IReadOnlyDictionary<string, string>? variants = null,
             string? animate = null,
             string? initial = null,
-            string? exit = null)
+            string? exit = null,
+            string? layoutId = null)
         {
             var resolvedTransition = transition ?? StyleTransition.Fade;
             if (duration != null || easing != null || delay != null)
@@ -1744,6 +1745,7 @@ namespace Velvet
                 Animate = animate,
                 Initial = initial,
                 Exit = exit,
+                LayoutId = layoutId,
             };
         }
 

--- a/Packages/com.velvet.core/Runtime/Component/VNodeTypes.cs
+++ b/Packages/com.velvet.core/Runtime/Component/VNodeTypes.cs
@@ -131,6 +131,20 @@ namespace Velvet
         /// Null = use the transition's own ExitFrom/ExitTo classes.
         /// </summary>
         public string? Exit { get; init; }
+
+        /// <summary>
+        /// Shared-element layout animation identity (Framer Motion's <c>layoutId</c> parity). When a Motion
+        /// carrying this same string patches at a resolved layout rect (position and/or size) different from
+        /// the rect the SAME id last settled at — including a different physical element entirely, e.g. after
+        /// a same-key type flip or a move to a different parent — it tweens from the old rect to the new one
+        /// (FLIP: capture the old rect, let layout settle at the new one, apply an inverse transform, then
+        /// spring that inverse back to zero) instead of jump-cutting. Independent of <see cref="Variants"/>/
+        /// <see cref="Animate"/>: a layoutId tween runs from the ACTUAL rect delta, not a class-defined
+        /// from/to pair. Null = no layout animation (ordinary jump-cut on a rect change, matching every other
+        /// element). Two Motions in the same tree must never share a live layoutId simultaneously — the
+        /// second one to patch silently steals the registration (see MotionLayoutIdDriver).
+        /// </summary>
+        public string? LayoutId { get; init; }
     }
 
     /// <summary>

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberElementCleaner.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberElementCleaner.cs
@@ -198,6 +198,11 @@ namespace Velvet
             // living) must not run even though it can still be attached at this point — DOM detachment is the
             // caller's own job, performed after this cleanup.
             _ctx.StyleAnimationScheduler.CancelExitForTeardown(element);
+            // Must run BEFORE ClearElementSideTables below: it reads ElementToLayoutId (one of the
+            // pure side-tables that call clears) to find this element's layoutId, if any, and cancels
+            // its in-flight tick / drops its LayoutIdRegistry entry so a departing element's tween
+            // never keeps ticking against it.
+            MotionLayoutIdDriver.CancelForTeardown(element, _ctx);
             _ctx.EventManager.UnbindAll(element);
             _ctx.ComponentRegistry.Remove(element);
             DetachManipulator(element, _ctx.GestureManipulators);

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodeFactory.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodeFactory.cs
@@ -312,6 +312,19 @@ namespace Velvet
                                 + "enter. An inherited animate label does not yet drive one.");
                         }
                     }
+                    // Shared-element layout animation (Framer's layoutId) on a freshly-created element —
+                    // the same-key-type-flip case PatchMotion's own registration cannot reach (a type
+                    // flip tears down the OLD element and creates a genuinely NEW one for the SAME id,
+                    // never routing through PatchMotion at all). MotionLayoutIdDriver.OnPatched already
+                    // handles "new physical element, existing registry entry" by falling back to the
+                    // registry's own stored rect instead of this element's own (nonexistent) layout
+                    // history — see its own comment.
+                    if (motionNode.LayoutId != null)
+                    {
+                        var lt = motionNode.Transition;
+                        MotionLayoutIdDriver.OnPatched(element, motionNode.LayoutId,
+                            lt?.Stiffness ?? 100f, lt?.Damping ?? 10f, lt?.Mass ?? 1f, _ctx);
+                    }
                     return element;
                 }
                 case AnimatePresenceNode:

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
@@ -476,6 +476,20 @@ namespace Velvet
             // Motion (allowWrap false); a Motion thus carries no ring binding, so this only updates/unwraps an
             // (absent by this rule) binding.
             _appliers.ApplyRingOnPatch(element, appliedNew, suppress: false, allowWrap: false);
+
+            // Shared-element layout animation (Framer's layoutId): independent of the variant swap
+            // above — runs from the ACTUAL resolved-rect delta, not a class-defined from/to pair — so
+            // it fires whether or not this patch also changed Variants/Animate. Falls back to
+            // StyleTransitionConfig's own documented spring defaults (Stiffness 100 / Damping 10 /
+            // Mass 1) when this Motion declares no Transition, since a layoutId tween needs SOME spring
+            // shape to animate with and Velvet does not imitate Framer's implicit default transition
+            // for the variant swap either.
+            if (newNode.LayoutId != null)
+            {
+                var t = newNode.Transition;
+                MotionLayoutIdDriver.OnPatched(element, newNode.LayoutId,
+                    t?.Stiffness ?? 100f, t?.Damping ?? 10f, t?.Mass ?? 1f, _ctx);
+            }
         }
 
         // Resolves the MotionOrchestrationFrame this node exposes to its OWN inheriting children:

--- a/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System.Collections.Generic;
+using UnityEngine;
 using UnityEngine.UIElements;
 
 namespace Velvet
@@ -269,6 +270,27 @@ namespace Velvet
         // A pure side-table (bare Remove on teardown), so it is enrolled in _pureElementSideTables and cleared
         // on element cleanup / reconciler dispose through that mechanism.
         public Dictionary<VisualElement, string> MotionChildLabel { get; } = new();
+
+        // The last VisualElement a V.Motion(layoutId:) id settled at, and the resolved layout rect
+        // (parent-relative, from element.layout) it settled at — used by MotionLayoutIdDriver to
+        // detect a rect change (including across a DIFFERENT physical element entirely, e.g. after a
+        // same-key type flip or a move to a different parent) and FLIP-tween from the old rect to the
+        // new one. Keyed by the id string, not an element, so it cannot ride the _pureElementSideTables
+        // auto-clear mechanism below (that clears entries keyed BY a departing element, not entries
+        // that happen to reference one as a value) — ElementToLayoutId is the reverse index that makes
+        // manual cleanup possible: when an element is torn down, look up its id here, and only then
+        // remove the LayoutIdRegistry entry IF it still points at this exact element (a same-key type
+        // flip may already have overwritten it with the replacement before the old element's own
+        // teardown runs).
+        public Dictionary<string, (VisualElement Element, Rect Rect)> LayoutIdRegistry { get; } = new();
+        public Dictionary<VisualElement, string> ElementToLayoutId { get; } = new();
+
+        // The recurring physics tick for an in-flight layoutId FLIP tween, keyed by the animating
+        // element. Owns a real scheduled resource (unlike ElementToLayoutId above), so it is deliberately
+        // NOT enrolled in _pureElementSideTables — MotionLayoutIdDriver.CancelForTeardown pauses and
+        // removes it explicitly, mirroring StyleAnimationScheduler's own spring-tick teardown for the
+        // variant enter/exit case.
+        public Dictionary<VisualElement, IVisualElementScheduledItem> LayoutIdTicks { get; } = new();
 
         // Per-element drop-shadow bookkeeping for the shadow-* className layer, keyed by the element
         // itself — the shadow needs NO structural wrapper. Like skew and gradient, the shadow is painted
@@ -732,6 +754,7 @@ namespace Velvet
                 SupportsVariants,
                 MotionAppliedClasses,
                 MotionChildLabel,
+                ElementToLayoutId,
                 TextEffects,
                 TextRawText,
             };

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/MotionLayoutIdPatchTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/MotionLayoutIdPatchTests.cs
@@ -1,0 +1,84 @@
+using NUnit.Framework;
+using UnityEngine.UIElements;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Specifies V.Motion(layoutId:)'s FLIP behavior end to end through a real (simulated) panel and
+    /// reconcile pass: when a Motion's resolved layout rect changes across a re-render while carrying
+    /// the same layoutId, MotionLayoutIdDriver applies an inverse inline transform immediately after
+    /// layout settles at the new rect, then springs it back to zero over subsequent ticks — instead of
+    /// jump-cutting straight to the new pose.
+    /// </summary>
+    [TestFixture]
+    internal sealed class MotionLayoutIdPatchTests : MotionSimulatedPanelTestsBase
+    {
+        private static StateUpdater<bool> s_setMoved;
+
+        public override void SetUp()
+        {
+            base.SetUp();
+            s_setMoved = default;
+        }
+
+        [Component]
+        private static VNode SharedBoxRender()
+        {
+            var (moved, setMoved) = Hooks.UseState(false);
+            s_setMoved = setMoved;
+            return V.Div(children: new VNode[]
+            {
+                V.Motion(
+                    name: "shared",
+                    layoutId: "shared-box",
+                    transition: new StyleTransitionConfig { Type = TransitionType.Spring, Stiffness = 100f, Damping = 10f, Mass = 1f },
+                    className: moved
+                        ? "absolute left-[200px] top-[0px] w-[100px] h-[100px]"
+                        : "absolute left-[0px] top-[0px] w-[100px] h-[100px]"),
+            });
+        }
+
+        [Test]
+        public void Given_ALayoutIdMotion_When_ItsRectChangesAcrossARerender_Then_AnInverseTranslateAppliesImmediatelyAfterLayoutSettles()
+        {
+            // Arrange
+            using var mounted = V.Mount(Root, V.Component(SharedBoxRender, key: "root"));
+            Tick();
+            var element = Root.Q<VisualElement>("shared");
+            Assume.That(element, Is.Not.Null, "Precondition: the Motion mounted");
+
+            // Act — move the Motion 200px to the right; wait one tick for GeometryChangedEvent to fire and
+            // the driver to apply the inverse pose.
+            s_setMoved.Invoke(true);
+            mounted.FlushStateForTest();
+            Tick();
+
+            // Assert — the element is pinned at (roughly) its OLD screen position via an inline translate,
+            // even though the resolved layout already moved it 200px right (translate.x ~= -200).
+            Assert.That(element.style.translate.value.x.value, Is.LessThan(-50f));
+        }
+
+        [Test]
+        public void Given_ALayoutIdMotion_When_SeveralTicksElapseAfterARectChange_Then_TheInverseTranslateSettlesToZero()
+        {
+            // Arrange
+            using var mounted = V.Mount(Root, V.Component(SharedBoxRender, key: "root"));
+            Tick();
+            var element = Root.Q<VisualElement>("shared");
+            s_setMoved.Invoke(true);
+            mounted.FlushStateForTest();
+            Tick();
+            Assume.That(element.style.translate.value.x.value, Is.LessThan(-50f),
+                "Precondition: the inverse pose applied after the rect change");
+
+            // Act — let the spring settle.
+            AdvancePast(2f);
+
+            // Assert — the inline translate override is cleared once the spring settles (StyleKeyword.Null),
+            // reporting back to StyleKeyword.Auto / 0 the way MotionSpringDriver.ClearInlineOverrides always
+            // leaves a settled channel.
+            Assert.That(element.style.translate.keyword, Is.EqualTo(StyleKeyword.Null));
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/MotionLayoutIdPatchTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/MotionLayoutIdPatchTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: fa6e11bfa488e48b69b18bb5cea149fc

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/MotionLayoutIdPlaybackTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/MotionLayoutIdPlaybackTests.cs
@@ -1,0 +1,109 @@
+#if UNITY_EDITOR
+using System.Collections;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.TestTools;
+using UnityEngine.UIElements;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins that V.Motion(layoutId:)'s FLIP tween actually plays on a real runtime panel: a rect change
+    /// across a re-render passes through an intermediate inline translate on its way back to zero,
+    /// instead of jump-cutting straight to the new pose the moment layout settles.
+    /// </summary>
+    internal sealed class MotionLayoutIdPlaybackTests
+    {
+        private static StateUpdater<bool> s_setMoved;
+
+        private GameObject _go;
+        private PanelSettings _settings;
+        private MountedTree _mounted;
+        private TargetFrameRateScope _frameRateScope;
+
+        [UnitySetUp]
+        public IEnumerator UnitySetUp()
+        {
+            _frameRateScope = new TargetFrameRateScope(120);
+            s_setMoved = default;
+            yield break;
+        }
+
+        [UnityTearDown]
+        public IEnumerator UnityTearDown()
+        {
+            _frameRateScope.Dispose();
+            _mounted?.Dispose();
+            _mounted = null;
+            if (_go != null) Object.Destroy(_go);
+            if (_settings != null) Object.Destroy(_settings);
+            yield return null;
+        }
+
+        [Component]
+        private static VNode SharedBoxRender()
+        {
+            var (moved, setMoved) = Hooks.UseState(false);
+            s_setMoved = setMoved;
+            return V.Div(children: new VNode[]
+            {
+                V.Motion(
+                    name: "shared",
+                    layoutId: "shared-box",
+                    transition: new StyleTransitionConfig { Type = TransitionType.Spring, Stiffness = 80f, Damping = 10f, Mass = 1f },
+                    className: moved
+                        ? "absolute left-[200px] top-[0px] w-[100px] h-[100px]"
+                        : "absolute left-[0px] top-[0px] w-[100px] h-[100px]"),
+            });
+        }
+
+        [UnityTest]
+        public IEnumerator Given_ALayoutIdMotionOnARuntimePanel_When_ItsRectChanges_Then_TheInlineTranslatePassesThroughAnIntermediateValueOnItsWayToZero()
+        {
+            // Arrange — a real UIDocument panel with the bundled utilities so left-[..]/top-[..]/w-[..]/
+            // h-[..] resolve.
+            _go = new GameObject("LayoutIdPlayback");
+            var doc = _go.AddComponent<UIDocument>();
+            _settings = ScriptableObject.CreateInstance<PanelSettings>();
+            _settings.scaleMode = PanelScaleMode.ConstantPixelSize;
+            doc.panelSettings = _settings;
+            yield return null;
+            var sheet = AssetDatabase.LoadAssetAtPath<StyleSheet>(
+                "Packages/com.velvet.core/Runtime/Styles/StyleUtilities.uss");
+            Assume.That(sheet, Is.Not.Null, "Precondition: the bundled StyleUtilities.uss loads");
+            doc.rootVisualElement.styleSheets.Add(sheet);
+            _mounted = V.Mount(doc.rootVisualElement, V.Component(SharedBoxRender, key: "root"));
+            var element = doc.rootVisualElement.Q<VisualElement>("shared");
+            Assume.That(element, Is.Not.Null, "Precondition: the Motion mounted");
+            yield return null;
+
+            // Act — move the Motion 200px right, then sample the inline translate.x across real frames.
+            s_setMoved.Invoke(true);
+            var sawIntermediate = false;
+            var sawNearZero = false;
+            var deadline = Time.realtimeSinceStartupAsDouble + 2.0;
+            while (Time.realtimeSinceStartupAsDouble < deadline)
+            {
+                var t = element.resolvedStyle.translate.x;
+                // The inverse pose starts near -200 (the old-minus-new position delta) and springs back
+                // toward 0 — "intermediate" here means strictly between the two, not merely nonzero.
+                if (t < -20f && t > -180f)
+                {
+                    sawIntermediate = true;
+                }
+                if (!sawNearZero && sawIntermediate && Mathf.Abs(t) < 1f)
+                {
+                    sawNearZero = true;
+                    break;
+                }
+                yield return null;
+            }
+
+            // Assert
+            Assert.That((sawIntermediate, sawNearZero), Is.EqualTo((true, true)));
+        }
+    }
+}
+#endif

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/MotionLayoutIdPlaybackTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/MotionLayoutIdPlaybackTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 86dabf1c9e2c9480789b3e1477f0610e

--- a/Packages/com.velvet.core/Runtime/Styling/MotionLayoutIdDriver.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/MotionLayoutIdDriver.cs
@@ -1,0 +1,147 @@
+#nullable enable
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace Velvet
+{
+    // Framer Motion's layoutId parity: FLIP (First-Last-Invert-Play) shared-element layout animation.
+    // When a V.Motion(layoutId:) patches at a resolved layout rect different from the rect the SAME id
+    // last settled at — including across a DIFFERENT physical element entirely, e.g. after a same-key
+    // type flip or a move to a different parent — it tweens from the old rect to the new one instead of
+    // jump-cutting: capture the OLD rect, let this frame's layout settle at the NEW one, compute the
+    // delta, apply it as an inline inverse transform (Invert), then spring that inverse back to zero
+    // (Play). Reuses MotionSpringDriver's existing panel-independent physics channels (translate x/y,
+    // uniform scale) — the same machinery every other spring-driven Motion transition already shares —
+    // rather than building a second driver.
+    //
+    // Scope: uniform scale only. MotionSpringDriver.SpringChannel.Scale drives a single Vector2(v, v);
+    // a non-uniform rect change (width and height scale by different factors) averages the two axis
+    // scale factors instead of distorting the element on two independent axes — Framer Motion itself
+    // falls back to the same kind of approximation (via `layout="preserve-aspect"` guidance) when an
+    // element's own aspect ratio changes across the animated rects.
+    internal static class MotionLayoutIdDriver
+    {
+        // Called from FiberNodePatcher.PatchMotion for a MotionNode carrying a LayoutId, once the
+        // patch's own class/style/children work is done. element.layout still holds the PRE-patch
+        // resolved rect at this point (this frame's Yoga pass has not run yet) — capturing it now is the
+        // same "read .layout synchronously before the mutation that invalidates it" pattern
+        // GeneralPathReconciler.PinExitingChildOutOfFlow uses for a PopLayout exit. The NEW rect is not
+        // trustworthy yet (a reparented/freshly-created element's .layout stays stale until the next
+        // Yoga pass — see FiberWrapperElementAppliers's clip-wrapper comment on the same window), so it
+        // is captured on this element's own first post-patch GeometryChangedEvent instead.
+        internal static void OnPatched(VisualElement element, string layoutId, float stiffness, float damping, float mass, ReconcilerContext ctx)
+        {
+            var hadPrevious = ctx.LayoutIdRegistry.TryGetValue(layoutId, out var previous);
+            // A same-key type flip creates a NEW element for the SAME layoutId — its own .layout has
+            // never been resolved (fresh element), so the old rect has to come from the id's last known
+            // settle point instead of this element's own (nonexistent) history.
+            var oldRect = ReferenceEquals(previous.Element, element) ? element.layout : previous.Rect;
+
+            ctx.ElementToLayoutId[element] = layoutId;
+            // Placeholder until the post-patch GeometryChangedEvent below overwrites it with the real
+            // new rect — anything reading the registry in between (a second, concurrent layoutId patch
+            // elsewhere in the same pass) sees the STALE rect, which only risks that other patch's own
+            // delta momentarily missing a change this element hasn't settled into yet, never corrupting
+            // it.
+            ctx.LayoutIdRegistry[layoutId] = (element, oldRect);
+
+            if (!hadPrevious || !IsFiniteRect(oldRect))
+            {
+                // First-ever registration for this id, or the captured rect is not a real resolved
+                // layout (NaN — an EditMode pass with no forced layout) — nothing to tween from.
+                return;
+            }
+
+            element.RegisterCallback<GeometryChangedEvent>(OnGeometrySettled);
+
+            void OnGeometrySettled(GeometryChangedEvent evt)
+            {
+                element.UnregisterCallback<GeometryChangedEvent>(OnGeometrySettled);
+                var newRect = element.layout;
+                if (!IsFiniteRect(newRect)) return;
+
+                ctx.LayoutIdRegistry[layoutId] = (element, newRect);
+
+                var plan = ComputeDeltaPlan(oldRect, newRect);
+                if (plan.IsEmpty) return;
+
+                var state = MotionSpringDriver.Create(plan, stiffness, damping, mass);
+                if (state == null) return;
+
+                // Cancel a tween already in flight on this same element before starting a fresh one — a
+                // rapid-fire re-layout (two patches within one tween's own lifetime) must retarget from
+                // wherever the element visually sits right now, not stack a second independent tick.
+                CancelForTeardown(element, ctx);
+                MotionSpringDriver.ApplyCurrentValues(element, state);
+                StartTick(element, state, ctx);
+            }
+        }
+
+        private static void StartTick(VisualElement element, MotionSpringState state, ReconcilerContext ctx)
+        {
+            var host = element.panel?.visualTree;
+            if (host == null) return;
+
+            ctx.LayoutIdTicks[element] = host.schedule.Execute((TimerState ts) =>
+            {
+                var dt = ts.deltaTime / 1000f;
+                if (dt <= 0f) return;
+                if (!MotionSpringDriver.Step(element, state, dt)) return;
+
+                if (ctx.LayoutIdTicks.TryGetValue(element, out var self))
+                {
+                    self.Pause();
+                    ctx.LayoutIdTicks.Remove(element);
+                }
+                MotionSpringDriver.ClearInlineOverrides(element, state);
+            }).Every(StyleAnimateDriver.TickMs);
+        }
+
+        // Cancels any in-flight tick and drops the registry entries for a departing element — called
+        // from FiberElementCleaner before an element is pooled/disposed, so a layoutId tween never keeps
+        // ticking against (or leaves a stale rect behind for) a torn-down element. Also called internally
+        // above to retarget a rapid re-layout instead of stacking concurrent ticks on one element.
+        internal static void CancelForTeardown(VisualElement element, ReconcilerContext ctx)
+        {
+            if (ctx.LayoutIdTicks.TryGetValue(element, out var tick))
+            {
+                tick.Pause();
+                ctx.LayoutIdTicks.Remove(element);
+            }
+            if (ctx.ElementToLayoutId.TryGetValue(element, out var layoutId)
+                && ctx.LayoutIdRegistry.TryGetValue(layoutId, out var current)
+                && ReferenceEquals(current.Element, element))
+            {
+                ctx.LayoutIdRegistry.Remove(layoutId);
+            }
+        }
+
+        // Pure(ish) mechanics, panel-free by design (mirrors MotionSpringDriverTests' own rationale for
+        // testing the spring math directly): resolves an old→new rect pair into a SpringPlan whose
+        // TranslateX/Y channels animate the position delta back to zero and whose Scale channel
+        // animates the (averaged, uniform) size ratio back to 1 — empty (IsEmpty) when the rects are
+        // equal within Mathf.Approximately's tolerance, so the caller can skip building spring state
+        // for a patch that didn't actually move/resize anything.
+        internal static MotionSpringClassParser.SpringPlan ComputeDeltaPlan(Rect oldRect, Rect newRect)
+        {
+            var dx = oldRect.x - newRect.x;
+            var dy = oldRect.y - newRect.y;
+            var scaleX = newRect.width > 0.01f ? oldRect.width / newRect.width : 1f;
+            var scaleY = newRect.height > 0.01f ? oldRect.height / newRect.height : 1f;
+            var scale = (scaleX + scaleY) / 2f;
+
+            var translateChanged = !Mathf.Approximately(dx, 0f) || !Mathf.Approximately(dy, 0f);
+            var scaleChanged = !Mathf.Approximately(scale, 1f);
+
+            return new MotionSpringClassParser.SpringPlan
+            {
+                TranslateX = translateChanged ? (dx, 0f) : null,
+                TranslateY = translateChanged ? (dy, 0f) : null,
+                Scale = scaleChanged ? (scale, 1f) : null,
+            };
+        }
+
+        private static bool IsFiniteRect(Rect r) =>
+            float.IsFinite(r.x) && float.IsFinite(r.y) && float.IsFinite(r.width) && float.IsFinite(r.height);
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Styling/MotionLayoutIdDriver.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Styling/MotionLayoutIdDriver.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b119c7f9b61344ce6903448e30a2ca84

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/MotionLayoutIdDriverTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/MotionLayoutIdDriverTests.cs
@@ -1,0 +1,78 @@
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins <see cref="MotionLayoutIdDriver.ComputeDeltaPlan"/>: the pure old-rect/new-rect → SpringPlan
+    /// math behind V.Motion's layoutId (Framer's shared-element layout animation parity). Panel-free by
+    /// design, mirroring <c>MotionSpringDriverTests</c>' own rationale — this resolves numeric deltas
+    /// directly from two Rects, with no style resolution or scheduler tick involved.
+    /// </summary>
+    [TestFixture]
+    internal sealed class MotionLayoutIdDriverTests
+    {
+        [Test]
+        public void Given_TwoIdenticalRects_When_DeltaComputed_Then_ThePlanIsEmpty()
+        {
+            // Arrange
+            var rect = new Rect(10f, 20f, 100f, 50f);
+
+            // Act
+            var plan = MotionLayoutIdDriver.ComputeDeltaPlan(rect, rect);
+
+            // Assert
+            Assert.That(plan.IsEmpty, Is.True);
+        }
+
+        [Test]
+        public void Given_ARectMovedWithoutResizing_When_DeltaComputed_Then_OnlyTranslateChannelsAreSet()
+        {
+            // Arrange — moved from (10,20) to (110,220), same 100x50 size.
+            var oldRect = new Rect(10f, 20f, 100f, 50f);
+            var newRect = new Rect(110f, 220f, 100f, 50f);
+
+            // Act
+            var plan = MotionLayoutIdDriver.ComputeDeltaPlan(oldRect, newRect);
+            (float, float)? expectedX = (-100f, 0f);
+            (float, float)? expectedY = (-200f, 0f);
+            (float, float)? expectedScale = null;
+
+            // Assert — TranslateX/Y carry the OLD-minus-NEW delta (the inverse offset to apply immediately,
+            // animating back toward 0), Scale stays unset (no size change).
+            Assert.That((plan.TranslateX, plan.TranslateY, plan.Scale), Is.EqualTo((expectedX, expectedY, expectedScale)));
+        }
+
+        [Test]
+        public void Given_ARectResizedWithoutMoving_When_DeltaComputed_Then_OnlyTheScaleChannelIsSet()
+        {
+            // Arrange — grew from 100x100 to 200x200 (uniform 2x), position unchanged.
+            var oldRect = new Rect(0f, 0f, 100f, 100f);
+            var newRect = new Rect(0f, 0f, 200f, 200f);
+
+            // Act
+            var plan = MotionLayoutIdDriver.ComputeDeltaPlan(oldRect, newRect);
+            (float, float)? expectedTranslateX = null;
+            (float, float)? expectedScale = (0.5f, 1f);
+
+            // Assert — Scale's "from" is oldSize/newSize (0.5: the inverse pose to start from, since the
+            // element is now visually twice as big and must start scaled down to 0.5 before springing to 1).
+            Assert.That((plan.TranslateX, plan.Scale), Is.EqualTo((expectedTranslateX, expectedScale)));
+        }
+
+        [Test]
+        public void Given_ANonUniformResize_When_DeltaComputed_Then_TheScaleFactorIsTheAverageOfBothAxes()
+        {
+            // Arrange — width unchanged (ratio 1), height doubled (ratio 0.5) — averages to 0.75.
+            var oldRect = new Rect(0f, 0f, 100f, 100f);
+            var newRect = new Rect(0f, 0f, 100f, 200f);
+
+            // Act
+            var plan = MotionLayoutIdDriver.ComputeDeltaPlan(oldRect, newRect);
+            (float, float)? expectedScale = (0.75f, 1f);
+
+            // Assert
+            Assert.That(plan.Scale, Is.EqualTo(expectedScale));
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/MotionLayoutIdDriverTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/MotionLayoutIdDriverTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b99f9d5a68c6b406f9e7d0da96b8c203


### PR DESCRIPTION
## Summary

Framer Motion's `layoutId` parity. When a `V.Motion(layoutId:)` carrying the same id patches at a resolved layout rect (position and/or size) different from the rect that id last settled at -- including across a same-key type flip or a move to a different parent -- it tweens from the old rect to the new one instead of jump-cutting: FLIP (First-Last-Invert-Play).

The old rect is captured synchronously from `element.layout` right before the patch (mirroring `AnimatePresence`'s `PopLayout` mode's own "read `.layout` before the mutation that invalidates it" pattern); the new rect isn't trustworthy until the element's own next `GeometryChangedEvent` (a reparented/freshly-created element's `.layout` stays stale until the following layout pass), where the delta is computed, applied as an immediate inverse inline transform, then sprung back to zero.

Reuses `MotionSpringDriver`'s existing panel-independent physics channels (translate x/y, uniform scale) rather than building a second animation driver -- the same machinery every other spring-driven Motion transition already shares. Falls back to `StyleTransitionConfig`'s own spring defaults when the Motion declares no `Transition`, since `layoutId` is independent of `Variants`/`Animate` (it runs from the actual rect delta, not a class-defined from/to pair).

Scoped to uniform scale: UI Toolkit's `scale` style has no independent X/Y factor, so a non-uniform rect change averages the two axis scale factors.

## Test plan

- `MotionLayoutIdDriverTests`: pure old-rect/new-rect → SpringPlan math, panel-free.
- `MotionLayoutIdPatchTests`: end-to-end through a real (simulated) panel and reconcile pass -- inverse translate applies immediately after layout settles, then clears once the spring settles.
- `MotionLayoutIdPlaybackTests`: real runtime `UIDocument` panel, confirms the inline translate passes through an intermediate value on its way back to zero.
- Full EditMode (2769/2769) and PlayMode (47/47) suites passed.

Closes #36
