### PR TITLE
fix(velvet): keep a filtered element's skew silhouette and drop-shadow bleed from clipping to the layout rect

### DIFF
--- a/Packages/com.velvet.core/Runtime/Reconciler/ChildElementPlacement.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ChildElementPlacement.cs
@@ -255,8 +255,11 @@ namespace Velvet
                 }
                 else
                 {
-                    parent.Add(element);
-                    insertHint = parent.childCount - 1;
+                    // Insert before any trailing filter bounds-spacer (not parent.Add, which appends past it)
+                    // so a skewed / shadowed + filtered container keeps its spacer last through the reorder.
+                    var end = SilhouetteBoundsSpacer.NonSpacerChildCount(parent);
+                    parent.Insert(end, element);
+                    insertHint = end;
                 }
             }
         }

--- a/Packages/com.velvet.core/Runtime/Reconciler/ChildReconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ChildReconciler.cs
@@ -126,7 +126,7 @@ namespace Velvet
                 _cleaner.RemoveElement(parent, slotStart + i);
             }
             var newElement = _factory.CreateElement(newNode);
-            var insertIndex = clampInsertIndex ? Math.Min(slotStart + i, parent.childCount) : slotStart + i;
+            var insertIndex = clampInsertIndex ? Math.Min(slotStart + i, SilhouetteBoundsSpacer.NonSpacerChildCount(parent)) : slotStart + i;
             parent.Insert(insertIndex, newElement);
             return checkAbortAfterCreate && _ctx.IsAborted;
         }
@@ -280,7 +280,10 @@ namespace Velvet
                         continue;
                 }
                 var resolvedTarget = target!;
-                var slotStart = resolvedTarget.childCount;
+                // Exclude a trailing filter bounds-spacer (a skewed / shadowed + filtered target carries one):
+                // portal children must land BEFORE it so it stays last and the recorded slot start does not
+                // drift when the spacer self-heals to the end.
+                var slotStart = SilhouetteBoundsSpacer.NonSpacerChildCount(resolvedTarget);
                 // Restore the context that enclosed the Portal's tree position (captured at enqueue) so the
                 // children mount under their enclosing Providers / MotionContext rather than an empty cursor.
                 // The children's own reconcile pushes/pops on top of these and balances out, so popping the
@@ -331,7 +334,7 @@ namespace Velvet
                         f.DetachedMountContext = detachedContext;
                     }
                 }
-                var slotLength = resolvedTarget.childCount - slotStart;
+                var slotLength = SilhouetteBoundsSpacer.NonSpacerChildCount(resolvedTarget) - slotStart;
                 _ctx.PortalState[placeholder] = new PortalSlotInfo(resolvedTarget, slotStart, slotLength);
             }
         }
@@ -434,7 +437,10 @@ namespace Velvet
             VisualElement? parent, VNode?[]? oldNodes, VNode?[]? newNodes, int slotStart, int slotLimit)
         {
             if (parent == null || oldNodes == null || newNodes == null) return false;
-            var rangeEnd = Math.Min(parent.childCount, slotLimit);
+            // NonSpacerChildCount, not raw childCount: a trailing filter bounds-spacer on a skewed / shadowed +
+            // filtered parent is not a keyed row, so it must not pad `available` (masking a real desync) nor be
+            // the first element the removal loop below tears out.
+            var rangeEnd = Math.Min(SilhouetteBoundsSpacer.NonSpacerChildCount(parent), slotLimit);
             var available = rangeEnd - slotStart;
             if (available < 0) available = 0;
             if (oldNodes.Length <= available) return false;
@@ -448,7 +454,7 @@ namespace Velvet
             {
                 var element = _factory.CreateElement(newNodes[i]);
                 if (_ctx.IsAborted) return true;
-                parent.Insert(Math.Min(slotStart + i, parent.childCount), element);
+                parent.Insert(Math.Min(slotStart + i, SilhouetteBoundsSpacer.NonSpacerChildCount(parent)), element);
             }
             return true;
         }
@@ -519,7 +525,7 @@ namespace Velvet
                     // Bound by slotLimit (this fiber's range end), not just childCount: for a non-last inline
                     // tenant childCount includes the following sibling's rows, so an unbounded check would treat a
                     // sibling row as this fiber's and PATCH it. Out of range → create within this fiber's range.
-                    var slotExists = slotStart + i < Math.Min(parent.childCount, slotLimit);
+                    var slotExists = slotStart + i < Math.Min(SilhouetteBoundsSpacer.NonSpacerChildCount(parent), slotLimit);
                     if (PatchOrReplaceAtSlot(parent, slotStart, i, oldNodes[i], newNodes[i],
                             slotExists, clampInsertIndex: true, checkAbortAfterCreate: true))
                     {
@@ -555,7 +561,8 @@ namespace Velvet
 
                     // DOM-desync recovery (see the Common phase): when the live container is shorter than the
                     // baseline claims, the tail slot to remove may not exist — skip it instead of over-indexing.
-                    if (slotStart + i >= parent.childCount)
+                    // NonSpacerChildCount so a trailing filter bounds-spacer is never the slot removal targets.
+                    if (slotStart + i >= SilhouetteBoundsSpacer.NonSpacerChildCount(parent))
                     {
                         continue;
                     }
@@ -602,7 +609,7 @@ namespace Velvet
                 // equivalent to Add (slotStart + i == parent.childCount at this point). Clamp to childCount so a
                 // DOM-desync resume directly into this phase (the live range shrank since the slice was parked)
                 // appends rather than over-indexing — symmetric with the Common-phase create-on-missing guard.
-                parent.Insert(Math.Min(slotStart + i, parent.childCount), newElement);
+                parent.Insert(Math.Min(slotStart + i, SilhouetteBoundsSpacer.NonSpacerChildCount(parent)), newElement);
 
                 if (budgeted && _stopwatch!.Elapsed.TotalMilliseconds > frameBudgetMs)
                 {
@@ -1303,9 +1310,12 @@ namespace Velvet
         // stale element as the new type. Both the synchronous and time-sliced keyed paths gate on this.
         private static void AssertDomIndexInvariant(int slotStart, int oldIndex, VisualElement parent)
         {
+            // NonSpacerChildCount so a trailing filter bounds-spacer does not loosen the bound (masking a real
+            // Pass-1 ordering violation); keyed rows always precede the spacer, so the access itself is in range.
+            var rendered = SilhouetteBoundsSpacer.NonSpacerChildCount(parent);
             UnityEngine.Debug.Assert(
-                slotStart + oldIndex < parent.childCount,
-                $"[ChildReconciler] DOM index invariant violated: slotStart + old.index={slotStart + oldIndex} >= parent.childCount={parent.childCount}. " +
+                slotStart + oldIndex < rendered,
+                $"[ChildReconciler] DOM index invariant violated: slotStart + old.index={slotStart + oldIndex} >= renderedChildCount={rendered}. " +
                 "Pass 1 may have modified parent's child order.");
         }
 

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
@@ -2056,7 +2056,10 @@ namespace Velvet
             var outer = ResolveOuter(element);
             if (outer.parent != null)
             {
-                EvaluateStructural(element, outer.parent.IndexOf(outer), outer.parent.childCount, rules);
+                // Exclude the trailing filter bounds-spacer(s) from the sibling count: they are internal
+                // render-bounds children, not part of the logical child list a first:/last:/nth match sees.
+                EvaluateStructural(element, outer.parent.IndexOf(outer),
+                    SilhouetteBoundsSpacer.NonSpacerChildCount(outer.parent), rules);
             }
         }
 
@@ -2083,7 +2086,9 @@ namespace Velvet
                 return;
             }
 
-            var count = container.childCount;
+            // The trailing filter bounds-spacer(s) are internal render-bounds children, not logical siblings:
+            // exclude them from the count and skip evaluating them so first:/last:/nth match the real children.
+            var count = SilhouetteBoundsSpacer.NonSpacerChildCount(container);
             for (var i = 0; i < count; i++)
             {
                 // The slot may hold a shadow / clip-path WRAPPER; the structural rules are keyed by the inner.

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberWrapperElementAppliers.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberWrapperElementAppliers.cs
@@ -40,6 +40,38 @@ namespace Velvet
             // sheared mesh (the rectangular background-image the non-skew path would set cannot follow the
             // shear). ApplyGradientOnCreate runs next and defers to this binding.
             SyncSkewGradient(element, binding, classNames);
+            SkewSilhouette.SetWantSpacer(element, binding, CarriesFilter(classNames));
+        }
+
+        // True when the class list carries an inline filter — a static filter-* utility or the animate-hue
+        // motion (which drives style.filter every frame) — in the base classes OR any state variant. A filter
+        // promotes the element to an offscreen render tree sized to its layout boundingBox, which clips a
+        // sheared silhouette / shadow bleed; the paint layers answer with a bounds-spacer (SilhouetteBoundsSpacer)
+        // that widens boundingBox. The spacer must exist whenever a filter COULD apply (a variant applies its
+        // payload at state time, outside this reconcile pass), so both checks peel variant layers to the leaf.
+        private static bool CarriesFilter(string[] classNames)
+        {
+            if (classNames == null)
+            {
+                return false;
+            }
+            if (StyleFilterValueParser.HasFilterClass(classNames))
+            {
+                return true;
+            }
+            foreach (var cls in classNames)
+            {
+                var leaf = cls;
+                while (StyleVariantClass.TryParse(leaf, out _, out var payload))
+                {
+                    leaf = payload;
+                }
+                if (leaf != null && leaf.StartsWith("animate-hue", StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+            return false;
         }
 
         // Feeds the gradient resolved from the element's class list into a skew binding (or clears it), so
@@ -82,6 +114,8 @@ namespace Velvet
                 if (classesChanged)
                 {
                     SyncSkewGradient(element, binding, newClassNames);
+                    // A filter utility / animate-hue can appear or vanish without the skew tokens changing.
+                    SkewSilhouette.SetWantSpacer(element, binding, CarriesFilter(newClassNames));
                 }
                 return binding.Spec.XDeg;
             }
@@ -94,6 +128,7 @@ namespace Velvet
                 binding.Spec = spec;
                 SkewSilhouette.SyncStashOnPatch(element, binding, classesChanged: true);
                 SyncSkewGradient(element, binding, newClassNames);
+                SkewSilhouette.SetWantSpacer(element, binding, CarriesFilter(newClassNames));
                 element.MarkDirtyRepaint();
                 return spec.XDeg;
             }
@@ -103,6 +138,7 @@ namespace Velvet
                 _ctx.SkewBindings[element] = fresh;
                 SkewSilhouette.SyncStashOnPatch(element, fresh, classesChanged: true);
                 SyncSkewGradient(element, fresh, newClassNames);
+                SkewSilhouette.SetWantSpacer(element, fresh, CarriesFilter(newClassNames));
                 return spec.XDeg;
             }
             if (bound)
@@ -331,8 +367,9 @@ namespace Velvet
             // suppressing the native chrome and repainting an upright fill over the shadow quad. skew-y casters
             // have skewXDeg 0 yet are skewed, so this gate is the SkewBindings presence, not the X angle.
             var casterSkewed = _ctx.SkewBindings.ContainsKey(element);
-            _ctx.ShadowBindings[element] =
-                DropShadowSilhouette.Attach(element, spec, classNames, skewXDeg, casterSkewed);
+            var shadowBinding = DropShadowSilhouette.Attach(element, spec, classNames, skewXDeg, casterSkewed);
+            _ctx.ShadowBindings[element] = shadowBinding;
+            DropShadowSilhouette.SetWantSpacer(element, shadowBinding, CarriesFilter(classNames));
         }
 
         // Patch-time reconciliation of an element's shadow state against its new class list. Mirrors the
@@ -364,11 +401,13 @@ namespace Velvet
             if (want && bound)
             {
                 DropShadowSilhouette.Sync(element, binding, spec, classNames, skewXDeg, casterSkewed);
+                DropShadowSilhouette.SetWantSpacer(element, binding, CarriesFilter(classNames));
             }
             else if (want)
             {
-                _ctx.ShadowBindings[element] =
-                    DropShadowSilhouette.Attach(element, spec, classNames, skewXDeg, casterSkewed);
+                var fresh = DropShadowSilhouette.Attach(element, spec, classNames, skewXDeg, casterSkewed);
+                _ctx.ShadowBindings[element] = fresh;
+                DropShadowSilhouette.SetWantSpacer(element, fresh, CarriesFilter(classNames));
             }
             else if (bound)
             {

--- a/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
@@ -183,7 +183,7 @@ namespace Velvet
             // IndexOutOfRange — the time-sliced keyed path asserts this invariant; the general path
             // can be re-entered mid-suspend so it guards defensively.
             var oldMatched = commit.OldKeyMap.TryGetValue(key, out var old)
-                && slotStart + old.index < parent.childCount;
+                && slotStart + old.index < SilhouetteBoundsSpacer.NonSpacerChildCount(parent);
             if (oldMatched && commit.UsedKeys.Contains(key))
             {
                 // A second new-side sibling resolved the same old entry its first occurrence already

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ShadowFilterSpacerTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ShadowFilterSpacerTests.cs
@@ -1,0 +1,110 @@
+using System.Linq;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.UIElements;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins the filter bounds-spacer on the drop-shadow layer: a shadowed element under an inline filter (the
+    /// filter's offscreen render tree would clip the shadow bleed to the layout rect) gets a trailing spacer
+    /// that widens boundingBox, and it appears / vanishes with the filter. The reconciler-safety mechanics are
+    /// shared with the skew layer (SilhouetteBoundsSpacer) and pinned there. GWT, one assert each.
+    /// </summary>
+    [TestFixture]
+    internal sealed class ShadowFilterSpacerTests
+    {
+        private const string ShadowFilter = "w-[200px] h-[80px] shadow-lg hue-rotate-90";
+        private const string ShadowNoFilter = "w-[200px] h-[80px] shadow-lg";
+
+        private EditorWindow _window;
+        private MountedTree _mounted;
+        private static StateUpdater<string> s_setClass;
+
+        [SetUp]
+        public void SetUp()
+        {
+            TestGraphics.IgnoreIfHeadless("an EditorWindow panel");
+            s_setClass = default;
+            _window = ScriptableObject.CreateInstance<TestHostWindow>();
+            _window.position = new Rect(0, 0, 800, 600);
+            _window.Show();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _mounted?.Dispose();
+            _mounted = null;
+            if (_window != null)
+            {
+                _window.Close();
+                UnityEngine.Object.DestroyImmediate(_window);
+                _window = null;
+            }
+        }
+
+        [Component]
+        private static VNode RenderCard()
+        {
+            var (cls, setClass) = Hooks.UseState(ShadowFilter);
+            s_setClass = setClass;
+            return V.Div(className: cls, name: "card");
+        }
+
+        private FiberBatchScheduler Scheduler => _mounted.Root.Reconciler.Context.BatchScheduler;
+        private VisualElement Card => _window.rootVisualElement.Q<VisualElement>("card");
+        private int SpacerCount() => Enumerable.Range(0, Card.childCount)
+            .Count(i => SilhouetteBoundsSpacer.IsSpacer(Card[i]));
+
+        private void Mount() => _mounted = V.Mount(_window.rootVisualElement, V.Component(RenderCard));
+
+        private void SetClass(string cls)
+        {
+            s_setClass.Invoke(cls);
+            Scheduler.DrainImmediateForTest();
+        }
+
+        [Test]
+        public void Given_AShadowedFilteredElement_When_Mounted_Then_ASpacerIsAdded()
+        {
+            Mount();
+
+            Assert.That(SpacerCount(), Is.EqualTo(1));
+        }
+
+        [Test]
+        public void Given_AShadowedElementWithoutFilter_When_Mounted_Then_NoSpacerIsAdded()
+        {
+            Mount();
+            SetClass(ShadowNoFilter);
+
+            Assert.That(SpacerCount(), Is.EqualTo(0));
+        }
+
+        [Test]
+        public void Given_TheFilterRemovedOnPatch_When_Drained_Then_TheSpacerIsGone()
+        {
+            Mount();
+            Assume.That(SpacerCount(), Is.EqualTo(1), "Precondition: the spacer was present under the filter");
+            SetClass(ShadowNoFilter);
+
+            Assert.That(SpacerCount(), Is.EqualTo(0));
+        }
+
+        [Test]
+        public void Given_TheFilterAddedOnPatch_When_Drained_Then_TheSpacerAppears()
+        {
+            Mount();
+            SetClass(ShadowNoFilter);
+            Assume.That(SpacerCount(), Is.EqualTo(0), "Precondition: no spacer without a filter");
+            SetClass(ShadowFilter);
+
+            Assert.That(SpacerCount(), Is.EqualTo(1));
+        }
+
+        private sealed class TestHostWindow : EditorWindow { }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ShadowFilterSpacerTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ShadowFilterSpacerTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: cb5781d7a993d433a809cfed5ce6efd4

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/SkewFilterSpacerTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/SkewFilterSpacerTests.cs
@@ -1,0 +1,233 @@
+using System;
+using System.Linq;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.UIElements;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins the filter bounds-spacer: a skewed element under an inline filter (a filter clips the sheared
+    /// silhouette to the layout rect, so a transparent last-child spacer widens the element's boundingBox to
+    /// keep it) gets exactly one trailing spacer, the spacer is kept LAST so the positional child reconciler
+    /// never mistakes it for a rendered child, keyed child reconciliation stays correct alongside it, and the
+    /// spacer appears / vanishes with the filter. GWT, one assert each.
+    /// </summary>
+    [TestFixture]
+    internal sealed class SkewFilterSpacerTests
+    {
+        private const string SkewFilter = "w-[200px] -skew-x-6 hue-rotate-90 flex flex-col";
+        private const string SkewNoFilter = "w-[200px] -skew-x-6 flex flex-col";
+
+        private EditorWindow _window;
+        private MountedTree _mounted;
+        private static StateUpdater<string[]> s_setItems;
+        private static StateUpdater<string> s_setClass;
+
+        [SetUp]
+        public void SetUp()
+        {
+            TestGraphics.IgnoreIfHeadless("an EditorWindow panel");
+            s_setItems = default;
+            s_setClass = default;
+            _window = ScriptableObject.CreateInstance<TestHostWindow>();
+            _window.position = new Rect(0, 0, 800, 600);
+            _window.Show();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _mounted?.Dispose();
+            _mounted = null;
+            if (_window != null)
+            {
+                _window.Close();
+                UnityEngine.Object.DestroyImmediate(_window);
+                _window = null;
+            }
+        }
+
+        [Component]
+        private static VNode RenderContainer()
+        {
+            var (cls, setClass) = Hooks.UseState(SkewFilter);
+            var (items, setItems) = Hooks.UseState(new[] { "a", "b", "c" });
+            s_setClass = setClass;
+            s_setItems = setItems;
+            return V.Div(className: cls, name: "box",
+                children: items.Select(it => (VNode?)V.Div(key: it, name: it, className: "h-[20px]")).ToArray());
+        }
+
+        private FiberBatchScheduler Scheduler => _mounted.Root.Reconciler.Context.BatchScheduler;
+        private VisualElement Box => _window.rootVisualElement.Q<VisualElement>("box");
+
+        // The rendered (non-spacer) children in order, by name.
+        private string[] ChildNames() => Enumerable.Range(0, Box.childCount)
+            .Select(i => Box[i])
+            .Where(c => !SilhouetteBoundsSpacer.IsSpacer(c))
+            .Select(c => c.name)
+            .ToArray();
+
+        private int SpacerCount() => Enumerable.Range(0, Box.childCount)
+            .Count(i => SilhouetteBoundsSpacer.IsSpacer(Box[i]));
+
+        private bool SpacerIsLast() => Box.childCount > 0 && SilhouetteBoundsSpacer.IsSpacer(Box[Box.childCount - 1]);
+
+        private void Mount()
+        {
+            _mounted = V.Mount(_window.rootVisualElement, V.Component(RenderContainer));
+        }
+
+        private void SetItems(string[] items)
+        {
+            s_setItems.Invoke(items);
+            Scheduler.DrainImmediateForTest();
+        }
+
+        private void SetClass(string cls)
+        {
+            s_setClass.Invoke(cls);
+            Scheduler.DrainImmediateForTest();
+        }
+
+        [Test]
+        public void Given_ASkewedFilteredContainer_When_Mounted_Then_OneSpacerIsAdded()
+        {
+            Mount();
+
+            Assert.That(SpacerCount(), Is.EqualTo(1));
+        }
+
+        [Test]
+        public void Given_ASkewedFilteredContainer_When_Mounted_Then_TheSpacerIsLast()
+        {
+            Mount();
+
+            Assert.That(SpacerIsLast(), Is.True);
+        }
+
+        [Test]
+        public void Given_ASkewedFilteredContainer_When_Mounted_Then_TheRenderedChildrenAreIntact()
+        {
+            Mount();
+
+            Assert.That(ChildNames(), Is.EqualTo(new[] { "a", "b", "c" }));
+        }
+
+        [Test]
+        public void Given_AChildRemoved_When_Drained_Then_TheRemainingChildrenReconcileCorrectly()
+        {
+            Mount();
+            SetItems(new[] { "a", "c" });
+
+            Assert.That(ChildNames(), Is.EqualTo(new[] { "a", "c" }));
+        }
+
+        [Test]
+        public void Given_ChildrenReorderedAndAdded_When_Drained_Then_TheChildrenReconcileCorrectly()
+        {
+            Mount();
+            SetItems(new[] { "c", "a", "b", "d" });
+
+            Assert.That(ChildNames(), Is.EqualTo(new[] { "c", "a", "b", "d" }));
+        }
+
+        [Test]
+        public void Given_ChildrenReorderedAndAdded_When_Drained_Then_TheSpacerStaysLastAndSingle()
+        {
+            Mount();
+            SetItems(new[] { "c", "a", "b", "d" });
+
+            Assert.That(SpacerIsLast() && SpacerCount() == 1, Is.True);
+        }
+
+        [Test]
+        public void Given_AllChildrenRemoved_When_Drained_Then_OnlyTheSpacerRemains()
+        {
+            Mount();
+            SetItems(Array.Empty<string>());
+
+            Assert.That(Box.childCount == 1 && SpacerIsLast(), Is.True);
+        }
+
+        [Test]
+        public void Given_TheFilterRemoved_When_Drained_Then_TheSpacerIsGone()
+        {
+            Mount();
+            Assume.That(SpacerCount(), Is.EqualTo(1), "Precondition: the spacer was present under the filter");
+            SetClass(SkewNoFilter);
+
+            Assert.That(SpacerCount(), Is.EqualTo(0));
+        }
+
+        [Test]
+        public void Given_TheFilterRemoved_When_Drained_Then_TheChildrenSurvive()
+        {
+            Mount();
+            SetClass(SkewNoFilter);
+
+            Assert.That(ChildNames(), Is.EqualTo(new[] { "a", "b", "c" }));
+        }
+
+        [Test]
+        public void Given_TheFilterAddedOnPatch_When_Drained_Then_TheSpacerAppears()
+        {
+            Mount();
+            SetClass(SkewNoFilter);
+            Assume.That(SpacerCount(), Is.EqualTo(0), "Precondition: no spacer without a filter");
+            SetClass(SkewFilter);
+
+            Assert.That(SpacerCount(), Is.EqualTo(1));
+        }
+
+        [Test]
+        public void Given_ASkewedElementWithAVariantOnlyFilter_When_Patched_Then_ASpacerIsAdded()
+        {
+            // A filter carried only by a state variant (hover:blur-sm) is applied by a manipulator at state
+            // time, outside the reconcile — so the spacer must exist whenever a filter COULD apply, not only
+            // while the state is active.
+            Mount();
+            SetClass("w-[200px] -skew-x-6 hover:blur-sm flex flex-col");
+
+            Assert.That(SpacerCount(), Is.EqualTo(1));
+        }
+
+        [Test]
+        public void Given_SkewAndShadowAndFilter_When_Patched_Then_TwoSpacersAreAdded()
+        {
+            // Both paint layers reserve their own bounds; the two spacers coexist as trailing children.
+            Mount();
+            SetClass("w-[200px] -skew-x-6 shadow-lg hue-rotate-90 flex flex-col");
+
+            Assert.That(SpacerCount(), Is.EqualTo(2));
+        }
+
+        [Test]
+        public void Given_SkewAndShadowAndFilter_When_Patched_Then_TheRenderedChildrenAreStillIntact()
+        {
+            // Two trailing spacers must not disturb the reconciled children.
+            Mount();
+            SetClass("w-[200px] -skew-x-6 shadow-lg hue-rotate-90 flex flex-col");
+
+            Assert.That(ChildNames(), Is.EqualTo(new[] { "a", "b", "c" }));
+        }
+
+        [Test]
+        public void Given_SkewAndShadowAndFilter_When_Patched_Then_BothSpacersTrailAllRenderedChildren()
+        {
+            // The last two children are the spacers; every rendered child precedes them.
+            Mount();
+            SetClass("w-[200px] -skew-x-6 shadow-lg hue-rotate-90 flex flex-col");
+            var trailingTwoAreSpacers = Box.childCount >= 2
+                && SilhouetteBoundsSpacer.IsSpacer(Box[Box.childCount - 1])
+                && SilhouetteBoundsSpacer.IsSpacer(Box[Box.childCount - 2]);
+
+            Assert.That(trailingTwoAreSpacers, Is.True);
+        }
+
+        private sealed class TestHostWindow : EditorWindow { }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/SkewFilterSpacerTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/SkewFilterSpacerTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 910218116280343658dcda885e43cef0

--- a/Packages/com.velvet.core/Runtime/Styling/DropShadowSilhouette.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/DropShadowSilhouette.cs
@@ -32,6 +32,13 @@ namespace Velvet
         // resolvedStyle.borderTopLeftRadius once on a panel — the same precedence the wrapper path used.
         public float CornerRadius;
 
+        // When the caster carries an inline filter, the shadow bleed (painted outside the box) would be
+        // clipped to the layout rect by the filter's offscreen render tree. A transparent last-child spacer
+        // sized to the shadow's extent widens boundingBox so the bleed survives. WantSpacer is decided by the
+        // reconciler from the class list; BoundsSpacer is the child. See SilhouetteBoundsSpacer.
+        public bool WantSpacer;
+        public VisualElement? BoundsSpacer;
+
         public Action<MeshGenerationContext>? OnGenerate;
         public EventCallback<GeometryChangedEvent>? OnGeometryChanged;
         public EventCallback<CustomStyleResolvedEvent>? OnStyleResolved;
@@ -190,6 +197,8 @@ namespace Velvet
                 {
                     binding.Face.TryStash(element);
                 }
+                // Size the filter bounds-spacer to the now-known shadow extent (no-op when not wanted).
+                SyncBoundsSpacer(element, binding);
                 element.MarkDirtyRepaint();
             };
             element.RegisterCallback(binding.OnGeometryChanged);
@@ -234,8 +243,40 @@ namespace Velvet
             {
                 binding.Face.Release(element);
             }
+            SilhouetteBoundsSpacer.Remove(element, ref binding.BoundsSpacer);
             s_byElement.Remove(element);
             element.MarkDirtyRepaint();
+        }
+
+        // Records whether the caster carries a filter (so its shadow bleed needs the bounds-spacer to survive
+        // the filter's offscreen render tree) and syncs the spacer now. Called from the reconciler on create /
+        // patch; the geometry callback re-syncs when the size / radius settles.
+        public static void SetWantSpacer(VisualElement element, DropShadowBinding binding, bool want)
+        {
+            binding.WantSpacer = want;
+            SyncBoundsSpacer(element, binding);
+        }
+
+        // Sizes (or removes) the bounds-spacer to the shadow's extent: the baked quad (box grown by
+        // blur + ExtraPadding per side, shifted by the offset) unioned with the box, and — for a skewed caster,
+        // whose shadow shears with it — grown by the shear overhang. Empty AABB until layout gives a size.
+        private static void SyncBoundsSpacer(VisualElement element, DropShadowBinding binding)
+        {
+            var aabb = default(Rect);
+            if (SilhouetteBoundsSpacer.TryGetLayoutSize(element, out var w, out var h))
+            {
+                var spec = binding.Spec;
+                var pad = DropShadowBaker.QuantizePx(spec.Blur) + DropShadowBaker.ExtraPadding
+                    + DropShadowBaker.QuantizePx(spec.Spread);
+                var quad = new Rect(-pad + spec.OffsetX, -pad + spec.OffsetY, w + (2f * pad), h + (2f * pad));
+                aabb = SilhouetteBoundsSpacer.Union(new Rect(0f, 0f, w, h), quad);
+                if (binding.CasterSkewed)
+                {
+                    var tanX = Mathf.Tan(binding.SkewXDeg * Mathf.Deg2Rad);
+                    aabb = SilhouetteBoundsSpacer.ExpandForShear(aabb, tanX, 0f);
+                }
+            }
+            SilhouetteBoundsSpacer.Sync(element, ref binding.BoundsSpacer, binding.WantSpacer, aabb);
         }
 
         // Re-applies the spec / skew of an already-attached element after a patch, refreshing the radius from

--- a/Packages/com.velvet.core/Runtime/Styling/SilhouetteBoundsSpacer.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/SilhouetteBoundsSpacer.cs
@@ -1,0 +1,179 @@
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace Velvet
+{
+    /// <summary>
+    /// Keeps a filtered caster's own <c>generateVisualContent</c> overflow (a sheared skew silhouette, a
+    /// drop-shadow bleed) from being clipped when UI Toolkit renders the element through a filter.
+    /// </summary>
+    /// <remarks>
+    /// An inline <c>style.filter</c> promotes the element to a nested render tree whose offscreen texture is
+    /// sized to the element's <c>boundingBox</c> — the layout rect unioned with each LAYOUT child's box, never
+    /// the element's own gVC paint. So any paint drawn outside the layout rect (which the skew / shadow paints
+    /// do by design) falls outside that texture and is dropped, collapsing a sheared silhouette back to a
+    /// rectangle. UITK exposes no API to widen an element's own render bounds.
+    /// <para>
+    /// The fix is a transparent, picking-ignored, absolutely-positioned SPACER child sized to the paint's
+    /// overflow AABB: <c>UpdateBoundingBox</c> unions a child's layout rect into the parent's boundingBox, which
+    /// is exactly what sizes the filter texture, so the caster's own overflow now falls inside it and survives.
+    /// The spacer is kept as the LAST child so the positional child reconciler (which only ever addresses the
+    /// slots <c>[0, vnodeChildCount)</c>) never mistakes it for a rendered child, and it is torn down with the
+    /// paint binding. It is added only while a filter is present (widening boundingBox otherwise would perturb
+    /// picking / scroll-content bounds for no benefit).
+    /// </para>
+    /// </remarks>
+    internal static class SilhouetteBoundsSpacer
+    {
+        // Marks the reconciler-invisible spacer so tests / tooling can identify it and cleanup can find it.
+        internal const string MarkerClass = "velvet-bounds-spacer";
+        internal const string SpacerName = "velvet-bounds-spacer";
+
+        // A little slack beyond the computed AABB absorbs the stroke half-width, antialiasing, and any
+        // border/padding offset between the gVC origin and the absolute-positioning origin. Over-covering only
+        // grows the offscreen texture slightly; it is never visible (the spacer paints nothing).
+        private const float Slack = 4f;
+
+        /// <summary>
+        /// Ensures <paramref name="caster"/> carries (when <paramref name="want"/>) a last-child spacer whose
+        /// layout rect covers <paramref name="aabbLocal"/> — the paint's overflow AABB in the caster's local
+        /// space (its x/y may be negative for left/top overflow). Removes the spacer when not wanted.
+        /// </summary>
+        internal static void Sync(VisualElement caster, ref VisualElement? spacer, bool want, Rect aabbLocal)
+        {
+            if (!want)
+            {
+                Remove(caster, ref spacer);
+                return;
+            }
+
+            // Attach the spacer as soon as it is wanted — even before layout gives a size (create time, or
+            // EditMode where the player-loop never runs layout). It sizes to the paint's extent once the AABB
+            // is known (the geometry callback re-syncs), so it widens boundingBox exactly when a real filter
+            // pass can clip; an unsized spacer is a harmless empty trailing child in the meantime.
+            if (spacer == null)
+            {
+                spacer = new VisualElement { name = SpacerName, pickingMode = PickingMode.Ignore };
+                spacer.AddToClassList(MarkerClass);
+                // position:absolute takes the spacer out of flex flow (no sibling shift) and, on a panel, makes
+                // StyleOutOfFlowChild treat it as out-of-flow so the index-driven child manipulators (gap /
+                // grid / divide) skip it. Off panel StyleOutOfFlowChild recognizes it by the MarkerClass
+                // instead — the spacer deliberately carries NO "absolute" utility class, so a user's
+                // has-[.absolute]: selector cannot false-match this internal child. Structural variants and the
+                // child reconciler likewise skip it by the MarkerClass (they count DOM children, which CSS
+                // structural selectors include — the spacer is the one internal child that must not).
+                spacer.style.position = Position.Absolute;
+            }
+
+            // Keep it in the trailing spacer zone (after every rendered child) so the child reconciler's
+            // [0, vnodeChildCount) indexing never reaches it. "After all rendered children" (not "strictly
+            // last") keeps a second spacer — a skewed element that also drops a shadow — stable instead of the
+            // two ping-ponging for the last slot each sync.
+            if (!IsAfterAllRenderedChildren(caster, spacer))
+            {
+                if (spacer.parent == caster)
+                {
+                    caster.Remove(spacer);
+                }
+                caster.Add(spacer);
+            }
+
+            if (aabbLocal.width > 0f && aabbLocal.height > 0f
+                && !float.IsNaN(aabbLocal.width) && !float.IsNaN(aabbLocal.height))
+            {
+                spacer.style.left = aabbLocal.xMin - Slack;
+                spacer.style.top = aabbLocal.yMin - Slack;
+                spacer.style.width = aabbLocal.width + (2f * Slack);
+                spacer.style.height = aabbLocal.height + (2f * Slack);
+            }
+        }
+
+        // True when child is a bounds-spacer (the internal, reconciler-invisible render-bounds child).
+        internal static bool IsSpacer(VisualElement child)
+            => child != null && child.ClassListContains(MarkerClass);
+
+        // True when spacer is a child of caster and no RENDERED (non-spacer) child follows it — the placement
+        // invariant that keeps it outside the child reconciler's [0, renderedChildCount) index range.
+        private static bool IsAfterAllRenderedChildren(VisualElement caster, VisualElement spacer)
+        {
+            var idx = caster.IndexOf(spacer);
+            if (idx < 0)
+            {
+                return false;
+            }
+            for (var i = idx + 1; i < caster.childCount; i++)
+            {
+                if (!IsSpacer(caster[i]))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        // The container's child count excluding the trailing bounds-spacer(s). The spacers are always kept
+        // last, so the real children occupy [0, this) — the range the child reconciler and structural
+        // variants must treat as the whole child list.
+        internal static int NonSpacerChildCount(VisualElement container)
+        {
+            var n = container.childCount;
+            while (n > 0 && IsSpacer(container[n - 1]))
+            {
+                n--;
+            }
+            return n;
+        }
+
+        internal static void Remove(VisualElement caster, ref VisualElement? spacer)
+        {
+            if (spacer == null)
+            {
+                return;
+            }
+            if (ReferenceEquals(spacer.parent, caster))
+            {
+                caster.Remove(spacer);
+            }
+            spacer = null;
+        }
+
+        // The overflow AABB of a sheared silhouette in the caster's local space, from the shear model
+        // x' = x + (y - h/2)*tanX, y' = y + (x - w/2)*tanY over the box [0,w]x[0,h]: the shear pushes the box
+        // out by half the cross-extent times the tangent on each side.
+        internal static Rect ShearedAabb(float w, float h, float tanX, float tanY)
+        {
+            var ox = 0.5f * h * Mathf.Abs(tanX);
+            var oy = 0.5f * w * Mathf.Abs(tanY);
+            return new Rect(-ox, -oy, w + (2f * ox), h + (2f * oy));
+        }
+
+        // Grows a rect outward by the shear overhang its own extent produces (same model as ShearedAabb),
+        // so a shadow quad on a skewed caster — which shears with the caster — stays covered.
+        internal static Rect ExpandForShear(Rect r, float tanX, float tanY)
+        {
+            var ox = 0.5f * r.height * Mathf.Abs(tanX);
+            var oy = 0.5f * r.width * Mathf.Abs(tanY);
+            return new Rect(r.xMin - ox, r.yMin - oy, r.width + (2f * ox), r.height + (2f * oy));
+        }
+
+        // The caster's laid-out size, or false when layout has not resolved one yet (pre-layout / EditMode,
+        // where the spacer attaches unsized and the geometry callback re-sizes it). Shared by the skew and
+        // shadow layers so the "laid out" gate cannot drift between them.
+        internal static bool TryGetLayoutSize(VisualElement element, out float w, out float h)
+        {
+            w = element.layout.width;
+            h = element.layout.height;
+            return w > 0f && h > 0f && !float.IsNaN(w) && !float.IsNaN(h);
+        }
+
+        // Axis-aligned union of two rects.
+        internal static Rect Union(Rect a, Rect b)
+        {
+            var xMin = Mathf.Min(a.xMin, b.xMin);
+            var yMin = Mathf.Min(a.yMin, b.yMin);
+            var xMax = Mathf.Max(a.xMax, b.xMax);
+            var yMax = Mathf.Max(a.yMax, b.yMax);
+            return new Rect(xMin, yMin, xMax - xMin, yMax - yMin);
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Styling/SilhouetteBoundsSpacer.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Styling/SilhouetteBoundsSpacer.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7d4da7c351c3e4bab89a12c96d90cfdb

--- a/Packages/com.velvet.core/Runtime/Styling/SkewSilhouette.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/SkewSilhouette.cs
@@ -46,6 +46,15 @@ namespace Velvet
         // to skip a redundant re-bake; GradBaked gates it (SetGradient clears it so a spec change re-bakes).
         public (int w, int h, int sx, int sy, int tl, int tr, int br, int bl) GradKey;
         public bool GradBaked;
+
+        // When the caster carries an inline filter, the sheared silhouette would be clipped to the layout
+        // rect by the filter's offscreen render tree (sized to boundingBox, which excludes gVC overflow). A
+        // transparent last-child spacer sized to the sheared AABB widens boundingBox so the silhouette
+        // survives. WantSpacer is decided by the reconciler from the class list (a filter utility / animate-hue
+        // present); BoundsSpacer is the child, created / sized once layout gives a real size and destroyed on
+        // detach. See SilhouetteBoundsSpacer.
+        public bool WantSpacer;
+        public VisualElement? BoundsSpacer;
     }
 
     /// <summary>
@@ -119,6 +128,8 @@ namespace Velvet
                 // Bake the gradient silhouette once layout gives a real size (the bake needs the element
                 // pixel size + radius). Graphics.Blit here is safe — a geometry callback, not mesh generation.
                 SyncGradientBake(element, binding);
+                // Size the filter bounds-spacer to the now-known sheared extent (no-op when not wanted).
+                SyncBoundsSpacer(element, binding);
             };
             element.RegisterCallback(binding.OnGeometryChanged);
             // Synchronous attempt: if the resolver's inline bg-[…]/border-[…] are already on the element,
@@ -147,7 +158,32 @@ namespace Velvet
                 binding.Face.Release(element);
             }
             DestroyGradientTex(binding);
+            SilhouetteBoundsSpacer.Remove(element, ref binding.BoundsSpacer);
             element.MarkDirtyRepaint();
+        }
+
+        // Records whether the caster carries a filter (so its sheared silhouette needs the bounds-spacer to
+        // survive the filter's offscreen render tree) and syncs the spacer now. Called from the reconciler on
+        // create / patch; the geometry callback re-syncs when the size settles. Reads the live layout, so it is
+        // a no-op-safe re-run at any time.
+        public static void SetWantSpacer(VisualElement element, SkewBinding binding, bool want)
+        {
+            binding.WantSpacer = want;
+            SyncBoundsSpacer(element, binding);
+        }
+
+        // Sizes (or removes) the bounds-spacer to the sheared AABB from the live layout + skew. The gVC
+        // silhouette is drawn centred on the box, so the spacer covers [-ox, w+ox] x [-oy, h+oy].
+        private static void SyncBoundsSpacer(VisualElement element, SkewBinding binding)
+        {
+            // The AABB is empty until layout gives a real size; Sync then attaches the spacer now (so it exists
+            // for the reconciler / a create before layout) and sizes it once the geometry callback re-runs.
+            var aabb = SilhouetteBoundsSpacer.TryGetLayoutSize(element, out var w, out var h)
+                ? SilhouetteBoundsSpacer.ShearedAabb(w, h,
+                    Mathf.Tan(binding.Spec.XDeg * Mathf.Deg2Rad),
+                    Mathf.Tan(binding.Spec.YDeg * Mathf.Deg2Rad))
+                : default;
+            SilhouetteBoundsSpacer.Sync(element, ref binding.BoundsSpacer, binding.WantSpacer, aabb);
         }
 
         // Sets or clears the gradient fill for a skewed element, fed by the reconciler from the same class

--- a/Packages/com.velvet.core/Runtime/Styling/StyleFilterValueParser.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleFilterValueParser.cs
@@ -289,6 +289,43 @@ namespace Velvet
                 || cls.StartsWith("saturate-", StringComparison.Ordinal);
         }
 
+        // True when the leaf token is a filter utility — a named preset (blur-sm, -hue-rotate-90, bare
+        // blur/grayscale/…), a bracket form (blur-[6px], -hue-rotate-[30deg]), or a custom filter-[name:..].
+        // IsFilterPreset already matches every bracket form (each is "<family>-[..]" and its
+        // StartsWith("<family>-") check fires on the "<family>-" prefix), so the only case it misses is the
+        // custom filter-[..] token.
+        internal static bool IsFilterLeaf(string? leaf)
+            => leaf != null && (IsFilterPreset(leaf) || leaf.StartsWith("filter-[", StringComparison.Ordinal));
+
+        // True when ANY class resolves to a filter utility, INCLUDING one carried by a state variant
+        // (hover:blur-sm, dark:hue-rotate-90, sm:blur-md, group-hover:filter-[…], and stacked forms). A variant
+        // filter is applied by a manipulator at state time — outside the reconcile path that decides the
+        // bounds-spacer — so the spacer must exist whenever a filter COULD apply, not only when it is active;
+        // peeling the variant layers to the leaf utility mirrors StyleClipPathClass.WantsClipWrapper, which
+        // keeps its wrapper alive for a variant-only clip for the same reason. Loose like IsFilterPreset: a
+        // matched-but-invalid suffix still gates true, which is harmless for the consumer (the bounds-spacer
+        // reserves render bounds — over-reserving is invisible, under-reserving would clip the paint).
+        internal static bool HasFilterClass(string[] classNames)
+        {
+            if (classNames == null)
+            {
+                return false;
+            }
+            foreach (var cls in classNames)
+            {
+                var leaf = cls;
+                while (StyleVariantClass.TryParse(leaf, out _, out var payload))
+                {
+                    leaf = payload;
+                }
+                if (IsFilterLeaf(leaf))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
         // Parses the non-bracket named filter presets (blur-sm, blur, grayscale, contrast-125,
         // hue-rotate-90, grayscale-0, ...) to the same Filter* properties as the bracket forms, so they merge
         // through ApplyCombinedFilter. hue-rotate is the only filter with a negative preset (-hue-rotate-90).

--- a/Packages/com.velvet.core/Runtime/Styling/StyleOutOfFlowChild.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleOutOfFlowChild.cs
@@ -20,6 +20,13 @@ namespace Velvet
         // StyleGapManipulator.IsRow/IsWrap already use for flex-direction / flex-wrap.
         internal static bool IsOutOfFlow(VisualElement child)
         {
+            // The filter bounds-spacer is always out of flow (position:absolute) and must never occupy a
+            // gap / grid / divide slot; recognize it by its marker so it does not need the "absolute" utility
+            // class (which would leak into a user's has-[.absolute]: selector).
+            if (SilhouetteBoundsSpacer.IsSpacer(child))
+            {
+                return true;
+            }
             if (child.panel != null)
             {
                 return child.resolvedStyle.position == Position.Absolute;

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/SilhouetteBoundsSpacerTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/SilhouetteBoundsSpacerTests.cs
@@ -1,0 +1,115 @@
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Specifies the pure geometry of the filter bounds-spacer: the sheared silhouette AABB, the shear growth
+    /// applied to a shadow quad, the axis-aligned union, and the trailing-spacer child count. GWT, one assert
+    /// each; these need no panel.
+    /// </summary>
+    [TestFixture]
+    internal sealed class SilhouetteBoundsSpacerTests
+    {
+        [Test]
+        public void Given_ASkewX_When_AabbComputed_Then_ItGrowsWidthByHeightTimesTan()
+        {
+            // Arrange — a 100x40 box sheared on X by tan = 0.5.
+            // Act
+            var aabb = SilhouetteBoundsSpacer.ShearedAabb(100f, 40f, 0.5f, 0f);
+
+            // Assert — width grows by h*|tanX| = 40*0.5 = 20 (10 each side).
+            Assert.That(aabb.width, Is.EqualTo(120f).Within(1e-4f));
+        }
+
+        [Test]
+        public void Given_ASkewX_When_AabbComputed_Then_ItOverhangsLeftByHalfHeightTimesTan()
+        {
+            // Act
+            var aabb = SilhouetteBoundsSpacer.ShearedAabb(100f, 40f, 0.5f, 0f);
+
+            // Assert — the left overhang is -(h/2)*|tanX| = -10.
+            Assert.That(aabb.xMin, Is.EqualTo(-10f).Within(1e-4f));
+        }
+
+        [Test]
+        public void Given_ASkewY_When_AabbComputed_Then_ItGrowsHeightByWidthTimesTan()
+        {
+            // Act
+            var aabb = SilhouetteBoundsSpacer.ShearedAabb(100f, 40f, 0f, 0.25f);
+
+            // Assert — height grows by w*|tanY| = 100*0.25 = 25.
+            Assert.That(aabb.height, Is.EqualTo(65f).Within(1e-4f));
+        }
+
+        [Test]
+        public void Given_NoSkew_When_AabbComputed_Then_ItIsExactlyTheBox()
+        {
+            // Act
+            var aabb = SilhouetteBoundsSpacer.ShearedAabb(100f, 40f, 0f, 0f);
+
+            // Assert
+            Assert.That(aabb, Is.EqualTo(new Rect(0f, 0f, 100f, 40f)));
+        }
+
+        [Test]
+        public void Given_TwoRects_When_Unioned_Then_TheResultEnclosesBoth()
+        {
+            // Arrange — the box and a shadow quad shifted up-left and larger.
+            var box = new Rect(0f, 0f, 100f, 40f);
+            var quad = new Rect(-30f, -20f, 160f, 100f);
+
+            // Act
+            var u = SilhouetteBoundsSpacer.Union(box, quad);
+
+            // Assert — the union spans from the quad's min to its max (it encloses the box).
+            Assert.That(u, Is.EqualTo(new Rect(-30f, -20f, 160f, 100f)));
+        }
+
+        [Test]
+        public void Given_ARect_When_ExpandedForShear_Then_ItGrowsByItsOwnExtentTimesTan()
+        {
+            // Arrange — a 100x40 rect at origin, tan = 0.5 on X.
+            var r = new Rect(0f, 0f, 100f, 40f);
+
+            // Act
+            var e = SilhouetteBoundsSpacer.ExpandForShear(r, 0.5f, 0f);
+
+            // Assert — grows width by height*|tanX| = 20.
+            Assert.That(e.width, Is.EqualTo(120f).Within(1e-4f));
+        }
+
+        [Test]
+        public void Given_ContainerWithTrailingSpacer_When_Counted_Then_TheSpacerIsExcluded()
+        {
+            // Arrange — two rendered children then a spacer.
+            var container = new VisualElement();
+            container.Add(new VisualElement());
+            container.Add(new VisualElement());
+            var spacer = new VisualElement();
+            spacer.AddToClassList(SilhouetteBoundsSpacer.MarkerClass);
+            container.Add(spacer);
+
+            // Act / Assert
+            Assert.That(SilhouetteBoundsSpacer.NonSpacerChildCount(container), Is.EqualTo(2));
+        }
+
+        [Test]
+        public void Given_ContainerWithTwoTrailingSpacers_When_Counted_Then_BothAreExcluded()
+        {
+            // Arrange — one rendered child then two spacers (a skewed + shadowed caster).
+            var container = new VisualElement();
+            container.Add(new VisualElement());
+            for (var i = 0; i < 2; i++)
+            {
+                var s = new VisualElement();
+                s.AddToClassList(SilhouetteBoundsSpacer.MarkerClass);
+                container.Add(s);
+            }
+
+            // Act / Assert
+            Assert.That(SilhouetteBoundsSpacer.NonSpacerChildCount(container), Is.EqualTo(1));
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/SilhouetteBoundsSpacerTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/SilhouetteBoundsSpacerTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c15e87b981af74b4aafc3540a2a46888


### PR DESCRIPTION
Advances #70 (skew + drop-shadow; `V.Particles` still open).

## Problem

An inline filter — a static `filter-*` utility, or the `animate-hue` motion — promotes an element to a nested render tree whose offscreen texture is sized to the element's layout `boundingBox`. A skew silhouette and a drop-shadow bleed are painted in the element's own `generateVisualContent`, deliberately OUTSIDE the layout rect, so the filter texture clips them: a `-skew-x-12` gradient box collapses to a rectangle under `hue-rotate-90`, and a `shadow-*` halo is cut to the box edge. CSS composes `filter` with `transform: skewX()` and with `box-shadow` without clipping, so this is a parity gap.

## Fix

`VisualElement.UpdateBoundingBox` unions each LAYOUT child's rect into the parent's `boundingBox`. So the paint layers attach a transparent, picking-ignored, `position:absolute` **bounds spacer** child sized to the paint's overflow AABB (`SilhouetteBoundsSpacer`); its rect widens the caster's `boundingBox`, which is exactly what sizes the filter texture, so the caster's own overflowing paint now falls inside it and survives. No shader, no custom filter asset; the circumscribe look and the element's footprint are preserved.

The spacer is added whenever a filter COULD apply — including one carried by a state variant (`hover:blur-sm`, `dark:hue-rotate-90`), detected by peeling variant layers to the leaf utility, mirroring how the clip-path wrapper stays alive for a variant-only clip.

The spacer is kept after all rendered children and is invisible to the child-facing layers:

- the positional child reconciler counts real children via `NonSpacerChildCount` (identical to `childCount` when no spacer is present) at every count and insert-clamp site — portal slot start/length, DOM-desync recovery, keyed placement;
- structural variants (`first:` / `last:` / `nth`) exclude trailing spacers from their sibling count;
- gap / grid / divide skip it as out-of-flow (`StyleOutOfFlowChild`), recognized by its marker so it needs no `absolute` utility class (which a `has-[.absolute]:` selector would false-match).

## Tests

- `SilhouetteBoundsSpacerTests` — the AABB / union / shear-expand / trailing-count geometry.
- `SkewFilterSpacerTests`, `ShadowFilterSpacerTests` — spacer presence/removal with the filter, keyed child reconciliation alongside a trailing spacer, variant-only filters, and the two-spacer skew+shadow case.

Full EditMode + PlayMode suites green.
