### PR TITLE
chore: prepare v1.4.0 release

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-07-17
+
 ### Added
 
 - Drag-and-drop primitives, dnd-kit core parity: `V.DndContext` (the scope — `onDragStart` /

--- a/Packages/com.velvet.core/package.json
+++ b/Packages/com.velvet.core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.velvet.core",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "displayName": "Velvet",
   "description": "React-style declarative UI framework for Unity UI Toolkit. Provides virtual DOM, reconciliation engine, hooks, and component model.",
   "license": "MIT",


### PR DESCRIPTION
Dates the [Unreleased] section as 1.4.0 (focus/gamepad navigation layer, cross-panel focus escape, drag-and-drop primitives, V.Anchored, UseAnimationSequence, V.Motion layoutId, cross-panel input routing, plus the pooled-control focusable fix and real-input hardening) and bumps the package version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)