### PR TITLE
feat: Hooks.UseAnimationSequence timeline orchestration

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `Hooks.UseAnimationSequence(steps:)`: Framer Motion's `useAnimate` timeline parity — plays an
+  ordered `AnimationSequenceStep` array (`To` label changes, `Wait` gaps, `Call` callbacks) over
+  time and exposes the active step's label/transition to feed straight into a coordinator
+  `V.Motion(animate:, transition:)`, so a multi-stage animation no longer needs to be hand-rolled
+  with `UseEffect` + a timer + `UseState`. Descendant Motions inherit the coordinator's label
+  exactly as they already do for any hand-toggled label, so "animate several elements one at a
+  time" is just `StaggerChildrenSec` on a step's own transition — no new reconciler wiring.
+  `autoplay` / `loop` / `deps` and imperative `Play`/`Pause`/`Restart` controls round out the API.
 - `V.Motion(layoutId:)`: Framer Motion's shared-element layout animation parity. When a Motion
   carrying the same `layoutId` string patches at a resolved layout rect different from the rect
   that id last settled at — including across a same-key type flip or a move to a different

--- a/Packages/com.velvet.core/Documentation~/motion.md
+++ b/Packages/com.velvet.core/Documentation~/motion.md
@@ -184,6 +184,71 @@ V.Motion(layoutId: "card-3", className: expanded ? "absolute left-[0px] top-[0px
   element's own next `GeometryChangedEvent`, since a reparented/freshly-created element's
   `.layout` stays stale until the following layout pass.
 
+## Timelines (`Hooks.UseAnimationSequence`)
+
+```csharp
+var (seq, controls) = Hooks.UseAnimationSequence(new[]
+{
+    // 1. float in place for 0.5s
+    AnimationSequenceStep.To("floating", holdSec: 0.5f),
+
+    // emit particles the instant the float step becomes current
+    AnimationSequenceStep.Call(() => OnEmitParticles()),
+
+    // 2. fly toward the target, one particle at a time -- StaggerChildrenSec does the fan-out
+    AnimationSequenceStep.To("flying", transition: new StyleTransitionConfig
+    {
+        Type = TransitionType.Spring, Stiffness = 220f, Damping = 18f, StaggerChildrenSec = 0.08f,
+    }, holdSec: 0.9f),
+
+    // 3. fire the arrival event once the hold above has elapsed
+    AnimationSequenceStep.Call(() => OnArrived()),
+});
+
+return V.Motion(key: "coordinator", animate: seq.CurrentLabel, transition: seq.CurrentTransition,
+    children: /* descendant Motions with no own `animate` inherit seq.CurrentLabel */);
+```
+
+Framer Motion's `useAnimate` parity target: `UseAnimationSequence` owns the clock (it is itself built
+on `UseFrame`) and walks an ordered `AnimationSequenceStep[]`, so a multi-stage animation ("float, then
+emit, then fly to target one at a time, then fire an arrival event") never needs to be hand-rolled with
+`UseEffect` + a timer + `UseState`.
+
+A step is exactly one of:
+
+- **`AnimationSequenceStep.To(label, transition?, holdSec?)`** -- activates `label` on the sequence's
+  coordinator Motion. Its effect commits the moment the walker *arrives* at the step (not once its hold
+  elapses) -- "holds on this step" means the label is already active and the cursor is waiting before
+  moving to the next one. `transition` reuses the most recent non-null transition earlier in the
+  sequence when omitted (falling back to `StyleTransition.Fade` if none has been set yet); `holdSec`
+  defaults to that transition's `DurationSec + DelaySec` for a tween. A `Spring`-typed step needs an
+  explicit `holdSec` -- a spring's settle time is physics-derived, not statically knowable -- an omitted
+  one logs a warning and falls back to a fixed estimate rather than stalling the sequence.
+- **`AnimationSequenceStep.Wait(seconds)`** -- holds the current label for `seconds` with no effect of
+  its own.
+- **`AnimationSequenceStep.Call(callback)`** -- fires `callback` synchronously on arrival, then advances
+  immediately (never holds the cursor).
+
+**"One at a time" needs no separate multi-target API.** Descendant Motions with no own `animate` inherit
+the coordinator's label exactly as they already do for any hand-toggled label change (see "Label
+inheritance" above); a `To` step's own `transition` declaring `StaggerChildrenSec` fans that swap out
+across those descendants in document order, the same mechanism `V.Motion`'s orchestration knobs already
+provide.
+
+`autoplay` (default `true`) starts the sequence on mount; pass `false` and call `controls.Play()` (e.g.
+from an `onClick`) to start it on demand. `loop: true` wraps the cursor back to step 0 once the last
+step's hold elapses instead of latching `AnimationSequenceState.IsComplete`. `deps` follows the same
+convention as every other deps-taking hook, but — unlike `UseEffect` — omitting it resets the walker on
+**mount only**, not on every render: a freshly-built `steps` array literal in the component body (the
+common case) must not restart an in-flight sequence every render. `controls.Restart()` returns to step 0
+and re-commits its effect (including firing a `Call` step 0's callback again) without implicitly
+resuming a paused sequence.
+
+Not attempted: an arbitrary-selector scope ref (`useAnimate`'s `[scopeRef, animate]`) reaching elements
+outside the declarative Motion/variant tree, and overlapping/parallel tracks (Framer's `"<"` / `"+0.2"`
+relative-offset DSL) -- steps are a strict FIFO queue; two independently-timed tracks need two separate
+`UseAnimationSequence` coordinators.
+
 ## Transition semantics: one config, every update
 
 Every variant update rides the Motion's own `StyleTransitionConfig` — mount enters

--- a/Packages/com.velvet.core/Documentation~/motion.md
+++ b/Packages/com.velvet.core/Documentation~/motion.md
@@ -186,29 +186,6 @@ V.Motion(layoutId: "card-3", className: expanded ? "absolute left-[0px] top-[0px
 
 ## Timelines (`Hooks.UseAnimationSequence`)
 
-```csharp
-var (seq, controls) = Hooks.UseAnimationSequence(new[]
-{
-    // 1. float in place for 0.5s
-    AnimationSequenceStep.To("floating", holdSec: 0.5f),
-
-    // emit particles the instant the float step becomes current
-    AnimationSequenceStep.Call(() => OnEmitParticles()),
-
-    // 2. fly toward the target, one particle at a time -- StaggerChildrenSec does the fan-out
-    AnimationSequenceStep.To("flying", transition: new StyleTransitionConfig
-    {
-        Type = TransitionType.Spring, Stiffness = 220f, Damping = 18f, StaggerChildrenSec = 0.08f,
-    }, holdSec: 0.9f),
-
-    // 3. fire the arrival event once the hold above has elapsed
-    AnimationSequenceStep.Call(() => OnArrived()),
-});
-
-return V.Motion(key: "coordinator", animate: seq.CurrentLabel, transition: seq.CurrentTransition,
-    children: /* descendant Motions with no own `animate` inherit seq.CurrentLabel */);
-```
-
 Framer Motion's `useAnimate` parity target: `UseAnimationSequence` owns the clock (it is itself built
 on `UseFrame`) and walks an ordered `AnimationSequenceStep[]`, so a multi-stage animation ("float, then
 emit, then fly to target one at a time, then fire an arrival event") never needs to be hand-rolled with

--- a/Packages/com.velvet.core/Runtime/Hooks/AnimationSequenceTypes.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/AnimationSequenceTypes.cs
@@ -1,0 +1,132 @@
+#nullable enable
+using System;
+
+namespace Velvet
+{
+    // Which effect an AnimationSequenceStep carries. Internal: callers only ever construct a step through
+    // the public static factories below, never read Kind directly.
+    internal enum AnimationSequenceStepKind
+    {
+        To,
+        Wait,
+        Call,
+    }
+
+    /// <summary>
+    /// One step in an animation sequence played by <see cref="Hooks.UseAnimationSequence"/>. A step is
+    /// exactly one of: a variant-label change (<see cref="To"/>), a pure timing gap (<see cref="Wait"/>), or a
+    /// synchronous C# callback (<see cref="Call"/>).
+    /// </summary>
+    public readonly struct AnimationSequenceStep
+    {
+        internal AnimationSequenceStepKind Kind { get; }
+
+        /// <summary>The variant label to activate. Non-null only on a <see cref="To"/> step.</summary>
+        public string? Label { get; }
+
+        /// <summary>
+        /// The transition driving this label change. Null means "reuse the most recent non-null transition
+        /// earlier in the sequence", falling back to <see cref="StyleTransition"/>'s <c>Fade</c> preset (the
+        /// same default <c>V.Motion</c> itself uses) if none has been set yet. Only meaningful on a
+        /// <see cref="To"/> step.
+        /// </summary>
+        public StyleTransitionConfig? Transition { get; }
+
+        /// <summary>
+        /// How long the sequence holds on this step before advancing. On a <see cref="To"/> step, null derives
+        /// the hold from <see cref="Transition"/> (<c>DurationSec + DelaySec</c> for
+        /// <see cref="TransitionType.Tween"/>); a <see cref="TransitionType.Spring"/>-typed <see cref="To"/>
+        /// step with no explicit hold logs a warning and falls back to a fixed estimate, since a spring's
+        /// settle time is physics-derived and not statically knowable (matches
+        /// <see cref="StyleTransitionConfig"/>'s own documented "DurationSec is ignored for Spring" contract).
+        /// Required on <see cref="Wait"/> (negative values clamp to 0). Always 0 on <see cref="Call"/>.
+        /// </summary>
+        public float? HoldSec { get; }
+
+        /// <summary>The callback to invoke. Non-null only on a <see cref="Call"/> step.</summary>
+        public Action? Callback { get; }
+
+        private AnimationSequenceStep(AnimationSequenceStepKind kind, string? label,
+            StyleTransitionConfig? transition, float? holdSec, Action? callback)
+        {
+            Kind = kind;
+            Label = label;
+            Transition = transition;
+            HoldSec = holdSec;
+            Callback = callback;
+        }
+
+        /// <summary>
+        /// Activates <paramref name="label"/> on the sequence's coordinator — feeds straight into
+        /// <c>V.Motion(animate:, transition:)</c>. Descendant Motions with no own <c>animate</c> inherit it
+        /// exactly as they do for any hand-toggled label, including <c>StaggerChildrenSec</c> fan-out when
+        /// <paramref name="transition"/> declares it — "one at a time" across a list of such descendants needs
+        /// no separate multi-target API.
+        /// </summary>
+        /// <param name="label">The variant label to activate. Must not be null.</param>
+        /// <param name="transition">See <see cref="Transition"/>.</param>
+        /// <param name="holdSec">See <see cref="HoldSec"/>.</param>
+        public static AnimationSequenceStep To(string label, StyleTransitionConfig? transition = null, float? holdSec = null)
+        {
+            if (label == null) throw new ArgumentNullException(nameof(label));
+            return new AnimationSequenceStep(AnimationSequenceStepKind.To, label, transition, holdSec, null);
+        }
+
+        /// <summary>Holds the current label for <paramref name="seconds"/> before advancing. No visual effect of its own.</summary>
+        /// <param name="seconds">Hold duration. Negative values clamp to 0.</param>
+        public static AnimationSequenceStep Wait(float seconds)
+            => new(AnimationSequenceStepKind.Wait, null, null, Math.Max(0f, seconds), null);
+
+        /// <summary>Fires <paramref name="callback"/> synchronously on arrival, then advances immediately — never holds the cursor.</summary>
+        /// <param name="callback">The callback to invoke. Must not be null.</param>
+        public static AnimationSequenceStep Call(Action callback)
+        {
+            if (callback == null) throw new ArgumentNullException(nameof(callback));
+            return new AnimationSequenceStep(AnimationSequenceStepKind.Call, null, null, 0f, callback);
+        }
+    }
+
+    /// <summary>Per-render snapshot of a sequence, returned by <see cref="Hooks.UseAnimationSequence"/>.</summary>
+    public readonly struct AnimationSequenceState
+    {
+        /// <summary>The label of the most recently activated <see cref="AnimationSequenceStep"/> <c>To</c> step, or null before the first one runs.</summary>
+        public string? CurrentLabel { get; }
+
+        /// <summary>The transition that accompanied <see cref="CurrentLabel"/>.</summary>
+        public StyleTransitionConfig? CurrentTransition { get; }
+
+        /// <summary>Index into the authored <c>steps</c> array of the step currently holding the cursor.</summary>
+        public int StepIndex { get; }
+
+        /// <summary>True once the cursor has advanced past the last step. Never latches true when <c>loop</c> is set.</summary>
+        public bool IsComplete { get; }
+
+        internal AnimationSequenceState(string? currentLabel, StyleTransitionConfig? currentTransition, int stepIndex, bool isComplete)
+        {
+            CurrentLabel = currentLabel;
+            CurrentTransition = currentTransition;
+            StepIndex = stepIndex;
+            IsComplete = isComplete;
+        }
+    }
+
+    /// <summary>Imperative controls for a sequence started by <see cref="Hooks.UseAnimationSequence"/>.</summary>
+    public readonly struct AnimationSequenceControls
+    {
+        /// <summary>Resumes advancing (idempotent). Also what <c>autoplay: true</c> starts with on mount.</summary>
+        public Action Play { get; }
+
+        /// <summary>Freezes the cursor at its current step — elapsed time stops accumulating toward the next hold.</summary>
+        public Action Pause { get; }
+
+        /// <summary>Returns to step 0 and re-commits its effect (firing a <c>Call</c> step 0's callback again). Does not implicitly unpause.</summary>
+        public Action Restart { get; }
+
+        internal AnimationSequenceControls(Action play, Action pause, Action restart)
+        {
+            Play = play;
+            Pause = pause;
+            Restart = restart;
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Hooks/AnimationSequenceTypes.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/AnimationSequenceTypes.cs
@@ -77,7 +77,13 @@ namespace Velvet
         public static AnimationSequenceStep Wait(float seconds)
             => new(AnimationSequenceStepKind.Wait, null, null, Math.Max(0f, seconds), null);
 
-        /// <summary>Fires <paramref name="callback"/> synchronously on arrival, then advances immediately — never holds the cursor.</summary>
+        /// <summary>
+        /// Fires <paramref name="callback"/> synchronously on arrival, then advances immediately — never holds
+        /// the cursor. Step 0's callback re-fires under the Editor's StrictMode mount double-invoke diagnostic
+        /// (same expectation as any <c>UseEffect</c> mount factory with a non-idempotent body): write it to
+        /// tolerate running twice if the sequence's own mount matters, exactly as React's own StrictMode
+        /// guidance recommends for an effect that isn't naturally idempotent.
+        /// </summary>
         /// <param name="callback">The callback to invoke. Must not be null.</param>
         public static AnimationSequenceStep Call(Action callback)
         {

--- a/Packages/com.velvet.core/Runtime/Hooks/AnimationSequenceTypes.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Hooks/AnimationSequenceTypes.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e70aa13e8609f414eaa2b3d6e49a0e05

--- a/Packages/com.velvet.core/Runtime/Hooks/Hooks.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Hooks.cs
@@ -1029,8 +1029,19 @@ namespace Velvet
             IReadOnlyList<AnimationSequenceStep> steps, bool autoplay = true, bool loop = false, object?[]? deps = null)
         {
             if (steps == null) throw new ArgumentNullException(nameof(steps));
+            var fiber = Resolve("UseAnimationSequence");
             var walker = UseRef(() => new SequenceWalker());
             var (_, bumpRenderVersion) = UseState(0);
+
+            // Tracks the LATEST render's steps for controls.Restart() to read (see below) — mirrors UseFrame's
+            // own `latest.Set(onFrame)` pattern: a re-render must not leave an earlier render's Restart closing
+            // over a stale steps array, and the StrictMode throwaway diagnostic pass's steps must never become
+            // "latest" since that render is discarded.
+            var latestSteps = UseRef<IReadOnlyList<AnimationSequenceStep>>();
+            if (!IsStrictDiagnosticPass(fiber))
+            {
+                latestSteps.Set(steps);
+            }
 
             UseEffect(() =>
             {
@@ -1046,9 +1057,9 @@ namespace Velvet
                 {
                     return;
                 }
-                var beforeIndex = walker.Current.StepIndex;
+                var beforeGeneration = walker.Current.Generation;
                 walker.Current.Advance(dt, loop);
-                if (walker.Current.StepIndex != beforeIndex || walker.Current.IsComplete)
+                if (walker.Current.Generation != beforeGeneration || walker.Current.IsComplete)
                 {
                     bumpRenderVersion.Invoke(v => v + 1);
                 }
@@ -1059,7 +1070,7 @@ namespace Velvet
                 pause: () => walker.Current.IsPaused = true,
                 restart: () =>
                 {
-                    walker.Current.Reset(steps);
+                    walker.Current.Reset(latestSteps.Current ?? steps);
                     bumpRenderVersion.Invoke(v => v + 1);
                 });
 

--- a/Packages/com.velvet.core/Runtime/Hooks/Hooks.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Hooks.cs
@@ -998,6 +998,76 @@ namespace Velvet
 
         #endregion
 
+        #region UseAnimationSequence
+
+        /// <summary>
+        /// Plays an ordered <see cref="AnimationSequenceStep"/> array over time, exposing the active step's
+        /// label/transition to feed straight into a coordinator <c>V.Motion(animate:, transition:)</c>.
+        /// Velvet's timeline primitive (Framer Motion's <c>useAnimate</c> parity target): the hook owns the
+        /// clock (via <see cref="UseFrame"/>) and the step walk, so a caller never hand-rolls
+        /// <see cref="UseEffect(Func{Action},object[])"/> plus a timer plus <see cref="UseState{T}(T)"/> to
+        /// sequence a multi-stage animation. Descendant <c>V.Motion</c> nodes with no own <c>animate</c>
+        /// inherit the coordinator's label exactly as they already do for any hand-toggled label change; "one
+        /// at a time" fan-out across a list of such descendants is <c>StaggerChildrenSec</c> on a step's own
+        /// <see cref="AnimationSequenceStep.Transition"/> — there is no separate multi-target API.
+        /// </summary>
+        /// <param name="steps">The ordered sequence. Must not be null.</param>
+        /// <param name="autoplay">Starts advancing on mount when true (default). When false, call
+        /// <c>controls.Play()</c> — e.g. from an <c>onClick</c> handler — to start it on demand. Only read on
+        /// mount / a <paramref name="deps"/> change, not on every render, so a later <c>controls.Pause()</c>
+        /// is not fought by a re-render that keeps passing <c>autoplay: true</c>.</param>
+        /// <param name="loop">When true, the cursor wraps to step 0 after the last step's hold elapses and
+        /// <see cref="AnimationSequenceState.IsComplete"/> never latches.</param>
+        /// <param name="deps">
+        /// Unlike <see cref="UseEffect(Func{Action},object[])"/>, omitting this (or passing null) resets the
+        /// walker on MOUNT ONLY, not on every render — a freshly-built <paramref name="steps"/> array literal
+        /// in the component body (the common case) must not restart an in-flight sequence every render. Pass
+        /// an explicit array to restart the sequence when one of its entries changes, same convention as every
+        /// other deps-taking hook.
+        /// </param>
+        public static (AnimationSequenceState state, AnimationSequenceControls controls) UseAnimationSequence(
+            IReadOnlyList<AnimationSequenceStep> steps, bool autoplay = true, bool loop = false, object?[]? deps = null)
+        {
+            if (steps == null) throw new ArgumentNullException(nameof(steps));
+            var walker = UseRef(() => new SequenceWalker());
+            var (_, bumpRenderVersion) = UseState(0);
+
+            UseEffect(() =>
+            {
+                walker.Current.Reset(steps);
+                walker.Current.IsPaused = !autoplay;
+                bumpRenderVersion.Invoke(v => v + 1);
+                return (Action)null;
+            }, deps ?? Array.Empty<object>());
+
+            UseFrame(dt =>
+            {
+                if (walker.Current.IsPaused || walker.Current.IsComplete)
+                {
+                    return;
+                }
+                var beforeIndex = walker.Current.StepIndex;
+                walker.Current.Advance(dt, loop);
+                if (walker.Current.StepIndex != beforeIndex || walker.Current.IsComplete)
+                {
+                    bumpRenderVersion.Invoke(v => v + 1);
+                }
+            });
+
+            var controls = new AnimationSequenceControls(
+                play: () => walker.Current.IsPaused = false,
+                pause: () => walker.Current.IsPaused = true,
+                restart: () =>
+                {
+                    walker.Current.Reset(steps);
+                    bumpRenderVersion.Invoke(v => v + 1);
+                });
+
+            return (walker.Current.ToState(), controls);
+        }
+
+        #endregion
+
         #region Refs
 
         /// <summary>

--- a/Packages/com.velvet.core/Runtime/Hooks/SequenceWalker.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/SequenceWalker.cs
@@ -17,8 +17,15 @@ namespace Velvet
         // A Spring-typed To step with no explicit HoldSec has no statically knowable settle time; rather than
         // stall the sequence forever (or throw from inside a per-frame tick — this codebase's animation config
         // validators warn-and-degrade instead of throwing, see StyleAnimationScheduler.ValidateSpringParameters),
-        // fall back to this fixed estimate and log once.
+        // fall back to this fixed estimate and log once per step index per Reset.
         private const float FallbackSpringHoldSec = 0.5f;
+
+        // Bounds the number of Reset() calls a Call step's own callback can trigger reentrantly (e.g. a
+        // "restart on checkpoint" pattern) within one arrival — see ArriveAtStart. Recursing through Arrive
+        // itself for this would grow the C# call stack without limit (a Call step that always restarts is a
+        // legitimate, if degenerate, construct) and risk an uncatchable StackOverflowException; this instead
+        // drains pending reentrant resets in a plain loop, so the call stack never grows past a constant depth.
+        private const int MaxReentrantResets = 64;
 
         private IReadOnlyList<AnimationSequenceStep> _steps = Array.Empty<AnimationSequenceStep>();
         private int _stepIndex;
@@ -27,6 +34,10 @@ namespace Velvet
         private string? _currentLabel;
         private StyleTransitionConfig? _currentTransition;
         private bool _isComplete;
+        private int _generation;
+        private bool _isArriving;
+        private IReadOnlyList<AnimationSequenceStep>? _pendingResetSteps;
+        private HashSet<int>? _springFallbackWarnedIndices;
 
         // Frozen by Hooks.UseAnimationSequence's controls.Pause()/Play(); Advance is simply never called while
         // true (the caller gates it), so there is nothing more for this flag to do here.
@@ -36,23 +47,23 @@ namespace Velvet
 
         public int StepIndex => _stepIndex;
 
-        // Re-seeds the walker at step 0 and immediately commits its effect. Called exactly once per mount (or
-        // deps change) from Hooks.UseAnimationSequence's effect, and again from controls.Restart() — both
-        // callers are responsible for not calling this more than once per logical "start", since a Call step 0
-        // fires its callback here.
+        // Bumped on every committed Arrive (a real step transition, including a same-index re-arrival on a
+        // single-step loop), independent of StepIndex — a caller diffing StepIndex alone would miss the
+        // single-step-loop case, where "next" wraps back to the same index it started from.
+        public int Generation => _generation;
+
+        // Re-seeds the walker at step 0 and immediately commits its effect. Called once per mount (or deps
+        // change) from Hooks.UseAnimationSequence's effect, and again from controls.Restart(). Reentrant-safe:
+        // a Call step's own callback invoking this (directly, or via controls.Restart()) while an arrival is
+        // already in flight defers the reset instead of recursing — see ArriveAtStart.
         public void Reset(IReadOnlyList<AnimationSequenceStep>? steps)
         {
-            _steps = steps ?? Array.Empty<AnimationSequenceStep>();
-            _stepIndex = 0;
-            _elapsedInStepSec = 0f;
-            _currentHoldSec = 0f;
-            _currentLabel = null;
-            _currentTransition = null;
-            _isComplete = _steps.Count == 0;
-            if (!_isComplete)
+            if (_isArriving)
             {
-                Arrive(0);
+                _pendingResetSteps = steps ?? Array.Empty<AnimationSequenceStep>();
+                return;
             }
+            ResetImmediate(steps);
         }
 
         // Advances the cursor by dt seconds, committing every step whose hold elapses along the way (a
@@ -82,29 +93,123 @@ namespace Velvet
                     }
                     next = 0;
                 }
-                Arrive(next);
+                ArriveAtStart(next);
             }
             return _stepIndex;
         }
 
         public AnimationSequenceState ToState() => new(_currentLabel, _currentTransition, _stepIndex, _isComplete);
 
+        private void ResetImmediate(IReadOnlyList<AnimationSequenceStep>? steps)
+        {
+            _steps = steps ?? Array.Empty<AnimationSequenceStep>();
+            _stepIndex = 0;
+            _elapsedInStepSec = 0f;
+            _currentHoldSec = 0f;
+            _currentLabel = null;
+            _currentTransition = null;
+            _isComplete = _steps.Count == 0;
+            _springFallbackWarnedIndices?.Clear();
+            WarnAboutUnvalidatedToSteps();
+            if (!_isComplete)
+            {
+                ArriveAtStart(0);
+            }
+        }
+
+        // A default(AnimationSequenceStep) (an unfilled array/list slot) bypasses the To/Wait/Call factories'
+        // own validation entirely — struct default-construction cannot be blocked by a private constructor in
+        // C#. Its Kind reads as To (the enum's zero value) with a null Label, which Arrive would otherwise
+        // adopt silently. Caught once per Reset rather than per-Arrive, since the steps list itself is fixed
+        // for the lifetime of a single Reset generation.
+        private void WarnAboutUnvalidatedToSteps()
+        {
+            for (var i = 0; i < _steps.Count; i++)
+            {
+                var step = _steps[i];
+                if (step.Kind == AnimationSequenceStepKind.To && step.Label == null)
+                {
+                    FiberLogger.LogWarning("AnimationSequence",
+                        $"steps[{i}] is a default(AnimationSequenceStep), not one built through To/Wait/Call "
+                        + "(a likely unfilled array slot). Treating it as a no-op Wait(0) instead of a To step "
+                        + "with a null label.");
+                }
+            }
+        }
+
+        // Commits the step at `index` (Arrive), then drains any Reset() calls the step's own Call callback
+        // triggered reentrantly. The drain is a plain loop, not recursion through this method, so the C# call
+        // stack depth stays constant no matter how many times a callback restarts the sequence from within
+        // itself — see MaxReentrantResets.
+        private void ArriveAtStart(int index)
+        {
+            _isArriving = true;
+            try
+            {
+                Arrive(index);
+            }
+            finally
+            {
+                _isArriving = false;
+            }
+
+            var guard = MaxReentrantResets;
+            while (_pendingResetSteps != null && guard-- > 0)
+            {
+                var pending = _pendingResetSteps;
+                _pendingResetSteps = null;
+                _steps = pending;
+                _stepIndex = 0;
+                _elapsedInStepSec = 0f;
+                _currentHoldSec = 0f;
+                _currentLabel = null;
+                _currentTransition = null;
+                _isComplete = _steps.Count == 0;
+                _springFallbackWarnedIndices?.Clear();
+                WarnAboutUnvalidatedToSteps();
+                if (_isComplete)
+                {
+                    break;
+                }
+                _isArriving = true;
+                try
+                {
+                    Arrive(0);
+                }
+                finally
+                {
+                    _isArriving = false;
+                }
+            }
+            if (_pendingResetSteps != null)
+            {
+                FiberLogger.LogWarning("AnimationSequence",
+                    "A step's callback kept restarting the sequence reentrantly past the safety limit "
+                    + $"({MaxReentrantResets}); the extra restart requests were dropped this frame.");
+                _pendingResetSteps = null;
+            }
+        }
+
         // Commits the effect of the step at `index` (fires a Call callback synchronously, or adopts a To
-        // step's label/transition) and resolves the hold the walker parks on before advancing further. A
-        // thrown Call callback propagates straight out of here, through Advance(), into the UseFrame tick that
-        // called it — UseFrame's own try/catch already routes a user-callback exception to the nearest error
-        // boundary, so this needs no guard of its own.
+        // step's label/transition), resolves the hold the walker parks on before advancing further, and bumps
+        // Generation so a caller diffing it (rather than StepIndex alone) always sees a real commit. A thrown
+        // Call callback propagates straight out of here, through Advance(), into the UseFrame tick that called
+        // it — UseFrame's own try/catch already routes a user-callback exception to the nearest error boundary,
+        // so this needs no guard of its own. Does NOT touch _elapsedInStepSec: Advance's own loop already
+        // carries the overshoot past this step's hold into the next one before calling this, and Reset/
+        // ArriveAtStart's own callers zero it explicitly for a fresh start — resetting it here a second time
+        // would discard that carried-over remainder.
         private void Arrive(int index)
         {
             _stepIndex = index;
-            _elapsedInStepSec = 0f;
+            _generation++;
             var step = _steps[index];
             switch (step.Kind)
             {
                 case AnimationSequenceStepKind.To:
                     _currentLabel = step.Label;
                     _currentTransition = step.Transition ?? _currentTransition ?? StyleTransition.Fade;
-                    _currentHoldSec = Math.Max(0f, step.HoldSec ?? ResolveHoldFromTransition(_currentTransition));
+                    _currentHoldSec = Math.Max(0f, step.HoldSec ?? ResolveHoldFromTransition(index, _currentTransition));
                     break;
                 case AnimationSequenceStepKind.Wait:
                     _currentHoldSec = Math.Max(0f, step.HoldSec ?? 0f);
@@ -116,16 +221,39 @@ namespace Velvet
             }
         }
 
-        private static float ResolveHoldFromTransition(StyleTransitionConfig transition)
+        // Auto-derives a To step's hold from its transition when the step declares no explicit HoldSec.
+        // Mirrors StyleAnimationScheduler.SlowestPropertyTimeoutMs's own "slowest overridden property wins"
+        // rule: a PropertyOverrides entry can give one property a longer duration/delay than the top-level
+        // values (StyleTransitionConfig's own documented example: opacity in 0.15s while scale takes 0.5s), and
+        // the walker must not advance past a step while a property that override still governs is mid-tween.
+        private float ResolveHoldFromTransition(int index, StyleTransitionConfig transition)
         {
             if (transition.Type == TransitionType.Spring)
             {
-                FiberLogger.LogWarning("AnimationSequence",
-                    "A To step used a Spring transition with no explicit holdSec — a spring's settle time is "
-                    + $"physics-derived, not statically knowable. Falling back to {FallbackSpringHoldSec}s.");
+                if ((_springFallbackWarnedIndices ??= new HashSet<int>()).Add(index))
+                {
+                    FiberLogger.LogWarning("AnimationSequence",
+                        "A To step used a Spring transition with no explicit holdSec — a spring's settle time is "
+                        + $"physics-derived, not statically knowable. Falling back to {FallbackSpringHoldSec}s.");
+                }
                 return FallbackSpringHoldSec;
             }
-            return transition.DurationSec + transition.DelaySec;
+
+            var hold = transition.DurationSec + transition.DelaySec;
+            var overrides = transition.PropertyOverrides;
+            if (overrides != null)
+            {
+                for (var i = 0; i < overrides.Count; i++)
+                {
+                    var o = overrides[i];
+                    var overrideHold = (o.DurationSec ?? transition.DurationSec) + (o.DelaySec ?? transition.DelaySec);
+                    if (overrideHold > hold)
+                    {
+                        hold = overrideHold;
+                    }
+                }
+            }
+            return hold;
         }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Hooks/SequenceWalker.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/SequenceWalker.cs
@@ -1,0 +1,131 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+
+namespace Velvet
+{
+    // Frame-driven state machine walking an AnimationSequenceStep[] for Hooks.UseAnimationSequence. Owns no
+    // VisualElement/VNode/scheduler state of its own — Advance is driven by UseFrame's own per-frame delta
+    // (see Hooks.UseAnimationSequence), and every observable effect is read back out through ToState() so the
+    // caller can feed it straight into a coordinating V.Motion(animate:, transition:) prop. A step's effect
+    // (a To step's label/transition, or a Call step's callback) commits the moment the walker ARRIVES at that
+    // step, not once its hold elapses — "holds on this step" means the effect already happened and the cursor
+    // is now waiting before moving to the NEXT one, mirroring "float in place for 0.5s" reading as "become
+    // floating now, stay floating for 0.5s".
+    internal sealed class SequenceWalker
+    {
+        // A Spring-typed To step with no explicit HoldSec has no statically knowable settle time; rather than
+        // stall the sequence forever (or throw from inside a per-frame tick — this codebase's animation config
+        // validators warn-and-degrade instead of throwing, see StyleAnimationScheduler.ValidateSpringParameters),
+        // fall back to this fixed estimate and log once.
+        private const float FallbackSpringHoldSec = 0.5f;
+
+        private IReadOnlyList<AnimationSequenceStep> _steps = Array.Empty<AnimationSequenceStep>();
+        private int _stepIndex;
+        private float _elapsedInStepSec;
+        private float _currentHoldSec;
+        private string? _currentLabel;
+        private StyleTransitionConfig? _currentTransition;
+        private bool _isComplete;
+
+        // Frozen by Hooks.UseAnimationSequence's controls.Pause()/Play(); Advance is simply never called while
+        // true (the caller gates it), so there is nothing more for this flag to do here.
+        public bool IsPaused { get; set; }
+
+        public bool IsComplete => _isComplete;
+
+        public int StepIndex => _stepIndex;
+
+        // Re-seeds the walker at step 0 and immediately commits its effect. Called exactly once per mount (or
+        // deps change) from Hooks.UseAnimationSequence's effect, and again from controls.Restart() — both
+        // callers are responsible for not calling this more than once per logical "start", since a Call step 0
+        // fires its callback here.
+        public void Reset(IReadOnlyList<AnimationSequenceStep>? steps)
+        {
+            _steps = steps ?? Array.Empty<AnimationSequenceStep>();
+            _stepIndex = 0;
+            _elapsedInStepSec = 0f;
+            _currentHoldSec = 0f;
+            _currentLabel = null;
+            _currentTransition = null;
+            _isComplete = _steps.Count == 0;
+            if (!_isComplete)
+            {
+                Arrive(0);
+            }
+        }
+
+        // Advances the cursor by dt seconds, committing every step whose hold elapses along the way (a
+        // zero-hold Wait/Call chain can cross several steps within one call). Returns the committed step
+        // index so the caller can diff it against its own re-render trigger. The iteration count is bounded to
+        // _steps.Count + 1 so an all-zero-hold loop (with loop: true) cannot spin forever inside one call — it
+        // still keeps progressing on every subsequent frame instead.
+        public int Advance(float dt, bool loop)
+        {
+            if (_isComplete || _steps.Count == 0)
+            {
+                return _stepIndex;
+            }
+
+            _elapsedInStepSec += dt;
+            var guard = _steps.Count + 1;
+            while (!_isComplete && _elapsedInStepSec >= _currentHoldSec && guard-- > 0)
+            {
+                _elapsedInStepSec -= _currentHoldSec;
+                var next = _stepIndex + 1;
+                if (next >= _steps.Count)
+                {
+                    if (!loop)
+                    {
+                        _isComplete = true;
+                        break;
+                    }
+                    next = 0;
+                }
+                Arrive(next);
+            }
+            return _stepIndex;
+        }
+
+        public AnimationSequenceState ToState() => new(_currentLabel, _currentTransition, _stepIndex, _isComplete);
+
+        // Commits the effect of the step at `index` (fires a Call callback synchronously, or adopts a To
+        // step's label/transition) and resolves the hold the walker parks on before advancing further. A
+        // thrown Call callback propagates straight out of here, through Advance(), into the UseFrame tick that
+        // called it — UseFrame's own try/catch already routes a user-callback exception to the nearest error
+        // boundary, so this needs no guard of its own.
+        private void Arrive(int index)
+        {
+            _stepIndex = index;
+            _elapsedInStepSec = 0f;
+            var step = _steps[index];
+            switch (step.Kind)
+            {
+                case AnimationSequenceStepKind.To:
+                    _currentLabel = step.Label;
+                    _currentTransition = step.Transition ?? _currentTransition ?? StyleTransition.Fade;
+                    _currentHoldSec = Math.Max(0f, step.HoldSec ?? ResolveHoldFromTransition(_currentTransition));
+                    break;
+                case AnimationSequenceStepKind.Wait:
+                    _currentHoldSec = Math.Max(0f, step.HoldSec ?? 0f);
+                    break;
+                case AnimationSequenceStepKind.Call:
+                    _currentHoldSec = 0f;
+                    step.Callback?.Invoke();
+                    break;
+            }
+        }
+
+        private static float ResolveHoldFromTransition(StyleTransitionConfig transition)
+        {
+            if (transition.Type == TransitionType.Spring)
+            {
+                FiberLogger.LogWarning("AnimationSequence",
+                    "A To step used a Spring transition with no explicit holdSec — a spring's settle time is "
+                    + $"physics-derived, not statically knowable. Falling back to {FallbackSpringHoldSec}s.");
+                return FallbackSpringHoldSec;
+            }
+            return transition.DurationSec + transition.DelaySec;
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Hooks/SequenceWalker.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Hooks/SequenceWalker.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 744ea1e6afb3c4f218aaa528f15d096b

--- a/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseAnimationSequenceTests.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseAnimationSequenceTests.cs
@@ -21,6 +21,7 @@ namespace Velvet.Tests
         private static AnimationSequenceState s_state;
         private static AnimationSequenceControls s_controls;
         private static int s_callCount;
+        private static int s_renderCount;
 
         [SetUp]
         public void SetUp()
@@ -30,6 +31,7 @@ namespace Velvet.Tests
             s_autoplay = true;
             s_loop = false;
             s_callCount = 0;
+            s_renderCount = 0;
         }
 
         [TearDown]
@@ -44,6 +46,7 @@ namespace Velvet.Tests
         [Component]
         private static VNode SequenceHost()
         {
+            s_renderCount++;
             var (state, controls) = Hooks.UseAnimationSequence(s_steps, autoplay: s_autoplay, loop: s_loop);
             s_state = state;
             s_controls = controls;
@@ -87,8 +90,10 @@ namespace Velvet.Tests
             // Act
             Mount();
 
-            // Assert — the walker's Reset (run by the mount effect) commits step 0 before the first paint,
-            // so the very first observable render already reflects it rather than a null "not started yet".
+            // Assert — Mount() flushes the mount effect (which runs Reset, committing step 0) before ever
+            // reading s_state. In production the effect is still post-paint like any UseEffect, so the actual
+            // first painted frame shows no active label yet; this pins the state this test's own flushed
+            // helper observes, not a claim about literal first-paint timing.
             Assert.That(s_state.CurrentLabel, Is.EqualTo("a"));
         }
 
@@ -227,6 +232,73 @@ namespace Velvet.Tests
                     EditorPanelTestHelpers.DriveSchedulerOnce(_host.Panel);
                 }
             });
+        }
+
+        [Test]
+        public void Given_ASingleClockJumpSpanningTwoHolds_When_Advanced_Then_TheOvershootCarriesIntoTheThirdStepInsteadOfStallingAtTheSecond()
+        {
+            // Arrange — three 50ms holds; a single 120ms jump should cross step 0 AND step 1 (50ms each, 100ms
+            // total) with 20ms left over into step 2, landing on "c" in one tick rather than stalling on "b".
+            s_steps = new[]
+            {
+                AnimationSequenceStep.To("a", new StyleTransitionConfig { DurationSec = 0.05f }),
+                AnimationSequenceStep.To("b", new StyleTransitionConfig { DurationSec = 0.05f }),
+                AnimationSequenceStep.To("c", new StyleTransitionConfig { DurationSec = 0.05f }),
+            };
+            Mount();
+
+            // Act — one single large jump, one single scheduler drive (not the small-increment AdvancePast
+            // helper, which would never exercise a multi-hold crossing within one Advance() call).
+            UseFrameFakeClockHost.Ms += 120;
+            EditorPanelTestHelpers.DriveSchedulerOnce(_host.Panel);
+            _mounted.FlushStateForTest();
+
+            // Assert
+            Assert.That(s_state.CurrentLabel, Is.EqualTo("c"));
+        }
+
+        [Test]
+        public void Given_ASingleStepCallSequenceThatLoops_When_TimeAdvances_Then_TheComponentKeepsReRenderingOnEachRecommit()
+        {
+            // Arrange — a 1-step loop wraps back to the SAME index (0) on every recommit, so a re-render
+            // trigger keyed on "did StepIndex change" would never fire again after the first tick.
+            s_steps = new[] { AnimationSequenceStep.Call(() => s_callCount++) };
+            s_loop = true;
+            Mount();
+            var renderCountAfterMount = s_renderCount;
+            Assume.That(s_callCount, Is.GreaterThan(0), "Precondition: step 0's callback already fired once on mount");
+
+            // Act — a zero-hold step re-arrives every tick regardless of dt.
+            UseFrameFakeClockHost.Ms += 16;
+            EditorPanelTestHelpers.DriveSchedulerOnce(_host.Panel);
+            _mounted.FlushStateForTest();
+
+            // Assert
+            Assert.That(s_renderCount, Is.GreaterThan(renderCountAfterMount));
+        }
+
+        [Test]
+        public void Given_AToStepWithAPropertyOverrideLongerThanTheTopLevelDuration_When_OnlyTheTopLevelDurationHasElapsed_Then_TheStepIsStillCurrent()
+        {
+            // Arrange — the top-level DurationSec (50ms) is shorter than the "translate" override's own (300ms);
+            // the auto-derived hold must follow the slower override, matching StyleAnimationScheduler's own
+            // "completion sized off the slowest overridden property" rule for the same StyleTransitionConfig.
+            s_steps = new[]
+            {
+                AnimationSequenceStep.To("a", new StyleTransitionConfig
+                {
+                    DurationSec = 0.05f,
+                    PropertyOverrides = new[] { new StylePropertyTransition("translate", durationSec: 0.3f) },
+                }),
+                AnimationSequenceStep.To("b", new StyleTransitionConfig { DurationSec = 0.05f }),
+            };
+            Mount();
+
+            // Act — past the top-level 50ms but well short of the override's 300ms.
+            AdvancePast(0.1f);
+
+            // Assert
+            Assert.That(s_state.CurrentLabel, Is.EqualTo("a"));
         }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseAnimationSequenceTests.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseAnimationSequenceTests.cs
@@ -1,0 +1,232 @@
+using NUnit.Framework;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins <c>Hooks.UseAnimationSequence</c>'s step-walk contract on the EditMode fake clock (reusing
+    /// <see cref="UseFrameFakeClockHost"/>'s shared Ms/ReadFakeClock harness, since the hook is itself built on
+    /// <c>UseFrame</c>): a <c>To</c> step's label/transition take effect the moment the walker arrives at it and
+    /// hold until the next step's turn, a <c>Wait</c> step holds the current label with no effect of its own, a
+    /// <c>Call</c> step fires synchronously on arrival, and <c>controls</c> / <c>loop</c> behave as documented.
+    /// </summary>
+    internal sealed class UseAnimationSequenceTests
+    {
+        private HeadlessEditorPanelHost _host;
+        private MountedTree _mounted;
+
+        private static AnimationSequenceStep[] s_steps;
+        private static bool s_autoplay;
+        private static bool s_loop;
+        private static AnimationSequenceState s_state;
+        private static AnimationSequenceControls s_controls;
+        private static int s_callCount;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _host = new HeadlessEditorPanelHost();
+            UseFrameFakeClockHost.Reset();
+            s_autoplay = true;
+            s_loop = false;
+            s_callCount = 0;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _mounted?.Dispose();
+            _mounted = null;
+            _host?.Dispose();
+            _host = null;
+        }
+
+        [Component]
+        private static VNode SequenceHost()
+        {
+            var (state, controls) = Hooks.UseAnimationSequence(s_steps, autoplay: s_autoplay, loop: s_loop);
+            s_state = state;
+            s_controls = controls;
+            return V.Div(className: "w-[10px] h-[10px]");
+        }
+
+        // Mounts on the fake clock, flushes the mount effect (Reset + the resulting re-render) and arms
+        // UseFrame's own tick, mirroring UseFramePerFrameContractTests' own arm sequence.
+        private void Mount()
+        {
+            EditorPanelTestHelpers.SetPanelTimeFunction(_host.Panel, UseFrameFakeClockHost.ReadFakeClock);
+            _mounted = V.Mount(_host.Root, V.Component(SequenceHost, key: "root"));
+            _mounted.FlushEffectsForTest();
+            _mounted.FlushStateForTest();
+            EditorPanelTestHelpers.DriveSchedulerOnce(_host.Panel);
+        }
+
+        // Steps the fake clock forward in small increments well past `seconds`, then flushes whatever state
+        // update UseFrame's tick queued along the way — mirrors MotionSimulatedPanelTestsBase.AdvancePast.
+        private void AdvancePast(float seconds)
+        {
+            var ticks = (int)(seconds * 1000f / 16f) + 2;
+            for (var i = 0; i < ticks; i++)
+            {
+                UseFrameFakeClockHost.Ms += 16;
+                EditorPanelTestHelpers.DriveSchedulerOnce(_host.Panel);
+            }
+            _mounted.FlushStateForTest();
+        }
+
+        [Test]
+        public void Given_ATwoStepSequence_When_Mounted_Then_CurrentLabelIsAlreadyTheFirstSteps()
+        {
+            // Arrange
+            s_steps = new[]
+            {
+                AnimationSequenceStep.To("a", new StyleTransitionConfig { DurationSec = 0.5f }),
+                AnimationSequenceStep.To("b", new StyleTransitionConfig { DurationSec = 0.2f }),
+            };
+
+            // Act
+            Mount();
+
+            // Assert — the walker's Reset (run by the mount effect) commits step 0 before the first paint,
+            // so the very first observable render already reflects it rather than a null "not started yet".
+            Assert.That(s_state.CurrentLabel, Is.EqualTo("a"));
+        }
+
+        [Test]
+        public void Given_TwoToStepsWithATweenTransition_When_TheFirstStepsHoldElapses_Then_CurrentLabelSwitchesToTheSecondStep()
+        {
+            // Arrange
+            s_steps = new[]
+            {
+                AnimationSequenceStep.To("a", new StyleTransitionConfig { DurationSec = 0.3f }),
+                AnimationSequenceStep.To("b", new StyleTransitionConfig { DurationSec = 0.2f }),
+            };
+            Mount();
+            Assume.That(s_state.CurrentLabel, Is.EqualTo("a"), "Precondition: step 0 is current right after mount");
+
+            // Act
+            AdvancePast(0.3f);
+
+            // Assert
+            Assert.That(s_state.CurrentLabel, Is.EqualTo("b"));
+        }
+
+        [Test]
+        public void Given_AWaitStepBetweenTwoToSteps_When_OnlyThePrecedingStepsHoldHasElapsed_Then_CurrentLabelStaysAtThePriorStepThroughTheWait()
+        {
+            // Arrange — step 0's hold (0.2s) elapses, landing inside the 0.5s Wait; step 1 must not have
+            // become current yet.
+            s_steps = new[]
+            {
+                AnimationSequenceStep.To("a", new StyleTransitionConfig { DurationSec = 0.2f }),
+                AnimationSequenceStep.Wait(0.5f),
+                AnimationSequenceStep.To("b", new StyleTransitionConfig { DurationSec = 0.1f }),
+            };
+            Mount();
+
+            // Act
+            AdvancePast(0.3f);
+
+            // Assert
+            Assert.That(s_state.CurrentLabel, Is.EqualTo("a"));
+        }
+
+        [Test]
+        public void Given_ACallStepBetweenTwoToSteps_When_TheWalkerCrossesIt_Then_TheCallbackHasFiredByTheTimeTheNextToStepIsCurrent()
+        {
+            // Arrange
+            s_steps = new[]
+            {
+                AnimationSequenceStep.To("a", new StyleTransitionConfig { DurationSec = 0.2f }),
+                AnimationSequenceStep.Call(() => s_callCount++),
+                AnimationSequenceStep.To("b", new StyleTransitionConfig { DurationSec = 1f }),
+            };
+            Mount();
+
+            // Act
+            AdvancePast(0.2f);
+
+            // Assert — a zero-hold Call step is crossed in the same Advance() as the To step right after it,
+            // so both are already true together once the clock has passed step 0's own hold.
+            Assert.That((s_callCount, s_state.CurrentLabel), Is.EqualTo((1, "b")));
+        }
+
+        [Test]
+        public void Given_ANonLoopingSequence_When_TheLastStepsHoldElapses_Then_IsCompleteBecomesTrue()
+        {
+            // Arrange
+            s_steps = new[] { AnimationSequenceStep.To("a", new StyleTransitionConfig { DurationSec = 0.1f }) };
+            s_loop = false;
+            Mount();
+
+            // Act
+            AdvancePast(0.1f);
+
+            // Assert
+            Assert.That(s_state.IsComplete, Is.True);
+        }
+
+        [Test]
+        public void Given_ControlsPauseCalledRightAfterMount_When_TimeAdvancesPastTheFirstStepsHold_Then_StepIndexDoesNotAdvance()
+        {
+            // Arrange
+            s_steps = new[]
+            {
+                AnimationSequenceStep.To("a", new StyleTransitionConfig { DurationSec = 0.1f }),
+                AnimationSequenceStep.To("b", new StyleTransitionConfig { DurationSec = 0.1f }),
+            };
+            Mount();
+            s_controls.Pause();
+
+            // Act
+            AdvancePast(0.5f);
+
+            // Assert
+            Assert.That(s_state.StepIndex, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void Given_ALoopingTwoStepSequence_When_TimeAdvancesPastBothHolds_Then_TheCursorWrapsBackToStepZero()
+        {
+            // Arrange
+            s_steps = new[]
+            {
+                AnimationSequenceStep.To("a", new StyleTransitionConfig { DurationSec = 0.1f }),
+                AnimationSequenceStep.To("b", new StyleTransitionConfig { DurationSec = 0.1f }),
+            };
+            s_loop = true;
+            Mount();
+
+            // Act — past both holds (0.2s total) and back around into step 0's own hold again.
+            AdvancePast(0.25f);
+
+            // Assert
+            Assert.That((s_state.StepIndex, s_state.CurrentLabel), Is.EqualTo((0, "a")));
+        }
+
+        [Test]
+        public void Given_TheHostUnmountsMidSequence_When_TheSchedulerContinuesTicking_Then_NoExceptionIsThrown()
+        {
+            // Arrange
+            s_steps = new[]
+            {
+                AnimationSequenceStep.To("a", new StyleTransitionConfig { DurationSec = 0.5f }),
+                AnimationSequenceStep.To("b", new StyleTransitionConfig { DurationSec = 0.2f }),
+            };
+            Mount();
+            _mounted.Dispose();
+            _mounted = null;
+
+            // Act & Assert — UseFrame's own unmount contract stops the tick; nothing here should throw even
+            // though the fake clock keeps advancing well past where step 1 would otherwise have become current.
+            Assert.DoesNotThrow(() =>
+            {
+                for (var i = 0; i < 40; i++)
+                {
+                    UseFrameFakeClockHost.Ms += 16;
+                    EditorPanelTestHelpers.DriveSchedulerOnce(_host.Panel);
+                }
+            });
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseAnimationSequenceTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseAnimationSequenceTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 307043d1c975e48fca15d9fd56227002


### PR DESCRIPTION
## Summary

Framer Motion's `useAnimate` parity target: `Hooks.UseAnimationSequence` plays an ordered `AnimationSequenceStep` array over time (label changes via `To`, timing gaps via `Wait`, callbacks via `Call`) and exposes the active step's label/transition to feed straight into a coordinator `V.Motion(animate:, transition:)`, so a multi-stage animation no longer needs to be hand-rolled with `UseEffect` + a timer + `UseState`.

Descendant Motions with no own `animate` inherit the coordinator's label exactly as they already do for any hand-toggled label change, so "animate several elements one at a time" is just `StaggerChildrenSec` on a step's own transition -- no new reconciler wiring, reusing the existing `MotionOrchestrationFrame` mechanism entirely as-is.

`autoplay` / `loop` / `deps` and imperative `Play`/`Pause`/`Restart` controls round out the API.

## Fixes from review

A 10-angle review surfaced several real defects in the step-walker's timing/re-render/reentrancy logic, all fixed:
- An elapsed-time overshoot across a crossed step's hold was discarded instead of carried into the next step, capping progress to one transition per `Advance()` call regardless of `dt`.
- The re-render trigger missed a same-index re-arrival on a single-step looping sequence; switched to a generation counter.
- A Spring-typed step's missing-`holdSec` warning re-logged every loop pass instead of once.
- The auto-derived hold ignored `PropertyOverrides`, which can make an individual property outlast the top-level duration.
- `controls.Restart` could close over a stale `steps` array across renders.
- A `Call` step's callback invoking `Restart()` reentrantly could recurse without bound (uncatchable `StackOverflowException`); now drains through a bounded loop.
- An unfilled `AnimationSequenceStep` array slot silently adopted a null label instead of warning.

## Test plan

- `UseAnimationSequenceTests`: 11 EditMode tests on the fake-clock harness, covering step-arrival timing, `Wait`/`Call` ordering, `IsComplete`, `loop` wraparound, controls, unmount mid-sequence, and the review-driven fixes above (each verified RED without its fix).
- Full EditMode (2780/2783, 3 pre-existing skips) and PlayMode (47/47) suites passed.

Closes #37