### PR TITLE
fix(velvet): flush pending passive effects before a discrete event's render

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A prior commit's pending passive effect (`Hooks.UseEffect`) now runs BEFORE a discrete event's
+  re-render, matching React's flush-passive-effects-before-update: a click handler that re-renders no
+  longer commits its render ahead of an effect that has not run yet. Scoped to the discrete-event
+  boundary, so a mount / commit-phase flush still leaves passive effects pending for the scheduler tick.
 - The default ring color (`ring` / `ring-2` with no explicit `ring-<color>`) is now blue-500 at 0.5
   alpha, matching Tailwind's `--tw-ring-color`, instead of fully opaque. An explicit ring color stays
   opaque.

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberBatchScheduler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberBatchScheduler.cs
@@ -64,6 +64,10 @@ namespace Velvet
         // whole-tree flush) run in a single pass with no tier separation and read the live store snapshot.
         private Action<bool>? _onDrainBegin;
         private Action? _onDrainEnd;
+        // Flushes any pending passive effects from a prior commit, wired by the owning Reconciler. Run before a
+        // synchronous discrete-event drain so those effects commit before the new update's render — React's
+        // flushPassiveEffects-before-update.
+        private Action? _flushPassiveEffects;
 
         // True when an immediate drain has just established snapshot pins that a pending delayed drain should
         // reuse (the delayed drain continues the immediate drain's wave). Set by DrainImmediate, consumed by
@@ -114,6 +118,10 @@ namespace Velvet
             _onDrainBegin = onDrainBegin;
             _onDrainEnd = onDrainEnd;
         }
+
+        // Registers the pending-passive-effect flush run before a synchronous discrete-event drain (React's
+        // flushPassiveEffects-before-update). Called once by the owning Reconciler.
+        internal void SetPassiveEffectFlush(Action flush) => _flushPassiveEffects = flush;
 
         // Enqueues fiber for a batched flush at the next frame boundary
         // (Normal / Urgent priority) and registers the single shared drain callback if not already pending.
@@ -347,6 +355,16 @@ namespace Velvet
         {
             if (_draining || (_reconcileActiveProbe?.Invoke() ?? false)) return;
             DrainImmediate();
+        }
+
+        // Flushes a prior commit's pending passive effects (React's flushPassiveEffects-before-update), driven
+        // by the discrete-event boundary so an effect runs before that event's render — NOT from the mount /
+        // commit-phase FlushImmediate callers, which must leave passive effects pending for the scheduler tick.
+        // Gated like FlushImmediate so it never re-enters a live drain / reconcile.
+        internal void FlushPendingPassiveEffects()
+        {
+            if (_draining || (_reconcileActiveProbe?.Invoke() ?? false)) return;
+            _flushPassiveEffects?.Invoke();
         }
 
         // Drops fiber from both pending queues. Called on Unmount / Dispose so a

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberDiscreteEventScope.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberDiscreteEventScope.cs
@@ -30,7 +30,18 @@ namespace Velvet
                 FiberWorkLoop.IsInDiscreteEvent = wasInDiscreteEvent;
                 if (!wasInDiscreteEvent)
                 {
-                    batchScheduler?.FlushImmediate();
+                    // React flushes a prior commit's pending passive effects before a discrete update's render,
+                    // so the effect runs before this event's re-render. Scoped to the discrete boundary (not the
+                    // mount / commit-phase FlushImmediate callers, which keep passive effects pending). The
+                    // event's own flush still runs even if a runaway passive-effect loop throws its guard.
+                    try
+                    {
+                        batchScheduler?.FlushPendingPassiveEffects();
+                    }
+                    finally
+                    {
+                        batchScheduler?.FlushImmediate();
+                    }
                 }
             }
         }

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberEffects.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberEffects.cs
@@ -400,6 +400,14 @@ namespace Velvet
                 if (rootFiber != null) RunEffects(rootFiber);
                 return;
             }
+            FlushPendingPassiveEffects(context);
+        }
+
+        // Context overload: the batch scheduler drives this before a synchronous discrete-event flush so a
+        // prior commit's pending passive effects run before the new update's render — React's
+        // flushPassiveEffects-before-update. A no-op when nothing is pending.
+        internal static void FlushPendingPassiveEffects(ReconcilerContext context)
+        {
             // An effect setup may setState and stage a fresh batch synchronously; drain until quiescent.
             // Bounded to surface a runaway effect-stages-effect loop as a test failure rather than a hang.
             var guard = 0;

--- a/Packages/com.velvet.core/Runtime/Reconciler/Reconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Reconciler.cs
@@ -82,6 +82,9 @@ namespace Velvet
                 // Lets the batch scheduler block a synchronous discrete-event flush while any reconcile
                 // pass (including a time-sliced resume that runs outside the batch Drain) is on the stack.
                 _ctx.BatchScheduler.SetReconcileActiveProbe(() => _ctx.SharedReconcileDepth > 0);
+                // React flushes pending passive effects before a new discrete-event update; wire the scheduler
+                // to drain them at that boundary so an effect from a prior commit runs before the next render.
+                _ctx.BatchScheduler.SetPassiveEffectFlush(() => FiberEffects.FlushPendingPassiveEffects(_ctx));
                 // Brackets each drain to drive (1) the UseStore cross-tier tearing guard — pinning is active only
                 // inside a drain, the immediate drain opens a fresh wave (reset = true) and the delayed drain
                 // reuses it (reset = false) — and (2) the layout-effect commit phase: fibers defer their effect

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/PassiveEffectFlushBeforeUpdateTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/PassiveEffectFlushBeforeUpdateTests.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine.UIElements;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins React's flushPassiveEffects-before-update: a prior render's pending passive effect runs before a
+    /// new discrete-event update's render, not after. A dep-change re-render schedules the effect (the EditMode
+    /// scheduler never ticks, so it stays pending); a discrete click's synchronous flush must drain it first.
+    /// GWT, one assert.
+    /// </summary>
+    [TestFixture]
+    internal sealed class PassiveEffectFlushBeforeUpdateTests
+    {
+        private VisualElement _root;
+        private MountedTree _mounted;
+        private static readonly List<string> s_log = new();
+        private static StateUpdater<int> s_setDep;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _root = new VisualElement();
+            s_log.Clear();
+            s_setDep = default;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _mounted?.Dispose();
+            _mounted = null;
+        }
+
+        [Component]
+        private static VNode Widget()
+        {
+            var (dep, setDep) = Hooks.UseState(0);
+            var (tick, setTick) = Hooks.UseState(0);
+            s_setDep = setDep;
+            s_log.Add($"render:t{tick}:d{dep}");
+            Hooks.UseEffect(() =>
+            {
+                s_log.Add($"effect:d{dep}");
+                return () => { };
+            }, new object[] { dep });
+            return V.Button(name: "btn", onClick: () => setTick.Invoke(t => t + 1));
+        }
+
+        [Test]
+        public void Given_APendingPassiveEffect_When_ADiscreteClickReRenders_Then_TheEffectRunsBeforeTheClicksRender()
+        {
+            // Arrange — mounted (its mount effect already ran), then a dep change re-renders and SCHEDULES a
+            // fresh passive effect (effect:d1) that the EditMode scheduler never drains, so it stays pending.
+            _mounted = V.Mount(_root, V.Component(Widget, key: "w"));
+            s_log.Clear();
+            s_setDep.Invoke(1);
+            _mounted.FlushStateForTest();
+            Assume.That(s_log, Is.EqualTo(new[] { "render:t0:d1" }), "Precondition: re-rendered, effect:d1 pending");
+            s_log.Clear();
+
+            // Act — a real discrete click setStates; its FlushImmediate must flush the pending effect first.
+            _root.Q<Button>("btn").SimulateClick();
+
+            // Assert — the pending effect commits before the click's re-render (render:t1:d1), as React orders it.
+            Assert.That(s_log, Is.EqualTo(new[] { "effect:d1", "render:t1:d1" }));
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/PassiveEffectFlushBeforeUpdateTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/PassiveEffectFlushBeforeUpdateTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9b0042c417425428381ae71c4879659a


### PR DESCRIPTION
## Problem

React runs a prior commit's pending passive effects (`useEffect`) before processing a new discrete-event update, so an effect setup commits before that event's render. Velvet re-rendered synchronously on a discrete event without first draining pending passive effects, so a click that re-rendered committed its render ahead of an effect that had not run yet (`['render','effect']` instead of React's `['effect','render']`).

## Fix

The discrete-event boundary (`FiberDiscreteEventScope.Run`) now flushes pending passive effects before its synchronous flush, at the outermost boundary. `FiberEffects.FlushPendingPassiveEffects` gains a context overload; `FiberBatchScheduler.FlushPendingPassiveEffects()` invokes it, gated (like `FlushImmediate`) so it never re-enters a live drain/reconcile; the `Reconciler` wires it.

Scoped to the discrete boundary rather than `FlushImmediate` itself: the mount / commit-phase `FlushImmediate` callers must leave passive effects pending for the scheduler tick (running them there breaks the mount contract). The event's own `FlushImmediate` runs even if a runaway passive loop throws its guard (try/finally).

## Tests

`PassiveEffectFlushBeforeUpdateTests` — a dep-change re-render schedules a passive effect (pending in EditMode); a discrete `SimulateClick` flushes it before the click's re-render. Full EditMode (2910) and PlayMode (73) green; the mount-keeps-effects-pending contract is preserved (the 3 tests an earlier FlushImmediate-scoped attempt broke stay green).