### PR TITLE
feat(velvet): order UseFrame callbacks by priority via a per-panel dispatcher

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `Hooks.UseFrame` gains a `priority` parameter — r3f's `useFrame(callback, renderPriority)` ordering
+  parity. Lower runs earlier within the same panel; equal priorities fall back to subscription (mount)
+  order. Backing this, per-frame callbacks now subscribe to a single per-panel dispatcher instead of
+  each scheduling their own engine tick, so firing order also stays stable across a keyed reorder of a
+  callback's host, which the previous per-element scheduling did not guarantee.
+
 ## [1.5.0] - 2026-07-19
 
 ### Added

--- a/Packages/com.velvet.core/Documentation~/particles.md
+++ b/Packages/com.velvet.core/Documentation~/particles.md
@@ -73,7 +73,7 @@ static VNode Hud()
 ```
 
 `Hooks.UseFrame(dt => …)` runs the callback once per frame with the elapsed seconds while
-the component stays mounted, and stops on unmount. Two properties define it:
+the component stays mounted, and stops on unmount. Three properties define it:
 
 - **The latest closure always runs.** A re-render swaps the callback without re-subscribing,
   so captured state is never stale. Under the default compiler memoization hooks always run
@@ -83,5 +83,13 @@ the component stays mounted, and stops on unmount. Two properties define it:
 - **No render per frame.** Per-frame data bypasses component state entirely; write to refs,
   imperative handles, or element styles from the callback. Setting state per frame would
   re-render the world every tick — that is the anti-pattern this hook exists to avoid.
+- **Ordered across components.** An optional second argument, `priority` (default 0), orders
+  callbacks within the same panel — lower runs earlier, equal priorities fall back to mount
+  order — for the rare case where one `UseFrame` callback needs to read what another already
+  wrote this same frame. Unlike r3f's `useFrame(callback, renderPriority)`, a positive priority
+  has no side effect beyond ordering; Unity's own rendering has no internal loop for it to take
+  over.
 
-Frames tick while the component's host is attached to a panel and pause while it is not.
+Frames tick while the component's host is attached to a panel and pause while it is not, and
+that stays true across a keyed reorder of the host — the component's position in the panel's
+firing order does not reshuffle just because its element moved.

--- a/Packages/com.velvet.core/Runtime/Hooks/Hooks.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Hooks.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Threading;
 using Cysharp.Threading.Tasks;
+using UnityEngine.UIElements;
 
 namespace Velvet
 {
@@ -908,20 +909,43 @@ namespace Velvet
         /// per-frame data flows without touching component state (the escape hatch for
         /// simulation-driven visuals; setting state per frame would re-render the world every tick).
         /// Frames tick while the component's host is attached to a panel and pause while it is not.
+        /// <paramref name="priority"/> orders callbacks within the SAME panel — lower runs earlier,
+        /// equal priorities run in subscription (mount) order, and this stays true across a keyed
+        /// reorder of the host — r3f's <c>useFrame(callback, renderPriority)</c> parity. Unlike r3f, a
+        /// positive priority has no side effect beyond ordering: Unity's rendering is independent of
+        /// this scheduler, so there is no internal render call for it to take over. The latest render's
+        /// priority applies live, the same way <paramref name="onFrame"/> does — changing it does not
+        /// restart the subscription or move it among same-priority siblings.
         /// </summary>
         /// <param name="onFrame">Invoked once per frame with the elapsed time in seconds (always positive).</param>
-        public static void UseFrame(Action<float> onFrame)
+        /// <param name="priority">Lower runs earlier within the same panel this frame. Defaults to 0.</param>
+        public static void UseFrame(Action<float> onFrame, int priority = 0)
         {
             if (onFrame == null) throw new ArgumentNullException(nameof(onFrame));
             var fiber = Resolve("UseFrame");
-            // Every render overwrites the ref slot, and the tick below reads through it — that is what
-            // swaps in the latest closure without re-subscribing (the effect's empty deps never re-run).
-            // StrictMode's throwaway diagnostic pass must not swap the LIVE closure (its captures are
-            // the discarded pass's state), matching UseImperativeHandle's gate.
+            // Every render overwrites the ref slot, and the subscribed callback below reads through it —
+            // that is what swaps in the latest closure without re-subscribing (the effect's empty deps
+            // never re-run). StrictMode's throwaway diagnostic pass must not swap the LIVE closure (its
+            // captures are the discarded pass's state), matching UseImperativeHandle's gate.
             var latest = UseRef<Action<float>>();
+            // Kept live independent of whether a Subscription exists yet: a host that has not attached to
+            // a panel on its first several renders (an off-tree subtree, a not-yet-revealed Suspense
+            // branch) would otherwise lose every priority value except the very first one — EnsureSubscribed
+            // below has nothing else to fall back on once no live Subscription exists to mutate directly.
+            var latestPriority = UseMutableRef<int>(priority);
+            var subscriptionRef = UseRef<UseFrameDispatcher.Subscription>();
             if (!IsStrictDiagnosticPass(fiber))
             {
                 latest.Set(onFrame);
+                latestPriority.Current = priority;
+                // Applied directly to the live Subscription object (not deferred to the effect, which
+                // never re-runs for a priority-only change) — same "latest render wins" treatment as
+                // onFrame above, so a priority change takes effect next tick without disturbing this
+                // subscription's position among same-priority siblings.
+                if (subscriptionRef.Current != null)
+                {
+                    subscriptionRef.Current.Priority = priority;
+                }
             }
 
             UseEffect(() =>
@@ -933,65 +957,77 @@ namespace Velvet
                 {
                     return null;
                 }
-                UnityEngine.UIElements.IVisualElementScheduledItem? tick = null;
-                void StartTickIfNeeded()
+
+                UseFrameDispatcher? dispatcher = null;
+                UseFrameDispatcher.Subscription? subscription = null;
+
+                void EnsureSubscribed()
                 {
-                    if (tick != null)
+                    var panel = host.panel;
+                    if (panel == null)
                     {
                         return;
                     }
-                    tick = host.schedule.Execute((UnityEngine.UIElements.TimerState ts) =>
+                    var currentDispatcher = UseFrameDispatcher.GetOrCreate(panel);
+                    if (subscription != null && ReferenceEquals(dispatcher, currentDispatcher))
                     {
-                        // TimerState.start is the previous callback's time for a repeating item (or the
-                        // schedule time for the first firing), so deltaTime is already exactly the
-                        // elapsed interval — no separate "last tick" bookkeeping. A zero delta
-                        // (same-frame flush) is skipped so the callback only ever observes positive,
-                        // frame-sized seconds; a hitch spike is clamped the way Time.deltaTime clamps
-                        // its own, so a stall cannot teleport a user simulation by one giant step. The
-                        // zero interval fires on every scheduler update — once per frame — rather than
-                        // imposing a wall-clock floor that would skip frames on fast panels.
-                        var dt = ts.deltaTime / 1000f;
-                        if (dt <= 0f)
-                        {
-                            return;
-                        }
-                        dt = UnityEngine.Mathf.Min(dt, UnityEngine.Time.maximumDeltaTime);
+                        // Same panel as before a transient detach (a keyed reorder is the common case) —
+                        // resume the SAME slot instead of resubscribing, which is what keeps this
+                        // component's position stable relative to same-priority siblings instead of
+                        // migrating to the end of the group the way a plain per-element scheduled item
+                        // would (see UseFrameDispatcher's own remarks).
+                        subscription.Active = true;
+                        return;
+                    }
+                    // First attach, or a move to a genuinely different panel (rare, and not tracked as a
+                    // stable cross-panel identity): latestPriority.Current is always this render's value
+                    // regardless of whether a Subscription existed to carry it, so it is the correct
+                    // source here too — not just for the true-first-subscribe case.
+                    if (subscription != null)
+                    {
+                        dispatcher!.Unsubscribe(subscription);
+                    }
+                    dispatcher = currentDispatcher;
+                    subscription = dispatcher.Subscribe(latestPriority.Current, dt =>
+                    {
                         try
                         {
                             latest.Current?.Invoke(dt);
                         }
                         catch (Exception ex)
                         {
-                            // Contained like an effect exception: an escaped throw would abort the rest
-                            // of this panel's scheduled updates for the frame and re-fire every frame
-                            // thereafter (the scheduler never unschedules a throwing item), and the
-                            // nearest error boundary must receive user-callback failures either way.
+                            // Contained like an effect exception: an escaped throw must not stop the
+                            // dispatcher's tick from reaching the rest of this panel's subscribers, and
+                            // the nearest error boundary must receive user-callback failures either way.
                             ComponentBoundarySearch.PropagateException(fiber, ex);
                         }
-                    }).Every(0);
+                    });
+                    subscriptionRef.Set(subscription);
                 }
-                // A recurring item like this Every(0) tick survives a keyed reorder's detach/re-attach
-                // on its own: UI Toolkit's own per-item attach/detach handling pauses it when the host
-                // leaves the panel and reschedules the SAME item when the host returns (the detach and
-                // re-attach even cancel out in the scheduler's own bookkeeping when, as here, both land
-                // in a single pass), so nothing needs to re-arm it. A one-shot item has no such luck —
-                // its delay restarts in full on every re-attach. The tick is therefore only ever
-                // created once; an explicit Pause on every detach, as this hook used to do, would
-                // defeat that built-in survival and force a fresh item to be armed on every attach for
-                // no benefit.
-                UnityEngine.UIElements.EventCallback<UnityEngine.UIElements.AttachToPanelEvent> onAttach = _ => StartTickIfNeeded();
-                host.RegisterCallback(onAttach);
-                // The passive effect runs post-commit, so the host is ordinarily already attached and
-                // no AttachToPanelEvent is coming — arm the first tick directly.
-                if (host.panel != null)
+
+                EventCallback<AttachToPanelEvent> onAttach = _ => EnsureSubscribed();
+                EventCallback<DetachFromPanelEvent> onDetach = _ =>
                 {
-                    StartTickIfNeeded();
-                }
+                    if (subscription != null)
+                    {
+                        subscription.Active = false;
+                    }
+                };
+
+                host.RegisterCallback(onAttach);
+                host.RegisterCallback(onDetach);
+                // The passive effect runs post-commit, so the host is ordinarily already attached and no
+                // AttachToPanelEvent is coming — subscribe directly.
+                EnsureSubscribed();
+
                 return () =>
                 {
                     host.UnregisterCallback(onAttach);
-                    tick?.Pause();
-                    tick = null;
+                    host.UnregisterCallback(onDetach);
+                    if (subscription != null)
+                    {
+                        dispatcher!.Unsubscribe(subscription);
+                    }
                 };
             }, Array.Empty<object>());
         }

--- a/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseFrameDispatcherLifecycleTests.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseFrameDispatcherLifecycleTests.cs
@@ -1,0 +1,210 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine.UIElements;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins <see cref="UseFrameDispatcher"/>'s per-panel scoping, true-unmount cleanup, and per-subscriber
+    /// timing baselines on the EditMode fake clock — properties its own class doc promises ("One
+    /// dispatcher per panel") but that <see cref="UseFrameKeyedReorderTests"/> (reorder survival) and
+    /// <see cref="UseFramePriorityTests"/> (ordering) don't themselves exercise: two panels never see each
+    /// other's subscribers, a host that TRULY unmounts (not just reorders) stops firing while its
+    /// still-mounted siblings keep their relative order undisturbed, a panel whose subscriber count drops
+    /// to zero still fires a freshly mounted host later, and a late-joining subscriber's first real delta
+    /// reflects only its OWN elapsed time — never a stall an earlier, unrelated subscriber on the same
+    /// panel had already accumulated before the late joiner even existed.
+    /// </summary>
+    internal sealed class UseFrameDispatcherLifecycleTests
+    {
+        private static readonly List<string> s_order = new();
+        private static bool s_mountSecond = true;
+
+        [Component]
+        private static VNode HostA()
+        {
+            Hooks.UseFrame(_ => s_order.Add("A"));
+            return V.Div(className: "w-[1px] h-[1px]");
+        }
+
+        [Component]
+        private static VNode HostB()
+        {
+            Hooks.UseFrame(_ => s_order.Add("B"));
+            return V.Div(className: "w-[1px] h-[1px]");
+        }
+
+        // B renders only while s_mountSecond is true — the CLAUDE.md-documented "cond ? node : null" idiom
+        // for a real unmount, distinct from a keyed reorder (which never removes a VNode from the tree).
+        [Component]
+        private static VNode TwoHostParent()
+        {
+            var (mountSecond, setMountSecond) = Hooks.UseState(s_mountSecond);
+            s_setMountSecond = setMountSecond;
+            return V.Div(children: new VNode[]
+            {
+                V.Component(HostA, key: "a"),
+                mountSecond ? V.Component(HostB, key: "b") : null,
+            });
+        }
+
+        private static StateUpdater<bool> s_setMountSecond;
+
+        private HeadlessEditorPanelHost _host;
+        private MountedTree _mounted;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _host = new HeadlessEditorPanelHost();
+            UseFrameFakeClockHost.Reset();
+            s_mountSecond = true;
+            s_order.Clear();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _mounted?.Dispose();
+            _mounted = null;
+            _host?.Dispose();
+            _host = null;
+        }
+
+        private void MountAndArm(VNode root, HeadlessEditorPanelHost host)
+        {
+            EditorPanelTestHelpers.SetPanelTimeFunction(host.Panel, UseFrameFakeClockHost.ReadFakeClock);
+            _mounted = V.Mount(host.Root, root);
+            _mounted.FlushEffectsForTest();
+            EditorPanelTestHelpers.DriveSchedulerOnce(host.Panel); // absorbs the zero-delta arm-time firing
+        }
+
+        [Test]
+        public void Given_ATrulyUnmountedHost_When_Ticked_Then_ItStopsFiringAndItsSiblingIsUndisturbed()
+        {
+            // Arrange
+            MountAndArm(V.Component(TwoHostParent, key: "root"), _host);
+            s_order.Clear();
+            UseFrameFakeClockHost.Ms += 16;
+            EditorPanelTestHelpers.DriveSchedulerOnce(_host.Panel);
+            Assume.That(s_order, Is.EqualTo(new[] { "A", "B" }), "Precondition: both hosts fire before B unmounts");
+
+            // Act — B leaves the tree entirely (VNode becomes null), not just a reorder.
+            s_mountSecond = false;
+            s_setMountSecond.Invoke(false);
+            _mounted.FlushStateForTest();
+            s_order.Clear();
+            UseFrameFakeClockHost.Ms += 16;
+            EditorPanelTestHelpers.DriveSchedulerOnce(_host.Panel);
+
+            // Assert — A keeps firing on its own, undisturbed; B never fires again.
+            Assert.That(s_order, Is.EqualTo(new[] { "A" }));
+        }
+
+        [Test]
+        public void Given_TwoSeparatePanels_When_OneTicks_Then_TheOtherPanelsSubscriberDoesNotFire()
+        {
+            // Arrange — two independent hosts/panels, each with its own fake clock, each mounting ONE
+            // ticking component (HostA on panel 1, HostB on panel 2). UseFrameDispatcher's per-panel
+            // ConditionalWeakTable means these must never share firing.
+            using var hostPanel2 = new HeadlessEditorPanelHost();
+            MountAndArm(V.Component(HostA, key: "root-1"), _host);
+            var mounted1 = _mounted;
+            EditorPanelTestHelpers.SetPanelTimeFunction(hostPanel2.Panel, UseFrameFakeClockHost.ReadFakeClock);
+            var mounted2 = V.Mount(hostPanel2.Root, V.Component(HostB, key: "root-2"));
+            mounted2.FlushEffectsForTest();
+            EditorPanelTestHelpers.DriveSchedulerOnce(hostPanel2.Panel);
+            try
+            {
+                s_order.Clear();
+
+                // Act — only panel 1's scheduler advances.
+                UseFrameFakeClockHost.Ms += 16;
+                EditorPanelTestHelpers.DriveSchedulerOnce(_host.Panel);
+
+                // Assert — panel 2's host (subscribed to a DIFFERENT dispatcher instance) never fired.
+                Assert.That(s_order, Is.EqualTo(new[] { "A" }));
+            }
+            finally
+            {
+                mounted2.Dispose();
+                mounted1.Dispose();
+                _mounted = null;
+            }
+        }
+
+        [Test]
+        public void Given_APanelDrainedToZeroSubscribers_When_ANewHostMountsLater_Then_ItStartsFiring()
+        {
+            // Arrange — mount and then fully unmount the only host on this panel, draining
+            // UseFrameDispatcher's subscriber list to zero (which pauses its own scheduled tick).
+            MountAndArm(V.Component(HostA, key: "root"), _host);
+            s_order.Clear();
+            _mounted.Dispose();
+            _mounted = null;
+
+            // Act — a fresh host mounts on the SAME panel afterward.
+            EditorPanelTestHelpers.SetPanelTimeFunction(_host.Panel, UseFrameFakeClockHost.ReadFakeClock);
+            _mounted = V.Mount(_host.Root, V.Component(HostB, key: "root2"));
+            _mounted.FlushEffectsForTest();
+            EditorPanelTestHelpers.DriveSchedulerOnce(_host.Panel); // absorbs the zero-delta arm-time firing
+            s_order.Clear();
+            UseFrameFakeClockHost.Ms += 16;
+            EditorPanelTestHelpers.DriveSchedulerOnce(_host.Panel);
+
+            // Assert — the dispatcher re-armed its tick rather than staying paused forever.
+            Assert.That(s_order, Is.EqualTo(new[] { "B" }));
+        }
+
+        private static readonly List<float> s_observedDts = new();
+
+        [Component]
+        private static VNode DtRecordingHost()
+        {
+            Hooks.UseFrame(dt => s_observedDts.Add(dt));
+            return V.Div(className: "w-[1px] h-[1px]");
+        }
+
+        [Test]
+        public void Given_ALateJoiningSubscriber_When_AnEarlierOneOnTheSamePanelHasBeenStalled_Then_ItsFirstDeltaIsSmall()
+        {
+            // Arrange — HostA mounts and ticks once (baseline established), then the clock jumps far
+            // ahead WITHOUT driving the scheduler in between — simulating a panel that stalled (an
+            // unfocused Editor window, a hitch) before a second, unrelated component mounts onto the
+            // SAME panel and joins the SAME dispatcher HostA is already subscribed to.
+            MountAndArm(V.Component(HostA, key: "root-1"), _host);
+            UseFrameFakeClockHost.Ms += 500;
+            var secondRoot = new VisualElement();
+            _host.Root.Add(secondRoot);
+            var second = V.Mount(secondRoot, V.Component(DtRecordingHost, key: "root-2"));
+            second.FlushEffectsForTest();
+            try
+            {
+                s_observedDts.Clear();
+
+                // Act — the FIRST drive after DtRecordingHost joins only baselines its own clock (see
+                // UseFrameDispatcher.Tick's per-Subscription LastTimeMs) and records nothing for it; a
+                // second, small clock step is what exercises its first REAL delta. Both drives feed the
+                // SAME s_observedDts list — deliberately not split across a separate precondition check —
+                // so a regression that skips the baseline pass (and fires immediately with a borrowed,
+                // inflated delta) shows up as a hard Assert failure below, not a merely-inconclusive one.
+                EditorPanelTestHelpers.DriveSchedulerOnce(_host.Panel);
+                UseFrameFakeClockHost.Ms += 16;
+                EditorPanelTestHelpers.DriveSchedulerOnce(_host.Panel);
+
+                // Assert — exactly one delta was EVER recorded across both drives (the baseline pass
+                // contributes none), and it reflects only the 16ms step since DtRecordingHost was
+                // baselined — never the 500ms HostA had already been stalled for before DtRecordingHost
+                // even existed. A dt shared verbatim across every same-panel subscriber would instead
+                // record a SECOND entry here too, from the first drive, clamped to Time.maximumDeltaTime.
+                Assert.That((s_observedDts.Count, s_observedDts.Count == 1 && s_observedDts[0] < 0.1f),
+                    Is.EqualTo((1, true)));
+            }
+            finally
+            {
+                second.Dispose();
+            }
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseFrameDispatcherLifecycleTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseFrameDispatcherLifecycleTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 829003d2fa7f4489c9dabcdbea47eb31

--- a/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseFrameDispatcherReentrancyTests.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseFrameDispatcherReentrancyTests.cs
@@ -1,0 +1,113 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins <see cref="UseFrameDispatcher"/>'s reentrancy guard on the EditMode fake clock: an error
+    /// boundary's fallback swap, triggered synchronously from inside one subscriber's callback, can
+    /// dispose a LATER-sorted sibling before <c>Tick</c>'s own snapshot foreach ever reaches that
+    /// sibling's entry — <c>Unsubscribe</c> must clear <c>Active</c> immediately (not just remove the
+    /// entry from the list) so the stale snapshot reference is skipped rather than firing once more on an
+    /// already-disposed component.
+    /// </summary>
+    internal sealed class UseFrameDispatcherReentrancyTests
+    {
+        // An order log, not a bare counter: a log rules out the confound "Victim simply fired before
+        // Thrower this tick" — which would also produce a nonzero Victim count but would not demonstrate
+        // a callback firing AFTER its owning component was synchronously unmounted.
+        private static readonly List<string> s_log = new();
+        private static bool s_shouldThrow;
+
+        private HeadlessEditorPanelHost _host;
+        private MountedTree _mounted;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _host = new HeadlessEditorPanelHost();
+            UseFrameFakeClockHost.Reset();
+            s_shouldThrow = false;
+            s_log.Clear();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _mounted?.Dispose();
+            _mounted = null;
+            _host?.Dispose();
+            _host = null;
+        }
+
+        [Component]
+        private static VNode ThrowerHost()
+        {
+            Hooks.UseFrame(_ =>
+            {
+                s_log.Add("Thrower-entered");
+                if (s_shouldThrow)
+                {
+                    throw new System.InvalidOperationException("reentrancy probe");
+                }
+            });
+            return V.Div(className: "w-[1px] h-[1px]");
+        }
+
+        [Component]
+        private static VNode VictimHost()
+        {
+            Hooks.UseFrame(_ => s_log.Add("Victim-fired"));
+            return V.Div(className: "w-[1px] h-[1px]");
+        }
+
+        // Mounted AFTER ThrowerHost (left-to-right Fragment children), so its UseFrame subscribes with a
+        // LATER sequence number and sorts after the thrower's in the SAME tick — the ordering this test
+        // needs to reach the thrower's boundary-triggering exception before Victim's own snapshot entry.
+        [Component(IsErrorBoundary = true)]
+        private static VNode Boundary()
+        {
+            Hooks.UseFallback(_ =>
+            {
+                s_log.Add("Fallback-shown");
+                return V.Div(name: "fallback");
+            });
+            return V.Fragment(new VNode[]
+            {
+                V.Component(ThrowerHost, key: "thrower"),
+                V.Component(VictimHost, key: "victim"),
+            });
+        }
+
+        [Test]
+        public void Given_SiblingThrowsMidTick_When_TheBoundarySwapUnmountsTheOtherSiblingSynchronously_Then_ItNeverFiresAfterward()
+        {
+            // Arrange — one ordinary tick first, proving BOTH siblings are genuinely subscribed and
+            // ticking before the throw is armed (ruling out "Victim was never live to begin with" as an
+            // alternate explanation for it never appearing in the log later).
+            EditorPanelTestHelpers.SetPanelTimeFunction(_host.Panel, UseFrameFakeClockHost.ReadFakeClock);
+            _mounted = V.Mount(_host.Root, V.Component(Boundary, key: "root"));
+            _mounted.FlushEffectsForTest();
+            EditorPanelTestHelpers.DriveSchedulerOnce(_host.Panel); // absorbs the zero-delta arm-time firing
+            s_log.Clear();
+            UseFrameFakeClockHost.Ms += 16;
+            EditorPanelTestHelpers.DriveSchedulerOnce(_host.Panel);
+            Assume.That(s_log, Is.EqualTo(new[] { "Thrower-entered", "Victim-fired" }),
+                "Precondition: both siblings tick normally before the throw is armed");
+
+            // Act — one more scheduler update, now with the throw armed: Thrower's callback runs and
+            // throws, routing synchronously to the boundary's fallback swap (which disposes BOTH Thrower
+            // and Victim), all before the dispatcher's own snapshot foreach for this same tick ever
+            // reaches Victim's entry.
+            s_log.Clear();
+            s_shouldThrow = true;
+            UseFrameFakeClockHost.Ms += 16;
+            EditorPanelTestHelpers.DriveSchedulerOnce(_host.Panel);
+
+            // Assert — Victim never fires, in this tick or (since it is now fully unsubscribed) any later
+            // one: the log holds only the thrower's entry and the fallback swap, never "Victim-fired".
+            Assert.That(s_log, Is.EqualTo(new[] { "Thrower-entered", "Fallback-shown" }));
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseFrameDispatcherReentrancyTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseFrameDispatcherReentrancyTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0854f792894da40b38593c9a11614a59

--- a/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseFrameKeyedReorderTests.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseFrameKeyedReorderTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using NUnit.Framework;
 using UnityEngine.UIElements;
 using Velvet.TestUtilities;
@@ -7,12 +8,63 @@ namespace Velvet.Tests
     /// <summary>
     /// Pins UseFrame's recurring tick across a keyed reorder deterministically, on the EditMode fake clock:
     /// a keyed reorder detaches and re-inserts the ticking host's element, and the tick must keep firing
-    /// afterward without needing to be re-armed by hand. Complements
-    /// <see cref="UseFramePerFrameContractTests"/> (cadence) with the reorder-survival contract that
-    /// PlayMode's <c>UseFramePlaybackTests</c> exercises on a real, wall-clock-driven scheduler.
+    /// afterward without needing to be re-armed by hand — and, separately, that firing order between
+    /// DIFFERENT components' UseFrame callbacks stays put across such a reorder too, backing up
+    /// <see cref="UseFrameDispatcher"/>'s own contract (a transient detach pauses a subscription in place
+    /// rather than re-appending it). Complements <see cref="UseFramePerFrameContractTests"/> (cadence) with
+    /// the reorder-survival contract that PlayMode's <c>UseFramePlaybackTests</c> exercises on a real,
+    /// wall-clock-driven scheduler.
     /// </summary>
     internal sealed class UseFrameKeyedReorderTests
     {
+        // Order log for ThreeHostReorderParent below: each host's UseFrame appends its own id, so a test
+        // can observe firing order between DIFFERENT components' callbacks (UseFrameFakeClockHost.Calls is
+        // a single counter and cannot distinguish which of several hosts fired). Static for the same
+        // reason the fake clock is: [Component] methods must be static.
+        private static readonly List<string> s_order = new();
+
+        [Component]
+        private static VNode HostA()
+        {
+            Hooks.UseFrame(_ => s_order.Add("A"));
+            return V.Div(className: "w-[1px] h-[1px]");
+        }
+
+        [Component]
+        private static VNode HostB()
+        {
+            Hooks.UseFrame(_ => s_order.Add("B"));
+            return V.Div(className: "w-[1px] h-[1px]");
+        }
+
+        [Component]
+        private static VNode HostC()
+        {
+            Hooks.UseFrame(_ => s_order.Add("C"));
+            return V.Div(className: "w-[1px] h-[1px]");
+        }
+
+        // Three dedicated keyed items, old order [A, B, C]. Swapping to [B, A, C] traces through
+        // ChildElementPlacement.ComputeLisAnchors as: domIndices (old index, in new order) = [1, 0, 2] →
+        // patience-sort LIS = {A, C} (newElements indices 1 and 2) → B is the ONE index left out of the
+        // LIS, so ReorderToNewElementOrder physically removes and reinserts ONLY B's element. A and C's
+        // elements are never touched, isolating B's scheduled-item re-registration from theirs.
+        [Component]
+        private static VNode ThreeHostReorderParent()
+        {
+            var (swapped, setSwapped) = Hooks.UseState(false);
+            var a = V.Div(key: "a", children: new VNode[] { V.Component(HostA) });
+            var b = V.Div(key: "b", children: new VNode[] { V.Component(HostB) });
+            var c = V.Div(key: "c", children: new VNode[] { V.Component(HostC) });
+            return V.Div(children: new VNode[]
+            {
+                V.Button(name: "reorder", onClick: () => setSwapped.Invoke(true)),
+                V.Div(className: "flex-col", children: swapped
+                    ? new VNode[] { b, a, c }
+                    : new VNode[] { a, b, c }),
+            });
+        }
+
         private HeadlessEditorPanelHost _host;
         private MountedTree _mounted;
 
@@ -86,6 +138,38 @@ namespace Velvet.Tests
 
             // Assert — the tick kept firing after the reorder moved its host, with no manual re-arming.
             Assert.That(UseFrameFakeClockHost.Calls, Is.GreaterThan(callsBeforeReorder));
+        }
+
+        [Test]
+        public void Given_ThreeTickingHosts_When_AKeyedReorderMovesOnlyTheMiddleOne_Then_FiringOrderStaysAtRegistrationOrder()
+        {
+            // Arrange — mount A, B, C (registration order A, B, C), and confirm a scheduler update fires
+            // them in that same order before anything has moved.
+            EditorPanelTestHelpers.SetPanelTimeFunction(_host.Panel, UseFrameFakeClockHost.ReadFakeClock);
+            _mounted = V.Mount(_host.Root, V.Component(ThreeHostReorderParent, key: "root"));
+            _mounted.FlushEffectsForTest();
+            EditorPanelTestHelpers.DriveSchedulerOnce(_host.Panel); // absorbs the zero-delta arm-time firing
+            s_order.Clear();
+            UseFrameFakeClockHost.Ms += 16;
+            EditorPanelTestHelpers.DriveSchedulerOnce(_host.Panel);
+            Assume.That(s_order, Is.EqualTo(new[] { "A", "B", "C" }),
+                "Precondition: the scheduler fires newly-mounted hosts in registration order");
+
+            // Act — a keyed reorder (a real discrete click, which commits synchronously) puts B in front of
+            // A (see ThreeHostReorderParent's own note on why only B's element is actually detached and
+            // reinserted — A and C stay physically untouched), then the clock advances one more tick.
+            _host.Root.Q<Button>("reorder").SimulateClick();
+            s_order.Clear();
+            UseFrameFakeClockHost.Ms += 16;
+            EditorPanelTestHelpers.DriveSchedulerOnce(_host.Panel);
+
+            // Assert — B's firing position is UNCHANGED despite its element being physically detached and
+            // reinserted first in DOM/keyed order: UseFrameDispatcher subscribes per PANEL, not per host
+            // element, so B's transient detach only flips its Subscription.Active off and back on — the
+            // slot B already held in the dispatcher's ordered list is never vacated, unlike a plain
+            // per-element IVisualElementScheduledItem (which UI Toolkit's own scheduler re-appends to the
+            // end of its internal list on every re-attach; see UseFrameDispatcher's own remarks).
+            Assert.That(s_order, Is.EqualTo(new[] { "A", "B", "C" }));
         }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseFramePriorityTests.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseFramePriorityTests.cs
@@ -1,0 +1,177 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins UseFrame's <c>priority</c> parameter on the EditMode fake clock: lower runs earlier within a
+    /// panel regardless of mount order, equal priorities fall back to subscription (mount) order, and a
+    /// priority change on a live subscription applies on the very next tick without a remount. Complements
+    /// <see cref="UseFrameKeyedReorderTests"/> (order stays put across a keyed reorder) — together they
+    /// specify <see cref="UseFrameDispatcher"/>'s full ordering contract.
+    /// </summary>
+    internal sealed class UseFramePriorityTests
+    {
+        // Order log each host's UseFrame appends its own id to — UseFrameFakeClockHost.Calls is a single
+        // counter and cannot distinguish which of several hosts fired, or in what order.
+        private static readonly List<string> s_order = new();
+        private static int s_priorityA;
+        private static int s_priorityB;
+        private static int s_priorityC;
+        private static StateUpdater<int> s_setPriorityLive;
+
+        [Component]
+        private static VNode HostA()
+        {
+            Hooks.UseFrame(_ => s_order.Add("A"), s_priorityA);
+            return V.Div(className: "w-[1px] h-[1px]");
+        }
+
+        [Component]
+        private static VNode HostB()
+        {
+            Hooks.UseFrame(_ => s_order.Add("B"), s_priorityB);
+            return V.Div(className: "w-[1px] h-[1px]");
+        }
+
+        [Component]
+        private static VNode HostC()
+        {
+            Hooks.UseFrame(_ => s_order.Add("C"), s_priorityC);
+            return V.Div(className: "w-[1px] h-[1px]");
+        }
+
+        // Mounted C, B, A — deliberately the REVERSE of alphabetical/priority order, so a test asserting
+        // firing order A, B, C can only be explained by priority, never by coincidentally matching mount
+        // order too.
+        [Component]
+        private static VNode ThreeHostParent()
+        {
+            return V.Div(children: new VNode[]
+            {
+                V.Component(HostC, key: "c"),
+                V.Component(HostB, key: "b"),
+                V.Component(HostA, key: "a"),
+            });
+        }
+
+        [Component]
+        private static VNode LiveHost()
+        {
+            var (priority, setPriority) = Hooks.UseState(0);
+            s_setPriorityLive = setPriority;
+            Hooks.UseFrame(_ => s_order.Add("Live"), priority);
+            return V.Div(className: "w-[1px] h-[1px]");
+        }
+
+        [Component]
+        private static VNode FixedHost()
+        {
+            Hooks.UseFrame(_ => s_order.Add("Fixed"), 0);
+            return V.Div(className: "w-[1px] h-[1px]");
+        }
+
+        // Mounted Fixed then Live, both at the default priority 0 — ties break by mount order, so the
+        // baseline firing order is Fixed, Live until a test moves Live's priority below 0.
+        [Component]
+        private static VNode LiveParent()
+        {
+            return V.Div(children: new VNode[]
+            {
+                V.Component(FixedHost, key: "fixed"),
+                V.Component(LiveHost, key: "live"),
+            });
+        }
+
+        private HeadlessEditorPanelHost _host;
+        private MountedTree _mounted;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _host = new HeadlessEditorPanelHost();
+            UseFrameFakeClockHost.Reset();
+            s_priorityA = 0;
+            s_priorityB = 0;
+            s_priorityC = 0;
+            s_order.Clear();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _mounted?.Dispose();
+            _mounted = null;
+            _host?.Dispose();
+            _host = null;
+        }
+
+        // Shared arrange: mount, run the passive effect that subscribes each host, absorb the zero-delta
+        // arm-time firing (TimerState.start equals "now" on the very first fire, per
+        // UseFramePerFrameContractTests), then clear the log so a test's own Act starts from empty.
+        private void MountAndArm(VNode root)
+        {
+            EditorPanelTestHelpers.SetPanelTimeFunction(_host.Panel, UseFrameFakeClockHost.ReadFakeClock);
+            _mounted = V.Mount(_host.Root, root);
+            _mounted.FlushEffectsForTest();
+            EditorPanelTestHelpers.DriveSchedulerOnce(_host.Panel);
+            s_order.Clear();
+        }
+
+        private void Tick()
+        {
+            UseFrameFakeClockHost.Ms += 16;
+            EditorPanelTestHelpers.DriveSchedulerOnce(_host.Panel);
+        }
+
+        [Test]
+        public void Given_MountOrderCBA_When_PrioritiesAre123ForABC_Then_FiringFollowsPriorityOrder()
+        {
+            // Arrange
+            s_priorityA = 1;
+            s_priorityB = 2;
+            s_priorityC = 3;
+            MountAndArm(V.Component(ThreeHostParent, key: "root"));
+
+            // Act
+            Tick();
+
+            // Assert — mounted C, B, A but fires A, B, C: priority order wins over mount order.
+            Assert.That(s_order, Is.EqualTo(new[] { "A", "B", "C" }));
+        }
+
+        [Test]
+        public void Given_EqualPriorities_When_Ticked_Then_FiringFollowsMountOrder()
+        {
+            // Arrange — every host stays at the default priority 0 (SetUp).
+            MountAndArm(V.Component(ThreeHostParent, key: "root"));
+
+            // Act
+            Tick();
+
+            // Assert — ties fall back to subscription order, matching ThreeHostParent's own C, B, A
+            // mount order exactly (no priority is pulling anything out of place).
+            Assert.That(s_order, Is.EqualTo(new[] { "C", "B", "A" }));
+        }
+
+        [Test]
+        public void Given_APriorityLoweredAcrossARerender_When_TickedAgain_Then_TheNewPriorityAppliesLive()
+        {
+            // Arrange — Fixed then Live, both priority 0: ties break by mount order (Fixed first).
+            MountAndArm(V.Component(LiveParent, key: "root"));
+            Tick();
+            Assume.That(s_order, Is.EqualTo(new[] { "Fixed", "Live" }),
+                "Precondition: equal priorities fire in mount order before Live's priority changes");
+
+            // Act — Live's priority drops below Fixed's, live, with no remount involved.
+            s_setPriorityLive.Invoke(-1);
+            _mounted.FlushStateForTest();
+            s_order.Clear();
+            Tick();
+
+            // Assert — the very next tick already reflects the new priority.
+            Assert.That(s_order, Is.EqualTo(new[] { "Live", "Fixed" }));
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseFramePriorityTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseFramePriorityTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: cec42802c61d24d49b0befd6d78a127b

--- a/Packages/com.velvet.core/Runtime/Hooks/Tests/PlayMode/UseFramePlaybackTests.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Tests/PlayMode/UseFramePlaybackTests.cs
@@ -221,5 +221,76 @@ namespace Velvet.Tests
             // exceptions do, instead of escaping into the panel's scheduler update.
             Assert.That(s_fallbackShown, Is.True);
         }
+
+        private static int s_siblingCalls;
+        private static bool s_siblingProbeShouldThrow;
+
+        [Component]
+        private static VNode SiblingFrameHost()
+        {
+            Hooks.UseFrame(_ => s_siblingCalls++);
+            return V.Div(className: "w-[10px] h-[10px]");
+        }
+
+        // A separately-gated thrower (distinct from ThrowingFrameHost, which always throws and is
+        // shared with the simpler test above): this one only throws once armed, so the test below can
+        // first prove the sibling is genuinely live before the boundary swap disposes it.
+        [Component]
+        private static VNode GatedThrowingFrameHost()
+        {
+            Hooks.UseFrame(_ =>
+            {
+                if (s_siblingProbeShouldThrow)
+                {
+                    throw new System.InvalidOperationException("frame boom (sibling probe)");
+                }
+            });
+            return V.Div(className: "w-[10px] h-[10px]");
+        }
+
+        // Mounted AFTER GatedThrowingFrameHost (left-to-right children order), so its UseFrame subscribes
+        // with a LATER sequence number and sorts after the thrower's in UseFrameDispatcher.Tick's
+        // per-update pass — the ordering this test needs to reach the thrower's boundary-triggering
+        // exception BEFORE its own entry in that same tick's snapshot.
+        [Component(IsErrorBoundary = true)]
+        private static VNode FrameBoundaryWithSibling()
+        {
+            Hooks.UseFallback(_ =>
+            {
+                s_fallbackShown = true;
+                return V.Div(name: "frame-fallback-with-sibling");
+            });
+            return V.Div(children: new VNode[]
+            {
+                V.Component(GatedThrowingFrameHost, key: "thrower"),
+                V.Component(SiblingFrameHost, key: "sibling"),
+            });
+        }
+
+        [UnityTest]
+        public IEnumerator Given_AThrowingFrameCallback_When_ALaterSiblingSharesTheSameTick_Then_TheSiblingNeverFiresPastTheBoundarySwap()
+        {
+            // Arrange — let both siblings tick normally first, proving the sibling is genuinely live and
+            // subscribed before the throw is armed (ruling out "it was never live to begin with" as an
+            // alternate explanation for its call count never moving afterward).
+            var root = CreatePanelRoot();
+            yield return null;
+            _mounted = V.Mount(root, V.Component(FrameBoundaryWithSibling, key: "root"));
+            yield return WaitRealtime(0.3);
+            Assume.That(s_siblingCalls, Is.GreaterThan(0),
+                "Precondition: the sibling ticks normally before the throw is armed");
+
+            // Act — arm the throw. The thrower's exception triggers a SYNCHRONOUS fallback swap (from
+            // inside UseFrameDispatcher.Tick's own foreach) that disposes the ENTIRE boundary subtree,
+            // including the still-pending sibling entry in that same tick's snapshot; settling further
+            // afterward confirms no zombie invocation on that tick or any later one (the sibling is fully
+            // removed from the dispatcher once truly unmounted).
+            s_siblingCalls = 0;
+            s_siblingProbeShouldThrow = true;
+            yield return WaitRealtime(0.5);
+
+            // Assert — the fallback swap happened, and the sibling never fired again afterward.
+            Assert.That((s_fallbackShown, s_siblingCalls), Is.EqualTo((true, 0)));
+        }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Hooks/UseFrameDispatcher.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/UseFrameDispatcher.cs
@@ -1,0 +1,147 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace Velvet
+{
+    /// <summary>
+    /// One dispatcher per panel: a single stable scheduled tick, hosted on the panel's own root element
+    /// (never itself subject to a keyed reorder), fanning out every frame to every live
+    /// <see cref="Hooks.UseFrame(System.Action{float}, int)"/> subscriber in that panel, in
+    /// <c>priority</c> order (ties broken by subscription order) — r3f's
+    /// <c>useFrame(callback, renderPriority)</c> ordering parity. A positive priority carries no other
+    /// side effect here (unlike r3f, where it also hands the caller manual control of the render loop):
+    /// Unity's own rendering is independent of this scheduler, so there is no internal render call to
+    /// take over.
+    /// </summary>
+    /// <remarks>
+    /// Subscribing per-PANEL rather than per-component-HOST (the one scheduled item per component this
+    /// replaced) is what makes order both deterministic and stable across a keyed reorder: a transient
+    /// detach only flips <see cref="Subscription.Active"/> off and back on — the slot in the ordered list
+    /// is never vacated — where a plain per-element <c>IVisualElementScheduledItem</c> is re-appended to
+    /// the end of UI Toolkit's own internal scheduler list on every re-attach (verified by decompiling
+    /// <c>TimerEventScheduler</c>/<c>BaseVisualElementScheduledItem</c>), silently reshuffling order.
+    /// </remarks>
+    internal sealed class UseFrameDispatcher
+    {
+        internal sealed class Subscription
+        {
+            public int Priority;
+            public bool Active;
+            internal readonly long Sequence;
+            internal readonly Action<float> Callback;
+            // Null until this subscription has been through one Tick pass. A per-subscription baseline —
+            // not the shared tick item's own start/now — is what a late joiner needs: without it, a
+            // subscriber that joins a panel where an EARLIER subscriber has been ticking for a while
+            // would inherit that earlier subscriber's elapsed-since-last-fire on its own first tick
+            // (measured and confirmed: a panel stalled 500ms before a second host mounts hands that host a
+            // dt of Time.maximumDeltaTime on its very first-ever callback, not a small "just mounted" one).
+            internal long? LastTimeMs;
+
+            internal Subscription(long sequence, int priority, Action<float> callback)
+            {
+                Sequence = sequence;
+                Priority = priority;
+                Callback = callback;
+                Active = true;
+            }
+        }
+
+        // Keyed by the panel itself (not the caller) and weak on that key so a destroyed panel's
+        // dispatcher — and the scheduled tick it owns — becomes collectible without any explicit
+        // teardown hook; UI Toolkit's own panel disposal already stops delivering scheduler updates to
+        // an item whose host panel is gone.
+        private static readonly ConditionalWeakTable<IPanel, UseFrameDispatcher> s_perPanel = new();
+
+        private readonly IPanel _panel;
+        private readonly List<Subscription> _subscriptions = new();
+        private IVisualElementScheduledItem? _tick;
+        private long _nextSequence;
+
+        private UseFrameDispatcher(IPanel panel)
+        {
+            _panel = panel;
+        }
+
+        internal static UseFrameDispatcher GetOrCreate(IPanel panel)
+        {
+            return s_perPanel.GetValue(panel, static p => new UseFrameDispatcher(p));
+        }
+
+        internal Subscription Subscribe(int priority, Action<float> callback)
+        {
+            var subscription = new Subscription(_nextSequence++, priority, callback);
+            _subscriptions.Add(subscription);
+            // Every(0): fires once per panel scheduler update (not a wall-clock interval) — the
+            // per-update cadence Hooks.UseFrame documents. One shared item drives every subscriber's own
+            // Tick pass, but each still measures its OWN elapsed time via Subscription.LastTimeMs, not
+            // this item's.
+            _tick ??= _panel.visualTree.schedule.Execute((TimerState ts) => Tick(ts)).Every(0);
+            return subscription;
+        }
+
+        internal void Unsubscribe(Subscription subscription)
+        {
+            // Setting Active=false (not just removing from the list) matters because Tick's foreach below
+            // runs over a SNAPSHOT taken at the start of that tick: a callback that synchronously disposes
+            // a later-sorted sibling this same tick (an error boundary's fallback swap unmounting it
+            // mid-iteration) can reach this Unsubscribe call before the snapshot's own walk gets to that
+            // sibling's entry — the snapshot still holds the reference, and Active is what stops it firing
+            // posthumously on an already-disposed subscriber.
+            subscription.Active = false;
+            _subscriptions.Remove(subscription);
+            if (_subscriptions.Count == 0)
+            {
+                _tick?.Pause();
+                _tick = null;
+            }
+        }
+
+        private void Tick(TimerState ts)
+        {
+            // domIndices-free re-sort every tick: subscriber counts here are dozens at most, and a
+            // sort over that is not worth tracking a dirty flag to skip. (Priority, Sequence) is a
+            // strictly unique compound key (Sequence never repeats), so an unstable Array.Sort under
+            // List.Sort still yields one deterministic order — no tie-break subtlety to worry about.
+            _subscriptions.Sort(static (a, b) =>
+            {
+                var byPriority = a.Priority.CompareTo(b.Priority);
+                return byPriority != 0 ? byPriority : a.Sequence.CompareTo(b.Sequence);
+            });
+            // Snapshot via ToArray: a callback that itself mounts/unmounts a UseFrame sibling (adding
+            // or removing a Subscription mid-tick) must not perturb this pass's own iteration.
+            foreach (var subscription in _subscriptions.ToArray())
+            {
+                // LastTimeMs is not refreshed while inactive, so a pause accumulates real elapsed time
+                // rather than freezing it — reactivating hands the next callback a dt spanning the WHOLE
+                // paused interval (still clamped below like any other). The only currently-reachable pause
+                // is a same-frame keyed-reorder detach+reattach (zero elapsed time either way), so this
+                // choice is unobserved today; it is deliberate, not an oversight, should a future pause
+                // ever span real time.
+                if (!subscription.Active) continue;
+
+                // Per-subscription delta (see Subscription.LastTimeMs) rather than one dt shared by the
+                // whole panel: a subscription with no baseline yet only records one here and skips
+                // invoking this pass, matching a freshly-armed engine scheduled item's own zero-delta
+                // first fire — the callback only ever observes a real elapsed span it was actually
+                // present for.
+                if (subscription.LastTimeMs is not { } lastMs)
+                {
+                    subscription.LastTimeMs = ts.now;
+                    continue;
+                }
+                var dt = (ts.now - lastMs) / 1000f;
+                subscription.LastTimeMs = ts.now;
+                // Mirrors the per-subscriber cadence guard this replaced: a zero delta (same-frame
+                // flush) is skipped so the callback only ever observes positive, frame-sized seconds,
+                // and a hitch spike is clamped the way Time.deltaTime clamps its own.
+                if (dt <= 0f) continue;
+                dt = Mathf.Min(dt, Time.maximumDeltaTime);
+                subscription.Callback(dt);
+            }
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Hooks/UseFrameDispatcher.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Hooks/UseFrameDispatcher.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: aeece92dbc38447ba83d3f013946de4b


### PR DESCRIPTION
## What

`Hooks.UseFrame` gains an optional `priority` parameter (#105): lower runs earlier within the same panel, equal priorities fall back to subscription (mount) order, and the latest render's priority applies live — a priority-only change takes effect next tick without re-subscribing or moving the callback among same-priority siblings. A positive priority has no side effect beyond ordering (Unity's own rendering has no internal loop to hand over, unlike the upstream API's render-priority mode).

## How

Per-frame callbacks now subscribe to a single **per-panel dispatcher** (`UseFrameDispatcher`, one stable scheduled tick on the panel root) instead of each scheduling their own engine tick. This is what makes ordering possible at all: the engine scheduler re-appends a per-element scheduled item to the end of its internal list on every host re-attach — including the same-frame detach/reattach of a keyed reorder — so cross-component firing order could silently reshuffle under the old per-element scheme.

The dispatcher design also covers three correctness edges the centralization would otherwise introduce:

- **Reorder stability**: a transiently-detached subscription is paused in place (its slot in the ordered list is never vacated), so firing order stays stable across a keyed reorder of the callback's host.
- **Per-subscription timing**: each subscription measures its own elapsed time against the panel clock, so a callback that joins a panel late never inherits a stall an earlier subscriber had already accumulated — its first delta reflects only time it was actually present for.
- **Reentrancy safety**: unsubscribing deactivates the entry immediately, so an error boundary's synchronous fallback swap triggered from inside one callback cannot fire a later-sorted sibling that same swap just disposed.

## Docs

`Documentation~/particles.md`'s UseFrame section documents the ordering contract; the `UseFrame` XML doc covers the live-priority semantics.

## Tests

- `UseFramePriorityTests` (EditMode): priority beats mount order, ties fall back to mount order, a priority lowered across a re-render applies on the next tick.
- `UseFrameKeyedReorderTests` (EditMode): the tick keeps firing across a keyed reorder, and cross-component firing order stays at registration order when only the middle of three hosts physically moves.
- `UseFrameDispatcherLifecycleTests` (EditMode): per-panel isolation, true-unmount removal with siblings undisturbed, tick re-arming after draining to zero subscribers, and the late-joiner first-delta contract.
- `UseFrameDispatcherReentrancyTests` (EditMode) + a PlayMode sibling test: a mid-tick throw routed through an error boundary never fires the disposed sibling, with a precondition proving the sibling was live beforehand.

3055/3055 EditMode and 83/83 PlayMode tests pass locally.

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)