### PR TITLE
fix(velvet): offset the filter bounds-spacer by the caster's border

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A `skew-*` sheared silhouette and a `shadow-*` / `drop-shadow-*` bleed no longer clip to the layout
+  rect when the same element carries an inline filter (`blur-*`, `hue-rotate-*`, `animate-hue`, or a
+  variant such as `hover:blur-sm`). A filter renders the element through an offscreen tree sized to its
+  layout box, which dropped the paint drawn outside that box; a transparent, non-interactive spacer
+  child sized to the paint's extent now widens the element's render bounds so the overflow survives,
+  matching how CSS composes `filter` with `transform: skewX()` and `box-shadow`.
+- `V.Particles` quads that draw beyond the host rect survive an inline filter the same way, tracked to
+  the live particle extent as the simulation moves; the reserved bounds return to the box when the
+  effect drains and are skipped entirely when no filter is present.
+- The filter bounds-spacer now offsets itself by the caster's border width (parsed from the class list,
+  so state borders like `hover:border-8` count too), so an element whose border is thicker than the
+  paint's overhang no longer clips a strip of the sheared silhouette / shadow / particle overflow.
 - Callback refs follow React's re-invocation contract: a ref cycles (cleanup, then setup) only
   when its callback identity changes or the host element remounts — a patch carrying the same
   delegate no longer re-invokes it on every render, so a reference-stable ref (`Hooks.UseCallback`)

--- a/Packages/com.velvet.core/Runtime/Component/ParticlesDriver.cs
+++ b/Packages/com.velvet.core/Runtime/Component/ParticlesDriver.cs
@@ -52,6 +52,10 @@ namespace Velvet
         public VisualElement? BoundsSpacer;
         public Rect LiveExtentLocal;
         public Rect AppliedSpacerAabb;
+        // The caster's left/top border, parsed from the class list, to shift the spacer origin into padding-box
+        // space (see SilhouetteBoundsSpacer.BorderInset).
+        public float BorderLeft;
+        public float BorderTop;
 
         public ParticlesBinding(ParticlesSettings settings)
         {
@@ -120,9 +124,10 @@ namespace Velvet
         // A filter comes and goes independent of the effect (a class swap, a state variant), so the reconciler
         // drives this from the class list on every patch, not only on a Particles-settings change. The extent
         // itself follows the live particles through the repaint tick, not this call.
-        public static void SetWantSpacer(VisualElement element, ParticlesBinding binding, bool want)
+        public static void SetWantSpacer(VisualElement element, ParticlesBinding binding, bool want, string[] classNames)
         {
             binding.WantSpacer = want;
+            SilhouetteBoundsSpacer.BorderInset(classNames, out binding.BorderLeft, out binding.BorderTop);
             SyncBoundsSpacer(element, binding);
         }
 
@@ -164,7 +169,8 @@ namespace Velvet
             {
                 reserved = box;
             }
-            var quantized = QuantizeOutward(reserved);
+            var quantized = SilhouetteBoundsSpacer.ShiftToPaddingBox(
+                QuantizeOutward(reserved), binding.BorderLeft, binding.BorderTop);
             if (quantized == binding.AppliedSpacerAabb)
             {
                 return;

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberWrapperElementAppliers.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberWrapperElementAppliers.cs
@@ -40,7 +40,7 @@ namespace Velvet
             // sheared mesh (the rectangular background-image the non-skew path would set cannot follow the
             // shear). ApplyGradientOnCreate runs next and defers to this binding.
             SyncSkewGradient(element, binding, classNames);
-            SkewSilhouette.SetWantSpacer(element, binding, CarriesFilter(classNames));
+            SkewSilhouette.SetWantSpacer(element, binding, CarriesFilter(classNames), classNames);
         }
 
         // True when the class list carries an inline filter — a static filter-* utility or the animate-hue
@@ -115,7 +115,7 @@ namespace Velvet
                 {
                     SyncSkewGradient(element, binding, newClassNames);
                     // A filter utility / animate-hue can appear or vanish without the skew tokens changing.
-                    SkewSilhouette.SetWantSpacer(element, binding, CarriesFilter(newClassNames));
+                    SkewSilhouette.SetWantSpacer(element, binding, CarriesFilter(newClassNames), newClassNames);
                 }
                 return binding.Spec.XDeg;
             }
@@ -128,7 +128,7 @@ namespace Velvet
                 binding.Spec = spec;
                 SkewSilhouette.SyncStashOnPatch(element, binding, classesChanged: true);
                 SyncSkewGradient(element, binding, newClassNames);
-                SkewSilhouette.SetWantSpacer(element, binding, CarriesFilter(newClassNames));
+                SkewSilhouette.SetWantSpacer(element, binding, CarriesFilter(newClassNames), newClassNames);
                 element.MarkDirtyRepaint();
                 return spec.XDeg;
             }
@@ -138,7 +138,7 @@ namespace Velvet
                 _ctx.SkewBindings[element] = fresh;
                 SkewSilhouette.SyncStashOnPatch(element, fresh, classesChanged: true);
                 SyncSkewGradient(element, fresh, newClassNames);
-                SkewSilhouette.SetWantSpacer(element, fresh, CarriesFilter(newClassNames));
+                SkewSilhouette.SetWantSpacer(element, fresh, CarriesFilter(newClassNames), newClassNames);
                 return spec.XDeg;
             }
             if (bound)
@@ -369,7 +369,7 @@ namespace Velvet
             var casterSkewed = _ctx.SkewBindings.ContainsKey(element);
             var shadowBinding = DropShadowSilhouette.Attach(element, spec, classNames, skewXDeg, casterSkewed);
             _ctx.ShadowBindings[element] = shadowBinding;
-            DropShadowSilhouette.SetWantSpacer(element, shadowBinding, CarriesFilter(classNames));
+            DropShadowSilhouette.SetWantSpacer(element, shadowBinding, CarriesFilter(classNames), classNames);
         }
 
         // Patch-time reconciliation of an element's shadow state against its new class list. Mirrors the
@@ -401,13 +401,13 @@ namespace Velvet
             if (want && bound)
             {
                 DropShadowSilhouette.Sync(element, binding, spec, classNames, skewXDeg, casterSkewed);
-                DropShadowSilhouette.SetWantSpacer(element, binding, CarriesFilter(classNames));
+                DropShadowSilhouette.SetWantSpacer(element, binding, CarriesFilter(classNames), classNames);
             }
             else if (want)
             {
                 var fresh = DropShadowSilhouette.Attach(element, spec, classNames, skewXDeg, casterSkewed);
                 _ctx.ShadowBindings[element] = fresh;
-                DropShadowSilhouette.SetWantSpacer(element, fresh, CarriesFilter(classNames));
+                DropShadowSilhouette.SetWantSpacer(element, fresh, CarriesFilter(classNames), classNames);
             }
             else if (bound)
             {
@@ -968,7 +968,7 @@ namespace Velvet
         {
             if (element is ParticlesElement && _ctx.ParticlesBindings.TryGetValue(element, out var binding))
             {
-                ParticlesDriver.SetWantSpacer(element, binding, CarriesFilter(classNames));
+                ParticlesDriver.SetWantSpacer(element, binding, CarriesFilter(classNames), classNames);
             }
         }
 

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/FilterSpacerBorderOffsetPlaybackTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/FilterSpacerBorderOffsetPlaybackTests.cs
@@ -1,0 +1,78 @@
+using System.Collections;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using UnityEngine.UIElements;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins on a real runtime panel that the filter bounds-spacer offsets itself by the caster's border. The
+    /// spacer's left/top resolve against the padding box, while the sheared silhouette it must cover is in the
+    /// caster's border-box space, so the border (parsed from the class list — here the USS-scale `border-8`, not
+    /// an inline bracket value) is subtracted when positioning. Without that subtraction a border thicker than
+    /// the shear overhang leaves the spacer's border-box edge inside the box, clipping the overflow.
+    /// </summary>
+    [Timeout(120000)]
+    internal sealed class FilterSpacerBorderOffsetPlaybackTests
+    {
+        private RenderTexturePanelHost _host;
+        private MountedTree _mounted;
+
+        [UnityTearDown]
+        public IEnumerator UnityTearDown()
+        {
+            _mounted?.Dispose();
+            _mounted = null;
+            _host?.Dispose();
+            _host = null;
+            yield return null;
+        }
+
+        private static VisualElement FindSpacer(VisualElement caster)
+        {
+            for (var i = 0; i < caster.childCount; i++)
+            {
+                if (SilhouetteBoundsSpacer.IsSpacer(caster[i]))
+                {
+                    return caster[i];
+                }
+            }
+            return null;
+        }
+
+        [UnityTest]
+        public IEnumerator Given_ABorderThickerThanTheShearOverhang_When_Rendered_Then_TheSpacerReachesPastTheBorderBoxEdge()
+        {
+            // Arrange — the 8px USS-scale border exceeds the shallow -skew-x-4 overhang (~2.8px) on an 80px-tall
+            // box, under a filter, so an unsubtracted border would push the spacer's border-box edge positive.
+            _host = new RenderTexturePanelHost("BorderSpacerPanel", 300, 300);
+            _mounted = V.Mount(_host.Root,
+                V.Div(className: "w-[200px] h-[80px] -skew-x-4 border-8 hue-rotate-90", name: "box"));
+            var box = _host.Root.Q<VisualElement>("box");
+            Assume.That(box, Is.Not.Null, "Precondition: the element mounted");
+
+            // Act — advance until the geometry callback has sized the spacer (bounded to survive any warmup).
+            VisualElement spacer = null;
+            var deadline = Time.realtimeSinceStartupAsDouble + 30.0;
+            while (Time.realtimeSinceStartupAsDouble < deadline)
+            {
+                yield return null;
+                spacer = FindSpacer(box);
+                if (spacer != null && spacer.resolvedStyle.width > 0f)
+                {
+                    break;
+                }
+            }
+            Assume.That(spacer, Is.Not.Null, "Precondition: the filtered skewed element carries a spacer");
+            Assume.That(spacer.resolvedStyle.width, Is.GreaterThan(0f), "Precondition: the spacer was sized");
+
+            // Assert — resolvedStyle.left is the spacer's used position from the caster's border-box origin
+            // (Yoga adds the parent's border to the padding-box-relative inline left). It must reach left of
+            // that origin to cover the shear that leans past the corner; without subtracting the border when
+            // positioning, a border thicker than the overhang would leave this positive (inside the box).
+            Assert.That(spacer.resolvedStyle.left, Is.LessThan(0f));
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/FilterSpacerBorderOffsetPlaybackTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/FilterSpacerBorderOffsetPlaybackTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 05bc5fcf699b64da98ef27989c38a127

--- a/Packages/com.velvet.core/Runtime/Styling/DropShadowSilhouette.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/DropShadowSilhouette.cs
@@ -38,6 +38,10 @@ namespace Velvet
         // reconciler from the class list; BoundsSpacer is the child. See SilhouetteBoundsSpacer.
         public bool WantSpacer;
         public VisualElement? BoundsSpacer;
+        // The caster's left/top border, parsed from the class list, to shift the spacer origin into padding-box
+        // space (see SilhouetteBoundsSpacer.BorderInset).
+        public float BorderLeft;
+        public float BorderTop;
 
         public Action<MeshGenerationContext>? OnGenerate;
         public EventCallback<GeometryChangedEvent>? OnGeometryChanged;
@@ -251,9 +255,10 @@ namespace Velvet
         // Records whether the caster carries a filter (so its shadow bleed needs the bounds-spacer to survive
         // the filter's offscreen render tree) and syncs the spacer now. Called from the reconciler on create /
         // patch; the geometry callback re-syncs when the size / radius settles.
-        public static void SetWantSpacer(VisualElement element, DropShadowBinding binding, bool want)
+        public static void SetWantSpacer(VisualElement element, DropShadowBinding binding, bool want, string[] classNames)
         {
             binding.WantSpacer = want;
+            SilhouetteBoundsSpacer.BorderInset(classNames, out binding.BorderLeft, out binding.BorderTop);
             SyncBoundsSpacer(element, binding);
         }
 
@@ -276,6 +281,7 @@ namespace Velvet
                     aabb = SilhouetteBoundsSpacer.ExpandForShear(aabb, tanX, 0f);
                 }
             }
+            aabb = SilhouetteBoundsSpacer.ShiftToPaddingBox(aabb, binding.BorderLeft, binding.BorderTop);
             SilhouetteBoundsSpacer.Sync(element, ref binding.BoundsSpacer, binding.WantSpacer, aabb);
         }
 

--- a/Packages/com.velvet.core/Runtime/Styling/SilhouetteBoundsSpacer.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/SilhouetteBoundsSpacer.cs
@@ -29,9 +29,9 @@ namespace Velvet
         internal const string MarkerClass = "velvet-bounds-spacer";
         internal const string SpacerName = "velvet-bounds-spacer";
 
-        // A little slack beyond the computed AABB absorbs the stroke half-width, antialiasing, and any
-        // border/padding offset between the gVC origin and the absolute-positioning origin. Over-covering only
-        // grows the offscreen texture slightly; it is never visible (the spacer paints nothing).
+        // A little slack beyond the computed AABB absorbs the stroke half-width and antialiasing (the
+        // border-box vs padding-box origin offset is handled exactly in Sync, not by this fudge). Over-covering
+        // only grows the offscreen texture slightly; it is never visible (the spacer paints nothing).
         private const float Slack = 4f;
 
         /// <summary>
@@ -81,6 +81,9 @@ namespace Velvet
             if (aabbLocal.width > 0f && aabbLocal.height > 0f
                 && !float.IsNaN(aabbLocal.width) && !float.IsNaN(aabbLocal.height))
             {
+                // aabbLocal is the paint extent in the caster's border-box gVC space; the caller has already
+                // shifted its origin left/up by the caster's border so this padding-box-relative left/top lands
+                // the coverage correctly in border-box space (see BorderInset / the paint layers' aabb shift).
                 spacer.style.left = aabbLocal.xMin - Slack;
                 spacer.style.top = aabbLocal.yMin - Slack;
                 spacer.style.width = aabbLocal.width + (2f * Slack);
@@ -156,6 +159,107 @@ namespace Velvet
             return new Rect(r.xMin - ox, r.yMin - oy, r.width + (2f * ox), r.height + (2f * oy));
         }
 
+        // The left/top border width the class list implies, in px, so a caller can shift the paint AABB into
+        // padding-box space (the origin an absolute child's left/top resolve against) and keep the spacer's
+        // coverage correct under any border. Parsed straight from the classes — not resolvedStyle (unresolved
+        // at the paint layers' one-shot geometry-callback sizing time) nor inline style (misses the USS-class
+        // scale borders border/border-2/…). Variant layers are peeled so a state border (hover:border-8) is
+        // reserved for too, and the MAX across classes is taken: over-covering is invisible, under-covering
+        // clips. Mirrors the fixed scale in _borders.uss (border=1, border-N=N, per-side the same).
+        internal static void BorderInset(string[] classNames, out float left, out float top)
+        {
+            left = 0f;
+            top = 0f;
+            if (classNames == null)
+            {
+                return;
+            }
+            foreach (var cls in classNames)
+            {
+                // Strip !important before peeling variants (a bang sits at the class edge, e.g. border-8! /
+                // !border-8) so the border is still recognized under the important modifier.
+                var leaf = StyleArbitraryValueResolver.StripImportant(cls, out _);
+                while (StyleVariantClass.TryParse(leaf, out _, out var payload))
+                {
+                    leaf = payload;
+                }
+                if (TryParseBorderLeaf(leaf, out var affectsLeft, out var affectsTop, out var width))
+                {
+                    if (affectsLeft && width > left) { left = width; }
+                    if (affectsTop && width > top) { top = width; }
+                }
+            }
+        }
+
+        // Parses one border-width leaf to which origin sides it insets and by how much. Returns false for
+        // color / style / non-width border classes (border-red-500, border-dashed) and non-border classes.
+        private static bool TryParseBorderLeaf(string leaf, out bool affectsLeft, out bool affectsTop, out float width)
+        {
+            affectsLeft = false;
+            affectsTop = false;
+            width = 0f;
+            if (leaf == null)
+            {
+                return false;
+            }
+            if (leaf == "border")
+            {
+                affectsLeft = true;
+                affectsTop = true;
+                width = 1f;
+                return true;
+            }
+            if (!leaf.StartsWith("border-", System.StringComparison.Ordinal))
+            {
+                return false;
+            }
+            var rest = leaf.Substring("border-".Length);
+            // Per-side form: a side letter (t/r/b/l/x/y), optionally "-<width>". Only left-affecting (l, x) and
+            // top-affecting (t, y) sides matter for the top-left origin; r/b are irrelevant to the shift.
+            var c0 = rest.Length > 0 ? rest[0] : '\0';
+            var isSide = (rest.Length == 1 || (rest.Length > 1 && rest[1] == '-')) && "trblxy".IndexOf(c0) >= 0;
+            if (isSide)
+            {
+                var widthPart = rest.Length > 1 ? rest.Substring(2) : string.Empty;
+                if (widthPart.Length == 0)
+                {
+                    width = 1f;
+                }
+                else if (!TryParseWidth(widthPart, out width))
+                {
+                    return false;
+                }
+                affectsLeft = c0 == 'l' || c0 == 'x';
+                affectsTop = c0 == 't' || c0 == 'y';
+                return affectsLeft || affectsTop;
+            }
+            // All-sides form: border-<width> / border-[Npx]. A color/style token fails TryParseWidth.
+            if (TryParseWidth(rest, out width))
+            {
+                affectsLeft = true;
+                affectsTop = true;
+                return true;
+            }
+            return false;
+        }
+
+        // A border-width token to px: an integer (0/2/4/8/…) or an arbitrary bracket value. The bracket form
+        // delegates to the resolver's own length grammar so it matches the width actually applied (px and rem;
+        // a percent border width is meaningless and left unreserved — over-covering, never a clip).
+        private static bool TryParseWidth(string s, out float width)
+        {
+            width = 0f;
+            if (string.IsNullOrEmpty(s))
+            {
+                return false;
+            }
+            if (s[0] == '[')
+            {
+                return StyleArbitraryValueResolver.TryParseArbitraryPixels(s, out width);
+            }
+            return int.TryParse(s, out var i) && i >= 0 && (width = i) >= 0f;
+        }
+
         // The caster's laid-out size, or false when layout has not resolved one yet (pre-layout / EditMode,
         // where the spacer attaches unsized and the geometry callback re-sizes it). Shared by the skew and
         // shadow layers so the "laid out" gate cannot drift between them.
@@ -164,6 +268,19 @@ namespace Velvet
             w = element.layout.width;
             h = element.layout.height;
             return w > 0f && h > 0f && !float.IsNaN(w) && !float.IsNaN(h);
+        }
+
+        // Shifts a paint AABB (in the caster's border-box gVC space) into the padding-box space an absolute
+        // child's left/top resolve against, by insetting its origin by the caster's border. Keeps the size, so
+        // Sync's `xMin - Slack` / `xMax + Slack` land the coverage correctly in border-box space. A no-op for an
+        // empty AABB (pre-layout) or a zero border.
+        internal static Rect ShiftToPaddingBox(Rect aabbLocal, float borderLeft, float borderTop)
+        {
+            if (aabbLocal.width <= 0f || aabbLocal.height <= 0f)
+            {
+                return aabbLocal;
+            }
+            return new Rect(aabbLocal.xMin - borderLeft, aabbLocal.yMin - borderTop, aabbLocal.width, aabbLocal.height);
         }
 
         // Axis-aligned union of two rects.

--- a/Packages/com.velvet.core/Runtime/Styling/SkewSilhouette.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/SkewSilhouette.cs
@@ -55,6 +55,10 @@ namespace Velvet
         // detach. See SilhouetteBoundsSpacer.
         public bool WantSpacer;
         public VisualElement? BoundsSpacer;
+        // The caster's left/top border, parsed from the class list, so the spacer's padding-box-relative
+        // origin is shifted back into border-box space (see SilhouetteBoundsSpacer.BorderInset).
+        public float BorderLeft;
+        public float BorderTop;
     }
 
     /// <summary>
@@ -166,9 +170,10 @@ namespace Velvet
         // survive the filter's offscreen render tree) and syncs the spacer now. Called from the reconciler on
         // create / patch; the geometry callback re-syncs when the size settles. Reads the live layout, so it is
         // a no-op-safe re-run at any time.
-        public static void SetWantSpacer(VisualElement element, SkewBinding binding, bool want)
+        public static void SetWantSpacer(VisualElement element, SkewBinding binding, bool want, string[] classNames)
         {
             binding.WantSpacer = want;
+            SilhouetteBoundsSpacer.BorderInset(classNames, out binding.BorderLeft, out binding.BorderTop);
             SyncBoundsSpacer(element, binding);
         }
 
@@ -183,6 +188,7 @@ namespace Velvet
                     Mathf.Tan(binding.Spec.XDeg * Mathf.Deg2Rad),
                     Mathf.Tan(binding.Spec.YDeg * Mathf.Deg2Rad))
                 : default;
+            aabb = SilhouetteBoundsSpacer.ShiftToPaddingBox(aabb, binding.BorderLeft, binding.BorderTop);
             SilhouetteBoundsSpacer.Sync(element, ref binding.BoundsSpacer, binding.WantSpacer, aabb);
         }
 

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/SilhouetteBoundsSpacerTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/SilhouetteBoundsSpacerTests.cs
@@ -111,5 +111,105 @@ namespace Velvet.Tests
             // Act / Assert
             Assert.That(SilhouetteBoundsSpacer.NonSpacerChildCount(container), Is.EqualTo(1));
         }
+
+        [Test]
+        public void Given_AllSidesScaleBorder_When_InsetParsed_Then_LeftMatchesTheScale()
+        {
+            SilhouetteBoundsSpacer.BorderInset(new[] { "border-8" }, out var left, out _);
+
+            Assert.That(left, Is.EqualTo(8f));
+        }
+
+        [Test]
+        public void Given_BareBorder_When_InsetParsed_Then_TopIsOne()
+        {
+            SilhouetteBoundsSpacer.BorderInset(new[] { "border" }, out _, out var top);
+
+            Assert.That(top, Is.EqualTo(1f));
+        }
+
+        [Test]
+        public void Given_ALeftOnlyBorder_When_InsetParsed_Then_TopStaysZero()
+        {
+            SilhouetteBoundsSpacer.BorderInset(new[] { "border-l-4" }, out _, out var top);
+
+            Assert.That(top, Is.EqualTo(0f));
+        }
+
+        [Test]
+        public void Given_AnXAxisBorder_When_InsetParsed_Then_LeftIsInset()
+        {
+            // border-x sets the left (and right) border; only left matters for the top-left origin.
+            SilhouetteBoundsSpacer.BorderInset(new[] { "border-x-4" }, out var left, out _);
+
+            Assert.That(left, Is.EqualTo(4f));
+        }
+
+        [Test]
+        public void Given_ABorderColorClass_When_InsetParsed_Then_ItContributesNoInset()
+        {
+            // border-red-500 is a color, not a width — it must not be read as an inset.
+            SilhouetteBoundsSpacer.BorderInset(new[] { "border-red-500" }, out var left, out var top);
+
+            Assert.That(left + top, Is.EqualTo(0f));
+        }
+
+        [Test]
+        public void Given_AVariantCarriedBorder_When_InsetParsed_Then_ItIsStillReserved()
+        {
+            // A state border (hover:border-8) applies outside the reconcile, so it must be reserved for.
+            SilhouetteBoundsSpacer.BorderInset(new[] { "hover:border-8" }, out var left, out _);
+
+            Assert.That(left, Is.EqualTo(8f));
+        }
+
+        [Test]
+        public void Given_AnArbitraryBorder_When_InsetParsed_Then_ThePixelValueIsRead()
+        {
+            SilhouetteBoundsSpacer.BorderInset(new[] { "border-[16px]" }, out var left, out _);
+
+            Assert.That(left, Is.EqualTo(16f));
+        }
+
+        [Test]
+        public void Given_ConflictingBorders_When_InsetParsed_Then_TheMaxIsTaken()
+        {
+            // Over-covering is invisible, so the widest left-affecting class wins rather than the cascade.
+            SilhouetteBoundsSpacer.BorderInset(new[] { "border-2", "border-l-8" }, out var left, out _);
+
+            Assert.That(left, Is.EqualTo(8f));
+        }
+
+        [Test]
+        public void Given_AnImportantBorder_When_InsetParsed_Then_TheBangIsStrippedAndReserved()
+        {
+            SilhouetteBoundsSpacer.BorderInset(new[] { "border-8!" }, out var left, out _);
+
+            Assert.That(left, Is.EqualTo(8f));
+        }
+
+        [Test]
+        public void Given_AnArbitraryRemBorder_When_InsetParsed_Then_ItConvertsAtSixteenPxPerRem()
+        {
+            SilhouetteBoundsSpacer.BorderInset(new[] { "border-[2rem]" }, out var left, out _);
+
+            Assert.That(left, Is.EqualTo(32f));
+        }
+
+        [Test]
+        public void Given_APaintAabb_When_ShiftedToPaddingBox_Then_TheOriginInsetsByTheBorder()
+        {
+            var shifted = SilhouetteBoundsSpacer.ShiftToPaddingBox(new Rect(-10f, -6f, 120f, 60f), 8f, 4f);
+
+            Assert.That(shifted.xMin, Is.EqualTo(-18f).Within(1e-4f));
+        }
+
+        [Test]
+        public void Given_APaintAabb_When_ShiftedToPaddingBox_Then_TheSizeIsUnchanged()
+        {
+            var shifted = SilhouetteBoundsSpacer.ShiftToPaddingBox(new Rect(-10f, -6f, 120f, 60f), 8f, 4f);
+
+            Assert.That(shifted.width, Is.EqualTo(120f).Within(1e-4f));
+        }
     }
 }


### PR DESCRIPTION
## Problem

The filter bounds-spacer (the transparent child that widens a filtered element's render bounds so a `skew-*` silhouette / `shadow-*` bleed / `V.Particles` overflow survives the filter's offscreen texture) is positioned with `position: absolute`, whose `left`/`top` resolve against the **padding box**. But the paint it must cover is drawn in the caster's **border-box** gVC space. A border thicker than the spacer's fixed slack shifts its coverage inward, clipping a border-wide strip of the overflow (e.g. `border-8 -skew-x-4 hue-rotate-90`).

## Fix

Parse the caster's left/top border from the class list (`SilhouetteBoundsSpacer.BorderInset`) and shift the paint AABB into padding-box space (`ShiftToPaddingBox`) before sizing the spacer.

The class list is the only border source that is both **complete** and **available in time**:
- `resolvedStyle.borderLeftWidth` is unresolved at the skew/shadow paint layers' one-shot geometry callback (it fires before styles resolve and never re-fires for a fixed-size box).
- inline `style.borderLeftWidth` misses the USS-scale utilities (`border`, `border-2/4/8`, per-side) — only bracket values land inline.

The parser peels variant layers and strips `!important` so a state border (`hover:border-8!`) is reserved for too, routes arbitrary widths through the resolver's own length grammar (px, rem), ignores color/style tokens (`border-red-500`), and takes the **max** across classes (over-covering is invisible; under-covering clips).

## Tests

- `SilhouetteBoundsSpacerTests` — 12 unit tests pinning `BorderInset` (USS scale, per-side, `border-x`, variant-carried, arbitrary px/rem, `!important`, color-ignored, max-wins) and `ShiftToPaddingBox`.
- `FilterSpacerBorderOffsetPlaybackTests` — on a real panel a `border-8` filtered skewed element's spacer reaches past the border-box origin (RED before, GREEN after).

Full EditMode (2906) and PlayMode (73) green; the border=0 common case is a no-op (unchanged behavior).

## Changelog

Also records the three filter-clip fixes (skew/shadow #71, particles #72, this border offset) under `[Unreleased]`.