### PR TITLE
feat(velvet): approximate text-balance via a measure-and-narrow manipulator

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `text-balance` approximates CSS `text-wrap: balance` on a `TextElement` (Label / Button / …). UI
+  Toolkit's text engine exposes no line-break hook, so `StyleTextBalanceManipulator` narrows the box
+  instead: it binary-searches the public `TextElement.MeasureTextSize` — the same method the engine's own
+  autosize pass already calls — for the narrowest inline `maxWidth` that keeps the measured height at or
+  under a normal (unbalanced) layout's height at the same available width, so the existing line count
+  redistributes more evenly instead of leaving a near-empty last line. Applied only when the text actually
+  wraps to 2+ lines; a single-line label's box is left untouched, matching CSS balance being a no-op
+  there. Unlike real `text-wrap: balance`, this approximation can shrink the element's own box (narrowing
+  via `maxWidth` rather than only moving line breaks within a fixed box) — the full deviation writeup is
+  in `Documentation~/fonts.md`. Needs a wrapping white-space (`text-wrap` / `whitespace-normal`, …)
+  alongside it — Velvet's `Label` default is `nowrap`, so `text-balance` alone is a no-op there.
 - `Hooks.UseFrame` gains a `priority` parameter — r3f's `useFrame(callback, renderPriority)` ordering
   parity. Lower runs earlier within the same panel; equal priorities fall back to subscription (mount)
   order. Backing this, per-frame callbacks now subscribe to a single per-panel dispatcher instead of

--- a/Packages/com.velvet.core/Documentation~/fonts.md
+++ b/Packages/com.velvet.core/Documentation~/fonts.md
@@ -106,9 +106,9 @@ them (not a Velvet decision).
 **Supported (shipped):** `font-<family>` / `font-thin`…`font-black` / `italic` / `not-italic` /
 `text-xs`…`text-4xl` (font-size) / `text-left|center|right|start|end` (`-unity-text-align`) /
 `tracking-*` (`letter-spacing`) / `whitespace-normal|nowrap|pre|pre-wrap|pre-line` /
-`text-wrap` / `text-nowrap` / `truncate` / `text-ellipsis` / `text-clip` (`text-overflow: ellipsis | clip`) /
-text color / `uppercase` `lowercase` `capitalize` `normal-case` (text-transform) /
-`underline` `line-through` `no-underline` (text-decoration).
+`text-wrap` / `text-nowrap` / `text-balance` / `truncate` / `text-ellipsis` / `text-clip`
+(`text-overflow: ellipsis | clip`) / text color / `uppercase` `lowercase` `capitalize` `normal-case`
+(text-transform) / `underline` `line-through` `no-underline` (text-decoration).
 
 **Text-transform / text-decoration are realised by mutating the displayed text** (UI Toolkit has no property
 for either): the string is upper/lower/title-cased, and underline / line-through wrap it in the `<u>` / `<s>`
@@ -133,6 +133,61 @@ over a text-mutating one is the less surprising outcome), and — exactly like h
 `whitespace-pre-line` from reaching that subtree at all, rather than merely leaving the collapse unapplied
 on that one element.
 
+**`text-balance`** approximates CSS `text-wrap: balance` even though UI Toolkit's text engine exposes no
+line-break hook at all (there is no way to influence *where* a line wraps). `StyleTextBalanceManipulator`
+sidesteps that by not touching line breaks: it binary-searches the public
+`TextElement.MeasureTextSize(text, width, widthMode, height, heightMode)` — the same method the engine's
+own autosize pass already calls — for the **narrowest inline `maxWidth`** that keeps the measured height
+at or under the height a normal (unbalanced) layout would take at the element's available width. Since
+font metrics are constant across candidates, comparing heights stands in for comparing line counts: a
+width narrow enough to add a line always measures taller and is rejected. The result reads more evenly
+than a near-empty last line, the same visual goal as the real CSS feature.
+
+Two deviations from CSS, both documented on the manipulator itself and worth knowing before reaching for
+this class:
+
+- **The box can shrink.** Real `text-wrap: balance` never resizes the element — only where its lines
+  break. This approximation instead narrows the box via `maxWidth`, so anything sized from that box (a
+  background, alignment relative to it) reads against a smaller box than an unbalanced sibling would
+  have. Applied only when the text actually wraps to 2+ lines (see below), so a single-line label's box
+  is never touched.
+- **`maxWidth` is measured against the PARENT's content width**, not the element's own — reading the
+  element's own already-narrowed width back would ratchet it narrower every pass instead of converging.
+  This is exact when the element is its parent's sole / stretch-to-fill child (the common
+  paragraph/heading usage) and an over-estimate when siblings share the row or the element carries its
+  own narrower `max-w-*`. An over-estimate only makes balancing less aggressive (it never widens the box
+  past what normal layout already gives it), so the deviation is a conservative under-balance, never a
+  wrong one. `text-balance` otherwise owns the element's inline `maxWidth` outright while its class is
+  present — a co-present `max-w-*` utility on the same element is overwritten, the same ownership rule
+  `grid-cols-*` applies to a column's width — and that ownership is enforced every patch (not just once at
+  attach), so a `max-w-*` value that changes in the same render as a still-present `text-balance` is
+  re-overwritten before the render ends. Removing the `text-balance` class instead RESTORES a co-present
+  `max-w-*` utility's own value rather than leaving `maxWidth` cleared.
+
+**Prerequisite — needs a wrapping white-space too:** Velvet's `Label` ships with no bundled base
+white-space rule, so its engine default is `nowrap`. `text-balance` alone is therefore a **silent no-op**
+on a default `Label` — pair it with `text-wrap` / `whitespace-normal` (or another wrapping white-space)
+for it to have any effect.
+
+**Single-line gate:** CSS balance is a no-op on one line, and since this approximation instead shrinks the
+box, applying it to single-line text would shrink that box for no CSS-parity benefit. The manipulator
+only writes a narrower `maxWidth` when the natural height at the available width exceeds the text's
+unconstrained single-line height (2+ lines); otherwise any previously-applied `maxWidth` is cleared. An
+element with `white-space: nowrap` reaches the same "single line" outcome through this same comparison
+(`MeasureTextSize` already measures against the element's own resolved white-space), so no separate check
+is needed for it — this is also why the prerequisite above is silent rather than a thrown error: nowrap
+text always measures as "single line" and the gate above clears (or never writes) a `maxWidth` for it.
+
+**Staleness:** the manipulator re-derives on attach; on its own `GeometryChangedEvent`; on a listener on
+the PARENT's `GeometryChangedEvent` (needed because the manipulator's own `maxWidth` write pins the
+element's resolved size, so an ancestor WIDENING never changes the element's own rect and would otherwise
+never re-fire the search — listening on the parent directly, the same element the available width is read
+from, closes that gap); and on the `ChangeEvent<string>` UI Toolkit raises whenever `.text` is reassigned
+on a live element (covers a text swap that happens to keep the same wrapped box size, and therefore raises
+no geometry event, from going stale). What's left uncovered: a resize confined entirely to a `ScrollView`
+parent's own content viewport with no accompanying change to the `ScrollView`'s own outer rect (e.g. a
+scrollbar toggling) — a narrower edge case than the ancestor-resize gap the parent listener closes.
+
 **Not expressible in UI Toolkit (no USS property — intentionally absent):**
 
 | Tailwind | Why omitted |
@@ -142,7 +197,7 @@ on that one element.
 | `antialiased` / `subpixel-antialiased` (font-smoothing) | Text renders as SDF alpha-blend only — no antialiasing-mode axis to switch |
 | `font-stretch-*` | No variable-font / width-axis support |
 | `tabular-nums` etc. (font-variant-numeric) | No OpenType feature-substitution slot in the runtime font pipeline |
-| `text-balance` / `text-pretty` | Browser line-breaking heuristics (best-fit paragraph shaping); UI Toolkit's text generator has no such heuristic to opt into |
+| `text-pretty` | Also a browser line-breaking heuristic, and a distinct one from `balance` (avoids orphans without redistributing every line) — not aliased to `text-balance` since the two have different goals; unsupported for now |
 
 None of the font-smoothing / font-stretch / font-variant-numeric rows above are reproducible at runtime by
 any class or `refCallback` — there is no engine hook to flip. Where the *look* matters (tabular figures in a

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberElementCleaner.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberElementCleaner.cs
@@ -243,6 +243,7 @@ namespace Velvet
             DetachManipulator(element, _ctx.GapManipulators);
             DetachManipulator(element, _ctx.DivideManipulators);
             DetachManipulator(element, _ctx.GridManipulators);
+            DetachManipulator(element, _ctx.TextBalanceManipulators);
             DetachManipulator(element, _ctx.ChildVariantManipulators);
             // Drop the arbitrary-value layer stack so a pooled widget does not inherit a prior consumer's
             // base/variant layers (state ghosting across pool reuse).

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodeFactory.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodeFactory.cs
@@ -100,6 +100,7 @@ namespace Velvet
                     _patcher.ApplyGapManipulator(element, elementNode.ClassNames);
                     _patcher.ApplyDivideManipulator(element, elementNode.ClassNames);
                     _patcher.ApplyGridManipulator(element, elementNode.ClassNames);
+                    _patcher.ApplyTextBalanceManipulator(element, elementNode.ClassNames);
                     // Same post-children timing: structural variants (first:/last:/odd:/…) need the placed children.
                     _patcher.ApplyStructuralVariants(element);
                     // has-[.class]: (element as subject) likewise needs the placed children to scan.
@@ -314,6 +315,7 @@ namespace Velvet
                     _patcher.ApplyGapManipulator(element, appliedClasses);
                     _patcher.ApplyDivideManipulator(element, appliedClasses);
                     _patcher.ApplyGridManipulator(element, appliedClasses);
+                    _patcher.ApplyTextBalanceManipulator(element, appliedClasses);
                     _patcher.ApplyStructuralVariants(element);
                     _patcher.ApplyHasClassVariants(element);
                     _patcher.ApplyHasVariantManipulators(element);

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
@@ -277,6 +277,9 @@ namespace Velvet
         //   margins (-gap/2) — and so it re-applies against the current child set (a child add / remove
         //   re-spaces even when the className did not change). Divide / grid follow at the same timing
         //   for the same child-set reason.
+        // - text-balance follows at the same slot for consistency (every per-element style manipulator
+        //   attaches from one place), though its own ordering is not load-bearing: it measures the
+        //   element's own text, not a shared child edge or the child set.
         // - Structural variants (first:/last:/nth) re-derive every child's position-based match from the
         //   final sibling order.
         // - has-[.class]: re-evaluated with the element AS subject (its descendants drive its own payload),
@@ -301,6 +304,10 @@ namespace Velvet
             ApplyGapManipulator(element, classNames);
             ApplyDivideManipulator(element, classNames);
             ApplyGridManipulator(element, classNames);
+            // text-balance reads no shared child edge and no child set at all (it measures the element's
+            // OWN text), so its position relative to the trio above is not load-bearing — attached here
+            // only to keep every per-element style manipulator wired from one place.
+            ApplyTextBalanceManipulator(element, classNames);
             ApplyStructuralVariants(element);
             ApplyHasClassVariants(element);
             ApplyHasVariantManipulators(element);
@@ -2315,6 +2322,47 @@ namespace Velvet
                 var manipulator = new StyleGridManipulator(spec);
                 element.AddManipulator(manipulator);
                 _ctx.GridManipulators[element] = manipulator;
+            }
+        }
+
+        // Configures the element's StyleTextBalanceManipulator from the `text-balance` token in
+        // classNames. Unlike Gap/Grid/Divide, text-balance carries no per-element spec value to diff (it
+        // is a bare flag the manipulator re-derives entirely from its own events) — but it still needs an
+        // "update existing manipulator" branch that runs every patch: Refresh() forces a full re-derive so
+        // text-balance re-wins its inline maxWidth slot even when a co-present max-w-* utility's inline
+        // write — applied earlier in this SAME patch by DiffClassList/ApplyClassNames — changed value
+        // without anything the manipulator's own events would otherwise catch. Mirrors
+        // ApplyGapManipulator's timing — call AFTER the container's children have been reconciled
+        // (harmless here since text-balance does not read children, but keeps every per-element style
+        // manipulator attached at the same, single, well-known point in the pass).
+        internal void ApplyTextBalanceManipulator(VisualElement element, string[] classNames)
+        {
+            // Fast early-out for the ~99% of elements with no text-balance class and no existing manipulator.
+            if (!StyleTextBalanceClass.HasTextBalanceClass(classNames))
+            {
+                if (_ctx.TextBalanceManipulators.TryGetValue(element, out var stale))
+                {
+                    element.RemoveManipulator(stale);
+                    _ctx.TextBalanceManipulators.Remove(element);
+                    // Detach unconditionally nulls the shared maxWidth slot text-balance owned while
+                    // present; restore a co-present max-w-* utility's own value the same way a detached
+                    // Hue/Pulse motion's shared inline slot is restored
+                    // (FiberWrapperElementAppliers.RestoreSharedInlineSlot) — otherwise removing JUST the
+                    // text-balance token would also erase an unrelated max-width the element still carries.
+                    ReapplyArbitraryValues(element, classNames);
+                }
+                return;
+            }
+
+            if (_ctx.TextBalanceManipulators.TryGetValue(element, out var existing))
+            {
+                existing.Refresh();
+            }
+            else
+            {
+                var manipulator = new StyleTextBalanceManipulator();
+                element.AddManipulator(manipulator);
+                _ctx.TextBalanceManipulators[element] = manipulator;
             }
         }
 

--- a/Packages/com.velvet.core/Runtime/Reconciler/Reconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Reconciler.cs
@@ -616,6 +616,12 @@ namespace Velvet
             }
 
             _ctx.GridManipulators.Clear();
+            foreach (var (element, manipulator) in _ctx.TextBalanceManipulators)
+            {
+                element.RemoveManipulator(manipulator);
+            }
+
+            _ctx.TextBalanceManipulators.Clear();
             foreach (var (element, manipulator) in _ctx.ChildVariantManipulators)
             {
                 element.RemoveManipulator(manipulator);

--- a/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
@@ -255,6 +255,9 @@ namespace Velvet
         public Dictionary<VisualElement, StyleGapManipulator> GapManipulators { get; } = new();
         public Dictionary<VisualElement, StyleDivideManipulator> DivideManipulators { get; } = new();
         public Dictionary<VisualElement, StyleGridManipulator> GridManipulators { get; } = new();
+        // text-balance's per-element measure-and-narrow manipulator. Mirrors GapManipulators /
+        // GridManipulators; removed on cleanup / dispose.
+        public Dictionary<VisualElement, StyleTextBalanceManipulator> TextBalanceManipulators { get; } = new();
 
         // Per-divided-child dashed / dotted divider paint (divide-dashed / divide-dotted), keyed by the CHILD
         // element (not the container) — the divider is painted on the child's own generateVisualContent, since

--- a/Packages/com.velvet.core/Runtime/Styles/_typography.uss
+++ b/Packages/com.velvet.core/Runtime/Styles/_typography.uss
@@ -81,8 +81,11 @@
 .whitespace-pre-wrap { white-space: pre-wrap; }
 
 /* Text wrap aliases (Tailwind: text-wrap / text-nowrap). text-balance / text-pretty are browser
-   line-breaking HEURISTICS (best-fit paragraph shaping), not a white-space value, so UI Toolkit's text
-   generator has nothing to opt into and they are intentionally omitted regardless of white-space's range. */
+   line-breaking HEURISTICS (best-fit paragraph shaping), not a white-space value, so there is no rule
+   for either here. text-pretty has no UI Toolkit hook and is intentionally omitted. text-balance DOES
+   have a class-facing effect, but not through USS: StyleTextBalanceManipulator approximates it in C# by
+   binary-searching TextElement.MeasureTextSize for the narrowest inline maxWidth that keeps the same
+   line count — see StyleTextBalanceManipulator.cs and Documentation~/fonts.md. */
 .text-wrap { white-space: normal; }
 .text-nowrap { white-space: nowrap; }
 

--- a/Packages/com.velvet.core/Runtime/Styling/StyleTextBalanceClass.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleTextBalanceClass.cs
@@ -1,0 +1,28 @@
+namespace Velvet
+{
+    // Recognizes Tailwind's `text-balance` utility for StyleTextBalanceManipulator. Unlike gap-* /
+    // grid-cols-*, text-balance carries no scale or arbitrary-value form — it is a bare, parameterless
+    // flag — so the classifier is a single exact-match scan rather than a prefix + TryExtract pair.
+    internal static class StyleTextBalanceClass
+    {
+        private const string ClassName = "text-balance";
+
+        // Cheap early-out gate: true when classNames carries the exact `text-balance` token. No
+        // allocation — used to skip manipulator attach/lookup on the common element with no such class.
+        public static bool HasTextBalanceClass(string[] classNames)
+        {
+            if (classNames == null)
+            {
+                return false;
+            }
+            foreach (var cls in classNames)
+            {
+                if (cls == ClassName)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Styling/StyleTextBalanceClass.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleTextBalanceClass.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2a4385d7356cd4437b4a55e5408b8882

--- a/Packages/com.velvet.core/Runtime/Styling/StyleTextBalanceManipulator.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleTextBalanceManipulator.cs
@@ -1,0 +1,355 @@
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace Velvet
+{
+    // Framework-level approximation of CSS `text-wrap: balance` for a TextElement (Label / Button / …)
+    // carrying the `text-balance` class. UI Toolkit's text engine exposes no line-break hook — there is
+    // no way to influence WHERE a line wraps — so balance cannot be realized the way a browser does it
+    // (re-flowing line breaks within a fixed box). Instead this manipulator narrows the box itself:
+    // TextElement.MeasureTextSize(text, width, widthMode, height, heightMode) is the same public method
+    // the engine's own measure callback (TextElement.DoMeasure) already calls every autosize pass, so a
+    // bounded binary search over it — a handful of calls — costs the same order of work UI Toolkit
+    // already pays, and:
+    //   1. measures the natural height at the element's available width (the height a normal, unbalanced
+    //      layout would take);
+    //   2. binary-searches the NARROWEST width that keeps the measured height at or under that natural
+    //      height (font metrics are constant across candidates, so comparing HEIGHTS is a stand-in for
+    //      comparing line counts — a narrower width that adds a line always measures taller);
+    //   3. writes that width as an inline `maxWidth`, so the box shrinks and the same text redistributes
+    //      across its existing line count more evenly instead of leaving a near-empty last line.
+    //
+    // Deviation from CSS (documented, not solved): real `text-wrap: balance` never changes the box's own
+    // width — only where lines break inside it. Our approximation narrows the box via `maxWidth`, so the
+    // element's outer width (and anything sized from it — a background, a sibling relying on its bounds)
+    // can shrink on balanced multi-line text, and text alignment then reads relative to that SMALLER box
+    // rather than the original one. See Documentation~/fonts.md for the full writeup.
+    //
+    // The available-width problem. The width to balance AGAINST is the box's width BEFORE this
+    // manipulator's own constraint — but this manipulator is the thing that writes the element's OWN
+    // maxWidth, so target.contentRect.width is self-contaminated the moment a narrower maxWidth has
+    // already taken effect: re-deriving "natural" from an already-balanced width would ratchet narrower
+    // every pass instead of converging. StyleGridManipulator sidesteps the analogous problem by reading a
+    // width it never writes (the container's, while it sizes the CHILDREN) — this manipulator mirrors
+    // that discipline by reading the PARENT's contentRect (never written by this manipulator) minus the
+    // target's own resolved horizontal margin, instead of the target's own contentRect. This is exact
+    // when the target is the parent's sole / stretch-to-fill child (the common paragraph/heading case)
+    // and an OVER-estimate when siblings share the row or the target carries its own narrower width /
+    // max-width utility — but an over-estimate only makes the search less aggressive (maxWidth resolves
+    // wide enough to never bind, so the box falls back to whatever flex would have given it anyway); it
+    // never widens the box past what normal layout would already produce, so the deviation is a
+    // conservative under-balance, not a wrong one. text-balance therefore OWNS the element's inline
+    // maxWidth outright while its class is present — like StyleGridManipulator owns a column's width — so
+    // a co-present max-w-* utility's inline write is overwritten. Unlike a one-time attach-time overwrite,
+    // this ownership is enforced every patch: FiberNodePatcher.ApplyTextBalanceManipulator calls Refresh()
+    // on an already-attached manipulator on every pass where the class remains present (mirroring
+    // StyleGridManipulator.UpdateSpec / StyleGapManipulator.UpdateGap), so a same-patch max-w-* write that
+    // lands earlier in the same pass (DiffClassList / ApplyClassNames apply class-driven inline styles
+    // before this manipulator runs) is always re-overwritten before the patch ends, rather than sitting
+    // exposed until an unrelated geometry event happens to fire. Ownership ends when the text-balance
+    // class itself is removed: the teardown that clears the inline maxWidth then restores a co-present
+    // max-w-* utility's own value via FiberNodePatcher.ReapplyArbitraryValues — the same shared-inline-slot
+    // restore FiberWrapperElementAppliers.RestoreSharedInlineSlot performs after detaching a Hue/Pulse
+    // motion — so removing just the text-balance token does not also erase an unrelated max-width the
+    // element still carries.
+    //
+    // Single-line gate. CSS balance is a visual no-op on a single line. Since this approximation instead
+    // shrinks the box, applying it to a single line would shrink a label to its tight text width and
+    // change its box (background, centering-within-box) for no CSS-parity benefit — so Apply only writes
+    // a narrower maxWidth when the text actually wraps (natural height at the available width exceeds the
+    // unconstrained single-line height); otherwise any previously-written inline maxWidth is cleared.
+    // Feeding a nowrap element through the same comparison naturally reaches the same "single line"
+    // verdict without a separate white-space check, because MeasureTextSize already accounts for the
+    // element's own resolved white-space when it measures.
+    //
+    // Prerequisite: Velvet's Label ships with no bundled base white-space rule, so its engine default is
+    // nowrap. text-balance alone is therefore a silent no-op on a default Label — it also needs
+    // `text-wrap` / `whitespace-normal` (or another wrap-enabling white-space) applied, or MeasureTextSize
+    // reaches the single-line gate above on every measurement regardless of the text's length.
+    //
+    // Re-application / staleness. Re-derives on: AttachToPanelEvent (first resolve, and re-resolve after
+    // a reparent that lands on an already-appropriately-sized rect with no fresh GeometryChangedEvent);
+    // GeometryChangedEvent on the TARGET (the target's own resolved rect changed — covers the feedback its
+    // own maxWidth write provokes, guarded below); GeometryChangedEvent on the PARENT (see the
+    // ancestor-resize discussion below); and ChangeEvent<string> (TextElement dispatches this whenever
+    // `.text` is set to a new value WHILE attached to a panel — see TextElement's
+    // INotifyValueChanged<string>.value setter — so a text swap that happens to keep the exact same
+    // wrapped box size, and would therefore raise no GeometryChangedEvent, is still caught).
+    //
+    // The ancestor-resize problem. Listening on the target alone is not enough: the maxWidth THIS
+    // manipulator writes pins the target's own resolved size, so once it is narrower than the parent, an
+    // ancestor WIDENING never changes the target's own rect at all (it stays clamped at the old maxWidth)
+    // — no GeometryChangedEvent fires on the target, and the search stays stuck at the old, now-too-narrow
+    // value forever; a narrowing ancestor that does not yet cross the clamped value is missed the same
+    // way. Grid/Gap do not have this problem because they listen on the exact element whose contentRect
+    // their own sizing reads (their own target IS the container); here that element is the PARENT (see
+    // the available-width discussion above), so this manipulator additionally subscribes
+    // GeometryChangedEvent on textElement.parent directly — the plain hierarchy parent, not
+    // FiberNodePatcher.GetChildContainer(parent), to keep the subscribe/unsubscribe bookkeeping as simple
+    // as the target's own listeners already are. The subscription is (re-)synced at the top of every
+    // Apply() call, not only from AttachToPanelEvent, so a mid-life reparent is picked up by whichever
+    // event fires next regardless of exactly how UI Toolkit sequences Attach/Detach for a same-panel
+    // reparent. What remains uncovered: a resize confined entirely to a ScrollView parent's OWN
+    // contentContainer (GetChildContainer's ScrollView case) with no accompanying change to the
+    // ScrollView's own outer rect — e.g. a scrollbar toggling — since the subscription is the ScrollView
+    // itself, not its contentContainer. A grandparent-or-higher resize is NOT a separate gap: available is
+    // read from the parent's own contentRect, so if the parent's rect is genuinely unaffected by a
+    // grandparent change, there is nothing that needed re-deriving in the first place.
+    //
+    // Feedback-loop guard. A signature over the available width (rounded), the text's hash, and the
+    // resolved font size makes a GeometryChangedEvent that this manipulator's own maxWidth write provoked
+    // — with none of those inputs actually different — a no-op regardless of which of the two
+    // GeometryChangedEvent listeners fired it, mirroring StyleGridManipulator's documented discipline
+    // exactly.
+    //
+    // Lifecycle mirrors the other per-element style manipulators (StyleGapManipulator /
+    // StyleGridManipulator): the reconciler attaches one per text-balance element, keeps it in
+    // ReconcilerContext.TextBalanceManipulators, and removes it on cleanup / dispose.
+    // UnregisterCallbacksFromTarget clears the inline maxWidth it wrote (and drops the parent
+    // subscription above) so removing the class or unmounting leaves no residue on the TARGET; a class
+    // removal additionally has the reconciler restore a co-present max-w-* utility right after, per the
+    // ownership paragraph above (a full unmount has no "current class list" to restore against, so it
+    // does not). FiberElementPoolReset also nulls maxWidth generically on every pooled element as a
+    // second line of defense against a pooled Label ghosting a prior consumer's balanced width.
+    internal sealed class StyleTextBalanceManipulator : Manipulator
+    {
+        // Bounded binary-search depth: enough precision to land within a fraction of a pixel of the true
+        // narrowest width without an unbounded measure-call budget.
+        private const int MaxIterations = 8;
+
+        // Floor for the search range, expressed as a fraction of the available width, so the search never
+        // measures a degenerate near-zero width. A too-narrow candidate simply measures TALLER than the
+        // natural height and is rejected by the comparison, so this floor only bounds the search range —
+        // it does not need to equal the longest word's width for correctness.
+        private const float MinWidthFraction = 0.1f;
+
+        // Sub-pixel tolerance on height comparisons, mirroring StyleGridManipulator's WrapSafetyPx: absorbs
+        // float rounding so an unchanged wrap outcome does not misregister as "one line taller".
+        private const float HeightEpsilonPx = 0.5f;
+
+        private int _lastSignature;
+        private bool _hasSignature;
+
+        // The parent currently subscribed for OnParentGeometryChanged — see the class doc's
+        // ancestor-resize discussion. Tracked (rather than re-derived on every check) so SyncParentSubscription
+        // can cheaply no-op when the parent has not changed, and so it can unregister the exact callback it
+        // registered when the parent DOES change (or the manipulator detaches).
+        private VisualElement? _subscribedParent;
+
+        protected override void RegisterCallbacksOnTarget()
+        {
+            target.RegisterCallback<AttachToPanelEvent>(OnAttach);
+            target.RegisterCallback<GeometryChangedEvent>(OnGeometryChanged);
+            target.RegisterCallback<ChangeEvent<string>>(OnTextChanged);
+            Apply();
+        }
+
+        protected override void UnregisterCallbacksFromTarget()
+        {
+            Clear();
+            target.UnregisterCallback<AttachToPanelEvent>(OnAttach);
+            target.UnregisterCallback<GeometryChangedEvent>(OnGeometryChanged);
+            target.UnregisterCallback<ChangeEvent<string>>(OnTextChanged);
+        }
+
+        // Forces the next Apply() to fully re-derive even when nothing this manipulator's own signature
+        // tracks has changed — mirrors StyleGridManipulator.UpdateSpec / StyleGapManipulator.UpdateGap.
+        // FiberNodePatcher.ApplyTextBalanceManipulator calls this on an already-attached manipulator every
+        // patch the text-balance class remains present, so a co-present max-w-* utility's inline write —
+        // applied earlier in the SAME patch by DiffClassList / ApplyClassNames — is always re-overwritten
+        // before the patch ends, instead of silently winning the shared maxWidth slot until an unrelated
+        // geometry event happens to fire.
+        public void Refresh()
+        {
+            _hasSignature = false;
+            Apply();
+        }
+
+        private void OnAttach(AttachToPanelEvent evt)
+        {
+            _hasSignature = false;
+            Apply();
+        }
+
+        private void OnGeometryChanged(GeometryChangedEvent evt) => Apply();
+
+        private void OnTextChanged(ChangeEvent<string> evt) => Apply();
+
+        // Re-fires Apply() when the PARENT's own resolved rect changes — the half of ancestor-resize
+        // staleness the target's own GeometryChangedEvent cannot see once a narrower inline maxWidth pins
+        // the target's size (see the class doc's ancestor-resize discussion).
+        private void OnParentGeometryChanged(GeometryChangedEvent evt) => Apply();
+
+        // Keeps the parent subscription in sync with the CURRENT hierarchy parent. Called at the top of
+        // every Apply() — not only from AttachToPanelEvent — so a mid-life reparent is picked up by
+        // whichever event happens to fire next, without needing to know whether UI Toolkit raises
+        // Attach/Detach for a same-panel reparent. Cheap no-op when the parent has not changed.
+        private void SyncParentSubscription(VisualElement? parent)
+        {
+            if (ReferenceEquals(parent, _subscribedParent))
+            {
+                return;
+            }
+            _subscribedParent?.UnregisterCallback<GeometryChangedEvent>(OnParentGeometryChanged);
+            _subscribedParent = parent;
+            _subscribedParent?.RegisterCallback<GeometryChangedEvent>(OnParentGeometryChanged);
+        }
+
+        // Recomputes the balanced width from the current text / available width / font size, early-out
+        // when nothing relevant to the last application has changed.
+        private void Apply()
+        {
+            if (target is not TextElement textElement)
+            {
+                return;
+            }
+
+            var parent = textElement.parent;
+            // Re-sync BEFORE the parent-null early-out (not just from AttachToPanelEvent) so every Apply()
+            // call — from whichever event triggered it — keeps the subscription pointed at the CURRENT
+            // parent. See the class doc's ancestor-resize discussion.
+            SyncParentSubscription(parent);
+            if (parent == null)
+            {
+                // Off-panel / detached: nothing meaningful to measure against yet. Defer to the next
+                // AttachToPanelEvent / GeometryChangedEvent, mirroring StyleGridManipulator's off-panel
+                // deferral (it re-arms _hasSignature so a later resolve is never skipped as a false repeat).
+                _hasSignature = false;
+                return;
+            }
+
+            // The PARENT's content width is never written by this manipulator (only the target's OWN
+            // maxWidth is), so — unlike target.contentRect.width — it cannot be self-contaminated by a
+            // previous pass's narrower write. See the available-width discussion in the class doc comment.
+            var container = FiberNodePatcher.GetChildContainer(parent);
+            var available = container.contentRect.width
+                - textElement.resolvedStyle.marginLeft - textElement.resolvedStyle.marginRight;
+            var hasWidth = available > 0f && !float.IsNaN(available);
+            if (!hasWidth)
+            {
+                _hasSignature = false;
+                return;
+            }
+
+            var text = textElement.text ?? string.Empty;
+            var fontSize = textElement.resolvedStyle.fontSize;
+            var signature = ComputeSignature(available, text, fontSize);
+            if (_hasSignature && signature == _lastSignature)
+            {
+                return;
+            }
+
+            if (string.IsNullOrEmpty(text))
+            {
+                ClearMaxWidth(textElement);
+                _lastSignature = signature;
+                _hasSignature = true;
+                return;
+            }
+
+            // The text's own preferred size with no width constraint at all — the single-line reference
+            // (or however many hard line breaks it already carries, but no SOFT wrap on top of those).
+            var singleLineHeight = textElement.MeasureTextSize(
+                text, float.NaN, VisualElement.MeasureMode.Undefined,
+                float.NaN, VisualElement.MeasureMode.Undefined).y;
+            // The height a normal (unbalanced) layout would take at the full available width.
+            var naturalHeight = textElement.MeasureTextSize(
+                text, available, VisualElement.MeasureMode.Exactly,
+                float.NaN, VisualElement.MeasureMode.Undefined).y;
+
+            if (naturalHeight <= 0f || float.IsNaN(naturalHeight))
+            {
+                // Degenerate measurement (e.g. the font has not resolved yet): return WITHOUT recording
+                // _lastSignature/_hasSignature for this signature. Caching a verdict derived from a
+                // degenerate height would make a later, valid measurement with the same available
+                // width/text/font-size early-out forever at the top-of-method signature check — the
+                // signature alone cannot distinguish "genuinely unchanged" from "the font resolved since".
+                // Leaving _hasSignature as-is lets the next triggering event retry from scratch.
+                return;
+            }
+
+            if (naturalHeight <= singleLineHeight + HeightEpsilonPx)
+            {
+                // Single line at the available width (includes an element whose resolved white-space is
+                // nowrap, since MeasureTextSize already measures against the element's own resolved
+                // style): CSS balance is a visual no-op here, and our box-narrowing approximation would
+                // only shrink the box for no parity benefit, so leave it alone.
+                ClearMaxWidth(textElement);
+                _lastSignature = signature;
+                _hasSignature = true;
+                return;
+            }
+
+            var minWidth = Mathf.Max(1f, available * MinWidthFraction);
+            var narrowest = FindNarrowestWidth(textElement, text, minWidth, available, naturalHeight);
+            textElement.style.maxWidth = new StyleLength(narrowest);
+
+            _lastSignature = signature;
+            _hasSignature = true;
+        }
+
+        // Binary search over [lo, hi] for the narrowest width whose measured height still fits under
+        // naturalHeight. hi (the available width) is always feasible by construction (its own measured
+        // height IS naturalHeight), so it is a safe fallback if the loop's precision never beats it.
+        private static float FindNarrowestWidth(
+            TextElement textElement, string text, float lo, float hi, float naturalHeight)
+        {
+            var best = hi;
+            for (var i = 0; i < MaxIterations; i++)
+            {
+                var mid = (lo + hi) * 0.5f;
+                var height = textElement.MeasureTextSize(
+                    text, mid, VisualElement.MeasureMode.Exactly,
+                    float.NaN, VisualElement.MeasureMode.Undefined).y;
+                if (height <= naturalHeight + HeightEpsilonPx)
+                {
+                    // Still fits the natural line count at this narrower width: it is feasible, so record
+                    // it and keep searching narrower. A too-narrow candidate instead measures TALLER (an
+                    // extra wrapped line) and falls into the else branch, which the search rejects.
+                    best = mid;
+                    hi = mid;
+                }
+                else
+                {
+                    lo = mid;
+                }
+            }
+            return best;
+        }
+
+        private static void ClearMaxWidth(TextElement textElement)
+        {
+            textElement.style.maxWidth = new StyleLength(StyleKeyword.Null);
+        }
+
+        // Clears the inline maxWidth this manipulator wrote and drops the parent subscription (invoked on
+        // detach / removal). Restoring a co-present max-w-* utility's own value, when this is a class
+        // removal rather than a full unmount, is the CALLER's job (FiberNodePatcher.ReapplyArbitraryValues
+        // — see the class doc's ownership paragraph): this manipulator has no access to the element's
+        // current class list, only FiberNodePatcher does.
+        private void Clear()
+        {
+            if (target is TextElement textElement)
+            {
+                ClearMaxWidth(textElement);
+            }
+            SyncParentSubscription(null);
+            _hasSignature = false;
+        }
+
+        // A hash of the inputs that change the balanced width: the available width (rounded to skip float
+        // jitter), the full text (a length-only signature would miss a same-length text swap), and the
+        // resolved font size (a size change re-wraps the same text differently).
+        private static int ComputeSignature(float available, string text, float fontSize)
+        {
+            unchecked
+            {
+                var hash = 17;
+                hash = hash * 31 + Mathf.RoundToInt(available);
+                hash = hash * 31 + text.GetHashCode();
+                hash = hash * 31 + fontSize.GetHashCode();
+                return hash;
+            }
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Styling/StyleTextBalanceManipulator.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleTextBalanceManipulator.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 94176ddf889bb455890029c28ad50eeb

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/TextBalanceParityTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/TextBalanceParityTests.cs
@@ -1,0 +1,210 @@
+using System.Reflection;
+using NUnit.Framework;
+using UnityEngine.UIElements;
+
+using Velvet;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Specifies the <c>text-balance</c> classifier + <see cref="StyleTextBalanceManipulator"/> lifecycle
+    /// contract: the manipulator attaches exactly when the class is present, detaches when the class is
+    /// removed (clearing any inline <c>maxWidth</c> it may have written), and a pooled <see cref="Label"/>
+    /// carries neither a ghost manipulator nor a ghost <c>maxWidth</c> value into its next consumer.
+    /// </summary>
+    /// <remarks>
+    /// EditMode has no resolved layout (<c>ReconcilerScope.Root</c> is never attached to a panel), so
+    /// <see cref="StyleTextBalanceManipulator"/>'s own <c>Apply</c> always defers (no resolved parent
+    /// width to measure against) — exactly like <see cref="StyleGridManipulator"/>'s off-panel column
+    /// width. These tests therefore pin the wiring (attach / detach / pool hygiene) only; the actual
+    /// measure-and-narrow behavior needs a real panel and is covered by the PlayMode spec
+    /// (<c>TextBalancePlaybackTests</c>). A stale <c>maxWidth</c> is seeded by hand where a test needs one,
+    /// standing in for what a prior LIVE computation would have written.
+    /// </remarks>
+    [TestFixture]
+    internal sealed class TextBalanceParityTests
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            // The Label pool is a process-wide static; start every test from empty so a pool-count
+            // assertion is deterministic regardless of what earlier tests in this fixture rented/returned.
+            VNodePool.ClearLabelPoolForTesting();
+        }
+
+        [Test]
+        public void Given_TextBalanceClass_When_Reconciled_Then_RegistersOneTextBalanceManipulator()
+        {
+            // Arrange
+            using var scope = new ReconcilerScope();
+            var tree = new VNode[] { V.Label(className: "text-balance", text: "hello") };
+
+            // Act
+            scope.Reconciler.Reconcile(scope.Root, System.Array.Empty<VNode>(), tree);
+
+            // Assert
+            Assert.That(GetManipulatorCount(scope.Reconciler), Is.EqualTo(1));
+        }
+
+        [Test]
+        public void Given_NoTextBalanceClass_When_Reconciled_Then_RegistersNoTextBalanceManipulator()
+        {
+            // Arrange
+            using var scope = new ReconcilerScope();
+            var tree = new VNode[] { V.Label(text: "hello") };
+
+            // Act
+            scope.Reconciler.Reconcile(scope.Root, System.Array.Empty<VNode>(), tree);
+
+            // Assert
+            Assert.That(GetManipulatorCount(scope.Reconciler), Is.EqualTo(0));
+        }
+
+        [Test]
+        public void Given_TextBalanceManipulator_When_ClassPatchedAway_Then_ManipulatorRemoved()
+        {
+            // Arrange
+            using var scope = new ReconcilerScope();
+            var tree1 = new VNode[] { V.Label(className: "text-balance", text: "hello") };
+            scope.Reconciler.Reconcile(scope.Root, System.Array.Empty<VNode>(), tree1);
+            Assume.That(GetManipulatorCount(scope.Reconciler), Is.EqualTo(1),
+                "Precondition: the text-balance class registered a manipulator");
+
+            // Act — patch the same label without the text-balance class.
+            var tree2 = new VNode[] { V.Label(text: "hello") };
+            scope.Reconciler.Reconcile(scope.Root, tree1, tree2);
+
+            // Assert
+            Assert.That(GetManipulatorCount(scope.Reconciler), Is.EqualTo(0));
+        }
+
+        [Test]
+        public void Given_TextBalanceManipulator_When_ClassPatchedAway_Then_InlineMaxWidthCleared()
+        {
+            // Arrange
+            using var scope = new ReconcilerScope();
+            var tree1 = new VNode[] { V.Label(className: "text-balance", text: "hello") };
+            scope.Reconciler.Reconcile(scope.Root, System.Array.Empty<VNode>(), tree1);
+            var label = scope.Root.Q<Label>();
+            Assume.That(label, Is.Not.Null, "Precondition: the label mounted");
+            // Off-panel Apply() defers (no resolved parent width to measure against), so seed the value a
+            // LIVE computation would have written, pinning the detach path independently of layout.
+            label.style.maxWidth = new StyleLength(50f);
+
+            // Act — patch the same label without the text-balance class.
+            var tree2 = new VNode[] { V.Label(text: "hello") };
+            scope.Reconciler.Reconcile(scope.Root, tree1, tree2);
+
+            // Assert
+            Assert.That(label.style.maxWidth.keyword, Is.EqualTo(StyleKeyword.Null));
+        }
+
+        // Pins the END-TO-END pool-reuse pipeline, not the manipulator's OWN Clear() in isolation: a full
+        // removal also runs FiberElementPoolReset's generic maxWidth null (applied to every pooled
+        // element regardless of text-balance), so a green result here does not by itself prove the
+        // manipulator's own Clear() ran at all — the generic reset alone would produce the same outcome.
+        // Given_TextBalanceManipulator_When_ClassPatchedAway_Then_InlineMaxWidthCleared below is the
+        // manipulator-specific pin: a same-element class-removal PATCH never returns the element to the
+        // pool, so it isolates Clear() from the generic reset.
+        [Test]
+        public void Given_ATextBalanceLabelWithAStaleMaxWidth_When_RemovedAndPooledThenRecreated_Then_NoStaleMaxWidthGhosts()
+        {
+            // Arrange
+            using var scope = new ReconcilerScope();
+            var tree1 = new VNode[] { V.Label(className: "text-balance", text: "hello") };
+            scope.Reconciler.Reconcile(scope.Root, System.Array.Empty<VNode>(), tree1);
+            var original = scope.Root.Q<Label>();
+            Assume.That(original, Is.Not.Null, "Precondition: the label mounted");
+            // Simulate a prior LIVE balance computation's result (off-panel Apply() never writes one itself).
+            original.style.maxWidth = new StyleLength(42f);
+
+            // Act — remove (returns the label to the pool with the stale maxWidth still on it), then
+            // recreate a text-balance label at the same position, renting the SAME pooled instance back.
+            scope.Reconciler.Reconcile(scope.Root, tree1, System.Array.Empty<VNode>());
+            Assume.That(VNodePool.LabelPoolCountForTesting, Is.EqualTo(1),
+                "Precondition: the label was returned to the pool");
+            var tree3 = new VNode[] { V.Label(className: "text-balance", text: "world") };
+            scope.Reconciler.Reconcile(scope.Root, System.Array.Empty<VNode>(), tree3);
+            var recreated = scope.Root.Q<Label>();
+            Assume.That(ReferenceEquals(original, recreated), Is.True,
+                "Precondition: the same pooled Label instance was rented back");
+
+            // Assert
+            Assert.That(recreated.style.maxWidth.keyword, Is.EqualTo(StyleKeyword.Null));
+        }
+
+        [Test]
+        public void Given_ATextBalanceLabel_When_RemovedAndPooledThenRecreated_Then_ExactlyOneManipulatorRegistered()
+        {
+            // Arrange
+            using var scope = new ReconcilerScope();
+            var tree1 = new VNode[] { V.Label(className: "text-balance", text: "hello") };
+            scope.Reconciler.Reconcile(scope.Root, System.Array.Empty<VNode>(), tree1);
+            scope.Reconciler.Reconcile(scope.Root, tree1, System.Array.Empty<VNode>());
+            Assume.That(GetManipulatorCount(scope.Reconciler), Is.EqualTo(0),
+                "Precondition: removing the label detached its manipulator");
+
+            // Act — recreate a text-balance label at the same position, renting the pooled instance back.
+            var tree3 = new VNode[] { V.Label(className: "text-balance", text: "world") };
+            scope.Reconciler.Reconcile(scope.Root, System.Array.Empty<VNode>(), tree3);
+
+            // Assert — exactly one manipulator registered, not a stale duplicate left by the pool round-trip.
+            Assert.That(GetManipulatorCount(scope.Reconciler), Is.EqualTo(1));
+        }
+
+        [Test]
+        public void Given_ATextBalanceClassOnAMotionsOwnElement_When_Reconciled_Then_RegistersOneTextBalanceManipulator()
+        {
+            // Arrange — elementType: typeof(Label) makes the Motion's OWN underlying element a Label, so
+            // this exercises FiberNodeFactory's Motion-creation call to ApplyTextBalanceManipulator (a
+            // call site distinct from the plain-ElementNode one every other test in this fixture goes
+            // through, since a Div/Label wrapped BY a Motion is created via that Motion path instead).
+            using var scope = new ReconcilerScope();
+            var tree = new VNode[]
+            {
+                V.Motion(className: "text-balance", elementType: typeof(Label),
+                    props: new FiberElementProps { Text = "hello" }),
+            };
+
+            // Act
+            scope.Reconciler.Reconcile(scope.Root, System.Array.Empty<VNode>(), tree);
+
+            // Assert
+            Assert.That(GetManipulatorCount(scope.Reconciler), Is.EqualTo(1));
+        }
+
+        [Test]
+        public void Given_ATextBalanceLabelWithACoPresentMaxWidthUtility_When_TextBalanceClassPatchedAway_Then_TheUtilitysMaxWidthIsRestored()
+        {
+            // Arrange
+            using var scope = new ReconcilerScope();
+            var tree1 = new VNode[] { V.Label(className: "text-balance max-w-[50px]", text: "hello") };
+            scope.Reconciler.Reconcile(scope.Root, System.Array.Empty<VNode>(), tree1);
+            var label = scope.Root.Q<Label>();
+            Assume.That(label, Is.Not.Null, "Precondition: the label mounted");
+            Assume.That(label.style.maxWidth.value.value, Is.EqualTo(50f),
+                "Precondition: the co-present max-w-[50px] utility resolved its own value at mount");
+
+            // Act — patch away JUST the text-balance token; the max-w-[50px] utility stays in the class list.
+            var tree2 = new VNode[] { V.Label(className: "max-w-[50px]", text: "hello") };
+            scope.Reconciler.Reconcile(scope.Root, tree1, tree2);
+
+            // Assert — the utility's own value survives text-balance's teardown instead of being left
+            // cleared by it (StyleTextBalanceManipulator.Clear unconditionally nulls maxWidth first; the
+            // reconciler must restore the co-present utility's value right after).
+            Assert.That(label.style.maxWidth.value.value, Is.EqualTo(50f));
+        }
+
+        private static int GetManipulatorCount(Reconciler reconciler)
+        {
+            var ctxField = typeof(Reconciler).GetField("_ctx", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.That(ctxField, Is.Not.Null, "_ctx field not found");
+            var ctx = ctxField.GetValue(reconciler);
+            var prop = ctx.GetType().GetProperty("TextBalanceManipulators");
+            Assert.That(prop, Is.Not.Null, "TextBalanceManipulators property not found");
+            var dict = prop.GetValue(ctx) as System.Collections.IDictionary;
+            return dict?.Count ?? 0;
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/TextBalanceParityTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/TextBalanceParityTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b4adb46d9d8fb4c3d8243c2547f01aa5

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/PlayMode/TextBalancePlaybackTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/PlayMode/TextBalancePlaybackTests.cs
@@ -1,0 +1,267 @@
+using System;
+using System.Collections;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using UnityEngine.UIElements;
+using Velvet.TestUtilities;
+using static Velvet.TestUtilities.PlayModeRealtimeTestHelpers;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins <see cref="StyleTextBalanceManipulator"/>'s actual measure-and-narrow behavior against a real
+    /// runtime panel — <c>TextBalanceParityTests</c> (EditMode) only pins the classifier + attach/detach
+    /// wiring, since EditMode never resolves layout and the manipulator's own <c>Apply</c> defers without
+    /// one.
+    /// </summary>
+    /// <remarks>
+    /// A themeless <see cref="RenderTexturePanelHost"/> panel has no font — every Label measures zero
+    /// tall — and a Label's engine default is nowrap, so every label here supplies both inline via
+    /// refCallback (a built-in Font plus <c>WhiteSpace.Normal</c>) rather than relying on a stylesheet
+    /// that was never loaded onto this panel. No stylesheet is needed for the `w-[Npx]` wrapper width or
+    /// the `text-balance` class either: both are arbitrary-value / classifier tokens Velvet resolves in
+    /// C#, independent of any USS asset (mirrors <c>BuiltInFilterShaderPlaybackTests</c>' own
+    /// stylesheet-less `w-[100px]` usage).
+    /// </remarks>
+    internal sealed class TextBalancePlaybackTests
+    {
+        private RenderTexturePanelHost _host;
+        private MountedTree _mounted;
+
+        // Stable delegate identity (a static readonly field, not a per-render closure), mirroring
+        // StyleTextEffectPanelTests.s_manualWhiteSpaceRef: both labels in a pair share the identical font
+        // and wrap setting, so the only difference between them is the text-balance class itself.
+        private static readonly Func<VisualElement, Action> s_wrapWithFontRef = element =>
+        {
+            element.style.whiteSpace = WhiteSpace.Normal;
+            element.style.unityFontDefinition = new StyleFontDefinition(
+                FontDefinition.FromFont(UnityEngine.Resources.GetBuiltinResource<UnityEngine.Font>("LegacyRuntime.ttf")));
+            return null;
+        };
+
+        // Many short words so the wrap point has real work to do at any wrapper width used below (100px
+        // up to ~350px) — reused by the state-driven tests, which each need long-wrapping text at a
+        // width chosen after mount rather than at construction time like MountPair's own literal.
+        private const string LongWrapText = "This label carries enough short plain words to wrap across many lines " +
+            "inside a narrow box so the balance search over its width has real work to do and a " +
+            "clearly uneven last line to fix";
+
+        private static StateUpdater<bool> s_setWrapperWide;
+        private static StateUpdater<string> s_setSwapText;
+        private static StateUpdater<bool> s_setAddMaxWidth;
+
+        [UnitySetUp]
+        public IEnumerator UnitySetUp()
+        {
+            s_setWrapperWide = default;
+            s_setSwapText = default;
+            s_setAddMaxWidth = default;
+            yield break;
+        }
+
+        [UnityTearDown]
+        public IEnumerator UnityTearDown()
+        {
+            _mounted?.Dispose();
+            _mounted = null;
+            _host?.Dispose();
+            _host = null;
+            yield return null;
+        }
+
+        // Mounts an unbalanced/balanced sibling pair with identical text inside identically-sized wrapper
+        // containers (the parent width StyleTextBalanceManipulator measures against), then waits for
+        // layout to settle.
+        private IEnumerator MountPair(string text, int wrapperWidthPx)
+        {
+            _host = new RenderTexturePanelHost("TextBalancePanel", 400, 400);
+            var tree = V.Div(children: new VNode[]
+            {
+                V.Div(className: $"w-[{wrapperWidthPx}px]", children: new VNode[]
+                {
+                    V.Label(name: "unbalanced", text: text, refCallback: s_wrapWithFontRef),
+                }),
+                V.Div(className: $"w-[{wrapperWidthPx}px]", children: new VNode[]
+                {
+                    V.Label(name: "balanced", text: text, className: "text-balance", refCallback: s_wrapWithFontRef),
+                }),
+            });
+            _mounted = V.Mount(_host.Root, tree);
+            yield return WaitRealtime(0.5);
+        }
+
+        [UnityTest]
+        public IEnumerator Given_AWrappedMultiLineLabel_When_Balanced_Then_ItIsNarrowerThanItsUnbalancedSiblingAtTheSameHeight()
+        {
+            // Arrange — many short words in a narrow wrapper reliably wrap into several densely-packed
+            // lines regardless of the panel's (unthemed) default font size.
+            const string text = LongWrapText;
+
+            // Act
+            yield return MountPair(text, 100);
+            var unbalanced = _host.Root.Q<Label>("unbalanced");
+            var balanced = _host.Root.Q<Label>("balanced");
+
+            // Self-referential rather than a hardcoded pixel guess: any real multi-line wrap totals well
+            // over 1.5x a single font-size unit, regardless of what the panel's actual default size is.
+            Assume.That(unbalanced.resolvedStyle.height, Is.GreaterThan(unbalanced.resolvedStyle.fontSize * 1.5f),
+                "Precondition: the long text actually wrapped onto multiple lines in the unbalanced sibling");
+
+            // Assert — the core balance property, as one tuple: a narrower box (balance did something) at
+            // the SAME line count (it did not also wrap an extra line to get there — an extra-wrapped-line
+            // regression must fail this, not just Inconclusive out as a precondition). Resolved layout
+            // floats can carry sub-pixel rounding noise even for identical text/font on two elements, so
+            // the height half uses the same 0.5px tolerance this fixture's other height/width comparisons
+            // already accept.
+            Assert.That(
+                (balanced.resolvedStyle.width < unbalanced.resolvedStyle.width,
+                 Mathf.Abs(balanced.resolvedStyle.height - unbalanced.resolvedStyle.height) < 0.5f),
+                Is.EqualTo((true, true)));
+        }
+
+        [UnityTest]
+        public IEnumerator Given_ASingleLineLabel_When_Balanced_Then_ItKeepsItsFullUnbalancedBoxWidth()
+        {
+            // Arrange — short text in a wide wrapper stays on a single line regardless of the panel's
+            // default font size.
+            const string text = "Hi";
+
+            // Act
+            yield return MountPair(text, 480);
+            var unbalanced = _host.Root.Q<Label>("unbalanced");
+            var balanced = _host.Root.Q<Label>("balanced");
+
+            Assume.That(unbalanced.resolvedStyle.height, Is.LessThan(unbalanced.resolvedStyle.fontSize * 1.8f),
+                "Precondition: the short text stayed on a single line in the unbalanced sibling");
+
+            // Assert — the multi-line-only gate: a single-line label's box is left untouched.
+            Assert.That(balanced.resolvedStyle.width, Is.EqualTo(unbalanced.resolvedStyle.width).Within(0.5f));
+        }
+
+        // The wrapper (the balanced label's PARENT) toggles between a narrow and a wide width class —
+        // state-driven so the SAME element widens after mount instead of two separately-mounted trees.
+        [Component]
+        private static VNode WidenHost()
+        {
+            var (wide, setWide) = Hooks.UseState(false);
+            s_setWrapperWide = setWide;
+            return V.Div(className: wide ? "w-[350px]" : "w-[100px]", children: new VNode[]
+            {
+                V.Label(name: "balanced", text: LongWrapText, className: "text-balance", refCallback: s_wrapWithFontRef),
+            });
+        }
+
+        [UnityTest]
+        public IEnumerator Given_ABalancedLabel_When_ItsWrapperWidensAfterMount_Then_ItRebalancesToAWiderMaxWidth()
+        {
+            // Arrange
+            _host = new RenderTexturePanelHost("TextBalanceWidenPanel", 400, 400);
+            _mounted = V.Mount(_host.Root, V.Component(WidenHost, key: "root"));
+            yield return WaitRealtime(0.5);
+            var balanced = _host.Root.Q<Label>("balanced");
+            Assume.That(balanced, Is.Not.Null, "Precondition: the label mounted");
+            var narrowWidth = balanced.resolvedStyle.width;
+            Assume.That(balanced.resolvedStyle.height, Is.GreaterThan(balanced.resolvedStyle.fontSize * 1.5f),
+                "Precondition: the text wrapped multi-line at the narrow wrapper, so balance wrote a real narrower maxWidth");
+
+            // Act — widen the wrapper, an ANCESTOR of the label, not the label itself.
+            s_setWrapperWide.Invoke(true);
+            yield return WaitRealtime(0.6);
+
+            Assume.That(balanced.resolvedStyle.height, Is.GreaterThan(balanced.resolvedStyle.fontSize * 1.5f),
+                "Precondition: the text still wraps multi-line at the wider wrapper, so this is a real re-balance and not the single-line clear path");
+
+            // Assert — the manipulator's own maxWidth write pins the target's size, so only a listener on
+            // the PARENT's own GeometryChangedEvent (not just the target's) can catch an ancestor widening
+            // and re-run the search; without it the label stays stuck at the narrow value forever.
+            Assert.That(balanced.resolvedStyle.width, Is.GreaterThan(narrowWidth));
+        }
+
+        // The label's own text toggles between a short single-line string and LongWrapText, at a fixed
+        // wrapper width — state-driven so the CHANGE happens after mount via TextElement's ChangeEvent<string>.
+        [Component]
+        private static VNode TextSwapHost()
+        {
+            var (text, setText) = Hooks.UseState("Hi");
+            s_setSwapText = setText;
+            return V.Div(className: "w-[140px]", children: new VNode[]
+            {
+                V.Label(name: "balanced", text: text, className: "text-balance", refCallback: s_wrapWithFontRef),
+            });
+        }
+
+        [UnityTest]
+        public IEnumerator Given_ABalancedLabel_When_ItsTextChangesToAWrappingStringAfterMount_Then_TheInlineMaxWidthAppears()
+        {
+            // Arrange — mounts short enough to sit on one line, which the multi-line gate leaves entirely
+            // unconstrained: no inline maxWidth exists yet, giving the swap below a clean edge to observe.
+            _host = new RenderTexturePanelHost("TextBalanceTextSwapPanel", 400, 400);
+            _mounted = V.Mount(_host.Root, V.Component(TextSwapHost, key: "root"));
+            yield return WaitRealtime(0.5);
+            var balanced = _host.Root.Q<Label>("balanced");
+            Assume.That(balanced, Is.Not.Null, "Precondition: the label mounted");
+            Assume.That(balanced.resolvedStyle.height, Is.LessThan(balanced.resolvedStyle.fontSize * 1.8f),
+                "Precondition: the short initial text stayed on a single line");
+            Assume.That(balanced.style.maxWidth.keyword, Is.EqualTo(StyleKeyword.Null),
+                "Precondition: a single-line label carries no balanced constraint to begin with");
+
+            // Act — swap in text long enough to wrap at the SAME (unchanged) wrapper width.
+            s_setSwapText.Invoke(LongWrapText);
+            yield return WaitRealtime(0.6);
+
+            Assume.That(balanced.resolvedStyle.height, Is.GreaterThan(balanced.resolvedStyle.fontSize * 1.5f),
+                "Precondition: the new text actually wrapped onto multiple lines");
+
+            // Assert — a text change re-triggers the balance computation THROUGH SOME PATH: the multi-line
+            // gate flips from "leave unconstrained" to "write the searched bound", so an inline maxWidth
+            // appearing at all proves the swap re-ran the search. This swap changes the label's resolved
+            // height, so the geometry listener alone would also re-run it — the text-change notification
+            // is NOT isolated here (isolating it needs a same-height swap, whose construction depends on
+            // font metrics too fragile to pin). The magnitude of the resulting width is deliberately not
+            // asserted either — how densely text packs at the wrapper's width is font-metric trivia, not
+            // the re-trigger contract under test.
+            Assert.That(balanced.style.maxWidth.keyword, Is.Not.EqualTo(StyleKeyword.Null));
+        }
+
+        // The label's classNames toggles a co-present max-w-[400px] utility on/off alongside the
+        // ever-present text-balance token — state-driven so the utility's own inline write lands in a
+        // LATER patch than the one that first established the manipulator's own balanced value.
+        [Component]
+        private static VNode OwnershipHost()
+        {
+            var (addMaxWidth, setAddMaxWidth) = Hooks.UseState(false);
+            s_setAddMaxWidth = setAddMaxWidth;
+            var cls = addMaxWidth ? "text-balance max-w-[400px]" : "text-balance";
+            return V.Div(className: "w-[100px]", children: new VNode[]
+            {
+                V.Label(name: "balanced", text: LongWrapText, className: cls, refCallback: s_wrapWithFontRef),
+            });
+        }
+
+        [UnityTest]
+        public IEnumerator Given_ABalancedLabel_When_AMaxWidthUtilityIsAddedInALaterPatch_Then_BalanceKeepsOwningTheInlineMaxWidth()
+        {
+            // Arrange — mounts with text-balance alone so its own computed maxWidth is already established
+            // before the utility ever enters the class list.
+            _host = new RenderTexturePanelHost("TextBalanceOwnershipPanel", 400, 400);
+            _mounted = V.Mount(_host.Root, V.Component(OwnershipHost, key: "root"));
+            yield return WaitRealtime(0.5);
+            var balanced = _host.Root.Q<Label>("balanced");
+            Assume.That(balanced, Is.Not.Null, "Precondition: the label mounted");
+            Assume.That(balanced.resolvedStyle.height, Is.GreaterThan(balanced.resolvedStyle.fontSize * 1.5f),
+                "Precondition: the text wrapped, so text-balance wrote a real (not cleared) maxWidth");
+            var balancedMaxWidth = balanced.style.maxWidth.value.value;
+
+            // Act — patch in a co-present max-w-[400px] utility on the SAME element, in the SAME render
+            // that first applies it: DiffClassList's inline write and the manipulator's own Refresh() both
+            // touch style.maxWidth in this one patch.
+            s_setAddMaxWidth.Invoke(true);
+            yield return WaitRealtime(0.6);
+
+            // Assert — text-balance re-asserts every patch while its class is present, so the utility's
+            // own 400px write never survives past the same patch that introduced it.
+            Assert.That(balanced.style.maxWidth.value.value, Is.EqualTo(balancedMaxWidth).Within(0.5f));
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/PlayMode/TextBalancePlaybackTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/PlayMode/TextBalancePlaybackTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b535844d1747246c2be0beeb1a4dc6c1


### PR DESCRIPTION
## What

Tailwind `text-balance` (CSS `text-wrap: balance`), the last implementable utility from #96's cluster: multi-line text redistributes across its existing line count instead of stranding a near-empty last line.

## How

The text engine exposes no line-break hook, so balanced breaking cannot be done natively. Instead, `StyleTextBalanceManipulator` binary-searches the public `TextElement.MeasureTextSize` — the same method the engine's own autosize pass already calls, so the bounded search (≤10 calls) costs the same order the engine already pays — for the narrowest inline `maxWidth` that keeps the measured height at or under the unbalanced layout's height at the parent-imposed available width. Font metrics are constant across candidates, so comparing heights stands in for comparing line counts.

Key mechanics:
- **Feedback-loop guard**: a signature over (available width, text, font size) makes the geometry event its own write provokes a no-op — the established manipulator discipline.
- **Staleness triggers**: the element's own geometry event, a listener on the **parent** (the manipulator's own `maxWidth` write pins the element's rect, so an ancestor widening would otherwise never re-fire), and the text-change notification the element raises when `.text` is reassigned.
- **Ownership**: while the class is present, balance owns the inline `maxWidth` slot and re-asserts it every patch; removing the class restores a co-present `max-w-*` utility's own value.
- **Single-line gate**: CSS balance is a no-op on one line, and this approximation would otherwise shrink the box for no benefit — one-line text is left entirely unconstrained.

## Documented deviations

Unlike real CSS balance, the box itself can narrow (the approximation moves the box edge, not the break positions), and wrapping is a prerequisite — a default label is `nowrap`, so `text-balance` composes with `text-wrap`/`whitespace-normal`. Both spelled out in `Documentation~/fonts.md`, alongside the residual staleness edge (a ScrollView-viewport-only resize).

## Tests

EditMode lifecycle (attach on class, detach + inline clear on class removal, `max-w-*` restore after removal, Motion-hosted element, pool-reuse no-ghost); PlayMode behavior on a real panel (balanced narrower than an unbalanced sibling **at the same height** — the same-line-count invariant is asserted, not assumed; single-line keeps full width; wrapper widening re-balances wider; a text swap re-triggers the search; balance keeps owning `maxWidth` when a `max-w-*` utility arrives in a later patch).

3137/3137 EditMode and 88/88 PlayMode tests pass locally on the merged state.

Part of #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)