### PR TITLE
feat(velvet): bubble events along the logical chain for same-panel registry portals

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `V.Portal(targetId:)` (the same-panel registry portal) now bubbles `events:` handlers to the
+  logical ancestor chain outside the call site, matching the synthetic bubbling
+  `V.Portal(layer:)`/`V.WorldSpace` already had. `PointerDown`/`Up`/`Move`/`Enter`/`Leave`,
+  `Wheel`, `KeyDown`/`Up`, and `FocusIn`/`Out` bindings on an `events:` prop now reach a logical
+  ancestor's handler the same way in all three portal forms; an element that is both a physical
+  ancestor of the resolved target and a logical ancestor of the call site still fires exactly
+  once (native bubbling already covers it, so the synthetic walk stops there instead of
+  double-firing). `ClickedBinding`/`ChangeEventBinding<T>` (no underlying bubbling event object)
+  and `FocusEvent`/`BlurEvent` (UI Toolkit dispatches them target-only, never bubbling to a
+  bridge listener) stay physical-tree-only, as documented.
 - `Hooks.UseFrame` gains a `priority` parameter — r3f's `useFrame(callback, renderPriority)` ordering
   parity. Lower runs earlier within the same panel; equal priorities fall back to subscription (mount)
   order. Backing this, per-frame callbacks now subscribe to a single per-panel dispatcher instead of
@@ -20,6 +30,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (defaults to `Physics.DefaultRaycastLayers`). `distanceFactor` scales the element by that value
   divided by its current camera distance, faking perspective size falloff for otherwise-flat
   screen-space content; it is the reference distance at which scale is exactly 1 and must be positive.
+
+### Fixed
+
+- `V.Portal(layer:)`/`V.WorldSpace` synthetic event bubbling now stops when a handler calls
+  `StopPropagation()` partway up the logical ancestor chain, instead of continuing to invoke
+  every remaining ancestor regardless. Also fixes nested portals/world-space (one mounted inside
+  another's content): the outward walk now escapes every enclosing boundary to reach the
+  outermost logical ancestor, instead of stopping at the inner boundary's own physical
+  target/host root.
+- `V.Portal(targetId:)`/`V.Portal(layer:)`/`V.WorldSpace` children added by a patch AFTER the
+  portal's first mount now bubble `events:` handlers to the logical ancestor chain too — e.g. a
+  `V.Portal` that renders no children until some later state flips true. Previously this only
+  worked for children present at the very first mount (or, for `V.Portal(targetId:)`, a registry
+  target's one-time late-registration heal); anything mounted by a later patch of an
+  already-mounted portal reached its physical ancestors but never its logical ones.
 
 ## [1.5.0] - 2026-07-19
 

--- a/Packages/com.velvet.core/Documentation~/portals.md
+++ b/Packages/com.velvet.core/Documentation~/portals.md
@@ -17,19 +17,25 @@ all three forms:
 
 - **Context crosses.** A `V.Provider` above the portal call site is visible to the children.
 - **Stores cross.** `UseStore` subscriptions are independent of panels.
-- **`events:` handlers cross for `V.Portal(layer:)`/`V.WorldSpace`, not for
-  `V.Portal(targetId:)`.** UI Toolkit computes native propagation from the physical tree, so a
-  logical ancestor's handler never sees a same-panel portal child's events by itself
-  (`V.Portal(targetId:)` reparents within the SAME panel, and there is no API to redirect UI
-  Toolkit's own dispatcher along a logical chain there — documented deviation). But a
-  `V.Portal(layer:)`/`V.WorldSpace` host is a wholly separate Panel, where native bubbling
-  cannot cross the boundary at all (no physical ancestor to bubble into) — so Velvet bridges it
-  itself: `PointerDown`/`Up`/`Move`/`Enter`/`Leave`, `Wheel`, `KeyDown`/`Up`, and
-  `FocusIn`/`Out`/`Focus`/`Blur` bindings on an `events:` prop bubble synthetically to the
-  logical ancestor chain outside the host panel (mirrors React's own root-level event
-  delegation — walking the logical parent chain, not the DOM). `ClickedBinding` (`Button`'s
-  native click) and `ChangeEventBinding<T>` (field value-change) stay panel-local for now — see
-  "Cross-panel input routing" below.
+- **`events:` handlers cross in all three portal forms**, through the same synthetic-bubbling
+  mechanism: `PointerDown`/`Up`/`Move`/`Enter`/`Leave`, `Wheel`, `KeyDown`/`Up`, and
+  `FocusIn`/`Out` bindings on an `events:` prop bubble to the logical ancestor chain outside the
+  portal boundary (mirrors React's own root-level event delegation — walking the logical parent
+  chain, not the DOM). For `V.Portal(layer:)`/`V.WorldSpace`, the host is a wholly separate Panel
+  where native bubbling cannot cross the boundary at all (no physical ancestor to bubble into) —
+  Velvet's bridge is the only way a logical ancestor ever sees the event. For
+  `V.Portal(targetId:)` (same panel, no separate Panel object involved), the target's own
+  physical ancestors already receive the event through ordinary native bubbling; the bridge adds
+  the LOGICAL ancestor chain on top of that, and an element that happens to be both — a physical
+  ancestor of the target AND a logical ancestor of the call site — still fires exactly once (the
+  synthetic walk detects that native bubbling already covers it and stops there rather than
+  double-firing). `ClickedBinding` (`Button`'s native click has no underlying event object to
+  carry across a boundary) and `ChangeEventBinding<T>` (field value-change, same reason) stay
+  physical-tree-only in every form — as do `FocusEvent`/`BlurEvent`, which, unlike
+  `FocusInEvent`/`FocusOutEvent`, UI Toolkit dispatches target-only with no bubble, so a bridge
+  listener can never observe one raised on a descendant in the first place. See "Cross-panel
+  input routing" below for the two gaps specific to `V.Portal(layer:)`/`V.WorldSpace` (picking
+  order and focus hand-off) that this same-mechanism story does not cover.
 - **Physical-walk styling does not cross, anywhere.** Relational `group-`/`peer-` variants and
   focus-within variants (`has-[:focus]:`, `group-focus-within:`) resolve against the physical
   tree in every portal form, including `V.Portal(layer:)`/`V.WorldSpace` — they register their

--- a/Packages/com.velvet.core/Runtime/Component/V.cs
+++ b/Packages/com.velvet.core/Runtime/Component/V.cs
@@ -1466,17 +1466,19 @@ namespace Velvet
         /// <paramref name="targetId"/> must reference an ID previously registered via <c>FiberPortalRegistry.Register</c>.
         /// </summary>
         /// <remarks>
-        /// Behavior boundary: context inheritance follows the LOGICAL tree (children inherit the
-        /// context enclosing the V.Portal call site), but EVENT BUBBLING does NOT. Velvet physically
-        /// reparents the children under the registered target element, so UI Toolkit bubbles their
-        /// pointer / click / change events up the target's PHYSICAL ancestor chain — not up the logical
-        /// ancestors of the V.Portal call site. A handler that must observe a portal child's event has to
-        /// be placed on the target element's own ancestor chain (or attached directly to the portal
-        /// children). The idealized model — where portal events also bubble through the logical tree — is
-        /// not reproducible here: UI Toolkit computes every event's propagation path from the physical
-        /// visual tree and exposes no API to redirect it along a logical chain, so faithful logical
-        /// bubbling would require re-implementing the dispatcher (which would double-fire handlers on
-        /// shared ancestors and could recurse across nested portals).
+        /// Context inheritance and event bubbling both follow the LOGICAL tree. Children inherit the
+        /// context enclosing the V.Portal call site, and an <c>events:</c> handler on a logical
+        /// ancestor of the call site also fires for a pointer / key / focus event raised on a portal
+        /// child: Velvet physically reparents the children under the registered target element (so UI
+        /// Toolkit's own native dispatch bubbles them up the target's PHYSICAL ancestor chain too),
+        /// then separately bridges the event synthetically to the logical ancestor chain outside the
+        /// call site. An element that happens to sit on BOTH chains — a physical ancestor of the
+        /// target AND a logical ancestor of the call site — still fires exactly once: the synthetic
+        /// walk detects that native bubbling already covers it and stops there rather than
+        /// double-firing. <c>Button</c>'s native click
+        /// (<c>ClickedBinding</c>) and field value-change (<c>ChangeEventBinding&lt;T&gt;</c>) stay
+        /// physical-tree-only in every portal form — neither has an underlying bubbling event object to
+        /// carry across a logical boundary. See the portals documentation for the full contract.
         /// </remarks>
         /// <param name="targetId">Portal target ID registered via <c>FiberPortalRegistry.Register</c>.</param>
         /// <param name="children">Descendant VNodes mounted into the resolved portal target.</param>
@@ -1496,11 +1498,13 @@ namespace Velvet
         /// Renders <paramref name="children"/> into a framework-managed screen-space layer panel
         /// sorted around the app's main panel — one host panel per layer per reconciler, created
         /// lazily and destroyed with the reconciler. Like every portal, the children stay part of the
-        /// LOGICAL tree (context and state cross the boundary) while attaching physically to the layer
-        /// panel — so event bubbling, relational <c>group-</c>/<c>peer-</c> variants and focus-within
-        /// do not cross, and responsive breakpoints evaluate against the layer panel's own width.
-        /// Screen-space layers always composite over the 3D scene; UI that must sit among scene
-        /// geometry is <see cref="WorldSpace"/>'s territory.
+        /// LOGICAL tree: context and state cross the boundary, and an <c>events:</c> handler on a
+        /// logical ancestor of the call site also fires for a pointer / key / focus event raised on a
+        /// child, bridged synthetically across the separate host Panel. Relational
+        /// <c>group-</c>/<c>peer-</c> variants and focus-within do NOT cross (they register their own
+        /// native callbacks directly, bypassing the bridge), and responsive breakpoints evaluate
+        /// against the layer panel's own width. Screen-space layers always composite over the 3D
+        /// scene; UI that must sit among scene geometry is <see cref="WorldSpace"/>'s territory.
         /// </summary>
         /// <param name="layer">The framework-managed layer panel to attach the children to.</param>
         /// <param name="children">Descendant VNodes mounted into the layer panel.</param>
@@ -1524,8 +1528,14 @@ namespace Velvet
         /// <c>&lt;Html&gt;</c> parity point), unlike the always-on-top screen-space layers. The host
         /// (GameObject + world-space panel) is created on mount, follows <paramref name="position"/> /
         /// <paramref name="rotation"/> updates, and is destroyed on unmount. Children stay part of the
-        /// logical tree (context and state cross; events do not — the panel boundary is physical).
-        /// Display-only: world-space input routing is not wired.
+        /// logical tree: context and state cross, and an <c>events:</c> handler on a logical ancestor
+        /// of the call site also fires for a pointer / key / focus event raised on a child, bridged
+        /// synthetically across the separate host Panel. Velvet does not arbitrate world-space pointer
+        /// DELIVERY itself the way it does screen-space layer picking order: a <c>BoxCollider</c> sized
+        /// to the panel is attached to the host, and Unity's own runtime input system drives picking
+        /// and delivery through it once a Play session is running (see the package's cross-panel input
+        /// routing docs). The event bridging above applies to whatever that system delivers, as well as
+        /// to a programmatically dispatched event (e.g. in tests).
         /// </summary>
         /// <param name="position">World position of the panel host.</param>
         /// <param name="rotation">World rotation of the panel host (identity when omitted).</param>

--- a/Packages/com.velvet.core/Runtime/Reconciler/ChildReconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ChildReconciler.cs
@@ -267,10 +267,26 @@ namespace Velvet
                         break;
                     }
                     case PortalNode registryPortal:
+                    {
                         // The target was resolved (non-null) at enqueue: the create path never
                         // queues a registry portal without one.
                         children = registryPortal.Children ?? Array.Empty<VNode>();
+                        // Same-panel synthetic-bubbling bridge: attached ONCE per resolved target,
+                        // guarded by SamePanelPortalBridges (see its own comment for why the guard
+                        // lives here rather than at a single creation call site — unlike a layer/
+                        // world-space host, a registry target is an ordinary, already-existing
+                        // element with no one-time "just created it" moment to hook). Never attached
+                        // from FiberPortalRegistry.Register itself: that registry is a bare global
+                        // static with no ReconcilerContext to guard duplicate attaches with or later
+                        // dispose the bridge through.
+                        var registryTarget = target!;
+                        if (!_ctx.SamePanelPortalBridges.ContainsKey(registryTarget))
+                        {
+                            _ctx.SamePanelPortalBridges[registryTarget] =
+                                FiberCrossPanelEventDispatcher.AttachBridge(registryTarget, _ctx);
+                        }
                         break;
+                    }
                     default:
                         // Only PortalNode / WorldSpaceNode enqueue deferred mounts; anything else is
                         // a missing branch for a new node kind and must fail loudly rather than

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberCrossPanelInput.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberCrossPanelInput.cs
@@ -5,28 +5,44 @@ using UnityEngine.UIElements;
 
 namespace Velvet
 {
-    // Everything that routes pointer/focus input across the boundary between a Velvet-managed host
-    // panel (V.Portal(layer:) / V.WorldSpace) and the panel its content logically belongs to. Two
-    // distinct mechanisms live in this one file because they are the two ends of the same pipe —
+    // Everything that routes pointer/focus input across the boundary between a Portal's/WorldSpace's
+    // PHYSICAL attachment point and the panel its content LOGICALLY belongs to. That boundary is a
+    // separate Velvet-managed host panel for V.Portal(layer:) / V.WorldSpace, or — same panel, no
+    // separate Panel object involved — the registered target element itself for V.Portal(targetId:).
+    // Two distinct mechanisms live in this one file because they are the two ends of the same pipe —
     // reading either without the other misses half of how a cross-panel event actually travels:
     //
-    //   FiberCrossPanelEventDispatcher: an event that ALREADY reached a host panel (native dispatch
-    //   bubbled it there, inside that panel) continues OUTWARD toward the logical ancestor chain —
-    //   the "exit" side.
+    //   FiberCrossPanelEventDispatcher: an event that ALREADY reached a portal/world-space boundary
+    //   (native dispatch bubbled it there) continues OUTWARD toward the logical ancestor chain — the
+    //   "exit" side. This is the ONLY mechanism V.Portal(targetId:) needs — there is no "entry" side
+    //   for it, since the event started in the same panel to begin with.
     //
     //   FiberCrossPanelPointerRouter: an event arriving at the MAIN panel is redirected INTO a
     //   higher-priority host panel FIRST, before the main panel's own dispatch processes it — the
-    //   "entry" side.
+    //   "entry" side. Screen-space layer hosts only (see its own comment); irrelevant to
+    //   V.Portal(targetId:), which never creates a separate panel to route into.
     //
     // Both share ReconcilerContext.LayerHosts / WorldSpaceBindings (which panels exist) and
     // FiberEventBindingManager.TryInvokeSynthetic (how a handler is invoked once the right element is
     // found) — see those for the rest of the mechanism this file builds on.
 
-    // Bridges a native UI Toolkit event that finished bubbling within one panel (a V.Portal(layer:) or
-    // V.WorldSpace host panel) toward the logical ancestor chain OUTSIDE that panel. A host panel's
-    // rootVisualElement has no physical parent for native bubbling to continue into — it is a wholly
-    // separate Panel/PanelSettings/UIDocument from whatever panel logically encloses the
-    // V.Portal/V.WorldSpace call site.
+    // Bridges a native UI Toolkit event that finished bubbling within one panel toward the logical
+    // ancestor chain OUTSIDE the Portal/WorldSpace boundary it just bubbled through. AttachBridge is
+    // called from two different kinds of place, distinguished by whether the returned unbind Action
+    // matters:
+    //   - PanelHostFactory.CreateLayerHost/CreateWorldSpaceHost, ONCE per framework-owned host panel,
+    //     on that host's rootVisualElement. A host panel has no physical parent for native bubbling to
+    //     continue into (a wholly separate Panel/PanelSettings/UIDocument), so this is the only way
+    //     further bubbling can happen at all. The unbind Action is discarded here: the host root is
+    //     destroyed wholesale with its GameObject (PanelHostFactory.Destroy), taking the callbacks
+    //     with it.
+    //   - ChildReconciler's registry-portal drain branch, ONCE per resolved V.Portal(targetId:) target
+    //     element (see ReconcilerContext.SamePanelPortalBridges). A same-panel target DOES have a
+    //     physical parent chain that keeps bubbling on its own, but that chain reflects the target's
+    //     OWN position, not the Portal's LOGICAL one, so this bridge still needs to run to reach the
+    //     latter. The unbind Action is retained and invoked at Reconciler.Dispose: a registry target
+    //     is an ordinary, already-live user element that normally outlives this reconciler, unlike a
+    //     framework-owned host root.
     //
     // Mirrors React's own root-level event delegation (a single listener per event type at the DOM
     // root, walking Fiber.return instead of the DOM to build the dispatch order — see
@@ -35,7 +51,10 @@ namespace Velvet
     // UI Toolkit's own native dispatch already does it (FiberEventBindingManager.Bind's direct
     // RegisterCallback<T> registrations on each element), since that already agrees with the logical
     // tree everywhere except at a portal/world-space boundary. This dispatcher only takes over at the
-    // ONE seam where physical bubbling structurally cannot continue: a host panel's root.
+    // seams where physical bubbling structurally cannot reach the logical chain: a host panel's root
+    // (nothing physical above it at all), and a same-panel registry target (something physical above
+    // it, but not the right thing — see Continue's truncation check for how a same-panel target avoids
+    // double-invoking whatever the two chains share).
     //
     // Known limitation: resolving "which ComponentFiber logically owns this event" depends on
     // FiberNodeFactory stamping element.userData with _ctx.FiberStack.Current at CreateElement time —
@@ -43,47 +62,91 @@ namespace Velvet
     // child that is a bare host element (e.g. V.Portal(children: [V.Div(...)])) with no enclosing
     // V.Component gets userData stamped from whatever fiber happens to be current during the deferred
     // drain (see ChildReconciler.DrainPendingPortalMounts), which is not reliably the logical
-    // enclosing component. Wrap portal/world-space children in a component to get correct cross-panel
-    // bubbling; a bare element's own events: handlers still fire normally (native, same-panel), only
-    // its FURTHER bubbling past the panel boundary is affected.
+    // enclosing component. Wrap portal/world-space children in a component to get correct synthetic
+    // bubbling; a bare element's own events: handlers still fire normally (native bubbling is
+    // unaffected everywhere), only its FURTHER bubbling past the portal boundary is affected.
     internal static class FiberCrossPanelEventDispatcher
     {
-        // Registers one BubbleUp listener per synthetic-bubbling-eligible event type on a newly created
-        // host panel's root — called once, when PanelHostFactory creates the panel (layer or
-        // world-space). Each listener fires only after UI Toolkit's own native dispatch has already
-        // bubbled the event through every element inside this panel (BubbleUp is the last phase to
-        // run), so nothing here duplicates a handler UI Toolkit's own dispatcher already invoked.
-        // Matches the event set FiberEventBindingManager.TryInvokeSynthetic supports — see its own
-        // comment for why ClickedBinding/ChangeEventBinding<T> are excluded.
-        internal static void AttachBridge(VisualElement panelRoot, ReconcilerContext ctx)
+        // Registers one BubbleUp listener per synthetic-bubbling-eligible event type on bridgeAnchor —
+        // either a newly created host panel's root (called once, from PanelHostFactory) or a resolved
+        // V.Portal(targetId:) target element (called once per target, from ChildReconciler's registry-
+        // portal drain branch — see ReconcilerContext.SamePanelPortalBridges for the attach-once guard).
+        // Each listener fires only after UI Toolkit's own native dispatch has already bubbled the event
+        // through every element AT OR BELOW bridgeAnchor (BubbleUp is the last phase to run on a given
+        // element), so nothing here duplicates a handler UI Toolkit's own dispatcher already invoked at
+        // or below that point. Matches the event set FiberEventBindingManager.TryInvokeSynthetic
+        // supports — see its own comment for why ClickedBinding/ChangeEventBinding<T> are excluded.
+        // Returns the delegate that undoes every registration below, for a caller that needs to detach
+        // it later (see the class comment above); a caller that never needs to (a framework-owned host
+        // root, destroyed wholesale) is free to discard it.
+        internal static System.Action AttachBridge(VisualElement bridgeAnchor, ReconcilerContext ctx)
         {
-            panelRoot.RegisterCallback<PointerDownEvent>(evt => Continue(evt, evt.target as VisualElement, ctx));
-            panelRoot.RegisterCallback<PointerUpEvent>(evt => Continue(evt, evt.target as VisualElement, ctx));
-            panelRoot.RegisterCallback<PointerMoveEvent>(evt => Continue(evt, evt.target as VisualElement, ctx));
-            panelRoot.RegisterCallback<PointerEnterEvent>(evt => Continue(evt, evt.target as VisualElement, ctx));
-            panelRoot.RegisterCallback<PointerLeaveEvent>(evt => Continue(evt, evt.target as VisualElement, ctx));
-            panelRoot.RegisterCallback<WheelEvent>(evt => Continue(evt, evt.target as VisualElement, ctx));
-            panelRoot.RegisterCallback<KeyDownEvent>(evt => Continue(evt, evt.target as VisualElement, ctx));
-            panelRoot.RegisterCallback<KeyUpEvent>(evt => Continue(evt, evt.target as VisualElement, ctx));
-            panelRoot.RegisterCallback<FocusInEvent>(evt => Continue(evt, evt.target as VisualElement, ctx));
-            panelRoot.RegisterCallback<FocusOutEvent>(evt => Continue(evt, evt.target as VisualElement, ctx));
+            EventCallback<PointerDownEvent> onPointerDown = evt => Continue(evt, evt.target as VisualElement, ctx, bridgeAnchor);
+            EventCallback<PointerUpEvent> onPointerUp = evt => Continue(evt, evt.target as VisualElement, ctx, bridgeAnchor);
+            EventCallback<PointerMoveEvent> onPointerMove = evt => Continue(evt, evt.target as VisualElement, ctx, bridgeAnchor);
+            EventCallback<PointerEnterEvent> onPointerEnter = evt => Continue(evt, evt.target as VisualElement, ctx, bridgeAnchor);
+            EventCallback<PointerLeaveEvent> onPointerLeave = evt => Continue(evt, evt.target as VisualElement, ctx, bridgeAnchor);
+            EventCallback<WheelEvent> onWheel = evt => Continue(evt, evt.target as VisualElement, ctx, bridgeAnchor);
+            EventCallback<KeyDownEvent> onKeyDown = evt => Continue(evt, evt.target as VisualElement, ctx, bridgeAnchor);
+            EventCallback<KeyUpEvent> onKeyUp = evt => Continue(evt, evt.target as VisualElement, ctx, bridgeAnchor);
+            EventCallback<FocusInEvent> onFocusIn = evt => Continue(evt, evt.target as VisualElement, ctx, bridgeAnchor);
+            EventCallback<FocusOutEvent> onFocusOut = evt => Continue(evt, evt.target as VisualElement, ctx, bridgeAnchor);
+            // FocusEvent/BlurEvent are deliberately NOT registered here, even though
+            // FiberEventBindingManager.TryInvokeSynthetic has a case for both (kept there for symmetry
+            // with the other binding kinds, and reachable if some other caller ever synthesizes one).
+            // Per Unity's own UIElements API docs, FocusEvent/BlurEvent "trickle down and do not bubble
+            // up" — target-only, unlike FocusInEvent/FocusOutEvent which explicitly "trickle down and
+            // bubble up". A BubbleUp listener registered HERE, on bridgeAnchor (an ancestor of the
+            // actual focused/blurred element in every real case — a host panel root or a registry
+            // target container is essentially never itself the focus target), would structurally never
+            // receive one raised on a descendant: the event simply never reaches bridgeAnchor. This
+            // mirrors FiberFocusNavigator.AttachToRoot's own choice of FocusIn/Out over Focus/Blur for
+            // its own panel-root-level tracking.
+            // GeometryChangedEvent is excluded for the same target-only reason, even though
+            // TryInvokeSynthetic has a case for it too: per Unity's own docs it does not bubble or
+            // trickle down, only ever dispatching to the element whose own geometry just changed, so a
+            // BubbleUp listener on bridgeAnchor could likewise never receive one raised on a descendant.
+            bridgeAnchor.RegisterCallback(onPointerDown);
+            bridgeAnchor.RegisterCallback(onPointerUp);
+            bridgeAnchor.RegisterCallback(onPointerMove);
+            bridgeAnchor.RegisterCallback(onPointerEnter);
+            bridgeAnchor.RegisterCallback(onPointerLeave);
+            bridgeAnchor.RegisterCallback(onWheel);
+            bridgeAnchor.RegisterCallback(onKeyDown);
+            bridgeAnchor.RegisterCallback(onKeyUp);
+            bridgeAnchor.RegisterCallback(onFocusIn);
+            bridgeAnchor.RegisterCallback(onFocusOut);
+
+            return () =>
+            {
+                bridgeAnchor.UnregisterCallback(onPointerDown);
+                bridgeAnchor.UnregisterCallback(onPointerUp);
+                bridgeAnchor.UnregisterCallback(onPointerMove);
+                bridgeAnchor.UnregisterCallback(onPointerEnter);
+                bridgeAnchor.UnregisterCallback(onPointerLeave);
+                bridgeAnchor.UnregisterCallback(onWheel);
+                bridgeAnchor.UnregisterCallback(onKeyDown);
+                bridgeAnchor.UnregisterCallback(onKeyUp);
+                bridgeAnchor.UnregisterCallback(onFocusIn);
+                bridgeAnchor.UnregisterCallback(onFocusOut);
+            };
         }
 
-        private static void Continue(EventBase evt, VisualElement? target, ReconcilerContext ctx)
+        private static void Continue(EventBase evt, VisualElement? target, ReconcilerContext ctx, VisualElement bridgeAnchor)
         {
             if (target == null) return;
 
-            // Walk from the native target up to (and including) the panel root, looking for the
-            // element whose owning fiber carries a DetachedMountContext — stamped only on the
-            // top-level child(ren) a Portal/WorldSpace drain produced (DrainPendingPortalMounts). This
-            // is a metadata scan only (no handler invocation along the way), so it cannot double-fire
+            // Walk from the native target up to (and including) bridgeAnchor, looking for the element
+            // whose owning fiber carries a DetachedMountContext — stamped only on the top-level
+            // child(ren) a Portal/WorldSpace drain produced (DrainPendingPortalMounts). This is a
+            // metadata scan only (no handler invocation along the way), so it cannot double-fire
             // anything even though it retraces ground the native dispatch already covered.
             ComponentFiber? logicalParent = null;
             for (var current = target; current != null; current = current.parent)
             {
                 if (current.userData is ComponentFiber { DetachedMountContext: { } dmc })
                 {
-                    logicalParent = dmc.LogicalParent;
+                    logicalParent = ResolveOutermostLogicalAncestor(dmc.LogicalParent);
                     break;
                 }
             }
@@ -91,25 +154,77 @@ namespace Velvet
             if (logicalParent?.MountPoint == null) return;
 
             // From here on, walk outward from the logical ancestor's OWN physical location, invoking
-            // each element's own synthetic handler directly. This is genuinely new ground the native
-            // dispatch never reached — logicalParent.MountPoint lives in a completely different Panel
-            // than evt's original native target.
+            // each element's own synthetic handler directly.
             for (var current = logicalParent.MountPoint; current != null; current = NextLogicalAncestor(current))
             {
+                // A synthetic handler invoked on an earlier hop may itself call StopPropagation() —
+                // honor it exactly like the native BubbleUp phase this walk continues would (this read
+                // was previously missing, so a synthetic StopPropagation() had no effect on the rest of
+                // the walk — a real bug, since every OTHER stage of dispatch in this codebase respects
+                // the flag).
+                if (evt.isPropagationStopped) break;
+                // Same-panel targets sit in the SAME physical tree as their own remaining ancestors:
+                // the native dispatch that is STILL bubbling this exact evt (this callback fired
+                // mid-bubble, at bridgeAnchor, not after the whole dispatch finished) will visit
+                // bridgeAnchor's own ancestors on its own once this callback returns, provided
+                // propagation was not already stopped (checked above). Stopping the synthetic walk the
+                // moment it reaches that same ground avoids invoking a shared handler twice — the two
+                // chains always eventually reconverge, at minimum at the panel root itself. For a
+                // cross-panel host (bridgeAnchor = a separate panel's root), this can never match
+                // anything in the synthetic chain (a completely different Panel), so the check is a
+                // harmless no-op there and the full walk always runs exactly as it did before same-panel
+                // support existed.
+                if (IsCoveredByNativeBubbling(current, bridgeAnchor)) break;
                 ctx.EventManager.TryInvokeSynthetic(current, evt);
             }
         }
 
+        // True when candidate is bridgeAnchor itself, or one of ITS OWN physical ancestors — elements
+        // the SAME native bubble dispatch that produced evt is guaranteed to visit on its own once the
+        // BubbleUp callback registered on bridgeAnchor returns (nothing between here and there calls
+        // StopPropagation). Walked inline on every call rather than precomputed once into a
+        // HashSet<VisualElement>: these chains are short (a handful of levels), and this runs on every
+        // hop of a walk that itself runs on every PointerMove/Enter/Leave — trading a few extra
+        // reference comparisons for zero per-event allocation.
+        private static bool IsCoveredByNativeBubbling(VisualElement candidate, VisualElement bridgeAnchor)
+        {
+            for (var ancestor = bridgeAnchor; ancestor != null; ancestor = ancestor.parent)
+            {
+                if (ReferenceEquals(ancestor, candidate)) return true;
+            }
+            return false;
+        }
+
+        // Chases DetachedMountContext.LogicalParent while fiber is ITSELF a detached-mount top-level
+        // child — a Portal/WorldSpace nested inside another Portal's/WorldSpace's content — instead of
+        // stopping at the immediate LogicalParent. A nested detached mount's own MountPoint is the
+        // INNER boundary's target/host root: a physical location, not that fiber's true logical
+        // position (a registry target is not a logical-tree ancestor of anything logically inside it; a
+        // host panel root's own physical parent is UI-Toolkit-internal and belongs to a different Panel
+        // than the outer logical chain). Escaping every nested boundary before reading MountPoint
+        // mirrors FiberContextSpine.Push, which treats a nested DetachedMountContext as its own spine
+        // edge rather than trusting an intermediate MountPoint — without this, a doubly-nested portal's
+        // outward walk would invoke a meaningless element once and then dead-end on ITS unrelated
+        // ancestors, never reaching the outer Portal's true logical chain.
+        private static ComponentFiber? ResolveOutermostLogicalAncestor(ComponentFiber? fiber)
+        {
+            while (fiber?.DetachedMountContext is { LogicalParent: { } outer })
+            {
+                fiber = outer;
+            }
+            return fiber;
+        }
+
         // Advances one step further up the synthetic chain: the ordinary physical parent, UNLESS
         // current is itself another portal/world-space boundary's top-level child (a nested portal),
-        // in which case the walk must hop through ITS OWN LogicalParent.MountPoint the same way — a
-        // plain VisualElement.parent walk would silently stop at that panel's root, same as the outer
-        // walk in Continue above.
+        // in which case the walk must hop through ITS OWN (fully resolved) logical ancestor the same
+        // way — a plain VisualElement.parent walk would silently dead-end there, same as the outer walk
+        // in Continue above.
         private static VisualElement? NextLogicalAncestor(VisualElement current)
         {
             if (current.userData is ComponentFiber { DetachedMountContext: { } dmc })
             {
-                return dmc.LogicalParent?.MountPoint;
+                return ResolveOutermostLogicalAncestor(dmc.LogicalParent)?.MountPoint;
             }
             return current.parent;
         }

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberElementCleaner.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberElementCleaner.cs
@@ -441,6 +441,10 @@ namespace Velvet
         // have their slotStart shifted by -slotLength so subsequent patches stay
         // correctly addressed. Entry removal happens before target mutation to prevent double
         // processing via CleanupDescendants recursion.
+        // Deliberately does NOT touch ReconcilerContext.SamePanelPortalBridges: a same-panel target's
+        // synthetic-bubbling bridge (if this was a registry portal) stays attached even once this is
+        // the last Portal on that target — see that field's own comment for why leaving it is both
+        // correct (a harmless no-op) and simpler than reference-counting per-target attaches.
         private void CleanupPortal(VisualElement element)
         {
             if (!_ctx.PortalState.TryGetValue(element, out var portalInfo))

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
@@ -564,6 +564,21 @@ namespace Velvet
         {
             VisualElement? target;
             string describe;
+            // Non-null only when this call is healing a target that just registered (populated in the
+            // registry else-branch below). DrainPendingPortalMounts stamps DetachedMountContext on a
+            // normal mount's newly-created top-level children so FiberCrossPanelEventDispatcher.Continue
+            // can find its way from the target back to the logical chain; a heal instead creates those
+            // children through this ordinary synchronous patch, which never runs that stamp. Snapshotting
+            // here (before the shared PatchPortalChildren call below) and stamping after lets the heal
+            // apply the same marker to whatever it just created, without touching the drain path or any
+            // other patch of an already-healthy Portal. Every OTHER path through this method (the layer
+            // branch below, and the already-resolved registry branch) needs the identical marker for the
+            // identical reason — see steadyStateDeclaringFiber further down, after target resolves either
+            // way. This one stays split out because it is the only branch cheap enough to afford a fresh
+            // HashSet outright: PatchPortalChildren permanently records the resolved target the first time
+            // it runs, so this branch never re-enters for the same placeholder again.
+            ComponentFiber? healingDeclaringFiber = null;
+            HashSet<ComponentFiber>? healingChildFibersBefore = null;
             if (newNode.Layer is { } layer)
             {
                 // The per-layer framework host was created when the mount drained and persists
@@ -605,10 +620,96 @@ namespace Velvet
                         FiberLogger.LogWarning("Portal", $"Target \"{describe}\" is not registered. Children will not be rendered.");
                         return;
                     }
+                    // The mount-time attach (ChildReconciler's registry-portal drain branch) never ran
+                    // for this target: CreateElement returned a hidden placeholder without enqueuing a
+                    // drain entry while the id was still unregistered, so this first healing patch is
+                    // this Portal's only chance to attach the same-panel synthetic-bubbling bridge.
+                    // Guarded exactly like that branch — a target another Portal already bridged is not
+                    // double-attached — and self-limiting to one run per heal even without the guard:
+                    // PatchPortalChildren below records this resolved target, so every later patch on
+                    // this placeholder takes the `if` branch above instead of ever re-entering here.
+                    if (!_ctx.SamePanelPortalBridges.ContainsKey(target))
+                    {
+                        _ctx.SamePanelPortalBridges[target] =
+                            FiberCrossPanelEventDispatcher.AttachBridge(target, _ctx);
+                    }
+                    // FiberStack.Current is genuinely the declaring fiber here (RenderAndReconcile keeps
+                    // it pushed for the whole patch of its own returned tree — unlike DrainPendingPortalMounts,
+                    // which runs later with the reconcile root current instead), so it doubles as both the
+                    // ComponentRegistry parent new children below will actually register under AND the
+                    // logical ancestor FiberCrossPanelEventDispatcher.Continue needs.
+                    healingDeclaringFiber = _ctx.FiberStack.Current;
+                    if (healingDeclaringFiber != null)
+                    {
+                        healingChildFibersBefore = new HashSet<ComponentFiber>();
+                        for (var f = healingDeclaringFiber.Child; f != null; f = f.Sibling)
+                        {
+                            healingChildFibersBefore.Add(f);
+                        }
+                    }
                 }
             }
 
-            PatchPortalChildren(placeholder, target, oldNode.Children, newNode.Children, describe);
+            // Every patch that reaches here WITHOUT healing (the layer branch above, or the
+            // already-resolved registry branch) still needs the same DetachedMountContext marker: a
+            // Portal can drain its first mount with ZERO top-level children (e.g. `V.Portal(id,
+            // children: isOpen ? real : Array.Empty<VNode>())`) and gain its first ones on a LATER
+            // patch — long after DrainPendingPortalMounts' own one-time stamp already ran with nothing
+            // to mark. Unlike the heal branch above (at most once per placeholder, ever), this runs on
+            // EVERY patch of an already-mounted Portal, so the "before" snapshot is rented from the
+            // shared pool instead of freshly allocated — the walk itself is already cheap (a declaring
+            // fiber's own direct children are typically a handful at most); pooling removes the one part
+            // of it that would otherwise cost real GC pressure across many patches per frame.
+            var steadyStateDeclaringFiber = healingDeclaringFiber == null ? _ctx.FiberStack.Current : null;
+            HashSet<ComponentFiber>? steadyStateChildFibersBefore = null;
+            if (steadyStateDeclaringFiber != null)
+            {
+                steadyStateChildFibersBefore = _ctx.BufferPool.RentFiberSet();
+                for (var f = steadyStateDeclaringFiber.Child; f != null; f = f.Sibling)
+                {
+                    steadyStateChildFibersBefore.Add(f);
+                }
+            }
+            try
+            {
+                PatchPortalChildren(placeholder, target, oldNode.Children, newNode.Children, describe);
+
+                if (healingDeclaringFiber != null)
+                {
+                    StampNewTopLevelChildren(healingDeclaringFiber, healingChildFibersBefore!, newNode.Children);
+                }
+                else if (steadyStateDeclaringFiber != null)
+                {
+                    StampNewTopLevelChildren(steadyStateDeclaringFiber, steadyStateChildFibersBefore!, newNode.Children);
+                }
+            }
+            finally
+            {
+                if (steadyStateChildFibersBefore != null)
+                {
+                    _ctx.BufferPool.ReturnFiberSet(steadyStateChildFibersBefore);
+                }
+            }
+        }
+
+        // Stamps DetachedMountContext on every top-level child of declaringFiber NOT present in
+        // childFibersBefore — the fibers this specific PatchPortalChildren call just created — so
+        // FiberCrossPanelEventDispatcher.Continue can resolve the logical ancestor for a pointer/focus
+        // event landing on them. Shared by PatchPortal's one-time heal and every steady-state patch of
+        // an already-mounted Portal/WorldSpace (see each call site for why its "before" set comes from a
+        // different source); the diff itself — walk the current list, skip anything already in the
+        // "before" set, lazily create one DetachedMountContext for the rest — is identical either way.
+        private void StampNewTopLevelChildren(
+            ComponentFiber declaringFiber, HashSet<ComponentFiber> childFibersBefore, VNode?[]? descendantNodes)
+        {
+            DetachedMountContext? detached = null;
+            for (var f = declaringFiber.Child; f != null; f = f.Sibling)
+            {
+                if (childFibersBefore.Contains(f)) continue;
+                detached ??= new DetachedMountContext(_ctx.ComponentContextStack.SnapshotTops(),
+                    descendantNodes, declaringFiber, declaringFiber);
+                f.DetachedMountContext = detached;
+            }
         }
 
         // Applies the diff for a WorldSpaceNode: the host transform and virtual panel size follow
@@ -650,7 +751,39 @@ namespace Velvet
                 FiberFocusNavigator.ConfigureChainedPlaceholder(placeholder, record,
                     newNode.FocusOrder == PanelFocusOrder.Chained, _ctx);
             }
-            PatchPortalChildren(placeholder, record.Document.rootVisualElement, oldNode.Children, newNode.Children, "world-space");
+
+            // Every patch reaches here already resolved — a world-space host has no "late
+            // registration" heal path the way a registry Portal does (DrainPendingPortalMounts creates
+            // it outright on first mount, never leaving it to a later patch to resolve) — so this
+            // always stamps through the same steady-state mechanism PatchPortal's own already-resolved
+            // path uses (see its own comment): a world-space panel can likewise mount with zero
+            // children and gain its first ones on a later patch, after the one-time drain stamp already
+            // ran with nothing to mark.
+            var declaringFiber = _ctx.FiberStack.Current;
+            HashSet<ComponentFiber>? childFibersBefore = null;
+            if (declaringFiber != null)
+            {
+                childFibersBefore = _ctx.BufferPool.RentFiberSet();
+                for (var f = declaringFiber.Child; f != null; f = f.Sibling)
+                {
+                    childFibersBefore.Add(f);
+                }
+            }
+            try
+            {
+                PatchPortalChildren(placeholder, record.Document.rootVisualElement, oldNode.Children, newNode.Children, "world-space");
+                if (declaringFiber != null)
+                {
+                    StampNewTopLevelChildren(declaringFiber, childFibersBefore!, newNode.Children);
+                }
+            }
+            finally
+            {
+                if (childFibersBefore != null)
+                {
+                    _ctx.BufferPool.ReturnFiberSet(childFibersBefore);
+                }
+            }
         }
 
         // The shared slot-range child patch for every portal flavor (registry, layer, world-space):

--- a/Packages/com.velvet.core/Runtime/Reconciler/Reconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Reconciler.cs
@@ -624,6 +624,15 @@ namespace Velvet
             _ctx.ChildVariantManipulators.Clear();
             _ctx.PortalState.Clear();
             _ctx.PendingPortalMounts.Clear();
+            // Same-panel registry-portal targets are ordinary, user-owned elements that commonly
+            // outlive this reconciler (unlike the framework-owned hosts destroyed wholesale below), so
+            // each bridge is detached explicitly rather than left to die with a GameObject — see
+            // ReconcilerContext.SamePanelPortalBridges for the full rationale.
+            foreach (var unbind in _ctx.SamePanelPortalBridges.Values)
+            {
+                unbind();
+            }
+            _ctx.SamePanelPortalBridges.Clear();
             // Layer and world-space hosts are framework-owned GameObjects with runtime-created
             // panel assets: destroy them so a disposed tree leaves no hidden panels behind. The
             // unmount reconcile already removed their children; a still-live layer host with zero

--- a/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
@@ -488,6 +488,34 @@ namespace Velvet
         // reconciler disposal.
         public Dictionary<VisualElement, PanelHostRecord> WorldSpaceBindings { get; } = new();
 
+        // Same-panel registry-portal (V.Portal(targetId:)) resolved TARGET elements that already carry
+        // FiberCrossPanelEventDispatcher's synthetic-bubbling bridge, mapped to the delegate that
+        // detaches it. Doubles as the attach-once guard: ChildReconciler's registry-portal drain branch
+        // checks this before calling AttachBridge, since multiple Portals — or repeated mounts of the
+        // same Portal — commonly resolve to the SAME target (see PortalSlotInfo's own multi-Portal-per-
+        // target contract), and re-attaching would stack duplicate callbacks. The guard is scoped to
+        // this one context: a second, independently mounted reconciler whose own Portal resolves to the
+        // same registered target attaches its own bridge through its own instance of this dictionary,
+        // since it has no way to see this one. Harmless — Continue's ancestor walk itself is ctx-agnostic
+        // (it reads userData off the shared VisualElement, not off ctx), but the invocation at the end of
+        // that walk goes through THIS ctx's own EventManager, whose bindings table only ever learned
+        // about elements this context itself bound; a chain resolved via the other context's fibers has
+        // no matching entry there, so the second listener never double-invokes a handler — just redundant
+        // scanning on every event that reaches the shared target.
+        // Deliberately NOT cleared when the one Portal that triggered the attach unmounts:
+        // FiberElementCleaner.CleanupPortal only removes THAT Portal's own slot range from the target's
+        // children (a registry target is always user-owned and outlives any one Portal mounted into
+        // it), so a bridge with no remaining DetachedMountContext-tagged descendant under the target is
+        // a harmless no-op the next time an event reaches it (Continue's own ancestor scan finds
+        // nothing and returns immediately) — and staying attached lets a LATER Portal mount (the same
+        // id re-registered, or the same Portal remounting) skip re-attaching for free.
+        // Reconciler.Dispose is therefore the only teardown point: a registry target commonly outlives
+        // this reconciler (the app owns it independently of any one mounted tree), so leaving the
+        // callbacks attached past disposal would leak a closure over a now-dead ReconcilerContext onto
+        // still-live app UI — mirroring NavigatorAttachments' identical "panel roots... can outlive
+        // this reconciler" teardown rationale.
+        public Dictionary<VisualElement, System.Action> SamePanelPortalBridges { get; } = new();
+
         // The declaring panel's driving UIDocument per panel, filled by
         // PanelHostFactory.ResolveDeclaring so each distinct declaring panel costs one
         // FindObjectsOfTypeAll scan per reconciler instead of one per host mount. Only the document

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/CrossPanelEventBubblingTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/CrossPanelEventBubblingTests.cs
@@ -171,6 +171,61 @@ namespace Velvet.Tests
             Assert.That((s_handlerFired, s_handlerEventTarget == portalTarget), Is.EqualTo((true, true)));
         }
 
+        [Component]
+        private static VNode StopPropagationPortalHostRender()
+        {
+            return V.Portal(UILayer.Overlay, children: new VNode[]
+            {
+                V.Component(StopPropagationPortalChildRender),
+            });
+        }
+
+        [Component]
+        private static VNode StopPropagationPortalChildRender() => V.Motion(name: "stop-portal-target");
+
+        [Test]
+        public void Given_AnInnerLogicalHandlerStopsPropagation_When_APointerDownInsideALayerPortal_Then_TheOuterLogicalHandlerDoesNotFire()
+        {
+            // Arrange — two logical ancestors stacked outward from the portal: "inner" stops
+            // propagation, so "outer" — reached only by a LATER hop of the same outward synthetic
+            // walk — must not fire. Pins the fix: Continue previously never checked
+            // evt.isPropagationStopped between hops, so a synthetic StopPropagation() had no effect
+            // on the rest of the walk.
+            var outerFired = false;
+            var innerFired = false;
+            var outerBinding = new PointerDownBinding { Handler = _ => outerFired = true };
+            var innerBinding = new PointerDownBinding
+            {
+                Handler = evt =>
+                {
+                    innerFired = true;
+                    evt.StopPropagation();
+                },
+            };
+            _mounted = V.Mount(_host.Root, V.Motion(
+                name: "outer",
+                events: new FiberEventBinding[] { outerBinding },
+                children: new VNode[]
+                {
+                    V.Motion(
+                        name: "inner",
+                        events: new FiberEventBinding[] { innerBinding },
+                        children: new VNode[] { V.Component(StopPropagationPortalHostRender) }),
+                }));
+
+            var hostDoc = FindHostDocumentContaining("stop-portal-target");
+            Assume.That(hostDoc, Is.Not.Null, "Precondition: the layer host panel exists");
+            var portalTarget = hostDoc.rootVisualElement.Q<VisualElement>("stop-portal-target");
+            Assume.That(portalTarget, Is.Not.Null, "Precondition: the portal's child mounted under the host");
+
+            // Act
+            using var evt = PointerDownEvent.GetPooled();
+            hostDoc.rootVisualElement.SimulateBubbledEvent(evt, portalTarget);
+
+            // Assert
+            Assert.That((innerFired, outerFired), Is.EqualTo((true, false)));
+        }
+
         private UIDocument FindHostDocumentContaining(string childName)
         {
             foreach (var doc in UnityEngine.Resources.FindObjectsOfTypeAll<UIDocument>())

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/PortalEventBubblingTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/PortalEventBubblingTests.cs
@@ -11,26 +11,34 @@ namespace Velvet.Tests
     /// <summary>
     /// Pins the event-bubbling contract of <see cref="V.Portal"/>, the axis orthogonal to the slot bookkeeping
     /// covered by <see cref="PortalTests"/>. A Portal physically reparents its children under the registered
-    /// target element, so UI Toolkit bubbles their pointer / click / change events up the target's PHYSICAL
-    /// ancestor chain — NOT up the logical ancestors of the V.Portal call site. This is a deliberate deviation:
-    /// the ideal would be for portal events to bubble through the logical component tree; UI Toolkit computes every
-    /// event's propagation path from the physical element tree and exposes no API to redirect it along a logical
-    /// chain, so faithful logical bubbling is not reproducible without re-implementing the dispatcher. These tests
-    /// are GREEN today and guard against an accidental future re-route that would silently change these expectations.
+    /// target element, so UI Toolkit's OWN native dispatch bubbles their pointer / click / change events up the
+    /// target's PHYSICAL ancestor chain. Velvet separately bridges pointer / key / focus events (not click / value-
+    /// change, which have no underlying bubbling event object) synthetically to the LOGICAL ancestor chain of the
+    /// <c>V.Portal</c> call site too — the same mechanism <c>V.Portal(layer:)</c>/<c>V.WorldSpace</c> already had for
+    /// their separate host panels, extended to this same-panel form (see
+    /// <see cref="SamePanelPortalBubblingTests"/> for the fuller synthetic-bubbling contract: truncation against a
+    /// shared ancestor, nested portals, <c>StopPropagation</c>). This file stays scoped to what changes at the
+    /// Portal-specific boundary: physical bubbling keeps working exactly as before, and a logical-ancestor handler
+    /// now ALSO fires.
     /// </summary>
     /// <remarks>
     /// Mounted in a real <see cref="EditorWindow"/> panel because events only dispatch under a live panel: the
     /// logical ancestor and the portal target both hang off the same panel root so a synthetic
     /// <see cref="PointerDownEvent"/> on a portal child propagates through the real focus/event controller. The
-    /// reconciler is driven directly (mirroring <see cref="PortalTests"/>) rather than the <c>V.Mount</c> path,
-    /// because the contract under test is the physical reparenting the reconciler performs. The registry's static
-    /// target table is cleared in <see cref="SetUp"/> and <see cref="TearDown"/> so registrations never leak.
+    /// physical-bubbling test drives the reconciler directly (mirroring <see cref="PortalTests"/>), because the
+    /// contract under test there is only the physical reparenting the reconciler performs and needs no fiber
+    /// machinery. The logical-bubbling test goes through <c>V.Mount</c> instead: the synthetic bridge resolves the
+    /// logical ancestor from <c>DetachedMountContext</c>, which is stamped only while a real root fiber stays
+    /// current on <c>FiberStack</c> through the post-reconcile drain — a bare <c>Reconciler.Reconcile</c> call
+    /// never establishes one. The registry's static target table is cleared in <see cref="SetUp"/> and
+    /// <see cref="TearDown"/> so registrations never leak.
     /// </remarks>
     [TestFixture]
     internal sealed class PortalEventBubblingTests
     {
         private EditorWindow _window;
         private Reconciler _reconciler;
+        private MountedTree _mounted;
         private VisualElement _logicalAncestor;
         private VisualElement _portalTarget;
 
@@ -57,6 +65,8 @@ namespace Velvet.Tests
         [TearDown]
         public void TearDown()
         {
+            _mounted?.Dispose();
+            _mounted = null;
             _reconciler.Dispose();
             FiberPortalRegistry.Clear();
             if (_window != null)
@@ -75,41 +85,51 @@ namespace Velvet.Tests
             el.SendEvent(evt);
         }
 
-        [Test]
-        public void Given_PortalChildFiresPointerDown_When_HandlerOnLogicalAncestor_Then_HandlerNotInvoked()
+        [Component]
+        private static VNode LogicalAncestorPortalHostRender()
         {
-            // Arrange — the logical ancestor carries a Velvet PointerDownBinding (its own handler-wiring path); its
-            // child is a Portal whose single leaf physically mounts under the target, off the ancestor's chain.
+            return V.Portal("evt-target", children: new VNode[] { V.Component(LogicalAncestorPortalChildRender) });
+        }
+
+        [Component]
+        private static VNode LogicalAncestorPortalChildRender() => V.Div(name: "pc");
+
+        [Test]
+        public void Given_PortalChildFiresPointerDown_When_HandlerOnLogicalAncestor_Then_HandlerInvoked()
+        {
+            // Arrange — the logical ancestor carries a Velvet PointerDownBinding; its child is a registry Portal
+            // whose content physically mounts under the target, off the ancestor's physical chain. Both the
+            // Portal call site and its content are wrapped in components (rather than bare elements) so the
+            // portal drain (ChildReconciler.DrainPendingPortalMounts) has top-level ComponentFibers to stamp
+            // DetachedMountContext onto — see FiberCrossPanelEventDispatcher's own comment on the bare-element
+            // limitation this mirrors from the layer/world-space case.
             var bubbledToLogical = false;
-            var children = new VNode[]
-            {
-                V.Motion(
-                    name: "logical",
-                    events: new FiberEventBinding[]
-                    {
-                        new PointerDownBinding { Handler = _ => bubbledToLogical = true },
-                    },
-                    children: new VNode[]
-                    {
-                        V.Portal("evt-target", children: new VNode[] { V.Div(name: "pc") }),
-                    }),
-            };
-            _reconciler.Reconcile(_logicalAncestor, Array.Empty<VNode>(), children);
+            var binding = new PointerDownBinding { Handler = _ => bubbledToLogical = true };
+            _mounted = V.Mount(_logicalAncestor, V.Motion(
+                name: "logical",
+                events: new FiberEventBinding[] { binding },
+                children: new VNode[] { V.Component(LogicalAncestorPortalHostRender) }));
             var portalChild = _portalTarget.Q<VisualElement>("pc");
             Assume.That(portalChild, Is.Not.Null, "Precondition: the portal child mounted physically under the target");
 
-            // Act — fire a pointer-down on the portal child; it bubbles up the target's physical chain.
+            // Act — fire a pointer-down on the portal child; it bubbles up the target's physical chain and,
+            // separately, synthetically to the logical ancestor chain outside the call site.
             DispatchPointerDown(portalChild);
 
             // Assert
-            Assert.That(bubbledToLogical, Is.False,
-                "Portal events do not bubble to the logical ancestor (physical-tree bubbling; documented React deviation)");
+            Assert.That(bubbledToLogical, Is.True,
+                "V.Portal(targetId:) events now bubble synthetically to the logical ancestor chain, mirroring V.Portal(layer:)/V.WorldSpace");
         }
 
         [Test]
         public void Given_PortalChildFiresPointerDown_When_HandlerOnPhysicalTargetAncestor_Then_HandlerInvoked()
         {
             // Arrange — the same mount, plus a raw callback on the target (the portal child's physical ancestor).
+            // The portal content here is a BARE V.Div (no enclosing V.Component) and the mount goes through the
+            // bare reconciler (no root fiber), so the same-panel synthetic bridge that auto-attaches to
+            // _portalTarget on every registry-portal mount (see ReconcilerContext.SamePanelPortalBridges) finds
+            // no DetachedMountContext to resolve and is a no-op here — this test is unaffected and still pins
+            // ordinary native physical bubbling in isolation from the synthetic path.
             var bubbledToPhysical = false;
             EventCallback<PointerDownEvent> onTargetPointerDown = _ => bubbledToPhysical = true;
             _portalTarget.RegisterCallback(onTargetPointerDown);

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/SamePanelPortalBubblingTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/SamePanelPortalBubblingTests.cs
@@ -1,0 +1,544 @@
+using System;
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.TestTools;
+using UnityEngine.UIElements;
+using Velvet;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins the fuller synthetic-bubbling contract of <c>V.Portal(targetId:)</c>
+    /// (<see cref="FiberCrossPanelEventDispatcher"/>, attached per resolved target from
+    /// <c>ChildReconciler</c>'s registry-portal drain branch — see
+    /// <c>ReconcilerContext.SamePanelPortalBridges</c>): the truncation guard against a handler that is
+    /// both a physical AND a logical ancestor firing twice, <c>StopPropagation</c> mid-chain, nested
+    /// same-panel portals, and the <c>events:</c>-only scoping that also governs
+    /// <c>V.Portal(layer:)</c>/<c>V.WorldSpace</c>. The BASIC case (a plain logical-ancestor handler
+    /// firing at all) is pinned in <see cref="PortalEventBubblingTests"/> alongside the physical-bubbling
+    /// contract it shares a file with; this fixture is scoped to what is genuinely NEW about the
+    /// same-panel form specifically.
+    /// </summary>
+    /// <remarks>
+    /// Uses a real, live-dispatched <see cref="PointerDownEvent"/> (<c>VisualElement.SendEvent</c> under a
+    /// real <see cref="EditorWindow"/> panel) rather than <c>CrossPanelEventBubblingTests</c>'
+    /// <c>SimulateBubbledEvent</c> reflection helper: a same-panel target's remaining physical ancestors
+    /// genuinely keep bubbling in the SAME live dispatch once this bridge's BubbleUp callback returns (see
+    /// <c>FiberCrossPanelEventDispatcher.Continue</c>'s own comment), so exercising that interaction for
+    /// real — rather than asserting against a single simulated hop — is what makes the truncation-guard
+    /// tests below trustworthy. This is unlike the cross-panel case, where two genuinely bubbling-connected
+    /// Panels cannot be constructed at all and simulation is the only option. Every mount goes through
+    /// <c>V.Mount</c> (not a bare <c>Reconciler.Reconcile</c> call): the synthetic bridge resolves the
+    /// logical ancestor from <c>DetachedMountContext</c>, which is stamped only while a real root fiber
+    /// stays current on <c>FiberStack</c> through the post-reconcile drain.
+    /// </remarks>
+    [TestFixture]
+    internal sealed class SamePanelPortalBubblingTests
+    {
+        private EditorWindow _window;
+        private MountedTree _mounted;
+        private VisualElement _root;
+
+        [SetUp]
+        public void SetUp()
+        {
+            TestGraphics.IgnoreIfHeadless("an EditorWindow panel");
+
+            _window = ScriptableObject.CreateInstance<TestHostWindow>();
+            _window.Show();
+            FiberPortalRegistry.Clear();
+
+            _root = new VisualElement();
+            _window.rootVisualElement.Add(_root);
+
+            // Static fixture fields hold the latest StateUpdater from whichever test last rendered their
+            // owning component; a stale reference left over from a previous test would invoke a setter
+            // against an already-disposed fiber tree (CrossPanelEventBubblingTests' own SetUp convention).
+            s_showRegressionPortal = default;
+            s_bumpLateHeal = default;
+            s_showRemountPortal = default;
+            s_showGrowthChildren = default;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _mounted?.Dispose();
+            _mounted = null;
+            FiberPortalRegistry.Clear();
+            if (_window != null)
+            {
+                _window.Close();
+                UnityEngine.Object.DestroyImmediate(_window);
+                _window = null;
+            }
+        }
+
+        // Pooled-event dispatch is the canonical EditMode way to fire a real bubbling event without a
+        // player loop (mirrors PortalEventBubblingTests.DispatchPointerDown).
+        private static void DispatchPointerDown(VisualElement el)
+        {
+            using var evt = PointerDownEvent.GetPooled();
+            evt.target = el;
+            el.SendEvent(evt);
+        }
+
+        #region Basic
+
+        [Component]
+        private static VNode BasicPortalHostRender()
+            => V.Portal("same-panel-basic-target", children: new VNode[] { V.Component(BasicPortalChildRender) });
+
+        [Component]
+        private static VNode BasicPortalChildRender() => V.Div(name: "basic-pc");
+
+        [Test]
+        public void Given_PointerDownOnRegistryPortalContent_When_HandlerOnLogicalAncestor_Then_HandlerInvoked()
+        {
+            // Arrange — the target is registered before mount (the registry portal resolves it
+            // synchronously at CreateElement time) and lives fully outside the mounted tree, so only
+            // the synthetic bridge — not any physical relationship — can reach the logical ancestor.
+            var target = new VisualElement();
+            _window.rootVisualElement.Add(target);
+            FiberPortalRegistry.Register("same-panel-basic-target", target);
+            var bubbled = false;
+            var binding = new PointerDownBinding { Handler = _ => bubbled = true };
+            _mounted = V.Mount(_root, V.Motion(
+                name: "basic-logical",
+                events: new FiberEventBinding[] { binding },
+                children: new VNode[] { V.Component(BasicPortalHostRender) }));
+            var portalChild = target.Q<VisualElement>("basic-pc");
+            Assume.That(portalChild, Is.Not.Null, "Precondition: the portal child mounted physically under the target");
+
+            // Act
+            DispatchPointerDown(portalChild);
+
+            // Assert
+            Assert.That(bubbled, Is.True);
+        }
+
+        #endregion
+
+        #region Truncation (the load-bearing regression)
+
+        private static StateUpdater<bool> s_showRegressionPortal;
+
+        [Component]
+        private static VNode RegressionCallerRender()
+        {
+            var (showPortal, setShowPortal) = Hooks.UseState(false);
+            s_showRegressionPortal = setShowPortal;
+            return V.When(showPortal, () => V.Portal("same-panel-regression-target",
+                children: new VNode[] { V.Component(RegressionPortalChildRender) }));
+        }
+
+        [Component]
+        private static VNode RegressionPortalChildRender() => V.Div(name: "regression-pc");
+
+        [Test]
+        public void Given_HandlerOnElementBothPhysicalAndLogicalAncestor_When_PortalChildFiresPointerDown_Then_HandlerFiresExactlyOnce()
+        {
+            // Arrange — "shared" is BOTH a physical ancestor of the resolved target (via "slot", an
+            // always-empty V.Div Velvet never diffs children into, so a manually added child is safe
+            // from ever being touched by a later reconcile) AND the logical ancestor of the Portal call
+            // site (its caller mounts as "shared"'s own direct inline child). The target is registered,
+            // and physically nested under "slot", BEFORE the Portal itself ever renders — revealed only
+            // by a later setState (V.Mount cannot express "mount already showing this" for something
+            // that also needs a not-yet-registered target) — so the registry always resolves a real
+            // element by the time the Portal node is created.
+            var fireCount = 0;
+            var binding = new PointerDownBinding { Handler = _ => fireCount++ };
+            _mounted = V.Mount(_root, V.Motion(
+                name: "shared",
+                events: new FiberEventBinding[] { binding },
+                children: new VNode[] { V.Div(name: "slot"), V.Component(RegressionCallerRender) }));
+            var slot = _root.Q<VisualElement>("slot");
+            Assume.That(slot, Is.Not.Null, "Precondition: the static slot mounted");
+            var target = new VisualElement();
+            slot.Add(target);
+            FiberPortalRegistry.Register("same-panel-regression-target", target);
+            s_showRegressionPortal.Invoke(true);
+            _mounted.FlushStateForTest();
+            var portalChild = target.Q<VisualElement>("regression-pc");
+            Assume.That(portalChild, Is.Not.Null, "Precondition: the portal child mounted physically under the target");
+
+            // Act — the SAME pointer-down bubbles up the target's physical chain (through "slot" to
+            // "shared", natively) and would ALSO reach "shared" via the synthetic logical walk if that
+            // walk were not truncated.
+            DispatchPointerDown(portalChild);
+
+            // Assert
+            Assert.That(fireCount, Is.EqualTo(1));
+        }
+
+        #endregion
+
+        #region StopPropagation
+
+        [Component]
+        private static VNode StopPropagationCallerRender()
+            => V.Portal("same-panel-stop-target", children: new VNode[] { V.Component(StopPropagationPortalChildRender) });
+
+        [Component]
+        private static VNode StopPropagationPortalChildRender() => V.Div(name: "stop-pc");
+
+        [Test]
+        public void Given_InnerLogicalHandlerStopsPropagation_When_PortalChildFiresPointerDown_Then_OuterLogicalHandlerDoesNotFire()
+        {
+            // Arrange — two logical ancestors stacked outward from the Portal call site. The inner one
+            // stops propagation; the outer one is reached only by a LATER hop of the same outward
+            // synthetic walk, pinning the fix: Continue previously never checked
+            // evt.isPropagationStopped between hops, so a synthetic StopPropagation() had no effect.
+            var innerFired = false;
+            var outerFired = false;
+            var innerBinding = new PointerDownBinding { Handler = evt => { innerFired = true; evt.StopPropagation(); } };
+            var outerBinding = new PointerDownBinding { Handler = _ => outerFired = true };
+            var target = new VisualElement();
+            _window.rootVisualElement.Add(target);
+            FiberPortalRegistry.Register("same-panel-stop-target", target);
+            _mounted = V.Mount(_root, V.Motion(
+                name: "outer",
+                events: new FiberEventBinding[] { outerBinding },
+                children: new VNode[]
+                {
+                    V.Motion(
+                        name: "inner",
+                        events: new FiberEventBinding[] { innerBinding },
+                        children: new VNode[] { V.Component(StopPropagationCallerRender) }),
+                }));
+            var portalChild = target.Q<VisualElement>("stop-pc");
+            Assume.That(portalChild, Is.Not.Null, "Precondition: the portal child mounted physically under the target");
+
+            // Act
+            DispatchPointerDown(portalChild);
+
+            // Assert
+            Assert.That((innerFired, outerFired), Is.EqualTo((true, false)));
+        }
+
+        #endregion
+
+        #region Nested same-panel portals
+
+        [Component]
+        private static VNode NestedOuterHostRender()
+            => V.Portal("same-panel-nested-a", children: new VNode[] { V.Component(NestedInnerCallerRender) });
+
+        [Component]
+        private static VNode NestedInnerCallerRender()
+            => V.Portal("same-panel-nested-b", children: new VNode[] { V.Component(NestedInnerPortalChildRender) });
+
+        [Component]
+        private static VNode NestedInnerPortalChildRender() => V.Div(name: "nested-pc");
+
+        [Test]
+        public void Given_PortalNestedInsideAnotherPortalsContent_When_InnerContentFiresPointerDown_Then_OutermostLogicalAncestorHandlerFires()
+        {
+            // Arrange — Portal A's content is a component that itself calls Portal B: B's own
+            // LogicalParent fiber is ITSELF a detached-mount top-level child of A (not an ordinarily-
+            // mounted fiber), so reaching the outermost logical ancestor requires escaping BOTH
+            // boundaries, not just the innermost one.
+            var bubbled = false;
+            var binding = new PointerDownBinding { Handler = _ => bubbled = true };
+            var targetA = new VisualElement();
+            var targetB = new VisualElement();
+            _window.rootVisualElement.Add(targetA);
+            _window.rootVisualElement.Add(targetB);
+            FiberPortalRegistry.Register("same-panel-nested-a", targetA);
+            FiberPortalRegistry.Register("same-panel-nested-b", targetB);
+            _mounted = V.Mount(_root, V.Motion(
+                name: "nested-logical",
+                events: new FiberEventBinding[] { binding },
+                children: new VNode[] { V.Component(NestedOuterHostRender) }));
+            var portalChild = targetB.Q<VisualElement>("nested-pc");
+            Assume.That(portalChild, Is.Not.Null, "Precondition: the innermost portal child mounted physically under target B");
+
+            // Act
+            DispatchPointerDown(portalChild);
+
+            // Assert
+            Assert.That(bubbled, Is.True);
+        }
+
+        #endregion
+
+        #region Scoping
+
+        [Component]
+        private static VNode ScopingPortalHostRender()
+            => V.Portal("same-panel-scoping-target", children: new VNode[] { V.Component(ScopingPortalChildRender) });
+
+        [Component]
+        private static VNode ScopingPortalChildRender() => V.Div(name: "scoping-pc");
+
+        [Test]
+        public void Given_RawRegisterCallbackOnLogicalAncestor_When_PortalChildFiresPointerDown_Then_HandlerNotInvoked()
+        {
+            // Arrange — the logical ancestor's handler is registered via the raw UI Toolkit API, not
+            // Velvet's events: prop, so FiberEventBindingManager never learns about it:
+            // TryInvokeSynthetic resolves exclusively from its own _bindingsByElement table (populated
+            // only by Bind), never a native RegisterCallback registration regardless of who made it.
+            var target = new VisualElement();
+            _window.rootVisualElement.Add(target);
+            FiberPortalRegistry.Register("same-panel-scoping-target", target);
+            _mounted = V.Mount(_root, V.Motion(
+                name: "scoping-logical",
+                children: new VNode[] { V.Component(ScopingPortalHostRender) }));
+            var logicalAncestor = _root.Q<VisualElement>("scoping-logical");
+            Assume.That(logicalAncestor, Is.Not.Null, "Precondition: the logical ancestor mounted");
+            var rawFired = false;
+            EventCallback<PointerDownEvent> onPointerDown = _ => rawFired = true;
+            logicalAncestor.RegisterCallback(onPointerDown);
+            var portalChild = target.Q<VisualElement>("scoping-pc");
+            Assume.That(portalChild, Is.Not.Null, "Precondition: the portal child mounted physically under the target");
+
+            // Act
+            DispatchPointerDown(portalChild);
+            logicalAncestor.UnregisterCallback(onPointerDown);
+
+            // Assert
+            Assert.That(rawFired, Is.False);
+        }
+
+        #endregion
+
+        #region Late registration healing (Fix 1 regression)
+
+        private static StateUpdater<int> s_bumpLateHeal;
+
+        [Component]
+        private static VNode LateHealCallerRender()
+        {
+            var (_, bump) = Hooks.UseState(0);
+            s_bumpLateHeal = bump;
+            return V.Portal("same-panel-late-heal-target",
+                children: new VNode[] { V.Component(LateHealPortalChildRender) });
+        }
+
+        [Component]
+        private static VNode LateHealPortalChildRender() => V.Div(name: "late-heal-pc");
+
+        [Test]
+        public void Given_TargetRegisteredAfterMount_When_PatchedAfterRegistration_Then_LogicalAncestorHandlerFires()
+        {
+            // Arrange — the target does not exist at mount time: CreateElement's registry-portal branch
+            // warns and returns a hidden placeholder without enqueuing a DrainPendingPortalMounts entry,
+            // so the mount-time attach (ChildReconciler's drain branch) never runs for this target. The
+            // only remaining place the bridge can attach is PatchPortal's healing branch, on the first
+            // patch after the id registers.
+            LogAssert.Expect(LogType.Warning,
+                "[Portal] Target \"same-panel-late-heal-target\" is not registered. Children will not be rendered.");
+            var bubbled = false;
+            var binding = new PointerDownBinding { Handler = _ => bubbled = true };
+            _mounted = V.Mount(_root, V.Motion(
+                name: "late-heal-logical",
+                events: new FiberEventBinding[] { binding },
+                children: new VNode[] { V.Component(LateHealCallerRender) }));
+            var target = new VisualElement();
+            _window.rootVisualElement.Add(target);
+            FiberPortalRegistry.Register("same-panel-late-heal-target", target);
+
+            // Act — an unrelated state bump re-renders the caller and patches the Portal, which heals:
+            // the now-registered target resolves and its children mount into it for the first time.
+            s_bumpLateHeal.Invoke(v => v + 1);
+            _mounted.FlushStateForTest();
+            var portalChild = target.Q<VisualElement>("late-heal-pc");
+            Assume.That(portalChild, Is.Not.Null, "Precondition: the heal mounted the portal child physically under the target");
+            DispatchPointerDown(portalChild);
+
+            // Assert
+            Assert.That(bubbled, Is.True);
+        }
+
+        #endregion
+
+        #region Growth after the initial mount (already-resolved patch)
+
+        private static StateUpdater<bool> s_showGrowthChildren;
+
+        [Component]
+        private static VNode GrowthCallerRender()
+        {
+            var (show, setShow) = Hooks.UseState(false);
+            s_showGrowthChildren = setShow;
+            return V.Portal("same-panel-growth-target",
+                children: show ? new VNode[] { V.Component(GrowthPortalChildRender) } : Array.Empty<VNode>());
+        }
+
+        [Component]
+        private static VNode GrowthPortalChildRender() => V.Div(name: "growth-pc");
+
+        [Test]
+        public void Given_RegistryPortalMountedWithNoChildren_When_ALaterPatchAddsAChild_Then_LogicalAncestorHandlerFires()
+        {
+            // Arrange — unlike the late-registration-heal case above, the target IS registered before
+            // mount, so the Portal resolves and drains through DrainPendingPortalMounts on the very
+            // first render — with ZERO children, since `show` starts false. That one-time drain stamp
+            // finds nothing new to mark, and PatchPortalChildren's own bookkeeping already records this
+            // placeholder's target as resolved (PortalState[placeholder].Target != null), so the
+            // steady-state (already-resolved) branch of PatchPortal — not the healing branch pinned
+            // above — is what this test exercises once the child actually mounts.
+            var target = new VisualElement();
+            _window.rootVisualElement.Add(target);
+            FiberPortalRegistry.Register("same-panel-growth-target", target);
+            var bubbled = false;
+            var binding = new PointerDownBinding { Handler = _ => bubbled = true };
+            _mounted = V.Mount(_root, V.Motion(
+                name: "growth-logical",
+                events: new FiberEventBinding[] { binding },
+                children: new VNode[] { V.Component(GrowthCallerRender) }));
+            Assume.That(target.childCount, Is.EqualTo(0), "Precondition: the portal drained with no children");
+
+            // Act — flipping `show` patches the ALREADY-RESOLVED Portal and mounts its first top-level
+            // child, long after the initial (empty) drain's own stamp already ran with nothing to mark.
+            s_showGrowthChildren.Invoke(true);
+            _mounted.FlushStateForTest();
+            var portalChild = target.Q<VisualElement>("growth-pc");
+            Assume.That(portalChild, Is.Not.Null, "Precondition: the later patch mounted the portal child physically under the target");
+            DispatchPointerDown(portalChild);
+
+            // Assert
+            Assert.That(bubbled, Is.True);
+        }
+
+        #endregion
+
+        #region Remount to the same target
+
+        private static StateUpdater<bool> s_showRemountPortal;
+
+        [Component]
+        private static VNode RemountCallerRender()
+        {
+            var (show, setShow) = Hooks.UseState(true);
+            s_showRemountPortal = setShow;
+            return V.When(show, () => V.Portal("same-panel-remount-target",
+                children: new VNode[] { V.Component(RemountPortalChildRender) }));
+        }
+
+        [Component]
+        private static VNode RemountPortalChildRender() => V.Div(name: "remount-pc");
+
+        [Test]
+        public void Given_PortalUnmountedThenRemountedToTheSameTarget_When_PortalChildFiresPointerDown_Then_HandlerStillFires()
+        {
+            // Arrange — the target is registered once and never re-registered; only the Portal above it
+            // unmounts and remounts. SamePanelPortalBridges is deliberately never cleared when a Portal's
+            // own children unmount (see that field's own comment on ReconcilerContext), so the remount
+            // must reuse the already-attached bridge rather than needing, or getting, a second attach.
+            var target = new VisualElement();
+            _window.rootVisualElement.Add(target);
+            FiberPortalRegistry.Register("same-panel-remount-target", target);
+            var bubbled = false;
+            var binding = new PointerDownBinding { Handler = _ => bubbled = true };
+            _mounted = V.Mount(_root, V.Motion(
+                name: "remount-logical",
+                events: new FiberEventBinding[] { binding },
+                children: new VNode[] { V.Component(RemountCallerRender) }));
+            Assume.That(target.childCount, Is.EqualTo(1), "Precondition: the portal mounted its child under the target");
+
+            // Act — hide (the portal's own slot range on the target clears) then show again (a fresh
+            // placeholder resolves the SAME registered target and remounts into it).
+            s_showRemountPortal.Invoke(false);
+            _mounted.FlushStateForTest();
+            Assume.That(target.childCount, Is.EqualTo(0), "Precondition: hiding unmounted the portal's children");
+            s_showRemountPortal.Invoke(true);
+            _mounted.FlushStateForTest();
+            var portalChild = target.Q<VisualElement>("remount-pc");
+            Assume.That(portalChild, Is.Not.Null, "Precondition: the remount mounted the portal child physically under the target again");
+            DispatchPointerDown(portalChild);
+
+            // Assert
+            Assert.That(bubbled, Is.True);
+        }
+
+        #endregion
+
+        #region Non-pointer events
+
+        [Component]
+        private static VNode KeyDownPortalHostRender()
+            => V.Portal("same-panel-keydown-target", children: new VNode[] { V.Component(KeyDownPortalChildRender) });
+
+        [Component]
+        private static VNode KeyDownPortalChildRender() => V.Div(name: "keydown-pc");
+
+        // Mirrors DispatchPointerDown for a discrete non-pointer event: DndInteractionTests dispatches
+        // Escape the same way (evt.target set explicitly, so delivery does not depend on panel focus).
+        private static void DispatchKeyDown(VisualElement el)
+        {
+            using var evt = KeyDownEvent.GetPooled('\0', KeyCode.Escape, EventModifiers.None);
+            evt.target = el;
+            el.SendEvent(evt);
+        }
+
+        [Test]
+        public void Given_KeyDownOnRegistryPortalContent_When_HandlerOnLogicalAncestor_Then_HandlerInvoked()
+        {
+            // Arrange — same shape as the pointer-down Basic case, but for a KeyDownEvent: AttachBridge
+            // registers a KeyDownEvent listener alongside the pointer ones, so a non-pointer discrete
+            // event must cross the same-panel boundary too, not just pointer input.
+            var target = new VisualElement();
+            _window.rootVisualElement.Add(target);
+            FiberPortalRegistry.Register("same-panel-keydown-target", target);
+            var bubbled = false;
+            var binding = new KeyDownBinding { Handler = _ => bubbled = true };
+            _mounted = V.Mount(_root, V.Motion(
+                name: "keydown-logical",
+                events: new FiberEventBinding[] { binding },
+                children: new VNode[] { V.Component(KeyDownPortalHostRender) }));
+            var portalChild = target.Q<VisualElement>("keydown-pc");
+            Assume.That(portalChild, Is.Not.Null, "Precondition: the portal child mounted physically under the target");
+
+            // Act
+            DispatchKeyDown(portalChild);
+
+            // Assert
+            Assert.That(bubbled, Is.True);
+        }
+
+        #endregion
+
+        #region Target element itself
+
+        [Component]
+        private static VNode TargetSelfPortalHostRender()
+            => V.Portal("same-panel-target-self-target", children: new VNode[] { V.Component(TargetSelfPortalChildRender) });
+
+        [Component]
+        private static VNode TargetSelfPortalChildRender() => V.Div(name: "target-self-pc");
+
+        [Test]
+        public void Given_PointerDownOnTheRegistryTargetItself_When_Dispatched_Then_LogicalAncestorHandlerDoesNotFire()
+        {
+            // Arrange — dispatch directly on the registry TARGET container, not on the Portal's own
+            // content. Continue's walk looks for a DetachedMountContext starting AT the native event
+            // target: that marker lives only on the Portal's own top-level children, never on the
+            // pre-existing target container itself, so the walk finds nothing and the bridge is a no-op.
+            var target = new VisualElement();
+            _window.rootVisualElement.Add(target);
+            FiberPortalRegistry.Register("same-panel-target-self-target", target);
+            var bubbled = false;
+            var binding = new PointerDownBinding { Handler = _ => bubbled = true };
+            _mounted = V.Mount(_root, V.Motion(
+                name: "target-self-logical",
+                events: new FiberEventBinding[] { binding },
+                children: new VNode[] { V.Component(TargetSelfPortalHostRender) }));
+            var portalChild = target.Q<VisualElement>("target-self-pc");
+            Assume.That(portalChild, Is.Not.Null, "Precondition: the portal child mounted physically under the target");
+
+            // Act
+            DispatchPointerDown(target);
+
+            // Assert
+            Assert.That(bubbled, Is.False);
+        }
+
+        #endregion
+
+        /// <summary>Minimal EditorWindow host that supplies a real panel with an event controller.</summary>
+        private sealed class TestHostWindow : EditorWindow { }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/SamePanelPortalBubblingTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/SamePanelPortalBubblingTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: cb7ec0348171c48c38dc508e3f813e6c


### PR DESCRIPTION
## What

`V.Portal(targetId:)` — the same-panel registry portal — now bubbles `events:` handlers to the logical ancestor chain outside the call site, closing the gap with `V.Portal(layer:)`/`V.WorldSpace`, which already had synthetic logical-chain bubbling (#93). The same ~10 event categories cross in all three portal forms now; `ClickedBinding`/`ChangeEventBinding<T>` (no underlying bubbling event object) and `FocusEvent`/`BlurEvent` (dispatched target-only by the engine) stay physical-tree-only, as documented.

## How

The existing per-target bridge generalizes to a same-panel anchor: it attaches once per resolved registry target, and when native bubbling finishes inside portal content, Velvet-bound handlers along the logical fiber chain are invoked directly (never re-dispatched — the public API offers no single-element delivery, and direct invocation sidesteps event pooling entirely). The same-panel twist is the **truncation guard**: unlike a separate-panel host, a registry target's remaining physical ancestors keep receiving the event through ordinary native bubbling, so the synthetic walk stops the moment it reaches an element native delivery still covers — an element that is both a physical ancestor of the target and a logical ancestor of the call site fires exactly once.

## Fixes to the shipped mechanism

Working through the same code surfaced three pre-existing gaps, fixed here:

- The walk now honors `StopPropagation()` between hops (previously every remaining ancestor was invoked regardless).
- A doubly-nested portal's outward walk now escapes every detached-mount boundary transitively, instead of dead-ending on the inner boundary's own physical target.
- The logical-parent marker is now stamped on children mounted through the late-registration healing path AND on children added by a patch after the portal's first mount (e.g. a portal that renders no children until a state flips true) — previously only first-mount children got it, so later-added children silently never bubbled and could mis-classify their own state-update flushes.

## Tests

New EditMode fixture (real `EditorWindow` + live `SendEvent` dispatch, so the truncation interaction with genuine native bubbling is exercised for real): basic logical-ancestor delivery, the exactly-once truncation regression, `StopPropagation` mid-chain (both same-panel and cross-panel), nested same-panel portals, late-registered-target healing, remount to the same target, children added by a later patch, `KeyDown` through the bridge, an event on the registry target itself (no over-trigger), and raw-`RegisterCallback` scoping. The pre-existing physical-bubbling pin is kept; the physical-only assertion it carried is inverted to pin the new contract.

3099/3099 EditMode and 83/83 PlayMode tests pass locally on the merged state.

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)