### PR TITLE
feat(velvet): add whitespace-pre, whitespace-pre-wrap, and whitespace-pre-line utilities

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -20,6 +20,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (defaults to `Physics.DefaultRaycastLayers`). `distanceFactor` scales the element by that value
   divided by its current camera distance, faking perspective size falloff for otherwise-flat
   screen-space content; it is the reference distance at which scale is exactly 1 and must be positive.
+- `whitespace-pre`, `whitespace-pre-wrap`, and `whitespace-pre-line` utilities, filling out the previous
+  `whitespace-normal` / `whitespace-nowrap`-only pair. The first two map directly onto
+  `UnityEngine.UIElements.WhiteSpace`'s two other native values. `whitespace-pre-line` has no matching
+  engine value, so it is realised the same way as `uppercase` / `underline` — a display-string rewrite
+  (collapse space/tab runs to one space, keep newlines, drop whitespace sitting at a line edge — a CRLF
+  pair or a lone CR counts as a newline too, per CSS's segment-break normalization) plus an inline
+  `white-space: pre-wrap` write on every text leaf whose resolved axis is pre-line (not just once on the
+  class-bearing element — `Label`/`TextElement`'s own default theme rule for `white-space` always beats an
+  inherited value, so only a per-leaf write reaches a descendant Label) so the preserved newlines still
+  render as breaks and the text still wraps — and it inherits/cascades the same way `uppercase` /
+  `underline` do. An explicit `whitespace-*` class on the same element wins over `whitespace-pre-line`
+  there, and — like `normal-case` / `no-underline` — also blocks a farther ancestor's
+  `whitespace-pre-line` from reaching that subtree.
 
 ## [1.5.0] - 2026-07-19
 

--- a/Packages/com.velvet.core/Documentation~/fonts.md
+++ b/Packages/com.velvet.core/Documentation~/fonts.md
@@ -105,9 +105,10 @@ them (not a Velvet decision).
 
 **Supported (shipped):** `font-<family>` / `font-thin`…`font-black` / `italic` / `not-italic` /
 `text-xs`…`text-4xl` (font-size) / `text-left|center|right|start|end` (`-unity-text-align`) /
-`tracking-*` (`letter-spacing`) / `whitespace-normal|nowrap` / `text-wrap` / `text-nowrap` /
-`truncate` / `text-ellipsis` / `text-clip` (`text-overflow: ellipsis | clip`) / text color /
-`uppercase` `lowercase` `capitalize` `normal-case` (text-transform) / `underline` `line-through` `no-underline` (text-decoration).
+`tracking-*` (`letter-spacing`) / `whitespace-normal|nowrap|pre|pre-wrap|pre-line` /
+`text-wrap` / `text-nowrap` / `truncate` / `text-ellipsis` / `text-clip` (`text-overflow: ellipsis | clip`) /
+text color / `uppercase` `lowercase` `capitalize` `normal-case` (text-transform) /
+`underline` `line-through` `no-underline` (text-decoration).
 
 **Text-transform / text-decoration are realised by mutating the displayed text** (UI Toolkit has no property
 for either): the string is upper/lower/title-cased, and underline / line-through wrap it in the `<u>` / `<s>`
@@ -115,16 +116,39 @@ rich-text tags UITK renders (`enableRichText` is on by default). Both **inherit*
 an ancestor and the descendant text leaves pick it up (`StyleTextEffectResolver` walks ancestors). See it for
 the one cascade-freshness caveat (an ancestor's class toggled without that ancestor re-rendering).
 
+**`white-space`** has four native USS values, and `whitespace-normal`, `whitespace-nowrap`,
+`whitespace-pre`, and `whitespace-pre-wrap` map directly onto them — no C# involved.
+**`whitespace-pre-line`** is the exception:
+there is no matching engine value, so it is realised the same way as text-transform / text-decoration — a
+display-string rewrite (collapse runs of spaces/tabs to one space, keep newlines, and drop whitespace that
+sits right at a line edge) plus an inline `white-space: pre-wrap` write on every text leaf whose resolved
+whitespace axis is pre-line, so the preserved newlines still render as breaks and the text still wraps. The
+write is per-leaf rather than written once on the class-bearing element: `Label`/`TextElement` carries its
+own element-level `white-space` rule from the default theme/USS, and an element's own matching rule always
+beats an INHERITED value in the cascade, so a write on an ancestor alone would never reach a descendant
+Label. It inherits and cascades the same way text-transform / text-decoration do: an explicit
+`whitespace-*` class always wins on the SAME element (a single-purpose, literal utility taking precedence
+over a text-mutating one is the less surprising outcome), and — exactly like how `normal-case` /
+`no-underline` stop an inherited transform / decoration — it also blocks a farther ancestor's
+`whitespace-pre-line` from reaching that subtree at all, rather than merely leaving the collapse unapplied
+on that one element.
+
 **Not expressible in UI Toolkit (no USS property — intentionally absent):**
 
 | Tailwind | Why omitted |
 |---|---|
 | `leading-*` (line-height) | USS has no `line-height` (`-unity-paragraph-spacing` is paragraph gap, not line-height) |
 | `overline` (text-decoration) | UI Toolkit rich text has no overline tag (`<u>` / `<s>` only) |
-| `antialiased` / `subpixel-antialiased` (font-smoothing) | No USS property |
-| `font-stretch-*` | No USS property |
-| `tabular-nums` etc. (font-variant-numeric) | Not exposed in USS |
-| `whitespace-pre` / `pre-wrap` / `text-balance` / `text-pretty` | `white-space` only accepts `normal` / `nowrap` |
+| `antialiased` / `subpixel-antialiased` (font-smoothing) | Text renders as SDF alpha-blend only — no antialiasing-mode axis to switch |
+| `font-stretch-*` | No variable-font / width-axis support |
+| `tabular-nums` etc. (font-variant-numeric) | No OpenType feature-substitution slot in the runtime font pipeline |
+| `text-balance` / `text-pretty` | Browser line-breaking heuristics (best-fit paragraph shaping); UI Toolkit's text generator has no such heuristic to opt into |
+
+None of the font-smoothing / font-stretch / font-variant-numeric rows above are reproducible at runtime by
+any class or `refCallback` — there is no engine hook to flip. Where the *look* matters (tabular figures in a
+price list, a condensed headline face, …), register a purpose-built Font Asset for that face through the
+same `font-family` mechanism (`VelvetFonts.Register`) and select it with `font-<name>`; that reaches the
+visual result directly instead of trying to toggle a feature the text stack does not expose.
 
 UI Toolkit *does* expose `word-spacing`, `-unity-paragraph-spacing`, and `-unity-text-outline-*`,
 but none has a standard Tailwind utility, so Velvet leaves them to arbitrary inline styles via

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
@@ -183,6 +183,17 @@ namespace Velvet
                 else
                 {
                     _ctx.TextRawText.Remove(element);
+                    // The element stays MOUNTED across this transition (no pool cycle), so
+                    // ReconcilerContext.ClearElementSideTables never runs for it, and with no raw text left
+                    // to resolve from, StyleTextEffectResolver.ApplyToElement can never run for it again
+                    // either — nothing would otherwise clear a resolver-owned inline PreWrap this element
+                    // was carrying, leaking it forever. Mirrors FiberElementPoolReset's unconditional
+                    // whiteSpace null on the pool-RETURN path, scoped to just the element the resolver
+                    // actually wrote to (see StyleTextEffectResolver's type comment for the ownership rule).
+                    if (_ctx.TextWhitespaceOwned.Remove(element))
+                    {
+                        element.style.whiteSpace = StyleKeyword.Null;
+                    }
                 }
             }
             // After DiffProps (and the class-driven config it follows): re-sync the data-/aria- attribute

--- a/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
@@ -149,12 +149,18 @@ namespace Velvet
         // before re-deriving. Cleared on element cleanup / reconciler dispose.
         public Dictionary<VisualElement, List<string[]>> SupportsVariants { get; } = new();
 
-        // text-transform / text-decoration (uppercase / underline / …). UI Toolkit has no property for either,
-        // so they are realised by mutating the displayed text (StyleTextEffectResolver). TextEffects holds each
-        // element's OWN parsed effect (the cascade source); TextRawText holds the untransformed text captured at
-        // the text-set seams so the effect re-applies idempotently. Both are pure (teardown = Remove(element)).
+        // text-transform / text-decoration / whitespace-pre-line (uppercase / underline / … / the pre-line
+        // collapse). UI Toolkit has no property for any of them, so they are realised by mutating the
+        // displayed text (StyleTextEffectResolver). TextEffects holds each element's OWN parsed effect (the
+        // cascade source); TextRawText holds the untransformed text captured at the text-set seams so the
+        // effect re-applies idempotently. TextWhitespaceOwned is a THIRD table, set-shaped (a Dictionary with
+        // a trivial bool value): presence means this element's CURRENT inline style.whiteSpace was written by
+        // the resolver itself, so a later resolve that is no longer PreLine clears only what the resolver
+        // owns — never a value set directly by other means (e.g. a refCallback, a pattern the framework
+        // treats as legitimate — see RefCallbacks below). All three are pure (teardown = Remove(element)).
         public Dictionary<VisualElement, TextEffect> TextEffects { get; } = new();
         public Dictionary<VisualElement, string> TextRawText { get; } = new();
+        public Dictionary<VisualElement, bool> TextWhitespaceOwned { get; } = new();
 
         // The per-element "pure" side-tables (structural / has-[.class]: / data-/aria- rules + their attribute
         // store / supports- / Motion applied-classes) — those whose teardown is a plain Remove(element): no
@@ -849,6 +855,7 @@ namespace Velvet
                 ElementToLayoutId,
                 TextEffects,
                 TextRawText,
+                TextWhitespaceOwned,
             };
         }
     }

--- a/Packages/com.velvet.core/Runtime/Styles/_typography.uss
+++ b/Packages/com.velvet.core/Runtime/Styles/_typography.uss
@@ -71,12 +71,18 @@
 .text-top-center { -unity-text-align: upper-center; }
 .text-top-left { -unity-text-align: upper-left; }
 
-/* White Space */
+/* White Space. UnityEngine.UIElements.WhiteSpace has four members — normal / nowrap / pre / pre-wrap —
+   all reachable directly from USS. whitespace-pre-line has no rule here: CSS pre-line (collapse
+   space/tab runs, keep newlines) has no matching enum member, so it is realised in C# instead — a
+   display-string rewrite plus an inline `white-space: pre-wrap` write — see StyleTextEffectResolver.cs. */
 .whitespace-normal { white-space: normal; }
 .whitespace-nowrap { white-space: nowrap; }
+.whitespace-pre { white-space: pre; }
+.whitespace-pre-wrap { white-space: pre-wrap; }
 
-/* Text wrap aliases (Tailwind: text-wrap / text-nowrap). UI Toolkit's white-space only has the
-   normal/nowrap axis, so text-balance / text-pretty have no equivalent and are intentionally omitted. */
+/* Text wrap aliases (Tailwind: text-wrap / text-nowrap). text-balance / text-pretty are browser
+   line-breaking HEURISTICS (best-fit paragraph shaping), not a white-space value, so UI Toolkit's text
+   generator has nothing to opt into and they are intentionally omitted regardless of white-space's range. */
 .text-wrap { white-space: normal; }
 .text-nowrap { white-space: nowrap; }
 

--- a/Packages/com.velvet.core/Runtime/Styling/StyleTextEffectClass.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleTextEffectClass.cs
@@ -24,45 +24,71 @@ namespace Velvet
         LineThrough, // line-through -> <s>
     }
 
-    // An element's OWN text-transform / text-decoration intent, each axis independent and nullable: null means
-    // the axis carries no token on this element (inherit), a non-null value (incl. the explicit None reset) wins
-    // over an ancestor. CSS text-transform / text-decoration both inherit, which Unity UI Toolkit does NOT do for
-    // these (there is no UITK property), so Velvet realises them by mutating the displayed text — uppercasing the
-    // string and wrapping it in the rich-text <u>/<s> tags UI Toolkit renders (enableRichText is on by default).
+    // The whitespace-collapse an element requests. None is the EXPLICIT reset: every direct, literal
+    // whitespace-{normal,nowrap,pre,pre-wrap} class resolves here, not merely to "no collapse" but to a real
+    // value that BLOCKS a farther ancestor's whitespace-pre-line from reaching this element — mirroring how
+    // normal-case / no-underline block Transform / Decoration. Unset is a null WhitespaceCollapseKind? in
+    // TextEffect (inherit an ancestor's collapse, if any).
+    internal enum WhitespaceCollapseKind
+    {
+        None,    // whitespace-normal / whitespace-nowrap / whitespace-pre / whitespace-pre-wrap
+        PreLine, // whitespace-pre-line
+    }
+
+    // An element's OWN text-transform / text-decoration / whitespace-collapse intent, each axis independent
+    // and nullable: null means the axis carries no token on this element (inherit), a non-null value (incl.
+    // the explicit None reset every axis has) wins over an ancestor. CSS text-transform / text-decoration /
+    // white-space all inherit; Unity UI Toolkit only natively inherits white-space (it lives in
+    // inheritedData) — text-transform / text-decoration have no UITK property at all — so Velvet realises
+    // all three the same way regardless, by mutating the displayed text: uppercasing/title-casing the
+    // string, wrapping it in the rich-text <u>/<s> tags UI Toolkit renders (enableRichText is on by
+    // default), and/or collapsing space/tab runs.
+    //
+    // Whitespace still needs the same manual cascade walk as Transform/Decoration despite white-space
+    // natively inheriting: no UITK enum member expresses CSS pre-line's collapse, so a C# string mutation is
+    // the only way to realise it, and that mutation cannot itself propagate through the visual tree the way
+    // a real inherited USS property does — it must reach every leaf whose EFFECTIVE (cascade-resolved) value
+    // is PreLine, exactly like Transform/Decoration (see StyleTextEffectResolver.ResolveEffective).
     internal readonly struct TextEffect : IEquatable<TextEffect>
     {
         public readonly TextTransformKind? Transform;
         public readonly TextDecorationKind? Decoration;
+        public readonly WhitespaceCollapseKind? Whitespace;
 
-        public TextEffect(TextTransformKind? transform, TextDecorationKind? decoration)
+        public TextEffect(TextTransformKind? transform, TextDecorationKind? decoration, WhitespaceCollapseKind? whitespace)
         {
             Transform = transform;
             Decoration = decoration;
+            Whitespace = whitespace;
         }
 
-        // True when neither axis carries a token (nothing to track for this element).
-        public bool IsEmpty => Transform == null && Decoration == null;
+        // True when no axis carries a token (nothing to track for this element).
+        public bool IsEmpty => Transform == null && Decoration == null && Whitespace == null;
 
-        public bool Equals(TextEffect other) => Transform == other.Transform && Decoration == other.Decoration;
+        public bool Equals(TextEffect other) =>
+            Transform == other.Transform && Decoration == other.Decoration && Whitespace == other.Whitespace;
         public override bool Equals(object obj) => obj is TextEffect o && Equals(o);
-        public override int GetHashCode() => unchecked(((Transform?.GetHashCode() ?? -1) * 397) ^ (Decoration?.GetHashCode() ?? -1));
+        public override int GetHashCode() =>
+            unchecked((((Transform?.GetHashCode() ?? -1) * 397) ^ (Decoration?.GetHashCode() ?? -1)) * 397 ^ (Whitespace?.GetHashCode() ?? -1));
     }
 
-    // Parses the text-transform / text-decoration utilities into a TextEffect, and applies a resolved
-    // effect to a raw string. Pure and allocation-light; the reconciler owns the per-element side-tables and the
-    // cascade (walking ancestors for the nearest non-null axis).
+    // Parses the text-transform / text-decoration / whitespace-pre-line utilities into a TextEffect, and
+    // applies a resolved effect to a raw string. Pure and allocation-light; the reconciler owns the
+    // per-element side-tables and the cascade (walking ancestors for the nearest non-null axis).
     internal static class StyleTextEffectClass
     {
-        // Resolves an element's OWN effect from its class list (last token wins per axis). Returns an empty
-        // TextEffect (both axes null) when no text-transform / text-decoration token is present.
+        // Resolves an element's OWN effect from its class list (last token wins per axis, except Whitespace —
+        // see below). Returns an empty TextEffect (every axis null) when no recognised token is present.
         public static TextEffect Parse(string[] classNames)
         {
             TextTransformKind? transform = null;
             TextDecorationKind? decoration = null;
+            WhitespaceCollapseKind? whitespace = null;
             if (classNames == null)
             {
                 return default;
             }
+            var sawExplicitWhitespaceClass = false;
             foreach (var cls in classNames)
             {
                 switch (cls)
@@ -74,22 +100,52 @@ namespace Velvet
                     case "underline": decoration = TextDecorationKind.Underline; break;
                     case "line-through": decoration = TextDecorationKind.LineThrough; break;
                     case "no-underline": decoration = TextDecorationKind.None; break;
+                    case "whitespace-pre-line": whitespace = WhitespaceCollapseKind.PreLine; break;
+                    case "whitespace-normal":
+                    case "whitespace-nowrap":
+                    case "whitespace-pre":
+                    case "whitespace-pre-wrap":
+                        sawExplicitWhitespaceClass = true;
+                        break;
                 }
             }
-            return new TextEffect(transform, decoration);
+            // An explicit whitespace-{normal,nowrap,pre,pre-wrap} class on the SAME element always wins over
+            // that element's own whitespace-pre-line token, regardless of which appears earlier/later in the
+            // class list — order-dependent "last wins" (the rule every other case above uses) is not a
+            // meaningful concept across two independently-authored utility families, so the choice is made
+            // unconditionally instead. This is the least-surprising option: pre-line mutates the displayed
+            // string, so a reader who also reached for a direct, single-purpose whitespace-* class most
+            // likely wants its literal CSS-standard behavior, not a silently-collapsed one. Resolving to the
+            // explicit None reset (not back to unset) settles the conflict on THIS element AND stops a
+            // pre-line request from a FARTHER ancestor from still reaching this element through the normal
+            // cascade — the same explicit-reset semantics normal-case / no-underline already give
+            // Transform/Decoration.
+            if (sawExplicitWhitespaceClass)
+            {
+                whitespace = WhitespaceCollapseKind.None;
+            }
+            return new TextEffect(transform, decoration, whitespace);
         }
 
-        // Applies a resolved transform + decoration to a raw string. Transform runs first (on the plain text),
-        // then the decoration wraps the result in its rich-text tag. A null/None axis is a no-op. Empty text is
-        // returned unchanged (no empty <u></u>). The transform assumes plain text; pre-existing rich-text markup
-        // in the raw string is the caller's concern.
-        public static string Apply(string raw, TextTransformKind? transform, TextDecorationKind? decoration)
+        // Applies a resolved whitespace-pre-line collapse, then transform, then decoration to a raw string, in
+        // that order — CSS resolves white-space processing before text-transform, so collapsing first means
+        // Capitalize's word-boundary scan and the decoration wrap both see the already-normalized text. A
+        // null/None axis on any parameter is a no-op. Empty text is returned unchanged (no empty <u></u>) —
+        // checked both before AND after the collapse, since an all-whitespace input can collapse all the way
+        // down to empty too (every run in it touches a line edge). The transform assumes plain text;
+        // pre-existing rich-text markup in the raw string is the caller's concern.
+        public static string Apply(string raw, TextTransformKind? transform, TextDecorationKind? decoration, WhitespaceCollapseKind? whitespace = null)
         {
             if (string.IsNullOrEmpty(raw))
             {
                 return raw;
             }
-            var text = ApplyTransform(raw, transform);
+            var text = whitespace == WhitespaceCollapseKind.PreLine ? CollapseForPreLine(raw) : raw;
+            if (string.IsNullOrEmpty(text))
+            {
+                return text;
+            }
+            text = ApplyTransform(text, transform);
             return ApplyDecoration(text, decoration);
         }
 
@@ -112,6 +168,61 @@ namespace Velvet
                 case TextDecorationKind.LineThrough: return "<s>" + text + "</s>";
                 default: return text; // None / null
             }
+        }
+
+        // CSS pre-line's own text mutation: runs of spaces/tabs fold to a single space and newlines are kept
+        // as forced breaks, but a run touching a line edge — the very start of a line, the very end of a
+        // line, or the start/end of the whole string — collapses away entirely rather than leaving a stray
+        // space there, mirroring how CSS drops the whitespace immediately around a preserved segment break.
+        // CSS Text Level 3 also normalizes segment breaks: a '\r\n' pair and a lone '\r' are both treated as
+        // a single break equivalent to '\n', so both are folded to '\n' before the line-edge logic above
+        // sees them (a '\r\n' pair also consumes its own trailing '\n' so it still yields exactly one break,
+        // not two). Manual single pass over the string (no Regex) to stay allocation-light, matching
+        // Capitalize below; the sentinel iteration (i == text.Length) closes out a trailing run exactly like
+        // a real line break would, without appending anything for it.
+        private static string CollapseForPreLine(string text)
+        {
+            var sb = new StringBuilder(text.Length);
+            var inRun = false;
+            var atLineStart = true; // true until a non-run character is written on the current line
+            for (var i = 0; i <= text.Length; i++)
+            {
+                var atEnd = i == text.Length;
+                var ch = atEnd ? '\n' : text[i];
+                if (!atEnd && ch == '\r')
+                {
+                    // Normalize onto the '\n' sentinel the rest of this walk already keys line edges off
+                    // of; a '\r\n' pair swallows its own trailing '\n' here so it is not also counted as a
+                    // second, separate break.
+                    ch = '\n';
+                    if (i + 1 < text.Length && text[i + 1] == '\n')
+                    {
+                        i++;
+                    }
+                }
+                if (!atEnd && (ch == ' ' || ch == '\t'))
+                {
+                    inRun = true;
+                    continue;
+                }
+                if (inRun)
+                {
+                    // A run survives as a single space only strictly inside a line: not immediately after the
+                    // previous line break (or the string's start) and not immediately before this one.
+                    if (!atLineStart && ch != '\n')
+                    {
+                        sb.Append(' ');
+                    }
+                    inRun = false;
+                }
+                if (atEnd)
+                {
+                    break;
+                }
+                sb.Append(ch);
+                atLineStart = ch == '\n';
+            }
+            return sb.ToString();
         }
 
         // Title-cases each whitespace-separated word (the first letter of every word uppercased, the rest left

--- a/Packages/com.velvet.core/Runtime/Styling/StyleTextEffectResolver.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleTextEffectResolver.cs
@@ -3,21 +3,69 @@ using UnityEngine.UIElements;
 
 namespace Velvet
 {
-    // Realises text-transform (uppercase / lowercase / capitalize / normal-case) and text-decoration
-    // (underline / line-through) by mutating the displayed text — Unity UI Toolkit has no property for either,
-    // so the string is upper/lower/title-cased and wrapped in the <u>/<s> rich-text tags UITK renders. CSS
-    // inherits both; UITK does not, so the effect cascades by walking ancestors (StyleTextEffectClass holds the
-    // pure parse + string ops; this owns the reconciler-side cascade and the per-element side-tables).
+    // Realises text-transform (uppercase / lowercase / capitalize / normal-case), text-decoration
+    // (underline / line-through), and whitespace-pre-line by mutating the displayed text — Unity UI Toolkit
+    // has no property for any of the three, so the string is upper/lower/title-cased, wrapped in the <u>/<s>
+    // rich-text tags UITK renders, and/or has its space/tab runs collapsed. CSS inherits all three; UITK does
+    // not (for text-transform / text-decoration there is no UITK property at all; white-space DOES natively
+    // inherit, but no enum value expresses pre-line's collapse, so the STRING rewrite still needs the same
+    // treatment — see the Whitespace remarks on TextEffect). So every axis cascades by walking ancestors
+    // (StyleTextEffectClass holds the pure parse + string ops; this owns the reconciler-side cascade and the
+    // per-element side-tables).
     //
-    // Two per-element side-tables (both pure, on ReconcilerContext): TextEffects = an element's OWN parsed
-    // effect (each axis nullable so an explicit normal-case / no-underline reset is distinct from "inherit");
-    // TextRawText = the untransformed text last seen for a text-bearing element, captured at the text-set seams
-    // so the effect can be re-applied idempotently (the element's live .text may already be transformed).
+    // Three per-element side-tables (all pure, on ReconcilerContext): TextEffects = an element's OWN parsed
+    // effect (each axis nullable so an explicit reset — normal-case / no-underline / an explicit
+    // whitespace-* class — is distinct from "inherit"); TextRawText = the untransformed text last seen for a
+    // text-bearing element, captured at the text-set seams so the effect can be re-applied idempotently (the
+    // element's live .text may already be transformed); TextWhitespaceOwned = a set (Dictionary with a
+    // trivial value) of elements whose CURRENT inline `style.whiteSpace` was written by THIS resolver — see
+    // the ownership discussion below ApplyToElement. All three ride element cleanup / pool reuse for free via
+    // ReconcilerContext.ClearElementSideTables.
     //
-    // KNOWN LIMITATION: toggling a text-transform / -decoration class on an ANCESTOR re-cascades to descendants
-    // only when that ancestor is re-rendered (its post-children pass walks them). A descendant whose own text is
-    // unchanged and whose ancestor's class changed without the ancestor re-patching keeps its prior effect until
-    // its next text update — the common static case (effect set at mount) is fully correct.
+    // PreLine ALSO drives an inline `white-space: pre-wrap` write, so the preserved newlines render as
+    // breaks and wrapping still works. That write happens in ApplyToElement (below), on EVERY text leaf
+    // whose EFFECTIVE (cascade-resolved) axis is PreLine — the same call, off the same resolved value, that
+    // already drives the string collapse. An earlier design instead wrote it ONCE, only on the element whose
+    // OWN class list carried whitespace-pre-line, and left native UI Toolkit inheritance of `white-space` to
+    // carry it to descendants; that cannot work for the primary use case (a class on a container Div, text
+    // in a descendant Label) because Label/TextElement carries its own element-level `white-space` rule from
+    // the default theme/USS, and an element's OWN matching USS rule always beats an INHERITED value in the
+    // cascade regardless of specificity — so the write never reached a descendant Label no matter how it
+    // got there. Writing per-leaf off the RESOLVED value sidesteps that: a leaf with its own explicit
+    // whitespace-{normal,nowrap,pre,pre-wrap} class resolves its own axis first in ResolveEffective (the
+    // walk starts at the leaf itself), so it never receives the write and its own USS class governs
+    // untouched — no separate "does this leaf opt itself out" check is needed, ResolveEffective already IS
+    // that check, and the write and the collapsed string now always agree for the same leaf by construction.
+    //
+    // The write's clear-when-not-PreLine (ApplyToElement) is OWNERSHIP-gated via TextWhitespaceOwned, not
+    // unconditional: it clears style.whiteSpace back to StyleKeyword.Null only when this element is
+    // CURRENTLY marked owned there (and then drops the mark); any other leaf — one this resolver never
+    // wrote to at all — is left completely untouched. An earlier design cleared unconditionally on every
+    // non-PreLine call, reasoning that no other Velvet system ever writes `style.whiteSpace` inline besides
+    // FiberElementPoolReset's pool-RETURN sweep (a real second writer, but one that only ever runs on a
+    // pooled element BETWEEN tenants, never on one that is still live) — that reasoning was wrong: a
+    // consumer's refCallback can write style.whiteSpace directly (a pattern the framework's own docs treat
+    // as legitimate, see ReconcilerContext.RefCallbacks), and the unconditional clear silently clobbered it
+    // on this element's very next mount-or-patch text-effect pass, whether or not PreLine was involved
+    // anywhere in the tree. Ownership-tracking fixes that: the resolver now only ever undoes its OWN prior
+    // write, so an element it never touched keeps whatever any other writer put there.
+    //
+    // TextWhitespaceOwned rides the same ClearElementSideTables sweep as TextEffects/TextRawText, so a
+    // normal unmount or pool return scrubs it for free — FiberElementPoolReset's unconditional
+    // `style.whiteSpace = null` on the pool-RETURN path remains the backstop for a freshly-rented element
+    // whose new node carries no Text prop at all (CaptureRaw never fires for it, so the TextRawText gate
+    // below never runs and never gets a chance to clear anything itself). The one path that does NOT go
+    // through that sweep is a still-MOUNTED TextElement whose Text prop patches to null: the element keeps
+    // living, so ClearElementSideTables never runs for it, yet ApplyToElement can no longer run for it
+    // either (no tracked raw text left to resolve from) — without an explicit clear at that transition, a
+    // leaf that carried an owned inline PreWrap would keep it forever. FiberNodePatcher.PatchBaseElement
+    // clears TextWhitespaceOwned at exactly that site; see the comment there.
+    //
+    // KNOWN LIMITATION: toggling a text-transform / text-decoration / whitespace-pre-line class on an
+    // ANCESTOR re-cascades to descendants only when that ancestor is re-rendered (its post-children pass
+    // walks them). A descendant whose own text is unchanged and whose ancestor's class changed without the
+    // ancestor re-patching keeps its prior effect — string AND, for PreLine, the inline `white-space` write
+    // alike — until its next text update; the common static case (effect set at mount) is fully correct.
     internal static class StyleTextEffectResolver
     {
         // Captures the untransformed text for a text-bearing element at a text-set seam (TextNode create/patch,
@@ -39,10 +87,12 @@ namespace Velvet
         }
 
         // Syncs an element's OWN effect from its class list and applies the (cascade-resolved) effect to its own
-        // text and — when it carries an effect — its descendant text. Called from the post-children hook on
-        // create and patch, so it runs after the element's text, its classes, and its children are all in place.
+        // text and — when it carries an effect (now OR before this call) — its descendant text. Called from the
+        // post-children hook on create and patch, so it runs after the element's text, its classes, and its
+        // children are all in place.
         public static void Apply(ReconcilerContext ctx, VisualElement element, string[] classNames)
         {
+            ctx.TextEffects.TryGetValue(element, out var previous);
             var own = StyleTextEffectClass.Parse(classNames);
             if (own.IsEmpty)
             {
@@ -53,14 +103,23 @@ namespace Velvet
                 ctx.TextEffects[element] = own;
             }
 
-            // The element's own text (Label / Button carrying a Text prop) reflects its cascade-resolved effect.
+            // The element's own text (Label / Button carrying a Text prop) reflects its cascade-resolved
+            // effect — including the inline pre-wrap write for PreLine (see ApplyToElement). No own-axis
+            // shortcut is needed here: ApplyToElement resolves from THIS element via ResolveEffective, which
+            // checks the TextEffects entry just written above first, so an own PreLine token (or reset) is
+            // already the first thing the walk finds.
             ApplyToElement(ctx, element);
 
             // An element carrying an effect cascades it to descendant text (the V.Div("uppercase", V.Text(...))
-            // shape, where the text leaf has no class of its own). Gated on a non-empty own effect so the common
-            // no-effect element pays nothing. The reset forms (normal-case / no-underline) also cascade — they
-            // re-resolve descendants against the nearest surviving ancestor effect.
-            if (!own.IsEmpty)
+            // shape, where the text leaf has no class of its own). Gated on "own OR previous carrying an
+            // effect" — not simply "own effect present" — so a patch that DROPS the last effect-bearing class
+            // (own goes from non-empty to empty) still re-walks descendants: nothing else re-resolves a
+            // descendant TextNode leaf whose own text prop is unchanged (PatchText only calls OnTextSet when
+            // the text prop itself changes), so without this walk it would keep showing the removed effect —
+            // string AND, for PreLine, the inline whitespace write alike — forever. The reset forms
+            // (normal-case / no-underline / an explicit whitespace-* class) also cascade — they re-resolve
+            // descendants against the nearest surviving ancestor effect.
+            if (!own.IsEmpty || !previous.IsEmpty)
             {
                 ApplyToDescendants(ctx, element);
             }
@@ -73,8 +132,22 @@ namespace Velvet
         {
             if (element is TextElement te && ctx.TextRawText.TryGetValue(te, out var raw))
             {
-                var (transform, decoration) = ResolveEffective(ctx, te);
-                te.text = StyleTextEffectClass.Apply(raw, transform, decoration);
+                var (transform, decoration, whitespace) = ResolveEffective(ctx, te);
+                te.text = StyleTextEffectClass.Apply(raw, transform, decoration, whitespace);
+                // Per-leaf inline pre-wrap write, off the SAME resolved value that just drove the string
+                // collapse above, so the two can never disagree for this leaf. Ownership-gated (see the type
+                // comment / TextWhitespaceOwned): PreLine writes-and-marks; a non-PreLine resolve clears ONLY
+                // when this element is currently marked, so a leaf this resolver never wrote to — including
+                // one a consumer's refCallback wrote style.whiteSpace on directly — is never touched either way.
+                if (whitespace == WhitespaceCollapseKind.PreLine)
+                {
+                    te.style.whiteSpace = WhiteSpace.PreWrap;
+                    ctx.TextWhitespaceOwned[te] = true;
+                }
+                else if (ctx.TextWhitespaceOwned.Remove(te))
+                {
+                    te.style.whiteSpace = StyleKeyword.Null;
+                }
             }
         }
 
@@ -91,14 +164,19 @@ namespace Velvet
             }
         }
 
-        // The cascade: the nearest ancestor-or-self that sets each axis wins (each axis resolved independently),
-        // mirroring CSS inheritance of text-transform / text-decoration. A null axis on every ancestor means no
-        // effect on that axis.
-        private static (TextTransformKind? transform, TextDecorationKind? decoration) ResolveEffective(
+        // The cascade: the nearest ancestor-or-self that sets each axis wins (each axis resolved
+        // independently), mirroring CSS inheritance of text-transform / text-decoration / white-space. A null
+        // axis on every ancestor means no effect on that axis. An explicit None on an axis (normal-case /
+        // no-underline / an explicit whitespace-* class) also wins and stops the walk for THAT axis — it is a
+        // real resolved value, not "no token" — so it blocks a farther ancestor's non-None value from
+        // reaching this element. Feeds BOTH the string rewrite and, for Whitespace, the inline pre-wrap style
+        // write in ApplyToElement — one resolve, two writes off the same value, so they can never disagree.
+        private static (TextTransformKind? transform, TextDecorationKind? decoration, WhitespaceCollapseKind? whitespace) ResolveEffective(
             ReconcilerContext ctx, VisualElement element)
         {
             TextTransformKind? transform = null;
             TextDecorationKind? decoration = null;
+            WhitespaceCollapseKind? whitespace = null;
             for (var e = element; e != null; e = e.hierarchy.parent)
             {
                 if (!ctx.TextEffects.TryGetValue(e, out var eff))
@@ -107,12 +185,13 @@ namespace Velvet
                 }
                 transform ??= eff.Transform;
                 decoration ??= eff.Decoration;
-                if (transform != null && decoration != null)
+                whitespace ??= eff.Whitespace;
+                if (transform != null && decoration != null && whitespace != null)
                 {
                     break;
                 }
             }
-            return (transform, decoration);
+            return (transform, decoration, whitespace);
         }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/StyleTextEffectClassTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/StyleTextEffectClassTests.cs
@@ -3,10 +3,12 @@ using NUnit.Framework;
 namespace Velvet.Tests
 {
     /// <summary>
-    /// Pure coverage for <see cref="StyleTextEffectClass"/>: parsing the text-transform / text-decoration
-    /// utilities into a <see cref="TextEffect"/> (each axis nullable so an explicit reset differs from unset),
-    /// and applying a resolved effect to a raw string (transform first, then the rich-text decoration wrap).
-    /// GWT, one assert per case.
+    /// Pure coverage for <see cref="StyleTextEffectClass"/>: parsing the text-transform / text-decoration /
+    /// whitespace-pre-line utilities into a <see cref="TextEffect"/> (each axis nullable so an explicit reset
+    /// differs from unset — an explicit whitespace-* class resolves the Whitespace axis to its own None
+    /// reset, mirroring normal-case / no-underline, see Parse), and applying a resolved effect to a raw
+    /// string (pre-line collapse first, then transform, then the rich-text decoration wrap). GWT, one assert
+    /// per case.
     /// </summary>
     [TestFixture]
     internal sealed class StyleTextEffectClassTests
@@ -87,6 +89,132 @@ namespace Velvet.Tests
         public void Given_NoneTransform_When_Applied_Then_TextUnchanged()
         {
             Assert.That(StyleTextEffectClass.Apply("MixedCase", TextTransformKind.None, null), Is.EqualTo("MixedCase"));
+        }
+
+        [Test]
+        public void Given_WhitespacePreLine_When_Parsed_Then_WhitespaceIsPreLine()
+        {
+            Assert.That(StyleTextEffectClass.Parse(new[] { "whitespace-pre-line" }).Whitespace, Is.EqualTo(WhitespaceCollapseKind.PreLine));
+        }
+
+        [Test]
+        public void Given_NoWhitespaceTokens_When_Parsed_Then_WhitespaceIsUnsetNull()
+        {
+            Assert.That(StyleTextEffectClass.Parse(new[] { "bg-red-500", "p-4" }).Whitespace, Is.Null);
+        }
+
+        [Test]
+        public void Given_WhitespacePreLineAndExplicitWhitespacePreOnSameElement_When_Parsed_Then_ExplicitClassWinsWithNone()
+        {
+            // The direct, single-purpose whitespace-pre class wins over pre-line's collapsing rewrite when
+            // both tokens sit on the same element (see the Why comment in Parse for the full rationale) —
+            // and resolves to the explicit None reset, not back to unset, so it also blocks a farther
+            // ancestor's pre-line from reaching this subtree.
+            Assert.That(
+                StyleTextEffectClass.Parse(new[] { "whitespace-pre-line", "whitespace-pre" }).Whitespace,
+                Is.EqualTo(WhitespaceCollapseKind.None));
+        }
+
+        [Test]
+        public void Given_WhitespaceNowrapAlone_When_Parsed_Then_WhitespaceIsExplicitNone()
+        {
+            // Mirrors normal-case / no-underline: an explicit whitespace-* class is tracked as the None reset
+            // even with no ancestor whitespace-pre-line around, because blocking a FARTHER ancestor's
+            // pre-line is the whole point of the reset — Parse cannot know at parse time whether an ancestor
+            // exists to block.
+            Assert.That(StyleTextEffectClass.Parse(new[] { "whitespace-nowrap" }).Whitespace, Is.EqualTo(WhitespaceCollapseKind.None));
+        }
+
+        [Test]
+        public void Given_SpaceAndTabRuns_When_CollapsedForPreLine_Then_EachRunFoldsToASingleSpace()
+        {
+            Assert.That(
+                StyleTextEffectClass.Apply("a  b\tc \t d", null, null, WhitespaceCollapseKind.PreLine),
+                Is.EqualTo("a b c d"));
+        }
+
+        [Test]
+        public void Given_ConsecutiveNewlines_When_CollapsedForPreLine_Then_TheyArePreserved()
+        {
+            // A blank line (two consecutive newlines with nothing between) survives verbatim — pre-line
+            // preserves every forced break, not just single ones.
+            Assert.That(
+                StyleTextEffectClass.Apply("a\nb\n\nc", null, null, WhitespaceCollapseKind.PreLine),
+                Is.EqualTo("a\nb\n\nc"));
+        }
+
+        [Test]
+        public void Given_LeadingAndTrailingSpacesPerLine_When_CollapsedForPreLine_Then_TheyCollapseAway()
+        {
+            // Covers both the whole string's edges and the internal per-line edges around the shared \n.
+            Assert.That(
+                StyleTextEffectClass.Apply("  first line  \n  second line  ", null, null, WhitespaceCollapseKind.PreLine),
+                Is.EqualTo("first line\nsecond line"));
+        }
+
+        [Test]
+        public void Given_CrLfPair_When_CollapsedForPreLine_Then_CollapsesToSingleNewline()
+        {
+            // CSS Text Level 3 segment-break normalization: a '\r\n' pair is ONE break, equivalent to '\n' —
+            // not two — and the run of spaces touching it still collapses away like any other line edge.
+            Assert.That(
+                StyleTextEffectClass.Apply("a  \r\nb", null, null, WhitespaceCollapseKind.PreLine),
+                Is.EqualTo("a\nb"));
+        }
+
+        [Test]
+        public void Given_BareCarriageReturn_When_CollapsedForPreLine_Then_TreatedAsNewline()
+        {
+            Assert.That(
+                StyleTextEffectClass.Apply("a\rb", null, null, WhitespaceCollapseKind.PreLine),
+                Is.EqualTo("a\nb"));
+        }
+
+        [Test]
+        public void Given_ConsecutiveCrLfPairs_When_CollapsedForPreLine_Then_BlankLineSurvives()
+        {
+            Assert.That(
+                StyleTextEffectClass.Apply("a\r\n\r\nb", null, null, WhitespaceCollapseKind.PreLine),
+                Is.EqualTo("a\n\nb"));
+        }
+
+        [Test]
+        public void Given_NonBreakingSpaceRun_When_CollapsedForPreLine_Then_NotCollapsed()
+        {
+            // NBSP (U+00A0) is not a collapsible whitespace character for pre-line — only literal space/tab
+            // runs fold, matching CSS's own segment-break / whitespace-collapsing rules. Built via a char
+            // cast instead of an embedded literal so the non-breaking space stays unambiguous in source.
+            var nbsp = ((char)0x00A0).ToString();
+
+            Assert.That(StyleTextEffectClass.Apply($"a{nbsp}{nbsp}b", null, null, WhitespaceCollapseKind.PreLine), Is.EqualTo($"a{nbsp}{nbsp}b"));
+        }
+
+        [Test]
+        public void Given_AllWhitespaceInput_When_CollapsedWithDecoration_Then_ResultIsEmptyWithNoTags()
+        {
+            // The collapse alone can fully consume an all-whitespace string (every run in it touches a line
+            // edge); the empty result must still honor the "empty text returned unchanged" contract instead
+            // of wrapping an empty string in a decoration tag.
+            Assert.That(
+                StyleTextEffectClass.Apply("   ", null, TextDecorationKind.Underline, WhitespaceCollapseKind.PreLine),
+                Is.EqualTo(""));
+        }
+
+        [Test]
+        public void Given_WhitespaceNull_When_Applied_Then_SpaceRunsAreLeftUncollapsed()
+        {
+            // whitespace defaults to null (off) so every pre-existing 3-arg Apply call site keeps its behavior.
+            Assert.That(StyleTextEffectClass.Apply("a   b", null, null), Is.EqualTo("a   b"));
+        }
+
+        [Test]
+        public void Given_PreLineWithTransformAndDecoration_When_Applied_Then_CollapseRunsBeforeThem()
+        {
+            // Pipeline order: collapse the raw text first, then uppercase, then wrap — matching CSS's own
+            // white-space-before-text-transform resolution order.
+            Assert.That(
+                StyleTextEffectClass.Apply("a   B", TextTransformKind.Upper, TextDecorationKind.Underline, WhitespaceCollapseKind.PreLine),
+                Is.EqualTo("<u>A B</u>"));
         }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/StyleTextEffectPanelTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/StyleTextEffectPanelTests.cs
@@ -1,3 +1,4 @@
+using System;
 using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.UIElements;
@@ -5,22 +6,43 @@ using UnityEngine.UIElements;
 namespace Velvet.Tests
 {
     /// <summary>
-    /// End-to-end coverage for text-transform / text-decoration on a real reconcile: the effect cascades from
-    /// the class-bearing element onto descendant text leaves (a TextNode has no class of its own), applies to an
-    /// element's own Text prop, resets via normal-case, and re-applies when the text changes. Reading
-    /// <c>Label.text</c> after mount/patch (no layout needed — the effect mutates the string). GWT, one assert.
+    /// End-to-end coverage for text-transform / text-decoration / whitespace-pre-line on a real reconcile: the
+    /// effect cascades from the class-bearing element onto descendant text leaves (a TextNode has no class of
+    /// its own), applies to an element's own Text prop, resets via normal-case (or, for pre-line, via a class
+    /// list that no longer carries whitespace-pre-line — or via a descendant's own explicit whitespace-*
+    /// class, which blocks the cascade rather than merely omitting it), and re-applies when the text changes.
+    /// Reading <c>Label.text</c> after mount/patch needs no layout pass (the effect mutates the string);
+    /// reading pre-line's inline <c>style.whiteSpace</c> needs no layout pass either (an inline C# write, not
+    /// a resolved USS value) — except the one test below that deliberately reads <c>resolvedStyle</c>
+    /// instead, to prove the inline write actually wins UI Toolkit's real cascade over the Label's own
+    /// baked-in element-level <c>white-space</c> rule (an own USS rule otherwise beats an INHERITED value,
+    /// which is why the write has to land on the leaf itself and not just an ancestor). GWT, one assert.
     /// </summary>
     [TestFixture]
     internal sealed class StyleTextEffectPanelTests : PanelTestBase
     {
         private static StateUpdater<string> s_setText;
         private static StateUpdater<string> s_setInnerText;
+        private static StateUpdater<string> s_setPreLineClass;
+        private static StateUpdater<string> s_setPoolReuseState;
+        private static StateUpdater<string> s_setPreLineAncestorClass;
+        private static StateUpdater<string> s_setUppercaseAncestorClass;
+        private static StateUpdater<string> s_setPreLineText;
+        private static StateUpdater<string> s_setUppercaseRefText;
+        private static StateUpdater<string> s_setCascadeParentClass;
 
         protected override Rect WindowSize => new Rect(0, 0, 400, 400);
 
         public override void SetUp()
         {
             s_setText = default;
+            s_setPreLineClass = default;
+            s_setPoolReuseState = default;
+            s_setPreLineAncestorClass = default;
+            s_setUppercaseAncestorClass = default;
+            s_setPreLineText = default;
+            s_setUppercaseRefText = default;
+            s_setCascadeParentClass = default;
             base.SetUp();
         }
 
@@ -93,6 +115,272 @@ namespace Velvet.Tests
             Assert.That(_window.rootVisualElement.Q<Label>().text, Is.EqualTo("TWO"));
         }
 
+        [Test]
+        public void Given_AncestorUppercaseClassRemoved_When_DescendantTextUnchanged_Then_DescendantRevertsToRaw()
+        {
+            // The ancestor loses its LAST effect-bearing class on a patch (its own effect goes from
+            // non-empty to empty), but the descendant TextNode leaf's text prop never changes across the
+            // patch — nothing but the descendant walk re-resolves it (PatchText only re-applies when the text
+            // prop itself changes), so a gate that skips that walk whenever the ancestor's OWN effect is now
+            // empty would leave the leaf stuck showing the removed transform forever.
+            Mount(V.Component(RenderUppercaseAncestorToggle));
+            Assume.That(_window.rootVisualElement.Q<Label>().text, Is.EqualTo("HI"), "Precondition: initial uppercase");
+
+            s_setUppercaseAncestorClass.Invoke("");
+            _mounted.Root.Reconciler.Context.BatchScheduler.DrainImmediateForTest();
+
+            Assert.That(_window.rootVisualElement.Q<Label>().text, Is.EqualTo("hi"));
+        }
+
+        [Test]
+        public void Given_WhitespacePreLineOnLabelItself_When_Mounted_Then_OwnTextIsCollapsed()
+        {
+            var label = MountAndFindLabel(V.Label(className: "whitespace-pre-line", text: "a   b"));
+
+            Assert.That(label.text, Is.EqualTo("a b"));
+        }
+
+        [Test]
+        public void Given_WhitespacePreLineOnParent_When_Mounted_Then_ChildTextLeafIsCollapsed()
+        {
+            // The text leaf has no class; the collapse cascades from the parent, mirroring how
+            // transform/decoration cascade from an ancestor onto a class-less V.Text leaf.
+            var label = MountAndFindLabel(V.Div(className: "whitespace-pre-line", V.Text("a   b")));
+
+            Assert.That(label.text, Is.EqualTo("a b"));
+        }
+
+        [Test]
+        public void Given_WhitespacePreLineAncestorAndExplicitNowrapDescendant_When_Mounted_Then_DescendantTextNotCollapsedAndNoInlineWrite()
+        {
+            // An explicit whitespace-* class on a descendant must BLOCK a farther ancestor's pre-line from
+            // reaching it, mirroring how normal-case / no-underline block Transform / Decoration — the
+            // descendant's own explicit choice wins, it is not merely invisible to the cascade. Pinned on
+            // both halves of what the cascade drives together off the one resolved value (the collapsed
+            // string and the inline pre-wrap write): a descendant that opts itself out must show neither.
+            Mount(V.Div(className: "whitespace-pre-line",
+                V.Label(name: "explicit", className: "whitespace-nowrap", text: "a   b"),
+                V.Label(name: "inherited", text: "c   d")));
+            var explicitLabel = _window.rootVisualElement.Q<Label>("explicit");
+
+            Assert.That((explicitLabel.text, explicitLabel.style.whiteSpace.keyword), Is.EqualTo(("a   b", StyleKeyword.Null)));
+        }
+
+        [Test]
+        public void Given_WhitespacePreLineAncestorAndPlainSiblingDescendant_When_Mounted_Then_SiblingTextCollapsed()
+        {
+            // Inverse control for the test above, mounted from the identical tree: a sibling with no
+            // whitespace class of its own still inherits and collapses normally, proving the block above is
+            // specific to the explicit class rather than a general regression of the cascade.
+            Mount(V.Div(className: "whitespace-pre-line",
+                V.Label(name: "explicit", className: "whitespace-nowrap", text: "a   b"),
+                V.Label(name: "inherited", text: "c   d")));
+
+            Assert.That(_window.rootVisualElement.Q<Label>("inherited").text, Is.EqualTo("c d"));
+        }
+
+        [Test]
+        public void Given_WhitespacePreLineOnLabelItself_When_Mounted_Then_InlineWhiteSpaceIsPreWrap()
+        {
+            // The collapsed text still needs to WRAP and render its (absent, here) newlines as breaks, so
+            // pre-line also writes an inline white-space: pre-wrap — read directly off the inline style
+            // (no layout pass needed), not resolvedStyle, mirroring how StyleFontResolver's own inline
+            // writes are asserted elsewhere in this codebase.
+            var label = MountAndFindLabel(V.Label(className: "whitespace-pre-line", text: "a   b"));
+
+            Assert.That(label.style.whiteSpace.value, Is.EqualTo(WhiteSpace.PreWrap));
+        }
+
+        [Test]
+        public void Given_WhitespacePreLineOnParent_When_Resolved_Then_ChildLeafGetsInlinePreWrap()
+        {
+            // The text leaf (a Label, like every UI Toolkit TextElement) carries its own element-level
+            // white-space rule from the default theme/USS, which always beats an INHERITED value in the
+            // cascade — so a write on the ancestor Div alone would never reach it. The leaf gets its OWN
+            // inline write instead (ApplyToElement, driven by the resolved — cascade, not merely own — axis).
+            // Reading resolvedStyle here (rather than the inline style directly, as the sibling test above
+            // does) proves that write actually wins the real UI Toolkit cascade over the leaf's own default
+            // rule, not merely that a C# field was set.
+            var label = MountAndFindLabel(V.Div(className: "whitespace-pre-line", V.Text("a   b")));
+            ForcePanelUpdate(label.panel);
+
+            Assert.That(label.resolvedStyle.whiteSpace, Is.EqualTo(WhiteSpace.PreWrap));
+        }
+
+        [Test]
+        public void Given_WhitespacePreLineOnParent_When_Mounted_Then_ParentContainerHasNoInlineWhiteSpace()
+        {
+            // Documents the contract rather than detecting a regression: ApplyToElement's write is gated on
+            // `element is TextElement` (see its own guard), and a plain Div is not one — a container renders
+            // no text of its own, so it structurally CANNOT receive the write no matter what the resolver's
+            // internals do, making this assertion true by construction rather than a live probe of resolver
+            // behavior. Kept as an explicit pin of that gate (className alone is not sufficient — only a
+            // text-bearing element ever qualifies) rather than removed. V.Text has no wrapper, so the found
+            // Label's direct hierarchy parent IS the class-bearing Div.
+            var label = MountAndFindLabel(V.Div(className: "whitespace-pre-line", V.Text("a   b")));
+
+            Assert.That(label.parent.style.whiteSpace.keyword, Is.EqualTo(StyleKeyword.Null));
+        }
+
+        [Test]
+        public void Given_WhitespacePreLineAndExplicitWhitespacePreOnSameElement_When_Mounted_Then_NoInlineWhiteSpaceWritten()
+        {
+            // End-to-end pin for the same-element precedence rule: the explicit whitespace-pre class wins
+            // over whitespace-pre-line locally (resolves to the None reset) — ResolveEffective finds this
+            // element's own TextEffects entry before it would ever walk to an ancestor, so the resolved axis
+            // is None, not PreLine, and the inline pre-wrap write must never fire; the element keeps whatever
+            // whitespace-pre's own USS class rule resolves to instead.
+            var label = MountAndFindLabel(V.Label(className: "whitespace-pre-line whitespace-pre", text: "a   b"));
+
+            Assert.That(label.style.whiteSpace.keyword, Is.EqualTo(StyleKeyword.Null));
+        }
+
+        [Test]
+        public void Given_UppercaseOnlyLabelWithRefWrittenWhiteSpace_When_Patched_Then_InlineWhiteSpaceSurvivesUntouched()
+        {
+            // No whitespace utility anywhere in this tree — only uppercase. The refCallback writes
+            // style.whiteSpace directly at mount, a pattern the framework's own docs treat as legitimate
+            // (ReconcilerContext.RefCallbacks). ApplyToElement still runs for this label on every mount/patch
+            // pass (it is text-bearing and tracks a raw text) but must never touch a property it never
+            // itself wrote to. No Assume precondition here (unlike the sibling pre-line tests): under the old
+            // unconditional clear-when-not-PreLine write, Apply() runs immediately after the refCallback in
+            // BOTH the create and patch call sites, so the ref's value was already stomped to
+            // StyleKeyword.Null at MOUNT, before any patch — gating on it surviving mount would itself go
+            // Inconclusive rather than cleanly RED. The single assert below, after both mount and a driven
+            // patch, is the honest regression pin.
+            Mount(V.Component(RenderUppercaseOnlyWithManualWhiteSpaceRef));
+
+            s_setUppercaseRefText.Invoke("there");
+            _mounted.Root.Reconciler.Context.BatchScheduler.DrainImmediateForTest();
+
+            Assert.That(_window.rootVisualElement.Q<Label>().style.whiteSpace.value, Is.EqualTo(WhiteSpace.Pre));
+        }
+
+        [Test]
+        public void Given_WhitespacePreLineClassRemoved_When_Patched_Then_TextRestoredToRaw()
+        {
+            // Pins the raw-text side-table re-derivation, not any own/previous gate: ApplyToElement re-applies
+            // an element's OWN text (and, for PreLine, its own inline white-space) from the tracked raw and
+            // the freshly resolved axis on every call, unconditionally — this label carries both its text AND
+            // its class, so the same-element case never touches the own/previous gate that guards the
+            // DESCENDANT walk (a separate concern — see ApplyToDescendants). The inline-clear sibling test
+            // right below pins that SAME unconditional recompute, just for the whiteSpace half of it.
+            Mount(V.Component(RenderPreLineToggle));
+            Assume.That(_window.rootVisualElement.Q<Label>().text, Is.EqualTo("a b"), "Precondition: initial collapse");
+
+            s_setPreLineClass.Invoke("");
+            _mounted.Root.Reconciler.Context.BatchScheduler.DrainImmediateForTest();
+
+            Assert.That(_window.rootVisualElement.Q<Label>().text, Is.EqualTo("a   b"));
+        }
+
+        [Test]
+        public void Given_WhitespacePreLineClassRemoved_When_Patched_Then_InlineWhiteSpaceIsCleared()
+        {
+            // The inline pre-wrap write must not survive past the class that requested it, or the element
+            // would keep wrapping/breaking like pre-line forever, off any USS fallback it might otherwise
+            // resolve to.
+            Mount(V.Component(RenderPreLineToggle));
+            var label = _window.rootVisualElement.Q<Label>();
+            Assume.That(label.style.whiteSpace.value, Is.EqualTo(WhiteSpace.PreWrap), "Precondition: inline pre-wrap set");
+
+            s_setPreLineClass.Invoke("");
+            _mounted.Root.Reconciler.Context.BatchScheduler.DrainImmediateForTest();
+
+            Assert.That(label.style.whiteSpace.keyword, Is.EqualTo(StyleKeyword.Null));
+        }
+
+        [Test]
+        public void Given_WhitespacePreLineTextPropPatchedToNull_When_Patched_Then_InlineWhiteSpaceIsCleared()
+        {
+            // The whitespace-pre-line class stays; only the Text prop patches to null (the label stays
+            // mounted — no pool cycle). FiberNodePatcher drops the TextRawText entry for that transition,
+            // which stops ApplyToElement from ever running for this element again — the leak this pins:
+            // without an explicit clear at that same site, the inline pre-wrap write it left behind would
+            // survive forever instead of clearing along with the text.
+            Mount(V.Component(RenderPreLineTextPropToggle));
+            var label = _window.rootVisualElement.Q<Label>();
+            Assume.That(label.style.whiteSpace.value, Is.EqualTo(WhiteSpace.PreWrap), "Precondition: inline pre-wrap set");
+
+            s_setPreLineText.Invoke((string)null);
+            _mounted.Root.Reconciler.Context.BatchScheduler.DrainImmediateForTest();
+
+            Assert.That(label.style.whiteSpace.keyword, Is.EqualTo(StyleKeyword.Null));
+        }
+
+        [Test]
+        public void Given_AncestorPreLineClassRemoved_When_DescendantTextUnchanged_Then_DescendantRevertsToRaw()
+        {
+            // The failure mode this pins: a patch that removes the LAST effect-bearing class from an
+            // ancestor (its own effect goes from non-empty to empty) must still re-walk descendants — a
+            // descendant TextNode leaf whose own text prop is unchanged is never re-resolved by anything
+            // else (PatchText only calls OnTextSet when the text prop itself changes), so without the walk
+            // it would keep showing the stale collapsed string forever.
+            Mount(V.Component(RenderPreLineAncestorToggle));
+            Assume.That(_window.rootVisualElement.Q<Label>().text, Is.EqualTo("a b"), "Precondition: initial collapse");
+
+            s_setPreLineAncestorClass.Invoke("");
+            _mounted.Root.Reconciler.Context.BatchScheduler.DrainImmediateForTest();
+
+            Assert.That(_window.rootVisualElement.Q<Label>().text, Is.EqualTo("a   b"));
+        }
+
+        [Test]
+        public void Given_ThreeLevelCascade_When_Mounted_Then_LeafIsCollapsedAndUppercased()
+        {
+            // Grandparent carries whitespace-pre-line, parent carries uppercase (a DIFFERENT axis), and the
+            // leaf itself carries neither — both effects must independently cascade THROUGH the
+            // intermediate parent to reach the leaf, not just the direct grandparent-to-leaf hop the other
+            // cascade tests in this fixture already cover at 2 levels.
+            var label = MountAndFindLabel(V.Div(className: "whitespace-pre-line",
+                V.Div(className: "uppercase", V.Text("a   b c"))));
+
+            Assert.That(label.text, Is.EqualTo("A B C"));
+        }
+
+        [Test]
+        public void Given_ThreeLevelCascadeParentUppercaseRemoved_When_Patched_Then_LeafStaysCollapsedButNotUppercased()
+        {
+            // Same 3-level shape as above; the patch removes ONLY the parent's uppercase (the grandparent's
+            // whitespace-pre-line class is untouched) and the leaf's own text prop never changes across the
+            // patch — nothing but the descendant re-walk (ApplyToDescendants, triggered by the parent's
+            // effect going non-empty -> empty) re-resolves it. Pins that the grandparent's surviving axis
+            // and the parent's just-removed one resolve independently through a 3-level chain.
+            Mount(V.Component(RenderThreeLevelCascade));
+            Assume.That(_window.rootVisualElement.Q<Label>().text, Is.EqualTo("A B C"), "Precondition: initial collapse+uppercase");
+
+            s_setCascadeParentClass.Invoke("");
+            _mounted.Root.Reconciler.Context.BatchScheduler.DrainImmediateForTest();
+
+            Assert.That(_window.rootVisualElement.Q<Label>().text, Is.EqualTo("a b c"));
+        }
+
+        [Test]
+        public void Given_LabelPooledWithPreLineState_When_RentedAgainWithoutTheClass_Then_NewLabelHasNoInlineWhiteSpace()
+        {
+            // Arrange — mount a pre-line Label, then hide it (a Label -> Div swap removes it, returning it to
+            // VNodePool while it still carries the inline pre-wrap write), then show a different, unrelated
+            // plain label. VNodePool's Label pool is LIFO and nothing else rents a Label in between, so this
+            // deterministically hands the same instance back.
+            Mount(V.Component(RenderPoolReuseHost));
+            var scheduler = _mounted.Root.Reconciler.Context.BatchScheduler;
+            Assume.That(_window.rootVisualElement.Q<Label>("leaf").style.whiteSpace.value, Is.EqualTo(WhiteSpace.PreWrap),
+                "Precondition: the first label carries the inline pre-wrap write");
+            s_setPoolReuseState.Invoke("hidden");
+            scheduler.DrainImmediateForTest();
+            Assume.That(_window.rootVisualElement.Q<Label>("leaf"), Is.Null, "Precondition: the label is pooled while hidden");
+
+            // Act — an unrelated plain label rents the pooled instance back.
+            s_setPoolReuseState.Invoke("plain");
+            scheduler.DrainImmediateForTest();
+
+            // Assert — the recycled instance carries no leftover inline pre-wrap AND no leftover collapsed
+            // text from the previous consumer's side-table entry (a ghosted TextEffects/TextRawText row would
+            // still show "c d" here, not the fixture's raw, uncollapsed "c   d").
+            var recycled = _window.rootVisualElement.Q<Label>("leaf");
+            Assert.That((recycled.style.whiteSpace.keyword, recycled.text), Is.EqualTo((StyleKeyword.Null, "c   d")));
+        }
+
         private void Mount(VNode tree)
         {
             _mounted = V.Mount(_window.rootVisualElement, tree);
@@ -112,6 +400,87 @@ namespace Velvet.Tests
             var (text, setText) = Hooks.UseState("one");
             s_setInnerText = setText;
             return V.Text(text);
+        }
+
+        [Component]
+        private static VNode RenderPreLineToggle()
+        {
+            var (cls, setCls) = Hooks.UseState("whitespace-pre-line");
+            s_setPreLineClass = setCls;
+            return V.Label(className: cls, text: "a   b");
+        }
+
+        [Component]
+        private static VNode RenderPreLineAncestorToggle()
+        {
+            // Unlike RenderPreLineToggle, the class-bearing element and the text leaf are DIFFERENT elements
+            // (a Div ancestor, a separate V.Text child) — the shape the ApplyToDescendants gate guards, as
+            // opposed to the same-element ApplyToElement path RenderPreLineToggle exercises.
+            var (cls, setCls) = Hooks.UseState("whitespace-pre-line");
+            s_setPreLineAncestorClass = setCls;
+            return V.Div(className: cls, V.Text("a   b"));
+        }
+
+        [Component]
+        private static VNode RenderUppercaseAncestorToggle()
+        {
+            var (cls, setCls) = Hooks.UseState("uppercase");
+            s_setUppercaseAncestorClass = setCls;
+            return V.Div(className: cls, V.Text("hi"));
+        }
+
+        [Component]
+        private static VNode RenderPreLineTextPropToggle()
+        {
+            // Unlike RenderPreLineToggle (which toggles the CLASS), this toggles the Text PROP itself while
+            // whitespace-pre-line stays on the class list throughout — exercising the Text->null transition
+            // on a still-mounted element, the one path where the owned inline write must be cleared without
+            // an unmount or pool cycle ever running.
+            var (text, setText) = Hooks.UseState("a   b");
+            s_setPreLineText = setText;
+            return V.Label(className: "whitespace-pre-line", text: text);
+        }
+
+        // Stable delegate identity (a static readonly field, not a per-render closure) so InvokeRefCallback's
+        // same-identity skip means this fires exactly once, at mount — the driven patch below then exercises
+        // ONLY the text-effect pass's own restraint, not a re-firing ref re-asserting the value each time.
+        private static readonly Func<VisualElement, Action> s_manualWhiteSpaceRef = element =>
+        {
+            element.style.whiteSpace = WhiteSpace.Pre;
+            return null;
+        };
+
+        [Component]
+        private static VNode RenderUppercaseOnlyWithManualWhiteSpaceRef()
+        {
+            var (text, setText) = Hooks.UseState("hi");
+            s_setUppercaseRefText = setText;
+            return V.Label(className: "uppercase", text: text, refCallback: s_manualWhiteSpaceRef);
+        }
+
+        [Component]
+        private static VNode RenderThreeLevelCascade()
+        {
+            var (parentCls, setParentCls) = Hooks.UseState("uppercase");
+            s_setCascadeParentClass = setParentCls;
+            return V.Div(className: "whitespace-pre-line",
+                V.Div(className: parentCls, V.Text("a   b c")));
+        }
+
+        [Component]
+        private static VNode RenderPoolReuseHost()
+        {
+            var (state, setState) = Hooks.UseState("pre-line");
+            s_setPoolReuseState = setState;
+            if (state == "pre-line")
+            {
+                return V.Label(name: "leaf", className: "whitespace-pre-line", text: "a   b");
+            }
+            if (state == "plain")
+            {
+                return V.Label(name: "leaf", text: "c   d");
+            }
+            return V.Div(name: "placeholder");
         }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/WhitespaceUtilityUssTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/WhitespaceUtilityUssTests.cs
@@ -1,0 +1,44 @@
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine.UIElements;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Resolved-style coverage for the whitespace-pre / whitespace-pre-wrap utilities (<c>_typography.uss</c>)
+    /// — the two whitespace-* values that map straight onto a <see cref="WhiteSpace"/> enum member.
+    /// whitespace-pre-line is NOT covered here: it has no USS rule of its own (a display-string rewrite
+    /// instead — see <c>StyleTextEffectClassTests</c> / <c>StyleTextEffectPanelTests</c>). Mounts a leaf
+    /// inside a real <see cref="UnityEditor.EditorWindow"/> panel with the bundled
+    /// <c>StyleUtilities.uss</c> attached, forces a layout pass so the cascade resolves, then reads
+    /// <c>resolvedStyle</c>. GWT, one assert per case.
+    /// </summary>
+    [TestFixture]
+    internal sealed class WhitespaceUtilityUssTests : PanelTestBase
+    {
+        private const string StyleSheetPath = "Packages/com.velvet.core/Runtime/Styles/StyleUtilities.uss";
+
+        protected override void LoadStyleSheets()
+        {
+            var sheet = AssetDatabase.LoadAssetAtPath<StyleSheet>(StyleSheetPath);
+            Assume.That(sheet, Is.Not.Null, "Precondition: the bundled StyleUtilities.uss loads");
+            _window.rootVisualElement.styleSheets.Add(sheet);
+        }
+
+        [Test]
+        public void Given_WhitespacePre_When_Resolved_Then_WhiteSpaceIsPre()
+        {
+            var leaf = MountAndResolve("whitespace-pre");
+
+            Assert.That(leaf.resolvedStyle.whiteSpace, Is.EqualTo(WhiteSpace.Pre));
+        }
+
+        [Test]
+        public void Given_WhitespacePreWrap_When_Resolved_Then_WhiteSpaceIsPreWrap()
+        {
+            var leaf = MountAndResolve("whitespace-pre-wrap");
+
+            Assert.That(leaf.resolvedStyle.whiteSpace, Is.EqualTo(WhiteSpace.PreWrap));
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/WhitespaceUtilityUssTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/WhitespaceUtilityUssTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9fd6fa94af5384e0f93513d79cec17eb


### PR DESCRIPTION
## What

Fills out the `whitespace-*` utility family beyond the existing `whitespace-normal` / `whitespace-nowrap` pair (part of #96):

- **`whitespace-pre` / `whitespace-pre-wrap`** — plain USS classes. The engine's `WhiteSpace` enum carries `Pre` and `PreWrap` in this Unity version, the USS keyword parser accepts both, and both text-generator backends honor them (preserve-whitespace with and without wrapping). The bundled stylesheet comment and `Documentation~/fonts.md` previously claimed the enum only has normal/nowrap — both corrected.
- **`whitespace-pre-line`** — no engine value exists, so it rides the display-string rewrite subsystem as a third axis beside `text-transform` / `text-decoration`: space/tab runs collapse to one space, runs touching a line edge drop entirely, newlines are preserved (CRLF and lone CR normalize to a single break), and each affected text leaf receives an inline `white-space: pre-wrap` write so the preserved breaks render and wrapping still works.

## Design notes

- **Per-leaf write, not on the class bearer**: a text element's own theme-level `white-space` rule always beats an inherited value, so writing once on a container ancestor never reaches a descendant label — each leaf whose resolved axis is pre-line gets the write directly.
- **Ownership-tracked clear**: the resolver records which leaves it styled and only ever clears a value it wrote itself — a manual inline `white-space` write made through a `refCallback` on an uninvolved leaf is never touched, and a leaf whose `Text` prop empties while mounted is cleaned up at that exact transition rather than leaking the write.
- **Stop-sentinel cascade**: an explicit `whitespace-*` class both wins on its own element and blocks a farther ancestor's `pre-line` for that subtree — the same contract `normal-case` / `no-underline` already follow, so all three rewrite axes cascade uniformly.
- Also documented in `fonts.md`: `font-variant-numeric`, `antialiased` / `subpixel-antialiased`, and `font-stretch-*` are not reproducible at runtime (each has an engine-level blocker), with a pointer to the font-family mechanism for achieving the look via a purpose-built font asset.

## Tests

New/extended EditMode coverage: resolved-style checks for the two USS classes against the real bundled sheet; collapse-algorithm units (blank-line preservation, CRLF/CR normalization, NBSP non-collapse, line-edge drops, empty-after-collapse with decoration); cascade panel tests (own element, descendant leaf, three-level chains, explicit-class blocking, same-element precedence); lifecycle tests (class removal restores raw text and clears the inline write, text-prop-to-null clears it on a still-mounted element, a refCallback's own inline write survives untouched, pooled-element reuse shows no ghosting).

3088/3088 EditMode and 83/83 PlayMode tests pass locally.

Part of #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)