### PR TITLE
feat(velvet): drive exact cubic-bezier easings for scheduler tweens (#80)

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -15,6 +15,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   tween drives the filter parameters frame-by-frame; opt in with `transition-filter` (honoring `duration-*`
   and the easing longhand). Non-interpolable changes (a custom filter, or an ambiguous add/remove) and the
   off-panel / zero-duration cases fall back to an instant write.
+- A third transition model, `StyleTransitionConfig { Type = TransitionType.Bezier, BezierX1,
+  BezierY1, BezierX2, BezierY2 }`: variant enters / exits sample an EXACT CSS
+  `cubic-bezier(x1,y1,x2,y2)` curve every tick instead of one of the five `EasingMode` keywords,
+  which cannot express an arbitrary numeric curve. Sibling to the spring model — it shares its
+  channel scope (opacity and the translate/scale/rotate transform trio) and its
+  one-curve-drives-both-directions contract — but keeps a fixed `DurationSec` like a plain tween;
+  only the easing shape differs. Defaults to Tailwind's own default curve,
+  `cubic-bezier(0.4, 0, 0.2, 1)`, the exact curve the bundled USS only approximates with the
+  `ease-in-out` keyword. `BezierX1`/`BezierX2` outside `[0,1]` is invalid per the `cubic-bezier()`
+  spec (a timing function must stay monotone in time) and falls back to that default curve with a
+  one-shot console warning instead of being silently clamped into range.
 
 ### Fixed
 

--- a/Packages/com.velvet.core/Documentation~/motion.md
+++ b/Packages/com.velvet.core/Documentation~/motion.md
@@ -3,9 +3,9 @@
 `V.Motion` and `V.AnimatePresence` model [Framer Motion](https://www.framer.com/motion/)'s
 declarative animation API on Unity UI Toolkit. This guide covers the variant-driven feature set:
 labels and inheritance, mount enters, exits and `PopLayout`, orchestration
-(`staggerChildren` / `delayChildren` / `when`), per-property transition overrides, and spring
-physics — plus the transition semantics that tie them together: **one config, every update**
-(and the instant opt-out; see the last section).
+(`staggerChildren` / `delayChildren` / `when`), per-property transition overrides, spring physics,
+and exact cubic-bezier easing — plus the transition semantics that tie them together: **one
+config, every update** (and the instant opt-out; see the last section).
 
 The `StyleTransition` presets (`Fade`, `SlideUp`, `ScaleIn`, `FadeSlideUp`, …) and
 `whileHoverClass` / `whileTapClass` gestures are covered in the README; everything below uses
@@ -155,6 +155,22 @@ new StyleTransitionConfig
   a label mid-spring retargets from the current value and velocity.
 - Non-finite / non-positive `Stiffness` / `Damping` / `Mass` log a warning and complete
   immediately rather than freezing the element mid-pose.
+
+## Cubic-bezier easing
+
+`TransitionType.Bezier` is Spring's other non-CSS sibling: instead of `EasingMode`'s five keyword
+curves, it samples an exact numeric CSS `cubic-bezier(x1,y1,x2,y2)` curve every tick — the same
+algorithm every browser's `cubic-bezier()` runs — via `BezierX1` / `BezierY1` / `BezierX2` /
+`BezierY2`. Unlike a spring it keeps a fixed `DurationSec`, exactly like a plain tween; only the
+shape of the easing differs. It shares Spring's channel scope (opacity and the
+translate/scale/rotate transform trio only) and its one-curve-drives-both-directions contract —
+there is no separate exit curve, and `PropertyOverrides` is not read. Defaults to Tailwind's own
+default curve, `cubic-bezier(0.4, 0, 0.2, 1)`, the exact curve the bundled USS only approximates
+with the `ease-in-out` keyword. `BezierX1` / `BezierX2` must stay in `[0,1]`, since a CSS timing
+function is a function of time and so must be monotone; a value outside that range is invalid and
+falls back to the default curve with a one-shot console warning instead of being silently clamped.
+`BezierY1` / `BezierY2` are left unclamped, so an overshoot/anticipate curve genuinely passes its
+target mid-tween.
 
 ## Shared-element layout animation (`layoutId`)
 

--- a/Packages/com.velvet.core/Runtime/Hooks/AnimationSequenceTypes.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/AnimationSequenceTypes.cs
@@ -35,7 +35,8 @@ namespace Velvet
         /// <summary>
         /// How long the sequence holds on this step before advancing. On a <see cref="To"/> step, null derives
         /// the hold from <see cref="Transition"/> (<c>DurationSec + DelaySec</c> for
-        /// <see cref="TransitionType.Tween"/>); a <see cref="TransitionType.Spring"/>-typed <see cref="To"/>
+        /// <see cref="TransitionType.Tween"/> or <see cref="TransitionType.Bezier"/>, both fixed-duration); a
+        /// <see cref="TransitionType.Spring"/>-typed <see cref="To"/>
         /// step with no explicit hold logs a warning and falls back to a fixed estimate, since a spring's
         /// settle time is physics-derived and not statically knowable (matches
         /// <see cref="StyleTransitionConfig"/>'s own documented "DurationSec is ignored for Spring" contract).

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/BezierTweenLifecycleTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/BezierTweenLifecycleTests.cs
@@ -1,0 +1,339 @@
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.UIElements;
+using UnityEngine.UIElements.TestFramework;
+using UnityEditor.UIElements.TestFramework;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins the bezier driver's lifecycle against a live (simulated) panel — the coverage the panel-free driver
+    /// units cannot give, the bezier sibling of <see cref="MotionSpringLifecycleTests"/>. A bezier tween must:
+    /// start once its element is attached (both production call sites play the enter BEFORE insertion); play a
+    /// presence exit; leave a resolver-backed resting value (e.g. <c>translate-x-4</c>, inline-only, no USS rule)
+    /// intact after completing; hand off to a fresh full-duration reversal on a cancel while ticking; scrub its
+    /// inline pose when its subtree is torn down mid-exit (a pooled element must not keep receiving tick writes);
+    /// complete an exit whose variants animate no bezier channel exactly once; release a cancel that lands before
+    /// its delayed tick started; and never hand off to a reversal on a teardown cancel.
+    /// </summary>
+    [TestFixture]
+    internal sealed class BezierTweenLifecycleTests
+    {
+        private static readonly Dictionary<string, string> s_fade = new()
+        {
+            ["hidden"] = "opacity-0",
+            ["visible"] = "opacity-100",
+        };
+
+        private static readonly Dictionary<string, string> s_slide = new()
+        {
+            ["hidden"] = "opacity-0",
+            ["visible"] = "opacity-100 translate-x-4",
+        };
+
+        // Colors are not a bezier channel: an exit between these labels resolves to an empty plan.
+        private static readonly Dictionary<string, string> s_paint = new()
+        {
+            ["visible"] = "bg-white",
+            ["hidden"] = "bg-black",
+        };
+
+        private readonly record struct SetState(string Keys);
+
+        private sealed class SetStore : Store<SetState>
+        {
+            public SetStore(string initial) : base(new SetState(initial)) { }
+            public void Set(string keys) => SetState(_ => new SetState(keys));
+            protected override void ResetCore() => SetState(_ => new SetState("a"));
+        }
+
+        private readonly record struct ToggleState(bool Show);
+
+        private sealed class ToggleStore : Store<ToggleState>
+        {
+            public ToggleStore() : base(new ToggleState(true)) { }
+            public void Set(bool show) => SetState(_ => new ToggleState(show));
+            protected override void ResetCore() => SetState(_ => new ToggleState(true));
+        }
+
+        private static SetStore s_store;
+        private static ToggleStore s_outerStore;
+        private static Dictionary<string, string> s_hostVariants;
+        private static StyleTransitionConfig s_hostTransition;
+        private static Action s_onExitComplete;
+
+        private EditorPanelSimulator _sim;
+        private Reconciler _reconciler;
+
+        [SetUp]
+        public void SetUp()
+        {
+            PanelSimulator.ResetCurrentTime();
+            _sim = new EditorPanelSimulator { panelSize = new Vector2(800, 600) };
+            _sim.ResetTimePerSimulatedFrameToDefault();
+            _reconciler = new Reconciler();
+            s_store = null;
+            s_outerStore = null;
+            s_hostVariants = null;
+            s_hostTransition = null;
+            s_onExitComplete = null;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _reconciler?.Dispose();
+            _sim?.Dispose();
+            _sim = null;
+        }
+
+        private VisualElement Root => _sim.rootVisualElement;
+
+        private void Tick() => _sim.FrameUpdateMs(16);
+
+        private void AdvancePast(float seconds)
+        {
+            var steps = (int)((seconds + 0.2f) * 1000f / 16f) + 1;
+            for (var i = 0; i < steps; i++) Tick();
+        }
+
+        // A bezier is a fixed-duration model (unlike a spring), so DurationSec must be positive. The curve is
+        // left at Tailwind's own default (BezierX1..Y2 defaults).
+        private static StyleTransitionConfig Bezier(float delaySec = 0f) => new()
+        {
+            Type = TransitionType.Bezier,
+            DurationSec = 0.3f,
+            DelaySec = delaySec,
+        };
+
+        [Component]
+        private static VNode PresenceHost()
+        {
+            var keys = Hooks.UseStore(s_store, s => s.Keys);
+            var children = new List<VNode>();
+            foreach (var key in keys)
+            {
+                children.Add(V.Motion(name: "item-" + key, key: key.ToString(),
+                    variants: s_hostVariants, animate: "visible", exit: "hidden",
+                    transition: s_hostTransition));
+            }
+            return V.Div(name: "host", children: new VNode[]
+            {
+                V.AnimatePresence(key: "presence", initial: false,
+                    onExitComplete: s_onExitComplete, children: children.ToArray()),
+            });
+        }
+
+        [Component]
+        private static VNode OuterGate()
+        {
+            var show = Hooks.UseStore(s_outerStore, s => s.Show);
+            return V.Div(name: "outer", children: show
+                ? new VNode[] { V.Component(PresenceHost, key: "host") }
+                : Array.Empty<VNode>());
+        }
+
+        [Test]
+        public void Given_AStandaloneBezierEnter_When_ThePanelTicks_Then_TheElementSettlesAtItsAnimatePose()
+        {
+            // Arrange / Act — the enter plays inside CreateElement (detached); the panel then attaches the
+            // element and ticks. The bezier must start once attached, not silently give up.
+            _reconciler.Reconcile(Root, Array.Empty<VNode>(), new VNode[]
+            {
+                V.Motion(key: "m", name: "m", variants: s_fade,
+                    initial: "hidden", animate: "visible", transition: Bezier()),
+            });
+            var m = Root.Q<VisualElement>("m");
+            Assume.That(m, Is.Not.Null, "Precondition: the motion mounted");
+            AdvancePast(1f);
+
+            // Assert — the tween ran to rest instead of freezing at the pinned from-pose.
+            Assert.That(m.resolvedStyle.opacity, Is.EqualTo(1f).Within(1e-2f));
+        }
+
+        [Test]
+        public void Given_ABezierConfigWithDuration_When_APresenceChildExits_Then_TheGhostStaysWhileTheTweenPlays()
+        {
+            // Arrange
+            s_hostVariants = s_fade;
+            s_hostTransition = Bezier();
+            using var store = new SetStore("a");
+            s_store = store;
+            using var mounted = V.Mount(Root, V.Component(PresenceHost, key: "host"));
+            var scheduler = mounted.Root.Reconciler.Context.BatchScheduler;
+            Tick();
+
+            // Act — remove the key; a bezier exit must play, so the ghost stays mounted.
+            store.Set("");
+            scheduler.DrainImmediateForTest();
+
+            // Assert — the child is still present as an exiting ghost, not instant-removed.
+            Assert.AreEqual(1, Root.Q<VisualElement>("host").childCount);
+        }
+
+        [Test]
+        public void Given_ABezierWhoseRestingVariantUsesAResolverValue_When_ItSettles_Then_TheValueIsKept()
+        {
+            // Arrange / Act — translate-x-4 exists only as a resolver-applied inline style (no USS rule), so the
+            // completion path must leave the element at 16px, not clear it to identity.
+            _reconciler.Reconcile(Root, Array.Empty<VNode>(), new VNode[]
+            {
+                V.Motion(key: "m", name: "m", variants: s_slide,
+                    initial: "hidden", animate: "visible", transition: Bezier()),
+            });
+            var m = Root.Q<VisualElement>("m");
+            AdvancePast(1f);
+
+            // Assert — the resolver-owned resting translate survives the tween's completion.
+            Assert.That(m.resolvedStyle.translate.x, Is.EqualTo(16f).Within(0.5f));
+        }
+
+        [Test]
+        public void Given_ABezierExitCancelledMidTick_When_TheReversalCompletes_Then_TheInlinePoseIsReleased()
+        {
+            // Arrange — drives StyleAnimationScheduler directly on a REAL attached element, so this exercises the
+            // reversal hand-off (Retarget + move into the enter map) on a tick that is actually running.
+            var scheduler = new StyleAnimationScheduler();
+            var element = new VisualElement();
+            Root.Add(element);
+            element.AddToClassList("opacity-100");
+            var config = new StyleTransitionConfig
+            {
+                Type = TransitionType.Bezier,
+                DurationSec = 0.3f,
+                ExitFromClass = "opacity-100",
+                ExitToClass = "opacity-0",
+            };
+            scheduler.PlayExit(element, config, onComplete: null, restoreFromOnCancel: true);
+            Tick();
+            Assume.That(element.style.opacity.keyword, Is.Not.EqualTo(StyleKeyword.Null),
+                "Precondition: the exit's tick is actively writing an inline opacity override");
+
+            // Act — cancel mid-tick (an exit reversal), then let the reversal run its full duration.
+            scheduler.CancelExit(element);
+            AdvancePast(1f);
+
+            // Assert — the reversal ran to completion and released the inline pose (no dead pending entry
+            // pinning stale inline opacity).
+            Assert.That(element.style.opacity.keyword, Is.EqualTo(StyleKeyword.Null));
+        }
+
+        [Test]
+        public void Given_AMidExitBezierSubtree_When_ItIsTornDown_Then_TheDetachedElementCarriesNoInlinePose()
+        {
+            // Arrange — a bezier exit is in flight when the whole presence subtree unmounts.
+            s_hostVariants = s_fade;
+            s_hostTransition = Bezier();
+            using var store = new SetStore("a");
+            s_store = store;
+            using var outer = new ToggleStore();
+            s_outerStore = outer;
+            using var mounted = V.Mount(Root, V.Component(OuterGate, key: "outer"));
+            var scheduler = mounted.Root.Reconciler.Context.BatchScheduler;
+            Tick();
+            store.Set("");
+            scheduler.DrainImmediateForTest();
+            Tick();
+            var item = Root.Q<VisualElement>("item-a");
+            Assume.That(item, Is.Not.Null, "Precondition: the ghost is exiting");
+
+            // Act — tear the subtree down mid-exit (the element heads back to the pool).
+            outer.Set(false);
+            scheduler.DrainImmediateForTest();
+
+            // Assert — teardown scrubs the tween's inline pose immediately; no reversal may keep ticking styles
+            // onto (and eventually null-clearing) a pooled element.
+            Assert.That(item.style.opacity.keyword, Is.EqualTo(StyleKeyword.Null));
+        }
+
+        [Test]
+        public void Given_ABezierExitWithNoAnimatableChannel_When_TheKeyIsRemoved_Then_TheGhostDropsAndExitCompleteFiresOnce()
+        {
+            // Arrange — the exit variant only changes colors (not a bezier channel), so the plan is empty and the
+            // exit must complete once, not replay against the per-pass exit bookkeeping forever.
+            s_hostVariants = s_paint;
+            s_hostTransition = new StyleTransitionConfig { Type = TransitionType.Bezier, DurationSec = 0.5f };
+            var exitCompleteCalls = 0;
+            s_onExitComplete = () => exitCompleteCalls++;
+            using var store = new SetStore("a");
+            s_store = store;
+            using var mounted = V.Mount(Root, V.Component(PresenceHost, key: "host"));
+            var scheduler = mounted.Root.Reconciler.Context.BatchScheduler;
+            Tick();
+
+            // Act — remove the key and drain several times (the completion re-render included).
+            store.Set("");
+            for (var i = 0; i < 6; i++)
+            {
+                scheduler.DrainImmediateForTest();
+            }
+
+            // Assert — the ghost is gone and onExitComplete fired exactly once (no re-render loop).
+            Assert.That((Root.Q<VisualElement>("host").childCount, exitCompleteCalls),
+                Is.EqualTo((0, 1)));
+        }
+
+        [Test]
+        public void Given_ABezierExitCancelledBeforeItsDelayedTickEverStarted_When_TimeAdvances_Then_NoDeadRetargetLingersForever()
+        {
+            // Arrange — a 0.4s delay means the recurring tick has not started (Bezier.Tick is still null) by the
+            // time the cancel below lands, so the reversal branch must NOT try to hand off to a tick that nothing
+            // would ever start.
+            var scheduler = new StyleAnimationScheduler();
+            var element = new VisualElement();
+            Root.Add(element);
+            element.AddToClassList("opacity-100");
+            var config = new StyleTransitionConfig
+            {
+                Type = TransitionType.Bezier,
+                DurationSec = 0.3f,
+                DelaySec = 0.4f,
+                ExitFromClass = "opacity-100",
+                ExitToClass = "opacity-0",
+            };
+            scheduler.PlayExit(element, config, onComplete: null, restoreFromOnCancel: true);
+            Tick();
+            Assume.That(element.style.opacity.keyword, Is.Not.EqualTo(StyleKeyword.Null),
+                "Precondition: the exit's ApplyCurrentValues wrote an inline opacity override");
+
+            // Act — cancel while still parked behind the delay, then let plenty of time pass.
+            scheduler.CancelExit(element);
+            AdvancePast(1f);
+
+            // Assert — the inline opacity override is released immediately by the cancel instead of waiting on a
+            // tick that nothing would ever start.
+            Assert.That(element.style.opacity.keyword, Is.EqualTo(StyleKeyword.Null));
+        }
+
+        [Test]
+        public void Given_AnActivelyTickingBezierExit_When_CancelledForTeardown_Then_ItNeverHandsOffToAReversal()
+        {
+            // Arrange — no delay, so the panel-root tick is already running when the teardown cancel lands.
+            var scheduler = new StyleAnimationScheduler();
+            var element = new VisualElement();
+            Root.Add(element);
+            element.AddToClassList("opacity-100");
+            var config = new StyleTransitionConfig
+            {
+                Type = TransitionType.Bezier,
+                DurationSec = 0.3f,
+                ExitFromClass = "opacity-100",
+                ExitToClass = "opacity-0",
+            };
+            scheduler.PlayExit(element, config, onComplete: null, restoreFromOnCancel: true);
+            Tick();
+            Assume.That(element.style.opacity.keyword, Is.Not.EqualTo(StyleKeyword.Null),
+                "Precondition: the exit's tick is actively writing an inline opacity override");
+
+            // Act — the element is being torn down for good, not merely interrupted.
+            scheduler.CancelExitForTeardown(element);
+
+            // Assert — the teardown cancel finalized immediately instead of parking a reversal whose recurring
+            // tick would keep writing inline styles onto this (about to be pooled) element.
+            Assert.That(element.style.opacity.keyword, Is.EqualTo(StyleKeyword.Null));
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/BezierTweenLifecycleTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/BezierTweenLifecycleTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8a49d7e827cf4fc7b3b433d1af982c35

--- a/Packages/com.velvet.core/Runtime/Styling/BezierTweenDriver.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/BezierTweenDriver.cs
@@ -1,0 +1,198 @@
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace Velvet
+{
+    /// <summary>
+    /// One bezier-tweened channel: the value it started from and the value it is heading to, plus the value it
+    /// snaps back toward on an exit-cancel hand-off (its <see cref="From"/> at construction — same semantics as
+    /// <see cref="SpringChannel.RestingTarget"/>).
+    /// </summary>
+    internal sealed class BezierTweenChannel
+    {
+        // From is not readonly: Retarget freezes the channel's current sampled value here to begin a reversal
+        // from wherever the forward tween had reached.
+        public float From;
+        public float To;
+        public readonly float RestingTarget;
+
+        public BezierTweenChannel(float from, float to)
+        {
+            From = from;
+            To = to;
+            RestingTarget = from;
+        }
+    }
+
+    /// <summary>
+    /// Running state for one bezier-driven Motion variant enter/exit: up to five channels (see
+    /// <see cref="SpringAxis"/>; translate x/y are always present together, never alone — see
+    /// <see cref="MotionSpringClassParser.Resolve"/>), the four cubic-bezier control-point coordinates, the
+    /// fixed duration, elapsed time, the recurring tick handle, and the completion callback. Owned by
+    /// <c>StyleAnimationScheduler</c>'s <c>PendingAnimation</c>.
+    /// </summary>
+    internal sealed class BezierTweenState
+    {
+        public BezierTweenChannel? Opacity;
+        public BezierTweenChannel? TranslateX;
+        public BezierTweenChannel? TranslateY;
+        public BezierTweenChannel? Scale;
+        public BezierTweenChannel? Rotate;
+
+        // CSS-parameter order: cubic-bezier(X1,Y1,X2,Y2).
+        public float X1;
+        public float Y1;
+        public float X2;
+        public float Y2;
+
+        public float DurationSec;
+        public float ElapsedSec;
+
+        // The recurring tick, scheduled on the panel root. Paused (and nulled) once the tween completes, or on cancel.
+        public IVisualElementScheduledItem? Tick;
+
+        // Runs once the tween completes (after the driver has already cleared the inline overrides). The
+        // natural-completion caller sets this to its onComplete; an exit-cancel hand-off (see
+        // StyleAnimationScheduler.CancelPending) clears it to null — a reversal completing is not "finishing"
+        // anything the original caller asked for.
+        public System.Action? OnSettled;
+    }
+
+    /// <summary>
+    /// Mechanics for a bezier-driven Motion variant enter/exit: builds the per-channel state from a resolved
+    /// <see cref="MotionSpringClassParser.SpringPlan"/> (the same driver-agnostic channel resolution the spring
+    /// path uses), and applies/steps/clears the inline styles a channel owns, sampling its progress through
+    /// <see cref="CubicBezierEvaluator"/>. The bezier sibling of <see cref="MotionSpringDriver"/>: architecturally
+    /// a per-frame direct-value-write model (bypassing CSS transitions to get an EXACT curve), but with a
+    /// deterministic fixed-duration completion instead of the spring's physics-derived settle. Takes no dependency
+    /// on scheduling or panels — see <see cref="StyleAnimationScheduler"/> for the piece that decides WHEN to
+    /// start/stop/retarget one of these and owns the recurring tick.
+    /// </summary>
+    internal static class BezierTweenDriver
+    {
+        /// <summary>
+        /// Builds the running state from a resolved plan and the curve/duration, or null when the plan animates
+        /// nothing (the caller should treat this exactly like a zero-duration tween: land the classes and complete
+        /// immediately).
+        /// </summary>
+        public static BezierTweenState? Create(MotionSpringClassParser.SpringPlan plan,
+            float x1, float y1, float x2, float y2, float durationSec)
+        {
+            if (plan.IsEmpty)
+            {
+                return null;
+            }
+            var state = new BezierTweenState
+            {
+                X1 = x1,
+                Y1 = y1,
+                X2 = x2,
+                Y2 = y2,
+                DurationSec = durationSec,
+            };
+            if (plan.Opacity is { } o) state.Opacity = new BezierTweenChannel(o.from, o.to);
+            if (plan.TranslateX is { } tx) state.TranslateX = new BezierTweenChannel(tx.from, tx.to);
+            if (plan.TranslateY is { } ty) state.TranslateY = new BezierTweenChannel(ty.from, ty.to);
+            if (plan.Scale is { } s) state.Scale = new BezierTweenChannel(s.from, s.to);
+            if (plan.Rotate is { } r) state.Rotate = new BezierTweenChannel(r.from, r.to);
+            return state;
+        }
+
+        /// <summary>
+        /// Writes each channel's CURRENT eased value as an inline style, synchronously — so the element shows the
+        /// from-pose on the very first rendered frame instead of flashing at the (already-applied) resting
+        /// classes' value until the first tick runs.
+        /// </summary>
+        public static void ApplyCurrentValues(VisualElement element, BezierTweenState state)
+            => ApplyEased(element, state, CurrentEased(state));
+
+        /// <summary>
+        /// Advances elapsed time by <paramref name="dtSec"/> and re-applies the inline styles at the newly eased
+        /// progress. Returns true once elapsed time has reached the fixed duration — a deterministic completion,
+        /// unlike the spring's convergence-based settle.
+        /// </summary>
+        public static bool Step(VisualElement element, BezierTweenState state, float dtSec)
+        {
+            if (dtSec > 0f)
+            {
+                state.ElapsedSec += dtSec;
+            }
+            ApplyEased(element, state, CurrentEased(state));
+            return state.ElapsedSec >= state.DurationSec;
+        }
+
+        /// <summary>Clears every inline override this state ever wrote, letting the (already-resting) classes take back over.</summary>
+        public static void ClearInlineOverrides(VisualElement element, BezierTweenState state)
+        {
+            if (state.Opacity != null) element.style.opacity = StyleKeyword.Null;
+            if (state.TranslateX != null || state.TranslateY != null) element.style.translate = StyleKeyword.Null;
+            if (state.Scale != null) element.style.scale = StyleKeyword.Null;
+            if (state.Rotate != null) element.style.rotate = StyleKeyword.Null;
+        }
+
+        /// <summary>
+        /// Freezes each active channel's CURRENT sampled value as its new <see cref="BezierTweenChannel.From"/>,
+        /// points its <see cref="BezierTweenChannel.To"/> back at <see cref="BezierTweenChannel.RestingTarget"/>,
+        /// and resets <see cref="BezierTweenState.ElapsedSec"/> to zero — a fresh full-duration reversal from
+        /// wherever the forward tween currently is (exactly how a re-triggered CSS transition behaves, not a
+        /// time-reversed replay). The exit-cancel hand-off.
+        /// </summary>
+        public static void Retarget(BezierTweenState state)
+        {
+            var eased = CurrentEased(state);
+            RetargetChannel(state.Opacity, eased);
+            RetargetChannel(state.TranslateX, eased);
+            RetargetChannel(state.TranslateY, eased);
+            RetargetChannel(state.Scale, eased);
+            RetargetChannel(state.Rotate, eased);
+            state.ElapsedSec = 0f;
+        }
+
+        private static void RetargetChannel(BezierTweenChannel? channel, float eased)
+        {
+            if (channel == null)
+            {
+                return;
+            }
+            channel.From = Mathf.LerpUnclamped(channel.From, channel.To, eased);
+            channel.To = channel.RestingTarget;
+        }
+
+        // The eased output for the current elapsed fraction. A zero duration reads as complete (eased at
+        // progress 1) rather than dividing by zero — the scheduler never builds one (ValidateBezierParameters
+        // rejects a zero duration), but a direct driver caller might.
+        private static float CurrentEased(BezierTweenState state)
+        {
+            var progress = state.DurationSec > 0f
+                ? Mathf.Clamp01(state.ElapsedSec / state.DurationSec)
+                : 1f;
+            return CubicBezierEvaluator.Evaluate(state.X1, state.Y1, state.X2, state.Y2, progress);
+        }
+
+        // LerpUnclamped (not Lerp): an overshoot/anticipate curve samples eased values outside [0,1], and the
+        // channel value must actually pass its target for that to be visible — clamping would silently flatten it.
+        private static void ApplyEased(VisualElement element, BezierTweenState state, float eased)
+        {
+            if (state.Opacity != null)
+            {
+                element.style.opacity = Mathf.LerpUnclamped(state.Opacity.From, state.Opacity.To, eased);
+            }
+            if (state.TranslateX != null || state.TranslateY != null)
+            {
+                var x = state.TranslateX != null ? Mathf.LerpUnclamped(state.TranslateX.From, state.TranslateX.To, eased) : 0f;
+                var y = state.TranslateY != null ? Mathf.LerpUnclamped(state.TranslateY.From, state.TranslateY.To, eased) : 0f;
+                element.style.translate = new Translate(new Length(x), new Length(y));
+            }
+            if (state.Scale != null)
+            {
+                var v = Mathf.LerpUnclamped(state.Scale.From, state.Scale.To, eased);
+                element.style.scale = new Scale(new Vector2(v, v));
+            }
+            if (state.Rotate != null)
+            {
+                var v = Mathf.LerpUnclamped(state.Rotate.From, state.Rotate.To, eased);
+                element.style.rotate = new Rotate(Angle.Degrees(v));
+            }
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Styling/BezierTweenDriver.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Styling/BezierTweenDriver.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: deb208bcc797459295b49d48cfa40eac

--- a/Packages/com.velvet.core/Runtime/Styling/CubicBezierEvaluator.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/CubicBezierEvaluator.cs
@@ -1,0 +1,167 @@
+using UnityEngine;
+
+namespace Velvet
+{
+    /// <summary>
+    /// Evaluates a CSS <c>cubic-bezier(x1,y1,x2,y2)</c> easing curve EXACTLY, the way every browser's
+    /// <c>cubic-bezier()</c> does — a fixed-duration tween's easing sampled through the real spec algorithm
+    /// rather than approximated by one of UI Toolkit's five <c>EasingMode</c> keywords (which cannot express an
+    /// arbitrary numeric curve). Pure math: no <c>VisualElement</c> / panel dependency and zero allocations, so
+    /// it can be exercised directly — see <see cref="BezierTweenDriver"/> for the piece that applies a sampled
+    /// value to a Motion's animated style properties.
+    /// </summary>
+    /// <remarks>
+    /// The endpoints are fixed at (0,0) and (1,1); the two control points (x1,y1) and (x2,y2) shape the curve.
+    /// A CSS timing function is a function of TIME, so x must stay monotone: an x1/x2 outside [0,1] makes the
+    /// whole curve invalid per the <c>cubic-bezier()</c> spec, exactly like a browser rejecting the declaration —
+    /// <see cref="Evaluate"/> warns once and falls back to the default curve instead of clamping the offending
+    /// coordinate into range. y is left UNCLAMPED so an overshoot/anticipate curve (a control point with y
+    /// outside [0,1]) genuinely passes its target mid-tween instead of being flattened.
+    /// </remarks>
+    internal static class CubicBezierEvaluator
+    {
+        // Newton-Raphson converges quadratically for the well-conditioned curves a UI easing uses, so a small
+        // fixed budget is plenty; bisection picks up the rare flat-derivative case the fallback exists for.
+        private const int NewtonIterations = 8;
+        private const int BisectionIterations = 32;
+
+        // The x-solve residual is in [0,1] units, so this absolute tolerance is already well below one output
+        // step of any realistic tween duration.
+        private const float ConvergenceEpsilon = 1e-6f;
+
+        // Below this slope Newton's correction (residual / derivative) explodes or reverses; hand off to
+        // bisection instead of taking a wild step.
+        private const float MinSlope = 1e-6f;
+
+        // The fallback curve for an invalid x1/x2 — Tailwind's own default, and the same default
+        // StyleTransitionConfig.BezierX1..Y2 already carry, so a rejected value degrades to what an
+        // unconfigured Motion would have played anyway rather than an arbitrary hardcoded curve.
+        private const float DefaultX1 = 0.4f;
+        private const float DefaultY1 = 0f;
+        private const float DefaultX2 = 0.2f;
+        private const float DefaultY2 = 1f;
+
+        // Evaluate runs on every tick of a running tween (up to 60/sec), so a per-call warning would spam the
+        // console for the whole animation instead of surfacing the misconfiguration once. Reset alongside every
+        // other subsystem's warn-once state on domain reload / play mode entry.
+        private static bool s_warnedInvalidControlPoints;
+
+#if UNITY_EDITOR
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+        private static void ResetWarnOnceState() => s_warnedInvalidControlPoints = false;
+#endif
+
+        /// <summary>
+        /// Maps a normalized progress <paramref name="t"/> in [0,1] to its eased output. Endpoints short-circuit
+        /// (t&lt;=0 -&gt; 0, t&gt;=1 -&gt; 1); the identity curve (x1==y1 &amp;&amp; x2==y2, e.g. the linear
+        /// <c>cubic-bezier(0,0,1,1)</c>) returns <paramref name="t"/> directly.
+        /// </summary>
+        public static float Evaluate(float x1, float y1, float x2, float y2, float t)
+        {
+            if (t <= 0f)
+            {
+                return 0f;
+            }
+            if (t >= 1f)
+            {
+                return 1f;
+            }
+
+            // A CSS timing function must be monotone in time, so an x1/x2 outside [0,1] makes the WHOLE curve
+            // invalid — not just the offending coordinate — the same way a browser rejects the entire
+            // cubic-bezier() declaration rather than clamping one axis into range.
+            if (x1 < 0f || x1 > 1f || x2 < 0f || x2 > 1f)
+            {
+                WarnInvalidControlPoints(x1, x2);
+                x1 = DefaultX1;
+                y1 = DefaultY1;
+                x2 = DefaultX2;
+                y2 = DefaultY2;
+            }
+
+            // When the x and y control coordinates coincide the x-curve equals the y-curve, so solving x(s)=t and
+            // evaluating y(s) just returns t — the linear/identity fast path, and correct for any such curve.
+            if (x1 == y1 && x2 == y2)
+            {
+                return t;
+            }
+
+            var s = SolveForParam(x1, x2, t);
+            return SampleCurve(y1, y2, s);
+        }
+
+        private static void WarnInvalidControlPoints(float x1, float x2)
+        {
+            if (s_warnedInvalidControlPoints)
+            {
+                return;
+            }
+            s_warnedInvalidControlPoints = true;
+            FiberLogger.LogWarning("Bezier",
+                $"cubic-bezier control points x1={x1}, x2={x2} are outside [0,1], which is invalid — a timing " +
+                "function must be monotone in time. Falling back to the default curve, cubic-bezier(0.4, 0, 0.2, 1).");
+        }
+
+        // Bézier with endpoints fixed at 0 and 1 collapses to the cubic polynomial (a*s + b)*s*s + c*s, whose
+        // coefficients depend only on the two intermediate control coordinates. Shared by both axes.
+        private static float SampleCurve(float c1, float c2, float s)
+        {
+            var c = 3f * c1;
+            var b = 3f * (c2 - c1) - c;
+            var a = 1f - c - b;
+            return ((a * s + b) * s + c) * s;
+        }
+
+        private static float SampleDerivative(float c1, float c2, float s)
+        {
+            var c = 3f * c1;
+            var b = 3f * (c2 - c1) - c;
+            var a = 1f - c - b;
+            return (3f * a * s + 2f * b) * s + c;
+        }
+
+        // Inverts x(s)=targetX for the curve parameter s. Newton-Raphson seeded at s=targetX (a good guess since
+        // x is monotone over [0,1]); on a too-flat derivative it falls back to bisection, which is bounded rather
+        // than looping to float underflow so a pathological curve can never spin here forever.
+        private static float SolveForParam(float x1, float x2, float targetX)
+        {
+            var s = targetX;
+            for (var i = 0; i < NewtonIterations; i++)
+            {
+                var residual = SampleCurve(x1, x2, s) - targetX;
+                if (Mathf.Abs(residual) < ConvergenceEpsilon)
+                {
+                    return s;
+                }
+                var slope = SampleDerivative(x1, x2, s);
+                if (Mathf.Abs(slope) < MinSlope)
+                {
+                    break;
+                }
+                s -= residual / slope;
+            }
+
+            var low = 0f;
+            var high = 1f;
+            s = targetX;
+            for (var i = 0; i < BisectionIterations && low < high; i++)
+            {
+                var x = SampleCurve(x1, x2, s);
+                if (Mathf.Abs(x - targetX) < ConvergenceEpsilon)
+                {
+                    return s;
+                }
+                if (targetX > x)
+                {
+                    low = s;
+                }
+                else
+                {
+                    high = s;
+                }
+                s = (high - low) * 0.5f + low;
+            }
+            return s;
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Styling/CubicBezierEvaluator.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Styling/CubicBezierEvaluator.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: daf5358d9a134e6c9508d4717a57a8c4

--- a/Packages/com.velvet.core/Runtime/Styling/StyleAnimationScheduler.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleAnimationScheduler.cs
@@ -61,6 +61,16 @@ namespace Velvet
                 return;
             }
 
+            if (config.Type == TransitionType.Bezier)
+            {
+                // Same "reachable only in principle" caveat as the Spring branch above: a classic (non-variant)
+                // config carries no enter classes, so this no-ops to an immediate complete — kept for symmetry.
+                StartBezierVariant(element, config.EnterFromClasses, config.EnterToClasses, config.DelaySec,
+                    config.BezierX1, config.BezierY1, config.BezierX2, config.BezierY2, config.DurationSec,
+                    onComplete, additionalDelaySec, restingClasses: null, isExit: false);
+                return;
+            }
+
             // Classic transition enter: the to-classes are a TRANSIENT overlay (resting state = the element's
             // base classes), so they are removed on completion (variantMode: false). Per-property overrides are
             // wired only where a variant swap sets transition-property: all (see PlayVariantEnter / PlayExit); a
@@ -79,7 +89,8 @@ namespace Velvet
         {
             PlayVariantEnter(element, fromClasses, toClasses, config.DurationSec, config.Easing, config.DelaySec,
                 onComplete, additionalDelaySec, config.PropertyOverrides,
-                config.Type, config.Stiffness, config.Damping, config.Mass);
+                config.Type, config.Stiffness, config.Damping, config.Mass,
+                config.BezierX1, config.BezierY1, config.BezierX2, config.BezierY2);
         }
 
         // Variant-driven enter (initial → animate). Unlike PlayEnter, the
@@ -92,10 +103,13 @@ namespace Velvet
         // type/stiffness/damping/mass: the enclosing StyleTransitionConfig's spring knobs (Tween/100/10/1 by
         // default — the caller passes the config's own values through, since this overload takes the
         // already-unpacked timing primitives rather than the config itself).
+        // bezierX1/bezierY1/bezierX2/bezierY2: the config's cubic-bezier control points (Tailwind's own default
+        // curve by default), meaningful only when type is Bezier — passed through the same way.
         public void PlayVariantEnter(VisualElement? element, string[]? fromClasses, string[]? toClasses,
             float durationSec, EasingMode easing, float delaySec, Action? onComplete = null, float additionalDelaySec = 0f,
             IReadOnlyList<StylePropertyTransition>? propertyOverrides = null,
-            TransitionType type = TransitionType.Tween, float stiffness = 100f, float damping = 10f, float mass = 1f)
+            TransitionType type = TransitionType.Tween, float stiffness = 100f, float damping = 10f, float mass = 1f,
+            float bezierX1 = 0.4f, float bezierY1 = 0f, float bezierX2 = 0.2f, float bezierY2 = 1f)
         {
             if (element == null)
             {
@@ -106,6 +120,14 @@ namespace Velvet
             {
                 StartSpringVariant(element, fromClasses ?? System.Array.Empty<string>(), toClasses ?? System.Array.Empty<string>(),
                     delaySec, stiffness, damping, mass, onComplete, additionalDelaySec,
+                    restingClasses: null, isExit: false);
+                return;
+            }
+
+            if (type == TransitionType.Bezier)
+            {
+                StartBezierVariant(element, fromClasses ?? System.Array.Empty<string>(), toClasses ?? System.Array.Empty<string>(),
+                    delaySec, bezierX1, bezierY1, bezierX2, bezierY2, durationSec, onComplete, additionalDelaySec,
                     restingClasses: null, isExit: false);
                 return;
             }
@@ -287,6 +309,18 @@ namespace Velvet
                 // still eventually complete so the reconciler's ghost-removal re-render fires.
                 StartSpringVariant(element, config.ExitFromClasses, config.ExitToClasses, config.DelaySec,
                     config.Stiffness, config.Damping, config.Mass, onComplete, additionalDelaySec,
+                    restingClasses: restoreFromOnCancel ? config.ExitFromClasses : null,
+                    isExit: true);
+                return;
+            }
+
+            if (config.Type == TransitionType.Bezier)
+            {
+                // One curve drives both directions (no ExitBezier* fields — mirrors the spring reusing its single
+                // stiffness/damping/mass for the exit). Deferred-to-attach when off-panel, same as the spring exit.
+                StartBezierVariant(element, config.ExitFromClasses, config.ExitToClasses, config.DelaySec,
+                    config.BezierX1, config.BezierY1, config.BezierX2, config.BezierY2, config.DurationSec,
+                    onComplete, additionalDelaySec,
                     restingClasses: restoreFromOnCancel ? config.ExitFromClasses : null,
                     isExit: true);
                 return;
@@ -561,6 +595,98 @@ namespace Velvet
             }
         }
 
+        // Starts a bezier-driven variant enter/exit (StyleTransitionConfig.Type == Bezier). Structurally the
+        // spring's sibling (StartSpringVariant), not the tween's: it bypasses CSS transitions to sample an EXACT
+        // cubic-bezier curve, so the from→to class swap lands IMMEDIATELY at rest and a per-frame tick
+        // (StartBezierTick) drives the resolved channels via inline styles. The one difference from the spring is
+        // its completion is a fixed duration (BezierTweenDriver.Step reports done once elapsed reaches it) rather
+        // than a dynamic settle. x1/y1/x2/y2 are the CSS cubic-bezier control points; durationSec is the fixed
+        // tween length. See StartSpringVariant for the shared restingClasses / isExit / off-panel-defer contract.
+        private void StartBezierVariant(VisualElement element, string[] fromClasses, string[] toClasses,
+            float delaySec, float x1, float y1, float x2, float y2, float durationSec,
+            Action? onComplete, float additionalDelaySec, string[]? restingClasses, bool isExit)
+        {
+            var map = isExit ? _pendingExits : _pendingEnters;
+
+            // Read BEFORE the class swap lands (same rationale as StartSpringVariant): a translate axis the swap
+            // names on neither side rests at the element's own current inline translate rather than snapping to 0.
+            var restingTranslate = element.style.translate.value;
+            var plan = MotionSpringClassParser.Resolve(fromClasses, toClasses,
+                restingTranslate.x.value, restingTranslate.y.value);
+            // An invalid configuration (see ValidateBezierParameters) degrades exactly like an empty plan below:
+            // no state is built, so the shared "land the classes, complete immediately" branch handles it. A zero
+            // duration is one such case — it completes immediately with no warning, exactly like a Tween's None.
+            var state = ValidateBezierParameters(x1, y1, x2, y2, durationSec)
+                ? BezierTweenDriver.Create(plan, x1, y1, x2, y2, durationSec)
+                : null;
+
+            CancelPending(map, element, animateReversal: isExit);
+
+            StyleAnimationClassUtils.RemoveClasses(element, fromClasses);
+            StyleAnimationClassUtils.AddClasses(element, toClasses);
+
+            if (state == null)
+            {
+                onComplete?.Invoke();
+                return;
+            }
+
+            BezierTweenDriver.ApplyCurrentValues(element, state);
+
+            var pending = new PendingAnimation
+            {
+                FromClasses = fromClasses,
+                ToClasses = toClasses,
+                RestingClasses = restingClasses,
+                AnimatingElement = element,
+                Bezier = state,
+            };
+            pending.Shadows = CollectShadowsForCoFade(element, pending, isExit ? 1f : 0f);
+            state.OnSettled = onComplete;
+            map[element] = pending;
+
+            void ScheduleStart()
+            {
+                // Superseded before it ever got to start (a cancel-before-attach removed this exact pending).
+                if (!map.TryGetValue(element, out var current) || !ReferenceEquals(current, pending))
+                {
+                    return;
+                }
+                var totalDelayMs = (long)((delaySec + additionalDelaySec) * 1000);
+                if (totalDelayMs <= 0)
+                {
+                    StartBezierTick(element, pending);
+                    return;
+                }
+
+                // See StartSpringVariant for why a delayed start parks on the panel-root host (survives a
+                // transient reorder detach) rather than element.schedule.
+                var host = element.panel?.visualTree;
+                if (host == null)
+                {
+                    return;
+                }
+                var scheduled = host.schedule.Execute(() =>
+                {
+                    if (map.TryGetValue(element, out var stillCurrent) && ReferenceEquals(stillCurrent, pending))
+                    {
+                        StartBezierTick(element, pending);
+                    }
+                });
+                scheduled.ExecuteLater(totalDelayMs);
+                pending.ScheduledItem = scheduled;
+            }
+
+            if (element.panel != null)
+            {
+                ScheduleStart();
+            }
+            else
+            {
+                DeferUntilAttached(element, pending, ScheduleStart);
+            }
+        }
+
         // Starts the recurring spring tick on the panel root — the stable host, mirroring the shadow co-fade
         // tick's own rationale: a recurring item survives a keyed reorder's detach/re-attach of the animating
         // element on its own (UI Toolkit pauses and reschedules it automatically), but the panel root is
@@ -622,7 +748,55 @@ namespace Velvet
                 // when this subtree carries none, the common case).
                 EndShadowCoFade(pending);
                 MotionSpringDriver.ClearInlineOverrides(element, state);
-                ReapplySpringOwnedInlineValues(element);
+                ReapplyMotionOwnedInlineValues(element);
+                state.OnSettled?.Invoke();
+            }).Every(StyleAnimateDriver.TickMs);
+        }
+
+        // The bezier sibling of StartSpringTick: identical panel-root recurring-tick shape (same stable-host and
+        // same-clock deltaTime rationale — see StartSpringTick), stepping the fixed-duration bezier tween instead
+        // of the spring's physics and finalizing once BezierTweenDriver.Step reports elapsed has reached the
+        // duration rather than a dynamic settle. No-op if there is no host (guards rather than throws).
+        private void StartBezierTick(VisualElement element, PendingAnimation pending)
+        {
+            var state = pending.Bezier;
+            if (state == null)
+            {
+                return;
+            }
+            var host = element.panel?.visualTree;
+            if (host == null)
+            {
+                return;
+            }
+
+            StartShadowCoFadeTick(pending);
+
+            state.Tick = host.schedule.Execute((TimerState ts) =>
+            {
+                var dt = ts.deltaTime / 1000f;
+                if (dt <= 0f)
+                {
+                    return;
+                }
+
+                var completed = BezierTweenDriver.Step(element, state, dt);
+                if (!completed)
+                {
+                    return;
+                }
+
+                state.Tick?.Pause();
+                state.Tick = null;
+                // Probe both maps, not just the one this play started into: an exit-cancel reversal hand-off
+                // (CancelPending) can have MOVED it into _pendingEnters since then (same as the spring path).
+                if (!RemoveIfCurrent(_pendingExits, element, pending))
+                {
+                    RemoveIfCurrent(_pendingEnters, element, pending);
+                }
+                EndShadowCoFade(pending);
+                BezierTweenDriver.ClearInlineOverrides(element, state);
+                ReapplyMotionOwnedInlineValues(element);
                 state.OnSettled?.Invoke();
             }).Every(StyleAnimateDriver.TickMs);
         }
@@ -641,17 +815,19 @@ namespace Velvet
             return false;
         }
 
-        // MotionSpringDriver.ClearInlineOverrides nulls whichever style slots the spring wrote (opacity /
+        // A driver's ClearInlineOverrides (spring or bezier) nulls whichever style slots it wrote (opacity /
         // translate / scale / rotate), letting the cascade take back over — but a class the element still
         // carries can OWN one of those same slots as a resolver-applied inline value with no USS rule behind
         // it at all (translate-x-4, translate-x-[100px], opacity-[.5] — see MotionSpringClassParser's own scope
         // note: translate has no USS form whatsoever), so clearing the slot loses that value instead of letting
         // it fall back to a cascade rule that does not exist. DiffClassList only re-applies such a value when a
         // class REMOVAL triggers it; nothing removes a class here (the swap already landed its classes back
-        // when the spring started), so nobody else re-asserts it. Re-read the element's OWN current class list
+        // when the motion started), so nobody else re-asserts it. Re-read the element's OWN current class list
         // and re-apply whatever inline-resolved values it still names, mirroring
         // FiberWrapperElementAppliers.RestoreSharedInlineSlot's identical problem for the animate-* motions.
-        private static void ReapplySpringOwnedInlineValues(VisualElement element)
+        // Driver-agnostic (takes only the element, reads its own class list), so both the spring and bezier
+        // settle/cancel paths share it.
+        private static void ReapplyMotionOwnedInlineValues(VisualElement element)
         {
             List<string>? classes = null;
             foreach (var cls in element.GetClasses())
@@ -732,6 +908,35 @@ namespace Velvet
             FiberLogger.LogWarning("Spring",
                 $"Invalid spring parameters (stiffness={stiffness}, damping={damping}, mass={mass}). " +
                 "Expected finite, positive values for all three. Completing immediately instead of ticking forever.");
+            return false;
+        }
+
+        // Validates a bezier play's control points and duration. Duration is validated like the tween path
+        // (ValidateDuration), NOT ignored like a spring's: a zero duration is an intentional "no animation" (the
+        // same silent immediate-complete as StyleTransitionConfig.None), while a negative / out-of-range duration
+        // or a non-finite control point IS a misconfiguration and warns. A NaN/Infinity control point would
+        // propagate into every inline style write (LerpUnclamped) and never reach a target, so the tick this
+        // drives would run forever and its completion callback — the only thing that removes a presence exit's
+        // ghost — would never fire. The control points' x range ([0,1], a monotone timing function) is validated
+        // downstream in CubicBezierEvaluator instead: it degrades an out-of-range value to the default curve
+        // rather than the forever-tick failure mode this method exists to catch, so it is not re-checked here.
+        private static bool ValidateBezierParameters(float x1, float y1, float x2, float y2, float durationSec)
+        {
+            if (durationSec == 0f)
+            {
+                return false;
+            }
+
+            if (float.IsFinite(x1) && float.IsFinite(y1) && float.IsFinite(x2) && float.IsFinite(y2)
+                && durationSec > 0f && durationSec <= MaxDurationSec)
+            {
+                return true;
+            }
+
+            FiberLogger.LogWarning("Bezier",
+                $"Invalid bezier parameters (x1={x1}, y1={y1}, x2={x2}, y2={y2}, duration={durationSec}). " +
+                $"Expected finite control points and 0 < duration <= {MaxDurationSec}. " +
+                "Completing immediately instead of ticking forever.");
             return false;
         }
 
@@ -918,7 +1123,32 @@ namespace Velvet
                         spring.Tick?.Pause();
                         spring.Tick = null;
                         MotionSpringDriver.ClearInlineOverrides(element, spring);
-                        ReapplySpringOwnedInlineValues(element);
+                        ReapplyMotionOwnedInlineValues(element);
+                    }
+                    return;
+                }
+
+                if (pending.Bezier != null)
+                {
+                    var bezier = pending.Bezier;
+                    if (!forTeardown && animateReversal && element.panel != null && bezier.Tick != null)
+                    {
+                        // Hand off to a reversal exactly like the spring branch above: freeze each channel at its
+                        // current sampled value, retarget it back toward its resting value, drop the original
+                        // completion, and move ownership into the enter map. Requires a tick that has actually
+                        // started (bezier.Tick != null) — a cancel that lands while still parked behind the delay
+                        // has no running tick to redirect and nothing would ever start one, so it finalizes below.
+                        BezierTweenDriver.Retarget(bezier);
+                        bezier.OnSettled = null;
+                        CancelPending(_pendingEnters, element);
+                        _pendingEnters[element] = pending;
+                    }
+                    else
+                    {
+                        bezier.Tick?.Pause();
+                        bezier.Tick = null;
+                        BezierTweenDriver.ClearInlineOverrides(element, bezier);
+                        ReapplyMotionOwnedInlineValues(element);
                     }
                     return;
                 }
@@ -1022,7 +1252,15 @@ namespace Velvet
                     // a spring entry, which never touches transition-* styles or rents a TimeValue list).
                     pending.Spring.Tick?.Pause();
                     MotionSpringDriver.ClearInlineOverrides(element, pending.Spring);
-                    ReapplySpringOwnedInlineValues(element);
+                    ReapplyMotionOwnedInlineValues(element);
+                }
+                if (pending.Bezier != null)
+                {
+                    // A hard stop, no reversal (same as the spring branch above; the tween-only clears below are
+                    // no-ops for a bezier entry, which never touches transition-* styles or rents a TimeValue list).
+                    pending.Bezier.Tick?.Pause();
+                    BezierTweenDriver.ClearInlineOverrides(element, pending.Bezier);
+                    ReapplyMotionOwnedInlineValues(element);
                 }
                 ClearTransitionStyles(element);
                 ReturnDurationList(pending.DurationList);
@@ -1234,6 +1472,9 @@ namespace Velvet
             // as a field here — a spring's exit-cancel hand-off can MOVE it from one to the other, and the
             // settled tick just probes both (see RemoveIfCurrent) rather than keeping that choice in sync.
             public MotionSpringState? Spring;
+            // Non-null for a bezier-driven entry (StartBezierVariant) — the bezier sibling of Spring. Mutually
+            // exclusive with it per play (which one is set depends on config.Type); both null for a plain tween.
+            public BezierTweenState? Bezier;
         }
 
     }

--- a/Packages/com.velvet.core/Runtime/Styling/StyleTransitionConfig.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleTransitionConfig.cs
@@ -35,8 +35,9 @@ namespace Velvet
 
         /// <summary>
         /// Selects the animation model: a USS <c>transition-*</c> class swap (<see cref="TransitionType.Tween"/>,
-        /// the default) or a physics-integrated spring (<see cref="TransitionType.Spring"/>). See
-        /// <see cref="TransitionType"/> for the full contract, including what a spring does and does not animate.
+        /// the default), a physics-integrated spring (<see cref="TransitionType.Spring"/>), or a fixed-duration
+        /// tween whose easing is an EXACT numeric cubic-bezier curve (<see cref="TransitionType.Bezier"/>). See
+        /// <see cref="TransitionType"/> for the full contract, including what each does and does not animate.
         /// </summary>
         /// <remarks>Equivalent to setting Framer Motion's <c>transition.type</c> to <c>"tween"</c> / <c>"spring"</c>
         /// for users migrating from Framer Motion — except Velvet defaults to <c>Tween</c> where Framer defaults
@@ -62,10 +63,39 @@ namespace Velvet
         public float Mass { get; init; } = 1f;
 
         /// <summary>
+        /// First control point's X (only meaningful when <see cref="Type"/> is <see cref="TransitionType.Bezier"/>).
+        /// CSS <c>cubic-bezier(x1,y1,x2,y2)</c> parameter order. X must stay in [0,1] (a timing function must be
+        /// monotone in time); a value outside that range is invalid per the <c>cubic-bezier()</c> spec and
+        /// degrades to the default curve below with a one-shot warning, rather than being silently clamped.
+        /// Defaults to Tailwind's own default curve, <c>cubic-bezier(0.4, 0, 0.2, 1)</c> — the exact curve the
+        /// bundled USS only approximates with the <c>ease-in-out</c> keyword.
+        /// </summary>
+        public float BezierX1 { get; init; } = 0.4f;
+
+        /// <summary>
+        /// First control point's Y (only meaningful when <see cref="Type"/> is <see cref="TransitionType.Bezier"/>).
+        /// Left unclamped so an overshoot/anticipate curve is preserved. See <see cref="BezierX1"/>.
+        /// </summary>
+        public float BezierY1 { get; init; } = 0f;
+
+        /// <summary>
+        /// Second control point's X (only meaningful when <see cref="Type"/> is <see cref="TransitionType.Bezier"/>).
+        /// Must stay in [0,1]. See <see cref="BezierX1"/>.
+        /// </summary>
+        public float BezierX2 { get; init; } = 0.2f;
+
+        /// <summary>
+        /// Second control point's Y (only meaningful when <see cref="Type"/> is <see cref="TransitionType.Bezier"/>).
+        /// Left unclamped so an overshoot/anticipate curve is preserved. See <see cref="BezierX1"/>.
+        /// </summary>
+        public float BezierY2 { get; init; } = 1f;
+
+        /// <summary>
         /// Animation duration (seconds). Applied as the inline transition-duration style.
         /// Ignored when <see cref="Type"/> is <see cref="TransitionType.Spring"/>: a spring's settle time is
         /// decided entirely by <see cref="Stiffness"/> / <see cref="Damping"/> / <see cref="Mass"/>, not a fixed
-        /// duration.
+        /// duration. For <see cref="TransitionType.Bezier"/> it IS the (fixed) duration, exactly as for a plain
+        /// tween — only the easing sampling differs.
         /// </summary>
         public float DurationSec { get; init; }
 
@@ -73,13 +103,18 @@ namespace Velvet
         /// Easing mode. Applied as the inline transition-timing-function style.
         /// Defaults to EaseOut (for enter). Presets in StyleTransition.cs configure enter/exit easing separately.
         /// Ignored when <see cref="Type"/> is <see cref="TransitionType.Spring"/>: the physics integration IS the
-        /// curve.
+        /// curve. Also ignored when <see cref="Type"/> is <see cref="TransitionType.Bezier"/>: the
+        /// <see cref="BezierX1"/>/<see cref="BezierY1"/>/<see cref="BezierX2"/>/<see cref="BezierY2"/> control
+        /// points ARE the curve (an exact numeric one no <c>EasingMode</c> keyword can express).
         /// </summary>
         public EasingMode Easing { get; init; } = EasingMode.EaseOut;
 
         /// <summary>
         /// Easing mode for exit. When null, <see cref="Easing"/> is reused.
         /// The presets in StyleTransition.cs typically use EaseOut for enter and EaseIn for exit.
+        /// Ignored when <see cref="Type"/> is <see cref="TransitionType.Spring"/> or
+        /// <see cref="TransitionType.Bezier"/>: like a spring's single stiffness/damping/mass, one bezier curve
+        /// drives BOTH directions — there is no separate exit curve.
         /// </summary>
         public EasingMode? ExitEasing { get; init; }
 
@@ -103,10 +138,11 @@ namespace Velvet
         /// all (a variant-driven enter, or an exit driven by a <c>variants</c> + <c>exit</c> label) — a preset
         /// transition's own USS-declared transition-property is untouched. Null (default) preserves today's
         /// behavior unchanged.
-        /// Not read when <see cref="Type"/> is <see cref="TransitionType.Spring"/>: a spring drives every animated
-        /// channel with the SAME <see cref="Stiffness"/> / <see cref="Damping"/> / <see cref="Mass"/> — there is no
-        /// per-property override of the spring model itself (only <see cref="TransitionType.Tween"/>'s per-property
-        /// duration/easing/delay can be overridden this way).
+        /// Not read when <see cref="Type"/> is <see cref="TransitionType.Spring"/> or
+        /// <see cref="TransitionType.Bezier"/>: both drive every animated channel with the SAME curve — a spring's
+        /// <see cref="Stiffness"/> / <see cref="Damping"/> / <see cref="Mass"/>, a bezier's four control points —
+        /// so there is no per-property override of the model itself (only <see cref="TransitionType.Tween"/>'s
+        /// per-property duration/easing/delay can be overridden this way).
         /// </summary>
         public IReadOnlyList<StylePropertyTransition>? PropertyOverrides { get; init; }
 
@@ -205,6 +241,10 @@ namespace Velvet
                 Stiffness = Stiffness,
                 Damping = Damping,
                 Mass = Mass,
+                BezierX1 = BezierX1,
+                BezierY1 = BezierY1,
+                BezierX2 = BezierX2,
+                BezierY2 = BezierY2,
                 // Class names are identical, so share the parsed arrays (avoids re-parsing).
                 _enterFromClasses = _enterFromClasses,
                 _enterToClasses = _enterToClasses,
@@ -239,6 +279,10 @@ namespace Velvet
                 Stiffness = Stiffness,
                 Damping = Damping,
                 Mass = Mass,
+                BezierX1 = BezierX1,
+                BezierY1 = BezierY1,
+                BezierX2 = BezierX2,
+                BezierY2 = BezierY2,
             };
         }
 
@@ -306,6 +350,22 @@ namespace Velvet
         /// plain classes, just without a tween/spring transition on them).
         /// </summary>
         Spring,
+
+        /// <summary>
+        /// A fixed-duration tween like <see cref="Tween"/>, but with its easing sampled from an EXACT numeric
+        /// <c>cubic-bezier(</c><see cref="StyleTransitionConfig.BezierX1"/>, <see cref="StyleTransitionConfig.BezierY1"/>,
+        /// <see cref="StyleTransitionConfig.BezierX2"/>, <see cref="StyleTransitionConfig.BezierY2"/><c>)</c> curve
+        /// instead of one of UI Toolkit's five <c>EasingMode</c> keywords (which cannot express an arbitrary
+        /// cubic-bezier). Like <see cref="Spring"/>, this cannot be expressed by CSS/USS transitions, so it is
+        /// driven by a per-frame tick that writes inline styles directly — and so shares the spring's channel
+        /// scope EXACTLY: only OPACITY and the transform trio (translate x/y in pixels, uniform scale, rotate
+        /// degrees) are animated; everything else applies as a plain class with no tween. One curve drives BOTH
+        /// enter and exit (there is no separate exit curve, mirroring the spring's single stiffness/damping/mass),
+        /// and <see cref="StyleTransitionConfig.PropertyOverrides"/> is not read (no per-property curve). A zero
+        /// <see cref="StyleTransitionConfig.DurationSec"/> completes immediately with no animation, exactly like a
+        /// zero-duration <see cref="Tween"/>.
+        /// </summary>
+        Bezier,
     }
 
     /// <summary>

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/BezierConfigValidationTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/BezierConfigValidationTests.cs
@@ -1,0 +1,78 @@
+using System.Text.RegularExpressions;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using UnityEngine.UIElements;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins validation of user-supplied bezier parameters, mirroring the spring path's guard: a non-finite
+    /// control point would propagate into every inline style write and never reach the target, so the tick this
+    /// drives would run forever and its completion callback — the only thing that removes a presence exit's ghost
+    /// — would never fire. A negative / out-of-range duration is likewise a misconfiguration. Both must warn and
+    /// complete immediately. A ZERO duration, by contrast, is an intentional "no animation" (like
+    /// <c>StyleTransitionConfig.None</c>) and must complete silently — NUnit's strict LogAssert mode fails on any
+    /// unexpected log, so the absence of a <c>LogAssert.Expect</c> in that case also pins "no warning".
+    /// </summary>
+    [TestFixture]
+    internal sealed class BezierConfigValidationTests
+    {
+        [Test]
+        public void Given_ANaNBezierControlPoint_When_AVariantEnterPlays_Then_ItWarnsAndCompletesImmediately()
+        {
+            // Arrange
+            var scheduler = new StyleAnimationScheduler();
+            var element = new VisualElement();
+            var completed = false;
+            LogAssert.Expect(LogType.Warning, new Regex("[Bb]ezier"));
+
+            // Act — a NaN control point would propagate NaN into every style write.
+            scheduler.PlayVariantEnter(element, new[] { "opacity-0" }, new[] { "opacity-100" },
+                0.3f, EasingMode.Linear, 0f, onComplete: () => completed = true,
+                additionalDelaySec: 0f, propertyOverrides: null,
+                type: TransitionType.Bezier, bezierX1: float.NaN, bezierY1: 0f, bezierX2: 0.2f, bezierY2: 1f);
+
+            // Assert — the play degrades to an immediate completion instead of a forever-tick.
+            Assert.That(completed, Is.True);
+        }
+
+        [Test]
+        public void Given_ANegativeBezierDuration_When_AVariantEnterPlays_Then_ItWarnsAndCompletesImmediately()
+        {
+            // Arrange
+            var scheduler = new StyleAnimationScheduler();
+            var element = new VisualElement();
+            var completed = false;
+            LogAssert.Expect(LogType.Warning, new Regex("[Bb]ezier"));
+
+            // Act — a negative duration is out of the accepted range (unlike a zero, which is intentional).
+            scheduler.PlayVariantEnter(element, new[] { "opacity-0" }, new[] { "opacity-100" },
+                -1f, EasingMode.Linear, 0f, onComplete: () => completed = true,
+                additionalDelaySec: 0f, propertyOverrides: null,
+                type: TransitionType.Bezier, bezierX1: 0.4f, bezierY1: 0f, bezierX2: 0.2f, bezierY2: 1f);
+
+            // Assert
+            Assert.That(completed, Is.True);
+        }
+
+        [Test]
+        public void Given_AZeroBezierDuration_When_AVariantEnterPlays_Then_ItCompletesImmediatelyWithoutWarning()
+        {
+            // Arrange — no LogAssert.Expect: a zero duration is an intentional no-animation, so any warning here
+            // would fail the test under NUnit's strict LogAssert mode.
+            var scheduler = new StyleAnimationScheduler();
+            var element = new VisualElement();
+            var completed = false;
+
+            // Act — a zero duration degrades exactly like StyleTransitionConfig.None: silent immediate complete.
+            scheduler.PlayVariantEnter(element, new[] { "opacity-0" }, new[] { "opacity-100" },
+                0f, EasingMode.Linear, 0f, onComplete: () => completed = true,
+                additionalDelaySec: 0f, propertyOverrides: null,
+                type: TransitionType.Bezier, bezierX1: 0.4f, bezierY1: 0f, bezierX2: 0.2f, bezierY2: 1f);
+
+            // Assert
+            Assert.That(completed, Is.True);
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/BezierConfigValidationTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/BezierConfigValidationTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 25898e96da2a41a486103810b091836b

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/BezierTweenDriverTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/BezierTweenDriverTests.cs
@@ -1,0 +1,191 @@
+using NUnit.Framework;
+using UnityEngine.UIElements;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins the bezier-driven variant enter/exit (<c>StyleTransitionConfig.Type == Bezier</c>): the from→to class
+    /// swap lands at rest IMMEDIATELY (no CSS-transition-triggering frame boundary), the per-frame tick
+    /// (<see cref="BezierTweenDriver.Step"/>) moves the inline style along the exact cubic-bezier curve and
+    /// reports done once elapsed reaches the fixed duration, and an exit-cancel retarget
+    /// (<see cref="BezierTweenDriver.Retarget"/>) restarts a fresh full-duration reversal from the current value.
+    /// </summary>
+    /// <remarks>
+    /// Panel-free by design, exactly like <see cref="MotionSpringDriverTests"/>: the scheduler's bezier path never
+    /// reads <c>resolvedStyle</c> (numeric from/to values come from <see cref="MotionSpringClassParser"/>'s
+    /// class-name parsing), and the recurring tick it registers needs a live panel clock the EditMode PlayerLoop
+    /// never drives — so the tick's own math is exercised by calling <see cref="BezierTweenDriver.Step"/> directly
+    /// in a loop. GWT, one assert per case (Assume for preconditions).
+    /// </remarks>
+    [TestFixture]
+    internal sealed class BezierTweenDriverTests
+    {
+        private const float FixedDeltaSec = 1f / 60f;
+
+        // Tailwind's own default curve, cubic-bezier(0.4,0,0.2,1).
+        private const float X1 = 0.4f;
+        private const float Y1 = 0f;
+        private const float X2 = 0.2f;
+        private const float Y2 = 1f;
+
+        [Test]
+        public void Given_ABezierVariantEnter_When_Started_Then_ClassesLandAtRestWithInlineOpacityAtTheFromValue()
+        {
+            // Arrange — the element already carries the resting (to) class, matching PlayVariantEnter's
+            // precondition (the factory / reconciler create it with variants[animate] applied before calling this).
+            var scheduler = new StyleAnimationScheduler();
+            var element = new VisualElement();
+            element.AddToClassList("opacity-100");
+
+            // Act — a bezier enter from "hidden" (opacity-0) to the already-applied "visible" (opacity-100).
+            scheduler.PlayVariantEnter(element, fromClasses: new[] { "opacity-0" }, toClasses: new[] { "opacity-100" },
+                durationSec: 0.3f, easing: EasingMode.EaseOut, delaySec: 0f,
+                type: TransitionType.Bezier, bezierX1: X1, bezierY1: Y1, bezierX2: X2, bezierY2: Y2);
+
+            // Assert — the class swap resolved immediately (opacity-100 present, opacity-0 never added), and the
+            // inline style shows the FROM pose synchronously so the element does not flash at the resting value.
+            Assert.That(
+                (element.ClassListContains("opacity-100"), element.ClassListContains("opacity-0"), element.style.opacity.value),
+                Is.EqualTo((true, false, 0f)));
+        }
+
+        [Test]
+        public void Given_ABezierDrivenOpacityChannel_When_SteppedRepeatedly_Then_TheInlineOpacityMovesTowardTheTarget()
+        {
+            // Arrange — an opacity bezier starting at 0, heading to 1 over a full second (so neither sample below
+            // has reached the end yet).
+            var element = new VisualElement();
+            var plan = MotionSpringClassParser.Resolve(new[] { "opacity-0" }, new[] { "opacity-100" });
+            var state = BezierTweenDriver.Create(plan, X1, Y1, X2, Y2, durationSec: 1f);
+            Assume.That(state, Is.Not.Null, "Precondition: the plan resolves an opacity channel");
+            BezierTweenDriver.ApplyCurrentValues(element, state!);
+            Assume.That(element.style.opacity.value, Is.EqualTo(0f), "Precondition: starts at the from-value");
+
+            // Act — a handful of early ticks, then many more later ticks.
+            for (var i = 0; i < 5; i++)
+            {
+                BezierTweenDriver.Step(element, state!, FixedDeltaSec);
+            }
+            var earlyOpacity = element.style.opacity.value;
+            for (var i = 0; i < 40; i++)
+            {
+                BezierTweenDriver.Step(element, state!, FixedDeltaSec);
+            }
+            var laterOpacity = element.style.opacity.value;
+
+            // Assert — opacity has moved further toward the target (1) as more ticks run.
+            Assert.That(laterOpacity, Is.GreaterThan(earlyOpacity));
+        }
+
+        [Test]
+        public void Given_ABezierDrivenOpacityChannel_When_SteppedUntilElapsedReachesDuration_Then_TheOpacityRestsExactlyAtTheTarget()
+        {
+            // Arrange
+            var element = new VisualElement();
+            var plan = MotionSpringClassParser.Resolve(new[] { "opacity-0" }, new[] { "opacity-100" });
+            var state = BezierTweenDriver.Create(plan, X1, Y1, X2, Y2, durationSec: 0.3f);
+            Assume.That(state, Is.Not.Null, "Precondition: the plan resolves an opacity channel");
+            BezierTweenDriver.ApplyCurrentValues(element, state!);
+
+            // Act — step until elapsed reaches the fixed duration (the cap only guards against a regression that
+            // never completes).
+            var completed = false;
+            for (var i = 0; i < 600 && !completed; i++)
+            {
+                completed = BezierTweenDriver.Step(element, state!, FixedDeltaSec);
+            }
+            Assume.That(completed, Is.True, "Precondition: the tween completed within the tick budget");
+
+            // Assert — the t>=1 early-return is exact, so the value rests EXACTLY at the target (tighter than a
+            // spring's convergence-based settle).
+            Assert.That(element.style.opacity.value, Is.EqualTo(1f));
+        }
+
+        [Test]
+        public void Given_ASettledBezierChannel_When_InlineOverridesCleared_Then_TheOpacityStyleIsRemoved()
+        {
+            // Arrange — run the tween to completion first (Assume guards the precondition).
+            var element = new VisualElement();
+            var plan = MotionSpringClassParser.Resolve(new[] { "opacity-0" }, new[] { "opacity-100" });
+            var state = BezierTweenDriver.Create(plan, X1, Y1, X2, Y2, durationSec: 0.3f);
+            Assume.That(state, Is.Not.Null, "Precondition: the plan resolves an opacity channel");
+            BezierTweenDriver.ApplyCurrentValues(element, state!);
+            var completed = false;
+            for (var i = 0; i < 600 && !completed; i++)
+            {
+                completed = BezierTweenDriver.Step(element, state!, FixedDeltaSec);
+            }
+            Assume.That(completed, Is.True, "Precondition: the tween completed within the tick budget");
+
+            // Act — the scheduler calls this on completion so the resting classes' own opacity takes back over.
+            BezierTweenDriver.ClearInlineOverrides(element, state!);
+
+            // Assert
+            Assert.That(element.style.opacity.keyword, Is.EqualTo(StyleKeyword.Null));
+        }
+
+        [Test]
+        public void Given_ABezierChannelMidExit_When_Retargeted_Then_ItHeadsBackTowardTheValueItStartedFrom()
+        {
+            // Arrange — an exit-shaped channel: starts at the resting value (1, opaque) and heads to the exit
+            // value (0). A few ticks in, it is partway there but not yet done.
+            var element = new VisualElement();
+            var plan = MotionSpringClassParser.Resolve(new[] { "opacity-100" }, new[] { "opacity-0" });
+            var state = BezierTweenDriver.Create(plan, X1, Y1, X2, Y2, durationSec: 1f);
+            Assume.That(state, Is.Not.Null, "Precondition: the plan resolves an opacity channel");
+            BezierTweenDriver.ApplyCurrentValues(element, state!);
+            for (var i = 0; i < 5; i++)
+            {
+                BezierTweenDriver.Step(element, state!, FixedDeltaSec);
+            }
+            Assume.That(state!.Opacity!.To, Is.EqualTo(0f), "Precondition: heading toward the exit value");
+
+            // Act — an exit-cancel (the key re-entered mid-exit): retarget back toward the resting value.
+            BezierTweenDriver.Retarget(state!);
+
+            // Assert — the channel's goal flipped to the value it originally started from (its RestingTarget).
+            Assert.That(state!.Opacity!.To, Is.EqualTo(1f));
+        }
+
+        [Test]
+        public void Given_ABezierChannelMidExit_When_Retargeted_Then_ElapsedResetsToZero()
+        {
+            // Arrange — pins the "fresh full-duration reversal" design decision explicitly (no spring analog):
+            // a retarget restarts the clock rather than replaying time in reverse.
+            var element = new VisualElement();
+            var plan = MotionSpringClassParser.Resolve(new[] { "opacity-100" }, new[] { "opacity-0" });
+            var state = BezierTweenDriver.Create(plan, X1, Y1, X2, Y2, durationSec: 1f);
+            Assume.That(state, Is.Not.Null, "Precondition: the plan resolves an opacity channel");
+            BezierTweenDriver.ApplyCurrentValues(element, state!);
+            for (var i = 0; i < 5; i++)
+            {
+                BezierTweenDriver.Step(element, state!, FixedDeltaSec);
+            }
+            Assume.That(state!.ElapsedSec, Is.GreaterThan(0f), "Precondition: the forward tween has advanced");
+
+            // Act
+            BezierTweenDriver.Retarget(state!);
+
+            // Assert — the reversal starts from a clean clock.
+            Assert.That(state!.ElapsedSec, Is.EqualTo(0f));
+        }
+
+        [Test]
+        public void Given_AnOvershootBezierCurve_When_SteppedPartway_Then_TheInlineValueExceedsTheTargetMomentarily()
+        {
+            // Arrange — an overshoot curve (y1 past 1) driving opacity 0→1. This is the regression pin that
+            // would catch someone substituting Mathf.Lerp for Mathf.LerpUnclamped: a clamp would silently flatten
+            // the overshoot and this assert would go RED.
+            var element = new VisualElement();
+            var plan = MotionSpringClassParser.Resolve(new[] { "opacity-0" }, new[] { "opacity-100" });
+            var state = BezierTweenDriver.Create(plan, 0.34f, 1.56f, 0.64f, 1f, durationSec: 1f);
+            Assume.That(state, Is.Not.Null, "Precondition: the plan resolves an opacity channel");
+
+            // Act — advance to 60% of the duration, where the overshoot curve is already past its target.
+            BezierTweenDriver.Step(element, state!, 0.6f);
+
+            // Assert — the inline value momentarily exceeds the target (1), i.e. it actually overshoots.
+            Assert.That(element.style.opacity.value, Is.GreaterThan(1f));
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/BezierTweenDriverTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/BezierTweenDriverTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: baa2f35da598443ba043f8d6403fc6b6

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/CubicBezierEvaluatorTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/CubicBezierEvaluatorTests.cs
@@ -1,0 +1,146 @@
+using System.Reflection;
+using System.Text.RegularExpressions;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins the pure CSS <c>cubic-bezier(x1,y1,x2,y2)</c> evaluation (<see cref="CubicBezierEvaluator.Evaluate"/>):
+    /// the boundary clamps, the linear/identity fast path, an exact front-loaded reference point that a keyword
+    /// easing could not reproduce, an unclamped overshoot, solver monotonicity, and the out-of-range x1/x2
+    /// reject-and-fall-back-to-default-curve path (with its one-shot warning). Panel-free by design — the
+    /// evaluator is pure math with no <c>VisualElement</c>/panel dependency.
+    /// </summary>
+    /// <remarks>
+    /// The reference midpoint (0.7756) was computed independently with a Python implementation of the same
+    /// WebKit UnitBezier Newton/bisection algorithm every browser's <c>cubic-bezier()</c> is built on. GWT, one
+    /// assert per case (Assume for preconditions). The warn-once static is reset before/after every test
+    /// (reflection, mirroring DropShadowBakeTests) so the out-of-range cases stay deterministic regardless of
+    /// run order or of another fixture having already tripped the same one-shot flag.
+    /// </remarks>
+    [TestFixture]
+    internal sealed class CubicBezierEvaluatorTests
+    {
+        private const BindingFlags Priv = BindingFlags.NonPublic | BindingFlags.Static;
+        private static readonly MethodInfo ResetWarnOnceMethod =
+            typeof(CubicBezierEvaluator).GetMethod("ResetWarnOnceState", Priv);
+
+        [SetUp]
+        public void SetUp() => ResetWarnOnceMethod?.Invoke(null, null);
+
+        [TearDown]
+        public void TearDown() => ResetWarnOnceMethod?.Invoke(null, null);
+
+        [Test]
+        public void Given_TInputZero_When_Evaluated_Then_ReturnsZero()
+        {
+            // Arrange / Act — the lower boundary short-circuits regardless of the curve.
+            var output = CubicBezierEvaluator.Evaluate(0.4f, 0f, 0.2f, 1f, 0f);
+
+            // Assert
+            Assert.That(output, Is.EqualTo(0f));
+        }
+
+        [Test]
+        public void Given_TInputOne_When_Evaluated_Then_ReturnsOne()
+        {
+            // Arrange / Act — the upper boundary short-circuits regardless of the curve.
+            var output = CubicBezierEvaluator.Evaluate(0.4f, 0f, 0.2f, 1f, 1f);
+
+            // Assert
+            Assert.That(output, Is.EqualTo(1f));
+        }
+
+        [Test]
+        public void Given_TheLinearIdentityCurve_When_EvaluatedAtAnArbitraryT_Then_TheOutputEqualsTheInput()
+        {
+            // Arrange / Act — cubic-bezier(0,0,1,1) is the identity curve: the fast path returns t directly.
+            var output = CubicBezierEvaluator.Evaluate(0f, 0f, 1f, 1f, 0.37f);
+
+            // Assert
+            Assert.That(output, Is.EqualTo(0.37f).Within(1e-4f));
+        }
+
+        [Test]
+        public void Given_TailwindsDefaultCurve_When_EvaluatedAtItsMidpoint_Then_ItFrontLoadsPastTheLinearMidpoint()
+        {
+            // Arrange / Act — Tailwind's own default curve, cubic-bezier(0.4,0,0.2,1). The whole reason this
+            // exists: at the temporal midpoint the eased progress is ~0.776, NOT the 0.5 the closest keyword
+            // (ease-in-out, symmetric) would give — an exact curve no EasingMode keyword can express.
+            var output = CubicBezierEvaluator.Evaluate(0.4f, 0f, 0.2f, 1f, 0.5f);
+
+            // Assert
+            Assert.That(output, Is.EqualTo(0.7756f).Within(0.001f));
+        }
+
+        [Test]
+        public void Given_AnOvershootCurve_When_EvaluatedPastItsPeak_Then_TheOutputExceedsOne()
+        {
+            // Arrange / Act — a back/anticipate curve whose control points push y past 1; the evaluator leaves
+            // y1/y2 unclamped, so the eased output genuinely overshoots its target mid-curve.
+            var output = CubicBezierEvaluator.Evaluate(0.34f, 1.56f, 0.64f, 1f, 0.6f);
+
+            // Assert
+            Assert.That(output, Is.GreaterThan(1f));
+        }
+
+        [Test]
+        public void Given_AMonotonicEaseCurve_When_EvaluatedAtIncreasingInputs_Then_TheOutputNeverDecreases()
+        {
+            // Arrange — a solver-robustness sweep (independent of any hand-computed value): a well-behaved ease
+            // curve must map increasing time to non-decreasing output across the whole range.
+            var nonDecreasing = true;
+            var previous = float.NegativeInfinity;
+
+            // Act — step-0.05 sweep folded into one boolean.
+            for (var t = 0f; t <= 1f + 1e-4f; t += 0.05f)
+            {
+                var output = CubicBezierEvaluator.Evaluate(0.4f, 0f, 0.2f, 1f, t);
+                if (output < previous - 1e-5f)
+                {
+                    nonDecreasing = false;
+                }
+                previous = output;
+            }
+
+            // Assert
+            Assert.That(nonDecreasing, Is.True);
+        }
+
+        [Test]
+        public void Given_AnX1AboveOne_When_Evaluated_Then_TheOutputMatchesTheDefaultCurveInsteadOfClamping()
+        {
+            // Arrange — an x1 above 1 is invalid (a timing function's x must stay monotone); silently clamping
+            // it to 1 would evaluate a DIFFERENT curve, cubic-bezier(1,0,0.2,1), not the default one. The
+            // reference is a valid call, so it logs nothing.
+            var expected = CubicBezierEvaluator.Evaluate(0.4f, 0f, 0.2f, 1f, 0.5f);
+            LogAssert.Expect(LogType.Warning, new Regex("[Bb]ezier"));
+
+            // Act
+            var output = CubicBezierEvaluator.Evaluate(2f, 0f, 0.2f, 1f, 0.5f);
+
+            // Assert
+            Assert.That(output, Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void Given_ASecondInvalidCall_When_Evaluated_Then_ItStaysSilentButStillFallsBack()
+        {
+            // Arrange — Evaluate runs on every tick of a running tween (up to 60/sec); the first invalid call
+            // consumes the one-shot warning so a whole animation's worth of subsequent ticks does not spam it.
+            // No LogAssert.Expect is registered for the second call below, so an unexpected repeat warning would
+            // fail this test under the project's strict LogAssert mode.
+            LogAssert.Expect(LogType.Warning, new Regex("[Bb]ezier"));
+            CubicBezierEvaluator.Evaluate(2f, 0f, 0.2f, 1f, 0.3f);
+            var expected = CubicBezierEvaluator.Evaluate(0.4f, 0f, 0.2f, 1f, 0.6f);
+
+            // Act
+            var output = CubicBezierEvaluator.Evaluate(2f, 0f, 0.2f, 1f, 0.6f);
+
+            // Assert — the fallback still applies even though the diagnostic stays silent the second time.
+            Assert.That(output, Is.EqualTo(expected));
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/CubicBezierEvaluatorTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/CubicBezierEvaluatorTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: fa23821e7c264ba7a0dcc17d9d1b3f90

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/StyleTransitionConfigBezierPassthroughTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/StyleTransitionConfigBezierPassthroughTests.cs
@@ -1,0 +1,56 @@
+using NUnit.Framework;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins that a custom bezier curve survives the config's copy builders unchanged. <see cref="StyleTransitionConfig.With"/>
+    /// and <see cref="StyleTransitionConfig.WithExitClasses"/> each rebuild the config through an object
+    /// initializer that must copy every knob; forgetting the four <c>Bezier*</c> fields there would silently reset
+    /// a caller's curve back to the default on every <c>.With(...)</c> — the highest-value regression pin against
+    /// that copy-paste-and-forget-one-field bug class.
+    /// </summary>
+    [TestFixture]
+    internal sealed class StyleTransitionConfigBezierPassthroughTests
+    {
+        // A deliberately non-default curve, so a reset back to the (0.4,0,0.2,1) default would be visible.
+        private static StyleTransitionConfig CustomBezier() => new()
+        {
+            Type = TransitionType.Bezier,
+            DurationSec = 0.3f,
+            BezierX1 = 0.11f,
+            BezierY1 = 0.22f,
+            BezierX2 = 0.33f,
+            BezierY2 = 0.44f,
+        };
+
+        [Test]
+        public void Given_ACustomBezierConfig_When_WithIsCalled_Then_TheCurveSurvivesUnchanged()
+        {
+            // Arrange
+            var config = CustomBezier();
+
+            // Act — With() only tunes the top-level timing; the curve must pass through untouched.
+            var result = config.With(durationSec: 0.5f);
+
+            // Assert
+            Assert.That(
+                (result.BezierX1, result.BezierY1, result.BezierX2, result.BezierY2),
+                Is.EqualTo((0.11f, 0.22f, 0.33f, 0.44f)));
+        }
+
+        [Test]
+        public void Given_ACustomBezierConfig_When_WithExitClassesIsCalled_Then_TheCurveSurvivesUnchanged()
+        {
+            // Arrange
+            var config = CustomBezier();
+
+            // Act — WithExitClasses() replaces only the exit class pair; the curve must pass through untouched.
+            var result = config.WithExitClasses("opacity-100", "opacity-0");
+
+            // Assert
+            Assert.That(
+                (result.BezierX1, result.BezierY1, result.BezierX2, result.BezierY2),
+                Is.EqualTo((0.11f, 0.22f, 0.33f, 0.44f)));
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/StyleTransitionConfigBezierPassthroughTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/StyleTransitionConfigBezierPassthroughTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 80b7e9d7d27f4227a9c593b544d897ba


### PR DESCRIPTION
## What
A third transition model — `StyleTransitionConfig { Type = TransitionType.Bezier, BezierX1, BezierY1, BezierX2, BezierY2 }` — samples an EXACT CSS `cubic-bezier(x1,y1,x2,y2)` curve every tick, instead of one of the five UITK `EasingMode` keywords (which cannot express an arbitrary numeric curve). Defaults to Tailwind's own `cubic-bezier(0.4, 0, 0.2, 1)`, the curve the bundled USS only approximates with the `ease-in-out` keyword.

## How
Sibling to the spring model: shares its channel scope (opacity + the translate/scale/rotate trio) and one-curve-drives-both-directions contract, but keeps a fixed `DurationSec`. A `BezierTweenDriver` samples `CubicBezierEvaluator` frame-by-frame through the panel-root scheduler. `BezierX1`/`BezierX2` outside `[0,1]` is invalid per the `cubic-bezier()` spec and falls back to the default curve with a one-shot warning, rather than being silently clamped.

## Tests
Pure `CubicBezierEvaluator` sampling + out-of-range fallback, bezier config validation, and driver lifecycle — all EditMode, RED/GREEN.

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)