### PR TITLE
refactor(velvet): commit layout effects subtree-wide two-phase

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A parent's layout-effect (`Hooks.UseLayoutEffect`) cleanup now runs before an inline child's layout-effect
+  setup when both re-run on one commit, matching React's all-cleanups-before-all-setups across the whole
+  subtree — previously that held only within a batch of inline siblings, and a parent committed after its
+  inline children were fully committed (their setups included), so a parent cleanup could read state a child
+  setup had just written. The inline-effect drain now splits into a cleanup pass and a setup pass with the
+  parent interleaved between them; a layout effect that mounts more inline children commits them as a
+  follow-up pass, as React runs effect-mounted work in a subsequent commit rather than the current one.
 - A `checked:` variant value no longer beats a concurrent `hover:` / `focus:` / `active:` value on the
   same property. Tailwind's variant order emits `checked` before the interaction states, so on a hovered
   checked control the interaction state wins the tie; the layer priority now ranks `checked` below them

--- a/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseLayoutEffectTests.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseLayoutEffectTests.cs
@@ -464,7 +464,7 @@ namespace Velvet.Tests
             // Act
             using var mounted = V.Mount(_root, V.Component(EffectWithRefRender, key: "withref"));
 
-            // Assert — the refCallback fires during Reconcile, before RunLayoutEffects, so Current is committed
+            // Assert — the refCallback fires during Reconcile, before the layout-effect commit, so Current is committed
             Assert.That(capturedElement, Is.SameAs(_root.Q<Label>()),
                 "The layout effect factory observes Ref.Current already committed");
         }

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberEffects.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberEffects.cs
@@ -13,15 +13,9 @@ namespace Velvet
     {
         #region Effects
 
-        // Runs the effects pending change that were queued during Render, in 2-pass order
-        // (all cleanup → all effect). mountDoubleInvoke is forwarded so the
-        // Editor-only effect double-cycle runs on the mount commit only.
-        private static void RunLayoutEffects(ComponentFiber fiber, bool mountDoubleInvoke = false)
-            => HookEffectExecutor.RunPendingEffects(fiber, fiber.PendingLayoutEffects, mountDoubleInvoke);
-
         // Runs insertion effects (Hooks.UseInsertionEffect) synchronously.
         // Insertion effects fire before layout effects of the same commit, so every commit site invokes this
-        // immediately before RunLayoutEffects.
+        // immediately before the layout-effect cleanup pass.
         private static void RunInsertionEffects(ComponentFiber fiber, bool mountDoubleInvoke = false)
             => HookEffectExecutor.RunPendingEffects(fiber, fiber.PendingInsertionEffects, mountDoubleInvoke);
 
@@ -52,10 +46,33 @@ namespace Velvet
 
         private static void CommitSubtreeEffectsNow(ComponentFiber fiber, bool mountDoubleInvoke)
         {
-            DrainDeferredInlineLayoutEffects(fiber);
+            // React commits ALL layout-effect cleanups (the mutation phase) across a whole subtree before ANY
+            // layout-effect setup (the layout phase). This root fiber and the inline children MountInline
+            // deferred onto the drain stack form one subtree, so their layout effects run as one cleanup pass
+            // then one setup pass with the root interleaved between: the root's cleanup runs before a child's
+            // setup, so a child setup that writes shared state can no longer be observed by the root's cleanup —
+            // React's [child.cleanup, root.cleanup, child.setup, root.setup]. Committing each child fully before
+            // the root began (the child's setup ahead of the root's cleanup) inverted that pair. Imperative
+            // handles and layout setups belong to the setup pass; insertion effects run in the cleanup pass
+            // (React runs them during mutation).
+            var stack = fiber.Reconciler?.Context.DeferredInlineLayoutEffectFibers;
+            List<(ComponentFiber Fiber, bool IsMount)>? inlineBatch = null;
+            if (stack is { Count: > 0 })
+            {
+                inlineBatch = new List<(ComponentFiber Fiber, bool IsMount)>(stack.Count);
+                DrainInlineLayoutCleanupsOneBatch(fiber, inlineBatch);
+            }
             RunInsertionEffects(fiber, mountDoubleInvoke);
+            HookEffectExecutor.RunCleanups(fiber, fiber.PendingLayoutEffects);
+
+            if (inlineBatch != null) RunInlineLayoutSetups(inlineBatch);
             FiberHookCommit.RunImperativeHandleSlots(fiber);
-            RunLayoutEffects(fiber, mountDoubleInvoke);
+            HookEffectExecutor.RunFactoriesAndClear(fiber, fiber.PendingLayoutEffects, mountDoubleInvoke);
+
+            // A setup (a child's or this root's) that mounted more inline children pushed them onto the drain
+            // stack: they are a subsequent pass, committed after this root's layout phase — React runs
+            // effect-mounted work in a follow-up commit, not the current one.
+            DrainDeferredInlineLayoutEffects(fiber);
             ScheduleRunEffects(fiber, mountDoubleInvoke);
         }
 
@@ -88,18 +105,35 @@ namespace Velvet
             }
         }
 
-        // Drains layout effects that MountInline deferred while the parent
-        // expansion was still committing child elements (DOM mutation + ref attach). Layout
-        // effects run after the DOM mutations + ref attach are committed for the
-        // entire subtree, so every inline-mounted fiber's UseLayoutEffect observes
-        // already-attached refs. Top-level reconcile entries (Mount,
-        // FlushState) invoke this before their own RunLayoutEffects
-        // so the root commits last; MountInline never calls it directly because nested inline
-        // mounts must all settle before any layout effect runs. Drained in LIFO order so the
-        // deepest fiber runs first — layout effects commit children
-        // before their parent (bottom-up), so a parent layout effect that reads a child's
-        // imperative handle / measured size observes the child's already-applied effect.
+        // Commits inline fibers still on the deferred-inline stack, each batch in its own cleanup-then-setup
+        // two-phase. MountInline defers a fiber's layout effects here instead of running them at mount so they
+        // observe the parent expansion's already-attached child refs; CommitSubtreeEffectsNow drains the first
+        // batch interleaved with its own root, then calls this to pick up any fibers a setup mounted. The outer
+        // loop re-drains because an inline setup can synchronously push MORE deferred fibers (e.g. a
+        // UseLayoutEffect that mounts another inline child) — each such push is a fresh subtree, committed after
+        // the one that mounted it, matching how React runs effect-mounted work in a follow-up commit.
         private static void DrainDeferredInlineLayoutEffects(ComponentFiber rootFiber)
+        {
+            var stack = rootFiber.Reconciler?.Context.DeferredInlineLayoutEffectFibers;
+            if (stack == null) return;
+            while (stack.Count > 0)
+            {
+                var ordered = new List<(ComponentFiber Fiber, bool IsMount)>(stack.Count);
+                DrainInlineLayoutCleanupsOneBatch(rootFiber, ordered);
+                RunInlineLayoutSetups(ordered);
+            }
+        }
+
+        // Snapshots the current deferred-inline stack as one batch, orders it post-order (children before
+        // parents), and runs the layout-effect CLEANUP pass over that order into `ordered` — per fiber, its
+        // insertion effects then its layout-effect cleanups. The caller feeds the same `ordered` list to
+        // RunInlineLayoutSetups for the SETUP pass; splitting the two lets CommitSubtreeEffectsNow interleave
+        // its root fiber's own cleanup/setup between them, so React's all-cleanups-before-all-setups holds
+        // across the root/child boundary and not just within the child batch. Ordering off a snapshot and
+        // running after is equivalent to running mid-walk: an effect that synchronously pushes MORE deferred
+        // fibers lands on the stack and is picked up by the caller's re-drain, not this already-captured batch.
+        private static void DrainInlineLayoutCleanupsOneBatch(
+            ComponentFiber rootFiber, List<(ComponentFiber Fiber, bool IsMount)> ordered)
         {
             var reconciler = rootFiber.Reconciler;
             if (reconciler == null) return;
@@ -107,60 +141,52 @@ namespace Velvet
             if (stack == null || stack.Count == 0) return;
             var bufferPool = reconciler.Context.BufferPool;
 
-            // Outer loop: an inline-effect callback can synchronously push more deferred fibers
-            // (e.g., a UseLayoutEffect that mounts another inline child). The old `while Pop`
-            // picked them up incrementally; our snapshot-based pass needs to re-drain explicitly.
-            while (stack.Count > 0)
+            // The stack was populated in DFS pre-order during reconcile (parent before children, siblings
+            // left-to-right). A naive LIFO drain would run sibling B before sibling A — layout effects visit
+            // siblings left-to-right then their parent (post-order DFS, LtR). Reconstruct that order.
+            var entries = new List<(ComponentFiber Fiber, bool IsMount)>(stack.Count);
+            while (stack.Count > 0) entries.Add(stack.Pop());
+            entries.Reverse();
+
+            // Dedup: the same fiber pushed twice (MountInline + a follow-up RenderInlineForExpansion bundled in
+            // the same reconcile pass) must drain ONCE. Walk in reverse so the last entry wins — Mount is
+            // architecturally first, so IsMount=false (the update) prevails.
+            var pushedSet = bufferPool.RentFiberSet();
+            var deduped = new List<(ComponentFiber Fiber, bool IsMount)>(entries.Count);
+            for (var i = entries.Count - 1; i >= 0; i--)
             {
-                // The stack was populated in DFS pre-order during reconcile (parent before children,
-                // siblings in left-to-right reconcile-walk order). Naive LIFO drain (`while Pop`)
-                // would run sibling B before sibling A — layout effects visit
-                // siblings left-to-right then their parent (post-order DFS, LtR). Reconstruct the
-                // post-order sequence via fiber.Parent ancestry.
-                var entries = new List<(ComponentFiber Fiber, bool IsMount)>(stack.Count);
-                while (stack.Count > 0) entries.Add(stack.Pop());
-                entries.Reverse();
+                if (pushedSet.Add(entries[i].Fiber)) deduped.Add(entries[i]);
+            }
+            deduped.Reverse();
 
-                // Dedup: the same fiber pushed twice (MountInline + a follow-up
-                // RenderInlineForExpansion bundled in the same reconcile pass) must drain ONCE,
-                // not twice. Walk in reverse so the last (latest semantics) entry wins — Mount is
-                // architecturally first in this scenario, so IsMount=false (the update) prevails.
-                var pushedSet = bufferPool.RentFiberSet();
-                var deduped = new List<(ComponentFiber Fiber, bool IsMount)>(entries.Count);
-                for (var i = entries.Count - 1; i >= 0; i--)
-                {
-                    if (pushedSet.Add(entries[i].Fiber)) deduped.Add(entries[i]);
-                }
-                deduped.Reverse();
+            OrderByNearestStagedAncestorPostOrder(deduped, pushedSet, static e => e.Fiber, ordered);
+            bufferPool.ReturnFiberSet(pushedSet);
 
-                // Reconstruct the post-order sequence over the deduped snapshot (nearest-staged-ancestor
-                // grouping — see OrderByNearestStagedAncestorPostOrder), then commit each fiber's deferred
-                // effects in that order. The traversal reads only the snapshot built above, so ordering
-                // first and running after is equivalent to running mid-walk; an effect that synchronously
-                // pushes MORE deferred fibers lands on the stack and is picked up by the outer re-drain
-                // loop, exactly as before.
-                var ordered = new List<(ComponentFiber Fiber, bool IsMount)>(deduped.Count);
-                OrderByNearestStagedAncestorPostOrder(deduped, pushedSet, static e => e.Fiber, ordered);
-                bufferPool.ReturnFiberSet(pushedSet);
+            // Cleanup pass — React's mutation phase. Running every cleanup before any setup is the point of the
+            // split: a later fiber's cleanup must not observe state an earlier fiber's setup wrote. Insertion
+            // effects belong to the mutation phase too; imperative handles and layout setups defer to the setup
+            // pass so a parent setup can observe a child's already-committed handle.
+            for (var i = 0; i < ordered.Count; i++)
+            {
+                var (deferred, isMount) = ordered[i];
+                if (deferred == null || deferred.IsDisposed) continue;
+                RunInsertionEffects(deferred, mountDoubleInvoke: isMount);
+                HookEffectExecutor.RunCleanups(deferred, deferred.PendingLayoutEffects);
+            }
+        }
 
-                for (var i = 0; i < ordered.Count; i++)
-                {
-                    // Children already committed (post-order) — commit this fiber's deferred effects.
-                    // Mount commits run the Editor-only double-invoke; re-expansion commits (parent
-                    // re-render reaching an existing inline child) only run prior cleanup + new setup
-                    // for deps-changed slots. Insertion effects fire before layout effects.
-                    // UseImperativeHandle commits between insertion and layout effects so a
-                    // parent layout effect / handle factory observes the child's handle already
-                    // written into its parent ref (imperative handles are part of the
-                    // layout-effect phase). 2-phase separation (all-insertion → all-layout across the
-                    // subtree, splitting DOM mutation from layout-effect commit) is tracked
-                    // separately for the broader CommitSubtreeEffects refactor.
-                    var (deferred, isMount) = ordered[i];
-                    if (deferred == null || deferred.IsDisposed) continue;
-                    RunInsertionEffects(deferred, mountDoubleInvoke: isMount);
-                    FiberHookCommit.RunImperativeHandleSlots(deferred);
-                    RunLayoutEffects(deferred, mountDoubleInvoke: isMount);
-                }
+        // Runs the layout-effect SETUP pass over a batch DrainInlineLayoutCleanupsOneBatch already ordered and
+        // cleaned up: each fiber's imperative handles then its layout-effect setups, in post-order (a parent
+        // setup observes a child's already-committed handle). A setup that mounts more inline children pushes
+        // them onto the drain stack for the caller's re-drain.
+        private static void RunInlineLayoutSetups(List<(ComponentFiber Fiber, bool IsMount)> ordered)
+        {
+            for (var i = 0; i < ordered.Count; i++)
+            {
+                var (deferred, isMount) = ordered[i];
+                if (deferred == null || deferred.IsDisposed) continue;
+                FiberHookCommit.RunImperativeHandleSlots(deferred);
+                HookEffectExecutor.RunFactoriesAndClear(deferred, deferred.PendingLayoutEffects, mountDoubleInvoke: isMount);
             }
         }
 

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberRenderer.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberRenderer.cs
@@ -92,7 +92,7 @@ namespace Velvet
             // defers child CreateElement / InvokeRefCallback to the parent expansion which
             // happens AFTER MountInline returns, so running LayoutEffects here would observe
             // stale (null) refs. Push the fiber onto the deferred stack and let the top-level
-            // reconcile entry drain it (LIFO = bottom-up) before its own RunLayoutEffects so the
+            // reconcile entry drain it (LIFO = bottom-up) before its own layout-effect commit so the
             // root commits last.
             fiber.Reconciler!.Context.DeferredInlineLayoutEffectFibers.Push((fiber, IsMount: true));
             FiberEffects.ScheduleRunEffects(fiber, mountDoubleInvoke: true);
@@ -385,7 +385,7 @@ namespace Velvet
                 // Clear once before the render-phase loop. The committed pending-layout length is
                 // captured just below; each discarded attempt is truncated back to it, and the settled
                 // attempt re-collects exactly the layout effects it renders. UseLayoutEffect runs
-                // synchronously in RunLayoutEffects right after this returns, so the list is empty again
+                // synchronously in the layout-effect commit right after this returns, so the list is empty again
                 // before the next RenderAndReconcile.
                 fiber.PendingLayoutEffects?.Clear();
                 fiber.PendingInsertionEffects?.Clear();

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberWorkLoop.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberWorkLoop.cs
@@ -148,11 +148,11 @@ namespace Velvet
             }
         }
 
-        // Flushes the dirty state and runs RenderAndReconcile + RunLayoutEffects.
+        // Flushes the dirty state and runs RenderAndReconcile + the layout-effect commit.
         // Normally invoked automatically via schedule.Execute.
         // In test environments (no panel attached), call manually after a hook setter fires to confirm
         // immediate reflection.
-        // RunLayoutEffects is intentionally outside the OnRenderError guard.
+        // The layout-effect commit is intentionally outside the OnRenderError guard.
         // An error thrown from an effect is not routed to an Error Boundary; Velvet
         // instead try-catches each effect individually and emits via Debug.LogException.
         // Returns immediately if the fiber is not mounted or not dirty.

--- a/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
@@ -482,7 +482,7 @@ namespace Velvet
         // RenderAndReconcile(deferReconcile: true) so the parent expansion calls
         // CreateElement + InvokeRefCallback for child elements AFTER MountInline
         // returns; running LayoutEffects inside MountInline would observe stale (null) refs.
-        // The top-level reconcile entry drains this stack before its own RunLayoutEffects so
+        // The top-level reconcile entry drains this stack before its own layout-effect commit so
         // every layout effect runs once all child refs are attached. A Stack (LIFO) is used so
         // the drain runs deepest-first — layout effects commit children
         // before their parent (bottom-up), so a parent layout effect that reads a child's
@@ -490,7 +490,7 @@ namespace Velvet
         // Both Mount and update commits push onto this stack: MountInline pushes with
         // IsMount: true, RenderInlineForExpansion (parent re-render reaching an
         // existing inline child) pushes with IsMount: false. The drain forwards the flag
-        // to RunInsertionEffects / RunLayoutEffects as mountDoubleInvoke so
+        // to the insertion- and layout-effect passes as mountDoubleInvoke so
         // the Editor-only mount double-invoke fires only on initial Mount, not on the deps-changed
         // re-expansion path: a layout effect on an update fires its deps
         // cleanup + setup once, not twice.

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/InlineChildLayoutEffectTwoPhaseTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/InlineChildLayoutEffectTwoPhaseTests.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine.UIElements;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins React's all-cleanups-before-all-setups for inline-effect commits: across the parent/inline-child
+    /// boundary (a parent cleanup that reads state an inline child's setup writes observes the pre-update value)
+    /// and across a batch of inline siblings (every sibling's cleanup precedes any sibling's setup). Committing
+    /// a fiber fully — its setup included — before a later fiber's cleanup ran would invert the pair.
+    /// </summary>
+    [TestFixture]
+    internal sealed class InlineChildLayoutEffectTwoPhaseTests
+    {
+        private VisualElement _root;
+        private static List<string> s_log;
+        private static Action<int> s_parentSet;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _root = new VisualElement();
+            s_log = new List<string>();
+            s_parentSet = null;
+        }
+
+        // Inline child: keyed on the tick prop so its layout effect re-runs when the parent re-renders. The
+        // setup logs; a null cleanup keeps the cleanup pass silent so only the parent's cleanup is recorded.
+        [Component]
+        private static VNode Child(int tick)
+        {
+            Hooks.UseLayoutEffect(() => { s_log.Add("child:setup"); return (Action)null; }, new object[] { tick });
+            return V.Label(name: "child", text: $"c{tick}");
+        }
+
+        // Parent: owns the tick state, passes it to the inline child, and has a layout effect whose CLEANUP
+        // logs. The parent's cleanup must land before the child's setup on the re-render commit.
+        [Component]
+        private static VNode Parent()
+        {
+            var (tick, setTick) = Hooks.UseState(0);
+            s_parentSet = setTick;
+            Hooks.UseLayoutEffect(
+                () => (Action)(() => s_log.Add("parent:cleanup")),
+                new object[] { tick });
+            return V.Div(name: "parent", children: new VNode[]
+            {
+                V.Component(Child, tick, key: "child"),
+            });
+        }
+
+        [Test]
+        public void Given_ParentAndInlineChildLayoutEffectsRerun_When_Committed_Then_ParentCleanupPrecedesChildSetup()
+        {
+            // Arrange — mount, then discard the mount-phase log so only the update commit is measured.
+            using var mounted = V.Mount(_root, V.Component(Parent, key: "parent"));
+            s_log.Clear();
+
+            // Act — the parent re-renders and re-expands the child inline; both layout effects re-run.
+            s_parentSet.Invoke(1);
+            mounted.FlushStateForTest();
+
+            // Assert — parent cleanup (mutation phase) runs before child setup (layout phase).
+            Assume.That(s_log, Does.Contain("parent:cleanup").And.Contain("child:setup"),
+                "Precondition: both the parent cleanup and the child setup ran on this commit");
+            Assert.That(s_log.IndexOf("parent:cleanup"), Is.LessThan(s_log.IndexOf("child:setup")),
+                "React commits all layout cleanups before all layout setups across the parent/inline-child boundary");
+        }
+
+        private static Action<int> s_siblingSet;
+
+        // Inline sibling: logs both its cleanup and setup, keyed on the tick prop so both re-run on the parent's
+        // re-render. Two siblings together pin that every sibling's cleanup precedes any sibling's setup.
+        [Component]
+        private static VNode SiblingA(int tick)
+        {
+            Hooks.UseLayoutEffect(() =>
+            {
+                s_log.Add("a:setup");
+                return (Action)(() => s_log.Add("a:cleanup"));
+            }, new object[] { tick });
+            return V.Label(name: "a", text: $"a{tick}");
+        }
+
+        [Component]
+        private static VNode SiblingB(int tick)
+        {
+            Hooks.UseLayoutEffect(() =>
+            {
+                s_log.Add("b:setup");
+                return (Action)(() => s_log.Add("b:cleanup"));
+            }, new object[] { tick });
+            return V.Label(name: "b", text: $"b{tick}");
+        }
+
+        [Component]
+        private static VNode SiblingParent()
+        {
+            var (tick, setTick) = Hooks.UseState(0);
+            s_siblingSet = setTick;
+            return V.Div(name: "sibling-parent", children: new VNode[]
+            {
+                V.Component(SiblingA, tick, key: "a"),
+                V.Component(SiblingB, tick, key: "b"),
+            });
+        }
+
+        [Test]
+        public void Given_TwoInlineSiblingsLayoutEffectsRerun_When_Committed_Then_AllCleanupsPrecedeAllSetups()
+        {
+            // Arrange — mount, then discard the mount-phase log (setups only) so only the update commit counts.
+            using var mounted = V.Mount(_root, V.Component(SiblingParent, key: "sibling-parent"));
+            s_log.Clear();
+
+            // Act — the parent re-renders and re-expands both siblings inline; every layout effect re-runs.
+            s_siblingSet.Invoke(1);
+            mounted.FlushStateForTest();
+
+            // Assert — the last cleanup across the batch runs before the first setup (all cleanups, then all setups).
+            var lastCleanup = Math.Max(s_log.IndexOf("a:cleanup"), s_log.IndexOf("b:cleanup"));
+            var firstSetup = Math.Min(s_log.IndexOf("a:setup"), s_log.IndexOf("b:setup"));
+            Assume.That(s_log, Does.Contain("a:cleanup").And.Contain("b:setup"),
+                "Precondition: both siblings' cleanup and setup ran on this commit");
+            Assert.That(lastCleanup, Is.LessThan(firstSetup),
+                "Every inline sibling's layout cleanup commits before any sibling's layout setup (React mutation-before-layout)");
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/InlineChildLayoutEffectTwoPhaseTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/InlineChildLayoutEffectTwoPhaseTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 833bb0261013543569f15a0ad1fc2794


### PR DESCRIPTION
## What

Layout-effect commit now applies React's all-cleanups-before-all-setups ordering across the whole parent/inline-child subtree, not just within a batch of inline siblings.

Previously `CommitSubtreeEffectsNow` drained the inline children fully — each child's cleanup AND setup — before the root fiber's own cleanup ran. So a parent's `UseLayoutEffect` cleanup could observe state an inline child's setup had just written: the pair `[child.cleanup, parent.cleanup, child.setup, parent.setup]` that React guarantees was inverted to `[child.cleanup, child.setup, parent.cleanup, parent.setup]`.

## How

- Split the inline-effect drain into a cleanup pass (`DrainInlineLayoutCleanupsOneBatch`) and a setup pass (`RunInlineLayoutSetups`).
- `CommitSubtreeEffectsNow` interleaves the root fiber's own cleanup/setup between the two passes.
- A layout effect that mounts more inline children now commits them as a follow-up pass, matching React running effect-mounted work in a subsequent commit rather than the current one.
- Removed the now-inlined `RunLayoutEffects` wrapper and updated comments that referenced it.

## Tests

`InlineChildLayoutEffectTwoPhaseTests` pins that (a) a parent's layout cleanup precedes an inline child's layout setup and (b) every inline sibling's cleanup precedes any sibling's setup, on the re-render commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)