### PR TITLE
fix: commit-phase state writes schedule instead of vanishing; refs follow React's identity contract

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Callback refs follow React's re-invocation contract: a ref cycles (cleanup, then setup) only
+  when its callback identity changes or the host element remounts — a patch carrying the same
+  delegate no longer re-invokes it on every render, so a reference-stable ref (`Hooks.UseCallback`)
+  installs once and its cleanup means the element is genuinely going away.
+- Hook state writes landing in the COMMIT phase of the same fiber's flush (a callback ref invoked
+  during a patch, an event dispatched from a detach) are no longer silently discarded: the
+  render-phase-update window now covers only the component body, so commit-phase writes schedule an
+  ordinary follow-up render — and the frame's batch drain keeps draining until the queue is quiet
+  (React's setState-in-commit semantics), capped at React's maximum update depth of 50. A runaway
+  commit-phase loop logs an error and defers the remainder to the next frame instead of throwing,
+  so one component's loop cannot abandon the rest of the batch. Dropped writes used to desync the
+  slot value from the committed UI and poison the setter's equality bail for the next genuine edge
+  with the same value; `Hooks.UseFocusRing` sheds its deferred-correction workaround accordingly
+  (its cleanup now writes the flags directly).
+
 - The fiber-tree recycle path now returns factory-rented props bags / event arrays / child arrays
   from EVERY nesting level of a retired tree — previously only the top level was recycled, so any
   props-carrying element nested under another element (or under `V.Portal` / `V.WorldSpace` /

--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -29,8 +29,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   frame, while a drop keeps every other component's work alive. Dropped writes used to desync the
   slot value from the committed UI and poison the setter's equality bail for the next genuine edge
   with the same value; `Hooks.UseFocusRing` sheds its deferred-correction workaround accordingly
-  (its cleanup writes the flags directly, and its setup seeds an already-focused element so a ref
-  composed in a per-render lambda cannot strand the ring dark).
+  (its cleanup writes the flags directly; when composing its `Ref` with other per-element work,
+  wrap the composed lambda in `Hooks.UseCallback` — a fresh-identity ref cycling per patch is the
+  same re-render feedback an inline ref writing state produces in React).
 
 - The fiber-tree recycle path now returns factory-rented props bags / event arrays / child arrays
   from EVERY nesting level of a retired tree — previously only the top level was recycled, so any

--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -12,17 +12,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Callback refs follow React's re-invocation contract: a ref cycles (cleanup, then setup) only
   when its callback identity changes or the host element remounts — a patch carrying the same
   delegate no longer re-invokes it on every render, so a reference-stable ref (`Hooks.UseCallback`)
-  installs once and its cleanup means the element is genuinely going away.
+  installs once and its cleanup means the element is genuinely going away. `Ref<T>.SetElement` is
+  now an identity-stable delegate for the Ref's lifetime (a method group converted to a fresh
+  delegate per render, so the object-ref pattern could never benefit from the gate), hook calls
+  from commit-phase code fail fast with the invalid-hook-call error instead of corrupting the slot
+  cursor, and reconciler disposal detaches every still-installed ref that a diverged teardown
+  skipped.
 - Hook state writes landing in the COMMIT phase of the same fiber's flush (a callback ref invoked
   during a patch, an event dispatched from a detach) are no longer silently discarded: the
   render-phase-update window now covers only the component body, so commit-phase writes schedule an
-  ordinary follow-up render — and the frame's batch drain keeps draining until the queue is quiet
-  (React's setState-in-commit semantics), capped at React's maximum update depth of 50. A runaway
-  commit-phase loop logs an error and defers the remainder to the next frame instead of throwing,
-  so one component's loop cannot abandon the rest of the batch. Dropped writes used to desync the
+  ordinary follow-up render — and the flush keeps draining until the queue is quiet (React's
+  setState-in-commit semantics) whichever entry point ran it: the frame drain, a delayed-tier
+  drain, a discrete-event flush, or the initial mount. Runaway commit-phase loops hit React's
+  maximum update depth (50); the overflow logs an error and DROPS the runaway update instead of
+  throwing — a throw here cannot reach an error boundary and a deferred runaway would re-arm every
+  frame, while a drop keeps every other component's work alive. Dropped writes used to desync the
   slot value from the committed UI and poison the setter's equality bail for the next genuine edge
   with the same value; `Hooks.UseFocusRing` sheds its deferred-correction workaround accordingly
-  (its cleanup now writes the flags directly).
+  (its cleanup writes the flags directly, and its setup seeds an already-focused element so a ref
+  composed in a per-render lambda cannot strand the ring dark).
 
 - The fiber-tree recycle path now returns factory-rented props bags / event arrays / child arrays
   from EVERY nesting level of a retired tree — previously only the top level was recycled, so any

--- a/Packages/com.velvet.core/Runtime/Component/ComponentFiber.cs
+++ b/Packages/com.velvet.core/Runtime/Component/ComponentFiber.cs
@@ -164,6 +164,18 @@ namespace Velvet
         /// </summary>
         public bool IsRendering { get; internal set; }
 
+        /// <summary>
+        /// True only while the component BODY is on the stack (a render-phase-loop attempt or the
+        /// StrictMode diagnostic invocation) — a strict subset of <see cref="IsRendering"/>, which
+        /// spans the whole render-and-commit flush. The distinction decides what a setter for this
+        /// fiber's own state means: inside the body it is a render-phase update (discard the
+        /// attempt and re-run), while later in the same flush (a callback ref invoked during the
+        /// patch, an event dispatched from a detach) it schedules an ordinary follow-up render —
+        /// treating commit-phase writes as render-phase ones silently discarded them, desyncing the
+        /// slot value from the committed UI and poisoning the setter's equality bail.
+        /// </summary>
+        internal bool IsInRenderPhase;
+
 #if UNITY_EDITOR
         /// <summary>
         /// Set only while the StrictMode diagnostic (throwaway second) render runs. Hooks consult this to

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/VNodePoolZeroAllocTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/VNodePoolZeroAllocTests.cs
@@ -46,42 +46,49 @@ namespace Velvet.Tests.Performance
             }
         }
 
+        // Warming must include the measured DELEGATE itself, not just the pool: the first execution
+        // of a code path can charge one-time runtime work (JIT, lazy statics) to the measuring
+        // scope, which surfaced as a rare order-sensitive false red on this guard.
+
         [Test]
         public void Given_WarmPropsPool_When_RentReturnCycle_Then_DoesNotAllocate()
         {
-            // Warm: the first rent/return populates the pool so later cycles reuse the instance.
-            VNodePool.ReturnProps(VNodePool.RentProps());
-
-            Assert.That(() =>
+            // Warm: the first cycle populates the pool AND runs the measured delegate once.
+            NUnit.Framework.TestDelegate cycle = () =>
             {
                 var props = VNodePool.RentProps();
                 VNodePool.ReturnProps(props);
-            }, Is.Not.AllocatingGCMemory());
+            };
+            cycle();
+
+            Assert.That(cycle, Is.Not.AllocatingGCMemory());
         }
 
         [Test]
         public void Given_WarmSingleEventArrayPool_When_RentReturnCycle_Then_DoesNotAllocate()
         {
-            VNodePool.ReturnEventArray(VNodePool.RentSingleEventArray());
-
-            Assert.That(() =>
+            NUnit.Framework.TestDelegate cycle = () =>
             {
                 var events = VNodePool.RentSingleEventArray();
                 VNodePool.ReturnEventArray(events);
-            }, Is.Not.AllocatingGCMemory());
+            };
+            cycle();
+
+            Assert.That(cycle, Is.Not.AllocatingGCMemory());
         }
 
         [Test]
         public void Given_WarmNodeArrayPool_When_RentReturnCycle_Then_DoesNotAllocate()
         {
-            // Warm the length-keyed bucket (first call allocates the array, the dictionary entry and the stack).
-            VNodePool.ReturnNodeArray(VNodePool.RentNodeArray(4));
-
-            Assert.That(() =>
+            // The first cycle also warms the length-keyed bucket (array, dictionary entry, stack).
+            NUnit.Framework.TestDelegate cycle = () =>
             {
                 var array = VNodePool.RentNodeArray(4);
                 VNodePool.ReturnNodeArray(array);
-            }, Is.Not.AllocatingGCMemory());
+            };
+            cycle();
+
+            Assert.That(cycle, Is.Not.AllocatingGCMemory());
         }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Hooks/HookGuard.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/HookGuard.cs
@@ -7,9 +7,14 @@ namespace Velvet
         // Throws when a hook is invoked outside of a Render() context.
         // Called from the Hooks static class.
         // fiber == null means there is no Current on FiberAmbientStack, i.e. we are outside Render().
+        // The gate is the render-phase WINDOW (the body on the stack), not the whole flush: the
+        // commit phase legitimately runs user code (callback refs) with the ambient fiber still
+        // pushed, and a hook call from there must fail fast here — the cursor is parked past the
+        // settled body's reads, so letting it through would append a slot and shift the next
+        // render's positional pairing, surfacing one render later as a misleading count mismatch.
         internal static void ThrowIfNotRendering(ComponentFiber? fiber, string hookName)
         {
-            if (fiber == null || !fiber.IsRendering)
+            if (fiber == null || !fiber.IsInRenderPhase)
             {
                 var typeName = fiber?.Body?.Method?.Name ?? "[Component]";
                 throw new InvalidOperationException(

--- a/Packages/com.velvet.core/Runtime/Hooks/Hooks.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Hooks.cs
@@ -1104,6 +1104,18 @@ namespace Velvet
                     }
                 });
                 signals.Hook(element, seedChecked: false, registerChecked: false);
+                // Seed: the signals are edge-driven, so hooking an element that ALREADY holds focus
+                // raises no Focus edge. A ref composed inside a per-render lambda cycles on every
+                // patch (fresh identity), and its cleanup below writes the flags false on the
+                // still-focused element — without this seed the ring would go dark and stay dark
+                // until a real blur+refocus. Focus-visible is deliberately NOT seeded: the input
+                // modality that produced the pre-existing focus is unknown here, and understating
+                // the ring beats inventing a keyboard modality a pointer created.
+                if (element.panel?.focusController?.focusedElement is UnityEngine.UIElements.VisualElement alreadyHeld
+                    && (alreadyHeld == element || element.Contains(alreadyHeld)))
+                {
+                    setFocused.Invoke(true);
+                }
                 return () =>
                 {
                     signals.Unhook();

--- a/Packages/com.velvet.core/Runtime/Hooks/Hooks.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Hooks.cs
@@ -1093,12 +1093,6 @@ namespace Velvet
         {
             var (isFocused, setFocused) = UseState(false);
             var (isFocusVisible, setFocusVisible) = UseState(false);
-            // Generation cell + latest-hooked-element cell, shared by every ref invocation of this hook
-            // instance: each setup stamps a new generation and records its element, so a cleanup's
-            // deferred work can tell whether it was superseded — and by WHAT.
-            var generation = UseRef<int[]>(() => new int[1]);
-            var hookedElement = UseRef<UnityEngine.UIElements.VisualElement[]>(
-                () => new UnityEngine.UIElements.VisualElement[1]);
             var refCallback = UseCallback<Func<UnityEngine.UIElements.VisualElement, Action>>(element =>
             {
                 var signals = new ElementLocalVariantSignals((signal, on) =>
@@ -1110,51 +1104,26 @@ namespace Velvet
                     }
                 });
                 signals.Hook(element, seedChecked: false, registerChecked: false);
-                var gen = ++generation.Current[0];
-                hookedElement.Current[0] = element;
                 return () =>
                 {
                     signals.Unhook();
-                    // The cleanup itself writes no state: the reconciler re-invokes a ref (cleanup + setup)
-                    // on every patch of the host element, i.e. MID-FLUSH, where a state write is silently
-                    // lost (the fiber's dirty flag clears when the flush ends) and its lost pending value
-                    // then dedups away the NEXT genuine edge with the same value. But an element unmounting
-                    // WHILE FOCUSED gets no Blur through these signals either — the unhook above runs before
-                    // the element leaves the panel — which would strand IsFocused/IsFocusVisible at true on
-                    // a still-mounted component. So when the element holds focus at cleanup time, the
-                    // correction is deferred to the panel's next scheduler tick — safely OUTSIDE any flush.
-                    // At the tick, a superseding hookup only cancels the correction when ITS element
-                    // actually holds focus (a patch re-invoking the ref on the same still-focused element):
-                    // a ref that moved to a REPLACEMENT element must still correct, because the old
-                    // element's focus died with it and the unfocused replacement will never emit the Blur
-                    // edge. The setters are already no-ops if the component itself unmounted.
+                    // An element torn down WHILE FOCUSED gets no Blur through these signals (the
+                    // unhook above runs before the element leaves the panel), which would strand
+                    // the flags at true on a still-mounted component. The ref cycles only on
+                    // identity change or a host remount — never per patch — and a state write from
+                    // the commit phase schedules an ordinary follow-up render, so the correction is
+                    // a plain setter call; the setters are no-ops if the component itself unmounted.
                     var panel = element.panel;
-                    if (panel?.visualTree == null) return;
-                    if (panel.focusController?.focusedElement is not UnityEngine.UIElements.VisualElement held
-                        || (held != element && !element.Contains(held)))
+                    if (panel?.focusController?.focusedElement is UnityEngine.UIElements.VisualElement held
+                        && (held == element || element.Contains(held)))
                     {
-                        return;
-                    }
-                    panel.visualTree.schedule.Execute(() =>
-                    {
-                        if (generation.Current[0] != gen)
-                        {
-                            var current = hookedElement.Current[0];
-                            if (current != null
-                                && current.panel?.focusController?.focusedElement
-                                    is UnityEngine.UIElements.VisualElement nowHeld
-                                && (nowHeld == current || current.Contains(nowHeld)))
-                            {
-                                return;
-                            }
-                        }
                         setFocused.Invoke(false);
                         setFocusVisible.Invoke(false);
-                    });
+                    }
                 };
-                // Deps are the two setters and the two refs — all reference-stable across renders — so
-                // the ref identity never changes across re-renders.
-            }, setFocused, setFocusVisible, generation, hookedElement);
+                // Deps are the two setters — reference-stable across renders — so the ref identity
+                // never changes and a patch leaves the installed ref untouched.
+            }, setFocused, setFocusVisible);
             return new FocusRing(isFocused, isFocusVisible, refCallback);
         }
 

--- a/Packages/com.velvet.core/Runtime/Hooks/Hooks.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Hooks.cs
@@ -1088,6 +1088,13 @@ namespace Velvet
         /// styling, the <c>focus-visible:</c> class variant already covers the same distinction without a
         /// hook — reach for this when the component must RENDER differently (e.g. a "press A to select"
         /// hint), not just restyle.
+        /// <para>
+        /// When composing <see cref="FocusRing.Ref"/> with other per-element work in one callback,
+        /// wrap the composed lambda in <c>Hooks.UseCallback</c>: a per-render lambda is a fresh
+        /// identity each render, so every patch would cycle the ref (cleanup on a still-focused
+        /// element, then re-setup) — the same re-render feedback an inline ref writing state
+        /// produces in React.
+        /// </para>
         /// </summary>
         public static FocusRing UseFocusRing()
         {
@@ -1104,18 +1111,6 @@ namespace Velvet
                     }
                 });
                 signals.Hook(element, seedChecked: false, registerChecked: false);
-                // Seed: the signals are edge-driven, so hooking an element that ALREADY holds focus
-                // raises no Focus edge. A ref composed inside a per-render lambda cycles on every
-                // patch (fresh identity), and its cleanup below writes the flags false on the
-                // still-focused element — without this seed the ring would go dark and stay dark
-                // until a real blur+refocus. Focus-visible is deliberately NOT seeded: the input
-                // modality that produced the pre-existing focus is unknown here, and understating
-                // the ring beats inventing a keyboard modality a pointer created.
-                if (element.panel?.focusController?.focusedElement is UnityEngine.UIElements.VisualElement alreadyHeld
-                    && (alreadyHeld == element || element.Contains(alreadyHeld)))
-                {
-                    setFocused.Invoke(true);
-                }
                 return () =>
                 {
                     signals.Unhook();

--- a/Packages/com.velvet.core/Runtime/Hooks/Ref.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Ref.cs
@@ -12,14 +12,24 @@ namespace Velvet
     /// <typeparam name="T">Type being referenced. Only constrained to class; not restricted to VisualElement.</typeparam>
     public sealed class Ref<T> : IHookRefSetter where T : class
     {
-        // The SetElement cleanup always performs the same action (Set(null)) for a given Ref<T> instance,
-        // so allocate it once in the ctor to avoid per-mount closure allocation.
+        // Both delegates are allocated once per Ref so their identities are stable for the Ref's
+        // lifetime: the cleanup always performs the same action (Set(null)), and the setter itself
+        // must be ONE delegate instance — a method group (`refCallback: _ref.SetElement`) would
+        // convert to a fresh delegate every render, so the reconciler's ref-identity gate (a ref
+        // cycles only when its identity changes) could never recognize the same Ref across patches
+        // and would cycle it per render, React's object-ref contract broken by a C# conversion detail.
         private readonly Action _clearAction;
+        private readonly Func<VisualElement, Action> _setElement;
 
         /// <summary>Creates an empty ref whose <see cref="Current"/> is null until assigned.</summary>
         public Ref()
         {
             _clearAction = () => ((IHookRefSetter)this).Set(null);
+            _setElement = element =>
+            {
+                ((IHookRefSetter)this).Set(element);
+                return _clearAction;
+            };
         }
 
         /// <summary>Referenced target. null before mount and after unmount. Can be overwritten at any time via <see cref="Set(T?)"/>.</summary>
@@ -34,15 +44,13 @@ namespace Velvet
         /// <summary>
         /// Callback ref setter. Used as <c>V.Button(refCallback: _ref.SetElement)</c>.
         /// Stores the element into <see cref="Current"/>; the returned <c>Action</c> is the cleanup that
-        /// resets <c>Current = null</c> on detach.
+        /// resets <c>Current = null</c> on detach. The same delegate instance is returned for the
+        /// Ref's lifetime, so a patch that passes it again leaves the installed ref untouched
+        /// (React's object-ref stability).
         /// For T values not derived from VisualElement, <c>element as T</c> is always null, so this is
         /// primarily used for Element-node refs.
         /// </summary>
-        public Action SetElement(VisualElement element)
-        {
-            ((IHookRefSetter)this).Set(element);
-            return _clearAction;
-        }
+        public Func<VisualElement, Action> SetElement => _setElement;
 
         void IHookRefSetter.Set(object? value) => Current = value as T;
 

--- a/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseFocusRingTests.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseFocusRingTests.cs
@@ -51,9 +51,9 @@ namespace Velvet.Tests
 
         private static StateUpdater<int> s_bumpComposed;
 
-        // The ring's ref is COMPOSED inside a per-render lambda (the only way to combine it with
-        // other per-element work), so every patch cycles the ref with a fresh identity — the
-        // cleanup fires on the still-focused element and the setup must re-light the ring.
+        // The ring's ref is COMPOSED with other per-element work, wrapped in UseCallback — the
+        // documented composition recipe: the composed identity stays stable across renders, so a
+        // patch leaves the installed ref untouched and the lit ring survives unrelated re-renders.
         [Component]
         private static VNode ComposedRingHost()
         {
@@ -61,30 +61,32 @@ namespace Velvet.Tests
             s_ring = ring;
             var (count, setCount) = Hooks.UseState(0);
             s_bumpComposed = setCount;
+            var composedRef = Hooks.UseCallback<System.Func<VisualElement, System.Action>>(
+                element => ring.Ref(element), ring.Ref);
             return V.Div(children: new VNode[]
             {
                 V.Label(text: "count-" + count),
-                V.Button(name: "target", refCallback: element => ring.Ref(element)),
+                V.Button(name: "target", refCallback: composedRef),
             });
         }
 
         [Test]
-        public void Given_AFocusedRingBehindAPerRenderComposedRef_When_AnUnrelatedRerenderCyclesTheRef_Then_TheRingStaysLit()
+        public void Given_AFocusedRingBehindAComposedStableRef_When_AnUnrelatedRerenderPatchesTheHost_Then_TheRingStaysLit()
         {
-            // Arrange — mounted with a composed (fresh-identity) ref, then really focused.
+            // Arrange — mounted with the UseCallback-composed ref, then really focused.
             _mounted = V.Mount(_host.Root, V.Component(ComposedRingHost, key: "root"));
             _host.Root.Q<VisualElement>("target").Focus();
             _mounted.FlushStateForTest();
             Assume.That(s_ring.IsFocused, Is.True, "Precondition: the ring lit for the focused element");
 
-            // Act — an unrelated state change patches the host; the fresh-identity ref cycles
-            // (cleanup writes the flags false on the still-focused element, setup re-hooks it).
+            // Act — an unrelated state change patches the host; the stable composed identity means
+            // the installed ref is left untouched (no cleanup fires on the still-focused element).
             s_bumpComposed.Invoke(1);
             _mounted.FlushStateForTest();
 
-            // Assert — the setup's focus seed re-lit the ring within the same flush.
+            // Assert
             Assert.That(s_ring.IsFocused, Is.True,
-                "A ref cycling on a still-focused element must not leave the ring dark");
+                "A stable composed ref must survive unrelated patches without darkening the ring");
         }
 
         [Test]

--- a/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseFocusRingTests.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseFocusRingTests.cs
@@ -49,6 +49,44 @@ namespace Velvet.Tests
             return _host.Root.Q<VisualElement>("target");
         }
 
+        private static StateUpdater<int> s_bumpComposed;
+
+        // The ring's ref is COMPOSED inside a per-render lambda (the only way to combine it with
+        // other per-element work), so every patch cycles the ref with a fresh identity — the
+        // cleanup fires on the still-focused element and the setup must re-light the ring.
+        [Component]
+        private static VNode ComposedRingHost()
+        {
+            var ring = Hooks.UseFocusRing();
+            s_ring = ring;
+            var (count, setCount) = Hooks.UseState(0);
+            s_bumpComposed = setCount;
+            return V.Div(children: new VNode[]
+            {
+                V.Label(text: "count-" + count),
+                V.Button(name: "target", refCallback: element => ring.Ref(element)),
+            });
+        }
+
+        [Test]
+        public void Given_AFocusedRingBehindAPerRenderComposedRef_When_AnUnrelatedRerenderCyclesTheRef_Then_TheRingStaysLit()
+        {
+            // Arrange — mounted with a composed (fresh-identity) ref, then really focused.
+            _mounted = V.Mount(_host.Root, V.Component(ComposedRingHost, key: "root"));
+            _host.Root.Q<VisualElement>("target").Focus();
+            _mounted.FlushStateForTest();
+            Assume.That(s_ring.IsFocused, Is.True, "Precondition: the ring lit for the focused element");
+
+            // Act — an unrelated state change patches the host; the fresh-identity ref cycles
+            // (cleanup writes the flags false on the still-focused element, setup re-hooks it).
+            s_bumpComposed.Invoke(1);
+            _mounted.FlushStateForTest();
+
+            // Assert — the setup's focus seed re-lit the ring within the same flush.
+            Assert.That(s_ring.IsFocused, Is.True,
+                "A ref cycling on a still-focused element must not leave the ring dark");
+        }
+
         [Test]
         public void Given_AComponentUsingUseFocusRing_When_ItsElementGainsFocusWithoutAPointerPress_Then_IsFocusVisibleBecomesTrue()
         {

--- a/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseFocusRingTests.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseFocusRingTests.cs
@@ -104,7 +104,9 @@ namespace Velvet.Tests
             Assume.That(s_ring.IsFocused, Is.True, "Precondition: the ring lit for the focused element");
 
             // Act — the element unmounts while focused; no Blur can reach the already-unhooked
-            // signals, so the correction rides the panel's next scheduler tick.
+            // signals, so the ref cleanup writes the correction directly (a commit-phase write that
+            // the drain's follow-up pass commits). The extra scheduler tick and flush stay: the
+            // contract is "settled by the next tick at the latest", not a specific write path.
             s_setShowTarget.Invoke(false);
             _mounted.FlushStateForTest();
             EditorPanelTestHelpers.DriveSchedulerOnce(_host.Panel);
@@ -138,9 +140,11 @@ namespace Velvet.Tests
             _mounted.FlushStateForTest();
             Assume.That(s_ring.IsFocused, Is.True, "Precondition: the ring lit for the focused element");
 
-            // Act — a same-key type flip replaces the element under the SAME ref in one flush: the old
-            // element's focus dies with it and the replacement was never focused, so the deferred
-            // correction must fire even though a newer hookup superseded the one that scheduled it.
+            // Act — a same-key type flip replaces the element under the SAME ref in one flush: the
+            // old element's focus dies with it and the replacement was never focused, so the OLD
+            // hookup's cleanup must write the correction even though a newer hookup follows it in
+            // the same flush. The extra tick and flush stay: the contract is "settled by the next
+            // tick at the latest", not a specific write path.
             s_setShowTarget.Invoke(true);
             _mounted.FlushStateForTest();
             EditorPanelTestHelpers.DriveSchedulerOnce(_host.Panel);

--- a/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseLayoutEffectTests.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseLayoutEffectTests.cs
@@ -512,38 +512,37 @@ namespace Velvet.Tests
         }
 
         [Test]
-        public void Given_SetStateInsideEffect_When_Mounted_Then_NewStateIsNotYetVisible()
+        public void Given_SetStateInsideEffect_When_Mounted_Then_TheNewStateIsVisibleBeforeTheCallerRegainsControl()
         {
             // Arrange + Act
             using var mounted = V.Mount(_root, V.Component(EffectSetStateRender, key: "setstate"));
 
-            // Assert — the in-effect setter has been scheduled but not yet flushed
-            Assert.That(s_effectSetStateCurrentCount, Is.EqualTo(0),
-                "The new state is not visible immediately after the initial render");
+            // Assert — a layout-effect setState flushes synchronously before the mount returns
+            // (before anything can paint), so the caller never observes the pre-write state.
+            Assert.That(s_effectSetStateCurrentCount, Is.EqualTo(1),
+                "The in-effect setter commits before the initial mount returns");
         }
 
         [Test]
-        public void Given_SetStateInsideEffect_When_StateFlushed_Then_NewStateBecomesVisible()
+        public void Given_SetStateInsideEffect_When_AnotherFlushRuns_Then_NothingFurtherCommits()
         {
-            // Arrange
+            // Arrange — the mount already committed the in-effect write.
             using var mounted = V.Mount(_root, V.Component(EffectSetStateRender, key: "setstate"));
-            Assume.That(s_effectSetStateCurrentCount, Is.EqualTo(0), "Precondition: the new state is not yet visible");
+            Assume.That(s_effectSetStateCurrentCount, Is.EqualTo(1), "Precondition: the write committed at mount");
 
             // Act
             mounted.FlushStateForTest();
 
-            // Assert
-            Assert.That(s_effectSetStateCurrentCount, Is.EqualTo(1), "The in-effect setter is applied after flush");
+            // Assert — the guarded setter converged; later flushes find nothing to do.
+            Assert.That(s_effectSetStateCurrentCount, Is.EqualTo(1), "The settled state does not change again");
         }
 
         [Test]
-        public void Given_SetStateInsideEffect_When_StateFlushed_Then_RendersExactlyTwice()
+        public void Given_SetStateInsideEffect_When_Mounted_Then_RendersExactlyTwice()
         {
-            // Arrange
+            // Arrange + Act — the mount runs the initial render, the effect writes, and the
+            // synchronous follow-up pass commits the second render before returning.
             using var mounted = V.Mount(_root, V.Component(EffectSetStateRender, key: "setstate"));
-
-            // Act
-            mounted.FlushStateForTest();
 
             // Assert — initial render + the render triggered by the setter inside the effect
             Assert.That(s_effectSetStateRenderCount, Is.EqualTo(2),

--- a/Packages/com.velvet.core/Runtime/Reconciler/DndActiveDrag.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/DndActiveDrag.cs
@@ -573,8 +573,10 @@ namespace Velvet
         // Teardown-flavored cancel, called by FiberElementCleaner / the drivers when the source, its
         // scope, or the whole tree is going away MID-FLUSH. The scrub runs synchronously (the element
         // must reach the pool clean), but the user OnDragCancel is deferred to the panel's next
-        // scheduler tick: a state write from inside the flush is silently lost (the fiber's dirty flag
-        // clears when the flush ends) and its lost pending value dedups away the next genuine edge.
+        // scheduler tick: while a commit-phase STATE WRITE is safe mid-flush (it schedules a
+        // follow-up render), an arbitrary user callback is not — it can read a half-mutated tree or
+        // re-enter the reconciler through anything beyond a setter, so it runs once the flush is
+        // done, mirroring how effect callbacks run after the commit.
         // Reconciler disposal passes deferUserCallback: false — a deferred item would fire against the
         // disposed tree (or never, if the panel dies with it), so the callback runs inline as a best
         // effort (its state writes no-op on disposed fibers; external side effects still run).

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberBatchScheduler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberBatchScheduler.cs
@@ -70,6 +70,11 @@ namespace Velvet
         // DrainDelayed; a solo delayed drain finds it false and opens a fresh wave.
         private bool _delayedContinuesWave;
 
+        // Set by ScheduleImmediate whenever intake happens while a drain is live; the delayed drain
+        // resets it before draining and reads it after, to decide whether its commits spawned
+        // immediate-tier work owed the setState-in-commit boundary pass (see DrainDelayed).
+        private bool _immediateWorkArrivedMidDrain;
+
         // Tree-stable element the drain callbacks are registered on (the root mount element). A
         // descendant's MountPoint can detach from the panel before the next frame, which stops a
         // scheduled item registered on it and would strand still-mounted fibers that joined the same
@@ -115,6 +120,10 @@ namespace Velvet
         internal void ScheduleImmediate(ComponentFiber fiber)
         {
             if (fiber?.MountPoint == null) return;
+            // Monotonic mid-drain intake marker for the delayed drain's boundary pass: a net count
+            // comparison would be masked when the drain's own commits also REMOVED entries (an
+            // unmount, a subsume) or when the write dedups onto a fiber already queued.
+            if (_draining) _immediateWorkArrivedMidDrain = true;
             if (_immediateSet.Add(fiber)) _immediateOrder.Add(fiber);
             if (_immediateScheduled || _anchor == null) return;
             _immediateScheduled = true;
@@ -162,10 +171,11 @@ namespace Velvet
                     // Runaway commit-phase loop (a component writing a NEW value on every pass).
                     // React throws here; a throw from the frame callback cannot reach an error
                     // boundary and would only re-arm next frame, burning the full cap every frame
-                    // forever — so the runaway update is DROPPED instead: the still-queued fibers
-                    // settle (lanes cleared, dirty dropped) and the UI keeps the last committed
-                    // state. Only the runaway writers can still be queued this deep — every
-                    // well-behaved fiber flushed in an earlier pass and never re-enqueued.
+                    // forever — so the runaway update is DROPPED instead and the UI keeps the last
+                    // committed state. Only the IMMEDIATE-tier lanes are dropped: a fiber can be
+                    // queued this deep with an unrelated Transition/Deferred lane still pending (the
+                    // runaway's commits may write bystanders each pass), and wiping that lane would
+                    // strand its delayed-tier work (a StartTransition left isPending forever).
                     FiberLogger.LogError("Scheduler",
                         "Maximum update depth exceeded. A component repeatedly schedules state"
                         + " updates from its commit phase (a callback ref or an effect writing a"
@@ -176,7 +186,16 @@ namespace Velvet
                     _immediateSet.Clear();
                     for (var i = 0; i < _drainBuffer.Count; i++)
                     {
-                        FiberRenderer.SettleSubsumedFiber(_drainBuffer[i]);
+                        var dropped = _drainBuffer[i];
+                        dropped.LaneQueue?.Remove(FiberUpdatePriority.Urgent);
+                        dropped.LaneQueue?.Remove(FiberUpdatePriority.Normal);
+                        if (dropped.LaneQueue == null || dropped.LaneQueue.Count == 0)
+                        {
+                            dropped.IsDirty = false;
+                            dropped.ClearAllTransitionPending();
+                        }
+                        // else: a delayed-tier lane survives — the fiber stays dirty and enrolled on
+                        // that tier, so its pending Transition/Deferred work still commits there.
                     }
                     _drainBuffer.Clear();
                     break;
@@ -207,8 +226,9 @@ namespace Velvet
             _delayedContinuesWave = false;
             // Immediate-tier work that PRE-DATES this drain belongs to the next frame callback (its own
             // wave); only work this drain's commits spawn is owed the setState-in-commit guarantee, so
-            // the boundary pass below is gated on the queue having GROWN during the drain.
-            var preexistingImmediateCount = _immediateOrder.Count;
+            // the boundary pass below is gated on the monotonic intake marker (never on a net count,
+            // which the drain's own removals or a dedup onto an already-queued fiber would mask).
+            _immediateWorkArrivedMidDrain = false;
             Drain(_delayedOrder, _delayedSet, resetWave: !continuesImmediateWave);
             // A commit-phase write during a DELAYED-tier commit enqueues on the immediate tier; the
             // setState-in-commit guarantee (the follow-up render commits before this frame callback
@@ -216,7 +236,7 @@ namespace Velvet
             // desync for the next immediate callback to converge. (When new and pre-dated work mixed
             // in the window, the boundary pass carries both — the write's immediacy outranks holding
             // unrelated work back for one frame.)
-            if (_immediateOrder.Count > preexistingImmediateCount)
+            if (_immediateWorkArrivedMidDrain && _immediateOrder.Count > 0)
             {
                 DrainImmediate();
             }
@@ -346,6 +366,7 @@ namespace Velvet
             _delayedOrder.Clear();
             _delayedSet.Clear();
             _delayedContinuesWave = false;
+            _immediateWorkArrivedMidDrain = false;
             _immediateScheduled = false;
             _delayedScheduled = false;
             _anchor = null;

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberBatchScheduler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberBatchScheduler.cs
@@ -16,6 +16,13 @@ namespace Velvet
     // preserved — only the scheduler-callback count collapses to one per tier.
     internal sealed class FiberBatchScheduler
     {
+        // Cap on the drain-until-quiet passes one DrainImmediate performs (React's
+        // "Maximum update depth exceeded" limit): each pass exists for commit-phase writes (a
+        // callback ref or an event dispatched during a commit re-enqueues its fiber mid-drain),
+        // and a component whose commit writes a NEW value every pass would otherwise spin the
+        // drain forever inside one frame callback.
+        private const int NestedUpdateLimit = 50;
+
         // Insertion-ordered pending queues: the List preserves enqueue order so the drain matches the
         // pre-batching schedule.Execute registration order (a parent dirtied before its child flushes
         // first, so the parent's reconcile does not redundantly rebuild the child's subtree), and the
@@ -140,6 +147,28 @@ namespace Velvet
             // pins the now-current store snapshot.
             var openedWave = _immediateOrder.Count > 0;
             Drain(_immediateOrder, _immediateSet, resetWave: true);
+            // Commit-phase state writes (a callback ref invoked during the patch, an event
+            // dispatched from a detach) re-enqueue their fiber mid-drain. Keep draining until the
+            // queue is quiet so the follow-up render commits before this frame callback yields —
+            // React's "setState during the commit schedules a follow-up pass before paint". Each
+            // extra pass opens a fresh snapshot wave (the write moved state forward). Runaway loops
+            // hit NestedUpdateLimit; unlike React's throw, the overflow logs an error and leaves
+            // the remainder queued for the next frame — throwing here would abandon every OTHER
+            // fiber's pending work in the same batch for one component's runaway commit loop.
+            var nestedPasses = 0;
+            while (_immediateOrder.Count > 0)
+            {
+                if (++nestedPasses >= NestedUpdateLimit)
+                {
+                    FiberLogger.LogError("Scheduler",
+                        "Maximum update depth exceeded. A component repeatedly schedules state"
+                        + " updates from its commit phase (a callback ref or an effect writing on"
+                        + " every pass). The remaining update is deferred to the next frame.");
+                    break;
+                }
+                openedWave = true;
+                Drain(_immediateOrder, _immediateSet, resetWave: true);
+            }
             // A delayed drain already pending after this immediate drain CONTINUES this wave (it should reuse the
             // pins this drain just established). A delayed drain that arrives later, with no immediate drain to pin
             // first, is a separate wave and must open fresh. Only hand off when this drain actually opened a wave.

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberBatchScheduler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberBatchScheduler.cs
@@ -16,11 +16,13 @@ namespace Velvet
     // preserved — only the scheduler-callback count collapses to one per tier.
     internal sealed class FiberBatchScheduler
     {
-        // Cap on the drain-until-quiet passes one DrainImmediate performs (React's
-        // "Maximum update depth exceeded" limit): each pass exists for commit-phase writes (a
-        // callback ref or an event dispatched during a commit re-enqueues its fiber mid-drain),
-        // and a component whose commit writes a NEW value every pass would otherwise spin the
-        // drain forever inside one frame callback.
+        // Cap on the drain-until-quiet passes one DrainImmediate performs — React's
+        // "Maximum update depth exceeded" limit (one initial pass plus this many nested ones):
+        // each pass exists for commit-phase writes (a callback ref or an event dispatched during
+        // a commit re-enqueues its fiber mid-drain), and a component whose commit writes a NEW
+        // value every pass would otherwise spin the drain forever inside one frame callback.
+        // Overflow DROPS the runaway update (see DrainImmediate) rather than deferring it — a
+        // deferred runaway re-arms every frame and burns the full cap forever.
         private const int NestedUpdateLimit = 50;
 
         // Insertion-ordered pending queues: the List preserves enqueue order so the drain matches the
@@ -142,37 +144,57 @@ namespace Velvet
 
         private void DrainImmediate()
         {
-            _immediateScheduled = false;
-            // The immediate drain opens a fresh tearing-guard wave (reset = true): its first UseStore read
-            // pins the now-current store snapshot.
-            var openedWave = _immediateOrder.Count > 0;
-            Drain(_immediateOrder, _immediateSet, resetWave: true);
             // Commit-phase state writes (a callback ref invoked during the patch, an event
             // dispatched from a detach) re-enqueue their fiber mid-drain. Keep draining until the
             // queue is quiet so the follow-up render commits before this frame callback yields —
             // React's "setState during the commit schedules a follow-up pass before paint". Each
-            // extra pass opens a fresh snapshot wave (the write moved state forward). Runaway loops
-            // hit NestedUpdateLimit; unlike React's throw, the overflow logs an error and leaves
-            // the remainder queued for the next frame — throwing here would abandon every OTHER
-            // fiber's pending work in the same batch for one component's runaway commit loop.
-            var nestedPasses = 0;
+            // pass opens a fresh tearing-guard wave (a commit write moved state forward, so its
+            // first UseStore read re-pins the now-current snapshot). _immediateScheduled stays SET
+            // for the whole loop: the loop itself consumes every mid-drain enqueue, so registering
+            // another frame callback for one would only fire an empty drain next frame (dead
+            // scheduler churn that also skews the coalescing counter).
+            var openedWave = false;
+            var totalPasses = 0;
             while (_immediateOrder.Count > 0)
             {
-                if (++nestedPasses >= NestedUpdateLimit)
+                if (totalPasses > NestedUpdateLimit)
                 {
+                    // Runaway commit-phase loop (a component writing a NEW value on every pass).
+                    // React throws here; a throw from the frame callback cannot reach an error
+                    // boundary and would only re-arm next frame, burning the full cap every frame
+                    // forever — so the runaway update is DROPPED instead: the still-queued fibers
+                    // settle (lanes cleared, dirty dropped) and the UI keeps the last committed
+                    // state. Only the runaway writers can still be queued this deep — every
+                    // well-behaved fiber flushed in an earlier pass and never re-enqueued.
                     FiberLogger.LogError("Scheduler",
                         "Maximum update depth exceeded. A component repeatedly schedules state"
-                        + " updates from its commit phase (a callback ref or an effect writing on"
-                        + " every pass). The remaining update is deferred to the next frame.");
+                        + " updates from its commit phase (a callback ref or an effect writing a"
+                        + " new value on every pass). The runaway update was dropped.");
+                    _drainBuffer.Clear();
+                    _drainBuffer.AddRange(_immediateOrder);
+                    _immediateOrder.Clear();
+                    _immediateSet.Clear();
+                    for (var i = 0; i < _drainBuffer.Count; i++)
+                    {
+                        FiberRenderer.SettleSubsumedFiber(_drainBuffer[i]);
+                    }
+                    _drainBuffer.Clear();
                     break;
                 }
+                totalPasses++;
                 openedWave = true;
                 Drain(_immediateOrder, _immediateSet, resetWave: true);
             }
+            _immediateScheduled = false;
             // A delayed drain already pending after this immediate drain CONTINUES this wave (it should reuse the
             // pins this drain just established). A delayed drain that arrives later, with no immediate drain to pin
-            // first, is a separate wave and must open fresh. Only hand off when this drain actually opened a wave.
-            _delayedContinuesWave = openedWave && _delayedScheduled;
+            // first, is a separate wave and must open fresh. Only hand off when this drain actually opened a wave —
+            // and an EMPTY run (a callback whose work an earlier synchronous drain already consumed) must not
+            // clobber a hand-off that earlier drain established.
+            if (openedWave)
+            {
+                _delayedContinuesWave = _delayedScheduled;
+            }
         }
 
         private void DrainDelayed()
@@ -183,7 +205,21 @@ namespace Velvet
             // than a stale pin retained from a prior wave.
             var continuesImmediateWave = _delayedContinuesWave;
             _delayedContinuesWave = false;
+            // Immediate-tier work that PRE-DATES this drain belongs to the next frame callback (its own
+            // wave); only work this drain's commits spawn is owed the setState-in-commit guarantee, so
+            // the boundary pass below is gated on the queue having GROWN during the drain.
+            var preexistingImmediateCount = _immediateOrder.Count;
             Drain(_delayedOrder, _delayedSet, resetWave: !continuesImmediateWave);
+            // A commit-phase write during a DELAYED-tier commit enqueues on the immediate tier; the
+            // setState-in-commit guarantee (the follow-up render commits before this frame callback
+            // yields) is tier-agnostic, so drain it now rather than leaving a one-frame slot/UI
+            // desync for the next immediate callback to converge. (When new and pre-dated work mixed
+            // in the window, the boundary pass carries both — the write's immediacy outranks holding
+            // unrelated work back for one frame.)
+            if (_immediateOrder.Count > preexistingImmediateCount)
+            {
+                DrainImmediate();
+            }
         }
 
         private void Drain(List<ComponentFiber> order, HashSet<ComponentFiber> set, bool resetWave)

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberBeginWork.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberBeginWork.cs
@@ -69,18 +69,7 @@ namespace Velvet
                 // CommitSettledHookDeps: a render that throws partway must not leave the committed
                 // list empty/partial, or the Provider-change walk would skip this fiber forever.
                 fiber.BeginDependencyStaging();
-                // The render-phase window opens strictly around the body: a setter firing inside it
-                // is a render-phase update (this loop consumes the flag); one firing later in the
-                // flush (commit phase) must schedule normally instead — see ComponentFiber.IsInRenderPhase.
-                fiber.IsInRenderPhase = true;
-                try
-                {
-                    rendered = Render(fiber);
-                }
-                finally
-                {
-                    fiber.IsInRenderPhase = false;
-                }
+                rendered = InvokeBodyInRenderPhase(fiber);
                 if (!fiber.HasRenderPhaseUpdate)
                 {
                     break;
@@ -104,6 +93,24 @@ namespace Velvet
                 }
             }
             return rendered;
+        }
+
+        // The ONE place that opens the render-phase window around a body invocation, so its two
+        // callers (the render-phase loop above and the StrictMode diagnostic) cannot drift on the
+        // window's extent: a setter firing inside it is a render-phase update (discard-and-rerun);
+        // one firing anywhere else in the flush schedules an ordinary follow-up render — see
+        // ComponentFiber.IsInRenderPhase.
+        internal static VNode InvokeBodyInRenderPhase(ComponentFiber fiber)
+        {
+            fiber.IsInRenderPhase = true;
+            try
+            {
+                return Render(fiber);
+            }
+            finally
+            {
+                fiber.IsInRenderPhase = false;
+            }
         }
 
         // Settle: promote the final attempt's staged deps to the committed baseline so the next

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberBeginWork.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberBeginWork.cs
@@ -69,7 +69,18 @@ namespace Velvet
                 // CommitSettledHookDeps: a render that throws partway must not leave the committed
                 // list empty/partial, or the Provider-change walk would skip this fiber forever.
                 fiber.BeginDependencyStaging();
-                rendered = Render(fiber);
+                // The render-phase window opens strictly around the body: a setter firing inside it
+                // is a render-phase update (this loop consumes the flag); one firing later in the
+                // flush (commit phase) must schedule normally instead — see ComponentFiber.IsInRenderPhase.
+                fiber.IsInRenderPhase = true;
+                try
+                {
+                    rendered = Render(fiber);
+                }
+                finally
+                {
+                    fiber.IsInRenderPhase = false;
+                }
                 if (!fiber.HasRenderPhaseUpdate)
                 {
                     break;

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberDiscreteEventScope.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberDiscreteEventScope.cs
@@ -7,8 +7,10 @@ namespace Velvet
     /// Brackets a discrete user-input handler: marks <see cref="FiberWorkLoop.IsInDiscreteEvent"/> for its
     /// duration so hook-triggered renders take the Urgent lane, then — at the outermost discrete boundary —
     /// flushes the owning context's immediate batch synchronously so the update commits in the same frame.
-    /// The flag is restored before the flush so updates scheduled by effects that run during the flush fall
-    /// back to the Normal next-frame lane rather than recursing synchronously. Shared by
+    /// The flag is restored before the flush so updates scheduled by effects that run during the flush take
+    /// the Normal lane; they still commit within this same synchronous flush (the drain loops until its
+    /// queue is quiet — React's setState-in-commit semantics — with the maximum-update-depth cap bounding a
+    /// runaway feedback pair), just without escalating the discrete Urgent classification. Shared by
     /// <c>FiberEventBindingManager</c> (clicks, value changes, discrete pointer/key bindings) and the
     /// drag-and-drop session (<c>OnDragStart</c>/<c>OnDragEnd</c>/<c>OnDragCancel</c>), so a drag commit
     /// behaves exactly like a click handler's.

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberElementCleaner.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberElementCleaner.cs
@@ -187,10 +187,10 @@ namespace Velvet
         // CleanupDescendants.
         private void CleanupElementResources(VisualElement element)
         {
-            if (_ctx.RefCleanups.TryGetValue(element, out var refCleanup))
+            if (_ctx.RefCallbacks.TryGetValue(element, out var installedRef))
             {
-                _ctx.RefCleanups.Remove(element);
-                refCleanup?.Invoke();
+                _ctx.RefCallbacks.Remove(element);
+                installedRef.Cleanup?.Invoke();
             }
             _ctx.StyleAnimationScheduler.CancelEnter(element);
             // Teardown-flavored: this element is being released for good (pool return / disposal), not merely

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberElementCleaner.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberElementCleaner.cs
@@ -370,8 +370,10 @@ namespace Velvet
             }
             // Drag-and-drop bindings: the draggable's pointer-down armer unregisters, and an element that
             // is the active session's source or scope cancels that session teardown-flavored (synchronous
-            // scrub so the element reaches the pool clean, deferred user callback — the cleaner runs
-            // mid-flush, where a user state write would be silently lost; see DndActiveDrag).
+            // scrub so the element reaches the pool clean, deferred user callback — an ARBITRARY user
+            // callback run mid-flush could read a half-mutated tree or re-enter the reconciler, so it
+            // waits for the flush like effect callbacks do; see DndActiveDrag. Plain state writes from
+            // mid-flush are safe — they schedule a follow-up render.)
             if (_ctx.DndScopeBindings.ContainsKey(element))
             {
                 DndScopeDriver.Detach(element, _ctx);

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberRenderer.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberRenderer.cs
@@ -606,7 +606,17 @@ namespace Velvet
                 // dependency list (matching the real committed render) stays intact.
                 fiber.BeginDependencyStaging();
                 fiber.HasRenderPhaseUpdate = false;
-                diagnosticTree = FiberTreeReturn.NormalizeToArray(FiberBeginWork.Render(fiber));
+                // The diagnostic re-runs the BODY, so it opens the same render-phase window the real
+                // render-phase loop does — the impure-setState check below reads the flag this sets.
+                fiber.IsInRenderPhase = true;
+                try
+                {
+                    diagnosticTree = FiberTreeReturn.NormalizeToArray(FiberBeginWork.Render(fiber));
+                }
+                finally
+                {
+                    fiber.IsInRenderPhase = false;
+                }
 
                 var diagnosticSignature = FiberStrictMode.ComputeSignature(diagnosticTree);
                 if (!string.Equals(committedSignature, diagnosticSignature, StringComparison.Ordinal))

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberRenderer.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberRenderer.cs
@@ -66,6 +66,11 @@ namespace Velvet
             SetupMount(fiber, mountPoint, sharedContext);
             RenderAndReconcile(fiber);
             FiberEffects.CommitSubtreeEffects(fiber, mountDoubleInvoke: true);
+            // The setState-in-commit guarantee is entry-point-agnostic: a callback ref or layout
+            // effect that writes state during THIS mount (the measure-in-ref pattern) must commit
+            // before the caller regains control, exactly as a drain-driven flush loops until quiet —
+            // otherwise the first painted frame shows the pre-write state.
+            fiber.Reconciler?.Context.BatchScheduler.FlushImmediate();
         }
 
         // Inline-mount variant for wrapper-less fibers. The fiber's render output is held on the
@@ -606,17 +611,9 @@ namespace Velvet
                 // dependency list (matching the real committed render) stays intact.
                 fiber.BeginDependencyStaging();
                 fiber.HasRenderPhaseUpdate = false;
-                // The diagnostic re-runs the BODY, so it opens the same render-phase window the real
-                // render-phase loop does — the impure-setState check below reads the flag this sets.
-                fiber.IsInRenderPhase = true;
-                try
-                {
-                    diagnosticTree = FiberTreeReturn.NormalizeToArray(FiberBeginWork.Render(fiber));
-                }
-                finally
-                {
-                    fiber.IsInRenderPhase = false;
-                }
+                // The diagnostic re-runs the BODY through the same render-phase window the real
+                // render-phase loop uses — the impure-setState check below reads the flag it sets.
+                diagnosticTree = FiberTreeReturn.NormalizeToArray(FiberBeginWork.InvokeBodyInRenderPhase(fiber));
 
                 var diagnosticSignature = FiberStrictMode.ComputeSignature(diagnosticTree);
                 if (!string.Equals(committedSignature, diagnosticSignature, StringComparison.Ordinal))

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberWorkLoop.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberWorkLoop.cs
@@ -46,14 +46,18 @@ namespace Velvet
                 return;
             }
 
-            // Render-phase setState: the setter updates this fiber's own state while this same fiber
-            // is rendering. Such updates are processed synchronously (discard the in-progress
-            // output and re-run Render() before committing) instead of scheduling a next-frame
-            // re-render. Flag the fiber and let the render loop in RenderAndReconcile re-run; the
-            // state slot already holds the new value by the time this is called. A setter for a
-            // *different* fiber that fires during this fiber's render falls through to the regular
-            // next-frame schedule below.
-            if (fiber.IsRendering && ReferenceEquals(FiberAmbientStack.Current, fiber))
+            // Render-phase setState: the setter updates this fiber's own state while this same
+            // fiber's BODY is on the stack. Such updates are processed synchronously (discard the
+            // in-progress output and re-run Render() before committing) instead of scheduling a
+            // next-frame re-render. Flag the fiber and let the render loop in RenderAndReconcile
+            // re-run; the state slot already holds the new value by the time this is called. The
+            // gate is the render-phase window, NOT IsRendering: a write landing later in the same
+            // flush (a callback ref invoked during the patch, an event dispatched from a detach) is
+            // a commit-phase update that falls through to the regular schedule below — React's
+            // "setState in a commit schedules a follow-up pass" — where the flag would be consumed
+            // by nobody and cleared, silently dropping the write. A setter for a *different* fiber
+            // that fires during this fiber's render also falls through.
+            if (fiber.IsInRenderPhase && ReferenceEquals(FiberAmbientStack.Current, fiber))
             {
                 fiber.HasRenderPhaseUpdate = true;
                 return;

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberWorkLoop.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberWorkLoop.cs
@@ -352,6 +352,12 @@ namespace Velvet
                     // has- ancestor that did not itself reconcile. Scoped to this flush's region (the fiber's
                     // MountPoint subtree) — see RefreshHasVariants.
                     FiberNodePatcher.RefreshHasVariants(fiber.Reconciler?.Context, fiber.MountPoint);
+                    // The setState-in-commit guarantee is entry-point-agnostic: this terminal slice's
+                    // commits may have invoked callback refs that wrote state (the measure-in-ref
+                    // pattern), and the resume runs outside any batch drain — flush now so the write
+                    // commits before the frame yields. Safe here: the pass completed (no pending
+                    // work) and the reconcile-active bracket was exited by ContinueReconcile above.
+                    fiber.Reconciler?.Context.BatchScheduler.FlushImmediate();
                 }
             }
             catch (Exception ex)

--- a/Packages/com.velvet.core/Runtime/Reconciler/Reconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Reconciler.cs
@@ -423,6 +423,24 @@ namespace Velvet
             _ctx.ComponentRegistry.Dispose();
             _ctx.FiberMemoCache.DisposeAndReturnCachedTrees();
             _ctx.WrapperToInnerMap.Clear();
+            // Detach every still-installed callback ref: an element the unmount reconcile skipped (a
+            // parked time-sliced baseline diverged from the DOM, an aborted teardown) never passes
+            // through the element cleaner, and the ref contract is that every attached ref detaches
+            // when its root goes away — Ref<T>.Current must not keep pointing at a dead element and a
+            // user cleanup releasing external resources must run. Best-effort per entry: one throwing
+            // cleanup must not strand the rest.
+            foreach (var (_, installedRef) in _ctx.RefCallbacks)
+            {
+                try
+                {
+                    installedRef.Cleanup?.Invoke();
+                }
+                catch (System.Exception ex)
+                {
+                    FiberLogger.LogException("Reconciler", ex);
+                }
+            }
+            _ctx.RefCallbacks.Clear();
             // Shadowed elements hold paint + re-bake callbacks: detach so a still-mounted element released at
             // root disposal carries no Velvet residue. Then dispose the shared bake Material once (the baked
             // shadow textures are cached process-wide and outlive the reconciler, like the gradient bakes).

--- a/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
@@ -558,26 +558,33 @@ namespace Velvet
         // resume / unmount paths; a stale leftover entry only over-spares (leak-safe direction).
         internal HashSet<ComponentFiber> ParkedBaselineFibers { get; } = new();
 
-        // Cleanup callback returned from a callback ref (BaseElementNode.RefCallback).
-        // Fires when the element detaches from the DOM, releasing resources such as
-        // resetting Ref<T>.Current to null.
-        public Dictionary<VisualElement, System.Action> RefCleanups { get; } = new();
+        // Callback-ref bookkeeping per element (BaseElementNode.RefCallback): the callback identity
+        // that installed the current ref plus its returned cleanup. The identity is stored so a
+        // patch can tell a STABLE ref apart from a swapped one — matching React, a ref cycles
+        // (cleanup, then setup) only when its identity changes or the element remounts. The cleanup
+        // fires when the element detaches from the DOM, releasing resources such as resetting
+        // Ref<T>.Current to null.
+        public Dictionary<VisualElement, (System.Func<VisualElement, System.Action> Callback, System.Action? Cleanup)>
+            RefCallbacks { get; } = new();
 
-        // Invokes a callback ref and stores the returned cleanup in RefCleanups.
-        // If the same element already has a previously registered cleanup, fires it first and replaces
-        // it (the case where re-patch changes callback identity).
+        // Invokes a callback ref and records (identity, cleanup) in RefCallbacks. A patch carrying
+        // the SAME callback delegate is a no-op: unconditionally re-invoking made any state write in
+        // a ref cleanup a per-patch mid-flush write, forcing consumers into deferred-correction
+        // workarounds. An entry is stored even when the setup returns no cleanup — the identity is
+        // what makes the stable-ref skip possible.
         internal void InvokeRefCallback(VisualElement element, System.Func<VisualElement, System.Action>? refCallback)
         {
-            // Remove first: if a user-defined cleanup throws, leaving a stale entry would cause
-            // a double-fire on the next reconcile. Remove → Invoke order preserves exception safety.
-            if (RefCleanups.TryGetValue(element, out var oldCleanup))
+            if (RefCallbacks.TryGetValue(element, out var installed))
             {
-                RefCleanups.Remove(element);
-                oldCleanup?.Invoke();
+                if (refCallback != null && ReferenceEquals(installed.Callback, refCallback)) return;
+                // Remove first: if a user-defined cleanup throws, leaving a stale entry would cause
+                // a double-fire on the next reconcile. Remove → Invoke order preserves exception safety.
+                RefCallbacks.Remove(element);
+                installed.Cleanup?.Invoke();
             }
             if (refCallback == null) return;
             var cleanup = refCallback(element);
-            if (cleanup != null) RefCleanups[element] = cleanup;
+            RefCallbacks[element] = (refCallback, cleanup);
         }
 
         // DOM-less AnimatePresence keeps its per-boundary state in PresenceStates (below); the old

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/AutoBatchingTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/AutoBatchingTests.cs
@@ -290,11 +290,13 @@ namespace Velvet.Tests
         }
 
         [Test]
-        public void Given_ImmediateFlushDuringDrain_When_DrainInProgress_Then_DiscreteUpdateIsDeferredNotCommitted()
+        public void Given_ImmediateFlushDuringDrain_When_TheDelayedDrainEnds_Then_TheSiblingCommitsAtTheBoundaryNotReentrantly()
         {
             // A FlushImmediate raised while a drain is on the stack must no-op: re-entering would re-enter the
             // reconciler at depth > 0 (corrupting shared abort / context-snapshot state) and clobber the shared
-            // drain buffer. The sibling update it schedules stays queued on the immediate tier.
+            // drain buffer. The sibling update it schedules stays queued on the immediate tier and commits at
+            // the drain's own boundary — the setState-in-commit guarantee is tier-agnostic, so the delayed
+            // drain's tail runs the immediate queue rather than leaving a one-frame slot/UI desync.
             // Arrange
             using var mounted = MountReentrantPair();
             Assume.That((s_reentrantHostRenderCount, s_reentrantSiblingRenderCount), Is.EqualTo((1, 1)),
@@ -307,28 +309,27 @@ namespace Velvet.Tests
             // Act
             Scheduler(mounted).DrainDelayedForTest();
 
-            // Assert
-            Assert.AreEqual(1, s_reentrantSiblingRenderCount,
-                "FlushImmediate no-ops during a drain; the discrete sibling update is deferred, not committed re-entrantly");
+            // Assert — exactly one boundary commit: the mid-drain FlushImmediate did not run it re-entrantly
+            // (that would have flushed against a half-committed host), the drain tail did.
+            Assert.AreEqual(2, s_reentrantSiblingRenderCount,
+                "The sibling update commits once, at the delayed drain's boundary");
         }
 
         [Test]
-        public void Given_ImmediateFlushDuringDrain_When_NextFrameDrains_Then_DeferredUpdateCommits()
+        public void Given_ImmediateFlushDuringDrain_When_TheDelayedDrainEnds_Then_NothingIsLeftForTheNextFrame()
         {
             // Arrange
             using var mounted = MountReentrantPair();
             s_reentrantArmed = true;
             s_reentrantHostFiber.ScheduleRerenderForTest(FiberUpdatePriority.Transition);
+
+            // Act
             Scheduler(mounted).DrainDelayedForTest();
-            Assume.That(Scheduler(mounted).ImmediatePendingCount, Is.EqualTo(1),
-                "Precondition: the deferred sibling update stays enrolled on the immediate tier");
 
-            // Act — the next-frame immediate drain (no reconcile on the stack) commits it
-            Scheduler(mounted).DrainImmediateForTest();
-
-            // Assert
-            Assert.AreEqual(2, s_reentrantSiblingRenderCount,
-                "The deferred update commits on the next-frame immediate drain");
+            // Assert — the boundary commit consumed the queue: a next-frame callback would find nothing,
+            // so the committed UI and the state slots agree within the same frame that wrote them.
+            Assert.AreEqual(0, Scheduler(mounted).ImmediatePendingCount,
+                "The delayed drain's tail leaves no immediate-tier remainder");
         }
 
         #region Async batching

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/CommitPhaseStateWriteTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/CommitPhaseStateWriteTests.cs
@@ -1,0 +1,118 @@
+using System;
+using NUnit.Framework;
+using UnityEngine.TestTools;
+using UnityEngine.UIElements;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins React's commit-phase update semantics: a hook state write that lands while the SAME
+    /// fiber's flush is past its render phase (a callback ref invoked during the patch, an event
+    /// dispatched from a detach) is not a render-phase update — it schedules an ordinary follow-up
+    /// render, and the batch drain keeps draining until the queue is quiet (with the
+    /// maximum-update-depth cap) so the follow-up commits before the frame yields. Silently
+    /// dropping such a write desynced the slot value from the committed UI and poisoned the
+    /// setter's equality bail for the NEXT genuine edge with the same value.
+    /// </summary>
+    [TestFixture]
+    internal sealed class CommitPhaseStateWriteTests
+    {
+        private sealed class CounterStore : Store<int>
+        {
+            public CounterStore() : base(0) { }
+            public void Increment() => SetState(x => x + 1);
+            protected override void ResetCore() => SetState(_ => 0);
+        }
+
+        private static CounterStore s_store;
+
+        private VisualElement _root;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _root = new VisualElement();
+            s_store = null;
+        }
+
+        // The ref callback is deliberately a fresh delegate every render, so every patch cycles it
+        // (identity change) and the setup runs DURING the commit — the mid-flush write under test.
+        // The write is edge-guarded so the follow-up render (which re-cycles the ref) converges.
+        [Component]
+        private static VNode CommitWriteHost()
+        {
+            var count = Hooks.UseStore(s_store, x => x);
+            var (sawCommitWrite, setSawCommitWrite) = Hooks.UseState(false);
+            return V.Div(name: "host", children: new VNode[]
+            {
+                V.Label(name: "flag", text: sawCommitWrite ? "written" : "pending"),
+                V.Button(name: "target", text: "target-" + count, refCallback: element =>
+                {
+                    if (count > 0) setSawCommitWrite.Invoke(true);
+                    return null;
+                }),
+            });
+        }
+
+        [Test]
+        public void Given_ARefSetupWritingStateDuringTheCommit_When_TheDrainEnds_Then_TheWriteHasCommitted()
+        {
+            // Arrange — mounted with the flag pending; the first store write patches the host and
+            // the ref setup (running mid-commit) writes the fiber's own state.
+            using var store = new CounterStore();
+            s_store = store;
+            using var mounted = V.Mount(_root, V.Component(CommitWriteHost, key: "host"));
+            var scheduler = mounted.Root.Reconciler.Context.BatchScheduler;
+            Assume.That(_root.Q<Label>("flag").text, Is.EqualTo("pending"),
+                "Precondition: the flag state starts false");
+
+            // Act — one drain: the store-driven render runs, the commit writes state, and the
+            // drain's follow-up pass commits that write before returning.
+            store.Increment();
+            scheduler.DrainImmediateForTest();
+
+            // Assert — the commit-phase write re-rendered within the same drain (not dropped, not
+            // deferred past the frame).
+            Assert.That(_root.Q<Label>("flag").text, Is.EqualTo("written"),
+                "A commit-phase state write must schedule and commit a follow-up render");
+        }
+
+        // Writes a NEW value on every ref cycle, so each follow-up render schedules another one:
+        // a runaway commit-phase loop the drain must cap rather than spin forever.
+        [Component]
+        private static VNode RunawayCommitWriteHost()
+        {
+            var count = Hooks.UseStore(s_store, x => x);
+            var (spins, setSpins) = Hooks.UseState(0);
+            return V.Div(name: "host", children: new VNode[]
+            {
+                V.Label(name: "spins", text: "spins-" + spins),
+                V.Button(name: "target", text: "target-" + count, refCallback: element =>
+                {
+                    if (count > 0) setSpins.Invoke(spins + 1);
+                    return null;
+                }),
+            });
+        }
+
+        [Test]
+        public void Given_ARunawayCommitPhaseWriteLoop_When_TheDrainHitsTheUpdateDepthCap_Then_ItLogsAndLeavesTheRestForTheNextFrame()
+        {
+            // Arrange — mounted quiet, then the first store write starts the self-sustaining loop.
+            using var store = new CounterStore();
+            s_store = store;
+            using var mounted = V.Mount(_root, V.Component(RunawayCommitWriteHost, key: "host"));
+            var scheduler = mounted.Root.Reconciler.Context.BatchScheduler;
+            LogAssert.Expect(UnityEngine.LogType.Error, new System.Text.RegularExpressions.Regex("Maximum update depth"));
+
+            // Act — a single drain must terminate at the cap instead of spinning forever.
+            store.Increment();
+            scheduler.DrainImmediateForTest();
+
+            // Assert — the loop was cut off with work still pending for the next frame boundary
+            // (the queue is not empty), rather than the drain looping to completion or dropping it.
+            Assert.That(scheduler.ImmediatePendingCount, Is.GreaterThan(0),
+                "The capped drain must defer the still-pending update instead of dropping it");
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/CommitPhaseStateWriteTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/CommitPhaseStateWriteTests.cs
@@ -96,7 +96,7 @@ namespace Velvet.Tests
         }
 
         [Test]
-        public void Given_ARunawayCommitPhaseWriteLoop_When_TheDrainHitsTheUpdateDepthCap_Then_ItLogsAndLeavesTheRestForTheNextFrame()
+        public void Given_ARunawayCommitPhaseWriteLoop_When_TheDrainHitsTheUpdateDepthCap_Then_ItLogsAndDropsTheRunawayUpdate()
         {
             // Arrange — mounted quiet, then the first store write starts the self-sustaining loop.
             using var store = new CounterStore();
@@ -109,10 +109,13 @@ namespace Velvet.Tests
             store.Increment();
             scheduler.DrainImmediateForTest();
 
-            // Assert — the loop was cut off with work still pending for the next frame boundary
-            // (the queue is not empty), rather than the drain looping to completion or dropping it.
-            Assert.That(scheduler.ImmediatePendingCount, Is.GreaterThan(0),
-                "The capped drain must defer the still-pending update instead of dropping it");
+            // Assert — the loop genuinely ran (the spin counter committed past its initial value)
+            // and the runaway update was then DROPPED, not deferred: a deferred runaway would re-arm
+            // and burn the full cap again every frame forever, so the queue must end empty.
+            Assert.That(
+                (_root.Q<Label>("spins").text != "spins-0", scheduler.ImmediatePendingCount),
+                Is.EqualTo((true, 0)),
+                "The capped drain must drop the runaway update after real passes ran");
         }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/CommitPhaseStateWriteTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/CommitPhaseStateWriteTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1872ebc3b1d0b4d61a05060effeb0cca

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ReconcilerRefTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ReconcilerRefTests.cs
@@ -8,14 +8,16 @@ namespace Velvet.Tests
     /// <summary>
     /// Specifies the callback-ref and creation-callback contract of element reconciliation.
     /// <list type="bullet">
-    /// <item>A callback ref runs on element creation and again on each patch, receiving the live
-    /// element; when the element is reused by a patch it receives that same instance.</item>
-    /// <item>A callback ref may return a cleanup action; the cleanup fires when the element is removed,
-    /// and when a patch swaps the callback identity on the same element the old cleanup fires before
-    /// the new callback runs as setup. A null cleanup return is a no-op on removal.</item>
+    /// <item>A callback ref runs on element creation, receiving the live element. On a patch it is
+    /// identity-gated (React's contract): the same callback delegate leaves the installed ref
+    /// untouched, while a changed identity cycles it — the old cleanup fires, then the new callback
+    /// runs as setup against the same reused instance. (The per-render lambdas these tests pass are
+    /// fresh identities, so their patches cycle.)</item>
+    /// <item>A callback ref may return a cleanup action; the cleanup fires when the element is removed.
+    /// A null cleanup return is a no-op on removal.</item>
     /// <item>A typed <c>Ref&lt;T&gt;</c> exposes the element through <c>Current</c>; its
-    /// <c>SetElement</c> cleanup resets <c>Current</c> to null on removal, and across patches of the
-    /// same element <c>Current</c> stays the live instance (never transiently null).</item>
+    /// <c>SetElement</c> delegate is identity-stable for the Ref's lifetime (so patches leave it
+    /// installed), and its cleanup resets <c>Current</c> to null on removal.</item>
     /// <item>Keyed reconciliation that reuses an element keeps the same instance bound to its ref
     /// across a reorder.</item>
     /// <item>The creation callback (<c>OnCreated</c>) runs only when the element is created — never on

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/RefCallbackIdentityTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/RefCallbackIdentityTests.cs
@@ -1,0 +1,131 @@
+using System;
+using NUnit.Framework;
+using UnityEngine.UIElements;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins the callback-ref re-invocation contract to React's: a ref cycles (cleanup, then setup)
+    /// only when its identity changes or the host element remounts — a patch that carries the SAME
+    /// callback delegate leaves the installed ref untouched. Unconditionally re-invoking on every
+    /// patch made any state write inside a ref cleanup a per-patch mid-flush write, which is what
+    /// forced consumers (focus-ring style hooks) into deferred-correction workarounds.
+    /// </summary>
+    [TestFixture]
+    internal sealed class RefCallbackIdentityTests
+    {
+        private sealed class CounterStore : Store<int>
+        {
+            public CounterStore() : base(0) { }
+            public void Increment() => SetState(x => x + 1);
+            protected override void ResetCore() => SetState(_ => 0);
+        }
+
+        private static CounterStore s_store;
+        private static int s_setupCount;
+        private static int s_cleanupCount;
+
+        private VisualElement _root;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _root = new VisualElement();
+            s_store = null;
+            s_setupCount = 0;
+            s_cleanupCount = 0;
+        }
+
+        // The ref is reference-stable across renders (UseCallback with stable deps), while the
+        // label text changes every render so each store write really patches the host subtree.
+        [Component]
+        private static VNode StableRefHost()
+        {
+            var count = Hooks.UseStore(s_store, x => x);
+            var refCallback = Hooks.UseCallback<Func<VisualElement, Action>>(element =>
+            {
+                s_setupCount++;
+                return () => s_cleanupCount++;
+            }, 1);
+            return V.Div(name: "host", children: new VNode[]
+            {
+                V.Label(text: "count-" + count),
+                V.Button(name: "target", text: "target-" + count, refCallback: refCallback),
+            });
+        }
+
+        [Test]
+        public void Given_AStableRefCallback_When_TheHostElementPatches_Then_TheRefIsNotReinvoked()
+        {
+            // Arrange — mounted once (one setup), then patched twice with the same callback identity.
+            using var store = new CounterStore();
+            s_store = store;
+            using var mounted = V.Mount(_root, V.Component(StableRefHost, key: "host"));
+            var scheduler = mounted.Root.Reconciler.Context.BatchScheduler;
+            Assume.That(s_setupCount, Is.EqualTo(1), "Precondition: mount ran the ref setup once");
+
+            // Act
+            store.Increment();
+            scheduler.DrainImmediateForTest();
+            store.Increment();
+            scheduler.DrainImmediateForTest();
+
+            // Assert — the installed ref survived both patches untouched (no cleanup+setup cycles).
+            Assert.That((s_setupCount, s_cleanupCount), Is.EqualTo((1, 0)),
+                "A patch carrying the same callback identity must not re-invoke the ref");
+        }
+
+        // Alternates between two distinct callback identities per render parity.
+        private static readonly Func<VisualElement, Action> s_refA = _ => { s_setupCount++; return () => s_cleanupCount++; };
+        private static readonly Func<VisualElement, Action> s_refB = _ => { s_setupCount++; return () => s_cleanupCount++; };
+
+        [Component]
+        private static VNode SwappingRefHost()
+        {
+            var count = Hooks.UseStore(s_store, x => x);
+            return V.Div(name: "host", children: new VNode[]
+            {
+                V.Button(name: "target", text: "target", refCallback: count % 2 == 0 ? s_refA : s_refB),
+            });
+        }
+
+        [Test]
+        public void Given_ARefCallbackIdentityChange_When_TheHostElementPatches_Then_TheOldRefCleansUpAndTheNewOneRuns()
+        {
+            // Arrange — mounted with identity A installed.
+            using var store = new CounterStore();
+            s_store = store;
+            using var mounted = V.Mount(_root, V.Component(SwappingRefHost, key: "host"));
+            var scheduler = mounted.Root.Reconciler.Context.BatchScheduler;
+            Assume.That(s_setupCount, Is.EqualTo(1), "Precondition: mount ran identity A's setup once");
+
+            // Act — the patch swaps to identity B.
+            store.Increment();
+            scheduler.DrainImmediateForTest();
+
+            // Assert — A's cleanup fired and B's setup ran (React's identity-change cycle).
+            Assert.That((s_setupCount, s_cleanupCount), Is.EqualTo((2, 1)),
+                "An identity change must run the old cleanup and the new setup exactly once each");
+        }
+
+        [Test]
+        public void Given_AStableRefCallback_When_TheHostElementUnmounts_Then_TheCleanupStillFires()
+        {
+            // Arrange — mounted, patched once (no re-invoke), then the whole tree unmounts.
+            using var store = new CounterStore();
+            s_store = store;
+            var mounted = V.Mount(_root, V.Component(StableRefHost, key: "host"));
+            var scheduler = mounted.Root.Reconciler.Context.BatchScheduler;
+            store.Increment();
+            scheduler.DrainImmediateForTest();
+            Assume.That(s_cleanupCount, Is.EqualTo(0), "Precondition: no cleanup while mounted");
+
+            // Act
+            mounted.Dispose();
+
+            // Assert — the detach path still finds and fires the stored cleanup.
+            Assert.That(s_cleanupCount, Is.EqualTo(1),
+                "Unmount must fire the installed ref's cleanup exactly once");
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/RefCallbackIdentityTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/RefCallbackIdentityTests.cs
@@ -128,8 +128,9 @@ namespace Velvet.Tests
                 "Unmount must fire the installed ref's cleanup exactly once");
         }
 
-        // A capture-less static delegate: the same identity across two INDEPENDENT mounts, which is
-        // how a pooled element could meet the same callback again on its next tenant.
+        // A capture-less static delegate: the same identity across two tenancies WITHIN one mounted
+        // tree (one ReconcilerContext), which is how a pooled element re-rented under the SAME
+        // per-context identity table could meet the same callback again.
         private static readonly Func<VisualElement, Action> s_pooledTenantRef = _ =>
         {
             s_setupCount++;
@@ -137,30 +138,41 @@ namespace Velvet.Tests
         };
 
         [Component]
-        private static VNode PooledTenantHost() =>
-            V.Div(name: "host", children: new VNode[]
+        private static VNode PooledTenantHost()
+        {
+            var count = Hooks.UseStore(s_store, x => x);
+            return V.Div(name: "host", children: new VNode[]
             {
-                V.Button(name: "target", text: "target", refCallback: s_pooledTenantRef),
+                count % 2 == 0
+                    ? V.Button(name: "target", text: "target", key: "tenant", refCallback: s_pooledTenantRef)
+                    : null,
             });
+        }
 
         [Test]
-        public void Given_AHostUnmountedAndRemountedWithTheSameRefIdentity_When_TheNewTenantMounts_Then_TheSetupRunsAgain()
+        public void Given_ATenantRemovedAndRecreatedWithinOneTree_When_ThePooledElementIsReRented_Then_TheSetupRunsAgain()
         {
-            // Arrange — first mount installs the ref, unmount cleans it up and pools the element.
-            // The identity gate keys on the STORED entry, which the element cleaner must have
-            // removed on the way to the pool — a stale entry would make the same-identity remount
-            // silently skip its setup (no signals hooked, refs never set) instead of running it.
-            var first = V.Mount(_root, V.Component(PooledTenantHost, key: "first"));
-            first.Dispose();
+            // Arrange — mounted with the tenant visible (setup ran), then hidden: the cleanup fires
+            // and the element returns to the pool, which must scrub the per-context identity entry —
+            // a stale entry would make the same-identity re-rent under the SAME context silently
+            // skip its setup (no signals hooked, refs never set) instead of running it.
+            using var store = new CounterStore();
+            s_store = store;
+            using var mounted = V.Mount(_root, V.Component(PooledTenantHost, key: "host"));
+            var scheduler = mounted.Root.Reconciler.Context.BatchScheduler;
+            store.Increment();
+            scheduler.DrainImmediateForTest();
             Assume.That((s_setupCount, s_cleanupCount), Is.EqualTo((1, 1)),
-                "Precondition: the first tenant ran one setup and one cleanup");
+                "Precondition: the first tenancy ran one setup and one cleanup");
 
-            // Act — a fresh mount whose element may be the pooled instance, under the SAME delegate.
-            using var second = V.Mount(new VisualElement(), V.Component(PooledTenantHost, key: "second"));
+            // Act — show the tenant again: the recreated button (likely the pooled instance) mounts
+            // under the same callback identity and the same context.
+            store.Increment();
+            scheduler.DrainImmediateForTest();
 
-            // Assert — the new tenant's setup ran (the pool return scrubbed the identity entry).
+            // Assert — the new tenancy's setup ran.
             Assert.That(s_setupCount, Is.EqualTo(2),
-                "A remounted element under the same ref identity must run its setup again");
+                "A re-rented element under the same ref identity must run its setup again");
         }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/RefCallbackIdentityTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/RefCallbackIdentityTests.cs
@@ -127,5 +127,40 @@ namespace Velvet.Tests
             Assert.That(s_cleanupCount, Is.EqualTo(1),
                 "Unmount must fire the installed ref's cleanup exactly once");
         }
+
+        // A capture-less static delegate: the same identity across two INDEPENDENT mounts, which is
+        // how a pooled element could meet the same callback again on its next tenant.
+        private static readonly Func<VisualElement, Action> s_pooledTenantRef = _ =>
+        {
+            s_setupCount++;
+            return () => s_cleanupCount++;
+        };
+
+        [Component]
+        private static VNode PooledTenantHost() =>
+            V.Div(name: "host", children: new VNode[]
+            {
+                V.Button(name: "target", text: "target", refCallback: s_pooledTenantRef),
+            });
+
+        [Test]
+        public void Given_AHostUnmountedAndRemountedWithTheSameRefIdentity_When_TheNewTenantMounts_Then_TheSetupRunsAgain()
+        {
+            // Arrange — first mount installs the ref, unmount cleans it up and pools the element.
+            // The identity gate keys on the STORED entry, which the element cleaner must have
+            // removed on the way to the pool — a stale entry would make the same-identity remount
+            // silently skip its setup (no signals hooked, refs never set) instead of running it.
+            var first = V.Mount(_root, V.Component(PooledTenantHost, key: "first"));
+            first.Dispose();
+            Assume.That((s_setupCount, s_cleanupCount), Is.EqualTo((1, 1)),
+                "Precondition: the first tenant ran one setup and one cleanup");
+
+            // Act — a fresh mount whose element may be the pooled instance, under the SAME delegate.
+            using var second = V.Mount(new VisualElement(), V.Component(PooledTenantHost, key: "second"));
+
+            // Assert — the new tenant's setup ran (the pool return scrubbed the identity entry).
+            Assert.That(s_setupCount, Is.EqualTo(2),
+                "A remounted element under the same ref identity must run its setup again");
+        }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/RefCallbackIdentityTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/RefCallbackIdentityTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 470a7d3d09f4e43b6aa45c97926d33a1


### PR DESCRIPTION
## Problem (#62)

A hook state write landing while the same fiber's flush was past its render phase — a callback ref invoked during a patch, an event dispatched from a detach — raised the render-phase-update flag after the render loop had stopped consuming it, so the flush's `finally` cleared it silently: the slot value advanced with no re-render, desyncing committed UI from state, and the poisoned value then equality-bailed the NEXT genuine edge. Two shipped features carried local workarounds (`UseFocusRing`'s deferred panel-tick correction, DnD's teardown deferral rationale).

Feeding the problem: the reconciler re-invoked callback refs on EVERY patch of the host element (React re-invokes only on identity change or remount), which made every ref cleanup a mid-flush writer in the first place.

## Fix

- **Ref identity parity** — `RefCallbacks` stores the installed callback identity per element; a patch carrying the same delegate leaves the ref untouched, an identity change cycles it (old cleanup → new setup), pool returns scrub the entry, and reconciler disposal detaches whatever a diverged teardown skipped. `Ref<T>.SetElement` became an identity-stable cached delegate (a method group minted a fresh delegate per render, so the framework's own object-ref pattern could never benefit — and stopped cycling only when the auto-memo happened to hit).
- **Commit-phase writes schedule** — the render-phase-update window (`IsInRenderPhase`, one shared open/close helper) covers only the component body; writes landing later in the flush take the ordinary schedule. `HookGuard` now gates hook CALLS on the same window, so a hook called from a ref fails fast instead of corrupting the slot cursor.
- **Drain-until-quiet, everywhere** — the frame drain loops until its queue is quiet (React's setState-in-commit-flushes-before-paint), and the guarantee is entry-point-agnostic: the delayed-tier drain runs a boundary pass when its commits spawned immediate work (monotonic intake flag — net counts get masked by removals/dedup), the initial mount flushes before returning, and a terminal time-sliced resume slice flushes too. Runaway loops hit React's maximum update depth (50); overflow logs an error and drops the runaway's immediate lanes only — a throw can't reach a boundary from the frame callback, a deferred runaway re-arms forever, and bystanders' Transition/Deferred lanes survive the drop.
- **`UseFocusRing` simplified** — the generation/hooked-element cells and panel-tick deferral existed only because per-patch ref cycles dropped their writes; the cleanup now writes the flags directly. Composing its `Ref` requires a `UseCallback`-wrapped lambda (documented on the hook): a fresh-identity composed ref cycling per patch is the same inline-ref-writing-state feedback React has.

## Tests

- RED→GREEN pins: stable ref not re-invoked across patches; commit-phase ref write commits within the same drain; runaway loop capped, logged, and dropped with real passes counted.
- Contract pins: identity-change cycle, unmount cleanup, same-context pooled re-rent runs setup again, composed-stable-ref ring survival, layout-effect mount writes commit before `V.Mount` returns (moved to the parity contract), reentrant delayed-drain boundary commit + empty remainder.
- Full suites green locally: EditMode 2857, PlayMode 71.

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)