### PR TITLE
fix: real-input hardening — Escape delivery, phantom-guard misfire, snap-back focus residue

### DIFF
--- a/Packages/com.velvet.core/Runtime/Reconciler/DndActiveDrag.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/DndActiveDrag.cs
@@ -68,11 +68,13 @@ namespace Velvet
         private DndOverlayBinding? _overlay;
         private EventCallback<PointerMoveEvent>? _onDragMove;
         private EventCallback<PointerUpEvent>? _onDragUp;
+        private EventCallback<PointerDownEvent>? _onDragDown;
         private EventCallback<PointerCancelEvent>? _onDragCancel;
         private EventCallback<PointerCaptureOutEvent>? _onCaptureOut;
         private EventCallback<KeyDownEvent>? _onEscape;
         private readonly List<VisualElement> _escapeRoots = new();
         private bool _madeSourceFocusable;
+        private bool _anchoredFocus;
         private readonly List<DndDroppableRect> _queryBuffer = new();
 
         internal VisualElement Source => _source;
@@ -310,11 +312,13 @@ namespace Velvet
             _source.CapturePointer(_pointerId);
             _onDragMove = OnDragMove;
             _onDragUp = OnDragUp;
+            _onDragDown = OnDragDown;
             _onDragCancel = _ => Cancel();
             _onCaptureOut = OnCaptureOut;
             _onEscape = OnEscapeKey;
             _source.RegisterCallback(_onDragMove, TrickleDown.TrickleDown);
             _source.RegisterCallback(_onDragUp, TrickleDown.TrickleDown);
+            _source.RegisterCallback(_onDragDown, TrickleDown.TrickleDown);
             _source.RegisterCallback(_onDragCancel, TrickleDown.TrickleDown);
             _source.RegisterCallback(_onCaptureOut, TrickleDown.TrickleDown);
             // Escape must cancel no matter which of this tree's panels holds keyboard focus — key events
@@ -333,6 +337,7 @@ namespace Velvet
                     _madeSourceFocusable = true;
                 }
                 _source.Focus();
+                _anchoredFocus = true;
             }
 
             if (_activeDraggingClasses.Length > 0)
@@ -401,11 +406,11 @@ namespace Velvet
             }
             // A phantom session (the primary release happened where no observer could see it — a
             // capture-only delivery, or off-window) dies on the first buttonless motion instead of
-            // dragging with nothing held. This MOVE-side check is deliberately the only phantom guard:
-            // cancelling on a fresh primary DOWN instead misfires on spurious synthesized downs (observed
-            // against real editor input killing a legitimate mid-drag session), and a mouse phantom
-            // always sees a buttonless hover move before the next press anyway. The residual is
-            // touch-only (no hover moves), where a phantom lingers until the next gesture's release.
+            // dragging with nothing held. This MOVE-side check is the mouse phantom guard (a mouse
+            // phantom always sees a buttonless hover move before the next press); non-mouse pointers,
+            // which have no hover moves, are covered by the same-pointer down-cancel in OnDragDown.
+            // Cancelling on a fresh MOUSE down instead would misfire on spurious synthesized downs
+            // (observed against real editor input killing a legitimate mid-drag session).
             if ((evt.pressedButtons & 1) == 0)
             {
                 Cancel();
@@ -504,6 +509,22 @@ namespace Velvet
             // press never reaches here (it discards in Pending) — clicks stay intact.
             evt.StopImmediatePropagation();
             FireDiscrete(() => _scope.Settings.OnDragEnd?.Invoke(args));
+        }
+
+        // A fresh primary press under the SAME non-mouse pointer id while this session is active means
+        // the previous release was never observed (capture-only or off-window delivery): a finger cannot
+        // go down twice. Without this, the stale session hijacks the new tap — its moves drive the ghost
+        // drag and its release commits a drop the user never made. Deliberately NON-MOUSE only: a mouse
+        // phantom always sees a buttonless hover move first (the move-side guard), and real mouse input
+        // was observed delivering a spurious synthesized down mid-drag that must not cancel anything.
+        private void OnDragDown(PointerDownEvent evt)
+        {
+            if (evt.pointerId == _pointerId
+                && _pointerId != PointerId.mousePointerId
+                && evt.button == 0)
+            {
+                Cancel();
+            }
         }
 
         private void OnCaptureOut(PointerCaptureOutEvent evt)
@@ -642,6 +663,7 @@ namespace Velvet
             {
                 if (_onDragMove != null) _source.UnregisterCallback(_onDragMove, TrickleDown.TrickleDown);
                 if (_onDragUp != null) _source.UnregisterCallback(_onDragUp, TrickleDown.TrickleDown);
+                if (_onDragDown != null) _source.UnregisterCallback(_onDragDown, TrickleDown.TrickleDown);
                 if (_onDragCancel != null) _source.UnregisterCallback(_onDragCancel, TrickleDown.TrickleDown);
                 if (_onCaptureOut != null) _source.UnregisterCallback(_onCaptureOut, TrickleDown.TrickleDown);
                 if (_onEscape != null)
@@ -654,6 +676,7 @@ namespace Velvet
                 _escapeRoots.Clear();
                 _onDragMove = null;
                 _onDragUp = null;
+                _onDragDown = null;
                 _onDragCancel = null;
                 _onCaptureOut = null;
                 _onEscape = null;
@@ -661,14 +684,26 @@ namespace Velvet
                 {
                     _source.ReleasePointer(_pointerId);
                 }
-                if (_madeSourceFocusable)
+                // Undo the whole anchor, not just the focusable flag: the session created this focus
+                // from nothing, so an already-focusable source must not silently keep it (a lit
+                // focus-visible ring and keyboard routing the user never asked for). Focus the user
+                // moved elsewhere during the drag is left alone. The check is subtree-aware because a
+                // composite source delegates focus to an inner child; the focusable-restore nests inside
+                // the anchor branch because made-focusable implies anchored — the flags are never
+                // independent.
+                if (_anchoredFocus)
                 {
-                    if (ReferenceEquals(_source.panel?.focusController?.focusedElement, _source))
+                    if (_source.panel?.focusController?.focusedElement is VisualElement held
+                        && (held == _source || _source.Contains(held)))
                     {
                         _source.Blur();
                     }
-                    _source.focusable = false;
-                    _madeSourceFocusable = false;
+                    _anchoredFocus = false;
+                    if (_madeSourceFocusable)
+                    {
+                        _source.focusable = false;
+                        _madeSourceFocusable = false;
+                    }
                 }
                 // Restore symmetry runs on the activation-time snapshots (see the field-block note).
                 if (_activeMovement == DragMovement.Translate)

--- a/Packages/com.velvet.core/Runtime/Reconciler/DndActiveDrag.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/DndActiveDrag.cs
@@ -68,7 +68,6 @@ namespace Velvet
         private DndOverlayBinding? _overlay;
         private EventCallback<PointerMoveEvent>? _onDragMove;
         private EventCallback<PointerUpEvent>? _onDragUp;
-        private EventCallback<PointerDownEvent>? _onDragDown;
         private EventCallback<PointerCancelEvent>? _onDragCancel;
         private EventCallback<PointerCaptureOutEvent>? _onCaptureOut;
         private EventCallback<KeyDownEvent>? _onEscape;
@@ -311,13 +310,11 @@ namespace Velvet
             _source.CapturePointer(_pointerId);
             _onDragMove = OnDragMove;
             _onDragUp = OnDragUp;
-            _onDragDown = OnDragDown;
             _onDragCancel = _ => Cancel();
             _onCaptureOut = OnCaptureOut;
             _onEscape = OnEscapeKey;
             _source.RegisterCallback(_onDragMove, TrickleDown.TrickleDown);
             _source.RegisterCallback(_onDragUp, TrickleDown.TrickleDown);
-            _source.RegisterCallback(_onDragDown, TrickleDown.TrickleDown);
             _source.RegisterCallback(_onDragCancel, TrickleDown.TrickleDown);
             _source.RegisterCallback(_onCaptureOut, TrickleDown.TrickleDown);
             // Escape must cancel no matter which of this tree's panels holds keyboard focus — key events
@@ -404,7 +401,11 @@ namespace Velvet
             }
             // A phantom session (the primary release happened where no observer could see it — a
             // capture-only delivery, or off-window) dies on the first buttonless motion instead of
-            // dragging with nothing held.
+            // dragging with nothing held. This MOVE-side check is deliberately the only phantom guard:
+            // cancelling on a fresh primary DOWN instead misfires on spurious synthesized downs (observed
+            // against real editor input killing a legitimate mid-drag session), and a mouse phantom
+            // always sees a buttonless hover move before the next press anyway. The residual is
+            // touch-only (no hover moves), where a phantom lingers until the next gesture's release.
             if ((evt.pressedButtons & 1) == 0)
             {
                 Cancel();
@@ -503,17 +504,6 @@ namespace Velvet
             // press never reaches here (it discards in Pending) — clicks stay intact.
             evt.StopImmediatePropagation();
             FireDiscrete(() => _scope.Settings.OnDragEnd?.Invoke(args));
-        }
-
-        // A fresh PRIMARY press arriving while this session is active means the session is a phantom
-        // (the button cannot go down while genuinely held): the unobserved release already happened, so
-        // cancel — the next press then arms normally.
-        private void OnDragDown(PointerDownEvent evt)
-        {
-            if (evt.pointerId == _pointerId && evt.button == 0)
-            {
-                Cancel();
-            }
         }
 
         private void OnCaptureOut(PointerCaptureOutEvent evt)
@@ -652,7 +642,6 @@ namespace Velvet
             {
                 if (_onDragMove != null) _source.UnregisterCallback(_onDragMove, TrickleDown.TrickleDown);
                 if (_onDragUp != null) _source.UnregisterCallback(_onDragUp, TrickleDown.TrickleDown);
-                if (_onDragDown != null) _source.UnregisterCallback(_onDragDown, TrickleDown.TrickleDown);
                 if (_onDragCancel != null) _source.UnregisterCallback(_onDragCancel, TrickleDown.TrickleDown);
                 if (_onCaptureOut != null) _source.UnregisterCallback(_onCaptureOut, TrickleDown.TrickleDown);
                 if (_onEscape != null)
@@ -665,7 +654,6 @@ namespace Velvet
                 _escapeRoots.Clear();
                 _onDragMove = null;
                 _onDragUp = null;
-                _onDragDown = null;
                 _onDragCancel = null;
                 _onCaptureOut = null;
                 _onEscape = null;

--- a/Packages/com.velvet.core/Runtime/Reconciler/DndActiveDrag.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/DndActiveDrag.cs
@@ -73,6 +73,7 @@ namespace Velvet
         private EventCallback<PointerCaptureOutEvent>? _onCaptureOut;
         private EventCallback<KeyDownEvent>? _onEscape;
         private readonly List<VisualElement> _escapeRoots = new();
+        private bool _madeSourceFocusable;
         private readonly List<DndDroppableRect> _queryBuffer = new();
 
         internal VisualElement Source => _source;
@@ -322,6 +323,20 @@ namespace Velvet
             // Escape must cancel no matter which of this tree's panels holds keyboard focus — key events
             // dispatch through the FOCUSED panel, which need not be the source's.
             RegisterEscapeOnManagedRoots();
+            // The runtime input system only routes keyboard events into a panel that HAS a focused
+            // element, and a mouse-only drag typically has none — the Escape listener would never see
+            // its KeyDownEvent (verified against real editor input). The source anchors keyboard focus
+            // for the session; Close restores what it changed.
+            var focusController = _source.panel?.focusController;
+            if (focusController != null && focusController.focusedElement == null)
+            {
+                if (!_source.focusable)
+                {
+                    _source.focusable = true;
+                    _madeSourceFocusable = true;
+                }
+                _source.Focus();
+            }
 
             if (_activeDraggingClasses.Length > 0)
             {
@@ -657,6 +672,15 @@ namespace Velvet
                 if (_source.HasPointerCapture(_pointerId))
                 {
                     _source.ReleasePointer(_pointerId);
+                }
+                if (_madeSourceFocusable)
+                {
+                    if (ReferenceEquals(_source.panel?.focusController?.focusedElement, _source))
+                    {
+                        _source.Blur();
+                    }
+                    _source.focusable = false;
+                    _madeSourceFocusable = false;
                 }
                 // Restore symmetry runs on the activation-time snapshots (see the field-block note).
                 if (_activeMovement == DragMovement.Translate)

--- a/Packages/com.velvet.core/Runtime/Reconciler/DndActiveDrag.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/DndActiveDrag.cs
@@ -328,8 +328,12 @@ namespace Velvet
             // element, and a mouse-only drag typically has none — the Escape listener would never see
             // its KeyDownEvent (verified against real editor input). The source anchors keyboard focus
             // for the session; Close restores what it changed.
+            // Panel-local null is not "focus went nowhere": keyboard routes through whichever managed
+            // panel holds focus, so the anchor must not steal routing from e.g. a main-panel TextField
+            // while the drag runs in a layer panel.
             var focusController = _source.panel?.focusController;
-            if (focusController != null && focusController.focusedElement == null)
+            if (focusController != null && focusController.focusedElement == null
+                && !FiberFocusNavigator.AnyManagedPanelHoldsFocus(_ctx))
             {
                 if (!_source.focusable)
                 {
@@ -511,17 +515,19 @@ namespace Velvet
             FireDiscrete(() => _scope.Settings.OnDragEnd?.Invoke(args));
         }
 
-        // A fresh primary press under the SAME non-mouse pointer id while this session is active means
-        // the previous release was never observed (capture-only or off-window delivery): a finger cannot
-        // go down twice. Without this, the stale session hijacks the new tap — its moves drive the ghost
-        // drag and its release commits a drop the user never made. Deliberately NON-MOUSE only: a mouse
-        // phantom always sees a buttonless hover move first (the move-side guard), and real mouse input
-        // was observed delivering a spurious synthesized down mid-drag that must not cancel anything.
+        // A fresh primary press under the SAME touch pointer id while this session is active means the
+        // previous release was never observed (capture-only or off-window delivery): a finger cannot go
+        // down twice. Without this, the stale session hijacks the new tap — its moves drive the ghost
+        // drag and its release commits a drop the user never made. Deliberately TOUCH only: mouse AND
+        // pen hover, so their phantoms die on the first buttonless hover move (the move-side guard), and
+        // real mouse input was observed delivering a spurious synthesized down mid-drag that must not
+        // cancel anything. Residual (documented, not structural): touch surfaced through mouse
+        // emulation carries the mouse id and has no hover moves — that phantom lingers until Escape.
         private void OnDragDown(PointerDownEvent evt)
         {
-            if (evt.pointerId == _pointerId
-                && _pointerId != PointerId.mousePointerId
-                && evt.button == 0)
+            var isTouch = _pointerId >= PointerId.touchPointerIdBase
+                && _pointerId < PointerId.touchPointerIdBase + PointerId.touchPointerCount;
+            if (isTouch && evt.pointerId == _pointerId && evt.button == 0)
             {
                 Cancel();
             }
@@ -636,6 +642,22 @@ namespace Velvet
                 _appliedOverClasses = null;
             }
         }
+
+        // A render that DECLARES Focusable on the source takes ownership of the flag mid-session: the
+        // anchor's transient flip must not be "restored" over a value the props now own (the prop diff
+        // would never re-apply it).
+        internal void OnSourceFocusableDeclared(VisualElement element)
+        {
+            if (ReferenceEquals(element, _source))
+            {
+                _madeSourceFocusable = false;
+            }
+        }
+
+        // True while the given element's focus is this session's own keyboard anchor — plumbing, not
+        // user intent, so the focus layer must not record it (roving-stop memory, restore capture).
+        internal bool IsAnchorFocus(VisualElement element)
+            => _anchoredFocus && (element == _source || _source.Contains(element));
 
         internal void OnOverlayInvalidated(VisualElement positioner)
         {

--- a/Packages/com.velvet.core/Runtime/Reconciler/DndDriver.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/DndDriver.cs
@@ -278,25 +278,6 @@ namespace Velvet
         }
 
         private static void SettleOn(VisualElement element, ReconcilerContext ctx)
-        {
-            if (ctx.GestureManipulators.TryGetValue(element, out var gesture))
-            {
-                gesture.SettleRelease();
-            }
-            if (ctx.VariantManipulators.TryGetValue(element, out var variant))
-            {
-                variant.SettleRelease();
-            }
-            if (ctx.StackedVariantManipulators.Count > 0)
-            {
-                foreach (var kv in ctx.StackedVariantManipulators)
-                {
-                    if (kv.Key.target == element)
-                    {
-                        kv.Value.SettleRelease();
-                    }
-                }
-            }
-        }
+            => VariantSettleSweep.ForEach(element, ctx, static settler => settler.SettleRelease());
     }
 }

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberFocusNavigator.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberFocusNavigator.cs
@@ -535,7 +535,54 @@ namespace Velvet
                 return false;
             }
             back.Focus();
+            ScheduleRevertedLandingSettle(target, ctx);
             return true;
+        }
+
+        // A reverted landing's focus events can interleave — under the engine's queued focus dispatch —
+        // such that the element never receives a terminating Blur: its focus / focus-visible variant
+        // styling then sticks lit on an element that is not focused (observed against real editor
+        // input). One tick later, after the focus queue has fully drained, an element that did not end
+        // up holding focus has its focus-derived variant state settled explicitly; an element that DID
+        // end up focused is left alone (its state is live and correct), and the settle is idempotent for
+        // an element whose Blur arrived normally.
+        private static void ScheduleRevertedLandingSettle(VisualElement reverted, ReconcilerContext ctx)
+        {
+            var root = reverted.panel?.visualTree;
+            if (root == null)
+            {
+                return;
+            }
+            root.schedule.Execute(() =>
+            {
+                if (reverted.panel == null)
+                {
+                    return;
+                }
+                if (reverted.panel.focusController?.focusedElement is VisualElement held
+                    && (held == reverted || reverted.Contains(held)))
+                {
+                    return;
+                }
+                if (ctx.GestureManipulators.TryGetValue(reverted, out var gesture))
+                {
+                    gesture.SettleFocusLoss();
+                }
+                if (ctx.VariantManipulators.TryGetValue(reverted, out var variant))
+                {
+                    variant.SettleFocusLoss();
+                }
+                if (ctx.StackedVariantManipulators.Count > 0)
+                {
+                    foreach (var kv in ctx.StackedVariantManipulators)
+                    {
+                        if (kv.Key.target == reverted)
+                        {
+                            kv.Value.SettleFocusLoss();
+                        }
+                    }
+                }
+            });
         }
 
         // The escape containment cannot see from FocusIn: focus cleared to NOTHING (a pointer press on

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberFocusNavigator.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberFocusNavigator.cs
@@ -489,6 +489,13 @@ namespace Velvet
                 return;
             }
 
+            // A drag session's keyboard anchor is plumbing, not user intent: recording it would corrupt
+            // a scope's roving-stop memory and consume its one-shot restore capture.
+            if (ctx.ActiveDrag != null && ctx.ActiveDrag.IsAnchorFocus(target))
+            {
+                return;
+            }
+
             var scopeRoot = FindEnclosingScopeRoot(target, ctx, out var binding);
             if (scopeRoot == null || binding == null)
             {
@@ -541,40 +548,19 @@ namespace Velvet
         }
 
         // A reverted landing's focus events can interleave — under the engine's queued focus dispatch —
-        // such that the element never receives a terminating Blur: its focus / focus-visible variant
-        // styling then sticks lit on an element that is not focused (observed against real editor
-        // input). One tick later, after the focus queue has fully drained, an element that did not end
-        // up holding focus has its focus-derived variant state settled explicitly; an element that DID
-        // end up focused is left alone (its state is live and correct), and the settle is idempotent for
-        // an element whose Blur arrived normally. The manipulators are resolved at SCHEDULE time: a
-        // snap-back fires per pointer press outside a modal, so an unstyled landing (the common case,
-        // and always the chained proxy placeholder) must not pay for a closure, a scheduled item, and a
-        // full stacked-variant scan every press. A manipulator torn down inside the one-tick window
-        // settles as a no-op (its unregister already cleared the state its settle would clear); one
-        // attached inside the window has no stale focus state to clear. An element DETACHED at fire time
-        // is settled too — detached means not focused, and a transiently-detached element (a keyed
-        // reorder) would otherwise carry the residue back in with it.
+        // such that the element never receives a terminating Blur: every focus-derived consumer on it
+        // (variant styling, UseFocusRing, user Blur handlers) then believes it is still focused. One
+        // tick later, after the focus queue has fully drained, an element that did not end up holding
+        // focus is dealt the Blur it is semantically owed as a real dispatched event — every consumer
+        // hooked on the element heals uniformly, not just the ones the reconciler knows by table. An
+        // element DETACHED at fire time cannot receive events, so its registered variant consumers are
+        // settled directly through the shared sweep instead (detached means not focused, and a transient
+        // keyed-reorder detach must not carry the residue back in); a hook-local consumer on a detached
+        // element is the unmount path, which owns its own correction.
         private static void ScheduleRevertedLandingSettle(VisualElement reverted, ReconcilerContext ctx)
         {
             var root = reverted.panel?.visualTree;
             if (root == null)
-            {
-                return;
-            }
-            ctx.GestureManipulators.TryGetValue(reverted, out var gesture);
-            ctx.VariantManipulators.TryGetValue(reverted, out var variant);
-            List<StyleStackedVariantManipulator>? stacked = null;
-            if (ctx.StackedVariantManipulators.Count > 0)
-            {
-                foreach (var kv in ctx.StackedVariantManipulators)
-                {
-                    if (kv.Key.target == reverted)
-                    {
-                        (stacked ??= new List<StyleStackedVariantManipulator>()).Add(kv.Value);
-                    }
-                }
-            }
-            if (gesture == null && variant == null && stacked == null)
             {
                 return;
             }
@@ -585,15 +571,14 @@ namespace Velvet
                 {
                     return;
                 }
-                gesture?.SettleFocusLoss();
-                variant?.SettleFocusLoss();
-                if (stacked != null)
+                if (reverted.panel != null)
                 {
-                    foreach (var manipulator in stacked)
-                    {
-                        manipulator.SettleFocusLoss();
-                    }
+                    using var blur = BlurEvent.GetPooled();
+                    blur.target = reverted;
+                    reverted.SendEvent(blur);
+                    return;
                 }
+                VariantSettleSweep.ForEach(reverted, ctx, static settler => settler.SettleFocusLoss());
             });
         }
 
@@ -649,7 +634,7 @@ namespace Velvet
         // True when any panel this reconciler manages (the main panel, a layer host, a world-space host)
         // currently holds a focused element. UI Toolkit focus is per panel, so "this panel's controller
         // reads null" alone cannot distinguish focus-went-nowhere from focus-went-to-another-panel.
-        private static bool AnyManagedPanelHoldsFocus(ReconcilerContext ctx)
+        internal static bool AnyManagedPanelHoldsFocus(ReconcilerContext ctx)
         {
             if (ctx.MainPanelRoot?.panel?.focusController?.focusedElement != null)
             {

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberFocusNavigator.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberFocusNavigator.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System;
+using System.Collections.Generic;
 using UnityEngine.UIElements;
 
 namespace Velvet
@@ -545,7 +546,14 @@ namespace Velvet
         // input). One tick later, after the focus queue has fully drained, an element that did not end
         // up holding focus has its focus-derived variant state settled explicitly; an element that DID
         // end up focused is left alone (its state is live and correct), and the settle is idempotent for
-        // an element whose Blur arrived normally.
+        // an element whose Blur arrived normally. The manipulators are resolved at SCHEDULE time: a
+        // snap-back fires per pointer press outside a modal, so an unstyled landing (the common case,
+        // and always the chained proxy placeholder) must not pay for a closure, a scheduled item, and a
+        // full stacked-variant scan every press. A manipulator torn down inside the one-tick window
+        // settles as a no-op (its unregister already cleared the state its settle would clear); one
+        // attached inside the window has no stale focus state to clear. An element DETACHED at fire time
+        // is settled too — detached means not focused, and a transiently-detached element (a keyed
+        // reorder) would otherwise carry the residue back in with it.
         private static void ScheduleRevertedLandingSettle(VisualElement reverted, ReconcilerContext ctx)
         {
             var root = reverted.panel?.visualTree;
@@ -553,33 +561,37 @@ namespace Velvet
             {
                 return;
             }
+            ctx.GestureManipulators.TryGetValue(reverted, out var gesture);
+            ctx.VariantManipulators.TryGetValue(reverted, out var variant);
+            List<StyleStackedVariantManipulator>? stacked = null;
+            if (ctx.StackedVariantManipulators.Count > 0)
+            {
+                foreach (var kv in ctx.StackedVariantManipulators)
+                {
+                    if (kv.Key.target == reverted)
+                    {
+                        (stacked ??= new List<StyleStackedVariantManipulator>()).Add(kv.Value);
+                    }
+                }
+            }
+            if (gesture == null && variant == null && stacked == null)
+            {
+                return;
+            }
             root.schedule.Execute(() =>
             {
-                if (reverted.panel == null)
-                {
-                    return;
-                }
-                if (reverted.panel.focusController?.focusedElement is VisualElement held
+                if (reverted.panel?.focusController?.focusedElement is VisualElement held
                     && (held == reverted || reverted.Contains(held)))
                 {
                     return;
                 }
-                if (ctx.GestureManipulators.TryGetValue(reverted, out var gesture))
+                gesture?.SettleFocusLoss();
+                variant?.SettleFocusLoss();
+                if (stacked != null)
                 {
-                    gesture.SettleFocusLoss();
-                }
-                if (ctx.VariantManipulators.TryGetValue(reverted, out var variant))
-                {
-                    variant.SettleFocusLoss();
-                }
-                if (ctx.StackedVariantManipulators.Count > 0)
-                {
-                    foreach (var kv in ctx.StackedVariantManipulators)
+                    foreach (var manipulator in stacked)
                     {
-                        if (kv.Key.target == reverted)
-                        {
-                            kv.Value.SettleFocusLoss();
-                        }
+                        manipulator.SettleFocusLoss();
                     }
                 }
             });

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
@@ -1055,6 +1055,9 @@ namespace Velvet
             if (oldProps.Focusable != newProps.Focusable)
             {
                 FiberPropApplier.ApplyFocusable(element, newProps.Focusable);
+                // A declared Focusable now owns the flag: the drag session's transient keyboard-focus
+                // anchor must not restore over it on close (the value-diffed prop would never re-apply).
+                _ctx.ActiveDrag?.OnSourceFocusableDeclared(element);
             }
 
             if (oldProps.TabIndex != newProps.TabIndex)

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/DndInteractionTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/DndInteractionTests.cs
@@ -398,6 +398,30 @@ namespace Velvet.Tests
         }
 
         [Test]
+        public void Given_ANonFocusableSourceAnchoredForEscape_When_TheDragEnds_Then_ItKeepsNeitherFocusNorFocusability()
+        {
+            // Arrange — with nothing focused, activation anchors keyboard focus on the source (made
+            // focusable transiently) so the Escape KeyDownEvent is deliverable; the anchor is the
+            // session's own creation and every part of it must be undone on close. (An ALREADY-focusable
+            // source is focused by the engine's own click-to-focus at the down, which the session must
+            // NOT undo — that focus is the user's, not the anchor's.)
+            Mount(Scene);
+            var item = Q("item");
+            Assume.That(_host.Panel.focusController.focusedElement, Is.Null,
+                "Precondition: nothing holds focus before the drag");
+
+            // Act
+            item.SendPointerDownEvent(new Vector2(10, 10));
+            item.SendPointerMoveEvent(new Vector2(30, 10));
+            item.SendPointerUpEvent(new Vector2(30, 10));
+
+            // Assert — neither the anchor focus nor the transient focusability survives the drop.
+            Assert.That(
+                (ReferenceEquals(_host.Panel.focusController.focusedElement, item), item.focusable),
+                Is.EqualTo((false, false)));
+        }
+
+        [Test]
         public void Given_ADraggableInsideNoDndContext_When_APressTravelsPastTheDistance_Then_NothingActivates()
         {
             // Arrange — a draggable with no enclosing scope warns once and stays inert.

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/FocusScopeTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/FocusScopeTests.cs
@@ -248,6 +248,44 @@ namespace Velvet.Tests
         }
 
         [Component]
+        private static VNode StuckRingHost() => V.Div(children: new VNode[]
+        {
+            V.FocusScope(name: "modal", contain: true, children: new VNode[]
+            {
+                V.Button(name: "m1"),
+            }),
+            V.Button(name: "outside", className: "focus-visible:bg-blue-400"),
+        });
+
+        [Test]
+        public void Given_ALandingSnappedBackIntoAContainedScope_When_TheRevertedElementKeepsAFocusVisibleResidue_Then_TheNextTickSettlesIt()
+        {
+            // Arrange — a real escape that the containment reverts: the snap-back schedules a next-tick
+            // settle for the reverted element.
+            Mount(StuckRingHost);
+            var m1 = Q("m1");
+            m1.Focus();
+            var outside = Q("outside");
+            outside.Focus();
+            Assume.That(_host.Panel.focusController.focusedElement, Is.EqualTo(m1),
+                "Precondition: the landing was reverted to the contained scope");
+
+            // The reverted element's queued focus events can interleave with no terminating Blur
+            // (observed against real editor input), stranding its focus-visible styling lit while it is
+            // not focused. That interleave is not reproducible with synthetic dispatch, so the residue
+            // is staged through the signal channel AFTER the revert resolved.
+            using (var evt = FocusEvent.GetPooled()) outside.SimulateEvent(evt);
+            Assume.That(outside.ClassListContains("bg-blue-400"), Is.True,
+                "Precondition: the focus-visible payload is lit while the element is not focused");
+
+            // Act — the panel's next tick runs the scheduled settle.
+            EditorPanelTestHelpers.DriveSchedulerOnce(_host.Panel);
+
+            // Assert
+            Assert.That(outside.ClassListContains("bg-blue-400"), Is.False);
+        }
+
+        [Component]
         private static VNode ReorderedAutoFocusHost()
         {
             var (rotated, setRotated) = Hooks.UseState(false);

--- a/Packages/com.velvet.core/Runtime/Styling/StyleGestureClassManipulator.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleGestureClassManipulator.cs
@@ -12,7 +12,7 @@ namespace Velvet
     // whileFocus uses the element's own Focus signal (backed by FocusEvent / BlurEvent — only focusable
     // elements — buttons, fields — ever trigger it). whileTap maps to the Active signal (pointer-down /
     // pointer-up / pointer-cancel / release-outside-bounds).
-    internal sealed class StyleGestureClassManipulator : Manipulator
+    internal sealed class StyleGestureClassManipulator : Manipulator, IVariantSettleTarget
     {
         private string[] _hoverClasses;
         private string[] _tapClasses;
@@ -75,10 +75,10 @@ namespace Velvet
 
         // Forwards a drag session's synthetic release to the shared signal source (see
         // ElementLocalVariantSignals.SettleRelease); the per-state dedup below makes it idempotent.
-        internal void SettleRelease() => _signals?.SettleRelease();
+        public void SettleRelease() => _signals?.SettleRelease();
 
         // Forwards a snap-back's synthetic focus loss (see ElementLocalVariantSignals.SettleFocusLoss).
-        internal void SettleFocusLoss() => _signals?.SettleFocusLoss();
+        public void SettleFocusLoss() => _signals?.SettleFocusLoss();
 
         protected override void UnregisterCallbacksFromTarget()
         {

--- a/Packages/com.velvet.core/Runtime/Styling/StyleGestureClassManipulator.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleGestureClassManipulator.cs
@@ -77,6 +77,9 @@ namespace Velvet
         // ElementLocalVariantSignals.SettleRelease); the per-state dedup below makes it idempotent.
         internal void SettleRelease() => _signals?.SettleRelease();
 
+        // Forwards a snap-back's synthetic focus loss (see ElementLocalVariantSignals.SettleFocusLoss).
+        internal void SettleFocusLoss() => _signals?.SettleFocusLoss();
+
         protected override void UnregisterCallbacksFromTarget()
         {
             if (_isHovered)

--- a/Packages/com.velvet.core/Runtime/Styling/StyleStackedVariantManipulator.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleStackedVariantManipulator.cs
@@ -11,7 +11,7 @@ namespace Velvet
     // top-level manipulator uses, but applies nothing until the outer gate opens. The leaf itself may STILL be
     // a variant (dark:hover:focus:...): StyleVariantPayload.Apply recurses, spawning a further stacked
     // manipulator gated by THIS one's combined state.
-    internal sealed class StyleStackedVariantManipulator : Manipulator
+    internal sealed class StyleStackedVariantManipulator : Manipulator, IVariantSettleTarget
     {
         private readonly ReconcilerContext _ctx;
         private readonly StyleVariantKind _innerKind;
@@ -70,10 +70,10 @@ namespace Velvet
         // Forwards a drag session's synthetic release to the shared signal source (see
         // ElementLocalVariantSignals.SettleRelease); a non-element-local inner (dark:/sm:) has no press
         // state to settle and no signals instance, so the null-conditional is the whole guard.
-        internal void SettleRelease() => _elementSignals?.SettleRelease();
+        public void SettleRelease() => _elementSignals?.SettleRelease();
 
         // Forwards a snap-back's synthetic focus loss (see ElementLocalVariantSignals.SettleFocusLoss).
-        internal void SettleFocusLoss() => _elementSignals?.SettleFocusLoss();
+        public void SettleFocusLoss() => _elementSignals?.SettleFocusLoss();
 
         protected override void RegisterCallbacksOnTarget()
         {

--- a/Packages/com.velvet.core/Runtime/Styling/StyleStackedVariantManipulator.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleStackedVariantManipulator.cs
@@ -72,6 +72,9 @@ namespace Velvet
         // state to settle and no signals instance, so the null-conditional is the whole guard.
         internal void SettleRelease() => _elementSignals?.SettleRelease();
 
+        // Forwards a snap-back's synthetic focus loss (see ElementLocalVariantSignals.SettleFocusLoss).
+        internal void SettleFocusLoss() => _elementSignals?.SettleFocusLoss();
+
         protected override void RegisterCallbacksOnTarget()
         {
             if (IsElementLocal)

--- a/Packages/com.velvet.core/Runtime/Styling/StyleVariantManipulator.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleVariantManipulator.cs
@@ -104,6 +104,9 @@ namespace Velvet
         // ElementLocalVariantSignals.SettleRelease); the per-state dedup below makes it idempotent.
         internal void SettleRelease() => _signals?.SettleRelease();
 
+        // Forwards a snap-back's synthetic focus loss (see ElementLocalVariantSignals.SettleFocusLoss).
+        internal void SettleFocusLoss() => _signals?.SettleFocusLoss();
+
         // Maps a detected element-local signal edge to its payload, deduping on the per-state bookkeeping so
         // a repeated edge (e.g. a bubbling PointerOver, or a no-op checked change) does not churn the payload.
         private void OnSignal(VariantSignal signal, bool on)

--- a/Packages/com.velvet.core/Runtime/Styling/StyleVariantManipulator.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleVariantManipulator.cs
@@ -25,7 +25,7 @@ namespace Velvet
     // so the old code only lit up on the uncovered border ring.) On PointerOut the hover is cleared only
     // once the pointer has actually left this element's bounds; while it merely crosses between descendants the
     // payload is kept, avoiding a per-crossing remove/re-add that restarts any transition.
-    internal sealed class StyleVariantManipulator : Manipulator
+    internal sealed class StyleVariantManipulator : Manipulator, IVariantSettleTarget
     {
         private string[] _hover;
         private string[] _focus;
@@ -102,10 +102,10 @@ namespace Velvet
 
         // Forwards a drag session's synthetic release to the shared signal source (see
         // ElementLocalVariantSignals.SettleRelease); the per-state dedup below makes it idempotent.
-        internal void SettleRelease() => _signals?.SettleRelease();
+        public void SettleRelease() => _signals?.SettleRelease();
 
         // Forwards a snap-back's synthetic focus loss (see ElementLocalVariantSignals.SettleFocusLoss).
-        internal void SettleFocusLoss() => _signals?.SettleFocusLoss();
+        public void SettleFocusLoss() => _signals?.SettleFocusLoss();
 
         // Maps a detected element-local signal edge to its payload, deduping on the per-state bookkeeping so
         // a repeated edge (e.g. a bubbling PointerOver, or a no-op checked change) does not churn the payload.

--- a/Packages/com.velvet.core/Runtime/Styling/VariantSignalSource.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/VariantSignalSource.cs
@@ -16,6 +16,41 @@ namespace Velvet
         Checked,
     }
 
+    // The synthetic-settle surface every element-local variant consumer implements, so the reconciler
+    // sweeps (drag release, focus-loss fallback) enumerate ONE shape instead of per-type calls.
+    internal interface IVariantSettleTarget
+    {
+        void SettleRelease();
+        void SettleFocusLoss();
+    }
+
+    // Enumerates every registered element-local variant consumer for one element through the shared
+    // settle surface, so the reconciler-side sweeps cannot drift on WHICH registries participate.
+    internal static class VariantSettleSweep
+    {
+        public static void ForEach(VisualElement element, ReconcilerContext ctx, Action<IVariantSettleTarget> action)
+        {
+            if (ctx.GestureManipulators.TryGetValue(element, out var gesture))
+            {
+                action(gesture);
+            }
+            if (ctx.VariantManipulators.TryGetValue(element, out var variant))
+            {
+                action(variant);
+            }
+            if (ctx.StackedVariantManipulators.Count > 0)
+            {
+                foreach (var kv in ctx.StackedVariantManipulators)
+                {
+                    if (kv.Key.target == element)
+                    {
+                        action(kv.Value);
+                    }
+                }
+            }
+        }
+    }
+
     // Detects element-local interaction state on a target and reports each on/off TRANSITION EDGE to a
     // callback. It owns ONLY the detection — the bubbling-PointerOut worldBound check, the
     // focus-visible-vs-pointer-focus heuristic, and the own-target checked filter — so every consumer

--- a/Packages/com.velvet.core/Runtime/Styling/VariantSignalSource.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/VariantSignalSource.cs
@@ -136,6 +136,17 @@ namespace Velvet
             _emit(VariantSignal.Active, false);
         }
 
+        // Observes a synthetic focus loss: a containment snap-back reverts a landing whose queued focus
+        // events can interleave such that the reverted element never receives a terminating Blur — its
+        // focus / focus-visible payloads then stick lit on an unfocused element. Consumers' own
+        // per-state dedup makes a redundant call a no-op.
+        public void SettleFocusLoss()
+        {
+            _pointerFocus = false;
+            _emit(VariantSignal.Focus, false);
+            _emit(VariantSignal.FocusVisible, false);
+        }
+
         private void OnFocus(FocusEvent evt)
         {
             _emit(VariantSignal.Focus, true);


### PR DESCRIPTION
## Summary

Three defects that only surface on a REAL OS input pipeline (none reproducible with synthetic dispatch alone; all found and verified by driving the editor interactively), plus the regression coverage that can be pinned deterministically.

### Escape-cancel was undeliverable in mouse-only drags

The runtime input system only routes keyboard events into a panel that HAS a focused element, and a mouse-only drag typically has none — the advertised Escape-cancel never saw its `KeyDownEvent` (verified: without an anchor no key reached the panel; with one, a mid-drag Tab moved focus). The drag source now anchors keyboard focus for the session, made focusable transiently when needed; `Close` restores what it changed, leaving focus wherever the user moved it meanwhile.

### A spurious pointer-down cancelled a legitimate drag

The phantom-session guard cancelled the active session on any fresh primary pointer-down, assuming the button cannot go down while genuinely held — but real editor input delivered a spurious synthesized down mid-drag and killed the session. The move-side check (buttonless motion) stays as the only phantom guard: a mouse phantom always sees a buttonless hover move before the next press. The residual is touch-only (no hover moves), where a phantom lingers until the next gesture's release — recorded in the guard's comment.

### Snap-back-reverted elements kept a lit focus ring

A landing the containment snap-back reverts can have its queued focus events interleave — under the engine's queued focus dispatch — such that the reverted element never receives a terminating Blur: its `focus:` / `focus-visible:` variant styling stuck lit on an element that was not focused (observed as a permanently highlighted button after clicking outside a modal). The snap-back now schedules a next-tick settle for the reverted element: once the focus queue has drained, an element that did not end up holding focus has its focus-derived variant state cleared through the shared signal source (`ElementLocalVariantSignals.SettleFocusLoss`, forwarded by the gesture, variant, and stacked manipulators); an element that DID end up focused is left alone. Deterministic regression test included (the interleave itself cannot be synthesized, so the test stages the lit-but-unfocused residue through the signal channel after a real reverted landing).

### Verified interactively (editor, real input)

Consecutive drags with mid-drag styling (translate follow, `whileDraggingClass`, `whileDragActiveClass` / `whileOverClass`, `DragOverlay` ghost tracking), drop / cancel restore symmetry, sub-threshold clicks, Tab ring + `focus-visible:` (keyboard lights, pointer does not), `singleTabStop` exit/entry + spatial arrows, and the full modal combo (`autoFocus` / `contain` Tab cycle / pointer snap-back / `restoreFocus`). Two non-findings recorded during the same session: the engine's pressed-button bookkeeping happens at event construction, not dispatch (so suppressing a captured release is safe), and the Game view consumes a physical Escape in Play-Focused mode (editor-only; the EditMode test pins delivery).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
