### PR TITLE
fix: harden focus-layer containment, scheduling, and pool-lifecycle edges

### DIFF
--- a/Packages/com.velvet.core/Runtime/Hooks/Hooks.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Hooks.cs
@@ -1093,11 +1093,12 @@ namespace Velvet
         {
             var (isFocused, setFocused) = UseState(false);
             var (isFocusVisible, setFocusVisible) = UseState(false);
-            // Generation cell shared by every ref invocation of this hook instance: each setup stamps a new
-            // generation, so a cleanup's deferred work can tell whether it is still the LATEST hookup for
-            // this component or was superseded (a patch re-invoking the ref, or the ref moving to a
-            // replacement element).
+            // Generation cell + latest-hooked-element cell, shared by every ref invocation of this hook
+            // instance: each setup stamps a new generation and records its element, so a cleanup's
+            // deferred work can tell whether it was superseded — and by WHAT.
             var generation = UseRef<int[]>(() => new int[1]);
+            var hookedElement = UseRef<UnityEngine.UIElements.VisualElement[]>(
+                () => new UnityEngine.UIElements.VisualElement[1]);
             var refCallback = UseCallback<Func<UnityEngine.UIElements.VisualElement, Action>>(element =>
             {
                 var signals = new ElementLocalVariantSignals((signal, on) =>
@@ -1110,6 +1111,7 @@ namespace Velvet
                 });
                 signals.Hook(element, seedChecked: false, registerChecked: false);
                 var gen = ++generation.Current[0];
+                hookedElement.Current[0] = element;
                 return () =>
                 {
                     signals.Unhook();
@@ -1120,10 +1122,12 @@ namespace Velvet
                     // WHILE FOCUSED gets no Blur through these signals either — the unhook above runs before
                     // the element leaves the panel — which would strand IsFocused/IsFocusVisible at true on
                     // a still-mounted component. So when the element holds focus at cleanup time, the
-                    // correction is deferred to the panel's next scheduler tick — safely OUTSIDE any flush —
-                    // and fires only if no newer hookup superseded this one (a patch's re-invoke stamps a
-                    // new generation synchronously right after this cleanup, turning the deferred write into
-                    // a no-op; the setters are already no-ops if the component itself unmounted).
+                    // correction is deferred to the panel's next scheduler tick — safely OUTSIDE any flush.
+                    // At the tick, a superseding hookup only cancels the correction when ITS element
+                    // actually holds focus (a patch re-invoking the ref on the same still-focused element):
+                    // a ref that moved to a REPLACEMENT element must still correct, because the old
+                    // element's focus died with it and the unfocused replacement will never emit the Blur
+                    // edge. The setters are already no-ops if the component itself unmounted.
                     var panel = element.panel;
                     if (panel?.visualTree == null) return;
                     if (panel.focusController?.focusedElement is not UnityEngine.UIElements.VisualElement held
@@ -1133,14 +1137,24 @@ namespace Velvet
                     }
                     panel.visualTree.schedule.Execute(() =>
                     {
-                        if (generation.Current[0] != gen) return;
+                        if (generation.Current[0] != gen)
+                        {
+                            var current = hookedElement.Current[0];
+                            if (current != null
+                                && current.panel?.focusController?.focusedElement
+                                    is UnityEngine.UIElements.VisualElement nowHeld
+                                && (nowHeld == current || current.Contains(nowHeld)))
+                            {
+                                return;
+                            }
+                        }
                         setFocused.Invoke(false);
                         setFocusVisible.Invoke(false);
                     });
                 };
-                // Deps are the two setters and the generation ref — all reference-stable across renders —
-                // so the ref identity never changes across re-renders.
-            }, setFocused, setFocusVisible, generation);
+                // Deps are the two setters and the two refs — all reference-stable across renders — so
+                // the ref identity never changes across re-renders.
+            }, setFocused, setFocusVisible, generation, hookedElement);
             return new FocusRing(isFocused, isFocusVisible, refCallback);
         }
 

--- a/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseFocusRingTests.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseFocusRingTests.cs
@@ -114,6 +114,42 @@ namespace Velvet.Tests
             Assert.That(s_ring.IsFocused, Is.False);
         }
 
+        [Component]
+        private static VNode SwappingRingHost()
+        {
+            var ring = Hooks.UseFocusRing();
+            s_ring = ring;
+            var (swapped, setSwapped) = Hooks.UseState(false);
+            s_setShowTarget = setSwapped;
+            return V.Div(children: new VNode[]
+            {
+                swapped
+                    ? (VNode)V.Div(name: "target2", key: "t", refCallback: ring.Ref)
+                    : V.Button(name: "target", key: "t", refCallback: ring.Ref),
+            });
+        }
+
+        [Test]
+        public void Given_AFocusedRingElement_When_TheRefMovesToAReplacementElement_Then_IsFocusedReturnsToFalse()
+        {
+            // Arrange
+            _mounted = V.Mount(_host.Root, V.Component(SwappingRingHost, key: "root"));
+            _host.Root.Q<VisualElement>("target").Focus();
+            _mounted.FlushStateForTest();
+            Assume.That(s_ring.IsFocused, Is.True, "Precondition: the ring lit for the focused element");
+
+            // Act — a same-key type flip replaces the element under the SAME ref in one flush: the old
+            // element's focus dies with it and the replacement was never focused, so the deferred
+            // correction must fire even though a newer hookup superseded the one that scheduled it.
+            s_setShowTarget.Invoke(true);
+            _mounted.FlushStateForTest();
+            EditorPanelTestHelpers.DriveSchedulerOnce(_host.Panel);
+            _mounted.FlushStateForTest();
+
+            // Assert
+            Assert.That(s_ring.IsFocused, Is.False);
+        }
+
         [Test]
         public void Given_AFocusVisibleRing_When_TheElementBlurs_Then_IsFocusVisibleReturnsToFalse()
         {

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberElementCleaner.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberElementCleaner.cs
@@ -322,11 +322,13 @@ namespace Velvet
                 AnchoredDriver.Detach(element, anchoredBinding);
                 _ctx.AnchoredBindings.Remove(element);
             }
-            if (_ctx.FocusScopeBindings.TryGetValue(element, out var focusScopeBinding))
+            if (_ctx.FocusScopeBindings.Remove(element, out var focusScopeBinding))
             {
-                // RestoreFocus must run BEFORE this element physically leaves the tree (UI Toolkit clears
-                // the focused element the moment it detaches — the same ordering RescueFocusFromWorldSpaceHost
-                // exists for): if the scope still holds focus, return it to where it came from on first entry.
+                // The registry entry is dropped BEFORE the restore focus fires: the restore's own FocusIn
+                // must not see the dying scope as a live contain scope, or the snap-back would revert the
+                // restore straight back into the detaching subtree. RestoreFocus itself must still run
+                // BEFORE this element physically leaves the tree (UI Toolkit clears the focused element
+                // the moment it detaches — the same ordering RescueFocusFromWorldSpaceHost exists for).
                 if (focusScopeBinding.Settings.RestoreFocus
                     && element.panel?.focusController?.focusedElement is VisualElement held
                     && element.Contains(held))
@@ -338,7 +340,6 @@ namespace Velvet
                     }
                 }
                 FocusScopeDriver.Detach(element, focusScopeBinding);
-                _ctx.FocusScopeBindings.Remove(element);
             }
             // A departing element must not linger as any scope's remembered member or restore target:
             // pooled primitives get recycled into unrelated roles, and the liveness checks at use time
@@ -360,6 +361,12 @@ namespace Velvet
             {
                 var chainedHostRoot = chainedRecord.Document != null ? chainedRecord.Document.rootVisualElement : null;
                 FiberFocusNavigator.ReleaseChainedOwnership(element, chainedHostRoot, _ctx);
+            }
+            // A deferred navigator attach hook still pending on this element unregisters with it — a
+            // pooled element must not carry a live hook into its next role.
+            if (_ctx.NavigatorPendingAttachHooks.Count > 0)
+            {
+                FiberFocusNavigator.ReleasePendingAttachHooks(element, _ctx);
             }
             if (_ctx.VirtualListControllers.TryGetValue(element, out var virtualListController))
             {

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberFocusNavigator.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberFocusNavigator.cs
@@ -30,8 +30,9 @@ namespace Velvet
         public VisualElement? LastFocusedMember;
         public VisualElement? RestoreTarget;
         public bool RestoreCaptured;
-        // AutoFocus is mount-once, matching React: a keyed reorder physically re-attaches the scope
-        // (RemoveAt + Insert), and re-firing there would steal focus from wherever the user moved on.
+        // AutoFocus is mount-once, matching React: the latch is set on the scope's FIRST attach no matter
+        // what the setting held then, so neither a keyed reorder's re-attach nor a post-mount settings
+        // flip can ever fire it again.
         public bool AutoFocusFired;
         public EventCallback<AttachToPanelEvent>? OnAttach;
 
@@ -54,6 +55,8 @@ namespace Velvet
     /// layer composes with rather than reimplements. Sequential prediction and redirection use the public
     /// <see cref="VisualElementFocusRing"/> — the exact class the runtime ring delegates Next/Previous to
     /// (<c>NavigateFocusRing.m_Ring</c>), so predictions cannot drift from what the engine would have done.
+    /// Containment always resolves through the NEAREST enclosing contain scope — an element inside a plain
+    /// or SingleTabStop scope nested in a modal still belongs to the modal's containment, on every path.
     /// </summary>
     internal static class FiberFocusNavigator
     {
@@ -65,9 +68,10 @@ namespace Velvet
         // anchor is always the panel's TRUE root (panel.visualTree): registering on anything narrower
         // would compute subtree rings that drift from the engine's own panel-wide ring, and registering
         // per call-site element would stack duplicate listeners whose relative order inverts the branch
-        // priority. An element with no panel yet defers via a tracked self-removing attach hook. Called
-        // from V.Mount (main panel), ConfigureChainedPlaceholder (declaring + host panels), and the
-        // focus-scope attach hook (whatever panel the scope lands in).
+        // priority. An element with no panel yet defers via a tracked self-removing attach hook (one per
+        // element — repeat calls while detached dedup). Called from V.Mount (main panel),
+        // ConfigureChainedPlaceholder (declaring + host panels), and the focus-scope attach hook
+        // (whatever panel the scope lands in).
         internal static void EnsureAttached(VisualElement? element, ReconcilerContext ctx)
         {
             if (element == null)
@@ -80,6 +84,13 @@ namespace Velvet
                 AttachToRoot(root, ctx);
                 return;
             }
+            foreach (var (pendingElement, _) in ctx.NavigatorPendingAttachHooks)
+            {
+                if (ReferenceEquals(pendingElement, element))
+                {
+                    return;
+                }
+            }
             EventCallback<AttachToPanelEvent> hook = null!;
             hook = _ =>
             {
@@ -89,6 +100,22 @@ namespace Velvet
             };
             element.RegisterCallback(hook);
             ctx.NavigatorPendingAttachHooks.Add((element, hook));
+        }
+
+        // Unregisters and forgets any deferred attach hook still pending on `element`. Part of the
+        // element-teardown scrub: a pooled element must not carry a live hook into its next role (it
+        // would attach the navigator to whatever panel the recycled element lands in).
+        internal static void ReleasePendingAttachHooks(VisualElement element, ReconcilerContext ctx)
+        {
+            for (var i = ctx.NavigatorPendingAttachHooks.Count - 1; i >= 0; i--)
+            {
+                var (pendingElement, hook) = ctx.NavigatorPendingAttachHooks[i];
+                if (ReferenceEquals(pendingElement, element))
+                {
+                    element.UnregisterCallback(hook);
+                    ctx.NavigatorPendingAttachHooks.RemoveAt(i);
+                }
+            }
         }
 
         private static void AttachToRoot(VisualElement? root, ReconcilerContext ctx)
@@ -157,6 +184,7 @@ namespace Velvet
                 placeholder.style.height = StyleKeyword.Null;
                 placeholder.focusable = false;
                 placeholder.tabIndex = 0;
+                ReleasePendingAttachHooks(placeholder, ctx);
                 ReleaseChainedOwnership(placeholder, hostRoot, ctx);
             }
         }
@@ -201,53 +229,72 @@ namespace Velvet
                 return;
             }
 
-            // Innermost scope wins (nested modals resolve naturally: the walk starts at the focused element
-            // and the first registered scope root on the parent chain is the closest enclosing one).
+            // Containment resolves through the NEAREST contain scope; the innermost scope of any kind
+            // decides SingleTabStop behavior. A scope that is both contain and singleTabStop behaves as
+            // contain (the pre-existing precedence).
+            var containRoot = FindEnclosingContainScopeRoot(focused, ctx, out _);
             var scopeRoot = FindEnclosingScopeRoot(focused, ctx, out var binding);
-            if (scopeRoot != null && binding != null)
+            var singleTabStop = scopeRoot != null && binding is { Settings.SingleTabStop: true }
+                && !ReferenceEquals(scopeRoot, containRoot);
+
+            if (singleTabStop)
             {
-                if (binding.Settings.Contain)
+                // The whole subtree acts as ONE tab stop: walk the sequential ring in the move's
+                // direction, skipping every other member of this scope, and land on the first focusable
+                // outside it. The walk ring is bounded by the nearest enclosing CONTAIN scope when one
+                // exists — a group inside a modal must wrap within the modal, never escape it.
+                var ring = new VisualElementFocusRing(containRoot ?? panelRoot);
+                var direction = ToRingDirection(forward);
+                // The ring's direction-first element: stepping onto it mid-walk means the walk crossed
+                // the ring edge (wrapped) — in a chained host, that crossing is the boundary exit.
+                var ringEdge = ring.GetNextFocusable(null, direction);
+                var candidate = ring.GetNextFocusable(focused, direction) as VisualElement;
+                var wrapped = candidate != null && ReferenceEquals(candidate, ringEdge);
+                var guard = MaxRingWalk;
+                while (candidate != null && candidate != focused && scopeRoot!.Contains(candidate) && guard-- > 0)
                 {
-                    // A ring scoped to the subtree root computes the same sequential order the panel ring
-                    // would, restricted to the scope's members — and wraps at the scope edges, which IS the
-                    // containment contract.
-                    var scoped = new VisualElementFocusRing(scopeRoot);
-                    Redirect(evt, panel!, scoped.GetNextFocusable(focused, ToRingDirection(forward)) as VisualElement);
-                    return;
+                    candidate = ring.GetNextFocusable(candidate, direction) as VisualElement;
+                    if (candidate != null && ReferenceEquals(candidate, ringEdge))
+                    {
+                        wrapped = true;
+                    }
                 }
-                if (binding.Settings.SingleTabStop)
+                if (candidate != null && candidate != focused && !scopeRoot!.Contains(candidate))
                 {
-                    // The whole subtree acts as ONE tab stop: walk the sequential ring in the move's
-                    // direction, skipping every other member of this scope, and land on the first focusable
-                    // outside it. The walk ring is bounded by the nearest enclosing CONTAIN scope when one
-                    // exists — a group inside a modal must wrap within the modal, never escape it through
-                    // the group's own exit.
-                    var containRoot = FindEnclosingContainScopeRoot(scopeRoot.parent, ctx, out _);
-                    var ring = new VisualElementFocusRing(containRoot ?? panelRoot);
-                    var direction = ToRingDirection(forward);
-                    var candidate = ring.GetNextFocusable(focused, direction) as VisualElement;
-                    var guard = MaxRingWalk;
-                    while (candidate != null && candidate != focused && scopeRoot.Contains(candidate) && guard-- > 0)
-                    {
-                        candidate = ring.GetNextFocusable(candidate, direction) as VisualElement;
-                    }
-                    if (candidate != null && candidate != focused && !scopeRoot.Contains(candidate))
-                    {
-                        Redirect(evt, panel!, ResolveScopeEntryTarget(candidate, ctx));
-                        return;
-                    }
-                    // Every reachable focusable is a member. In a chained host the group's one-stop exit
-                    // crosses the panel boundary (a portal'd roving toolbar is the natural gamepad case);
-                    // anywhere else the move is suppressed with focus held in place — the engine default
-                    // would cycle the members, breaking the one-stop contract.
-                    if (TryChainedEscape(evt, panel!, panelRoot, focused, forward, ctx, requireRingEdge: false))
+                    // A wrap in an unconstrained chained host takes the boundary exit instead of landing
+                    // back at the ring's start — the pinned iframe contract: Tab past the host ring's
+                    // end exits to the declaring panel.
+                    if (wrapped && containRoot == null
+                        && TryChainedEscape(evt, panel!, panelRoot, focused, forward, ctx, requireRingEdge: false))
                     {
                         return;
                     }
-                    panel!.focusController.IgnoreEvent(evt);
-                    evt.StopPropagation();
+                    Redirect(evt, panel!, ResolveScopeEntryTarget(candidate, ctx));
                     return;
                 }
+                // Every reachable focusable is a member. In an unconstrained chained host the one-stop
+                // exit crosses the panel boundary; under containment (or with nowhere to go) the move is
+                // suppressed with focus held in place — the engine default would cycle the members,
+                // breaking the one-stop contract, and a boundary escape would break the modal.
+                if (containRoot == null
+                    && TryChainedEscape(evt, panel!, panelRoot, focused, forward, ctx, requireRingEdge: false))
+                {
+                    return;
+                }
+                panel!.focusController.IgnoreEvent(evt);
+                evt.StopPropagation();
+                return;
+            }
+
+            if (containRoot != null)
+            {
+                // A ring scoped to the contain root computes the same sequential order the panel ring
+                // would, restricted to the scope's members — and wraps at the scope edges, which IS the
+                // containment contract. Keyed on the NEAREST contain scope, so focus sitting in a plain
+                // scope nested inside a modal still wraps within the modal.
+                var scoped = new VisualElementFocusRing(containRoot);
+                Redirect(evt, panel!, scoped.GetNextFocusable(focused, ToRingDirection(forward)) as VisualElement);
+                return;
             }
 
             // Chained host escape: focus sits in a host panel that joined its declaring panel's Tab order,
@@ -304,7 +351,8 @@ namespace Velvet
         // The chained-host boundary exit. With requireRingEdge, escapes only when the engine's own move
         // would wrap around the host ring's edge (the normal Tab-past-the-end case); without it, escapes
         // unconditionally in the move's direction (the SingleTabStop-covers-the-whole-host case, where ANY
-        // member is the exit point). Returns true when the move was converted into a cross-panel hop.
+        // member is the exit point — the caller has already established no contain scope intervenes).
+        // Returns true when the move was converted into a cross-panel hop.
         private static bool TryChainedEscape(
             NavigationMoveEvent evt, IPanel panel, VisualElement panelRoot, VisualElement focused,
             bool forward, ReconcilerContext ctx, bool requireRingEdge)
@@ -329,9 +377,7 @@ namespace Velvet
                 }
             }
             var declaringRoot = placeholder.panel.visualTree;
-            var declaringRing = new VisualElementFocusRing(declaringRoot);
-            var escapeTarget = declaringRing.GetNextFocusable(placeholder, direction) as VisualElement;
-            if (escapeTarget == null || ReferenceEquals(escapeTarget, placeholder))
+            if (ResolveEscapeTarget(placeholder, declaringRoot, direction, ctx) == null)
             {
                 return false;
             }
@@ -342,23 +388,38 @@ namespace Velvet
             // panels holding a focused element simultaneously gets reconciled against the still-focused
             // source panel, unfocusing the target again. The placeholder-entry direction needs no such hop:
             // it runs inside a FOCUS event, whose nested switches ride the engine's pending-focus gate.
-            // The hop is scheduled on the DECLARING PANEL'S ROOT, never on the target element: a one-shot
-            // scheduled item on an element that detaches before executing restarts in full when the element
-            // re-attaches — for a pooled widget that means a stale Focus() firing on whatever unrelated
-            // role it was recycled into. The root is stable, and the fire-time guard skips a target that
-            // left the panel in the window between the hop and the tick.
+            // The hop is scheduled on the DECLARING PANEL'S ROOT (stable, never pooled), and the landing is
+            // RE-RESOLVED at fire time from the placeholder's then-current ring position — a landing
+            // captured now could be unmounted and pool-recycled into an unrelated same-panel role within
+            // the one-tick window, which no identity guard on the captured reference can detect.
             panel.focusController.IgnoreEvent(evt);
             evt.StopPropagation();
             focused.Blur();
             declaringRoot.schedule.Execute(() =>
             {
-                if (escapeTarget.panel != declaringRoot.panel || !escapeTarget.canGrabFocus)
+                if (placeholder.panel == null || placeholder.panel.visualTree != declaringRoot)
                 {
                     return;
                 }
-                ResolveScopeEntryTarget(escapeTarget, ctx).Focus();
+                var target = ResolveEscapeTarget(placeholder, declaringRoot, direction, ctx);
+                if (target != null)
+                {
+                    ResolveScopeEntryTarget(target, ctx).Focus();
+                }
             });
             return true;
+        }
+
+        // The declaring-panel element the escape lands on: the next focusable after/before the
+        // placeholder, in a ring bounded by the placeholder's own nearest contain scope when one exists —
+        // a chained portal declared inside a modal must hand focus back within the modal, never past it.
+        private static VisualElement? ResolveEscapeTarget(
+            VisualElement placeholder, VisualElement declaringRoot, FocusChangeDirection direction, ReconcilerContext ctx)
+        {
+            var placeholderContain = FindEnclosingContainScopeRoot(placeholder, ctx, out _);
+            var ring = new VisualElementFocusRing(placeholderContain ?? declaringRoot);
+            var target = ring.GetNextFocusable(placeholder, direction) as VisualElement;
+            return target == null || ReferenceEquals(target, placeholder) || !target.canGrabFocus ? null : target;
         }
 
         // Resolves the chained placeholder owning `panel`'s ring-edge escape. The registry is keyed by the
@@ -385,9 +446,17 @@ namespace Velvet
 
             // Chained placeholder forwarding: the placeholder is a zero-size proxy tab stop in the declaring
             // panel's ring — focus reaching it means the sequential order crossed the portal's call site, so
-            // hand focus into the host panel at the edge matching the travel direction.
+            // hand focus into the host panel at the edge matching the travel direction. Containment is
+            // checked FIRST: a placeholder outside the scope that held focus is an escape like any other
+            // (a spatial move can land here), and forwarding it would cross the panel boundary out of a
+            // modal. A placeholder INSIDE the modal forwards normally — the portal is the modal's own
+            // content.
             if (ctx.ChainedPlaceholders.TryGetValue(target, out var hostRecord))
             {
+                if (TrySnapBackToContainScope(target, evt.relatedTarget as VisualElement, ctx))
+                {
+                    return;
+                }
                 var hostRoot = hostRecord.Document != null ? hostRecord.Document.rootVisualElement : null;
                 if (hostRoot != null)
                 {
@@ -405,42 +474,18 @@ namespace Velvet
 
             // Contain snap-back: focus left a contained scope through a path the sequential interception
             // cannot see (a spatial 2D move, or a pointer press outside) — pull it back inside within the
-            // same event flush. Evaluated BEFORE the landing scope's own bookkeeping, against the nearest
-            // CONTAIN scope enclosing the element focus came FROM: containment must hold no matter where
-            // the escape landed (a sibling scope, an outer scope, or scope-less space), and the departure
-            // scope's own walk skips non-contain scopes nested inside the modal. A nested Focus() from
-            // inside a FocusIn handler starts a new pending switch that wins (the engine's pending-focus
-            // gate), so the snap-back is deterministic; the depth guard keeps two contained scopes from
-            // ping-ponging — while a snap-back's own nested dispatch runs, its landing is accepted as-is
-            // (the scope that held focus wins).
-            if (ctx.ContainSnapBackDepth == 0
-                && evt.relatedTarget is VisualElement from && from.panel == target.panel)
+            // same event flush. A landing INSIDE any contain scope stands instead: the scope receiving
+            // focus claims it (React Aria's newest-scope activation — a stacked dialog must be able to
+            // take focus from the modal underneath), and because a snap-back's own landing is by
+            // construction inside a contain scope, the recursion is structurally terminal — no re-entrancy
+            // flag needed (one would not work anyway: UI Toolkit QUEUES focus events raised from inside a
+            // dispatch, so a nested FocusIn runs only after this handler returns).
+            if (FindEnclosingContainScopeRoot(target, ctx, out _) == null
+                && TrySnapBackToContainScope(target, evt.relatedTarget as VisualElement, ctx))
             {
-                var containRoot = FindEnclosingContainScopeRoot(from, ctx, out var containBinding);
-                if (containRoot != null && containBinding != null && !containRoot.Contains(target))
-                {
-                    var back = containBinding.LastFocusedMember;
-                    if (back == null || back.panel == null || !containRoot.Contains(back) || !back.canGrabFocus)
-                    {
-                        back = new VisualElementFocusRing(containRoot)
-                            .GetNextFocusable(null, VisualElementFocusChangeDirection.right) as VisualElement;
-                    }
-                    if (back != null)
-                    {
-                        ctx.ContainSnapBackDepth++;
-                        try
-                        {
-                            back.Focus();
-                        }
-                        finally
-                        {
-                            ctx.ContainSnapBackDepth--;
-                        }
-                        // The landing was reverted: recording it in the landing scope's bookkeeping would
-                        // corrupt that scope's roving memory with a member the user never actually reached.
-                        return;
-                    }
-                }
+                // The landing was reverted: recording it in the landing scope's bookkeeping would corrupt
+                // that scope's roving memory with a member the user never actually reached.
+                return;
             }
 
             var scopeRoot = FindEnclosingScopeRoot(target, ctx, out var binding);
@@ -462,22 +507,56 @@ namespace Velvet
             }
         }
 
+        // The shared snap-back: when focus is leaving `relatedTarget`'s nearest contain scope for a
+        // `target` outside it (same panel — cross-panel moves are never snapped), refocus the scope's
+        // remembered member (else its ring-first) and report true. The scope must still be REGISTERED:
+        // FiberElementCleaner drops a dying scope's registry entry before firing its restore focus, so a
+        // teardown's restore is never reverted back into the detaching subtree.
+        private static bool TrySnapBackToContainScope(
+            VisualElement target, VisualElement? relatedTarget, ReconcilerContext ctx)
+        {
+            if (relatedTarget == null || relatedTarget.panel != target.panel)
+            {
+                return false;
+            }
+            var containRoot = FindEnclosingContainScopeRoot(relatedTarget, ctx, out var binding);
+            if (containRoot == null || binding == null || containRoot.Contains(target))
+            {
+                return false;
+            }
+            var back = binding.LastFocusedMember;
+            if (back == null || back.panel == null || !containRoot.Contains(back) || !back.canGrabFocus)
+            {
+                back = new VisualElementFocusRing(containRoot)
+                    .GetNextFocusable(null, VisualElementFocusChangeDirection.right) as VisualElement;
+            }
+            if (back == null)
+            {
+                return false;
+            }
+            back.Focus();
+            return true;
+        }
+
         // The escape containment cannot see from FocusIn: focus cleared to NOTHING (a pointer press on
         // empty non-focusable space, or a programmatic Blur) raises no FocusInEvent for the snap-back to
         // ride — only this FocusOut with a null relatedTarget. The re-focus is deferred one scheduler tick
         // and re-validated at fire time, because the identical event also fires when the focused element
-        // (or the whole scope) is being torn down mid-flush: by the tick, a real teardown has detached the
-        // scope root (skip — RestoreFocus owns that path), and a legitimate move has repopulated
-        // focusedElement (skip — the FocusIn side owns it); only the true "focus went nowhere" case
-        // remains, and containment pulls it back inside.
+        // (or the whole scope) is being torn down mid-flush, and when focus legitimately moves to ANOTHER
+        // panel (the engine blurs the old panel to nothing on a panel switch). By the tick: a real
+        // teardown has detached the scope root or replaced its binding (skip — the binding identity check
+        // covers a pooled root recycled into a NEW scope under the same element key), a same-panel move
+        // has repopulated focusedElement (skip — the FocusIn side owns it), and a cross-panel move left
+        // some other managed panel holding focus (skip — containment is per panel and must not fight it).
+        // Only the true "focus went nowhere" case remains, and containment pulls it back inside.
         private static void OnFocusOut(FocusOutEvent evt, ReconcilerContext ctx)
         {
             if (evt.relatedTarget != null || evt.target is not VisualElement leaving)
             {
                 return;
             }
-            var containRoot = FindEnclosingContainScopeRoot(leaving, ctx, out _);
-            if (containRoot == null)
+            var containRoot = FindEnclosingContainScopeRoot(leaving, ctx, out var armedBinding);
+            if (containRoot == null || armedBinding == null)
             {
                 return;
             }
@@ -490,12 +569,12 @@ namespace Velvet
             {
                 if (containRoot.panel == null
                     || !ctx.FocusScopeBindings.TryGetValue(containRoot, out var binding)
+                    || !ReferenceEquals(binding, armedBinding)
                     || !binding.Settings.Contain)
                 {
                     return;
                 }
-                var controller = containRoot.panel.focusController;
-                if (controller == null || controller.focusedElement != null)
+                if (AnyManagedPanelHoldsFocus(ctx))
                 {
                     return;
                 }
@@ -506,6 +585,34 @@ namespace Velvet
                 }
                 back?.Focus();
             });
+        }
+
+        // True when any panel this reconciler manages (the main panel, a layer host, a world-space host)
+        // currently holds a focused element. UI Toolkit focus is per panel, so "this panel's controller
+        // reads null" alone cannot distinguish focus-went-nowhere from focus-went-to-another-panel.
+        private static bool AnyManagedPanelHoldsFocus(ReconcilerContext ctx)
+        {
+            if (ctx.MainPanelRoot?.panel?.focusController?.focusedElement != null)
+            {
+                return true;
+            }
+            foreach (var host in ctx.LayerHosts.Values)
+            {
+                if (host.Document != null
+                    && host.Document.rootVisualElement?.panel?.focusController?.focusedElement != null)
+                {
+                    return true;
+                }
+            }
+            foreach (var record in ctx.WorldSpaceBindings.Values)
+            {
+                if (record.Document != null
+                    && record.Document.rootVisualElement?.panel?.focusController?.focusedElement != null)
+                {
+                    return true;
+                }
+            }
+            return false;
         }
 
         // Walks the parent chain from `element` (inclusive) to the first registered scope root. Physical
@@ -570,15 +677,18 @@ namespace Velvet
             binding.OnAttach = _ =>
             {
                 FiberFocusNavigator.EnsureAttached(element, ctx);
-                // Mount-once, matching React's autoFocus (it acts on mount, never again): without the
-                // latch, every physical re-attach — a keyed reorder moves the subtree via RemoveAt +
-                // Insert — would re-fire and steal focus from wherever the user moved on. The transient
-                // detach of a reorder also clears panel focus, so AutoFocusFirst's focus-already-inside
-                // guard cannot cover the reorder case by itself.
-                if (binding.Settings.AutoFocus && !binding.AutoFocusFired)
+                // Mount-once, matching React's autoFocus (it acts on mount, never again): the latch is
+                // taken on the FIRST attach regardless of the setting's value at that moment, so a
+                // post-mount settings flip cannot re-arm it for a later physical re-attach (a keyed
+                // reorder moves the subtree via RemoveAt + Insert, whose transient detach also clears
+                // panel focus — AutoFocusFirst's focus-already-inside guard cannot cover that by itself).
+                if (!binding.AutoFocusFired)
                 {
                     binding.AutoFocusFired = true;
-                    AutoFocusFirst(element);
+                    if (binding.Settings.AutoFocus)
+                    {
+                        AutoFocusFirst(element);
+                    }
                 }
             };
             element.RegisterCallback(binding.OnAttach);

--- a/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
@@ -388,11 +388,6 @@ namespace Velvet
         // fired.
         public List<(VisualElement Element, EventCallback<AttachToPanelEvent> Hook)> NavigatorPendingAttachHooks { get; } = new();
 
-        // Re-entrancy depth of the Contain snap-back's nested Focus dispatch: while > 0, a further
-        // snap-back is suppressed so two contained scopes resolve deterministically (the scope that held
-        // focus wins) instead of ping-ponging Focus calls until the stack dies.
-        public int ContainSnapBackDepth;
-
         // Per-Portal placeholder bookkeeping. SlotStart + SlotLength identify the
         // range of FiberPortalRegistry.Get(TargetId).Children owned by this Portal — the
         // invariant that lets multiple Portals coexist on the same target without overwriting each

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/FocusScopeTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/FocusScopeTests.cs
@@ -20,6 +20,7 @@ namespace Velvet.Tests
         private static StateUpdater<bool> s_setShowScope;
         private static StateUpdater<bool> s_setRotated;
         private static StateUpdater<bool> s_setShowOpener;
+        private static StateUpdater<bool> s_setAutoFocusOn;
 
         [SetUp]
         public void SetUp()
@@ -28,6 +29,7 @@ namespace Velvet.Tests
             s_setShowScope = default;
             s_setRotated = default;
             s_setShowOpener = default;
+            s_setAutoFocusOn = default;
         }
 
         [TearDown]
@@ -422,6 +424,155 @@ namespace Velvet.Tests
             // Assert — one attachment, keyed by the panel's true root, never the mount target.
             Assert.That(_mounted.Root.Reconciler.Context.NavigatorAttachments.Keys,
                 Is.EquivalentTo(new[] { _host.Panel.visualTree }));
+        }
+
+        [Component]
+        private static VNode StackedModalsHost()
+        {
+            var (showSecond, setShowSecond) = Hooks.UseState(false);
+            s_setShowScope = setShowSecond;
+            return V.Div(children: new VNode[]
+            {
+                V.FocusScope(name: "modalA", key: "modalA", contain: true, children: new VNode[]
+                {
+                    V.Button(name: "a1"),
+                }),
+                showSecond
+                    ? V.FocusScope(name: "modalB", key: "modalB", contain: true, autoFocus: true, children: new VNode[]
+                    {
+                        V.Button(name: "b1"),
+                    })
+                    : null,
+            });
+        }
+
+        [Test]
+        public void Given_AContainedScopeHoldingFocus_When_ANewContainedScopeMountsWithAutoFocus_Then_TheNewScopeTakesFocus()
+        {
+            // Arrange
+            Mount(StackedModalsHost);
+            Q("a1").Focus();
+            Assume.That(_host.Panel.focusController.focusedElement, Is.EqualTo(Q("a1")),
+                "Precondition: the first modal holds focus");
+
+            // Act — a stacked dialog: modal B mounts on top and auto-focuses. A landing inside a
+            // contained scope claims focus (the scope receiving focus wins — React Aria's newest-scope
+            // activation); the old-scope snap-back must not yank it back underneath the overlay.
+            s_setShowScope.Invoke(true);
+            _mounted.FlushStateForTest();
+            EditorPanelTestHelpers.ForcePanelUpdate(_host.Panel);
+
+            // Assert
+            Assert.That(_host.Panel.focusController.focusedElement, Is.EqualTo(Q("b1")));
+        }
+
+        [Component]
+        private static VNode TwoContainedScopesHost() => V.Div(children: new VNode[]
+        {
+            V.FocusScope(name: "modalA", contain: true, children: new VNode[]
+            {
+                V.Button(name: "a1"),
+            }),
+            V.FocusScope(name: "modalB", contain: true, children: new VNode[]
+            {
+                V.Button(name: "x1"),
+            }),
+        });
+
+        [Test]
+        public void Given_TwoContainedScopes_When_APointerStyleMoveCrossesBetweenThem_Then_TheReceivingScopeKeepsFocus()
+        {
+            // Arrange — pinned as a terminal-recursion guard: a landing inside a contain scope stands
+            // (the receiving scope claims focus), which is what makes cross-scope moves converge. UI
+            // Toolkit QUEUES focus events raised from inside a dispatch, so any design that snaps this
+            // landing back degenerates into two scopes queueing Focus calls at each other forever — a
+            // main-thread livelock, which is why the pre-fix behavior could not be pinned as a failing
+            // assertion.
+            Mount(TwoContainedScopesHost);
+            var a1 = Q("a1");
+            a1.Focus();
+            Assume.That(_host.Panel.focusController.focusedElement, Is.EqualTo(a1),
+                "Precondition: the first contained scope holds focus");
+
+            // Act
+            var x1 = Q("x1");
+            x1.Focus();
+
+            // Assert
+            Assert.That(_host.Panel.focusController.focusedElement, Is.EqualTo(x1));
+        }
+
+        [Component]
+        private static VNode RestoringModalHost()
+        {
+            var (showScope, setShowScope) = Hooks.UseState(true);
+            s_setShowOpener = setShowScope;
+            return V.Div(children: new VNode[]
+            {
+                V.Button(name: "opener"),
+                showScope
+                    ? V.FocusScope(name: "modal", key: "modal", contain: true, restoreFocus: true, children: new VNode[]
+                    {
+                        V.Button(name: "inner"),
+                    })
+                    : null,
+            });
+        }
+
+        [Test]
+        public void Given_AContainedRestoringScope_When_ItUnmountsWhileHoldingFocus_Then_FocusReturnsToTheOpener()
+        {
+            // Arrange — the standard modal combo: contain + restoreFocus together.
+            Mount(RestoringModalHost);
+            Q("opener").Focus();
+            Q("inner").Focus();
+            Assume.That(_host.Panel.focusController.focusedElement, Is.EqualTo(Q("inner")),
+                "Precondition: focus sits inside the modal");
+
+            // Act — the restore's own FocusIn must not see the dying scope as a live contain scope
+            // (the snap-back would revert the restore straight back into the detaching subtree).
+            s_setShowOpener.Invoke(false);
+            _mounted.FlushStateForTest();
+
+            // Assert
+            Assert.That(_host.Panel.focusController.focusedElement, Is.EqualTo(Q("opener")));
+        }
+
+        [Component]
+        private static VNode LatchBypassHost()
+        {
+            var (autoFocusOn, setAutoFocusOn) = Hooks.UseState(false);
+            s_setAutoFocusOn = setAutoFocusOn;
+            var (rotated, setRotated) = Hooks.UseState(false);
+            s_setRotated = setRotated;
+            var scope = V.FocusScope(name: "scope", key: "scope", autoFocus: autoFocusOn, children: new VNode[]
+            {
+                V.Button(name: "first"),
+            });
+            var b1 = V.Button(name: "b1", key: "b1");
+            var b2 = V.Button(name: "b2", key: "b2");
+            return V.Div(children: rotated ? new VNode[] { b1, b2, scope } : new VNode[] { scope, b1, b2 });
+        }
+
+        [Test]
+        public void Given_AScopeWhoseAutoFocusTurnedOnAfterMount_When_AReorderReattachesIt_Then_FocusIsStillNotStolen()
+        {
+            // Arrange — autoFocus is mount-once like React's: a post-mount settings flip must not
+            // re-arm it for the next physical re-attach.
+            Mount(LatchBypassHost);
+            var b1 = Q("b1");
+            b1.Focus();
+            s_setAutoFocusOn.Invoke(true);
+            _mounted.FlushStateForTest();
+            Assume.That(_host.Panel.focusController.focusedElement, Is.EqualTo(b1),
+                "Precondition: the settings flip alone must not move focus");
+
+            // Act — the keyed rotation physically re-attaches the scope.
+            s_setRotated.Invoke(true);
+            _mounted.FlushStateForTest();
+
+            // Assert
+            Assert.That(_host.Panel.focusController.focusedElement, Is.EqualTo(b1));
         }
 
         [Test]

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/FocusChainedPortalTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/FocusChainedPortalTests.cs
@@ -239,6 +239,128 @@ namespace Velvet.Tests
             Assert.That(main1.panel.focusController.focusedElement, Is.EqualTo(main1));
         }
 
+        [Component]
+        private static VNode ContainedStsPortalHost() => V.Div(children: new VNode[]
+        {
+            V.Button(name: "main1"),
+            V.Portal(UILayer.Overlay, key: "portal", focusOrder: PanelFocusOrder.Chained, children: new VNode[]
+            {
+                V.FocusScope(name: "modal", contain: true, children: new VNode[]
+                {
+                    V.FocusScope(name: "group", singleTabStop: true, children: new VNode[]
+                    {
+                        V.Button(name: "p1"),
+                        V.Button(name: "p2"),
+                    }),
+                }),
+            }),
+        });
+
+        [UnityTest]
+        public IEnumerator Given_AContainedGroupCoveringAChainedHost_When_TabDispatchesFromAMember_Then_FocusNeverEscapesTheModal()
+        {
+            // Arrange — a contain modal inside a chained host whose only focusables are one
+            // singleTabStop group: the group's one-stop exit finds no candidate, and the chained
+            // boundary escape must NOT override the modal's containment.
+            _mounted = V.Mount(_panelGo.GetComponent<UIDocument>().rootVisualElement,
+                V.Component(ContainedStsPortalHost, key: "root"));
+            yield return null;
+            yield return null;
+            var p1 = HostElement("p1");
+            p1.Focus();
+            Assume.That(p1.panel.focusController.focusedElement, Is.EqualTo(p1),
+                "Precondition: a modal group member holds focus");
+
+            // Act
+            SendMove(p1, NavigationMoveEvent.Direction.Next);
+            yield return null;
+            yield return null;
+            yield return null;
+
+            // Assert — the declaring panel must not have received focus.
+            var main1 = Main("main1");
+            Assert.That(main1.panel.focusController.focusedElement, Is.Not.EqualTo(main1));
+        }
+
+        [Component]
+        private static VNode EdgeGroupPortalHost() => V.Div(children: new VNode[]
+        {
+            V.Button(name: "main1"),
+            V.Portal(UILayer.Overlay, key: "portal", focusOrder: PanelFocusOrder.Chained, children: new VNode[]
+            {
+                V.Button(name: "x"),
+                V.FocusScope(name: "group", singleTabStop: true, children: new VNode[]
+                {
+                    V.Button(name: "g1"),
+                    V.Button(name: "g2"),
+                }),
+            }),
+        });
+
+        [UnityTest]
+        public IEnumerator Given_ASingleTabStopGroupAtAChainedHostsRingEdge_When_TabExitsForward_Then_FocusEscapesToTheDeclaringPanel()
+        {
+            // Arrange — the group sits at the END of the host ring, with another focusable before it:
+            // the group's exit walk WRAPS past the ring edge, and the pinned iframe contract says a
+            // move past the host ring's end exits to the declaring panel — never wraps back to "x".
+            _mounted = V.Mount(_panelGo.GetComponent<UIDocument>().rootVisualElement,
+                V.Component(EdgeGroupPortalHost, key: "root"));
+            yield return null;
+            yield return null;
+            var g2 = HostElement("g2");
+            g2.Focus();
+            Assume.That(g2.panel.focusController.focusedElement, Is.EqualTo(g2),
+                "Precondition: the edge group's member holds focus");
+
+            // Act
+            SendMove(g2, NavigationMoveEvent.Direction.Next);
+            yield return null;
+            yield return null;
+            yield return null;
+
+            // Assert
+            var main1 = Main("main1");
+            Assert.That(main1.panel.focusController.focusedElement, Is.EqualTo(main1));
+        }
+
+        [Component]
+        private static VNode ModalWithIsolatedPortalHost() => V.Div(children: new VNode[]
+        {
+            V.FocusScope(name: "modal", contain: true, children: new VNode[]
+            {
+                V.Button(name: "m1"),
+            }),
+            V.Portal(UILayer.Overlay, key: "portal", focusOrder: PanelFocusOrder.Isolated, children: new VNode[]
+            {
+                V.Button(name: "p1"),
+            }),
+        });
+
+        [UnityTest]
+        public IEnumerator Given_AContainedScopeInTheMainPanel_When_FocusLegitimatelyMovesToAnotherPanel_Then_TheModalDoesNotStealItBack()
+        {
+            // Arrange — a cross-panel focus move blurs the old panel to NOTHING (the same FocusOut
+            // signature as a click on empty space), but here focus went somewhere: another managed
+            // panel. The containment re-focus must recognize that and stand down.
+            _mounted = V.Mount(_panelGo.GetComponent<UIDocument>().rootVisualElement,
+                V.Component(ModalWithIsolatedPortalHost, key: "root"));
+            yield return null;
+            yield return null;
+            var m1 = Main("m1");
+            m1.Focus();
+            Assume.That(m1.panel.focusController.focusedElement, Is.EqualTo(m1),
+                "Precondition: the modal holds focus");
+
+            // Act
+            m1.Blur();
+            HostElement("p1").Focus();
+            yield return null;
+            yield return null;
+
+            // Assert — the main panel must stay unfocused instead of the modal yanking focus back.
+            Assert.That(m1.panel.focusController.focusedElement, Is.Null);
+        }
+
         [UnityTest]
         public IEnumerator Given_AChainedLayerPortal_When_AKeyDownDispatchesInsideTheHost_Then_ItStillReachesItsHandler()
         {


### PR DESCRIPTION
## Summary

Hardening pass over the focus / gamepad navigation layer (follow-up to #59): containment now holds on every path it can be escaped through, deferred focus work is safe against pooling and cross-panel moves, and `autoFocus` is strictly mount-once.

### Containment

- **A landing inside a contain scope stands.** The scope receiving focus claims it (React Aria's newest-scope activation), so a stacked dialog can take focus from the modal underneath. This also makes cross-scope moves structurally terminal: UI Toolkit QUEUES focus events raised from inside a dispatch, so a re-entrancy flag cannot suppress a nested snap-back — two contained scopes could previously queue `Focus()` calls at each other forever (a main-thread livelock). The flag is gone; termination is by construction.
- **Containment resolves through the NEAREST contain scope everywhere.** A sequential move from a plain (or roving) scope nested inside a modal now wraps within the modal instead of consulting only the innermost scope.
- **A `singleTabStop` group can no longer exit a modal through a chained boundary.** The exhausted-exit escape is gated on no enclosing contain scope; conversely, in an unconstrained chained host, an exit walk that WRAPS the host ring now takes the boundary escape (the pinned iframe contract: Tab past the host ring's end exits) instead of landing back at the ring start.
- **Chained escape landings are bounded by the placeholder's own contain scope**, and a placeholder reached from inside a contain scope snaps back instead of forwarding focus across the panel boundary.
- **`contain` + `restoreFocus` works together** (the standard modal combo): the cleaner drops a dying scope's registry entry before firing the restore focus, so the restore's own FocusIn no longer sees the dying scope as live containment and reverts the restore into the detaching subtree.
- **The FocusOut containment rescue re-validates before firing**: binding identity (a pooled scope root recycled into a NEW scope under the same element key must not attract focus), and whether any managed panel took focus meanwhile — a legitimate cross-panel move blurs the old panel to nothing, which is otherwise indistinguishable from a click on empty space.

### Scheduling / pooling

- **The chained escape hop re-resolves its landing at fire time** from the placeholder's then-current ring position. A landing captured at hop time can be unmounted and pool-recycled into an unrelated same-panel role within the one-tick window, which no identity guard on the captured reference can detect.
- **Deferred navigator attach hooks** dedup per element, and unregister when their element is torn down or a chained placeholder flips back to `Isolated` — a pooled element never carries a live hook into its next role.

### autoFocus

Mount-once is now literal: the latch is taken on the scope's FIRST attach regardless of the setting's value at that moment, so a post-mount `autoFocus` flip cannot re-arm it for a later keyed-reorder re-attach.

### UseFocusRing

A ref moving to a REPLACEMENT element while the old element held focus no longer strands `IsFocused`/`IsFocusVisible` at true: the deferred correction now yields only to a superseding hookup whose element actually holds focus.

### Tests

Six regressions verified RED before the fix and GREEN after (stacked-modal focus claim, contain+restore teardown, autoFocus latch bypass, ring ref migration, chained edge-group escape, cross-panel modal steal-back), plus two pins whose pre-fix behavior is a race or livelock and cannot be expressed as a failing assertion — each documents that in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
