### PR TITLE
fix(velvet): correct skew-child translate across out-of-flow, ScrollView, and teardown

### DIFF
--- a/Packages/com.velvet.core/Runtime/Styling/StyleSkewChildTranslateManipulator.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleSkewChildTranslateManipulator.cs
@@ -201,22 +201,29 @@ namespace Velvet
             return new Vector2(dx, dy);
         }
 
-        // Restores the captured translate onto every child the manipulator still owns, then stops tracking all.
-        // Invoked on unskew / detach. A child that has left management — gone out-of-flow, moved out of the
-        // container, or been pooled and reused for another node — is NOT written to: its present translate is
-        // legitimately its own (acquired after the manipulator relinquished it), so forcing the stale pre-shear
-        // capture back would clobber it. Only a still-seated in-flow child currently carries the shear write and
-        // must get its own translate back.
+        // Restores the captured translate onto every child the manipulator wrote a shear to, then stops tracking
+        // all. Invoked on unskew / detach, which can fire before any re-seat has relinquished a child that just
+        // went out-of-flow — so this teardown must relinquish such a child the same way DropUnmanaged would, not
+        // skip it. A still-owned in-flow child is restored unconditionally (it always carries the latest shear); a
+        // child now out-of-flow but still attached and STILL carrying the exact shear is restored too, so the
+        // stale offset does not leak on a seatless element (and cannot be re-captured as its 'own' baseline on a
+        // later return to flow). A child that has left the container — or one out-of-flow that already carries a
+        // translate it authored across the transition — keeps that value: forcing the stale capture back would clobber it.
         private void Clear()
         {
             var container = ChildContainer;
             foreach (var pair in _seated)
             {
-                if (IsManaged(pair.Key, container))
+                var child = pair.Key;
+                if (IsManaged(child, container))
                 {
-                    pair.Key.style.translate = pair.Value.Own;
+                    child.style.translate = pair.Value.Own;
                 }
-                pair.Key.UnregisterCallback<DetachFromPanelEvent>(OnChildDetach);
+                else
+                {
+                    RestoreRelinquishedShear(child, pair.Value, container);
+                }
+                child.UnregisterCallback<DetachFromPanelEvent>(OnChildDetach);
             }
             _seated.Clear();
             _hasSignature = false;
@@ -244,22 +251,25 @@ namespace Velvet
             {
                 foreach (var child in stale)
                 {
-                    // Still parented to the container ⟹ it went out-of-flow (the one non-managed reason left
-                    // once container membership holds). Clear the stale shear by restoring the pre-shear capture,
-                    // but ONLY while the child still carries the exact shear the manipulator last wrote: the
-                    // out-of-flow signal lags the class change, so the child may have authored its own translate
-                    // across the same transition — a current value that no longer matches the shear is that
-                    // authored translate and must survive, not be clobbered back to the stale capture.
-                    if (child.parent == container)
-                    {
-                        var seat = _seated[child];
-                        if (child.style.translate == seat.Shear)
-                        {
-                            child.style.translate = seat.Own;
-                        }
-                    }
+                    // A still-parented non-managed child went out-of-flow (the one non-managed reason left once
+                    // container membership holds); restore its pre-shear capture, guarded so a translate it
+                    // authored across the same transition survives. See RestoreRelinquishedShear.
+                    RestoreRelinquishedShear(child, _seated[child], container);
                     Forget(child);
                 }
+            }
+        }
+
+        // Restores a relinquished child's captured pre-shear translate, but ONLY while it is still attached to the
+        // container AND still carries the exact shear the manipulator last wrote. The out-of-flow signal is
+        // resolvedStyle-based and lags the class change, so a child can author its own translate across the same
+        // transition: a current value that no longer matches the shear is that authored translate and must
+        // survive. A child that has left the container is not restored — its translate is legitimately its own.
+        private static void RestoreRelinquishedShear(VisualElement child, in SeatState seat, VisualElement? container)
+        {
+            if (container != null && child.parent == container && child.style.translate == seat.Shear)
+            {
+                child.style.translate = seat.Own;
             }
         }
 

--- a/Packages/com.velvet.core/Runtime/Styling/StyleSkewChildTranslateManipulator.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleSkewChildTranslateManipulator.cs
@@ -30,21 +30,49 @@ namespace Velvet
     // gap's ml-2 overwrite); a needs-its-own-translate child wants an inner wrapper. To make a STATIC
     // translate-x-* survive losing the parent's skew, the child's own inline translate is CAPTURED before the
     // first shear overwrite and written back on reset — GetClasses cannot recover it, since translate has no
-    // USS form and the reconciler applies translate-x-* inline without recording it in the class list. The
-    // capture is written back ONLY onto a child the manipulator still owns at reset: a child that has since gone
-    // out-of-flow, moved out of the container, or been recycled by the element pool for another node is released
-    // untouched, so a translate it legitimately acquired after leaving management is never clobbered by a stale
-    // capture. A child leaving the panel drops itself from tracking the instant it detaches, closing the window
-    // where the pool could reuse its instance while a stale capture was still keyed to it.
+    // USS form and the reconciler applies translate-x-* inline without recording it in the class list. At reset
+    // the capture is written back ONLY onto a child the manipulator still owns (a direct in-flow child): one that
+    // moved out of the container or was recycled by the element pool for another node is released untouched, so a
+    // translate it legitimately acquired after leaving management is never clobbered by a stale capture. A child
+    // that transitions to OUT-OF-FLOW while still attached is handled eagerly instead: it holds no seat in the
+    // slanted frame yet still carries the shear write, so its captured pre-shear translate is restored and it is
+    // dropped — but ONLY while it still carries the exact shear the manipulator last wrote. The out-of-flow
+    // signal is resolvedStyle-based and can lag the class change by a re-seat pass, so a child can go out-of-flow
+    // AND author its own translate before the relinquish fires; a current translate that no longer matches the
+    // last shear is that authored value, and is left untouched rather than clobbered back to the stale capture.
+    // Restoring only the still-untouched shear keeps a stale offset from lingering on a seatless element and from
+    // being re-captured as a 'baseline' on a later return to flow. A child leaving the panel drops itself from
+    // tracking the instant it detaches, closing the window where the pool could reuse its instance while a stale
+    // capture was still keyed to it.
     internal sealed class StyleSkewChildTranslateManipulator : Manipulator
     {
         private readonly SkewBinding _binding;
 
-        // Every child a shear translate was written to, mapped to the child's OWN translate captured just
-        // before the first overwrite. Unskew writes the captured value back onto a child the manipulator still
-        // owns, so its static translate-x-* is preserved rather than erased (a child with none was captured as
-        // Null); a child that has left management is dropped from here untouched instead.
-        private readonly Dictionary<VisualElement, StyleTranslate> _seated = new();
+        // A tracked child's captured pre-shear OWN translate paired with the LAST shear the manipulator wrote to
+        // it. Own restores the child's static translate-x-* on relinquish (a child with none was captured as
+        // Null); Shear is the proof-of-ownership probe — the child still carrying that exact value means the
+        // manipulator's write is intact and safe to clear, whereas any other value is one the child authored
+        // itself and must survive.
+        private readonly struct SeatState
+        {
+            public readonly StyleTranslate Own;
+            public readonly StyleTranslate Shear;
+
+            public SeatState(StyleTranslate own, StyleTranslate shear)
+            {
+                Own = own;
+                Shear = shear;
+            }
+
+            public SeatState WithShear(StyleTranslate shear) => new SeatState(Own, shear);
+        }
+
+        // Every child a shear translate was written to, mapped to its seat state. Unskew writes the captured Own
+        // back onto a child the manipulator still owns, so its static translate-x-* is preserved rather than
+        // erased. A child that goes out-of-flow while still attached is restored to its capture and dropped — but
+        // only while it still carries the last Shear, so a translate it authored across the transition survives;
+        // one that has left the container entirely is dropped untouched, its translate now legitimately its own.
+        private readonly Dictionary<VisualElement, SeatState> _seated = new();
 
         // Signature of the last successful Apply. Apply() early-returns when it is unchanged, so the
         // GeometryChanged churn the manipulator's own writes provoke, and patches that touch nothing relevant,
@@ -95,12 +123,15 @@ namespace Velvet
                 return;
             }
 
-            // Measure the shear box in the SAME frame the children's layout is expressed in. For a ScrollView the
-            // children sit in contentContainer, offset several levels below the caster, so reading the box from
-            // the caster while reading child centroids relative to the container would mix two frames and seat
-            // every child against the wrong centre. For a plain element the container IS the caster.
-            var w = container.layout.width;
-            var h = container.layout.height;
+            // The shear box is the CASTER's OWN layout — the box SkewSilhouette.Draw shears the silhouette at.
+            // For a ScrollView the children live in contentContainer, whose resolved height is the full unclamped
+            // content extent, not the visible caster box; reading the box from the container would centre the
+            // shear on the content midpoint and seat every child against a line the silhouette never paints.
+            // Children are still enumerated from the container, where their laid-out centroids live; for a plain
+            // element the container IS the caster, so the two boxes coincide.
+            var box = target.layout;
+            var w = box.width;
+            var h = box.height;
             if (w <= 0f || h <= 0f || float.IsNaN(w) || float.IsNaN(h))
             {
                 return;
@@ -135,17 +166,24 @@ namespace Velvet
                     // A freshly added child not yet through a Yoga pass — seat it on the next geometry event.
                     continue;
                 }
-                // Capture the child's own translate once, before the first overwrite, so unskew can restore it.
-                if (!_seated.ContainsKey(child))
+                var offset = ComputeOffset(
+                    layout.x + (layout.width * 0.5f), layout.y + (layout.height * 0.5f), w, h, tanX, tanY);
+                StyleTranslate shear = new Translate(new Length(offset.x), new Length(offset.y));
+                // Capture the child's own translate once, before the first overwrite, so unskew can restore it;
+                // record the shear just written so relinquish can tell a still-owned seat from a translate the
+                // child later authored for itself.
+                if (_seated.TryGetValue(child, out var seat))
                 {
-                    _seated[child] = child.style.translate;
+                    _seated[child] = seat.WithShear(shear);
+                }
+                else
+                {
+                    _seated[child] = new SeatState(child.style.translate, shear);
                     // A seated child leaving the panel drops itself from tracking before the element pool can
                     // hand the instance to an unrelated node, so a later restore never lands a stale capture.
                     child.RegisterCallback<DetachFromPanelEvent>(OnChildDetach);
                 }
-                var offset = ComputeOffset(
-                    layout.x + (layout.width * 0.5f), layout.y + (layout.height * 0.5f), w, h, tanX, tanY);
-                child.style.translate = new Translate(new Length(offset.x), new Length(offset.y));
+                child.style.translate = shear;
             }
 
             _lastSignature = signature;
@@ -176,7 +214,7 @@ namespace Velvet
             {
                 if (IsManaged(pair.Key, container))
                 {
-                    pair.Key.style.translate = pair.Value;
+                    pair.Key.style.translate = pair.Value.Own;
                 }
                 pair.Key.UnregisterCallback<DetachFromPanelEvent>(OnChildDetach);
             }
@@ -184,9 +222,14 @@ namespace Velvet
             _hasSignature = false;
         }
 
-        // Drops every tracked child the manipulator no longer owns (out-of-flow now, or no longer a child of the
-        // container), without a write — for the same reason Clear skips them, the departed child's translate is
-        // its own now. Dropping also frees a re-seat to re-capture a fresh baseline should the child come back.
+        // Relinquishes every tracked child the manipulator no longer owns before the re-seat, in two kinds. A
+        // child still under this container but now OUT-OF-FLOW may still carry the shear translate the manipulator
+        // wrote while holding no seat in the slanted frame — restore its captured pre-shear translate so that
+        // stale offset does not linger (leaving it would also let a later return to flow re-capture the shear as
+        // the child's 'own' baseline and restore it forever on a future unskew), but only while it still carries
+        // that exact shear so a translate it authored across the transition is not clobbered. A child that has
+        // LEFT the container keeps whatever translate it has: it is legitimately its own now, exactly as Clear
+        // leaves it. Either way the drop frees a re-seat to re-capture a fresh baseline should the child return.
         private void DropUnmanaged(VisualElement container)
         {
             List<VisualElement>? stale = null;
@@ -201,6 +244,20 @@ namespace Velvet
             {
                 foreach (var child in stale)
                 {
+                    // Still parented to the container ⟹ it went out-of-flow (the one non-managed reason left
+                    // once container membership holds). Clear the stale shear by restoring the pre-shear capture,
+                    // but ONLY while the child still carries the exact shear the manipulator last wrote: the
+                    // out-of-flow signal lags the class change, so the child may have authored its own translate
+                    // across the same transition — a current value that no longer matches the shear is that
+                    // authored translate and must survive, not be clobbered back to the stale capture.
+                    if (child.parent == container)
+                    {
+                        var seat = _seated[child];
+                        if (child.style.translate == seat.Shear)
+                        {
+                            child.style.translate = seat.Own;
+                        }
+                    }
                     Forget(child);
                 }
             }
@@ -218,7 +275,9 @@ namespace Velvet
             }
         }
 
-        // Stops tracking a child and unhooks its detach callback.
+        // The single relinquish primitive both DropUnmanaged and OnChildDetach funnel through. The Remove gate
+        // makes it idempotent: whichever path fires second finds the child already gone, so the detach callback
+        // is never double-unregistered and an already-relinquished element is never touched again.
         private void Forget(VisualElement child)
         {
             if (_seated.Remove(child))

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/SkewChildTranslateManipulatorTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/SkewChildTranslateManipulatorTests.cs
@@ -15,9 +15,14 @@ namespace Velvet.Tests
     /// ways, (2) removing skew resets the children's translate, (3) a child added to an already-skewed steady
     /// state is seated by the reconciler's re-run (not by a geometry event, which is deliberately withheld), (4)
     /// an out-of-flow <c>.absolute</c> child is skipped, (5) a child's own static <c>translate-x-*</c> survives
-    /// the parent being unskewed, and (6) a translate a child acquires AFTER it transitions out-of-flow survives
-    /// the parent being unskewed rather than being clobbered by the stale pre-shear capture. GWT, one assert per
-    /// case.
+    /// the parent being unskewed, (6) a translate a child acquires AFTER it transitions out-of-flow survives
+    /// the parent being unskewed rather than being clobbered by the stale pre-shear capture, (7) a seated child
+    /// that transitions out-of-flow WITHOUT acquiring its own translate has the stale shear offset cleared (not
+    /// left carrying it), (8) inside an overflowing ScrollView the seat frame is the caster's own visible box
+    /// (where the silhouette paints), not contentContainer's full content extent, and (9) a child that goes
+    /// out-of-flow AND authors its own translate across the same transition keeps that translate — the relinquish
+    /// clears only a still-untouched shear, so the authored value is not clobbered back to the stale capture even
+    /// though the out-of-flow signal lags the class change. GWT, one assert per case.
     /// </summary>
     [TestFixture]
     internal sealed class SkewChildTranslateManipulatorTests : PanelTestBase
@@ -112,6 +117,18 @@ namespace Velvet.Tests
                 V.Div(key: "t", name: "t", className: "translate-x-1 h-[24px]"),
                 V.Div(key: "b", name: "b", className: "h-[24px]"),
             });
+        }
+
+        [Component]
+        private static VNode RenderSkewedOverflowingScrollView()
+        {
+            // A fixed-height skewed ScrollView whose rows overflow it, so contentContainer's resolved height (the
+            // full content extent) is far taller than the ScrollView's own visible box — the two candidate shear
+            // frames the seat could centre on.
+            return V.ScrollView(className: "skew-x-12 w-[200px] h-[100px]", name: "sv",
+                children: Enumerable.Range(0, 5)
+                    .Select(i => (VNode?)V.Div(key: "r" + i, name: "r" + i, className: "h-[40px] w-full"))
+                    .ToArray());
         }
 
         [Test]
@@ -262,6 +279,86 @@ namespace Velvet.Tests
 
             // Assert — unskew released the out-of-flow child untouched instead of restoring the stale Null capture.
             Assert.That(child.style.translate.value.x.value, Is.EqualTo(4f).Within(0.01f));
+        }
+
+        [Test]
+        public void Given_SeatedInFlowChildTransitionsOutOfFlow_When_Reseated_Then_StaleShearTranslateIsCleared()
+        {
+            // Arrange — a child seated in-flow under a skewed caster carries a shear translate (its captured
+            // pre-shear translate is Null, since it authored none of its own).
+            _mounted = V.Mount(_window.rootVisualElement, V.Component(RenderFlowTransitionColumn));
+            var col = _window.rootVisualElement.Q<VisualElement>("col");
+            var child = _window.rootVisualElement.Q<VisualElement>("m");
+            SeatViaGeometry(col);
+            Assume.That(child.style.translate.keyword, Is.Not.EqualTo(StyleKeyword.Null),
+                "Precondition: the in-flow child carried a shear translate while managed");
+
+            // Act — move the child out of flow (still attached under the same caster) and re-seat, without the
+            // child ever acquiring a translate of its own.
+            s_setChildClass.Invoke("absolute h-[24px]");
+            Drain();
+            SeatViaGeometry(col);
+
+            // Assert — relinquishing the now-out-of-flow child restored its captured pre-shear translate (Null
+            // here), so the stale shear offset does not survive on an element that holds no seat in the slanted
+            // frame (and cannot be re-captured as its 'own' baseline should it return to flow).
+            Assert.That(child.style.translate.keyword, Is.EqualTo(StyleKeyword.Null));
+        }
+
+        [Test]
+        public void Given_ChildGoesOutOfFlowAndAuthorsOwnTranslateSameTransition_When_Reseated_Then_ItsTranslateSurvives()
+        {
+            // Arrange — a child seated in-flow under a skewed caster (its captured own-translate is Null, since it
+            // authored none), carrying a shear translate the manipulator wrote.
+            _mounted = V.Mount(_window.rootVisualElement, V.Component(RenderFlowTransitionColumn));
+            var col = _window.rootVisualElement.Q<VisualElement>("col");
+            var child = _window.rootVisualElement.Q<VisualElement>("m");
+            SeatViaGeometry(col);
+            Assume.That(child.style.translate.keyword, Is.Not.EqualTo(StyleKeyword.Null),
+                "Precondition: the in-flow child carried a shear translate while managed");
+
+            // Act — in ONE transition the child both goes out-of-flow AND authors its own translate-x-1 (4px).
+            // The out-of-flow signal is resolvedStyle-based and lags this class change, so the reconciler applies
+            // the child's 4px while the manipulator still considers it managed; the relinquish only fires on the
+            // next re-seat, once the signal has caught up and the child already carries its authored value.
+            s_setChildClass.Invoke("absolute translate-x-1 h-[24px]");
+            Drain();
+            SeatViaGeometry(col);
+            Assume.That(child.resolvedStyle.position, Is.EqualTo(Position.Absolute),
+                "Precondition: the child transitioned out of flow, so the relinquish path ran for it");
+
+            // Assert — the relinquish cleared the shear only if the child still carried it; here the child had
+            // replaced it with its own 4px, so that authored translate survives instead of being clobbered back
+            // to the stale Null capture.
+            Assert.That(child.style.translate.value.x.value, Is.EqualTo(4f).Within(0.01f));
+        }
+
+        [Test]
+        public void Given_SkewedScrollViewWithOverflowingContent_When_Seated_Then_ChildSeatedAgainstCasterBoxNotContentExtent()
+        {
+            // Arrange — a skew-x-12 ScrollView clipped to 100px over 200px of rows. A row whose centroid sits
+            // BELOW the caster's visible-box centre but ABOVE the full-content centre leans one way when the seat
+            // frame is the caster's own box (where SkewSilhouette paints) and the OTHER way when it is
+            // contentContainer's content extent, so its translate sign reveals which box fed the seat.
+            _mounted = V.Mount(_window.rootVisualElement, V.Component(RenderSkewedOverflowingScrollView));
+            var sv = _window.rootVisualElement.Q<ScrollView>("sv");
+            var content = sv.contentContainer;
+            var row = _window.rootVisualElement.Q<VisualElement>("r1");
+            SeatViaGeometry(sv);
+            var casterCenterY = sv.layout.height * 0.5f;
+            var contentCenterY = content.layout.height * 0.5f;
+            var rowCenterY = row.layout.y + (row.layout.height * 0.5f);
+            Assume.That(content.layout.height, Is.GreaterThan(sv.layout.height),
+                "Precondition: the content overflows the caster's visible box, so the two shear frames differ");
+            Assume.That(rowCenterY, Is.GreaterThan(casterCenterY).And.LessThan(contentCenterY),
+                "Precondition: the row centroid lies between the caster centre and the content centre, so the shear-box choice flips its sign");
+            Assume.That(row.style.translate.keyword, Is.Not.EqualTo(StyleKeyword.Null),
+                "Precondition: the manipulator seated the row");
+
+            // Assert — a positive dx means the seat used the caster's visible box (the row is below its centre
+            // under positive skewX); the content-extent frame would place the row above centre and lean it
+            // negative.
+            Assert.That(row.style.translate.value.x.value, Is.GreaterThan(0f));
         }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/SkewChildTranslateManipulatorTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/SkewChildTranslateManipulatorTests.cs
@@ -306,6 +306,36 @@ namespace Velvet.Tests
         }
 
         [Test]
+        public void Given_SeatedChildOutOfFlowWithoutReseat_When_CasterUnskewedTearsDownManipulator_Then_StaleShearTranslateIsCleared()
+        {
+            // Arrange — a child seated in-flow under a skewed caster carries a shear translate (its captured
+            // pre-shear translate is Null, since it authored none of its own).
+            _mounted = V.Mount(_window.rootVisualElement, V.Component(RenderFlowTransitionColumn));
+            var col = _window.rootVisualElement.Q<VisualElement>("col");
+            var child = _window.rootVisualElement.Q<VisualElement>("m");
+            SeatViaGeometry(col);
+            Assume.That(child.style.translate.keyword, Is.Not.EqualTo(StyleKeyword.Null),
+                "Precondition: the in-flow child carried a shear translate while managed");
+
+            // Act — move the child out of flow and let its resolved position settle WITHOUT delivering a geometry
+            // event, so no re-seat runs and the manipulator still tracks it as an in-flow seat carrying the shear;
+            // then unskew the caster, tearing the manipulator down through Detach ⟶ RemoveManipulator ⟶ Clear
+            // rather than a re-seat's DropUnmanaged.
+            s_setChildClass.Invoke("absolute h-[24px]");
+            Drain();
+            ForcePanelUpdate(col.panel);
+            Assume.That(child.resolvedStyle.position == Position.Absolute
+                && child.style.translate.keyword != StyleKeyword.Null, Is.True,
+                "Precondition: the child is out-of-flow but the un-reseated manipulator still holds its shear write");
+            s_setCasterClass.Invoke("w-[120px] h-[200px]");
+            Drain();
+
+            // Assert — teardown restored the still-shear-carrying out-of-flow child to its captured pre-shear
+            // translate (Null here), so the stale shear does not leak on a seatless element the manipulator let go.
+            Assert.That(child.style.translate.keyword, Is.EqualTo(StyleKeyword.Null));
+        }
+
+        [Test]
         public void Given_ChildGoesOutOfFlowAndAuthorsOwnTranslateSameTransition_When_Reseated_Then_ItsTranslateSurvives()
         {
             // Arrange — a child seated in-flow under a skewed caster (its captured own-translate is Null, since it


### PR DESCRIPTION
The per-child shear translate a skewed caster applies (StyleSkewChildTranslateManipulator) mis-seated its children in three situations:

- **ScrollView frame**: children in a ScrollView live in `contentContainer`, whose resolved height is the full unclamped content extent, not the visible caster box the silhouette is sheared at. The shear box now reads the caster's own layout, so rows seat against the line the silhouette actually paints.
- **Out-of-flow transition**: a child that goes out-of-flow while still attached holds no seat in the slanted frame yet still carries the shear write. The re-seat now restores its captured pre-shear translate — but only while it still carries the exact shear written, so a translate it authored across the same transition (the out-of-flow signal lags the class change) survives untouched.
- **Teardown**: `Clear()` (unskew / detach) previously restored only still-managed in-flow children, so an out-of-flow child that transitioned without an intervening re-seat leaked the stale shear after the caster was unskewed. Teardown and re-seat now share one `RestoreRelinquishedShear` guard.

Panel-backed RED/GREEN pins added for each path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
