### PR TITLE
fix(velvet): route a shadowed child's dashed divider through the solid path

### DIFF
--- a/Packages/com.velvet.core/Runtime/Styling/StyleDivideManipulator.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleDivideManipulator.cs
@@ -33,8 +33,13 @@ namespace Velvet
     //
     // Limitations: an explicit per-child border on the SAME edge the divider draws on (e.g. border-l on a
     // child of a divide-x row) is OVERWRITTEN — this manipulator owns that edge, exactly as the gap
-    // manipulator owns its margin edge. A child that is itself skewed keeps its border-left owned by
-    // SkewSilhouette, so its divider renders solid (a documented known limitation).
+    // manipulator owns its margin edge. A child whose border face is owned by a higher paint layer — a skew
+    // silhouette or a drop shadow — keeps its border owned there, so its dashed divider renders solid (a
+    // documented known limitation, mirroring the element-level border-dashed gate which defers to either).
+    // An IMPLICIT (no divide-{color}) dashed divider takes its color from the divided child's would-be border
+    // color, captured and re-resolved on the CONTAINER's Apply (reconcile / GeometryChanged / attach) — the same
+    // container-Apply cadence the gap manipulator runs on. A child that re-renders on its own fiber alone, with
+    // no container Apply, keeps the last captured color until an unrelated container reconcile.
     //
     // Out-of-flow children (position: absolute) are excluded from the index walk — see
     // StyleOutOfFlowChild — the same way StyleGapManipulator excludes them: an out-of-flow child (a
@@ -153,16 +158,18 @@ namespace Velvet
         // paints the stroke on the child's own generateVisualContent (DivideDashChildBinding).
         private void ApplyToChild(VisualElement child, Edge edge, bool isDivider)
         {
-            // A skewed child's SkewSilhouette owns its border face, so a dashed divider can only render solid
-            // there — route it through the solid path (documented known limitation).
+            // A skew silhouette or a drop shadow owns the child's border face and repaints a solid border, so a
+            // dashed divider on the same child would fight it — route it through the solid path (documented known
+            // limitation). Gates on EITHER owner, mirroring the element-level border-dashed gate.
             var dashed = (_spec.Style == BorderLineStyle.Dashed || _spec.Style == BorderLineStyle.Dotted)
-                && !_ctx.SkewBindings.ContainsKey(child);
+                && !_ctx.SkewBindings.ContainsKey(child)
+                && !_ctx.ShadowBindings.ContainsKey(child);
 
             if (!dashed || !isDivider)
             {
-                // Solid divider, the first child (no divider), or a skewed child: a plain inline border. Detach
-                // any stale dash paint (e.g. a divide-dashed → divide-solid flip, or a colored child reordered
-                // to the first slot).
+                // Solid divider, the first child (no divider), or a child whose face a skew / shadow layer owns:
+                // a plain inline border. Detach any stale dash paint (e.g. a divide-dashed → divide-solid flip, or
+                // a colored child reordered to the first slot).
                 DetachDash(child);
                 var width = isDivider ? new StyleFloat(_spec.Width) : new StyleFloat(StyleKeyword.Null);
                 // Own the edge's color channel on EVERY pass (like the gap manipulator owns its margin): write

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/DivideClassParityTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/DivideClassParityTests.cs
@@ -437,6 +437,22 @@ namespace Velvet.Tests
             Assert.That(scope.Reconciler.Context.DivideDashBindings[scope.Root[0][1]].Color, Is.EqualTo(green));
         }
 
+        [Test]
+        public void Given_DivideXDashedRow_When_ADividerChildIsShadowed_Then_ThatChildGetsNoDashedPaint()
+        {
+            // Arrange — a drop shadow owns the child's border face and repaints a solid border, so a dashed
+            // divider on the same child would fight it: the dashed layer must defer to the face owner (a solid
+            // divider, no paint), the same as for a skewed child and as the element-level border-dashed gate does.
+            using var scope = new ReconcilerScope();
+            var tree = new VNode[] { DividerRowWithColoredChild("flex flex-row divide-x divide-dashed divide-gray-200", "shadow-lg") };
+
+            // Act
+            scope.Reconciler.Reconcile(scope.Root, System.Array.Empty<VNode>(), tree);
+
+            // Assert — the shadowed divider child carries no dashed paint binding (it renders a solid divider).
+            Assert.That(scope.Reconciler.Context.DivideDashBindings.ContainsKey(scope.Root[0][1]), Is.False);
+        }
+
         #endregion
 
         private static VNode DividerRowWithColoredChild(string className, string childBorderClass)


### PR DESCRIPTION
Two fixes for the `divide-dashed` / `divide-dotted` divider (#83):

- **Shadow gate** — the eligibility gate deferred only to a child's skew silhouette, not its drop shadow, so a shadowed divided child drew a dashed divider that fought the shadow layer already repainting a solid border. It now gates on EITHER owner (skew or shadow), mirroring the element-level `border-dashed` gate which already defers to both.

- **Implicit color cadence** — an implicit (no `divide-{color}`) dashed divider takes its color from the divided child's own would-be border color, resolved on the container's `Apply` (reconcile / GeometryChanged / attach). Re-resolving it at paint time was a no-op for the mainline case: the manipulator masks the child's inline border with the suppression sentinel, so a paint-time read only ever sees the sentinel. The container-Apply resolution is kept and the cadence documented (a child re-rendering on its own fiber alone does not move the divider).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
