### PR TITLE
feat(velvet): add occlude and distanceFactor to V.Anchored

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `V.Anchored` gains `occlude` and `distanceFactor`, closing two of drei `<Html>`'s parity gaps.
+  `occlude: true` hides the element while a solid (non-trigger) collider sits between the camera and
+  the target — an opt-in physics query every tick, off by default — via the new `occludeLayerMask`
+  (defaults to `Physics.DefaultRaycastLayers`). `distanceFactor` scales the element by that value
+  divided by its current camera distance, faking perspective size falloff for otherwise-flat
+  screen-space content; it is the reference distance at which scale is exactly 1 and must be positive.
+
 ## [1.5.0] - 2026-07-19
 
 ### Added

--- a/Packages/com.velvet.core/Documentation~/portals.md
+++ b/Packages/com.velvet.core/Documentation~/portals.md
@@ -150,9 +150,19 @@ navigation never crosses panels.
 drei's `<Html>` parity in its DEFAULT mode: a plain screen-space element whose `left`/`top`
 track a 3D scene Transform's projected position every frame, re-derived through
 `RuntimePanelUtils.CameraTransformWorldToPanel` on the target's own camera (or
-`Camera.main` when none is given). Not depth-tested — unlike `V.WorldSpace` above, this is
-ordinary 2D UI drawn in the normal screen-space paint order, so it is never occluded by scene
-geometry; it just sits wherever its target currently projects to.
+`Camera.main` when none is given). This is ordinary 2D UI drawn in the normal screen-space
+paint order, so it has no inherent scene depth on its own — it just sits wherever its target
+currently projects to, unlike `V.WorldSpace` above, which renders content INTO the 3D scene
+and is occluded by scene geometry for free. `occlude: true` opts into an explicit stand-in for
+that test instead: a physics `Linecast` between the camera and the target hides the element
+when a solid (non-trigger) collider sits between them, scoped by `occludeLayerMask` (a target
+whose own collider sits on that mask will typically occlude itself — scope the mask to scene
+geometry that excludes it). `distanceFactor` scales the element by itself divided by the
+current camera distance — a cheap fake for perspective size falloff on otherwise-flat content;
+it is the reference distance at which scale is exactly 1. Left unset, Anchored never touches
+the element's `scale` style at all, so it composes freely with a `scale-*` class or a Motion
+scale variant; setting it makes Anchored own that style slot every tick instead, so combining
+it with either of those is a straightforward conflict, not an integration.
 
 `V.Anchored` forces `position: absolute` inline (dynamic positioning has no other way to
 work), so pass layout classes for everything else — sizing, background, text, and so on —
@@ -173,6 +183,3 @@ without reflecting into an internal engine property — so it silently receives 
 near-raw-world-space values `RuntimePanelUtils.CameraTransformWorldToPanel` is documented to
 degrade to for a `V.WorldSpace` host (see above). `V.Anchored` targets an ordinary screen-space
 panel only.
-
-Raycast-based occlusion against scene geometry — drei's `<Html occlude>` opt-in — is not
-implemented: an explicit, documented scope cut for now, not an oversight.

--- a/Packages/com.velvet.core/Runtime/Component/V.cs
+++ b/Packages/com.velvet.core/Runtime/Component/V.cs
@@ -1554,11 +1554,11 @@ namespace Velvet
 
         /// <summary>
         /// Screen-space element that tracks a 3D scene Transform's projected position every frame — drei's
-        /// <c>&lt;Html&gt;</c> parity (default screen-space projection mode). Not depth-tested against scene
-        /// geometry (unlike <see cref="WorldSpace"/>, which renders content INTO the 3D scene and can be
-        /// occluded by it): this is ordinary 2D UI, positioned dynamically. Forces <c>position: absolute</c>
-        /// inline (dynamic left/top positioning has no other way to work; see AnchoredDriver.Attach) — pass
-        /// layout classes for everything else.
+        /// <c>&lt;Html&gt;</c> parity (default screen-space projection mode). This is ordinary 2D UI with no
+        /// inherent scene depth (unlike <see cref="WorldSpace"/>, which renders content INTO the 3D scene and
+        /// is occluded by it for free) — <paramref name="occlude"/> opts into an explicit physics stand-in for
+        /// that test. Forces <c>position: absolute</c> inline (dynamic left/top positioning has no other way
+        /// to work; see AnchoredDriver.Attach) — pass layout classes for everything else.
         /// </summary>
         /// <param name="target">The Transform this element's screen position tracks. Null (or a Transform
         /// destroyed later) mounts an inert, hidden (display: none) element until a live target is supplied —
@@ -1570,12 +1570,29 @@ namespace Velvet
         /// <param name="offset">Pixel offset applied after projection (e.g. to center a label on the point).</param>
         /// <param name="hideWhenBehindCamera">When true (default), the element is hidden (display: none)
         /// while <paramref name="target"/> is behind the camera rather than jumping to a wrong on-screen spot.</param>
+        /// <param name="occlude">When true, a solid (non-trigger) collider between the camera and
+        /// <paramref name="target"/> hides the element — an extra physics query every tick, so it is off by
+        /// default rather than a standing cost every consumer pays. A target whose own collider sits on
+        /// <paramref name="occludeLayerMask"/> will typically occlude itself; scope the mask to scene geometry
+        /// that excludes it.</param>
+        /// <param name="occludeLayerMask">Which colliders count as occluders when <paramref name="occlude"/>
+        /// is true. Null (default) resolves to <see cref="Physics.DefaultRaycastLayers"/>.</param>
+        /// <param name="distanceFactor">When set, scales the element by this value divided by its current
+        /// distance to the camera — drei's <c>&lt;Html distanceFactor&gt;</c> parity, faking perspective size
+        /// falloff for otherwise-flat screen-space content. Null (default) leaves the element unscaled and
+        /// never touches <c>style.scale</c>, so it composes with a <c>scale-*</c> class or a Motion scale
+        /// variant on the same element; a non-null value OWNS that style slot every tick instead and will
+        /// fight either of those for it. Must be positive when supplied.</param>
         /// <returns>The created <see cref="ElementNode"/>.</returns>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="distanceFactor"/> is &lt;= 0, NaN, or positive infinity.</exception>
         public static ElementNode Anchored(
             Transform? target,
             Camera? camera = null,
             Vector2? offset = null,
             bool hideWhenBehindCamera = true,
+            bool occlude = false,
+            LayerMask? occludeLayerMask = null,
+            float? distanceFactor = null,
             string? className = null,
             string? key = null,
             string? name = null,
@@ -1589,8 +1606,13 @@ namespace Velvet
             IReadOnlyDictionary<string, string>? data = null,
             IReadOnlyDictionary<string, string>? aria = null)
         {
+            // Validated BEFORE renting pooled props so a throwing call leaks nothing (mirrors V.SceneView):
+            // the settings constructor fail-fasts on an invalid distanceFactor for every construction path,
+            // this factory included.
+            var anchored = new AnchoredSettings(target, camera, offset ?? Vector2.zero, hideWhenBehindCamera,
+                occlude, occludeLayerMask, distanceFactor);
             var mergedProps = WithAttributes(props, data, aria) ?? VNodePool.RentProps();
-            mergedProps.Anchored = new AnchoredSettings(target, camera, offset ?? Vector2.zero, hideWhenBehindCamera);
+            mergedProps.Anchored = anchored;
 
             return new ElementNode
             {

--- a/Packages/com.velvet.core/Runtime/Reconciler/AnchoredDriver.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/AnchoredDriver.cs
@@ -15,6 +15,9 @@ namespace Velvet
         public IVisualElementScheduledItem? Tick;
         public EventCallback<GeometryChangedEvent>? OnGeometryChanged;
         public bool WarnedAboutUnsupportedPanel;
+        // Tracks whether THIS binding is the one currently holding element.style.scale, so it only ever
+        // clears a value it actually wrote — see AnchoredDriver.ClearAppliedScale.
+        public bool HasAppliedDistanceFactorScale;
 
         public AnchoredBinding(AnchoredSettings settings)
         {
@@ -30,8 +33,10 @@ namespace Velvet
     /// Toolkit resolves <c>position: absolute</c> <c>left</c>/<c>top</c> against the immediate parent, not the
     /// panel root, unlike CSS's nearest-positioned-ancestor walk), and writes the result as inline
     /// <c>left</c>/<c>top</c> — drei's
-    /// <c>&lt;Html&gt;</c> parity (screen-space projection, not depth-tested against scene geometry, unlike
-    /// <c>V.WorldSpace</c>). <c>RuntimePanelUtils.CameraTransformWorldToPanel</c> is correct here specifically
+    /// <c>&lt;Html&gt;</c> parity (screen-space projection; unlike <c>V.WorldSpace</c>, which renders content
+    /// INTO the 3D scene and is depth-tested for free, this is ordinary 2D UI with no inherent scene depth —
+    /// <see cref="AnchoredSettings.Occlude"/> opts into an explicit physics stand-in for that test).
+    /// <c>RuntimePanelUtils.CameraTransformWorldToPanel</c> is correct here specifically
     /// because the element lives in an ordinary screen-space (Overlay/Camera) panel: <c>PanelSettings.
     /// ApplyPanelSettings</c> only resolves the scale factor this API divides by (<c>ScreenToPanel</c>'s
     /// <c>screen / scale</c>) for non-WorldSpace render modes — the same API returns the input essentially
@@ -46,6 +51,12 @@ namespace Velvet
     {
         // Per-frame cadence, matching the sibling per-frame element drivers (SceneViewDriver, ParticlesDriver).
         internal const long TickIntervalMs = 16;
+
+        // Below this camera-to-target distance, distanceFactor / distance diverges toward whatever float
+        // range is left rather than anything a screen-space scale should read as — a real-world Unity
+        // scene can plausibly put a camera this close to a target (unlike Mathf.Epsilon, which only
+        // excludes an exact, near-impossible 0), so scale holds at 1 instead of ballooning.
+        private const float MinDistanceFactorDistance = 0.01f;
 
         public static AnchoredBinding Attach(VisualElement element, AnchoredSettings settings)
         {
@@ -88,13 +99,26 @@ namespace Velvet
                 binding.OnGeometryChanged = null;
             }
             // Release every inline style Attach/Sync forced, so a pooled element does not ghost a stale
-            // absolute position (or a display:none from having last synced behind the camera) onto whatever
-            // it is reused for next — the recurring pool-reuse footgun this codebase's own reset helpers
-            // (e.g. FiberElementPoolReset) exist to avoid.
+            // absolute position (or a display:none from having last synced behind the camera) onto
+            // whatever it is reused for next — the recurring pool-reuse footgun this codebase's own reset
+            // helpers (e.g. FiberElementPoolReset) exist to avoid.
             element.style.position = StyleKeyword.Null;
             element.style.left = StyleKeyword.Null;
             element.style.top = StyleKeyword.Null;
             element.style.display = StyleKeyword.Null;
+            ClearAppliedScale(element, binding);
+        }
+
+        // Clears element.style.scale ONLY when this binding is the one that last wrote it (distanceFactor
+        // was in effect) — an unconditional clear here would also stomp a scale value some OTHER system
+        // (a scale-* utility class, a Motion hover/tap/transition variant) is independently driving on the
+        // same element, since nothing about V.Anchored implies it owns that style slot unless
+        // distanceFactor actually opted it in.
+        private static void ClearAppliedScale(VisualElement element, AnchoredBinding binding)
+        {
+            if (!binding.HasAppliedDistanceFactorScale) return;
+            element.style.scale = StyleKeyword.Null;
+            binding.HasAppliedDistanceFactorScale = false;
         }
 
         private static void Sync(VisualElement element, AnchoredBinding binding)
@@ -103,6 +127,7 @@ namespace Velvet
             if (target == null)
             {
                 element.style.display = DisplayStyle.None;
+                ClearAppliedScale(element, binding);
                 return;
             }
 
@@ -120,6 +145,7 @@ namespace Velvet
                 // in the scene) — there is no sensible position to hold, so hide rather than freeze at a
                 // screen position that no longer corresponds to anything, mirroring the target==null branch.
                 element.style.display = DisplayStyle.None;
+                ClearAppliedScale(element, binding);
                 return;
             }
 
@@ -137,6 +163,7 @@ namespace Velvet
                 if (binding.Settings.HideWhenBehindCamera)
                 {
                     element.style.display = DisplayStyle.None;
+                    ClearAppliedScale(element, binding);
                 }
                 return;
             }
@@ -158,6 +185,22 @@ namespace Velvet
                         + "Hiding it instead of showing a stale or arbitrary position.");
                 }
                 element.style.display = DisplayStyle.None;
+                ClearAppliedScale(element, binding);
+                return;
+            }
+
+            // Opt-in physics stand-in for scene depth (drei's <Html occlude> parity): a solid collider
+            // between the camera and the target hides the element instead of painting it through scene
+            // geometry. Linecast's endpoint sits exactly at the target's own pivot, so a target whose own
+            // collider encloses that pivot will typically self-occlude — scope OccludeLayerMask to scene
+            // geometry that excludes the target's layer rather than trying to filter the target out of a
+            // hit result (RaycastAll's allocation is not worth paying for every tick of every binding).
+            // Triggers never occlude: they are gameplay volumes, not solid geometry.
+            if (binding.Settings.Occlude && Physics.Linecast(
+                    camera.transform.position, target.position, binding.Settings.OccludeLayerMask, QueryTriggerInteraction.Ignore))
+            {
+                element.style.display = DisplayStyle.None;
+                ClearAppliedScale(element, binding);
                 return;
             }
 
@@ -196,6 +239,28 @@ namespace Velvet
             var offset = binding.Settings.Offset;
             element.style.left = localPoint.x + offset.x;
             element.style.top = localPoint.y + offset.y;
+
+            var distanceFactor = binding.Settings.DistanceFactor;
+            if (distanceFactor.HasValue)
+            {
+                // drei's <Html distanceFactor> parity: flat screen-space content has no inherent size in
+                // the scene, so faking perspective falloff means scaling it inversely with camera distance
+                // — distanceFactor is the reference distance at which scale is exactly 1. toTarget (from the
+                // behind-camera test above) already holds camera-to-target; reused here rather than a
+                // second Vector3.Distance call.
+                var distance = toTarget.magnitude;
+                var scale = distance > MinDistanceFactorDistance ? distanceFactor.Value / distance : 1f;
+                element.style.scale = new Scale(new Vector2(scale, scale));
+                binding.HasAppliedDistanceFactorScale = true;
+            }
+            else
+            {
+                // Only clears a value THIS binding applied on an earlier tick (distanceFactor was set
+                // then, cleared now) — never touches style.scale when distanceFactor has never been set,
+                // so an Anchored element combined with a scale-* class or a Motion scale variant on the
+                // same element is left entirely to whichever of those systems is actually driving it.
+                ClearAppliedScale(element, binding);
+            }
         }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberElementProps.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberElementProps.cs
@@ -232,7 +232,11 @@ namespace Velvet
     /// <summary>
     /// The 3D Transform an Anchored element's screen position tracks, plus the camera whose projection
     /// drives it (null resolves to <see cref="Camera.main"/> on every tick, so a scene's active camera
-    /// can change without a settings update) and a pixel offset applied after projection.
+    /// can change without a settings update), a pixel offset applied after projection, an opt-in physics
+    /// occlusion test, and an opt-in camera-distance scale factor. The constructor fail-fasts on a
+    /// non-positive or NaN <see cref="DistanceFactor"/> so every construction path (the factory, wrapper
+    /// hosts, direct construction) shares one guard; a <c>with</c> expression bypasses it like any record
+    /// init.
     /// </summary>
     public sealed record AnchoredSettings
     {
@@ -240,13 +244,25 @@ namespace Velvet
         public Camera? Camera { get; init; }
         public Vector2 Offset { get; init; }
         public bool HideWhenBehindCamera { get; init; } = true;
+        public bool Occlude { get; init; }
+        public LayerMask OccludeLayerMask { get; init; } = Physics.DefaultRaycastLayers;
+        public float? DistanceFactor { get; init; }
 
-        public AnchoredSettings(Transform? target, Camera? camera = null, Vector2 offset = default, bool hideWhenBehindCamera = true)
+        /// <exception cref="System.ArgumentOutOfRangeException"><paramref name="distanceFactor"/> is &lt;= 0, NaN, or positive infinity.</exception>
+        public AnchoredSettings(Transform? target, Camera? camera = null, Vector2 offset = default,
+            bool hideWhenBehindCamera = true, bool occlude = false, LayerMask? occludeLayerMask = null,
+            float? distanceFactor = null)
         {
             Target = target;
             Camera = camera;
             Offset = offset;
             HideWhenBehindCamera = hideWhenBehindCamera;
+            Occlude = occlude;
+            OccludeLayerMask = occludeLayerMask ?? Physics.DefaultRaycastLayers;
+            DistanceFactor = distanceFactor.HasValue
+                ? VelvetArgUtil.RequirePositiveFinite(distanceFactor.Value, nameof(distanceFactor),
+                    "distanceFactor must be positive; it is the reference distance at which scale is 1.")
+                : null;
         }
     }
 
@@ -256,8 +272,9 @@ namespace Velvet
     {
         internal static float RequirePositiveFinite(float value, string paramName, string message)
         {
-            // The negated > comparison catches NaN too.
-            if (!(value > 0f))
+            // The negated > comparison catches NaN and non-positive values; PositiveInfinity is > 0f so
+            // it slips past that check on its own and needs its own guard to actually be "finite".
+            if (!(value > 0f) || float.IsPositiveInfinity(value))
             {
                 throw new System.ArgumentOutOfRangeException(paramName, message);
             }

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/AnchoredTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/AnchoredTests.cs
@@ -10,7 +10,10 @@ namespace Velvet.Tests
     /// the element out of flow (<c>position: absolute</c>), a target behind the camera hides the element
     /// (<c>display: none</c>) WITHOUT reaching the real screen-projection call (see the class remarks on why
     /// that matters for this fixture), unmounting releases the binding and every inline style it drove, and a
-    /// patched target updates the SAME binding rather than tearing down and recreating it.
+    /// patched target updates the SAME binding rather than tearing down and recreating it. Also specifies
+    /// <c>distanceFactor</c>'s numeric precondition: it must be positive and finite (rejecting <c>0</c>,
+    /// negative values, and <c>float.PositiveInfinity</c>) on every construction path — the settings record
+    /// directly, and the factory both with and without leaking a pooled props bag on the throwing path.
     /// </summary>
     /// <remarks>
     /// Deliberately does NOT assert the actual projected left/top for an in-front-of-camera target:
@@ -122,6 +125,62 @@ namespace Velvet.Tests
 
             // Assert
             Assert.That(element.style.display.value, Is.EqualTo(DisplayStyle.None));
+        }
+
+        [Test]
+        public void Given_ADirectlyConstructedSettings_When_TheDistanceFactorIsInvalid_Then_ItThrows()
+        {
+            // Arrange — the factory's fail-fast guard must hold for every construction path (fixtures and
+            // wrapper hosts can build the settings record directly too), or an invalid distanceFactor
+            // silently degrades to a degenerate scale instead of the documented exception.
+            // Act & Assert
+            Assert.Throws<ArgumentOutOfRangeException>(() => new AnchoredSettings(_targetGo.transform, distanceFactor: 0f));
+        }
+
+        [Test]
+        public void Given_AnInvalidDistanceFactor_When_TheFactoryRuns_Then_ItThrows()
+        {
+            // Act & Assert — an invalid required numeric factory argument fails fast at the call site, like
+            // the other factories with numeric preconditions (e.g. V.SceneView's resolutionScale).
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => V.Anchored(_targetGo.transform, distanceFactor: -1f));
+        }
+
+        [Test]
+        public void Given_APositiveInfinityDistanceFactor_When_TheFactoryRuns_Then_ItThrows()
+        {
+            // Arrange & Act & Assert — RequirePositiveFinite's negated `> 0f` comparison alone lets
+            // +Infinity through (Infinity > 0f is true); it needs its own explicit rejection, or the
+            // next Sync writes an Infinity scale straight into the live style system.
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => V.Anchored(_targetGo.transform, distanceFactor: float.PositiveInfinity));
+        }
+
+        [Test]
+        public void Given_AnInvalidDistanceFactor_When_TheFactoryThrows_Then_NoPooledPropsLeak()
+        {
+            // Arrange — the factory rents a pooled props bag; a throwing validation must not leave it
+            // stranded in the pool's ownership ledger (each failing render would leak one).
+            var ledger = typeof(VNodePool).GetField("s_ownedProps",
+                System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic);
+            Assume.That(ledger, Is.Not.Null, "Precondition: the pool ownership ledger exists");
+            var set = ledger.GetValue(null);
+            var count = set.GetType().GetProperty("Count");
+            Assume.That(count, Is.Not.Null, "Precondition: the ledger exposes a count");
+            var before = (int)count.GetValue(set);
+
+            // Act
+            try
+            {
+                V.Anchored(_targetGo.transform, distanceFactor: 0f);
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+            }
+
+            // Assert
+            var after = (int)count.GetValue(set);
+            Assert.That(after, Is.EqualTo(before));
         }
 
         [Test]

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/AnchoredPlaybackTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/AnchoredPlaybackTests.cs
@@ -15,9 +15,13 @@ namespace Velvet.Tests
     /// (Y-flipped for panel space, the same conversion <c>RuntimePanelUtils.CameraTransformWorldToPanel</c>
     /// performs internally) independently says it should be — including when nested inside an offset parent
     /// container, and that <c>Props.Visible = false</c> still hides an Anchored element despite the driver's
-    /// own inline display writes. Complements <see cref="AnchoredTests"/> (EditMode, wiring + the behind-camera/
+    /// own inline display writes. Also pins <c>occlude</c> (a blocking collider hides the element, the flag
+    /// actually gates the physics query rather than always/never running, and toggling it on a LIVE binding —
+    /// not just at Attach — reacts correctly), <c>distanceFactor</c> (the resolved scale, and that leaving it
+    /// unset never touches a pre-existing inline scale some OTHER system owns on the same element). Complements
+    /// <see cref="AnchoredTests"/> (EditMode, wiring + numeric-precondition validation + the behind-camera/
     /// no-camera/unsupported-panel hide paths only — an editor-simulated panel cannot exercise the real
-    /// runtime-panel projection call).
+    /// runtime-panel projection call, the occlusion physics query, or the distanceFactor scale write).
     /// </summary>
     internal sealed class AnchoredPlaybackTests
     {
@@ -25,6 +29,9 @@ namespace Velvet.Tests
         private static Camera s_camera;
         private static bool s_nestInOffsetContainer;
         private static bool s_visible = true;
+        private static bool s_occlude;
+        private static float? s_distanceFactor;
+        private static StateUpdater<bool> s_setOccludeLive;
 
         private GameObject _panelGo;
         private GameObject _cameraGo;
@@ -35,7 +42,12 @@ namespace Velvet.Tests
         [Component]
         private static VNode AnchoredHost()
         {
+            // occlude flows through UseState (s_occlude only seeds the INITIAL value) so a test can flip
+            // it on a LIVE binding via s_setOccludeLive — AnchoredDriver.Update, not a fresh Attach.
+            var (occlude, setOcclude) = Hooks.UseState(s_occlude);
+            s_setOccludeLive = setOcclude;
             var anchored = V.Anchored(s_target, camera: s_camera, name: "anchored", className: "w-[10px] h-[10px]",
+                occlude: occlude, distanceFactor: s_distanceFactor,
                 props: new FiberElementProps { Visible = s_visible });
             // Margin, not padding: position:absolute's containing block is the parent's PADDING edge (CSS/UI
             // Toolkit semantics), so padding alone wouldn't actually move an absolute child's origin — margin
@@ -50,6 +62,8 @@ namespace Velvet.Tests
         {
             s_nestInOffsetContainer = false;
             s_visible = true;
+            s_occlude = false;
+            s_distanceFactor = null;
 
             _panelGo = new GameObject("AnchoredPlaybackPanel");
             var doc = _panelGo.AddComponent<UIDocument>();
@@ -166,6 +180,149 @@ namespace Velvet.Tests
             // Assert — the driver's own inline display write must not outrank Props.Visible = false's "hidden"
             // USS class (element.style.display should stay StyleKeyword.Null, not an inline override).
             Assert.That(element.resolvedStyle.display, Is.EqualTo(DisplayStyle.None));
+        }
+
+        [UnityTest]
+        public IEnumerator Given_OccludeIsTrueAndAColliderBlocksTheLineOfSight_When_ARealPanelTicks_Then_TheElementIsHidden()
+        {
+            // Arrange — a solid collider sitting directly on the segment between the camera (z=-10) and
+            // the target (z=0), so the physics stand-in for scene depth has something to hit.
+            var blockerGo = new GameObject("AnchoredPlaybackOccluder", typeof(BoxCollider));
+            try
+            {
+                blockerGo.transform.position = new Vector3(0f, 0f, -5f);
+                s_occlude = true;
+                yield return Mount();
+                var element = _panelGo.GetComponent<UIDocument>().rootVisualElement.Q<VisualElement>("anchored");
+                Assume.That(element, Is.Not.Null, "Precondition: the Anchored element mounted");
+
+                // Act
+                yield return null;
+                yield return null;
+
+                // Assert
+                Assert.That(element.resolvedStyle.display, Is.EqualTo(DisplayStyle.None));
+            }
+            finally
+            {
+                Object.Destroy(blockerGo);
+            }
+        }
+
+        [UnityTest]
+        public IEnumerator Given_OccludeIsTrueAndNothingBlocksTheLineOfSight_When_ARealPanelTicks_Then_TheElementStaysVisible()
+        {
+            // Arrange — occlude opted in, but the scene has no collider at all for the Linecast to hit.
+            s_occlude = true;
+            yield return Mount();
+            var element = _panelGo.GetComponent<UIDocument>().rootVisualElement.Q<VisualElement>("anchored");
+            Assume.That(element, Is.Not.Null, "Precondition: the Anchored element mounted");
+
+            // Act
+            yield return null;
+            yield return null;
+
+            // Assert — opting into occlusion must not hide the element on its own; only an actual hit does.
+            Assert.That(element.resolvedStyle.display, Is.EqualTo(DisplayStyle.Flex));
+        }
+
+        [UnityTest]
+        public IEnumerator Given_ADistanceFactor_When_ARealPanelTicks_Then_TheElementIsScaledByFactorOverDistance()
+        {
+            // Arrange — the camera sits 10 units from the target (UnitySetUp's z=-10 vs. the target's
+            // z=0), so a distanceFactor of 5 should resolve to a 0.5x scale.
+            s_distanceFactor = 5f;
+            yield return Mount();
+            var element = _panelGo.GetComponent<UIDocument>().rootVisualElement.Q<VisualElement>("anchored");
+            Assume.That(element, Is.Not.Null, "Precondition: the Anchored element mounted");
+
+            // Act
+            yield return null;
+            yield return null;
+
+            // Assert
+            Assert.That(element.resolvedStyle.scale.value.x, Is.EqualTo(0.5f).Within(0.05f));
+        }
+
+        [UnityTest]
+        public IEnumerator Given_OccludeIsFalseAndAColliderBlocksTheLineOfSight_When_ARealPanelTicks_Then_TheElementStaysVisible()
+        {
+            // Arrange — the same blocking collider as the occlude:true tests, but occlude left at its
+            // default false: proves the flag actually GATES the Linecast rather than it always running
+            // (or never running) regardless of the setting.
+            var blockerGo = new GameObject("AnchoredPlaybackOccluderGateCheck", typeof(BoxCollider));
+            try
+            {
+                blockerGo.transform.position = new Vector3(0f, 0f, -5f);
+                yield return Mount();
+                var element = _panelGo.GetComponent<UIDocument>().rootVisualElement.Q<VisualElement>("anchored");
+                Assume.That(element, Is.Not.Null, "Precondition: the Anchored element mounted");
+
+                // Act
+                yield return null;
+                yield return null;
+
+                // Assert
+                Assert.That(element.resolvedStyle.display, Is.EqualTo(DisplayStyle.Flex));
+            }
+            finally
+            {
+                Object.Destroy(blockerGo);
+            }
+        }
+
+        [UnityTest]
+        public IEnumerator Given_AnElementWithAPreExistingInlineScale_When_ARealPanelTicksWithoutADistanceFactor_Then_TheScaleIsUntouched()
+        {
+            // Arrange — simulate another system (a scale-* utility, a Motion hover/tap/transition
+            // variant) already owning this element's inline scale; distanceFactor stays unset (the
+            // UnitySetUp default).
+            yield return Mount();
+            var element = _panelGo.GetComponent<UIDocument>().rootVisualElement.Q<VisualElement>("anchored");
+            Assume.That(element, Is.Not.Null, "Precondition: the Anchored element mounted");
+            element.style.scale = new Scale(new Vector2(2f, 2f));
+
+            // Act
+            yield return null;
+            yield return null;
+
+            // Assert — AnchoredDriver must never touch style.scale when distanceFactor was never set, or
+            // it would silently fight whatever else is driving that same inline property on the same
+            // element (the regression a prior revision of this driver had: it unconditionally nulled
+            // style.scale every tick regardless of whether distanceFactor was ever in play).
+            Assert.That((element.resolvedStyle.scale.value.x, element.resolvedStyle.scale.value.y), Is.EqualTo((2f, 2f)));
+        }
+
+        [UnityTest]
+        public IEnumerator Given_OccludeToggledOnALiveBinding_When_AColliderAlreadyBlocksTheLineOfSight_Then_TheElementBecomesHidden()
+        {
+            // Arrange — mount with occlude OFF despite a collider already blocking the line of sight, so
+            // the element starts visible; occlude then flips on through React state (AnchoredDriver.Update
+            // on the SAME binding), not a fresh Attach.
+            var blockerGo = new GameObject("AnchoredPlaybackLiveOccluder", typeof(BoxCollider));
+            try
+            {
+                blockerGo.transform.position = new Vector3(0f, 0f, -5f);
+                yield return Mount();
+                var element = _panelGo.GetComponent<UIDocument>().rootVisualElement.Q<VisualElement>("anchored");
+                Assume.That(element, Is.Not.Null, "Precondition: the Anchored element mounted");
+                yield return null;
+                yield return null;
+                Assume.That(element.resolvedStyle.display, Is.EqualTo(DisplayStyle.Flex),
+                    "Precondition: occlude starts off, so the blocking collider does not hide the element yet");
+
+                // Act
+                s_setOccludeLive.Invoke(true);
+                yield return null;
+                yield return null;
+
+                // Assert
+                Assert.That(element.resolvedStyle.display, Is.EqualTo(DisplayStyle.None));
+            }
+            finally
+            {
+                Object.Destroy(blockerGo);
+            }
         }
     }
 }


### PR DESCRIPTION
## What

`V.Anchored` gains two opt-in settings, closing two screen-space-anchor parity gaps (#104):

- **`occlude`** (with `occludeLayerMask`, default `Physics.DefaultRaycastLayers`): hides the element while a solid (non-trigger) collider sits between the camera and the target, via one `Physics.Linecast` per tick. Off by default so the physics query is never a standing cost; triggers never occlude. A target whose own collider sits on the mask will typically occlude itself, so the mask should be scoped to scene geometry that excludes it.
- **`distanceFactor`**: scales the element by the value divided by its current camera distance — perspective size falloff for otherwise-flat screen-space content. It is the reference distance at which scale is exactly 1, must be positive and finite, and holds scale at 1 below a small minimum distance instead of diverging.

## Why the scale write is edge-triggered

`element.style.scale` is a shared inline slot also driven by `scale-*` utilities and Motion scale variants. The driver therefore only writes (and only clears) scale while `distanceFactor` is actually set, tracked by a per-binding ownership flag — leaving it unset composes cleanly with any other scale driver on the same element, and every hide branch plus detach releases only a value this binding itself applied.

## Also included

- `RequirePositiveFinite` (shared by `SceneViewSettings` / `ParticlesSettings` / the new `distanceFactor` guard) now rejects `float.PositiveInfinity`, which previously slipped past the `> 0` check.
- `Documentation~/portals.md` updated: the old "occlusion is not implemented — documented scope cut" note is gone, and the ownership rule for `distanceFactor` vs. other scale drivers is documented.

## Tests

- EditMode (`AnchoredTests`): fail-fast validation for `distanceFactor` on both construction paths (settings record and factory), including `+Infinity`, plus a no-pooled-props-leak check on the throwing path.
- PlayMode (`AnchoredPlaybackTests`, real `UIDocument` panel + real physics): occlusion hides / stays visible with nothing blocking / `occlude: false` ignores a blocking collider (proves the flag gates the query), live toggling `occlude` on an existing binding, the resolved `distanceFactor` scale, and a pre-existing inline scale surviving ticks when `distanceFactor` is unset.

3055/3055 EditMode and 83/83 PlayMode tests pass locally.

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)