### PR TITLE
feat: V.Anchored screen-space scene-anchored elements

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `V.Anchored(target:)`: drei's `<Html>` parity in its default screen-space projection mode — a
+  plain 2D element whose `left`/`top` track a 3D scene Transform's projected position every frame
+  via `RuntimePanelUtils.CameraTransformWorldToPanel`. Not depth-tested against scene geometry
+  (unlike `V.WorldSpace`, which renders content INTO the 3D scene): ordinary screen-space UI,
+  positioned dynamically. Forces `position: absolute`; hides itself while the target is behind the
+  camera rather than jumping to a wrong spot. Raycast-based occlusion (drei's `<Html occlude>`) is
+  an explicit scope cut, not yet implemented.
 - `Hooks.UseAnimationSequence(steps:)`: Framer Motion's `useAnimate` timeline parity — plays an
   ordered `AnimationSequenceStep` array (`To` label changes, `Wait` gaps, `Call` callbacks) over
   time and exposes the active step's label/transition to feed straight into a coordinator

--- a/Packages/com.velvet.core/Documentation~/portals.md
+++ b/Packages/com.velvet.core/Documentation~/portals.md
@@ -123,10 +123,10 @@ V.WorldSpace(position: signpost.position, rotation: signpost.rotation,
 ```
 
 Each `V.WorldSpace` owns a world-space panel host (a framework-managed object positioned by
-the given transform values) — the drei `<Html>` parity point. World-space panels are
-**depth-tested**: scene geometry can occlude them and they can sit behind it, which no
-screen-space layer can do. `position` / `rotation` updates on later renders move the live
-host; `panelSize` is the panel's virtual resolution in pixels.
+the given transform values). World-space panels are **depth-tested**: scene geometry can
+occlude them and they can sit behind it, which no screen-space layer can do — the point where
+this differs from `V.Anchored` below. `position` / `rotation` updates on later renders move
+the live host; `panelSize` is the panel's virtual resolution in pixels.
 
 A `BoxCollider` sized to the panel's world extent is attached to the host automatically, so
 Unity's own runtime input system can pick and route pointer input into the panel — see
@@ -135,3 +135,24 @@ Unity's own runtime input system can pick and route pointer input into the panel
 A world-space host follows the same declaring-panel sync as the layers, and a host destroyed
 externally (a scene unload) is skipped safely on later patches — remount the `V.WorldSpace`
 node to rebuild it.
+
+## Screen-space anchored elements: `V.Anchored`
+
+drei's `<Html>` parity in its DEFAULT mode: a plain screen-space element whose `left`/`top`
+track a 3D scene Transform's projected position every frame, re-derived through
+`RuntimePanelUtils.CameraTransformWorldToPanel` on the target's own camera (or
+`Camera.main` when none is given). Not depth-tested — unlike `V.WorldSpace` above, this is
+ordinary 2D UI drawn in the normal screen-space paint order, so it is never occluded by scene
+geometry; it just sits wherever its target currently projects to.
+
+`V.Anchored` forces `position: absolute` inline (dynamic positioning has no other way to
+work), so pass layout classes for everything else — sizing, background, text, and so on —
+exactly as on any other element. The optional pixel offset nudges the projected point (handy
+for centering a label rather than pinning its top-left corner to it), and the element hides
+itself (`display: none`) whenever its target sits behind the camera rather than jumping to a
+wrong on-screen spot — the same "don't draw a mis-projected point" rule drei's own
+`isObjectBehindCamera` check applies, toggleable off if a caller wants the element to keep
+tracking (and clip) regardless.
+
+Raycast-based occlusion against scene geometry — drei's `<Html occlude>` opt-in — is not
+implemented: an explicit, documented scope cut for now, not an oversight.

--- a/Packages/com.velvet.core/Documentation~/portals.md
+++ b/Packages/com.velvet.core/Documentation~/portals.md
@@ -147,12 +147,23 @@ geometry; it just sits wherever its target currently projects to.
 
 `V.Anchored` forces `position: absolute` inline (dynamic positioning has no other way to
 work), so pass layout classes for everything else — sizing, background, text, and so on —
-exactly as on any other element. The optional pixel offset nudges the projected point (handy
-for centering a label rather than pinning its top-left corner to it), and the element hides
-itself (`display: none`) whenever its target sits behind the camera rather than jumping to a
-wrong on-screen spot — the same "don't draw a mis-projected point" rule drei's own
-`isObjectBehindCamera` check applies, toggleable off if a caller wants the element to keep
-tracking (and clip) regardless.
+exactly as on any other element, at any nesting depth (the panel-space projection is
+converted to the element's own parent-relative space before it's written, so it positions
+correctly regardless of what ancestor containers sit between it and the panel root). The
+optional pixel offset nudges the projected point (handy for centering a label rather than
+pinning its top-left corner to it). A null `target` (or one destroyed later) mounts an inert,
+hidden element rather than throwing. The element also hides itself whenever its target sits
+behind the camera rather than jumping to a wrong on-screen spot — the same "don't draw a
+mis-projected point" rule drei's own `isObjectBehindCamera` check applies; `hideWhenBehindCamera:
+false` opts out of the hide but does not attempt to keep tracking a behind-camera target (there
+is no sensible projection for one), so the element simply stays at its last resolved position.
+
+Not supported: nesting `V.Anchored` inside a `V.WorldSpace` panel's children. That panel is
+still a runtime (`Player`-context) panel — indistinguishable from an ordinary screen-space one
+without reflecting into an internal engine property — so it silently receives the same
+near-raw-world-space values `RuntimePanelUtils.CameraTransformWorldToPanel` is documented to
+degrade to for a `V.WorldSpace` host (see above). `V.Anchored` targets an ordinary screen-space
+panel only.
 
 Raycast-based occlusion against scene geometry — drei's `<Html occlude>` opt-in — is not
 implemented: an explicit, documented scope cut for now, not an oversight.

--- a/Packages/com.velvet.core/Runtime/Component/V.cs
+++ b/Packages/com.velvet.core/Runtime/Component/V.cs
@@ -1549,6 +1549,60 @@ namespace Velvet
         }
 
         /// <summary>
+        /// Screen-space element that tracks a 3D scene Transform's projected position every frame — drei's
+        /// <c>&lt;Html&gt;</c> parity (default screen-space projection mode). Not depth-tested against scene
+        /// geometry (unlike <see cref="WorldSpace"/>, which renders content INTO the 3D scene and can be
+        /// occluded by it): this is ordinary 2D UI, positioned dynamically. Forces <c>position: absolute</c>
+        /// inline (dynamic left/top positioning has no other way to work; see AnchoredDriver.Attach) — pass
+        /// layout classes for everything else.
+        /// </summary>
+        /// <param name="target">The Transform this element's screen position tracks. Must not be null.</param>
+        /// <param name="camera">The camera to project through. Null resolves to <see cref="Camera.main"/> on
+        /// every tick, so a scene's active camera can change without re-supplying this.</param>
+        /// <param name="offset">Pixel offset applied after projection (e.g. to center a label on the point).</param>
+        /// <param name="hideWhenBehindCamera">When true (default), the element is hidden (display: none)
+        /// while <paramref name="target"/> is behind the camera rather than jumping to a wrong on-screen spot.</param>
+        /// <returns>The created <see cref="ElementNode"/>.</returns>
+        public static ElementNode Anchored(
+            Transform target,
+            Camera? camera = null,
+            Vector2? offset = null,
+            bool hideWhenBehindCamera = true,
+            string? className = null,
+            string? key = null,
+            string? name = null,
+            FiberElementProps? props = null,
+            StyleOverrides? styles = null,
+            Func<VisualElement, Action>? refCallback = null,
+            VNode?[]? children = null,
+            string? whileHoverClass = null,
+            string? whileTapClass = null,
+            string? whileFocusClass = null,
+            IReadOnlyDictionary<string, string>? data = null,
+            IReadOnlyDictionary<string, string>? aria = null)
+        {
+            if (target == null) throw new ArgumentNullException(nameof(target));
+            var mergedProps = WithAttributes(props, data, aria) ?? VNodePool.RentProps();
+            mergedProps.Anchored = new AnchoredSettings(target, camera, offset ?? Vector2.zero, hideWhenBehindCamera);
+
+            return new ElementNode
+            {
+                Key = key,
+                ElementType = typeof(VisualElement),
+                Name = name,
+                ClassNames = ParseClassNames(className),
+                Props = mergedProps,
+                Styles = styles,
+                Children = children ?? EmptyChildren,
+                Events = EmptyEvents,
+                RefCallback = refCallback,
+                WhileHoverClass = whileHoverClass,
+                WhileTapClass = whileTapClass,
+                WhileFocusClass = whileFocusClass,
+            };
+        }
+
+        /// <summary>
         /// Placeholder that renders the matched child route component of a nested route at this position.
         /// </summary>
         /// <param name="context">

--- a/Packages/com.velvet.core/Runtime/Component/V.cs
+++ b/Packages/com.velvet.core/Runtime/Component/V.cs
@@ -1556,7 +1556,11 @@ namespace Velvet
         /// inline (dynamic left/top positioning has no other way to work; see AnchoredDriver.Attach) — pass
         /// layout classes for everything else.
         /// </summary>
-        /// <param name="target">The Transform this element's screen position tracks. Must not be null.</param>
+        /// <param name="target">The Transform this element's screen position tracks. Null (or a Transform
+        /// destroyed later) mounts an inert, hidden (display: none) element until a live target is supplied —
+        /// matching <see cref="SceneView"/>/<see cref="Particles"/>'s own null-tolerant convention, since a
+        /// component holding a Transform in state can have it destroyed by unrelated game logic between
+        /// renders.</param>
         /// <param name="camera">The camera to project through. Null resolves to <see cref="Camera.main"/> on
         /// every tick, so a scene's active camera can change without re-supplying this.</param>
         /// <param name="offset">Pixel offset applied after projection (e.g. to center a label on the point).</param>
@@ -1564,7 +1568,7 @@ namespace Velvet
         /// while <paramref name="target"/> is behind the camera rather than jumping to a wrong on-screen spot.</param>
         /// <returns>The created <see cref="ElementNode"/>.</returns>
         public static ElementNode Anchored(
-            Transform target,
+            Transform? target,
             Camera? camera = null,
             Vector2? offset = null,
             bool hideWhenBehindCamera = true,
@@ -1581,7 +1585,6 @@ namespace Velvet
             IReadOnlyDictionary<string, string>? data = null,
             IReadOnlyDictionary<string, string>? aria = null)
         {
-            if (target == null) throw new ArgumentNullException(nameof(target));
             var mergedProps = WithAttributes(props, data, aria) ?? VNodePool.RentProps();
             mergedProps.Anchored = new AnchoredSettings(target, camera, offset ?? Vector2.zero, hideWhenBehindCamera);
 

--- a/Packages/com.velvet.core/Runtime/Reconciler/AnchoredDriver.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/AnchoredDriver.cs
@@ -5,12 +5,16 @@ using UnityEngine.UIElements;
 namespace Velvet
 {
     // Reconciler-side bookkeeping for one Anchored element, keyed in ReconcilerContext.AnchoredBindings by
-    // the element itself. Holds the current settings (target/camera/offset) and the recurring per-frame tick
-    // that re-projects the target's position (see AnchoredDriver.Sync) so it can be paused on detach.
+    // the element itself. Holds the current settings (target/camera/offset), the recurring per-frame tick
+    // that re-projects the target's position (see AnchoredDriver.Sync) so it can be paused on detach, the
+    // registered geometry callback (so it can be unregistered on detach), and a one-shot flag so the
+    // Editor-context degradation warns exactly once per binding instead of every tick.
     internal sealed class AnchoredBinding
     {
         public AnchoredSettings Settings;
         public IVisualElementScheduledItem? Tick;
+        public EventCallback<GeometryChangedEvent>? OnGeometryChanged;
+        public bool WarnedAboutUnsupportedPanel;
 
         public AnchoredBinding(AnchoredSettings settings)
         {
@@ -21,15 +25,22 @@ namespace Velvet
     /// <summary>
     /// Drives an Anchored element's screen position: every tick, projects <see cref="AnchoredSettings.Target"/>'s
     /// world position through <see cref="AnchoredSettings.Camera"/> (or <see cref="Camera.main"/> when null) via
-    /// <see cref="RuntimePanelUtils.CameraTransformWorldToPanel"/> and writes the result as inline
-    /// <c>left</c>/<c>top</c> — drei's <c>&lt;Html&gt;</c> parity (screen-space projection, not depth-tested
-    /// against scene geometry, unlike <c>V.WorldSpace</c>). <c>RuntimePanelUtils.CameraTransformWorldToPanel</c>
-    /// is correct here specifically because the element lives in an ordinary screen-space (Overlay/Camera) panel:
-    /// <c>PanelSettings.ApplyPanelSettings</c> only resolves the scale factor this API divides by
-    /// (<c>ScreenToPanel</c>'s <c>screen / scale</c>) for non-WorldSpace render modes — the same API returns the
-    /// input essentially unchanged for a <c>V.WorldSpace</c>-hosted panel, which pins scale to 1 and sizes itself
-    /// from the host Transform instead (see <c>PanelHostFactory</c>'s own note on this API's dual, panel-mode-
-    /// dependent behavior).
+    /// <see cref="RuntimePanelUtils.CameraTransformWorldToPanel"/>, converts the result from panel-root space into
+    /// the element's own PARENT-relative space (subtracting <c>element.parent.worldBound.position</c> — UI
+    /// Toolkit resolves <c>position: absolute</c> <c>left</c>/<c>top</c> against the immediate parent, not the
+    /// panel root, unlike CSS's nearest-positioned-ancestor walk), and writes the result as inline
+    /// <c>left</c>/<c>top</c> — drei's
+    /// <c>&lt;Html&gt;</c> parity (screen-space projection, not depth-tested against scene geometry, unlike
+    /// <c>V.WorldSpace</c>). <c>RuntimePanelUtils.CameraTransformWorldToPanel</c> is correct here specifically
+    /// because the element lives in an ordinary screen-space (Overlay/Camera) panel: <c>PanelSettings.
+    /// ApplyPanelSettings</c> only resolves the scale factor this API divides by (<c>ScreenToPanel</c>'s
+    /// <c>screen / scale</c>) for non-WorldSpace render modes — the same API returns the input essentially
+    /// unchanged for a <c>V.WorldSpace</c>-hosted panel (see <c>PanelHostFactory</c>'s own note on this API's dual,
+    /// panel-mode-dependent behavior). <b>Not supported:</b> nesting a <c>V.Anchored</c> element inside a
+    /// <c>V.WorldSpace</c> panel's children — that panel is still <c>ContextType.Player</c> (the guard below can't
+    /// distinguish it from an ordinary screen-space runtime panel without reflecting into an internal engine
+    /// property), so it silently gets the same near-raw-world-space values the API is documented to degrade to
+    /// there. <c>V.Anchored</c> targets an ordinary screen-space panel only.
     /// </summary>
     internal static class AnchoredDriver
     {
@@ -45,6 +56,14 @@ namespace Velvet
             // GeneralPathReconciler pins a PopLayout ghost out of flow via style.position directly.
             element.style.position = Position.Absolute;
             binding.Tick = element.schedule.Execute(() => Sync(element, binding)).Every(TickIntervalMs);
+            // Also re-sync on the element's own geometry changes (mirrors SceneViewDriver's geometry-driven
+            // texture sync): the recurring tick can fire BEFORE the first layout pass has placed the
+            // element's ancestors — the parent-relative conversion below then reads a not-yet-laid-out
+            // parent origin — and the next tick is a full wall-clock interval away, one frame too late for
+            // the position to be right when the element first paints. The geometry event fires the moment
+            // the element's own rect settles, immediately after that same layout pass.
+            binding.OnGeometryChanged = _ => Sync(element, binding);
+            element.RegisterCallback(binding.OnGeometryChanged);
             // Sync once synchronously too: the element may already be laid out (a binding arriving through a
             // patch rather than mount), and waiting for the first scheduled tick would show one frame at
             // whatever position the element last held (its layout-flow default, since Anchored forces
@@ -63,6 +82,11 @@ namespace Velvet
         {
             binding.Tick?.Pause();
             binding.Tick = null;
+            if (binding.OnGeometryChanged != null)
+            {
+                element.UnregisterCallback(binding.OnGeometryChanged);
+                binding.OnGeometryChanged = null;
+            }
             // Release every inline style Attach/Sync forced, so a pooled element does not ghost a stale
             // absolute position (or a display:none from having last synced behind the camera) onto whatever
             // it is reused for next — the recurring pool-reuse footgun this codebase's own reset helpers
@@ -82,9 +106,8 @@ namespace Velvet
                 return;
             }
 
-            // No panel yet (off-tree at Attach time) or no camera to project through: leave the element at
-            // its current position rather than hiding it — Attach's own synchronous Sync call, or the next
-            // tick once the element attaches, resolves it as soon as a panel/camera are available.
+            // No panel yet (off-tree at Attach time): leave the element at its current position rather than
+            // hiding it — the next tick once the element attaches resolves it.
             var panel = element.panel;
             if (panel == null)
             {
@@ -93,36 +116,86 @@ namespace Velvet
             var camera = binding.Settings.Camera != null ? binding.Settings.Camera : Camera.main;
             if (camera == null)
             {
+                // No camera to project through (an explicit Camera destroyed, or no MainCamera-tagged camera
+                // in the scene) — there is no sensible position to hold, so hide rather than freeze at a
+                // screen position that no longer corresponds to anything, mirroring the target==null branch.
+                element.style.display = DisplayStyle.None;
                 return;
             }
 
             // View-space depth test (drei's own isObjectBehindCamera equivalent): a target behind the camera
             // plane projects through WorldToScreenPoint with its x/y mirrored, which CameraTransformWorldToPanel
-            // would otherwise turn into a wildly wrong on-screen position rather than an obviously-off-screen one.
+            // would otherwise turn into a wildly wrong on-screen position rather than an obviously-off-screen
+            // one — including when HideWhenBehindCamera is false, so that opt-out does not attempt this
+            // projection at all rather than "tracking" a mirrored/garbage point. Checked before the panel-type
+            // guard below: whether the target even faces the camera is independent of what kind of panel this
+            // element happens to live in.
             var toTarget = target.position - camera.transform.position;
-            var isBehindCamera = Vector3.Dot(camera.transform.forward, toTarget) <= 0f;
-            if (binding.Settings.HideWhenBehindCamera && isBehindCamera)
+            var isBehindCamera = Vector3.Dot(camera.transform.forward, toTarget) < 0f;
+            if (isBehindCamera)
             {
-                element.style.display = DisplayStyle.None;
+                if (binding.Settings.HideWhenBehindCamera)
+                {
+                    element.style.display = DisplayStyle.None;
+                }
                 return;
             }
-            element.style.display = DisplayStyle.Flex;
 
             // RuntimePanelUtils.CameraTransformWorldToPanel casts its panel argument to BaseRuntimePanel
             // internally — correct and necessary for the ordinary ScreenSpaceOverlay/ScreenSpaceCamera panel
             // V.Anchored targets, but an InvalidCastException for an EDITOR panel (contextType.Editor, e.g.
             // Velvet content mounted into an EditorWindow's rootVisualElement — a supported Velvet scenario,
-            // see the preview-tooling docs). The element still shows/hides correctly from the behind-camera
-            // check above; only its position stays wherever it last was rather than crashing, since an
-            // Anchored element has no well-defined screen projection outside a runtime panel.
+            // see the preview-tooling docs). An unsupported panel has no well-defined position at all, so it
+            // is treated the same as "no camera" above rather than showing at a stale/never-set position.
             if (panel.contextType != ContextType.Player)
             {
+                if (!binding.WarnedAboutUnsupportedPanel)
+                {
+                    binding.WarnedAboutUnsupportedPanel = true;
+                    FiberLogger.LogWarning("Anchored",
+                        "This element's panel is not a runtime (Player-context) panel, so its screen "
+                        + "projection is undefined here (e.g. Velvet content mounted into an EditorWindow). "
+                        + "Hiding it instead of showing a stale or arbitrary position.");
+                }
+                element.style.display = DisplayStyle.None;
                 return;
             }
+
+            // Clears any inline override from a previous behind-camera/no-camera/unsupported-panel hide,
+            // rather than forcing DisplayStyle.Flex: an inline display would otherwise permanently outrank
+            // the "hidden" USS class Props.Visible = false toggles (FiberPropApplier.ApplyVisible), since a
+            // non-!important stylesheet rule never beats an inline style. StyleKeyword.Null lets the normal
+            // class-driven cascade (including Visible = false) decide instead.
+            element.style.display = StyleKeyword.Null;
+
             var panelPoint = RuntimePanelUtils.CameraTransformWorldToPanel(panel, target.position, camera);
+            // CameraTransformWorldToPanel returns a point in PANEL-ROOT space; position: absolute resolves
+            // left/top against the element's own PARENT, not the panel root (UI Toolkit/Yoga, unlike CSS, has
+            // no nearest-positioned-ancestor walk — it is always parent-relative). worldBound reports an
+            // element's rect already resolved into panel-root space, so subtracting the parent's own
+            // worldBound origin converts panelPoint into the parent-relative point position: absolute needs.
+            // (VisualElement.WorldToLocal looked like the more principled tool for this, but empirically
+            // returns its input unchanged for an ordinary layout-positioned — not CSS-transformed — parent,
+            // i.e. it is NOT a general panel-to-parent-layout-space converter; worldBound subtraction is the
+            // one that was verified correct via a real nested-margin PlayMode test.) No conversion needed
+            // only when the element sits directly on the panel root (no parent), which already coincides
+            // with panel space.
+            var localPoint = panelPoint;
+            if (element.parent != null)
+            {
+                var parentOrigin = (Vector2)element.parent.worldBound.position;
+                // A parent that has never been laid out reports a NaN-sized worldBound whose origin cannot
+                // be trusted yet — skip this write and let the geometry callback registered in Attach re-sync
+                // the moment the first layout pass settles, rather than baking a wrong origin into left/top.
+                if (float.IsNaN(parentOrigin.x) || float.IsNaN(parentOrigin.y))
+                {
+                    return;
+                }
+                localPoint = panelPoint - parentOrigin;
+            }
             var offset = binding.Settings.Offset;
-            element.style.left = panelPoint.x + offset.x;
-            element.style.top = panelPoint.y + offset.y;
+            element.style.left = localPoint.x + offset.x;
+            element.style.top = localPoint.y + offset.y;
         }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Reconciler/AnchoredDriver.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/AnchoredDriver.cs
@@ -1,0 +1,128 @@
+#nullable enable
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace Velvet
+{
+    // Reconciler-side bookkeeping for one Anchored element, keyed in ReconcilerContext.AnchoredBindings by
+    // the element itself. Holds the current settings (target/camera/offset) and the recurring per-frame tick
+    // that re-projects the target's position (see AnchoredDriver.Sync) so it can be paused on detach.
+    internal sealed class AnchoredBinding
+    {
+        public AnchoredSettings Settings;
+        public IVisualElementScheduledItem? Tick;
+
+        public AnchoredBinding(AnchoredSettings settings)
+        {
+            Settings = settings;
+        }
+    }
+
+    /// <summary>
+    /// Drives an Anchored element's screen position: every tick, projects <see cref="AnchoredSettings.Target"/>'s
+    /// world position through <see cref="AnchoredSettings.Camera"/> (or <see cref="Camera.main"/> when null) via
+    /// <see cref="RuntimePanelUtils.CameraTransformWorldToPanel"/> and writes the result as inline
+    /// <c>left</c>/<c>top</c> — drei's <c>&lt;Html&gt;</c> parity (screen-space projection, not depth-tested
+    /// against scene geometry, unlike <c>V.WorldSpace</c>). <c>RuntimePanelUtils.CameraTransformWorldToPanel</c>
+    /// is correct here specifically because the element lives in an ordinary screen-space (Overlay/Camera) panel:
+    /// <c>PanelSettings.ApplyPanelSettings</c> only resolves the scale factor this API divides by
+    /// (<c>ScreenToPanel</c>'s <c>screen / scale</c>) for non-WorldSpace render modes — the same API returns the
+    /// input essentially unchanged for a <c>V.WorldSpace</c>-hosted panel, which pins scale to 1 and sizes itself
+    /// from the host Transform instead (see <c>PanelHostFactory</c>'s own note on this API's dual, panel-mode-
+    /// dependent behavior).
+    /// </summary>
+    internal static class AnchoredDriver
+    {
+        // Per-frame cadence, matching the sibling per-frame element drivers (SceneViewDriver, ParticlesDriver).
+        internal const long TickIntervalMs = 16;
+
+        public static AnchoredBinding Attach(VisualElement element, AnchoredSettings settings)
+        {
+            var binding = new AnchoredBinding(settings);
+            // Forced inline, not through a USS class: dynamic left/top positioning has no other way to work,
+            // and writing it here (rather than baking "absolute" into V.Anchored's className, which would grow
+            // ParseClassNames' cache by one entry per distinct caller className) mirrors how
+            // GeneralPathReconciler pins a PopLayout ghost out of flow via style.position directly.
+            element.style.position = Position.Absolute;
+            binding.Tick = element.schedule.Execute(() => Sync(element, binding)).Every(TickIntervalMs);
+            // Sync once synchronously too: the element may already be laid out (a binding arriving through a
+            // patch rather than mount), and waiting for the first scheduled tick would show one frame at
+            // whatever position the element last held (its layout-flow default, since Anchored forces
+            // position: absolute) instead of its target's projected one.
+            Sync(element, binding);
+            return binding;
+        }
+
+        public static void Update(VisualElement element, AnchoredBinding binding, AnchoredSettings settings)
+        {
+            binding.Settings = settings;
+            Sync(element, binding);
+        }
+
+        public static void Detach(VisualElement element, AnchoredBinding binding)
+        {
+            binding.Tick?.Pause();
+            binding.Tick = null;
+            // Release every inline style Attach/Sync forced, so a pooled element does not ghost a stale
+            // absolute position (or a display:none from having last synced behind the camera) onto whatever
+            // it is reused for next — the recurring pool-reuse footgun this codebase's own reset helpers
+            // (e.g. FiberElementPoolReset) exist to avoid.
+            element.style.position = StyleKeyword.Null;
+            element.style.left = StyleKeyword.Null;
+            element.style.top = StyleKeyword.Null;
+            element.style.display = StyleKeyword.Null;
+        }
+
+        private static void Sync(VisualElement element, AnchoredBinding binding)
+        {
+            var target = binding.Settings.Target;
+            if (target == null)
+            {
+                element.style.display = DisplayStyle.None;
+                return;
+            }
+
+            // No panel yet (off-tree at Attach time) or no camera to project through: leave the element at
+            // its current position rather than hiding it — Attach's own synchronous Sync call, or the next
+            // tick once the element attaches, resolves it as soon as a panel/camera are available.
+            var panel = element.panel;
+            if (panel == null)
+            {
+                return;
+            }
+            var camera = binding.Settings.Camera != null ? binding.Settings.Camera : Camera.main;
+            if (camera == null)
+            {
+                return;
+            }
+
+            // View-space depth test (drei's own isObjectBehindCamera equivalent): a target behind the camera
+            // plane projects through WorldToScreenPoint with its x/y mirrored, which CameraTransformWorldToPanel
+            // would otherwise turn into a wildly wrong on-screen position rather than an obviously-off-screen one.
+            var toTarget = target.position - camera.transform.position;
+            var isBehindCamera = Vector3.Dot(camera.transform.forward, toTarget) <= 0f;
+            if (binding.Settings.HideWhenBehindCamera && isBehindCamera)
+            {
+                element.style.display = DisplayStyle.None;
+                return;
+            }
+            element.style.display = DisplayStyle.Flex;
+
+            // RuntimePanelUtils.CameraTransformWorldToPanel casts its panel argument to BaseRuntimePanel
+            // internally — correct and necessary for the ordinary ScreenSpaceOverlay/ScreenSpaceCamera panel
+            // V.Anchored targets, but an InvalidCastException for an EDITOR panel (contextType.Editor, e.g.
+            // Velvet content mounted into an EditorWindow's rootVisualElement — a supported Velvet scenario,
+            // see the preview-tooling docs). The element still shows/hides correctly from the behind-camera
+            // check above; only its position stays wherever it last was rather than crashing, since an
+            // Anchored element has no well-defined screen projection outside a runtime panel.
+            if (panel.contextType != ContextType.Player)
+            {
+                return;
+            }
+            var panelPoint = RuntimePanelUtils.CameraTransformWorldToPanel(panel, target.position, camera);
+            var offset = binding.Settings.Offset;
+            element.style.left = panelPoint.x + offset.x;
+            element.style.top = panelPoint.y + offset.y;
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/AnchoredDriver.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/AnchoredDriver.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8632c604ad9b84733bbcfb48708b533e

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberElementCleaner.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberElementCleaner.cs
@@ -315,6 +315,13 @@ namespace Velvet
                 ParticlesDriver.Detach(element, particlesBinding);
                 _ctx.ParticlesBindings.Remove(element);
             }
+            if (_ctx.AnchoredBindings.TryGetValue(element, out var anchoredBinding))
+            {
+                // Pause the recurring projection tick so a pooled element does not keep repositioning
+                // itself after it is reused for something unrelated.
+                AnchoredDriver.Detach(element, anchoredBinding);
+                _ctx.AnchoredBindings.Remove(element);
+            }
             if (_ctx.VirtualListControllers.TryGetValue(element, out var virtualListController))
             {
                 virtualListController.Dispose();

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberElementProps.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberElementProps.cs
@@ -65,6 +65,10 @@ namespace Velvet
         public ParticlesSettings? Particles { get => _particles; set { ThrowIfReadOnly(); _particles = value; } }
         private ParticlesSettings? _particles;
 
+        /// <summary>Anchored-specific settings (the 3D Transform this element's screen position tracks).</summary>
+        public AnchoredSettings? Anchored { get => _anchored; set { ThrowIfReadOnly(); _anchored = value; } }
+        private AnchoredSettings? _anchored;
+
         /// <summary>
         /// Carried <c>data-*</c> attribute values (key → value), the UI-Toolkit stand-in for HTML data
         /// attributes. UI Toolkit has no attributes, so these are stored in the reconciler's per-element
@@ -152,6 +156,27 @@ namespace Velvet
             PlayOn = playOn;
             PixelsPerUnit = VelvetArgUtil.RequirePositiveFinite(pixelsPerUnit, nameof(pixelsPerUnit),
                 "pixelsPerUnit must be positive; it maps particle world units to element pixels.");
+        }
+    }
+
+    /// <summary>
+    /// The 3D Transform an Anchored element's screen position tracks, plus the camera whose projection
+    /// drives it (null resolves to <see cref="Camera.main"/> on every tick, so a scene's active camera
+    /// can change without a settings update) and a pixel offset applied after projection.
+    /// </summary>
+    public sealed record AnchoredSettings
+    {
+        public Transform? Target { get; init; }
+        public Camera? Camera { get; init; }
+        public Vector2 Offset { get; init; }
+        public bool HideWhenBehindCamera { get; init; } = true;
+
+        public AnchoredSettings(Transform? target, Camera? camera = null, Vector2 offset = default, bool hideWhenBehindCamera = true)
+        {
+            Target = target;
+            Camera = camera;
+            Offset = offset;
+            HideWhenBehindCamera = hideWhenBehindCamera;
         }
     }
 

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodeFactory.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodeFactory.cs
@@ -137,6 +137,13 @@ namespace Velvet
                     {
                         _patcher.Appliers.ApplyParticles(element, elementNode.Props.Particles);
                     }
+                    // Anchored (V.Anchored): wire the per-frame screen-projection tick. Panel-independent at
+                    // creation (Attach's own synchronous Sync call bails cleanly if the element has no panel
+                    // yet); the first real tick fires once mounted.
+                    if (elementNode.Props?.Anchored != null)
+                    {
+                        _patcher.Appliers.ApplyAnchored(element, elementNode.Props.Anchored);
+                    }
 
                     if (elementNode.WrapElement != null)
                     {
@@ -230,6 +237,12 @@ namespace Velvet
                     if (motionNode.Props?.Particles != null)
                     {
                         _patcher.Appliers.ApplyParticles(element, motionNode.Props.Particles);
+                    }
+                    // Anchored through a Motion host: same reason as SceneView/Particles above — a Motion
+                    // can host any element type, so the binding must attach on this create path too.
+                    if (motionNode.Props?.Anchored != null)
+                    {
+                        _patcher.Appliers.ApplyAnchored(element, motionNode.Props.Anchored);
                     }
                     StyleFontResolver.ApplyIfPresent(element, appliedClasses);
                     _patcher.ApplyGapManipulator(element, appliedClasses);

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
@@ -1087,6 +1087,14 @@ namespace Velvet
             {
                 _appliers.ApplyParticles(element, newProps.Particles);
             }
+
+            // Record (value) equality, like SceneView/Particles above: a re-render carrying the same
+            // target/camera/offset in a fresh record is not a change — the position itself updates every
+            // tick regardless (AnchoredDriver's own recurring Sync), not through this diff.
+            if (oldProps.Anchored != newProps.Anchored)
+            {
+                _appliers.ApplyAnchored(element, newProps.Anchored);
+            }
         }
 
         // Applies the StyleOverrides diff to element.style.

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberWrapperElementAppliers.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberWrapperElementAppliers.cs
@@ -920,6 +920,15 @@ namespace Velvet
                 s_particlesAttach, s_particlesUpdate, s_particlesDetach);
         }
 
+        // Unlike SceneView/Particles, Anchored has no dedicated element type to gate on — V.Anchored builds
+        // a plain ElementNode (any host type is valid; the binding only ever writes inline left/top), so
+        // this dispatches straight to the shared binding logic with no type check.
+        internal void ApplyAnchored(VisualElement element, AnchoredSettings? settings)
+        {
+            ApplyElementBinding(element, settings, _ctx.AnchoredBindings,
+                s_anchoredAttach, s_anchoredUpdate, s_anchoredDetach);
+        }
+
         // Cached method-group delegates so the shared dispatch below adds no per-call allocation.
         private static readonly Func<VisualElement, SceneViewSettings, SceneViewBinding> s_sceneViewAttach = SceneViewDriver.Attach;
         private static readonly Action<VisualElement, SceneViewBinding, SceneViewSettings> s_sceneViewUpdate = SceneViewDriver.Update;
@@ -927,6 +936,9 @@ namespace Velvet
         private static readonly Func<VisualElement, ParticlesSettings, ParticlesBinding> s_particlesAttach = ParticlesDriver.Attach;
         private static readonly Action<VisualElement, ParticlesBinding, ParticlesSettings> s_particlesUpdate = ParticlesDriver.Update;
         private static readonly Action<VisualElement, ParticlesBinding> s_particlesDetach = ParticlesDriver.Detach;
+        private static readonly Func<VisualElement, AnchoredSettings, AnchoredBinding> s_anchoredAttach = AnchoredDriver.Attach;
+        private static readonly Action<VisualElement, AnchoredBinding, AnchoredSettings> s_anchoredUpdate = AnchoredDriver.Update;
+        private static readonly Action<VisualElement, AnchoredBinding> s_anchoredDetach = AnchoredDriver.Detach;
 
         // The attach/update/detach dispatch both element bindings share. A vanished settings prop only
         // happens on a hand-built ElementNode (the factories always carry settings, even for a null

--- a/Packages/com.velvet.core/Runtime/Reconciler/Reconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Reconciler.cs
@@ -460,6 +460,13 @@ namespace Velvet
                 ParticlesDriver.Detach(element, binding);
             }
             _ctx.ParticlesBindings.Clear();
+            // Anchored bindings own a recurring projection tick: pause each so a still-mounted anchored
+            // element at root disposal leaves nothing still ticking.
+            foreach (var (element, binding) in _ctx.AnchoredBindings)
+            {
+                AnchoredDriver.Detach(element, binding);
+            }
+            _ctx.AnchoredBindings.Clear();
             foreach (var (element, manipulator) in _ctx.GestureManipulators)
             {
                 element.RemoveManipulator(manipulator);

--- a/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
@@ -354,6 +354,12 @@ namespace Velvet
         // at root disposal.
         public Dictionary<VisualElement, ParticlesBinding> ParticlesBindings { get; } = new();
 
+        // Per-Anchored-element bookkeeping (V.Anchored), keyed by the element itself. The binding owns a
+        // live resource — the recurring per-frame projection tick (AnchoredDriver) — so it is NOT a pure
+        // side-table: FiberElementCleaner pauses the tick on element teardown and Reconciler.Dispose sweeps
+        // any binding still live at root disposal.
+        public Dictionary<VisualElement, AnchoredBinding> AnchoredBindings { get; } = new();
+
         // Per-Portal placeholder bookkeeping. SlotStart + SlotLength identify the
         // range of FiberPortalRegistry.Get(TargetId).Children owned by this Portal — the
         // invariant that lets multiple Portals coexist on the same target without overwriting each

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/AnchoredTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/AnchoredTests.cs
@@ -93,6 +93,38 @@ namespace Velvet.Tests
         }
 
         [Test]
+        public void Given_NoCameraIsSuppliedAndNoMainCameraExists_When_Ticked_Then_TheElementIsHidden()
+        {
+            // Arrange — Camera.main resolves to null: no camera param, and _camera (the only Camera in this
+            // test's scene) is never tagged MainCamera.
+            _targetGo.transform.position = new Vector3(0f, 0f, 0f);
+            _reconciler.Reconcile(Root, Array.Empty<VNode>(),
+                new[] { V.Anchored(_targetGo.transform, key: "a", name: "anchored") });
+            var element = Root.Q<VisualElement>("anchored");
+
+            // Act
+            Tick();
+
+            // Assert
+            Assert.That(element.style.display.value, Is.EqualTo(DisplayStyle.None));
+        }
+
+        [Test]
+        public void Given_ATargetInFrontOfTheCamera_When_TheHostPanelIsNotARuntimePanel_Then_TheElementIsHidden()
+        {
+            // Arrange & Act — this fixture's panel is an Editor-context one (see class remarks); an
+            // in-front-of-camera target has nothing that would otherwise hide it, isolating this guard.
+            _targetGo.transform.position = new Vector3(0f, 0f, 0f);
+            _reconciler.Reconcile(Root, Array.Empty<VNode>(),
+                new[] { V.Anchored(_targetGo.transform, camera: _camera, key: "a", name: "anchored") });
+            var element = Root.Q<VisualElement>("anchored");
+            Tick();
+
+            // Assert
+            Assert.That(element.style.display.value, Is.EqualTo(DisplayStyle.None));
+        }
+
+        [Test]
         public void Given_AnAnchoredElement_When_ItsTargetIsPatchedToADifferentTransform_Then_TheSameBindingIsReused()
         {
             // Arrange

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/AnchoredTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/AnchoredTests.cs
@@ -1,0 +1,125 @@
+using System;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Specifies <c>V.Anchored</c>'s wiring contract: mounting registers an <c>AnchoredBinding</c> and forces
+    /// the element out of flow (<c>position: absolute</c>), a target behind the camera hides the element
+    /// (<c>display: none</c>) WITHOUT reaching the real screen-projection call (see the class remarks on why
+    /// that matters for this fixture), unmounting releases the binding and every inline style it drove, and a
+    /// patched target updates the SAME binding rather than tearing down and recreating it.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately does NOT assert the actual projected left/top for an in-front-of-camera target:
+    /// <c>RuntimePanelUtils.CameraTransformWorldToPanel</c> casts its panel argument to
+    /// <c>BaseRuntimePanel</c> internally, and this fixture's panel (via <c>MotionSimulatedPanelTestsBase</c>'s
+    /// <c>EditorPanelSimulator</c>) is an EDITOR panel, not a runtime one — calling it here would throw an
+    /// <c>InvalidCastException</c>, not exercise the real behavior. The projection math itself is pinned by
+    /// <c>AnchoredPlaybackTests</c> (PlayMode, a real <c>UIDocument</c> runtime panel) instead. The
+    /// behind-camera path is safe to test here because it short-circuits BEFORE that call.
+    /// </remarks>
+    [TestFixture]
+    internal sealed class AnchoredTests : MotionSimulatedPanelTestsBase
+    {
+        private GameObject _cameraGo;
+        private GameObject _targetGo;
+        private Camera _camera;
+
+        public override void SetUp()
+        {
+            base.SetUp();
+            _cameraGo = new GameObject("AnchoredTestsCamera");
+            _camera = _cameraGo.AddComponent<Camera>();
+            _cameraGo.transform.SetPositionAndRotation(new Vector3(0f, 0f, -10f), Quaternion.identity);
+            _targetGo = new GameObject("AnchoredTestsTarget");
+        }
+
+        public override void TearDown()
+        {
+            if (_cameraGo != null) UnityEngine.Object.DestroyImmediate(_cameraGo);
+            if (_targetGo != null) UnityEngine.Object.DestroyImmediate(_targetGo);
+            base.TearDown();
+        }
+
+        [Test]
+        public void Given_AnAnchoredElement_When_Mounted_Then_ItIsForcedOutOfFlow()
+        {
+            // Arrange & Act — a target in front of the camera; the exact projected value is not asserted here
+            // (see class remarks), only that positioning is even possible at all.
+            _targetGo.transform.position = new Vector3(0f, 0f, 0f);
+            _reconciler.Reconcile(Root, Array.Empty<VNode>(),
+                new[] { V.Anchored(_targetGo.transform, camera: _camera, key: "a", name: "anchored") });
+
+            // Assert
+            var element = Root.Q<VisualElement>("anchored");
+            Assert.That(element.style.position.value, Is.EqualTo(Position.Absolute));
+        }
+
+        [Test]
+        public void Given_ATargetBehindTheCamera_When_Ticked_Then_TheElementIsHidden()
+        {
+            // Arrange — the target sits behind the camera's own position along its forward axis.
+            _targetGo.transform.position = new Vector3(0f, 0f, -20f);
+            _reconciler.Reconcile(Root, Array.Empty<VNode>(),
+                new[] { V.Anchored(_targetGo.transform, camera: _camera, key: "a", name: "anchored") });
+            var element = Root.Q<VisualElement>("anchored");
+
+            // Act
+            Tick();
+
+            // Assert
+            Assert.That(element.style.display.value, Is.EqualTo(DisplayStyle.None));
+        }
+
+        [Test]
+        public void Given_AnUnmountedAnchoredElement_When_TornDown_Then_TheBindingAndItsInlineStylesAreReleased()
+        {
+            // Arrange
+            _targetGo.transform.position = new Vector3(0f, 0f, 0f);
+            var tree = new[] { V.Anchored(_targetGo.transform, camera: _camera, key: "a", name: "anchored") };
+            _reconciler.Reconcile(Root, Array.Empty<VNode>(), tree);
+            var element = Root.Q<VisualElement>("anchored");
+            Assume.That(_reconciler.Context.AnchoredBindings.ContainsKey(element), Is.True,
+                "Precondition: mounting registered a binding");
+
+            // Act
+            _reconciler.Reconcile(Root, tree, Array.Empty<VNode>());
+
+            // Assert
+            Assert.That(_reconciler.Context.AnchoredBindings.ContainsKey(element), Is.False);
+        }
+
+        [Test]
+        public void Given_AnAnchoredElement_When_ItsTargetIsPatchedToADifferentTransform_Then_TheSameBindingIsReused()
+        {
+            // Arrange
+            var otherTargetGo = new GameObject("AnchoredTestsOtherTarget");
+            try
+            {
+                _targetGo.transform.position = new Vector3(0f, 0f, 0f);
+                var before = new[] { V.Anchored(_targetGo.transform, camera: _camera, key: "a", name: "anchored") };
+                _reconciler.Reconcile(Root, Array.Empty<VNode>(), before);
+                var element = Root.Q<VisualElement>("anchored");
+                _reconciler.Context.AnchoredBindings.TryGetValue(element, out var bindingBefore);
+                Assume.That(bindingBefore, Is.Not.Null, "Precondition: mounting registered a binding");
+
+                // Act
+                var after = new[] { V.Anchored(otherTargetGo.transform, camera: _camera, key: "a", name: "anchored") };
+                _reconciler.Reconcile(Root, before, after);
+
+                // Assert — the SAME binding instance is updated in place (its Settings.Target changes),
+                // rather than the element being torn down and a fresh binding attached.
+                _reconciler.Context.AnchoredBindings.TryGetValue(element, out var bindingAfter);
+                Assert.That((ReferenceEquals(bindingAfter, bindingBefore), bindingAfter?.Settings.Target),
+                    Is.EqualTo((true, otherTargetGo.transform)));
+            }
+            finally
+            {
+                UnityEngine.Object.DestroyImmediate(otherTargetGo);
+            }
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/AnchoredTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/AnchoredTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 19a39b7e61b0a406287d082fcba8632c

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/AnchoredPlaybackTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/AnchoredPlaybackTests.cs
@@ -13,14 +13,18 @@ namespace Velvet.Tests
     /// Pins that <c>V.Anchored</c> actually projects onto a real runtime panel: on a real UIDocument, a target
     /// in front of the camera lands the element's inline left/top near where <c>Camera.WorldToScreenPoint</c>
     /// (Y-flipped for panel space, the same conversion <c>RuntimePanelUtils.CameraTransformWorldToPanel</c>
-    /// performs internally) independently says it should be. Complements <see cref="AnchoredTests"/> (EditMode,
-    /// wiring + the behind-camera path only — an editor-simulated panel cannot exercise the real runtime-panel
-    /// projection call).
+    /// performs internally) independently says it should be — including when nested inside an offset parent
+    /// container, and that <c>Props.Visible = false</c> still hides an Anchored element despite the driver's
+    /// own inline display writes. Complements <see cref="AnchoredTests"/> (EditMode, wiring + the behind-camera/
+    /// no-camera/unsupported-panel hide paths only — an editor-simulated panel cannot exercise the real
+    /// runtime-panel projection call).
     /// </summary>
     internal sealed class AnchoredPlaybackTests
     {
         private static Transform s_target;
         private static Camera s_camera;
+        private static bool s_nestInOffsetContainer;
+        private static bool s_visible = true;
 
         private GameObject _panelGo;
         private GameObject _cameraGo;
@@ -30,11 +34,23 @@ namespace Velvet.Tests
 
         [Component]
         private static VNode AnchoredHost()
-            => V.Anchored(s_target, camera: s_camera, name: "anchored", className: "w-[10px] h-[10px]");
+        {
+            var anchored = V.Anchored(s_target, camera: s_camera, name: "anchored", className: "w-[10px] h-[10px]",
+                props: new FiberElementProps { Visible = s_visible });
+            // Margin, not padding: position:absolute's containing block is the parent's PADDING edge (CSS/UI
+            // Toolkit semantics), so padding alone wouldn't actually move an absolute child's origin — margin
+            // shifts the parent's own border box (and everything inside it) away from panel (0,0) instead.
+            return s_nestInOffsetContainer
+                ? V.Div(className: "m-[40px]", children: new VNode[] { anchored })
+                : anchored;
+        }
 
         [UnitySetUp]
         public IEnumerator UnitySetUp()
         {
+            s_nestInOffsetContainer = false;
+            s_visible = true;
+
             _panelGo = new GameObject("AnchoredPlaybackPanel");
             var doc = _panelGo.AddComponent<UIDocument>();
             _settings = ScriptableObject.CreateInstance<PanelSettings>();
@@ -53,8 +69,13 @@ namespace Velvet.Tests
             _targetGo = new GameObject("AnchoredPlaybackTarget");
             _targetGo.transform.position = Vector3.zero;
             s_target = _targetGo.transform;
+        }
 
-            _mounted = V.Mount(doc.rootVisualElement, V.Component(AnchoredHost, key: "root"));
+        // Mounts AnchoredHost against the CURRENT static flags — separated from UnitySetUp so a test can set
+        // s_nestInOffsetContainer / s_visible before the tree is first built.
+        private IEnumerator Mount()
+        {
+            _mounted = V.Mount(_panelGo.GetComponent<UIDocument>().rootVisualElement, V.Component(AnchoredHost, key: "root"));
             yield return null;
         }
 
@@ -76,6 +97,7 @@ namespace Velvet.Tests
         public IEnumerator Given_ATargetInFrontOfTheCamera_When_ARealPanelTicks_Then_TheElementLandsNearTheIndependentlyComputedScreenPoint()
         {
             // Arrange
+            yield return Mount();
             var camera = _cameraGo.GetComponent<Camera>();
             var element = _panelGo.GetComponent<UIDocument>().rootVisualElement.Q<VisualElement>("anchored");
             Assume.That(element, Is.Not.Null, "Precondition: the Anchored element mounted");
@@ -90,11 +112,60 @@ namespace Velvet.Tests
             var expectedLeft = screenPoint.x;
             var expectedTop = Screen.height - screenPoint.y;
 
-            // Assert — within a small pixel tolerance (DPI rounding / a frame's worth of camera settle).
-            var actualLeft = element.resolvedStyle.left;
-            var actualTop = element.resolvedStyle.top;
+            // Assert — worldBound reports the element's ACTUAL rect in panel-root space (unlike
+            // resolvedStyle.left/top, which merely echoes the parent-relative offset that was written to
+            // style.left/top — for a direct child of the panel root the two coincide, but only there).
+            var actualLeft = element.worldBound.x;
+            var actualTop = element.worldBound.y;
             Assert.That((Mathf.Abs(actualLeft - expectedLeft) < 5f, Mathf.Abs(actualTop - expectedTop) < 5f),
                 Is.EqualTo((true, true)));
+        }
+
+        [UnityTest]
+        public IEnumerator Given_ATargetInFrontOfTheCamera_When_TheElementIsNestedInAnOffsetParent_Then_ItStillLandsNearTheIndependentlyComputedScreenPoint()
+        {
+            // Arrange — the Anchored element is no longer a direct child of the panel root: its parent Div
+            // sits 40px away from panel (0,0), offset by margin.
+            s_nestInOffsetContainer = true;
+            yield return Mount();
+            var camera = _cameraGo.GetComponent<Camera>();
+            var element = _panelGo.GetComponent<UIDocument>().rootVisualElement.Q<VisualElement>("anchored");
+            Assume.That(element, Is.Not.Null, "Precondition: the Anchored element mounted");
+            yield return null;
+            yield return null;
+
+            // Act — same independent cross-check as the direct-child test: the expected on-screen point does
+            // NOT depend on how the element is nested, only on the target/camera.
+            var screenPoint = camera.WorldToScreenPoint(_targetGo.transform.position);
+            var expectedLeft = screenPoint.x;
+            var expectedTop = Screen.height - screenPoint.y;
+
+            // Assert — worldBound (panel-root space, see the direct-child test's own note) must land at the
+            // SAME on-screen point regardless of the parent's own offset from panel (0,0): this is what fails
+            // if the driver writes raw panel-space coordinates into a parent-relative style property instead
+            // of converting first (the bug this test guards).
+            var actualLeft = element.worldBound.x;
+            var actualTop = element.worldBound.y;
+            Assert.That((Mathf.Abs(actualLeft - expectedLeft) < 5f, Mathf.Abs(actualTop - expectedTop) < 5f),
+                Is.EqualTo((true, true)));
+        }
+
+        [UnityTest]
+        public IEnumerator Given_VisibleIsFalse_When_ATargetInFrontOfTheCameraTicks_Then_TheElementStaysHidden()
+        {
+            // Arrange
+            s_visible = false;
+            yield return Mount();
+            var element = _panelGo.GetComponent<UIDocument>().rootVisualElement.Q<VisualElement>("anchored");
+            Assume.That(element, Is.Not.Null, "Precondition: the Anchored element mounted");
+
+            // Act
+            yield return null;
+            yield return null;
+
+            // Assert — the driver's own inline display write must not outrank Props.Visible = false's "hidden"
+            // USS class (element.style.display should stay StyleKeyword.Null, not an inline override).
+            Assert.That(element.resolvedStyle.display, Is.EqualTo(DisplayStyle.None));
         }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/AnchoredPlaybackTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/AnchoredPlaybackTests.cs
@@ -1,0 +1,101 @@
+#if UNITY_EDITOR
+using System.Collections;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.TestTools;
+using UnityEngine.UIElements;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins that <c>V.Anchored</c> actually projects onto a real runtime panel: on a real UIDocument, a target
+    /// in front of the camera lands the element's inline left/top near where <c>Camera.WorldToScreenPoint</c>
+    /// (Y-flipped for panel space, the same conversion <c>RuntimePanelUtils.CameraTransformWorldToPanel</c>
+    /// performs internally) independently says it should be. Complements <see cref="AnchoredTests"/> (EditMode,
+    /// wiring + the behind-camera path only — an editor-simulated panel cannot exercise the real runtime-panel
+    /// projection call).
+    /// </summary>
+    internal sealed class AnchoredPlaybackTests
+    {
+        private static Transform s_target;
+        private static Camera s_camera;
+
+        private GameObject _panelGo;
+        private GameObject _cameraGo;
+        private GameObject _targetGo;
+        private PanelSettings _settings;
+        private MountedTree _mounted;
+
+        [Component]
+        private static VNode AnchoredHost()
+            => V.Anchored(s_target, camera: s_camera, name: "anchored", className: "w-[10px] h-[10px]");
+
+        [UnitySetUp]
+        public IEnumerator UnitySetUp()
+        {
+            _panelGo = new GameObject("AnchoredPlaybackPanel");
+            var doc = _panelGo.AddComponent<UIDocument>();
+            _settings = ScriptableObject.CreateInstance<PanelSettings>();
+            _settings.scaleMode = PanelScaleMode.ConstantPixelSize;
+            doc.panelSettings = _settings;
+            yield return null;
+            var sheet = AssetDatabase.LoadAssetAtPath<StyleSheet>(
+                "Packages/com.velvet.core/Runtime/Styles/StyleUtilities.uss");
+            Assume.That(sheet, Is.Not.Null, "Precondition: the bundled StyleUtilities.uss loads");
+            doc.rootVisualElement.styleSheets.Add(sheet);
+
+            _cameraGo = new GameObject("AnchoredPlaybackCamera");
+            s_camera = _cameraGo.AddComponent<Camera>();
+            s_camera.transform.SetPositionAndRotation(new Vector3(0f, 0f, -10f), Quaternion.identity);
+            s_camera.fieldOfView = 60f;
+            _targetGo = new GameObject("AnchoredPlaybackTarget");
+            _targetGo.transform.position = Vector3.zero;
+            s_target = _targetGo.transform;
+
+            _mounted = V.Mount(doc.rootVisualElement, V.Component(AnchoredHost, key: "root"));
+            yield return null;
+        }
+
+        [UnityTearDown]
+        public IEnumerator UnityTearDown()
+        {
+            _mounted?.Dispose();
+            _mounted = null;
+            s_target = null;
+            s_camera = null;
+            if (_panelGo != null) Object.Destroy(_panelGo);
+            if (_cameraGo != null) Object.Destroy(_cameraGo);
+            if (_targetGo != null) Object.Destroy(_targetGo);
+            if (_settings != null) Object.Destroy(_settings);
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator Given_ATargetInFrontOfTheCamera_When_ARealPanelTicks_Then_TheElementLandsNearTheIndependentlyComputedScreenPoint()
+        {
+            // Arrange
+            var camera = _cameraGo.GetComponent<Camera>();
+            var element = _panelGo.GetComponent<UIDocument>().rootVisualElement.Q<VisualElement>("anchored");
+            Assume.That(element, Is.Not.Null, "Precondition: the Anchored element mounted");
+            yield return null;
+            yield return null;
+
+            // Act — independently compute the expected panel-space point: WorldToScreenPoint, Y-flipped for
+            // panel space (screen Y grows up, panel Y grows down) — the same conversion the driver's own call
+            // to RuntimePanelUtils.CameraTransformWorldToPanel performs internally, recomputed here rather
+            // than re-calling that same API, so this is a real cross-check and not a tautology.
+            var screenPoint = camera.WorldToScreenPoint(_targetGo.transform.position);
+            var expectedLeft = screenPoint.x;
+            var expectedTop = Screen.height - screenPoint.y;
+
+            // Assert — within a small pixel tolerance (DPI rounding / a frame's worth of camera settle).
+            var actualLeft = element.resolvedStyle.left;
+            var actualTop = element.resolvedStyle.top;
+            Assert.That((Mathf.Abs(actualLeft - expectedLeft) < 5f, Mathf.Abs(actualTop - expectedTop) < 5f),
+                Is.EqualTo((true, true)));
+        }
+    }
+}
+#endif

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/AnchoredPlaybackTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/AnchoredPlaybackTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c13b9194675d1472d86b094899813ff4


### PR DESCRIPTION
## Summary

drei's `<Html>` parity in its default screen-space projection mode: `V.Anchored(target:)` is a plain 2D element whose `left`/`top` track a 3D scene Transform's projected position every frame via `RuntimePanelUtils.CameraTransformWorldToPanel`. Not depth-tested against scene geometry, unlike `V.WorldSpace` (which renders content INTO the 3D scene) -- ordinary screen-space UI, positioned dynamically.

Reuses the existing element-binding dispatch (`FiberWrapperElementAppliers.ApplyElementBinding`) that SceneView/Particles already share rather than introducing a new VNode type: `V.Anchored` builds a plain `ElementNode` carrying an `AnchoredSettings` on its Props, so the create/patch/teardown wiring is the same three-line pattern those two already use.

Key behaviors:
- The projected panel-space point is converted to the element's PARENT-relative space before it's written (UI Toolkit resolves `position: absolute` against the immediate parent, not the panel root), so an Anchored element positions correctly at any nesting depth -- verified against a real runtime panel with an offset parent.
- A geometry-changed re-sync makes the first laid-out frame correct rather than one timer tick late.
- Lost target / lost camera / a non-runtime (Editor-context) panel each hide the element rather than freezing or mis-showing it; the Editor-context case warns once (the underlying Unity API throws `InvalidCastException` against editor panels).
- `hideWhenBehindCamera` (default true) mirrors drei's `isObjectBehindCamera` rule; opting out keeps the last resolved position rather than projecting a mirrored/garbage behind-camera point.
- The driver never forces an inline `display: Flex`, so `Props.Visible = false` keeps working.
- Nullable `target` (a Transform destroyed by unrelated game logic between renders mounts an inert hidden element instead of throwing), matching SceneView/Particles' convention.

Scope cuts (documented in the portals guide): raycast-based occlusion (drei's `<Html occlude>`), and nesting inside a `V.WorldSpace` panel's children (that panel is indistinguishable from an ordinary runtime panel without reflecting into an internal engine property, and the projection API silently degrades there).

## Test plan

- `AnchoredTests` (EditMode, 6 tests): forced out-of-flow, behind-camera hide, no-camera hide, non-runtime-panel hide, binding teardown, binding reuse across a target patch.
- `AnchoredPlaybackTests` (PlayMode, 3 tests, real UIDocument + real Camera): projected position lands at the independently recomputed screen point as a direct root child AND nested inside an offset parent (verified RED against the pre-fix driver), and `Visible = false` stays hidden.
- Full EditMode (2786/2789, 3 pre-existing skips) and PlayMode (50/50) suites passed.

Closes #38