### PR TITLE
fix(velvet): reject [&>*] tokens nesting an ungated variant behind state layers

### DIFF
--- a/Packages/com.velvet.core/Runtime/Styling/StyleChildVariantClass.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleChildVariantClass.cs
@@ -16,9 +16,13 @@ namespace Velvet
     // with NO gating owner reachable through that path — a structural (first:/nth-child), has-, attribute-,
     // supports-, or (self-)child-variant — is rejected at parse time (it would only ever be a dead token),
     // mirroring the has- extractor's reject-list precisely (which, unlike the structural config's stricter
-    // list, keeps state variants because they DO reach a gating owner here). The self-nesting reject matters
-    // because a child is never itself the CONTAINER a nested [&>*]: would need to walk — [&>*]:[&>*]:mt-2 has
-    // nothing to apply the inner wrap to and must not silently degrade into applying mt-2 directly.
+    // list, keeps state variants because they DO reach a gating owner here). Because a state variant DOES
+    // compose, an ungated variant can hide one or more state layers deep ([&>*]:hover:first:mt-2,
+    // [&>*]:dark:has-[.x]:mt-2, [&>*]:hover:[&>*]:mt-2) and still be dead, so the reject peels every leading
+    // state layer and re-checks the whole reject-list at each depth, not only at the payload's head. The
+    // self-nesting reject is one of that list for the same reason it never gates: a child is never itself the
+    // CONTAINER a nested [&>*]: would walk, so the inner wrap has nothing to apply to and must not silently
+    // degrade into applying the leaf directly.
     //
     // This recognizes only the literal [&>*]: direct-child scope, not a general child-combinator family.
     internal static class StyleChildVariantClass
@@ -50,10 +54,10 @@ namespace Velvet
         }
 
         // Splits a [&>*]:<payload> token into its wrapped payload. Returns false for a non-token, an empty
-        // payload, or a payload with no gating owner reachable through StyleVariantPayload.Apply — a
-        // structural / has- / attribute- / supports- / (self-nested) child-variant — which would only become
-        // a dead token. A state variant (hover:, dark:hover:, group-hover:) IS accepted: it composes through
-        // GateStackedVariant.
+        // payload, or a payload that — at its head or behind any number of intervening state layers — carries a
+        // variant with no gating owner reachable through StyleVariantPayload.Apply: a structural / has- /
+        // attribute- / supports- / (self-nested) child-variant, which would only become a dead token. A state
+        // variant (hover:, dark:hover:, group-hover:) IS accepted: it composes through GateStackedVariant.
         public static bool TryParse(string? cls, out string payload)
         {
             payload = string.Empty;
@@ -62,17 +66,44 @@ namespace Velvet
                 return false;
             }
             var inner = cls!.Substring(Prefix.Length);
-            if (inner.Length == 0
-                || StyleStructuralVariantClass.IsStructural(inner)
-                || StyleHasVariantClass.IsHas(inner)
-                || StyleAttributeVariantClass.IsAttribute(inner)
-                || StyleSupportsVariantClass.IsSupports(inner)
-                || IsChildVariant(inner))
+            if (inner.Length == 0 || NestsUngatedVariant(inner))
             {
                 return false;
             }
             payload = inner;
             return true;
+        }
+
+        // True when payload — at its head or behind any number of intervening state-variant layers — carries a
+        // variant with no gating owner reachable through StyleVariantPayload.Apply: a structural / has- /
+        // attribute- / supports- / (self-nested) child-variant. Only state variants (hover:, dark:,
+        // group-hover:) compose through Apply, so those are the only peelable layers; every other variant kind
+        // is a dead token here whether it leads the payload or hides one or more state layers deep
+        // (hover:first:mt-2, dark:has-[.x]:mt-2, hover:[&>*]:mt-2). A self-nested [&>*] is rejected for the same
+        // reason it never gates: a child is not the CONTAINER that inner wrap would walk. Peel each leading
+        // state layer and re-check the whole reject-list at every depth; each peel strips the segment after the
+        // variant's ':', so payload strictly shrinks and the loop terminates.
+        private static bool NestsUngatedVariant(string payload)
+        {
+            var current = payload;
+            while (true)
+            {
+                if (StyleStructuralVariantClass.IsStructural(current)
+                    || StyleHasVariantClass.IsHas(current)
+                    || StyleAttributeVariantClass.IsAttribute(current)
+                    || StyleSupportsVariantClass.IsSupports(current)
+                    || IsChildVariant(current))
+                {
+                    return true;
+                }
+                // Only a leading state variant is peelable; a non-variant remainder is the leaf utility, with
+                // nothing left to peel, so no ungated variant is nested behind it.
+                if (!StyleVariantClass.TryParse(current, out _, out var next) || string.IsNullOrEmpty(next))
+                {
+                    return false;
+                }
+                current = next!;
+            }
         }
 
         // Collects the wrapped payload of EVERY [&>*]: token, unlike gap / divide's last-value-wins scalar:

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/ChildVariantClassParityTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/ChildVariantClassParityTests.cs
@@ -67,6 +67,35 @@ namespace Velvet.Tests
         }
 
         [Test]
+        public void Given_ChildVariantNestingChildVariantBehindStateLayer_When_Parsed_Then_Declines()
+        {
+            // Act — the nested [&>*] hides behind an intervening state layer (hover: / dark:). It still has no
+            // CONTAINER to walk at that depth, so it must be rejected exactly like the immediate [&>*]:[&>*]:
+            // form — the reject peels state-variant layers rather than only inspecting the immediate inner token.
+            var hoverNested = StyleChildVariantClass.TryParse("[&>*]:hover:[&>*]:mt-2", out _);
+            var darkNested = StyleChildVariantClass.TryParse("[&>*]:dark:[&>*]:mt-2", out _);
+
+            // Assert — neither state-mediated self-nest is admitted.
+            Assert.That((hoverNested, darkNested), Is.EqualTo((false, false)));
+        }
+
+        [Test]
+        public void Given_ChildVariantHidingUngatedVariantBehindStateLayer_When_Parsed_Then_Declines()
+        {
+            // Act — each ungated kind (structural / has- / attribute- / supports-) hides behind an intervening
+            // state layer (hover: / dark:). None reaches a gating owner at that depth, so — exactly like the same
+            // kind sitting at the payload head — each must be rejected: the reject peels state layers and
+            // re-checks the whole reject-list at every depth, not only the immediate inner token.
+            var structural = StyleChildVariantClass.TryParse("[&>*]:hover:first:mt-2", out _);
+            var has = StyleChildVariantClass.TryParse("[&>*]:hover:has-[.x]:mt-2", out _);
+            var attribute = StyleChildVariantClass.TryParse("[&>*]:dark:data-[open=true]:mt-2", out _);
+            var supports = StyleChildVariantClass.TryParse("[&>*]:hover:supports-[display:flex]:mt-2", out _);
+
+            // Assert — no state-mediated ungated variant is admitted.
+            Assert.That((structural, has, attribute, supports), Is.EqualTo((false, false, false, false)));
+        }
+
+        [Test]
         public void Given_ChildVariantWrappingStateVariantPayload_When_Parsed_Then_AcceptsComposedPayload()
         {
             // Act — a state variant (hover:) DOES compose through GateStackedVariant, so the whole


### PR DESCRIPTION
`[&>*]:<payload>` (`StyleChildVariantClass.TryParse`) only inspected the *immediate* inner token when rejecting a payload that reaches no gating owner. Because state variants compose, an ungated variant kind — structural (`first:`), `has-`, attribute (`data-`/`aria-`), `supports-`, or a self-nested `[&>*]` — can hide one or more state layers deep and still be a dead token:

- `[&>*]:hover:[&>*]:mt-2` — a nested child-combinator behind `hover:`
- `[&>*]:hover:first:mt-2`, `[&>*]:dark:has-[.x]:mt-2` — structural / has- behind a state layer

These slipped past the head-only check and silently degraded to applying the leaf utility directly. `NestsUngatedVariant` now peels each leading *state* layer (the only composable kind) and re-checks the whole reject-list at every depth, so a dead token is rejected wherever it sits.

Parse-level RED/GREEN pins added for the state-mediated self-nest and each ungated kind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
