### PR TITLE
fix(velvet): keep a filtered particles element's overflow quads from clipping to the layout rect

### DIFF
--- a/Packages/com.velvet.core/Runtime/Component/ParticlesDriver.cs
+++ b/Packages/com.velvet.core/Runtime/Component/ParticlesDriver.cs
@@ -43,6 +43,15 @@ namespace Velvet
         // and each ParticleSystem property access is a native call.
         public bool HostLoops;
         public float HostDuration;
+        // An inline filter renders the element through an offscreen tree sized to its layout boundingBox, so
+        // the particle quads drawn beyond the host rect clip; a last-child spacer widens the boundingBox to
+        // cover them (shared with the skew / shadow paints via SilhouetteBoundsSpacer). Unlike those static
+        // AABBs the particles move every frame, hence the quantize + last-applied cache below: without them
+        // the spacer would re-layout (and the filter texture reallocate) on every tick.
+        public bool WantSpacer;
+        public VisualElement? BoundsSpacer;
+        public Rect LiveExtentLocal;
+        public Rect AppliedSpacerAabb;
 
         public ParticlesBinding(ParticlesSettings settings)
         {
@@ -108,6 +117,72 @@ namespace Velvet
             element.MarkDirtyRepaint();
         }
 
+        // A filter comes and goes independent of the effect (a class swap, a state variant), so the reconciler
+        // drives this from the class list on every patch, not only on a Particles-settings change. The extent
+        // itself follows the live particles through the repaint tick, not this call.
+        public static void SetWantSpacer(VisualElement element, ParticlesBinding binding, bool want)
+        {
+            binding.WantSpacer = want;
+            SyncBoundsSpacer(element, binding);
+        }
+
+        // So an animating burst that grows a few pixels a frame re-lays-out the spacer (and reallocates the
+        // filter texture) only when its extent crosses a bucket, not every tick. Over-covering by up to a
+        // bucket is invisible — the spacer paints nothing.
+        private const float SpacerQuantum = 32f;
+
+        // Off-panel / pre-layout there is no extent yet, but the spacer still attaches unsized: the reconciler
+        // must count it as a trailing child from the moment a filter wants it, and the tick sizes it once
+        // layout and a live simulation resolve a real extent.
+        private static void SyncBoundsSpacer(VisualElement element, ParticlesBinding binding)
+        {
+            if (!binding.WantSpacer)
+            {
+                SilhouetteBoundsSpacer.Remove(element, ref binding.BoundsSpacer);
+                binding.AppliedSpacerAabb = default;
+                return;
+            }
+            if (!SilhouetteBoundsSpacer.TryGetLayoutSize(element, out var w, out var h))
+            {
+                SilhouetteBoundsSpacer.Sync(element, ref binding.BoundsSpacer, true, default);
+                return;
+            }
+            var box = new Rect(0f, 0f, w, h);
+            var live = binding.LiveExtentLocal;
+            Rect reserved;
+            if (live.width > 0f && live.height > 0f)
+            {
+                // Lead the live extent by a quantum: the extent this reads was stashed by Draw one frame ago,
+                // so a fast-growing burst would otherwise outrun the reserved bounds between frames and clip
+                // its leading edge. The headroom keeps growth up to a quantum per frame covered. No lookahead
+                // for the box-only fallback (nothing overflows there).
+                var u = SilhouetteBoundsSpacer.Union(box, live);
+                reserved = new Rect(u.xMin - SpacerQuantum, u.yMin - SpacerQuantum,
+                    u.width + (2f * SpacerQuantum), u.height + (2f * SpacerQuantum));
+            }
+            else
+            {
+                reserved = box;
+            }
+            var quantized = QuantizeOutward(reserved);
+            if (quantized == binding.AppliedSpacerAabb)
+            {
+                return;
+            }
+            binding.AppliedSpacerAabb = quantized;
+            SilhouetteBoundsSpacer.Sync(element, ref binding.BoundsSpacer, true, quantized);
+        }
+
+        // Outward, not nearest, so the reserved bounds never fall short of the live extent between buckets.
+        private static Rect QuantizeOutward(Rect r)
+        {
+            var xMin = Mathf.Floor(r.xMin / SpacerQuantum) * SpacerQuantum;
+            var yMin = Mathf.Floor(r.yMin / SpacerQuantum) * SpacerQuantum;
+            var xMax = Mathf.Ceil(r.xMax / SpacerQuantum) * SpacerQuantum;
+            var yMax = Mathf.Ceil(r.yMax / SpacerQuantum) * SpacerQuantum;
+            return new Rect(xMin, yMin, xMax - xMin, yMax - yMin);
+        }
+
         // Full teardown: clears the imperative handlers, unregisters the painter and the panel
         // callbacks, pauses the repaint tick, and destroys the hidden host.
         public static void Detach(VisualElement element, ParticlesBinding binding)
@@ -124,6 +199,7 @@ namespace Velvet
             }
             StopRepaintTick(binding);
             DestroyHost(binding);
+            SilhouetteBoundsSpacer.Remove(element, ref binding.BoundsSpacer);
             element.MarkDirtyRepaint();
         }
 
@@ -158,6 +234,14 @@ namespace Velvet
                 ApplyPlayTrigger(binding);
             }
             SyncRepaintTick(element, binding);
+            if (binding.Host == null)
+            {
+                // A null / destroyed effect draws nothing, and the tick that would otherwise collapse the
+                // reserved bounds on drain is now parked — so return them to the box here, else the filter
+                // texture stays oversized at the last live extent until the effect returns or unmount.
+                binding.LiveExtentLocal = default;
+                SyncBoundsSpacer(element, binding);
+            }
         }
 
         // Clones the source effect into the hidden simulation host: renderer disabled (no camera may
@@ -290,23 +374,34 @@ namespace Velvet
             var buffer = binding.Buffer;
             if (host == null || buffer == null)
             {
+                binding.LiveExtentLocal = default;
                 return;
             }
             var w = element.layout.width;
             var h = element.layout.height;
             if (w <= 0f || h <= 0f || float.IsNaN(w) || float.IsNaN(h))
             {
+                binding.LiveExtentLocal = default;
                 return;
             }
             var count = host.GetParticles(buffer);
             if (count <= 0)
             {
+                // No live quads, so the spacer collapses back to the box on the next tick.
+                binding.LiveExtentLocal = default;
                 return;
             }
 
             var ppu = binding.Settings.PixelsPerUnit;
             var cx = w * 0.5f;
             var cy = h * 0.5f;
+            // Only a filtered element consumes the extent, so the far more common no-filter case skips the
+            // per-particle reach work and the Rect write entirely.
+            var track = binding.WantSpacer;
+            var minX = float.MaxValue;
+            var minY = float.MaxValue;
+            var maxX = float.MinValue;
+            var maxY = float.MinValue;
             var mwd = mgc.Allocate(4 * count, 6 * count, binding.Texture);
             for (var q = 0; q < count; q++)
             {
@@ -317,6 +412,17 @@ namespace Velvet
                 var cos = Mathf.Cos(rad);
                 var sin = Mathf.Sin(rad);
                 Color32 tint = p.GetCurrentColor(host);
+
+                if (track)
+                {
+                    // A `half`-half-extent square rotated by the particle's rotation reaches half*(|cos| + |sin|)
+                    // on each axis — the bound the filter spacer must cover to keep the quad from clipping.
+                    var reach = half * (Mathf.Abs(cos) + Mathf.Abs(sin));
+                    if (center.x - reach < minX) { minX = center.x - reach; }
+                    if (center.y - reach < minY) { minY = center.y - reach; }
+                    if (center.x + reach > maxX) { maxX = center.x + reach; }
+                    if (center.y + reach > maxY) { maxY = center.y + reach; }
+                }
 
                 // Corner offsets rotated around the particle center; UVs raw 0..1 with v flipped at the
                 // top (UI Toolkit remaps them into the atlas slot), matching the sibling quad painters.
@@ -331,6 +437,10 @@ namespace Velvet
                 mwd.SetNextIndex((ushort)(b + 0));
                 mwd.SetNextIndex((ushort)(b + 2));
                 mwd.SetNextIndex((ushort)(b + 3));
+            }
+            if (track)
+            {
+                binding.LiveExtentLocal = new Rect(minX, minY, maxX - minX, maxY - minY);
             }
         }
 
@@ -371,15 +481,25 @@ namespace Velvet
                 || (!playing && binding.LogicallyPlaying && EditorSimulationDrained(host, binding)))
             {
                 StopRepaintTick(binding);
+                // Collapse the reserved bounds before the tick parks, else a one-shot burst leaves the filter
+                // texture oversized until unmount (Play() / Sync re-arm the tick and the extent re-grows).
+                binding.LiveExtentLocal = default;
+                SyncBoundsSpacer(element, binding);
             }
-            else if (!playing && binding.LogicallyPlaying && dt > 0f)
+            else
             {
-                // Outside Play Mode the engine never steps a particle system's clock on its own, so an
-                // editor-context panel (preview tooling, EditMode fixtures) would repaint one frozen
-                // frame forever. Advance the hidden host by the tick's real elapsed time, clamped the
-                // way frame deltas are clamped; children advance in step for coherence even though
-                // only the root is drawn.
-                host.Simulate(Mathf.Min(dt, Time.maximumDeltaTime), withChildren: true, restart: false, fixedTimeStep: false);
+                if (!playing && binding.LogicallyPlaying && dt > 0f)
+                {
+                    // Outside Play Mode the engine never steps a particle system's clock on its own, so an
+                    // editor-context panel (preview tooling, EditMode fixtures) would repaint one frozen
+                    // frame forever. Advance the hidden host by the tick's real elapsed time, clamped the
+                    // way frame deltas are clamped; children advance in step for coherence even though
+                    // only the root is drawn.
+                    host.Simulate(Mathf.Min(dt, Time.maximumDeltaTime), withChildren: true, restart: false, fixedTimeStep: false);
+                }
+                // Draw stashed the extent last repaint, one frame behind the particles — invisible after the
+                // quantize + slack, and it saves a second GetParticles here.
+                SyncBoundsSpacer(element, binding);
             }
             element.MarkDirtyRepaint();
         }

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodeFactory.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodeFactory.cs
@@ -136,6 +136,8 @@ namespace Velvet
                     if (elementNode.Props?.Particles != null)
                     {
                         _patcher.Appliers.ApplyParticles(element, elementNode.Props.Particles);
+                        // After ApplyParticles: the spacer sync needs the binding that call creates.
+                        _patcher.Appliers.ApplyParticlesSpacer(element, elementNode.ClassNames);
                     }
                     // Anchored (V.Anchored): wire the per-frame screen-projection tick. Panel-independent at
                     // creation (Attach's own synchronous Sync call bails cleanly if the element has no panel
@@ -263,6 +265,8 @@ namespace Velvet
                     if (motionNode.Props?.Particles != null)
                     {
                         _patcher.Appliers.ApplyParticles(element, motionNode.Props.Particles);
+                        // After ApplyParticles, as on the plain element path.
+                        _patcher.Appliers.ApplyParticlesSpacer(element, appliedClasses);
                     }
                     // Anchored through a Motion host: same reason as SceneView/Particles above — a Motion
                     // can host any element type, so the binding must attach on this create path too.

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
@@ -285,6 +285,10 @@ namespace Velvet
             StyleTextEffectResolver.Apply(_ctx, element, classNames);
             _appliers.ApplyGradientOnPatch(element, classNames, skewable: gradientSkewable);
             _appliers.ApplyAnimateOnPatch(element, classNames);
+            // Here, not in the Particles-settings diff: the spacer follows the class list (a filter comes and
+            // goes via a class swap or variant), and this pass is the one hook shared by the element and Motion
+            // patch paths — a particle can be Motion-hosted.
+            _appliers.ApplyParticlesSpacer(element, classNames);
         }
 
         private void PatchText(Label label, TextNode oldNode, TextNode newNode)

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberWrapperElementAppliers.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberWrapperElementAppliers.cs
@@ -959,6 +959,19 @@ namespace Velvet
                 s_particlesAttach, s_particlesUpdate, s_particlesDetach);
         }
 
+        // A filter clips the particle quads drawn beyond the host rect (it renders the element through an
+        // offscreen tree sized to the layout box); the driver reserves render bounds to keep them, gated on
+        // the same variant-peeling filter check as the skew / shadow paints. Driven on every patch rather than
+        // the Particles-settings diff, because a filter comes and goes independent of the effect — a class
+        // swap, or a state variant the reconcile pass never sees active.
+        internal void ApplyParticlesSpacer(VisualElement element, string[] classNames)
+        {
+            if (element is ParticlesElement && _ctx.ParticlesBindings.TryGetValue(element, out var binding))
+            {
+                ParticlesDriver.SetWantSpacer(element, binding, CarriesFilter(classNames));
+            }
+        }
+
         // Unlike SceneView/Particles, Anchored has no dedicated element type to gate on — V.Anchored builds
         // a plain ElementNode (any host type is valid; the binding only ever writes inline left/top), so
         // this dispatches straight to the shared binding logic with no type check.

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ParticlesFilterSpacerTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ParticlesFilterSpacerTests.cs
@@ -1,0 +1,196 @@
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.UIElements;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins the filter bounds-spacer for V.Particles at the reconcile boundary: a filter would clip the
+    /// particle quads that draw beyond the host rect, so a transparent last-child spacer widens the element's
+    /// boundingBox to keep them. The spacer appears with a filter — base, variant-carried, or animate-hue —
+    /// and vanishes when the filter goes, driven by the class list rather than the effect. GWT, one assert each.
+    /// </summary>
+    internal sealed class ParticlesFilterSpacerTests
+    {
+        private const string Filtered = "w-[128px] h-[128px] hue-rotate-90";
+        private const string Unfiltered = "w-[128px] h-[128px]";
+
+        private HeadlessEditorPanelHost _host;
+        private MountedTree _mounted;
+        private readonly List<Object> _spawned = new();
+        private static ParticleSystem s_effect;
+        private static StateUpdater<string> s_setClass;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _host = new HeadlessEditorPanelHost();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _mounted?.Dispose();
+            _mounted = null;
+            _host?.Dispose();
+            _host = null;
+            foreach (var obj in _spawned)
+            {
+                if (obj != null) Object.DestroyImmediate(obj);
+            }
+            _spawned.Clear();
+            s_effect = null;
+            s_setClass = default;
+        }
+
+        private ParticleSystem CreateEffect()
+        {
+            var go = new GameObject("fx-source");
+            _spawned.Add(go);
+            var ps = go.AddComponent<ParticleSystem>();
+            var main = ps.main;
+            main.playOnAwake = false;
+            ps.Stop(true, ParticleSystemStopBehavior.StopEmittingAndClear);
+            return ps;
+        }
+
+        // Manual trigger keeps the host stopped: the spacer is gated on the filter, not on any live particles.
+        [Component]
+        private static VNode Host()
+        {
+            var (cls, setClass) = Hooks.UseState(Filtered);
+            s_setClass = setClass;
+            return V.Particles(s_effect, className: cls, name: "fx", playOn: PlayTrigger.Manual);
+        }
+
+        private void MountAndLayout()
+        {
+            _mounted = V.Mount(_host.Root, V.Component(Host, key: "root"));
+            EditorPanelTestHelpers.ForcePanelUpdate(_host.Panel);
+        }
+
+        private void MountUnfilteredAndLayout()
+        {
+            _mounted = V.Mount(_host.Root,
+                V.Particles(s_effect, className: Unfiltered, name: "fx", playOn: PlayTrigger.Manual));
+            EditorPanelTestHelpers.ForcePanelUpdate(_host.Panel);
+        }
+
+        private void MountWithClassAndLayout(string className)
+        {
+            _mounted = V.Mount(_host.Root,
+                V.Particles(s_effect, className: className, name: "fx", playOn: PlayTrigger.Manual));
+            EditorPanelTestHelpers.ForcePanelUpdate(_host.Panel);
+        }
+
+        private void SetClass(string cls)
+        {
+            s_setClass.Invoke(cls);
+            _mounted.FlushStateForTest();
+            EditorPanelTestHelpers.ForcePanelUpdate(_host.Panel);
+        }
+
+        private VisualElement Particle => _host.Root.Q<VisualElement>("fx");
+
+        private int SpacerCount() => Enumerable.Range(0, Particle.childCount)
+            .Count(i => SilhouetteBoundsSpacer.IsSpacer(Particle[i]));
+
+        [Test]
+        public void Given_AFilteredParticles_When_Mounted_Then_OneSpacerIsAdded()
+        {
+            s_effect = CreateEffect();
+            MountAndLayout();
+
+            Assert.That(SpacerCount(), Is.EqualTo(1));
+        }
+
+        [Test]
+        public void Given_AnUnfilteredParticles_When_Mounted_Then_NoSpacerIsAdded()
+        {
+            s_effect = CreateEffect();
+            MountUnfilteredAndLayout();
+
+            Assert.That(SpacerCount(), Is.EqualTo(0));
+        }
+
+        [Test]
+        public void Given_AFilteredParticles_When_Mounted_Then_TheSpacerIsTheHostsOnlyChild()
+        {
+            // Particles carry no rendered children, so the spacer must be the single child — and recognized
+            // as a spacer, not a rendered one.
+            s_effect = CreateEffect();
+            MountAndLayout();
+
+            Assert.That(Particle.childCount == 1 && SilhouetteBoundsSpacer.IsSpacer(Particle[0]), Is.True);
+        }
+
+        [Test]
+        public void Given_TheFilterRemoved_When_Repatched_Then_TheSpacerIsGone()
+        {
+            s_effect = CreateEffect();
+            MountAndLayout();
+            Assume.That(SpacerCount(), Is.EqualTo(1), "Precondition: the spacer was present under the filter");
+            SetClass(Unfiltered);
+
+            Assert.That(SpacerCount(), Is.EqualTo(0));
+        }
+
+        [Test]
+        public void Given_TheFilterAdded_When_Repatched_Then_TheSpacerAppears()
+        {
+            s_effect = CreateEffect();
+            _mounted = V.Mount(_host.Root, V.Component(HostStartingUnfiltered, key: "root"));
+            EditorPanelTestHelpers.ForcePanelUpdate(_host.Panel);
+            Assume.That(SpacerCount(), Is.EqualTo(0), "Precondition: no spacer without a filter");
+            SetClass(Filtered);
+
+            Assert.That(SpacerCount(), Is.EqualTo(1));
+        }
+
+        [Component]
+        private static VNode HostStartingUnfiltered()
+        {
+            var (cls, setClass) = Hooks.UseState(Unfiltered);
+            s_setClass = setClass;
+            return V.Particles(s_effect, className: cls, name: "fx", playOn: PlayTrigger.Manual);
+        }
+
+        [Test]
+        public void Given_AReRenderThatKeepsTheFilter_When_Repatched_Then_TheSpacerSurvivesAsTheOnlyChild()
+        {
+            // Particles reconcile against an empty child list every patch; that pass must not drop, duplicate,
+            // or orphan the lone spacer while the filter holds (a raw-childCount site would index into it).
+            s_effect = CreateEffect();
+            MountAndLayout();
+            Assume.That(SpacerCount(), Is.EqualTo(1), "Precondition: one spacer under the initial filter");
+            SetClass("w-[128px] h-[128px] blur-sm");
+
+            Assert.That(Particle.childCount == 1 && SilhouetteBoundsSpacer.IsSpacer(Particle[0]), Is.True);
+        }
+
+        [Test]
+        public void Given_AVariantOnlyFilter_When_Mounted_Then_ASpacerIsAdded()
+        {
+            // A filter carried only by a state variant applies at state time, outside the reconcile — so the
+            // spacer must exist whenever a filter COULD apply, not only while the state is active.
+            s_effect = CreateEffect();
+            MountWithClassAndLayout("w-[128px] h-[128px] hover:blur-sm");
+
+            Assert.That(SpacerCount(), Is.EqualTo(1));
+        }
+
+        [Test]
+        public void Given_AnAnimateHueFilter_When_Mounted_Then_ASpacerIsAdded()
+        {
+            // animate-hue writes style.filter every frame, so it promotes the element the same way a static
+            // filter utility does.
+            s_effect = CreateEffect();
+            MountWithClassAndLayout("w-[128px] h-[128px] animate-hue");
+
+            Assert.That(SpacerCount(), Is.EqualTo(1));
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ParticlesFilterSpacerTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ParticlesFilterSpacerTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f0be1e21548a64a3bb5baacaeed56180

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/ParticlesPlaybackTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/ParticlesPlaybackTests.cs
@@ -146,7 +146,7 @@ namespace Velvet.Tests
         {
             // Arrange — a filter renders the element through an offscreen tree sized to its layout box, so the
             // quads drawn past the small rect would clip. The fix tracks the live particle extent into a spacer
-            // whose layout reaches beyond the host rect; a spacer merely pinned to the box would not.
+            // that reaches beyond the host rect; a spacer merely pinned to the box would not.
             var effect = CreateEmitter();
             _host = new RenderTexturePanelHost("ParticlesPanel", 300, 300);
             _mounted = V.Mount(_host.Root,
@@ -154,13 +154,24 @@ namespace Velvet.Tests
             var element = _host.Root.Q<ParticlesElement>();
             Assume.That(element, Is.Not.Null, "Precondition: the particles element mounted");
 
-            // Act — let the burst populate and draw quads beyond the 40px box.
-            yield return WaitRealtime(0.8);
-            var spacer = FindBoundsSpacer(element);
-            Assume.That(spacer, Is.Not.Null, "Precondition: the filtered element carries a bounds-spacer");
+            // Act — the spacer is sized by the tick reading the extent Draw stashed a frame earlier, a
+            // multi-frame chain (draw → stash → tick → size). Advance until it settles rather than a fixed
+            // realtime wait, so the GPU-less runner's one-time multi-second draw warmup can't starve the chain.
+            var reached = false;
+            var deadline = Time.realtimeSinceStartupAsDouble + 180.0;
+            while (Time.realtimeSinceStartupAsDouble < deadline)
+            {
+                yield return null;
+                var spacer = FindBoundsSpacer(element);
+                if (spacer != null && spacer.resolvedStyle.width > element.resolvedStyle.width)
+                {
+                    reached = true;
+                    break;
+                }
+            }
 
             // Assert
-            Assert.That(spacer.layout.width, Is.GreaterThan(element.layout.width));
+            Assert.That(reached, Is.True);
         }
 
         [UnityTest]

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/ParticlesPlaybackTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/ParticlesPlaybackTests.cs
@@ -126,6 +126,43 @@ namespace Velvet.Tests
             Assert.That(differing, Is.GreaterThan(30));
         }
 
+        // The internal bounds-spacer child, or null. Widening the caster's boundingBox (the size of the
+        // filter's offscreen texture) is exactly what the spacer's layout rect does, so its resolved size
+        // extending past the host rect is the public proxy for "the filtered quads are no longer clipped".
+        private static VisualElement FindBoundsSpacer(VisualElement host)
+        {
+            for (var i = 0; i < host.childCount; i++)
+            {
+                if (SilhouetteBoundsSpacer.IsSpacer(host[i]))
+                {
+                    return host[i];
+                }
+            }
+            return null;
+        }
+
+        [UnityTest]
+        public IEnumerator Given_AFilteredLiveSimulation_When_FramesAdvance_Then_TheReservedBoundsCoverTheOverflow()
+        {
+            // Arrange — a filter renders the element through an offscreen tree sized to its layout box, so the
+            // quads drawn past the small rect would clip. The fix tracks the live particle extent into a spacer
+            // whose layout reaches beyond the host rect; a spacer merely pinned to the box would not.
+            var effect = CreateEmitter();
+            _host = new RenderTexturePanelHost("ParticlesPanel", 300, 300);
+            _mounted = V.Mount(_host.Root,
+                V.Particles(effect, className: "w-[40px] h-[40px] hue-rotate-90", playOn: PlayTrigger.Mount));
+            var element = _host.Root.Q<ParticlesElement>();
+            Assume.That(element, Is.Not.Null, "Precondition: the particles element mounted");
+
+            // Act — let the burst populate and draw quads beyond the 40px box.
+            yield return WaitRealtime(0.8);
+            var spacer = FindBoundsSpacer(element);
+            Assume.That(spacer, Is.Not.Null, "Precondition: the filtered element carries a bounds-spacer");
+
+            // Assert
+            Assert.That(spacer.layout.width, Is.GreaterThan(element.layout.width));
+        }
+
         [UnityTest]
         public IEnumerator Given_AManualPlayTrigger_When_FramesAdvance_Then_NothingRenders()
         {


### PR DESCRIPTION
## Problem

`V.Particles` draws its simulation as textured quads that deliberately extend beyond the host rect (overflow is visible by default, like any painted content). When the element also carries an inline filter — a static `filter-*` utility (`blur-*`, `hue-rotate-*`, …), the `animate-hue` motion, or a variant like `hover:blur-sm` — UI Toolkit promotes it to an offscreen render tree whose texture is sized to the element's layout `boundingBox`. The overflowing quads fall outside that texture and are clipped to the layout rect.

This is the `V.Particles` case of the composition gap already closed for skew silhouettes and drop-shadow bleed (#71); it is the last open item in #70.

## Fix

Reuse `SilhouetteBoundsSpacer` (the same helper the skew/shadow paints use): a transparent, picking-ignored, `position:absolute` last-child spacer sized to the drawn particle extent. `UpdateBoundingBox` unions a child's layout rect into the parent's `boundingBox`, which is exactly what sizes the filter texture — so the caster's own overflow now falls inside it and survives.

Unlike the skew/shadow AABBs, the particle extent is **dynamic** (the quads move every frame):

- `Draw` accumulates the drawn quads' AABB each frame (piggybacking on the existing `GetParticles`) and stashes it on the binding — a field write only, no tree mutation inside `generateVisualContent`.
- The repaint tick re-sizes the spacer from that extent, **quantized** to a grid so a moving burst does not relayout the spacer (and reallocate the filter texture) every frame, with a **one-quantum growth lookahead** so a fast expansion is not clipped for the one frame the stashed extent lags behind.
- The extent work is skipped entirely when no filter is present (the common case).
- When the effect drains / goes null, the reserved bounds collapse back to the box.

Filter detection reuses the variant-aware `CarriesFilter`, wired on create (plain element and Motion host) and on every patch via the shared post-children pass — independent of the effect-settings diff, since a filter can appear/vanish without the effect changing.

## Tests

- EditMode (`ParticlesFilterSpacerTests`): the spacer appears with a base / variant-only / `animate-hue` filter, is absent without one, appears/vanishes across patches, and survives an empty-children reconcile as the host's only child.
- PlayMode (`ParticlesPlaybackTests`): under a live filtered simulation the reserved bounds grow past the host rect.

Full EditMode and PlayMode suites green.

## Known limitation (pre-existing, shared helper)

The spacer is positioned relative to the padding box while the quads paint in border-box space, compensated by a fixed slack; a border thicker than that slack can shift coverage by a few pixels. This is inherited unchanged from `SilhouetteBoundsSpacer` (affects skew/shadow identically) and is out of scope here.

Closes #70.