### PR TITLE
fix(velvet): rank the checked: variant below hover/focus/active, matching Tailwind

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A `checked:` variant value no longer beats a concurrent `hover:` / `focus:` / `active:` value on the
+  same property. Tailwind's variant order emits `checked` before the interaction states, so on a hovered
+  checked control the interaction state wins the tie; the layer priority now ranks `checked` below them
+  to match (it previously ranked highest).
 - The default ring color (`ring` / `ring-2` with no explicit `ring-<color>`) is now blue-500 at 0.5
   alpha, matching Tailwind's `--tw-ring-color`, instead of fully opaque. An explicit ring color stays
   opaque.

--- a/Packages/com.velvet.core/Runtime/Styling/StyleArbitraryModel.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleArbitraryModel.cs
@@ -51,11 +51,16 @@ namespace Velvet
         public const int GroupFocusWithin = 36;
         public const int PeerFocusWithin = 37;
         public const int PeerChecked = 38;
+        // Element-local interaction states. Tailwind's default variant order emits `checked` BEFORE
+        // hover/focus/active, so on a same-property tie an interaction state (emitted later) wins over
+        // `checked:` — the checked layer therefore ranks BELOW them (but still above the relational
+        // group-/peer- layers). Getting this backwards would let a checked control's `checked:` value beat a
+        // concurrent `hover:` / `focus:` / `active:` value, which Tailwind does not.
+        public const int Checked = 39;
         public const int Hover = 40;
         public const int Focus = 50;
         public const int FocusVisible = 55;
         public const int Active = 60;
-        public const int Checked = 65;
 
         // The important modifier (!utility / utility!): the highest layer, so an important utility
         // wins over the base and every state/variant layer — the inline-style stand-in for CSS !important

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/ArbitraryValueTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/ArbitraryValueTests.cs
@@ -2206,6 +2206,32 @@ namespace Velvet.Tests
         }
 
         [Test]
+        public void Given_CheckedAndHoverWidthLayers_When_BothActive_Then_HoverWins()
+        {
+            // Tailwind emits checked before hover in its variant order, so a hovered checked control's
+            // hover:w-[200px] wins the same-property tie over checked:w-[100px].
+            var el = new VisualElement();
+            StyleArbitraryValueResolver.Apply(el, new ArbitraryStyle(ArbitraryProperty.Width, 100f, LengthUnit.Pixel), StyleLayerPriority.Checked);
+            StyleArbitraryValueResolver.Apply(el, new ArbitraryStyle(ArbitraryProperty.Width, 200f, LengthUnit.Pixel), StyleLayerPriority.Hover);
+
+            Assert.That(el.style.width.value.value, Is.EqualTo(200f));
+        }
+
+        [Test]
+        public void Given_CheckedAndHoverWidthLayers_When_HoverCleared_Then_CheckedIsRestored()
+        {
+            // Hover off falls back to the still-checked layer (not wiped), so the checked value returns.
+            var el = new VisualElement();
+            StyleArbitraryValueResolver.Apply(el, new ArbitraryStyle(ArbitraryProperty.Width, 100f, LengthUnit.Pixel), StyleLayerPriority.Checked);
+            StyleArbitraryValueResolver.Apply(el, new ArbitraryStyle(ArbitraryProperty.Width, 200f, LengthUnit.Pixel), StyleLayerPriority.Hover);
+            Assume.That(el.style.width.value.value, Is.EqualTo(200f), "Precondition: hover wins over checked");
+
+            StyleArbitraryValueResolver.Clear(el, ArbitraryProperty.Width, StyleLayerPriority.Hover);
+
+            Assert.That(el.style.width.value.value, Is.EqualTo(100f));
+        }
+
+        [Test]
         public void Given_TranslateYBaseAndTranslateXHover_When_TranslateXCleared_Then_TranslateYSurvives()
         {
             // Arrange — translate-y-[20px] (base) + hover:translate-x-[10px].


### PR DESCRIPTION
## Problem

Velvet layers state-variant arbitrary/inline values by an integer priority (higher wins). `checked:` ranked highest of the interaction states (above `active:`/`focus-visible:`/`focus:`/`hover:`). Tailwind's default variant order emits `checked` BEFORE the interaction states, so on a control that is both checked and hovered/focused/active, the interaction state wins a same-property tie — the reverse of Velvet.

## Fix

`StyleLayerPriority.Checked` moves from the top of the interaction band to just below `Hover` (above the relational `group-`/`peer-` layers). So `hover:` / `focus:` / `focus-visible:` / `active:` win over `checked:` on the same property, matching Tailwind, while a color-less/standalone `checked:` still applies and is restored when the interaction state clears.

## Tests

Two layering tests in `ArbitraryValueTests`: hover's `hover:w-[200px]` wins over `checked:w-[100px]` when both active (RED before, GREEN after); clearing hover falls back to the checked layer. Full EditMode (2911) and PlayMode (73) green; `CheckedVariantBehaviorTests` (class-payload path, USS source order) unaffected.

Note: Velvet's linear priority model ranks the whole element-local interaction band above the relational `group-`/`peer-` band — a pre-existing approximation of CSS specificity, unchanged here.