### PR TITLE
fix(velvet): match Tailwind's default transition curve and tracking scale

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The default ring color (`ring` / `ring-2` with no explicit `ring-<color>`) is now blue-500 at 0.5
   alpha, matching Tailwind's `--tw-ring-color`, instead of fully opaque. An explicit ring color stays
   opaque.
+- The default `transition-*` timing function is now `ease-in-out`, the closest UI Toolkit keyword to
+  Tailwind's default `cubic-bezier(0.4, 0, 0.2, 1)`, instead of the fast-start `ease-out`. An explicit
+  `ease-*` class still overrides it.
+- The `tracking-*` (letter-spacing) scale is baked at Tailwind's 16px root font (`tracking-widest` =
+  0.1em → 1.6px, etc.) so it matches Tailwind at the default text size, instead of the previous
+  ~25%-too-wide values.
 - A `skew-*` sheared silhouette and a `shadow-*` / `drop-shadow-*` bleed no longer clip to the layout
   rect when the same element carries an inline filter (`blur-*`, `hue-rotate-*`, `animate-hue`, or a
   variant such as `hover:blur-sm`). A filter renders the element through an offscreen tree sized to its

--- a/Packages/com.velvet.core/Runtime/Styles/_effects.uss
+++ b/Packages/com.velvet.core/Runtime/Styles/_effects.uss
@@ -47,7 +47,8 @@
 .transition-transform {
     transition-property: translate, scale, rotate;
     transition-duration: var(--duration-normal);
-    transition-timing-function: ease-out;
+    /* ease-in-out: the closest UI Toolkit keyword to Tailwind's default cubic-bezier(0.4, 0, 0.2, 1). */
+    transition-timing-function: ease-in-out;
 }
 
 /* object-fit (Tailwind) — for an element showing an image as background-image. Mapped onto background-size

--- a/Packages/com.velvet.core/Runtime/Styles/_state_variants.uss
+++ b/Packages/com.velvet.core/Runtime/Styles/_state_variants.uss
@@ -106,32 +106,34 @@
 /* Each property utility bundles a default duration + curve (Tailwind ships
  * transition-duration/timing-function inside every transition-* utility) so the class works
  * standalone — UI Toolkit's initial transition-duration is 0s, which would otherwise snap.
- * The explicit .duration-* / .ease-* classes below are declared later, so they still override. */
+ * The default curve is ease-in-out: Tailwind's default is cubic-bezier(0.4, 0, 0.2, 1), which UI
+ * Toolkit (no cubic-bezier easing) approximates most closely with its ease-in-out keyword, not the
+ * fast-start ease-out. The explicit .duration-* / .ease-* classes below are declared later and override. */
 .transition-all {
     transition-property: all;
     transition-duration: var(--duration-normal);
-    transition-timing-function: ease-out;
+    transition-timing-function: ease-in-out;
 }
 .transition-none { transition-property: none; }
 .transition-opacity {
     transition-property: opacity;
     transition-duration: var(--duration-normal);
-    transition-timing-function: ease-out;
+    transition-timing-function: ease-in-out;
 }
 .transition-colors {
     transition-property: background-color, border-color, color;
     transition-duration: var(--duration-normal);
-    transition-timing-function: ease-out;
+    transition-timing-function: ease-in-out;
 }
 .transition-colors-scale {
     transition-property: background-color, border-color, color, scale;
     transition-duration: var(--duration-normal);
-    transition-timing-function: ease-out;
+    transition-timing-function: ease-in-out;
 }
 .transition-colors-scale-opacity {
     transition-property: background-color, border-color, color, scale, opacity;
     transition-duration: var(--duration-normal);
-    transition-timing-function: ease-out;
+    transition-timing-function: ease-in-out;
 }
 .duration-fast { transition-duration: var(--duration-fast); }
 .duration-normal { transition-duration: var(--duration-normal); }

--- a/Packages/com.velvet.core/Runtime/Styles/_typography.uss
+++ b/Packages/com.velvet.core/Runtime/Styles/_typography.uss
@@ -91,11 +91,12 @@
 .text-ellipsis { text-overflow: ellipsis; }
 .text-clip { text-overflow: clip; }
 
-/* Letter Spacing (Tailwind: tracking-*).
-   USS letter-spacing has no `em` unit, so values are in px (use tracking-[2px] for arbitrary). */
-.tracking-tighter { letter-spacing: -1px; }
-.tracking-tight { letter-spacing: -0.5px; }
+/* Letter Spacing (Tailwind: tracking-*). USS letter-spacing has no `em` unit, so the em scale is
+   baked at Tailwind's 16px root font (tighter -0.05em, tight -0.025em, wide 0.025em, wider 0.05em,
+   widest 0.1em → the px values below), exact at the default text size (use tracking-[Npx] for others). */
+.tracking-tighter { letter-spacing: -0.8px; }
+.tracking-tight { letter-spacing: -0.4px; }
 .tracking-normal { letter-spacing: 0; }
-.tracking-wide { letter-spacing: 0.5px; }
-.tracking-wider { letter-spacing: 1px; }
-.tracking-widest { letter-spacing: 2px; }
+.tracking-wide { letter-spacing: 0.4px; }
+.tracking-wider { letter-spacing: 0.8px; }
+.tracking-widest { letter-spacing: 1.6px; }

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/TrackingScaleTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/TrackingScaleTests.cs
@@ -1,0 +1,49 @@
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine.UIElements;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins the tracking-* (letter-spacing) scale to Tailwind's em values baked at the 16px root font.
+    /// UI Toolkit letter-spacing has no em unit, so the scale is fixed px, exact at the default text size.
+    /// </summary>
+    [TestFixture]
+    internal sealed class TrackingScaleTests : PanelTestBase
+    {
+        private const string StyleSheetPath = "Packages/com.velvet.core/Runtime/Styles/StyleUtilities.uss";
+
+        protected override void LoadStyleSheets()
+        {
+            var sheet = AssetDatabase.LoadAssetAtPath<StyleSheet>(StyleSheetPath);
+            Assume.That(sheet, Is.Not.Null, "Precondition: the bundled StyleUtilities.uss loads");
+            _window.rootVisualElement.styleSheets.Add(sheet);
+        }
+
+        private VisualElement MountLeaf(string className)
+        {
+            _mounted = V.Mount(_window.rootVisualElement, V.Div(name: "leaf", className: className));
+            var leaf = _window.rootVisualElement.Q<VisualElement>("leaf");
+            ForcePanelUpdate(leaf.panel);
+            return leaf;
+        }
+
+        [Test]
+        public void Given_TrackingWidest_When_Resolved_Then_ItIsPointOneEmAtTheSixteenPxRoot()
+        {
+            // Tailwind tracking-widest is 0.1em; at the 16px root that is 1.6px.
+            var leaf = MountLeaf("tracking-widest");
+
+            Assert.That(leaf.resolvedStyle.letterSpacing, Is.EqualTo(1.6f).Within(1e-3f));
+        }
+
+        [Test]
+        public void Given_TrackingTight_When_Resolved_Then_ItIsNegativePointZeroTwoFiveEm()
+        {
+            // Tailwind tracking-tight is -0.025em; at the 16px root that is -0.4px.
+            var leaf = MountLeaf("tracking-tight");
+
+            Assert.That(leaf.resolvedStyle.letterSpacing, Is.EqualTo(-0.4f).Within(1e-3f));
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/TrackingScaleTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/TrackingScaleTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6cae70c218c844dbea5dddf4a3ad36ab

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/TransitionUtilityDefaultDurationTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/TransitionUtilityDefaultDurationTests.cs
@@ -76,5 +76,24 @@ namespace Velvet.Tests
             // Assert
             Assert.That(leaf.resolvedStyle.transitionDuration.First().value, Is.EqualTo(0f));
         }
+
+        [Test]
+        public void Given_TransitionColorsAlone_When_Resolved_Then_ItsDefaultCurveEasesInAndOut()
+        {
+            // Tailwind's default transition timing is cubic-bezier(0.4, 0, 0.2, 1); UI Toolkit has no
+            // cubic-bezier, so the bundled default is its closest keyword, ease-in-out (not fast-start ease-out).
+            var leaf = MountLeaf("transition-colors");
+
+            Assert.That(leaf.resolvedStyle.transitionTimingFunction.First().mode, Is.EqualTo(EasingMode.EaseInOut));
+        }
+
+        [Test]
+        public void Given_AnExplicitEaseClass_When_Resolved_Then_ItStillOverridesTheDefaultCurve()
+        {
+            // The .ease-* utilities are declared after the transition-* defaults, so an explicit curve wins.
+            var leaf = MountLeaf("transition-colors ease-linear");
+
+            Assert.That(leaf.resolvedStyle.transitionTimingFunction.First().mode, Is.EqualTo(EasingMode.Linear));
+        }
     }
 }


### PR DESCRIPTION
Two Tailwind-parity defaults in the bundled USS.

## Transition timing function

The `transition-*` property utilities (`transition-all`, `transition-opacity`, `transition-colors`, `transition-colors-scale`, `transition-colors-scale-opacity`, `transition-transform`) defaulted to `ease-out`. Tailwind's default is `cubic-bezier(0.4, 0, 0.2, 1)` — an ease-both-ends curve. UI Toolkit has no cubic-bezier easing, so the closest keyword is `ease-in-out`, not the fast-start `ease-out`. The explicit `.ease-*` utilities are unchanged and still override.

## Tracking (letter-spacing) scale

`tracking-*` was ~25% too wide. USS has no `em` unit, so the em scale is now baked at Tailwind's 16px root font (`tracking-widest` 0.1em → 1.6px, `tracking-tight` -0.025em → -0.4px, etc.) — exact at the default text size. `tracking-[Npx]` arbitrary values are unaffected.

## Tests

`TransitionUtilityDefaultDurationTests` (default curve == EaseInOut; explicit `ease-linear` still wins) and `TrackingScaleTests` (widest 1.6px, tight -0.4px). Full EditMode (2913) and PlayMode (73) green.