### PR TITLE
feat: drag-and-drop primitives (dnd-kit core parity)

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Drag-and-drop primitives, dnd-kit core parity: `V.DndContext` (the scope — `onDragStart` /
+  `onDragOver` / `onDragEnd` / `onDragCancel` callbacks, a pluggable `DndCollisionDetection`
+  delegate with `DndCollisions.RectIntersection` / `ClosestCenter` / `PointerWithin` built-ins,
+  and a scope-wide activation default), `V.Draggable(id:)` (activation constraints defaulting to
+  4 px of travel so clicks keep working on draggable controls; inline-translate or stay-put
+  movement; `whileDraggingClass:`), `V.Droppable(id:)` (`whileOverClass:` /
+  `whileDragActiveClass:`; live-rect collision, so mid-drag layout shifts are picked up
+  automatically), and `V.DragOverlay` (a portal-rendered, picking-ignored preview that tracks the
+  pointer on the Overlay layer). Escape cancels; drop/cancel callbacks commit state synchronously
+  like click handlers; a real drag ending on a Clickable source suppresses its `clicked` and
+  settles the press-derived `whileTap`/`active:` styling synthetically; everything a session
+  writes (capture, inline translate, classes) is restored on drop, cancel, and teardown —
+  including a source unmounting mid-drag, whose user cancel callback is deferred past the flush.
 - Focus / gamepad navigation layer, React Aria parity — composing with (never reimplementing)
   the engine's own focus machinery:
   - `V.FocusScope(contain:, restoreFocus:, autoFocus:, singleTabStop:)` (and the same knobs as a

--- a/Packages/com.velvet.core/Documentation~/drag-and-drop.md
+++ b/Packages/com.velvet.core/Documentation~/drag-and-drop.md
@@ -1,0 +1,112 @@
+# Drag and drop: the dnd-kit parity guide
+
+Velvet's drag-and-drop layer models [dnd-kit](https://dndkit.com/)'s core — `DndContext`,
+`useDraggable`, `useDroppable`, `DragOverlay`, and pluggable collision detection — on top of UI
+Toolkit's own pointer pipeline. Everything rides the element-binding discipline the rest of the
+framework uses: settings live on element props, the reconciler owns attach/update/detach, and a
+pooled element leaves with everything the session ever wrote restored.
+
+## The pieces
+
+- **`V.DndContext`** — the scope, dnd-kit's `DndContext`. A real container element (the same
+  decision as `V.FocusScope`): draggables and droppables pair with their nearest ancestor context
+  at event time, and one drag may be active per mounted tree at a time. Carries the four
+  callbacks (`onDragStart`, `onDragOver`, `onDragEnd`, `onDragCancel`), the collision strategy,
+  and a scope-wide default activation constraint.
+- **`V.Draggable(id:)`** — a drag source, dnd-kit's `useDraggable`. The element itself is the
+  drag node. `dragData:` carries an arbitrary payload into the callbacks; `movement:` chooses
+  whether the element itself follows the pointer (`Translate`, the default — an inline
+  `translate` written every move and restored afterward) or stays put (`None` — the
+  `V.DragOverlay` ghost pattern); `whileDraggingClass:` is the zero-re-render styling channel for
+  the dragging state.
+- **`V.Droppable(id:)`** — a drop target, dnd-kit's `useDroppable`. `whileOverClass:` applies
+  while it is the winning collision; `whileDragActiveClass:` applies to every enabled candidate
+  while any drag is live in the scope (dnd-kit's droppable `active` cue). `dropData:` rides into
+  the callbacks for accept-filtering, which stays app logic — exactly as in dnd-kit core.
+- **`V.DragOverlay`** — the portal-rendered drag preview, dnd-kit's `DragOverlay`. Expands to a
+  `V.Portal(UILayer.Overlay)` hosting a framework-positioned, picking-ignored container that is
+  sized to the source at activation and tracks the pointer while a drag is active (hidden
+  otherwise). What renders INSIDE it is ordinary user state — set an "active item" in
+  `onDragStart`, clear it in `onDragEnd`/`onDragCancel`, and render the preview conditionally:
+  dnd-kit's own `activeId` recipe.
+
+Any existing element can be a source, target, or scope through the corresponding
+`FiberElementProps` slots — the factories are sugar. An element carrying both `Draggable` and
+`Droppable` under the same id (the sortable-row shape) never collides with itself.
+
+## Activation: clicks keep working
+
+A press becomes a drag only after crossing an activation constraint (`DragActivation`). The
+default is 4 px of travel — a deliberate, documented deviation from dnd-kit's unconstrained
+`PointerSensor` default, because UI Toolkit's `Clickable` captures the pointer at pointer-down
+and a zero threshold would kill clicks on draggable buttons. A sub-threshold release is a plain
+click, completely untouched. `DragActivation.None` restores the raw dnd-kit behavior (the press
+is the drag); a `DelaySec` greater than zero switches to hold-to-drag (dnd-kit's either/or):
+activation after the hold, aborted if travel exceeds `Tolerance` first.
+
+After a REAL drag, the release is swallowed before `Clickable` sees it, so a draggable button
+does not also fire `clicked` — and the press-derived styling state (`whileTap`, `active:`) is
+settled synthetically, since the real pointer-up never reaches those listeners.
+
+One engine ground truth to know: while an element holds pointer capture, captured pointer events
+are delivered to that element only. An interactive CHILD that captures at its own pointer-down (a
+button inside a draggable card) therefore blacks out the draggable's view of the gesture —
+interactive capturing children are non-drag zones in distance mode. Put the `Draggable` setting
+on the interactive element itself (a draggable `V.Button` works: the captured events land on the
+same element), or use delay activation.
+
+## Collision detection
+
+The strategy is a delegate — `DndCollisionDetection` — receiving the active rect (the source's
+activation-time rect translated by the pointer delta: dnd-kit's translated-initial-rect
+semantics, correct even under `Movement.None`), the pointer position, and the pre-filtered
+candidates (in-scope, enabled, same panel, self excluded). Built-ins on `DndCollisions`:
+`RectIntersection` (largest overlap wins — the dnd-kit default), `ClosestCenter` (the sortable
+workhorse), and `PointerWithin` (pointer containment, innermost wins). A custom strategy is just
+a delegate; it must be pure over the query, since it runs on every move.
+
+Candidate rects are read live from the panel every move, so mid-drag layout shifts, scrolls, and
+droppables mounting/unmounting are picked up automatically — dnd-kit's `MeasuringConfiguration`
+has no equivalent because nothing is cached to configure.
+
+## Callbacks and state
+
+`onDragStart`, `onDragEnd`, and `onDragCancel` run in the same discrete-input bracket as click
+handlers: state written there commits synchronously in the same frame — a sortable list's
+`onDragEnd` reorder is visible immediately, and wrapping rows in `V.Motion(layoutId:)` makes the
+post-drop reorder animate with no extra wiring. `onDragOver` fires only when the winning target
+CHANGES (including to null) and stays on the normal frame-boundary lane, since it can fire every
+move.
+
+`isDragging` / `isOver` are deliberately NOT re-rendering booleans: the `while*Class` channels
+cover styling with zero re-renders, and structural state goes through the callbacks plus your own
+`UseState` — dnd-kit's own recipe. Escape cancels an active drag; a cancelled (or torn-down) drag
+restores the source's inline translate and every applied class by construction.
+
+## Scope cuts (each deliberate, with its dnd-kit name)
+
+- **Keyboard sensor + accessibility announcements** (`KeyboardSensor`, `announcements`) — pointer
+  only for now; keyboard DnD couples to the focus layer and is its own follow-up. Escape-cancel
+  IS included.
+- **Sensors abstraction** (`sensors`) — one implementation behind an abstraction is indirection;
+  a keyboard path would land as a second internal attachment, not a plugin API.
+- **`useDraggable`/`useDroppable` hooks returning re-rendering flags** — layerable later over the
+  same registries; the class channels and callbacks cover the pillars.
+- **Cross-panel drag** — source and droppables must share one panel; collision skips
+  foreign-panel candidates. Content inside `V.Portal(layer:)` / `V.WorldSpace` gets working DnD
+  within its own panel; the `DragOverlay` ghost is the one sanctioned cross-panel piece
+  (display-only, picking-ignored).
+- **Sortable preset** (`@dnd-kit/sortable`) — a separate package upstream, a separate issue here;
+  `V.Motion(layoutId:)` already animates the post-drop reorder.
+- **`dropAnimation`** on the overlay, **`modifiers`** (axis/bounds restriction), and
+  **auto-scroll** near container edges — additive later.
+- **`useDndMonitor` / `useDndContext`** introspection — no consumer yet.
+- **Ranked `Collision[]`** — a strategy returns a single winner; the context only ever consumed
+  the first collision anyway.
+- **Multi-touch / concurrent drags** — one active drag per mounted tree (dnd-kit's `active` is
+  singular too); extra pointer-downs during a session do not arm.
+
+Composition caveats, documented rather than solved: draggables inside an engine `ListView` with
+`reorderable: true` conflict with its internal drag processor (unsupported); the delta is
+panel-space, so a scaled ancestor skews tracking (a caveat dnd-kit shares); and the
+interactive-capturing-children rule above.

--- a/Packages/com.velvet.core/Runtime/Component/V.cs
+++ b/Packages/com.velvet.core/Runtime/Component/V.cs
@@ -1844,7 +1844,10 @@ namespace Velvet
         /// <returns>The created <see cref="PortalNode"/>.</returns>
         public static PortalNode DragOverlay(VNode?[]? children = null, string? key = null)
         {
-            var positionerProps = VNodePool.RentProps();
+            // Deliberately NOT a rented pool bag: the fiber-tree recycle path does not descend into
+            // PortalNode children, so a rented bag here would never flow back to the pool and its
+            // ownership tracking would pin one bag per render. A plain instance is ordinary garbage.
+            var positionerProps = new FiberElementProps();
             positionerProps.DragOverlay = new DragOverlaySettings();
             return Portal(UILayer.Overlay, key: key, children: new VNode?[]
             {

--- a/Packages/com.velvet.core/Runtime/Component/V.cs
+++ b/Packages/com.velvet.core/Runtime/Component/V.cs
@@ -1666,6 +1666,200 @@ namespace Velvet
         }
 
         /// <summary>
+        /// Drag-and-drop scope — dnd-kit's DndContext. A real container element (the FocusScope
+        /// precedent: the element is the stable scope identity and cleanup anchor). Draggables and
+        /// droppables pair with their nearest ancestor scope at event time; one drag may be active per
+        /// mounted tree at a time. Any existing container can be a scope via props
+        /// (<see cref="FiberElementProps.DndContext"/>) — this factory is convenience.
+        /// </summary>
+        /// <param name="onDragStart">Fired once when a press crosses its activation constraint.</param>
+        /// <param name="onDragOver">Fired when the winning drop target CHANGES (including to null).</param>
+        /// <param name="onDragEnd">Fired on release; state written here flushes synchronously like any
+        /// discrete input handler. Over is null when dropped on nothing.</param>
+        /// <param name="onDragCancel">Fired when a drag aborts (Escape, pointer cancel, lost capture,
+        /// or the source/scope unmounting mid-drag).</param>
+        /// <param name="collisionDetection">Collision strategy; null means
+        /// <see cref="DndCollisions.RectIntersection"/>.</param>
+        /// <param name="activation">Scope-wide activation default; a per-draggable override wins.</param>
+        /// <returns>The created <see cref="ElementNode"/>.</returns>
+        public static ElementNode DndContext(
+            Action<DragStartArgs>? onDragStart = null,
+            Action<DragOverArgs>? onDragOver = null,
+            Action<DragEndArgs>? onDragEnd = null,
+            Action<DragCancelArgs>? onDragCancel = null,
+            DndCollisionDetection? collisionDetection = null,
+            DragActivation? activation = null,
+            string? className = null,
+            string? key = null,
+            string? name = null,
+            FiberElementProps? props = null,
+            StyleOverrides? styles = null,
+            Func<VisualElement, Action>? refCallback = null,
+            VNode?[]? children = null,
+            string? whileHoverClass = null,
+            string? whileTapClass = null,
+            string? whileFocusClass = null,
+            IReadOnlyDictionary<string, string>? data = null,
+            IReadOnlyDictionary<string, string>? aria = null)
+        {
+            var mergedProps = WithAttributes(props, data, aria) ?? VNodePool.RentProps();
+            mergedProps.DndContext = new DndContextSettings(
+                onDragStart, onDragOver, onDragEnd, onDragCancel, collisionDetection, activation);
+
+            return new ElementNode
+            {
+                Key = key,
+                ElementType = typeof(VisualElement),
+                Name = name,
+                ClassNames = ParseClassNames(className),
+                Props = mergedProps,
+                Styles = styles,
+                Children = children ?? EmptyChildren,
+                Events = EmptyEvents,
+                RefCallback = refCallback,
+                WhileHoverClass = whileHoverClass,
+                WhileTapClass = whileTapClass,
+                WhileFocusClass = whileFocusClass,
+            };
+        }
+
+        /// <summary>
+        /// Drag source — dnd-kit's useDraggable. The element itself is the drag node; it must sit (at
+        /// any depth) under a <see cref="DndContext"/> scope.
+        /// </summary>
+        /// <param name="id">Identity reported to the scope callbacks. An element that is both draggable
+        /// and droppable under one id never collides with itself.</param>
+        /// <param name="dragData">Arbitrary payload carried into the callbacks.</param>
+        /// <param name="disabled">A disabled draggable never arms.</param>
+        /// <param name="movement"><see cref="DragMovement.Translate"/> (default) writes the pointer delta
+        /// as an inline translate during the drag; <see cref="DragMovement.None"/> leaves the source in
+        /// place (the V.DragOverlay ghost pattern).</param>
+        /// <param name="activation">Per-draggable activation constraint; wins over the scope's.</param>
+        /// <param name="whileDraggingClass">Classes applied while this element's drag is active — the
+        /// zero-re-render isDragging channel.</param>
+        /// <returns>The created <see cref="ElementNode"/>.</returns>
+        public static ElementNode Draggable(
+            string id,
+            object? dragData = null,
+            bool disabled = false,
+            DragMovement movement = DragMovement.Translate,
+            DragActivation? activation = null,
+            string? whileDraggingClass = null,
+            string? className = null,
+            string? key = null,
+            string? name = null,
+            FiberElementProps? props = null,
+            StyleOverrides? styles = null,
+            Func<VisualElement, Action>? refCallback = null,
+            VNode?[]? children = null,
+            string? whileHoverClass = null,
+            string? whileTapClass = null,
+            string? whileFocusClass = null,
+            IReadOnlyDictionary<string, string>? data = null,
+            IReadOnlyDictionary<string, string>? aria = null)
+        {
+            var mergedProps = WithAttributes(props, data, aria) ?? VNodePool.RentProps();
+            mergedProps.Draggable = new DraggableSettings(
+                id, dragData, disabled, movement, activation, whileDraggingClass);
+
+            return new ElementNode
+            {
+                Key = key,
+                ElementType = typeof(VisualElement),
+                Name = name,
+                ClassNames = ParseClassNames(className),
+                Props = mergedProps,
+                Styles = styles,
+                Children = children ?? EmptyChildren,
+                Events = EmptyEvents,
+                RefCallback = refCallback,
+                WhileHoverClass = whileHoverClass,
+                WhileTapClass = whileTapClass,
+                WhileFocusClass = whileFocusClass,
+            };
+        }
+
+        /// <summary>
+        /// Drop target — dnd-kit's useDroppable. Collides with the active drag's rect under the scope's
+        /// collision strategy; accept-filtering stays app logic in the scope callbacks (dnd-kit core
+        /// behavior).
+        /// </summary>
+        /// <param name="id">Identity reported to the scope callbacks.</param>
+        /// <param name="dropData">Arbitrary payload carried into the callbacks.</param>
+        /// <param name="disabled">A disabled droppable never collides.</param>
+        /// <param name="whileOverClass">Classes applied while this target is the winning collision.</param>
+        /// <param name="whileDragActiveClass">Classes applied to every enabled candidate while any drag
+        /// is live in scope (dnd-kit's droppable "active" cue).</param>
+        /// <returns>The created <see cref="ElementNode"/>.</returns>
+        public static ElementNode Droppable(
+            string id,
+            object? dropData = null,
+            bool disabled = false,
+            string? whileOverClass = null,
+            string? whileDragActiveClass = null,
+            string? className = null,
+            string? key = null,
+            string? name = null,
+            FiberElementProps? props = null,
+            StyleOverrides? styles = null,
+            Func<VisualElement, Action>? refCallback = null,
+            VNode?[]? children = null,
+            string? whileHoverClass = null,
+            string? whileTapClass = null,
+            string? whileFocusClass = null,
+            IReadOnlyDictionary<string, string>? data = null,
+            IReadOnlyDictionary<string, string>? aria = null)
+        {
+            var mergedProps = WithAttributes(props, data, aria) ?? VNodePool.RentProps();
+            mergedProps.Droppable = new DroppableSettings(
+                id, dropData, disabled, whileOverClass, whileDragActiveClass);
+
+            return new ElementNode
+            {
+                Key = key,
+                ElementType = typeof(VisualElement),
+                Name = name,
+                ClassNames = ParseClassNames(className),
+                Props = mergedProps,
+                Styles = styles,
+                Children = children ?? EmptyChildren,
+                Events = EmptyEvents,
+                RefCallback = refCallback,
+                WhileHoverClass = whileHoverClass,
+                WhileTapClass = whileTapClass,
+                WhileFocusClass = whileFocusClass,
+            };
+        }
+
+        /// <summary>
+        /// Portal-rendered drag preview — dnd-kit's DragOverlay. Expands to
+        /// <c>V.Portal(UILayer.Overlay)</c> hosting a framework-positioned, picking-ignored positioner
+        /// that is sized to the drag source at activation and tracks the pointer while a drag is active
+        /// (hidden otherwise). Render preview content conditionally from state set in
+        /// <c>onDragStart</c>/<c>onDragEnd</c> — dnd-kit's activeId recipe. Inherits
+        /// <c>V.Portal(layer:)</c>'s editor-context degradation.
+        /// </summary>
+        /// <param name="children">The preview content.</param>
+        /// <param name="key">Key used to disambiguate siblings at the same position.</param>
+        /// <returns>The created <see cref="PortalNode"/>.</returns>
+        public static PortalNode DragOverlay(VNode?[]? children = null, string? key = null)
+        {
+            var positionerProps = VNodePool.RentProps();
+            positionerProps.DragOverlay = new DragOverlaySettings();
+            return Portal(UILayer.Overlay, key: key, children: new VNode?[]
+            {
+                new ElementNode
+                {
+                    Key = "drag-overlay-positioner",
+                    ElementType = typeof(VisualElement),
+                    Props = positionerProps,
+                    Children = children ?? EmptyChildren,
+                    Events = EmptyEvents,
+                },
+            });
+        }
+
+        /// <summary>
         /// Placeholder that renders the matched child route component of a nested route at this position.
         /// </summary>
         /// <param name="context">

--- a/Packages/com.velvet.core/Runtime/Component/VNodePool.cs
+++ b/Packages/com.velvet.core/Runtime/Component/VNodePool.cs
@@ -61,6 +61,10 @@ namespace Velvet
             props.TabIndex = null;
             props.DelegatesFocus = null;
             props.FocusScope = null;
+            props.DndContext = null;
+            props.Draggable = null;
+            props.Droppable = null;
+            props.DragOverlay = null;
             props.Slider = null;
             props.ScrollView = null;
             props.TextField = null;

--- a/Packages/com.velvet.core/Runtime/Reconciler/DndActiveDrag.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/DndActiveDrag.cs
@@ -1,0 +1,630 @@
+#nullable enable
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace Velvet
+{
+    // The drag-gesture state machine — the single owner of one pointer-drag session per mounted tree,
+    // referenced solely from ReconcilerContext.ActiveDrag (null = idle). Armed (PENDING) by a draggable's
+    // pointer-down, promoted to ACTIVE when the activation constraint is crossed, and returned to idle on
+    // drop, cancel, or teardown. Two engine facts shape the event wiring (both verified against engine
+    // source and pinned by the DnD PlayMode tests):
+    //
+    //   1. CAPTURED pointer events are delivered to the capturing element ONLY — no trickle through
+    //      ancestors. So the PENDING phase observes moves on the panel root (nothing is captured yet;
+    //      a child that captures at its own pointer-down blacks the moves out, which makes interactive
+    //      capturing children documented non-drag zones in distance mode), while the ACTIVE phase
+    //      captures on the source and registers its drag-lifetime callbacks on the source itself.
+    //   2. TrickleDown-registered callbacks on the capturing element run before bubble-phase ones on the
+    //      same element, so the post-drag PointerUp can be swallowed (StopImmediatePropagation) before
+    //      UI Toolkit's own Clickable fires `clicked` — a real drag ending on a draggable Button must
+    //      not click it.
+    internal sealed class DndActiveDrag
+    {
+        private readonly ReconcilerContext _ctx;
+        private readonly VisualElement _scopeElement;
+        private readonly DndScopeBinding _scope;
+        private readonly VisualElement _source;
+        private readonly DndDraggableBinding _draggable;
+        private readonly VisualElement _panelRoot;
+        private readonly DragActivation _activation;
+        private readonly int _pointerId;
+
+        private bool _active;
+        private bool _closed;
+        private Vector2 _lastPointerPosition;
+        private float _pendingMaxTravel;
+
+        // Pending-phase observation (panel root; see the class note on captured delivery).
+        private EventCallback<PointerMoveEvent>? _onPendingMove;
+        private EventCallback<PointerUpEvent>? _onPendingUp;
+        private EventCallback<PointerCancelEvent>? _onPendingCancel;
+        // Hold-to-drag clock. Recurring (survives a mid-hold re-attach; the baseline is taken from the
+        // scheduler's own TimerState, so a restart is harmless) rather than a one-shot ExecuteLater,
+        // which restarts IN FULL on re-attach — the pool-ghosting time-bomb shape.
+        private IVisualElementScheduledItem? _delayTick;
+        private long _delayBaselineMs = -1;
+
+        // Active-session state.
+        private Vector2 _origin;
+        private Rect _originRect;
+        private Vector2 _grabOffset;
+        private StyleTranslate _savedTranslate;
+        private Vector2 _baseTranslate;
+        private Vector2 _delta;
+        private string? _overId;
+        private DndDroppableBinding? _overBinding;
+        private VisualElement? _overElement;
+        private readonly List<(VisualElement Element, string[] Classes)> _appliedActiveClasses = new();
+        private VisualElement? _overlayPositioner;
+        private DndOverlayBinding? _overlay;
+        private EventCallback<PointerMoveEvent>? _onDragMove;
+        private EventCallback<PointerUpEvent>? _onDragUp;
+        private EventCallback<PointerCancelEvent>? _onDragCancel;
+        private EventCallback<PointerCaptureOutEvent>? _onCaptureOut;
+        private EventCallback<KeyDownEvent>? _onEscape;
+        private readonly List<DndDroppableRect> _queryBuffer = new();
+
+        internal VisualElement Source => _source;
+        internal VisualElement ScopeElement => _scopeElement;
+        internal bool IsActivePhase => _active;
+
+        // See Arm: a stale pending session steps aside for a fresh press. No user callback fires — a
+        // pending session never surfaced anything.
+        internal void DiscardForRearm()
+        {
+            if (!_active)
+            {
+                Close();
+            }
+        }
+
+        // Arms a session from a draggable's pointer-down. Primary button only; no arming while another
+        // session (pending or active) exists; disabled draggables never arm; a draggable outside any
+        // DndContext warns once per binding and stays inert. No capture and no StopPropagation here —
+        // a press that never crosses the activation constraint must remain a plain click.
+        internal static void Arm(VisualElement source, DndDraggableBinding draggable, ReconcilerContext ctx, PointerDownEvent evt)
+        {
+            // A lingering PENDING session yields to a fresh press: a press whose release was delivered
+            // capture-only to a child (the non-drag-zone case) leaves its pending observers blind to the
+            // up, and without this hand-off the dead session would block every future drag. An ACTIVE
+            // session never yields — extra pointer-downs during a drag do not arm.
+            if (ctx.ActiveDrag != null)
+            {
+                if (ctx.ActiveDrag.IsActivePhase)
+                {
+                    return;
+                }
+                ctx.ActiveDrag.DiscardForRearm();
+            }
+            if (ctx.ActiveDrag != null || draggable.Settings.Disabled || evt.button != 0)
+            {
+                return;
+            }
+            var scopeElement = FindEnclosingScope(source, ctx, out var scope);
+            if (scopeElement == null || scope == null)
+            {
+                if (!draggable.WarnedNoScope)
+                {
+                    draggable.WarnedNoScope = true;
+                    FiberLogger.LogWarning("Dnd",
+                        "A draggable has no enclosing DndContext, so its presses can never become drags. "
+                        + "Wrap it (at any depth) in V.DndContext, or remove the Draggable setting.");
+                }
+                return;
+            }
+            var panelRoot = source.panel?.visualTree;
+            if (panelRoot == null)
+            {
+                return;
+            }
+            ctx.ActiveDrag = new DndActiveDrag(ctx, scopeElement, scope, source, draggable, panelRoot, evt);
+        }
+
+        private DndActiveDrag(
+            ReconcilerContext ctx, VisualElement scopeElement, DndScopeBinding scope,
+            VisualElement source, DndDraggableBinding draggable, VisualElement panelRoot, PointerDownEvent evt)
+        {
+            _ctx = ctx;
+            _scopeElement = scopeElement;
+            _scope = scope;
+            _source = source;
+            _draggable = draggable;
+            _panelRoot = panelRoot;
+            _pointerId = evt.pointerId;
+            _pressPosition = evt.position;
+            _lastPointerPosition = _pressPosition;
+            _activation = draggable.Settings.Activation ?? scope.Settings.Activation ?? DragActivation.Default;
+
+            if (_activation.DelaySec > 0f)
+            {
+                // Hold-to-drag: activation is time-based; travel only ABORTS (Tolerance), never activates.
+                _delayTick = _source.schedule.Execute(OnDelayTick).Every(16);
+            }
+            else if (_activation.Distance <= 0f)
+            {
+                // Unconstrained (DragActivation.None): dnd-kit's raw PointerSensor — the press IS the drag.
+                Activate();
+                return;
+            }
+            RegisterPendingObservers();
+        }
+
+        // Pending observers live on BOTH the panel root and the source: uncaptured moves flow through
+        // the root (covering fast travel that leaves the source's bounds before activation), while a
+        // press whose Clickable SOURCE captured at pointer-down delivers target-only — reaching the
+        // source's own callbacks but never the root's (a draggable V.Button must still activate). An
+        // uncaptured move over the source hits both registrations; OnPendingMove's state guards make
+        // the second invocation a no-op. A CHILD that captured keeps blacking out both — the documented
+        // non-drag zone.
+        private void RegisterPendingObservers()
+        {
+            _onPendingMove = OnPendingMove;
+            _onPendingUp = OnPendingUp;
+            _onPendingCancel = _ => DiscardPending();
+            _panelRoot.RegisterCallback(_onPendingMove, TrickleDown.TrickleDown);
+            _panelRoot.RegisterCallback(_onPendingUp, TrickleDown.TrickleDown);
+            _panelRoot.RegisterCallback(_onPendingCancel, TrickleDown.TrickleDown);
+            _source.RegisterCallback(_onPendingMove, TrickleDown.TrickleDown);
+            _source.RegisterCallback(_onPendingUp, TrickleDown.TrickleDown);
+            _source.RegisterCallback(_onPendingCancel, TrickleDown.TrickleDown);
+        }
+
+        private void OnPendingMove(PointerMoveEvent evt)
+        {
+            // Dual registration (root + source) can deliver one event twice; a move arriving after
+            // activation or discard is stale either way.
+            if (_closed || _active || evt.pointerId != _pointerId)
+            {
+                return;
+            }
+            // A stale Pending (the release happened where this panel could not observe it) must never
+            // spuriously activate: any move arriving with no buttons held discards the session lazily.
+            if (evt.pressedButtons == 0)
+            {
+                DiscardPending();
+                return;
+            }
+            _lastPointerPosition = evt.position;
+            var travel = (_lastPointerPosition - _pressPosition).magnitude;
+            if (travel > _pendingMaxTravel)
+            {
+                _pendingMaxTravel = travel;
+            }
+            if (_activation.DelaySec > 0f)
+            {
+                if (_pendingMaxTravel > _activation.Tolerance)
+                {
+                    DiscardPending();
+                }
+                return;
+            }
+            if (travel >= _activation.Distance)
+            {
+                Activate();
+            }
+        }
+
+        private Vector2 _pressPosition;
+
+        private void OnPendingUp(PointerUpEvent evt)
+        {
+            if (_closed || _active || evt.pointerId != _pointerId)
+            {
+                return;
+            }
+            // Sub-threshold release: a plain click, deliberately untouched (no suppression, no callback).
+            DiscardPending();
+        }
+
+        private void OnDelayTick(TimerState timer)
+        {
+            if (_delayBaselineMs < 0)
+            {
+                _delayBaselineMs = timer.now;
+                return;
+            }
+            if (timer.now - _delayBaselineMs >= (long)(_activation.DelaySec * 1000f))
+            {
+                if (_pendingMaxTravel <= _activation.Tolerance)
+                {
+                    Activate();
+                }
+                else
+                {
+                    DiscardPending();
+                }
+            }
+        }
+
+        private void DiscardPending()
+        {
+            if (_closed || _active)
+            {
+                return;
+            }
+            Close();
+        }
+
+        private void Activate()
+        {
+            _active = true;
+            UnregisterPendingObservers();
+            _delayTick?.Pause();
+            _delayTick = null;
+
+            _origin = _lastPointerPosition;
+            _originRect = _source.worldBound;
+            _grabOffset = _origin - _originRect.position;
+            _savedTranslate = _source.style.translate;
+            _baseTranslate = ResolveBaseTranslate(_savedTranslate);
+            _delta = Vector2.zero;
+
+            // Steals the pointer from a child that captured at its own pointer-down (its
+            // PointerCaptureOutEvent aborts its click — "it's a drag now"); from here every pointer event
+            // of this id is delivered to the source only, so the drag-lifetime callbacks live there.
+            _source.CapturePointer(_pointerId);
+            _onDragMove = OnDragMove;
+            _onDragUp = OnDragUp;
+            _onDragCancel = _ => Cancel();
+            _onCaptureOut = OnCaptureOut;
+            _onEscape = OnEscapeKey;
+            _source.RegisterCallback(_onDragMove, TrickleDown.TrickleDown);
+            _source.RegisterCallback(_onDragUp, TrickleDown.TrickleDown);
+            _source.RegisterCallback(_onDragCancel, TrickleDown.TrickleDown);
+            _source.RegisterCallback(_onCaptureOut, TrickleDown.TrickleDown);
+            _panelRoot.RegisterCallback(_onEscape, TrickleDown.TrickleDown);
+
+            if (_draggable.DraggingClasses.Length > 0)
+            {
+                StyleAnimationClassUtils.AddClasses(_source, _draggable.DraggingClasses);
+            }
+            ApplyDragActiveClasses();
+
+            _overlay = DndOverlayDriver.FindOverlay(_ctx, out _overlayPositioner);
+            if (_overlay != null && _overlayPositioner != null)
+            {
+                DndOverlayDriver.BeginSession(_overlayPositioner, _originRect.size);
+                DndOverlayDriver.SyncPosition(_overlayPositioner, _overlay, _source.panel, _lastPointerPosition, _grabOffset);
+            }
+
+            var args = new DragStartArgs(ActiveInfo(), _origin);
+            FireDiscrete(() => _scope.Settings.OnDragStart?.Invoke(args));
+        }
+
+        private void ApplyDragActiveClasses()
+        {
+            foreach (var (element, binding) in _ctx.DroppableBindings)
+            {
+                if (binding.ActiveClasses.Length == 0 || !IsCollisionCandidate(element, binding))
+                {
+                    continue;
+                }
+                StyleAnimationClassUtils.AddClasses(element, binding.ActiveClasses);
+                _appliedActiveClasses.Add((element, binding.ActiveClasses));
+            }
+        }
+
+        private bool IsCollisionCandidate(VisualElement element, DndDroppableBinding binding)
+            => !binding.Settings.Disabled
+               && element.panel != null && element.panel == _source.panel
+               && _scopeElement.Contains(element)
+               && binding.Settings.Id != _draggable.Settings.Id;
+
+        private void OnDragMove(PointerMoveEvent evt)
+        {
+            if (evt.pointerId != _pointerId)
+            {
+                return;
+            }
+            _lastPointerPosition = evt.position;
+            _delta = _lastPointerPosition - _origin;
+            if (_draggable.Settings.Movement == DragMovement.Translate)
+            {
+                _source.style.translate = new Translate(_baseTranslate.x + _delta.x, _baseTranslate.y + _delta.y);
+            }
+            if (_overlay != null && _overlayPositioner != null)
+            {
+                DndOverlayDriver.SyncPosition(_overlayPositioner, _overlay, _source.panel, _lastPointerPosition, _grabOffset);
+            }
+            UpdateCollision();
+            evt.StopPropagation();
+        }
+
+        private void UpdateCollision()
+        {
+            _queryBuffer.Clear();
+            foreach (var (element, binding) in _ctx.DroppableBindings)
+            {
+                if (IsCollisionCandidate(element, binding))
+                {
+                    _queryBuffer.Add(new DndDroppableRect(binding.Settings.Id, element.worldBound, binding.Settings.Data));
+                }
+            }
+            var strategy = _scope.Settings.CollisionDetection ?? DndCollisions.RectIntersection;
+            var query = new DndCollisionQuery(
+                new Rect(_originRect.position + _delta, _originRect.size), _lastPointerPosition, _queryBuffer);
+            SetOver(strategy(in query));
+        }
+
+        private void SetOver(string? winnerId)
+        {
+            if (winnerId == _overId)
+            {
+                return;
+            }
+            if (_overElement != null && _overBinding is { OverClasses.Length: > 0 })
+            {
+                StyleAnimationClassUtils.RemoveClasses(_overElement, _overBinding.OverClasses);
+            }
+            _overId = winnerId;
+            _overBinding = null;
+            _overElement = null;
+            if (winnerId != null)
+            {
+                foreach (var (element, binding) in _ctx.DroppableBindings)
+                {
+                    if (binding.Settings.Id == winnerId && IsCollisionCandidate(element, binding))
+                    {
+                        _overBinding = binding;
+                        _overElement = element;
+                        break;
+                    }
+                }
+                if (_overElement != null && _overBinding is { OverClasses.Length: > 0 })
+                {
+                    StyleAnimationClassUtils.AddClasses(_overElement, _overBinding.OverClasses);
+                }
+            }
+            // Over-change is continuous-lane feedback (it fires mid-move, potentially every frame):
+            // a plain invoke, never the discrete synchronous-flush bracket drop/cancel use.
+            var overInfo = CurrentOverInfo();
+            var args = new DragOverArgs(ActiveInfo(), overInfo, _delta);
+            _scope.Settings.OnDragOver?.Invoke(args);
+        }
+
+        private void OnDragUp(PointerUpEvent evt)
+        {
+            if (evt.pointerId != _pointerId)
+            {
+                return;
+            }
+            _lastPointerPosition = evt.position;
+            _delta = _lastPointerPosition - _origin;
+            var args = new DragEndArgs(ActiveInfo(), CurrentOverInfo(), _delta, _lastPointerPosition);
+            // Close the session BEFORE the user callback, deviating from "callback then scrub": OnDragEnd
+            // runs in the discrete bracket, whose synchronous flush may unmount the source (the sortable
+            // commit) — the cleaner would then find a live session mid-teardown and cancel-scrub what the
+            // drop already owned. With the session closed first, that path sees idle and does nothing.
+            Close();
+            DndPressVariantSettler.Settle(_source, _ctx);
+            // Swallowed before bubble-phase listeners on this same element run, so a Clickable on the
+            // source (a draggable V.Button) does not fire `clicked` after a REAL drag. A sub-threshold
+            // press never reaches here (it discards in Pending) — clicks stay intact.
+            evt.StopImmediatePropagation();
+            FireDiscrete(() => _scope.Settings.OnDragEnd?.Invoke(args));
+        }
+
+        private void OnCaptureOut(PointerCaptureOutEvent evt)
+        {
+            // Close() unregisters this callback BEFORE releasing the pointer, so a capture-out observed
+            // here is always external (another element stole the capture) — a cancel, not our own release.
+            if (evt.pointerId == _pointerId)
+            {
+                Cancel();
+            }
+        }
+
+        private void OnEscapeKey(KeyDownEvent evt)
+        {
+            if (evt.keyCode != KeyCode.Escape)
+            {
+                return;
+            }
+            evt.StopPropagation();
+            Cancel();
+        }
+
+        private void Cancel()
+        {
+            if (_closed)
+            {
+                return;
+            }
+            if (!_active)
+            {
+                Close();
+                return;
+            }
+            var args = new DragCancelArgs(ActiveInfo());
+            Close();
+            DndPressVariantSettler.Settle(_source, _ctx);
+            FireDiscrete(() => _scope.Settings.OnDragCancel?.Invoke(args));
+        }
+
+        // Teardown-flavored cancel, called by FiberElementCleaner / the drivers when the source, its
+        // scope, or the whole tree is going away MID-FLUSH. The scrub runs synchronously (the element
+        // must reach the pool clean), but the user OnDragCancel is deferred to the panel's next
+        // scheduler tick: a state write from inside the flush is silently lost (the fiber's dirty flag
+        // clears when the flush ends) and its lost pending value dedups away the next genuine edge.
+        internal void CancelForTeardown()
+        {
+            if (_closed)
+            {
+                return;
+            }
+            var wasActive = _active;
+            var deferRoot = _source.panel?.visualTree ?? _panelRoot;
+            var scope = _scope;
+            var args = wasActive ? new DragCancelArgs(ActiveInfo()) : null;
+            Close();
+            if (!wasActive || args == null)
+            {
+                return;
+            }
+            DndPressVariantSettler.Settle(_source, _ctx);
+            deferRoot.schedule.Execute(() =>
+                FiberDiscreteEventScope.Run(() => scope.Settings.OnDragCancel?.Invoke(args), _ctx.BatchScheduler));
+        }
+
+        // A droppable leaving mid-drag (unmount, or a settings flip to disabled) must drop out of this
+        // session's bookkeeping: its applied classes die with it, the over slot clears silently (the next
+        // move recomputes and fires OnDragOver as usual — no user callback from mid-flush here).
+        internal void OnDroppableInvalidated(VisualElement element)
+        {
+            for (var i = _appliedActiveClasses.Count - 1; i >= 0; i--)
+            {
+                if (ReferenceEquals(_appliedActiveClasses[i].Element, element))
+                {
+                    StyleAnimationClassUtils.RemoveClasses(element, _appliedActiveClasses[i].Classes);
+                    _appliedActiveClasses.RemoveAt(i);
+                }
+            }
+            if (ReferenceEquals(_overElement, element))
+            {
+                if (_overBinding is { OverClasses.Length: > 0 })
+                {
+                    StyleAnimationClassUtils.RemoveClasses(element, _overBinding.OverClasses);
+                }
+                _overId = null;
+                _overBinding = null;
+                _overElement = null;
+            }
+        }
+
+        internal void OnOverlayInvalidated(VisualElement positioner)
+        {
+            if (ReferenceEquals(_overlayPositioner, positioner))
+            {
+                _overlay = null;
+                _overlayPositioner = null;
+            }
+        }
+
+        // Restores everything this session ever wrote and returns the context to idle. Ordering note:
+        // the drag-lifetime callbacks unregister BEFORE ReleasePointer, so our own release's
+        // PointerCaptureOutEvent cannot re-enter as a cancel.
+        private void Close()
+        {
+            if (_closed)
+            {
+                return;
+            }
+            _closed = true;
+            UnregisterPendingObservers();
+            _delayTick?.Pause();
+            _delayTick = null;
+            if (_active)
+            {
+                if (_onDragMove != null) _source.UnregisterCallback(_onDragMove, TrickleDown.TrickleDown);
+                if (_onDragUp != null) _source.UnregisterCallback(_onDragUp, TrickleDown.TrickleDown);
+                if (_onDragCancel != null) _source.UnregisterCallback(_onDragCancel, TrickleDown.TrickleDown);
+                if (_onCaptureOut != null) _source.UnregisterCallback(_onCaptureOut, TrickleDown.TrickleDown);
+                if (_onEscape != null) _panelRoot.UnregisterCallback(_onEscape, TrickleDown.TrickleDown);
+                _onDragMove = null;
+                _onDragUp = null;
+                _onDragCancel = null;
+                _onCaptureOut = null;
+                _onEscape = null;
+                if (_source.HasPointerCapture(_pointerId))
+                {
+                    _source.ReleasePointer(_pointerId);
+                }
+                if (_draggable.Settings.Movement == DragMovement.Translate)
+                {
+                    _source.style.translate = _savedTranslate;
+                }
+                if (_draggable.DraggingClasses.Length > 0)
+                {
+                    StyleAnimationClassUtils.RemoveClasses(_source, _draggable.DraggingClasses);
+                }
+                foreach (var (element, classes) in _appliedActiveClasses)
+                {
+                    StyleAnimationClassUtils.RemoveClasses(element, classes);
+                }
+                _appliedActiveClasses.Clear();
+                if (_overElement != null && _overBinding is { OverClasses.Length: > 0 })
+                {
+                    StyleAnimationClassUtils.RemoveClasses(_overElement, _overBinding.OverClasses);
+                }
+                _overId = null;
+                _overBinding = null;
+                _overElement = null;
+                if (_overlayPositioner != null)
+                {
+                    DndOverlayDriver.EndSession(_overlayPositioner);
+                }
+                _overlay = null;
+                _overlayPositioner = null;
+            }
+            if (ReferenceEquals(_ctx.ActiveDrag, this))
+            {
+                _ctx.ActiveDrag = null;
+            }
+        }
+
+        private void UnregisterPendingObservers()
+        {
+            if (_onPendingMove != null)
+            {
+                _panelRoot.UnregisterCallback(_onPendingMove, TrickleDown.TrickleDown);
+                _source.UnregisterCallback(_onPendingMove, TrickleDown.TrickleDown);
+            }
+            if (_onPendingUp != null)
+            {
+                _panelRoot.UnregisterCallback(_onPendingUp, TrickleDown.TrickleDown);
+                _source.UnregisterCallback(_onPendingUp, TrickleDown.TrickleDown);
+            }
+            if (_onPendingCancel != null)
+            {
+                _panelRoot.UnregisterCallback(_onPendingCancel, TrickleDown.TrickleDown);
+                _source.UnregisterCallback(_onPendingCancel, TrickleDown.TrickleDown);
+            }
+            _onPendingMove = null;
+            _onPendingUp = null;
+            _onPendingCancel = null;
+        }
+
+        private DraggableInfo ActiveInfo()
+            => new(_draggable.Settings.Id, _draggable.Settings.Data, _source);
+
+        private DroppableInfo? CurrentOverInfo()
+            => _overBinding != null && _overElement != null
+                ? new DroppableInfo(_overBinding.Settings.Id, _overBinding.Settings.Data, _overElement)
+                : null;
+
+        private void FireDiscrete(System.Action callback)
+            => FiberDiscreteEventScope.Run(callback, _ctx.BatchScheduler);
+
+        private static Vector2 ResolveBaseTranslate(StyleTranslate saved)
+        {
+            // Only a concrete inline pixel translate composes additively with the drag delta; a keyword
+            // (unset/null) means zero base, and percent lengths have no panel-space meaning to add — the
+            // drag then drives from zero and the original value is restored verbatim at close.
+            if (saved.keyword != StyleKeyword.Undefined)
+            {
+                return Vector2.zero;
+            }
+            var value = saved.value;
+            var x = value.x.unit == LengthUnit.Pixel ? value.x.value : 0f;
+            var y = value.y.unit == LengthUnit.Pixel ? value.y.value : 0f;
+            return new Vector2(x, y);
+        }
+
+        private static VisualElement? FindEnclosingScope(
+            VisualElement element, ReconcilerContext ctx, out DndScopeBinding? binding)
+        {
+            for (var current = element; current != null; current = current.parent)
+            {
+                if (ctx.DndScopeBindings.TryGetValue(current, out var found))
+                {
+                    binding = found;
+                    return current;
+                }
+            }
+            binding = null;
+            return null;
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/DndActiveDrag.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/DndActiveDrag.cs
@@ -46,24 +46,33 @@ namespace Velvet
         private IVisualElementScheduledItem? _delayTick;
         private long _delayBaselineMs = -1;
 
-        // Active-session state.
+        // Active-session state. Movement mode and the applied class arrays are SNAPSHOTS taken when they
+        // are applied, never re-read from the live bindings: a mid-drag re-render may swap the settings
+        // records (DndDraggableDriver.Update / DndDroppableDriver.Reparse), and restoring by the new
+        // values would strand the actually-applied classes and inline translate on the element — the
+        // state-ghosting class this codebase's pool discipline exists to prevent.
         private Vector2 _origin;
         private Rect _originRect;
         private Vector2 _grabOffset;
         private StyleTranslate _savedTranslate;
         private Vector2 _baseTranslate;
         private Vector2 _delta;
+        private DragMovement _activeMovement;
+        private string[] _activeDraggingClasses = System.Array.Empty<string>();
         private string? _overId;
         private DndDroppableBinding? _overBinding;
         private VisualElement? _overElement;
+        private string[]? _appliedOverClasses;
         private readonly List<(VisualElement Element, string[] Classes)> _appliedActiveClasses = new();
         private VisualElement? _overlayPositioner;
         private DndOverlayBinding? _overlay;
         private EventCallback<PointerMoveEvent>? _onDragMove;
         private EventCallback<PointerUpEvent>? _onDragUp;
+        private EventCallback<PointerDownEvent>? _onDragDown;
         private EventCallback<PointerCancelEvent>? _onDragCancel;
         private EventCallback<PointerCaptureOutEvent>? _onCaptureOut;
         private EventCallback<KeyDownEvent>? _onEscape;
+        private readonly List<VisualElement> _escapeRoots = new();
         private readonly List<DndDroppableRect> _queryBuffer = new();
 
         internal VisualElement Source => _source;
@@ -86,6 +95,13 @@ namespace Velvet
         // a press that never crosses the activation constraint must remain a plain click.
         internal static void Arm(VisualElement source, DndDraggableBinding draggable, ReconcilerContext ctx, PointerDownEvent evt)
         {
+            // A press that can never arm (secondary button, disabled) is validated BEFORE any hand-off:
+            // it must not cost a live pending session its observers (a right-button chord mid-press
+            // would otherwise silently kill the held left gesture).
+            if (evt.button != 0 || draggable.Settings.Disabled)
+            {
+                return;
+            }
             // A lingering PENDING session yields to a fresh press: a press whose release was delivered
             // capture-only to a child (the non-drag-zone case) leaves its pending observers blind to the
             // up, and without this hand-off the dead session would block every future drag. An ACTIVE
@@ -98,7 +114,7 @@ namespace Velvet
                 }
                 ctx.ActiveDrag.DiscardForRearm();
             }
-            if (ctx.ActiveDrag != null || draggable.Settings.Disabled || evt.button != 0)
+            if (ctx.ActiveDrag != null)
             {
                 return;
             }
@@ -119,7 +135,14 @@ namespace Velvet
             {
                 return;
             }
-            ctx.ActiveDrag = new DndActiveDrag(ctx, scopeElement, scope, source, draggable, panelRoot, evt);
+            // The session is INSTALLED before it begins: DragActivation.None activates immediately, and
+            // its OnDragStart runs a synchronous discrete flush — a teardown that flush causes (the
+            // activeId recipe swapping the source out) must find ctx.ActiveDrag set, or every teardown
+            // interlock is bypassed and the closed session would be installed afterward, wedging arming
+            // for the tree's lifetime.
+            var session = new DndActiveDrag(ctx, scopeElement, scope, source, draggable, panelRoot, evt);
+            ctx.ActiveDrag = session;
+            session.Begin();
         }
 
         private DndActiveDrag(
@@ -136,11 +159,17 @@ namespace Velvet
             _pressPosition = evt.position;
             _lastPointerPosition = _pressPosition;
             _activation = draggable.Settings.Activation ?? scope.Settings.Activation ?? DragActivation.Default;
+        }
 
+        private void Begin()
+        {
             if (_activation.DelaySec > 0f)
             {
-                // Hold-to-drag: activation is time-based; travel only ABORTS (Tolerance), never activates.
-                _delayTick = _source.schedule.Execute(OnDelayTick).Every(16);
+                // Hold-to-drag: activation is time-based; travel only ABORTS (Tolerance), never
+                // activates. The clock rides the PANEL ROOT's scheduler, not the source's: a re-attach
+                // resets a recurring item's phase in full, so a source inside a keyed list that reorders
+                // every frame would postpone a source-scheduled tick forever.
+                _delayTick = _panelRoot.schedule.Execute(OnDelayTick).Every(16);
             }
             else if (_activation.Distance <= 0f)
             {
@@ -180,8 +209,10 @@ namespace Velvet
                 return;
             }
             // A stale Pending (the release happened where this panel could not observe it) must never
-            // spuriously activate: any move arriving with no buttons held discards the session lazily.
-            if (evt.pressedButtons == 0)
+            // spuriously activate: any move arriving without the PRIMARY button held discards the
+            // session lazily. Specifically bit 0, not the whole bitfield — a secondary-button drag after
+            // an unobserved left release must not keep a dead left-press session alive.
+            if ((evt.pressedButtons & 1) == 0)
             {
                 DiscardPending();
                 return;
@@ -210,7 +241,9 @@ namespace Velvet
 
         private void OnPendingUp(PointerUpEvent evt)
         {
-            if (_closed || _active || evt.pointerId != _pointerId)
+            // A secondary-button release is not the end of the primary-press gesture (UI Toolkit
+            // dispatches one PointerUpEvent per button under the same pointer id).
+            if (_closed || _active || evt.pointerId != _pointerId || evt.button != 0)
             {
                 return;
             }
@@ -227,6 +260,12 @@ namespace Velvet
             }
             if (timer.now - _delayBaselineMs >= (long)(_activation.DelaySec * 1000f))
             {
+                // A source mid-reorder (transiently detached) cannot take pointer capture; hold the
+                // elapsed clock and activate on a later tick once it is back in the panel.
+                if (_source.panel == null)
+                {
+                    return;
+                }
                 if (_pendingMaxTravel <= _activation.Tolerance)
                 {
                     Activate();
@@ -260,6 +299,10 @@ namespace Velvet
             _savedTranslate = _source.style.translate;
             _baseTranslate = ResolveBaseTranslate(_savedTranslate);
             _delta = Vector2.zero;
+            // Snapshot what the session applies (see the field-block note): restore symmetry must not
+            // depend on the live settings surviving the drag unchanged.
+            _activeMovement = _draggable.Settings.Movement;
+            _activeDraggingClasses = _draggable.DraggingClasses;
 
             // Steals the pointer from a child that captured at its own pointer-down (its
             // PointerCaptureOutEvent aborts its click — "it's a drag now"); from here every pointer event
@@ -267,18 +310,22 @@ namespace Velvet
             _source.CapturePointer(_pointerId);
             _onDragMove = OnDragMove;
             _onDragUp = OnDragUp;
+            _onDragDown = OnDragDown;
             _onDragCancel = _ => Cancel();
             _onCaptureOut = OnCaptureOut;
             _onEscape = OnEscapeKey;
             _source.RegisterCallback(_onDragMove, TrickleDown.TrickleDown);
             _source.RegisterCallback(_onDragUp, TrickleDown.TrickleDown);
+            _source.RegisterCallback(_onDragDown, TrickleDown.TrickleDown);
             _source.RegisterCallback(_onDragCancel, TrickleDown.TrickleDown);
             _source.RegisterCallback(_onCaptureOut, TrickleDown.TrickleDown);
-            _panelRoot.RegisterCallback(_onEscape, TrickleDown.TrickleDown);
+            // Escape must cancel no matter which of this tree's panels holds keyboard focus — key events
+            // dispatch through the FOCUSED panel, which need not be the source's.
+            RegisterEscapeOnManagedRoots();
 
-            if (_draggable.DraggingClasses.Length > 0)
+            if (_activeDraggingClasses.Length > 0)
             {
-                StyleAnimationClassUtils.AddClasses(_source, _draggable.DraggingClasses);
+                StyleAnimationClassUtils.AddClasses(_source, _activeDraggingClasses);
             }
             ApplyDragActiveClasses();
 
@@ -297,19 +344,41 @@ namespace Velvet
         {
             foreach (var (element, binding) in _ctx.DroppableBindings)
             {
-                if (binding.ActiveClasses.Length == 0 || !IsCollisionCandidate(element, binding))
+                if (IsCollisionCandidate(element, binding))
                 {
-                    continue;
+                    ApplyDragActiveClassTo(element, binding);
                 }
-                StyleAnimationClassUtils.AddClasses(element, binding.ActiveClasses);
-                _appliedActiveClasses.Add((element, binding.ActiveClasses));
             }
         }
 
+        // Applies the droppable "drag is live" cue exactly once per element per session. Also invoked
+        // from the per-move collision sweep, so a droppable that mounts or is re-enabled MID-drag (the
+        // activeId recipe conditionally rendering drop zones) gets the cue the moment it becomes a
+        // candidate — candidacy and the visual affordance must not diverge.
+        private void ApplyDragActiveClassTo(VisualElement element, DndDroppableBinding binding)
+        {
+            if (binding.ActiveClasses.Length == 0)
+            {
+                return;
+            }
+            for (var i = 0; i < _appliedActiveClasses.Count; i++)
+            {
+                if (ReferenceEquals(_appliedActiveClasses[i].Element, element))
+                {
+                    return;
+                }
+            }
+            StyleAnimationClassUtils.AddClasses(element, binding.ActiveClasses);
+            _appliedActiveClasses.Add((element, binding.ActiveClasses));
+        }
+
+        // Candidacy pairs a droppable with its NEAREST enclosing DndContext (dnd-kit keeps nested
+        // contexts isolated): subtree containment alone would leak an inner scope's droppables into an
+        // outer scope's drag, handing the outer callbacks drop ids they never registered.
         private bool IsCollisionCandidate(VisualElement element, DndDroppableBinding binding)
             => !binding.Settings.Disabled
                && element.panel != null && element.panel == _source.panel
-               && _scopeElement.Contains(element)
+               && ReferenceEquals(FindEnclosingScope(element, _ctx, out _), _scopeElement)
                && binding.Settings.Id != _draggable.Settings.Id;
 
         private void OnDragMove(PointerMoveEvent evt)
@@ -318,9 +387,17 @@ namespace Velvet
             {
                 return;
             }
+            // A phantom session (the primary release happened where no observer could see it — a
+            // capture-only delivery, or off-window) dies on the first buttonless motion instead of
+            // dragging with nothing held.
+            if ((evt.pressedButtons & 1) == 0)
+            {
+                Cancel();
+                return;
+            }
             _lastPointerPosition = evt.position;
             _delta = _lastPointerPosition - _origin;
-            if (_draggable.Settings.Movement == DragMovement.Translate)
+            if (_activeMovement == DragMovement.Translate)
             {
                 _source.style.translate = new Translate(_baseTranslate.x + _delta.x, _baseTranslate.y + _delta.y);
             }
@@ -339,6 +416,7 @@ namespace Velvet
             {
                 if (IsCollisionCandidate(element, binding))
                 {
+                    ApplyDragActiveClassTo(element, binding);
                     _queryBuffer.Add(new DndDroppableRect(binding.Settings.Id, element.worldBound, binding.Settings.Data));
                 }
             }
@@ -354,13 +432,14 @@ namespace Velvet
             {
                 return;
             }
-            if (_overElement != null && _overBinding is { OverClasses.Length: > 0 })
+            if (_overElement != null && _appliedOverClasses is { Length: > 0 })
             {
-                StyleAnimationClassUtils.RemoveClasses(_overElement, _overBinding.OverClasses);
+                StyleAnimationClassUtils.RemoveClasses(_overElement, _appliedOverClasses);
             }
             _overId = winnerId;
             _overBinding = null;
             _overElement = null;
+            _appliedOverClasses = null;
             if (winnerId != null)
             {
                 foreach (var (element, binding) in _ctx.DroppableBindings)
@@ -374,7 +453,10 @@ namespace Velvet
                 }
                 if (_overElement != null && _overBinding is { OverClasses.Length: > 0 })
                 {
-                    StyleAnimationClassUtils.AddClasses(_overElement, _overBinding.OverClasses);
+                    // Snapshot the applied array (see the field-block note): removal must target what
+                    // was actually applied, not a mid-drag re-parse.
+                    _appliedOverClasses = _overBinding.OverClasses;
+                    StyleAnimationClassUtils.AddClasses(_overElement, _appliedOverClasses);
                 }
             }
             // Over-change is continuous-lane feedback (it fires mid-move, potentially every frame):
@@ -386,7 +468,9 @@ namespace Velvet
 
         private void OnDragUp(PointerUpEvent evt)
         {
-            if (evt.pointerId != _pointerId)
+            // Only the PRIMARY release ends the drag — UI Toolkit dispatches one PointerUpEvent per
+            // button under the same pointer id, and a right-button tap mid-drag must not commit a drop.
+            if (evt.pointerId != _pointerId || evt.button != 0)
             {
                 return;
             }
@@ -404,6 +488,17 @@ namespace Velvet
             // press never reaches here (it discards in Pending) — clicks stay intact.
             evt.StopImmediatePropagation();
             FireDiscrete(() => _scope.Settings.OnDragEnd?.Invoke(args));
+        }
+
+        // A fresh PRIMARY press arriving while this session is active means the session is a phantom
+        // (the button cannot go down while genuinely held): the unobserved release already happened, so
+        // cancel — the next press then arms normally.
+        private void OnDragDown(PointerDownEvent evt)
+        {
+            if (evt.pointerId == _pointerId && evt.button == 0)
+            {
+                Cancel();
+            }
         }
 
         private void OnCaptureOut(PointerCaptureOutEvent evt)
@@ -448,7 +543,10 @@ namespace Velvet
         // must reach the pool clean), but the user OnDragCancel is deferred to the panel's next
         // scheduler tick: a state write from inside the flush is silently lost (the fiber's dirty flag
         // clears when the flush ends) and its lost pending value dedups away the next genuine edge.
-        internal void CancelForTeardown()
+        // Reconciler disposal passes deferUserCallback: false — a deferred item would fire against the
+        // disposed tree (or never, if the panel dies with it), so the callback runs inline as a best
+        // effort (its state writes no-op on disposed fibers; external side effects still run).
+        internal void CancelForTeardown(bool deferUserCallback = true)
         {
             if (_closed)
             {
@@ -464,8 +562,27 @@ namespace Velvet
                 return;
             }
             DndPressVariantSettler.Settle(_source, _ctx);
-            deferRoot.schedule.Execute(() =>
-                FiberDiscreteEventScope.Run(() => scope.Settings.OnDragCancel?.Invoke(args), _ctx.BatchScheduler));
+            if (!deferUserCallback)
+            {
+                InvokeCancelGuarded(scope, args);
+                return;
+            }
+            deferRoot.schedule.Execute(() => InvokeCancelGuarded(scope, args));
+        }
+
+        // A throwing scheduled item is never unscheduled — it would re-fire (re-invoking the user
+        // callback) and abort the panel's remaining scheduled items every frame — so the deferred
+        // cancel contains user exceptions itself, like the frame-tick hooks do.
+        private void InvokeCancelGuarded(DndScopeBinding scope, DragCancelArgs args)
+        {
+            try
+            {
+                FiberDiscreteEventScope.Run(() => scope.Settings.OnDragCancel?.Invoke(args), _ctx.BatchScheduler);
+            }
+            catch (System.Exception exception)
+            {
+                UnityEngine.Debug.LogException(exception);
+            }
         }
 
         // A droppable leaving mid-drag (unmount, or a settings flip to disabled) must drop out of this
@@ -483,13 +600,14 @@ namespace Velvet
             }
             if (ReferenceEquals(_overElement, element))
             {
-                if (_overBinding is { OverClasses.Length: > 0 })
+                if (_appliedOverClasses is { Length: > 0 })
                 {
-                    StyleAnimationClassUtils.RemoveClasses(element, _overBinding.OverClasses);
+                    StyleAnimationClassUtils.RemoveClasses(element, _appliedOverClasses);
                 }
                 _overId = null;
                 _overBinding = null;
                 _overElement = null;
+                _appliedOverClasses = null;
             }
         }
 
@@ -519,11 +637,20 @@ namespace Velvet
             {
                 if (_onDragMove != null) _source.UnregisterCallback(_onDragMove, TrickleDown.TrickleDown);
                 if (_onDragUp != null) _source.UnregisterCallback(_onDragUp, TrickleDown.TrickleDown);
+                if (_onDragDown != null) _source.UnregisterCallback(_onDragDown, TrickleDown.TrickleDown);
                 if (_onDragCancel != null) _source.UnregisterCallback(_onDragCancel, TrickleDown.TrickleDown);
                 if (_onCaptureOut != null) _source.UnregisterCallback(_onCaptureOut, TrickleDown.TrickleDown);
-                if (_onEscape != null) _panelRoot.UnregisterCallback(_onEscape, TrickleDown.TrickleDown);
+                if (_onEscape != null)
+                {
+                    foreach (var root in _escapeRoots)
+                    {
+                        root.UnregisterCallback(_onEscape, TrickleDown.TrickleDown);
+                    }
+                }
+                _escapeRoots.Clear();
                 _onDragMove = null;
                 _onDragUp = null;
+                _onDragDown = null;
                 _onDragCancel = null;
                 _onCaptureOut = null;
                 _onEscape = null;
@@ -531,26 +658,28 @@ namespace Velvet
                 {
                     _source.ReleasePointer(_pointerId);
                 }
-                if (_draggable.Settings.Movement == DragMovement.Translate)
+                // Restore symmetry runs on the activation-time snapshots (see the field-block note).
+                if (_activeMovement == DragMovement.Translate)
                 {
                     _source.style.translate = _savedTranslate;
                 }
-                if (_draggable.DraggingClasses.Length > 0)
+                if (_activeDraggingClasses.Length > 0)
                 {
-                    StyleAnimationClassUtils.RemoveClasses(_source, _draggable.DraggingClasses);
+                    StyleAnimationClassUtils.RemoveClasses(_source, _activeDraggingClasses);
                 }
                 foreach (var (element, classes) in _appliedActiveClasses)
                 {
                     StyleAnimationClassUtils.RemoveClasses(element, classes);
                 }
                 _appliedActiveClasses.Clear();
-                if (_overElement != null && _overBinding is { OverClasses.Length: > 0 })
+                if (_overElement != null && _appliedOverClasses is { Length: > 0 })
                 {
-                    StyleAnimationClassUtils.RemoveClasses(_overElement, _overBinding.OverClasses);
+                    StyleAnimationClassUtils.RemoveClasses(_overElement, _appliedOverClasses);
                 }
                 _overId = null;
                 _overBinding = null;
                 _overElement = null;
+                _appliedOverClasses = null;
                 if (_overlayPositioner != null)
                 {
                     DndOverlayDriver.EndSession(_overlayPositioner);
@@ -584,6 +713,39 @@ namespace Velvet
             _onPendingMove = null;
             _onPendingUp = null;
             _onPendingCancel = null;
+        }
+
+        // Key events dispatch through whichever panel holds keyboard focus, which need not be the
+        // source's panel in a tree spanning layer/world-space hosts — the Escape cancel listens on every
+        // managed panel root that exists at activation time.
+        private void RegisterEscapeOnManagedRoots()
+        {
+            void AddRoot(VisualElement? root)
+            {
+                if (root == null || _escapeRoots.Contains(root))
+                {
+                    return;
+                }
+                root.RegisterCallback(_onEscape, TrickleDown.TrickleDown);
+                _escapeRoots.Add(root);
+            }
+
+            AddRoot(_panelRoot);
+            AddRoot(_ctx.MainPanelRoot?.panel?.visualTree);
+            foreach (var host in _ctx.LayerHosts.Values)
+            {
+                if (host.Document != null)
+                {
+                    AddRoot(host.Document.rootVisualElement?.panel?.visualTree);
+                }
+            }
+            foreach (var record in _ctx.WorldSpaceBindings.Values)
+            {
+                if (record.Document != null)
+                {
+                    AddRoot(record.Document.rootVisualElement?.panel?.visualTree);
+                }
+            }
         }
 
         private DraggableInfo ActiveInfo()

--- a/Packages/com.velvet.core/Runtime/Reconciler/DndActiveDrag.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/DndActiveDrag.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b82721acc85da45a885cfd3520fb5025

--- a/Packages/com.velvet.core/Runtime/Reconciler/DndCollisions.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/DndCollisions.cs
@@ -1,0 +1,93 @@
+#nullable enable
+using UnityEngine;
+
+namespace Velvet
+{
+    /// <summary>
+    /// The built-in collision strategies — dnd-kit's <c>rectIntersection</c> / <c>closestCenter</c> /
+    /// <c>pointerWithin</c>. All are pure functions over a <see cref="DndCollisionQuery"/> (no panel
+    /// access), returning a single winning id or null. Documented deviation from dnd-kit: a strategy
+    /// returns one winner, not a ranked collision list — the context only ever consumes the first
+    /// collision anyway, and the delegate's return can be extended compatibly later. None of them
+    /// consider occlusion (dnd-kit parity — its strategies are rect-based too).
+    /// </summary>
+    public static class DndCollisions
+    {
+        /// <summary>Largest ActiveRect-droppable intersection area wins (the dnd-kit default). Ties
+        /// resolve by registration order (first candidate wins).</summary>
+        public static readonly DndCollisionDetection RectIntersection = (in DndCollisionQuery query) =>
+        {
+            string? winner = null;
+            var bestArea = 0f;
+            for (var i = 0; i < query.Droppables.Count; i++)
+            {
+                var candidate = query.Droppables[i];
+                var overlap = Intersection(query.ActiveRect, candidate.Rect);
+                var area = overlap.width * overlap.height;
+                if (area > bestArea)
+                {
+                    bestArea = area;
+                    winner = candidate.Id;
+                }
+            }
+            return winner;
+        };
+
+        /// <summary>Droppable whose center is nearest ActiveRect's center wins — the forgiving strategy
+        /// sortable lists and coarse grids want. Every candidate collides by definition, so this never
+        /// returns null while any candidate exists.</summary>
+        public static readonly DndCollisionDetection ClosestCenter = (in DndCollisionQuery query) =>
+        {
+            string? winner = null;
+            var bestDistance = float.MaxValue;
+            var activeCenter = query.ActiveRect.center;
+            for (var i = 0; i < query.Droppables.Count; i++)
+            {
+                var candidate = query.Droppables[i];
+                var distance = (candidate.Rect.center - activeCenter).sqrMagnitude;
+                if (distance < bestDistance)
+                {
+                    bestDistance = distance;
+                    winner = candidate.Id;
+                }
+            }
+            return winner;
+        };
+
+        /// <summary>Droppable rect containing the pointer wins; on nesting, the innermost (smallest
+        /// area) container takes it.</summary>
+        public static readonly DndCollisionDetection PointerWithin = (in DndCollisionQuery query) =>
+        {
+            string? winner = null;
+            var bestArea = float.MaxValue;
+            for (var i = 0; i < query.Droppables.Count; i++)
+            {
+                var candidate = query.Droppables[i];
+                if (!candidate.Rect.Contains(query.PointerPosition))
+                {
+                    continue;
+                }
+                var area = candidate.Rect.width * candidate.Rect.height;
+                if (area < bestArea)
+                {
+                    bestArea = area;
+                    winner = candidate.Id;
+                }
+            }
+            return winner;
+        };
+
+        private static Rect Intersection(Rect a, Rect b)
+        {
+            var xMin = Mathf.Max(a.xMin, b.xMin);
+            var yMin = Mathf.Max(a.yMin, b.yMin);
+            var xMax = Mathf.Min(a.xMax, b.xMax);
+            var yMax = Mathf.Min(a.yMax, b.yMax);
+            if (xMax <= xMin || yMax <= yMin)
+            {
+                return Rect.zero;
+            }
+            return Rect.MinMaxRect(xMin, yMin, xMax, yMax);
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/DndCollisions.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/DndCollisions.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b4504a4248d494d5f840c7c26196d789

--- a/Packages/com.velvet.core/Runtime/Reconciler/DndDriver.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/DndDriver.cs
@@ -1,0 +1,283 @@
+#nullable enable
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace Velvet
+{
+    // Reconciler-side bookkeeping for one DndContext element, keyed in ReconcilerContext.DndScopeBindings
+    // by the scope element. Holds only the latest settings — the scope carries no listeners of its own;
+    // draggables resolve their innermost scope at pointer-down time by walking the parent chain (the
+    // FiberFocusNavigator pattern), so a scope that re-renders with fresh delegates is picked up with no
+    // re-registration.
+    internal sealed class DndScopeBinding
+    {
+        public DndContextSettings Settings;
+
+        public DndScopeBinding(DndContextSettings settings)
+        {
+            Settings = settings;
+        }
+    }
+
+    // Bookkeeping for one draggable element: the latest settings, the parsed while-dragging classes, the
+    // registered pointer-down armer (binding-lifetime, NOT a FiberEventBinding — it must survive event-prop
+    // diffs untouched), and the one-shot no-scope warning flag.
+    internal sealed class DndDraggableBinding
+    {
+        public DraggableSettings Settings;
+        public string[] DraggingClasses;
+        public EventCallback<PointerDownEvent>? OnPointerDown;
+        public bool WarnedNoScope;
+
+        public DndDraggableBinding(DraggableSettings settings)
+        {
+            Settings = settings;
+            DraggingClasses = V.ParseClassNames(settings.WhileDraggingClass);
+        }
+    }
+
+    // Bookkeeping for one droppable element: the latest settings plus the parsed over/active class arrays.
+    internal sealed class DndDroppableBinding
+    {
+        public DroppableSettings Settings;
+        public string[] OverClasses;
+        public string[] ActiveClasses;
+
+        public DndDroppableBinding(DroppableSettings settings)
+        {
+            Settings = settings;
+            OverClasses = V.ParseClassNames(settings.WhileOverClass);
+            ActiveClasses = V.ParseClassNames(settings.WhileDragActiveClass);
+        }
+
+        public void Reparse()
+        {
+            OverClasses = V.ParseClassNames(Settings.WhileOverClass);
+            ActiveClasses = V.ParseClassNames(Settings.WhileDragActiveClass);
+        }
+    }
+
+    // Bookkeeping for one V.DragOverlay positioner: only the one-shot unsupported-panel warning — the
+    // positioner element itself is the registry key, and all session state lives on DndActiveDrag.
+    internal sealed class DndOverlayBinding
+    {
+        public bool WarnedUnsupportedPanel;
+    }
+
+    // Attach/Update/Detach for the DndContext scope slot, hand-inlined in FiberWrapperElementAppliers like
+    // ApplyFocusScope (the drivers need the ReconcilerContext).
+    internal static class DndScopeDriver
+    {
+        public static DndScopeBinding Attach(VisualElement element, DndContextSettings settings)
+            => new(settings);
+
+        // In-place refresh: fresh-but-equal records never re-attach (record equality gates the diff), and
+        // delegate-bearing records are refreshed on every inequality — cheap, and pointer-down resolves
+        // the binding at event time so nothing else needs rewiring.
+        public static void Update(DndScopeBinding binding, DndContextSettings settings)
+        {
+            binding.Settings = settings;
+        }
+
+        public static void Detach(VisualElement element, ReconcilerContext ctx)
+        {
+            // A scope disappearing mid-drag takes its session with it (its delegates and collision
+            // strategy are gone); teardown-flavored so the user cancel callback lands after the flush.
+            if (ctx.ActiveDrag != null && ReferenceEquals(ctx.ActiveDrag.ScopeElement, element))
+            {
+                ctx.ActiveDrag.CancelForTeardown();
+            }
+        }
+    }
+
+    internal static class DndDraggableDriver
+    {
+        public static DndDraggableBinding Attach(VisualElement element, DraggableSettings settings, ReconcilerContext ctx)
+        {
+            var binding = new DndDraggableBinding(settings);
+            // Binding-lifetime armer, TrickleDown: a Clickable on the same element (a draggable
+            // V.Button) stops the down's immediate propagation from its own bubble-phase handler, which
+            // would silence a later-registered bubble armer — the trickle phase runs deterministically
+            // first. Arming itself neither captures nor stops propagation: a press that never crosses
+            // the activation constraint must stay a plain click (see DndActiveDrag.Arm).
+            binding.OnPointerDown = evt => DndActiveDrag.Arm(element, binding, ctx, evt);
+            element.RegisterCallback(binding.OnPointerDown, TrickleDown.TrickleDown);
+            return binding;
+        }
+
+        public static void Update(VisualElement element, DndDraggableBinding binding, DraggableSettings settings, ReconcilerContext ctx)
+        {
+            var oldClass = binding.Settings.WhileDraggingClass;
+            binding.Settings = settings;
+            if (!string.Equals(oldClass, settings.WhileDraggingClass, System.StringComparison.Ordinal))
+            {
+                binding.DraggingClasses = V.ParseClassNames(settings.WhileDraggingClass);
+            }
+            // Disabling the active source mid-drag cancels its session; the Update runs mid-flush, so the
+            // teardown-flavored path (deferred user callback) is the safe one.
+            if (settings.Disabled && ctx.ActiveDrag != null && ReferenceEquals(ctx.ActiveDrag.Source, element))
+            {
+                ctx.ActiveDrag.CancelForTeardown();
+            }
+        }
+
+        public static void Detach(VisualElement element, DndDraggableBinding binding, ReconcilerContext ctx)
+        {
+            if (ctx.ActiveDrag != null && ReferenceEquals(ctx.ActiveDrag.Source, element))
+            {
+                ctx.ActiveDrag.CancelForTeardown();
+            }
+            if (binding.OnPointerDown != null)
+            {
+                element.UnregisterCallback(binding.OnPointerDown, TrickleDown.TrickleDown);
+                binding.OnPointerDown = null;
+            }
+        }
+    }
+
+    internal static class DndDroppableDriver
+    {
+        public static DndDroppableBinding Attach(VisualElement element, DroppableSettings settings)
+            => new(settings);
+
+        public static void Update(VisualElement element, DndDroppableBinding binding, DroppableSettings settings, ReconcilerContext ctx)
+        {
+            binding.Settings = settings;
+            binding.Reparse();
+            if (settings.Disabled)
+            {
+                ctx.ActiveDrag?.OnDroppableInvalidated(element);
+            }
+        }
+
+        public static void Detach(VisualElement element, ReconcilerContext ctx)
+        {
+            ctx.ActiveDrag?.OnDroppableInvalidated(element);
+        }
+    }
+
+    // The V.DragOverlay positioner: a framework-positioned, picking-ignored container on the Overlay
+    // layer panel that tracks the pointer while a drag is active and is display:none otherwise. Session
+    // begin/end and per-move positioning are driven by DndActiveDrag; this driver owns only the
+    // element's binding lifecycle and the panel-space conversion.
+    internal static class DndOverlayDriver
+    {
+        public static DndOverlayBinding Attach(VisualElement positioner)
+        {
+            // Forced inline for the same reason AnchoredDriver forces absolute: dynamic left/top has no
+            // other way to work. PickingMode.Ignore keeps the ghost from intercepting the drop or waking
+            // the cross-panel pointer router.
+            positioner.pickingMode = PickingMode.Ignore;
+            positioner.style.position = Position.Absolute;
+            positioner.style.display = DisplayStyle.None;
+            return new DndOverlayBinding();
+        }
+
+        public static void Detach(VisualElement positioner, ReconcilerContext ctx)
+        {
+            ctx.ActiveDrag?.OnOverlayInvalidated(positioner);
+            positioner.pickingMode = PickingMode.Position;
+            positioner.style.position = StyleKeyword.Null;
+            positioner.style.display = StyleKeyword.Null;
+            positioner.style.left = StyleKeyword.Null;
+            positioner.style.top = StyleKeyword.Null;
+            positioner.style.width = StyleKeyword.Null;
+            positioner.style.height = StyleKeyword.Null;
+        }
+
+        // One overlay per mounted tree: the first registered positioner wins (dnd-kit renders one
+        // DragOverlay per DndContext; several in one Velvet tree would fight over one pointer).
+        public static DndOverlayBinding? FindOverlay(ReconcilerContext ctx, out VisualElement? positioner)
+        {
+            foreach (var (element, binding) in ctx.DragOverlayBindings)
+            {
+                positioner = element;
+                return binding;
+            }
+            positioner = null;
+            return null;
+        }
+
+        public static void BeginSession(VisualElement positioner, Vector2 sourceSize)
+        {
+            positioner.style.display = DisplayStyle.Flex;
+            positioner.style.width = sourceSize.x;
+            positioner.style.height = sourceSize.y;
+        }
+
+        public static void EndSession(VisualElement positioner)
+        {
+            positioner.style.display = DisplayStyle.None;
+        }
+
+        // Converts the source panel's pointer position into the overlay panel's space through screen
+        // space (PanelToScreen's derived inverse affine + ScreenToPanel), and pins the positioner so the
+        // grab point stays under the pointer. Editor-context panels have no defined screen mapping for
+        // this conversion — degrade to hidden with a one-shot warning (the layer host itself already
+        // degrades in editor mounts; this guard covers a positioner that got created anyway).
+        public static void SyncPosition(
+            VisualElement positioner, DndOverlayBinding binding,
+            IPanel? sourcePanel, Vector2 pointerPanelPosition, Vector2 grabOffset)
+        {
+            var overlayPanel = positioner.panel;
+            if (overlayPanel == null || sourcePanel == null)
+            {
+                return;
+            }
+            Vector2 overlayLocal;
+            if (ReferenceEquals(overlayPanel, sourcePanel))
+            {
+                overlayLocal = pointerPanelPosition;
+            }
+            else
+            {
+                if (sourcePanel.contextType != ContextType.Player || overlayPanel.contextType != ContextType.Player)
+                {
+                    if (!binding.WarnedUnsupportedPanel)
+                    {
+                        binding.WarnedUnsupportedPanel = true;
+                        FiberLogger.LogWarning("Dnd",
+                            "V.DragOverlay needs runtime (Player-context) panels on both ends of its "
+                            + "panel-space conversion; hiding the overlay in this editor-context mount.");
+                    }
+                    positioner.style.display = DisplayStyle.None;
+                    return;
+                }
+                var screen = FiberCrossPanelPointerRouter.PanelToScreen(sourcePanel, pointerPanelPosition);
+                overlayLocal = RuntimePanelUtils.ScreenToPanel(overlayPanel, screen);
+            }
+            var topLeft = overlayLocal - grabOffset;
+            positioner.style.left = topLeft.x;
+            positioner.style.top = topLeft.y;
+        }
+    }
+
+    // Settles the press-derived styling state on a drag source after the session swallowed the real
+    // PointerUp (StopImmediatePropagation runs before the bubble-phase signal callbacks): every
+    // manipulator holding an ElementLocalVariantSignals on the element is told to observe a synthetic
+    // release, so whileTap / active: (and their stacked forms) cannot stick on.
+    internal static class DndPressVariantSettler
+    {
+        public static void Settle(VisualElement element, ReconcilerContext ctx)
+        {
+            if (ctx.GestureManipulators.TryGetValue(element, out var gesture))
+            {
+                gesture.SettleRelease();
+            }
+            if (ctx.VariantManipulators.TryGetValue(element, out var variant))
+            {
+                variant.SettleRelease();
+            }
+            if (ctx.StackedVariantManipulators.Count > 0)
+            {
+                foreach (var kv in ctx.StackedVariantManipulators)
+                {
+                    if (kv.Key.target == element)
+                    {
+                        kv.Value.SettleRelease();
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/DndDriver.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/DndDriver.cs
@@ -162,8 +162,17 @@ namespace Velvet
     // element's binding lifecycle and the panel-space conversion.
     internal static class DndOverlayDriver
     {
-        public static DndOverlayBinding Attach(VisualElement positioner)
+        public static DndOverlayBinding Attach(VisualElement positioner, ReconcilerContext ctx)
         {
+            // Dictionary enumeration order is unspecified once entries have churned, so which of several
+            // overlays a session picks is not deterministic — surface that at mount instead of letting
+            // the ghost jump between containers across drags.
+            if (ctx.DragOverlayBindings.Count > 0)
+            {
+                FiberLogger.LogWarning("Dnd",
+                    "More than one V.DragOverlay is mounted in this tree; which one shows the drag "
+                    + "preview is unspecified. Keep a single overlay per mounted tree.");
+            }
             // Forced inline for the same reason AnchoredDriver forces absolute: dynamic left/top has no
             // other way to work. PickingMode.Ignore keeps the ghost from intercepting the drop or waking
             // the cross-panel pointer router.
@@ -252,13 +261,23 @@ namespace Velvet
         }
     }
 
-    // Settles the press-derived styling state on a drag source after the session swallowed the real
-    // PointerUp (StopImmediatePropagation runs before the bubble-phase signal callbacks): every
-    // manipulator holding an ElementLocalVariantSignals on the element is told to observe a synthetic
-    // release, so whileTap / active: (and their stacked forms) cannot stick on.
+    // Settles the press-derived styling state after the session swallowed the real PointerUp
+    // (StopImmediatePropagation runs before the bubble-phase signal callbacks, and captured delivery
+    // hides it from ancestors entirely): every manipulator holding an ElementLocalVariantSignals on the
+    // source OR any of its ancestors is told to observe a synthetic release — the press's own
+    // PointerDown BUBBLED, so ancestors' whileTap / active: (and stacked forms) lit too and would
+    // otherwise stick on.
     internal static class DndPressVariantSettler
     {
         public static void Settle(VisualElement element, ReconcilerContext ctx)
+        {
+            for (var current = element; current != null; current = current.parent)
+            {
+                SettleOn(current, ctx);
+            }
+        }
+
+        private static void SettleOn(VisualElement element, ReconcilerContext ctx)
         {
             if (ctx.GestureManipulators.TryGetValue(element, out var gesture))
             {

--- a/Packages/com.velvet.core/Runtime/Reconciler/DndDriver.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/DndDriver.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: eae48190a777940bfab5c58a83258a31

--- a/Packages/com.velvet.core/Runtime/Reconciler/DndTypes.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/DndTypes.cs
@@ -1,0 +1,139 @@
+#nullable enable
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace Velvet
+{
+    /// <summary>
+    /// How an active drag moves its source element. <see cref="Translate"/> (the default) writes the
+    /// pointer delta as an inline <c>translate</c> on the source every move; <see cref="None"/> leaves the
+    /// source in place — the <c>V.DragOverlay</c> ghost pattern, where only the portal-rendered preview
+    /// follows the pointer.
+    /// </summary>
+    public enum DragMovement
+    {
+        Translate,
+        None,
+    }
+
+    /// <summary>
+    /// Constraint before a press becomes a drag, so clicks keep working on draggable elements.
+    /// <see cref="Distance"/> is panel px of travel before activation. A <see cref="DelaySec"/> &gt; 0
+    /// switches to hold-to-drag mode (dnd-kit's either/or): activation happens after the hold, aborted if
+    /// the observed travel exceeds <see cref="Tolerance"/> first. The default is Distance = 4 — a
+    /// documented deviation from dnd-kit's unconstrained PointerSensor default, because a zero threshold
+    /// would race UI Toolkit's own Clickable capture-at-down and kill clicks on draggable buttons;
+    /// <see cref="None"/> restores the raw dnd-kit behavior.
+    /// </summary>
+    public sealed record DragActivation(float Distance = 4f, float DelaySec = 0f, float Tolerance = 5f)
+    {
+        public static readonly DragActivation Default = new();
+        public static readonly DragActivation None = new(Distance: 0f);
+    }
+
+    /// <summary>The active drag source, as seen by every context callback.</summary>
+    public sealed record DraggableInfo(string Id, object? Data, VisualElement Element);
+
+    /// <summary>A drop target, as seen by the over/end callbacks.</summary>
+    public sealed record DroppableInfo(string Id, object? Data, VisualElement Element);
+
+    /// <summary>Fired once when a press crosses its activation constraint and becomes a drag.
+    /// <see cref="Origin"/> is the pointer's panel-space position at activation.</summary>
+    public sealed record DragStartArgs(DraggableInfo Active, Vector2 Origin);
+
+    /// <summary>Fired when the winning drop target CHANGES (including to null — leaving all targets).
+    /// <see cref="Delta"/> is the total panel-space translation since activation.</summary>
+    public sealed record DragOverArgs(DraggableInfo Active, DroppableInfo? Over, Vector2 Delta);
+
+    /// <summary>Fired on release. <see cref="Over"/> is null when dropped on nothing; state written here
+    /// flushes synchronously, like any discrete input handler.</summary>
+    public sealed record DragEndArgs(DraggableInfo Active, DroppableInfo? Over, Vector2 Delta, Vector2 Position);
+
+    /// <summary>Fired when a drag aborts without a drop: Escape, a pointer cancel, a lost pointer
+    /// capture, or the source/scope unmounting mid-drag.</summary>
+    public sealed record DragCancelArgs(DraggableInfo Active);
+
+    /// <summary>One drop candidate's live rect, as handed to a collision strategy.</summary>
+    public readonly struct DndDroppableRect
+    {
+        public string Id { get; }
+        /// <summary>Live <c>worldBound</c>, panel space — re-read every move, so mid-drag layout shifts
+        /// and scrolls are picked up automatically.</summary>
+        public Rect Rect { get; }
+        public object? Data { get; }
+
+        public DndDroppableRect(string id, Rect rect, object? data)
+        {
+            Id = id;
+            Rect = rect;
+            Data = data;
+        }
+    }
+
+    /// <summary>
+    /// Everything a collision strategy may consider. Candidates are pre-filtered: in-scope, enabled,
+    /// attached, same panel as the source, and the active draggable's own id excluded (an element that is
+    /// both draggable and droppable under one id never collides with itself).
+    /// </summary>
+    public readonly struct DndCollisionQuery
+    {
+        /// <summary>The source's activation-time <c>worldBound</c> translated by the current pointer
+        /// delta (dnd-kit's translated-initial-rect semantics) — correct even under
+        /// <see cref="DragMovement.None"/>, where the source element itself never moves.</summary>
+        public Rect ActiveRect { get; }
+        /// <summary>Current pointer position, panel space.</summary>
+        public Vector2 PointerPosition { get; }
+        public IReadOnlyList<DndDroppableRect> Droppables { get; }
+
+        public DndCollisionQuery(Rect activeRect, Vector2 pointerPosition, IReadOnlyList<DndDroppableRect> droppables)
+        {
+            ActiveRect = activeRect;
+            PointerPosition = pointerPosition;
+            Droppables = droppables;
+        }
+    }
+
+    /// <summary>Returns the winning droppable id, or null for no collision. Must be pure over the query —
+    /// it runs on every pointer move of an active drag.</summary>
+    public delegate string? DndCollisionDetection(in DndCollisionQuery query);
+
+    /// <summary>
+    /// Drag-and-drop scope configuration — dnd-kit's <c>DndContext</c> props. All callbacks are optional;
+    /// <see cref="CollisionDetection"/> null means <see cref="DndCollisions.RectIntersection"/>;
+    /// <see cref="Activation"/> is the scope-wide default a per-draggable override wins over.
+    /// </summary>
+    public sealed record DndContextSettings(
+        System.Action<DragStartArgs>? OnDragStart = null,
+        System.Action<DragOverArgs>? OnDragOver = null,
+        System.Action<DragEndArgs>? OnDragEnd = null,
+        System.Action<DragCancelArgs>? OnDragCancel = null,
+        DndCollisionDetection? CollisionDetection = null,
+        DragActivation? Activation = null);
+
+    /// <summary>Drag-source configuration — dnd-kit's <c>useDraggable</c> options. The element carrying
+    /// the setting is the drag node itself.</summary>
+    public sealed record DraggableSettings(
+        string Id,
+        object? Data = null,
+        bool Disabled = false,
+        DragMovement Movement = DragMovement.Translate,
+        DragActivation? Activation = null,
+        string? WhileDraggingClass = null);
+
+    /// <summary>Drop-target configuration — dnd-kit's <c>useDroppable</c> options.
+    /// <see cref="WhileOverClass"/> applies while this target is the winning collision;
+    /// <see cref="WhileDragActiveClass"/> applies to every enabled candidate while any drag is live in
+    /// scope (dnd-kit's droppable <c>active</c> cue).</summary>
+    public sealed record DroppableSettings(
+        string Id,
+        object? Data = null,
+        bool Disabled = false,
+        string? WhileOverClass = null,
+        string? WhileDragActiveClass = null);
+
+    /// <summary>Marker settings for the <c>V.DragOverlay</c> positioner element (framework-positioned,
+    /// picking-ignored, hidden while no drag is active). Carried on props so the overlay rides the same
+    /// binding lifecycle as every other element binding.</summary>
+    public sealed record DragOverlaySettings;
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/DndTypes.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/DndTypes.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3bb77edc20e82491cadd797e02805794

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberCrossPanelInput.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberCrossPanelInput.cs
@@ -192,7 +192,9 @@ namespace Velvet
         // 2D scale+translate between screen and panel space (never rotation), so the inverse affine
         // transform is derived from two well-separated screen samples rather than hand-deriving it from
         // PanelSettings' own scale-mode math (which differs per scaleMode and DPI configuration).
-        private static Vector2 PanelToScreen(IPanel panel, Vector2 panelPosition)
+        // Internal (not private): the drag-overlay positioner rides the same conversion for its
+        // source-panel → screen → overlay-panel hop.
+        internal static Vector2 PanelToScreen(IPanel panel, Vector2 panelPosition)
         {
             var screenA = Vector2.zero;
             var screenB = new Vector2(Screen.width, Screen.height);

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberDiscreteEventScope.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberDiscreteEventScope.cs
@@ -1,0 +1,36 @@
+#nullable enable
+using System;
+
+namespace Velvet
+{
+    /// <summary>
+    /// Brackets a discrete user-input handler: marks <see cref="FiberWorkLoop.IsInDiscreteEvent"/> for its
+    /// duration so hook-triggered renders take the Urgent lane, then — at the outermost discrete boundary —
+    /// flushes the owning context's immediate batch synchronously so the update commits in the same frame.
+    /// The flag is restored before the flush so updates scheduled by effects that run during the flush fall
+    /// back to the Normal next-frame lane rather than recursing synchronously. Shared by
+    /// <c>FiberEventBindingManager</c> (clicks, value changes, discrete pointer/key bindings) and the
+    /// drag-and-drop session (<c>OnDragStart</c>/<c>OnDragEnd</c>/<c>OnDragCancel</c>), so a drag commit
+    /// behaves exactly like a click handler's.
+    /// </summary>
+    internal static class FiberDiscreteEventScope
+    {
+        public static void Run(Action? handler, FiberBatchScheduler? batchScheduler)
+        {
+            var wasInDiscreteEvent = FiberWorkLoop.IsInDiscreteEvent;
+            FiberWorkLoop.IsInDiscreteEvent = true;
+            try
+            {
+                handler?.Invoke();
+            }
+            finally
+            {
+                FiberWorkLoop.IsInDiscreteEvent = wasInDiscreteEvent;
+                if (!wasInDiscreteEvent)
+                {
+                    batchScheduler?.FlushImmediate();
+                }
+            }
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberDiscreteEventScope.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberDiscreteEventScope.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5eb80cc8e28564bf48a8d943460335e8

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberElementCleaner.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberElementCleaner.cs
@@ -368,6 +368,30 @@ namespace Velvet
             {
                 FiberFocusNavigator.ReleasePendingAttachHooks(element, _ctx);
             }
+            // Drag-and-drop bindings: the draggable's pointer-down armer unregisters, and an element that
+            // is the active session's source or scope cancels that session teardown-flavored (synchronous
+            // scrub so the element reaches the pool clean, deferred user callback — the cleaner runs
+            // mid-flush, where a user state write would be silently lost; see DndActiveDrag).
+            if (_ctx.DndScopeBindings.ContainsKey(element))
+            {
+                DndScopeDriver.Detach(element, _ctx);
+                _ctx.DndScopeBindings.Remove(element);
+            }
+            if (_ctx.DraggableBindings.TryGetValue(element, out var draggableBinding))
+            {
+                DndDraggableDriver.Detach(element, draggableBinding, _ctx);
+                _ctx.DraggableBindings.Remove(element);
+            }
+            if (_ctx.DroppableBindings.ContainsKey(element))
+            {
+                DndDroppableDriver.Detach(element, _ctx);
+                _ctx.DroppableBindings.Remove(element);
+            }
+            if (_ctx.DragOverlayBindings.ContainsKey(element))
+            {
+                DndOverlayDriver.Detach(element, _ctx);
+                _ctx.DragOverlayBindings.Remove(element);
+            }
             if (_ctx.VirtualListControllers.TryGetValue(element, out var virtualListController))
             {
                 virtualListController.Dispose();

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberElementProps.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberElementProps.cs
@@ -65,6 +65,26 @@ namespace Velvet
         public FocusScopeSettings? FocusScope { get => _focusScope; set { ThrowIfReadOnly(); _focusScope = value; } }
         private FocusScopeSettings? _focusScope;
 
+        /// <summary>
+        /// Drag-and-drop scope configuration for this container element (dnd-kit's DndContext parity).
+        /// Draggables and droppables pair with their nearest ancestor scope at event time.
+        /// </summary>
+        public DndContextSettings? DndContext { get => _dndContext; set { ThrowIfReadOnly(); _dndContext = value; } }
+        private DndContextSettings? _dndContext;
+
+        /// <summary>Drag-source configuration (dnd-kit's useDraggable parity) — the element carrying it
+        /// is the drag node itself.</summary>
+        public DraggableSettings? Draggable { get => _draggable; set { ThrowIfReadOnly(); _draggable = value; } }
+        private DraggableSettings? _draggable;
+
+        /// <summary>Drop-target configuration (dnd-kit's useDroppable parity).</summary>
+        public DroppableSettings? Droppable { get => _droppable; set { ThrowIfReadOnly(); _droppable = value; } }
+        private DroppableSettings? _droppable;
+
+        /// <summary>Marker for the V.DragOverlay positioner (the framework-positioned drag preview).</summary>
+        public DragOverlaySettings? DragOverlay { get => _dragOverlay; set { ThrowIfReadOnly(); _dragOverlay = value; } }
+        private DragOverlaySettings? _dragOverlay;
+
         /// <summary>Slider-specific settings.</summary>
         public SliderSettings? Slider { get => _slider; set { ThrowIfReadOnly(); _slider = value; } }
         private SliderSettings? _slider;

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberEventBindingManager.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberEventBindingManager.cs
@@ -308,34 +308,16 @@ namespace Velvet
             actions.Add(() => field.UnregisterValueChangedCallback(callback));
         }
 
-        // Brackets a discrete user-input handler: marks FiberWorkLoop.IsInDiscreteEvent for its
-        // duration so hook-triggered renders take the Urgent lane, then — at the outermost discrete boundary —
-        // flushes the owning context's immediate batch synchronously so the update commits in the same frame.
-        // The flag is restored before the flush so updates scheduled by effects run
-        // during the flush fall back to the Normal next-frame lane rather than recursing synchronously.
-        // Two deliberate limitations of this synchronous flush, which the single-context lane stays correct for
+        // The discrete-input bracket lives in FiberDiscreteEventScope (shared with the drag-and-drop
+        // session, whose start/end/cancel commits must behave exactly like click handlers).
+        // Two deliberate limitations of its synchronous flush, which the single-context lane stays correct for
         // but which differ in flush timing for edge configurations: (1) only the owning context's batch is
         // drained synchronously, so Urgent updates a handler schedules on other ReconcilerContexts (e.g. a
         // shared-Store subscriber in a separately mounted tree) still commit on their own next-frame drain;
         // (2) layout-effect-scheduled updates during the synchronous flush take the Normal next-frame lane
         // rather than being re-flushed synchronously before paint.
         private void RunDiscrete(Action? handler)
-        {
-            var wasInDiscreteEvent = FiberWorkLoop.IsInDiscreteEvent;
-            FiberWorkLoop.IsInDiscreteEvent = true;
-            try
-            {
-                handler?.Invoke();
-            }
-            finally
-            {
-                FiberWorkLoop.IsInDiscreteEvent = wasInDiscreteEvent;
-                if (!wasInDiscreteEvent)
-                {
-                    _batchScheduler?.FlushImmediate();
-                }
-            }
-        }
+            => FiberDiscreteEventScope.Run(handler, _batchScheduler);
 
         private static Delegate? GetDelegate(FiberEventBinding binding)
         {

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodeFactory.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodeFactory.cs
@@ -151,6 +151,25 @@ namespace Velvet
                     {
                         _patcher.Appliers.ApplyFocusScope(element, elementNode.Props.FocusScope);
                     }
+                    // Drag-and-drop slots: register the bindings. Panel-independent at creation — the
+                    // draggable's pointer-down armer and the overlay's positioning resolve panels at
+                    // event time.
+                    if (elementNode.Props?.DndContext != null)
+                    {
+                        _patcher.Appliers.ApplyDndContext(element, elementNode.Props.DndContext);
+                    }
+                    if (elementNode.Props?.Draggable != null)
+                    {
+                        _patcher.Appliers.ApplyDraggable(element, elementNode.Props.Draggable);
+                    }
+                    if (elementNode.Props?.Droppable != null)
+                    {
+                        _patcher.Appliers.ApplyDroppable(element, elementNode.Props.Droppable);
+                    }
+                    if (elementNode.Props?.DragOverlay != null)
+                    {
+                        _patcher.Appliers.ApplyDragOverlay(element, elementNode.Props.DragOverlay);
+                    }
 
                     if (elementNode.WrapElement != null)
                     {
@@ -255,6 +274,24 @@ namespace Velvet
                     if (motionNode.Props?.FocusScope != null)
                     {
                         _patcher.Appliers.ApplyFocusScope(element, motionNode.Props.FocusScope);
+                    }
+                    // Drag-and-drop through a Motion host: a V.Motion wrapping a draggable/droppable is
+                    // first-class, so the bindings must attach on this create path too.
+                    if (motionNode.Props?.DndContext != null)
+                    {
+                        _patcher.Appliers.ApplyDndContext(element, motionNode.Props.DndContext);
+                    }
+                    if (motionNode.Props?.Draggable != null)
+                    {
+                        _patcher.Appliers.ApplyDraggable(element, motionNode.Props.Draggable);
+                    }
+                    if (motionNode.Props?.Droppable != null)
+                    {
+                        _patcher.Appliers.ApplyDroppable(element, motionNode.Props.Droppable);
+                    }
+                    if (motionNode.Props?.DragOverlay != null)
+                    {
+                        _patcher.Appliers.ApplyDragOverlay(element, motionNode.Props.DragOverlay);
                     }
                     StyleFontResolver.ApplyIfPresent(element, appliedClasses);
                     _patcher.ApplyGapManipulator(element, appliedClasses);

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
@@ -1122,6 +1122,25 @@ namespace Velvet
             {
                 _appliers.ApplyFocusScope(element, newProps.FocusScope);
             }
+
+            // Record (value) equality for all four drag-and-drop slots: fresh-but-equal settings never
+            // re-attach, and delegate-bearing records refresh their binding in place on any inequality.
+            if (oldProps.DndContext != newProps.DndContext)
+            {
+                _appliers.ApplyDndContext(element, newProps.DndContext);
+            }
+            if (oldProps.Draggable != newProps.Draggable)
+            {
+                _appliers.ApplyDraggable(element, newProps.Draggable);
+            }
+            if (oldProps.Droppable != newProps.Droppable)
+            {
+                _appliers.ApplyDroppable(element, newProps.Droppable);
+            }
+            if (oldProps.DragOverlay != newProps.DragOverlay)
+            {
+                _appliers.ApplyDragOverlay(element, newProps.DragOverlay);
+            }
         }
 
         // Applies the StyleOverrides diff to element.style.

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberWrapperElementAppliers.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberWrapperElementAppliers.cs
@@ -1021,7 +1021,7 @@ namespace Velvet
             }
             if (settings != null)
             {
-                _ctx.DragOverlayBindings[element] = DndOverlayDriver.Attach(element);
+                _ctx.DragOverlayBindings[element] = DndOverlayDriver.Attach(element, _ctx);
             }
         }
 

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberWrapperElementAppliers.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberWrapperElementAppliers.cs
@@ -950,6 +950,81 @@ namespace Velvet
             }
         }
 
+        // The four DnD slots share ApplyFocusScope's hand-inlined shape: the drivers need the
+        // ReconcilerContext (scope resolution, the active-session interlock), which the cached static
+        // delegates of the shared generic dispatch cannot carry.
+        internal void ApplyDndContext(VisualElement element, DndContextSettings? settings)
+        {
+            if (_ctx.DndScopeBindings.TryGetValue(element, out var binding))
+            {
+                if (settings == null)
+                {
+                    DndScopeDriver.Detach(element, _ctx);
+                    _ctx.DndScopeBindings.Remove(element);
+                    return;
+                }
+                DndScopeDriver.Update(binding, settings);
+            }
+            else if (settings != null)
+            {
+                _ctx.DndScopeBindings[element] = DndScopeDriver.Attach(element, settings);
+            }
+        }
+
+        internal void ApplyDraggable(VisualElement element, DraggableSettings? settings)
+        {
+            if (_ctx.DraggableBindings.TryGetValue(element, out var binding))
+            {
+                if (settings == null)
+                {
+                    DndDraggableDriver.Detach(element, binding, _ctx);
+                    _ctx.DraggableBindings.Remove(element);
+                    return;
+                }
+                DndDraggableDriver.Update(element, binding, settings, _ctx);
+            }
+            else if (settings != null)
+            {
+                _ctx.DraggableBindings[element] = DndDraggableDriver.Attach(element, settings, _ctx);
+            }
+        }
+
+        internal void ApplyDroppable(VisualElement element, DroppableSettings? settings)
+        {
+            if (_ctx.DroppableBindings.TryGetValue(element, out var binding))
+            {
+                if (settings == null)
+                {
+                    DndDroppableDriver.Detach(element, _ctx);
+                    _ctx.DroppableBindings.Remove(element);
+                    return;
+                }
+                DndDroppableDriver.Update(element, binding, settings, _ctx);
+            }
+            else if (settings != null)
+            {
+                _ctx.DroppableBindings[element] = DndDroppableDriver.Attach(element, settings);
+            }
+        }
+
+        internal void ApplyDragOverlay(VisualElement element, DragOverlaySettings? settings)
+        {
+            if (_ctx.DragOverlayBindings.TryGetValue(element, out _))
+            {
+                if (settings == null)
+                {
+                    DndOverlayDriver.Detach(element, _ctx);
+                    _ctx.DragOverlayBindings.Remove(element);
+                }
+                // The marker record carries no updatable state, so a live binding has nothing to refresh.
+                return;
+            }
+            if (settings != null)
+            {
+                _ctx.DragOverlayBindings[element] = DndOverlayDriver.Attach(element);
+            }
+        }
+
         // Cached method-group delegates so the shared dispatch below adds no per-call allocation.
         private static readonly Func<VisualElement, SceneViewSettings, SceneViewBinding> s_sceneViewAttach = SceneViewDriver.Attach;
         private static readonly Action<VisualElement, SceneViewBinding, SceneViewSettings> s_sceneViewUpdate = SceneViewDriver.Update;

--- a/Packages/com.velvet.core/Runtime/Reconciler/Reconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Reconciler.cs
@@ -478,6 +478,23 @@ namespace Velvet
             _ctx.ChainedPlaceholders.Clear();
             _ctx.ChainedHostRoots.Clear();
             FiberFocusNavigator.DetachAll(_ctx);
+            // Drag-and-drop: an active session scrubs first (it holds pointer capture, inline styles and
+            // classes on elements that outlive this reconciler), then the registries release their
+            // bindings (the draggable armer and the overlay's forced inline state are the two that own
+            // registered/forced element state).
+            _ctx.ActiveDrag?.CancelForTeardown();
+            foreach (var (element, binding) in _ctx.DraggableBindings)
+            {
+                DndDraggableDriver.Detach(element, binding, _ctx);
+            }
+            _ctx.DraggableBindings.Clear();
+            foreach (var (element, _) in _ctx.DragOverlayBindings)
+            {
+                DndOverlayDriver.Detach(element, _ctx);
+            }
+            _ctx.DragOverlayBindings.Clear();
+            _ctx.DndScopeBindings.Clear();
+            _ctx.DroppableBindings.Clear();
             foreach (var (element, manipulator) in _ctx.GestureManipulators)
             {
                 element.RemoveManipulator(manipulator);

--- a/Packages/com.velvet.core/Runtime/Reconciler/Reconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Reconciler.cs
@@ -482,7 +482,9 @@ namespace Velvet
             // classes on elements that outlive this reconciler), then the registries release their
             // bindings (the draggable armer and the overlay's forced inline state are the two that own
             // registered/forced element state).
-            _ctx.ActiveDrag?.CancelForTeardown();
+            // Inline (not deferred) user cancel: a deferred item would fire against the disposed tree,
+            // or never fire when the panel dies with it.
+            _ctx.ActiveDrag?.CancelForTeardown(deferUserCallback: false);
             foreach (var (element, binding) in _ctx.DraggableBindings)
             {
                 DndDraggableDriver.Detach(element, binding, _ctx);

--- a/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
@@ -388,6 +388,19 @@ namespace Velvet
         // fired.
         public List<(VisualElement Element, EventCallback<AttachToPanelEvent> Hook)> NavigatorPendingAttachHooks { get; } = new();
 
+        // Drag-and-drop registries (V.DndContext / V.Draggable / V.Droppable / V.DragOverlay), keyed by
+        // the carrying element. None are pure side-tables: the draggable binding owns a registered
+        // pointer-down armer, the overlay owns forced inline picking/position state, and all four are
+        // torn down explicitly by FiberElementCleaner and swept by Reconciler.Dispose.
+        public Dictionary<VisualElement, DndScopeBinding> DndScopeBindings { get; } = new();
+        public Dictionary<VisualElement, DndDraggableBinding> DraggableBindings { get; } = new();
+        public Dictionary<VisualElement, DndDroppableBinding> DroppableBindings { get; } = new();
+        public Dictionary<VisualElement, DndOverlayBinding> DragOverlayBindings { get; } = new();
+
+        // The one live drag session (pending or active) for this tree, owned by DndActiveDrag itself:
+        // null = idle. See DndActiveDrag for the state machine.
+        internal DndActiveDrag? ActiveDrag { get; set; }
+
         // Per-Portal placeholder bookkeeping. SlotStart + SlotLength identify the
         // range of FiberPortalRegistry.Get(TargetId).Children owned by this Portal — the
         // invariant that lets multiple Portals coexist on the same target without overwriting each

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/DndCollisionsTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/DndCollisionsTests.cs
@@ -1,0 +1,137 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins the three built-in collision strategies as pure functions over a
+    /// <c>DndCollisionQuery</c> — no panel involved: <c>RectIntersection</c> ranks by overlap area
+    /// (ties to registration order), <c>ClosestCenter</c> by center distance, and
+    /// <c>PointerWithin</c> by pointer containment with innermost-wins nesting.
+    /// </summary>
+    internal sealed class DndCollisionsTests
+    {
+        private static DndCollisionQuery Query(Rect activeRect, Vector2 pointer, params DndDroppableRect[] droppables)
+            => new(activeRect, pointer, new List<DndDroppableRect>(droppables));
+
+        private static DndDroppableRect Candidate(string id, Rect rect) => new(id, rect, null);
+
+        [Test]
+        public void Given_TwoOverlappingCandidates_When_RectIntersectionRuns_Then_TheLargerOverlapWins()
+        {
+            // Arrange — the active rect overlaps "small" by 10x10 and "large" by 30x10.
+            var query = Query(new Rect(0, 0, 40, 10), Vector2.zero,
+                Candidate("small", new Rect(30, 0, 100, 100)),
+                Candidate("large", new Rect(10, 0, 100, 100)));
+
+            // Act
+            var winner = DndCollisions.RectIntersection(in query);
+
+            // Assert
+            Assert.That(winner, Is.EqualTo("large"));
+        }
+
+        [Test]
+        public void Given_NoCandidateOverlapsTheActiveRect_When_RectIntersectionRuns_Then_NoCollisionIsReported()
+        {
+            // Arrange
+            var query = Query(new Rect(0, 0, 10, 10), Vector2.zero,
+                Candidate("far", new Rect(100, 100, 10, 10)));
+
+            // Act
+            var winner = DndCollisions.RectIntersection(in query);
+
+            // Assert
+            Assert.That(winner, Is.Null);
+        }
+
+        [Test]
+        public void Given_TwoCandidatesWithEqualOverlap_When_RectIntersectionRuns_Then_TheFirstRegisteredWins()
+        {
+            // Arrange — both candidates overlap the active rect by an identical 10x10 corner.
+            var query = Query(new Rect(0, 0, 20, 20), Vector2.zero,
+                Candidate("first", new Rect(10, 10, 50, 50)),
+                Candidate("second", new Rect(10, 10, 50, 50)));
+
+            // Act
+            var winner = DndCollisions.RectIntersection(in query);
+
+            // Assert — ties resolve deterministically by registration order.
+            Assert.That(winner, Is.EqualTo("first"));
+        }
+
+        [Test]
+        public void Given_TwoCandidates_When_ClosestCenterRuns_Then_TheNearerCenterWinsEvenWithoutOverlap()
+        {
+            // Arrange — neither candidate overlaps the active rect; "near" has the closer center.
+            var query = Query(new Rect(0, 0, 10, 10), Vector2.zero,
+                Candidate("far", new Rect(200, 200, 10, 10)),
+                Candidate("near", new Rect(30, 0, 10, 10)));
+
+            // Act
+            var winner = DndCollisions.ClosestCenter(in query);
+
+            // Assert
+            Assert.That(winner, Is.EqualTo("near"));
+        }
+
+        [Test]
+        public void Given_NoCandidates_When_ClosestCenterRuns_Then_NoCollisionIsReported()
+        {
+            // Arrange
+            var query = Query(new Rect(0, 0, 10, 10), Vector2.zero);
+
+            // Act
+            var winner = DndCollisions.ClosestCenter(in query);
+
+            // Assert
+            Assert.That(winner, Is.Null);
+        }
+
+        [Test]
+        public void Given_APointerInsideOneCandidate_When_PointerWithinRuns_Then_TheContainingRectWins()
+        {
+            // Arrange — the active rect overlaps "other" more, but the POINTER sits inside "hit".
+            var query = Query(new Rect(0, 0, 60, 60), new Vector2(105, 105),
+                Candidate("other", new Rect(0, 0, 50, 50)),
+                Candidate("hit", new Rect(100, 100, 20, 20)));
+
+            // Act
+            var winner = DndCollisions.PointerWithin(in query);
+
+            // Assert
+            Assert.That(winner, Is.EqualTo("hit"));
+        }
+
+        [Test]
+        public void Given_NestedCandidatesBothContainingThePointer_When_PointerWithinRuns_Then_TheInnermostWins()
+        {
+            // Arrange
+            var query = Query(new Rect(0, 0, 10, 10), new Vector2(55, 55),
+                Candidate("outer", new Rect(0, 0, 200, 200)),
+                Candidate("inner", new Rect(50, 50, 20, 20)));
+
+            // Act
+            var winner = DndCollisions.PointerWithin(in query);
+
+            // Assert — on nesting, the smallest containing rect takes the collision.
+            Assert.That(winner, Is.EqualTo("inner"));
+        }
+
+        [Test]
+        public void Given_APointerOutsideEveryCandidate_When_PointerWithinRuns_Then_NoCollisionIsReported()
+        {
+            // Arrange
+            var query = Query(new Rect(0, 0, 10, 10), new Vector2(500, 500),
+                Candidate("a", new Rect(0, 0, 50, 50)),
+                Candidate("b", new Rect(100, 100, 50, 50)));
+
+            // Act
+            var winner = DndCollisions.PointerWithin(in query);
+
+            // Assert
+            Assert.That(winner, Is.Null);
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/DndCollisionsTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/DndCollisionsTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d0e1d57c61a9a46d1bfa8e0c95370616

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/DndInteractionTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/DndInteractionTests.cs
@@ -24,6 +24,7 @@ namespace Velvet.Tests
         private static readonly List<string> s_ended = new();
         private static int s_cancelCount;
         private static StateUpdater<bool> s_setShowSource;
+        private static StateUpdater<bool> s_setAltDraggingClass;
 
         [SetUp]
         public void SetUp()
@@ -34,6 +35,7 @@ namespace Velvet.Tests
             s_ended.Clear();
             s_cancelCount = 0;
             s_setShowSource = default;
+            s_setAltDraggingClass = default;
         }
 
         [TearDown]
@@ -55,38 +57,17 @@ namespace Velvet.Tests
             EditorPanelTestHelpers.ForcePanelUpdate(_host.Panel);
         }
 
-        // Pointer events are constructed from IMGUI system events: that constructor path maintains the
-        // engine's own PointerDeviceState (pressed buttons), which the pending phase's stale-session
-        // check reads from the move events it observes.
+        // Thin aliases over the SHARED pointer senders (TestUtilities), which construct events from
+        // IMGUI system events so the engine's own PointerDeviceState (pressed buttons) stays truthful —
+        // one implementation for the EditMode and PlayMode suites, so the event shape cannot drift.
         private static void SendPointerDown(VisualElement target, Vector2 position)
-        {
-            using var evt = PointerDownEvent.GetPooled(new Event
-            {
-                type = EventType.MouseDown, mousePosition = position, button = 0, clickCount = 1,
-            });
-            evt.target = target;
-            target.SendEvent(evt);
-        }
+            => target.SendPointerDownEvent(position);
 
         private static void SendPointerMove(VisualElement target, Vector2 position)
-        {
-            using var evt = PointerMoveEvent.GetPooled(new Event
-            {
-                type = EventType.MouseDrag, mousePosition = position, button = 0,
-            });
-            evt.target = target;
-            target.SendEvent(evt);
-        }
+            => target.SendPointerMoveEvent(position);
 
         private static void SendPointerUp(VisualElement target, Vector2 position)
-        {
-            using var evt = PointerUpEvent.GetPooled(new Event
-            {
-                type = EventType.MouseUp, mousePosition = position, button = 0, clickCount = 1,
-            });
-            evt.target = target;
-            target.SendEvent(evt);
-        }
+            => target.SendPointerUpEvent(position);
 
         // A 300x300 scene: a 50x50 draggable at (0,0), a 100x100 droppable at (150,0), and a second,
         // disabled droppable at (150,150). Absolute placement keeps every rect deterministic.
@@ -133,20 +114,22 @@ namespace Velvet.Tests
         }
 
         [Test]
-        public void Given_ADraggableButtonWithAClickHandler_When_APressStaysBelowTheActivationDistance_Then_TheClickStillFires()
+        public void Given_ADraggableElement_When_APressStaysBelowTheActivationDistance_Then_ThePointerUpStillReachesBubbleListeners()
         {
-            // Arrange — the activation threshold exists exactly so draggable controls keep clicking.
+            // Arrange — the activation threshold exists exactly so presses on draggables keep behaving
+            // as plain clicks. (The real Clickable `clicked` contract needs the engine dispatcher's
+            // capture routing and is pinned by the PlayMode suite.)
             Mount(Scene);
             var item = Q("item");
-            var clicks = 0;
-            item.RegisterCallback<PointerUpEvent>(_ => clicks++);
+            var releases = 0;
+            item.RegisterCallback<PointerUpEvent>(_ => releases++);
 
             // Act
             SendPointerDown(item, new Vector2(10, 10));
             SendPointerUp(item, new Vector2(10, 10));
 
             // Assert — the sub-threshold release is untouched (no swallow, no suppression).
-            Assert.That(clicks, Is.EqualTo(1));
+            Assert.That(releases, Is.EqualTo(1));
         }
 
         [Test]
@@ -304,11 +287,11 @@ namespace Velvet.Tests
         }
 
         [Test]
-        public void Given_ASourceUnmountedMidDrag_When_ItsPooledElementIsRentedAgain_Then_NoDragResidueRemains()
+        public void Given_ASourceUnmountedMidDrag_When_TheFlushCompletes_Then_NoDragResidueRemainsOnTheElement()
         {
-            // Arrange — the source is a plain VisualElement (not poolable), so pin the scrub contract
-            // directly instead: after a mid-drag teardown the element carries no translate and no
-            // while-dragging class.
+            // Arrange — pins the teardown scrub contract on the element itself: after a mid-drag
+            // unmount it carries no translate and no while-dragging class (the pool's own reset is the
+            // second line of defense for poolable primitives, not exercised here).
             Mount(Scene);
             var item = Q("item");
             SendPointerDown(item, new Vector2(10, 10));
@@ -325,6 +308,93 @@ namespace Velvet.Tests
             Assert.That(
                 (item.ClassListContains("opacity-50"), item.style.translate.keyword == StyleKeyword.Undefined),
                 Is.EqualTo((false, false)));
+        }
+
+        [Component]
+        private static VNode ImmediateActivationScene()
+        {
+            var (showFirst, setShowFirst) = Hooks.UseState(true);
+            s_setShowSource = setShowFirst;
+            return V.DndContext(
+                onDragStart: e =>
+                {
+                    s_started.Add(e.Active.Id);
+                    // The activeId recipe taken to its edge: the immediate activation's own synchronous
+                    // flush unmounts the source.
+                    if (e.Active.Id == "first")
+                    {
+                        s_setShowSource.Invoke(false);
+                    }
+                },
+                className: "w-[300px] h-[300px]",
+                children: new VNode[]
+                {
+                    showFirst
+                        ? V.Draggable("first", key: "first", name: "first", activation: DragActivation.None,
+                            className: "absolute left-[0px] top-[0px] w-[50px] h-[50px]")
+                        : null,
+                    V.Draggable("second", key: "second", name: "second",
+                        className: "absolute left-[100px] top-[0px] w-[50px] h-[50px]"),
+                });
+        }
+
+        [Test]
+        public void Given_AnImmediateActivationWhoseStartUnmountsTheSource_When_TheNextPressArrives_Then_ArmingStillWorks()
+        {
+            // Arrange — DragActivation.None activates inside the pointer-down dispatch, and its
+            // OnDragStart flush tears the source down; the session must already be installed as the
+            // tree's active drag when that happens, or the torn-down session wedges arming forever.
+            Mount(ImmediateActivationScene);
+            Q("first").SendPointerDownEvent(new Vector2(10, 10));
+            Assume.That(s_started, Is.EqualTo(new[] { "first" }), "Precondition: the immediate drag started");
+
+            // Act — a fresh gesture on the surviving draggable.
+            var second = Q("second");
+            second.SendPointerDownEvent(new Vector2(110, 10));
+            second.SendPointerMoveEvent(new Vector2(130, 10));
+
+            // Assert
+            Assert.That(s_started, Is.EqualTo(new[] { "first", "second" }));
+        }
+
+        [Component]
+        private static VNode SwappingDraggingClassScene()
+        {
+            var (alt, setAlt) = Hooks.UseState(false);
+            s_setAltDraggingClass = setAlt;
+            return V.DndContext(
+                className: "w-[300px] h-[300px]",
+                children: new VNode[]
+                {
+                    V.Draggable("item", key: "item", name: "item",
+                        whileDraggingClass: alt ? "opacity-25" : "opacity-50",
+                        className: "absolute left-[0px] top-[0px] w-[50px] h-[50px]"),
+                });
+        }
+
+        [Test]
+        public void Given_AWhileDraggingClassThatChangesMidDrag_When_TheDragCancels_Then_TheOriginallyAppliedClassIsRemoved()
+        {
+            // Arrange — activate with "opacity-50" applied, then swap the setting mid-drag: restore
+            // symmetry must target what was actually applied, not the re-parsed replacement.
+            Mount(SwappingDraggingClassScene);
+            var item = Q("item");
+            item.SendPointerDownEvent(new Vector2(10, 10));
+            item.SendPointerMoveEvent(new Vector2(30, 10));
+            Assume.That(item.ClassListContains("opacity-50"), Is.True,
+                "Precondition: the activation-time dragging class is applied");
+            s_setAltDraggingClass.Invoke(true);
+            _mounted.FlushStateForTest();
+
+            // Act
+            using (var evt = KeyDownEvent.GetPooled('\0', KeyCode.Escape, EventModifiers.None))
+            {
+                evt.target = item;
+                item.SendEvent(evt);
+            }
+
+            // Assert
+            Assert.That(item.ClassListContains("opacity-50"), Is.False);
         }
 
         [Test]

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/DndInteractionTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/DndInteractionTests.cs
@@ -1,0 +1,355 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.UIElements;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Specifies the drag-and-drop session on a real (headless) editor panel, driven end-to-end through
+    /// the panel's own dispatcher (IMGUI-event-constructed pointer events via <c>SendEvent</c>, so the
+    /// engine's own pressed-button bookkeeping stays truthful): activation constraints keep clicks
+    /// working, an active drag writes/restores the inline translate, collision resolves against live
+    /// rects, Escape cancels, and a source unmounting mid-drag scrubs synchronously while deferring the
+    /// user cancel callback past the flush — the pool-reuse ghosting contract.
+    /// </summary>
+    internal sealed class DndInteractionTests
+    {
+        private HeadlessEditorPanelHost _host;
+        private MountedTree _mounted;
+
+        private static readonly List<string> s_started = new();
+        private static readonly List<string> s_overIds = new();
+        private static readonly List<string> s_ended = new();
+        private static int s_cancelCount;
+        private static StateUpdater<bool> s_setShowSource;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _host = new HeadlessEditorPanelHost();
+            s_started.Clear();
+            s_overIds.Clear();
+            s_ended.Clear();
+            s_cancelCount = 0;
+            s_setShowSource = default;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _mounted?.Dispose();
+            _mounted = null;
+            _host?.Dispose();
+            _host = null;
+        }
+
+        private VisualElement Q(string name) => _host.Root.Q<VisualElement>(name);
+
+        // Collision reads live worldBound rects, so the fixture forces the style/layout pass batchmode
+        // never runs on its own — the same discipline as every resolvedStyle-reading fixture.
+        private void Mount(System.Func<VNode> body)
+        {
+            _mounted = V.Mount(_host.Root, V.Component(body, key: "root"));
+            EditorPanelTestHelpers.ForcePanelUpdate(_host.Panel);
+        }
+
+        // Pointer events are constructed from IMGUI system events: that constructor path maintains the
+        // engine's own PointerDeviceState (pressed buttons), which the pending phase's stale-session
+        // check reads from the move events it observes.
+        private static void SendPointerDown(VisualElement target, Vector2 position)
+        {
+            using var evt = PointerDownEvent.GetPooled(new Event
+            {
+                type = EventType.MouseDown, mousePosition = position, button = 0, clickCount = 1,
+            });
+            evt.target = target;
+            target.SendEvent(evt);
+        }
+
+        private static void SendPointerMove(VisualElement target, Vector2 position)
+        {
+            using var evt = PointerMoveEvent.GetPooled(new Event
+            {
+                type = EventType.MouseDrag, mousePosition = position, button = 0,
+            });
+            evt.target = target;
+            target.SendEvent(evt);
+        }
+
+        private static void SendPointerUp(VisualElement target, Vector2 position)
+        {
+            using var evt = PointerUpEvent.GetPooled(new Event
+            {
+                type = EventType.MouseUp, mousePosition = position, button = 0, clickCount = 1,
+            });
+            evt.target = target;
+            target.SendEvent(evt);
+        }
+
+        // A 300x300 scene: a 50x50 draggable at (0,0), a 100x100 droppable at (150,0), and a second,
+        // disabled droppable at (150,150). Absolute placement keeps every rect deterministic.
+        [Component]
+        private static VNode Scene()
+        {
+            var (showSource, setShowSource) = Hooks.UseState(true);
+            s_setShowSource = setShowSource;
+            return V.DndContext(
+                onDragStart: e => s_started.Add(e.Active.Id),
+                onDragOver: e => s_overIds.Add(e.Over?.Id),
+                onDragEnd: e => s_ended.Add(e.Over?.Id),
+                onDragCancel: _ => s_cancelCount++,
+                className: "w-[300px] h-[300px]",
+                name: "scope",
+                children: new VNode[]
+                {
+                    showSource
+                        ? V.Draggable("item", key: "item", name: "item",
+                            whileDraggingClass: "opacity-50",
+                            className: "absolute left-[0px] top-[0px] w-[50px] h-[50px]")
+                        : null,
+                    V.Droppable("slot", key: "slot", name: "slot",
+                        className: "absolute left-[150px] top-[0px] w-[100px] h-[100px]"),
+                    V.Droppable("dead", key: "dead", name: "dead", disabled: true,
+                        className: "absolute left-[150px] top-[150px] w-[100px] h-[100px]"),
+                });
+        }
+
+        [Test]
+        public void Given_ADraggableWithDefaultActivation_When_APressTravelsBelowTheDistanceAndReleases_Then_NoDragEverStarts()
+        {
+            // Arrange
+            Mount(Scene);
+            var item = Q("item");
+
+            // Act — 2 px of travel, below the 4 px default constraint: a plain click gesture.
+            SendPointerDown(item, new Vector2(10, 10));
+            SendPointerMove(item, new Vector2(12, 10));
+            SendPointerUp(item, new Vector2(12, 10));
+
+            // Assert
+            Assert.That(s_started, Is.Empty);
+        }
+
+        [Test]
+        public void Given_ADraggableButtonWithAClickHandler_When_APressStaysBelowTheActivationDistance_Then_TheClickStillFires()
+        {
+            // Arrange — the activation threshold exists exactly so draggable controls keep clicking.
+            Mount(Scene);
+            var item = Q("item");
+            var clicks = 0;
+            item.RegisterCallback<PointerUpEvent>(_ => clicks++);
+
+            // Act
+            SendPointerDown(item, new Vector2(10, 10));
+            SendPointerUp(item, new Vector2(10, 10));
+
+            // Assert — the sub-threshold release is untouched (no swallow, no suppression).
+            Assert.That(clicks, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void Given_ADraggableWithDefaultActivation_When_TravelExceedsTheDistance_Then_TheDragStartsOnceWithTheActiveId()
+        {
+            // Arrange
+            Mount(Scene);
+            var item = Q("item");
+
+            // Act — cross the 4 px constraint, then keep moving (activation must not repeat).
+            SendPointerDown(item, new Vector2(10, 10));
+            SendPointerMove(item, new Vector2(20, 10));
+            SendPointerMove(item, new Vector2(30, 10));
+
+            // Assert
+            Assert.That(s_started, Is.EqualTo(new[] { "item" }));
+        }
+
+        [Test]
+        public void Given_AnActiveTranslateDrag_When_ThePointerMovesByADelta_Then_TheInlineTranslateFollowsIt()
+        {
+            // Arrange — activate first (10 px travel), so the delta below is measured from activation.
+            Mount(Scene);
+            var item = Q("item");
+            SendPointerDown(item, new Vector2(10, 10));
+            SendPointerMove(item, new Vector2(20, 10));
+            Assume.That(s_started, Is.Not.Empty, "Precondition: the drag activated");
+
+            // Act — move a further (15, 25) from the activation point.
+            SendPointerMove(item, new Vector2(35, 35));
+
+            // Assert
+            var translate = item.style.translate.value;
+            Assert.That((translate.x.value, translate.y.value), Is.EqualTo((15f, 25f)));
+        }
+
+        [Test]
+        public void Given_AnActiveDragOverlappingADroppable_When_ThePointerReleases_Then_OnDragEndReportsThatDroppable()
+        {
+            // Arrange
+            Mount(Scene);
+            var item = Q("item");
+            SendPointerDown(item, new Vector2(10, 10));
+            SendPointerMove(item, new Vector2(20, 10));
+            Assume.That(s_started, Is.Not.Empty, "Precondition: the drag activated");
+
+            // Act — drag the 50x50 source by +170 px so its translated rect overlaps the slot at x=150,
+            // then release there.
+            SendPointerMove(item, new Vector2(190, 20));
+            SendPointerUp(item, new Vector2(190, 20));
+
+            // Assert
+            Assert.That(s_ended, Is.EqualTo(new[] { "slot" }));
+        }
+
+        [Test]
+        public void Given_AnActiveDragOverEmptySpace_When_ThePointerReleases_Then_OnDragEndReportsNoTarget()
+        {
+            // Arrange
+            Mount(Scene);
+            var item = Q("item");
+            SendPointerDown(item, new Vector2(10, 10));
+            SendPointerMove(item, new Vector2(20, 10));
+            Assume.That(s_started, Is.Not.Empty, "Precondition: the drag activated");
+
+            // Act — release over the scene's empty bottom-left region.
+            SendPointerMove(item, new Vector2(30, 120));
+            SendPointerUp(item, new Vector2(30, 120));
+
+            // Assert
+            Assert.That(s_ended, Is.EqualTo(new object[] { null }));
+        }
+
+        [Test]
+        public void Given_ADisabledDroppableUnderTheDraggedRect_When_CollisionRuns_Then_ItNeverBecomesTheOverTarget()
+        {
+            // Arrange
+            Mount(Scene);
+            var item = Q("item");
+            SendPointerDown(item, new Vector2(10, 10));
+            SendPointerMove(item, new Vector2(20, 10));
+            Assume.That(s_started, Is.Not.Empty, "Precondition: the drag activated");
+
+            // Act — park the dragged rect squarely over the DISABLED droppable at (150,150).
+            SendPointerMove(item, new Vector2(190, 190));
+
+            // Assert — every over-change reported so far is null (entering the disabled rect must not
+            // produce a winner).
+            Assert.That(s_overIds, Has.All.Null);
+        }
+
+        [Test]
+        public void Given_AnActiveDrag_When_EscapeIsPressed_Then_TheDragCancels()
+        {
+            // Arrange
+            Mount(Scene);
+            var item = Q("item");
+            SendPointerDown(item, new Vector2(10, 10));
+            SendPointerMove(item, new Vector2(20, 10));
+            Assume.That(s_started, Is.Not.Empty, "Precondition: the drag activated");
+
+            // Act
+            using (var evt = KeyDownEvent.GetPooled('\0', KeyCode.Escape, EventModifiers.None))
+            {
+                evt.target = item;
+                item.SendEvent(evt);
+            }
+
+            // Assert
+            Assert.That(s_cancelCount, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void Given_ACancelledDrag_When_TheSessionCloses_Then_TheInlineTranslateIsRestored()
+        {
+            // Arrange
+            Mount(Scene);
+            var item = Q("item");
+            SendPointerDown(item, new Vector2(10, 10));
+            SendPointerMove(item, new Vector2(20, 10));
+            SendPointerMove(item, new Vector2(60, 60));
+            Assume.That(item.style.translate.keyword, Is.EqualTo(StyleKeyword.Undefined),
+                "Precondition: the drag wrote an inline translate");
+
+            // Act
+            using (var evt = KeyDownEvent.GetPooled('\0', KeyCode.Escape, EventModifiers.None))
+            {
+                evt.target = item;
+                item.SendEvent(evt);
+            }
+
+            // Assert — the pre-drag inline value (none) is restored verbatim.
+            Assert.That(item.style.translate.keyword, Is.Not.EqualTo(StyleKeyword.Undefined));
+        }
+
+        [Test]
+        public void Given_AnActiveDrag_When_TheSourceUnmountsMidFlush_Then_TheUserCancelFiresExactlyOnceAfterTheFlush()
+        {
+            // Arrange
+            Mount(Scene);
+            var item = Q("item");
+            SendPointerDown(item, new Vector2(10, 10));
+            SendPointerMove(item, new Vector2(20, 10));
+            Assume.That(s_started, Is.Not.Empty, "Precondition: the drag activated");
+
+            // Act — unmount the source mid-drag: the cleaner scrubs synchronously but must defer the
+            // user callback past the flush (a state write from inside it would be silently lost).
+            s_setShowSource.Invoke(false);
+            _mounted.FlushStateForTest();
+            var firedDuringFlush = s_cancelCount;
+            EditorPanelTestHelpers.DriveSchedulerOnce(_host.Panel);
+
+            // Assert
+            Assert.That((firedDuringFlush, s_cancelCount), Is.EqualTo((0, 1)));
+        }
+
+        [Test]
+        public void Given_ASourceUnmountedMidDrag_When_ItsPooledElementIsRentedAgain_Then_NoDragResidueRemains()
+        {
+            // Arrange — the source is a plain VisualElement (not poolable), so pin the scrub contract
+            // directly instead: after a mid-drag teardown the element carries no translate and no
+            // while-dragging class.
+            Mount(Scene);
+            var item = Q("item");
+            SendPointerDown(item, new Vector2(10, 10));
+            SendPointerMove(item, new Vector2(20, 10));
+            SendPointerMove(item, new Vector2(60, 60));
+            Assume.That(item.ClassListContains("opacity-50"), Is.True,
+                "Precondition: the while-dragging class is applied mid-drag");
+
+            // Act
+            s_setShowSource.Invoke(false);
+            _mounted.FlushStateForTest();
+
+            // Assert — everything the session wrote is gone the moment the element leaves.
+            Assert.That(
+                (item.ClassListContains("opacity-50"), item.style.translate.keyword == StyleKeyword.Undefined),
+                Is.EqualTo((false, false)));
+        }
+
+        [Test]
+        public void Given_ADraggableInsideNoDndContext_When_APressTravelsPastTheDistance_Then_NothingActivates()
+        {
+            // Arrange — a draggable with no enclosing scope warns once and stays inert.
+            _mounted = V.Mount(_host.Root, V.Component(OrphanDraggable, key: "root"));
+            EditorPanelTestHelpers.ForcePanelUpdate(_host.Panel);
+            var item = Q("orphan");
+            UnityEngine.TestTools.LogAssert.Expect(LogType.Warning, new System.Text.RegularExpressions.Regex("no enclosing DndContext"));
+
+            // Act
+            SendPointerDown(item, new Vector2(10, 10));
+            SendPointerMove(item, new Vector2(30, 10));
+
+            // Assert
+            Assert.That(s_started, Is.Empty);
+        }
+
+        [Component]
+        private static VNode OrphanDraggable() => V.Div(
+            className: "w-[300px] h-[300px]",
+            children: new VNode[]
+            {
+                V.Draggable("stray", name: "orphan", className: "w-[50px] h-[50px]"),
+            });
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/DndInteractionTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/DndInteractionTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8641e2db73eec48cfa48f8bfb34bf2be

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/DndPlayModeTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/DndPlayModeTests.cs
@@ -1,0 +1,311 @@
+#if UNITY_EDITOR
+using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using UnityEngine.UIElements;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins the drag-and-drop behaviors that only a real runtime panel with the engine's own pointer
+    /// dispatcher can prove: captured pointer events route to the capturing source regardless of where
+    /// they land (so a drag keeps tracking outside the source's bounds), a child that captures at its
+    /// own pointer-down blacks out distance activation (interactive capturing children are documented
+    /// non-drag zones) while its click stays intact, a real drag ending on a Clickable source does NOT
+    /// fire its click, and the DragOverlay positioner tracks the pointer on the Overlay layer panel with
+    /// picking disabled.
+    /// </summary>
+    internal sealed class DndPlayModeTests
+    {
+        private GameObject _panelGo;
+        private PanelSettings _settings;
+        private MountedTree _mounted;
+
+        private static readonly List<string> s_started = new();
+        private static readonly List<string> s_ended = new();
+
+        [UnitySetUp]
+        public IEnumerator UnitySetUp()
+        {
+            s_started.Clear();
+            s_ended.Clear();
+            _panelGo = new GameObject("DndPanel");
+            var doc = _panelGo.AddComponent<UIDocument>();
+            _settings = ScriptableObject.CreateInstance<PanelSettings>();
+            _settings.scaleMode = PanelScaleMode.ConstantPixelSize;
+            doc.panelSettings = _settings;
+            yield return null;
+        }
+
+        [UnityTearDown]
+        public IEnumerator UnityTearDown()
+        {
+            _mounted?.Dispose();
+            _mounted = null;
+            if (_panelGo != null) Object.Destroy(_panelGo);
+            if (_settings != null) Object.Destroy(_settings);
+            yield return null;
+        }
+
+        private VisualElement Main(string name)
+            => _panelGo.GetComponent<UIDocument>().rootVisualElement.Q<VisualElement>(name);
+
+        private static void SendPointerDown(VisualElement target, Vector2 position)
+        {
+            using var evt = PointerDownEvent.GetPooled(new Event
+            {
+                type = EventType.MouseDown, mousePosition = position, button = 0, clickCount = 1,
+            });
+            evt.target = target;
+            target.SendEvent(evt);
+        }
+
+        private static void SendPointerMove(VisualElement target, Vector2 position)
+        {
+            using var evt = PointerMoveEvent.GetPooled(new Event
+            {
+                type = EventType.MouseDrag, mousePosition = position, button = 0,
+            });
+            evt.target = target;
+            target.SendEvent(evt);
+        }
+
+        private static void SendPointerUp(VisualElement target, Vector2 position)
+        {
+            using var evt = PointerUpEvent.GetPooled(new Event
+            {
+                type = EventType.MouseUp, mousePosition = position, button = 0, clickCount = 1,
+            });
+            evt.target = target;
+            target.SendEvent(evt);
+        }
+
+        // No preset target: the panel's own dispatching strategy resolves the destination — the capturing
+        // element when a capture is held, else picking. This is the only dispatch shape that exercises
+        // the engine's real capture routing (a preset target short-circuits it).
+        private static void SendPointerMoveUntargeted(IPanel panel, Vector2 position)
+        {
+            using var evt = PointerMoveEvent.GetPooled(new Event
+            {
+                type = EventType.MouseDrag, mousePosition = position, button = 0,
+            });
+            panel.visualTree.SendEvent(evt);
+        }
+
+        [Component]
+        private static VNode PlainScene() => V.DndContext(
+            onDragStart: e => s_started.Add(e.Active.Id),
+            onDragEnd: e => s_ended.Add(e.Over?.Id),
+            className: "w-[300px] h-[300px]",
+            children: new VNode[]
+            {
+                V.Draggable("item", name: "item",
+                    className: "absolute left-[0px] top-[0px] w-[50px] h-[50px]"),
+            });
+
+        [UnityTest]
+        public IEnumerator Given_AnActiveDragHoldingPointerCapture_When_MovesDispatchToTheRoot_Then_TheDragStillTracksTheDelta()
+        {
+            // Arrange
+            _mounted = V.Mount(_panelGo.GetComponent<UIDocument>().rootVisualElement,
+                V.Component(PlainScene, key: "root"));
+            yield return null;
+            yield return null;
+            var item = Main("item");
+            SendPointerDown(item, new Vector2(10, 10));
+            SendPointerMove(item, new Vector2(20, 10));
+            Assume.That(s_started, Is.Not.Empty, "Precondition: the drag activated");
+
+            // Act — dispatch the next move with NO preset target, at a position far outside the
+            // source's bounds: the engine's own capture routing must deliver it to the capturing source.
+            SendPointerMoveUntargeted(item.panel, new Vector2(220, 110));
+            yield return null;
+
+            // Assert — delta from the activation point (20,10) is (200,100).
+            var translate = item.style.translate.value;
+            Assert.That((translate.x.value, translate.y.value), Is.EqualTo((200f, 100f)));
+        }
+
+        [Component]
+        private static VNode ClickableChildScene() => V.DndContext(
+            onDragStart: e => s_started.Add(e.Active.Id),
+            className: "w-[300px] h-[300px]",
+            children: new VNode[]
+            {
+                V.Draggable("card", name: "card",
+                    className: "absolute left-[0px] top-[0px] w-[100px] h-[100px]",
+                    children: new VNode[]
+                    {
+                        V.Button(name: "child", className: "w-[60px] h-[30px]"),
+                    }),
+            });
+
+        [UnityTest]
+        public IEnumerator Given_APressOnAClickableChildInsideADraggable_When_TheChildCapturesThePointer_Then_DistanceActivationNeverFires()
+        {
+            // Arrange — the engine ground truth: captured pointer events are delivered to the capturing
+            // element ONLY, so the pending phase's panel-root observers never see these moves. An
+            // interactive capturing child is a documented non-drag zone in distance mode.
+            _mounted = V.Mount(_panelGo.GetComponent<UIDocument>().rootVisualElement,
+                V.Component(ClickableChildScene, key: "root"));
+            yield return null;
+            yield return null;
+            var child = Main("child");
+
+            // Act — a press on the Button (whose Clickable captures at pointer-down), then travel far
+            // past the activation distance.
+            SendPointerDown(child, new Vector2(10, 10));
+            SendPointerMove(child, new Vector2(60, 10));
+            yield return null;
+
+            // Assert
+            Assert.That(s_started, Is.Empty);
+        }
+
+        [UnityTest]
+        public IEnumerator Given_APressOnAClickableChildInsideADraggable_When_ItReleasesInPlace_Then_TheChildsClickStillFires()
+        {
+            // Arrange
+            _mounted = V.Mount(_panelGo.GetComponent<UIDocument>().rootVisualElement,
+                V.Component(ClickableChildScene, key: "root"));
+            yield return null;
+            yield return null;
+            var child = (Button)Main("child");
+            var clicks = 0;
+            child.clicked += () => clicks++;
+
+            // Act
+            SendPointerDown(child, new Vector2(10, 10));
+            SendPointerUp(child, new Vector2(10, 10));
+            yield return null;
+
+            // Assert — the draggable ancestor's arming must not cost the child its click.
+            Assert.That(clicks, Is.EqualTo(1));
+        }
+
+        [Component]
+        private static VNode DraggableButtonScene() => V.DndContext(
+            onDragStart: e => s_started.Add(e.Active.Id),
+            onDragEnd: e => s_ended.Add(e.Over?.Id),
+            className: "w-[300px] h-[300px]",
+            children: new VNode[]
+            {
+                // V.Button has no props: parameter (its DSL surfaces text/enabled/tooltip only), so the
+                // draggable-Button shape is declared as a raw ElementNode carrying the Draggable slot —
+                // the props form any element type supports.
+                new ElementNode
+                {
+                    Key = "btn",
+                    ElementType = typeof(Button),
+                    Name = "btn",
+                    ClassNames = V.ParseClassNames("absolute left-[0px] top-[0px] w-[80px] h-[40px]"),
+                    Props = new FiberElementProps { Draggable = new DraggableSettings("btn") },
+                    Children = System.Array.Empty<VNode>(),
+                    Events = System.Array.Empty<FiberEventBinding>(),
+                },
+            });
+
+        [UnityTest]
+        public IEnumerator Given_ADraggableClickableButton_When_ARealDragEndsOnIt_Then_TheClickDoesNotFire()
+        {
+            // Arrange — the Draggable settings sit ON the Clickable's own element, so captured events
+            // reach the session's callbacks; the post-drag PointerUp must be swallowed before the
+            // Clickable's bubble handler turns it into a click.
+            _mounted = V.Mount(_panelGo.GetComponent<UIDocument>().rootVisualElement,
+                V.Component(DraggableButtonScene, key: "root"));
+            yield return null;
+            yield return null;
+            var btn = (Button)Main("btn");
+            var clicks = 0;
+            btn.clicked += () => clicks++;
+
+            // Act — a real drag: press, travel past the constraint, release.
+            SendPointerDown(btn, new Vector2(10, 10));
+            SendPointerMove(btn, new Vector2(40, 10));
+            SendPointerUp(btn, new Vector2(40, 10));
+            yield return null;
+
+            // Assert — the drag completed (OnDragEnd fired) and the click did not.
+            Assert.That((s_ended.Count, clicks), Is.EqualTo((1, 0)));
+        }
+
+        [Component]
+        private static VNode OverlayScene() => V.DndContext(
+            onDragStart: e => s_started.Add(e.Active.Id),
+            className: "w-[300px] h-[300px]",
+            children: new VNode[]
+            {
+                V.Draggable("item", name: "item", movement: DragMovement.None,
+                    className: "absolute left-[0px] top-[0px] w-[50px] h-[50px]"),
+                V.DragOverlay(key: "overlay", children: new VNode[]
+                {
+                    V.Label("ghost", name: "ghost"),
+                }),
+            });
+
+        private static VisualElement FindPositioner(VisualElement root)
+        {
+            // The positioner is the overlay host child carrying PickingMode.Ignore + absolute position
+            // (forced at Attach) — resolved structurally so the test does not depend on internal names.
+            var count = root.hierarchy.childCount;
+            for (var i = 0; i < count; i++)
+            {
+                var child = root.hierarchy[i];
+                if (child.pickingMode == PickingMode.Ignore)
+                {
+                    return child;
+                }
+                var nested = FindPositioner(child);
+                if (nested != null)
+                {
+                    return nested;
+                }
+            }
+            return null;
+        }
+
+        [UnityTest]
+        public IEnumerator Given_AnActiveDragWithADragOverlay_When_ThePointerMoves_Then_TheOverlayPositionerTracksItOnTheOverlayPanel()
+        {
+            // Arrange
+            _mounted = V.Mount(_panelGo.GetComponent<UIDocument>().rootVisualElement,
+                V.Component(OverlayScene, key: "root"));
+            yield return null;
+            yield return null;
+            var item = Main("item");
+            SendPointerDown(item, new Vector2(10, 10));
+            SendPointerMove(item, new Vector2(20, 10));
+            Assume.That(s_started, Is.Not.Empty, "Precondition: the drag activated");
+
+            // Act
+            SendPointerMove(item, new Vector2(120, 60));
+            yield return null;
+
+            // Assert — grab offset was (10,10) at the down... measured from the ACTIVATION point
+            // (20,10) against the source rect at (0,0): offset (20,10). The positioner's top-left is
+            // pointer − grabOffset = (100, 50) in the (identically-scaled) overlay panel space.
+            var positioner = FindPositioner(
+                _mounted.Root.Reconciler.Context.LayerHosts[UILayer.Overlay].Document.rootVisualElement);
+            Assert.That((positioner.style.left.value.value, positioner.style.top.value.value),
+                Is.EqualTo((100f, 50f)));
+        }
+
+        [UnityTest]
+        public IEnumerator Given_ADragOverlay_When_ItMounts_Then_ItsPositionerNeverInterceptsPicking()
+        {
+            // Arrange & Act
+            _mounted = V.Mount(_panelGo.GetComponent<UIDocument>().rootVisualElement,
+                V.Component(OverlayScene, key: "root"));
+            yield return null;
+            yield return null;
+
+            // Assert
+            var positioner = FindPositioner(
+                _mounted.Root.Reconciler.Context.LayerHosts[UILayer.Overlay].Document.rootVisualElement);
+            Assert.That(positioner.pickingMode, Is.EqualTo(PickingMode.Ignore));
+        }
+    }
+}
+#endif

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/DndPlayModeTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/DndPlayModeTests.cs
@@ -5,6 +5,7 @@ using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
 using UnityEngine.UIElements;
+using Velvet.TestUtilities;
 
 namespace Velvet.Tests
 {
@@ -52,47 +53,20 @@ namespace Velvet.Tests
         private VisualElement Main(string name)
             => _panelGo.GetComponent<UIDocument>().rootVisualElement.Q<VisualElement>(name);
 
+        // Thin aliases over the SHARED pointer senders (TestUtilities) — one implementation for the
+        // EditMode and PlayMode suites, so the event shape (IMGUI-event construction keeping
+        // PointerDeviceState truthful) cannot drift between them.
         private static void SendPointerDown(VisualElement target, Vector2 position)
-        {
-            using var evt = PointerDownEvent.GetPooled(new Event
-            {
-                type = EventType.MouseDown, mousePosition = position, button = 0, clickCount = 1,
-            });
-            evt.target = target;
-            target.SendEvent(evt);
-        }
+            => target.SendPointerDownEvent(position);
 
         private static void SendPointerMove(VisualElement target, Vector2 position)
-        {
-            using var evt = PointerMoveEvent.GetPooled(new Event
-            {
-                type = EventType.MouseDrag, mousePosition = position, button = 0,
-            });
-            evt.target = target;
-            target.SendEvent(evt);
-        }
+            => target.SendPointerMoveEvent(position);
 
         private static void SendPointerUp(VisualElement target, Vector2 position)
-        {
-            using var evt = PointerUpEvent.GetPooled(new Event
-            {
-                type = EventType.MouseUp, mousePosition = position, button = 0, clickCount = 1,
-            });
-            evt.target = target;
-            target.SendEvent(evt);
-        }
+            => target.SendPointerUpEvent(position);
 
-        // No preset target: the panel's own dispatching strategy resolves the destination — the capturing
-        // element when a capture is held, else picking. This is the only dispatch shape that exercises
-        // the engine's real capture routing (a preset target short-circuits it).
         private static void SendPointerMoveUntargeted(IPanel panel, Vector2 position)
-        {
-            using var evt = PointerMoveEvent.GetPooled(new Event
-            {
-                type = EventType.MouseDrag, mousePosition = position, button = 0,
-            });
-            panel.visualTree.SendEvent(evt);
-        }
+            => panel.SendPointerMoveUntargeted(position);
 
         [Component]
         private static VNode PlainScene() => V.DndContext(

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/DndPlayModeTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/DndPlayModeTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3944b73d4deae409282e81fe3a950634

--- a/Packages/com.velvet.core/Runtime/Styling/StyleGestureClassManipulator.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleGestureClassManipulator.cs
@@ -73,6 +73,10 @@ namespace Velvet
             _signals.Hook(target, seedChecked: false, registerChecked: false);
         }
 
+        // Forwards a drag session's synthetic release to the shared signal source (see
+        // ElementLocalVariantSignals.SettleRelease); the per-state dedup below makes it idempotent.
+        internal void SettleRelease() => _signals?.SettleRelease();
+
         protected override void UnregisterCallbacksFromTarget()
         {
             if (_isHovered)

--- a/Packages/com.velvet.core/Runtime/Styling/StyleStackedVariantManipulator.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleStackedVariantManipulator.cs
@@ -67,6 +67,11 @@ namespace Velvet
         // re-derive their truth on attach and are detached on close to release their subscriptions.
         internal bool RetainsAcrossOuterClose => IsElementLocal || IsRelational;
 
+        // Forwards a drag session's synthetic release to the shared signal source (see
+        // ElementLocalVariantSignals.SettleRelease); a non-element-local inner (dark:/sm:) has no press
+        // state to settle and no signals instance, so the null-conditional is the whole guard.
+        internal void SettleRelease() => _elementSignals?.SettleRelease();
+
         protected override void RegisterCallbacksOnTarget()
         {
             if (IsElementLocal)

--- a/Packages/com.velvet.core/Runtime/Styling/StyleVariantManipulator.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleVariantManipulator.cs
@@ -100,6 +100,10 @@ namespace Velvet
             _signals?.Unhook();
         }
 
+        // Forwards a drag session's synthetic release to the shared signal source (see
+        // ElementLocalVariantSignals.SettleRelease); the per-state dedup below makes it idempotent.
+        internal void SettleRelease() => _signals?.SettleRelease();
+
         // Maps a detected element-local signal edge to its payload, deduping on the per-state bookkeeping so
         // a repeated edge (e.g. a bubbling PointerOver, or a no-op checked change) does not churn the payload.
         private void OnSignal(VariantSignal signal, bool on)

--- a/Packages/com.velvet.core/Runtime/Styling/VariantSignalSource.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/VariantSignalSource.cs
@@ -118,23 +118,19 @@ namespace Velvet
             _emit(VariantSignal.Active, true);
         }
 
-        private void OnPointerUp(PointerUpEvent evt)
-        {
-            _pointerFocus = false;
-            _emit(VariantSignal.Active, false);
-        }
+        private void OnPointerUp(PointerUpEvent evt) => ReleasePress();
 
-        private void OnPointerCancel(PointerCancelEvent evt)
-        {
-            _pointerFocus = false;
-            _emit(VariantSignal.Active, false);
-        }
+        private void OnPointerCancel(PointerCancelEvent evt) => ReleasePress();
 
         // Observes a synthetic release: a drag session that captured the pointer swallows the real
         // PointerUp (StopImmediatePropagation before the bubble phase), so the Active edge these
         // callbacks would have produced never arrives — without this, whileTap / active: stick on after
         // every completed drag. Consumers' own per-state bookkeeping dedups a redundant call.
-        public void SettleRelease()
+        public void SettleRelease() => ReleasePress();
+
+        // The one release body all three release paths share, so a change to release semantics cannot
+        // drift between a real pointer-up, a cancel, and a drag's synthetic settle.
+        private void ReleasePress()
         {
             _pointerFocus = false;
             _emit(VariantSignal.Active, false);

--- a/Packages/com.velvet.core/Runtime/Styling/VariantSignalSource.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/VariantSignalSource.cs
@@ -130,6 +130,16 @@ namespace Velvet
             _emit(VariantSignal.Active, false);
         }
 
+        // Observes a synthetic release: a drag session that captured the pointer swallows the real
+        // PointerUp (StopImmediatePropagation before the bubble phase), so the Active edge these
+        // callbacks would have produced never arrives — without this, whileTap / active: stick on after
+        // every completed drag. Consumers' own per-state bookkeeping dedups a redundant call.
+        public void SettleRelease()
+        {
+            _pointerFocus = false;
+            _emit(VariantSignal.Active, false);
+        }
+
         private void OnFocus(FocusEvent evt)
         {
             _emit(VariantSignal.Focus, true);

--- a/Packages/com.velvet.core/TestUtilities/VisualElementTestExtensions.cs
+++ b/Packages/com.velvet.core/TestUtilities/VisualElementTestExtensions.cs
@@ -208,5 +208,59 @@ namespace Velvet.TestUtilities
                 ?? throw new InvalidOperationException(
                     "Could not find EventCallbackRegistry.InvokeCallbacks(EventBase, PropagationPhase). Unity internal API may have changed.");
         }
+
+        /// <summary>
+        /// Dispatches a primary-button pointer press through the target's panel, constructed from an
+        /// IMGUI system event — the constructor path that maintains the engine's own
+        /// <c>PointerDeviceState</c> (pressed buttons), which downstream <c>pressedButtons</c> checks
+        /// read from later moves. Shared by the pointer-gesture fixtures (EditMode and PlayMode), so the
+        /// event shape cannot drift between the suites.
+        /// </summary>
+        public static void SendPointerDownEvent(this VisualElement target, UnityEngine.Vector2 position)
+        {
+            using var evt = PointerDownEvent.GetPooled(new UnityEngine.Event
+            {
+                type = UnityEngine.EventType.MouseDown, mousePosition = position, button = 0, clickCount = 1,
+            });
+            evt.target = target;
+            target.SendEvent(evt);
+        }
+
+        /// <summary>Dispatches a primary-button drag move to the target; see <see cref="SendPointerDownEvent"/>.</summary>
+        public static void SendPointerMoveEvent(this VisualElement target, UnityEngine.Vector2 position)
+        {
+            using var evt = PointerMoveEvent.GetPooled(new UnityEngine.Event
+            {
+                type = UnityEngine.EventType.MouseDrag, mousePosition = position, button = 0,
+            });
+            evt.target = target;
+            target.SendEvent(evt);
+        }
+
+        /// <summary>Dispatches a primary-button release to the target; see <see cref="SendPointerDownEvent"/>.</summary>
+        public static void SendPointerUpEvent(this VisualElement target, UnityEngine.Vector2 position)
+        {
+            using var evt = PointerUpEvent.GetPooled(new UnityEngine.Event
+            {
+                type = UnityEngine.EventType.MouseUp, mousePosition = position, button = 0, clickCount = 1,
+            });
+            evt.target = target;
+            target.SendEvent(evt);
+        }
+
+        /// <summary>
+        /// Dispatches a drag move with NO preset target: the panel's own dispatching strategy resolves
+        /// the destination — the capturing element when a capture is held, else picking. The only
+        /// dispatch shape that exercises the engine's real capture routing (a preset target
+        /// short-circuits it).
+        /// </summary>
+        public static void SendPointerMoveUntargeted(this IPanel panel, UnityEngine.Vector2 position)
+        {
+            using var evt = PointerMoveEvent.GetPooled(new UnityEngine.Event
+            {
+                type = UnityEngine.EventType.MouseDrag, mousePosition = position, button = 0,
+            });
+            panel.visualTree.SendEvent(evt);
+        }
     }
 }


### PR DESCRIPTION
## Summary

Adds drag-and-drop primitives with dnd-kit core parity (#40), riding the element-binding discipline the rest of the framework uses: settings on element props, reconciler-owned attach/update/detach, and pool-clean teardown.

### Surface

- **`V.DndContext`** — the scope (dnd-kit's `DndContext`): `onDragStart` / `onDragOver` / `onDragEnd` / `onDragCancel`, a pluggable `DndCollisionDetection` delegate (built-ins on `DndCollisions`: `RectIntersection` — the dnd-kit default, `ClosestCenter`, `PointerWithin`), and a scope-wide `DragActivation` default. Draggables/droppables pair with their nearest ancestor scope at event time; one drag per mounted tree.
- **`V.Draggable(id:)`** — the source (`useDraggable`): `dragData:`, `disabled:`, `movement:` (`Translate` writes an inline translate every move and restores it afterward; `None` is the overlay-ghost pattern), per-draggable `activation:`, and `whileDraggingClass:` (the zero-re-render `isDragging` channel).
- **`V.Droppable(id:)`** — the target (`useDroppable`): `dropData:`, `disabled:`, `whileOverClass:`, `whileDragActiveClass:` (dnd-kit's droppable `active` cue). Candidate rects are read live from `worldBound` every move, so mid-drag layout shifts, scrolls, and droppable mounts/unmounts are picked up automatically — `MeasuringConfiguration` is obsoleted, not deferred.
- **`V.DragOverlay`** — the portal-rendered preview (`DragOverlay`): a picking-ignored, framework-positioned container on the `UILayer.Overlay` panel, sized to the source at activation, tracking the pointer via the source-panel → screen → overlay-panel affine conversion. Content is user state set in `onDragStart`/`onDragEnd` — dnd-kit's `activeId` recipe.

All four are also settable as `FiberElementProps` slots on any existing element (a `V.Motion` host included); an element that is both draggable and droppable under one id never collides with itself.

### The session state machine

One `DndActiveDrag` per tree owns the gesture, built on two engine facts verified in source and pinned by PlayMode tests: captured pointer events are delivered to the capturing element ONLY, and TrickleDown callbacks on the capturing element run before its bubble-phase ones.

- **Arming** is a TrickleDown pointer-down observer (a same-element `Clickable` stops the down's immediate propagation from its bubble handler, which would silence a bubble-phase armer). Arming neither captures nor stops propagation, validates the press (primary button, enabled) before letting it displace a lingering pending session, and installs the session as the tree's active drag BEFORE it begins — `DragActivation.None` activates inside the pointer-down dispatch, and the `onDragStart` flush may immediately tear the source down, which must find the session installed or every teardown interlock is bypassed.
- **Activation constraints keep clicks working**: 4 px of travel by default (a documented deviation from dnd-kit's unconstrained default — a zero threshold races `Clickable`'s capture-at-down), `DelaySec` for hold-to-drag with `Tolerance` abort, `DragActivation.None` for the raw behavior. A sub-threshold release is a plain click, untouched.
- **Pending observation** sits on both the panel root (fast travel that leaves the source's bounds) and the source itself (capture-only delivery when the source's own `Clickable` captured — a draggable Button drags). A child that captures at its own pointer-down blacks out both — interactive capturing children are documented non-drag zones — and a pending session stranded by a capture-only release yields to the next press.
- **Activation** captures the pointer on the source (stealing from a capturing child — its capture-out aborts its click), registers drag-lifetime callbacks target-side, snapshots the origin rect, inline translate, movement mode, and the applied class arrays (mid-drag re-renders may swap the settings records — restore symmetry must target what was actually applied, never a re-parse), applies the drag classes, and fires `onDragStart` in the same discrete bracket as click handlers (extracted `FiberDiscreteEventScope`, shared with the event manager) so state commits synchronously. Escape listens on every managed panel root (key events dispatch through whichever panel holds focus). Phantom sessions — a press whose release was delivered capture-only or off-window — die on the first buttonless motion or the next fresh primary press; a hold-to-drag clock rides the panel root's scheduler (a source-scheduled recurring item would reset its phase on every keyed-reorder re-attach) and only activates while the source is attached.
- **Drop** (primary-button release only — a right-button tap mid-drag is not a drop) closes the session BEFORE the user callback (its synchronous flush may unmount the source — the sortable commit — and the cleaner must find an idle session), settles the press-derived `whileTap`/`active:` styling synthetically on the source AND its ancestors (`ElementLocalVariantSignals.SettleRelease` — the press's down bubbled, the swallowed release does not), then fires `onDragEnd`.
- **Cancel** on Escape, pointer cancel, or external capture loss; **teardown mid-drag** (source/scope unmount, disable) scrubs synchronously so the element reaches the pool clean, and defers the user `onDragCancel` to the panel's next tick — a state write from inside the flush is silently lost — with the callback exception-contained (a throwing scheduled item would re-fire every frame). Reconciler disposal fires the cancel inline instead: a deferred item would run against the disposed tree, or never.

`onDragOver` fires only when the winning target changes (including to null) and stays on the normal lane. Collision candidacy pairs a droppable with its NEAREST enclosing context (nested `DndContext`s stay isolated, dnd-kit behavior), and a droppable that mounts or re-enables mid-drag receives `whileDragActiveClass` the moment it becomes a candidate. `isDragging`/`isOver` are deliberately not re-rendering booleans: the `while*Class` channels + callbacks are the dnd-kit-core recipe.

### Scope cuts

Documented in `Documentation~/drag-and-drop.md` with the dnd-kit name each maps to: keyboard sensor + announcements (couples to the focus layer; Escape-cancel IS included), the sensors abstraction, hook-shaped `isDragging`/`isOver`, cross-panel drag (the overlay ghost is the one sanctioned cross-panel piece), the sortable preset (`V.Motion(layoutId:)` already animates post-drop reorders), `dropAnimation`/`modifiers`/auto-scroll, monitor/introspection hooks, ranked `Collision[]`, and multi-touch concurrency. Composition caveats (engine `ListView reorderable`, scaled ancestors, capturing children) are documented rather than solved.

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)
