### PR TITLE
fix(velvet): default ring color to blue-500 at 0.5 alpha, matching Tailwind

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The default ring color (`ring` / `ring-2` with no explicit `ring-<color>`) is now blue-500 at 0.5
+  alpha, matching Tailwind's `--tw-ring-color`, instead of fully opaque. An explicit ring color stays
+  opaque.
 - A `skew-*` sheared silhouette and a `shadow-*` / `drop-shadow-*` bleed no longer clip to the layout
   rect when the same element carries an inline filter (`blur-*`, `hue-rotate-*`, `animate-hue`, or a
   variant such as `hover:blur-sm`). A filter renders the element through an offscreen tree sized to its

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/RingWrapTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/RingWrapTests.cs
@@ -49,7 +49,9 @@ namespace Velvet.Tests
         public void Given_BareRing_When_Reconciled_Then_OverlayUsesDefaultBlueRingColor()
         {
             using var scope = new ReconcilerScope();
+            // Tailwind's default ring color is blue-500 at 0.5 alpha (the palette token resolves opaque).
             VelvetPalette.TryResolveColorToken("blue-500", out var blue);
+            blue.a = 0.5f;
 
             Mount(scope, new VNode[] { V.Div(className: "ring", name: "card") });
 

--- a/Packages/com.velvet.core/Runtime/Styling/StyleRingClass.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleRingClass.cs
@@ -43,25 +43,40 @@ namespace Velvet
     // cancel an earlier ring in the cascade.
     internal static class StyleRingClass
     {
-        // The DEFAULT ring is 3px blue-500/… ; the bare `ring` and a color-only `ring-red-500` use it.
+        // The DEFAULT ring is 3px blue-500; the bare `ring` and a width-only `ring-2` use it (color applied at
+        // 0.5 alpha, see DefaultRingColor). An explicit `ring-<color>` is opaque and does not go through here.
         private const float DefaultRingWidth = 3f;
+        // The default ring's alpha. Tailwind renders a ring with no explicit color at blue-500 / 0.5, not full
+        // opacity; an explicit ring color stays opaque, and the outline default (below) is unaffected.
+        private const float DefaultRingAlpha = 0.5f;
         // Bare `outline` (outline-style: solid) — Velvet picks a thin default width; outline-{N} overrides.
         private const float DefaultOutlineWidth = 1f;
 
-        private static bool s_defaultRingColorResolved;
-        private static Color s_defaultRingColor = new(59f / 255f, 130f / 255f, 246f / 255f, 1f); // blue-500 fallback
+        private static bool s_blue500Resolved;
+        private static Color s_blue500 = new(59f / 255f, 130f / 255f, 246f / 255f, 1f); // opaque fallback
 
-        private static Color DefaultRingColor()
+        // The default band color, opaque, shared by the ring and outline defaults. The ring applies its own
+        // 0.5 alpha on top (DefaultRingColor); bare `outline` keeps this opaque (a color-less outline is a
+        // pre-existing currentColor approximation, out of scope, so its alpha must not change with the ring).
+        private static Color DefaultBandColor()
         {
-            if (!s_defaultRingColorResolved)
+            if (!s_blue500Resolved)
             {
                 if (VelvetPalette.TryResolveColorToken("blue-500", out var c))
                 {
-                    s_defaultRingColor = c;
+                    s_blue500 = c;
                 }
-                s_defaultRingColorResolved = true;
+                s_blue500Resolved = true;
             }
-            return s_defaultRingColor;
+            return s_blue500;
+        }
+
+        // A color-less ring: blue-500 at 0.5 alpha (Tailwind's default --tw-ring-color).
+        private static Color DefaultRingColor()
+        {
+            var c = DefaultBandColor();
+            c.a = DefaultRingAlpha;
+            return c;
         }
 
         // suffix → width (px). Shared by ring-{N} and outline-{N}; the ring/outline width scale.
@@ -202,7 +217,8 @@ namespace Velvet
                 return false; // ring-0 / outline-none: no ring
             }
 
-            var effectiveColor = colorSet ? color : DefaultRingColor();
+            // A color-less ring uses the 0.5-alpha default; a color-less outline keeps the opaque band color.
+            var effectiveColor = colorSet ? color : (isOutline ? DefaultBandColor() : DefaultRingColor());
             spec = new RingSpec(effectiveWidth, effectiveColor, Mathf.Max(0f, offset), inset);
             return true;
         }

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/StyleRingClassTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/StyleRingClassTests.cs
@@ -55,6 +55,27 @@ namespace Velvet.Tests
         }
 
         [Test]
+        public void Given_ADefaultColorRing_When_Extracted_Then_TheColorIsHalfAlpha()
+        {
+            // Tailwind's default ring color is blue-500 at 0.5 alpha, not full opacity.
+            Assert.That(Extract("ring-2").Color.a, Is.EqualTo(0.5f).Within(1e-4f));
+        }
+
+        [Test]
+        public void Given_AnExplicitColorRing_When_Extracted_Then_TheColorStaysOpaque()
+        {
+            // Only the DEFAULT ring color is semi-transparent; an explicit ring-<color> is opaque.
+            Assert.That(Extract("ring-2", "ring-red-500").Color.a, Is.EqualTo(1f).Within(1e-4f));
+        }
+
+        [Test]
+        public void Given_ABareOutline_When_Extracted_Then_TheColorStaysOpaque()
+        {
+            // The 0.5-alpha default is ring-only; a color-less outline keeps its opaque band color.
+            Assert.That(Extract("outline").Color.a, Is.EqualTo(1f).Within(1e-4f));
+        }
+
+        [Test]
         public void Given_RingZero_When_Extracted_Then_NoRing()
         {
             Assert.That(StyleRingClass.TryExtract(new[] { "ring-0" }, out _), Is.False);


### PR DESCRIPTION
## Problem

Tailwind's default ring color (`--tw-ring-color`, used by a ring with no explicit `ring-<color>` — bare `ring`, width-only `ring-2`) is **blue-500 at 0.5 alpha**. Velvet resolved it fully opaque.

## Fix

`StyleRingClass` now applies `0.5` alpha to the color-less ring default. An explicit `ring-<color>` sets the color slot and stays opaque. A color-less `outline` (which shared the same default) is routed to its own opaque band color, so this change does not alter outline — its color-less default remains a separate, pre-existing currentColor approximation.

## Tests

`StyleRingClassTests` (default ring 0.5, explicit ring opaque, bare outline opaque) and `RingWrapTests` (overlay default color now 0.5 alpha). Full EditMode green.