### PR TITLE
fix: recycle retired VNode trees at every depth via mark-and-sweep

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -27,11 +27,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reconcile pass, so a second retirement of a shared node can never recycle a NEW renter's live
   object); an aborted reconcile no longer recycles the retained baseline's own pooled parts; a
   fiber unmounting mid-pass reclaims its deferred baselines while its mark roots are intact; a
-  replaced `V.Memoized` inner tree and the memo cache's disposal now retire their cached subtrees;
-  discarded render-phase attempts retire their throwaway output; and the editor-only StrictMode
-  double-invoke pass neither recycles committed subtrees a memo hit shared into its diagnostic tree
-  nor stages that tree into the auto-memo slot. `V.DragOverlay`'s positioner props now come from
-  the pool too (the workaround for the old leak).
+  replaced `V.Memoized` inner tree, a replaced VNode-valued provider value, and the memo cache's
+  disposal now retire their cached subtrees; an `AnimatePresence` child retires when it leaves the
+  presence set (exit completion, instant removal, mid-exit re-entry); a disposed fiber retires its
+  element-in-state roots (unmount keeps them for a remount); discarded render-phase attempts retire
+  their throwaway output; and the editor-only StrictMode double-invoke pass neither recycles
+  committed subtrees a memo hit shared into its diagnostic tree nor stages that tree into the
+  auto-memo slot. `V.DragOverlay`'s positioner props now come from the pool too (the workaround
+  for the old leak).
 
 ## [1.4.0] - 2026-07-17
 

--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -13,15 +13,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   from EVERY nesting level of a retired tree — previously only the top level was recycled, so any
   props-carrying element nested under another element (or under `V.Portal` / `V.WorldSpace` /
   `V.Suspense` / provider children) stranded one pooled bag per re-render, pinned forever by the
-  pool's ownership tracking. The recycle is a mark-and-sweep: objects still reachable from the
-  committed tree or from memoized roots (compiler auto-memo slots, `Hooks.UseMemo`-held subtrees,
-  along the ancestor chain) are spared, so memo hits that legitimately share nodes across
-  consecutive renders keep their baselines intact. Pool returns are now idempotent (rent-scoped
-  ownership), double-return can no longer alias one bag to two renters, an aborted reconcile no
-  longer recycles the retained baseline's own pooled parts, and the editor-only StrictMode
-  double-invoke pass no longer recycles committed subtrees a memo hit shared into its discarded
-  diagnostic tree. `V.DragOverlay`'s positioner props now come from the pool too (the workaround
-  for the old leak).
+  pool's ownership tracking. The recycle is a mark-and-sweep: nodes still reachable from committed
+  state are spared, so renders that legitimately share node instances keep their baselines intact.
+  The live roots cover the committed and parked baselines, hook-slot-held node roots (compiler
+  auto-memo slots, plus `Hooks.UseMemo` / `UseState` / `UseRef` values that are a node or a list of
+  nodes) along the LOGICAL ancestor chain (portal-drained fibers hop back to their declaring
+  component), provider values, and exiting `AnimatePresence` ghosts (whose nodes presence
+  bookkeeping re-reads until the exit completes). Holding a factory-built node anywhere else across
+  renders — inside a user record or tuple, a component props record, a `Store` — is outside the
+  tracked surface and documented as unsupported.
+- Pooled-object lifetime hardening around the same recycle path: pool returns are idempotent
+  (rent-scoped ownership) and pass-deferred (a mid-pass return cannot be re-rented within the same
+  reconcile pass, so a second retirement of a shared node can never recycle a NEW renter's live
+  object); an aborted reconcile no longer recycles the retained baseline's own pooled parts; a
+  fiber unmounting mid-pass reclaims its deferred baselines while its mark roots are intact; a
+  replaced `V.Memoized` inner tree and the memo cache's disposal now retire their cached subtrees;
+  discarded render-phase attempts retire their throwaway output; and the editor-only StrictMode
+  double-invoke pass neither recycles committed subtrees a memo hit shared into its diagnostic tree
+  nor stages that tree into the auto-memo slot. `V.DragOverlay`'s positioner props now come from
+  the pool too (the workaround for the old leak).
 
 ## [1.4.0] - 2026-07-17
 

--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- The fiber-tree recycle path now returns factory-rented props bags / event arrays / child arrays
+  from EVERY nesting level of a retired tree — previously only the top level was recycled, so any
+  props-carrying element nested under another element (or under `V.Portal` / `V.WorldSpace` /
+  `V.Suspense` / provider children) stranded one pooled bag per re-render, pinned forever by the
+  pool's ownership tracking. The recycle is a mark-and-sweep: objects still reachable from the
+  committed tree or from memoized roots (compiler auto-memo slots, `Hooks.UseMemo`-held subtrees,
+  along the ancestor chain) are spared, so memo hits that legitimately share nodes across
+  consecutive renders keep their baselines intact. Pool returns are now idempotent (rent-scoped
+  ownership), double-return can no longer alias one bag to two renters, an aborted reconcile no
+  longer recycles the retained baseline's own pooled parts, and the editor-only StrictMode
+  double-invoke pass no longer recycles committed subtrees a memo hit shared into its discarded
+  diagnostic tree. `V.DragOverlay`'s positioner props now come from the pool too (the workaround
+  for the old leak).
+
 ## [1.4.0] - 2026-07-17
 
 ### Added

--- a/Packages/com.velvet.core/Runtime/Component/ComponentRegistry.cs
+++ b/Packages/com.velvet.core/Runtime/Component/ComponentRegistry.cs
@@ -183,7 +183,11 @@ namespace Velvet
                 RegisterFiber(anchor, positionKey, identity, fiber, isInline);
                 throw;
             }
-            catch { fiber.Detach(); FiberRenderer.Dispose(fiber); throw; }
+            // Dispose BEFORE any detach: Dispose's Unmount retires the committed tree with the parent
+            // chain intact (the recycle sweep marks ancestor-held memoized roots through it) and then
+            // detaches itself; detaching first would sever the chain and let the sweep recycle nodes
+            // a surviving ancestor's slot still owes to a comeback render.
+            catch { FiberRenderer.Dispose(fiber); throw; }
             RegisterFiber(anchor, positionKey, identity, fiber, isInline);
             return fiber;
         }
@@ -289,7 +293,15 @@ namespace Velvet
         {
             if (fiber.IsInlineMounted && fiber.PreviousTree != null)
             {
+                // Retire the tree's pooled objects HERE: nulling PreviousTree suppresses Unmount's
+                // DOM-side cleanup pass (correct — see above) but also its pool return, and no other
+                // path ever reaches this baseline again. Sweeping while the fiber's slots and parent
+                // chain are still intact keeps memo-shared nodes protected; the pass-scoped release
+                // staging keeps the rest un-rentable while the enclosing reconcile still reads its
+                // old-side captures of these nodes.
+                var retired = fiber.PreviousTree;
                 fiber.PreviousTree = null;
+                FiberTreeReturn.ReturnRetiredTree(retired, fiber);
             }
             FiberRenderer.Dispose(fiber);
             UnregisterFiber(fiber);

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/VNodePoolOwnershipTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/VNodePoolOwnershipTests.cs
@@ -90,6 +90,73 @@ namespace Velvet.Tests
         }
 
         [Test]
+        public void Given_ARentedEventArrayReturnedTwice_When_TwoRentsFollow_Then_TheyAreDistinctInstances()
+        {
+            // Arrange — same double-return discipline for the single-event-array pool.
+            var array = VNodePool.RentSingleEventArray();
+            VNodePool.ReturnEventArray(array);
+            VNodePool.ReturnEventArray(array);
+
+            // Act
+            var first = VNodePool.RentSingleEventArray();
+            var second = VNodePool.RentSingleEventArray();
+
+            // Assert
+            Assert.That(ReferenceEquals(first, second), Is.False);
+        }
+
+        [Test]
+        public void Given_AnOpenReleaseScope_When_ABagIsReturnedInsideIt_Then_ARentCannotGetItBackUntilTheScopeEnds()
+        {
+            // Arrange — a reconcile-pass-shaped release scope with one bag returned mid-scope. A tree
+            // retired mid-pass must not be re-rentable by a later factory call in the SAME pass, or a
+            // second retired tree reaching the same bag would recycle the new renter's live object.
+            var bag = VNodePool.RentProps();
+            VNodePool.BeginReleaseScope();
+            try
+            {
+                VNodePool.ReturnProps(bag);
+
+                // Act — drain every pooled bag; the staged one must not be among them.
+                var sawStagedBag = false;
+                for (var i = 0; i < 16; i++)
+                {
+                    if (ReferenceEquals(VNodePool.RentProps(), bag)) sawStagedBag = true;
+                }
+
+                // Assert
+                Assert.That(sawStagedBag, Is.False,
+                    "A bag returned inside a release scope must stay un-rentable until the scope ends");
+            }
+            finally
+            {
+                VNodePool.EndReleaseScope();
+            }
+        }
+
+        [Test]
+        public void Given_AReleaseScopeThatStagedAReturn_When_TheScopeEnds_Then_TheBagIsPoolableAgain()
+        {
+            // Arrange — drain the pool first so the flush target has room and the flushed bag sits on
+            // top of the stack, then stage one return inside a scope.
+            for (var i = 0; i < 16; i++)
+            {
+                VNodePool.RentProps();
+            }
+            var bag = VNodePool.RentProps();
+            VNodePool.BeginReleaseScope();
+            VNodePool.ReturnProps(bag);
+            VNodePool.EndReleaseScope();
+
+            // Act — the flushed bag is on top of the pool stack.
+            var rented = VNodePool.RentProps();
+
+            // Assert
+            Assert.That(ReferenceEquals(rented, bag), Is.True,
+                "A staged return must reach the pool when the scope ends");
+        }
+
+        [Test]
         public void Given_UserEventArrayNotRentedFromPool_When_ReturnEventArray_Then_ItIsNotCleared()
         {
             // Arrange — a caller-owned single-event array, as a component caching events would hold.

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/VNodePoolOwnershipTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/VNodePoolOwnershipTests.cs
@@ -57,6 +57,39 @@ namespace Velvet.Tests
         }
 
         [Test]
+        public void Given_ARentedPropsReturnedTwice_When_TwoRentsFollow_Then_TheyAreDistinctInstances()
+        {
+            // Arrange — the recycle sweep can reach one bag through several retired trees (a baseline
+            // retired by its owner and again by a parent expansion), so a double return must recycle once.
+            var bag = VNodePool.RentProps();
+            VNodePool.ReturnProps(bag);
+            VNodePool.ReturnProps(bag);
+
+            // Act — two rents; a double-pooled bag would come back for both.
+            var first = VNodePool.RentProps();
+            var second = VNodePool.RentProps();
+
+            // Assert — the pool never handed the same instance out twice.
+            Assert.That(ReferenceEquals(first, second), Is.False);
+        }
+
+        [Test]
+        public void Given_ARentedNodeArrayReturnedTwice_When_TwoRentsFollow_Then_TheyAreDistinctInstances()
+        {
+            // Arrange — same double-return discipline for the children-array pool.
+            var array = VNodePool.RentNodeArray(3);
+            VNodePool.ReturnNodeArray(array);
+            VNodePool.ReturnNodeArray(array);
+
+            // Act
+            var first = VNodePool.RentNodeArray(3);
+            var second = VNodePool.RentNodeArray(3);
+
+            // Assert
+            Assert.That(ReferenceEquals(first, second), Is.False);
+        }
+
+        [Test]
         public void Given_UserEventArrayNotRentedFromPool_When_ReturnEventArray_Then_ItIsNotCleared()
         {
             // Arrange — a caller-owned single-event array, as a component caching events would hold.

--- a/Packages/com.velvet.core/Runtime/Component/V.cs
+++ b/Packages/com.velvet.core/Runtime/Component/V.cs
@@ -1844,10 +1844,7 @@ namespace Velvet
         /// <returns>The created <see cref="PortalNode"/>.</returns>
         public static PortalNode DragOverlay(VNode?[]? children = null, string? key = null)
         {
-            // Deliberately NOT a rented pool bag: the fiber-tree recycle path does not descend into
-            // PortalNode children, so a rented bag here would never flow back to the pool and its
-            // ownership tracking would pin one bag per render. A plain instance is ordinary garbage.
-            var positionerProps = new FiberElementProps();
+            var positionerProps = VNodePool.RentProps();
             positionerProps.DragOverlay = new DragOverlaySettings();
             return Portal(UILayer.Overlay, key: key, children: new VNode?[]
             {

--- a/Packages/com.velvet.core/Runtime/Component/VNodePool.cs
+++ b/Packages/com.velvet.core/Runtime/Component/VNodePool.cs
@@ -10,6 +10,46 @@ namespace Velvet
     internal static class VNodePool
     {
         private const int MaxPoolSize = 8;
+
+        #region pass-scoped release staging
+
+        // While a reconcile pass is on the stack, returned objects are STAGED instead of pushed to
+        // their pools, and flushed when the outermost pass ends. This guarantees an object retired
+        // mid-pass (an error boundary swapping in its fallback, a mid-pass unmount) cannot be
+        // re-rented by a later factory call in the SAME pass: a second retired tree reaching the
+        // same object later in the pass must find it already out of the rented set (idempotent
+        // no-op) — if the object were re-rented in between, that second return would recycle the
+        // NEW renter's live object. Depth-counted so nested top-level entries (a portal drain's
+        // nested reconcile) flush only at the true outermost boundary. Rent never reads the
+        // staging lists, so a staged object is unreachable until the flush.
+        private static int s_releaseScopeDepth;
+        private static readonly List<FiberElementProps> s_stagedProps = new();
+        private static readonly List<FiberEventBinding[]> s_stagedEventArrays = new();
+        private static readonly List<VNode?[]> s_stagedNodeArrays = new();
+
+        internal static void BeginReleaseScope() => s_releaseScopeDepth++;
+
+        internal static void EndReleaseScope()
+        {
+            if (s_releaseScopeDepth > 0 && --s_releaseScopeDepth > 0) return;
+            if (s_stagedProps.Count > 0)
+            {
+                for (var i = 0; i < s_stagedProps.Count; i++) ReleaseProps(s_stagedProps[i]);
+                s_stagedProps.Clear();
+            }
+            if (s_stagedEventArrays.Count > 0)
+            {
+                for (var i = 0; i < s_stagedEventArrays.Count; i++) ReleaseEventArray(s_stagedEventArrays[i]);
+                s_stagedEventArrays.Clear();
+            }
+            if (s_stagedNodeArrays.Count > 0)
+            {
+                for (var i = 0; i < s_stagedNodeArrays.Count; i++) ReleaseNodeArray(s_stagedNodeArrays[i]);
+                s_stagedNodeArrays.Clear();
+            }
+        }
+
+        #endregion
         // Sized to absorb peak reconcile churn (typically ~30 mounts/unmounts in deep reflows).
         private const int MaxLabelPoolSize = 32;
         private const int MaxButtonPoolSize = 32;
@@ -43,6 +83,17 @@ namespace Velvet
             // Only recycle bags rented out by the pool; a caller-owned or already-returned bag is left
             // untouched (not cleared, not pooled) — Remove doubles as the membership test.
             if (!s_ownedProps.Remove(props)) return;
+            if (s_releaseScopeDepth > 0)
+            {
+                // Mid-pass return: keep the bag unreachable until the pass ends (see the staging region).
+                s_stagedProps.Add(props);
+                return;
+            }
+            ReleaseProps(props);
+        }
+
+        private static void ReleaseProps(FiberElementProps props)
+        {
             if (s_propsPool.Count >= MaxPoolSize)
             {
                 // Pool is full: drop this bag (let it be GC'd); it already left the rented-out set.
@@ -100,6 +151,16 @@ namespace Velvet
             // Only recycle arrays rented out by the pool; a caller-owned or already-returned array is
             // left untouched — Remove doubles as the membership test.
             if (!s_ownedSingleEventArrays.Remove(array)) return;
+            if (s_releaseScopeDepth > 0)
+            {
+                s_stagedEventArrays.Add(array);
+                return;
+            }
+            ReleaseEventArray(array);
+        }
+
+        private static void ReleaseEventArray(FiberEventBinding[] array)
+        {
             if (s_singleEventPool.Count >= MaxPoolSize)
             {
                 return;
@@ -137,7 +198,16 @@ namespace Velvet
             // Only recycle arrays rented out by the pool; a caller-owned or already-returned array is
             // left untouched (not cleared, not pooled) — Remove doubles as the membership test.
             if (!s_ownedNodeArrays.Remove(array)) return;
+            if (s_releaseScopeDepth > 0)
+            {
+                s_stagedNodeArrays.Add(array);
+                return;
+            }
+            ReleaseNodeArray(array);
+        }
 
+        private static void ReleaseNodeArray(VNode?[] array)
+        {
             if (!s_nodeArrayPools.TryGetValue(array.Length, out var pool))
             {
                 pool = new Stack<VNode?[]>();
@@ -265,6 +335,10 @@ namespace Velvet
         [UnityEngine.RuntimeInitializeOnLoadMethod(UnityEngine.RuntimeInitializeLoadType.SubsystemRegistration)]
         private static void ResetStaticFields()
         {
+            s_releaseScopeDepth = 0;
+            s_stagedProps.Clear();
+            s_stagedEventArrays.Clear();
+            s_stagedNodeArrays.Clear();
             s_propsPool.Clear();
             s_ownedProps.Clear();
             s_singleEventPool.Clear();

--- a/Packages/com.velvet.core/Runtime/Component/VNodePool.cs
+++ b/Packages/com.velvet.core/Runtime/Component/VNodePool.cs
@@ -21,34 +21,31 @@ namespace Velvet
 
         private static readonly Stack<FiberElementProps> s_propsPool = new();
 
-        // Identity set of props bags this pool created (via RentProps). ReturnProps clears + recycles
+        // Identity set of props bags currently RENTED OUT by this pool. ReturnProps clears + recycles
         // ONLY these — never a caller-supplied instance: the V.* factories accept a raw `props:`
         // argument a consumer may cache and reuse across renders, and clearing it would wipe an object
-        // the caller still holds and alias it into the shared pool. Mirrors s_ownedNodeArrays.
+        // the caller still holds and alias it into the shared pool. Membership is rent-scoped (added on
+        // Rent, removed on Return) rather than created-scoped, so the return is idempotent: the recycle
+        // sweep can encounter one bag through several retired trees (a baseline retired by its owner and
+        // again by a parent expansion) and only the first return recycles it. Mirrors s_ownedNodeArrays.
         private static readonly HashSet<FiberElementProps> s_ownedProps = new();
 
         public static FiberElementProps RentProps()
         {
-            if (s_propsPool.Count > 0)
-            {
-                // A pooled bag is already owned (recorded when first created); no set op on this hot path.
-                return s_propsPool.Pop();
-            }
-
-            var created = new FiberElementProps();
-            s_ownedProps.Add(created);
-            return created;
+            var rented = s_propsPool.Count > 0 ? s_propsPool.Pop() : new FiberElementProps();
+            s_ownedProps.Add(rented);
+            return rented;
         }
 
         public static void ReturnProps(FiberElementProps? props)
         {
             if (props == null || ReferenceEquals(props, FiberElementProps.Empty)) return;
-            // Only recycle bags the pool owns; a caller-owned bag is left untouched (not cleared, not pooled).
-            if (!s_ownedProps.Contains(props)) return;
+            // Only recycle bags rented out by the pool; a caller-owned or already-returned bag is left
+            // untouched (not cleared, not pooled) — Remove doubles as the membership test.
+            if (!s_ownedProps.Remove(props)) return;
             if (s_propsPool.Count >= MaxPoolSize)
             {
-                // Pool is full: drop this owned bag (let it be GC'd) and stop tracking it so the set does not leak.
-                s_ownedProps.Remove(props);
+                // Pool is full: drop this bag (let it be GC'd); it already left the rented-out set.
                 return;
             }
 
@@ -84,31 +81,27 @@ namespace Velvet
 
         private static readonly Stack<FiberEventBinding[]> s_singleEventPool = new();
 
-        // Identity set mirroring s_ownedProps: only arrays RentSingleEventArray created may be
-        // cleared and recycled — V.Motion accepts a raw `events:` array a consumer may cache and
-        // reuse across renders, and clearing slot 0 would sever the caller's handler in place.
+        // Identity set mirroring s_ownedProps (rent-scoped membership): only arrays currently rented
+        // out by RentSingleEventArray may be cleared and recycled — V.Motion accepts a raw `events:`
+        // array a consumer may cache and reuse across renders, and clearing slot 0 would sever the
+        // caller's handler in place.
         private static readonly HashSet<FiberEventBinding[]> s_ownedSingleEventArrays = new();
 
         public static FiberEventBinding[] RentSingleEventArray()
         {
-            if (s_singleEventPool.Count > 0)
-            {
-                return s_singleEventPool.Pop();
-            }
-
-            var created = new FiberEventBinding[1];
-            s_ownedSingleEventArrays.Add(created);
-            return created;
+            var rented = s_singleEventPool.Count > 0 ? s_singleEventPool.Pop() : new FiberEventBinding[1];
+            s_ownedSingleEventArrays.Add(rented);
+            return rented;
         }
 
         public static void ReturnEventArray(FiberEventBinding[] array)
         {
             if (array == null || array.Length != 1) return;
-            // Only recycle arrays the pool owns; a caller-owned array is left untouched.
-            if (!s_ownedSingleEventArrays.Contains(array)) return;
+            // Only recycle arrays rented out by the pool; a caller-owned or already-returned array is
+            // left untouched — Remove doubles as the membership test.
+            if (!s_ownedSingleEventArrays.Remove(array)) return;
             if (s_singleEventPool.Count >= MaxPoolSize)
             {
-                s_ownedSingleEventArrays.Remove(array);
                 return;
             }
 
@@ -122,30 +115,28 @@ namespace Velvet
 
         private static readonly Dictionary<int, Stack<VNode?[]>> s_nodeArrayPools = new();
 
-        // Identity set of arrays this pool created (via RentNodeArray). ReturnNodeArray clears + recycles ONLY
-        // these — never an array the caller owns. The recycle path returns every elem.Children / motion.Children,
-        // and a consumer may pass a cached / reused array there (e.g. `V.Div(children: s_static)`); clearing it
-        // would wipe the consumer's children on the next render. Reference equality (default for VNode[]).
+        // Identity set of arrays currently rented out by RentNodeArray (rent-scoped membership, like
+        // s_ownedProps). ReturnNodeArray clears + recycles ONLY these — never an array the caller owns.
+        // The recycle path returns every elem.Children / motion.Children, and a consumer may pass a
+        // cached / reused array there (e.g. `V.Div(children: s_static)`); clearing it would wipe the
+        // consumer's children on the next render. Reference equality (default for VNode[]).
         private static readonly HashSet<VNode?[]> s_ownedNodeArrays = new();
 
         public static VNode?[] RentNodeArray(int length)
         {
-            if (s_nodeArrayPools.TryGetValue(length, out var pool) && pool.Count > 0)
-            {
-                // A pooled array is already owned (recorded when first created); no set op on this hot path.
-                return pool.Pop();
-            }
-
-            var created = new VNode?[length];
-            s_ownedNodeArrays.Add(created);
-            return created;
+            var rented = s_nodeArrayPools.TryGetValue(length, out var pool) && pool.Count > 0
+                ? pool.Pop()
+                : new VNode?[length];
+            s_ownedNodeArrays.Add(rented);
+            return rented;
         }
 
         public static void ReturnNodeArray(VNode?[] array)
         {
             if (array == null || array.Length == 0) return;
-            // Only recycle arrays the pool owns; a caller-owned array is left untouched (not cleared, not pooled).
-            if (!s_ownedNodeArrays.Contains(array)) return;
+            // Only recycle arrays rented out by the pool; a caller-owned or already-returned array is
+            // left untouched (not cleared, not pooled) — Remove doubles as the membership test.
+            if (!s_ownedNodeArrays.Remove(array)) return;
 
             if (!s_nodeArrayPools.TryGetValue(array.Length, out var pool))
             {
@@ -155,8 +146,7 @@ namespace Velvet
 
             if (pool.Count >= MaxPoolSize)
             {
-                // Pool is full: drop this owned array (let it be GC'd) and stop tracking it so the set does not leak.
-                s_ownedNodeArrays.Remove(array);
+                // Pool is full: drop this array (let it be GC'd); it already left the rented-out set.
                 return;
             }
 
@@ -276,7 +266,9 @@ namespace Velvet
         private static void ResetStaticFields()
         {
             s_propsPool.Clear();
+            s_ownedProps.Clear();
             s_singleEventPool.Clear();
+            s_ownedSingleEventArrays.Clear();
             s_nodeArrayPools.Clear();
             s_ownedNodeArrays.Clear();
             s_labelPool.Clear();

--- a/Packages/com.velvet.core/Runtime/Component/VNodeTypes.cs
+++ b/Packages/com.velvet.core/Runtime/Component/VNodeTypes.cs
@@ -515,6 +515,12 @@ namespace Velvet
         /// live tracking. Returns the ComponentContext instance reference.
         /// </summary>
         internal abstract object ContextKey { get; }
+
+        // The provided value when it is a VNode root (slot-injection via context): the recycle
+        // mark must treat it as live — a consumer may have committed the value's node into its own
+        // tree — while the sweep never returns it (leaking a provider-held node is recoverable;
+        // recycling a consumed one is not).
+        internal abstract object? BoxedValueForRecycleMark { get; }
     }
 
     /// <summary>
@@ -531,6 +537,11 @@ namespace Velvet
         internal override void PushContext(ComponentContextStack stack) => stack.Push(Context, Value);
 
         internal override void PopContext(ComponentContextStack stack) => stack.Pop(Context);
+
+        private static readonly bool s_canHoldNodes = !typeof(T).IsValueType;
+
+        internal override object? BoxedValueForRecycleMark
+            => s_canHoldNodes ? HookSlotRecycleProbe.Probe(Value) : null;
 
         internal override bool HasValueChanged(ContextProviderNode other)
         {

--- a/Packages/com.velvet.core/Runtime/Hooks/HookSlots.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/HookSlots.cs
@@ -38,6 +38,12 @@ namespace Velvet
         public object?[]? NextDeps { get; set; }
         public bool Committed { get; set; }
         public abstract void Commit();
+
+        // The committed value when it is a memoized VNode root (a VNode or a VNode array), else null.
+        // The recycle sweep must not return pooled objects such a slot still holds: with stable deps
+        // the SAME instance re-enters a later committed tree (e.g. V.When toggling a memoized subtree),
+        // so its pooled parts stay live across renders that omit it.
+        public abstract object? RecycleMarkRoot { get; }
     }
 
     internal sealed class HookMemoValueSlot<T> : HookMemoValueSlot
@@ -51,6 +57,9 @@ namespace Velvet
             LastDeps = NextDeps;
             Committed = true;
         }
+
+        // The type tests fold to false for value-type T, so this never boxes.
+        public override object? RecycleMarkRoot => Value is VNode || Value is VNode?[] ? Value : null;
     }
 
     internal abstract class HookDeferredValueSlot { }

--- a/Packages/com.velvet.core/Runtime/Hooks/HookSlots.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/HookSlots.cs
@@ -32,6 +32,19 @@ namespace Velvet
         public object?[]? NextDeps { get; set; }
     }
 
+    // Shared probe for hook-slot values that may be memoized VNode roots. The recycle sweep must
+    // not return pooled objects a slot still holds: with stable inputs the SAME instance re-enters
+    // a later committed tree (e.g. V.When toggling a memoized subtree), so its pooled parts stay
+    // live across renders that omit it. Recognizes a node or any list of nodes (arrays and
+    // List&lt;VNode&gt; both satisfy the covariant IReadOnlyList) — a node buried inside a user
+    // composite (tuple / record) is NOT visible here; that boundary is part of the recycle
+    // contract documented on FiberTreeReturn.
+    internal static class HookSlotRecycleProbe
+    {
+        public static object? Probe(object? value)
+            => value is VNode || value is IReadOnlyList<VNode?> ? value : null;
+    }
+
     internal abstract class HookMemoValueSlot
     {
         public object?[]? LastDeps { get; set; }
@@ -39,10 +52,7 @@ namespace Velvet
         public bool Committed { get; set; }
         public abstract void Commit();
 
-        // The committed value when it is a memoized VNode root (a VNode or a VNode array), else null.
-        // The recycle sweep must not return pooled objects such a slot still holds: with stable deps
-        // the SAME instance re-enters a later committed tree (e.g. V.When toggling a memoized subtree),
-        // so its pooled parts stay live across renders that omit it.
+        // The committed value when it is a memoized VNode root — see HookSlotRecycleProbe.
         public abstract object? RecycleMarkRoot { get; }
     }
 
@@ -51,6 +61,10 @@ namespace Velvet
         public T Value = default!;
         public T NextValue = default!;
 
+        // Evaluated once per instantiation so struct-valued slots skip the probe without the
+        // box-then-isinst the raw type test would emit on backends that cannot fold it.
+        private static readonly bool s_canHoldNodes = !typeof(T).IsValueType;
+
         public override void Commit()
         {
             Value = NextValue;
@@ -58,8 +72,7 @@ namespace Velvet
             Committed = true;
         }
 
-        // The type tests fold to false for value-type T, so this never boxes.
-        public override object? RecycleMarkRoot => Value is VNode || Value is VNode?[] ? Value : null;
+        public override object? RecycleMarkRoot => s_canHoldNodes ? HookSlotRecycleProbe.Probe(Value) : null;
     }
 
     internal abstract class HookDeferredValueSlot { }
@@ -146,14 +159,28 @@ namespace Velvet
     internal sealed class HookRefSlot
     {
         public object Ref { get; set; } = null!;
+
+        // The held Ref&lt;T&gt;'s current value when it is a VNode root (element-in-ref caching) —
+        // see HookSlotRecycleProbe. Ref is typed object here, so the probe goes through the
+        // ref's own accessor.
+        public object? RecycleMarkRoot => (Ref as IHookRefSetter)?.RecycleMarkRoot;
     }
 
-    internal abstract class HookStateSlot { }
+    internal abstract class HookStateSlot
+    {
+        // The committed state value when it is a VNode root (React's element-in-state pattern) —
+        // see HookSlotRecycleProbe.
+        public abstract object? RecycleMarkRoot { get; }
+    }
 
     internal sealed class HookStateSlot<T> : HookStateSlot
     {
         public T Value = default!;
         public StateUpdater<T> Setter = default!;
+
+        private static readonly bool s_canHoldNodes = !typeof(T).IsValueType;
+
+        public override object? RecycleMarkRoot => s_canHoldNodes ? HookSlotRecycleProbe.Probe(Value) : null;
     }
 
     internal sealed class ReducerSlot<TState, TAction> : HookStateSlot
@@ -161,6 +188,10 @@ namespace Velvet
         public TState Value = default!;
         public Func<TState, TAction, TState> Reducer = null!;
         public Action<TAction> Dispatch = null!;
+
+        private static readonly bool s_canHoldNodes = !typeof(TState).IsValueType;
+
+        public override object? RecycleMarkRoot => s_canHoldNodes ? HookSlotRecycleProbe.Probe(Value) : null;
     }
 
     internal abstract class HookStoreSlot : IDisposable

--- a/Packages/com.velvet.core/Runtime/Hooks/Hooks.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Hooks.cs
@@ -2075,6 +2075,14 @@ namespace Velvet
         {
             if (deps == null) throw new ArgumentNullException(nameof(deps));
             var fiber = Resolve("StoreMemoizedVNode");
+#if UNITY_EDITOR
+            // The StrictMode diagnostic render is isolated from the commit: staging its throwaway
+            // output here would first spare that tree from the diagnostic's own retirement sweep
+            // (the mark reads NextCachedResult) and then strand it when the next real render
+            // restages the slot — one leaked subtree per double render. Mirrors the other
+            // externally-visible hook writes the diagnostic pass no-ops.
+            if (fiber.IsStrictDiagnosticPass) return;
+#endif
             if (fiber.MemoSlots == null || slotIndex < 0 || slotIndex >= fiber.MemoSlots.Count)
             {
                 throw new InvalidOperationException(

--- a/Packages/com.velvet.core/Runtime/Hooks/IHookRefSetter.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/IHookRefSetter.cs
@@ -9,5 +9,9 @@ namespace Velvet
     internal interface IHookRefSetter
     {
         void Set(object? value);
+
+        // The held value when it is a VNode root the recycle sweep must spare (element-in-ref
+        // caching) — see HookSlotRecycleProbe.
+        object? RecycleMarkRoot { get; }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Hooks/Ref.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Ref.cs
@@ -45,5 +45,7 @@ namespace Velvet
         }
 
         void IHookRefSetter.Set(object? value) => Current = value as T;
+
+        object? IHookRefSetter.RecycleMarkRoot => HookSlotRecycleProbe.Probe(Current);
     }
 }

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberBeginWork.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberBeginWork.cs
@@ -80,6 +80,11 @@ namespace Velvet
                 FiberHookCommit.DiscardRenderPhaseAttemptEffects(fiber,
                     committedLayoutEffectCount, committedInsertionEffectCount, committedEffectCount,
                     committedPendingLayoutCount, committedPendingInsertionCount, committedPendingEffectCount);
+                // The throwaway attempt's tree is never reconciled, so this is its only retirement
+                // point; without it every discarded attempt strands its rented bags in the pool's
+                // rented-out set. The owner mark spares whatever a memo hit shared with committed
+                // state or staged slots.
+                FiberTreeReturn.ReturnRetiredTree(FiberTreeReturn.NormalizeToArray(rendered), fiber);
                 if (++fiber.RenderPhaseSetStateCounter >= RenderPhaseUpdateLimit)
                 {
                     throw new InvalidOperationException(

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberCommitWork.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberCommitWork.cs
@@ -83,7 +83,7 @@ namespace Velvet
             {
                 fiber.Reconciler!.ContinueReconcile(frameBudgetMs: 0);
             }
-            FiberTreeReturn.ReturnPooledObjects(fiber.PendingOldTree);
+            FiberTreeReturn.ReturnRetiredTree(fiber.PendingOldTree, fiber);
             fiber.PendingOldTree = null;
         }
 
@@ -131,6 +131,8 @@ namespace Velvet
         }
 
         // Returns the prior committed tree to the VNode pool after the reconcile, or parks / defers it.
+        // The caller must have committed the new tree to fiber.PreviousTree already: the recycle sweep
+        // marks the committed tree live so nodes a memo hit shares across the two renders are spared.
         internal static void ReturnOldTreeAfterReconcile(
             ComponentFiber fiber, Reconciler? reconciler, VNode?[] oldTree, VNode?[]? prevPendingOldTree, bool deferReconcile)
         {
@@ -150,7 +152,7 @@ namespace Velvet
                 // pending-work / PendingOldTree case here.
                 if (oldTree is { Length: > 0 } && reconciler != null)
                 {
-                    reconciler.Context.DeferredInlineOldTreeReturns.Add(oldTree);
+                    reconciler.Context.DeferredInlineOldTreeReturns.Add((oldTree, fiber));
                 }
             }
             else if (reconciler != null && reconciler.HasPendingWork)
@@ -160,12 +162,12 @@ namespace Velvet
             }
             else
             {
-                FiberTreeReturn.ReturnPooledObjects(oldTree);
+                FiberTreeReturn.ReturnRetiredTree(oldTree, fiber);
             }
 
             if (prevPendingOldTree != null && prevPendingOldTree != oldTree)
             {
-                FiberTreeReturn.ReturnPooledObjects(prevPendingOldTree);
+                FiberTreeReturn.ReturnRetiredTree(prevPendingOldTree, fiber);
             }
         }
     }

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberCommitWork.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberCommitWork.cs
@@ -83,8 +83,13 @@ namespace Velvet
             {
                 fiber.Reconciler!.ContinueReconcile(frameBudgetMs: 0);
             }
-            FiberTreeReturn.ReturnRetiredTree(fiber.PendingOldTree, fiber);
+            fiber.Reconciler?.Context.ParkedBaselineFibers.Remove(fiber);
+            // Detach the parked baseline BEFORE retiring it: the sweep's own mark treats
+            // owner.PendingOldTree as live (other fibers' retirements must spare a parked diff's
+            // baseline), and a still-attached reference would spare this very sweep's target.
+            var parkedTree = fiber.PendingOldTree;
             fiber.PendingOldTree = null;
+            FiberTreeReturn.ReturnRetiredTree(parkedTree, fiber);
         }
 
         // Reconciles this render's output into the fiber's slot range and commits the sibling-shift delta.
@@ -150,14 +155,29 @@ namespace Velvet
                 // correctness restored. Skip empty trees (initial inline mount) so the queue holds only
                 // real baselines. A deferred render never schedules its own reconcile, so there is no
                 // pending-work / PendingOldTree case here.
-                if (oldTree is { Length: > 0 } && reconciler != null)
+                if (oldTree is { Length: > 0 })
                 {
-                    reconciler.Context.DeferredInlineOldTreeReturns.Add((oldTree, fiber));
+                    if (reconciler != null)
+                    {
+                        reconciler.Context.DeferredInlineOldTreeReturns.Add((oldTree, fiber));
+                    }
+                    else
+                    {
+                        // The fiber was disposed mid-render, so there is no context queue to defer
+                        // into — and no later drain that would ever reach this baseline. Retiring it
+                        // immediately is safe: the pass-scoped release staging keeps its objects
+                        // un-rentable until the enclosing pass (which may still read old-side
+                        // captures of these nodes) has fully ended.
+                        FiberTreeReturn.ReturnRetiredTree(oldTree, fiber);
+                    }
                 }
             }
             else if (reconciler != null && reconciler.HasPendingWork)
             {
                 fiber.PendingOldTree = oldTree;
+                // Registered so retirement sweeps elsewhere treat this parked baseline as live: the
+                // paused pass keeps diffing against it across frames.
+                reconciler.Context.ParkedBaselineFibers.Add(fiber);
                 fiber.MountPoint?.schedule.Execute(() => FiberWorkLoop.ContinueReconcile(fiber));
             }
             else
@@ -165,10 +185,18 @@ namespace Velvet
                 FiberTreeReturn.ReturnRetiredTree(oldTree, fiber);
             }
 
-            if (prevPendingOldTree != null && prevPendingOldTree != oldTree)
-            {
-                FiberTreeReturn.ReturnRetiredTree(prevPendingOldTree, fiber);
-            }
+            ReturnSupersededParkedBaseline(fiber, prevPendingOldTree, oldTree);
+        }
+
+        // Retires a superseded parked baseline. The identity guard encodes an aliasing rule shared
+        // by every caller (the normal path here, plus the abort and exception paths in
+        // FiberRenderer): PendingOldTree may be the very array a new render adopted as oldTree, and
+        // retiring it then would recycle the baseline that render still owns.
+        internal static void ReturnSupersededParkedBaseline(
+            ComponentFiber fiber, VNode?[]? prevPendingOldTree, VNode?[]? oldTree)
+        {
+            if (prevPendingOldTree == null || prevPendingOldTree == oldTree) return;
+            FiberTreeReturn.ReturnRetiredTree(prevPendingOldTree, fiber);
         }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberErrorBoundary.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberErrorBoundary.cs
@@ -92,8 +92,12 @@ namespace Velvet
                 // call above was in progress — nothing here to track bookkeeping for anymore.
                 return false;
             }
-            FiberTreeReturn.ReturnPooledObjects(fiber.PreviousTree);
+            // Commit the fallback as the new baseline BEFORE retiring the failed tree, so the recycle
+            // sweep's owner mark protects any node the two share (a memoized subtree that survived the
+            // failure and re-appears inside the fallback).
+            var failedTree = fiber.PreviousTree;
             fiber.PreviousTree = fallbackTree;
+            FiberTreeReturn.ReturnRetiredTree(failedTree, fiber);
             // FallbackContentFailed is set when a re-entrant TryCatch above declined because THIS
             // fiber's own fallback content threw (logged, or shown by a farther ancestor instead) — the
             // Reconcile call still returns normally either way, so this is the only place that can tell

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberMemoCache.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberMemoCache.cs
@@ -51,5 +51,18 @@ namespace Velvet
         }
 
         public void Clear() => _cache.Clear();
+
+        // Returns every cached inner tree to the VNode pool, then clears. Called at reconciler
+        // disposal: the whole mounted tree is torn down with it, so there is no committed successor
+        // to spare (a cached inner shared with an already-retired committed tree is a harmless
+        // overlap — pool returns are idempotent).
+        public void DisposeAndReturnCachedTrees()
+        {
+            foreach (var entry in _cache.Values)
+            {
+                FiberTreeReturn.ReturnRetiredTree(FiberTreeReturn.NormalizeToArray(entry.cached), owner: null);
+            }
+            _cache.Clear();
+        }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
@@ -693,6 +693,27 @@ namespace Velvet
                 if (newNode.HasValueChanged(oldNode))
                 {
                     _host.NotifyContextValueChange(newNode);
+                    // A replaced VNode-valued provider value has no other retirement point: the sweep
+                    // deliberately never returns provider values (a consumer may hold the CURRENT one),
+                    // but a superseded value is out of distribution for good — every subscribed consumer
+                    // re-renders off the change notification above and commits the NEW value's nodes,
+                    // and the pass-scoped release staging keeps the old parts un-rentable until those
+                    // re-renders have run. A consumer that committed the old node retires it through its
+                    // own old tree too; pool returns are idempotent, so the overlap is harmless.
+                    var oldValueRoot = oldNode.BoxedValueForRecycleMark;
+                    if (oldValueRoot != null && !ReferenceEquals(oldValueRoot, newNode.BoxedValueForRecycleMark))
+                    {
+                        switch (oldValueRoot)
+                        {
+                            case VNode oldValueNode:
+                                FiberTreeReturn.ReturnRetiredTree(
+                                    FiberTreeReturn.NormalizeToArray(oldValueNode), _ctx.FiberStack.Current);
+                                break;
+                            case VNode?[] oldValueTree:
+                                FiberTreeReturn.ReturnRetiredTree(oldValueTree, _ctx.FiberStack.Current);
+                                break;
+                        }
+                    }
                 }
                 var oldChildren = oldNode.Children ?? Array.Empty<VNode>();
                 var newChildren = newNode.Children ?? Array.Empty<VNode>();

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberRenderer.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberRenderer.cs
@@ -221,6 +221,21 @@ namespace Velvet
             // fiber alone held — including a node a slot cached while it was toggled out of the
             // output — is recycled instead of stranding when the slot lists are cleared.
             var slotRoots = FiberTreeReturn.CollectSlotRootsForUnmount(fiber);
+            if (fiber.IsDisposed)
+            {
+                // Terminal teardown (Dispose sets the flag before calling here): state slots never
+                // serve a remount, so their element-in-state roots retire with everything else. This
+                // must happen INSIDE Unmount, while the parent chain is still attached — the final
+                // sweep's mark walks that chain, and ancestor-held nodes that flowed into this
+                // fiber's state stay spared. The slots are cleared now so the sweep's own mark does
+                // not re-spare its targets; disposed setters are no-ops, so nothing repopulates them.
+                var stateRoots = FiberTreeReturn.CollectStateSlotRootsForDispose(fiber);
+                if (stateRoots != null)
+                {
+                    (slotRoots ??= new System.Collections.Generic.List<VNode>()).AddRange(stateRoots);
+                }
+                fiber.StateSlots?.Clear();
+            }
             VNode?[]? retiredTree = null;
             if (fiber.MountPoint != null && fiber.PreviousTree != null)
             {

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberRenderer.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberRenderer.cs
@@ -198,6 +198,13 @@ namespace Velvet
             // preserve zero-allocation. LaneState.Clear initializes all four queue/transition-related fields.
             fiber.Lanes?.Clear();
 
+            // A mid-pass unmount takes its own deferred inline baselines with it: the end-of-pass
+            // drain would otherwise sweep them AFTER this teardown nulls PreviousTree, disposes the
+            // slots, and severs Parent — an empty mark set that would recycle ancestor-held memoized
+            // nodes still owed a comeback render. Sweeping here, while the chain is intact, keeps
+            // those protections; outside a pass the queue is simply empty.
+            ReclaimDeferredInlineEntries(fiber);
+
             // Commit-phase deletion is post-order DFS — the deepest descendant's cleanups
             // must complete before the parent's. Reorder: child VE removal + child fiber dispose
             // run first (their effect cleanups fire via FiberEffects.RunOrphanFiberEffectCleanups
@@ -206,10 +213,14 @@ namespace Velvet
             // from the actual DOM contents; FiberElementCleaner.RemoveElement silently skips
             // out-of-range indices so only existing elements are removed. Any pending
             // PendingIndexedState is cleared at the top of this Reconcile call.
-            // The committed tree is retired at the bottom of this method, AFTER the memo slots are
-            // disposed: with this fiber's own slots already empty, the sweep's live mark reduces to
-            // ancestor-held memoized roots (nodes that flowed into this tree as props and survive for
-            // their owner's comeback render), so everything this fiber alone held is recycled.
+            // The committed tree, the parked baseline, and the fiber's own slot-held node roots
+            // (collected BEFORE the slots are disposed below) are retired together at the bottom of
+            // this method, AFTER slot disposal: with this fiber's own slots already empty, the
+            // sweep's live mark reduces to ancestor-held memoized roots (nodes that flowed into
+            // this tree as props and survive for their owner's comeback render), so everything this
+            // fiber alone held — including a node a slot cached while it was toggled out of the
+            // output — is recycled instead of stranding when the slot lists are cleared.
+            var slotRoots = FiberTreeReturn.CollectSlotRootsForUnmount(fiber);
             VNode?[]? retiredTree = null;
             if (fiber.MountPoint != null && fiber.PreviousTree != null)
             {
@@ -227,8 +238,10 @@ namespace Velvet
                 {
                     PopFiber(fiber, unmountPushed);
                 }
-                retiredTree = fiber.PreviousTree;
             }
+            // Captured unconditionally: a fiber whose MountPoint is already gone still owes its
+            // committed tree's pooled parts back to the pool.
+            retiredTree = fiber.PreviousTree;
 
             FiberEffects.CleanupAllInsertionEffects(fiber);
             FiberEffects.CleanupAllLayoutEffects(fiber);
@@ -258,9 +271,12 @@ namespace Velvet
             fiber.DetachedMountContext = null;
 
             fiber.PreviousTree = null;
-            FiberTreeReturn.ReturnRetiredTree(retiredTree, fiber);
-            FiberTreeReturn.ReturnRetiredTree(fiber.PendingOldTree, fiber);
+            fiber.Reconciler?.Context.ParkedBaselineFibers.Remove(fiber);
+            // Detach the parked baseline BEFORE the sweep — the mark treats owner.PendingOldTree as
+            // live, and a still-attached reference would spare this very sweep's target.
+            var parkedTree = fiber.PendingOldTree;
             fiber.PendingOldTree = null;
+            FiberTreeReturn.ReturnRetiredTreesForUnmount(fiber, retiredTree, parkedTree, slotRoots);
             fiber.Reconciler?.Dispose();
             fiber.Reconciler = null;
 
@@ -374,6 +390,13 @@ namespace Velvet
 
                 prevPendingOldTree = fiber.PendingOldTree;
                 fiber.PendingOldTree = null;
+                if (prevPendingOldTree != null)
+                {
+                    // The parked baseline is no longer read by a paused pass once captured here (the
+                    // force-drain above completed any remaining work), so retirement sweeps elsewhere
+                    // stop treating it as live.
+                    fiber.Reconciler?.Context.ParkedBaselineFibers.Remove(fiber);
+                }
 
                 FiberCommitWork.ReconcileIntoSlotRange(fiber, oldTree, newTree, frameBudgetMs, deferReconcile);
 
@@ -390,10 +413,7 @@ namespace Velvet
                     // (and a superseded parked baseline) retire here — never oldTree, which IS the
                     // retained PreviousTree baseline and must keep its pooled parts.
                     FiberTreeReturn.ReturnRetiredTree(newTree, fiber);
-                    if (prevPendingOldTree != null && prevPendingOldTree != oldTree)
-                    {
-                        FiberTreeReturn.ReturnRetiredTree(prevPendingOldTree, fiber);
-                    }
+                    FiberCommitWork.ReturnSupersededParkedBaseline(fiber, prevPendingOldTree, oldTree);
                 }
                 else
                 {
@@ -416,14 +436,15 @@ namespace Velvet
             }
             catch (Exception ex)
             {
-                if (prevPendingOldTree != null && prevPendingOldTree != oldTree)
-                {
-                    FiberTreeReturn.ReturnRetiredTree(prevPendingOldTree, fiber);
-                }
+                FiberCommitWork.ReturnSupersededParkedBaseline(fiber, prevPendingOldTree, oldTree);
                 if (fiber.PendingOldTree != null)
                 {
-                    FiberTreeReturn.ReturnRetiredTree(fiber.PendingOldTree, fiber);
+                    fiber.Reconciler?.Context.ParkedBaselineFibers.Remove(fiber);
+                    // Detach before retiring: the sweep's own mark treats owner.PendingOldTree as
+                    // live, and a still-attached reference would spare this very sweep's target.
+                    var abortedBaseline = fiber.PendingOldTree;
                     fiber.PendingOldTree = null;
+                    FiberTreeReturn.ReturnRetiredTree(abortedBaseline, fiber);
                 }
                 fiber.PendingLayoutEffects?.Clear();
                 fiber.PendingInsertionEffects?.Clear();
@@ -486,6 +507,22 @@ namespace Velvet
                 DoubleInvokeRenderForStrictMode(fiber, diagnosticCommittedTree);
             }
 #endif
+        }
+
+        // Sweeps and removes this fiber's own entries from the context's deferred inline-baseline
+        // queue — see the Unmount call site for why this must run before teardown empties the
+        // fiber's mark roots.
+        private static void ReclaimDeferredInlineEntries(ComponentFiber fiber)
+        {
+            var queue = fiber.Reconciler?.Context.DeferredInlineOldTreeReturns;
+            if (queue == null || queue.Count == 0) return;
+            for (var i = queue.Count - 1; i >= 0; i--)
+            {
+                if (!ReferenceEquals(queue[i].Owner, fiber)) continue;
+                var tree = queue[i].Tree;
+                queue.RemoveAt(i);
+                FiberTreeReturn.ReturnRetiredTree(tree, fiber);
+            }
         }
 
         // Pushes this fiber onto the Reconciler-side FiberStack. When a new Component is created during

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberRenderer.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberRenderer.cs
@@ -206,6 +206,11 @@ namespace Velvet
             // from the actual DOM contents; FiberElementCleaner.RemoveElement silently skips
             // out-of-range indices so only existing elements are removed. Any pending
             // PendingIndexedState is cleared at the top of this Reconcile call.
+            // The committed tree is retired at the bottom of this method, AFTER the memo slots are
+            // disposed: with this fiber's own slots already empty, the sweep's live mark reduces to
+            // ancestor-held memoized roots (nodes that flowed into this tree as props and survive for
+            // their owner's comeback render), so everything this fiber alone held is recycled.
+            VNode?[]? retiredTree = null;
             if (fiber.MountPoint != null && fiber.PreviousTree != null)
             {
                 // Push this fiber while reconciling its tree to empty so the old-side walk looks up its
@@ -222,7 +227,7 @@ namespace Velvet
                 {
                     PopFiber(fiber, unmountPushed);
                 }
-                FiberTreeReturn.ReturnPooledObjects(fiber.PreviousTree);
+                retiredTree = fiber.PreviousTree;
             }
 
             FiberEffects.CleanupAllInsertionEffects(fiber);
@@ -253,7 +258,8 @@ namespace Velvet
             fiber.DetachedMountContext = null;
 
             fiber.PreviousTree = null;
-            FiberTreeReturn.ReturnPooledObjects(fiber.PendingOldTree);
+            FiberTreeReturn.ReturnRetiredTree(retiredTree, fiber);
+            FiberTreeReturn.ReturnRetiredTree(fiber.PendingOldTree, fiber);
             fiber.PendingOldTree = null;
             fiber.Reconciler?.Dispose();
             fiber.Reconciler = null;
@@ -376,18 +382,25 @@ namespace Velvet
                 // A deleted fiber is treated as a no-op for post-render bookkeeping
                 // rather than continuing to schedule work on it.
                 var reconciler = fiber.Reconciler;
-                FiberCommitWork.ReturnOldTreeAfterReconcile(fiber, reconciler, oldTree, prevPendingOldTree, deferReconcile);
-
                 if (reconciler == null || reconciler.LastTopLevelWasAborted)
                 {
                     // A disposed fiber must not retain its newly rendered tree (post-commit
                     // would no longer see it). Aborted reconciles are likewise discarded so the
-                    // next render starts from the pre-throw PreviousTree.
-                    FiberTreeReturn.ReturnPooledObjects(newTree);
+                    // next render starts from the pre-throw PreviousTree. Only the DISCARDED output
+                    // (and a superseded parked baseline) retire here — never oldTree, which IS the
+                    // retained PreviousTree baseline and must keep its pooled parts.
+                    FiberTreeReturn.ReturnRetiredTree(newTree, fiber);
+                    if (prevPendingOldTree != null && prevPendingOldTree != oldTree)
+                    {
+                        FiberTreeReturn.ReturnRetiredTree(prevPendingOldTree, fiber);
+                    }
                 }
                 else
                 {
+                    // Commit the new tree BEFORE retiring the old one so the recycle sweep can mark
+                    // the committed state live (a memo hit legitimately shares nodes across the two).
                     fiber.PreviousTree = newTree;
+                    FiberCommitWork.ReturnOldTreeAfterReconcile(fiber, reconciler, oldTree, prevPendingOldTree, deferReconcile);
 #if UNITY_EDITOR
                     // The double-invoke diagnostic compares this fiber's own body output against a re-render of
                     // the same body, so it is independent of reconcile / commit timing. Inline mounts
@@ -405,11 +418,11 @@ namespace Velvet
             {
                 if (prevPendingOldTree != null && prevPendingOldTree != oldTree)
                 {
-                    FiberTreeReturn.ReturnPooledObjects(prevPendingOldTree);
+                    FiberTreeReturn.ReturnRetiredTree(prevPendingOldTree, fiber);
                 }
                 if (fiber.PendingOldTree != null)
                 {
-                    FiberTreeReturn.ReturnPooledObjects(fiber.PendingOldTree);
+                    FiberTreeReturn.ReturnRetiredTree(fiber.PendingOldTree, fiber);
                     fiber.PendingOldTree = null;
                 }
                 fiber.PendingLayoutEffects?.Clear();
@@ -576,10 +589,11 @@ namespace Velvet
             }
             finally
             {
-                // The diagnostic tree is discarded (never reconciled), so its descendant pooled props / events /
-                // child arrays have no owner to recycle them — return the whole tree recursively to avoid a
-                // pool drain that the committed (owned) tree would not cause.
-                FiberTreeReturn.ReturnPooledTreeRecursive(diagnosticTree);
+                // The diagnostic tree is discarded (never reconciled), so its pooled props / events /
+                // child arrays have no later retirement point — recycle it here to avoid a pool drain.
+                // The owner mark is essential: a memo hit during the diagnostic render returns the
+                // COMMITTED cached subtree, so parts of this discarded tree are the live tree.
+                FiberTreeReturn.ReturnRetiredTree(diagnosticTree, fiber);
                 contextSpine.Unwind();
                 // Discard the diagnostic's staged context reads; the committed list stays as the
                 // real render left it.

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberTreeReturn.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberTreeReturn.cs
@@ -145,19 +145,44 @@ namespace Velvet
             }
         }
 
-        // Collects the node roots the fiber's hook slots currently hold (see MarkFiberSlotRoots for
-        // the slot kinds), for ReturnRetiredTreesForUnmount. Allocates only when a slot actually
-        // holds a node — unmount-path-only cost.
+        // Collects the node roots held by the fiber's DISPOSABLE hook slots — the memo / ref slot
+        // lists Unmount clears — for ReturnRetiredTreesForUnmount. State slots are deliberately
+        // excluded: Unmount preserves them for a remount, so their held nodes stay live (and the
+        // mark, which reads the still-populated state slots, would spare them anyway). Allocates
+        // only when a slot actually holds a node — unmount-path-only cost.
         internal static List<VNode>? CollectSlotRootsForUnmount(ComponentFiber fiber)
         {
             List<VNode>? roots = null;
-            void Visit(VNode node)
-            {
-                roots ??= new List<VNode>();
-                roots.Add(node);
-            }
-            VisitFiberSlotRoots(fiber, Visit);
+            VisitDisposableSlotRoots(fiber, root => CollectRootNodes(root, ref roots));
             return roots;
+        }
+
+        // Collects the node roots held by the fiber's PERSISTENT (state / reducer) slots, for the
+        // terminal Dispose path: unlike Unmount, Dispose never remounts, so the caller clears the
+        // state slots and retires these roots — otherwise an element-in-state fiber would pin its
+        // node's pooled parts forever.
+        internal static List<VNode>? CollectStateSlotRootsForDispose(ComponentFiber fiber)
+        {
+            List<VNode>? roots = null;
+            VisitPersistentSlotRoots(fiber, root => CollectRootNodes(root, ref roots));
+            return roots;
+        }
+
+        private static void CollectRootNodes(object root, ref List<VNode>? roots)
+        {
+            switch (root)
+            {
+                case VNode node:
+                    (roots ??= new List<VNode>()).Add(node);
+                    break;
+                case IReadOnlyList<VNode?> list:
+                    for (var i = 0; i < list.Count; i++)
+                    {
+                        var node = list[i];
+                        if (node != null) (roots ??= new List<VNode>()).Add(node);
+                    }
+                    break;
+            }
         }
 
         #region live marks
@@ -213,8 +238,8 @@ namespace Velvet
         {
             if (owner == null) return;
 
-            MarkTreeRoot(owner.PreviousTree, live);
-            MarkTreeRoot(owner.PendingOldTree, live);
+            WalkTree(owner.PreviousTree, live, WalkMode.Mark);
+            WalkTree(owner.PendingOldTree, live, WalkMode.Mark);
 
             for (var fiber = owner; fiber != null; fiber = LogicalParentOf(fiber))
             {
@@ -241,7 +266,7 @@ namespace Velvet
             foreach (var parked in ctx.ParkedBaselineFibers)
             {
                 if (ReferenceEquals(parked, owner)) continue;
-                MarkTreeRoot(parked.PendingOldTree, live);
+                WalkTree(parked.PendingOldTree, live, WalkMode.Mark);
                 MarkFiberSlotRoots(parked, live);
             }
         }
@@ -254,15 +279,37 @@ namespace Velvet
 
         private static void MarkFiberSlotRoots(ComponentFiber fiber, HashSet<object> live)
         {
-            VisitFiberSlotRoots(fiber, node => MarkNode(node, live));
+            void Mark(object root) => MarkSlotRoot(root, live);
+            VisitDisposableSlotRoots(fiber, Mark);
+            VisitPersistentSlotRoots(fiber, Mark);
         }
 
-        // Enumerates the node roots a fiber's hook slots hold across renders: the compiler's
-        // auto-memo slots (whole-body trees), and any UseMemo / UseState / UseRef value that is a
-        // node or a list of nodes. A slot with stable inputs re-emits the SAME instance on a later
-        // render even when the current committed tree omits it (V.When toggling a memoized
-        // subtree), so slot-held roots must survive sweeps in between.
-        private static void VisitFiberSlotRoots(ComponentFiber fiber, Action<VNode> visit)
+        private static void MarkSlotRoot(object root, HashSet<object> live)
+        {
+            switch (root)
+            {
+                case VNode node:
+                    MarkNode(node, live);
+                    break;
+                case IReadOnlyList<VNode?> list:
+                    // A slot-held rented ARRAY can itself arrive at a sweep as a retired tree root
+                    // (a fragment-rooted body unwraps to its children array via NormalizeToArray),
+                    // so the array object joins the mark alongside its nodes.
+                    if (list is VNode?[] array) live.Add(array);
+                    for (var i = 0; i < list.Count; i++)
+                    {
+                        MarkNode(list[i], live);
+                    }
+                    break;
+            }
+        }
+
+        // Enumerates the node roots held by the slot lists Unmount DISPOSES (compiler auto-memo
+        // slots — whole-body trees — plus UseMemo / UseRef values that are a node or a list of
+        // nodes). A slot with stable inputs re-emits the SAME instance on a later render even when
+        // the current committed tree omits it (V.When toggling a memoized subtree), so these roots
+        // must survive sweeps while their slot lives — and retire with it when it is disposed.
+        private static void VisitDisposableSlotRoots(ComponentFiber fiber, Action<object> visitRoot)
         {
             var memoSlots = fiber.MemoSlots;
             if (memoSlots != null)
@@ -271,10 +318,10 @@ namespace Velvet
                 {
                     var slot = memoSlots[i];
                     if (slot == null) continue;
-                    if (slot.CachedResult != null) visit(slot.CachedResult);
+                    if (slot.CachedResult != null) visitRoot(slot.CachedResult);
                     if (slot.NextCachedResult != null && !ReferenceEquals(slot.NextCachedResult, slot.CachedResult))
                     {
-                        visit(slot.NextCachedResult);
+                        visitRoot(slot.NextCachedResult);
                     }
                 }
             }
@@ -284,16 +331,8 @@ namespace Velvet
             {
                 for (var i = 0; i < valueSlots.Count; i++)
                 {
-                    VisitSlotRootValue(valueSlots[i]?.RecycleMarkRoot, visit);
-                }
-            }
-
-            var stateSlots = fiber.StateSlots;
-            if (stateSlots != null)
-            {
-                for (var i = 0; i < stateSlots.Count; i++)
-                {
-                    VisitSlotRootValue(stateSlots[i]?.RecycleMarkRoot, visit);
+                    var root = valueSlots[i]?.RecycleMarkRoot;
+                    if (root != null) visitRoot(root);
                 }
             }
 
@@ -302,48 +341,37 @@ namespace Velvet
             {
                 for (var i = 0; i < refSlots.Count; i++)
                 {
-                    VisitSlotRootValue(refSlots[i]?.RecycleMarkRoot, visit);
+                    var root = refSlots[i]?.RecycleMarkRoot;
+                    if (root != null) visitRoot(root);
                 }
             }
         }
 
-        private static void VisitSlotRootValue(object? root, Action<VNode> visit)
+        // Enumerates the node roots held by the slot lists Unmount PRESERVES for a remount
+        // (UseState / UseReducer values). They stay live across unmount; the terminal Dispose path
+        // clears the slots and retires them.
+        private static void VisitPersistentSlotRoots(ComponentFiber fiber, Action<object> visitRoot)
         {
-            switch (root)
+            var stateSlots = fiber.StateSlots;
+            if (stateSlots != null)
             {
-                case VNode node:
-                    visit(node);
-                    break;
-                case IReadOnlyList<VNode?> list:
-                    for (var i = 0; i < list.Count; i++)
-                    {
-                        var node = list[i];
-                        if (node != null) visit(node);
-                    }
-                    break;
-            }
-        }
-
-        // Marks a baseline root array plus its nodes. Only the ROOT array needs an array-level
-        // mark: SweepTree consults the set for its entry array (guarding a retired==committed
-        // aliasing), while nested child arrays are only reachable through their node, which the
-        // sweep prunes on first.
-        private static void MarkTreeRoot(VNode?[]? tree, HashSet<object> live)
-        {
-            if (tree == null || tree.Length == 0) return;
-            live.Add(tree);
-            for (var i = 0; i < tree.Length; i++)
-            {
-                MarkNode(tree[i], live);
+                for (var i = 0; i < stateSlots.Count; i++)
+                {
+                    var root = stateSlots[i]?.RecycleMarkRoot;
+                    if (root != null) visitRoot(root);
+                }
             }
         }
 
         // Add returning false means this node was already marked through another path (a shared
-        // subtree reachable twice); its descendants are marked too, so stop. Marking NODES is
-        // sufficient: a factory rents exactly one props bag / event array per node, so a pooled
-        // part can only be shared by sharing its node, and the sweep prunes at marked nodes
-        // before ever consulting their parts (a caller-supplied part attached to two hand-built
-        // nodes is protected by pool ownership instead — Return no-ops on what was never rented).
+        // subtree reachable twice); its descendants are marked too, so stop. Marking is
+        // node-granular plus the tree ARRAYS: a factory rents exactly one props bag / event array
+        // per node, so pooled parts can only be shared by sharing their node, and the sweep prunes
+        // at marked nodes before ever consulting parts (a caller-supplied part attached to two
+        // hand-built nodes is protected by pool ownership instead — Return no-ops on what was
+        // never rented). Arrays must be marked individually because a live array can arrive at a
+        // sweep as a retired tree ROOT (fragment unwrapping), where SweepTree consults the set for
+        // the array itself before any node prune applies.
         private static void MarkNode(VNode? node, HashSet<object> live)
         {
             if (node == null || !live.Add(node)) return;
@@ -425,7 +453,8 @@ namespace Velvet
                 case ContextProviderNode provider:
                     if (mode == WalkMode.Mark)
                     {
-                        VisitSlotRootValue(provider.BoxedValueForRecycleMark, node2 => MarkNode(node2, live));
+                        var value = provider.BoxedValueForRecycleMark;
+                        if (value != null) MarkSlotRoot(value, live);
                     }
                     WalkTree(provider.Children, live, mode);
                     break;
@@ -443,6 +472,11 @@ namespace Velvet
             if (tree == null || tree.Length == 0) return;
             if (mode == WalkMode.Mark)
             {
+                // The array object joins the mark too: a live children array can arrive at a later
+                // sweep as a retired tree ROOT (a memoized fragment-rooted body unwraps to its
+                // children array via NormalizeToArray), and SweepTree's entry guard consults the
+                // set for the array before any node prune applies.
+                live.Add(tree);
                 for (var i = 0; i < tree.Length; i++)
                 {
                     MarkNode(tree[i], live);

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberTreeReturn.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberTreeReturn.cs
@@ -8,24 +8,36 @@ namespace Velvet
     // output, ReturnRetiredTree recycles a retired tree, and DrainDeferredInlineOldTreeReturns
     // flushes the deferred inline baselines at the top-level reconcile boundary.
     //
-    // Recycling is a mark-and-sweep over the RETIRED tree: the mark pass collects every object
-    // still reachable from the owner fiber's committed state (its PreviousTree, plus the memoized
-    // VNode roots of the fiber and its ancestor chain), and the sweep returns the retired tree's
-    // pooled objects RECURSIVELY, sparing anything marked live. Two forces make both halves
-    // necessary:
+    // Recycling is a mark-and-sweep over the RETIRED tree: the mark pass collects every node still
+    // reachable from committed state, and the sweep returns the retired tree's pooled objects
+    // RECURSIVELY, sparing marked subtrees. Two forces make both halves necessary:
     //   - Depth: factory-rented props bags / event arrays / child arrays sit at every nesting
-    //     level (and under Portal / WorldSpace / Suspense / Provider boundaries — those are
+    //     level (and under Portal / WorldSpace / Suspense / provider boundaries — those are
     //     logical boundaries, not recycle boundaries), so a top-level-only return strands one
     //     bag per render for every nested renting element.
-    //   - Sharing: memoization (the compiler's auto-memo slots, Hooks.UseMemo, a props-bail that
-    //     keeps a child's tree referencing parent-built nodes) legitimately carries the SAME node
-    //     instances across consecutive trees, so an unmarked recursive return would recycle
-    //     objects the committed tree still reads as its patch baseline — and the pool would hand
-    //     them to an unrelated mount to overwrite.
-    // A consumer-cached factory-built node that leaves the tree one render and returns later is
-    // outside this protection (nothing live references it in between); caching whole factory
-    // nodes across renders is not a supported pattern — cache with Hooks.UseMemo instead, whose
-    // slot the mark pass reads.
+    //   - Sharing: memoization legitimately carries the SAME node instances across consecutive
+    //     trees, so an unmarked recursive return would recycle objects the committed tree still
+    //     reads as its patch baseline — and the pool would hand them to an unrelated mount to
+    //     overwrite.
+    //
+    // The live-mark roots, per retirement:
+    //   - the owner fiber's committed PreviousTree and parked PendingOldTree;
+    //   - hook-slot-held node roots (auto-memo slots, Hooks.UseMemo / UseState / UseRef values
+    //     that are a VNode or a list of VNodes) of the owner and its LOGICAL ancestor chain — a
+    //     detached mount (portal / world-space drain) parents off the drain anchor, so the chain
+    //     hops through DetachedMountContext.LogicalParent to reach the declaring components whose
+    //     slots feed nodes in as props;
+    //   - AnimatePresence bookkeeping (PresenceStates' committed entries): an exiting ghost's
+    //     node outlives the tree that last emitted it, staying the old-side baseline until the
+    //     exit finishes;
+    //   - every parked PendingOldTree in the context: a paused time-sliced pass keeps reading its
+    //     baseline across frames, so no other fiber's retirement may recycle nodes it shares.
+    //
+    // Outside those roots, holding a factory-built node across renders is not tracked: a node
+    // carried inside a composite (a user record / tuple in a memo or state slot, a component
+    // props record, a Store) re-enters later renders with pooled parts the sweep may have
+    // recycled. Cache nodes directly in a UseMemo / UseState / UseRef slot (as the node or a
+    // list of nodes) — those slots the mark pass reads.
     internal static class FiberTreeReturn
     {
         internal static VNode?[] NormalizeToArray(VNode node)
@@ -44,66 +56,279 @@ namespace Velvet
         }
 
         // Returns the inline old trees queued by RenderInlineForExpansion during a reconcile
-        // pass to the VNode pool. Called once at the top-level reconcile boundary (after the whole pass has
-        // finished reading them as patch baselines and no renter can alias them) so the deferral does not
-        // add GC pressure — the nodes are pooled for the next pass, just not mid-pass. See
-        // ReconcilerContext.DeferredInlineOldTreeReturns for why the return must be deferred. Each entry
-        // carries its owning fiber so the sweep marks that fiber's NOW-committed tree as live (by drain
-        // time the owner's PreviousTree holds the render that retired this baseline).
+        // pass to the VNode pool. Called once at the top-level reconcile boundary (after the whole pass
+        // has finished reading them as patch baselines) so the deferral does not add GC pressure — the
+        // nodes are pooled for the next pass, just not mid-pass. See
+        // ReconcilerContext.DeferredInlineOldTreeReturns for why the return must be deferred.
+        // All entries share one mark pass (their owners' chains overlap heavily — K inline children
+        // under one parent would otherwise re-mark the same ancestors K times), then sweep against the
+        // union. Union marking only ever spares MORE, and an over-spared dead object is ordinary GC
+        // garbage, so correctness is one-sided.
         internal static void DrainDeferredInlineOldTreeReturns(ReconcilerContext ctx)
         {
             var queue = ctx.DeferredInlineOldTreeReturns;
             if (queue.Count == 0) return;
-            for (var i = 0; i < queue.Count; i++)
+            var live = AcquireLiveMarks();
+            try
             {
-                var (tree, owner) = queue[i];
-                ReturnRetiredTree(tree, owner);
+                for (var i = 0; i < queue.Count; i++)
+                {
+                    MarkOwnerRoots(queue[i].Owner, live);
+                }
+                for (var i = 0; i < queue.Count; i++)
+                {
+                    SweepTree(queue[i].Tree, live);
+                }
             }
-            queue.Clear();
+            finally
+            {
+                ReleaseLiveMarks(live);
+                queue.Clear();
+            }
         }
 
-        // Reused mark set. Main-thread only (like VNodePool) and non-reentrant by construction: neither
-        // the mark nor the sweep runs user code or re-enters the reconciler, so no nested return can
-        // begin while one is in progress. Cleared after each sweep to release object refs for GC.
-        private static readonly HashSet<object> s_liveMarks = new();
-
         // Returns retired's pooled objects (props bags, single-event arrays, node arrays) to
-        // VNodePool, recursing through every child-bearing node kind, while sparing objects still
-        // reachable from owner's committed state. Pass a null owner when the whole
-        // tree is being discarded with no committed successor (unmount teardown) — the sweep then
-        // returns everything unconditionally. Returns are idempotent (rent-scoped pool ownership),
-        // so a node reachable through two retired trees recycles exactly once.
+        // VNodePool, recursing through every child-bearing node kind, while sparing nodes still
+        // reachable from the live-mark roots (see the header). Pass a null owner only when the
+        // whole tree is being discarded with no committed successor and no owning fiber left (a
+        // memo cache torn down at reconciler disposal) — the sweep then returns everything.
+        // Returns are idempotent (rent-scoped pool ownership) and pass-deferred (VNodePool release
+        // staging), so a node reachable through several retired trees recycles exactly once and is
+        // never re-rented within the pass that retired it.
         internal static void ReturnRetiredTree(VNode?[]? retired, ComponentFiber? owner)
         {
             if (retired == null || retired.Length == 0) return;
 
-            var live = s_liveMarks;
+            var live = AcquireLiveMarks();
             try
             {
-                if (owner != null)
-                {
-                    MarkTree(owner.PreviousTree, live);
-                    // Memoized roots along the ancestor chain: a deps-stable Hooks.UseMemo (or auto-memo
-                    // slot) re-emits the same node instance on a LATER render even when the current
-                    // committed tree omits it (e.g. V.When(false, memoized)), and an ancestor's memoized
-                    // node can flow into this fiber's tree as props — so slot-held trees anywhere up the
-                    // chain must survive the sweep for their comeback render to reuse them intact.
-                    for (var fiber = owner; fiber != null; fiber = fiber.Parent)
-                    {
-                        MarkMemoRoots(fiber, live);
-                    }
-                }
+                MarkOwnerRoots(owner, live);
                 SweepTree(retired, live);
             }
             finally
             {
-                live.Clear();
+                ReleaseLiveMarks(live);
             }
         }
 
-        #region mark
+        // Unmount-time variant: retires the fiber's committed tree, its parked baseline, and the
+        // node roots its own (about-to-be-disposed) hook slots held — a slot-held node that is
+        // currently toggled OUT of the output is in no retiring tree, so without this it would
+        // strand when the slot lists are cleared. The caller passes the roots collected BEFORE
+        // slot disposal and calls this AFTER it, so the mark reduces to the surviving ancestors'
+        // roots (nodes that flowed into this fiber's trees as props and outlive it).
+        internal static void ReturnRetiredTreesForUnmount(
+            ComponentFiber fiber, VNode?[]? retiredTree, VNode?[]? parkedTree, List<VNode>? slotRoots)
+        {
+            if (retiredTree == null && parkedTree == null && (slotRoots == null || slotRoots.Count == 0))
+            {
+                return;
+            }
 
-        private static void MarkTree(VNode?[]? tree, HashSet<object> live)
+            var live = AcquireLiveMarks();
+            try
+            {
+                MarkOwnerRoots(fiber, live);
+                if (retiredTree != null) SweepTree(retiredTree, live);
+                if (parkedTree != null) SweepTree(parkedTree, live);
+                if (slotRoots != null)
+                {
+                    for (var i = 0; i < slotRoots.Count; i++)
+                    {
+                        SweepNode(slotRoots[i], live);
+                    }
+                }
+            }
+            finally
+            {
+                ReleaseLiveMarks(live);
+            }
+        }
+
+        // Collects the node roots the fiber's hook slots currently hold (see MarkFiberSlotRoots for
+        // the slot kinds), for ReturnRetiredTreesForUnmount. Allocates only when a slot actually
+        // holds a node — unmount-path-only cost.
+        internal static List<VNode>? CollectSlotRootsForUnmount(ComponentFiber fiber)
+        {
+            List<VNode>? roots = null;
+            void Visit(VNode node)
+            {
+                roots ??= new List<VNode>();
+                roots.Add(node);
+            }
+            VisitFiberSlotRoots(fiber, Visit);
+            return roots;
+        }
+
+        #region live marks
+
+        // Reused mark set, reference-identity keyed (VNodes and pooled parts have no equality
+        // overrides, but the default comparer still virtual-dispatches; reference hashing is
+        // branch-free). Main-thread only, like VNodePool. The in-use flag makes an unexpected
+        // nested retirement fall back to a fresh set instead of clearing the outer sweep's marks
+        // mid-walk — neither pass runs user code today, so the fallback is a structural guarantee
+        // rather than a hot path.
+        private static readonly HashSet<object> s_liveMarks = new(ReferenceComparer.Instance);
+        private static bool s_liveMarksInUse;
+
+        // A mark from one huge committed tree would otherwise pin its bucket storage for the
+        // process lifetime; past this count the set is trimmed after the sweep.
+        private const int LiveMarksTrimThreshold = 4096;
+
+        private static HashSet<object> AcquireLiveMarks()
+        {
+            if (s_liveMarksInUse)
+            {
+                return new HashSet<object>(ReferenceComparer.Instance);
+            }
+            s_liveMarksInUse = true;
+            return s_liveMarks;
+        }
+
+        private static void ReleaseLiveMarks(HashSet<object> live)
+        {
+            if (!ReferenceEquals(live, s_liveMarks)) return;
+            var oversized = live.Count > LiveMarksTrimThreshold;
+            live.Clear();
+            if (oversized)
+            {
+                live.TrimExcess();
+            }
+            s_liveMarksInUse = false;
+        }
+
+        private sealed class ReferenceComparer : IEqualityComparer<object>
+        {
+            public static readonly ReferenceComparer Instance = new();
+            bool IEqualityComparer<object>.Equals(object? a, object? b) => ReferenceEquals(a, b);
+            int IEqualityComparer<object>.GetHashCode(object o)
+                => System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(o);
+        }
+
+        // Marks everything committed state can reach from this owner: its two tree baselines, the
+        // slot roots along its logical ancestor chain, and the context-wide registries (presence
+        // ghosts, parked baselines). Safe to call for several owners into one set (union mark);
+        // already-marked subtrees short-circuit, so overlapping chains cost one walk.
+        private static void MarkOwnerRoots(ComponentFiber? owner, HashSet<object> live)
+        {
+            if (owner == null) return;
+
+            MarkTreeRoot(owner.PreviousTree, live);
+            MarkTreeRoot(owner.PendingOldTree, live);
+
+            for (var fiber = owner; fiber != null; fiber = LogicalParentOf(fiber))
+            {
+                MarkFiberSlotRoots(fiber, live);
+            }
+
+            var ctx = owner.Reconciler?.Context;
+            if (ctx == null) return;
+
+            // Exiting AnimatePresence ghosts: PresenceBoundaryState.Committed keeps re-emitting the
+            // removed child's node as the old-side baseline until its exit animation completes, long
+            // after the tree that last contained it retired.
+            foreach (var state in ctx.PresenceStates.Values)
+            {
+                var committed = state.Committed;
+                for (var i = 0; i < committed.Count; i++)
+                {
+                    MarkNode(committed[i].node, live);
+                }
+            }
+
+            // Parked time-sliced baselines: a paused pass keeps reading its PendingOldTree across
+            // frames, so another fiber's retirement in between must not recycle shared nodes.
+            foreach (var parked in ctx.ParkedBaselineFibers)
+            {
+                if (ReferenceEquals(parked, owner)) continue;
+                MarkTreeRoot(parked.PendingOldTree, live);
+                MarkFiberSlotRoots(parked, live);
+            }
+        }
+
+        // A detached mount (portal / world-space drain) parents off the drain anchor, not the
+        // component whose render declared it — hop through the captured logical parent so the
+        // declaring chain's slots are reachable from portal content.
+        private static ComponentFiber? LogicalParentOf(ComponentFiber fiber)
+            => fiber.DetachedMountContext?.LogicalParent ?? fiber.Parent;
+
+        private static void MarkFiberSlotRoots(ComponentFiber fiber, HashSet<object> live)
+        {
+            VisitFiberSlotRoots(fiber, node => MarkNode(node, live));
+        }
+
+        // Enumerates the node roots a fiber's hook slots hold across renders: the compiler's
+        // auto-memo slots (whole-body trees), and any UseMemo / UseState / UseRef value that is a
+        // node or a list of nodes. A slot with stable inputs re-emits the SAME instance on a later
+        // render even when the current committed tree omits it (V.When toggling a memoized
+        // subtree), so slot-held roots must survive sweeps in between.
+        private static void VisitFiberSlotRoots(ComponentFiber fiber, Action<VNode> visit)
+        {
+            var memoSlots = fiber.MemoSlots;
+            if (memoSlots != null)
+            {
+                for (var i = 0; i < memoSlots.Count; i++)
+                {
+                    var slot = memoSlots[i];
+                    if (slot == null) continue;
+                    if (slot.CachedResult != null) visit(slot.CachedResult);
+                    if (slot.NextCachedResult != null && !ReferenceEquals(slot.NextCachedResult, slot.CachedResult))
+                    {
+                        visit(slot.NextCachedResult);
+                    }
+                }
+            }
+
+            var valueSlots = fiber.MemoValueSlots;
+            if (valueSlots != null)
+            {
+                for (var i = 0; i < valueSlots.Count; i++)
+                {
+                    VisitSlotRootValue(valueSlots[i]?.RecycleMarkRoot, visit);
+                }
+            }
+
+            var stateSlots = fiber.StateSlots;
+            if (stateSlots != null)
+            {
+                for (var i = 0; i < stateSlots.Count; i++)
+                {
+                    VisitSlotRootValue(stateSlots[i]?.RecycleMarkRoot, visit);
+                }
+            }
+
+            var refSlots = fiber.RefSlots;
+            if (refSlots != null)
+            {
+                for (var i = 0; i < refSlots.Count; i++)
+                {
+                    VisitSlotRootValue(refSlots[i]?.RecycleMarkRoot, visit);
+                }
+            }
+        }
+
+        private static void VisitSlotRootValue(object? root, Action<VNode> visit)
+        {
+            switch (root)
+            {
+                case VNode node:
+                    visit(node);
+                    break;
+                case IReadOnlyList<VNode?> list:
+                    for (var i = 0; i < list.Count; i++)
+                    {
+                        var node = list[i];
+                        if (node != null) visit(node);
+                    }
+                    break;
+            }
+        }
+
+        // Marks a baseline root array plus its nodes. Only the ROOT array needs an array-level
+        // mark: SweepTree consults the set for its entry array (guarding a retired==committed
+        // aliasing), while nested child arrays are only reachable through their node, which the
+        // sweep prunes on first.
+        private static void MarkTreeRoot(VNode?[]? tree, HashSet<object> live)
         {
             if (tree == null || tree.Length == 0) return;
             live.Add(tree);
@@ -114,72 +339,15 @@ namespace Velvet
         }
 
         // Add returning false means this node was already marked through another path (a shared
-        // subtree reachable twice); its descendants are marked too, so stop.
+        // subtree reachable twice); its descendants are marked too, so stop. Marking NODES is
+        // sufficient: a factory rents exactly one props bag / event array per node, so a pooled
+        // part can only be shared by sharing its node, and the sweep prunes at marked nodes
+        // before ever consulting their parts (a caller-supplied part attached to two hand-built
+        // nodes is protected by pool ownership instead — Return no-ops on what was never rented).
         private static void MarkNode(VNode? node, HashSet<object> live)
         {
             if (node == null || !live.Add(node)) return;
-            switch (node)
-            {
-                case BaseElementNode element:
-                    if (element.Props != null) live.Add(element.Props);
-                    if (element.Events is { Length: > 0 }) live.Add(element.Events);
-                    MarkTree(element.Children, live);
-                    break;
-                case FragmentNode fragment:
-                    MarkTree(fragment.Children, live);
-                    break;
-                case PortalNode portal:
-                    MarkTree(portal.Children, live);
-                    break;
-                case WorldSpaceNode worldSpace:
-                    MarkTree(worldSpace.Children, live);
-                    break;
-                case SuspenseNode suspense:
-                    MarkNode(suspense.Fallback, live);
-                    MarkTree(suspense.Children, live);
-                    break;
-                case AnimatePresenceNode presence:
-                    MarkTree(presence.Children, live);
-                    break;
-                case ContextProviderNode provider:
-                    MarkTree(provider.Children, live);
-                    break;
-                    // MemoNode: its inner tree lives in the memo cache, which the sweep never descends
-                    // into — nothing to protect here. ComponentNode: its props are an opaque user value
-                    // the sweep cannot descend either; symmetry keeps both sides blind to it.
-            }
-        }
-
-        private static void MarkMemoRoots(ComponentFiber fiber, HashSet<object> live)
-        {
-            var memoSlots = fiber.MemoSlots;
-            if (memoSlots != null)
-            {
-                for (var i = 0; i < memoSlots.Count; i++)
-                {
-                    var slot = memoSlots[i];
-                    if (slot == null) continue;
-                    if (slot.CachedResult != null) MarkNode(slot.CachedResult, live);
-                    if (slot.NextCachedResult != null) MarkNode(slot.NextCachedResult, live);
-                }
-            }
-
-            var valueSlots = fiber.MemoValueSlots;
-            if (valueSlots != null)
-            {
-                for (var i = 0; i < valueSlots.Count; i++)
-                {
-                    switch (valueSlots[i]?.RecycleMarkRoot)
-                    {
-                        case VNode node:
-                            MarkNode(node, live);
-                            break;
-                        case VNode?[] tree:
-                            MarkTree(tree, live);
-                            break;
-                    }
-                }
-            }
+            WalkChildSlots(node, live, WalkMode.Mark);
         }
 
         #endregion
@@ -189,7 +357,7 @@ namespace Velvet
         private static void SweepTree(VNode?[] tree, HashSet<object> live)
         {
             if (tree == null || tree.Length == 0) return;
-            if (live.Contains(tree)) return;
+            if (live.Count > 0 && live.Contains(tree)) return;
             for (var i = 0; i < tree.Length; i++)
             {
                 SweepNode(tree[i], live);
@@ -202,39 +370,87 @@ namespace Velvet
             if (node == null) return;
             // A marked node's entire subtree is committed state — nothing below it retires.
             if (live.Count > 0 && live.Contains(node)) return;
+            WalkChildSlots(node, live, WalkMode.Sweep);
+            if (node is BaseElementNode element)
+            {
+                VNodePool.ReturnProps(element.Props);
+                if (element.Events is { Length: > 0 })
+                {
+                    VNodePool.ReturnEventArray(element.Events);
+                }
+            }
+        }
+
+        #endregion
+
+        #region shared child-slot walk
+
+        private enum WalkMode { Mark, Sweep }
+
+        // The ONE switch that knows which node kinds bear children (and which child slots they
+        // have). Mark and sweep both descend through here so the two passes cannot drift: a kind
+        // descended by one but not the other either re-opens the per-render leak (mark-only) or
+        // recycles live committed subtrees (sweep-only).
+        //
+        // Deliberately opaque on both sides: MemoNode (its inner lives in the memo cache — the
+        // cache's own replace / dispose paths retire it) and ComponentNode (its props are an
+        // opaque user value; a node passed through a props record is protected only while a
+        // slot along the logical ancestor chain also holds it — see the header contract).
+        // ContextProviderNode's VALUE is marked but never swept: a consumer may have committed the
+        // value's node into its own tree, and leaking a provider-held node is recoverable while
+        // recycling a consumed one is not.
+        private static void WalkChildSlots(VNode node, HashSet<object> live, WalkMode mode)
+        {
             switch (node)
             {
                 case BaseElementNode element:
-                    SweepTree(element.Children, live);
-                    if (element.Props != null && !live.Contains(element.Props))
-                    {
-                        VNodePool.ReturnProps(element.Props);
-                    }
-                    if (element.Events is { Length: > 0 } && !live.Contains(element.Events))
-                    {
-                        VNodePool.ReturnEventArray(element.Events);
-                    }
+                    WalkTree(element.Children, live, mode);
                     break;
                 case FragmentNode fragment:
-                    SweepTree(fragment.Children, live);
+                    WalkTree(fragment.Children, live, mode);
                     break;
                 case PortalNode portal:
-                    SweepTree(portal.Children, live);
+                    WalkTree(portal.Children, live, mode);
                     break;
                 case WorldSpaceNode worldSpace:
-                    SweepTree(worldSpace.Children, live);
+                    WalkTree(worldSpace.Children, live, mode);
                     break;
                 case SuspenseNode suspense:
-                    SweepNode(suspense.Fallback, live);
-                    SweepTree(suspense.Children, live);
+                    WalkOne(suspense.Fallback, live, mode);
+                    WalkTree(suspense.Children, live, mode);
                     break;
                 case AnimatePresenceNode presence:
-                    SweepTree(presence.Children, live);
+                    WalkTree(presence.Children, live, mode);
                     break;
                 case ContextProviderNode provider:
-                    SweepTree(provider.Children, live);
+                    if (mode == WalkMode.Mark)
+                    {
+                        VisitSlotRootValue(provider.BoxedValueForRecycleMark, node2 => MarkNode(node2, live));
+                    }
+                    WalkTree(provider.Children, live, mode);
                     break;
-                    // MemoNode / ComponentNode: see the matching note in MarkNode.
+            }
+        }
+
+        private static void WalkOne(VNode? node, HashSet<object> live, WalkMode mode)
+        {
+            if (mode == WalkMode.Mark) MarkNode(node, live);
+            else SweepNode(node, live);
+        }
+
+        private static void WalkTree(VNode?[]? tree, HashSet<object> live, WalkMode mode)
+        {
+            if (tree == null || tree.Length == 0) return;
+            if (mode == WalkMode.Mark)
+            {
+                for (var i = 0; i < tree.Length; i++)
+                {
+                    MarkNode(tree[i], live);
+                }
+            }
+            else
+            {
+                SweepTree(tree, live);
             }
         }
 

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberTreeReturn.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberTreeReturn.cs
@@ -1,12 +1,31 @@
 using System;
+using System.Collections.Generic;
 
 namespace Velvet
 {
     // Returns a committed VNode tree (and the inline old trees deferred during a reconcile pass)
     // to the VNode pool. Extracted from the render core: NormalizeToArray shapes a render body's
-    // output, ReturnPooledObjects recycles a tree's top-level pooled objects, and
-    // DrainDeferredInlineOldTreeReturns flushes the deferred inline baselines at the top-level
-    // reconcile boundary. ReturnPooledTreeRecursive (editor-only) recycles a never-reconciled tree.
+    // output, ReturnRetiredTree recycles a retired tree, and DrainDeferredInlineOldTreeReturns
+    // flushes the deferred inline baselines at the top-level reconcile boundary.
+    //
+    // Recycling is a mark-and-sweep over the RETIRED tree: the mark pass collects every object
+    // still reachable from the owner fiber's committed state (its PreviousTree, plus the memoized
+    // VNode roots of the fiber and its ancestor chain), and the sweep returns the retired tree's
+    // pooled objects RECURSIVELY, sparing anything marked live. Two forces make both halves
+    // necessary:
+    //   - Depth: factory-rented props bags / event arrays / child arrays sit at every nesting
+    //     level (and under Portal / WorldSpace / Suspense / Provider boundaries — those are
+    //     logical boundaries, not recycle boundaries), so a top-level-only return strands one
+    //     bag per render for every nested renting element.
+    //   - Sharing: memoization (the compiler's auto-memo slots, Hooks.UseMemo, a props-bail that
+    //     keeps a child's tree referencing parent-built nodes) legitimately carries the SAME node
+    //     instances across consecutive trees, so an unmarked recursive return would recycle
+    //     objects the committed tree still reads as its patch baseline — and the pool would hand
+    //     them to an unrelated mount to overwrite.
+    // A consumer-cached factory-built node that leaves the tree one render and returns later is
+    // outside this protection (nothing live references it in between); caching whole factory
+    // nodes across renders is not a supported pattern — cache with Hooks.UseMemo instead, whose
+    // slot the mark pass reads.
     internal static class FiberTreeReturn
     {
         internal static VNode?[] NormalizeToArray(VNode node)
@@ -28,87 +47,197 @@ namespace Velvet
         // pass to the VNode pool. Called once at the top-level reconcile boundary (after the whole pass has
         // finished reading them as patch baselines and no renter can alias them) so the deferral does not
         // add GC pressure — the nodes are pooled for the next pass, just not mid-pass. See
-        // ReconcilerContext.DeferredInlineOldTreeReturns for why the return must be deferred.
+        // ReconcilerContext.DeferredInlineOldTreeReturns for why the return must be deferred. Each entry
+        // carries its owning fiber so the sweep marks that fiber's NOW-committed tree as live (by drain
+        // time the owner's PreviousTree holds the render that retired this baseline).
         internal static void DrainDeferredInlineOldTreeReturns(ReconcilerContext ctx)
         {
             var queue = ctx.DeferredInlineOldTreeReturns;
             if (queue.Count == 0) return;
             for (var i = 0; i < queue.Count; i++)
             {
-                ReturnPooledObjects(queue[i]);
+                var (tree, owner) = queue[i];
+                ReturnRetiredTree(tree, owner);
             }
             queue.Clear();
         }
 
-        internal static void ReturnPooledObjects(VNode?[]? tree)
+        // Reused mark set. Main-thread only (like VNodePool) and non-reentrant by construction: neither
+        // the mark nor the sweep runs user code or re-enters the reconciler, so no nested return can
+        // begin while one is in progress. Cleared after each sweep to release object refs for GC.
+        private static readonly HashSet<object> s_liveMarks = new();
+
+        // Returns retired's pooled objects (props bags, single-event arrays, node arrays) to
+        // VNodePool, recursing through every child-bearing node kind, while sparing objects still
+        // reachable from owner's committed state. Pass a null owner when the whole
+        // tree is being discarded with no committed successor (unmount teardown) — the sweep then
+        // returns everything unconditionally. Returns are idempotent (rent-scoped pool ownership),
+        // so a node reachable through two retired trees recycles exactly once.
+        internal static void ReturnRetiredTree(VNode?[]? retired, ComponentFiber? owner)
+        {
+            if (retired == null || retired.Length == 0) return;
+
+            var live = s_liveMarks;
+            try
+            {
+                if (owner != null)
+                {
+                    MarkTree(owner.PreviousTree, live);
+                    // Memoized roots along the ancestor chain: a deps-stable Hooks.UseMemo (or auto-memo
+                    // slot) re-emits the same node instance on a LATER render even when the current
+                    // committed tree omits it (e.g. V.When(false, memoized)), and an ancestor's memoized
+                    // node can flow into this fiber's tree as props — so slot-held trees anywhere up the
+                    // chain must survive the sweep for their comeback render to reuse them intact.
+                    for (var fiber = owner; fiber != null; fiber = fiber.Parent)
+                    {
+                        MarkMemoRoots(fiber, live);
+                    }
+                }
+                SweepTree(retired, live);
+            }
+            finally
+            {
+                live.Clear();
+            }
+        }
+
+        #region mark
+
+        private static void MarkTree(VNode?[]? tree, HashSet<object> live)
         {
             if (tree == null || tree.Length == 0) return;
-
+            live.Add(tree);
             for (var i = 0; i < tree.Length; i++)
             {
-                switch (tree[i])
+                MarkNode(tree[i], live);
+            }
+        }
+
+        // Add returning false means this node was already marked through another path (a shared
+        // subtree reachable twice); its descendants are marked too, so stop.
+        private static void MarkNode(VNode? node, HashSet<object> live)
+        {
+            if (node == null || !live.Add(node)) return;
+            switch (node)
+            {
+                case BaseElementNode element:
+                    if (element.Props != null) live.Add(element.Props);
+                    if (element.Events is { Length: > 0 }) live.Add(element.Events);
+                    MarkTree(element.Children, live);
+                    break;
+                case FragmentNode fragment:
+                    MarkTree(fragment.Children, live);
+                    break;
+                case PortalNode portal:
+                    MarkTree(portal.Children, live);
+                    break;
+                case WorldSpaceNode worldSpace:
+                    MarkTree(worldSpace.Children, live);
+                    break;
+                case SuspenseNode suspense:
+                    MarkNode(suspense.Fallback, live);
+                    MarkTree(suspense.Children, live);
+                    break;
+                case AnimatePresenceNode presence:
+                    MarkTree(presence.Children, live);
+                    break;
+                case ContextProviderNode provider:
+                    MarkTree(provider.Children, live);
+                    break;
+                    // MemoNode: its inner tree lives in the memo cache, which the sweep never descends
+                    // into — nothing to protect here. ComponentNode: its props are an opaque user value
+                    // the sweep cannot descend either; symmetry keeps both sides blind to it.
+            }
+        }
+
+        private static void MarkMemoRoots(ComponentFiber fiber, HashSet<object> live)
+        {
+            var memoSlots = fiber.MemoSlots;
+            if (memoSlots != null)
+            {
+                for (var i = 0; i < memoSlots.Count; i++)
                 {
-                    case ElementNode elem:
-                        VNodePool.ReturnProps(elem.Props);
-                        VNodePool.ReturnEventArray(elem.Events);
-                        VNodePool.ReturnNodeArray(elem.Children);
-                        break;
-                    case MotionNode motion:
-                        VNodePool.ReturnProps(motion.Props);
-                        VNodePool.ReturnEventArray(motion.Events);
-                        VNodePool.ReturnNodeArray(motion.Children);
-                        break;
+                    var slot = memoSlots[i];
+                    if (slot == null) continue;
+                    if (slot.CachedResult != null) MarkNode(slot.CachedResult, live);
+                    if (slot.NextCachedResult != null) MarkNode(slot.NextCachedResult, live);
                 }
             }
 
-            VNodePool.ReturnNodeArray(tree);
-        }
-
-#if UNITY_EDITOR
-        // Returns every pooled object in tree recursively, including descendant element
-        // children. The normal flow returns only the top level because the reconciler recycles descendants as
-        // it walks the tree; a discarded tree that is never reconciled (the double-invoke diagnostic pass) has no
-        // such walk, so its descendants must be returned explicitly to avoid draining the pool.
-        internal static void ReturnPooledTreeRecursive(VNode?[]? tree)
-        {
-            if (tree == null || tree.Length == 0) return;
-
-            for (var i = 0; i < tree.Length; i++)
+            var valueSlots = fiber.MemoValueSlots;
+            if (valueSlots != null)
             {
-                switch (tree[i])
+                for (var i = 0; i < valueSlots.Count; i++)
                 {
-                    case ElementNode elem:
-                        ReturnPooledTreeRecursive(elem.Children);
-                        VNodePool.ReturnProps(elem.Props);
-                        VNodePool.ReturnEventArray(elem.Events);
-                        VNodePool.ReturnNodeArray(elem.Children);
-                        break;
-                    case MotionNode motion:
-                        ReturnPooledTreeRecursive(motion.Children);
-                        VNodePool.ReturnProps(motion.Props);
-                        VNodePool.ReturnEventArray(motion.Events);
-                        VNodePool.ReturnNodeArray(motion.Children);
-                        break;
-                    case FragmentNode fragment:
-                        ReturnPooledTreeRecursive(fragment.Children);
-                        break;
-                    case PortalNode portal:
-                        ReturnPooledTreeRecursive(portal.Children);
-                        break;
-                    case WorldSpaceNode worldSpace:
-                        ReturnPooledTreeRecursive(worldSpace.Children);
-                        break;
-                    case SuspenseNode suspense:
-                        ReturnPooledTreeRecursive(suspense.Children);
-                        break;
-                    case AnimatePresenceNode presence:
-                        ReturnPooledTreeRecursive(presence.Children);
-                        break;
+                    switch (valueSlots[i]?.RecycleMarkRoot)
+                    {
+                        case VNode node:
+                            MarkNode(node, live);
+                            break;
+                        case VNode?[] tree:
+                            MarkTree(tree, live);
+                            break;
+                    }
                 }
             }
+        }
 
+        #endregion
+
+        #region sweep
+
+        private static void SweepTree(VNode?[] tree, HashSet<object> live)
+        {
+            if (tree == null || tree.Length == 0) return;
+            if (live.Contains(tree)) return;
+            for (var i = 0; i < tree.Length; i++)
+            {
+                SweepNode(tree[i], live);
+            }
             VNodePool.ReturnNodeArray(tree);
         }
-#endif
+
+        private static void SweepNode(VNode? node, HashSet<object> live)
+        {
+            if (node == null) return;
+            // A marked node's entire subtree is committed state — nothing below it retires.
+            if (live.Count > 0 && live.Contains(node)) return;
+            switch (node)
+            {
+                case BaseElementNode element:
+                    SweepTree(element.Children, live);
+                    if (element.Props != null && !live.Contains(element.Props))
+                    {
+                        VNodePool.ReturnProps(element.Props);
+                    }
+                    if (element.Events is { Length: > 0 } && !live.Contains(element.Events))
+                    {
+                        VNodePool.ReturnEventArray(element.Events);
+                    }
+                    break;
+                case FragmentNode fragment:
+                    SweepTree(fragment.Children, live);
+                    break;
+                case PortalNode portal:
+                    SweepTree(portal.Children, live);
+                    break;
+                case WorldSpaceNode worldSpace:
+                    SweepTree(worldSpace.Children, live);
+                    break;
+                case SuspenseNode suspense:
+                    SweepNode(suspense.Fallback, live);
+                    SweepTree(suspense.Children, live);
+                    break;
+                case AnimatePresenceNode presence:
+                    SweepTree(presence.Children, live);
+                    break;
+                case ContextProviderNode provider:
+                    SweepTree(provider.Children, live);
+                    break;
+                    // MemoNode / ComponentNode: see the matching note in MarkNode.
+            }
+        }
+
+        #endregion
     }
 }

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberWorkLoop.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberWorkLoop.cs
@@ -333,7 +333,7 @@ namespace Velvet
                 }
                 else
                 {
-                    FiberTreeReturn.ReturnPooledObjects(fiber.PendingOldTree);
+                    FiberTreeReturn.ReturnRetiredTree(fiber.PendingOldTree, fiber);
                     fiber.PendingOldTree = null;
                     // The commit is now fully applied — run the insertion / layout / passive effects FlushState
                     // deferred while this reconcile was paused. Runs once, only on the terminal chunk.
@@ -348,7 +348,7 @@ namespace Velvet
             }
             catch (Exception ex)
             {
-                FiberTreeReturn.ReturnPooledObjects(fiber.PendingOldTree);
+                FiberTreeReturn.ReturnRetiredTree(fiber.PendingOldTree, fiber);
                 fiber.PendingOldTree = null;
                 FiberErrorBoundary.OnRenderError(fiber, ex);
             }

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberWorkLoop.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberWorkLoop.cs
@@ -333,8 +333,12 @@ namespace Velvet
                 }
                 else
                 {
-                    FiberTreeReturn.ReturnRetiredTree(fiber.PendingOldTree, fiber);
+                    fiber.Reconciler?.Context.ParkedBaselineFibers.Remove(fiber);
+                    // Detach before retiring: the sweep's own mark treats owner.PendingOldTree as
+                    // live, and a still-attached reference would spare this very sweep's target.
+                    var completedBaseline = fiber.PendingOldTree;
                     fiber.PendingOldTree = null;
+                    FiberTreeReturn.ReturnRetiredTree(completedBaseline, fiber);
                     // The commit is now fully applied — run the insertion / layout / passive effects FlushState
                     // deferred while this reconcile was paused. Runs once, only on the terminal chunk.
                     // Bottom-up — descendant effects (LIFO drain) before this fiber's.
@@ -348,8 +352,11 @@ namespace Velvet
             }
             catch (Exception ex)
             {
-                FiberTreeReturn.ReturnRetiredTree(fiber.PendingOldTree, fiber);
+                fiber.Reconciler?.Context.ParkedBaselineFibers.Remove(fiber);
+                // Detach before retiring — same self-mark hazard as the completion path above.
+                var abortedBaseline = fiber.PendingOldTree;
                 fiber.PendingOldTree = null;
+                FiberTreeReturn.ReturnRetiredTree(abortedBaseline, fiber);
                 FiberErrorBoundary.OnRenderError(fiber, ex);
             }
             finally

--- a/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
@@ -1078,6 +1078,10 @@ namespace Velvet
                             DisposeExitedGhostFibers(state, key);
                             // Leaving the committed set is the ghost node's last live root (presence bookkeeping
                             // was what kept it alive past its emitting render), so retire its pooled objects here.
+                            // The entry must leave state.Committed FIRST: the sweep's mark reads that very list
+                            // (other retirements must spare live ghosts), and a still-listed entry would spare
+                            // this sweep's own target. prevCommitted is a copy, so the loop is unaffected.
+                            RemovePresenceCommittedEntry(state.Committed, key);
                             FiberTreeReturn.ReturnRetiredTree(FiberTreeReturn.NormalizeToArray(node), boundaryFiber);
                             continue;
                         }
@@ -1089,7 +1093,8 @@ namespace Velvet
                             // No exit animation → immediate removal (skip emitting; the diff reaps the leaves).
                             state.Exiting.Remove(key);
                             removedInstantThisRender = true;
-                            // Same as the finished-exit drop above: the node leaves the committed set for good.
+                            // Same as the finished-exit drop above: leave the committed set, then retire.
+                            RemovePresenceCommittedEntry(state.Committed, key);
                             FiberTreeReturn.ReturnRetiredTree(FiberTreeReturn.NormalizeToArray(node), boundaryFiber);
                             continue;
                         }
@@ -1219,10 +1224,13 @@ namespace Velvet
                         {
                             // The re-entry replaces the ghost's node in the committed set. The OLD node was
                             // kept alive only by presence bookkeeping (a ghost is never part of the boundary's
-                            // own render output), so this replacement is its last reference — retire it.
+                            // own render output), so this replacement is its last reference — retire it. The
+                            // entry leaves state.Committed first, or the sweep's mark (which reads that list)
+                            // would spare its own target; prevCommitted is a copy, so the loop is unaffected.
                             var ghostNode = FindPresenceCommittedNode(prevCommitted, key);
                             if (ghostNode != null && !ReferenceEquals(ghostNode, node))
                             {
+                                RemovePresenceCommittedEntry(state.Committed, key);
                                 FiberTreeReturn.ReturnRetiredTree(
                                     FiberTreeReturn.NormalizeToArray(ghostNode), boundaryFiber);
                             }
@@ -1371,6 +1379,19 @@ namespace Velvet
                 if (list[i].key == key) return list[i].node;
             }
             return null;
+        }
+
+        private static void RemovePresenceCommittedEntry(
+            List<(string key, VNode node)> list, string? key)
+        {
+            for (var i = 0; i < list.Count; i++)
+            {
+                if (list[i].key == key)
+                {
+                    list.RemoveAt(i);
+                    return;
+                }
+            }
         }
 
         // AnimatePresenceMode.PopLayout: the instant a child's exit starts, pull it out of layout flow and pin

--- a/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
@@ -703,7 +703,17 @@ namespace Velvet
         {
             var memoScope = FiberKeying.MemoScope(fragmentKeyScope, nodeIndex);
             var cacheKey = FiberKeying.MemoCacheKey(memo.Key, memoScope);
-            var inner = _ctx.FiberMemoCache.GetOrCompute(cacheKey, memo);
+            var (inner, _, previousCached) = _ctx.FiberMemoCache.GetOrComputeWithHitInfo(cacheKey, memo);
+            if (previousCached != null)
+            {
+                // A deps change just replaced the cached inner tree. The memo wrapper is opaque to the
+                // recycle walk (a fiber's retired tree never descends into it), so this is the only
+                // point that can retire the replaced subtree's rented objects; the sweep's owner mark
+                // spares whatever the replacement or the owner's committed state still shares with it,
+                // and the pass-scoped release staging keeps the rest un-rentable until the pass ends.
+                FiberTreeReturn.ReturnRetiredTree(
+                    FiberTreeReturn.NormalizeToArray(previousCached), _ctx.FiberStack.Current);
+            }
             if (inner == null) return;
             var counters = _ctx.BufferPool.RentPositionCounter();
             try
@@ -1066,6 +1076,9 @@ namespace Velvet
                             // before the diff removes the leaves — otherwise a same-key re-entry would re-pair the
                             // undisposed fiber as a zombie whose local state updates no longer re-render.
                             DisposeExitedGhostFibers(state, key);
+                            // Leaving the committed set is the ghost node's last live root (presence bookkeeping
+                            // was what kept it alive past its emitting render), so retire its pooled objects here.
+                            FiberTreeReturn.ReturnRetiredTree(FiberTreeReturn.NormalizeToArray(node), boundaryFiber);
                             continue;
                         }
 
@@ -1076,6 +1089,8 @@ namespace Velvet
                             // No exit animation → immediate removal (skip emitting; the diff reaps the leaves).
                             state.Exiting.Remove(key);
                             removedInstantThisRender = true;
+                            // Same as the finished-exit drop above: the node leaves the committed set for good.
+                            FiberTreeReturn.ReturnRetiredTree(FiberTreeReturn.NormalizeToArray(node), boundaryFiber);
                             continue;
                         }
 
@@ -1200,6 +1215,18 @@ namespace Velvet
                     {
                         var wasExiting = state.Exiting.Remove(key);
                         var wasExitComplete = state.ExitComplete.Remove(key);
+                        if (wasExiting || wasExitComplete)
+                        {
+                            // The re-entry replaces the ghost's node in the committed set. The OLD node was
+                            // kept alive only by presence bookkeeping (a ghost is never part of the boundary's
+                            // own render output), so this replacement is its last reference — retire it.
+                            var ghostNode = FindPresenceCommittedNode(prevCommitted, key);
+                            if (ghostNode != null && !ReferenceEquals(ghostNode, node))
+                            {
+                                FiberTreeReturn.ReturnRetiredTree(
+                                    FiberTreeReturn.NormalizeToArray(ghostNode), boundaryFiber);
+                            }
+                        }
                         // The key is present again. If a completed exit's ghost was still awaiting its drop and the
                         // re-entry mounted a FRESH element (the detached ghost can't be reproduced, so the new
                         // anchor differs), its inline fibers escaped the orphan sweep exactly as on the normal drop
@@ -1334,6 +1361,16 @@ namespace Velvet
                 if (list[i].key == key) return true;
             }
             return false;
+        }
+
+        private static VNode? FindPresenceCommittedNode(
+            List<(string key, VNode node)> list, string? key)
+        {
+            for (var i = 0; i < list.Count; i++)
+            {
+                if (list[i].key == key) return list[i].node;
+            }
+            return null;
         }
 
         // AnimatePresenceMode.PopLayout: the instant a child's exit starts, pull it out of layout flow and pin

--- a/Packages/com.velvet.core/Runtime/Reconciler/Reconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Reconciler.cs
@@ -184,25 +184,35 @@ namespace Velvet
                     }
                     finally
                     {
-                        // Always clear the queue at top-level boundary so partially drained passes do
-                        // not leak placeholders into the next reconcile; an abort raised DURING the
-                        // drain (a boundary inside a portal's children) is consumed at this boundary
-                        // the same way.
-                        _ctx.PendingPortalMounts.Clear();
-                        _ctx.IsAborted = false;
-                        // Declaring-resolution misses are scoped to one top-level pass: retrying the
-                        // scan next pass is what lets a late-arriving declaring panel resolve.
-                        _ctx.DeclaringResolveMisses.Clear();
-                        // EffectiveKeys is scoped to one top-level pass. VNode references are fresh
-                        // per render, so unconsumed entries would otherwise accumulate across renders.
-                        _ctx.EffectiveKeys.Clear();
-                        // Return the inline children's old trees (queued by RenderInlineForExpansion) to the
-                        // VNode pool now that the whole pass is done using them as patch baselines — deferred
-                        // to here to avoid a mid-pass use-after-return that duplicates re-expanded subtrees.
-                        FiberTreeReturn.DrainDeferredInlineOldTreeReturns(_ctx);
-                        // Flush releases staged during the pass (AFTER the drain above, which stages more).
-                        VNodePool.EndReleaseScope();
-                        profilerScope.Dispose();
+                        try
+                        {
+                            // Always clear the queue at top-level boundary so partially drained passes do
+                            // not leak placeholders into the next reconcile; an abort raised DURING the
+                            // drain (a boundary inside a portal's children) is consumed at this boundary
+                            // the same way.
+                            _ctx.PendingPortalMounts.Clear();
+                            _ctx.IsAborted = false;
+                            // Declaring-resolution misses are scoped to one top-level pass: retrying the
+                            // scan next pass is what lets a late-arriving declaring panel resolve.
+                            _ctx.DeclaringResolveMisses.Clear();
+                            // EffectiveKeys is scoped to one top-level pass. VNode references are fresh
+                            // per render, so unconsumed entries would otherwise accumulate across renders.
+                            _ctx.EffectiveKeys.Clear();
+                            // Return the inline children's old trees (queued by RenderInlineForExpansion) to the
+                            // VNode pool now that the whole pass is done using them as patch baselines — deferred
+                            // to here to avoid a mid-pass use-after-return that duplicates re-expanded subtrees.
+                            FiberTreeReturn.DrainDeferredInlineOldTreeReturns(_ctx);
+                        }
+                        finally
+                        {
+                            // Flush releases staged during the pass (AFTER the drain above, which stages
+                            // more). Guaranteed even if the drain throws (its mark pass can execute a user
+                            // IReadOnlyList via the slot probes): a skipped flush would wedge the pool in
+                            // staging mode for the process lifetime — every later return staged, never
+                            // flushed, pools starving — with no recovery outside the editor's domain reload.
+                            VNodePool.EndReleaseScope();
+                            profilerScope.Dispose();
+                        }
                     }
                 }
             }

--- a/Packages/com.velvet.core/Runtime/Reconciler/Reconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Reconciler.cs
@@ -153,6 +153,10 @@ namespace Velvet
             if (isTopLevel)
             {
                 profilerScope = s_reconcileMarker.Auto();
+                // Stage pooled-object releases for the span of the pass so nothing retired mid-pass
+                // (a boundary fallback swap, a mid-pass unmount) can be re-rented by a later factory
+                // call in the SAME pass — see VNodePool's staging region.
+                VNodePool.BeginReleaseScope();
             }
 
             _ctx.SharedReconcileDepth++;
@@ -196,6 +200,8 @@ namespace Velvet
                         // VNode pool now that the whole pass is done using them as patch baselines — deferred
                         // to here to avoid a mid-pass use-after-return that duplicates re-expanded subtrees.
                         FiberTreeReturn.DrainDeferredInlineOldTreeReturns(_ctx);
+                        // Flush releases staged during the pass (AFTER the drain above, which stages more).
+                        VNodePool.EndReleaseScope();
                         profilerScope.Dispose();
                     }
                 }
@@ -237,6 +243,9 @@ namespace Velvet
             // without the probe a discrete event dispatched synchronously inside a slice would
             // re-enter the reconciler on the stack.
             _ctx.SharedReconcileDepth++;
+            // A resume slice rents and returns pooled objects like the original pass, so it gets the
+            // same release staging bracket (nested entries are depth-counted inside VNodePool).
+            VNodePool.BeginReleaseScope();
             try
             {
                 // Indexed and Keyed never become pending simultaneously (the other is cleared when a new
@@ -252,6 +261,7 @@ namespace Velvet
             }
             finally
             {
+                VNodePool.EndReleaseScope();
                 _ctx.SharedReconcileDepth--;
             }
         }
@@ -401,7 +411,7 @@ namespace Velvet
             _ctx.StyleAnimationScheduler.CancelAll();
             _ctx.EventManager.Clear();
             _ctx.ComponentRegistry.Dispose();
-            _ctx.FiberMemoCache.Clear();
+            _ctx.FiberMemoCache.DisposeAndReturnCachedTrees();
             _ctx.WrapperToInnerMap.Clear();
             // Shadowed elements hold paint + re-bake callbacks: detach so a still-mounted element released at
             // root disposal carries no Velvet residue. Then dispose the shared bake Material once (the baked

--- a/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
@@ -544,8 +544,9 @@ namespace Velvet
         // subtree instead of patching it (the subtree visibly duplicates). Deferring the return to the
         // top-level finally keeps the nodes alive for the whole pass (so the baseline stays intact and no
         // renter can alias them) while still pooling them for the next pass — no added GC pressure.
-        // Drained and cleared at the end of every top-level Reconcile.
-        public List<VNode?[]> DeferredInlineOldTreeReturns { get; } = new();
+        // Each entry carries the owning fiber so the drain-time sweep can mark that fiber's committed
+        // tree (and memoized roots) live. Drained and cleared at the end of every top-level Reconcile.
+        public List<(VNode?[] Tree, ComponentFiber Owner)> DeferredInlineOldTreeReturns { get; } = new();
 
         // Cleanup callback returned from a callback ref (BaseElementNode.RefCallback).
         // Fires when the element detaches from the DOM, releasing resources such as

--- a/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
@@ -545,8 +545,18 @@ namespace Velvet
         // top-level finally keeps the nodes alive for the whole pass (so the baseline stays intact and no
         // renter can alias them) while still pooling them for the next pass — no added GC pressure.
         // Each entry carries the owning fiber so the drain-time sweep can mark that fiber's committed
-        // tree (and memoized roots) live. Drained and cleared at the end of every top-level Reconcile.
+        // tree (and memoized roots) live. Drained and cleared at the end of every top-level Reconcile;
+        // a fiber unmounting mid-pass takes its own entries with it (FiberRenderer.Unmount) so they are
+        // swept while its committed state and parent chain are still intact rather than after teardown
+        // emptied the mark roots.
         public List<(VNode?[] Tree, ComponentFiber Owner)> DeferredInlineOldTreeReturns { get; } = new();
+
+        // Fibers whose time-sliced reconcile is parked with a PendingOldTree baseline. A paused pass
+        // keeps reading that baseline across frames, so every retirement sweep marks these baselines
+        // live — another fiber retiring in between must not recycle nodes a parked diff still reads
+        // (memo hits legitimately share instances across fibers' trees). Maintained by the park /
+        // resume / unmount paths; a stale leftover entry only over-spares (leak-safe direction).
+        internal HashSet<ComponentFiber> ParkedBaselineFibers { get; } = new();
 
         // Cleanup callback returned from a callback ref (BaseElementNode.RefCallback).
         // Fires when the element detaches from the DOM, releasing resources such as

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/RenderedTreePropsRecycleTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/RenderedTreePropsRecycleTests.cs
@@ -111,6 +111,11 @@ namespace Velvet.Tests
             return OwnedPropsCount() - baseline;
         }
 
+        // The bound is a small constant, NOT a fraction of RerenderCount: the contract is binary
+        // (retired bags round-trip, or the broken path leaks one per render), and a ratio would
+        // green-light a partial regression that leaks on every other render.
+        private const int OwnedGrowthTolerance = 2;
+
         [Test]
         public void Given_ATopLevelPropsRentingElement_When_TheTreeRerendersRepeatedly_Then_TheOwnershipSetDoesNotGrowPerRender()
         {
@@ -118,7 +123,7 @@ namespace Velvet.Tests
             var growth = MeasureOwnedGrowth(() => V.Component(TopLevelRenter, key: "top"));
 
             // Assert — retired bags round-trip through the pool instead of accumulating one per render.
-            Assert.That(growth, Is.LessThan(RerenderCount / 2),
+            Assert.That(growth, Is.LessThanOrEqualTo(OwnedGrowthTolerance),
                 "A top-level element's rented props bag must return to the pool when its tree is retired");
         }
 
@@ -129,7 +134,7 @@ namespace Velvet.Tests
             var growth = MeasureOwnedGrowth(() => V.Component(NestedRenter, key: "nested"));
 
             // Assert
-            Assert.That(growth, Is.LessThan(RerenderCount / 2),
+            Assert.That(growth, Is.LessThanOrEqualTo(OwnedGrowthTolerance),
                 "A nested element's rented props bag must return to the pool when its tree is retired");
         }
 
@@ -140,8 +145,32 @@ namespace Velvet.Tests
             var growth = MeasureOwnedGrowth(() => V.Component(PortalRenter, key: "portal"));
 
             // Assert
-            Assert.That(growth, Is.LessThan(RerenderCount / 2),
+            Assert.That(growth, Is.LessThanOrEqualTo(OwnedGrowthTolerance),
                 "A Portal-child element's rented props bag must return to the pool when its tree is retired");
+        }
+
+        // A V.Memoized whose deps CHANGE every render: each miss replaces the cached inner tree,
+        // and the replaced subtree's rented bag must flow back to the pool (the memo wrapper is
+        // opaque to the tree walk, so the cache's own replace path is its only retirement point).
+        [Component]
+        private static VNode DepsChangingMemoRenter()
+        {
+            var count = Hooks.UseStore(s_store, x => x);
+            return V.Div(name: "memo-churn", children: new VNode[]
+            {
+                V.Memoized(() => V.Button(text: "memo-" + count), count),
+            });
+        }
+
+        [Test]
+        public void Given_AMemoizedSubtreeWhoseDepsChangeEveryRender_When_TheCacheRecomputes_Then_TheReplacedInnerBagsReturnToThePool()
+        {
+            // Arrange / Act — every re-render misses the memo cache and replaces the inner tree.
+            var growth = MeasureOwnedGrowth(() => V.Component(DepsChangingMemoRenter, key: "memo-churn"));
+
+            // Assert — the replaced inner subtree's bag is retired on each recompute, not stranded.
+            Assert.That(growth, Is.LessThanOrEqualTo(OwnedGrowthTolerance),
+                "A replaced memo inner tree's rented props bag must return to the pool");
         }
 
         #endregion
@@ -227,6 +256,129 @@ namespace Velvet.Tests
             // not have been recycled by the hiding render's sweep.
             Assert.That(PropsPoolContains(slotHeldBag), Is.False,
                 "A UseMemo-held node's props bag must not be returned while the slot can re-emit it");
+        }
+
+        // React's element-in-state pattern: a node seeded into UseState and rendered conditionally
+        // re-enters the output from the STATE slot, so the hiding render's sweep must spare it.
+        [Component]
+        private static VNode StateHeldHost()
+        {
+            var count = Hooks.UseStore(s_store, x => x);
+            var (kept, _) = Hooks.UseState(() => s_capturedMemoNode = V.Button(text: "state-kept"));
+            return V.Div(name: "state-host", children: new VNode[]
+            {
+                V.Label(text: "count-" + count),
+                count % 2 == 0 ? kept : null,
+            });
+        }
+
+        [Test]
+        public void Given_AUseStateHeldSubtreeToggledOutOfTheOutput_When_TheHidingRenderRetiresTheOldTree_Then_TheSlotHeldBagStaysOutOfThePool()
+        {
+            // Arrange — mounted with the state-held subtree visible (count 0).
+            using var store = new CounterStore();
+            s_store = store;
+            using var mounted = V.Mount(_root, V.Component(StateHeldHost, key: "state-host"));
+            var scheduler = mounted.Root.Reconciler.Context.BatchScheduler;
+            var slotHeldBag = ((ElementNode)s_capturedMemoNode).Props;
+            Assume.That(slotHeldBag, Is.Not.Null, "Precondition: the state-held button rented a props bag");
+
+            // Act — count 1 hides the subtree.
+            store.Increment();
+            scheduler.DrainImmediateForTest();
+
+            // Assert — the state slot re-emits the node on the comeback render, so its bag must survive.
+            Assert.That(PropsPoolContains(slotHeldBag), Is.False,
+                "A UseState-held node's props bag must not be returned while the slot can re-emit it");
+        }
+
+        // A memoized LIST of nodes (List<VNode> satisfies the covariant IReadOnlyList probe) toggled
+        // out and back: the slot protection must see through the list wrapper.
+        [Component]
+        private static VNode ListMemoHost()
+        {
+            var count = Hooks.UseStore(s_store, x => x);
+            var kept = Hooks.UseMemo(() =>
+            {
+                s_capturedMemoNode = V.Button(text: "list-kept");
+                return new System.Collections.Generic.List<VNode> { s_capturedMemoNode };
+            }, 1);
+            return V.Div(name: "list-host", children: new VNode[]
+            {
+                V.Label(text: "count-" + count),
+                count % 2 == 0 ? kept[0] : null,
+            });
+        }
+
+        [Test]
+        public void Given_AUseMemoHeldListOfSubtrees_When_TheHidingRenderRetiresTheOldTree_Then_TheListedBagStaysOutOfThePool()
+        {
+            // Arrange
+            using var store = new CounterStore();
+            s_store = store;
+            using var mounted = V.Mount(_root, V.Component(ListMemoHost, key: "list-host"));
+            var scheduler = mounted.Root.Reconciler.Context.BatchScheduler;
+            var listedBag = ((ElementNode)s_capturedMemoNode).Props;
+            Assume.That(listedBag, Is.Not.Null, "Precondition: the listed button rented a props bag");
+
+            // Act — count 1 hides the subtree.
+            store.Increment();
+            scheduler.DrainImmediateForTest();
+
+            // Assert
+            Assert.That(PropsPoolContains(listedBag), Is.False,
+                "A node held via a memoized list must not have its bag returned while the slot can re-emit it");
+        }
+
+        // An exiting AnimatePresence ghost: the removal render retires the tree that last emitted
+        // the child, but presence bookkeeping keeps re-emitting the SAME node as the old-side
+        // baseline until the exit animation completes — so the sweep must spare the ghost subtree.
+        private static readonly System.Collections.Generic.Dictionary<string, string> s_fade = new()
+        {
+            ["visible"] = "opacity-100",
+            ["hidden"] = "opacity-0",
+        };
+
+        [Component]
+        private static VNode PresenceHost()
+        {
+            var count = Hooks.UseStore(s_store, x => x);
+            var children = new System.Collections.Generic.List<VNode>
+            {
+                V.Motion(name: "item-a", key: "a", variants: s_fade, animate: "visible", exit: "hidden",
+                    transition: new StyleTransitionConfig { DurationSec = 0.3f }),
+            };
+            if (count == 0)
+            {
+                children.Add(V.Motion(name: "item-b", key: "b", variants: s_fade, animate: "visible", exit: "hidden",
+                    transition: new StyleTransitionConfig { DurationSec = 0.3f },
+                    children: new VNode[] { s_capturedMemoNode = V.Button(text: "ghost-content") }));
+            }
+            return V.Div(name: "presence-host", children: new VNode[]
+            {
+                V.AnimatePresence(key: "presence", children: children.ToArray()),
+            });
+        }
+
+        [Test]
+        public void Given_AKeyedChildWithAnExitAnimation_When_ItsRemovalRenderRetiresTheOldTree_Then_TheGhostBagStaysOutOfThePool()
+        {
+            // Arrange — both children mounted; the ghost content's bag is captured at mount.
+            using var store = new CounterStore();
+            s_store = store;
+            using var mounted = V.Mount(_root, V.Component(PresenceHost, key: "presence-host"));
+            var scheduler = mounted.Root.Reconciler.Context.BatchScheduler;
+            var ghostBag = ((ElementNode)s_capturedMemoNode).Props;
+            Assume.That(ghostBag, Is.Not.Null, "Precondition: the ghost's button rented a props bag");
+
+            // Act — remove the keyed child; its exit animation keeps it mounted as a ghost whose node
+            // the presence bookkeeping re-reads until the exit finishes.
+            store.Increment();
+            scheduler.DrainImmediateForTest();
+
+            // Assert — the ghost subtree's bag was spared by the removal render's sweep.
+            Assert.That(PropsPoolContains(ghostBag), Is.False,
+                "An exiting ghost's props bag must not be returned while presence state still reads its node");
         }
 
         #endregion

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/RenderedTreePropsRecycleTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/RenderedTreePropsRecycleTests.cs
@@ -1,0 +1,234 @@
+using System.Collections.Generic;
+using System.Reflection;
+using NUnit.Framework;
+using UnityEngine.UIElements;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins the recycle contract for factory-rented <see cref="FiberElementProps"/> bags across
+    /// re-renders, in both directions.
+    /// <list type="bullet">
+    /// <item>Depth: a bag rented by a V.* factory for one committed tree must flow back to
+    /// <see cref="VNodePool"/> when that tree is retired, wherever the element sits — at the top
+    /// level of the fiber's tree, nested under an element, or under a Portal's children. A bag that
+    /// never returns is pinned forever by the pool's ownership identity set (one stranded bag per
+    /// render of that subtree) and starves the pool for sibling factories.</item>
+    /// <item>Sharing: memoization legitimately carries the SAME node instances across consecutive
+    /// trees (a memo hit, a deps-stable <c>Hooks.UseMemo</c> subtree toggled out of the output and
+    /// back), so the recursive recycle must spare anything the committed state still reaches —
+    /// returning it would let an unrelated mount rent and overwrite a live baseline.</item>
+    /// </list>
+    /// </summary>
+    [TestFixture]
+    internal sealed class RenderedTreePropsRecycleTests
+    {
+        private const int RerenderCount = 20;
+
+        // The pool's ownership identity set and pooled stack are deliberately private (production
+        // code exposes no test hooks); the probes read them via reflection from the test side.
+        private static int OwnedPropsCount()
+        {
+            var field = typeof(VNodePool).GetField("s_ownedProps", BindingFlags.NonPublic | BindingFlags.Static);
+            return ((HashSet<FiberElementProps>)field.GetValue(null)).Count;
+        }
+
+        private static bool PropsPoolContains(FiberElementProps props)
+        {
+            var field = typeof(VNodePool).GetField("s_propsPool", BindingFlags.NonPublic | BindingFlags.Static);
+            return ((Stack<FiberElementProps>)field.GetValue(null)).Contains(props);
+        }
+
+        private sealed class CounterStore : Store<int>
+        {
+            public CounterStore() : base(0) { }
+            public void Increment() => SetState(x => x + 1);
+            protected override void ResetCore() => SetState(_ => 0);
+        }
+
+        private static CounterStore s_store;
+        private static VNode s_capturedMemoNode;
+
+        private VisualElement _root;
+        private VisualElement _portalTarget;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _root = new VisualElement();
+            _portalTarget = new VisualElement();
+            FiberPortalRegistry.Clear();
+            FiberPortalRegistry.Register("props-recycle-probe", _portalTarget);
+            s_store = null;
+            s_capturedMemoNode = null;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            FiberPortalRegistry.Clear();
+        }
+
+        #region depth: retired bags return from every nesting position
+
+        // Each body renders exactly one props-renting element (Button with text) so the ownership
+        // set's growth isolates that single bag's return path. The counter is woven into the text
+        // so every store write produces a genuinely different tree (no memo bail).
+
+        [Component]
+        private static VNode TopLevelRenter()
+        {
+            var count = Hooks.UseStore(s_store, x => x);
+            return V.Button(text: "top-" + count);
+        }
+
+        [Component]
+        private static VNode NestedRenter()
+        {
+            var count = Hooks.UseStore(s_store, x => x);
+            return V.Div(name: "wrap", children: new VNode[] { V.Button(text: "nested-" + count) });
+        }
+
+        [Component]
+        private static VNode PortalRenter()
+        {
+            var count = Hooks.UseStore(s_store, x => x);
+            return V.Portal("props-recycle-probe", children: new VNode[] { V.Button(text: "portal-" + count) });
+        }
+
+        private int MeasureOwnedGrowth(System.Func<VNode> body)
+        {
+            using var store = new CounterStore();
+            s_store = store;
+            using var mounted = V.Mount(_root, body());
+            var scheduler = mounted.Root.Reconciler.Context.BatchScheduler;
+            var baseline = OwnedPropsCount();
+            for (var i = 0; i < RerenderCount; i++)
+            {
+                store.Increment();
+                scheduler.DrainImmediateForTest();
+            }
+            return OwnedPropsCount() - baseline;
+        }
+
+        [Test]
+        public void Given_ATopLevelPropsRentingElement_When_TheTreeRerendersRepeatedly_Then_TheOwnershipSetDoesNotGrowPerRender()
+        {
+            // Arrange / Act — twenty re-renders, each renting a fresh bag for the new tree.
+            var growth = MeasureOwnedGrowth(() => V.Component(TopLevelRenter, key: "top"));
+
+            // Assert — retired bags round-trip through the pool instead of accumulating one per render.
+            Assert.That(growth, Is.LessThan(RerenderCount / 2),
+                "A top-level element's rented props bag must return to the pool when its tree is retired");
+        }
+
+        [Test]
+        public void Given_APropsRentingElementNestedUnderAnElement_When_TheTreeRerendersRepeatedly_Then_TheOwnershipSetDoesNotGrowPerRender()
+        {
+            // Arrange / Act
+            var growth = MeasureOwnedGrowth(() => V.Component(NestedRenter, key: "nested"));
+
+            // Assert
+            Assert.That(growth, Is.LessThan(RerenderCount / 2),
+                "A nested element's rented props bag must return to the pool when its tree is retired");
+        }
+
+        [Test]
+        public void Given_APropsRentingElementUnderPortalChildren_When_TheTreeRerendersRepeatedly_Then_TheOwnershipSetDoesNotGrowPerRender()
+        {
+            // Arrange / Act
+            var growth = MeasureOwnedGrowth(() => V.Component(PortalRenter, key: "portal"));
+
+            // Assert
+            Assert.That(growth, Is.LessThan(RerenderCount / 2),
+                "A Portal-child element's rented props bag must return to the pool when its tree is retired");
+        }
+
+        #endregion
+
+        #region sharing: committed state is spared by the sweep
+
+        // A child whose only hook input never changes: the compiler's auto-memo hits on every
+        // parent-driven re-render and returns the SAME committed tree instance, so the child's old
+        // and new tree are one object graph and the retire sweep must spare all of it. The capture
+        // runs only on the miss render (a hit returns the cached tree before the body executes).
+        [Component]
+        private static VNode AutoMemoHitChild()
+        {
+            var (staticValue, _) = Hooks.UseState(0);
+            s_capturedMemoNode = V.Button(text: "auto-memo-" + staticValue);
+            return s_capturedMemoNode;
+        }
+
+        [Component]
+        private static VNode AutoMemoHitParent()
+        {
+            var count = Hooks.UseStore(s_store, x => x);
+            return V.Div(name: "host", children: new VNode[]
+            {
+                V.Label(text: "count-" + count),
+                V.Component(AutoMemoHitChild, key: "child"),
+            });
+        }
+
+        [Test]
+        public void Given_AChildWhoseAutoMemoHitsOnParentRerenders_When_TheChildOldTreeRetires_Then_TheSharedBagStaysOutOfThePool()
+        {
+            // Arrange — a mounted parent whose child returns the same cached tree on every re-render.
+            using var store = new CounterStore();
+            s_store = store;
+            using var mounted = V.Mount(_root, V.Component(AutoMemoHitParent, key: "memo-host"));
+            var scheduler = mounted.Root.Reconciler.Context.BatchScheduler;
+            var sharedBag = ((ElementNode)s_capturedMemoNode).Props;
+            Assume.That(sharedBag, Is.Not.Null, "Precondition: the memoized button rented a props bag");
+
+            // Act — two re-renders, each retiring a child old tree that IS the committed tree.
+            store.Increment();
+            scheduler.DrainImmediateForTest();
+            store.Increment();
+            scheduler.DrainImmediateForTest();
+
+            // Assert — the shared bag was never recycled out from under the committed tree.
+            Assert.That(PropsPoolContains(sharedBag), Is.False,
+                "A memo-shared node's props bag must not be returned while the committed tree still holds it");
+        }
+
+        // A deps-stable Hooks.UseMemo subtree that leaves the output on odd counts: the render that
+        // hides it retires an old tree still embedding the memoized node, and the node re-enters the
+        // output two renders later — so the slot-held instance must survive the sweep untouched.
+        [Component]
+        private static VNode ToggledMemoHost()
+        {
+            var count = Hooks.UseStore(s_store, x => x);
+            var kept = Hooks.UseMemo(() => s_capturedMemoNode = V.Button(text: "kept"), 1);
+            return V.Div(name: "toggle-host", children: new VNode[]
+            {
+                V.Label(text: "count-" + count),
+                count % 2 == 0 ? kept : null,
+            });
+        }
+
+        [Test]
+        public void Given_AUseMemoHeldSubtreeToggledOutOfTheOutput_When_TheHidingRenderRetiresTheOldTree_Then_TheSlotHeldBagStaysOutOfThePool()
+        {
+            // Arrange — mounted with the memoized subtree visible (count 0).
+            using var store = new CounterStore();
+            s_store = store;
+            using var mounted = V.Mount(_root, V.Component(ToggledMemoHost, key: "toggle-host"));
+            var scheduler = mounted.Root.Reconciler.Context.BatchScheduler;
+            var slotHeldBag = ((ElementNode)s_capturedMemoNode).Props;
+            Assume.That(slotHeldBag, Is.Not.Null, "Precondition: the memoized button rented a props bag");
+
+            // Act — count 1 hides the subtree; the retiring old tree still embeds the slot-held node.
+            store.Increment();
+            scheduler.DrainImmediateForTest();
+
+            // Assert — the UseMemo slot still owns the node for its comeback render, so its bag must
+            // not have been recycled by the hiding render's sweep.
+            Assert.That(PropsPoolContains(slotHeldBag), Is.False,
+                "A UseMemo-held node's props bag must not be returned while the slot can re-emit it");
+        }
+
+        #endregion
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/RenderedTreePropsRecycleTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/RenderedTreePropsRecycleTests.cs
@@ -33,10 +33,13 @@ namespace Velvet.Tests
             return ((HashSet<FiberElementProps>)field.GetValue(null)).Count;
         }
 
-        private static bool PropsPoolContains(FiberElementProps props)
+        // "Still rented out" is the spare-direction probe: a wrongly swept bag leaves the ownership
+        // set even when the pool is at capacity and drops it (a pool-content probe would read false
+        // either way, going green exactly when the pool is warm).
+        private static bool OwnedPropsContains(FiberElementProps props)
         {
-            var field = typeof(VNodePool).GetField("s_propsPool", BindingFlags.NonPublic | BindingFlags.Static);
-            return ((Stack<FiberElementProps>)field.GetValue(null)).Contains(props);
+            var field = typeof(VNodePool).GetField("s_ownedProps", BindingFlags.NonPublic | BindingFlags.Static);
+            return ((HashSet<FiberElementProps>)field.GetValue(null)).Contains(props);
         }
 
         private sealed class CounterStore : Store<int>
@@ -218,8 +221,8 @@ namespace Velvet.Tests
             scheduler.DrainImmediateForTest();
 
             // Assert — the shared bag was never recycled out from under the committed tree.
-            Assert.That(PropsPoolContains(sharedBag), Is.False,
-                "A memo-shared node's props bag must not be returned while the committed tree still holds it");
+            Assert.That(OwnedPropsContains(sharedBag), Is.True,
+                "A memo-shared node's props bag must stay rented out while the committed tree still holds it");
         }
 
         // A deps-stable Hooks.UseMemo subtree that leaves the output on odd counts: the render that
@@ -254,8 +257,8 @@ namespace Velvet.Tests
 
             // Assert — the UseMemo slot still owns the node for its comeback render, so its bag must
             // not have been recycled by the hiding render's sweep.
-            Assert.That(PropsPoolContains(slotHeldBag), Is.False,
-                "A UseMemo-held node's props bag must not be returned while the slot can re-emit it");
+            Assert.That(OwnedPropsContains(slotHeldBag), Is.True,
+                "A UseMemo-held node's props bag must stay rented out while the slot can re-emit it");
         }
 
         // React's element-in-state pattern: a node seeded into UseState and rendered conditionally
@@ -288,8 +291,8 @@ namespace Velvet.Tests
             scheduler.DrainImmediateForTest();
 
             // Assert — the state slot re-emits the node on the comeback render, so its bag must survive.
-            Assert.That(PropsPoolContains(slotHeldBag), Is.False,
-                "A UseState-held node's props bag must not be returned while the slot can re-emit it");
+            Assert.That(OwnedPropsContains(slotHeldBag), Is.True,
+                "A UseState-held node's props bag must stay rented out while the slot can re-emit it");
         }
 
         // A memoized LIST of nodes (List<VNode> satisfies the covariant IReadOnlyList probe) toggled
@@ -326,8 +329,8 @@ namespace Velvet.Tests
             scheduler.DrainImmediateForTest();
 
             // Assert
-            Assert.That(PropsPoolContains(listedBag), Is.False,
-                "A node held via a memoized list must not have its bag returned while the slot can re-emit it");
+            Assert.That(OwnedPropsContains(listedBag), Is.True,
+                "A node held via a memoized list must stay rented out while the slot can re-emit it");
         }
 
         // An exiting AnimatePresence ghost: the removal render retires the tree that last emitted
@@ -377,8 +380,51 @@ namespace Velvet.Tests
             scheduler.DrainImmediateForTest();
 
             // Assert — the ghost subtree's bag was spared by the removal render's sweep.
-            Assert.That(PropsPoolContains(ghostBag), Is.False,
-                "An exiting ghost's props bag must not be returned while presence state still reads its node");
+            Assert.That(OwnedPropsContains(ghostBag), Is.True,
+                "An exiting ghost's props bag must stay rented out while presence state still reads its node");
+        }
+
+        // The return direction of the presence contract: a keyed child WITHOUT an exit animation is
+        // dropped from the presence set the moment it is removed, and that drop is the node's last
+        // reference — its bag must actually flow back (the presence mark protects only LIVE ghosts,
+        // not ones leaving the committed set).
+        [Component]
+        private static VNode InstantRemovalHost()
+        {
+            var count = Hooks.UseStore(s_store, x => x);
+            var children = new System.Collections.Generic.List<VNode>
+            {
+                V.Motion(name: "stay", key: "stay", variants: s_fade, animate: "visible", exit: "hidden",
+                    transition: new StyleTransitionConfig { DurationSec = 0.3f }),
+            };
+            if (count == 0)
+            {
+                children.Add(s_capturedMemoNode = V.Button(text: "instant", key: "instant"));
+            }
+            return V.Div(name: "instant-host", children: new VNode[]
+            {
+                V.AnimatePresence(key: "presence", children: children.ToArray()),
+            });
+        }
+
+        [Test]
+        public void Given_AKeyedChildWithoutAnExitAnimation_When_ItsRemovalDropsItFromThePresenceSet_Then_ItsBagReturnsToThePool()
+        {
+            // Arrange — both children mounted; the instant child's bag is captured at mount.
+            using var store = new CounterStore();
+            s_store = store;
+            using var mounted = V.Mount(_root, V.Component(InstantRemovalHost, key: "instant-host"));
+            var scheduler = mounted.Root.Reconciler.Context.BatchScheduler;
+            var droppedBag = ((ElementNode)s_capturedMemoNode).Props;
+            Assume.That(droppedBag, Is.Not.Null, "Precondition: the instant child rented a props bag");
+
+            // Act — remove the keyed child; with no exit animation it leaves the presence set now.
+            store.Increment();
+            scheduler.DrainImmediateForTest();
+
+            // Assert — the drop actually retired the bag (it left the rented-out set).
+            Assert.That(OwnedPropsContains(droppedBag), Is.False,
+                "A dropped presence child's props bag must be returned when it leaves the committed set");
         }
 
         #endregion

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/RenderedTreePropsRecycleTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/RenderedTreePropsRecycleTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c5c5ba359523148dd974dd1cbad32a32


### PR DESCRIPTION
## Problem

The fiber-tree recycle path only returned the **top level** of a retired tree to `VNodePool`. A factory-rented props bag on any nested element — under another element, or under `V.Portal` / `V.WorldSpace` / `V.Suspense` / provider children — was never returned: the pool's ownership tracking pinned one stranded bag per re-render of that subtree (a probe showed exactly 20 stranded bags across 20 re-renders of `V.Div(V.Button(text:))`, the most common shape there is) while starving the pool for sibling factories. Portal children (#64) were one instance of the general hole.

Two latent corruption paths rode along: an aborted reconcile returned `oldTree`'s pooled parts while `PreviousTree` kept pointing at them, and the editor-only StrictMode double-invoke pass recursively recycled committed subtrees that a memo hit had shared into its discarded diagnostic tree.

## Fix

Recycling is now a **mark-and-sweep at the fiber boundary**:

- **Sweep** — `ReturnRetiredTree` descends every child-bearing node kind (elements, fragments, portals, world-space, suspense children **and fallback**, providers), returning props bags / single-event arrays / child arrays from every nesting level. One shared `WalkChildSlots` switch drives both passes so the kind lists cannot drift.
- **Mark** — nodes still reachable from committed state are spared: the committed and parked baselines, hook-slot-held roots (compiler auto-memo slots, plus `UseMemo` / `UseState` / `UseRef` values that are a node or a list of nodes) along the **logical** ancestor chain (portal-drained fibers hop back to their declaring component), provider values, and exiting `AnimatePresence` ghosts (presence bookkeeping re-reads their nodes until the exit completes).
- **Retirement points that never existed now do** — a replaced `V.Memoized` inner tree, a replaced VNode-valued provider value, memo-cache disposal, presence drop / instant removal / mid-exit re-entry, terminal `Dispose` of element-in-state roots, discarded render-phase attempts, and mid-pass unmounts reclaiming their deferred baselines.
- **Pool lifetime discipline** — ownership is rent-scoped (idempotent returns; double-return can no longer alias one bag to two renters) and releases are **pass-deferred**: a mid-pass return stays un-rentable until the outermost reconcile ends, so a second retirement of a shared object can never recycle a new renter's live bag.

Holding a factory-built node outside the tracked surface (inside a user record/tuple, a component props record, a `Store`) is documented as unsupported on `FiberTreeReturn`.

## Tests

- Ownership-growth probes for top-level / nested / portal-child / memo-churn positions (RED on main: +20 bags per 20 re-renders for nested and portal; GREEN here: ≤2).
- Sharing pins verified RED against a mark-disabled mutation: auto-memo hit trees, `UseMemo`-held subtrees (including `List<VNode>`), element-in-state, exiting presence ghosts.
- Return-direction pins: presence instant-removal actually returns; pool idempotence (props / node / event arrays); release-scope staging visibility and flush.
- Full suites green: EditMode 2850, PlayMode 71.

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)