### PR TITLE
test: pin panel-focus survival across keyed reorders (closes #63 as already-correct)

### DIFF
--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/KeyedReorderFocusTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/KeyedReorderFocusTests.cs
@@ -1,0 +1,133 @@
+using NUnit.Framework;
+using UnityEngine.UIElements;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins React DOM parity for panel focus across keyed reorders — a parity the ENGINE itself
+    /// provides and Velvet must not break: the placement walk moves a non-anchor element with
+    /// RemoveAt + Insert inside one flush, and UI Toolkit's focus bookkeeping validates the focused
+    /// element lazily, so an element re-inserted within the same frame keeps panel focus (and
+    /// receives no Blur), exactly like a DOM node moved with <c>insertBefore</c>. These specs exist
+    /// because the opposite was plausible enough to almost ship a re-focus workaround: any future
+    /// placement change that detaches across a frame boundary (or an engine behavior change) must
+    /// surface here, not as gamepad users silently losing their place in reordered lists.
+    /// </summary>
+    [TestFixture]
+    internal sealed class KeyedReorderFocusTests
+    {
+        private sealed class KeysStore : Store<string>
+        {
+            public KeysStore() : base("abc") { }
+            public void Set(string keys) => SetState(_ => keys);
+            protected override void ResetCore() => SetState(_ => "abc");
+        }
+
+        private static KeysStore s_store;
+
+        private HeadlessEditorPanelHost _host;
+        private MountedTree _mounted;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _host = new HeadlessEditorPanelHost();
+            s_store = null;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _mounted?.Dispose();
+            _mounted = null;
+            _host?.Dispose();
+            _host = null;
+        }
+
+        [Component]
+        private static VNode ReorderList()
+        {
+            var keys = Hooks.UseStore(s_store, x => x);
+            var children = new System.Collections.Generic.List<VNode>();
+            foreach (var key in keys)
+            {
+                children.Add(V.Button(name: "item-" + key, key: key.ToString(), text: key.ToString()));
+            }
+            return V.Div(name: "list", children: children.ToArray());
+        }
+
+        // "abc" -> "cba" leaves a single-element longest increasing subsequence, so the focused
+        // middle item is NOT an anchor and the walk physically moves it (RemoveAt + Insert).
+
+        [Test]
+        public void Given_AFocusedKeyedItem_When_AReorderMovesIt_Then_ItKeepsPanelFocus()
+        {
+            // Arrange — real panel focus on the middle item.
+            using var store = new KeysStore();
+            s_store = store;
+            _mounted = V.Mount(_host.Root, V.Component(ReorderList, key: "list"));
+            var item = _host.Root.Q<VisualElement>("item-b");
+            item.Focus();
+            _mounted.FlushStateForTest();
+            Assume.That(_host.Panel.focusController.focusedElement, Is.SameAs(item),
+                "Precondition: the middle item holds panel focus");
+
+            // Act — reverse the list; the focused item is moved by the placement walk.
+            store.Set("cba");
+            _mounted.FlushStateForTest();
+
+            // Assert — the same element instance still holds panel focus after its move.
+            Assert.That(_host.Panel.focusController.focusedElement, Is.SameAs(item),
+                "A keyed reorder that moves the focused element must not drop panel focus");
+        }
+
+        [Test]
+        public void Given_AFocusedKeyedItem_When_AReorderMovesIt_Then_NoBlurEdgeReachesIt()
+        {
+            // Arrange — hook consumers (focus rings, whileFocus styling) are edge-driven, so a
+            // same-frame move must ALSO stay silent on the event channel: a spurious Blur would
+            // flicker every focus-derived state even though panel focus survives.
+            using var store = new KeysStore();
+            s_store = store;
+            _mounted = V.Mount(_host.Root, V.Component(ReorderList, key: "list"));
+            var item = _host.Root.Q<VisualElement>("item-b");
+            var blurCount = 0;
+            item.RegisterCallback<BlurEvent>(_ => blurCount++);
+            item.Focus();
+            _mounted.FlushStateForTest();
+            Assume.That(_host.Panel.focusController.focusedElement, Is.SameAs(item),
+                "Precondition: the middle item holds panel focus");
+
+            // Act
+            store.Set("cba");
+            _mounted.FlushStateForTest();
+
+            // Assert
+            Assert.That(blurCount, Is.EqualTo(0),
+                "A same-frame move must not deliver a Blur to the moved element");
+        }
+
+        [Test]
+        public void Given_AFocusedKeyedItem_When_AReorderMovesIt_Then_ItsDomPositionFollowsTheNewOrder()
+        {
+            // Arrange — focus survival must not come at the cost of the reorder's outcome itself.
+            using var store = new KeysStore();
+            s_store = store;
+            _mounted = V.Mount(_host.Root, V.Component(ReorderList, key: "list"));
+            _host.Root.Q<VisualElement>("item-b").Focus();
+            _mounted.FlushStateForTest();
+
+            // Act
+            store.Set("cba");
+            _mounted.FlushStateForTest();
+
+            // Assert — the list committed the reversed order.
+            var list = _host.Root.Q<VisualElement>("list");
+            Assert.That(
+                (list.ElementAt(0).name, list.ElementAt(1).name, list.ElementAt(2).name),
+                Is.EqualTo(("item-c", "item-b", "item-a")),
+                "The reorder commits the new order with the focused element moved in place");
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/KeyedReorderFocusTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/KeyedReorderFocusTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 44c2a44e5b3994f10ac30cc89232ceb3


### PR DESCRIPTION
## Finding

#63 suspected that a keyed reorder moving the focused element drops panel focus (`RemoveAt` + `Insert` detaching it transiently). Empirical probes against a real focus controller show the premise does not hold:

- **Reorder** (`abc` → `cba`, the focused middle item is non-LIS and physically moves): the element lands at its new position, **panel focus stays on the same instance, and no Blur is delivered**. UI Toolkit validates the focused element lazily, so a same-frame re-insert never surfaces as a focus loss — the engine already provides React DOM's `insertBefore` parity here.
- **Removal**: panel focus is cleared — and no Blur event is delivered either (the lazy validation clears silently). This also corrects the assumption in #62/#63's text that a transient detach delivers a mid-flush Blur.

No runtime change is needed; a drafted re-focus workaround was reverted as unnecessary.

## Change

Three regression pins in `KeyedReorderFocusTests` keep the parity load-bearing:
1. the moved element keeps panel focus,
2. no Blur edge reaches it (focus-derived hook/styling state must not flicker),
3. the reorder still commits the new order.

A future placement change that detaches across a frame boundary — or an engine behavior change — fails these pins instead of silently breaking gamepad/keyboard list navigation.

Full suites green locally: EditMode 2860, PlayMode 71.

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)