### PR TITLE
feat(velvet): animate filter-* utilities via the scheduler tween (#79)

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Filter utilities (`blur-*`, `brightness-*`, …) now transition smoothly when they change on an element
+  carrying the new `transition-filter` class (e.g. `transition-filter hover:blur-md`), matching CSS
+  `transition: filter`. UI Toolkit cannot transition the inline `filter` property natively, so a scheduler
+  tween drives the filter parameters frame-by-frame; opt in with `transition-filter` (honoring `duration-*`
+  and the easing longhand). Non-interpolable changes (a custom filter, or an ambiguous add/remove) and the
+  off-panel / zero-duration cases fall back to an instant write.
+
 ### Fixed
 
 - A parent's layout-effect (`Hooks.UseLayoutEffect`) cleanup now runs before an inline child's layout-effect

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberElementCleaner.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberElementCleaner.cs
@@ -300,6 +300,13 @@ namespace Velvet
                 StyleAnimateDriver.Detach(element, animationBinding);
                 _ctx.AnimationBindings.Remove(element);
             }
+            if (_ctx.FilterTransitionBindings.TryGetValue(element, out var filterTransitionBinding))
+            {
+                // Pause the one-shot tick and unregister so a pooled element does not keep ticking a mid-flight
+                // filter tween. The inline filter itself is scrubbed by the pool reset + ClearAll above.
+                StyleFilterTransitionDriver.Detach(element, filterTransitionBinding);
+                _ctx.FilterTransitionBindings.Remove(element);
+            }
             if (_ctx.SceneViewBindings.TryGetValue(element, out var sceneViewBinding))
             {
                 // Release both ends of the camera-output pair: the geometry callback, the camera's target

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodeFactory.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodeFactory.cs
@@ -118,6 +118,10 @@ namespace Velvet
                     // animate-* motion (gradient pan / hue cycle) drives the element's own inline style; runs
                     // after the gradient so a pan mode sees the baked gradient already applied.
                     _patcher.Appliers.ApplyAnimateOnCreate(element, elementNode.ClassNames);
+                    // transition-filter opt-in: register the tween binding so a later filter change animates.
+                    // The mount's own filter is already applied instantly above (the binding is not enabled
+                    // yet), matching CSS's no-transition-on-initial-value.
+                    _patcher.Appliers.ApplyFilterTransitionOnCreate(element, elementNode.ClassNames);
                     // Drop shadow is wrapper-less too (the baked shadow texture is painted behind the
                     // element's own content, bleeding outside the box) — a non-structural paint like CSS
                     // box-shadow, so it composes with any wrap layer below and a user wrapElement. The paint
@@ -306,6 +310,9 @@ namespace Velvet
                     _patcher.ApplyHasVariantManipulators(element);
                     _patcher.Appliers.ApplyGradientOnCreate(element, appliedClasses);
                     _patcher.Appliers.ApplyAnimateOnCreate(element, appliedClasses);
+                    // transition-filter opt-in on a Motion host: a Motion can carry filter utilities + the
+                    // opt-in class just like a plain element, so register the tween binding here too.
+                    _patcher.Appliers.ApplyFilterTransitionOnCreate(element, appliedClasses);
                     // Motion does NOT paint a drop shadow: the animation scheduler hides a subtree's shadow
                     // paints for the lifetime of an enter / exit (the opacity-blind shadow would otherwise
                     // show through the fading caster as a dark box), and a shadow ON the animating Motion

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
@@ -285,6 +285,9 @@ namespace Velvet
             StyleTextEffectResolver.Apply(_ctx, element, classNames);
             _appliers.ApplyGradientOnPatch(element, classNames, skewable: gradientSkewable);
             _appliers.ApplyAnimateOnPatch(element, classNames);
+            // transition-filter opt-in: attach/keep/detach the tween binding against the new class list. The
+            // shared hook for both the element and Motion patch paths (a filter can be Motion-hosted).
+            _appliers.ApplyFilterTransitionOnPatch(element, classNames);
             // Here, not in the Particles-settings diff: the spacer follows the class list (a filter comes and
             // goes via a class swap or variant), and this pass is the one hook shared by the element and Motion
             // patch paths — a particle can be Motion-hosted.

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberWrapperElementAppliers.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberWrapperElementAppliers.cs
@@ -336,6 +336,80 @@ namespace Velvet
 
         #endregion
 
+        #region Filter transition
+
+        // Create-time entry point: when classNames carries the transition-filter opt-in, registers the tween
+        // binding so a later filter change (a hover variant, a reconcile-diff value swap) animates instead of
+        // snapping. Wrapper-less — the tween drives the element's own inline filter. The binding only ENABLES
+        // the tween; the filter itself is applied by the arbitrary-value resolver, which the tween's write hook
+        // (StyleFilterTransitionDriver.TryStartOrRedirect) sits inside.
+        internal void ApplyFilterTransitionOnCreate(VisualElement element, string[] classNames)
+        {
+            if (!HasFilterTransitionClass(classNames))
+            {
+                return;
+            }
+            var binding = new StyleFilterTransitionBinding();
+            _ctx.FilterTransitionBindings[element] = binding;
+            StyleFilterTransitionDriver.Register(element, binding);
+        }
+
+        // Patch-time reconciliation of the transition-filter opt-in against the new class list: attach the
+        // binding when the class first appears, keep it while present, tear it down when removed. NOTE: on the
+        // very patch that ADDS transition-filter, a filter value that changes in the same diff still applies
+        // INSTANTLY — SyncClassDrivenStyling (which resolves and writes the filter) runs before this pass, so
+        // the tween binding is not enabled yet when the write happens. This matches CSS, which does not
+        // retroactively animate a value that changed in the same paint the transition first became active;
+        // every SUBSEQUENT change transitions.
+        internal void ApplyFilterTransitionOnPatch(VisualElement element, string[] classNames)
+        {
+            var bound = _ctx.FilterTransitionBindings.TryGetValue(element, out var binding);
+            var want = HasFilterTransitionClass(classNames);
+            if (!bound && !want)
+            {
+                return;
+            }
+            if (want)
+            {
+                if (!bound)
+                {
+                    var fresh = new StyleFilterTransitionBinding();
+                    _ctx.FilterTransitionBindings[element] = fresh;
+                    StyleFilterTransitionDriver.Register(element, fresh);
+                }
+                return;
+            }
+            StyleFilterTransitionDriver.Detach(element, binding);
+            _ctx.FilterTransitionBindings.Remove(element);
+        }
+
+        // True when the class list carries the transition-filter opt-in in the base classes OR any state
+        // variant (peeling variant layers to the leaf, mirroring CarriesFilter). Scoped to the literal
+        // transition-filter token only — transition-all sets a real transition-property and rides UI Toolkit's
+        // native transition system, which cannot repaint an inline filter, so it is deliberately NOT an opt-in.
+        private static bool HasFilterTransitionClass(string[] classNames)
+        {
+            if (classNames == null)
+            {
+                return false;
+            }
+            foreach (var cls in classNames)
+            {
+                var leaf = cls;
+                while (StyleVariantClass.TryParse(leaf, out _, out var payload))
+                {
+                    leaf = payload;
+                }
+                if (leaf == "transition-filter")
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        #endregion
+
         #region Drop Shadow
 
         // Create-time entry point: when classNames carries a shadow-* utility, attaches the drop-shadow

--- a/Packages/com.velvet.core/Runtime/Reconciler/Reconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Reconciler.cs
@@ -486,6 +486,13 @@ namespace Velvet
                 StyleAnimateDriver.Detach(element, binding);
             }
             _ctx.AnimationBindings.Clear();
+            // filter-* transitions hold a one-shot scheduled tick: pause + unregister each so a still-mounted
+            // element released at root disposal stops ticking any in-flight filter tween.
+            foreach (var (element, binding) in _ctx.FilterTransitionBindings)
+            {
+                StyleFilterTransitionDriver.Detach(element, binding);
+            }
+            _ctx.FilterTransitionBindings.Clear();
             // SceneView bindings own a live RenderTexture with a camera rendering into it: release both
             // ends so a still-mounted scene view at root disposal leaves no orphaned texture and no
             // camera left targeting one.

--- a/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
@@ -340,6 +340,14 @@ namespace Velvet
         // side-tables); FiberElementCleaner / Reconciler.Dispose call StyleAnimateDriver.Detach.
         public Dictionary<VisualElement, StyleAnimateBinding> AnimationBindings { get; } = new();
 
+        // Per-element filter-* transition (transition-filter opt-in), keyed by the element itself — the tween
+        // drives the element's own inline filter with no wrapper. The binding holds a one-shot scheduled tick,
+        // so cleanup must PAUSE it (unlike the pure side-tables); FiberElementCleaner / Reconciler.Dispose call
+        // StyleFilterTransitionDriver.Detach. The driver's own ConditionalWeakTable is the lookup the resolver
+        // uses during event callbacks (no context there); this dictionary only mirrors the refs so the dispose
+        // sweep can enumerate them (a CWT is not enumerable).
+        public Dictionary<VisualElement, StyleFilterTransitionBinding> FilterTransitionBindings { get; } = new();
+
         // Per-SceneView-element bookkeeping (V.SceneView), keyed by the element itself. The binding
         // owns a live resource pair — the framework-created RenderTexture and the camera targeting it —
         // so it is NOT a pure side-table: FiberElementCleaner releases both ends on element teardown

--- a/Packages/com.velvet.core/Runtime/Styles/_effects.uss
+++ b/Packages/com.velvet.core/Runtime/Styles/_effects.uss
@@ -51,6 +51,18 @@
     transition-timing-function: ease-in-out;
 }
 
+/* transition-filter — opt-in for animating filter-* changes (blur-*, brightness-*, ...).
+ *
+ * Deliberately sets NO transition-property: filter. UI Toolkit stops repainting an inline filter once its
+ * transition-property is [filter], so a native transition would freeze the effect after the first frame.
+ * Instead this carries only the duration + timing-function, which a scheduler-tween driver reads to lerp the
+ * filter's parameters itself (StyleFilterTransitionDriver). duration-* / ease-* still override, declared later.
+ */
+.transition-filter {
+    transition-duration: var(--duration-normal);
+    transition-timing-function: ease-in-out;
+}
+
 /* object-fit (Tailwind) — for an element showing an image as background-image. Mapped onto background-size
    (the modern, non-deprecated property; keywords match the Tailwind names). object-contain / object-cover
    also center the image to match CSS object-fit's 50% 50% default object-position (UITK's background default

--- a/Packages/com.velvet.core/Runtime/Styling/StyleArbitraryValueResolver.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleArbitraryValueResolver.cs
@@ -981,12 +981,22 @@ namespace Velvet
                     (functions ??= new List<FilterFunction>()).Add(BuildCustomFilter(custom));
                 }
             }
+            // The transition-filter opt-in tween owns the write when active; it reads the current inline list as
+            // its from-side, so it must run BEFORE the instant write below (never observing its own write). It
+            // returns false — deferring to the instant write — for a non-opting element, off-panel, zero
+            // duration, or a non-interpolable change.
             if (functions == null)
             {
-                element.style.filter = StyleKeyword.Null;
+                if (!StyleFilterTransitionDriver.TryStartOrRedirect(element, null))
+                {
+                    element.style.filter = StyleKeyword.Null;
+                }
                 return;
             }
-            element.style.filter = functions;
+            if (!StyleFilterTransitionDriver.TryStartOrRedirect(element, functions))
+            {
+                element.style.filter = functions;
+            }
         }
 
         // Builds the FilterFunction for a filter-[name:args] custom filter. The public

--- a/Packages/com.velvet.core/Runtime/Styling/StyleFilterTransitionDriver.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleFilterTransitionDriver.cs
@@ -1,0 +1,504 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace Velvet
+{
+    // Per-element state for a filter-* transition (opt-in via the transition-filter class). Holds the
+    // one-shot tick that lerps the inline filter's parameters from the current applied value to the newly
+    // composed one, the precomputed aligned interpolation slots, and the exact static list to settle to.
+    internal sealed class StyleFilterTransitionBinding
+    {
+        // The one-shot tick, null when idle/settled. Scheduled on the PANEL ROOT (not the element) so a keyed
+        // reorder — which briefly detaches the element and would make UI Toolkit silently drop a per-element
+        // scheduled item — does not stall the tween. Paused + nulled on settle and on teardown.
+        public IVisualElementScheduledItem? Scheduled;
+        // Wall-clock start (Time.realtimeSinceStartupAsDouble). Progress is elapsed/duration so a dropped
+        // frame never accumulates drift.
+        public double StartTime;
+        public float DurationSec;
+        public EasingMode Easing;
+        // Precomputed aligned interpolation slots. Parameters are snapshotted at start (decoupled from the
+        // live inline list the tick overwrites every frame).
+        public StyleFilterTransitionDriver.Channel[] Channels = Array.Empty<StyleFilterTransitionDriver.Channel>();
+        // The exact static list to settle to on completion (null = clear the inline filter).
+        public List<FilterFunction>? Target;
+    }
+
+    // Drives filter-* transitions (blur / brightness / contrast / …) via the scheduler tween Velvet already
+    // uses for animate-hue. UI Toolkit cannot CSS-transition the inline filter — a [filter] transition-property
+    // stops it repainting the filter after the first frame — so the transition-filter utility deliberately sets
+    // only duration + timing and this driver lerps the filter parameters itself, writing a fresh inline list per
+    // frame (same repaint-dirtying reason as the Hue arm of StyleAnimateDriver).
+    //
+    // The write hook (TryStartOrRedirect) sits inside StyleArbitraryValueResolver.ApplyCombinedFilter — the sole
+    // site that composes and writes style.filter — so it covers every filter path (base blur-md, arbitrary
+    // blur-[6px], custom filter-[name:args], and the variant path hover:blur-md) with no per-manipulator wiring.
+    //
+    // Two documented precedence notes:
+    // - animate-hue owns style.filter unconditionally while active; combining transition-filter + animate-hue on
+    //   one element is unsupported (Hue wins). Hue's own Detach re-asserts static filters through
+    //   ApplyCombinedFilter, so a benign one-shot tween may kick off right after a Hue Detach — harmless.
+    // - On the very reconcile patch that ADDS transition-filter, the class-driven filter write runs (through
+    //   SyncClassDrivenStyling) BEFORE the applier enables the binding, so a value that changes in that same
+    //   patch applies instantly, not tweened — matching CSS, which likewise does not retroactively animate a
+    //   value that changed in the same paint the transition-property first became active. Every later change
+    //   (the common case: a hover-driven variant swap, which runs through the manipulator's event callback)
+    //   transitions correctly.
+    //
+    // The phase math (ApplyFrame / Ease / channel alignment) is pure and unit-tested directly; the scheduler
+    // wiring runs at runtime (the EditMode PlayerLoop does not tick, so tests drive ApplyFrame at explicit
+    // phases). The resolver runs during event callbacks with no ReconcilerContext, so the element→binding
+    // lookup lives in a ConditionalWeakTable (same reason the layer map does); ReconcilerContext mirrors the
+    // refs only so the dispose sweep can enumerate them.
+    internal static class StyleFilterTransitionDriver
+    {
+        // One precomputed interpolation slot: a filter function whose parameters lerp From→To. Parameters are
+        // snapshotted so the tick's per-frame overwrite of the live inline list cannot alias them.
+        internal readonly struct Channel
+        {
+            public readonly FilterFunctionType Type;
+            public readonly FilterParameter[] From;
+            public readonly FilterParameter[] To;
+
+            public Channel(FilterFunctionType type, FilterParameter[] from, FilterParameter[] to)
+            {
+                Type = type;
+                From = from;
+                To = to;
+            }
+        }
+
+        private static readonly ConditionalWeakTable<VisualElement, StyleFilterTransitionBinding> s_bindings = new();
+
+        // Enrolls a binding so the write hook can find it during a resolver callback. The reconciler owns the
+        // binding lifecycle (create on transition-filter present, Detach on absent / teardown).
+        public static void Register(VisualElement element, StyleFilterTransitionBinding binding)
+            => s_bindings.AddOrUpdate(element, binding);
+
+        public static void Unregister(VisualElement element) => s_bindings.Remove(element);
+
+        // The write hook, called from ApplyCombinedFilter with the freshly composed target list (null = clear).
+        // Returns true iff it took ownership of the write (started or redirected a tween); false lets the
+        // resolver perform its instant write. Everything a non-opting element pays is the first line's lookup.
+        internal static bool TryStartOrRedirect(VisualElement element, List<FilterFunction>? to)
+        {
+            // A binding exists only while the reconciler sees transition-filter on the element, so its presence
+            // IS the opt-in gate — a non-opting element pays only this lookup.
+            if (!s_bindings.TryGetValue(element, out var b))
+            {
+                return false;
+            }
+            // Off-panel: there is no host to tick and no paint to animate, so apply instantly (CSS does not
+            // transition an off-render value either).
+            if (element.panel == null)
+            {
+                Cancel(b);
+                return false;
+            }
+            // Duration + curve come from the resolved transition-* longhands the transition-filter class (and
+            // any duration-* / ease-* override) set. Already-resolved seconds; no unit conversion. The resolved
+            // lists are IEnumerable, so read the first entry (the whole-property value) via FirstOrDefault — an
+            // empty list yields 0s, which the guard below treats as "no transition, write instantly".
+            var duration = element.resolvedStyle.transitionDuration.FirstOrDefault().value;
+            if (duration <= 0f)
+            {
+                Cancel(b);
+                return false;
+            }
+            var easing = element.resolvedStyle.transitionTimingFunction.FirstOrDefault().mode;
+
+            // Read the CURRENT applied list as the from-side. During an in-flight tween this is last frame's
+            // interpolated list, so a redirect starts from where the eye is — not the tween's original start.
+            var from = element.style.filter.value;
+            if (!TryBuildChannels(from, to, out var channels))
+            {
+                // Non-interpolable (a custom filter, or an ambiguous add/remove) → discrete instant write.
+                Cancel(b);
+                return false;
+            }
+            if (ChannelsAreNoOp(channels))
+            {
+                // from == to: nothing to animate; let the resolver write the identical value.
+                return false;
+            }
+
+            b.Channels = channels;
+            b.Target = to;
+            b.DurationSec = duration;
+            b.Easing = easing;
+            b.StartTime = Time.realtimeSinceStartupAsDouble;
+            // Write the start frame now so there is no one-frame flash of the pre-change value.
+            ApplyFrame(element, b, 0f);
+            // Reuse a running tick — resetting StartTime/Channels/Target redirects it in place (the tick reads
+            // the binding fields each frame).
+            if (b.Scheduled == null)
+            {
+                StartTick(element, b);
+            }
+            return true;
+        }
+
+        // Applies one frame at progress t (pre-easing). Pure: builds a FRESH list every call (UI Toolkit's
+        // inline-filter setter dirties the element for repaint only when the backing list REFERENCE changes,
+        // so a reused list would paint the first frame then freeze). Public so tests drive specific phases
+        // without the runtime scheduler.
+        public static void ApplyFrame(VisualElement element, StyleFilterTransitionBinding b, float t)
+        {
+            var e = Ease(b.Easing, t);
+            var list = new List<FilterFunction>(b.Channels.Length);
+            foreach (var channel in b.Channels)
+            {
+                var fn = new FilterFunction(channel.Type);
+                for (var k = 0; k < channel.From.Length; k++)
+                {
+                    fn.AddParameter(LerpParam(channel.From[k], channel.To[k], e));
+                }
+                list.Add(fn);
+            }
+            element.style.filter = list;
+        }
+
+        private static void StartTick(VisualElement element, StyleFilterTransitionBinding b)
+        {
+            var host = element.panel.visualTree;
+            b.Scheduled = host.schedule.Execute(() =>
+            {
+                var elapsed = Time.realtimeSinceStartupAsDouble - b.StartTime;
+                var progress = b.DurationSec > 0f ? (float)(elapsed / b.DurationSec) : 1f;
+                if (progress >= 1f)
+                {
+                    // Settle to the EXACT composed static list so the tween lands on the resolver's own value.
+                    if (b.Target != null)
+                    {
+                        element.style.filter = b.Target;
+                    }
+                    else
+                    {
+                        element.style.filter = StyleKeyword.Null;
+                    }
+                    b.Scheduled?.Pause();
+                    b.Scheduled = null;
+                    return;
+                }
+                ApplyFrame(element, b, progress);
+            }).Every(StyleAnimateDriver.TickMs);
+        }
+
+        // Pauses + drops the tick, keeping the binding registered (idle). Used when a change resolves to an
+        // instant write (off-panel / zero-duration / non-interpolable) and by Detach.
+        private static void Cancel(StyleFilterTransitionBinding b)
+        {
+            b.Scheduled?.Pause();
+            b.Scheduled = null;
+        }
+
+        // Full teardown: settle a still-running tween, cancel the tick, unregister. Dropping the transition-filter
+        // class while a filter-* class the element still carries is unchanged does NOT re-resolve the static
+        // value (the reconciler only re-asserts filters it saw change), so a mid-frame interpolated value would
+        // otherwise freeze onto the element — settle it to the tween's target. Off-panel teardown skips the
+        // write: the element is unmounting and the pool reset scrubs style.filter before reuse.
+        public static void Detach(VisualElement element, StyleFilterTransitionBinding b)
+        {
+            if (b.Scheduled != null && element.panel != null)
+            {
+                if (b.Target != null)
+                {
+                    element.style.filter = b.Target;
+                }
+                else
+                {
+                    element.style.filter = StyleKeyword.Null;
+                }
+            }
+            Cancel(b);
+            Unregister(element);
+        }
+
+        #region Channel alignment
+
+        // Builds the aligned interpolation slots for from→to (both always in canonical filter order). Returns
+        // false — meaning "not interpolable, write instantly" — for a custom filter or an ambiguous add/remove
+        // (a UITK filter type that appears more than once, e.g. grayscale-* + saturate- both rendering as
+        // Grayscale, which cannot be paired by type alone). A null from is treated as an empty list (a
+        // freshly-mounted element with no inline filter reads null, not []).
+        internal static bool TryBuildChannels(List<FilterFunction>? from, List<FilterFunction>? to,
+            out Channel[] channels)
+        {
+            channels = Array.Empty<Channel>();
+            var fromCount = from?.Count ?? 0;
+            var toCount = to?.Count ?? 0;
+            if (fromCount == 0 && toCount == 0)
+            {
+                return false;
+            }
+            // A custom filter binds opaque shader material state; a numeric cross-fade is meaningless.
+            if (ContainsCustom(from) || ContainsCustom(to))
+            {
+                return false;
+            }
+
+            // Fast path: identical type sequence — the common case (a value change on the same filter set).
+            if (SameTypeSequence(from, to))
+            {
+                var paired = new Channel[fromCount];
+                for (var k = 0; k < fromCount; k++)
+                {
+                    var f = from![k];
+                    var t = to![k];
+                    if (f.parameterCount != t.parameterCount)
+                    {
+                        return false;
+                    }
+                    paired[k] = new Channel(f.type, Snapshot(f), Snapshot(t));
+                }
+                channels = paired;
+                return true;
+            }
+
+            // Different sequences: a filter was added or removed. Pairing by type is only unambiguous when each
+            // UITK type occurs at most once per list; otherwise (a repeated type) fall back to an instant write.
+            if (HasRepeatedType(from) || HasRepeatedType(to))
+            {
+                return false;
+            }
+
+            var merged = new List<Channel>(fromCount + toCount);
+            int i = 0, j = 0;
+            while (i < fromCount || j < toCount)
+            {
+                if (i < fromCount && j < toCount)
+                {
+                    var f = from![i];
+                    var t = to![j];
+                    if (f.type == t.type)
+                    {
+                        if (f.parameterCount != t.parameterCount)
+                        {
+                            return false;
+                        }
+                        merged.Add(new Channel(f.type, Snapshot(f), Snapshot(t)));
+                        i++;
+                        j++;
+                    }
+                    else if (CanonicalRank(f.type) < CanonicalRank(t.type))
+                    {
+                        merged.Add(FadeOut(f));
+                        i++;
+                    }
+                    else
+                    {
+                        merged.Add(FadeIn(t));
+                        j++;
+                    }
+                }
+                else if (i < fromCount)
+                {
+                    merged.Add(FadeOut(from![i]));
+                    i++;
+                }
+                else
+                {
+                    merged.Add(FadeIn(to![j]));
+                    j++;
+                }
+            }
+            channels = merged.ToArray();
+            return true;
+        }
+
+        // A filter present only in the to-list fades IN from its neutral value; one present only in from fades
+        // OUT to it. Matches CSS filter-list padding.
+        private static Channel FadeIn(FilterFunction f) => new Channel(f.type, IdentityParams(f), Snapshot(f));
+        private static Channel FadeOut(FilterFunction f) => new Channel(f.type, Snapshot(f), IdentityParams(f));
+
+        private static bool ContainsCustom(List<FilterFunction>? list)
+        {
+            if (list == null)
+            {
+                return false;
+            }
+            foreach (var f in list)
+            {
+                if (f.type == FilterFunctionType.Custom)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private static bool SameTypeSequence(List<FilterFunction>? a, List<FilterFunction>? b)
+        {
+            var ac = a?.Count ?? 0;
+            var bc = b?.Count ?? 0;
+            if (ac != bc)
+            {
+                return false;
+            }
+            for (var k = 0; k < ac; k++)
+            {
+                if (a![k].type != b![k].type)
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        private static bool HasRepeatedType(List<FilterFunction>? list)
+        {
+            if (list == null || list.Count < 2)
+            {
+                return false;
+            }
+            for (var i = 0; i < list.Count; i++)
+            {
+                for (var k = i + 1; k < list.Count; k++)
+                {
+                    if (list[i].type == list[k].type)
+                    {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+
+        // Canonical composition order of the UITK filter types (mirrors s_filterOrder in the resolver). Only
+        // consulted after repeated types are ruled out, so Grayscale mapping to one rank is unambiguous.
+        private static int CanonicalRank(FilterFunctionType type) => type switch
+        {
+            FilterFunctionType.Blur => 0,
+            FilterFunctionType.Tint => 1,
+            FilterFunctionType.Contrast => 2,
+            FilterFunctionType.Grayscale => 3,
+            FilterFunctionType.HueRotate => 4,
+            FilterFunctionType.Invert => 5,
+            FilterFunctionType.Sepia => 6,
+            _ => 7,
+        };
+
+        private static FilterParameter[] Snapshot(FilterFunction f)
+        {
+            var count = f.parameterCount;
+            var arr = new FilterParameter[count];
+            for (var k = 0; k < count; k++)
+            {
+                arr[k] = f.GetParameter(k);
+            }
+            return arr;
+        }
+
+        // The neutral parameters for a filter type — the value at which it is a no-op. Contrast is 1 (identity
+        // multiply); every other float filter (blur, grayscale/saturate, hue-rotate, invert, sepia) is off at
+        // 0; Tint (brightness) multiplies by a color, so its identity is white.
+        private static FilterParameter[] IdentityParams(FilterFunction f)
+        {
+            var count = f.parameterCount;
+            var arr = new FilterParameter[count];
+            for (var k = 0; k < count; k++)
+            {
+                var p = f.GetParameter(k);
+                arr[k] = p.type == FilterParameterType.Color
+                    ? new FilterParameter(Color.white)
+                    : new FilterParameter(f.type == FilterFunctionType.Contrast ? 1f : 0f);
+            }
+            return arr;
+        }
+
+        private static bool ChannelsAreNoOp(Channel[] channels)
+        {
+            foreach (var c in channels)
+            {
+                for (var k = 0; k < c.From.Length; k++)
+                {
+                    if (!ParamEqual(c.From[k], c.To[k]))
+                    {
+                        return false;
+                    }
+                }
+            }
+            return true;
+        }
+
+        private static bool ParamEqual(FilterParameter a, FilterParameter b)
+        {
+            if (a.type != b.type)
+            {
+                return false;
+            }
+            return a.type == FilterParameterType.Color
+                ? a.colorValue == b.colorValue
+                : Mathf.Approximately(a.floatValue, b.floatValue);
+        }
+
+        private static FilterParameter LerpParam(FilterParameter from, FilterParameter to, float e)
+            => from.type == FilterParameterType.Color
+                ? new FilterParameter(Color.Lerp(from.colorValue, to.colorValue, e))
+                : new FilterParameter(Mathf.Lerp(from.floatValue, to.floatValue, e));
+
+        #endregion
+
+        #region Easing
+
+        // Maps the five easing curves Velvet's .ease-* utilities expose onto their standard CSS cubic-bezier
+        // control points and evaluates them; any curve not exposed by a Velvet utility (only reachable via a
+        // hand-authored resolvedStyle) falls back to linear.
+        private static float Ease(EasingMode mode, float t)
+        {
+            t = Mathf.Clamp01(t);
+            return mode switch
+            {
+                EasingMode.Linear => t,
+                EasingMode.EaseIn => CubicBezier(0.42f, 0f, 1f, 1f, t),
+                EasingMode.EaseOut => CubicBezier(0f, 0f, 0.58f, 1f, t),
+                EasingMode.EaseInOut => CubicBezier(0.42f, 0f, 0.58f, 1f, t),
+                EasingMode.Ease => CubicBezier(0.25f, 0.1f, 0.25f, 1f, t),
+                _ => t,
+            };
+        }
+
+        // Standard CSS cubic-bezier easing: solve X(s)=x for the curve parameter s (Newton on the eased time
+        // axis, control points 0,x1,x2,1), then evaluate Y(s) (control points 0,y1,y2,1). A small, deliberately
+        // approximate solver — exact arbitrary-bezier easing is out of scope here.
+        private static float CubicBezier(float x1, float y1, float x2, float y2, float x)
+        {
+            var s = x;
+            for (var iter = 0; iter < 6; iter++)
+            {
+                var dx = BezierAxis(x1, x2, s) - x;
+                if (Mathf.Abs(dx) < 1e-5f)
+                {
+                    break;
+                }
+                var slope = BezierAxisDerivative(x1, x2, s);
+                if (Mathf.Abs(slope) < 1e-6f)
+                {
+                    break;
+                }
+                s -= dx / slope;
+            }
+            s = Mathf.Clamp01(s);
+            return BezierAxis(y1, y2, s);
+        }
+
+        // Cubic bezier along one axis with fixed endpoints 0 and 1; c1, c2 are the two inner control coords.
+        private static float BezierAxis(float c1, float c2, float s)
+        {
+            var u = 1f - s;
+            return (3f * u * u * s * c1) + (3f * u * s * s * c2) + (s * s * s);
+        }
+
+        private static float BezierAxisDerivative(float c1, float c2, float s)
+        {
+            var u = 1f - s;
+            return (3f * u * u * c1) + (6f * u * s * (c2 - c1)) + (3f * s * s * (1f - c2));
+        }
+
+        #endregion
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Styling/StyleFilterTransitionDriver.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleFilterTransitionDriver.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5b011a5387614d6d8d7a327bf91e1dd3

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/FilterTransitionPanelTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/FilterTransitionPanelTests.cs
@@ -1,0 +1,215 @@
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine.UIElements;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Coverage for the transition-filter opt-in tween (<see cref="StyleFilterTransitionDriver"/>), which lerps
+    /// the inline filter's parameters because UI Toolkit cannot CSS-transition an inline filter.
+    /// Group A drives the pure <see cref="StyleFilterTransitionDriver.ApplyFrame"/> at explicit phases (the
+    /// scheduler never ticks in EditMode; filter is geometry-independent, so no panel is needed to interpolate).
+    /// Group B mounts a real <see cref="EditorWindow"/> panel with the bundled stylesheet so the transition-*
+    /// longhands resolve, then exercises the real write hook through the arbitrary-value resolver. GWT, one
+    /// assert each.
+    /// </summary>
+    [TestFixture]
+    internal sealed class FilterTransitionPanelTests : PanelTestBase
+    {
+        private const string StyleSheetPath = "Packages/com.velvet.core/Runtime/Styles/StyleUtilities.uss";
+
+        protected override void LoadStyleSheets()
+        {
+            var sheet = AssetDatabase.LoadAssetAtPath<StyleSheet>(StyleSheetPath);
+            Assume.That(sheet, Is.Not.Null, "Precondition: the bundled StyleUtilities.uss loads");
+            _window.rootVisualElement.styleSheets.Add(sheet);
+        }
+
+        // A single-blur inline filter list, the simplest interpolable filter (one float parameter).
+        private static List<FilterFunction> BlurList(float px)
+        {
+            var fn = new FilterFunction(FilterFunctionType.Blur);
+            fn.AddParameter(new FilterParameter(px));
+            return new List<FilterFunction> { fn };
+        }
+
+        // Mounts a named leaf, forces a layout pass so resolvedStyle.transitionDuration resolves, and returns it.
+        private VisualElement MountResolved(string className)
+        {
+            _mounted = V.Mount(_window.rootVisualElement, V.Div(name: "card", className: className));
+            var element = _window.rootVisualElement.Q<VisualElement>("card");
+            ForcePanelUpdate(element.panel);
+            return element;
+        }
+
+        // Applies a blur through the arbitrary-value resolver — the exact path a class-diff / variant swap takes,
+        // so it flows through ApplyCombinedFilter's transition hook.
+        private static void ApplyBlur(VisualElement element, float px)
+            => StyleArbitraryValueResolver.Apply(element, new ArbitraryStyle(ArbitraryProperty.FilterBlur, px, LengthUnit.Pixel));
+
+        #region Group A — pure ApplyFrame
+
+        [Test]
+        public void Given_BlurTween_When_FrameAtMid_Then_BlurIsHalfway()
+        {
+            // Arrange — a blur 0 → 12 tween, linear, aligned into one channel.
+            var element = new VisualElement();
+            var to = BlurList(12f);
+            StyleFilterTransitionDriver.TryBuildChannels(BlurList(0f), to, out var channels);
+            var binding = new StyleFilterTransitionBinding { Channels = channels, Easing = EasingMode.Linear, Target = to };
+            Assume.That(channels.Length, Is.EqualTo(1), "Precondition: one blur channel aligns");
+
+            // Act — the midpoint frame.
+            StyleFilterTransitionDriver.ApplyFrame(element, binding, 0.5f);
+
+            // Assert — half of the way from 0 to 12 (an instant write would leave 0 or 12).
+            Assert.That(element.style.filter.value[0].GetParameter(0).floatValue, Is.EqualTo(6f));
+        }
+
+        [Test]
+        public void Given_TweenSecondFrame_When_FrameApplied_Then_FreshListReference()
+        {
+            // Arrange — UI Toolkit dirties the inline filter for repaint only when the backing list REFERENCE
+            // changes (it ref-compares, not content-compares), so each frame MUST write a fresh list.
+            var element = new VisualElement();
+            var to = BlurList(12f);
+            StyleFilterTransitionDriver.TryBuildChannels(BlurList(0f), to, out var channels);
+            var binding = new StyleFilterTransitionBinding { Channels = channels, Easing = EasingMode.Linear, Target = to };
+
+            // Act — two successive frames.
+            StyleFilterTransitionDriver.ApplyFrame(element, binding, 0.25f);
+            var first = element.style.filter.value;
+            StyleFilterTransitionDriver.ApplyFrame(element, binding, 0.5f);
+            var second = element.style.filter.value;
+
+            // Assert — a distinct reference each frame (RED if the driver reuses one mutated list).
+            Assert.That(ReferenceEquals(first, second), Is.False);
+        }
+
+        [Test]
+        public void Given_NoneToBlur_When_FrameAtMid_Then_BlurFadesInFromZero()
+        {
+            // Arrange — a freshly-mounted element has no inline filter, so its from-list reads null (not []); the
+            // added blur must fade in from its neutral value (0), not snap.
+            var element = new VisualElement();
+            var from = element.style.filter.value;
+            Assume.That(from, Is.Null, "Precondition: a fresh element has no inline filter list");
+            var to = BlurList(12f);
+            StyleFilterTransitionDriver.TryBuildChannels(from, to, out var channels);
+            var binding = new StyleFilterTransitionBinding { Channels = channels, Easing = EasingMode.Linear, Target = to };
+
+            // Act
+            StyleFilterTransitionDriver.ApplyFrame(element, binding, 0.5f);
+
+            // Assert — halfway between the neutral 0 and 12.
+            Assert.That(element.style.filter.value[0].GetParameter(0).floatValue, Is.EqualTo(6f));
+        }
+
+        [Test]
+        public void Given_EaseInOut_When_FrameAtQuarter_Then_ProgressBelowLinear()
+        {
+            // Arrange — the same blur 0 → 12, but ease-in-out, whose slow start puts the quarter-way progress
+            // below the linear value (linear at t=0.25 would be exactly 3).
+            var element = new VisualElement();
+            var to = BlurList(12f);
+            StyleFilterTransitionDriver.TryBuildChannels(BlurList(0f), to, out var channels);
+            var binding = new StyleFilterTransitionBinding { Channels = channels, Easing = EasingMode.EaseInOut, Target = to };
+
+            // Act
+            StyleFilterTransitionDriver.ApplyFrame(element, binding, 0.25f);
+
+            // Assert — RED if Ease ignores the mode and lerps linearly (which would land at 3).
+            Assert.That(element.style.filter.value[0].GetParameter(0).floatValue, Is.LessThan(3f));
+        }
+
+        #endregion
+
+        #region Group B — detection / kickoff on a real panel
+
+        [Test]
+        public void Given_TransitionFilter_When_FilterChanges_Then_TweenBindingRuns()
+        {
+            // Arrange — the opt-in class registers a binding; the bundled sheet resolves a non-zero duration.
+            var element = MountResolved("transition-filter");
+            var binding = _mounted.Root.Reconciler.Context.FilterTransitionBindings[element];
+            Assume.That(binding.Scheduled, Is.Null, "Precondition: no tween before the change");
+            Assume.That(element.resolvedStyle.transitionDuration.First().value, Is.GreaterThan(0f),
+                "Precondition: the transition-filter duration resolved");
+
+            // Act — a filter change through the resolver (the class-diff / variant path).
+            ApplyBlur(element, 12f);
+
+            // Assert — the tween's tick is live (RED without the ApplyCombinedFilter hook).
+            Assert.That(binding.Scheduled, Is.Not.Null);
+        }
+
+        [Test]
+        public void Given_NoTransitionFilterClass_When_FilterChanges_Then_InstantWrite()
+        {
+            // Arrange — no opt-in class, so no binding: the opt-in gate must keep the change instant.
+            var element = MountResolved("w-[100px] h-[40px]");
+            Assume.That(_mounted.Root.Reconciler.Context.FilterTransitionBindings.ContainsKey(element), Is.False,
+                "Precondition: no binding without the opt-in class");
+
+            // Act
+            ApplyBlur(element, 12f);
+
+            // Assert — the composed value lands immediately, un-tweened.
+            Assert.That(element.style.filter.value[0].GetParameter(0).floatValue, Is.EqualTo(12f));
+        }
+
+        [Test]
+        public void Given_ZeroDuration_When_FilterChanges_Then_InstantWrite()
+        {
+            // Arrange — duration-0 overrides the bundled default, so even with the opt-in the change is instant.
+            var element = MountResolved("transition-filter duration-0");
+            Assume.That(element.resolvedStyle.transitionDuration.First().value, Is.EqualTo(0f),
+                "Precondition: duration-0 resolved to zero");
+
+            // Act
+            ApplyBlur(element, 12f);
+
+            // Assert — the zero-duration guard writes the target immediately (RED if it started a 0s tween at 0).
+            Assert.That(element.style.filter.value[0].GetParameter(0).floatValue, Is.EqualTo(12f));
+        }
+
+        [Test]
+        public void Given_RunningTween_When_Detached_Then_TickPaused()
+        {
+            // Arrange — a running filter tween.
+            var element = MountResolved("transition-filter");
+            var binding = _mounted.Root.Reconciler.Context.FilterTransitionBindings[element];
+            ApplyBlur(element, 12f);
+            Assume.That(binding.Scheduled, Is.Not.Null, "Precondition: a tween is running");
+
+            // Act — teardown of the binding (class removed / element unmounted).
+            StyleFilterTransitionDriver.Detach(element, binding);
+
+            // Assert — the one-shot tick is paused and dropped (a filter transition owns no persistent slot).
+            Assert.That(binding.Scheduled, Is.Null);
+        }
+
+        [Test]
+        public void Given_RunningTweenAtMidFrame_When_DetachedWhileMounted_Then_SettlesToTarget()
+        {
+            // Arrange — a tween running to blur-12, advanced to a mid-frame so the inline value is neither end.
+            var element = MountResolved("transition-filter");
+            var binding = _mounted.Root.Reconciler.Context.FilterTransitionBindings[element];
+            ApplyBlur(element, 12f);
+            StyleFilterTransitionDriver.ApplyFrame(element, binding, 0.5f);
+            Assume.That(element.style.filter.value[0].GetParameter(0).floatValue, Is.EqualTo(6f),
+                "Precondition: the tween is mid-flight at half the target");
+
+            // Act — the opt-in class is dropped while the element stays mounted (the filter-* class is unchanged,
+            // so the resolver never re-asserts the static value).
+            StyleFilterTransitionDriver.Detach(element, binding);
+
+            // Assert — the cancelled tween settles to its target instead of freezing at the mid-frame value.
+            Assert.That(element.style.filter.value[0].GetParameter(0).floatValue, Is.EqualTo(12f));
+        }
+
+        #endregion
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/FilterTransitionPanelTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/FilterTransitionPanelTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: cb8f3bca854a4945b8f6297b0fa9e226


### PR DESCRIPTION
## What
Filter utilities (`blur-*`, `brightness-*`, …) now transition smoothly when they change on an element carrying the new `transition-filter` class (e.g. `transition-filter hover:blur-md`), matching CSS `transition: filter`.

## How
UI Toolkit cannot transition the inline `filter` property natively (it stops repainting once `transition-property` is `[filter]`). A new one-shot `StyleFilterTransitionDriver` drives the filter parameters frame-by-frame via the same panel-root scheduler tween `animate-hue` uses (writing a fresh filter list each frame for UITK's ref-compared repaint dirtying), hooked into the single `StyleArbitraryValueResolver.ApplyCombinedFilter` write site so every filter path (base / arbitrary / variant) is covered. Opt in with `transition-filter` (honoring `duration-*` and the easing longhand). Non-interpolable changes (a custom filter, or an ambiguous add/remove) and the off-panel / zero-duration cases fall back to an instant write. A tween cancelled while the element stays mounted settles to its target rather than freezing at a mid-frame value.

## Tests
`FilterTransitionPanelTests` — pure per-frame interpolation (fresh-list repaint invariant, none→blur identity padding, easing), and panel-level kickoff / opt-in gate / zero-duration / detach-settle.

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)