### PR TITLE
feat(velvet): approximate skew-* descendant shear via per-child translate manipulator (#81)

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -15,6 +15,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   tween drives the filter parameters frame-by-frame; opt in with `transition-filter` (honoring `duration-*`
   and the easing longhand). Non-interpolable changes (a custom filter, or an ambiguous add/remove) and the
   off-panel / zero-duration cases fall back to an instant write.
+- `skew-x-*` / `skew-y-*` now approximate CSS `skewX()` / `skewY()`'s **descendant shear**, not only the
+  caster's own painted silhouette. UI Toolkit's transform has no shear, so each in-flow direct child is given
+  an inline `translate` that seats its centroid where the shear would carry it — the per-row counter-translate
+  a CSS author would otherwise hand-write, applied automatically. The seat re-runs on child add / remove /
+  reorder and as layout settles; it is exact at each child's centroid and piecewise-constant across the child
+  (a real shear also rotates it), so a child large relative to the frame reads slightly off at its far corners
+  and a nested transform on the child is not composed. Out-of-flow children (`.absolute`, a `PopLayout` exit
+  ghost, the filter bounds-spacer) hold no seat and are skipped, and a child's own static `translate-x-*` /
+  `translate-y-*` is preserved when the parent later loses its skew — including a translate the child acquires
+  only after it moves out of flow, which is released untouched rather than reset to its pre-shear value.
 
 ### Fixed
 

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberWrapperElementAppliers.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberWrapperElementAppliers.cs
@@ -109,6 +109,10 @@ namespace Velvet
             if (bound && has && binding.Spec.SourceX == winnerX && binding.Spec.SourceY == winnerY)
             {
                 SkewSilhouette.SyncStashOnPatch(element, binding, classesChanged);
+                // Re-seat the descendant-shear child translate unconditionally (not gated on classesChanged): a
+                // child add / remove / reorder leaves the caster's own skew tokens untouched, so the children
+                // must still re-seat even when this element's class list did not change.
+                SkewSilhouette.SyncChildTranslate(binding);
                 // Re-resolve the gradient only when the class list changed (an unchanged list cannot
                 // have changed the gradient); SetGradient is itself a no-op when the spec is unchanged.
                 if (classesChanged)
@@ -127,6 +131,8 @@ namespace Velvet
             {
                 binding.Spec = spec;
                 SkewSilhouette.SyncStashOnPatch(element, binding, classesChanged: true);
+                // The manipulator reads Spec live, so the just-changed angle re-seats the children here.
+                SkewSilhouette.SyncChildTranslate(binding);
                 SyncSkewGradient(element, binding, newClassNames);
                 SkewSilhouette.SetWantSpacer(element, binding, CarriesFilter(newClassNames), newClassNames);
                 element.MarkDirtyRepaint();

--- a/Packages/com.velvet.core/Runtime/Styling/SkewSilhouette.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/SkewSilhouette.cs
@@ -59,6 +59,12 @@ namespace Velvet
         // origin is shifted back into border-box space (see SilhouetteBoundsSpacer.BorderInset).
         public float BorderLeft;
         public float BorderTop;
+
+        // Approximates skewX/skewY's descendant shear: seats each in-flow direct child's centroid at its
+        // sheared position via an inline translate (UI Toolkit's transform has no shear, so children would
+        // otherwise stay axis-aligned inside the slanted frame). Owned here so every Detach path tears it down
+        // for free; reads Spec live each pass, so a spec change needs no separate notification.
+        public StyleSkewChildTranslateManipulator? ChildTranslate;
     }
 
     /// <summary>
@@ -77,10 +83,14 @@ namespace Velvet
     /// branch already catches).
     /// <para>
     /// Caveat — this paints ONLY the element's own silhouette; it is NOT a real transform, so the element's
-    /// layout box and its children stay axis-aligned and do NOT follow the lean (unlike CSS
-    /// <c>transform: skewX()</c>, which shears descendants too). UI Toolkit has no shear transform — only
-    /// position/rotation/scale — so children must be offset manually (e.g. a per-row <c>translate-x</c> by the
-    /// frame's centre-based shear) to seat them inside a slanted frame.
+    /// layout box stays axis-aligned (unlike CSS <c>transform: skewX()</c>, which shears descendants too). UI
+    /// Toolkit has no shear transform — only position/rotation/scale — so descendant shear is
+    /// APPROXIMATED: <see cref="StyleSkewChildTranslateManipulator"/> writes each in-flow direct child an
+    /// inline translate that seats its centroid where the shear would carry it (the counter-translate a CSS
+    /// author would hand-write per row, made automatic). The approximation is exact only at each child's
+    /// centroid and piecewise-constant across the child — a real shear also rotates it — so a child large
+    /// relative to the frame reads slightly off at its far corners, and a nested transform on the child is not
+    /// composed.
     /// </para>
     /// </remarks>
     internal static class SkewSilhouette
@@ -140,6 +150,10 @@ namespace Velvet
             // suppress now so there is not even a one-frame ghost. Off-panel with no inline value it bails
             // and the events above pick it up.
             binding.Face.TryStash(element);
+            // Seat the direct children's approximate descendant shear. AddManipulator synchronously runs the
+            // manipulator's Apply once (a no-op pre-layout — the geometry callback re-seats once size resolves).
+            binding.ChildTranslate = new StyleSkewChildTranslateManipulator(binding);
+            element.AddManipulator(binding.ChildTranslate);
             element.MarkDirtyRepaint();
             return binding;
         }
@@ -160,6 +174,13 @@ namespace Velvet
             if (binding.SuppressionApplied)
             {
                 binding.Face.Release(element);
+            }
+            // RemoveManipulator runs the manipulator's UnregisterCallbacksFromTarget → Clear, which restores the
+            // translate each child carried before the shear overwrite (so a static translate-x-* is not erased).
+            if (binding.ChildTranslate != null)
+            {
+                element.RemoveManipulator(binding.ChildTranslate);
+                binding.ChildTranslate = null;
             }
             DestroyGradientTex(binding);
             SilhouetteBoundsSpacer.Remove(element, ref binding.BoundsSpacer);
@@ -224,6 +245,11 @@ namespace Velvet
         // for the three cases (resolver overwrote us / USS color may have moved beneath the sentinel / current).
         public static void SyncStashOnPatch(VisualElement element, SkewBinding binding, bool classesChanged)
             => binding.Face.SyncOnPatch(element, classesChanged);
+
+        // Re-seats the direct children's approximate descendant shear from the reconciler, the panel-independent
+        // path that also covers a child add / remove / reorder when the caster's own box did not change size (so
+        // no GeometryChangedEvent fires). The manipulator's own signature guard makes a no-change call cheap.
+        public static void SyncChildTranslate(SkewBinding binding) => binding.ChildTranslate?.Apply();
 
         private static void Draw(MeshGenerationContext mgc, VisualElement ve, SkewBinding binding)
         {

--- a/Packages/com.velvet.core/Runtime/Styling/StyleSkewChildTranslateManipulator.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleSkewChildTranslateManipulator.cs
@@ -1,0 +1,265 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace Velvet
+{
+    // Approximates CSS skewX / skewY's descendant shear on a skewed caster's direct children. UI Toolkit's
+    // transform has no shear, so SkewSilhouette paints only the caster's own box sheared while its children
+    // stay axis-aligned; without compensation they float free of the slanted frame. This manipulator writes
+    // each in-flow child a translate that seats its CENTROID where the shear would carry it, using the same
+    // model SilhouetteBoundsSpacer.ShearedAabb documents: a point (x, y) maps to
+    // (x + (y - h/2)*tanX, y + (x - w/2)*tanY). The compensation is exact only at each child's centroid and
+    // piecewise-constant across the child (a real shear also rotates it), so a child large relative to the
+    // caster reads slightly off at its far corners. It is the manual counter-translate a CSS author would
+    // otherwise hand-write per row, made automatic.
+    //
+    // Owned by the caster's SkewBinding rather than a ReconcilerContext dictionary, so every
+    // SkewSilhouette.Detach path (pool reset, root disposal) tears it down for free. Lifecycle mirrors
+    // StyleGapManipulator: the caster's own AttachToPanelEvent / GeometryChangedEvent re-seat children as
+    // layout settles, and the reconciler re-runs Apply on patch (SkewSilhouette.SyncChildTranslate) so a child
+    // add / remove / reorder re-seats even when the caster's own box did not change size — the case that fires
+    // no GeometryChangedEvent.
+    //
+    // Unlike gap's layout-independent margin writes, the centroid math needs a real Yoga pass: pre-layout it
+    // no-ops (the same NaN / non-positive guard SkewSilhouette.Draw uses) and defers to the first geometry
+    // event. Out-of-flow children (StyleOutOfFlowChild) are skipped — which also excludes the caster's own
+    // SilhouetteBoundsSpacer and any PopLayout-pinned exit ghost, whose frozen position a translate would
+    // fight. While active the manipulator OWNS each direct child's translate slot: an explicit translate-x-*
+    // on such a child, or a live spring / drag write, is overwritten every Apply (the same limitation class as
+    // gap's ml-2 overwrite); a needs-its-own-translate child wants an inner wrapper. To make a STATIC
+    // translate-x-* survive losing the parent's skew, the child's own inline translate is CAPTURED before the
+    // first shear overwrite and written back on reset — GetClasses cannot recover it, since translate has no
+    // USS form and the reconciler applies translate-x-* inline without recording it in the class list. The
+    // capture is written back ONLY onto a child the manipulator still owns at reset: a child that has since gone
+    // out-of-flow, moved out of the container, or been recycled by the element pool for another node is released
+    // untouched, so a translate it legitimately acquired after leaving management is never clobbered by a stale
+    // capture. A child leaving the panel drops itself from tracking the instant it detaches, closing the window
+    // where the pool could reuse its instance while a stale capture was still keyed to it.
+    internal sealed class StyleSkewChildTranslateManipulator : Manipulator
+    {
+        private readonly SkewBinding _binding;
+
+        // Every child a shear translate was written to, mapped to the child's OWN translate captured just
+        // before the first overwrite. Unskew writes the captured value back onto a child the manipulator still
+        // owns, so its static translate-x-* is preserved rather than erased (a child with none was captured as
+        // Null); a child that has left management is dropped from here untouched instead.
+        private readonly Dictionary<VisualElement, StyleTranslate> _seated = new();
+
+        // Signature of the last successful Apply. Apply() early-returns when it is unchanged, so the
+        // GeometryChanged churn the manipulator's own writes provoke, and patches that touch nothing relevant,
+        // are no-ops.
+        private int _lastSignature;
+        private bool _hasSignature;
+
+        public StyleSkewChildTranslateManipulator(SkewBinding binding)
+        {
+            _binding = binding;
+        }
+
+        protected override void RegisterCallbacksOnTarget()
+        {
+            target.RegisterCallback<AttachToPanelEvent>(OnAttach);
+            target.RegisterCallback<GeometryChangedEvent>(OnGeometryChanged);
+            Apply();
+        }
+
+        protected override void UnregisterCallbacksFromTarget()
+        {
+            Clear();
+            target.UnregisterCallback<AttachToPanelEvent>(OnAttach);
+            target.UnregisterCallback<GeometryChangedEvent>(OnGeometryChanged);
+        }
+
+        private void OnAttach(AttachToPanelEvent evt)
+        {
+            // layout only becomes meaningful on a panel; force a re-seat once attached.
+            _hasSignature = false;
+            Apply();
+        }
+
+        private void OnGeometryChanged(GeometryChangedEvent evt) => Apply();
+
+        // The children are reconciled into (a ScrollView's contentContainer; else the caster itself).
+        private VisualElement? ChildContainer
+            => target == null ? null : FiberNodePatcher.GetChildContainer(target);
+
+        // Seats every in-flow child's centroid at its sheared position. Reads the caster's live skew off the
+        // shared binding (single source with SkewSilhouette.Draw). No-op pre-layout (deferred to the first
+        // geometry event) and when nothing relevant changed since the last pass.
+        public void Apply()
+        {
+            var container = ChildContainer;
+            if (container == null)
+            {
+                return;
+            }
+
+            // Measure the shear box in the SAME frame the children's layout is expressed in. For a ScrollView the
+            // children sit in contentContainer, offset several levels below the caster, so reading the box from
+            // the caster while reading child centroids relative to the container would mix two frames and seat
+            // every child against the wrong centre. For a plain element the container IS the caster.
+            var w = container.layout.width;
+            var h = container.layout.height;
+            if (w <= 0f || h <= 0f || float.IsNaN(w) || float.IsNaN(h))
+            {
+                return;
+            }
+
+            var tanX = Mathf.Tan(_binding.Spec.XDeg * Mathf.Deg2Rad);
+            var tanY = Mathf.Tan(_binding.Spec.YDeg * Mathf.Deg2Rad);
+
+            var signature = ComputeSignature(container, w, h, tanX, tanY);
+            if (_hasSignature && signature == _lastSignature)
+            {
+                return;
+            }
+
+            // Relinquish any tracked child the manipulator no longer owns before re-seating the rest.
+            DropUnmanaged(container);
+
+            var count = container.childCount;
+            for (var i = 0; i < count; i++)
+            {
+                var child = container[i];
+                // An out-of-flow child holds no seat in the slanted frame: the bounds-spacer, a PopLayout exit
+                // ghost (whose pinned position a translate would fight), or an app-authored .absolute child.
+                if (StyleOutOfFlowChild.IsOutOfFlow(child))
+                {
+                    continue;
+                }
+                var layout = child.layout;
+                if (float.IsNaN(layout.x) || float.IsNaN(layout.y)
+                    || float.IsNaN(layout.width) || float.IsNaN(layout.height))
+                {
+                    // A freshly added child not yet through a Yoga pass — seat it on the next geometry event.
+                    continue;
+                }
+                // Capture the child's own translate once, before the first overwrite, so unskew can restore it.
+                if (!_seated.ContainsKey(child))
+                {
+                    _seated[child] = child.style.translate;
+                    // A seated child leaving the panel drops itself from tracking before the element pool can
+                    // hand the instance to an unrelated node, so a later restore never lands a stale capture.
+                    child.RegisterCallback<DetachFromPanelEvent>(OnChildDetach);
+                }
+                var offset = ComputeOffset(
+                    layout.x + (layout.width * 0.5f), layout.y + (layout.height * 0.5f), w, h, tanX, tanY);
+                child.style.translate = new Translate(new Length(offset.x), new Length(offset.y));
+            }
+
+            _lastSignature = signature;
+            _hasSignature = true;
+        }
+
+        // The sheared displacement of a child centroid on a caster of the given box and shear tangents, from
+        // the model SilhouetteBoundsSpacer.ShearedAabb documents: x' = x + (y - h/2)*tanX, y' = y + (x - w/2)*tanY.
+        // Pure and panel-independent so the seat math is unit-testable without a layout pass.
+        internal static Vector2 ComputeOffset(float childCenterX, float childCenterY,
+            float containerWidth, float containerHeight, float tanX, float tanY)
+        {
+            var dx = (childCenterY - (containerHeight * 0.5f)) * tanX;
+            var dy = (childCenterX - (containerWidth * 0.5f)) * tanY;
+            return new Vector2(dx, dy);
+        }
+
+        // Restores the captured translate onto every child the manipulator still owns, then stops tracking all.
+        // Invoked on unskew / detach. A child that has left management — gone out-of-flow, moved out of the
+        // container, or been pooled and reused for another node — is NOT written to: its present translate is
+        // legitimately its own (acquired after the manipulator relinquished it), so forcing the stale pre-shear
+        // capture back would clobber it. Only a still-seated in-flow child currently carries the shear write and
+        // must get its own translate back.
+        private void Clear()
+        {
+            var container = ChildContainer;
+            foreach (var pair in _seated)
+            {
+                if (IsManaged(pair.Key, container))
+                {
+                    pair.Key.style.translate = pair.Value;
+                }
+                pair.Key.UnregisterCallback<DetachFromPanelEvent>(OnChildDetach);
+            }
+            _seated.Clear();
+            _hasSignature = false;
+        }
+
+        // Drops every tracked child the manipulator no longer owns (out-of-flow now, or no longer a child of the
+        // container), without a write — for the same reason Clear skips them, the departed child's translate is
+        // its own now. Dropping also frees a re-seat to re-capture a fresh baseline should the child come back.
+        private void DropUnmanaged(VisualElement container)
+        {
+            List<VisualElement>? stale = null;
+            foreach (var pair in _seated)
+            {
+                if (!IsManaged(pair.Key, container))
+                {
+                    (stale ??= new List<VisualElement>()).Add(pair.Key);
+                }
+            }
+            if (stale != null)
+            {
+                foreach (var child in stale)
+                {
+                    Forget(child);
+                }
+            }
+        }
+
+        // A seated child leaving the panel is on its way to the element pool (or the whole tree is unmounting).
+        // Forget it now — without a write, since the pool scrubs translate on return — so the pool cannot hand
+        // the instance to an unrelated node while this manipulator still holds a stale capture keyed to it. The
+        // event trickles through the detaching subtree, so act only when this child is itself the one leaving.
+        private void OnChildDetach(DetachFromPanelEvent evt)
+        {
+            if (evt.currentTarget is VisualElement child && ReferenceEquals(evt.target, child))
+            {
+                Forget(child);
+            }
+        }
+
+        // Stops tracking a child and unhooks its detach callback.
+        private void Forget(VisualElement child)
+        {
+            if (_seated.Remove(child))
+            {
+                child.UnregisterCallback<DetachFromPanelEvent>(OnChildDetach);
+            }
+        }
+
+        // A child the manipulator currently owns: a direct in-flow child of the container. A child that has left
+        // the container or gone out-of-flow has been relinquished and its translate is its own.
+        private static bool IsManaged(VisualElement child, VisualElement? container)
+            => container != null && child.parent == container && !StyleOutOfFlowChild.IsOutOfFlow(child);
+
+        // Order-sensitive hash of everything the seat depends on: the caster box, both shear tangents, and each
+        // child's identity, in / out-of-flow state, and laid-out rect. Unlike gap's index-only signature the
+        // rect is included — a child that resizes in place shifts its centroid, so the compensation must change
+        // even though the child set did not.
+        private int ComputeSignature(VisualElement container, float w, float h, float tanX, float tanY)
+        {
+            unchecked
+            {
+                var hash = 17;
+                hash = (hash * 31) + w.GetHashCode();
+                hash = (hash * 31) + h.GetHashCode();
+                hash = (hash * 31) + tanX.GetHashCode();
+                hash = (hash * 31) + tanY.GetHashCode();
+                var count = container.childCount;
+                hash = (hash * 31) + count;
+                for (var i = 0; i < count; i++)
+                {
+                    var child = container[i];
+                    hash = (hash * 31) + System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode(child);
+                    hash = (hash * 31) + (StyleOutOfFlowChild.IsOutOfFlow(child) ? 1 : 0);
+                    var layout = child.layout;
+                    hash = (hash * 31) + layout.x.GetHashCode();
+                    hash = (hash * 31) + layout.y.GetHashCode();
+                    hash = (hash * 31) + layout.width.GetHashCode();
+                    hash = (hash * 31) + layout.height.GetHashCode();
+                }
+                return hash;
+            }
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Styling/StyleSkewChildTranslateManipulator.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleSkewChildTranslateManipulator.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3067377e49514bc0a2b2782483a15c90

--- a/Packages/com.velvet.core/Runtime/Styling/StyleSkewClass.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleSkewClass.cs
@@ -37,8 +37,11 @@ namespace Velvet
     // PARITY NOTE: CSS transform: skewX() shears the element AND its descendants. UI Toolkit's
     // transform supports only translate / rotate / scale — shear is unrepresentable — so Velvet's
     // skew is a documented deviation: it shears the element's own box silhouette (background +
-    // border, painted by SkewSilhouette) while children stay upright. This matches the dominant
-    // CSS usage (skew the card, counter-skew the content) with the counter-skew built in.
+    // border, painted by SkewSilhouette). The descendant shear is APPROXIMATED, not exact:
+    // StyleSkewChildTranslateManipulator seats each direct in-flow child's centroid where the shear would
+    // carry it via an inline translate, applied automatically (Velvet does the counter-translate a CSS author
+    // would otherwise hand-write per row). The seat is piecewise-constant — exact at each child's centroid,
+    // slightly off at the far corners of a child large relative to the frame, and it does not rotate the child.
     internal static class StyleSkewClass
     {
         private const string XPrefix = "skew-x-";

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/SkewChildTranslateManipulatorTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/SkewChildTranslateManipulatorTests.cs
@@ -1,0 +1,267 @@
+using System.Linq;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.UIElements;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Panel-backed contract for <see cref="StyleSkewChildTranslateManipulator"/>: the approximate descendant
+    /// shear a skewed caster applies to its direct children. A real Yoga pass is required (the seat reads each
+    /// child's laid-out centroid), so these mount into a genuine <see cref="EditorWindow"/> panel and force a
+    /// layout pass. The fixture pins that (1) a positive-skewX column leans its top and bottom rows opposite
+    /// ways, (2) removing skew resets the children's translate, (3) a child added to an already-skewed steady
+    /// state is seated by the reconciler's re-run (not by a geometry event, which is deliberately withheld), (4)
+    /// an out-of-flow <c>.absolute</c> child is skipped, (5) a child's own static <c>translate-x-*</c> survives
+    /// the parent being unskewed, and (6) a translate a child acquires AFTER it transitions out-of-flow survives
+    /// the parent being unskewed rather than being clobbered by the stale pre-shear capture. GWT, one assert per
+    /// case.
+    /// </summary>
+    [TestFixture]
+    internal sealed class SkewChildTranslateManipulatorTests : PanelTestBase
+    {
+        private const string StyleUtilitiesPath =
+            "Packages/com.velvet.core/Runtime/Styles/StyleUtilities.uss";
+
+        // Class-driven (skew ⇄ no-skew) and items-driven components, each with its own updater so a test drives
+        // exactly one. Reset per test in SetUp so a prior test's captured setter never leaks.
+        private static StateUpdater<string> s_setClass;
+        private static StateUpdater<string> s_setTranslateClass;
+        private static StateUpdater<string[]> s_setItems;
+        private static StateUpdater<string> s_setCasterClass;
+        private static StateUpdater<string> s_setChildClass;
+
+        protected override void LoadStyleSheets()
+        {
+            // A real panel is required for .absolute to resolve to position:absolute (the out-of-flow signal
+            // StyleOutOfFlowChild reads on panel); skew and translate-x-* carry no USS rule, so the sheet does
+            // not otherwise touch these trees.
+            var styleSheet = AssetDatabase.LoadAssetAtPath<StyleSheet>(StyleUtilitiesPath);
+            Assert.That(styleSheet, Is.Not.Null,
+                $"Could not load Velvet's StyleUtilities.uss at '{StyleUtilitiesPath}'.");
+            _window.rootVisualElement.styleSheets.Add(styleSheet);
+        }
+
+        public override void SetUp()
+        {
+            base.SetUp();
+            s_setClass = default;
+            s_setTranslateClass = default;
+            s_setItems = default;
+            s_setCasterClass = default;
+            s_setChildClass = default;
+        }
+
+        private void Drain() => _mounted.Root.Reconciler.Context.BatchScheduler.DrainImmediateForTest();
+
+        // Resolves layout, then delivers a GeometryChangedEvent so the manipulator reads the now-real centroids
+        // (the EditMode player loop delivers neither on its own).
+        private static void SeatViaGeometry(VisualElement caster)
+        {
+            ForcePanelUpdate(caster.panel);
+            using var evt = EventBase<GeometryChangedEvent>.GetPooled();
+            caster.SimulateEvent(evt);
+        }
+
+        [Component]
+        private static VNode RenderClassColumn()
+        {
+            var (cls, setClass) = Hooks.UseState("skew-x-12 w-[120px]");
+            s_setClass = setClass;
+            return V.Div(className: cls, name: "col", children: new VNode?[]
+            {
+                V.Div(key: "a", name: "a", className: "h-[24px]"),
+                V.Div(key: "b", name: "b", className: "h-[24px]"),
+            });
+        }
+
+        [Component]
+        private static VNode RenderItemsColumn()
+        {
+            var (items, setItems) = Hooks.UseState(new[] { "a", "b" });
+            s_setItems = setItems;
+            // A FIXED caster box (w+h) so adding a row does not resize the caster: the manipulator only listens to
+            // the CASTER's own GeometryChangedEvent, so an unchanged caster box guarantees the newly-added,
+            // freshly-laid-out row can be seated by nothing but the reconciler's SyncChildTranslate re-run.
+            return V.Div(className: "skew-x-12 w-[120px] h-[200px]", name: "col",
+                children: items.Select(it => (VNode?)V.Div(key: it, name: it, className: "h-[24px]")).ToArray());
+        }
+
+        [Component]
+        private static VNode RenderFlowTransitionColumn()
+        {
+            var (casterCls, setCaster) = Hooks.UseState("skew-x-12 w-[120px] h-[200px]");
+            var (childCls, setChild) = Hooks.UseState("h-[24px]");
+            s_setCasterClass = setCaster;
+            s_setChildClass = setChild;
+            return V.Div(className: casterCls, name: "col", children: new VNode?[]
+            {
+                V.Div(key: "m", name: "m", className: childCls),
+            });
+        }
+
+        [Component]
+        private static VNode RenderTranslateChildColumn()
+        {
+            var (cls, setClass) = Hooks.UseState("skew-x-12 w-[120px]");
+            s_setTranslateClass = setClass;
+            return V.Div(className: cls, name: "col", children: new VNode?[]
+            {
+                V.Div(key: "t", name: "t", className: "translate-x-1 h-[24px]"),
+                V.Div(key: "b", name: "b", className: "h-[24px]"),
+            });
+        }
+
+        [Test]
+        public void Given_SkewX12ColumnWithFixedHeightRows_When_Reconciled_Then_TopRowTranslatesOppositeBottomRow()
+        {
+            // Arrange — a positive-skewX column of three fixed-height rows: the top row's centroid is above the
+            // box centre and the bottom's below, so the shear carries them opposite ways along x.
+            _mounted = V.Mount(_window.rootVisualElement, V.Div(
+                className: "skew-x-12 w-[120px]", name: "col", children: new VNode?[]
+                {
+                    V.Div(key: "a", name: "a", className: "h-[24px]"),
+                    V.Div(key: "b", name: "b", className: "h-[24px]"),
+                    V.Div(key: "c", name: "c", className: "h-[24px]"),
+                }));
+            var col = _window.rootVisualElement.Q<VisualElement>("col");
+            var top = _window.rootVisualElement.Q<VisualElement>("a");
+            var bottom = _window.rootVisualElement.Q<VisualElement>("c");
+
+            // Act
+            SeatViaGeometry(col);
+            Assume.That(top.style.translate.keyword != StyleKeyword.Null
+                && bottom.style.translate.keyword != StyleKeyword.Null, Is.True,
+                "Precondition: the manipulator seated both the top and bottom rows");
+
+            // Assert
+            Assert.That(Mathf.Sign(top.style.translate.value.x.value),
+                Is.Not.EqualTo(Mathf.Sign(bottom.style.translate.value.x.value)));
+        }
+
+        [Test]
+        public void Given_SkewRemovedFromCaster_When_Patched_Then_ChildTranslateResetsToNull()
+        {
+            // Arrange — a skewed column whose children were seated by the manipulator.
+            _mounted = V.Mount(_window.rootVisualElement, V.Component(RenderClassColumn));
+            var col = _window.rootVisualElement.Q<VisualElement>("col");
+            var child = _window.rootVisualElement.Q<VisualElement>("a");
+            SeatViaGeometry(col);
+            Assume.That(child.style.translate.keyword, Is.Not.EqualTo(StyleKeyword.Null),
+                "Precondition: the child carried a shear translate while the caster was skewed");
+
+            // Act — patch the caster to a non-skewed class list on the same key.
+            s_setClass.Invoke("w-[120px]");
+            Drain();
+
+            // Assert — Detach's RemoveManipulator cleared the shear translate the child had no class to restore.
+            Assert.That(child.style.translate.keyword, Is.EqualTo(StyleKeyword.Null));
+        }
+
+        [Test]
+        public void Given_ChildAddedToAlreadySkewedSteadyStateContainer_When_Reconciled_Then_NewChildReceivesCounterShearTranslate()
+        {
+            // Arrange — a skewed column of two rows, laid out at a FIXED box, then a third row added under the
+            // SAME skew tokens. Seating the first two settles the caster box, so adding the third cannot resize
+            // the caster and therefore fires no caster GeometryChangedEvent.
+            _mounted = V.Mount(_window.rootVisualElement, V.Component(RenderItemsColumn));
+            var col = _window.rootVisualElement.Q<VisualElement>("col");
+            SeatViaGeometry(col);
+            s_setItems.Invoke(new[] { "a", "b", "c" });
+            Drain();
+            // Lay out the freshly added row. The caster box is unchanged (fixed size), so no caster geometry event
+            // fires and the manipulator's own geometry callback stays silent — isolating the next assertion to the
+            // reconciler's steady-state SyncChildTranslate re-run as the ONLY thing that can seat the new row.
+            ForcePanelUpdate(col.panel);
+            var added = _window.rootVisualElement.Q<VisualElement>("c");
+            Assume.That(added != null && !float.IsNaN(added.layout.height)
+                && added.style.translate.keyword == StyleKeyword.Null, Is.True,
+                "Precondition: the added row is laid out but NOT yet seated, so only SyncChildTranslate can seat it");
+
+            // Act — a steady-state patch (skew tokens unchanged) after layout.
+            s_setItems.Invoke(new[] { "a", "b", "c" });
+            Drain();
+
+            // Assert
+            Assert.That(added.style.translate.keyword, Is.Not.EqualTo(StyleKeyword.Null));
+        }
+
+        [Test]
+        public void Given_OutOfFlowAbsoluteChildUnderSkewedContainer_When_Reconciled_Then_AbsoluteChildTranslateStaysNull()
+        {
+            // Arrange — a skewed column with one in-flow child and one out-of-flow .absolute child.
+            _mounted = V.Mount(_window.rootVisualElement, V.Div(
+                className: "skew-x-12 w-[120px]", name: "col", children: new VNode?[]
+                {
+                    V.Div(key: "flow", name: "flow", className: "h-[24px]"),
+                    V.Div(key: "abs", name: "abs", className: "absolute h-[24px]"),
+                }));
+            var col = _window.rootVisualElement.Q<VisualElement>("col");
+            var flow = _window.rootVisualElement.Q<VisualElement>("flow");
+            var abs = _window.rootVisualElement.Q<VisualElement>("abs");
+
+            // Act
+            SeatViaGeometry(col);
+            Assume.That(flow.style.translate.keyword, Is.Not.EqualTo(StyleKeyword.Null),
+                "Precondition: the manipulator seated the in-flow child");
+            Assume.That(abs.resolvedStyle.position, Is.EqualTo(Position.Absolute),
+                "Precondition: the .absolute child resolved out of flow");
+
+            // Assert — the out-of-flow child holds no seat in the slanted frame, so its translate is untouched.
+            Assert.That(abs.style.translate.keyword, Is.EqualTo(StyleKeyword.Null));
+        }
+
+        [Test]
+        public void Given_ChildWithExplicitTranslateXUnderCaster_When_CasterUnskewed_Then_ChildsOwnTranslateXSurvives()
+        {
+            // Arrange — a child carries its own translate-x-1 (4px) under a skewed caster, which overwrites it
+            // with the shear seat while active.
+            _mounted = V.Mount(_window.rootVisualElement, V.Component(RenderTranslateChildColumn));
+            var col = _window.rootVisualElement.Q<VisualElement>("col");
+            var child = _window.rootVisualElement.Q<VisualElement>("t");
+            SeatViaGeometry(col);
+            Assume.That(Mathf.Approximately(child.style.translate.value.x.value, 4f), Is.False,
+                "Precondition: the manipulator overwrote the child's own translate-x while skewed");
+
+            // Act — unskew the caster.
+            s_setTranslateClass.Invoke("w-[120px]");
+            Drain();
+
+            // Assert — the child's own translate (captured before the shear overwrite) was restored, not nulled.
+            Assert.That(child.style.translate.value.x.value, Is.EqualTo(4f).Within(0.01f));
+        }
+
+        [Test]
+        public void Given_ChildWentOutOfFlowThenGainedOwnTranslate_When_CasterUnskewed_Then_ThatTranslateSurvives()
+        {
+            // Arrange — a child seated in-flow (its captured own-translate is Null), then transitioned out-of-flow
+            // (.absolute) and settled, then given its OWN translate-x-1 (4px) AFTER the transition. The manipulator
+            // relinquished the child when it went out-of-flow, so that 4px is legitimately the child's own — not a
+            // shear seat — and must not be clobbered when the caster is later unskewed.
+            _mounted = V.Mount(_window.rootVisualElement, V.Component(RenderFlowTransitionColumn));
+            var col = _window.rootVisualElement.Q<VisualElement>("col");
+            var child = _window.rootVisualElement.Q<VisualElement>("m");
+            SeatViaGeometry(col);
+            Assume.That(child.style.translate.keyword, Is.Not.EqualTo(StyleKeyword.Null),
+                "Precondition: the manipulator seated the in-flow child");
+
+            // Act — first move the child out of flow and settle its resolved position, so the manipulator stops
+            // owning it; then hand it its own translate-x-1; finally unskew the caster.
+            s_setChildClass.Invoke("absolute h-[24px]");
+            Drain();
+            SeatViaGeometry(col);
+            s_setChildClass.Invoke("absolute translate-x-1 h-[24px]");
+            Drain();
+            Assume.That(child.resolvedStyle.position == Position.Absolute
+                && Mathf.Approximately(child.style.translate.value.x.value, 4f), Is.True,
+                "Precondition: the out-of-flow child carries its OWN 4px translate before the caster is unskewed");
+            s_setCasterClass.Invoke("w-[120px] h-[200px]");
+            Drain();
+
+            // Assert — unskew released the out-of-flow child untouched instead of restoring the stale Null capture.
+            Assert.That(child.style.translate.value.x.value, Is.EqualTo(4f).Within(0.01f));
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/SkewChildTranslateManipulatorTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/SkewChildTranslateManipulatorTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: cc8fd3c16b774348ab8e7a3763ef6868

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/SkewChildTranslateOffsetTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/SkewChildTranslateOffsetTests.cs
@@ -1,0 +1,72 @@
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins the pure centroid-shear math behind <see cref="StyleSkewChildTranslateManipulator"/>: the
+    /// approximate descendant-shear offset a skewed caster writes onto a direct child. The model is the one
+    /// <c>SilhouetteBoundsSpacer.ShearedAabb</c> documents — <c>x' = x + (y - h/2)*tanX</c>,
+    /// <c>y' = y + (x - w/2)*tanY</c> — so a child ABOVE the box centre leans one way under positive
+    /// <c>skewX</c> and a child BELOW it the other, the axes never cross-couple, and a child exactly at the
+    /// centre (or a zero angle) gets no offset. Panel-free and layout-free: it drives
+    /// <see cref="StyleSkewChildTranslateManipulator.ComputeOffset"/> directly. GWT, one assert per case.
+    /// </summary>
+    [TestFixture]
+    internal sealed class SkewChildTranslateOffsetTests
+    {
+        [Test]
+        public void Given_ChildBelowContainerCenterUnderPositiveSkewX_When_ComputingOffset_Then_DxIsPositive()
+        {
+            // Arrange — a child whose centroid is below the box centre (centerY > h/2) under positive skewX.
+            const float w = 100f, h = 100f, tanX = 0.2f, tanY = 0f;
+            var childCenterY = (h * 0.5f) + 20f;
+
+            // Act
+            var offset = StyleSkewChildTranslateManipulator.ComputeOffset(w * 0.5f, childCenterY, w, h, tanX, tanY);
+
+            // Assert — matching SkewSpec's sign convention (positive X shifts the bottom edge right).
+            Assert.That(offset.x, Is.GreaterThan(0f));
+        }
+
+        [Test]
+        public void Given_ChildAtExactContainerCenter_When_ComputingOffset_Then_OffsetIsZero()
+        {
+            // Arrange — the centroid sits exactly at the box centre with both angles non-zero.
+            const float w = 120f, h = 80f, tanX = 0.3f, tanY = 0.15f;
+
+            // Act
+            var offset = StyleSkewChildTranslateManipulator.ComputeOffset(w * 0.5f, h * 0.5f, w, h, tanX, tanY);
+
+            // Assert — the shear leaves the exact centroid fixed (the one point the approximation is exact at).
+            Assert.That(offset, Is.EqualTo(Vector2.zero));
+        }
+
+        [Test]
+        public void Given_ZeroSkewAngles_When_ComputingOffset_Then_OffsetIsZeroRegardlessOfChildPosition()
+        {
+            // Arrange — an off-centre child but no shear on either axis.
+            const float w = 200f, h = 60f, tanX = 0f, tanY = 0f;
+
+            // Act
+            var offset = StyleSkewChildTranslateManipulator.ComputeOffset(10f, 5f, w, h, tanX, tanY);
+
+            // Assert — an unskewed frame seats every child at its own position (the post-unskew numeric path).
+            Assert.That(offset, Is.EqualTo(Vector2.zero));
+        }
+
+        [Test]
+        public void Given_SkewYOnly_When_ComputingOffset_Then_DxStaysZeroWhileDyTracksChildCenterX()
+        {
+            // Arrange — skewY only, on a child left of the box centre (centerX < w/2).
+            const float w = 100f, h = 100f, tanX = 0f, tanY = 0.25f;
+            var childCenterX = (w * 0.5f) - 40f;
+
+            // Act
+            var offset = StyleSkewChildTranslateManipulator.ComputeOffset(childCenterX, h * 0.5f, w, h, tanX, tanY);
+
+            // Assert — no cross term: skewY moves only dy (here negative for a left-of-centre child), never dx.
+            Assert.That(offset, Is.EqualTo(new Vector2(0f, -10f)));
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/SkewChildTranslateOffsetTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/SkewChildTranslateOffsetTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: eaf0eaf8208145f0bdc6b19950f188b8


### PR DESCRIPTION
## What
`skew-x-*` / `skew-y-*` now approximate CSS `skewX()` / `skewY()`'s **descendant shear**, not only the caster's own painted silhouette. Each in-flow direct child gets an inline `translate` seating its centroid where the shear would carry it — the per-row counter-translate a CSS author would otherwise hand-write, applied automatically.

## How
UI Toolkit's transform has no shear, so a manipulator (StyleGapManipulator lifecycle) computes per-direct-child `translate = (childCenterY - h/2)·tanX` and re-seats on child add/remove/reorder and as layout settles. It is exact at each child's centroid and piecewise-constant across the child (a real shear also rotates it), so a child large relative to the frame reads slightly off at its far corners — an explicit approximation. Out-of-flow children hold no seat; a child's own static `translate-*` is preserved when the parent loses its skew, including a translate acquired only after the child moves out of flow (released untouched, not reset).

## Tests
Per-child offset math, add/remove/reorder re-seat, out-of-flow skip, and the unskew-preserves-post-transition-translate regression — EditMode, RED/GREEN.

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)