### PR TITLE
feat: focus / gamepad navigation layer

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Focus / gamepad navigation layer, React Aria parity — composing with (never reimplementing)
+  the engine's own focus machinery:
+  - `V.FocusScope(contain:, restoreFocus:, autoFocus:, singleTabStop:)` (and the same knobs as a
+    `FocusScope` element prop on any container): scoped Tab containment with same-flush snap-back
+    for spatial/pointer exits, focus restore on unmount, mount autofocus, and the WAI-ARIA
+    composite-widget single-tab-stop (roving) contract — engine spatial 2D navigation inside a
+    group stays untouched.
+  - `TabIndex` / `DelegatesFocus` element props (with the documented engine trap that -1 removes
+    an element from BOTH the Tab ring and 2D navigation on runtime panels).
+  - `Hooks.UseFocusRing`: keyboard/gamepad-visible focus (vs pointer focus) as re-rendering
+    component state, riding the same element-local heuristic as the existing `focus-visible:`
+    styling variant.
+  - `V.Portal(layer:)` / `V.WorldSpace` accept `focusOrder: PanelFocusOrder.Chained` to join the
+    declaring panel's Tab order at the call site (iframe semantics) — the explicit, opt-in
+    cross-panel focus escape; `Isolated` (default) keeps today's internal wrap.
+  - All sequential interception rides one pinned engine contract (a TrickleDown
+    NavigationMoveEvent listener + `FocusController.IgnoreEvent` deterministically preempts the
+    post-dispatch default move), tripwired by dedicated PlayMode tests.
 - `V.Anchored(target:)`: drei's `<Html>` parity in its default screen-space projection mode — a
   plain 2D element whose `left`/`top` track a 3D scene Transform's projected position every frame
   via `RuntimePanelUtils.CameraTransformWorldToPanel`. Not depth-tested against scene geometry
@@ -52,6 +70,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A `Button`/`Slider`/`TextField`/`Toggle` recycled through the element pool silently lost its
+  focusability (the pool's common reset scrubs `focusable` to the plain-VisualElement default,
+  which is false, and nothing restored the type's own constructor default) — a recycled control
+  dropped out of Tab/gamepad navigation entirely. The type-specific pool resets now restore it.
 - A `ComponentNode` nested inside a tree reconciled via a direct `Reconciler.Reconcile()` call
   (rather than `V.Mount`) no longer bootstraps its own isolated `ReconcilerContext`. Its fiber now
   always joins the context of the `ComponentRegistry` that created it, instead of deriving one from

--- a/Packages/com.velvet.core/Documentation~/focus.md
+++ b/Packages/com.velvet.core/Documentation~/focus.md
@@ -17,16 +17,25 @@ for when no container exists yet). Four independent knobs, mirroring React Aria'
 
 - **`contain`** — Tab/Shift-Tab wrap within the subtree instead of leaving it, and a move that
   escapes anyway (a spatial d-pad flick, a pointer press outside) is snapped back inside within
-  the same event flush. The modal-dialog behavior.
+  the same event flush — wherever the escape landed, including inside another scope. A press on
+  empty non-focusable space clears focus to nothing first (no focus event ever lands anywhere),
+  so that path re-focuses the scope on the panel's next scheduler tick instead. When two
+  contained scopes are live at once, the one currently holding focus wins. The modal-dialog
+  behavior.
 - **`restoreFocus`** — when the scope unmounts while holding focus, focus returns to the element
   it came FROM when it first entered the scope (skipped if that element is gone or can no longer
-  take focus). Pair with `contain` for dialogs.
-- **`autoFocus`** — on attach, the scope's first focusable descendant takes focus (skipped when
-  focus already sits inside — a keyed reorder re-attaching the scope must not steal focus back).
+  take focus — an unmounted origin is dropped rather than chased into pool reuse). Pair with
+  `contain` for dialogs.
+- **`autoFocus`** — on mount, the scope's first focusable descendant takes focus (skipped when
+  focus already sits inside). Mount-once, like React's `autoFocus`: a keyed reorder physically
+  re-attaches the scope and must not steal focus back, so a re-attach never re-fires it.
 - **`singleTabStop`** — the whole subtree behaves as ONE Tab stop, the WAI-ARIA composite-widget
   (roving tabindex) contract: Tab from inside exits past the remaining members, and Tab entering
-  from outside lands on the member last used (else the first). Members keep their `tabIndex`,
-  so the engine's spatial navigation INSIDE the group — the arrow/d-pad story — is untouched.
+  from outside — in either direction — lands on the member last used (else the first). The exit
+  wraps within the nearest containing scope when the group is nested in one, and a group covering
+  every reachable focusable holds position (in a `Chained` host panel it exits across the panel
+  boundary instead — see below). Members keep their `tabIndex`, so the engine's spatial
+  navigation INSIDE the group — the arrow/d-pad story — is untouched.
 
 A documented deviation from the web: arrows/d-pad can spatially exit a `singleTabStop` group at
 its edge, because spatial navigation is geometric on runtime panels. That is gamepad-correct

--- a/Packages/com.velvet.core/Documentation~/focus.md
+++ b/Packages/com.velvet.core/Documentation~/focus.md
@@ -1,0 +1,90 @@
+# Focus & navigation: the React Aria parity guide
+
+Velvet's focus layer models [React Aria](https://react-spectrum.adobe.com/react-aria/)'s
+FocusScope / roving-tabindex / `useFocusRing` capabilities on top of UI Toolkit's own focus
+machinery — composing with the engine rather than replacing it. Two things the engine already
+does well are left completely untouched: **spatial 2D navigation** (arrows / d-pad / stick moves
+between focusables by their on-screen geometry, on every runtime panel, with no Velvet code
+involved), and the **sequential focus ring** itself (Velvet predicts and redirects it, but the
+order always comes from the engine's own ring class, so the two can never disagree).
+
+## Focus scopes
+
+A focus scope is a container element whose subtree carries focus-management behavior, declared
+either with the `V.FocusScope` factory or by setting the `FocusScope` element prop on any
+existing container (the modal Div you already render can be the scope — the factory is sugar
+for when no container exists yet). Four independent knobs, mirroring React Aria's props:
+
+- **`contain`** — Tab/Shift-Tab wrap within the subtree instead of leaving it, and a move that
+  escapes anyway (a spatial d-pad flick, a pointer press outside) is snapped back inside within
+  the same event flush. The modal-dialog behavior.
+- **`restoreFocus`** — when the scope unmounts while holding focus, focus returns to the element
+  it came FROM when it first entered the scope (skipped if that element is gone or can no longer
+  take focus). Pair with `contain` for dialogs.
+- **`autoFocus`** — on attach, the scope's first focusable descendant takes focus (skipped when
+  focus already sits inside — a keyed reorder re-attaching the scope must not steal focus back).
+- **`singleTabStop`** — the whole subtree behaves as ONE Tab stop, the WAI-ARIA composite-widget
+  (roving tabindex) contract: Tab from inside exits past the remaining members, and Tab entering
+  from outside lands on the member last used (else the first). Members keep their `tabIndex`,
+  so the engine's spatial navigation INSIDE the group — the arrow/d-pad story — is untouched.
+
+A documented deviation from the web: arrows/d-pad can spatially exit a `singleTabStop` group at
+its edge, because spatial navigation is geometric on runtime panels. That is gamepad-correct
+behavior with no web equivalent (the web has no spatial navigation to exit by).
+
+A deliberate engine trap to know about: setting `TabIndex` to -1 on a runtime panel removes the
+element from BOTH the Tab ring AND spatial 2D navigation — it is not the web's "focusable but
+not tab-reachable". That is exactly why `singleTabStop` is interception-based rather than a
+hand-rolled roving-tabindex over `TabIndex` values.
+
+## Element props
+
+Three focus-related element props ride `FiberElementProps` alongside the existing `Focusable`:
+`TabIndex` (positive values sort ahead of 0 in the sequential ring; see the -1 trap above),
+`DelegatesFocus` (focusing the element forwards to its first focusable child), and `FocusScope`
+(the settings record behind the scope knobs above).
+
+## Focus-visible styling and state
+
+The `focus-visible:` class variant already covers keyboard/gamepad-only focus styling — it
+lights for focus NOT caused by a pointer press on the element (keyboard, gamepad navigation, or
+programmatic focus) and stays dark for click-to-focus, mirroring CSS `:focus-visible`. Nothing
+new is needed for the styling channel.
+
+`Hooks.UseFocusRing` is the render-state channel for the same distinction — React Aria's
+`useFocusRing` parity: it returns the element's `IsFocused` / `IsFocusVisible` as re-rendering
+component state plus a `Ref` to pass as the element's `refCallback:`. Reach for it when the
+component must render differently (say, a "press A to select" hint), not just restyle; it rides
+the same element-local heuristic as the `focus-visible:` variant, so the two surfaces cannot
+drift apart.
+
+## Cross-panel Tab order (`PanelFocusOrder`)
+
+A `V.Portal(layer:)` / `V.WorldSpace` host panel owns its own focus ring, and by default that
+ring is **`Isolated`**: Tab wraps within the host panel and never crosses the boundary — the
+explicit-opt-in ruling from the cross-panel input-routing work, unchanged. Passing
+`focusOrder: PanelFocusOrder.Chained` opts the host into the declaring panel's Tab order at the
+portal's call site, with iframe semantics: tabbing through the declaring panel enters the host
+when the ring reaches the portal's position (landing on the host's first focusable; Shift-Tab
+enters at its last), and tabbing past the host's own last element exits back to the declaring
+panel element after the call site. Arrow/2D navigation never crosses panels, matching every web
+precedent for boundary crossing being sequential-only.
+
+The escape hop is deferred by one tick of the target panel's scheduler: a synchronous
+cross-panel focus handoff from inside another panel's event dispatch does not stick (verified
+empirically — the still-focused source panel wins the reconciliation), so the source element is
+blurred synchronously and the target focused on its own panel's next tick.
+
+## Scope cuts
+
+Recorded deviations/cuts, each deliberate: no imperative focus-manager handle (the declarative
+scopes cover the pillars; add-on surface when a concrete consumer appears); no
+`whileFocusVisibleClass` gesture prop (the `focus-visible:` variant and `UseFocusRing` cover
+both channels); no orientation/wrap options on `singleTabStop` (spatial navigation already
+handles in-group movement); no callback-shaped escape hook (call-site `Chained` has the web
+parity anchors; a resolver hook has none and is left as a recorded follow-up); no 2D
+cross-panel escape; no global input-modality tracker (the element-local focus-visible heuristic
+stands — a programmatic focus right after pointer use shows the ring, which is arguably right
+for gamepad UX); and cross-panel containment is not attempted (containment is per panel — a
+globally exclusive modal is the Topmost layer + full-screen scrim pattern, which makes outside
+input land in the modal's own panel physically).

--- a/Packages/com.velvet.core/Documentation~/portals.md
+++ b/Packages/com.velvet.core/Documentation~/portals.md
@@ -136,6 +136,15 @@ A world-space host follows the same declaring-panel sync as the layers, and a ho
 externally (a scene unload) is skipped safely on later patches — remount the `V.WorldSpace`
 node to rebuild it.
 
+## Cross-panel Tab order: `PanelFocusOrder`
+
+Both host flavors accept a `focusOrder:` argument. The default, `Isolated`, is the pre-existing
+behavior: the host panel's focus ring wraps internally and Tab never crosses the panel boundary
+(the explicit-opt-in stance of the cross-panel navigation decision). `Chained` joins the
+declaring panel's Tab order at the portal's call site with iframe semantics — see the focus
+guide for the full contract, including the one-tick deferral on the escape hop and why 2D
+navigation never crosses panels.
+
 ## Screen-space anchored elements: `V.Anchored`
 
 drei's `<Html>` parity in its DEFAULT mode: a plain screen-space element whose `left`/`top`

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/ButtonPoolHelperTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/ButtonPoolHelperTests.cs
@@ -35,7 +35,7 @@ namespace Velvet.Tests
         public void Given_ButtonWithCustomState_When_Reset_Then_ConsumerSetStateIsCleared()
         {
             // Arrange
-            var button = new Button { text = "hello", name = "my-button", tooltip = "my-tooltip", focusable = true, viewDataKey = "my-view-data" };
+            var button = new Button { text = "hello", name = "my-button", tooltip = "my-tooltip", focusable = false, viewDataKey = "my-view-data" };
             button.AddToClassList("custom-class");
             button.style.color = new StyleColor(Color.red);
             button.userData = 42;
@@ -45,8 +45,8 @@ namespace Velvet.Tests
 
             // Assert
             var actual = (button.text, button.userData, button.name, button.tooltip, button.focusable, button.viewDataKey);
-            Assert.AreEqual((string.Empty, (object)null, string.Empty, string.Empty, false, (string)null), actual,
-                "Reset clears every consumer-set field back to its constructed default");
+            Assert.AreEqual((string.Empty, (object)null, string.Empty, string.Empty, true, (string)null), actual,
+                "Reset returns every consumer-set field to its constructed default (focusable is TRUE for this widget type)");
         }
 
         [Test]

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/SliderPoolHelperTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/SliderPoolHelperTests.cs
@@ -37,7 +37,7 @@ namespace Velvet.Tests
         public void Given_SliderWithCustomState_When_Reset_Then_ConsumerSetStateIsCleared()
         {
             // Arrange
-            var slider = new Slider { value = 5.5f, label = "Volume", name = "my-slider", tooltip = "my-tooltip", focusable = true, viewDataKey = "my-view-data" };
+            var slider = new Slider { value = 5.5f, label = "Volume", name = "my-slider", tooltip = "my-tooltip", focusable = false, viewDataKey = "my-view-data" };
             slider.AddToClassList("custom-class");
             slider.style.color = new StyleColor(Color.red);
             slider.userData = 42;
@@ -47,8 +47,8 @@ namespace Velvet.Tests
 
             // Assert
             var actual = (slider.value, slider.label, slider.userData, slider.name, slider.tooltip, slider.focusable, slider.viewDataKey);
-            Assert.AreEqual((0f, string.Empty, (object)null, string.Empty, string.Empty, false, (string)null), actual,
-                "Reset clears every consumer-set field back to its constructed default");
+            Assert.AreEqual((0f, string.Empty, (object)null, string.Empty, string.Empty, true, (string)null), actual,
+                "Reset returns every consumer-set field to its constructed default (focusable is TRUE for this widget type)");
         }
 
         [Test]

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/TextFieldPoolHelperTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/TextFieldPoolHelperTests.cs
@@ -69,7 +69,7 @@ namespace Velvet.Tests
         public void Given_TextFieldWithCustomState_When_Reset_Then_ConsumerSetStateIsCleared()
         {
             // Arrange
-            var textField = new TextField { label = "Email", name = "my-text-field", tooltip = "my-tooltip", focusable = true, viewDataKey = "my-view-data" };
+            var textField = new TextField { label = "Email", name = "my-text-field", tooltip = "my-tooltip", focusable = false, viewDataKey = "my-view-data" };
             textField.AddToClassList("custom-class");
             textField.style.color = new StyleColor(Color.red);
             textField.userData = 42;
@@ -79,8 +79,8 @@ namespace Velvet.Tests
 
             // Assert
             var actual = (textField.label, textField.userData, textField.name, textField.tooltip, textField.focusable, textField.viewDataKey);
-            Assert.AreEqual((string.Empty, (object)null, string.Empty, string.Empty, false, (string)null), actual,
-                "Reset clears every consumer-set field back to its constructed default");
+            Assert.AreEqual((string.Empty, (object)null, string.Empty, string.Empty, true, (string)null), actual,
+                "Reset returns every consumer-set field to its constructed default (focusable is TRUE for this widget type)");
         }
 
         [Test]

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/TogglePoolHelperTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/TogglePoolHelperTests.cs
@@ -34,7 +34,7 @@ namespace Velvet.Tests
         public void Given_ToggleWithCustomState_When_Reset_Then_ConsumerSetStateIsCleared()
         {
             // Arrange
-            var toggle = new Toggle { value = true, label = "Enabled", name = "my-toggle", tooltip = "my-tooltip", focusable = true, viewDataKey = "my-view-data" };
+            var toggle = new Toggle { value = true, label = "Enabled", name = "my-toggle", tooltip = "my-tooltip", focusable = false, viewDataKey = "my-view-data" };
             toggle.AddToClassList("custom-class");
             toggle.style.color = new StyleColor(Color.red);
             toggle.userData = 42;
@@ -44,8 +44,8 @@ namespace Velvet.Tests
 
             // Assert
             var actual = (toggle.value, toggle.label, toggle.userData, toggle.name, toggle.tooltip, toggle.focusable, toggle.viewDataKey);
-            Assert.AreEqual((false, string.Empty, (object)null, string.Empty, string.Empty, false, (string)null), actual,
-                "Reset clears every consumer-set field back to its constructed default");
+            Assert.AreEqual((false, string.Empty, (object)null, string.Empty, string.Empty, true, (string)null), actual,
+                "Reset returns every consumer-set field to its constructed default (focusable is TRUE for this widget type)");
         }
 
         [Test]

--- a/Packages/com.velvet.core/Runtime/Component/V.Mount.cs
+++ b/Packages/com.velvet.core/Runtime/Component/V.Mount.cs
@@ -29,6 +29,9 @@ namespace Velvet
                 FiberCrossPanelPointerRouter.AttachToMainPanel(target, ctx);
                 ctx.CrossPanelRouterAttached = true;
             }
+            // Focus navigation (scopes, chained portals): the navigator attaches to the mount target's own
+            // panel root when already attached, and scope/placeholder attach hooks cover panels seen later.
+            FiberFocusNavigator.EnsureAttached(target.panel?.visualTree ?? target, ctx);
 #if UNITY_EDITOR
             // Auto-attach to DevTools: opening the inspector shows the live tree
             // with no manual Register call. Editor-only — the registry and this call are compiled out of

--- a/Packages/com.velvet.core/Runtime/Component/V.Mount.cs
+++ b/Packages/com.velvet.core/Runtime/Component/V.Mount.cs
@@ -29,9 +29,10 @@ namespace Velvet
                 FiberCrossPanelPointerRouter.AttachToMainPanel(target, ctx);
                 ctx.CrossPanelRouterAttached = true;
             }
-            // Focus navigation (scopes, chained portals): the navigator attaches to the mount target's own
-            // panel root when already attached, and scope/placeholder attach hooks cover panels seen later.
-            FiberFocusNavigator.EnsureAttached(target.panel?.visualTree ?? target, ctx);
+            // Focus navigation (scopes, chained portals): the navigator resolves the target's TRUE panel
+            // root and attaches there once; a target with no panel yet defers to its own AttachToPanelEvent
+            // so ring predictions are never computed from a non-root subtree.
+            FiberFocusNavigator.EnsureAttached(target, ctx);
 #if UNITY_EDITOR
             // Auto-attach to DevTools: opening the inspector shows the live tree
             // with no manual Register call. Editor-only — the registry and this call are compiled out of

--- a/Packages/com.velvet.core/Runtime/Component/V.cs
+++ b/Packages/com.velvet.core/Runtime/Component/V.cs
@@ -1618,10 +1618,12 @@ namespace Velvet
         /// container exists yet. Style it like any Div.
         /// </summary>
         /// <param name="contain">Tab/Shift-Tab wrap within the subtree; a 2D/pointer move that exits is
-        /// snapped back within the same event flush.</param>
+        /// snapped back within the same event flush (a press on empty space that clears focus to nothing
+        /// re-focuses on the panel's next tick).</param>
         /// <param name="restoreFocus">On unmount while holding focus, refocus the element focus came from
         /// when it first entered the scope.</param>
-        /// <param name="autoFocus">On attach, focus the scope's first focusable descendant.</param>
+        /// <param name="autoFocus">On mount (first attach only — never a keyed reorder's re-attach), focus
+        /// the scope's first focusable descendant.</param>
         /// <param name="singleTabStop">The subtree behaves as one Tab stop (roving); engine 2D
         /// arrow/dpad navigation inside is untouched.</param>
         /// <returns>The created <see cref="ElementNode"/>.</returns>

--- a/Packages/com.velvet.core/Runtime/Component/V.cs
+++ b/Packages/com.velvet.core/Runtime/Component/V.cs
@@ -1506,12 +1506,14 @@ namespace Velvet
         /// <param name="children">Descendant VNodes mounted into the layer panel.</param>
         /// <param name="key">Key used to disambiguate siblings at the same position.</param>
         /// <returns>The created <see cref="PortalNode"/>.</returns>
-        public static PortalNode Portal(UILayer layer, VNode?[]? children = null, string? key = null)
+        public static PortalNode Portal(UILayer layer, VNode?[]? children = null, string? key = null,
+            PanelFocusOrder focusOrder = PanelFocusOrder.Isolated)
         {
             return new PortalNode
             {
                 Key = key,
                 Layer = layer,
+                FocusOrder = focusOrder,
                 Children = children ?? EmptyChildren,
             };
         }
@@ -1536,7 +1538,8 @@ namespace Velvet
             Quaternion? rotation = null,
             Vector2? panelSize = null,
             VNode?[]? children = null,
-            string? key = null)
+            string? key = null,
+            PanelFocusOrder focusOrder = PanelFocusOrder.Isolated)
         {
             return new WorldSpaceNode
             {
@@ -1544,6 +1547,7 @@ namespace Velvet
                 Position = position,
                 Rotation = rotation ?? Quaternion.identity,
                 PanelSize = panelSize ?? new Vector2(1920f, 1080f),
+                FocusOrder = focusOrder,
                 Children = children ?? EmptyChildren,
             };
         }
@@ -1587,6 +1591,60 @@ namespace Velvet
         {
             var mergedProps = WithAttributes(props, data, aria) ?? VNodePool.RentProps();
             mergedProps.Anchored = new AnchoredSettings(target, camera, offset ?? Vector2.zero, hideWhenBehindCamera);
+
+            return new ElementNode
+            {
+                Key = key,
+                ElementType = typeof(VisualElement),
+                Name = name,
+                ClassNames = ParseClassNames(className),
+                Props = mergedProps,
+                Styles = styles,
+                Children = children ?? EmptyChildren,
+                Events = EmptyEvents,
+                RefCallback = refCallback,
+                WhileHoverClass = whileHoverClass,
+                WhileTapClass = whileTapClass,
+                WhileFocusClass = whileFocusClass,
+            };
+        }
+
+        /// <summary>
+        /// Container element whose subtree is a focus scope — React Aria's FocusScope. Deviation
+        /// (documented): Aria's scope is renderless (sentinel spans); Velvet's is a real VisualElement,
+        /// because UI Toolkit containment needs a subtree root for the scoped focus ring and the
+        /// membership test. Any existing container can be a scope via props
+        /// (<see cref="FiberElementProps.FocusScope"/>) — this factory is convenience for when no
+        /// container exists yet. Style it like any Div.
+        /// </summary>
+        /// <param name="contain">Tab/Shift-Tab wrap within the subtree; a 2D/pointer move that exits is
+        /// snapped back within the same event flush.</param>
+        /// <param name="restoreFocus">On unmount while holding focus, refocus the element focus came from
+        /// when it first entered the scope.</param>
+        /// <param name="autoFocus">On attach, focus the scope's first focusable descendant.</param>
+        /// <param name="singleTabStop">The subtree behaves as one Tab stop (roving); engine 2D
+        /// arrow/dpad navigation inside is untouched.</param>
+        /// <returns>The created <see cref="ElementNode"/>.</returns>
+        public static ElementNode FocusScope(
+            string? className = null,
+            string? key = null,
+            string? name = null,
+            bool contain = false,
+            bool restoreFocus = false,
+            bool autoFocus = false,
+            bool singleTabStop = false,
+            FiberElementProps? props = null,
+            StyleOverrides? styles = null,
+            Func<VisualElement, Action>? refCallback = null,
+            VNode?[]? children = null,
+            string? whileHoverClass = null,
+            string? whileTapClass = null,
+            string? whileFocusClass = null,
+            IReadOnlyDictionary<string, string>? data = null,
+            IReadOnlyDictionary<string, string>? aria = null)
+        {
+            var mergedProps = WithAttributes(props, data, aria) ?? VNodePool.RentProps();
+            mergedProps.FocusScope = new FocusScopeSettings(contain, restoreFocus, autoFocus, singleTabStop);
 
             return new ElementNode
             {

--- a/Packages/com.velvet.core/Runtime/Component/VNodePool.cs
+++ b/Packages/com.velvet.core/Runtime/Component/VNodePool.cs
@@ -58,12 +58,16 @@ namespace Velvet
             props.Visible = null;
             props.FieldValue = null;
             props.Focusable = null;
+            props.TabIndex = null;
+            props.DelegatesFocus = null;
+            props.FocusScope = null;
             props.Slider = null;
             props.ScrollView = null;
             props.TextField = null;
             props.Choices = null;
             props.SceneView = null;
             props.Particles = null;
+            props.Anchored = null;
             props.Data = null;
             props.Aria = null;
 

--- a/Packages/com.velvet.core/Runtime/Component/VNodeTypes.cs
+++ b/Packages/com.velvet.core/Runtime/Component/VNodeTypes.cs
@@ -275,6 +275,13 @@ namespace Velvet
         /// </summary>
         public UILayer? Layer { get; init; }
 
+        /// <summary>
+        /// How the layer host panel participates in sequential (Tab) focus order relative to the declaring
+        /// panel — see <see cref="PanelFocusOrder"/>. Only meaningful for a layer portal (<see cref="Layer"/>
+        /// set); a registry-target portal mounts into the same panel and has no boundary to chain across.
+        /// </summary>
+        public PanelFocusOrder FocusOrder { get; init; } = PanelFocusOrder.Isolated;
+
         /// <summary>Array of child nodes to render at the mount target.</summary>
         public VNode?[] Children { get; init; } = Array.Empty<VNode>();
     }
@@ -294,6 +301,12 @@ namespace Velvet
 
         /// <summary>Virtual panel resolution in pixels (the world-space size mode is fixed).</summary>
         public UnityEngine.Vector2 PanelSize { get; init; } = new(1920f, 1080f);
+
+        /// <summary>
+        /// How the world-space host panel participates in sequential (Tab) focus order relative to the
+        /// declaring panel — see <see cref="PanelFocusOrder"/>.
+        /// </summary>
+        public PanelFocusOrder FocusOrder { get; init; } = PanelFocusOrder.Isolated;
 
         /// <summary>Array of child nodes to render inside the world-space panel.</summary>
         public VNode?[] Children { get; init; } = Array.Empty<VNode>();

--- a/Packages/com.velvet.core/Runtime/Hooks/FocusRing.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/FocusRing.cs
@@ -1,0 +1,37 @@
+#nullable enable
+using System;
+using UnityEngine.UIElements;
+
+namespace Velvet
+{
+    /// <summary>
+    /// Focus state of the element carrying <see cref="Ref"/>, returned by <c>Hooks.UseFocusRing</c> —
+    /// React Aria's <c>useFocusRing</c> parity. Rides the same element-local focus-visible heuristic as the
+    /// <c>focus-visible:</c> styling variant (a pointer press on the element suppresses the visible state
+    /// for the focus it causes), so the two surfaces cannot drift.
+    /// </summary>
+    public readonly struct FocusRing
+    {
+        /// <summary>True while the element holds focus, from any input modality.</summary>
+        public bool IsFocused { get; }
+
+        /// <summary>
+        /// True while the element holds focus NOT caused by a pointer press on it — keyboard, gamepad
+        /// (navigation-event-driven), or programmatic focus.
+        /// </summary>
+        public bool IsFocusVisible { get; }
+
+        /// <summary>
+        /// Attach point: pass as the <c>refCallback:</c> argument of any <c>V.*</c> factory. The returned
+        /// cleanup detaches the listeners (the standard refCallback contract).
+        /// </summary>
+        public Func<VisualElement, Action> Ref { get; }
+
+        internal FocusRing(bool isFocused, bool isFocusVisible, Func<VisualElement, Action> @ref)
+        {
+            IsFocused = isFocused;
+            IsFocusVisible = isFocusVisible;
+            Ref = @ref;
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Hooks/FocusRing.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Hooks/FocusRing.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9ba451c9342cf4eb6b22c9289d0fa5c7

--- a/Packages/com.velvet.core/Runtime/Hooks/Hooks.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Hooks.cs
@@ -1093,6 +1093,11 @@ namespace Velvet
         {
             var (isFocused, setFocused) = UseState(false);
             var (isFocusVisible, setFocusVisible) = UseState(false);
+            // Generation cell shared by every ref invocation of this hook instance: each setup stamps a new
+            // generation, so a cleanup's deferred work can tell whether it is still the LATEST hookup for
+            // this component or was superseded (a patch re-invoking the ref, or the ref moving to a
+            // replacement element).
+            var generation = UseRef<int[]>(() => new int[1]);
             var refCallback = UseCallback<Func<UnityEngine.UIElements.VisualElement, Action>>(element =>
             {
                 var signals = new ElementLocalVariantSignals((signal, on) =>
@@ -1104,16 +1109,38 @@ namespace Velvet
                     }
                 });
                 signals.Hook(element, seedChecked: false, registerChecked: false);
-                // The cleanup ONLY unhooks — it deliberately writes no state. The reconciler re-invokes a
-                // ref (cleanup + setup) on every patch of the host element, i.e. MID-FLUSH: a state write
-                // from that phase is silently lost (the fiber's dirty flag clears when the flush ends), and
-                // the lost pending value then dedups away the NEXT genuine edge with the same value. An
-                // element that detaches while focused still resolves cleanly: the panel blurs it on the way
-                // out, and that Blur reaches these signals before this cleanup runs.
-                return signals.Unhook;
-                // Deps are the two setters — reference-stable across renders — so the ref identity never
-                // changes across re-renders.
-            }, setFocused, setFocusVisible);
+                var gen = ++generation.Current[0];
+                return () =>
+                {
+                    signals.Unhook();
+                    // The cleanup itself writes no state: the reconciler re-invokes a ref (cleanup + setup)
+                    // on every patch of the host element, i.e. MID-FLUSH, where a state write is silently
+                    // lost (the fiber's dirty flag clears when the flush ends) and its lost pending value
+                    // then dedups away the NEXT genuine edge with the same value. But an element unmounting
+                    // WHILE FOCUSED gets no Blur through these signals either — the unhook above runs before
+                    // the element leaves the panel — which would strand IsFocused/IsFocusVisible at true on
+                    // a still-mounted component. So when the element holds focus at cleanup time, the
+                    // correction is deferred to the panel's next scheduler tick — safely OUTSIDE any flush —
+                    // and fires only if no newer hookup superseded this one (a patch's re-invoke stamps a
+                    // new generation synchronously right after this cleanup, turning the deferred write into
+                    // a no-op; the setters are already no-ops if the component itself unmounted).
+                    var panel = element.panel;
+                    if (panel?.visualTree == null) return;
+                    if (panel.focusController?.focusedElement is not UnityEngine.UIElements.VisualElement held
+                        || (held != element && !element.Contains(held)))
+                    {
+                        return;
+                    }
+                    panel.visualTree.schedule.Execute(() =>
+                    {
+                        if (generation.Current[0] != gen) return;
+                        setFocused.Invoke(false);
+                        setFocusVisible.Invoke(false);
+                    });
+                };
+                // Deps are the two setters and the generation ref — all reference-stable across renders —
+                // so the ref identity never changes across re-renders.
+            }, setFocused, setFocusVisible, generation);
             return new FocusRing(isFocused, isFocusVisible, refCallback);
         }
 

--- a/Packages/com.velvet.core/Runtime/Hooks/Hooks.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Hooks.cs
@@ -1079,6 +1079,46 @@ namespace Velvet
 
         #endregion
 
+        #region UseFocusRing
+
+        /// <summary>
+        /// React Aria's <c>useFocusRing</c> parity: exposes an element's focus state — and specifically
+        /// keyboard/gamepad-visible focus, as distinct from pointer focus — as re-rendering component
+        /// state. Pass <see cref="FocusRing.Ref"/> as the target element's <c>refCallback:</c>. For pure
+        /// styling, the <c>focus-visible:</c> class variant already covers the same distinction without a
+        /// hook — reach for this when the component must RENDER differently (e.g. a "press A to select"
+        /// hint), not just restyle.
+        /// </summary>
+        public static FocusRing UseFocusRing()
+        {
+            var (isFocused, setFocused) = UseState(false);
+            var (isFocusVisible, setFocusVisible) = UseState(false);
+            var refCallback = UseCallback<Func<UnityEngine.UIElements.VisualElement, Action>>(element =>
+            {
+                var signals = new ElementLocalVariantSignals((signal, on) =>
+                {
+                    switch (signal)
+                    {
+                        case VariantSignal.Focus: setFocused.Invoke(on); break;
+                        case VariantSignal.FocusVisible: setFocusVisible.Invoke(on); break;
+                    }
+                });
+                signals.Hook(element, seedChecked: false, registerChecked: false);
+                // The cleanup ONLY unhooks — it deliberately writes no state. The reconciler re-invokes a
+                // ref (cleanup + setup) on every patch of the host element, i.e. MID-FLUSH: a state write
+                // from that phase is silently lost (the fiber's dirty flag clears when the flush ends), and
+                // the lost pending value then dedups away the NEXT genuine edge with the same value. An
+                // element that detaches while focused still resolves cleanly: the panel blurs it on the way
+                // out, and that Blur reaches these signals before this cleanup runs.
+                return signals.Unhook;
+                // Deps are the two setters — reference-stable across renders — so the ref identity never
+                // changes across re-renders.
+            }, setFocused, setFocusVisible);
+            return new FocusRing(isFocused, isFocusVisible, refCallback);
+        }
+
+        #endregion
+
         #region Refs
 
         /// <summary>

--- a/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseFocusRingTests.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseFocusRingTests.cs
@@ -1,0 +1,97 @@
+using NUnit.Framework;
+using UnityEngine.UIElements;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins <c>Hooks.UseFocusRing</c>'s React Aria <c>useFocusRing</c> contract: <c>IsFocused</c> follows
+    /// plain focus from any modality, while <c>IsFocusVisible</c> lights only for focus NOT caused by a
+    /// pointer press on the element — the same element-local heuristic the <c>focus-visible:</c> styling
+    /// variant rides, exercised here through the hook's re-rendering state channel instead of a class.
+    /// </summary>
+    internal sealed class UseFocusRingTests
+    {
+        private HeadlessEditorPanelHost _host;
+        private MountedTree _mounted;
+
+        private static FocusRing s_ring;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _host = new HeadlessEditorPanelHost();
+            s_ring = default;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _mounted?.Dispose();
+            _mounted = null;
+            _host?.Dispose();
+            _host = null;
+        }
+
+        [Component]
+        private static VNode RingHost()
+        {
+            var ring = Hooks.UseFocusRing();
+            s_ring = ring;
+            return V.Button(name: "target", refCallback: ring.Ref);
+        }
+
+        private VisualElement Mount()
+        {
+            _mounted = V.Mount(_host.Root, V.Component(RingHost, key: "root"));
+            return _host.Root.Q<VisualElement>("target");
+        }
+
+        [Test]
+        public void Given_AComponentUsingUseFocusRing_When_ItsElementGainsFocusWithoutAPointerPress_Then_IsFocusVisibleBecomesTrue()
+        {
+            // Arrange
+            var target = Mount();
+            Assume.That(s_ring.IsFocusVisible, Is.False, "Precondition: the ring starts dark");
+
+            // Act — focus arrives with no preceding pointer-down (Tab navigation / programmatic Focus).
+            using (var evt = FocusEvent.GetPooled()) target.SimulateEvent(evt);
+            _mounted.FlushStateForTest();
+
+            // Assert
+            Assert.That(s_ring.IsFocusVisible, Is.True);
+        }
+
+        [Test]
+        public void Given_AComponentUsingUseFocusRing_When_APointerPressOnTheElementCausesTheFocus_Then_IsFocusVisibleStaysFalse()
+        {
+            // Arrange
+            var target = Mount();
+
+            // Act — the click-to-focus path: a pointer-down on the element, then the focus it causes.
+            using (var evt = PointerDownEvent.GetPooled()) target.SimulateEvent(evt);
+            using (var evt = FocusEvent.GetPooled()) target.SimulateEvent(evt);
+            _mounted.FlushStateForTest();
+
+            // Assert — pointer-driven focus is focus, but not VISIBLE focus.
+            Assert.That((s_ring.IsFocused, s_ring.IsFocusVisible), Is.EqualTo((true, false)));
+        }
+
+        [Test]
+        public void Given_AFocusVisibleRing_When_TheElementBlurs_Then_IsFocusVisibleReturnsToFalse()
+        {
+            // Arrange
+            var target = Mount();
+            using (var evt = FocusEvent.GetPooled()) target.SimulateEvent(evt);
+            _mounted.FlushStateForTest();
+            Assume.That(s_ring.IsFocusVisible, Is.True, "Precondition: the ring lit for keyboard focus");
+
+            // Act
+            using (var evt = BlurEvent.GetPooled()) target.SimulateEvent(evt);
+            _mounted.FlushStateForTest();
+
+            // Assert
+            Assert.That(s_ring.IsFocusVisible, Is.False);
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseFocusRingTests.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseFocusRingTests.cs
@@ -16,12 +16,14 @@ namespace Velvet.Tests
         private MountedTree _mounted;
 
         private static FocusRing s_ring;
+        private static StateUpdater<bool> s_setShowTarget;
 
         [SetUp]
         public void SetUp()
         {
             _host = new HeadlessEditorPanelHost();
             s_ring = default;
+            s_setShowTarget = default;
         }
 
         [TearDown]
@@ -75,6 +77,41 @@ namespace Velvet.Tests
 
             // Assert — pointer-driven focus is focus, but not VISIBLE focus.
             Assert.That((s_ring.IsFocused, s_ring.IsFocusVisible), Is.EqualTo((true, false)));
+        }
+
+        [Component]
+        private static VNode CollapsingRingHost()
+        {
+            var ring = Hooks.UseFocusRing();
+            s_ring = ring;
+            var (showTarget, setShowTarget) = Hooks.UseState(true);
+            s_setShowTarget = setShowTarget;
+            return V.Div(children: new VNode[]
+            {
+                showTarget ? V.Button(name: "target", key: "target", refCallback: ring.Ref) : null,
+            });
+        }
+
+        [Test]
+        public void Given_AFocusedRingElement_When_ItUnmountsWhileTheComponentSurvives_Then_IsFocusedReturnsToFalse()
+        {
+            // Arrange — REAL panel focus (not a simulated event): the stuck-state correction keys off
+            // the focus controller's view of the element at cleanup time.
+            _mounted = V.Mount(_host.Root, V.Component(CollapsingRingHost, key: "root"));
+            var target = _host.Root.Q<VisualElement>("target");
+            target.Focus();
+            _mounted.FlushStateForTest();
+            Assume.That(s_ring.IsFocused, Is.True, "Precondition: the ring lit for the focused element");
+
+            // Act — the element unmounts while focused; no Blur can reach the already-unhooked
+            // signals, so the correction rides the panel's next scheduler tick.
+            s_setShowTarget.Invoke(false);
+            _mounted.FlushStateForTest();
+            EditorPanelTestHelpers.DriveSchedulerOnce(_host.Panel);
+            _mounted.FlushStateForTest();
+
+            // Assert
+            Assert.That(s_ring.IsFocused, Is.False);
         }
 
         [Test]

--- a/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseFocusRingTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseFocusRingTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5df55de8f2f0f49dca78f4e548ae1d35

--- a/Packages/com.velvet.core/Runtime/Reconciler/ChildReconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ChildReconciler.cs
@@ -252,6 +252,8 @@ namespace Velvet
                         }
                         target = layerHost.Document.rootVisualElement;
                         children = layerPortal.Children ?? Array.Empty<VNode>();
+                        FiberFocusNavigator.ConfigureChainedPlaceholder(placeholder, layerHost,
+                            layerPortal.FocusOrder == PanelFocusOrder.Chained, _ctx);
                         break;
                     }
                     case WorldSpaceNode worldSpaceNode:
@@ -260,6 +262,8 @@ namespace Velvet
                         _ctx.WorldSpaceBindings[placeholder] = record;
                         target = record.Document.rootVisualElement;
                         children = worldSpaceNode.Children ?? Array.Empty<VNode>();
+                        FiberFocusNavigator.ConfigureChainedPlaceholder(placeholder, record,
+                            worldSpaceNode.FocusOrder == PanelFocusOrder.Chained, _ctx);
                         break;
                     }
                     case PortalNode registryPortal:

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberElementCleaner.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberElementCleaner.cs
@@ -322,6 +322,35 @@ namespace Velvet
                 AnchoredDriver.Detach(element, anchoredBinding);
                 _ctx.AnchoredBindings.Remove(element);
             }
+            if (_ctx.FocusScopeBindings.TryGetValue(element, out var focusScopeBinding))
+            {
+                // RestoreFocus must run BEFORE this element physically leaves the tree (UI Toolkit clears
+                // the focused element the moment it detaches — the same ordering RescueFocusFromWorldSpaceHost
+                // exists for): if the scope still holds focus, return it to where it came from on first entry.
+                if (focusScopeBinding.Settings.RestoreFocus
+                    && element.panel?.focusController?.focusedElement is VisualElement held
+                    && element.Contains(held))
+                {
+                    var restore = focusScopeBinding.RestoreTarget;
+                    if (restore != null && restore.panel != null && restore.canGrabFocus)
+                    {
+                        restore.Focus();
+                    }
+                }
+                FocusScopeDriver.Detach(element, focusScopeBinding);
+                _ctx.FocusScopeBindings.Remove(element);
+            }
+            // A chained portal placeholder unmounting releases both chained registries (the reverse index
+            // only when this placeholder still owns the host's ring-edge escape).
+            if (_ctx.ChainedPlaceholders.Remove(element, out var chainedRecord))
+            {
+                var chainedHostRoot = chainedRecord.Document != null ? chainedRecord.Document.rootVisualElement : null;
+                if (chainedHostRoot != null && _ctx.ChainedHostRoots.TryGetValue(chainedHostRoot, out var owner)
+                    && ReferenceEquals(owner, element))
+                {
+                    _ctx.ChainedHostRoots.Remove(chainedHostRoot);
+                }
+            }
             if (_ctx.VirtualListControllers.TryGetValue(element, out var virtualListController))
             {
                 virtualListController.Dispose();

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberElementCleaner.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberElementCleaner.cs
@@ -340,16 +340,26 @@ namespace Velvet
                 FocusScopeDriver.Detach(element, focusScopeBinding);
                 _ctx.FocusScopeBindings.Remove(element);
             }
-            // A chained portal placeholder unmounting releases both chained registries (the reverse index
-            // only when this placeholder still owns the host's ring-edge escape).
+            // A departing element must not linger as any scope's remembered member or restore target:
+            // pooled primitives get recycled into unrelated roles, and the liveness checks at use time
+            // (panel / canGrabFocus / Contains) all pass again for a recycled element mounted elsewhere,
+            // so focus would land on a widget in a different logical role. Dropping the reference here
+            // makes those paths fall back (ring-first entry / skipped restore) instead.
+            if (_ctx.FocusScopeBindings.Count > 0)
+            {
+                foreach (var scopeBinding in _ctx.FocusScopeBindings.Values)
+                {
+                    if (ReferenceEquals(scopeBinding.LastFocusedMember, element)) scopeBinding.LastFocusedMember = null;
+                    if (ReferenceEquals(scopeBinding.RestoreTarget, element)) scopeBinding.RestoreTarget = null;
+                }
+            }
+            // A chained portal placeholder unmounting releases both chained registries; if it owned the
+            // host's ring-edge escape, ownership is handed to a surviving chained placeholder of the same
+            // host (removal from ChainedPlaceholders first, so the departing one cannot re-elect itself).
             if (_ctx.ChainedPlaceholders.Remove(element, out var chainedRecord))
             {
                 var chainedHostRoot = chainedRecord.Document != null ? chainedRecord.Document.rootVisualElement : null;
-                if (chainedHostRoot != null && _ctx.ChainedHostRoots.TryGetValue(chainedHostRoot, out var owner)
-                    && ReferenceEquals(owner, element))
-                {
-                    _ctx.ChainedHostRoots.Remove(chainedHostRoot);
-                }
+                FiberFocusNavigator.ReleaseChainedOwnership(element, chainedHostRoot, _ctx);
             }
             if (_ctx.VirtualListControllers.TryGetValue(element, out var virtualListController))
             {

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberElementFactory.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberElementFactory.cs
@@ -236,6 +236,16 @@ namespace Velvet
                 FiberPropApplier.ApplyFocusable(element, props.Focusable);
             }
 
+            if (props.TabIndex.HasValue)
+            {
+                FiberPropApplier.ApplyTabIndex(element, props.TabIndex);
+            }
+
+            if (props.DelegatesFocus.HasValue)
+            {
+                FiberPropApplier.ApplyDelegatesFocus(element, props.DelegatesFocus);
+            }
+
             if (props.FieldValue != null)
             {
                 FiberPropApplier.ApplyFieldValue(element, props.FieldValue);

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberElementPoolReset.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberElementPoolReset.cs
@@ -66,6 +66,10 @@ namespace Velvet
             element.name = string.Empty;
             element.tooltip = string.Empty;
             element.focusable = false;
+            // tabIndex and delegatesFocus are prop-settable (FiberElementProps.TabIndex/DelegatesFocus), so
+            // a pooled element must not carry them into its next consumer's focus order.
+            element.tabIndex = 0;
+            element.delegatesFocus = false;
             element.pickingMode = PickingMode.Position;
             element.viewDataKey = null;
             element.SetEnabled(true);

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberElementProps.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberElementProps.cs
@@ -41,6 +41,30 @@ namespace Velvet
         public bool? Focusable { get => _focusable; set { ThrowIfReadOnly(); _focusable = value; } }
         private bool? _focusable;
 
+        /// <summary>
+        /// Maps to the element's tabIndex. Positive values sort ahead of 0 in the sequential (Tab) ring.
+        /// Caution: on runtime panels, -1 removes the element from BOTH the Tab ring AND 2D arrow/dpad/stick
+        /// navigation — it is not the web's "focusable but not tab-reachable". For a group with one Tab
+        /// stop, use a focus scope with SingleTabStop instead.
+        /// </summary>
+        public int? TabIndex { get => _tabIndex; set { ThrowIfReadOnly(); _tabIndex = value; } }
+        private int? _tabIndex;
+
+        /// <summary>
+        /// Maps to the element's delegatesFocus: focusing this element forwards to its first focusable
+        /// child, and the focus rings skip the element itself.
+        /// </summary>
+        public bool? DelegatesFocus { get => _delegatesFocus; set { ThrowIfReadOnly(); _delegatesFocus = value; } }
+        private bool? _delegatesFocus;
+
+        /// <summary>
+        /// Focus-scope behavior for this container element (React Aria's FocusScope parity). Attachable to
+        /// ANY container — the modal Div you already have can be the scope; <c>V.FocusScope</c> is sugar for
+        /// when no container exists yet.
+        /// </summary>
+        public FocusScopeSettings? FocusScope { get => _focusScope; set { ThrowIfReadOnly(); _focusScope = value; } }
+        private FocusScopeSettings? _focusScope;
+
         /// <summary>Slider-specific settings.</summary>
         public SliderSettings? Slider { get => _slider; set { ThrowIfReadOnly(); _slider = value; } }
         private SliderSettings? _slider;
@@ -158,6 +182,28 @@ namespace Velvet
                 "pixelsPerUnit must be positive; it maps particle world units to element pixels.");
         }
     }
+
+    /// <summary>
+    /// Focus-management behavior for a container subtree — React Aria's FocusScope parity:
+    /// <see cref="Contain"/>/<see cref="RestoreFocus"/>/<see cref="AutoFocus"/> map 1:1;
+    /// <see cref="SingleTabStop"/> is the WAI-ARIA composite-widget (roving) contract adapted to UI Toolkit,
+    /// where arrow/dpad movement inside the group is already engine-native 2D navigation. Record structural
+    /// equality simplifies DiffProps.
+    /// </summary>
+    /// <param name="Contain">Tab/Shift-Tab wrap within the subtree (computed by a focus ring scoped to it);
+    /// a 2D/pointer move that exits the subtree is snapped back within the same event flush.</param>
+    /// <param name="RestoreFocus">On unmount while holding focus, refocus the element focus came FROM when
+    /// it first entered the scope (skipped if that element is detached or cannot grab focus).</param>
+    /// <param name="AutoFocus">On attach-to-panel, focus the scope's first focusable descendant (skipped
+    /// when focus is already inside the scope).</param>
+    /// <param name="SingleTabStop">The subtree behaves as one Tab stop: Tab from inside exits past the
+    /// remaining members; Tab entering from outside lands on the last-focused member (else the scope's
+    /// first). Members keep tabIndex 0, so engine 2D arrow/dpad navigation inside is untouched.</param>
+    public sealed record FocusScopeSettings(
+        bool Contain = false,
+        bool RestoreFocus = false,
+        bool AutoFocus = false,
+        bool SingleTabStop = false);
 
     /// <summary>
     /// The 3D Transform an Anchored element's screen position tracks, plus the camera whose projection

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberElementProps.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberElementProps.cs
@@ -191,14 +191,18 @@ namespace Velvet
     /// equality simplifies DiffProps.
     /// </summary>
     /// <param name="Contain">Tab/Shift-Tab wrap within the subtree (computed by a focus ring scoped to it);
-    /// a 2D/pointer move that exits the subtree is snapped back within the same event flush.</param>
+    /// a 2D/pointer move that exits the subtree is snapped back within the same event flush, wherever it
+    /// landed. A press on empty non-focusable space clears focus to nothing first — that path re-focuses
+    /// the scope on the panel's next scheduler tick instead.</param>
     /// <param name="RestoreFocus">On unmount while holding focus, refocus the element focus came FROM when
-    /// it first entered the scope (skipped if that element is detached or cannot grab focus).</param>
-    /// <param name="AutoFocus">On attach-to-panel, focus the scope's first focusable descendant (skipped
-    /// when focus is already inside the scope).</param>
+    /// it first entered the scope (skipped if that element is gone, detached, or cannot grab focus).</param>
+    /// <param name="AutoFocus">On mount (the scope's FIRST attach-to-panel, never a re-attach such as a
+    /// keyed reorder's), focus the scope's first focusable descendant (skipped when focus is already
+    /// inside the scope) — matching React's mount-once autoFocus.</param>
     /// <param name="SingleTabStop">The subtree behaves as one Tab stop: Tab from inside exits past the
-    /// remaining members; Tab entering from outside lands on the last-focused member (else the scope's
-    /// first). Members keep tabIndex 0, so engine 2D arrow/dpad navigation inside is untouched.</param>
+    /// remaining members (wrapping within the nearest containing scope, if any); Tab entering from outside
+    /// — in either direction — lands on the last-focused member, else the scope's first. Members keep
+    /// tabIndex 0, so engine 2D arrow/dpad navigation inside is untouched.</param>
     public sealed record FocusScopeSettings(
         bool Contain = false,
         bool RestoreFocus = false,

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberFocusNavigator.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberFocusNavigator.cs
@@ -30,6 +30,9 @@ namespace Velvet
         public VisualElement? LastFocusedMember;
         public VisualElement? RestoreTarget;
         public bool RestoreCaptured;
+        // AutoFocus is mount-once, matching React: a keyed reorder physically re-attaches the scope
+        // (RemoveAt + Insert), and re-firing there would steal focus from wherever the user moved on.
+        public bool AutoFocusFired;
         public EventCallback<AttachToPanelEvent>? OnAttach;
 
         public FocusScopeBinding(FocusScopeSettings settings)
@@ -40,7 +43,9 @@ namespace Velvet
 
     /// <summary>
     /// The single owner of every focus-navigation interception in Velvet — the keyboard sibling of
-    /// <c>FiberCrossPanelInput</c>'s two classes, attached exactly once per panel root (never per scope).
+    /// <c>FiberCrossPanelInput</c>'s two classes, attached exactly once per panel (always to the panel's
+    /// TRUE root, <c>panel.visualTree</c>, never to a subtree or per scope — an element whose panel is not
+    /// resolved yet defers the attach to its own <c>AttachToPanelEvent</c>).
     /// Sequential (Next/Previous) <see cref="NavigationMoveEvent"/>s are intercepted on the verified engine
     /// contract pinned by <c>FocusNavigationInterceptionTests</c>: the default focus move runs post-dispatch,
     /// after every listener, and its only suppression is <see cref="FocusController.IgnoreEvent"/> — so a
@@ -56,31 +61,65 @@ namespace Velvet
         // outside the scope) so a pathological ring cannot spin this listener unboundedly.
         private const int MaxRingWalk = 4096;
 
-        // Attaches the navigator's two listeners to a panel root exactly once (tracked in
-        // ctx.NavigatorAttachments so Reconciler.Dispose can unregister them). Called from V.Mount (main
-        // panel), PanelHostFactory (host panels), and lazily when a scope/chained placeholder attaches to a
-        // panel this navigator has not seen yet.
-        internal static void EnsureAttached(VisualElement? panelRoot, ReconcilerContext ctx)
+        // Attaches the navigator's listener trio to `element`'s panel root exactly once per panel. The
+        // anchor is always the panel's TRUE root (panel.visualTree): registering on anything narrower
+        // would compute subtree rings that drift from the engine's own panel-wide ring, and registering
+        // per call-site element would stack duplicate listeners whose relative order inverts the branch
+        // priority. An element with no panel yet defers via a tracked self-removing attach hook. Called
+        // from V.Mount (main panel), ConfigureChainedPlaceholder (declaring + host panels), and the
+        // focus-scope attach hook (whatever panel the scope lands in).
+        internal static void EnsureAttached(VisualElement? element, ReconcilerContext ctx)
         {
-            if (panelRoot == null || ctx.NavigatorAttachments.ContainsKey(panelRoot))
+            if (element == null)
             {
                 return;
             }
-            EventCallback<NavigationMoveEvent> onMove = evt => OnNavigationMove(evt, panelRoot, ctx);
+            var root = element.panel?.visualTree;
+            if (root != null)
+            {
+                AttachToRoot(root, ctx);
+                return;
+            }
+            EventCallback<AttachToPanelEvent> hook = null!;
+            hook = _ =>
+            {
+                element.UnregisterCallback(hook);
+                ctx.NavigatorPendingAttachHooks.Remove((element, hook));
+                AttachToRoot(element.panel?.visualTree, ctx);
+            };
+            element.RegisterCallback(hook);
+            ctx.NavigatorPendingAttachHooks.Add((element, hook));
+        }
+
+        private static void AttachToRoot(VisualElement? root, ReconcilerContext ctx)
+        {
+            if (root == null || ctx.NavigatorAttachments.ContainsKey(root))
+            {
+                return;
+            }
+            EventCallback<NavigationMoveEvent> onMove = evt => OnNavigationMove(evt, root, ctx);
             EventCallback<FocusInEvent> onFocusIn = evt => OnFocusIn(evt, ctx);
-            panelRoot.RegisterCallback(onMove, TrickleDown.TrickleDown);
-            panelRoot.RegisterCallback(onFocusIn);
-            ctx.NavigatorAttachments[panelRoot] = (onMove, onFocusIn);
+            EventCallback<FocusOutEvent> onFocusOut = evt => OnFocusOut(evt, ctx);
+            root.RegisterCallback(onMove, TrickleDown.TrickleDown);
+            root.RegisterCallback(onFocusIn);
+            root.RegisterCallback(onFocusOut);
+            ctx.NavigatorAttachments[root] = (onMove, onFocusIn, onFocusOut);
         }
 
         internal static void DetachAll(ReconcilerContext ctx)
         {
-            foreach (var (root, (onMove, onFocusIn)) in ctx.NavigatorAttachments)
+            foreach (var (root, callbacks) in ctx.NavigatorAttachments)
             {
-                root.UnregisterCallback(onMove, TrickleDown.TrickleDown);
-                root.UnregisterCallback(onFocusIn);
+                root.UnregisterCallback(callbacks.OnMove, TrickleDown.TrickleDown);
+                root.UnregisterCallback(callbacks.OnFocusIn);
+                root.UnregisterCallback(callbacks.OnFocusOut);
             }
             ctx.NavigatorAttachments.Clear();
+            foreach (var (element, hook) in ctx.NavigatorPendingAttachHooks)
+            {
+                element.UnregisterCallback(hook);
+            }
+            ctx.NavigatorPendingAttachHooks.Clear();
         }
 
         // Configures a portal placeholder's participation in the declaring panel's Tab order
@@ -103,9 +142,10 @@ namespace Velvet
                 placeholder.tabIndex = 0;
                 ctx.ChainedPlaceholders[placeholder] = record;
                 // A shared layer host can carry several portals; the first chained one owns the host's
-                // ring-edge escape (flow between two portals' slots stays panel-internal either way).
+                // ring-edge escape (flow between two portals' slots stays panel-internal either way), and
+                // ownership is handed to a survivor when the owner departs — see ReleaseChainedOwnership.
                 ctx.ChainedHostRoots.TryAdd(hostRoot, placeholder);
-                EnsureAttached(placeholder.panel?.visualTree, ctx);
+                EnsureAttached(placeholder, ctx);
                 EnsureAttached(hostRoot, ctx);
                 return;
             }
@@ -117,10 +157,31 @@ namespace Velvet
                 placeholder.style.height = StyleKeyword.Null;
                 placeholder.focusable = false;
                 placeholder.tabIndex = 0;
-                if (hostRoot != null && ctx.ChainedHostRoots.TryGetValue(hostRoot, out var owner)
-                    && ReferenceEquals(owner, placeholder))
+                ReleaseChainedOwnership(placeholder, hostRoot, ctx);
+            }
+        }
+
+        // Drops `placeholder`'s ring-edge-escape ownership of `hostRoot` and re-elects any surviving
+        // chained placeholder of the same host, so the remaining portals keep their exit. Runs when a
+        // chained portal unmounts (FiberElementCleaner) and when a patch flips it back to Isolated. The
+        // caller must have removed the departing placeholder from ChainedPlaceholders first, or it would
+        // re-elect itself.
+        internal static void ReleaseChainedOwnership(
+            VisualElement placeholder, VisualElement? hostRoot, ReconcilerContext ctx)
+        {
+            if (hostRoot == null || !ctx.ChainedHostRoots.TryGetValue(hostRoot, out var owner)
+                || !ReferenceEquals(owner, placeholder))
+            {
+                return;
+            }
+            ctx.ChainedHostRoots.Remove(hostRoot);
+            foreach (var (candidate, record) in ctx.ChainedPlaceholders)
+            {
+                var candidateRoot = record.Document != null ? record.Document.rootVisualElement : null;
+                if (ReferenceEquals(candidateRoot, hostRoot))
                 {
-                    ctx.ChainedHostRoots.Remove(hostRoot);
+                    ctx.ChainedHostRoots[hostRoot] = candidate;
+                    return;
                 }
             }
         }
@@ -156,9 +217,13 @@ namespace Velvet
                 }
                 if (binding.Settings.SingleTabStop)
                 {
-                    // The whole subtree acts as ONE tab stop: walk the panel ring in the move's direction,
-                    // skipping every other member of this scope, and land on the first focusable outside it.
-                    var ring = new VisualElementFocusRing(panelRoot);
+                    // The whole subtree acts as ONE tab stop: walk the sequential ring in the move's
+                    // direction, skipping every other member of this scope, and land on the first focusable
+                    // outside it. The walk ring is bounded by the nearest enclosing CONTAIN scope when one
+                    // exists — a group inside a modal must wrap within the modal, never escape it through
+                    // the group's own exit.
+                    var containRoot = FindEnclosingContainScopeRoot(scopeRoot.parent, ctx, out _);
+                    var ring = new VisualElementFocusRing(containRoot ?? panelRoot);
                     var direction = ToRingDirection(forward);
                     var candidate = ring.GetNextFocusable(focused, direction) as VisualElement;
                     var guard = MaxRingWalk;
@@ -168,8 +233,19 @@ namespace Velvet
                     }
                     if (candidate != null && candidate != focused && !scopeRoot.Contains(candidate))
                     {
-                        Redirect(evt, panel!, candidate);
+                        Redirect(evt, panel!, ResolveScopeEntryTarget(candidate, ctx));
+                        return;
                     }
+                    // Every reachable focusable is a member. In a chained host the group's one-stop exit
+                    // crosses the panel boundary (a portal'd roving toolbar is the natural gamepad case);
+                    // anywhere else the move is suppressed with focus held in place — the engine default
+                    // would cycle the members, breaking the one-stop contract.
+                    if (TryChainedEscape(evt, panel!, panelRoot, focused, forward, ctx, requireRingEdge: false))
+                    {
+                        return;
+                    }
+                    panel!.focusController.IgnoreEvent(evt);
+                    evt.StopPropagation();
                     return;
                 }
             }
@@ -177,41 +253,14 @@ namespace Velvet
             // Chained host escape: focus sits in a host panel that joined its declaring panel's Tab order,
             // and this move would wrap around the host's own ring edge — cross the boundary instead, to the
             // declaring-panel element right after (forward) / before (backward) the portal's placeholder.
-            if (ctx.ChainedHostRoots.TryGetValue(panelRoot, out var placeholder) && placeholder.panel != null)
+            if (TryChainedEscape(evt, panel!, panelRoot, focused, forward, ctx, requireRingEdge: true))
             {
-                var hostRing = new VisualElementFocusRing(panelRoot);
-                var direction = ToRingDirection(forward);
-                var predicted = hostRing.GetNextFocusable(focused, direction);
-                // GetNextFocusable(null, right) is the ring's first element and (null, left) its last, so a
-                // predicted move landing there is exactly the wrap this escape replaces. A single-element
-                // host wraps onto itself and still escapes, which is the correct chained behavior.
-                var ringEdge = hostRing.GetNextFocusable(null, direction);
-                if (predicted != null && ReferenceEquals(predicted, ringEdge))
-                {
-                    var declaringRing = new VisualElementFocusRing(placeholder.panel.visualTree);
-                    var escapeTarget = declaringRing.GetNextFocusable(placeholder, direction) as VisualElement;
-                    if (escapeTarget != null && !ReferenceEquals(escapeTarget, placeholder))
-                    {
-                        // This panel's own move is suppressed NOW, and ITS focused element is blurred
-                        // synchronously (its own controller, mid-its-own-dispatch — safe); the cross-panel
-                        // Focus is deferred to the TARGET panel's next scheduler tick. A synchronous Focus()
-                        // into another panel from inside this panel's dispatch does not stick (verified
-                        // empirically), and the blur must come first: two panels holding a focused element
-                        // simultaneously gets reconciled against the still-focused source panel, unfocusing
-                        // the target again. The placeholder-entry direction needs no such hop: it runs
-                        // inside a FOCUS event, whose nested switches ride the engine's pending-focus gate.
-                        panel!.focusController.IgnoreEvent(evt);
-                        evt.StopPropagation();
-                        focused.Blur();
-                        escapeTarget.schedule.Execute(() => escapeTarget.Focus());
-                    }
-                    return;
-                }
+                return;
             }
 
             // Entering a SingleTabStop scope from outside: the group is one tab stop, so the move lands on
-            // the member last used (else the predicted entry element, which for a forward move is the
-            // scope's ring-first anyway).
+            // the member last used, else the group's first member — from either direction (the WAI-ARIA
+            // composite contract; a backward move's raw prediction would be the group's ring-LAST).
             var panelRing = new VisualElementFocusRing(panelRoot);
             var entryPredicted = panelRing.GetNextFocusable(focused, ToRingDirection(forward)) as VisualElement;
             if (entryPredicted != null)
@@ -220,15 +269,111 @@ namespace Velvet
                 if (enteredRoot != null && enteredBinding is { Settings.SingleTabStop: true }
                     && !enteredRoot.Contains(focused))
                 {
-                    var last = enteredBinding.LastFocusedMember;
-                    if (last != null && last.panel != null && enteredRoot.Contains(last) && last.canGrabFocus)
+                    var landing = ResolveScopeEntryTarget(entryPredicted, ctx);
+                    if (!ReferenceEquals(landing, entryPredicted))
                     {
-                        Redirect(evt, panel!, last);
+                        Redirect(evt, panel!, landing);
                     }
-                    // No remembered member: the predicted element is already the correct entry point; let
-                    // the engine's own move proceed untouched.
+                    // Landing == predicted: the engine's own move already enters at the group's correct
+                    // stop (a forward move's raw prediction IS the group's ring-first).
                 }
             }
+        }
+
+        // A landing inside a SingleTabStop group must enter at the group's roving tab stop — the member
+        // last used, else the group's ring-first — no matter how the landing was produced (an engine
+        // prediction, an exit-walk redirect, a placeholder forwarding, or a cross-panel escape hop).
+        // Direction-agnostic by the WAI-ARIA composite contract: a backward entry lands on the same stop,
+        // never the group's last member. Landings outside any SingleTabStop scope pass through untouched.
+        private static VisualElement ResolveScopeEntryTarget(VisualElement candidate, ReconcilerContext ctx)
+        {
+            var root = FindEnclosingScopeRoot(candidate, ctx, out var binding);
+            if (root == null || binding is not { Settings.SingleTabStop: true })
+            {
+                return candidate;
+            }
+            var last = binding.LastFocusedMember;
+            if (last != null && last.panel != null && root.Contains(last) && last.canGrabFocus)
+            {
+                return last;
+            }
+            return new VisualElementFocusRing(root)
+                .GetNextFocusable(null, VisualElementFocusChangeDirection.right) as VisualElement ?? candidate;
+        }
+
+        // The chained-host boundary exit. With requireRingEdge, escapes only when the engine's own move
+        // would wrap around the host ring's edge (the normal Tab-past-the-end case); without it, escapes
+        // unconditionally in the move's direction (the SingleTabStop-covers-the-whole-host case, where ANY
+        // member is the exit point). Returns true when the move was converted into a cross-panel hop.
+        private static bool TryChainedEscape(
+            NavigationMoveEvent evt, IPanel panel, VisualElement panelRoot, VisualElement focused,
+            bool forward, ReconcilerContext ctx, bool requireRingEdge)
+        {
+            var placeholder = FindChainedPlaceholderForPanel(panel, ctx);
+            if (placeholder == null || placeholder.panel == null)
+            {
+                return false;
+            }
+            var direction = ToRingDirection(forward);
+            if (requireRingEdge)
+            {
+                var hostRing = new VisualElementFocusRing(panelRoot);
+                var predicted = hostRing.GetNextFocusable(focused, direction);
+                // GetNextFocusable(null, right) is the ring's first element and (null, left) its last, so a
+                // predicted move landing there is exactly the wrap this escape replaces. A single-element
+                // host wraps onto itself and still escapes, which is the correct chained behavior.
+                var ringEdge = hostRing.GetNextFocusable(null, direction);
+                if (predicted == null || !ReferenceEquals(predicted, ringEdge))
+                {
+                    return false;
+                }
+            }
+            var declaringRoot = placeholder.panel.visualTree;
+            var declaringRing = new VisualElementFocusRing(declaringRoot);
+            var escapeTarget = declaringRing.GetNextFocusable(placeholder, direction) as VisualElement;
+            if (escapeTarget == null || ReferenceEquals(escapeTarget, placeholder))
+            {
+                return false;
+            }
+            // This panel's own move is suppressed NOW, and ITS focused element is blurred synchronously
+            // (its own controller, mid-its-own-dispatch — safe); the cross-panel Focus is deferred to the
+            // TARGET panel's next scheduler tick. A synchronous Focus() into another panel from inside this
+            // panel's dispatch does not stick (verified empirically), and the blur must come first: two
+            // panels holding a focused element simultaneously gets reconciled against the still-focused
+            // source panel, unfocusing the target again. The placeholder-entry direction needs no such hop:
+            // it runs inside a FOCUS event, whose nested switches ride the engine's pending-focus gate.
+            // The hop is scheduled on the DECLARING PANEL'S ROOT, never on the target element: a one-shot
+            // scheduled item on an element that detaches before executing restarts in full when the element
+            // re-attaches — for a pooled widget that means a stale Focus() firing on whatever unrelated
+            // role it was recycled into. The root is stable, and the fire-time guard skips a target that
+            // left the panel in the window between the hop and the tick.
+            panel.focusController.IgnoreEvent(evt);
+            evt.StopPropagation();
+            focused.Blur();
+            declaringRoot.schedule.Execute(() =>
+            {
+                if (escapeTarget.panel != declaringRoot.panel || !escapeTarget.canGrabFocus)
+                {
+                    return;
+                }
+                ResolveScopeEntryTarget(escapeTarget, ctx).Focus();
+            });
+            return true;
+        }
+
+        // Resolves the chained placeholder owning `panel`'s ring-edge escape. The registry is keyed by the
+        // host's document root element; the lookup matches by panel identity so it is independent of which
+        // element the move listener happened to be registered on (the canonical visualTree).
+        private static VisualElement? FindChainedPlaceholderForPanel(IPanel panel, ReconcilerContext ctx)
+        {
+            foreach (var (hostRoot, placeholder) in ctx.ChainedHostRoots)
+            {
+                if (hostRoot.panel == panel)
+                {
+                    return placeholder;
+                }
+            }
+            return null;
         }
 
         private static void OnFocusIn(FocusInEvent evt, ReconcilerContext ctx)
@@ -247,27 +392,12 @@ namespace Velvet
                 if (hostRoot != null)
                 {
                     var backward = evt.direction == VisualElementFocusChangeDirection.left;
-                    var hostRing = new VisualElementFocusRing(hostRoot);
+                    var hostRing = new VisualElementFocusRing(hostRoot.panel?.visualTree ?? hostRoot);
                     var entry = hostRing.GetNextFocusable(null,
                         backward ? VisualElementFocusChangeDirection.left : VisualElementFocusChangeDirection.right) as VisualElement;
-                    entry?.Focus();
-                }
-                return;
-            }
-
-            var scopeRoot = FindEnclosingScopeRoot(target, ctx, out var binding);
-            if (scopeRoot != null && binding != null)
-            {
-                binding.LastFocusedMember = target;
-                // First entry from outside (or from nothing): remember where focus came from, so RestoreFocus
-                // can return it there when the scope unmounts while holding focus.
-                if (!binding.RestoreCaptured)
-                {
-                    var from = evt.relatedTarget as VisualElement;
-                    if (from == null || !scopeRoot.Contains(from))
+                    if (entry != null)
                     {
-                        binding.RestoreTarget = from;
-                        binding.RestoreCaptured = true;
+                        ResolveScopeEntryTarget(entry, ctx).Focus();
                     }
                 }
                 return;
@@ -275,23 +405,107 @@ namespace Velvet
 
             // Contain snap-back: focus left a contained scope through a path the sequential interception
             // cannot see (a spatial 2D move, or a pointer press outside) — pull it back inside within the
-            // same event flush. A nested Focus() from inside a FocusIn handler starts a new pending switch
-            // that wins (the engine's pending-focus gate), so this is deterministic, not a race.
-            if (evt.relatedTarget is VisualElement from2 && from2.panel == target.panel)
+            // same event flush. Evaluated BEFORE the landing scope's own bookkeeping, against the nearest
+            // CONTAIN scope enclosing the element focus came FROM: containment must hold no matter where
+            // the escape landed (a sibling scope, an outer scope, or scope-less space), and the departure
+            // scope's own walk skips non-contain scopes nested inside the modal. A nested Focus() from
+            // inside a FocusIn handler starts a new pending switch that wins (the engine's pending-focus
+            // gate), so the snap-back is deterministic; the depth guard keeps two contained scopes from
+            // ping-ponging — while a snap-back's own nested dispatch runs, its landing is accepted as-is
+            // (the scope that held focus wins).
+            if (ctx.ContainSnapBackDepth == 0
+                && evt.relatedTarget is VisualElement from && from.panel == target.panel)
             {
-                var fromScopeRoot = FindEnclosingScopeRoot(from2, ctx, out var fromBinding);
-                if (fromScopeRoot != null && fromBinding is { Settings.Contain: true }
-                    && !fromScopeRoot.Contains(target))
+                var containRoot = FindEnclosingContainScopeRoot(from, ctx, out var containBinding);
+                if (containRoot != null && containBinding != null && !containRoot.Contains(target))
                 {
-                    var back = fromBinding.LastFocusedMember;
-                    if (back == null || back.panel == null || !back.canGrabFocus)
+                    var back = containBinding.LastFocusedMember;
+                    if (back == null || back.panel == null || !containRoot.Contains(back) || !back.canGrabFocus)
                     {
-                        back = new VisualElementFocusRing(fromScopeRoot)
+                        back = new VisualElementFocusRing(containRoot)
                             .GetNextFocusable(null, VisualElementFocusChangeDirection.right) as VisualElement;
                     }
-                    back?.Focus();
+                    if (back != null)
+                    {
+                        ctx.ContainSnapBackDepth++;
+                        try
+                        {
+                            back.Focus();
+                        }
+                        finally
+                        {
+                            ctx.ContainSnapBackDepth--;
+                        }
+                        // The landing was reverted: recording it in the landing scope's bookkeeping would
+                        // corrupt that scope's roving memory with a member the user never actually reached.
+                        return;
+                    }
                 }
             }
+
+            var scopeRoot = FindEnclosingScopeRoot(target, ctx, out var binding);
+            if (scopeRoot == null || binding == null)
+            {
+                return;
+            }
+            binding.LastFocusedMember = target;
+            // First entry from outside (or from nothing): remember where focus came from, so RestoreFocus
+            // can return it there when the scope unmounts while holding focus.
+            if (!binding.RestoreCaptured)
+            {
+                var cameFrom = evt.relatedTarget as VisualElement;
+                if (cameFrom == null || !scopeRoot.Contains(cameFrom))
+                {
+                    binding.RestoreTarget = cameFrom;
+                    binding.RestoreCaptured = true;
+                }
+            }
+        }
+
+        // The escape containment cannot see from FocusIn: focus cleared to NOTHING (a pointer press on
+        // empty non-focusable space, or a programmatic Blur) raises no FocusInEvent for the snap-back to
+        // ride — only this FocusOut with a null relatedTarget. The re-focus is deferred one scheduler tick
+        // and re-validated at fire time, because the identical event also fires when the focused element
+        // (or the whole scope) is being torn down mid-flush: by the tick, a real teardown has detached the
+        // scope root (skip — RestoreFocus owns that path), and a legitimate move has repopulated
+        // focusedElement (skip — the FocusIn side owns it); only the true "focus went nowhere" case
+        // remains, and containment pulls it back inside.
+        private static void OnFocusOut(FocusOutEvent evt, ReconcilerContext ctx)
+        {
+            if (evt.relatedTarget != null || evt.target is not VisualElement leaving)
+            {
+                return;
+            }
+            var containRoot = FindEnclosingContainScopeRoot(leaving, ctx, out _);
+            if (containRoot == null)
+            {
+                return;
+            }
+            var root = leaving.panel?.visualTree;
+            if (root == null)
+            {
+                return;
+            }
+            root.schedule.Execute(() =>
+            {
+                if (containRoot.panel == null
+                    || !ctx.FocusScopeBindings.TryGetValue(containRoot, out var binding)
+                    || !binding.Settings.Contain)
+                {
+                    return;
+                }
+                var controller = containRoot.panel.focusController;
+                if (controller == null || controller.focusedElement != null)
+                {
+                    return;
+                }
+                var back = binding.LastFocusedMember;
+                if (back == null || back.panel == null || !containRoot.Contains(back) || !back.canGrabFocus)
+                {
+                    back = FocusScopeDriver.FindFirstFocusableInSubtree(containRoot);
+                }
+                back?.Focus();
+            });
         }
 
         // Walks the parent chain from `element` (inclusive) to the first registered scope root. Physical
@@ -303,6 +517,23 @@ namespace Velvet
             for (var current = element; current != null; current = current.parent)
             {
                 if (ctx.FocusScopeBindings.TryGetValue(current, out var found))
+                {
+                    binding = found;
+                    return current;
+                }
+            }
+            binding = null;
+            return null;
+        }
+
+        // Same walk, but resolving the nearest scope whose settings actually CONTAIN — an element inside a
+        // plain or SingleTabStop scope nested in a modal still belongs to the modal's containment.
+        private static VisualElement? FindEnclosingContainScopeRoot(
+            VisualElement? element, ReconcilerContext ctx, out FocusScopeBinding? binding)
+        {
+            for (var current = element; current != null; current = current.parent)
+            {
+                if (ctx.FocusScopeBindings.TryGetValue(current, out var found) && found.Settings.Contain)
                 {
                     binding = found;
                     return current;
@@ -338,9 +569,15 @@ namespace Velvet
             var binding = new FocusScopeBinding(settings);
             binding.OnAttach = _ =>
             {
-                FiberFocusNavigator.EnsureAttached(element.panel?.visualTree, ctx);
-                if (binding.Settings.AutoFocus)
+                FiberFocusNavigator.EnsureAttached(element, ctx);
+                // Mount-once, matching React's autoFocus (it acts on mount, never again): without the
+                // latch, every physical re-attach — a keyed reorder moves the subtree via RemoveAt +
+                // Insert — would re-fire and steal focus from wherever the user moved on. The transient
+                // detach of a reorder also clears panel focus, so AutoFocusFirst's focus-already-inside
+                // guard cannot cover the reorder case by itself.
+                if (binding.Settings.AutoFocus && !binding.AutoFocusFired)
                 {
+                    binding.AutoFocusFired = true;
                     AutoFocusFirst(element);
                 }
             };
@@ -367,11 +604,11 @@ namespace Velvet
         }
 
         // Focuses the scope's first focusable descendant (document order), skipped when focus already sits
-        // inside the scope — an AutoFocus modal re-attached by a keyed reorder must not steal focus back.
-        // Deliberately NOT computed through a focus ring: ring membership requires the element chain to be
-        // resolved as displayed, which has not happened yet at attach time (the panel's style pass runs
-        // after this frame's mounts) — the engine ring would read empty here. A plain traversal over the
-        // same focusability predicate (minus the displayed check) is what attach-time can actually answer.
+        // inside the scope. Deliberately NOT computed through a focus ring: ring membership requires the
+        // element chain to be resolved as displayed, which has not happened yet at attach time (the panel's
+        // style pass runs after this frame's mounts) — the engine ring would read empty here. A plain
+        // traversal over the same focusability predicate (minus the displayed check) is what attach-time
+        // can actually answer.
         private static void AutoFocusFirst(VisualElement scopeRoot)
         {
             var controller = scopeRoot.panel?.focusController;

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberFocusNavigator.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberFocusNavigator.cs
@@ -1,0 +1,404 @@
+#nullable enable
+using System;
+using UnityEngine.UIElements;
+
+namespace Velvet
+{
+    /// <summary>
+    /// How a host panel (<c>V.Portal(layer:)</c> / <c>V.WorldSpace</c>) participates in sequential
+    /// (Tab/Shift-Tab) focus order relative to the panel declaring it. <see cref="Isolated"/> (the default)
+    /// is the pre-existing behavior: the host panel's focus ring wraps internally and never crosses the
+    /// panel boundary — the explicit-opt-in stance of the cross-panel navigation decision.
+    /// <see cref="Chained"/> joins the declaring panel's Tab order at the portal's call site (iframe
+    /// semantics): Tab past the host ring's last element exits to the element after the portal's
+    /// placeholder; Tab reaching the placeholder's position enters the host at its ring-first (Shift-Tab
+    /// symmetric). Arrow/2D navigation never crosses panels.
+    /// </summary>
+    public enum PanelFocusOrder
+    {
+        Isolated,
+        Chained,
+    }
+
+    // Reconciler-side bookkeeping for one focus-scope element, keyed in ReconcilerContext.FocusScopeBindings
+    // by the scope root element itself. Mutable per-scope focus state the navigator maintains from FocusIn
+    // events: the member that last held focus (SingleTabStop re-entry / Contain snap-back target), and the
+    // element focus came FROM when it first entered the scope (RestoreFocus's target on unmount).
+    internal sealed class FocusScopeBinding
+    {
+        public FocusScopeSettings Settings;
+        public VisualElement? LastFocusedMember;
+        public VisualElement? RestoreTarget;
+        public bool RestoreCaptured;
+        public EventCallback<AttachToPanelEvent>? OnAttach;
+
+        public FocusScopeBinding(FocusScopeSettings settings)
+        {
+            Settings = settings;
+        }
+    }
+
+    /// <summary>
+    /// The single owner of every focus-navigation interception in Velvet — the keyboard sibling of
+    /// <c>FiberCrossPanelInput</c>'s two classes, attached exactly once per panel root (never per scope).
+    /// Sequential (Next/Previous) <see cref="NavigationMoveEvent"/>s are intercepted on the verified engine
+    /// contract pinned by <c>FocusNavigationInterceptionTests</c>: the default focus move runs post-dispatch,
+    /// after every listener, and its only suppression is <see cref="FocusController.IgnoreEvent"/> — so a
+    /// TrickleDown listener deterministically preempts it. Spatial moves (Left/Right/Up/Down) are NEVER
+    /// intercepted: 2D arrow/dpad/stick navigation is the engine's own <c>GetNextFocusable2D</c>, which this
+    /// layer composes with rather than reimplements. Sequential prediction and redirection use the public
+    /// <see cref="VisualElementFocusRing"/> — the exact class the runtime ring delegates Next/Previous to
+    /// (<c>NavigateFocusRing.m_Ring</c>), so predictions cannot drift from what the engine would have done.
+    /// </summary>
+    internal static class FiberFocusNavigator
+    {
+        // Bounds the SingleTabStop exit walk (skipping members while searching for the first focusable
+        // outside the scope) so a pathological ring cannot spin this listener unboundedly.
+        private const int MaxRingWalk = 4096;
+
+        // Attaches the navigator's two listeners to a panel root exactly once (tracked in
+        // ctx.NavigatorAttachments so Reconciler.Dispose can unregister them). Called from V.Mount (main
+        // panel), PanelHostFactory (host panels), and lazily when a scope/chained placeholder attaches to a
+        // panel this navigator has not seen yet.
+        internal static void EnsureAttached(VisualElement? panelRoot, ReconcilerContext ctx)
+        {
+            if (panelRoot == null || ctx.NavigatorAttachments.ContainsKey(panelRoot))
+            {
+                return;
+            }
+            EventCallback<NavigationMoveEvent> onMove = evt => OnNavigationMove(evt, panelRoot, ctx);
+            EventCallback<FocusInEvent> onFocusIn = evt => OnFocusIn(evt, ctx);
+            panelRoot.RegisterCallback(onMove, TrickleDown.TrickleDown);
+            panelRoot.RegisterCallback(onFocusIn);
+            ctx.NavigatorAttachments[panelRoot] = (onMove, onFocusIn);
+        }
+
+        internal static void DetachAll(ReconcilerContext ctx)
+        {
+            foreach (var (root, (onMove, onFocusIn)) in ctx.NavigatorAttachments)
+            {
+                root.UnregisterCallback(onMove, TrickleDown.TrickleDown);
+                root.UnregisterCallback(onFocusIn);
+            }
+            ctx.NavigatorAttachments.Clear();
+        }
+
+        // Configures a portal placeholder's participation in the declaring panel's Tab order
+        // (PanelFocusOrder). Chained: the hidden placeholder becomes a zero-size, out-of-flow proxy tab
+        // stop (ring membership requires the element to be displayed; absolute keeps it out of flex flow
+        // and the gap/divide index walks, which skip out-of-flow children) and both chained registries are
+        // wired. Isolated: everything is reset to the plain hidden placeholder — idempotent in both
+        // directions, so a patch flipping FocusOrder routes back through here.
+        internal static void ConfigureChainedPlaceholder(
+            VisualElement placeholder, PanelHostRecord record, bool chained, ReconcilerContext ctx)
+        {
+            var hostRoot = record.Document != null ? record.Document.rootVisualElement : null;
+            if (chained && hostRoot != null)
+            {
+                placeholder.style.display = DisplayStyle.Flex;
+                placeholder.style.position = Position.Absolute;
+                placeholder.style.width = 0f;
+                placeholder.style.height = 0f;
+                placeholder.focusable = true;
+                placeholder.tabIndex = 0;
+                ctx.ChainedPlaceholders[placeholder] = record;
+                // A shared layer host can carry several portals; the first chained one owns the host's
+                // ring-edge escape (flow between two portals' slots stays panel-internal either way).
+                ctx.ChainedHostRoots.TryAdd(hostRoot, placeholder);
+                EnsureAttached(placeholder.panel?.visualTree, ctx);
+                EnsureAttached(hostRoot, ctx);
+                return;
+            }
+            if (ctx.ChainedPlaceholders.Remove(placeholder))
+            {
+                placeholder.style.display = DisplayStyle.None;
+                placeholder.style.position = StyleKeyword.Null;
+                placeholder.style.width = StyleKeyword.Null;
+                placeholder.style.height = StyleKeyword.Null;
+                placeholder.focusable = false;
+                placeholder.tabIndex = 0;
+                if (hostRoot != null && ctx.ChainedHostRoots.TryGetValue(hostRoot, out var owner)
+                    && ReferenceEquals(owner, placeholder))
+                {
+                    ctx.ChainedHostRoots.Remove(hostRoot);
+                }
+            }
+        }
+
+        private static void OnNavigationMove(NavigationMoveEvent evt, VisualElement panelRoot, ReconcilerContext ctx)
+        {
+            // Spatial moves always fall through to the engine's own 2D navigation.
+            var forward = evt.direction == NavigationMoveEvent.Direction.Next;
+            if (!forward && evt.direction != NavigationMoveEvent.Direction.Previous)
+            {
+                return;
+            }
+            var panel = panelRoot.panel;
+            var focused = panel?.focusController?.focusedElement as VisualElement;
+            if (focused == null)
+            {
+                return;
+            }
+
+            // Innermost scope wins (nested modals resolve naturally: the walk starts at the focused element
+            // and the first registered scope root on the parent chain is the closest enclosing one).
+            var scopeRoot = FindEnclosingScopeRoot(focused, ctx, out var binding);
+            if (scopeRoot != null && binding != null)
+            {
+                if (binding.Settings.Contain)
+                {
+                    // A ring scoped to the subtree root computes the same sequential order the panel ring
+                    // would, restricted to the scope's members — and wraps at the scope edges, which IS the
+                    // containment contract.
+                    var scoped = new VisualElementFocusRing(scopeRoot);
+                    Redirect(evt, panel!, scoped.GetNextFocusable(focused, ToRingDirection(forward)) as VisualElement);
+                    return;
+                }
+                if (binding.Settings.SingleTabStop)
+                {
+                    // The whole subtree acts as ONE tab stop: walk the panel ring in the move's direction,
+                    // skipping every other member of this scope, and land on the first focusable outside it.
+                    var ring = new VisualElementFocusRing(panelRoot);
+                    var direction = ToRingDirection(forward);
+                    var candidate = ring.GetNextFocusable(focused, direction) as VisualElement;
+                    var guard = MaxRingWalk;
+                    while (candidate != null && candidate != focused && scopeRoot.Contains(candidate) && guard-- > 0)
+                    {
+                        candidate = ring.GetNextFocusable(candidate, direction) as VisualElement;
+                    }
+                    if (candidate != null && candidate != focused && !scopeRoot.Contains(candidate))
+                    {
+                        Redirect(evt, panel!, candidate);
+                    }
+                    return;
+                }
+            }
+
+            // Chained host escape: focus sits in a host panel that joined its declaring panel's Tab order,
+            // and this move would wrap around the host's own ring edge — cross the boundary instead, to the
+            // declaring-panel element right after (forward) / before (backward) the portal's placeholder.
+            if (ctx.ChainedHostRoots.TryGetValue(panelRoot, out var placeholder) && placeholder.panel != null)
+            {
+                var hostRing = new VisualElementFocusRing(panelRoot);
+                var direction = ToRingDirection(forward);
+                var predicted = hostRing.GetNextFocusable(focused, direction);
+                // GetNextFocusable(null, right) is the ring's first element and (null, left) its last, so a
+                // predicted move landing there is exactly the wrap this escape replaces. A single-element
+                // host wraps onto itself and still escapes, which is the correct chained behavior.
+                var ringEdge = hostRing.GetNextFocusable(null, direction);
+                if (predicted != null && ReferenceEquals(predicted, ringEdge))
+                {
+                    var declaringRing = new VisualElementFocusRing(placeholder.panel.visualTree);
+                    var escapeTarget = declaringRing.GetNextFocusable(placeholder, direction) as VisualElement;
+                    if (escapeTarget != null && !ReferenceEquals(escapeTarget, placeholder))
+                    {
+                        // This panel's own move is suppressed NOW, and ITS focused element is blurred
+                        // synchronously (its own controller, mid-its-own-dispatch — safe); the cross-panel
+                        // Focus is deferred to the TARGET panel's next scheduler tick. A synchronous Focus()
+                        // into another panel from inside this panel's dispatch does not stick (verified
+                        // empirically), and the blur must come first: two panels holding a focused element
+                        // simultaneously gets reconciled against the still-focused source panel, unfocusing
+                        // the target again. The placeholder-entry direction needs no such hop: it runs
+                        // inside a FOCUS event, whose nested switches ride the engine's pending-focus gate.
+                        panel!.focusController.IgnoreEvent(evt);
+                        evt.StopPropagation();
+                        focused.Blur();
+                        escapeTarget.schedule.Execute(() => escapeTarget.Focus());
+                    }
+                    return;
+                }
+            }
+
+            // Entering a SingleTabStop scope from outside: the group is one tab stop, so the move lands on
+            // the member last used (else the predicted entry element, which for a forward move is the
+            // scope's ring-first anyway).
+            var panelRing = new VisualElementFocusRing(panelRoot);
+            var entryPredicted = panelRing.GetNextFocusable(focused, ToRingDirection(forward)) as VisualElement;
+            if (entryPredicted != null)
+            {
+                var enteredRoot = FindEnclosingScopeRoot(entryPredicted, ctx, out var enteredBinding);
+                if (enteredRoot != null && enteredBinding is { Settings.SingleTabStop: true }
+                    && !enteredRoot.Contains(focused))
+                {
+                    var last = enteredBinding.LastFocusedMember;
+                    if (last != null && last.panel != null && enteredRoot.Contains(last) && last.canGrabFocus)
+                    {
+                        Redirect(evt, panel!, last);
+                    }
+                    // No remembered member: the predicted element is already the correct entry point; let
+                    // the engine's own move proceed untouched.
+                }
+            }
+        }
+
+        private static void OnFocusIn(FocusInEvent evt, ReconcilerContext ctx)
+        {
+            if (evt.target is not VisualElement target)
+            {
+                return;
+            }
+
+            // Chained placeholder forwarding: the placeholder is a zero-size proxy tab stop in the declaring
+            // panel's ring — focus reaching it means the sequential order crossed the portal's call site, so
+            // hand focus into the host panel at the edge matching the travel direction.
+            if (ctx.ChainedPlaceholders.TryGetValue(target, out var hostRecord))
+            {
+                var hostRoot = hostRecord.Document != null ? hostRecord.Document.rootVisualElement : null;
+                if (hostRoot != null)
+                {
+                    var backward = evt.direction == VisualElementFocusChangeDirection.left;
+                    var hostRing = new VisualElementFocusRing(hostRoot);
+                    var entry = hostRing.GetNextFocusable(null,
+                        backward ? VisualElementFocusChangeDirection.left : VisualElementFocusChangeDirection.right) as VisualElement;
+                    entry?.Focus();
+                }
+                return;
+            }
+
+            var scopeRoot = FindEnclosingScopeRoot(target, ctx, out var binding);
+            if (scopeRoot != null && binding != null)
+            {
+                binding.LastFocusedMember = target;
+                // First entry from outside (or from nothing): remember where focus came from, so RestoreFocus
+                // can return it there when the scope unmounts while holding focus.
+                if (!binding.RestoreCaptured)
+                {
+                    var from = evt.relatedTarget as VisualElement;
+                    if (from == null || !scopeRoot.Contains(from))
+                    {
+                        binding.RestoreTarget = from;
+                        binding.RestoreCaptured = true;
+                    }
+                }
+                return;
+            }
+
+            // Contain snap-back: focus left a contained scope through a path the sequential interception
+            // cannot see (a spatial 2D move, or a pointer press outside) — pull it back inside within the
+            // same event flush. A nested Focus() from inside a FocusIn handler starts a new pending switch
+            // that wins (the engine's pending-focus gate), so this is deterministic, not a race.
+            if (evt.relatedTarget is VisualElement from2 && from2.panel == target.panel)
+            {
+                var fromScopeRoot = FindEnclosingScopeRoot(from2, ctx, out var fromBinding);
+                if (fromScopeRoot != null && fromBinding is { Settings.Contain: true }
+                    && !fromScopeRoot.Contains(target))
+                {
+                    var back = fromBinding.LastFocusedMember;
+                    if (back == null || back.panel == null || !back.canGrabFocus)
+                    {
+                        back = new VisualElementFocusRing(fromScopeRoot)
+                            .GetNextFocusable(null, VisualElementFocusChangeDirection.right) as VisualElement;
+                    }
+                    back?.Focus();
+                }
+            }
+        }
+
+        // Walks the parent chain from `element` (inclusive) to the first registered scope root. Physical
+        // containment is deliberately the membership definition — robust at event time, across pool reuse,
+        // and against the logical-tree caveats that limit userData-based resolution for bare portal children.
+        private static VisualElement? FindEnclosingScopeRoot(
+            VisualElement element, ReconcilerContext ctx, out FocusScopeBinding? binding)
+        {
+            for (var current = element; current != null; current = current.parent)
+            {
+                if (ctx.FocusScopeBindings.TryGetValue(current, out var found))
+                {
+                    binding = found;
+                    return current;
+                }
+            }
+            binding = null;
+            return null;
+        }
+
+        private static FocusChangeDirection ToRingDirection(bool forward)
+            => forward ? VisualElementFocusChangeDirection.right : VisualElementFocusChangeDirection.left;
+
+        // The pinned suppression contract: IgnoreEvent is what the post-dispatch focus move actually checks;
+        // StopPropagation only silences other listeners (and is kept so a bubble-up default action like a
+        // text field's own SwitchFocusOnEvent cannot double-move).
+        private static void Redirect(NavigationMoveEvent evt, IPanel panel, VisualElement? target)
+        {
+            panel.focusController.IgnoreEvent(evt);
+            evt.StopPropagation();
+            target?.Focus();
+        }
+    }
+
+    // Attach/Update/Detach lifecycle for a focus-scope binding, dispatched through the shared
+    // ApplyElementBinding plumbing exactly like SceneView/Particles/Anchored. Attach registers the
+    // AutoFocus hook and lazily ensures the navigator on whatever panel the scope lands in; Detach is the
+    // pool-reuse scrub (RestoreFocus itself runs in FiberElementCleaner BEFORE the element leaves the tree,
+    // since focus dies the moment an element detaches).
+    internal static class FocusScopeDriver
+    {
+        public static FocusScopeBinding Attach(VisualElement element, FocusScopeSettings settings, ReconcilerContext ctx)
+        {
+            var binding = new FocusScopeBinding(settings);
+            binding.OnAttach = _ =>
+            {
+                FiberFocusNavigator.EnsureAttached(element.panel?.visualTree, ctx);
+                if (binding.Settings.AutoFocus)
+                {
+                    AutoFocusFirst(element);
+                }
+            };
+            element.RegisterCallback(binding.OnAttach);
+            if (element.panel != null)
+            {
+                binding.OnAttach(null!);
+            }
+            return binding;
+        }
+
+        public static void Update(VisualElement element, FocusScopeBinding binding, FocusScopeSettings settings)
+        {
+            binding.Settings = settings;
+        }
+
+        public static void Detach(VisualElement element, FocusScopeBinding binding)
+        {
+            if (binding.OnAttach != null)
+            {
+                element.UnregisterCallback(binding.OnAttach);
+                binding.OnAttach = null;
+            }
+        }
+
+        // Focuses the scope's first focusable descendant (document order), skipped when focus already sits
+        // inside the scope — an AutoFocus modal re-attached by a keyed reorder must not steal focus back.
+        // Deliberately NOT computed through a focus ring: ring membership requires the element chain to be
+        // resolved as displayed, which has not happened yet at attach time (the panel's style pass runs
+        // after this frame's mounts) — the engine ring would read empty here. A plain traversal over the
+        // same focusability predicate (minus the displayed check) is what attach-time can actually answer.
+        private static void AutoFocusFirst(VisualElement scopeRoot)
+        {
+            var controller = scopeRoot.panel?.focusController;
+            if (controller?.focusedElement is VisualElement current && scopeRoot.Contains(current))
+            {
+                return;
+            }
+            FindFirstFocusableInSubtree(scopeRoot)?.Focus();
+        }
+
+        internal static VisualElement? FindFirstFocusableInSubtree(VisualElement root)
+        {
+            var count = root.hierarchy.childCount;
+            for (var i = 0; i < count; i++)
+            {
+                var child = root.hierarchy[i];
+                if (child.canGrabFocus && child.tabIndex >= 0 && !child.delegatesFocus)
+                {
+                    return child;
+                }
+                var nested = FindFirstFocusableInSubtree(child);
+                if (nested != null)
+                {
+                    return nested;
+                }
+            }
+            return null;
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberFocusNavigator.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberFocusNavigator.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 05f0c8e686d8244229159644609bccf0

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodeFactory.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodeFactory.cs
@@ -144,6 +144,13 @@ namespace Velvet
                     {
                         _patcher.Appliers.ApplyAnchored(element, elementNode.Props.Anchored);
                     }
+                    // Focus scope (V.FocusScope / props.FocusScope): register the scope binding. AutoFocus
+                    // and the lazy navigator attach ride the binding's own AttachToPanelEvent, so an
+                    // off-panel create is fine here.
+                    if (elementNode.Props?.FocusScope != null)
+                    {
+                        _patcher.Appliers.ApplyFocusScope(element, elementNode.Props.FocusScope);
+                    }
 
                     if (elementNode.WrapElement != null)
                     {
@@ -243,6 +250,11 @@ namespace Velvet
                     if (motionNode.Props?.Anchored != null)
                     {
                         _patcher.Appliers.ApplyAnchored(element, motionNode.Props.Anchored);
+                    }
+                    // Focus scope through a Motion host: same reason as the sibling bindings above.
+                    if (motionNode.Props?.FocusScope != null)
+                    {
+                        _patcher.Appliers.ApplyFocusScope(element, motionNode.Props.FocusScope);
                     }
                     StyleFontResolver.ApplyIfPresent(element, appliedClasses);
                     _patcher.ApplyGapManipulator(element, appliedClasses);

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
@@ -560,6 +560,11 @@ namespace Velvet
                 // Recurring re-sync point for late declaring resolution and runtime drift.
                 PanelHostFactory.SyncDeclaring(layerHost, layer, placeholder.panel, _ctx);
                 target = layerHost.Document.rootVisualElement;
+                if (oldNode.FocusOrder != newNode.FocusOrder)
+                {
+                    FiberFocusNavigator.ConfigureChainedPlaceholder(placeholder, layerHost,
+                        newNode.FocusOrder == PanelFocusOrder.Chained, _ctx);
+                }
             }
             else
             {
@@ -621,6 +626,11 @@ namespace Velvet
             if (oldNode.PanelSize != newNode.PanelSize)
             {
                 record.Document.worldSpaceSize = newNode.PanelSize;
+            }
+            if (oldNode.FocusOrder != newNode.FocusOrder)
+            {
+                FiberFocusNavigator.ConfigureChainedPlaceholder(placeholder, record,
+                    newNode.FocusOrder == PanelFocusOrder.Chained, _ctx);
             }
             PatchPortalChildren(placeholder, record.Document.rootVisualElement, oldNode.Children, newNode.Children, "world-space");
         }
@@ -1047,6 +1057,16 @@ namespace Velvet
                 FiberPropApplier.ApplyFocusable(element, newProps.Focusable);
             }
 
+            if (oldProps.TabIndex != newProps.TabIndex)
+            {
+                FiberPropApplier.ApplyTabIndex(element, newProps.TabIndex);
+            }
+
+            if (oldProps.DelegatesFocus != newProps.DelegatesFocus)
+            {
+                FiberPropApplier.ApplyDelegatesFocus(element, newProps.DelegatesFocus);
+            }
+
             if (!Equals(oldProps.FieldValue, newProps.FieldValue))
             {
                 FiberPropApplier.ApplyFieldValue(element, newProps.FieldValue);
@@ -1094,6 +1114,13 @@ namespace Velvet
             if (oldProps.Anchored != newProps.Anchored)
             {
                 _appliers.ApplyAnchored(element, newProps.Anchored);
+            }
+
+            // Record (value) equality, like the bindings above: only an actual scope-behavior change (or a
+            // scope arriving/leaving) lands here.
+            if (oldProps.FocusScope != newProps.FocusScope)
+            {
+                _appliers.ApplyFocusScope(element, newProps.FocusScope);
             }
         }
 

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberPrimitiveElementPool.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberPrimitiveElementPool.cs
@@ -31,6 +31,11 @@ namespace Velvet
             FiberElementPoolReset.ResetClassListAndCommon(button, TextElement.ussClassName, Button.ussClassName);
             button.text = string.Empty;
             button.iconImage = default;
+            // The common reset scrubs focusable to the plain-VisualElement default (false), but a Button's
+            // OWN constructor default is focusable — without restoring it, a recycled button silently drops
+            // out of Tab/gamepad navigation, diverging from the freshly-constructed instance this reset
+            // promises to match.
+            button.focusable = true;
         }
     }
 
@@ -84,6 +89,10 @@ namespace Velvet
             slider.label = string.Empty;
             slider.direction = SliderDirection.Horizontal;
             slider.pageSize = 0f;
+            // See FiberButtonPoolHelper: the common reset's focusable=false is the plain-VisualElement
+            // default; a Slider's own constructor default is focusable, and dropping it would remove a
+            // recycled slider from Tab/gamepad navigation.
+            slider.focusable = true;
         }
     }
 
@@ -135,6 +144,9 @@ namespace Velvet
             textField.maxLength = DefaultMaxLength;
             textField.textSelection.SelectNone();
             textField.label = string.Empty;
+            // See FiberButtonPoolHelper: restore the type's own constructor default after the common
+            // reset's focusable=false, or a recycled field cannot be tabbed into.
+            textField.focusable = true;
         }
     }
 
@@ -161,6 +173,9 @@ namespace Velvet
             FiberElementPoolReset.ResetClassListAndCommon(toggle, BaseField<bool>.ussClassName, Toggle.ussClassName);
             toggle.SetValueWithoutNotify(false);
             toggle.label = string.Empty;
+            // See FiberButtonPoolHelper: restore the type's own constructor default after the common
+            // reset's focusable=false, or a recycled toggle drops out of Tab/gamepad navigation.
+            toggle.focusable = true;
         }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberPropApplier.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberPropApplier.cs
@@ -44,6 +44,12 @@ namespace Velvet
         public static void ApplyFocusable(VisualElement element, bool? focusable)
             => element.focusable = focusable ?? true;
 
+        public static void ApplyTabIndex(VisualElement element, int? tabIndex)
+            => element.tabIndex = tabIndex ?? 0;
+
+        public static void ApplyDelegatesFocus(VisualElement element, bool? delegatesFocus)
+            => element.delegatesFocus = delegatesFocus ?? false;
+
         public static void ApplyFieldValue(VisualElement element, object? value)
         {
             // A controlled field reflects its declared value, so clearing the value prop to null resets the

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberWrapperElementAppliers.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberWrapperElementAppliers.cs
@@ -929,6 +929,27 @@ namespace Velvet
                 s_anchoredAttach, s_anchoredUpdate, s_anchoredDetach);
         }
 
+        // Same attach/update/detach shape as the bindings above, inlined rather than routed through the
+        // shared generic dispatch: FocusScopeDriver.Attach needs the ReconcilerContext (the navigator's
+        // scope registry and lazy panel attach live there), which the cached static delegates cannot carry.
+        internal void ApplyFocusScope(VisualElement element, FocusScopeSettings? settings)
+        {
+            if (_ctx.FocusScopeBindings.TryGetValue(element, out var binding))
+            {
+                if (settings == null)
+                {
+                    FocusScopeDriver.Detach(element, binding);
+                    _ctx.FocusScopeBindings.Remove(element);
+                    return;
+                }
+                FocusScopeDriver.Update(element, binding, settings);
+            }
+            else if (settings != null)
+            {
+                _ctx.FocusScopeBindings[element] = FocusScopeDriver.Attach(element, settings, _ctx);
+            }
+        }
+
         // Cached method-group delegates so the shared dispatch below adds no per-call allocation.
         private static readonly Func<VisualElement, SceneViewSettings, SceneViewBinding> s_sceneViewAttach = SceneViewDriver.Attach;
         private static readonly Action<VisualElement, SceneViewBinding, SceneViewSettings> s_sceneViewUpdate = SceneViewDriver.Update;

--- a/Packages/com.velvet.core/Runtime/Reconciler/Reconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Reconciler.cs
@@ -467,6 +467,16 @@ namespace Velvet
                 AnchoredDriver.Detach(element, binding);
             }
             _ctx.AnchoredBindings.Clear();
+            // Focus-scope bindings own a registered attach callback each; the navigator's own listener
+            // pairs sit on panel roots that outlive this reconciler, so both are released explicitly.
+            foreach (var (element, binding) in _ctx.FocusScopeBindings)
+            {
+                FocusScopeDriver.Detach(element, binding);
+            }
+            _ctx.FocusScopeBindings.Clear();
+            _ctx.ChainedPlaceholders.Clear();
+            _ctx.ChainedHostRoots.Clear();
+            FiberFocusNavigator.DetachAll(_ctx);
             foreach (var (element, manipulator) in _ctx.GestureManipulators)
             {
                 element.RemoveManipulator(manipulator);

--- a/Packages/com.velvet.core/Runtime/Reconciler/Reconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Reconciler.cs
@@ -467,8 +467,9 @@ namespace Velvet
                 AnchoredDriver.Detach(element, binding);
             }
             _ctx.AnchoredBindings.Clear();
-            // Focus-scope bindings own a registered attach callback each; the navigator's own listener
-            // pairs sit on panel roots that outlive this reconciler, so both are released explicitly.
+            // Focus-scope bindings own a registered attach callback each; the navigator's listener trios
+            // (and any still-pending attach hooks) sit on elements that outlive this reconciler, so both
+            // are released explicitly.
             foreach (var (element, binding) in _ctx.FocusScopeBindings)
             {
                 FocusScopeDriver.Detach(element, binding);

--- a/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
@@ -360,6 +360,27 @@ namespace Velvet
         // any binding still live at root disposal.
         public Dictionary<VisualElement, AnchoredBinding> AnchoredBindings { get; } = new();
 
+        // Per-focus-scope bookkeeping (FiberElementProps.FocusScope / V.FocusScope), keyed by the scope
+        // root element. The binding owns a registered AttachToPanelEvent callback (AutoFocus / lazy
+        // navigator attach), so it is NOT a pure side-table: FiberElementCleaner fires RestoreFocus and
+        // detaches it on teardown, and Reconciler.Dispose sweeps any binding still live at root disposal.
+        // FiberFocusNavigator consults this registry at event time (innermost-scope resolution walks an
+        // element's parent chain against these keys).
+        public Dictionary<VisualElement, FocusScopeBinding> FocusScopeBindings { get; } = new();
+
+        // Chained-portal focus bookkeeping (PanelFocusOrder.Chained): the DECLARING-panel placeholder that
+        // acts as the portal's proxy tab stop → the host record its focus forwards into, plus the reverse
+        // index (host panel root → placeholder) the host-edge escape consults. Entries are added in
+        // DrainPendingPortalMounts and removed by FiberElementCleaner when the portal unmounts;
+        // Reconciler.Dispose sweeps the rest.
+        public Dictionary<VisualElement, PanelHostRecord> ChainedPlaceholders { get; } = new();
+        public Dictionary<VisualElement, VisualElement> ChainedHostRoots { get; } = new();
+
+        // The panel roots FiberFocusNavigator has attached its listener pair to, with the registered
+        // callbacks retained so Reconciler.Dispose can unregister them (panel roots belong to the user /
+        // the host panels and can outlive this reconciler).
+        public Dictionary<VisualElement, (EventCallback<NavigationMoveEvent> OnMove, EventCallback<FocusInEvent> OnFocusIn)> NavigatorAttachments { get; } = new();
+
         // Per-Portal placeholder bookkeeping. SlotStart + SlotLength identify the
         // range of FiberPortalRegistry.Get(TargetId).Children owned by this Portal — the
         // invariant that lets multiple Portals coexist on the same target without overwriting each

--- a/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
@@ -376,10 +376,22 @@ namespace Velvet
         public Dictionary<VisualElement, PanelHostRecord> ChainedPlaceholders { get; } = new();
         public Dictionary<VisualElement, VisualElement> ChainedHostRoots { get; } = new();
 
-        // The panel roots FiberFocusNavigator has attached its listener pair to, with the registered
+        // The panel roots FiberFocusNavigator has attached its listener trio to, with the registered
         // callbacks retained so Reconciler.Dispose can unregister them (panel roots belong to the user /
-        // the host panels and can outlive this reconciler).
-        public Dictionary<VisualElement, (EventCallback<NavigationMoveEvent> OnMove, EventCallback<FocusInEvent> OnFocusIn)> NavigatorAttachments { get; } = new();
+        // the host panels and can outlive this reconciler). Keyed by the panel's TRUE root
+        // (panel.visualTree), so two attach requests from different elements of one panel dedup.
+        public Dictionary<VisualElement, (EventCallback<NavigationMoveEvent> OnMove, EventCallback<FocusInEvent> OnFocusIn, EventCallback<FocusOutEvent> OnFocusOut)> NavigatorAttachments { get; } = new();
+
+        // Deferred navigator attachments: elements whose panel was unresolved when EnsureAttached ran (a
+        // detached mount root, a placeholder configured before its declaring tree attaches), each holding
+        // a self-removing AttachToPanelEvent hook. Tracked so DetachAll can unregister hooks that never
+        // fired.
+        public List<(VisualElement Element, EventCallback<AttachToPanelEvent> Hook)> NavigatorPendingAttachHooks { get; } = new();
+
+        // Re-entrancy depth of the Contain snap-back's nested Focus dispatch: while > 0, a further
+        // snap-back is suppressed so two contained scopes resolve deterministically (the scope that held
+        // focus wins) instead of ping-ponging Focus calls until the stack dies.
+        public int ContainSnapBackDepth;
 
         // Per-Portal placeholder bookkeeping. SlotStart + SlotLength identify the
         // range of FiberPortalRegistry.Get(TargetId).Children owned by this Portal — the

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/FocusScopeTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/FocusScopeTests.cs
@@ -18,12 +18,16 @@ namespace Velvet.Tests
         private MountedTree _mounted;
 
         private static StateUpdater<bool> s_setShowScope;
+        private static StateUpdater<bool> s_setRotated;
+        private static StateUpdater<bool> s_setShowOpener;
 
         [SetUp]
         public void SetUp()
         {
             _host = new HeadlessEditorPanelHost();
             s_setShowScope = default;
+            s_setRotated = default;
+            s_setShowOpener = default;
         }
 
         [TearDown]
@@ -184,6 +188,258 @@ namespace Velvet.Tests
 
             // Assert — entry lands on the remembered member, not the group's first.
             Assert.That(_host.Panel.focusController.focusedElement, Is.EqualTo(Q("g2")));
+        }
+
+        [Component]
+        private static VNode TwoScopesHost() => V.Div(children: new VNode[]
+        {
+            V.FocusScope(name: "modal", contain: true, children: new VNode[]
+            {
+                V.Button(name: "m1"),
+                V.Button(name: "m2"),
+            }),
+            V.FocusScope(name: "drawer", restoreFocus: true, children: new VNode[]
+            {
+                V.Button(name: "d1"),
+            }),
+        });
+
+        [Test]
+        public void Given_AContainedScopeHoldingFocus_When_FocusEscapesToAnElementInsideAnotherScope_Then_FocusSnapsBackToTheContainedScope()
+        {
+            // Arrange
+            Mount(TwoScopesHost);
+            var m1 = Q("m1");
+            m1.Focus();
+            Assume.That(_host.Panel.focusController.focusedElement, Is.EqualTo(m1),
+                "Precondition: the contained scope holds focus");
+
+            // Act — a pointer-press-shaped escape whose landing sits inside a DIFFERENT scope (the
+            // drawer): containment must hold no matter where the escape landed, not only for
+            // scope-less destinations.
+            Q("d1").Focus();
+
+            // Assert
+            Assert.That(_host.Panel.focusController.focusedElement, Is.EqualTo(m1));
+        }
+
+        [Test]
+        public void Given_AContainedScopeHoldingFocus_When_FocusIsClearedToNothing_Then_TheScopeRegainsFocusOnTheNextTick()
+        {
+            // Arrange
+            Mount(ContainedScopeHost);
+            var in1 = Q("in1");
+            in1.Focus();
+            Assume.That(_host.Panel.focusController.focusedElement, Is.EqualTo(in1),
+                "Precondition: the scope holds focus");
+
+            // Act — a press on empty non-focusable space clears focus to NOTHING: no FocusIn ever
+            // fires for the snap-back to ride, only a FocusOut with no destination, so the
+            // containment re-focus rides the panel's next scheduler tick instead.
+            in1.Blur();
+            Assume.That(_host.Panel.focusController.focusedElement, Is.Null,
+                "Precondition: focus was cleared to nothing");
+            EditorPanelTestHelpers.DriveSchedulerOnce(_host.Panel);
+
+            // Assert
+            Assert.That(_host.Panel.focusController.focusedElement, Is.EqualTo(in1));
+        }
+
+        [Component]
+        private static VNode ReorderedAutoFocusHost()
+        {
+            var (rotated, setRotated) = Hooks.UseState(false);
+            s_setRotated = setRotated;
+            var scope = V.FocusScope(name: "scope", key: "scope", autoFocus: true, children: new VNode[]
+            {
+                V.Button(name: "first"),
+            });
+            var b1 = V.Button(name: "b1", key: "b1");
+            var b2 = V.Button(name: "b2", key: "b2");
+            return V.Div(children: rotated ? new VNode[] { b1, b2, scope } : new VNode[] { scope, b1, b2 });
+        }
+
+        [Test]
+        public void Given_AnAutoFocusScopeInAKeyedList_When_AReorderReattachesTheScope_Then_FocusStaysWhereTheUserMovedIt()
+        {
+            // Arrange — AutoFocus fired once at mount; the user then moved focus outside the scope.
+            Mount(ReorderedAutoFocusHost);
+            Assume.That(_host.Panel.focusController.focusedElement, Is.EqualTo(Q("first")),
+                "Precondition: AutoFocus landed on the scope's first focusable at mount");
+            var b1 = Q("b1");
+            b1.Focus();
+
+            // Act — the keyed rotation physically moves the scope subtree (RemoveAt + Insert), firing
+            // a fresh AttachToPanelEvent on it.
+            s_setRotated.Invoke(true);
+            _mounted.FlushStateForTest();
+
+            // Assert — autoFocus is mount-once: a re-attach must not steal focus back.
+            Assert.That(_host.Panel.focusController.focusedElement, Is.EqualTo(b1));
+        }
+
+        [Component]
+        private static VNode TwoGroupsHost() => V.Div(children: new VNode[]
+        {
+            V.FocusScope(name: "groupA", singleTabStop: true, children: new VNode[]
+            {
+                V.Button(name: "a1"),
+                V.Button(name: "a2"),
+            }),
+            V.FocusScope(name: "groupB", singleTabStop: true, children: new VNode[]
+            {
+                V.Button(name: "b1"),
+                V.Button(name: "b2"),
+            }),
+        });
+
+        [Test]
+        public void Given_TwoAdjacentSingleTabStopGroups_When_TabExitsTheFirstIntoTheSecond_Then_FocusLandsOnTheSecondGroupsRememberedMember()
+        {
+            // Arrange — groupB remembers b2 as its roving tab stop; focus then sits in groupA.
+            Mount(TwoGroupsHost);
+            Q("b2").Focus();
+            var a1 = Q("a1");
+            a1.Focus();
+            Assume.That(_host.Panel.focusController.focusedElement, Is.EqualTo(a1),
+                "Precondition: a member of the first group holds focus");
+
+            // Act — the exit walk's raw landing crosses straight into groupB (its first member).
+            SendMove(a1, NavigationMoveEvent.Direction.Next);
+
+            // Assert — entry respects the roving contract even for a redirected landing: the
+            // remembered member wins, and groupB's memory is not corrupted to the raw candidate.
+            Assert.That(_host.Panel.focusController.focusedElement, Is.EqualTo(Q("b2")));
+        }
+
+        [Test]
+        public void Given_AFreshSingleTabStopGroup_When_ShiftTabEntersFromAfterIt_Then_FocusLandsOnTheGroupsFirstMember()
+        {
+            // Arrange
+            Mount(SingleTabStopHost);
+            var after = Q("after");
+            after.Focus();
+            Assume.That(_host.Panel.focusController.focusedElement, Is.EqualTo(after),
+                "Precondition: focus sits after the group");
+
+            // Act
+            SendMove(after, NavigationMoveEvent.Direction.Previous);
+
+            // Assert — the composite is one tab stop from either direction: with no remembered member
+            // the entry is the group's FIRST member, never its ring-last.
+            Assert.That(_host.Panel.focusController.focusedElement, Is.EqualTo(Q("g1")));
+        }
+
+        [Component]
+        private static VNode GroupInModalHost() => V.Div(children: new VNode[]
+        {
+            V.FocusScope(name: "modal", contain: true, children: new VNode[]
+            {
+                V.Button(name: "m1"),
+                V.FocusScope(name: "group", singleTabStop: true, children: new VNode[]
+                {
+                    V.Button(name: "g1"),
+                    V.Button(name: "g2"),
+                }),
+            }),
+            V.Button(name: "outside"),
+        });
+
+        [Test]
+        public void Given_ASingleTabStopGroupInsideAContainedScope_When_TabExitsTheGroup_Then_FocusWrapsWithinTheContainedScope()
+        {
+            // Arrange
+            Mount(GroupInModalHost);
+            var g1 = Q("g1");
+            g1.Focus();
+            Assume.That(_host.Panel.focusController.focusedElement, Is.EqualTo(g1),
+                "Precondition: a group member holds focus");
+
+            // Act — the group's one-stop exit must honor the enclosing modal's containment: the exit
+            // walk rides the modal's ring, wrapping to m1 instead of escaping to "outside".
+            SendMove(g1, NavigationMoveEvent.Direction.Next);
+
+            // Assert
+            Assert.That(_host.Panel.focusController.focusedElement, Is.EqualTo(Q("m1")));
+        }
+
+        [Component]
+        private static VNode DepartingRestoreTargetHost()
+        {
+            var (showOpener, setShowOpener) = Hooks.UseState(true);
+            s_setShowOpener = setShowOpener;
+            return V.Div(children: new VNode[]
+            {
+                showOpener ? V.Button(name: "opener", key: "opener") : null,
+                V.FocusScope(name: "scope", key: "scope", restoreFocus: true, children: new VNode[]
+                {
+                    V.Button(name: "inner"),
+                }),
+            });
+        }
+
+        [Test]
+        public void Given_AScopeWhoseRestoreTargetUnmounts_When_TheTargetsElementIsReleased_Then_TheScopeDropsItsRestoreReference()
+        {
+            // Arrange — focus enters the scope FROM the opener, capturing it as the restore target.
+            Mount(DepartingRestoreTargetHost);
+            Q("opener").Focus();
+            Q("inner").Focus();
+            var binding = _mounted.Root.Reconciler.Context.FocusScopeBindings[Q("scope")];
+            Assume.That(binding.RestoreTarget, Is.Not.Null,
+                "Precondition: the opener was captured as the restore target");
+
+            // Act — the opener unmounts; its pooled element will be recycled into an unrelated role,
+            // where the liveness checks at restore time (panel / canGrabFocus) pass again.
+            s_setShowOpener.Invoke(false);
+            _mounted.FlushStateForTest();
+
+            // Assert
+            Assert.That(binding.RestoreTarget, Is.Null);
+        }
+
+        [Component]
+        private static VNode PlainScopeHost() => V.Div(children: new VNode[]
+        {
+            V.FocusScope(name: "scope", contain: true, children: new VNode[]
+            {
+                V.Button(name: "s1"),
+            }),
+        });
+
+        [Test]
+        public void Given_AMountIntoADetachedRoot_When_TheRootAttachesToAPanel_Then_TheNavigatorListensOnTheTruePanelRootExactlyOnce()
+        {
+            // Arrange — mounting before the root has a panel: ring predictions computed from a
+            // non-root subtree would diverge from the engine's own panel-wide ring.
+            var detachedRoot = new VisualElement();
+            _mounted = V.Mount(detachedRoot, V.Component(PlainScopeHost, key: "root"));
+
+            // Act
+            _host.Root.Add(detachedRoot);
+            EditorPanelTestHelpers.ForcePanelUpdate(_host.Panel);
+
+            // Assert — one attachment, keyed by the panel's true root, never the mount target.
+            Assert.That(_mounted.Root.Reconciler.Context.NavigatorAttachments.Keys,
+                Is.EquivalentTo(new[] { _host.Panel.visualTree }));
+        }
+
+        [Test]
+        public void Given_APooledPropsBagThatCarriedFocusProps_When_ReturnedAndRentedAgain_Then_TheFocusPropsAreScrubbed()
+        {
+            // Arrange
+            var props = VNodePool.RentProps();
+            props.TabIndex = 3;
+            props.DelegatesFocus = true;
+            props.FocusScope = new FocusScopeSettings(Contain: true);
+
+            // Act
+            VNodePool.ReturnProps(props);
+            var reused = VNodePool.RentProps();
+
+            // Assert — a recycled bag must not ghost focus behavior onto an unrelated element.
+            Assert.That((reused.TabIndex, reused.DelegatesFocus, reused.FocusScope),
+                Is.EqualTo(((int?)null, (bool?)null, (FocusScopeSettings)null)));
         }
 
         [Test]

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/FocusScopeTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/FocusScopeTests.cs
@@ -1,0 +1,218 @@
+using NUnit.Framework;
+using UnityEngine.UIElements;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Specifies the focus-scope layer's sequential semantics on a real (headless) editor panel — the editor
+    /// focus ring maps NavigationMoveEvent Next/Previous exactly like the runtime ring's own sequential
+    /// delegate, so Tab-shaped moves dispatch deterministically here via SendEvent: containment wraps within
+    /// the scope, RestoreFocus returns focus where it came from on unmount, AutoFocus lands on the first
+    /// focusable descendant at attach, and SingleTabStop makes a whole subtree one Tab stop (exit skips the
+    /// remaining members; re-entry lands on the member last used).
+    /// </summary>
+    internal sealed class FocusScopeTests
+    {
+        private HeadlessEditorPanelHost _host;
+        private MountedTree _mounted;
+
+        private static StateUpdater<bool> s_setShowScope;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _host = new HeadlessEditorPanelHost();
+            s_setShowScope = default;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _mounted?.Dispose();
+            _mounted = null;
+            _host?.Dispose();
+            _host = null;
+        }
+
+        private VisualElement Q(string name) => _host.Root.Q<VisualElement>(name);
+
+        // Focus-ring membership requires every element's resolved display state, which batchmode never
+        // computes on its own — the same forced style pass resolvedStyle-reading fixtures already use.
+        private void Mount(System.Func<VNode> body)
+        {
+            _mounted = V.Mount(_host.Root, V.Component(body, key: "root"));
+            EditorPanelTestHelpers.ForcePanelUpdate(_host.Panel);
+        }
+
+        private void SendMove(VisualElement target, NavigationMoveEvent.Direction direction)
+        {
+            using var move = NavigationMoveEvent.GetPooled(direction);
+            move.target = target;
+            target.SendEvent(move);
+        }
+
+        [Component]
+        private static VNode ContainedScopeHost() => V.Div(children: new VNode[]
+        {
+            V.FocusScope(name: "scope", contain: true, children: new VNode[]
+            {
+                V.Button(name: "in1"),
+                V.Button(name: "in2"),
+            }),
+            V.Button(name: "outside"),
+        });
+
+        [Test]
+        public void Given_AContainedFocusScope_When_TabDispatchesFromItsLastFocusable_Then_FocusWrapsToTheScopesFirstFocusable()
+        {
+            // Arrange
+            Mount(ContainedScopeHost);
+            var in2 = Q("in2");
+            in2.Focus();
+            Assume.That(_host.Panel.focusController.focusedElement, Is.EqualTo(in2),
+                "Precondition: the scope's last focusable holds focus");
+
+            // Act
+            SendMove(in2, NavigationMoveEvent.Direction.Next);
+
+            // Assert — without containment the move would land on "outside"; the scoped ring wraps instead.
+            Assert.That(_host.Panel.focusController.focusedElement, Is.EqualTo(Q("in1")));
+        }
+
+        [Component]
+        private static VNode RestoreScopeHost()
+        {
+            var (showScope, setShowScope) = Hooks.UseState(true);
+            s_setShowScope = setShowScope;
+            return V.Div(children: new VNode[]
+            {
+                V.Button(name: "opener"),
+                showScope
+                    ? V.FocusScope(name: "scope", key: "scope", restoreFocus: true, children: new VNode[]
+                    {
+                        V.Button(name: "inner"),
+                    })
+                    : null,
+            });
+        }
+
+        [Test]
+        public void Given_AFocusScopeWithRestoreFocus_When_TheScopeUnmountsWhileHoldingFocus_Then_TheElementFocusCameFromRegainsFocus()
+        {
+            // Arrange — focus enters the scope FROM the opener (the navigator's FocusIn bookkeeping
+            // captures the opener as the restore target on that first entry).
+            Mount(RestoreScopeHost);
+            var opener = Q("opener");
+            opener.Focus();
+            Q("inner").Focus();
+            Assume.That(_host.Panel.focusController.focusedElement, Is.EqualTo(Q("inner")),
+                "Precondition: focus sits inside the scope");
+
+            // Act
+            s_setShowScope.Invoke(false);
+            _mounted.FlushStateForTest();
+
+            // Assert
+            Assert.That(_host.Panel.focusController.focusedElement, Is.EqualTo(opener));
+        }
+
+        [Component]
+        private static VNode AutoFocusScopeHost() => V.Div(children: new VNode[]
+        {
+            V.FocusScope(name: "scope", autoFocus: true, children: new VNode[]
+            {
+                V.Button(name: "first"),
+                V.Button(name: "second"),
+            }),
+        });
+
+        [Test]
+        public void Given_AFocusScopeWithAutoFocus_When_ItAttachesToAPanel_Then_ItsFirstFocusableDescendantHoldsFocus()
+        {
+            // Arrange & Act
+            Mount(AutoFocusScopeHost);
+
+            // Assert
+            Assert.That(_host.Panel.focusController.focusedElement, Is.EqualTo(Q("first")));
+        }
+
+        [Component]
+        private static VNode SingleTabStopHost() => V.Div(children: new VNode[]
+        {
+            V.Button(name: "before"),
+            V.FocusScope(name: "group", singleTabStop: true, children: new VNode[]
+            {
+                V.Button(name: "g1"),
+                V.Button(name: "g2"),
+                V.Button(name: "g3"),
+            }),
+            V.Button(name: "after"),
+        });
+
+        [Test]
+        public void Given_ASingleTabStopScopeWithAFocusedMember_When_TabDispatches_Then_FocusSkipsPastTheRemainingMembers()
+        {
+            // Arrange
+            Mount(SingleTabStopHost);
+            var g1 = Q("g1");
+            g1.Focus();
+            Assume.That(_host.Panel.focusController.focusedElement, Is.EqualTo(g1),
+                "Precondition: a group member holds focus");
+
+            // Act
+            SendMove(g1, NavigationMoveEvent.Direction.Next);
+
+            // Assert — the whole group is one Tab stop: g2/g3 are skipped.
+            Assert.That(_host.Panel.focusController.focusedElement, Is.EqualTo(Q("after")));
+        }
+
+        [Test]
+        public void Given_ASingleTabStopScopeLastLeftFromItsSecondMember_When_TabEntersFromOutside_Then_TheSecondMemberRegainsFocus()
+        {
+            // Arrange — g2 held focus once (recording it as the group's roving tab stop), then focus moved
+            // outside the group.
+            Mount(SingleTabStopHost);
+            Q("g2").Focus();
+            var before = Q("before");
+            before.Focus();
+            Assume.That(_host.Panel.focusController.focusedElement, Is.EqualTo(before),
+                "Precondition: focus sits outside the group");
+
+            // Act
+            SendMove(before, NavigationMoveEvent.Direction.Next);
+
+            // Assert — entry lands on the remembered member, not the group's first.
+            Assert.That(_host.Panel.focusController.focusedElement, Is.EqualTo(Q("g2")));
+        }
+
+        [Test]
+        public void Given_APooledElementThatCarriedATabIndex_When_ResetForThePool_Then_ItsTabIndexIsZero()
+        {
+            // Arrange
+            var element = new VisualElement { tabIndex = 5, delegatesFocus = true };
+
+            // Act
+            FiberElementPoolReset.ResetCommonState(element);
+
+            // Assert
+            Assert.That((element.tabIndex, element.delegatesFocus), Is.EqualTo((0, false)));
+        }
+
+        [Test]
+        public void Given_AButtonRecycledThroughThePool_When_RentedAgain_Then_ItIsFocusableLikeAFreshOne()
+        {
+            // Arrange — the pool's common reset scrubs focusable to the plain-VisualElement default (false),
+            // which is NOT a Button's own constructor default: without the type-specific restore, a recycled
+            // button silently drops out of Tab/gamepad navigation.
+            var button = VNodePool.RentButton();
+
+            // Act
+            VNodePool.ReturnButton(button);
+            var reused = VNodePool.RentButton();
+
+            // Assert
+            Assert.That(reused.focusable, Is.True);
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/FocusScopeTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/FocusScopeTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7c5e67ad964c94dee83f3d2024a6b229

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/FocusChainedPortalTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/FocusChainedPortalTests.cs
@@ -20,6 +20,7 @@ namespace Velvet.Tests
     internal sealed class FocusChainedPortalTests
     {
         private static PanelFocusOrder s_focusOrder;
+        private static StateUpdater<bool> s_setShowFirstPortal;
 
         private GameObject _panelGo;
         private PanelSettings _settings;
@@ -40,6 +41,7 @@ namespace Velvet.Tests
         public IEnumerator UnitySetUp()
         {
             s_focusOrder = PanelFocusOrder.Isolated;
+            s_setShowFirstPortal = default;
             _panelGo = new GameObject("ChainedPortalPanel");
             var doc = _panelGo.AddComponent<UIDocument>();
             _settings = ScriptableObject.CreateInstance<PanelSettings>();
@@ -146,6 +148,95 @@ namespace Velvet.Tests
             // Assert — the host's own ring wraps internally.
             var p1 = HostElement("p1");
             Assert.That(p1.panel.focusController.focusedElement, Is.EqualTo(p1));
+        }
+
+        [Component]
+        private static VNode StsPortalHost() => V.Div(children: new VNode[]
+        {
+            V.Button(name: "main1"),
+            V.Portal(UILayer.Overlay, key: "portal", focusOrder: PanelFocusOrder.Chained, children: new VNode[]
+            {
+                V.FocusScope(name: "group", singleTabStop: true, children: new VNode[]
+                {
+                    V.Button(name: "p1"),
+                    V.Button(name: "p2"),
+                }),
+            }),
+        });
+
+        [UnityTest]
+        public IEnumerator Given_AChainedHostWhoseContentIsOneSingleTabStopGroup_When_TabDispatchesFromAMember_Then_FocusEscapesToTheDeclaringPanel()
+        {
+            // Arrange — the natural gamepad case: a portal'd roving toolbar. The group's one-stop exit
+            // finds no candidate inside the host, so it must fall through to the chained boundary
+            // escape rather than letting the engine cycle the group's own members.
+            _mounted = V.Mount(_panelGo.GetComponent<UIDocument>().rootVisualElement,
+                V.Component(StsPortalHost, key: "root"));
+            yield return null;
+            yield return null;
+            var p1 = HostElement("p1");
+            p1.Focus();
+            Assume.That(p1.panel.focusController.focusedElement, Is.EqualTo(p1),
+                "Precondition: a group member holds focus");
+
+            // Act
+            SendMove(p1, NavigationMoveEvent.Direction.Next);
+            yield return null;
+            yield return null;
+            yield return null;
+
+            // Assert
+            var main1 = Main("main1");
+            Assert.That(main1.panel.focusController.focusedElement, Is.EqualTo(main1));
+        }
+
+        [Component]
+        private static VNode TwoChainedPortalsHost()
+        {
+            var (showFirst, setShowFirst) = Hooks.UseState(true);
+            s_setShowFirstPortal = setShowFirst;
+            return V.Div(children: new VNode[]
+            {
+                V.Button(name: "main1"),
+                showFirst
+                    ? V.Portal(UILayer.Overlay, key: "portalA", focusOrder: PanelFocusOrder.Chained, children: new VNode[]
+                    {
+                        V.Button(name: "a1"),
+                    })
+                    : null,
+                V.Portal(UILayer.Overlay, key: "portalB", focusOrder: PanelFocusOrder.Chained, children: new VNode[]
+                {
+                    V.Button(name: "b1"),
+                }),
+            });
+        }
+
+        [UnityTest]
+        public IEnumerator Given_TwoChainedPortalsSharingALayerHost_When_TheOwningPortalUnmounts_Then_TheSurvivorStillEscapesAtTheHostRingEdge()
+        {
+            // Arrange — portalA mounted first and owns the host's ring-edge escape; unmounting it must
+            // hand the escape to portalB, or the surviving chained portal silently loses its exit.
+            _mounted = V.Mount(_panelGo.GetComponent<UIDocument>().rootVisualElement,
+                V.Component(TwoChainedPortalsHost, key: "root"));
+            yield return null;
+            yield return null;
+            s_setShowFirstPortal.Invoke(false);
+            yield return null;
+            yield return null;
+            var b1 = HostElement("b1");
+            b1.Focus();
+            Assume.That(b1.panel.focusController.focusedElement, Is.EqualTo(b1),
+                "Precondition: the surviving portal's member holds focus");
+
+            // Act
+            SendMove(b1, NavigationMoveEvent.Direction.Next);
+            yield return null;
+            yield return null;
+            yield return null;
+
+            // Assert
+            var main1 = Main("main1");
+            Assert.That(main1.panel.focusController.focusedElement, Is.EqualTo(main1));
         }
 
         [UnityTest]

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/FocusChainedPortalTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/FocusChainedPortalTests.cs
@@ -1,0 +1,176 @@
+#if UNITY_EDITOR
+using System.Collections;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using UnityEngine.UIElements;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Specifies <c>PanelFocusOrder</c> on <c>V.Portal(layer:)</c> against real runtime panels:
+    /// <c>Chained</c> joins the declaring panel's Tab order at the portal's call site (Tab past the host
+    /// ring's last element exits to the declaring panel; Tab reaching the placeholder enters the host at its
+    /// ring-first), <c>Isolated</c> (the default) keeps the pre-existing internal wrap — the explicit-opt-in
+    /// ruling of the cross-panel navigation decision, pinned here as a regression guard — and only
+    /// <c>NavigationMoveEvent</c> is ever intercepted (a KeyDown reaching an element in a chained host is
+    /// untouched, the two-event gotcha).
+    /// </summary>
+    internal sealed class FocusChainedPortalTests
+    {
+        private static PanelFocusOrder s_focusOrder;
+
+        private GameObject _panelGo;
+        private PanelSettings _settings;
+        private MountedTree _mounted;
+
+        [Component]
+        private static VNode PortalHost() => V.Div(children: new VNode[]
+        {
+            V.Button(name: "main1"),
+            V.Portal(UILayer.Overlay, key: "portal", focusOrder: s_focusOrder, children: new VNode[]
+            {
+                V.Button(name: "p1"),
+                V.Button(name: "p2"),
+            }),
+        });
+
+        [UnitySetUp]
+        public IEnumerator UnitySetUp()
+        {
+            s_focusOrder = PanelFocusOrder.Isolated;
+            _panelGo = new GameObject("ChainedPortalPanel");
+            var doc = _panelGo.AddComponent<UIDocument>();
+            _settings = ScriptableObject.CreateInstance<PanelSettings>();
+            _settings.scaleMode = PanelScaleMode.ConstantPixelSize;
+            doc.panelSettings = _settings;
+            yield return null;
+        }
+
+        [UnityTearDown]
+        public IEnumerator UnityTearDown()
+        {
+            _mounted?.Dispose();
+            _mounted = null;
+            if (_panelGo != null) Object.Destroy(_panelGo);
+            if (_settings != null) Object.Destroy(_settings);
+            yield return null;
+        }
+
+        // Mounts under the CURRENT s_focusOrder and waits out the portal drain plus both panels' first
+        // style passes (focus-ring membership needs resolved display state on each panel).
+        private IEnumerator Mount()
+        {
+            _mounted = V.Mount(_panelGo.GetComponent<UIDocument>().rootVisualElement, V.Component(PortalHost, key: "root"));
+            yield return null;
+            yield return null;
+        }
+
+        // Resolved from THIS mount's own bookkeeping, never a scene-wide UIDocument scan: a previous test's
+        // host panel lingers as a destroy-pending object within the same frame, and a global scan can hand
+        // back the stale twin of the element under test.
+        private VisualElement Main(string name)
+            => _panelGo.GetComponent<UIDocument>().rootVisualElement.Q<VisualElement>(name);
+
+        private VisualElement HostElement(string name)
+            => _mounted.Root.Reconciler.Context.LayerHosts[UILayer.Overlay].Document.rootVisualElement.Q<VisualElement>(name);
+
+        private static void SendMove(VisualElement target, NavigationMoveEvent.Direction direction)
+        {
+            using var move = NavigationMoveEvent.GetPooled(direction);
+            move.target = target;
+            target.SendEvent(move);
+        }
+
+        [UnityTest]
+        public IEnumerator Given_AChainedLayerPortal_When_TabDispatchesFromTheHostRingsLastFocusable_Then_FocusLandsOnTheDeclaringPanelElementAfterThePlaceholder()
+        {
+            // Arrange
+            s_focusOrder = PanelFocusOrder.Chained;
+            yield return Mount();
+            var p2 = HostElement("p2");
+            Assume.That(p2, Is.Not.Null, "Precondition: the portal children mounted in the host panel");
+            p2.Focus();
+            Assume.That(p2.panel.focusController.focusedElement, Is.EqualTo(p2),
+                "Precondition: the host ring's last focusable holds focus");
+
+            // Act — the escape's cross-panel Focus lands on the target panel's next scheduler tick (see
+            // FiberFocusNavigator's own note on why it cannot be synchronous), so wait a few frames.
+            SendMove(p2, NavigationMoveEvent.Direction.Next);
+            yield return null;
+            yield return null;
+            yield return null;
+
+            // Assert — the declaring panel's ring past the placeholder wraps to main1 (the only other
+            // focusable there), instead of the host wrapping internally to p1.
+            var main1 = Main("main1");
+            Assert.That(main1.panel.focusController.focusedElement, Is.EqualTo(main1));
+        }
+
+        [UnityTest]
+        public IEnumerator Given_AChainedLayerPortal_When_TabReachesThePlaceholder_Then_FocusEntersTheHostAtItsRingFirst()
+        {
+            // Arrange
+            s_focusOrder = PanelFocusOrder.Chained;
+            yield return Mount();
+            var main1 = Main("main1");
+            main1.Focus();
+            Assume.That(main1.panel.focusController.focusedElement, Is.EqualTo(main1),
+                "Precondition: the declaring panel's element holds focus");
+
+            // Act — the engine's own move lands on the proxy placeholder; the FocusIn forwarding hands
+            // focus into the host panel.
+            SendMove(main1, NavigationMoveEvent.Direction.Next);
+            yield return null;
+
+            // Assert
+            var p1 = HostElement("p1");
+            Assert.That(p1.panel.focusController.focusedElement, Is.EqualTo(p1));
+        }
+
+        [UnityTest]
+        public IEnumerator Given_AnIsolatedLayerPortal_When_TabDispatchesFromTheHostRingsLastFocusable_Then_FocusWrapsWithinTheHostPanel()
+        {
+            // Arrange — the default: no opt-in, the #54-adjacent status quo stays byte-for-byte.
+            s_focusOrder = PanelFocusOrder.Isolated;
+            yield return Mount();
+            var p2 = HostElement("p2");
+            Assume.That(p2, Is.Not.Null, "Precondition: the portal children mounted in the host panel");
+            p2.Focus();
+
+            // Act
+            SendMove(p2, NavigationMoveEvent.Direction.Next);
+            yield return null;
+
+            // Assert — the host's own ring wraps internally.
+            var p1 = HostElement("p1");
+            Assert.That(p1.panel.focusController.focusedElement, Is.EqualTo(p1));
+        }
+
+        [UnityTest]
+        public IEnumerator Given_AChainedLayerPortal_When_AKeyDownDispatchesInsideTheHost_Then_ItStillReachesItsHandler()
+        {
+            // Arrange — only NavigationMoveEvent is intercepted; the co-arriving KeyDownEvent of a real Tab
+            // press must stay untouched for user handlers and the cross-panel KeyDown bridge.
+            s_focusOrder = PanelFocusOrder.Chained;
+            yield return Mount();
+            var p2 = HostElement("p2");
+            var received = 0;
+            p2.RegisterCallback<KeyDownEvent>(_ => received++);
+            p2.Focus();
+
+            // Act
+            using (var key = KeyDownEvent.GetPooled('\t', KeyCode.Tab, EventModifiers.None))
+            {
+                key.target = p2;
+                p2.SendEvent(key);
+            }
+            yield return null;
+
+            // Assert
+            Assert.That(received, Is.EqualTo(1));
+        }
+    }
+}
+#endif

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/FocusChainedPortalTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/FocusChainedPortalTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3c160be7ec6ff492bae277f71794d0ef

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/FocusNavigationInterceptionTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/FocusNavigationInterceptionTests.cs
@@ -1,0 +1,144 @@
+#if UNITY_EDITOR
+using System.Collections;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using UnityEngine.UIElements;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins the engine contract Velvet's focus-navigation layer is built on, against a REAL runtime panel's
+    /// own <c>FocusController</c>/<c>NavigateFocusRing</c>: a <c>NavigationMoveEvent</c>'s default focus move
+    /// runs in the event's post-dispatch step (after every listener), so a <c>TrickleDown</c> listener on the
+    /// panel root ALWAYS runs first — and the ONLY suppression that step respects is
+    /// <c>FocusController.IgnoreEvent</c> (its guard is the event's processed-by-focus-controller flag;
+    /// <c>StopPropagation</c> alone is invisible to it). If a Unity upgrade breaks either half, scoped focus
+    /// containment and cross-panel focus escape both lose their footing — these tests are the tripwire.
+    /// </summary>
+    internal sealed class FocusNavigationInterceptionTests
+    {
+        private GameObject _panelGo;
+        private PanelSettings _settings;
+        private Button _first;
+        private Button _second;
+
+        [UnitySetUp]
+        public IEnumerator UnitySetUp()
+        {
+            _panelGo = new GameObject("FocusInterceptionPanel");
+            var doc = _panelGo.AddComponent<UIDocument>();
+            _settings = ScriptableObject.CreateInstance<PanelSettings>();
+            _settings.scaleMode = PanelScaleMode.ConstantPixelSize;
+            doc.panelSettings = _settings;
+            yield return null;
+
+            _first = new Button { name = "first", text = "first" };
+            _second = new Button { name = "second", text = "second" };
+            doc.rootVisualElement.Add(_first);
+            doc.rootVisualElement.Add(_second);
+            yield return null;
+
+            _first.Focus();
+            yield return null;
+        }
+
+        [UnityTearDown]
+        public IEnumerator UnityTearDown()
+        {
+            if (_panelGo != null) Object.Destroy(_panelGo);
+            if (_settings != null) Object.Destroy(_settings);
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator Given_AFocusedElementOnARuntimePanel_When_ANavigationMoveEventDispatches_Then_TheDefaultFocusRingMovesFocus()
+        {
+            // Arrange
+            var panel = _first.panel;
+            Assume.That(panel.focusController.focusedElement, Is.EqualTo(_first),
+                "Precondition: the first button holds focus");
+
+            // Act — a real dispatch through the panel's own event pipeline (SendEvent runs the full
+            // pre-dispatch → propagation → post-dispatch sequence, unlike a bare callback-registry poke).
+            using (var move = NavigationMoveEvent.GetPooled(NavigationMoveEvent.Direction.Next))
+            {
+                move.target = _first;
+                _first.SendEvent(move);
+            }
+            yield return null;
+
+            // Assert — the control case: with no interception, the runtime focus ring advanced focus.
+            Assert.That(panel.focusController.focusedElement, Is.EqualTo(_second));
+        }
+
+        [UnityTest]
+        public IEnumerator Given_ATrickleDownRootListenerCallingIgnoreEvent_When_ANavigationMoveEventDispatches_Then_TheDefaultFocusMoveIsSuppressed()
+        {
+            // Arrange — the interception pattern under test: a TrickleDown listener on the panel ROOT marks
+            // the event as already-processed for the focus controller, then stops propagation.
+            var panel = _first.panel;
+            Assume.That(panel.focusController.focusedElement, Is.EqualTo(_first),
+                "Precondition: the first button holds focus");
+            var root = panel.visualTree;
+            EventCallback<NavigationMoveEvent> interceptor = evt =>
+            {
+                panel.focusController.IgnoreEvent(evt);
+                evt.StopPropagation();
+            };
+            root.RegisterCallback(interceptor, TrickleDown.TrickleDown);
+
+            // Act
+            try
+            {
+                using (var move = NavigationMoveEvent.GetPooled(NavigationMoveEvent.Direction.Next))
+                {
+                    move.target = _first;
+                    _first.SendEvent(move);
+                }
+                yield return null;
+            }
+            finally
+            {
+                root.UnregisterCallback(interceptor, TrickleDown.TrickleDown);
+            }
+
+            // Assert — focus never moved: the trickle-down listener genuinely preempted the default action
+            // rather than racing it.
+            Assert.That(panel.focusController.focusedElement, Is.EqualTo(_first));
+        }
+
+        [UnityTest]
+        public IEnumerator Given_ATrickleDownRootListenerCallingOnlyStopPropagation_When_ANavigationMoveEventDispatches_Then_TheDefaultFocusMoveStillRuns()
+        {
+            // Arrange — the negative contract: StopPropagation alone silences other listeners but the
+            // post-dispatch focus move ignores it (its only guard is the processed-by-focus-controller flag),
+            // so an interceptor that forgets IgnoreEvent does NOT actually contain focus.
+            var panel = _first.panel;
+            Assume.That(panel.focusController.focusedElement, Is.EqualTo(_first),
+                "Precondition: the first button holds focus");
+            var root = panel.visualTree;
+            EventCallback<NavigationMoveEvent> interceptor = evt => evt.StopPropagation();
+            root.RegisterCallback(interceptor, TrickleDown.TrickleDown);
+
+            // Act
+            try
+            {
+                using (var move = NavigationMoveEvent.GetPooled(NavigationMoveEvent.Direction.Next))
+                {
+                    move.target = _first;
+                    _first.SendEvent(move);
+                }
+                yield return null;
+            }
+            finally
+            {
+                root.UnregisterCallback(interceptor, TrickleDown.TrickleDown);
+            }
+
+            // Assert
+            Assert.That(panel.focusController.focusedElement, Is.EqualTo(_second));
+        }
+    }
+}
+#endif

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/FocusNavigationInterceptionTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/FocusNavigationInterceptionTests.cs
@@ -109,6 +109,48 @@ namespace Velvet.Tests
         }
 
         [UnityTest]
+        public IEnumerator Given_AFocusInHandlerFocusingAnotherElement_When_TheHandlersElementGainsFocus_Then_TheNestedFocusWins()
+        {
+            // Arrange — the engine's pending-focus gate: a Focus() call made from inside a FocusIn handler
+            // starts a new pending switch whose result wins. Scope snap-back and chained-placeholder
+            // forwarding both stand on this, so it gets its own tripwire.
+            var third = new Button { name = "third", text = "third" };
+            _first.panel.visualTree.Add(third);
+            _second.RegisterCallback<FocusInEvent>(_ => third.Focus());
+
+            // Act
+            _second.Focus();
+            yield return null;
+
+            // Assert
+            Assert.That(_first.panel.focusController.focusedElement, Is.EqualTo(third));
+        }
+
+        [UnityTest]
+        public IEnumerator Given_AVelvetConstructedFocusRing_When_TheEngineExecutesASequentialMove_Then_BothAgreeOnTheTarget()
+        {
+            // Arrange — sequential prediction rides a Velvet-built VisualElementFocusRing over the panel
+            // root; the runtime ring delegates its own Next/Previous to exactly that class, and this pins
+            // the agreement so an engine change to the delegation shows up as a red test, not a drift.
+            var panel = _first.panel;
+            Assume.That(panel.focusController.focusedElement, Is.EqualTo(_first),
+                "Precondition: the first button holds focus");
+            var predicted = new VisualElementFocusRing(panel.visualTree)
+                .GetNextFocusable(_first, VisualElementFocusChangeDirection.right);
+
+            // Act
+            using (var move = NavigationMoveEvent.GetPooled(NavigationMoveEvent.Direction.Next))
+            {
+                move.target = _first;
+                _first.SendEvent(move);
+            }
+            yield return null;
+
+            // Assert
+            Assert.That(panel.focusController.focusedElement, Is.EqualTo(predicted));
+        }
+
+        [UnityTest]
         public IEnumerator Given_ATrickleDownRootListenerCallingOnlyStopPropagation_When_ANavigationMoveEventDispatches_Then_TheDefaultFocusMoveStillRuns()
         {
             // Arrange — the negative contract: StopPropagation alone silences other listeners but the

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/FocusNavigationInterceptionTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/FocusNavigationInterceptionTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 99dac1c4769de4640ab38f1fcffa7072

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/FocusScopePlaybackTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/FocusScopePlaybackTests.cs
@@ -1,0 +1,86 @@
+#if UNITY_EDITOR
+using System.Collections;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.TestTools;
+using UnityEngine.UIElements;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins the containment path the sequential interception cannot cover, on a real runtime panel with real
+    /// layout: a spatial (2D) move that exits a contained scope is snapped back inside within the same event
+    /// flush — Velvet never predicts or reimplements the engine's 2D navigation, it observes the exit through
+    /// FocusIn and corrects it on the engine's own pending-focus gate.
+    /// </summary>
+    internal sealed class FocusScopePlaybackTests
+    {
+        private GameObject _panelGo;
+        private PanelSettings _settings;
+        private MountedTree _mounted;
+
+        [Component]
+        private static VNode ContainedColumnHost() => V.Div(className: "flex-col", children: new VNode[]
+        {
+            V.FocusScope(name: "scope", contain: true, children: new VNode[]
+            {
+                V.Button(name: "inside", className: "w-[100px] h-[40px]"),
+            }),
+            V.Button(name: "below", className: "w-[100px] h-[40px]"),
+        });
+
+        [UnitySetUp]
+        public IEnumerator UnitySetUp()
+        {
+            _panelGo = new GameObject("FocusScopePlaybackPanel");
+            var doc = _panelGo.AddComponent<UIDocument>();
+            _settings = ScriptableObject.CreateInstance<PanelSettings>();
+            _settings.scaleMode = PanelScaleMode.ConstantPixelSize;
+            doc.panelSettings = _settings;
+            yield return null;
+            var sheet = AssetDatabase.LoadAssetAtPath<StyleSheet>(
+                "Packages/com.velvet.core/Runtime/Styles/StyleUtilities.uss");
+            Assume.That(sheet, Is.Not.Null, "Precondition: the bundled StyleUtilities.uss loads");
+            doc.rootVisualElement.styleSheets.Add(sheet);
+            _mounted = V.Mount(doc.rootVisualElement, V.Component(ContainedColumnHost, key: "root"));
+            yield return null;
+            yield return null;
+        }
+
+        [UnityTearDown]
+        public IEnumerator UnityTearDown()
+        {
+            _mounted?.Dispose();
+            _mounted = null;
+            if (_panelGo != null) Object.Destroy(_panelGo);
+            if (_settings != null) Object.Destroy(_settings);
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator Given_AContainedFocusScope_When_ASpatialMoveWouldExitTheScope_Then_FocusIsBackInsideTheScopeAfterTheFlush()
+        {
+            // Arrange
+            var root = _panelGo.GetComponent<UIDocument>().rootVisualElement;
+            var inside = root.Q<VisualElement>("inside");
+            inside.Focus();
+            Assume.That(inside.panel.focusController.focusedElement, Is.EqualTo(inside),
+                "Precondition: the scope member holds focus");
+
+            // Act — a Down move: the engine's own 2D navigation lands on "below" (outside the scope), and
+            // the FocusIn snap-back pulls it back within the same flush.
+            using (var move = NavigationMoveEvent.GetPooled(NavigationMoveEvent.Direction.Down))
+            {
+                move.target = inside;
+                inside.SendEvent(move);
+            }
+            yield return null;
+
+            // Assert
+            Assert.That(inside.panel.focusController.focusedElement, Is.EqualTo(inside));
+        }
+    }
+}
+#endif

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/FocusScopePlaybackTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/FocusScopePlaybackTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0ec7538f0faa342098fe6774bce23276


### PR DESCRIPTION
## Summary

Adds the focus / gamepad navigation layer (#39) and the explicit cross-panel focus escape (#54), composing with UI Toolkit's own focus machinery rather than replacing it.

### Focus scopes (React Aria `FocusScope` parity)

- `V.FocusScope(contain:, restoreFocus:, autoFocus:, singleTabStop:)`, and the same knobs as a `FocusScope` element prop on any existing container.
- `contain` — Tab/Shift-Tab wrap within the scope (a subtree-scoped `VisualElementFocusRing`); spatial/pointer escapes snap back in the same event flush wherever they land (including inside another scope), and a press on empty space — focus cleared to nothing, so no focus event lands anywhere — re-focuses the scope on the panel's next scheduler tick. When two contained scopes are live at once, the one currently holding focus wins.
- `restoreFocus` — focus returns to where it came from when the scope unmounts while holding it; the restore reference is dropped if that element unmounts first, never chased into pool reuse.
- `autoFocus` — mount-once, like React: a keyed reorder's physical re-attach never steals focus back.
- `singleTabStop` — the WAI-ARIA composite (roving tabindex) contract: exit skips the remaining members (wrapping within an enclosing contain scope when nested), entry from either direction lands on the last-used member (else the first), and a group covering every reachable focusable holds position — or exits across the panel boundary in a chained host. Engine 2D spatial navigation inside the group is untouched.

### Element props

`TabIndex` / `DelegatesFocus` / `FocusScope` on `FiberElementProps` — with the documented engine trap that `tabIndex = -1` on a runtime panel removes an element from BOTH the Tab ring and 2D navigation (not the web's "focusable but not tab-reachable").

### Focus-visible state channel

`Hooks.UseFocusRing` — React Aria `useFocusRing` parity: `IsFocused` / `IsFocusVisible` as re-rendering component state riding the same element-local heuristic as the existing `focus-visible:` styling variant, so the two surfaces cannot drift. An element unmounting while focused corrects the state on the panel's next tick (its Blur can no longer reach the unhooked signals, and a mid-flush write would be lost).

### Cross-panel Tab order (#54)

`V.Portal(layer:)` / `V.WorldSpace` accept `focusOrder: PanelFocusOrder.Chained` — iframe semantics joining the declaring panel's Tab order at the portal's call site: sequential entry lands at the host's direction-matching ring edge, and the host's ring-edge exit hops back to the declaring-panel element after/before the placeholder. The hop blurs the source synchronously and focuses the target on its own panel's next scheduler tick, because a synchronous cross-panel focus from inside another panel's dispatch does not stick (verified empirically: the still-focused source panel wins the reconciliation). `Isolated` (the default) keeps the pre-existing internal wrap — the explicit-opt-in stance of the cross-panel input-routing decision. A shared layer host carrying several chained portals re-elects a surviving owner for the ring-edge escape when the owning portal unmounts or flips back to `Isolated`.

### Engine contract

All sequential interception rides one pinned contract: a TrickleDown `NavigationMoveEvent` listener plus `FocusController.IgnoreEvent` deterministically preempts the engine's post-dispatch default focus move (`StopPropagation` alone does not — pinned as a negative tripwire). Predictions use the public `VisualElementFocusRing`, the exact class the runtime ring delegates Next/Previous to, so they cannot drift from what the engine would have done. Spatial 2D navigation and KeyDown delivery are never touched. The navigator attaches exactly once per panel, always on `panel.visualTree` (deferred via a self-removing attach hook for not-yet-attached mount roots), so no duplicate listeners can invert branch priority and no subtree ring can diverge from the panel ring.

### Fixed along the way

- Pooled `Button`/`Slider`/`TextField`/`Toggle` lost `focusable` across pool reuse (the common reset scrubs it to the plain-`VisualElement` default, and nothing restored the widget's own constructor default) — a recycled control silently dropped out of Tab/gamepad navigation entirely.
- Pooled props bags did not scrub `TabIndex` / `DelegatesFocus` / `FocusScope` / `Anchored`, ghosting them onto unrelated elements on reuse.
- Scope bookkeeping (last-focused member / restore target) is swept when the referenced element departs, so pool recycling can never redirect focus to a widget in a different logical role.

### Docs

`Documentation~/focus.md` (new guide: the four scope knobs, the `tabIndex = -1` trap, the two focus-visible channels, `PanelFocusOrder`, and the recorded scope cuts) plus the cross-panel section of `portals.md`.

Closes #39
Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)
