### PR TITLE
feat(velvet): add leading-* line-height utilities via the rich-text tag

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -33,6 +33,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `underline` do. An explicit `whitespace-*` class on the same element wins over `whitespace-pre-line`
   there, and — like `normal-case` / `no-underline` — also blocks a farther ancestor's
   `whitespace-pre-line` from reaching that subtree.
+- `leading-none`…`leading-loose` and `leading-[Npx]` (line-height). USS has no line-height property, so
+  these realise it through UI Toolkit's rich-text `<line-height=X>` tag instead: the named presets emit
+  their Tailwind multiplier verbatim as `<line-height=1.625em>`, which the text engine itself resolves
+  against whatever font size is in effect at that point in the string — unlike `tracking-*`'s em scale,
+  which had to be pre-baked to px at a fixed 16px root, this composes correctly with any `text-*` size at
+  any value, with no lookup table. `leading-[Npx]` emits an absolute `<line-height=Npx>`; only the `px`
+  unit is accepted inside the bracket, and a malformed or unsupported-unit value is silently ignored.
+  Inherits and cascades the same way `uppercase` / `underline` / `whitespace-pre-line` do, with no reset
+  form of its own — Tailwind has no `leading-auto`, and every preset (`leading-none` included) is already a
+  real value rather than a sentinel.
 
 ## [1.5.0] - 2026-07-19
 

--- a/Packages/com.velvet.core/Documentation~/fonts.md
+++ b/Packages/com.velvet.core/Documentation~/fonts.md
@@ -105,7 +105,8 @@ them (not a Velvet decision).
 
 **Supported (shipped):** `font-<family>` / `font-thin`…`font-black` / `italic` / `not-italic` /
 `text-xs`…`text-4xl` (font-size) / `text-left|center|right|start|end` (`-unity-text-align`) /
-`tracking-*` (`letter-spacing`) / `whitespace-normal|nowrap|pre|pre-wrap|pre-line` /
+`tracking-*` (`letter-spacing`) / `leading-*` (`line-height`) /
+`whitespace-normal|nowrap|pre|pre-wrap|pre-line` /
 `text-wrap` / `text-nowrap` / `truncate` / `text-ellipsis` / `text-clip` (`text-overflow: ellipsis | clip`) /
 text color / `uppercase` `lowercase` `capitalize` `normal-case` (text-transform) /
 `underline` `line-through` `no-underline` (text-decoration).
@@ -114,7 +115,10 @@ text color / `uppercase` `lowercase` `capitalize` `normal-case` (text-transform)
 for either): the string is upper/lower/title-cased, and underline / line-through wrap it in the `<u>` / `<s>`
 rich-text tags UITK renders (`enableRichText` is on by default). Both **inherit** like CSS — put the class on
 an ancestor and the descendant text leaves pick it up (`StyleTextEffectResolver` walks ancestors). See it for
-the one cascade-freshness caveat (an ancestor's class toggled without that ancestor re-rendering).
+the one cascade-freshness caveat (an ancestor's class toggled without that ancestor re-rendering). If an
+element turns `enableRichText` off, the `<u>` / `<s>` markup is not interpreted — it shows up as literal text
+in the label instead, like any other rich-text tag on that element (`leading-*`'s `<line-height=X>` tag,
+below, has the identical caveat).
 
 **`white-space`** has four native USS values, and `whitespace-normal`, `whitespace-nowrap`,
 `whitespace-pre`, and `whitespace-pre-wrap` map directly onto them — no C# involved.
@@ -133,11 +137,30 @@ over a text-mutating one is the less surprising outcome), and — exactly like h
 `whitespace-pre-line` from reaching that subtree at all, rather than merely leaving the collapse unapplied
 on that one element.
 
+**`leading-*` (line-height)** has no USS property either — `-unity-paragraph-spacing` only affects explicit
+`\n` breaks, not the per-line advance a real line-height changes — so it is realised through UI Toolkit's
+rich-text `<line-height=X>` tag instead. Both text engines (the standard generator and the Advanced Text
+Generator) implement the tag natively, feeding it into the line-advance math at every line-break site; a
+following `</line-height>` restores the natural metric. The named presets (`leading-none` 1 · `leading-tight`
+1.25 · `leading-snug` 1.375 · `leading-normal` 1.5 · `leading-relaxed` 1.625 · `leading-loose` 2) emit their
+multiplier verbatim as `<line-height=1.625em>…</line-height>`; `leading-[Npx]` emits an absolute
+`<line-height=Npx>` — only the `px` unit is accepted inside the bracket for now, any other unit (or a
+malformed value) is silently ignored, like a malformed value on any other bracketed utility.
+Unlike `tracking-*`, whose em scale had to be **baked to px at Tailwind's 16px root font** (USS
+`letter-spacing` has no `em` unit — see `_typography.uss` — so `tracking-wide`'s 0.4px is only really 0.025em
+at exactly 16px, drifting off-ratio at any other size), `leading-*`'s em form is resolved by the **text engine
+itself** against whichever font size is actually in effect at that point in the string. It composes correctly
+with any `text-*` size — or one inherited from further up the tree — at any value, with no lookup table to
+keep in sync. `leading-*` inherits and cascades exactly like text-transform / text-decoration (a nearer
+ancestor's `leading-*` overrides a farther one's). It has no reset utility, unlike the other three axes:
+Tailwind defines no `leading-auto` below `leading-none`, and every preset — `leading-none`'s multiplier of 1
+included — is already a real value, so there is nothing for a descendant to reset back to the way
+`normal-case` / `no-underline` / an explicit `whitespace-*` class do.
+
 **Not expressible in UI Toolkit (no USS property — intentionally absent):**
 
 | Tailwind | Why omitted |
 |---|---|
-| `leading-*` (line-height) | USS has no `line-height` (`-unity-paragraph-spacing` is paragraph gap, not line-height) |
 | `overline` (text-decoration) | UI Toolkit rich text has no overline tag (`<u>` / `<s>` only) |
 | `antialiased` / `subpixel-antialiased` (font-smoothing) | Text renders as SDF alpha-blend only — no antialiasing-mode axis to switch |
 | `font-stretch-*` | No variable-font / width-axis support |

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberElementFactory.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberElementFactory.cs
@@ -188,6 +188,14 @@ namespace Velvet
                     continue;
                 }
 
+                // leading-[...] arbitrary line-height classes are owned by StyleTextEffectResolver (folded
+                // into the rich-text tag it wraps the display string in); like font-[...] they must not
+                // enter the USS class list, regardless of whether the bracket value itself parses.
+                if (StyleTextEffectClass.IsArbitraryLeadingClass(className))
+                {
+                    continue;
+                }
+
                 // Important modifier (!utility / utility!): strip the bang and, when present,
                 // elevate the inline-resolved utility to the Important layer so it wins over every other
                 // layer. A class-only utility has no inline form to elevate, so its bang is inert.

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
@@ -995,6 +995,15 @@ namespace Velvet
                 return;
             }
 
+            // leading-[...] arbitrary line-height classes are resolved from the whole class array by
+            // StyleTextEffectResolver and folded into the rich-text tag it wraps the display string in;
+            // like font-[...] they must not enter the USS class list, regardless of whether the bracket
+            // value itself parses.
+            if (StyleTextEffectClass.IsArbitraryLeadingClass(cls))
+            {
+                return;
+            }
+
             // Important modifier (!utility / utility!): strip the bang; when present, elevate the
             // inline-resolved utility to the Important layer. A class-only utility's bang is inert.
             var core = StyleArbitraryValueResolver.StripImportant(cls, out var important);
@@ -1061,6 +1070,14 @@ namespace Velvet
             // font-[...] arbitrary font classes never entered the class list (see AddClass); the inline
             // style they drove is cleared by StyleFontResolver on the class change, not here.
             if (StyleFontClass.IsArbitraryFontClass(cls))
+            {
+                return;
+            }
+
+            // leading-[...] arbitrary line-height classes never entered the class list (see AddClass); the
+            // rich-text tag they drove is cleared by StyleTextEffectResolver re-resolving on the class
+            // change, not here.
+            if (StyleTextEffectClass.IsArbitraryLeadingClass(cls))
             {
                 return;
             }

--- a/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
@@ -149,15 +149,16 @@ namespace Velvet
         // before re-deriving. Cleared on element cleanup / reconciler dispose.
         public Dictionary<VisualElement, List<string[]>> SupportsVariants { get; } = new();
 
-        // text-transform / text-decoration / whitespace-pre-line (uppercase / underline / … / the pre-line
-        // collapse). UI Toolkit has no property for any of them, so they are realised by mutating the
-        // displayed text (StyleTextEffectResolver). TextEffects holds each element's OWN parsed effect (the
-        // cascade source); TextRawText holds the untransformed text captured at the text-set seams so the
-        // effect re-applies idempotently. TextWhitespaceOwned is a THIRD table, set-shaped (a Dictionary with
-        // a trivial bool value): presence means this element's CURRENT inline style.whiteSpace was written by
-        // the resolver itself, so a later resolve that is no longer PreLine clears only what the resolver
-        // owns — never a value set directly by other means (e.g. a refCallback, a pattern the framework
-        // treats as legitimate — see RefCallbacks below). All three are pure (teardown = Remove(element)).
+        // text-transform / text-decoration / whitespace-pre-line / leading-* (uppercase / underline / … / the
+        // pre-line collapse / line-height). UI Toolkit has no property for any of them, so they are realised
+        // by mutating the displayed text (StyleTextEffectResolver). TextEffects holds each element's OWN
+        // parsed effect (the cascade source, now four axes — Leading rides the same table, see LeadingUnit);
+        // TextRawText holds the untransformed text captured at the text-set seams so the effect re-applies
+        // idempotently. TextWhitespaceOwned is a THIRD table, set-shaped (a Dictionary with a trivial bool
+        // value): presence means this element's CURRENT inline style.whiteSpace was written by the resolver
+        // itself, so a later resolve that is no longer PreLine clears only what the resolver owns — never a
+        // value set directly by other means (e.g. a refCallback, a pattern the framework treats as legitimate
+        // — see RefCallbacks below). All three are pure (teardown = Remove(element)).
         public Dictionary<VisualElement, TextEffect> TextEffects { get; } = new();
         public Dictionary<VisualElement, string> TextRawText { get; } = new();
         public Dictionary<VisualElement, bool> TextWhitespaceOwned { get; } = new();

--- a/Packages/com.velvet.core/Runtime/Styling/StyleArbitraryValueResolver.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleArbitraryValueResolver.cs
@@ -26,8 +26,8 @@ namespace Velvet
         // so its '!' is accepted but inert. Returns the input unchanged when no modifier is present.
         //
         // Scope: this is wired into the per-class dispatch (USS-class + inline-layer utilities). The
-        // array-scanned subsystem utilities (shadow-*, font-*, gap-*, divide-*, clip-path-*) do NOT
-        // participate in the USS/inline cascade that !important arbitrates — they are custom-drawn or
+        // array-scanned subsystem utilities (shadow-*, font-*, gap-*, divide-*, clip-path-*, leading-*) do
+        // NOT participate in the USS/inline cascade that !important arbitrates — they are custom-drawn or
         // resolved to inline that already wins — so the important form is not recognized for them; use the
         // plain form. (Adding the bang there would be a no-op elevation by definition.)
         public static string StripImportant(string className, out bool important)

--- a/Packages/com.velvet.core/Runtime/Styling/StyleFontClass.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleFontClass.cs
@@ -95,9 +95,23 @@ namespace Velvet
         /// style), so the reconciler must keep them out of the USS class list — unlike the non-bracket
         /// font classes (<c>font-bold</c>, <c>font-sans</c>, …) which stay in the list as the USS fallback.
         /// Single source of truth for the AddClass / RemoveClass / ApplyClassNames exclusion checks.
+        /// Routed through <see cref="StyleArbitraryValueResolver.StripImportant"/> first so an
+        /// important-modifier bang (<c>!font-[…]</c> / <c>font-[…]!</c>) is tolerated: the 3 call sites
+        /// above run THIS check before their own <c>StripImportant</c> call, so a bang'd token that only
+        /// matched the un-prefixed form would fall through, have its bang stripped downstream, and leak the
+        /// bare bracket core into the class list as a dead token. The modifier itself stays a no-op for
+        /// this family either way (see <c>StripImportant</c>'s own Scope comment) — this only makes the
+        /// classlist guard agree with the stripper on what counts as "this family".
         /// </summary>
-        public static bool IsArbitraryFontClass(string cls) =>
-            !string.IsNullOrEmpty(cls) && cls.StartsWith("font-[", StringComparison.Ordinal);
+        public static bool IsArbitraryFontClass(string cls)
+        {
+            if (string.IsNullOrEmpty(cls))
+            {
+                return false;
+            }
+            var core = StyleArbitraryValueResolver.StripImportant(cls, out _);
+            return core.StartsWith("font-[", StringComparison.Ordinal);
+        }
 
         /// <summary>
         /// Scans <paramref name="classNames"/> and folds every font utility into one

--- a/Packages/com.velvet.core/Runtime/Styling/StyleTextEffectClass.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleTextEffectClass.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
 
@@ -35,55 +36,114 @@ namespace Velvet
         PreLine, // whitespace-pre-line
     }
 
-    // An element's OWN text-transform / text-decoration / whitespace-collapse intent, each axis independent
-    // and nullable: null means the axis carries no token on this element (inherit), a non-null value (incl.
-    // the explicit None reset every axis has) wins over an ancestor. CSS text-transform / text-decoration /
-    // white-space all inherit; Unity UI Toolkit only natively inherits white-space (it lives in
-    // inheritedData) — text-transform / text-decoration have no UITK property at all — so Velvet realises
-    // all three the same way regardless, by mutating the displayed text: uppercasing/title-casing the
-    // string, wrapping it in the rich-text <u>/<s> tags UI Toolkit renders (enableRichText is on by
-    // default), and/or collapsing space/tab runs.
+    // Which unit a resolved Leading value carries: Em multiplies whatever font-size is in effect at the
+    // point the rich-text tag is generated (every named leading-* preset); Pixel is an absolute length
+    // (leading-[Npx]). Unlike TextTransformKind/TextDecorationKind/WhitespaceCollapseKind, this axis has
+    // deliberately no explicit-reset member: Tailwind defines no leading-auto utility below leading-none, and
+    // every named preset — including leading-none's own multiplier of 1 — is already a real, meaningful
+    // value rather than a sentinel standing in for "reset to nothing" the way normal-case / no-underline /
+    // an explicit whitespace-* class are. A None member here would have no Parse case that ever produces it
+    // and no caller that would ever need it, so it is left out rather than added purely for symmetry with
+    // the other three axes.
+    internal enum LeadingUnit
+    {
+        Em,
+        Pixel,
+    }
+
+    // A resolved leading-* value: the numeric multiplier/length plus which unit it is in. Nullable
+    // (LeadingValue?) in TextEffect exactly like the other three axes' own kinds — null means unset (inherit
+    // an ancestor's leading, if any); non-null is a real value that cascades and can be overridden by a
+    // nearer ancestor's own leading-* (the ??= resolution in StyleTextEffectResolver.ResolveEffective gives
+    // this for free, identical to Transform/Decoration/Whitespace).
+    internal readonly struct LeadingValue : IEquatable<LeadingValue>
+    {
+        public readonly LeadingUnit Unit;
+        public readonly float Value;
+
+        public LeadingValue(LeadingUnit unit, float value)
+        {
+            Unit = unit;
+            Value = value;
+        }
+
+        public bool Equals(LeadingValue other) => Unit == other.Unit && Value == other.Value;
+        public override bool Equals(object obj) => obj is LeadingValue o && Equals(o);
+        public override int GetHashCode() => unchecked((Unit.GetHashCode() * 397) ^ Value.GetHashCode());
+    }
+
+    // An element's OWN text-transform / text-decoration / whitespace-collapse / leading intent, each axis
+    // independent and nullable: null means the axis carries no token on this element (inherit), a non-null
+    // value (incl. the explicit None reset the first three axes have) wins over an ancestor. CSS
+    // text-transform / text-decoration / white-space / line-height all inherit; Unity UI Toolkit only
+    // natively inherits white-space (it lives in inheritedData) — text-transform / text-decoration /
+    // line-height have no UITK property at all — so Velvet realises all four the same way regardless, by
+    // mutating the displayed text: uppercasing/title-casing the string, wrapping it in the rich-text
+    // <u>/<s>/<line-height=X> tags UI Toolkit renders (enableRichText is on by default), and/or collapsing
+    // space/tab runs.
     //
     // Whitespace still needs the same manual cascade walk as Transform/Decoration despite white-space
     // natively inheriting: no UITK enum member expresses CSS pre-line's collapse, so a C# string mutation is
     // the only way to realise it, and that mutation cannot itself propagate through the visual tree the way
     // a real inherited USS property does — it must reach every leaf whose EFFECTIVE (cascade-resolved) value
-    // is PreLine, exactly like Transform/Decoration (see StyleTextEffectResolver.ResolveEffective).
+    // is PreLine, exactly like Transform/Decoration (see StyleTextEffectResolver.ResolveEffective). Leading
+    // has no USS property to inherit from at all (see LeadingUnit), so — like Transform/Decoration, and for
+    // the same underlying reason — it needs that identical manual walk too.
     internal readonly struct TextEffect : IEquatable<TextEffect>
     {
         public readonly TextTransformKind? Transform;
         public readonly TextDecorationKind? Decoration;
         public readonly WhitespaceCollapseKind? Whitespace;
+        public readonly LeadingValue? Leading;
 
-        public TextEffect(TextTransformKind? transform, TextDecorationKind? decoration, WhitespaceCollapseKind? whitespace)
+        public TextEffect(TextTransformKind? transform, TextDecorationKind? decoration, WhitespaceCollapseKind? whitespace, LeadingValue? leading)
         {
             Transform = transform;
             Decoration = decoration;
             Whitespace = whitespace;
+            Leading = leading;
         }
 
         // True when no axis carries a token (nothing to track for this element).
-        public bool IsEmpty => Transform == null && Decoration == null && Whitespace == null;
+        public bool IsEmpty => Transform == null && Decoration == null && Whitespace == null && Leading == null;
 
         public bool Equals(TextEffect other) =>
-            Transform == other.Transform && Decoration == other.Decoration && Whitespace == other.Whitespace;
+            Transform == other.Transform && Decoration == other.Decoration && Whitespace == other.Whitespace
+            && Leading.Equals(other.Leading);
         public override bool Equals(object obj) => obj is TextEffect o && Equals(o);
         public override int GetHashCode() =>
-            unchecked((((Transform?.GetHashCode() ?? -1) * 397) ^ (Decoration?.GetHashCode() ?? -1)) * 397 ^ (Whitespace?.GetHashCode() ?? -1));
+            unchecked(((((Transform?.GetHashCode() ?? -1) * 397) ^ (Decoration?.GetHashCode() ?? -1)) * 397 ^ (Whitespace?.GetHashCode() ?? -1)) * 397 ^ (Leading?.GetHashCode() ?? -1));
     }
 
-    // Parses the text-transform / text-decoration / whitespace-pre-line utilities into a TextEffect, and
-    // applies a resolved effect to a raw string. Pure and allocation-light; the reconciler owns the
-    // per-element side-tables and the cascade (walking ancestors for the nearest non-null axis).
+    // Parses the text-transform / text-decoration / whitespace-pre-line / leading-* utilities into a
+    // TextEffect, and applies a resolved effect to a raw string. Pure and allocation-light; the reconciler
+    // owns the per-element side-tables and the cascade (walking ancestors for the nearest non-null axis).
     internal static class StyleTextEffectClass
     {
+        // leading-* named presets -> em multiplier (Tailwind's own scale). Applied verbatim as the rich-text
+        // tag's <line-height=Nem> value — the ENGINE resolves the em against whatever font-size is in effect
+        // at that point in the string, so this table needs no font-size-aware pre-baking the way
+        // tracking-*'s em scale does in _typography.uss (see fonts.md).
+        private static readonly Dictionary<string, float> s_leadingPresets = new(StringComparer.Ordinal)
+        {
+            ["leading-none"] = 1f,
+            ["leading-tight"] = 1.25f,
+            ["leading-snug"] = 1.375f,
+            ["leading-normal"] = 1.5f,
+            ["leading-relaxed"] = 1.625f,
+            ["leading-loose"] = 2f,
+        };
+
         // Resolves an element's OWN effect from its class list (last token wins per axis, except Whitespace —
         // see below). Returns an empty TextEffect (every axis null) when no recognised token is present.
+        // Leading follows the same last-token-wins rule as Transform/Decoration: it has no reset form (see
+        // LeadingUnit), so there is nothing analogous to Whitespace's cross-family override to special-case.
         public static TextEffect Parse(string[] classNames)
         {
             TextTransformKind? transform = null;
             TextDecorationKind? decoration = null;
             WhitespaceCollapseKind? whitespace = null;
+            LeadingValue? leading = null;
             if (classNames == null)
             {
                 return default;
@@ -107,6 +167,16 @@ namespace Velvet
                     case "whitespace-pre-wrap":
                         sawExplicitWhitespaceClass = true;
                         break;
+                    default:
+                        if (s_leadingPresets.TryGetValue(cls, out var em))
+                        {
+                            leading = new LeadingValue(LeadingUnit.Em, em);
+                        }
+                        else if (TryParseLeadingBracket(cls, out var px))
+                        {
+                            leading = new LeadingValue(LeadingUnit.Pixel, px);
+                        }
+                        break;
                 }
             }
             // An explicit whitespace-{normal,nowrap,pre,pre-wrap} class on the SAME element always wins over
@@ -124,17 +194,78 @@ namespace Velvet
             {
                 whitespace = WhitespaceCollapseKind.None;
             }
-            return new TextEffect(transform, decoration, whitespace);
+            return new TextEffect(transform, decoration, whitespace, leading);
         }
 
-        // Applies a resolved whitespace-pre-line collapse, then transform, then decoration to a raw string, in
-        // that order — CSS resolves white-space processing before text-transform, so collapsing first means
-        // Capitalize's word-boundary scan and the decoration wrap both see the already-normalized text. A
-        // null/None axis on any parameter is a no-op. Empty text is returned unchanged (no empty <u></u>) —
-        // checked both before AND after the collapse, since an all-whitespace input can collapse all the way
-        // down to empty too (every run in it touches a line edge). The transform assumes plain text;
-        // pre-existing rich-text markup in the raw string is the caller's concern.
-        public static string Apply(string raw, TextTransformKind? transform, TextDecorationKind? decoration, WhitespaceCollapseKind? whitespace = null)
+        // True when cls is the leading-[...] arbitrary bracket form, regardless of whether its value parses.
+        // Mirrors StyleFontClass.IsArbitraryFontClass: the reconciler must keep this token out of the USS
+        // class list at the same sites (FiberElementFactory.ApplyClassNames, FiberNodePatcher.AddClass /
+        // RemoveClass) — a malformed leading-[...] must vanish exactly like a malformed font-[...] does,
+        // never sitting in the class list as a dead token. The named presets (leading-none, leading-tight,
+        // ...) need no such guard: an inert token in the class list is the established, harmless pattern
+        // every other axis's own real-value classes already use (uppercase, whitespace-pre-line, ...).
+        // Routed through StripImportant first so an important-modifier bang (!leading-[...] / leading-[...]!)
+        // is tolerated: the 3 call sites above run THIS check before their own StripImportant call, so a
+        // bang'd token that only matched the un-prefixed form would fall through, have its bang stripped
+        // downstream, and leak the bare bracket core into the class list as a dead token. The modifier
+        // itself stays a no-op for this family either way (see StripImportant's own Scope comment) — this
+        // only makes the classlist guard agree with the stripper on what counts as "this family".
+        public static bool IsArbitraryLeadingClass(string cls)
+        {
+            if (string.IsNullOrEmpty(cls))
+            {
+                return false;
+            }
+            var core = StyleArbitraryValueResolver.StripImportant(cls, out _);
+            return core.StartsWith("leading-[", StringComparison.Ordinal);
+        }
+
+        // Parses leading-[Npx]. Only the px unit is accepted inside the bracket for v1 — an explicit "px"
+        // suffix is REQUIRED (a bare unitless number, or any other unit such as em/%/rem, is rejected)
+        // because the feature is deliberately scoped down to px for its first iteration; widening to other
+        // units is left for later. A malformed or unsupported-unit value returns false and Leading is simply
+        // left unset for this token — silently, no Debug.LogWarning — mirroring
+        // StyleArbitraryValueResolver.TryParse's own established convention for a bracket value that fails to
+        // parse (e.g. w-[abc]): there, an unparsed token falls back to the USS class list, where it matches
+        // no selector and is inert; here, IsArbitraryLeadingClass's unconditional prefix check keeps it out
+        // of the class list too, so the result is the same inertness by a different, axis-appropriate route.
+        private static bool TryParseLeadingBracket(string cls, out float px)
+        {
+            px = 0f;
+            const string prefix = "leading-[";
+            if (!cls.StartsWith(prefix, StringComparison.Ordinal) || cls[cls.Length - 1] != ']')
+            {
+                return false;
+            }
+            var inner = cls.Substring(prefix.Length, cls.Length - prefix.Length - 1);
+            if (!inner.EndsWith("px", StringComparison.Ordinal))
+            {
+                return false;
+            }
+            var numeric = inner.Substring(0, inner.Length - 2);
+            return float.TryParse(numeric, NumberStyles.Float, CultureInfo.InvariantCulture, out px)
+                && !float.IsNaN(px) && !float.IsInfinity(px) && px >= 0f;
+        }
+
+        // Applies a resolved whitespace-pre-line collapse, then transform, then decoration, then leading to a
+        // raw string, in that order — CSS resolves white-space processing before text-transform, so
+        // collapsing first means Capitalize's word-boundary scan and the decoration wrap both see the
+        // already-normalized text. Leading wraps OUTERMOST, after decoration: line-height is a layout
+        // property with no bearing on the string's own content, so it never needs to observe (or interact
+        // with) what Transform/Decoration did to it — wrapping outside <u>/<s> leaves those tags' own nesting
+        // untouched and simply adds one more independent rich-text span around the whole result. A null/None
+        // axis on any parameter is a no-op. Empty text is returned unchanged (no empty <u></u>, no empty
+        // <line-height>...</line-height>) — checked both before AND after the collapse, since an
+        // all-whitespace input can collapse all the way down to empty too (every run in it touches a line
+        // edge); Transform/Decoration/Leading never turn a non-empty string empty, so that one guard pair
+        // upfront covers the whole pipeline. The transform assumes plain text; pre-existing rich-text markup
+        // in the raw string is the caller's concern.
+        public static string Apply(
+            string raw,
+            TextTransformKind? transform,
+            TextDecorationKind? decoration,
+            WhitespaceCollapseKind? whitespace = null,
+            LeadingValue? leading = null)
         {
             if (string.IsNullOrEmpty(raw))
             {
@@ -146,7 +277,8 @@ namespace Velvet
                 return text;
             }
             text = ApplyTransform(text, transform);
-            return ApplyDecoration(text, decoration);
+            text = ApplyDecoration(text, decoration);
+            return ApplyLeading(text, leading);
         }
 
         private static string ApplyTransform(string text, TextTransformKind? transform)
@@ -168,6 +300,25 @@ namespace Velvet
                 case TextDecorationKind.LineThrough: return "<s>" + text + "</s>";
                 default: return text; // None / null
             }
+        }
+
+        // Wraps text in the <line-height=X> rich-text tag both the standard and Advanced Text Generators
+        // implement (px / em / % forms; only em — the named presets — and px — the bracket form — are ever
+        // produced here). InvariantCulture on the number is required, not cosmetic: this is the first spot in
+        // this file that stringifies a float into markup the ENGINE itself re-parses, and a comma decimal
+        // separator (e.g. "1,625em" under a comma-decimal thread culture) does not match the tag's numeric
+        // grammar, so the tag would silently fail to apply — a new bug class for this axis, since
+        // Transform/Decoration never stringify a number at all.
+        private static string ApplyLeading(string text, LeadingValue? leading)
+        {
+            if (leading == null)
+            {
+                return text;
+            }
+            var value = leading.Value;
+            var unit = value.Unit == LeadingUnit.Pixel ? "px" : "em";
+            var amount = value.Value.ToString(CultureInfo.InvariantCulture);
+            return "<line-height=" + amount + unit + ">" + text + "</line-height>";
         }
 
         // CSS pre-line's own text mutation: runs of spaces/tabs fold to a single space and newlines are kept

--- a/Packages/com.velvet.core/Runtime/Styling/StyleTextEffectResolver.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleTextEffectResolver.cs
@@ -4,23 +4,26 @@ using UnityEngine.UIElements;
 namespace Velvet
 {
     // Realises text-transform (uppercase / lowercase / capitalize / normal-case), text-decoration
-    // (underline / line-through), and whitespace-pre-line by mutating the displayed text — Unity UI Toolkit
-    // has no property for any of the three, so the string is upper/lower/title-cased, wrapped in the <u>/<s>
-    // rich-text tags UITK renders, and/or has its space/tab runs collapsed. CSS inherits all three; UITK does
-    // not (for text-transform / text-decoration there is no UITK property at all; white-space DOES natively
-    // inherit, but no enum value expresses pre-line's collapse, so the STRING rewrite still needs the same
-    // treatment — see the Whitespace remarks on TextEffect). So every axis cascades by walking ancestors
-    // (StyleTextEffectClass holds the pure parse + string ops; this owns the reconciler-side cascade and the
-    // per-element side-tables).
+    // (underline / line-through), whitespace-pre-line, and leading-* (line-height) by mutating the displayed
+    // text — Unity UI Toolkit has no property for any of the four, so the string is upper/lower/title-cased,
+    // wrapped in the <u>/<s>/<line-height=X> rich-text tags UITK renders, and/or has its space/tab runs
+    // collapsed. CSS inherits all four; UITK does not (for text-transform / text-decoration / line-height
+    // there is no UITK property at all; white-space DOES natively inherit, but no enum value expresses
+    // pre-line's collapse, so the STRING rewrite still needs the same treatment — see the Whitespace remarks
+    // on TextEffect). So every axis cascades by walking ancestors (StyleTextEffectClass holds the pure parse
+    // + string ops; this owns the reconciler-side cascade and the per-element side-tables).
     //
     // Three per-element side-tables (all pure, on ReconcilerContext): TextEffects = an element's OWN parsed
     // effect (each axis nullable so an explicit reset — normal-case / no-underline / an explicit
-    // whitespace-* class — is distinct from "inherit"); TextRawText = the untransformed text last seen for a
-    // text-bearing element, captured at the text-set seams so the effect can be re-applied idempotently (the
-    // element's live .text may already be transformed); TextWhitespaceOwned = a set (Dictionary with a
-    // trivial value) of elements whose CURRENT inline `style.whiteSpace` was written by THIS resolver — see
-    // the ownership discussion below ApplyToElement. All three ride element cleanup / pool reuse for free via
-    // ReconcilerContext.ClearElementSideTables.
+    // whitespace-* class — is distinct from "inherit"; Leading has no reset form, see LeadingUnit, but is
+    // still nullable the same way for "inherit" vs. "this element sets a real value"); TextRawText = the
+    // untransformed text last seen for a text-bearing element, captured at the text-set seams so the effect
+    // can be re-applied idempotently (the element's live .text may already be transformed); TextWhitespaceOwned
+    // = a set (Dictionary with a trivial value) of elements whose CURRENT inline `style.whiteSpace` was
+    // written by THIS resolver — see the ownership discussion below ApplyToElement. All three ride element
+    // cleanup / pool reuse for free via ReconcilerContext.ClearElementSideTables. Leading needs no fourth
+    // table of its own: unlike PreLine it drives no separate inline style, only the SAME string rewrite
+    // TextEffects/TextRawText already carry, so it rides their existing cleanup for free too.
     //
     // PreLine ALSO drives an inline `white-space: pre-wrap` write, so the preserved newlines render as
     // breaks and wrapping still works. That write happens in ApplyToElement (below), on EVERY text leaf
@@ -61,11 +64,11 @@ namespace Velvet
     // leaf that carried an owned inline PreWrap would keep it forever. FiberNodePatcher.PatchBaseElement
     // clears TextWhitespaceOwned at exactly that site; see the comment there.
     //
-    // KNOWN LIMITATION: toggling a text-transform / text-decoration / whitespace-pre-line class on an
-    // ANCESTOR re-cascades to descendants only when that ancestor is re-rendered (its post-children pass
-    // walks them). A descendant whose own text is unchanged and whose ancestor's class changed without the
-    // ancestor re-patching keeps its prior effect — string AND, for PreLine, the inline `white-space` write
-    // alike — until its next text update; the common static case (effect set at mount) is fully correct.
+    // KNOWN LIMITATION: toggling a text-transform / text-decoration / whitespace-pre-line / leading-* class
+    // on an ANCESTOR re-cascades to descendants only when that ancestor is re-rendered (its post-children
+    // pass walks them). A descendant whose own text is unchanged and whose ancestor's class changed without
+    // the ancestor re-patching keeps its prior effect — string AND, for PreLine, the inline `white-space`
+    // write alike — until its next text update; the common static case (effect set at mount) is fully correct.
     internal static class StyleTextEffectResolver
     {
         // Captures the untransformed text for a text-bearing element at a text-set seam (TextNode create/patch,
@@ -132,8 +135,8 @@ namespace Velvet
         {
             if (element is TextElement te && ctx.TextRawText.TryGetValue(te, out var raw))
             {
-                var (transform, decoration, whitespace) = ResolveEffective(ctx, te);
-                te.text = StyleTextEffectClass.Apply(raw, transform, decoration, whitespace);
+                var (transform, decoration, whitespace, leading) = ResolveEffective(ctx, te);
+                te.text = StyleTextEffectClass.Apply(raw, transform, decoration, whitespace, leading);
                 // Per-leaf inline pre-wrap write, off the SAME resolved value that just drove the string
                 // collapse above, so the two can never disagree for this leaf. Ownership-gated (see the type
                 // comment / TextWhitespaceOwned): PreLine writes-and-marks; a non-PreLine resolve clears ONLY
@@ -165,18 +168,21 @@ namespace Velvet
         }
 
         // The cascade: the nearest ancestor-or-self that sets each axis wins (each axis resolved
-        // independently), mirroring CSS inheritance of text-transform / text-decoration / white-space. A null
-        // axis on every ancestor means no effect on that axis. An explicit None on an axis (normal-case /
-        // no-underline / an explicit whitespace-* class) also wins and stops the walk for THAT axis — it is a
-        // real resolved value, not "no token" — so it blocks a farther ancestor's non-None value from
-        // reaching this element. Feeds BOTH the string rewrite and, for Whitespace, the inline pre-wrap style
-        // write in ApplyToElement — one resolve, two writes off the same value, so they can never disagree.
-        private static (TextTransformKind? transform, TextDecorationKind? decoration, WhitespaceCollapseKind? whitespace) ResolveEffective(
+        // independently), mirroring CSS inheritance of text-transform / text-decoration / white-space /
+        // line-height. A null axis on every ancestor means no effect on that axis. An explicit None on
+        // Transform/Decoration/Whitespace (normal-case / no-underline / an explicit whitespace-* class) also
+        // wins and stops the walk for THAT axis — it is a real resolved value, not "no token" — so it blocks
+        // a farther ancestor's non-None value from reaching this element; Leading has no such explicit-reset
+        // value (see LeadingUnit), so its walk only ever stops on a real leading-* token or the tree's root.
+        // Feeds BOTH the string rewrite and, for Whitespace, the inline pre-wrap style write in
+        // ApplyToElement — one resolve, N writes off the same value, so they can never disagree.
+        private static (TextTransformKind? transform, TextDecorationKind? decoration, WhitespaceCollapseKind? whitespace, LeadingValue? leading) ResolveEffective(
             ReconcilerContext ctx, VisualElement element)
         {
             TextTransformKind? transform = null;
             TextDecorationKind? decoration = null;
             WhitespaceCollapseKind? whitespace = null;
+            LeadingValue? leading = null;
             for (var e = element; e != null; e = e.hierarchy.parent)
             {
                 if (!ctx.TextEffects.TryGetValue(e, out var eff))
@@ -186,12 +192,13 @@ namespace Velvet
                 transform ??= eff.Transform;
                 decoration ??= eff.Decoration;
                 whitespace ??= eff.Whitespace;
-                if (transform != null && decoration != null && whitespace != null)
+                leading ??= eff.Leading;
+                if (transform != null && decoration != null && whitespace != null && leading != null)
                 {
                     break;
                 }
             }
-            return (transform, decoration, whitespace);
+            return (transform, decoration, whitespace, leading);
         }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/StyleFontTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/StyleFontTests.cs
@@ -66,6 +66,12 @@ namespace Velvet.Tests
             yield return new TestCaseData("font-[550]", true)
                 .SetName("Given_BracketWeight_When_CheckedForArbitraryFontClass_Then_True");
 
+            // The important-modifier bang must not defeat this guard: StripImportant strips it at the 3
+            // guard call sites AFTER this check runs, so the predicate itself has to recognize the bang'd
+            // form or the bare bracket token leaks into the USS class list once the bang is gone.
+            yield return new TestCaseData("!font-[weight:550]", true)
+                .SetName("Given_BangPrefixedBracketWeight_When_CheckedForArbitraryFontClass_Then_True");
+
             // Non-bracket font classes stay in the list as the USS fallback; non-font brackets are unrelated.
             yield return new TestCaseData("font-bold", false)
                 .SetName("Given_FontBold_When_CheckedForArbitraryFontClass_Then_False");

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/StyleTextEffectClassTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/StyleTextEffectClassTests.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+using System.Threading;
 using NUnit.Framework;
 
 namespace Velvet.Tests
@@ -215,6 +217,343 @@ namespace Velvet.Tests
             Assert.That(
                 StyleTextEffectClass.Apply("a   B", TextTransformKind.Upper, TextDecorationKind.Underline, WhitespaceCollapseKind.PreLine),
                 Is.EqualTo("<u>A B</u>"));
+        }
+
+        [Test]
+        public void Given_LeadingNone_When_ParsedAndApplied_Then_ProducesOneEmTag()
+        {
+            // Arrange
+            var classNames = new[] { "leading-none" };
+
+            // Act
+            var effect = StyleTextEffectClass.Parse(classNames);
+            var result = StyleTextEffectClass.Apply("hi", null, null, null, effect.Leading);
+
+            // Assert
+            Assert.That(result, Is.EqualTo("<line-height=1em>hi</line-height>"));
+        }
+
+        [Test]
+        public void Given_LeadingTight_When_ParsedAndApplied_Then_ProducesOnePointTwoFiveEmTag()
+        {
+            // Arrange
+            var classNames = new[] { "leading-tight" };
+
+            // Act
+            var effect = StyleTextEffectClass.Parse(classNames);
+            var result = StyleTextEffectClass.Apply("hi", null, null, null, effect.Leading);
+
+            // Assert
+            Assert.That(result, Is.EqualTo("<line-height=1.25em>hi</line-height>"));
+        }
+
+        [Test]
+        public void Given_LeadingSnug_When_ParsedAndApplied_Then_ProducesOnePointThreeSevenFiveEmTag()
+        {
+            // Arrange
+            var classNames = new[] { "leading-snug" };
+
+            // Act
+            var effect = StyleTextEffectClass.Parse(classNames);
+            var result = StyleTextEffectClass.Apply("hi", null, null, null, effect.Leading);
+
+            // Assert
+            Assert.That(result, Is.EqualTo("<line-height=1.375em>hi</line-height>"));
+        }
+
+        [Test]
+        public void Given_LeadingNormal_When_ParsedAndApplied_Then_ProducesOnePointFiveEmTag()
+        {
+            // Arrange
+            var classNames = new[] { "leading-normal" };
+
+            // Act
+            var effect = StyleTextEffectClass.Parse(classNames);
+            var result = StyleTextEffectClass.Apply("hi", null, null, null, effect.Leading);
+
+            // Assert
+            Assert.That(result, Is.EqualTo("<line-height=1.5em>hi</line-height>"));
+        }
+
+        [Test]
+        public void Given_LeadingRelaxed_When_ParsedAndApplied_Then_ProducesOnePointSixTwoFiveEmTag()
+        {
+            // Arrange
+            var classNames = new[] { "leading-relaxed" };
+
+            // Act
+            var effect = StyleTextEffectClass.Parse(classNames);
+            var result = StyleTextEffectClass.Apply("hi", null, null, null, effect.Leading);
+
+            // Assert
+            Assert.That(result, Is.EqualTo("<line-height=1.625em>hi</line-height>"));
+        }
+
+        [Test]
+        public void Given_LeadingLoose_When_ParsedAndApplied_Then_ProducesTwoEmTag()
+        {
+            // Arrange
+            var classNames = new[] { "leading-loose" };
+
+            // Act
+            var effect = StyleTextEffectClass.Parse(classNames);
+            var result = StyleTextEffectClass.Apply("hi", null, null, null, effect.Leading);
+
+            // Assert
+            Assert.That(result, Is.EqualTo("<line-height=2em>hi</line-height>"));
+        }
+
+        [Test]
+        public void Given_LeadingBracketPx_When_ParsedAndApplied_Then_ProducesThePxTag()
+        {
+            // Arrange
+            var classNames = new[] { "leading-[24px]" };
+
+            // Act
+            var effect = StyleTextEffectClass.Parse(classNames);
+            var result = StyleTextEffectClass.Apply("hi", null, null, null, effect.Leading);
+
+            // Assert
+            Assert.That(result, Is.EqualTo("<line-height=24px>hi</line-height>"));
+        }
+
+        [Test]
+        public void Given_NoLeadingTokens_When_Parsed_Then_LeadingIsUnsetNull()
+        {
+            // Arrange
+            var classNames = new[] { "bg-red-500", "p-4" };
+
+            // Act
+            var effect = StyleTextEffectClass.Parse(classNames);
+
+            // Assert
+            Assert.That(effect.Leading, Is.Null);
+        }
+
+        [Test]
+        public void Given_LeadingBracketWithNonPxUnit_When_Parsed_Then_LeadingIsUnsetNull()
+        {
+            // Arrange — the bracket form accepts only px for v1; an em value inside the bracket (a
+            // plausible mistake, since the named presets DO use em) must be rejected rather than
+            // silently misinterpreted as a pixel count.
+            var classNames = new[] { "leading-[1.5em]" };
+
+            // Act
+            var effect = StyleTextEffectClass.Parse(classNames);
+
+            // Assert
+            Assert.That(effect.Leading, Is.Null);
+        }
+
+        [Test]
+        public void Given_LeadingBracketWithUnparseableNumber_When_Parsed_Then_LeadingIsUnsetNull()
+        {
+            // Arrange — a "px" suffix present but a non-numeric head, the other malformed shape
+            // TryParseLeadingBracket must reject.
+            var classNames = new[] { "leading-[abcpx]" };
+
+            // Act
+            var effect = StyleTextEffectClass.Parse(classNames);
+
+            // Assert
+            Assert.That(effect.Leading, Is.Null);
+        }
+
+        [Test]
+        public void Given_LeadingBracketWithNegativePx_When_Parsed_Then_LeadingIsUnsetNull()
+        {
+            // Arrange — a negative pixel count; TryParseLeadingBracket's own px >= 0f guard must reject it
+            // rather than producing a negative line-height the rich-text tag cannot express.
+            var classNames = new[] { "leading-[-5px]" };
+
+            // Act
+            var effect = StyleTextEffectClass.Parse(classNames);
+
+            // Assert
+            Assert.That(effect.Leading, Is.Null);
+        }
+
+        [Test]
+        public void Given_LeadingBracketEmpty_When_Parsed_Then_LeadingIsUnsetNull()
+        {
+            // Arrange — nothing at all between the brackets, so there is no "px" suffix to even find —
+            // the shortest possible malformed shape.
+            var classNames = new[] { "leading-[]" };
+
+            // Act
+            var effect = StyleTextEffectClass.Parse(classNames);
+
+            // Assert
+            Assert.That(effect.Leading, Is.Null);
+        }
+
+        [Test]
+        public void Given_LeadingBracketWithNoNumericPart_When_Parsed_Then_LeadingIsUnsetNull()
+        {
+            // Arrange — the "px" suffix is present but nothing precedes it, so the numeric head is empty
+            // rather than merely non-numeric (the shape Given_LeadingBracketWithUnparseableNumber covers).
+            var classNames = new[] { "leading-[px]" };
+
+            // Act
+            var effect = StyleTextEffectClass.Parse(classNames);
+
+            // Assert
+            Assert.That(effect.Leading, Is.Null);
+        }
+
+        [Test]
+        public void Given_LeadingBracketWithTrailingSpace_When_Parsed_Then_LeadingIsUnsetNull()
+        {
+            // Arrange — a trailing space before the closing bracket breaks the "px"-suffix match itself
+            // (the last two characters become "x ", not "px"), so this is rejected before the numeric
+            // parse even runs.
+            var classNames = new[] { "leading-[24px ]" };
+
+            // Act
+            var effect = StyleTextEffectClass.Parse(classNames);
+
+            // Assert
+            Assert.That(effect.Leading, Is.Null);
+        }
+
+        [Test]
+        public void Given_LeadingBracketClass_When_CheckedForArbitraryLeadingClass_Then_ReturnsTrue()
+        {
+            // Arrange
+            const string cls = "leading-[24px]";
+
+            // Act
+            var isArbitrary = StyleTextEffectClass.IsArbitraryLeadingClass(cls);
+
+            // Assert
+            Assert.That(isArbitrary, Is.True);
+        }
+
+        [Test]
+        public void Given_MalformedLeadingBracketClass_When_CheckedForArbitraryLeadingClass_Then_StillReturnsTrue()
+        {
+            // Arrange — the prefix-only check must exclude a malformed bracket value from the USS class
+            // list too, exactly like a malformed font-[...] never leaks in either (see IsArbitraryLeadingClass).
+            const string cls = "leading-[1.5em]";
+
+            // Act
+            var isArbitrary = StyleTextEffectClass.IsArbitraryLeadingClass(cls);
+
+            // Assert
+            Assert.That(isArbitrary, Is.True);
+        }
+
+        [Test]
+        public void Given_BangPrefixedLeadingBracketClass_When_CheckedForArbitraryLeadingClass_Then_ReturnsTrue()
+        {
+            // Arrange — the important-modifier bang must not defeat this guard: StripImportant strips it
+            // at the 3 guard call sites AFTER this check runs, so the predicate itself has to recognize
+            // the bang'd form or the bare bracket token leaks into the USS class list once the bang is gone.
+            const string cls = "!leading-[24px]";
+
+            // Act
+            var isArbitrary = StyleTextEffectClass.IsArbitraryLeadingClass(cls);
+
+            // Assert
+            Assert.That(isArbitrary, Is.True);
+        }
+
+        [Test]
+        public void Given_LeadingNamedPresetClass_When_CheckedForArbitraryLeadingClass_Then_ReturnsFalse()
+        {
+            // Arrange — a named preset is a plain (non-bracket) token and stays in the USS class list as
+            // an inert token, the same established pattern uppercase/whitespace-pre-line already use.
+            const string cls = "leading-relaxed";
+
+            // Act
+            var isArbitrary = StyleTextEffectClass.IsArbitraryLeadingClass(cls);
+
+            // Assert
+            Assert.That(isArbitrary, Is.False);
+        }
+
+        [Test]
+        public void Given_Null_When_CheckedForArbitraryLeadingClass_Then_ReturnsFalse()
+        {
+            // Act
+            var isArbitrary = StyleTextEffectClass.IsArbitraryLeadingClass(null);
+
+            // Assert
+            Assert.That(isArbitrary, Is.False);
+        }
+
+        [Test]
+        public void Given_LeadingNull_When_Applied_Then_TextUnchanged()
+        {
+            // Arrange — leading defaults to null (off) so every pre-existing 4-arg Apply call site keeps
+            // its behavior.
+
+            // Act
+            var result = StyleTextEffectClass.Apply("hi", null, null, null);
+
+            // Assert
+            Assert.That(result, Is.EqualTo("hi"));
+        }
+
+        [Test]
+        public void Given_EmptyText_When_AppliedWithLeading_Then_StaysEmptyWithNoLineHeightTag()
+        {
+            // Arrange
+            var leading = new LeadingValue(LeadingUnit.Em, 1.625f);
+
+            // Act
+            var result = StyleTextEffectClass.Apply("", null, null, null, leading);
+
+            // Assert
+            Assert.That(result, Is.EqualTo(""));
+        }
+
+        [Test]
+        public void Given_LeadingRelaxedValue_When_Applied_Then_TheEmMultiplierUsesADotDecimalNotComma()
+        {
+            // Arrange — 1.625 (leading-relaxed) has a fractional part, the exact shape a comma-decimal
+            // thread culture would corrupt into "1,625em" (breaking the tag's own numeric grammar) if
+            // InvariantCulture were ever dropped from the ToString call. The ambient culture on any known
+            // dev/CI machine (ja-JP, en-US, ...) already uses a dot, so it would not catch a dropped
+            // InvariantCulture call; de-DE is forced here specifically because its decimal separator is a
+            // comma, making this the one culture whose presence actually discriminates. Restored in
+            // finally so the switch never leaks into another test.
+            var originalCulture = Thread.CurrentThread.CurrentCulture;
+            var originalUiCulture = Thread.CurrentThread.CurrentUICulture;
+            Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo("de-DE");
+            Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo("de-DE");
+            var leading = new LeadingValue(LeadingUnit.Em, 1.625f);
+
+            try
+            {
+                // Act
+                var result = StyleTextEffectClass.Apply("hi", null, null, null, leading);
+
+                // Assert
+                Assert.That(result, Does.Contain("1.625em"));
+            }
+            finally
+            {
+                Thread.CurrentThread.CurrentCulture = originalCulture;
+                Thread.CurrentThread.CurrentUICulture = originalUiCulture;
+            }
+        }
+
+        [Test]
+        public void Given_LeadingWithUppercaseUnderlineAndWhitespacePreLine_When_Applied_Then_LeadingWrapsOutermost()
+        {
+            // Arrange — exercises all four axes together: PreLine collapses the space run first, then
+            // Transform uppercases, then Decoration wraps in <u>, then Leading wraps OUTERMOST last — a
+            // layout property independent of the string's own content, so it never interferes with <u>'s
+            // own nesting.
+            var leading = new LeadingValue(LeadingUnit.Em, 1.625f);
+
+            // Act
+            var result = StyleTextEffectClass.Apply(
+                "hi   there", TextTransformKind.Upper, TextDecorationKind.Underline, WhitespaceCollapseKind.PreLine, leading);
+
+            // Assert
+            Assert.That(result, Is.EqualTo("<line-height=1.625em><u>HI THERE</u></line-height>"));
         }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/StyleTextEffectPanelTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/StyleTextEffectPanelTests.cs
@@ -30,6 +30,9 @@ namespace Velvet.Tests
         private static StateUpdater<string> s_setPreLineText;
         private static StateUpdater<string> s_setUppercaseRefText;
         private static StateUpdater<string> s_setCascadeParentClass;
+        private static StateUpdater<string> s_setLeadingAncestorClass;
+        private static StateUpdater<string> s_setLeadingText;
+        private static StateUpdater<string> s_setLeadingPoolReuseState;
 
         protected override Rect WindowSize => new Rect(0, 0, 400, 400);
 
@@ -43,6 +46,9 @@ namespace Velvet.Tests
             s_setPreLineText = default;
             s_setUppercaseRefText = default;
             s_setCascadeParentClass = default;
+            s_setLeadingAncestorClass = default;
+            s_setLeadingText = default;
+            s_setLeadingPoolReuseState = default;
             base.SetUp();
         }
 
@@ -381,6 +387,102 @@ namespace Velvet.Tests
             Assert.That((recycled.style.whiteSpace.keyword, recycled.text), Is.EqualTo((StyleKeyword.Null, "c   d")));
         }
 
+        [Test]
+        public void Given_LeadingRelaxedOnParent_When_Mounted_Then_ChildTextLeafGetsTheLineHeightTag()
+        {
+            // Arrange & Act — the text leaf has no class; leading cascades from the parent, mirroring how
+            // transform/decoration cascade from an ancestor onto a class-less V.Text leaf.
+            var label = MountAndFindLabel(V.Div(className: "leading-relaxed", V.Text("hi")));
+
+            // Assert
+            Assert.That(label.text, Is.EqualTo("<line-height=1.625em>hi</line-height>"));
+        }
+
+        [Test]
+        public void Given_NearerAncestorLeadingOverridesFartherAncestorLeading_When_Mounted_Then_ChildLeafUsesNearerValue()
+        {
+            // Arrange & Act — outer leading-loose (2), inner leading-tight (1.25) — the nearer ancestor's
+            // own token wins, mirroring how a nearer normal-case overrides a farther uppercase.
+            var label = MountAndFindLabel(
+                V.Div(className: "leading-loose", V.Div(className: "leading-tight", V.Text("hi"))));
+
+            // Assert
+            Assert.That(label.text, Is.EqualTo("<line-height=1.25em>hi</line-height>"));
+        }
+
+        [Test]
+        public void Given_LeafOwnLeadingUnderAncestorLeading_When_Mounted_Then_LeafOwnValueWins()
+        {
+            // Arrange & Act — the Label itself carries leading-none while its ancestor carries
+            // leading-loose; ResolveEffective starts its walk at the leaf itself, so the leaf's own token
+            // is the first (and winning) one found, exactly like Transform/Decoration's own-vs-inherited
+            // precedence.
+            var label = MountAndFindLabel(
+                V.Div(className: "leading-loose", V.Label(className: "leading-none", text: "hi")));
+
+            // Assert
+            Assert.That(label.text, Is.EqualTo("<line-height=1em>hi</line-height>"));
+        }
+
+        [Test]
+        public void Given_AncestorLeadingClassRemoved_When_DescendantTextUnchanged_Then_DescendantRevertsToRaw()
+        {
+            // Mirrors the same gate Transform/Whitespace pin above: a patch that removes the LAST
+            // effect-bearing class from an ancestor (its own effect goes from non-empty to empty) must
+            // still re-walk descendants — a leaf whose own text prop is unchanged is never re-resolved by
+            // anything else (PatchText only calls OnTextSet when the text prop itself changes), so without
+            // the walk it would keep showing the stale line-height tag forever.
+            Mount(V.Component(RenderLeadingAncestorToggle));
+            Assume.That(_window.rootVisualElement.Q<Label>().text, Is.EqualTo("<line-height=1.625em>hi</line-height>"),
+                "Precondition: initial leading");
+
+            s_setLeadingAncestorClass.Invoke("");
+            _mounted.Root.Reconciler.Context.BatchScheduler.DrainImmediateForTest();
+
+            Assert.That(_window.rootVisualElement.Q<Label>().text, Is.EqualTo("hi"));
+        }
+
+        [Test]
+        public void Given_LeadingParent_When_TextChanges_Then_NewTextCarriesTheTag()
+        {
+            // A text change must re-cascade leading onto the leaf, from the new raw value, mirroring how
+            // Transform re-wraps a changed leaf (Given_UppercaseParent_When_TextChanges_...).
+            Mount(V.Component(RenderLeadingCard));
+            Assume.That(_window.rootVisualElement.Q<Label>().text, Is.EqualTo("<line-height=1.625em>hi</line-height>"),
+                "Precondition: initial leading");
+
+            s_setLeadingText.Invoke("there");
+            _mounted.Root.Reconciler.Context.BatchScheduler.DrainImmediateForTest();
+
+            Assert.That(_window.rootVisualElement.Q<Label>().text, Is.EqualTo("<line-height=1.625em>there</line-height>"));
+        }
+
+        [Test]
+        public void Given_LabelPooledWithLeadingState_When_RentedAgainWithoutTheClass_Then_NewLabelHasNoLineHeightTag()
+        {
+            // Arrange — mount a leading-loose Label, then hide it (a Label -> Div swap removes it,
+            // returning it to VNodePool while its text still carries the <line-height> tag), then show a
+            // different, unrelated plain label. VNodePool's Label pool is LIFO and nothing else rents a
+            // Label in between, so this deterministically hands the same instance back, mirroring the
+            // PreLine pool-reuse mechanism.
+            Mount(V.Component(RenderLeadingPoolReuseHost));
+            var scheduler = _mounted.Root.Reconciler.Context.BatchScheduler;
+            Assume.That(_window.rootVisualElement.Q<Label>("leaf").text, Is.EqualTo("<line-height=2em>hi</line-height>"),
+                "Precondition: the first label carries the line-height tag");
+            s_setLeadingPoolReuseState.Invoke("hidden");
+            scheduler.DrainImmediateForTest();
+            Assume.That(_window.rootVisualElement.Q<Label>("leaf"), Is.Null, "Precondition: the label is pooled while hidden");
+
+            // Act — an unrelated plain label rents the pooled instance back.
+            s_setLeadingPoolReuseState.Invoke("plain");
+            scheduler.DrainImmediateForTest();
+
+            // Assert — the recycled instance carries no leftover line-height tag from the previous
+            // consumer's side-table entry (a ghosted TextEffects/TextRawText row would still show a
+            // wrapped tag here, not the fixture's raw "there").
+            Assert.That(_window.rootVisualElement.Q<Label>("leaf").text, Is.EqualTo("there"));
+        }
+
         private void Mount(VNode tree)
         {
             _mounted = V.Mount(_window.rootVisualElement, tree);
@@ -479,6 +581,41 @@ namespace Velvet.Tests
             if (state == "plain")
             {
                 return V.Label(name: "leaf", text: "c   d");
+            }
+            return V.Div(name: "placeholder");
+        }
+
+        [Component]
+        private static VNode RenderLeadingAncestorToggle()
+        {
+            // Unlike a same-element toggle, the class-bearing element and the text leaf are DIFFERENT
+            // elements (a Div ancestor, a separate V.Text child) — the shape ApplyToDescendants guards,
+            // mirroring RenderPreLineAncestorToggle / RenderUppercaseAncestorToggle above.
+            var (cls, setCls) = Hooks.UseState("leading-relaxed");
+            s_setLeadingAncestorClass = setCls;
+            return V.Div(className: cls, V.Text("hi"));
+        }
+
+        [Component]
+        private static VNode RenderLeadingCard()
+        {
+            var (text, setText) = Hooks.UseState("hi");
+            s_setLeadingText = setText;
+            return V.Div(className: "leading-relaxed", V.Text(text));
+        }
+
+        [Component]
+        private static VNode RenderLeadingPoolReuseHost()
+        {
+            var (state, setState) = Hooks.UseState("leading");
+            s_setLeadingPoolReuseState = setState;
+            if (state == "leading")
+            {
+                return V.Label(name: "leaf", className: "leading-loose", text: "hi");
+            }
+            if (state == "plain")
+            {
+                return V.Label(name: "leaf", text: "there");
             }
             return V.Div(name: "placeholder");
         }

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/PlayMode/LeadingLineHeightPlaybackTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/PlayMode/LeadingLineHeightPlaybackTests.cs
@@ -1,0 +1,108 @@
+using System.Collections;
+using NUnit.Framework;
+using UnityEngine.TestTools;
+using UnityEngine.UIElements;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// The runtime layout proof for leading-* (line-height): a wrapped Label's MEASURED height depends on
+    /// the native text generator actually running a multi-line layout pass keyed off the
+    /// <c>&lt;line-height=X&gt;</c> tag — unlike the box-model reads other EditMode panel fixtures force via
+    /// the panel's ApplyStyles/UpdateForRepaint reflection helpers (<c>FlexDefaultDirectionParityTests</c>,
+    /// <c>ResponsiveBreakpointPanelTests</c>), no existing EditMode fixture in this codebase has ever
+    /// exercised that measurement (the whitespace-* resolved-style fixtures only assert the
+    /// <c>WhiteSpace</c> enum, never a measured height), so there is no precedent that the reflection trick
+    /// actually drives text shaping that far. Rather than gamble on that, this proves it on a REAL ticking
+    /// runtime panel instead, where a UIDocument's PlayerLoop-driven layout pass is exactly what a shipped
+    /// game already relies on. A weaker EditMode string-level pin (the tag text itself, not a measured
+    /// height) lives alongside the other three axes in <c>StyleTextEffectClassTests</c> /
+    /// <c>StyleTextEffectPanelTests</c>.
+    /// <para/>
+    /// Forces a width narrow enough to wrap the SAME long sentence into several lines at the SAME font size
+    /// for both labels: line-height changes the vertical advance BETWEEN lines, not a glyph's own
+    /// horizontal advance, so the wrap boundaries — and therefore the line count — are identical for both;
+    /// only the resulting total height differs. leading-none (1) and leading-loose (2) are used for maximum
+    /// contrast against measurement/rounding noise, and a short, unconstrained reference label (guaranteed
+    /// single-line) is used as an Assume precondition that the two long labels actually wrapped at all.
+    /// </summary>
+    internal sealed class LeadingLineHeightPlaybackTests
+    {
+        private const string WrappingText =
+            "Velvet renders declarative user interfaces for Unity UI Toolkit using familiar React style " +
+            "components and hooks throughout the entire framework";
+
+        // A themeless RenderTexture panel provides neither a font (empty runtime theme — every label
+        // measures 0 tall without one) nor the wrap behavior (a Label's own default style is nowrap, and
+        // no stylesheet is loaded here since leading-*/w-[...]/text-[...] are all inline-resolved), so
+        // both are supplied inline through the ref — the one channel that reaches a bare panel.
+        private static readonly System.Func<VisualElement, System.Action> s_enableTextMeasurement = el =>
+        {
+            el.style.whiteSpace = WhiteSpace.Normal;
+            el.style.unityFontDefinition = new StyleFontDefinition(FontDefinition.FromFont(
+                UnityEngine.Resources.GetBuiltinResource<UnityEngine.Font>("LegacyRuntime.ttf")));
+            return null;
+        };
+
+        private RenderTexturePanelHost _host;
+        private MountedTree _mounted;
+
+        [UnityTearDown]
+        public IEnumerator UnityTearDown()
+        {
+            _mounted?.Dispose();
+            _mounted = null;
+            _host?.Dispose();
+            _host = null;
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator Given_TwoWrappedLabelsDifferingOnlyInLeading_When_ARealPanelTicks_Then_TheLooserLeadingMeasuresTaller()
+        {
+            // Arrange — identical text, font size, and width; only leading-* differs between "tight" and
+            // "loose". "reference" carries the same font size and leading as "tight" but no width
+            // constraint, so it stays a single line — the precondition baseline proving the other two
+            // actually wrapped across multiple lines instead of measuring one line each (which would make
+            // the main assertion below true only by accident, not by the mechanism under test).
+            _host = new RenderTexturePanelHost("LeadingPlayback", 300, 1000);
+            _mounted = V.Mount(_host.Root, V.Div(children: new VNode[]
+            {
+                V.Label(name: "tight", className: "leading-none text-[16px] w-[140px]", text: WrappingText,
+                    refCallback: s_enableTextMeasurement),
+                V.Label(name: "loose", className: "leading-loose text-[16px] w-[140px]", text: WrappingText,
+                    refCallback: s_enableTextMeasurement),
+                V.Label(name: "reference", className: "leading-none text-[16px]", text: "x",
+                    refCallback: s_enableTextMeasurement),
+            }));
+            var tight = _host.Root.Q<Label>("tight");
+            var loose = _host.Root.Q<Label>("loose");
+            var reference = _host.Root.Q<Label>("reference");
+            Assume.That((tight != null, loose != null, reference != null), Is.EqualTo((true, true, true)),
+                "Precondition: all three labels mounted");
+
+            // Act — let the panel actually tick layout across several real frames (generous margin: a
+            // first-time text-shaping pass — font/glyph-atlas population plus the actual line-wrap — is
+            // heavier than the single-property resolves other playback fixtures settle in 1-2 frames).
+            yield return null;
+            yield return null;
+            yield return null;
+            yield return null;
+            yield return null;
+
+            // The three heights stay in the message (unlike a plain static precondition): a wrap failure
+            // here is otherwise opaque — no way to tell a font-less 0-height measurement from a genuine
+            // single-line non-wrap without seeing all three numbers side by side.
+            Assume.That(
+                (tight.resolvedStyle.height > reference.resolvedStyle.height,
+                    loose.resolvedStyle.height > reference.resolvedStyle.height),
+                Is.EqualTo((true, true)),
+                $"Precondition: both constrained labels wrapped (tight h={tight.resolvedStyle.height}, "
+                + $"loose h={loose.resolvedStyle.height}, reference h={reference.resolvedStyle.height})");
+
+            // Assert
+            Assert.That(loose.resolvedStyle.height, Is.GreaterThan(tight.resolvedStyle.height));
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/PlayMode/LeadingLineHeightPlaybackTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/PlayMode/LeadingLineHeightPlaybackTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ee8c6985c2ec74cbf97c76f280072b0f


### PR DESCRIPTION
## What

Tailwind `leading-*` (line-height) utilities (#95): the six named presets (`leading-none/tight/snug/normal/relaxed/loose` → 1 / 1.25 / 1.375 / 1.5 / 1.625 / 2) and the bracket form `leading-[Npx]`.

## How

USS has no line-height property (and the text generation settings' line-spacing field is a compiled-in dead constant), but a decompile pass established that **both** text generator backends fully implement a rich-text line-height tag with px/em forms, feeding real line-advance math at every break site. So `leading-*` rides the display-string rewrite subsystem as a fourth axis beside `text-transform` / `text-decoration` / the whitespace collapse:

- The processed string is wrapped outermost in the tag; presets emit **em multipliers**, which the engine resolves against the font size in effect at generation time — so they compose with any `text-*` size (own or inherited) with **no baked pixel table**, unlike `tracking-*`, which is exact only at the default size.
- Inheritance and nearest-ancestor override ride the same ancestor walk as the other axes.
- The multiplier is stringified with invariant culture — a comma-decimal locale cannot corrupt the tag (pinned by a test that forces a comma-decimal culture around the act).
- `leading-[Npx]` is excluded from the USS class list at the same sites as `font-[...]`; both exclusion predicates now also recognize an important bang on either end, closing a pre-existing gap where a bang-prefixed bracket token leaked into the live class list as a dead entry.

## Tests

- Pure units: all six preset→tag mappings, bracket px form, malformed brackets inert (negative / empty / no number / trailing space), nesting order with all four axes combined, the comma-locale invariance pin, predicate tests incl. bang forms.
- Panel (EditMode): cascade to a descendant leaf, nearer-ancestor override, own-class wins, ancestor-class removal reverts the leaf, text-change re-applies the tag, pooled-element reuse shows no tag ghosting.
- PlayMode (real `UIDocument` panel): two wrapped labels identical except `leading-none` vs `leading-loose` measure different heights — proving the tag drives the engine's actual line layout, not just the string. (The themeless test panel supplies a builtin font and wrap mode inline, since an empty runtime theme measures all text at zero height.)

3118/3118 EditMode and 84/84 PlayMode tests pass locally.

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)