### PR TITLE
fix(velvet): guard all cubic-bezier coordinates for finiteness; drop overrides from Bezier hold

### DIFF
--- a/Packages/com.velvet.core/Runtime/Hooks/SequenceWalker.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/SequenceWalker.cs
@@ -221,11 +221,13 @@ namespace Velvet
             }
         }
 
-        // Auto-derives a To step's hold from its transition when the step declares no explicit HoldSec.
-        // Mirrors StyleAnimationScheduler.SlowestPropertyTimeoutMs's own "slowest overridden property wins"
-        // rule: a PropertyOverrides entry can give one property a longer duration/delay than the top-level
-        // values (StyleTransitionConfig's own documented example: opacity in 0.15s while scale takes 0.5s), and
-        // the walker must not advance past a step while a property that override still governs is mid-tween.
+        // Auto-derives a To step's hold from its transition when the step declares no explicit HoldSec. A Spring
+        // has no statically knowable settle time and a Bezier drives every channel with one fixed-duration curve
+        // — both are handled specially below and ignore PropertyOverrides. Only a Tween reads them, mirroring
+        // StyleAnimationScheduler.SlowestPropertyTimeoutMs's own "slowest overridden property wins" rule: a
+        // PropertyOverrides entry can give one property a longer duration/delay than the top-level values
+        // (StyleTransitionConfig's own documented example: opacity in 0.15s while scale takes 0.5s), and the
+        // walker must not advance past a Tween step while a property that override still governs is mid-tween.
         private float ResolveHoldFromTransition(int index, StyleTransitionConfig transition)
         {
             if (transition.Type == TransitionType.Spring)
@@ -240,6 +242,16 @@ namespace Velvet
             }
 
             var hold = transition.DurationSec + transition.DelaySec;
+
+            // Bezier playback drives every channel with the SAME curve and never reads PropertyOverrides (like a
+            // spring's single stiffness/damping/mass), so its real span is the fixed DurationSec + DelaySec.
+            // Factoring a longer per-property override in here would park the walker on the step past the moment
+            // the tween it describes has actually finished.
+            if (transition.Type == TransitionType.Bezier)
+            {
+                return hold;
+            }
+
             var overrides = transition.PropertyOverrides;
             if (overrides != null)
             {

--- a/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseAnimationSequenceTests.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseAnimationSequenceTests.cs
@@ -300,5 +300,32 @@ namespace Velvet.Tests
             // Assert
             Assert.That(s_state.CurrentLabel, Is.EqualTo("a"));
         }
+
+        [Test]
+        public void Given_ABezierToStepWithAPropertyOverrideLongerThanTheTopLevelDuration_When_TheTopLevelDurationHasElapsed_Then_TheWalkerHasAdvancedPastIt()
+        {
+            // Arrange — a Bezier tween drives every channel with one fixed-duration curve and never reads
+            // PropertyOverrides (the same contract as a spring's single stiffness/damping/mass), so the
+            // auto-derived hold must be the fixed 50ms DurationSec, NOT the 300ms override a plain Tween would
+            // follow — otherwise the sequence stalls on the step long past when the tween it describes finished.
+            s_steps = new[]
+            {
+                AnimationSequenceStep.To("a", new StyleTransitionConfig
+                {
+                    Type = TransitionType.Bezier,
+                    DurationSec = 0.05f,
+                    PropertyOverrides = new[] { new StylePropertyTransition("translate", durationSec: 0.3f) },
+                }),
+                AnimationSequenceStep.To("b", new StyleTransitionConfig { Type = TransitionType.Bezier, DurationSec = 0.5f }),
+            };
+            Mount();
+            Assume.That(s_state.CurrentLabel, Is.EqualTo("a"), "Precondition: step 0 is current right after mount");
+
+            // Act — past the top-level 50ms but well short of the override's 300ms.
+            AdvancePast(0.1f);
+
+            // Assert
+            Assert.That(s_state.CurrentLabel, Is.EqualTo("b"));
+        }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Styling/CubicBezierEvaluator.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/CubicBezierEvaluator.cs
@@ -69,10 +69,15 @@ namespace Velvet
 
             // A CSS timing function must be monotone in time, so an x1/x2 outside [0,1] makes the WHOLE curve
             // invalid — not just the offending coordinate — the same way a browser rejects the entire
-            // cubic-bezier() declaration rather than clamping one axis into range.
-            if (x1 < 0f || x1 > 1f || x2 < 0f || x2 > 1f)
+            // cubic-bezier() declaration rather than clamping one axis into range. Finiteness is tested on ALL
+            // four control coordinates, not just the x's: every comparison against NaN is false, so a range check
+            // alone would wave a non-finite point straight through — and a NaN in y1/y2 clears the x-only range
+            // test yet still poisons SampleCurve(y1,y2,s) into a NaN output. Guarding every coordinate keeps
+            // Evaluate self-safe regardless of what a caller passes.
+            if (!float.IsFinite(x1) || !float.IsFinite(y1) || !float.IsFinite(x2) || !float.IsFinite(y2)
+                || x1 < 0f || x1 > 1f || x2 < 0f || x2 > 1f)
             {
-                WarnInvalidControlPoints(x1, x2);
+                WarnInvalidControlPoints(x1, y1, x2, y2);
                 x1 = DefaultX1;
                 y1 = DefaultY1;
                 x2 = DefaultX2;
@@ -90,7 +95,7 @@ namespace Velvet
             return SampleCurve(y1, y2, s);
         }
 
-        private static void WarnInvalidControlPoints(float x1, float x2)
+        private static void WarnInvalidControlPoints(float x1, float y1, float x2, float y2)
         {
             if (s_warnedInvalidControlPoints)
             {
@@ -98,8 +103,9 @@ namespace Velvet
             }
             s_warnedInvalidControlPoints = true;
             FiberLogger.LogWarning("Bezier",
-                $"cubic-bezier control points x1={x1}, x2={x2} are outside [0,1], which is invalid — a timing " +
-                "function must be monotone in time. Falling back to the default curve, cubic-bezier(0.4, 0, 0.2, 1).");
+                $"cubic-bezier control points (x1={x1}, y1={y1}, x2={x2}, y2={y2}) are invalid — a timing " +
+                "function's x must stay within [0,1] to be monotone in time, and every coordinate must be finite. " +
+                "Falling back to the default curve, cubic-bezier(0.4, 0, 0.2, 1).");
         }
 
         // Bézier with endpoints fixed at 0 and 1 collapses to the cubic polynomial (a*s + b)*s*s + c*s, whose

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/CubicBezierEvaluatorTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/CubicBezierEvaluatorTests.cs
@@ -9,9 +9,10 @@ namespace Velvet.Tests
     /// <summary>
     /// Pins the pure CSS <c>cubic-bezier(x1,y1,x2,y2)</c> evaluation (<see cref="CubicBezierEvaluator.Evaluate"/>):
     /// the boundary clamps, the linear/identity fast path, an exact front-loaded reference point that a keyword
-    /// easing could not reproduce, an unclamped overshoot, solver monotonicity, and the out-of-range x1/x2
-    /// reject-and-fall-back-to-default-curve path (with its one-shot warning). Panel-free by design — the
-    /// evaluator is pure math with no <c>VisualElement</c>/panel dependency.
+    /// easing could not reproduce, an unclamped overshoot, solver monotonicity, and the reject-and-fall-back-to-
+    /// default-curve path (with its one-shot warning) for both an out-of-range x1/x2 and a non-finite coordinate
+    /// on any of the four axes. Panel-free by design — the evaluator is pure math with no
+    /// <c>VisualElement</c>/panel dependency.
     /// </summary>
     /// <remarks>
     /// The reference midpoint (0.7756) was computed independently with a Python implementation of the same
@@ -120,6 +121,41 @@ namespace Velvet.Tests
 
             // Act
             var output = CubicBezierEvaluator.Evaluate(2f, 0f, 0.2f, 1f, 0.5f);
+
+            // Assert
+            Assert.That(output, Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void Given_ANaNXControlPoint_When_Evaluated_Then_TheOutputMatchesTheDefaultCurveInsteadOfPassingNaNThrough()
+        {
+            // Arrange — a NaN control point is not caught by an ordinary out-of-range comparison (every
+            // comparison against NaN is false), so without an explicit finiteness check the NaN would flow
+            // straight into the solver and poison the output; the finite fallback must degrade it to the default
+            // curve exactly like an out-of-range value. The reference is a valid call, so it logs nothing.
+            var expected = CubicBezierEvaluator.Evaluate(0.4f, 0f, 0.2f, 1f, 0.5f);
+            LogAssert.Expect(LogType.Warning, new Regex("[Bb]ezier"));
+
+            // Act
+            var output = CubicBezierEvaluator.Evaluate(float.NaN, 0f, 0.2f, 1f, 0.5f);
+
+            // Assert
+            Assert.That(output, Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void Given_ANaNYControlPoint_When_Evaluated_Then_TheOutputMatchesTheDefaultCurveInsteadOfPassingNaNThrough()
+        {
+            // Arrange — a NaN in y1/y2 survives the x-axis range/finiteness test (its x's are valid) but still
+            // poisons SampleCurve(y1,y2,s) into a NaN output, so the finiteness guard has to cover every
+            // coordinate, not just the two x's. With a valid x pair here, only guarding y catches this — it must
+            // degrade to the default curve and warn exactly like any other invalid control point. The reference
+            // is a valid call, so it logs nothing.
+            var expected = CubicBezierEvaluator.Evaluate(0.4f, 0f, 0.2f, 1f, 0.5f);
+            LogAssert.Expect(LogType.Warning, new Regex("[Bb]ezier"));
+
+            // Act
+            var output = CubicBezierEvaluator.Evaluate(0.4f, float.NaN, 0.2f, 1f, 0.5f);
 
             // Assert
             Assert.That(output, Is.EqualTo(expected));


### PR DESCRIPTION
Two guards for the cubic-bezier scheduler tween (#80):

- **Finiteness** — `CubicBezierEvaluator` only range-checked the x coordinates. Every comparison against NaN is false, so a non-finite control point waved straight through the range check; and a NaN in `y1`/`y2` (which the x-only test never sees) poisons `SampleCurve` into a NaN output. All four coordinates are now finiteness-checked before the range check, keeping `Evaluate` self-safe regardless of what a caller passes.

- **Sequence hold** — `ResolveHoldFromTransition` factored a per-property override into a Bezier step's auto-derived hold, but Bezier playback drives every channel with one fixed-duration curve and never reads `PropertyOverrides` (like a spring's single stiffness/damping/mass). Factoring an override in parked the sequence walker on the step past the moment its tween actually finished. Bezier now returns the plain `DurationSec + DelaySec`, matching its real span.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
