### PR TITLE
fix(velvet): tween built-in brightness/saturate filters; harden custom-definition asserts

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -13,8 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   carrying the new `transition-filter` class (e.g. `transition-filter hover:blur-md`), matching CSS
   `transition: filter`. UI Toolkit cannot transition the inline `filter` property natively, so a scheduler
   tween drives the filter parameters frame-by-frame; opt in with `transition-filter` (honoring `duration-*`
-  and the easing longhand). Non-interpolable changes (a custom filter, or an ambiguous add/remove) and the
-  off-panel / zero-duration cases fall back to an instant write.
+  and the easing longhand). The built-in `brightness-*` / `saturate-*` filters interpolate like the others
+  even though they render as custom-filter functions; only a user `filter-[name:args]` custom filter, an
+  ambiguous add/remove, or the off-panel / zero-duration cases fall back to an instant write.
 - A third transition model, `StyleTransitionConfig { Type = TransitionType.Bezier, BezierX1,
   BezierY1, BezierX2, BezierY2 }`: variant enters / exits sample an EXACT CSS
   `cubic-bezier(x1,y1,x2,y2)` curve every tick instead of one of the five `EasingMode` keywords,

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberElementCleaner.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberElementCleaner.cs
@@ -320,7 +320,8 @@ namespace Velvet
             if (_ctx.FilterTransitionBindings.TryGetValue(element, out var filterTransitionBinding))
             {
                 // Pause the one-shot tick and unregister so a pooled element does not keep ticking a mid-flight
-                // filter tween. The inline filter itself is scrubbed by the pool reset + ClearAll above.
+                // filter tween. The inline filter itself is scrubbed by FiberElementPoolReset before reuse; the
+                // ClearAll above only drops the arbitrary-value layer map, never style.filter.
                 StyleFilterTransitionDriver.Detach(element, filterTransitionBinding);
                 _ctx.FilterTransitionBindings.Remove(element);
             }

--- a/Packages/com.velvet.core/Runtime/Styling/BuiltInFilterDefinitions.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/BuiltInFilterDefinitions.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UIElements;
 
@@ -20,11 +21,28 @@ namespace Velvet
         private static FilterFunctionDefinition? s_brightness;
         private static FilterFunctionDefinition? s_saturate;
 
+        // Shader paths already warned about as missing, so a build that permanently lacks a filter shader logs
+        // once instead of on every resolve (the properties rebuild whenever the cached definition is null, so a
+        // missing shader is retried every access). Cleared on the editor reset below.
+        private static readonly HashSet<string> s_missingShaderWarned = new();
+
         internal static FilterFunctionDefinition? Brightness
             => IsUsable(s_brightness) ? s_brightness : s_brightness = Build("Velvet/FilterBrightness", "_Brightness", "velvet-brightness");
 
         internal static FilterFunctionDefinition? Saturate
             => IsUsable(s_saturate) ? s_saturate : s_saturate = Build("Velvet/FilterSaturate", "_Saturate", "velvet-saturate");
+
+        // Identity checks against the CACHED definitions only (never forcing a lazy Build): a caller probing an
+        // arbitrary function's definition must not load the brightness/saturate shaders as a side effect. A
+        // first-party custom exists on an element only after its definition was built, so a live built-in
+        // function always matches the cached reference here.
+        internal static bool IsBrightness(FilterFunctionDefinition? def) => def != null && ReferenceEquals(def, s_brightness);
+
+        internal static bool IsSaturate(FilterFunctionDefinition? def) => def != null && ReferenceEquals(def, s_saturate);
+
+        // True for either first-party built-in definition — the ones that interpolate like a native float
+        // filter, as opposed to a user filter-[name:args] custom whose parameters carry no tween semantics.
+        internal static bool IsBuiltIn(FilterFunctionDefinition? def) => IsBrightness(def) || IsSaturate(def);
 
         // A cached definition is reusable only while both it and the material its single pass binds are live.
         // A shader reimport can destroy the pass material out from under a surviving definition; UI Toolkit's
@@ -49,8 +67,11 @@ namespace Velvet
             var shader = Shader.Find(shaderPath);
             if (shader == null)
             {
-                FiberLogger.LogWarning("Filter", $"Shader not found: {shaderPath}. " +
-                    "Ensure it is included in the build (Always Included Shaders); the brightness/saturate layer is omitted.");
+                if (s_missingShaderWarned.Add(shaderPath))
+                {
+                    FiberLogger.LogWarning("Filter", $"Shader not found: {shaderPath}. " +
+                        "Ensure it is included in the build (Always Included Shaders); the brightness/saturate layer is omitted.");
+                }
                 return null;
             }
 
@@ -99,6 +120,9 @@ namespace Velvet
         {
             s_brightness = null;
             s_saturate = null;
+            // Re-arm the one-shot missing-shader warning so a shader edit that fixes availability (or newly
+            // breaks it) is reported once in the next session rather than staying silent.
+            s_missingShaderWarned.Clear();
         }
 #endif
     }

--- a/Packages/com.velvet.core/Runtime/Styling/StyleFilterTransitionDriver.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleFilterTransitionDriver.cs
@@ -61,12 +61,17 @@ namespace Velvet
         internal readonly struct Channel
         {
             public readonly FilterFunctionType Type;
+            // The bound definition for a first-party built-in Custom function (brightness/saturate); null for a
+            // native filter type. ApplyFrame rebuilds the function through it so a rebuilt Custom rebinds its
+            // shader material instead of collapsing to a definition-less Custom that renders nothing.
+            public readonly FilterFunctionDefinition? Definition;
             public readonly FilterParameter[] From;
             public readonly FilterParameter[] To;
 
-            public Channel(FilterFunctionType type, FilterParameter[] from, FilterParameter[] to)
+            public Channel(FilterFunctionType type, FilterFunctionDefinition? definition, FilterParameter[] from, FilterParameter[] to)
             {
                 Type = type;
+                Definition = definition;
                 From = from;
                 To = to;
             }
@@ -116,7 +121,7 @@ namespace Velvet
             var from = element.style.filter.value;
             if (!TryBuildChannels(from, to, out var channels))
             {
-                // Non-interpolable (a custom filter, or an ambiguous add/remove) → discrete instant write.
+                // Non-interpolable (a user custom filter, or an ambiguous add/remove) → discrete instant write.
                 Cancel(b);
                 return false;
             }
@@ -152,7 +157,11 @@ namespace Velvet
             var list = new List<FilterFunction>(b.Channels.Length);
             foreach (var channel in b.Channels)
             {
-                var fn = new FilterFunction(channel.Type);
+                // A first-party built-in Custom (brightness/saturate) must be rebuilt through its definition so
+                // it rebinds its shader; a native type is rebuilt by its FilterFunctionType.
+                var fn = channel.Definition != null
+                    ? new FilterFunction(channel.Definition)
+                    : new FilterFunction(channel.Type);
                 for (var k = 0; k < channel.From.Length; k++)
                 {
                     fn.AddParameter(LerpParam(channel.From[k], channel.To[k], e));
@@ -221,10 +230,11 @@ namespace Velvet
         #region Channel alignment
 
         // Builds the aligned interpolation slots for from→to (both always in canonical filter order). Returns
-        // false — meaning "not interpolable, write instantly" — for a custom filter or an ambiguous add/remove
-        // (a UITK filter type that appears more than once, e.g. grayscale-* + saturate- both rendering as
-        // Grayscale, which cannot be paired by type alone). A null from is treated as an empty list (a
-        // freshly-mounted element with no inline filter reads null, not []).
+        // false — meaning "not interpolable, write instantly" — for a user filter-[name:args] custom or an
+        // ambiguous add/remove (a channel that appears more than once, which cannot be paired by identity
+        // alone). The first-party brightness/saturate customs DO interpolate: each is a single float amount, so
+        // they pair like a native filter, keyed by their definition to stay distinct from one another. A null
+        // from is treated as an empty list (a freshly-mounted element with no inline filter reads null, not []).
         internal static bool TryBuildChannels(List<FilterFunction>? from, List<FilterFunction>? to,
             out Channel[] channels)
         {
@@ -235,14 +245,15 @@ namespace Velvet
             {
                 return false;
             }
-            // A custom filter binds opaque shader material state; a numeric cross-fade is meaningless.
-            if (ContainsCustom(from) || ContainsCustom(to))
+            // A user custom filter binds opaque shader material state; a numeric cross-fade is meaningless. The
+            // first-party brightness/saturate customs are excluded — they interpolate like a native filter.
+            if (ContainsUserCustom(from) || ContainsUserCustom(to))
             {
                 return false;
             }
 
-            // Fast path: identical type sequence — the common case (a value change on the same filter set).
-            if (SameTypeSequence(from, to))
+            // Fast path: identical channel sequence — the common case (a value change on the same filter set).
+            if (SameChannelSequence(from, to))
             {
                 var paired = new Channel[fromCount];
                 for (var k = 0; k < fromCount; k++)
@@ -253,15 +264,15 @@ namespace Velvet
                     {
                         return false;
                     }
-                    paired[k] = new Channel(f.type, Snapshot(f), Snapshot(t));
+                    paired[k] = new Channel(f.type, DefinitionOf(f), Snapshot(f), Snapshot(t));
                 }
                 channels = paired;
                 return true;
             }
 
-            // Different sequences: a filter was added or removed. Pairing by type is only unambiguous when each
-            // UITK type occurs at most once per list; otherwise (a repeated type) fall back to an instant write.
-            if (HasRepeatedType(from) || HasRepeatedType(to))
+            // Different sequences: a filter was added or removed. Pairing by channel is only unambiguous when
+            // each channel occurs at most once per list; otherwise (a repeat) fall back to an instant write.
+            if (HasRepeatedChannel(from) || HasRepeatedChannel(to))
             {
                 return false;
             }
@@ -274,17 +285,17 @@ namespace Velvet
                 {
                     var f = from![i];
                     var t = to![j];
-                    if (f.type == t.type)
+                    if (SameChannel(f, t))
                     {
                         if (f.parameterCount != t.parameterCount)
                         {
                             return false;
                         }
-                        merged.Add(new Channel(f.type, Snapshot(f), Snapshot(t)));
+                        merged.Add(new Channel(f.type, DefinitionOf(f), Snapshot(f), Snapshot(t)));
                         i++;
                         j++;
                     }
-                    else if (CanonicalRank(f.type) < CanonicalRank(t.type))
+                    else if (CanonicalRank(f) < CanonicalRank(t))
                     {
                         merged.Add(FadeOut(f));
                         i++;
@@ -312,10 +323,17 @@ namespace Velvet
 
         // A filter present only in the to-list fades IN from its neutral value; one present only in from fades
         // OUT to it. Matches CSS filter-list padding.
-        private static Channel FadeIn(FilterFunction f) => new Channel(f.type, IdentityParams(f), Snapshot(f));
-        private static Channel FadeOut(FilterFunction f) => new Channel(f.type, Snapshot(f), IdentityParams(f));
+        private static Channel FadeIn(FilterFunction f) => new Channel(f.type, DefinitionOf(f), IdentityParams(f), Snapshot(f));
+        private static Channel FadeOut(FilterFunction f) => new Channel(f.type, DefinitionOf(f), Snapshot(f), IdentityParams(f));
 
-        private static bool ContainsCustom(List<FilterFunction>? list)
+        // The definition to rebind when reconstructing a function each frame: the bound custom definition for a
+        // built-in custom, null for a native type (ApplyFrame rebuilds that by FilterFunctionType).
+        private static FilterFunctionDefinition? DefinitionOf(FilterFunction f)
+            => f.type == FilterFunctionType.Custom ? f.customDefinition : null;
+
+        // A USER custom (filter-[name:args]) forces an instant write; a first-party brightness/saturate custom
+        // does not, since it interpolates like a native float filter.
+        private static bool ContainsUserCustom(List<FilterFunction>? list)
         {
             if (list == null)
             {
@@ -323,7 +341,7 @@ namespace Velvet
             }
             foreach (var f in list)
             {
-                if (f.type == FilterFunctionType.Custom)
+                if (f.type == FilterFunctionType.Custom && !BuiltInFilterDefinitions.IsBuiltIn(f.customDefinition))
                 {
                     return true;
                 }
@@ -331,7 +349,19 @@ namespace Velvet
             return false;
         }
 
-        private static bool SameTypeSequence(List<FilterFunction>? a, List<FilterFunction>? b)
+        // Two functions share a channel when they are the same native filter type, or both the SAME first-party
+        // custom — brightness and saturate are distinct channels even though both are FilterFunctionType.Custom.
+        private static bool SameChannel(FilterFunction a, FilterFunction b)
+        {
+            if (a.type != b.type)
+            {
+                return false;
+            }
+            return a.type != FilterFunctionType.Custom
+                || ReferenceEquals(a.customDefinition, b.customDefinition);
+        }
+
+        private static bool SameChannelSequence(List<FilterFunction>? a, List<FilterFunction>? b)
         {
             var ac = a?.Count ?? 0;
             var bc = b?.Count ?? 0;
@@ -341,7 +371,7 @@ namespace Velvet
             }
             for (var k = 0; k < ac; k++)
             {
-                if (a![k].type != b![k].type)
+                if (!SameChannel(a![k], b![k]))
                 {
                     return false;
                 }
@@ -349,7 +379,7 @@ namespace Velvet
             return true;
         }
 
-        private static bool HasRepeatedType(List<FilterFunction>? list)
+        private static bool HasRepeatedChannel(List<FilterFunction>? list)
         {
             if (list == null || list.Count < 2)
             {
@@ -359,7 +389,7 @@ namespace Velvet
             {
                 for (var k = i + 1; k < list.Count; k++)
                 {
-                    if (list[i].type == list[k].type)
+                    if (SameChannel(list[i], list[k]))
                     {
                         return true;
                     }
@@ -368,19 +398,29 @@ namespace Velvet
             return false;
         }
 
-        // Canonical composition order of the UITK filter types (mirrors s_filterOrder in the resolver). Only
-        // consulted after repeated types are ruled out, so Grayscale mapping to one rank is unambiguous.
-        private static int CanonicalRank(FilterFunctionType type) => type switch
+        // Canonical composition order of the filter channels (mirrors s_filterOrder in the resolver): the two
+        // first-party customs slot by their definition — brightness right after blur, saturate right after
+        // invert — so an add/remove merge keeps the same order the resolver composes in. Only consulted after
+        // user customs and repeated channels are ruled out.
+        private static int CanonicalRank(FilterFunction f)
         {
-            FilterFunctionType.Blur => 0,
-            FilterFunctionType.Tint => 1,
-            FilterFunctionType.Contrast => 2,
-            FilterFunctionType.Grayscale => 3,
-            FilterFunctionType.HueRotate => 4,
-            FilterFunctionType.Invert => 5,
-            FilterFunctionType.Sepia => 6,
-            _ => 7,
-        };
+            if (f.type == FilterFunctionType.Custom)
+            {
+                return BuiltInFilterDefinitions.IsBrightness(f.customDefinition) ? 1
+                    : BuiltInFilterDefinitions.IsSaturate(f.customDefinition) ? 6
+                    : 8;
+            }
+            return f.type switch
+            {
+                FilterFunctionType.Blur => 0,
+                FilterFunctionType.Contrast => 2,
+                FilterFunctionType.Grayscale => 3,
+                FilterFunctionType.HueRotate => 4,
+                FilterFunctionType.Invert => 5,
+                FilterFunctionType.Sepia => 7,
+                _ => 8,
+            };
+        }
 
         private static FilterParameter[] Snapshot(FilterFunction f)
         {
@@ -393,19 +433,21 @@ namespace Velvet
             return arr;
         }
 
-        // The neutral parameters for a filter type — the value at which it is a no-op. Contrast is 1 (identity
-        // multiply); every other float filter (blur, grayscale/saturate, hue-rotate, invert, sepia) is off at
-        // 0; Tint (brightness) multiplies by a color, so its identity is white.
+        // The neutral parameters for a filter — the value at which it is a no-op. The multiplicative filters
+        // (contrast, and the first-party brightness/saturate customs) are off at 1; every other float filter
+        // (blur, grayscale, hue-rotate, invert, sepia) is off at 0; a color parameter's identity is white.
         private static FilterParameter[] IdentityParams(FilterFunction f)
         {
             var count = f.parameterCount;
             var arr = new FilterParameter[count];
+            var floatIdentity = f.type == FilterFunctionType.Contrast
+                || BuiltInFilterDefinitions.IsBuiltIn(f.customDefinition) ? 1f : 0f;
             for (var k = 0; k < count; k++)
             {
                 var p = f.GetParameter(k);
                 arr[k] = p.type == FilterParameterType.Color
                     ? new FilterParameter(Color.white)
-                    : new FilterParameter(f.type == FilterFunctionType.Contrast ? 1f : 0f);
+                    : new FilterParameter(floatIdentity);
             }
             return arr;
         }

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/BuiltInFilterShaderTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/BuiltInFilterShaderTests.cs
@@ -54,11 +54,13 @@ namespace Velvet.Tests
             // Act — an over-bright bracket value (N>1), a range the pre-shader parser rejected outright.
             var fn = ResolveSingle("brightness-[1.5]");
 
-            // Assert — resolves to exactly the built-in brightness Custom definition carrying the raw factor. RED
+            // Assert — resolves to exactly the built-in brightness Custom definition (matched by its filterName,
+            // not its reference: a material-invalidation rebuild hands back a fresh definition instance, which a
+            // reference compare would flake against once the cache re-primes) carrying the raw factor. RED
             // against the pre-shader path two ways: it rejected N>1 at parse (fn stays null), and even a value it
             // accepted bound the Tint filter, not this Custom definition.
-            Assert.That((fn?.type, fn?.customDefinition, fn?.GetParameter(0).floatValue),
-                Is.EqualTo((FilterFunctionType.Custom, BuiltInFilterDefinitions.Brightness, 1.5f)));
+            Assert.That((fn?.type, fn?.customDefinition?.filterName, fn?.GetParameter(0).floatValue),
+                Is.EqualTo(((FilterFunctionType?)FilterFunctionType.Custom, "velvet-brightness", (float?)1.5f)));
         }
 
         [Test]
@@ -70,8 +72,8 @@ namespace Velvet.Tests
             // Assert — resolves to exactly the built-in saturate Custom definition carrying the raw factor. RED
             // against the pre-shader path two ways: it rejected N>1 at parse (fn stays null), and even a value it
             // accepted bound the Grayscale filter, not this Custom definition.
-            Assert.That((fn?.type, fn?.customDefinition, fn?.GetParameter(0).floatValue),
-                Is.EqualTo((FilterFunctionType.Custom, BuiltInFilterDefinitions.Saturate, 1.5f)));
+            Assert.That((fn?.type, fn?.customDefinition?.filterName, fn?.GetParameter(0).floatValue),
+                Is.EqualTo(((FilterFunctionType?)FilterFunctionType.Custom, "velvet-saturate", (float?)1.5f)));
         }
 
         [Test]
@@ -87,8 +89,8 @@ namespace Velvet.Tests
 
             // Assert
             var f = el.style.filter.value;
-            Assert.That((f[0].customDefinition, f[1].type),
-                Is.EqualTo((BuiltInFilterDefinitions.Brightness, FilterFunctionType.Contrast)));
+            Assert.That((f[0].customDefinition?.filterName, f[1].type),
+                Is.EqualTo(("velvet-brightness", FilterFunctionType.Contrast)));
         }
 
         [Test]
@@ -103,8 +105,8 @@ namespace Velvet.Tests
 
             // Assert
             var f = el.style.filter.value;
-            Assert.That((f[0].customDefinition, f[1].type),
-                Is.EqualTo((BuiltInFilterDefinitions.Saturate, FilterFunctionType.Sepia)));
+            Assert.That((f[0].customDefinition?.filterName, f[1].type),
+                Is.EqualTo(("velvet-saturate", FilterFunctionType.Sepia)));
         }
 
         [Test]

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/BuiltInFilterShaderTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/BuiltInFilterShaderTests.cs
@@ -32,34 +32,46 @@ namespace Velvet.Tests
             StyleArbitraryValueResolver.Apply(el, in style);
         }
 
-        [Test]
-        public void Given_ABrightnessBracketValue_When_Applied_Then_TheInlineFilterBindsTheBuiltInBrightnessDefinition()
+        // Parses and applies a token to a fresh element, returning its single resolved FilterFunction — or null
+        // when the token does not parse or does not resolve to exactly one filter. Callers ASSERT (not Assume)
+        // on the result, so a token the pre-shader parser rejected outright — it capped brightness/saturate at
+        // 1 — surfaces as a Failure rather than an Assume-driven Inconclusive, keeping the test a valid RED.
+        private static FilterFunction? ResolveSingle(string token)
         {
-            // Arrange
             var el = new VisualElement();
-
-            // Act
-            ApplyToken(el, "brightness-[1.5]");
-
-            // Assert
-            var f = el.style.filter.value;
-            Assert.That((f.Count, f[0].type, f[0].customDefinition, f[0].GetParameter(0).floatValue),
-                Is.EqualTo((1, FilterFunctionType.Custom, BuiltInFilterDefinitions.Brightness, 1.5f)));
+            if (!StyleArbitraryValueResolver.TryParse(token, out var style))
+            {
+                return null;
+            }
+            StyleArbitraryValueResolver.Apply(el, in style);
+            var list = el.style.filter.value;
+            return list is { Count: 1 } ? list[0] : (FilterFunction?)null;
         }
 
         [Test]
-        public void Given_ASaturateBracketValue_When_Applied_Then_TheInlineFilterBindsTheBuiltInSaturateDefinition()
+        public void Given_ABrightnessBracketValue_When_Resolved_Then_TheInlineFilterBindsTheBuiltInBrightnessDefinition()
         {
-            // Arrange
-            var el = new VisualElement();
+            // Act — an over-bright bracket value (N>1), a range the pre-shader parser rejected outright.
+            var fn = ResolveSingle("brightness-[1.5]");
 
-            // Act
-            ApplyToken(el, "saturate-[1.5]");
+            // Assert — resolves to exactly the built-in brightness Custom definition carrying the raw factor. RED
+            // against the pre-shader path two ways: it rejected N>1 at parse (fn stays null), and even a value it
+            // accepted bound the Tint filter, not this Custom definition.
+            Assert.That((fn?.type, fn?.customDefinition, fn?.GetParameter(0).floatValue),
+                Is.EqualTo((FilterFunctionType.Custom, BuiltInFilterDefinitions.Brightness, 1.5f)));
+        }
 
-            // Assert
-            var f = el.style.filter.value;
-            Assert.That((f.Count, f[0].type, f[0].customDefinition, f[0].GetParameter(0).floatValue),
-                Is.EqualTo((1, FilterFunctionType.Custom, BuiltInFilterDefinitions.Saturate, 1.5f)));
+        [Test]
+        public void Given_ASaturateBracketValue_When_Resolved_Then_TheInlineFilterBindsTheBuiltInSaturateDefinition()
+        {
+            // Act — an over-saturate bracket value (N>1), a range the pre-shader parser rejected outright.
+            var fn = ResolveSingle("saturate-[1.5]");
+
+            // Assert — resolves to exactly the built-in saturate Custom definition carrying the raw factor. RED
+            // against the pre-shader path two ways: it rejected N>1 at parse (fn stays null), and even a value it
+            // accepted bound the Grayscale filter, not this Custom definition.
+            Assert.That((fn?.type, fn?.customDefinition, fn?.GetParameter(0).floatValue),
+                Is.EqualTo((FilterFunctionType.Custom, BuiltInFilterDefinitions.Saturate, 1.5f)));
         }
 
         [Test]
@@ -118,29 +130,25 @@ namespace Velvet.Tests
         }
 
         [Test]
-        public void Given_ABrightnessValueAboveOne_When_Applied_Then_TheShaderParameterCarriesTheUnclampedValue()
+        public void Given_ABrightnessValueAboveOne_When_Resolved_Then_TheShaderParameterCarriesTheUnclampedValue()
         {
-            // Arrange — a value that could not even reach Apply before the parser widening.
-            var el = new VisualElement();
+            // Act — a value the pre-shader parser rejected outright (it capped brightness at 1).
+            var fn = ResolveSingle("brightness-[2]");
 
-            // Act
-            ApplyToken(el, "brightness-[2]");
-
-            // Assert
-            Assert.That(el.style.filter.value[0].GetParameter(0).floatValue, Is.EqualTo(2f));
+            // Assert — the raw over-bright factor reaches the shader parameter unclamped. RED against the
+            // pre-shader parser, which rejected N>1 (fn stays null) instead of carrying 2.
+            Assert.That(fn?.GetParameter(0).floatValue, Is.EqualTo(2f));
         }
 
         [Test]
-        public void Given_ASaturateValueAboveOne_When_Applied_Then_TheShaderParameterCarriesTheUnclampedValue()
+        public void Given_ASaturateValueAboveOne_When_Resolved_Then_TheShaderParameterCarriesTheUnclampedValue()
         {
-            // Arrange
-            var el = new VisualElement();
+            // Act — a value the pre-shader parser rejected outright (it capped saturate at 1).
+            var fn = ResolveSingle("saturate-[2]");
 
-            // Act
-            ApplyToken(el, "saturate-[2]");
-
-            // Assert
-            Assert.That(el.style.filter.value[0].GetParameter(0).floatValue, Is.EqualTo(2f));
+            // Assert — the raw over-saturate factor reaches the shader parameter unclamped. RED against the
+            // pre-shader parser, which rejected N>1 (fn stays null) instead of carrying 2.
+            Assert.That(fn?.GetParameter(0).floatValue, Is.EqualTo(2f));
         }
 
         [Test]

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/FilterTransitionPanelTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/FilterTransitionPanelTests.cs
@@ -35,6 +35,17 @@ namespace Velvet.Tests
             return new List<FilterFunction> { fn };
         }
 
+        // A single brightness inline filter list. brightness renders as a FIRST-PARTY custom-filter function
+        // (FilterFunctionType.Custom bound to BuiltInFilterDefinitions.Brightness), so it exercises the driver's
+        // built-in-custom interpolation path — distinct from a user filter-[name:args] custom, which stays a
+        // discrete instant write.
+        private static List<FilterFunction> BrightnessList(float amount)
+        {
+            var fn = new FilterFunction(BuiltInFilterDefinitions.Brightness);
+            fn.AddParameter(new FilterParameter(amount));
+            return new List<FilterFunction> { fn };
+        }
+
         // Mounts a named leaf, forces a layout pass so resolvedStyle.transitionDuration resolves, and returns it.
         private VisualElement MountResolved(string className)
         {
@@ -86,6 +97,28 @@ namespace Velvet.Tests
 
             // Assert — a distinct reference each frame (RED if the driver reuses one mutated list).
             Assert.That(ReferenceEquals(first, second), Is.False);
+        }
+
+        [Test]
+        public void Given_BrightnessTween_When_FrameAtMid_Then_BrightnessIsHalfway()
+        {
+            // Arrange — a built-in brightness 1.0 → 1.5 tween. brightness composes as FilterFunctionType.Custom,
+            // so the driver must interpolate it like blur rather than treating every Custom as a discrete
+            // instant write (which would leave the aligned channels empty and write no filter at all).
+            Assume.That(BuiltInFilterDefinitions.Brightness, Is.Not.Null,
+                "Precondition: the brightness shader resolved into a definition");
+            var element = new VisualElement();
+            var to = BrightnessList(1.5f);
+            StyleFilterTransitionDriver.TryBuildChannels(BrightnessList(1f), to, out var channels);
+            var binding = new StyleFilterTransitionBinding { Channels = channels, Easing = EasingMode.Linear, Target = to };
+
+            // Act — the midpoint frame.
+            StyleFilterTransitionDriver.ApplyFrame(element, binding, 0.5f);
+
+            // Assert — halfway between 1.0 and 1.5. RED without the built-in-custom fix: TryBuildChannels bails
+            // on any Custom, leaving zero channels, so ApplyFrame writes an empty list (FirstOrDefault → 0).
+            Assert.That(element.style.filter.value.Select(fn => fn.GetParameter(0).floatValue).FirstOrDefault(),
+                Is.EqualTo(1.25f));
         }
 
         [Test]

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/FilterTransitionPanelTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/FilterTransitionPanelTests.cs
@@ -115,10 +115,16 @@ namespace Velvet.Tests
             // Act — the midpoint frame.
             StyleFilterTransitionDriver.ApplyFrame(element, binding, 0.5f);
 
-            // Assert — halfway between 1.0 and 1.5. RED without the built-in-custom fix: TryBuildChannels bails
-            // on any Custom, leaving zero channels, so ApplyFrame writes an empty list (FirstOrDefault → 0).
-            Assert.That(element.style.filter.value.Select(fn => fn.GetParameter(0).floatValue).FirstOrDefault(),
-                Is.EqualTo(1.25f));
+            // Assert — the rebuilt Custom carries the brightness definition (not a definition-less Custom that
+            // renders nothing) and lerps to halfway (1.25). RED without the built-in-custom fix (TryBuildChannels
+            // bails on any Custom → zero channels → empty list → fn null), and RED if ApplyFrame drops the
+            // definition threading (a rebuilt Custom would carry a null customDefinition). The definition's
+            // filterName is the probe, not its reference: a material-invalidation rebuild hands back a fresh
+            // definition instance, so a reference compare would flake once the cache is re-primed.
+            var list = element.style.filter.value;
+            FilterFunction? fn = list != null && list.Count > 0 ? list[0] : null;
+            Assert.That((fn?.type, fn?.customDefinition?.filterName, fn?.GetParameter(0).floatValue),
+                Is.EqualTo(((FilterFunctionType?)FilterFunctionType.Custom, "velvet-brightness", (float?)1.25f)));
         }
 
         [Test]


### PR DESCRIPTION
Two related fixes for the built-in brightness / saturate custom filters (#79 filter transition, #84 custom-filter shaders):

- **Transition tween** — the filter transition driver treated every `FilterFunctionType.Custom` as a discrete instant write, so a built-in `brightness-*` / `saturate-*` change under `transition-filter` left the aligned channels empty and wrote no filter at all. It now distinguishes a first-party built-in Custom (interpolated like a native filter, rebuilt through its definition so it rebinds the shader material) from a user `filter-[name:args]` Custom (still a discrete instant write).

- **Test hardening** — the built-in-definition asserts compared `FilterFunctionDefinition` by reference, which flakes under a full-suite run where a material GC re-primes the memoized definition into a fresh instance; they now match on the definition's `filterName`. Added a transition-tween pin that the rebuilt Custom carries its definition rather than collapsing to a definition-less Custom that renders nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
