### PR TITLE
feat(velvet): paint the overline decoration via generateVisualContent

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `overline` (text-decoration), joining the existing `underline` / `line-through` / `no-underline`
+  decoration axis. UI Toolkit rich text has no overline tag, so unlike the other three (a string rewrite)
+  it is PAINTED: a solid rule stroked above the leaf `TextElement`'s first line via
+  `generateVisualContent`, colored from `resolvedStyle.color`, sized to the text's natural width (clamped
+  to the content box), and honoring both components of `-unity-text-align` — its horizontal start, and,
+  for a middle/lower vertical anchor, where that first line actually sits. It cascades and resets
+  through the same axis as the others (`no-underline` clears it too), but the axis stays single-valued by
+  this subsystem's pre-existing design, so `underline overline` on one element resolves to the last
+  token rather than both lines composing as CSS allows. v1 scope: one rule positioned above the first
+  line only — a wrapped label's later lines carry no rule of their own yet.
 - `V.Portal(targetId:)` (the same-panel registry portal) now bubbles `events:` handlers to the
   logical ancestor chain outside the call site, matching the synthetic bubbling
   `V.Portal(layer:)`/`V.WorldSpace` already had. `PointerDown`/`Up`/`Move`/`Enter`/`Leave`,

--- a/Packages/com.velvet.core/Documentation~/fonts.md
+++ b/Packages/com.velvet.core/Documentation~/fonts.md
@@ -109,7 +109,7 @@ them (not a Velvet decision).
 `whitespace-normal|nowrap|pre|pre-wrap|pre-line` /
 `text-wrap` / `text-nowrap` / `truncate` / `text-ellipsis` / `text-clip` (`text-overflow: ellipsis | clip`) /
 text color / `uppercase` `lowercase` `capitalize` `normal-case` (text-transform) /
-`underline` `line-through` `no-underline` (text-decoration).
+`underline` `line-through` `overline` `no-underline` (text-decoration).
 
 **Text-transform / text-decoration are realised by mutating the displayed text** (UI Toolkit has no property
 for either): the string is upper/lower/title-cased, and underline / line-through wrap it in the `<u>` / `<s>`
@@ -119,6 +119,26 @@ the one cascade-freshness caveat (an ancestor's class toggled without that ances
 element turns `enableRichText` off, the `<u>` / `<s>` markup is not interpreted — it shows up as literal text
 in the label instead, like any other rich-text tag on that element (`leading-*`'s `<line-height=X>` tag,
 below, has the identical caveat).
+
+**`overline` is the one decoration value that cannot be a string rewrite:** UI Toolkit's rich text has no
+overline tag (only `<u>` / `<s>`), so instead of wrapping the string, `overline` **paints** a solid rule above
+the text via `generateVisualContent` on the leaf `TextElement` (`TextOverlinePainter` / `TextOverlineBinding`)
+— the string itself passes through unchanged. The stroke color tracks `resolvedStyle.color`, its thickness is
+~1/16th of the font size (floored at 1px, matching a typical browser ratio), and it follows `-unity-text-align`'s
+vertical component for where the FIRST line sits — top-aligned under an `upper-*` anchor, vertically centered
+under a `middle-*` anchor (the default for `text-left|center|right|start|end`, and UI Toolkit's own unstyled
+default), bottom-aligned under a `lower-*` anchor — then nudges down a small, documented fraction of the font
+size from that line's own top edge as an approximation of CSS's ascent-line placement (UI Toolkit exposes no
+public, synchronously-reachable ascent metric to place it exactly). It still joins the
+SAME decoration axis as `underline` / `line-through` / `no-underline` — cascade, inheritance, and the
+`no-underline` reset all apply to it for free — but the axis stays single-valued by this subsystem's
+pre-existing design: CSS lets `text-decoration-line` combine multiple lines (`underline overline` shows
+both), Velvet's decoration axis resolves exactly one value, last-token-wins, so `underline overline` on one
+element renders only the overline, not both. **v1 scope:** one rule, positioned above the FIRST line only and
+sized to the text's natural single-line-equivalent width (clamped to the content width) — per-line metrics of
+wrapped text are not publicly reachable in a way usable synchronously from `generateVisualContent`, so a
+multi-line label shows the rule above its top line only; a documented limitation, with per-line placement
+left as future work.
 
 **`white-space`** has four native USS values, and `whitespace-normal`, `whitespace-nowrap`,
 `whitespace-pre`, and `whitespace-pre-wrap` map directly onto them — no C# involved.
@@ -161,7 +181,6 @@ included — is already a real value, so there is nothing for a descendant to re
 
 | Tailwind | Why omitted |
 |---|---|
-| `overline` (text-decoration) | UI Toolkit rich text has no overline tag (`<u>` / `<s>` only) |
 | `antialiased` / `subpixel-antialiased` (font-smoothing) | Text renders as SDF alpha-blend only — no antialiasing-mode axis to switch |
 | `font-stretch-*` | No variable-font / width-axis support |
 | `tabular-nums` etc. (font-variant-numeric) | No OpenType feature-substitution slot in the runtime font pipeline |

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberElementCleaner.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberElementCleaner.cs
@@ -302,6 +302,14 @@ namespace Velvet
                 DivideDashPainter.Detach(element, divideDashBinding);
                 _ctx.DivideDashBindings.Remove(element);
             }
+            if (_ctx.TextOverlineBindings.TryGetValue(element, out var overlineBinding))
+            {
+                // The overline rule is a generateVisualContent delegate, not a style property, so the pool
+                // reset cannot scrub it — detach unhooks the paint callback so a pooled element cannot ghost
+                // a painted rule onto its next consumer.
+                TextOverlineSilhouette.Detach(element, overlineBinding);
+                _ctx.TextOverlineBindings.Remove(element);
+            }
             if (_ctx.GradientBackgrounds.ContainsKey(element))
             {
                 // Clear the baked gradient background-image so a pooled element cannot ghost a prior

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
@@ -194,6 +194,15 @@ namespace Velvet
                     {
                         element.style.whiteSpace = StyleKeyword.Null;
                     }
+                    // Same leak, same fix, for the Overline paint binding (see StyleTextEffectResolver's
+                    // type comment): with no raw text left, ApplyToElement can never run again to detach it,
+                    // so a generateVisualContent subscription this element carried would otherwise survive
+                    // forever on an element that no longer has any text to decorate at all.
+                    if (_ctx.TextOverlineBindings.TryGetValue(element, out var overlineBinding))
+                    {
+                        TextOverlineSilhouette.Detach(element, overlineBinding);
+                        _ctx.TextOverlineBindings.Remove(element);
+                    }
                 }
             }
             // After DiffProps (and the class-driven config it follows): re-sync the data-/aria- attribute

--- a/Packages/com.velvet.core/Runtime/Reconciler/Reconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Reconciler.cs
@@ -485,6 +485,13 @@ namespace Velvet
                 DivideDashPainter.Detach(element, binding);
             }
             _ctx.DivideDashBindings.Clear();
+            // Overline rules are a generateVisualContent delegate (not a style property, so unscrubbed by the
+            // pool reset): detach each so a still-mounted text leaf at root disposal leaves no live delegate.
+            foreach (var (element, binding) in _ctx.TextOverlineBindings)
+            {
+                TextOverlineSilhouette.Detach(element, binding);
+            }
+            _ctx.TextOverlineBindings.Clear();
             // Gradient elements hold an inline background-image referencing a shared baked texture: clear
             // the inline image so a still-mounted element released at root disposal carries no residue
             // (the cached textures themselves are shared and outlive the reconciler).

--- a/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
@@ -163,6 +163,16 @@ namespace Velvet
         public Dictionary<VisualElement, string> TextRawText { get; } = new();
         public Dictionary<VisualElement, bool> TextWhitespaceOwned { get; } = new();
 
+        // A FOURTH table for the same subsystem, backing the Decoration axis's Overline value specifically:
+        // UI Toolkit rich text has no overline tag (unlike Underline/LineThrough, which rewrite the string
+        // with <u>/<s>), so Overline is realised as a generateVisualContent PAINT binding on the leaf
+        // TextElement instead — see TextOverlineBinding / TextOverlineSilhouette. Unlike the three pure
+        // tables above, an entry here owns a live delegate subscription (like ShadowBindings / SkewBindings
+        // / BorderStyleBindings below), so it is deliberately NOT enrolled in _pureElementSideTables —
+        // FiberElementCleaner detaches the callback explicitly before an element is torn down or returned to
+        // the pool, mirroring exactly how those three paint bindings are swept.
+        public Dictionary<VisualElement, TextOverlineBinding> TextOverlineBindings { get; } = new();
+
         // The per-element "pure" side-tables (structural / has-[.class]: / data-/aria- rules + their attribute
         // store / supports- / Motion applied-classes) — those whose teardown is a plain Remove(element): no
         // manipulator to detach and no resource (a shader Material, a baked VectorImage, an event subscription,

--- a/Packages/com.velvet.core/Runtime/Styling/StyleTextEffectClass.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleTextEffectClass.cs
@@ -16,13 +16,21 @@ namespace Velvet
         Capitalize,  // capitalize (title-case: first letter of each word)
     }
 
-    // The text-decoration an element requests. None is the EXPLICIT reset (no-underline); unset is a null
-    // TextDecorationKind? in TextEffect. UI Toolkit text has no overline rich-text tag, so overline is omitted.
+    // The text-decoration an element requests. None is the EXPLICIT reset (no-underline, which clears
+    // Overline too — mirroring CSS's text-decoration-line: none clearing every line); unset is a null
+    // TextDecorationKind? in TextEffect. UI Toolkit rich text has no overline tag (only <u>/<s>), so unlike
+    // Underline/LineThrough, Overline is never realised as a string rewrite — StyleTextEffectClass.Apply
+    // passes the string through unchanged for it, and the leaf paints a rule instead (see
+    // StyleTextEffectResolver.ApplyToElement / TextOverlineBinding). It still shares this single axis with
+    // Underline/LineThrough/None (last-token-wins on one element, cascades/resets the same way) rather than
+    // getting its own axis, even though CSS lets text-decoration-line combine multiple lines — see the Why
+    // comment in Parse.
     internal enum TextDecorationKind
     {
         None,        // no-underline
-        Underline,   // underline   -> <u>
+        Underline,   // underline    -> <u>
         LineThrough, // line-through -> <s>
+        Overline,    // overline     -> painted, no tag
     }
 
     // The whitespace-collapse an element requests. None is the EXPLICIT reset: every direct, literal
@@ -80,7 +88,10 @@ namespace Velvet
     // line-height have no UITK property at all — so Velvet realises all four the same way regardless, by
     // mutating the displayed text: uppercasing/title-casing the string, wrapping it in the rich-text
     // <u>/<s>/<line-height=X> tags UI Toolkit renders (enableRichText is on by default), and/or collapsing
-    // space/tab runs.
+    // space/tab runs. Decoration's Overline value is the one exception to the string-mutation story: UI
+    // Toolkit rich text has no overline tag to wrap with, so it cascades through this SAME struct/axis (it
+    // is still just a TextDecorationKind value) but is realised as a PAINTED rule on the leaf instead — see
+    // StyleTextEffectResolver.ApplyToElement and TextOverlineBinding.
     //
     // Whitespace still needs the same manual cascade walk as Transform/Decoration despite white-space
     // natively inheriting: no UITK enum member expresses CSS pre-line's collapse, so a C# string mutation is
@@ -138,6 +149,12 @@ namespace Velvet
         // see below). Returns an empty TextEffect (every axis null) when no recognised token is present.
         // Leading follows the same last-token-wins rule as Transform/Decoration: it has no reset form (see
         // LeadingUnit), so there is nothing analogous to Whitespace's cross-family override to special-case.
+        // Decoration's last-token-wins rule also covers Overline: CSS's text-decoration-line can combine
+        // multiple lines in one declaration (underline overline both render), but this axis resolves to
+        // exactly ONE TextDecorationKind value per element by pre-existing design (predating Overline) — so
+        // "underline overline" here picks the LAST token (Overline), it does not compose both onto the
+        // element the way CSS would. Documented as a deviation in fonts.md; not re-litigated by adding
+        // Overline.
         public static TextEffect Parse(string[] classNames)
         {
             TextTransformKind? transform = null;
@@ -159,6 +176,7 @@ namespace Velvet
                     case "normal-case": transform = TextTransformKind.None; break;
                     case "underline": decoration = TextDecorationKind.Underline; break;
                     case "line-through": decoration = TextDecorationKind.LineThrough; break;
+                    case "overline": decoration = TextDecorationKind.Overline; break;
                     case "no-underline": decoration = TextDecorationKind.None; break;
                     case "whitespace-pre-line": whitespace = WhitespaceCollapseKind.PreLine; break;
                     case "whitespace-normal":
@@ -298,6 +316,11 @@ namespace Velvet
             {
                 case TextDecorationKind.Underline: return "<u>" + text + "</u>";
                 case TextDecorationKind.LineThrough: return "<s>" + text + "</s>";
+                // Overline has no rich-text tag to wrap with (UI Toolkit's markup vocabulary is <u>/<s>
+                // only) — spelled out rather than left to fall through to default, so a reader does not
+                // mistake the no-op for an oversight. The leaf paints a rule instead; see
+                // StyleTextEffectResolver.ApplyToElement.
+                case TextDecorationKind.Overline: return text;
                 default: return text; // None / null
             }
         }

--- a/Packages/com.velvet.core/Runtime/Styling/StyleTextEffectResolver.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleTextEffectResolver.cs
@@ -4,16 +4,19 @@ using UnityEngine.UIElements;
 namespace Velvet
 {
     // Realises text-transform (uppercase / lowercase / capitalize / normal-case), text-decoration
-    // (underline / line-through), whitespace-pre-line, and leading-* (line-height) by mutating the displayed
-    // text — Unity UI Toolkit has no property for any of the four, so the string is upper/lower/title-cased,
-    // wrapped in the <u>/<s>/<line-height=X> rich-text tags UITK renders, and/or has its space/tab runs
-    // collapsed. CSS inherits all four; UITK does not (for text-transform / text-decoration / line-height
-    // there is no UITK property at all; white-space DOES natively inherit, but no enum value expresses
-    // pre-line's collapse, so the STRING rewrite still needs the same treatment — see the Whitespace remarks
-    // on TextEffect). So every axis cascades by walking ancestors (StyleTextEffectClass holds the pure parse
-    // + string ops; this owns the reconciler-side cascade and the per-element side-tables).
+    // (underline / line-through / overline), whitespace-pre-line, and leading-* (line-height) by mutating
+    // the displayed text — Unity UI Toolkit has no property for any of the four axes, so the string is
+    // upper/lower/title-cased, wrapped in the <u>/<s>/<line-height=X> rich-text tags UITK renders, and/or has
+    // its space/tab runs collapsed. Overline is the one value with no tag to wrap with (UI Toolkit's rich
+    // text vocabulary is <u>/<s> only), so instead of a string rewrite it attaches a PAINTED rule via a
+    // generateVisualContent binding — see the fourth side-table below and TextOverlineBinding. CSS inherits
+    // all four axes; UITK does not (for text-transform / text-decoration / line-height there is no UITK
+    // property at all; white-space DOES natively inherit, but no enum value expresses pre-line's collapse,
+    // so the STRING rewrite still needs the same treatment — see the Whitespace remarks on TextEffect). So
+    // every axis cascades by walking ancestors (StyleTextEffectClass holds the pure parse + string ops; this
+    // owns the reconciler-side cascade and the per-element side-tables).
     //
-    // Three per-element side-tables (all pure, on ReconcilerContext): TextEffects = an element's OWN parsed
+    // Three per-element side-tables are pure (on ReconcilerContext): TextEffects = an element's OWN parsed
     // effect (each axis nullable so an explicit reset — normal-case / no-underline / an explicit
     // whitespace-* class — is distinct from "inherit"; Leading has no reset form, see LeadingUnit, but is
     // still nullable the same way for "inherit" vs. "this element sets a real value"); TextRawText = the
@@ -21,9 +24,13 @@ namespace Velvet
     // can be re-applied idempotently (the element's live .text may already be transformed); TextWhitespaceOwned
     // = a set (Dictionary with a trivial value) of elements whose CURRENT inline `style.whiteSpace` was
     // written by THIS resolver — see the ownership discussion below ApplyToElement. All three ride element
-    // cleanup / pool reuse for free via ReconcilerContext.ClearElementSideTables. Leading needs no fourth
-    // table of its own: unlike PreLine it drives no separate inline style, only the SAME string rewrite
-    // TextEffects/TextRawText already carry, so it rides their existing cleanup for free too.
+    // cleanup / pool reuse for free via ReconcilerContext.ClearElementSideTables. Leading needs no table of
+    // its own: unlike PreLine it drives no separate inline style, only the SAME string rewrite
+    // TextEffects/TextRawText already carry, so it rides their existing cleanup for free too. A FOURTH table,
+    // TextOverlineBindings, is NOT pure: it owns a live generateVisualContent subscription (one per leaf with
+    // decoration == Overline), so FiberElementCleaner detaches it explicitly instead of riding the plain
+    // side-table sweep — see the Overline remarks below ApplyToElement and the table's own comment on
+    // ReconcilerContext.
     //
     // PreLine ALSO drives an inline `white-space: pre-wrap` write, so the preserved newlines render as
     // breaks and wrapping still works. That write happens in ApplyToElement (below), on EVERY text leaf
@@ -64,11 +71,21 @@ namespace Velvet
     // leaf that carried an owned inline PreWrap would keep it forever. FiberNodePatcher.PatchBaseElement
     // clears TextWhitespaceOwned at exactly that site; see the comment there.
     //
+    // Overline is likewise gated in ApplyToElement, off the SAME resolved Decoration value the string
+    // rewrite above just used: a leaf that resolves to Overline gets a TextOverlineBinding attached (a
+    // no-op if one is already tracked for it) and one that no longer does gets its existing binding
+    // detached — so the paint and the (absent) string change can never disagree about which axis is active.
+    // TextOverlineBindings is NOT a pure side-table (see its own comment on ReconcilerContext): the same
+    // still-MOUNTED-Text-prop-patched-to-null transition above would otherwise leak its generateVisualContent
+    // subscription forever (ClearElementSideTables never runs, and ApplyToElement can never run again to
+    // detach it either), so FiberNodePatcher.PatchBaseElement detaches it at that exact site too.
+    //
     // KNOWN LIMITATION: toggling a text-transform / text-decoration / whitespace-pre-line / leading-* class
     // on an ANCESTOR re-cascades to descendants only when that ancestor is re-rendered (its post-children
     // pass walks them). A descendant whose own text is unchanged and whose ancestor's class changed without
     // the ancestor re-patching keeps its prior effect — string AND, for PreLine, the inline `white-space`
-    // write alike — until its next text update; the common static case (effect set at mount) is fully correct.
+    // write AND, for Overline, the painted binding alike — until its next text update; the common static
+    // case (effect set at mount) is fully correct.
     internal static class StyleTextEffectResolver
     {
         // Captures the untransformed text for a text-bearing element at a text-set seam (TextNode create/patch,
@@ -150,6 +167,45 @@ namespace Velvet
                 else if (ctx.TextWhitespaceOwned.Remove(te))
                 {
                     te.style.whiteSpace = StyleKeyword.Null;
+                }
+
+                // Overline paint, off the SAME resolved decoration the string rewrite above just used (it
+                // left the string itself unchanged — see StyleTextEffectClass.ApplyDecoration): attach a
+                // binding the first time this leaf resolves to Overline, detach it the moment it no longer
+                // does. Unlike the whitespace write there is nothing to disagree with here (no other system
+                // ever attaches this binding), so no ownership gate is needed — presence in
+                // TextOverlineBindings IS the ownership.
+                if (decoration == TextDecorationKind.Overline)
+                {
+                    // Repaint belongs on the ATTACH transition only — Attach's own MarkDirtyRepaint already
+                    // covers a fresh subscription's first paint — NOT on a steady-state revisit where the
+                    // binding already exists, or every patch of every overlined leaf pays a full mesh regen
+                    // whether or not anything the paint reads actually changed. This is safe because every
+                    // value Draw reads is already dirtied through its OWN native channel by the time it
+                    // changes: TextElement's text setter always raises Repaint (SetValueWithoutNotify diffs
+                    // the string and calls IncrementVersion(Layout|Repaint) or Repaint); font-size and
+                    // -unity-text-align are both explicit Repaint-raising properties in UI Toolkit's own
+                    // ComputedStyle diff (ComputedStyle.CompareChanges); and contentRect only ever moves as
+                    // the result of a resolved layout change, which the layout pass itself always pairs with
+                    // Repaint the moment a box's resolved size actually changes (VisualTreeLayoutUpdater.
+                    // UpdateSubTree raises Size and Repaint together, unconditionally, no fast path). The one
+                    // real gap found: a resolvedStyle.color-ONLY change raises
+                    // VersionChangeType.Color, not Repaint, and an element that opts into the native
+                    // UsageHints.DynamicColor perf hint can patch that color in place without a full repaint
+                    // (RenderEvents.OnColorChanged's dynamic-color fast path) — Velvet itself never sets that
+                    // hint, so closing it here would mean paying an unconditional repaint on every visit to
+                    // guard a combination this framework never produces; left as a documented, self-correcting
+                    // gap (any OTHER later change on the element still repaints it) rather than gated.
+                    if (!ctx.TextOverlineBindings.TryGetValue(te, out var overline))
+                    {
+                        overline = TextOverlineSilhouette.Attach(te);
+                        ctx.TextOverlineBindings[te] = overline;
+                    }
+                }
+                else if (ctx.TextOverlineBindings.TryGetValue(te, out var overline))
+                {
+                    TextOverlineSilhouette.Detach(te, overline);
+                    ctx.TextOverlineBindings.Remove(te);
                 }
             }
         }

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/StyleTextEffectClassTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/StyleTextEffectClassTests.cs
@@ -41,6 +41,34 @@ namespace Velvet.Tests
         }
 
         [Test]
+        public void Given_Overline_When_Parsed_Then_DecorationIsOverline()
+        {
+            Assert.That(StyleTextEffectClass.Parse(new[] { "overline" }).Decoration, Is.EqualTo(TextDecorationKind.Overline));
+        }
+
+        [Test]
+        public void Given_UnderlineThenOverline_When_Parsed_Then_LastTokenWinsWithOverline()
+        {
+            // The decoration axis is single-valued by this subsystem's pre-existing design — CSS lets
+            // text-decoration-line combine multiple lines, but Velvet resolves exactly one value per
+            // element — so two decoration tokens on the same element resolve last-token-wins like every
+            // other axis, not a combined underline+overline.
+            Assert.That(
+                StyleTextEffectClass.Parse(new[] { "underline", "overline" }).Decoration,
+                Is.EqualTo(TextDecorationKind.Overline));
+        }
+
+        [Test]
+        public void Given_OverlineThenNoUnderline_When_Parsed_Then_DecorationResetsToNone()
+        {
+            // no-underline is CSS's text-decoration-line: none sentinel for the WHOLE axis, so it clears an
+            // overline set earlier on the same element too, not just underline/line-through.
+            Assert.That(
+                StyleTextEffectClass.Parse(new[] { "overline", "no-underline" }).Decoration,
+                Is.EqualTo(TextDecorationKind.None));
+        }
+
+        [Test]
         public void Given_TransformAndDecoration_When_Parsed_Then_BothAxesSet()
         {
             var e = StyleTextEffectClass.Parse(new[] { "uppercase", "underline" });
@@ -71,6 +99,14 @@ namespace Velvet.Tests
         public void Given_LineThrough_When_Applied_Then_WrappedInSTag()
         {
             Assert.That(StyleTextEffectClass.Apply("hi", null, TextDecorationKind.LineThrough), Is.EqualTo("<s>hi</s>"));
+        }
+
+        [Test]
+        public void Given_Overline_When_Applied_Then_TextIsUnchanged()
+        {
+            // UI Toolkit rich text has no overline tag, so unlike Underline/LineThrough this leaves the
+            // string alone — the leaf paints a rule instead (StyleTextEffectResolver.ApplyToElement).
+            Assert.That(StyleTextEffectClass.Apply("hi", null, TextDecorationKind.Overline), Is.EqualTo("hi"));
         }
 
         [Test]
@@ -554,6 +590,23 @@ namespace Velvet.Tests
 
             // Assert
             Assert.That(result, Is.EqualTo("<line-height=1.625em><u>HI THERE</u></line-height>"));
+        }
+
+        [Test]
+        public void Given_OverlineUppercaseAndLeadingCombined_When_Applied_Then_StringCarriesCaseAndLeadingButNoDecorationTag()
+        {
+            // Arrange — overline has no rich-text tag (UI Toolkit has none), so the resolved string must
+            // carry exactly what Transform + Leading alone would produce: uppercase and the line-height
+            // wrap, but no <u>/<s> pair anywhere — unlike Underline/LineThrough, which always add one.
+            var classNames = new[] { "overline", "uppercase", "leading-tight" };
+
+            // Act
+            var effect = StyleTextEffectClass.Parse(classNames);
+            var result = StyleTextEffectClass.Apply(
+                "hi", effect.Transform, effect.Decoration, effect.Whitespace, effect.Leading);
+
+            // Assert
+            Assert.That(result, Is.EqualTo("<line-height=1.25em>HI</line-height>"));
         }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/StyleTextEffectPanelTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/StyleTextEffectPanelTests.cs
@@ -33,6 +33,9 @@ namespace Velvet.Tests
         private static StateUpdater<string> s_setLeadingAncestorClass;
         private static StateUpdater<string> s_setLeadingText;
         private static StateUpdater<string> s_setLeadingPoolReuseState;
+        private static StateUpdater<string> s_setOverlineClass;
+        private static StateUpdater<string> s_setOverlinePoolReuseState;
+        private static StateUpdater<string> s_setOverlineText;
 
         protected override Rect WindowSize => new Rect(0, 0, 400, 400);
 
@@ -49,6 +52,9 @@ namespace Velvet.Tests
             s_setLeadingAncestorClass = default;
             s_setLeadingText = default;
             s_setLeadingPoolReuseState = default;
+            s_setOverlineClass = default;
+            s_setOverlinePoolReuseState = default;
+            s_setOverlineText = default;
             base.SetUp();
         }
 
@@ -483,6 +489,99 @@ namespace Velvet.Tests
             Assert.That(_window.rootVisualElement.Q<Label>("leaf").text, Is.EqualTo("there"));
         }
 
+        [Test]
+        public void Given_OverlineOnLabelItself_When_Mounted_Then_BindingIsRegisteredForTheLeaf()
+        {
+            var label = MountAndFindLabel(V.Label(className: "overline", text: "hi"));
+
+            Assert.That(_mounted.Root.Reconciler.Context.TextOverlineBindings.ContainsKey(label), Is.True);
+        }
+
+        [Test]
+        public void Given_OverlineOnParent_When_Mounted_Then_ChildTextLeafBindingIsRegistered()
+        {
+            // The text leaf has no class of its own; the binding cascades from the parent, mirroring how
+            // transform/decoration cascade onto a class-less V.Text leaf.
+            var label = MountAndFindLabel(V.Div(className: "overline", V.Text("hi")));
+
+            Assert.That(_mounted.Root.Reconciler.Context.TextOverlineBindings.ContainsKey(label), Is.True);
+        }
+
+        [Test]
+        public void Given_OverlineAndNoUnderlineOnSameElement_When_Mounted_Then_NoBindingIsRegistered()
+        {
+            // no-underline resolves the SAME axis to None (see StyleTextEffectClassTests), so the leaf must
+            // never attach a binding at all — not attach-then-immediately-detach.
+            var label = MountAndFindLabel(V.Label(className: "overline no-underline", text: "hi"));
+
+            Assert.That(_mounted.Root.Reconciler.Context.TextOverlineBindings.ContainsKey(label), Is.False);
+        }
+
+        [Test]
+        public void Given_OverlineClassRemoved_When_Patched_Then_BindingIsDetached()
+        {
+            Mount(V.Component(RenderOverlineToggle));
+            var ctx = _mounted.Root.Reconciler.Context;
+            var label = _window.rootVisualElement.Q<Label>("leaf");
+            Assume.That(ctx.TextOverlineBindings.ContainsKey(label), Is.True,
+                "Precondition: the overline binding attached at mount");
+
+            s_setOverlineClass.Invoke("");
+            ctx.BatchScheduler.DrainImmediateForTest();
+
+            Assert.That(ctx.TextOverlineBindings.ContainsKey(label), Is.False);
+        }
+
+        [Test]
+        public void Given_OverlineTextPropPatchedToNull_When_Patched_Then_BindingIsDetached()
+        {
+            // The overline class stays; only the Text prop patches to null (the label stays mounted — no
+            // pool cycle, so ClearElementSideTables never runs for it). FiberNodePatcher drops the
+            // TextRawText entry for that transition, which stops ApplyToElement from ever running for this
+            // element again — the leak this pins: without an explicit detach at that same site, the
+            // generateVisualContent subscription it left behind would survive forever instead of clearing
+            // along with the text (mirrors the PreLine inline-whitespace sibling case for the same transition).
+            Mount(V.Component(RenderOverlineTextPropToggle));
+            var ctx = _mounted.Root.Reconciler.Context;
+            var label = _window.rootVisualElement.Q<Label>("leaf");
+            Assume.That(ctx.TextOverlineBindings.ContainsKey(label), Is.True,
+                "Precondition: the overline binding attached at mount");
+
+            s_setOverlineText.Invoke((string)null);
+            ctx.BatchScheduler.DrainImmediateForTest();
+
+            Assert.That(ctx.TextOverlineBindings.ContainsKey(label), Is.False);
+        }
+
+        [Test]
+        public void Given_LabelPooledWithOverlineState_When_RentedAgainWithoutTheClass_Then_NewLabelHasNoBinding()
+        {
+            // Arrange — mount an overline Label, then hide it (a Label -> Div swap removes it, returning it
+            // to VNodePool while it still carries the binding), then show a different, unrelated plain
+            // label. VNodePool's Label pool is LIFO and nothing else rents a Label in between, so this
+            // deterministically hands the same instance back, mirroring the PreLine/Leading pool-reuse tests.
+            Mount(V.Component(RenderOverlinePoolReuseHost));
+            var ctx = _mounted.Root.Reconciler.Context;
+            var scheduler = ctx.BatchScheduler;
+            var firstLabel = _window.rootVisualElement.Q<Label>("leaf");
+            Assume.That(ctx.TextOverlineBindings.ContainsKey(firstLabel), Is.True,
+                "Precondition: the first label carries an overline binding");
+            s_setOverlinePoolReuseState.Invoke("hidden");
+            scheduler.DrainImmediateForTest();
+            Assume.That(_window.rootVisualElement.Q<Label>("leaf"), Is.Null, "Precondition: the label is pooled while hidden");
+
+            // Act — an unrelated plain label rents the pooled instance back.
+            s_setOverlinePoolReuseState.Invoke("plain");
+            scheduler.DrainImmediateForTest();
+
+            // Assert — genuinely the SAME recycled instance (not a coincidentally-unbound new one), carrying
+            // no leftover binding from the previous consumer.
+            var recycled = _window.rootVisualElement.Q<Label>("leaf");
+            Assert.That(
+                (ReferenceEquals(recycled, firstLabel), ctx.TextOverlineBindings.ContainsKey(recycled)),
+                Is.EqualTo((true, false)));
+        }
+
         private void Mount(VNode tree)
         {
             _mounted = V.Mount(_window.rootVisualElement, tree);
@@ -618,6 +717,42 @@ namespace Velvet.Tests
                 return V.Label(name: "leaf", text: "there");
             }
             return V.Div(name: "placeholder");
+        }
+
+        [Component]
+        private static VNode RenderOverlineToggle()
+        {
+            var (cls, setCls) = Hooks.UseState("overline");
+            s_setOverlineClass = setCls;
+            return V.Label(name: "leaf", className: cls, text: "hi");
+        }
+
+        [Component]
+        private static VNode RenderOverlinePoolReuseHost()
+        {
+            var (state, setState) = Hooks.UseState("overline");
+            s_setOverlinePoolReuseState = setState;
+            if (state == "overline")
+            {
+                return V.Label(name: "leaf", className: "overline", text: "hi");
+            }
+            if (state == "plain")
+            {
+                return V.Label(name: "leaf", text: "there");
+            }
+            return V.Div(name: "placeholder");
+        }
+
+        [Component]
+        private static VNode RenderOverlineTextPropToggle()
+        {
+            // Unlike RenderOverlineToggle (which toggles the CLASS), this toggles the Text PROP itself while
+            // overline stays on the class list throughout — exercising the Text->null transition on a still-
+            // mounted element, the one path where the live generateVisualContent subscription must be
+            // detached without an unmount or pool cycle ever running (see FiberNodePatcher.PatchBaseElement).
+            var (text, setText) = Hooks.UseState("hi");
+            s_setOverlineText = setText;
+            return V.Label(name: "leaf", className: "overline", text: text);
         }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/TextOverlinePainterTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/TextOverlinePainterTests.cs
@@ -1,0 +1,221 @@
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Specifies the pure geometry behind the <c>overline</c> text-decoration's painted rule
+    /// (<see cref="TextOverlinePainter.TryComputeGeometry"/>) and its thickness rule
+    /// (<see cref="TextOverlinePainter.ResolveThickness"/>, public, tested directly). The horizontal/vertical
+    /// anchor resolvers are private, so — mirroring how <c>DashedBorderPainterTests</c> never calls
+    /// <c>DashedBorderPainter</c>'s private <c>ComputeDashes</c> / <c>ComputeDots</c> directly — they are
+    /// exercised only through TryComputeGeometry's own output. Both measurements the function needs (the
+    /// text's natural width and the wrapped text block's height) are ordinary parameters supplied by the
+    /// caller, not a live <c>MeasureTextSize</c> call, so every case here runs headless with no panel and no
+    /// TextElement. GWT, one assert per case.
+    /// </summary>
+    [TestFixture]
+    internal sealed class TextOverlinePainterTests
+    {
+        private static (bool Ok, Vector2 From, Vector2 To, float LineWidth) Compute(
+            Rect contentRect, float measuredWidth, float textBlockHeight, float fontSize, TextAnchor align)
+        {
+            var ok = TextOverlinePainter.TryComputeGeometry(
+                contentRect, measuredWidth, textBlockHeight, fontSize, align, out var from, out var to, out var lineWidth);
+            return (ok, from, to, lineWidth);
+        }
+
+        [Test]
+        public void Given_AnUpperLeftAnchor_When_GeometryComputed_Then_TheRuleStartsAtTheContentBoxLeftEdge()
+        {
+            // Arrange — a 100-wide content box; a 40-wide run leaves 60 of leftover space.
+            var contentRect = new Rect(10f, 20f, 100f, 50f);
+
+            // Act
+            var (ok, from, _, _) = Compute(
+                contentRect: contentRect, measuredWidth: 40f, textBlockHeight: 20f, fontSize: 16f, align: TextAnchor.UpperLeft);
+
+            // Assert
+            Assume.That(ok, Is.True, "Precondition: a well-formed content rect computes geometry");
+            Assert.That(from.x, Is.EqualTo(10f));
+        }
+
+        [Test]
+        public void Given_AnUpperCenterAnchor_When_GeometryComputed_Then_TheRuleIsCenteredInTheContentBox()
+        {
+            // Arrange — the 60 leftover units (100 - 40) split evenly, 30 on each side of the content box.
+            var contentRect = new Rect(10f, 20f, 100f, 50f);
+
+            // Act
+            var (ok, from, _, _) = Compute(
+                contentRect: contentRect, measuredWidth: 40f, textBlockHeight: 20f, fontSize: 16f, align: TextAnchor.UpperCenter);
+
+            // Assert
+            Assume.That(ok, Is.True, "Precondition: a well-formed content rect computes geometry");
+            Assert.That(from.x, Is.EqualTo(40f));
+        }
+
+        [Test]
+        public void Given_AnUpperRightAnchor_When_GeometryComputed_Then_TheRuleEndsAtTheContentBoxRightEdge()
+        {
+            // Arrange
+            var contentRect = new Rect(10f, 20f, 100f, 50f);
+
+            // Act
+            var (ok, _, to, _) = Compute(
+                contentRect: contentRect, measuredWidth: 40f, textBlockHeight: 20f, fontSize: 16f, align: TextAnchor.UpperRight);
+
+            // Assert
+            Assume.That(ok, Is.True, "Precondition: a well-formed content rect computes geometry");
+            Assert.That(to.x, Is.EqualTo(110f));
+        }
+
+        [Test]
+        public void Given_AnUpperAnchor_When_GeometryComputed_Then_TheYBaseIsTheContentBoxTopPlusTheFontNudge()
+        {
+            // Arrange — Upper* top-aligns the whole text block to the content box, so the first (only, here)
+            // line's top IS the content box's own top edge (yMin = 20).
+            var contentRect = new Rect(10f, 20f, 100f, 50f);
+
+            // Act
+            var (ok, from, _, _) = Compute(
+                contentRect: contentRect, measuredWidth: 40f, textBlockHeight: 20f, fontSize: 16f, align: TextAnchor.UpperLeft);
+
+            // Assert — yMin (20) + 15% of the 16px font (2.4).
+            Assume.That(ok, Is.True, "Precondition: a well-formed content rect computes geometry");
+            Assert.That(from.y, Is.EqualTo(22.4f).Within(1e-3f));
+        }
+
+        [Test]
+        public void Given_AMiddleAnchor_When_GeometryComputed_Then_TheYBaseIsTheCenteredBlocksTopPlusTheFontNudge()
+        {
+            // Arrange — a middle anchor centers the 20-tall block in the 50-tall content box (center.y = 45):
+            // the block spans 35..55, so the first line's top is 35, not the content box's own top (20).
+            var contentRect = new Rect(10f, 20f, 100f, 50f);
+
+            // Act
+            var (ok, from, _, _) = Compute(
+                contentRect: contentRect, measuredWidth: 40f, textBlockHeight: 20f, fontSize: 16f, align: TextAnchor.MiddleLeft);
+
+            // Assert — 35 + 2.4.
+            Assume.That(ok, Is.True, "Precondition: a well-formed content rect computes geometry");
+            Assert.That(from.y, Is.EqualTo(37.4f).Within(1e-3f));
+        }
+
+        [Test]
+        public void Given_ALowerAnchor_When_GeometryComputed_Then_TheYBaseIsTheBottomAlignedBlocksTopPlusTheFontNudge()
+        {
+            // Arrange — a lower anchor bottom-aligns the 20-tall block to the content box's own bottom (yMax
+            // = 70), so the block's (and so the first line's) top is 50 (70 - 20), not the content box's own
+            // top (20).
+            var contentRect = new Rect(10f, 20f, 100f, 50f);
+
+            // Act
+            var (ok, from, _, _) = Compute(
+                contentRect: contentRect, measuredWidth: 40f, textBlockHeight: 20f, fontSize: 16f, align: TextAnchor.LowerLeft);
+
+            // Assert — 50 + 2.4.
+            Assume.That(ok, Is.True, "Precondition: a well-formed content rect computes geometry");
+            Assert.That(from.y, Is.EqualTo(52.4f).Within(1e-3f));
+        }
+
+        [Test]
+        public void Given_AZeroWidthContentRect_When_GeometryComputed_Then_ItReturnsFalse()
+        {
+            // Arrange — a degenerate (zero-width) content box, the shape a collapsed layout can produce.
+            var contentRect = new Rect(0f, 0f, 0f, 50f);
+
+            // Act
+            var (ok, _, _, _) = Compute(
+                contentRect: contentRect, measuredWidth: 10f, textBlockHeight: 10f, fontSize: 16f, align: TextAnchor.UpperLeft);
+
+            // Assert
+            Assert.That(ok, Is.False);
+        }
+
+        [Test]
+        public void Given_AZeroHeightContentRect_When_GeometryComputed_Then_ItReturnsFalse()
+        {
+            // Arrange
+            var contentRect = new Rect(0f, 0f, 100f, 0f);
+
+            // Act
+            var (ok, _, _, _) = Compute(
+                contentRect: contentRect, measuredWidth: 10f, textBlockHeight: 10f, fontSize: 16f, align: TextAnchor.UpperLeft);
+
+            // Assert
+            Assert.That(ok, Is.False);
+        }
+
+        [Test]
+        public void Given_ANaNHeightContentRect_When_GeometryComputed_Then_ItReturnsFalse()
+        {
+            // Arrange — a NaN dimension, the shape an unresolved layout read before the first pass settles
+            // can produce.
+            var contentRect = new Rect(0f, 0f, 100f, float.NaN);
+
+            // Act
+            var (ok, _, _, _) = Compute(
+                contentRect: contentRect, measuredWidth: 10f, textBlockHeight: 10f, fontSize: 16f, align: TextAnchor.UpperLeft);
+
+            // Assert
+            Assert.That(ok, Is.False);
+        }
+
+        [Test]
+        public void Given_EmptyText_When_GeometryComputed_Then_TheRuleIsAZeroLengthRun()
+        {
+            // Arrange — an empty run measures to 0 width; the content box itself is still well-formed.
+            var contentRect = new Rect(10f, 20f, 100f, 50f);
+
+            // Act
+            var (ok, from, to, _) = Compute(
+                contentRect: contentRect, measuredWidth: 0f, textBlockHeight: 20f, fontSize: 16f, align: TextAnchor.UpperLeft);
+
+            // Assert
+            Assume.That(ok, Is.True, "Precondition: a well-formed content rect still computes geometry for empty text");
+            Assert.That(from, Is.EqualTo(to));
+        }
+
+        [Test]
+        public void Given_ANaturalWidthWiderThanTheContentBox_When_GeometryComputed_Then_TheRuleClampsToTheContentWidth()
+        {
+            // Arrange — a 150-wide natural measurement against a 100-wide content box.
+            var contentRect = new Rect(10f, 20f, 100f, 50f);
+
+            // Act
+            var (ok, from, to, _) = Compute(
+                contentRect: contentRect, measuredWidth: 150f, textBlockHeight: 20f, fontSize: 16f, align: TextAnchor.UpperLeft);
+
+            // Assert
+            Assume.That(ok, Is.True, "Precondition: a well-formed content rect computes geometry");
+            Assert.That(to.x - from.x, Is.EqualTo(100f));
+        }
+
+        [Test]
+        public void Given_ATinyFontSize_When_ThicknessResolved_Then_ItIsFlooredAtOnePixel()
+        {
+            // Arrange — 4 / 16 = 0.25, below the 1px floor.
+            const float fontSize = 4f;
+
+            // Act
+            var thickness = TextOverlinePainter.ResolveThickness(fontSize);
+
+            // Assert
+            Assert.That(thickness, Is.EqualTo(1f));
+        }
+
+        [Test]
+        public void Given_A32PixelFontSize_When_ThicknessResolved_Then_ItIsTwoPixels()
+        {
+            // Arrange — 32 / 16 = 2, above the floor, so the plain ratio applies unmodified.
+            const float fontSize = 32f;
+
+            // Act
+            var thickness = TextOverlinePainter.ResolveThickness(fontSize);
+
+            // Assert
+            Assert.That(thickness, Is.EqualTo(2f));
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/TextOverlinePainterTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/TextOverlinePainterTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d143b6c5ca584c6fbfef890c1b452483

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/PlayMode/TextOverlinePlaybackTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/PlayMode/TextOverlinePlaybackTests.cs
@@ -1,0 +1,142 @@
+using System.Collections;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using UnityEngine.UIElements;
+using Velvet.TestUtilities;
+using static Velvet.TestUtilities.PlayModeRealtimeTestHelpers;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// The runtime paint proof for <c>overline</c>: UI Toolkit's rich text has no overline tag, so the
+    /// decoration is realised as a <c>generateVisualContent</c> PAINT (<see cref="TextOverlinePainter"/> /
+    /// <see cref="TextOverlineBinding"/>) rather than a string rewrite. An EditMode fixture
+    /// (<c>StyleTextEffectPanelTests</c>) already pins that the binding gets attached/detached at the right
+    /// times; this instead proves something actually reaches the mesh, on a real ticking runtime panel, by
+    /// reading back pixels (mirroring the SceneView / Particles / built-in-filter playback specs).
+    /// </summary>
+    /// <remarks>
+    /// The test string ("moon") is deliberately all x-height glyphs — no ascenders, descenders, or dots — so
+    /// its own ink never reaches the TOP band of the label's resolved line box regardless of the exact font
+    /// metrics (see <see cref="CountRedPixelsInTopBand"/> for the margin reasoning). That band is also where
+    /// <see cref="TextOverlinePainter"/> places its rule. Both the glyph ink and the rule share the SAME
+    /// inline <c>text-[#ff0000]</c> color (the painter reads <c>resolvedStyle.color</c>), so the established
+    /// <see cref="RenderTexturePixelReader.IsRedPixel"/> heuristic — built for exactly this saturated-red
+    /// test-color convention — detects either one without a bespoke threshold.
+    /// </remarks>
+    [Timeout(600000)]
+    internal sealed class TextOverlinePlaybackTests
+    {
+        private const string GlyphOnlyText = "moon";
+        private const string LabelClasses = "text-[48px] text-[#ff0000]";
+
+        // A themeless RenderTexture panel supplies neither a font (an empty runtime theme measures every
+        // label 0 tall) nor wrap behavior, so both are supplied inline through the ref — the one channel
+        // that reaches a bare panel (mirrors LeadingLineHeightPlaybackTests' identical incantation).
+        private static readonly System.Func<VisualElement, System.Action> s_enableTextMeasurement = el =>
+        {
+            el.style.whiteSpace = WhiteSpace.Normal;
+            el.style.unityFontDefinition = new StyleFontDefinition(FontDefinition.FromFont(
+                UnityEngine.Resources.GetBuiltinResource<UnityEngine.Font>("LegacyRuntime.ttf")));
+            return null;
+        };
+
+        private RenderTexturePanelHost _host;
+        private MountedTree _mounted;
+        private TargetFrameRateScope _frameRateScope;
+
+        [UnitySetUp]
+        public IEnumerator UnitySetUp()
+        {
+            _frameRateScope = new TargetFrameRateScope(120);
+            yield break;
+        }
+
+        [UnityTearDown]
+        public IEnumerator UnityTearDown()
+        {
+            _frameRateScope.Dispose();
+            DisposePanel();
+            yield return null;
+        }
+
+        private void DisposePanel()
+        {
+            _mounted?.Dispose();
+            _mounted = null;
+            _host?.Dispose();
+            _host = null;
+        }
+
+        // Mounts a single Label, with or without `overline`, and lets a real panel tick layout + a first
+        // paint. A generous realtime wait (not a fixed frame count) absorbs a first-run text-shaping /
+        // glyph-atlas warm-up, the same posture BuiltInFilterShaderPlaybackTests takes for its own
+        // first-draw GPU warm-up.
+        private IEnumerator MountLabel(bool overline)
+        {
+            _host = new RenderTexturePanelHost("OverlinePanel", 260, 140);
+            var classNames = overline ? "overline " + LabelClasses : LabelClasses;
+            _mounted = V.Mount(_host.Root, V.Label(
+                name: "lbl", className: classNames, text: GlyphOnlyText, refCallback: s_enableTextMeasurement));
+            yield return WaitRealtime(0.5);
+        }
+
+        // Counts red pixels in the TOP band (the top 20% of the label's own resolved height) of the ONLY
+        // label in the panel. That fraction is chosen with margin on both sides for typical sans-serif
+        // metrics: TextOverlinePainter places its rule ~15% of the FONT size below the content box's top —
+        // roughly 12% of a ~1.2x-font-size line box — comfortably inside a 20% band; "moon"'s x-height ink
+        // starts only around 40% down from the same top (line box top -> baseline is ~0.95em for a typical
+        // sans-serif, x-height is ~0.5em, leaving ~0.45em, i.e. ~37% of a 1.2em line box, of clear space
+        // above it) — comfortably outside a 20% band. Either estimate would have to be off by roughly double
+        // for the two bands to collide.
+        private int CountRedPixelsInTopBand()
+        {
+            var label = _host.Root.Q<Label>("lbl");
+            var textureWidth = _host.TargetTexture.width;
+            var textureHeight = _host.TargetTexture.height;
+            var bandHeight = Mathf.Max(4f, label.layout.height * 0.2f);
+            var x = Mathf.Clamp(Mathf.RoundToInt(label.layout.x), 0, textureWidth);
+            // Clamped to the texture bounds defensively — the panel is sized with generous margin around
+            // the expected text width, but ReadPixels cannot tolerate a region reaching past the texture.
+            var bandWidth = Mathf.Clamp(Mathf.RoundToInt(label.layout.width), 1, textureWidth - x);
+            // ReadPixels is bottom-origin (see SceneViewPlaybackTests): the label sits at the panel's
+            // top-left (the ONLY element mounted, under default non-absolute flow), so its top band (small
+            // panel-Y) maps to the texture's TOP rows — the HIGHEST y-from-bottom values.
+            var yFromBottom = Mathf.Clamp(Mathf.RoundToInt(textureHeight - (label.layout.y + bandHeight)), 0, textureHeight - 1);
+            var bandHeightPx = Mathf.Clamp(Mathf.RoundToInt(bandHeight), 1, textureHeight - yFromBottom);
+            var region = new RectInt(x, yFromBottom, bandWidth, bandHeightPx);
+            var pixels = RenderTexturePixelReader.ReadPixels(_host.TargetTexture, region);
+            var count = 0;
+            foreach (var p in pixels)
+            {
+                if (RenderTexturePixelReader.IsRedPixel(p)) count++;
+            }
+            return count;
+        }
+
+        [UnityTest]
+        public IEnumerator Given_OverlineLabel_When_Rendered_Then_TopBandShowsMoreRedThanTheNoOverlineSibling()
+        {
+            // Arrange & Act — baseline: identical text/font/color with no overline class at all.
+            yield return MountLabel(overline: false);
+            var baselineLabel = _host.Root.Q<Label>("lbl");
+            Assume.That(baselineLabel != null && baselineLabel.layout.height > 0f, Is.True,
+                "Precondition: the baseline label mounted and resolved a real layout height");
+            var baseline = CountRedPixelsInTopBand();
+            // A generous margin, not strict zero: the band is chosen to sit clear of "moon"'s x-height ink
+            // (see the type remarks), but a strict-zero precondition would turn a stray anti-aliased pixel
+            // into an Inconclusive rather than a clean pass, without making the final comparison below any
+            // less meaningful either way.
+            Assume.That(baseline, Is.LessThan(5),
+                $"Precondition: the no-overline label's x-height-only glyphs stay clear of the top band (got {baseline} red pixels)");
+            DisposePanel();
+
+            // Act — the identical label with only `overline` added.
+            yield return MountLabel(overline: true);
+
+            // Assert
+            Assert.That(CountRedPixelsInTopBand(), Is.GreaterThan(baseline));
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/PlayMode/TextOverlinePlaybackTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/PlayMode/TextOverlinePlaybackTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: cd485c4ae1fc4bba808b155c63a004e1

--- a/Packages/com.velvet.core/Runtime/Styling/TextOverlineBinding.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/TextOverlineBinding.cs
@@ -1,0 +1,79 @@
+using System;
+using UnityEngine.UIElements;
+
+namespace Velvet
+{
+    // Reconciler-side bookkeeping for one leaf TextElement's PAINTED overline (the Decoration axis's
+    // Overline value — see TextDecorationKind), keyed in ReconcilerContext.TextOverlineBindings by the
+    // element itself. Unlike BorderStyleBinding there is no native property to suppress and nothing to
+    // stash: the rule is purely ADDITIVE paint above the glyph run, so the binding holds only the
+    // registered callback (needed so Detach can unhook it) — every value the paint itself needs (text,
+    // color, font size, alignment, layout) is read fresh from the element at each Draw, per
+    // StyleTextEffectResolver's own "resolve fresh, no caching" contract for this axis.
+    internal sealed class TextOverlineBinding
+    {
+        public Action<MeshGenerationContext>? OnGenerate;
+    }
+
+    /// <summary>
+    /// Paints the <c>overline</c> text-decoration — a solid rule stroked above a leaf TextElement's first
+    /// line via Painter2D in the element's own <c>generateVisualContent</c>. UI Toolkit's rich text has no
+    /// overline tag (only <c>&lt;u&gt;</c> / <c>&lt;s&gt;</c>), so unlike underline / line-through this
+    /// cannot be a string rewrite; <see cref="TextOverlinePainter"/> computes the rule's geometry.
+    /// </summary>
+    /// <remarks>
+    /// v1 scope: ONE rule, positioned above the FIRST line and sized to the text's natural
+    /// single-line-equivalent width (clamped to the content width). Per-line metrics of wrapped text are not
+    /// publicly reachable in a way usable synchronously from <c>generateVisualContent</c> (there is a public
+    /// per-glyph vertex hook, <c>TextElement.PostProcessTextVertices</c>, but it runs job-dependent and out
+    /// of sync with <c>generateVisualContent</c>), so a multi-line label gets one rule above its top line
+    /// only — a documented limitation, not a bug; per-line placement is future work.
+    /// </remarks>
+    internal static class TextOverlineSilhouette
+    {
+        // Wires the paint callback onto the element and returns the binding. Prepended (not appended) so the
+        // rule paints BEHIND the glyphs: TextElement (Label, Button) registers its own text-rendering
+        // callback at construction, before this Attach call ever runs, and prepending ours keeps it from
+        // being invoked AFTER (over) the text — the same ordering rule BorderStyleSilhouette keeps for a
+        // dashed outline, and it also matches how a browser paints a decoration line behind the glyph ink,
+        // so a tall glyph that dips into the rule's band is not visually interrupted by it.
+        public static TextOverlineBinding Attach(VisualElement element)
+        {
+            var binding = new TextOverlineBinding();
+            binding.OnGenerate = mgc => Draw(mgc, (TextElement)element);
+            element.generateVisualContent = binding.OnGenerate + element.generateVisualContent;
+            element.MarkDirtyRepaint();
+            return binding;
+        }
+
+        // Unregisters the paint callback so a detached or pooled element cannot ghost the rule onto its
+        // next consumer.
+        public static void Detach(VisualElement element, TextOverlineBinding binding)
+        {
+            element.generateVisualContent -= binding.OnGenerate;
+            element.MarkDirtyRepaint();
+        }
+
+        private static void Draw(MeshGenerationContext mgc, TextElement element)
+        {
+            // Two different measurements for two different axes: an UNCONSTRAINED measure gives the text's
+            // natural single-line-equivalent width (what ResolveStartX centers/right-aligns horizontally,
+            // unrelated to how the text actually wraps); a measure pinned to the content width via Exactly
+            // gives the (possibly wrapped, multi-line) block's real rendered height — what ResolveFirstLineTop
+            // needs to place a Middle/Lower-anchored block vertically. Both are read fresh here (not cached)
+            // per this file's own contract, and passed in so TryComputeGeometry stays pure and unit-testable.
+            var measuredWidth = element.MeasureTextSize(
+                element.text, 0f, VisualElement.MeasureMode.Undefined, 0f, VisualElement.MeasureMode.Undefined).x;
+            var textBlockHeight = element.MeasureTextSize(
+                element.text, element.contentRect.width, VisualElement.MeasureMode.Exactly,
+                0f, VisualElement.MeasureMode.Undefined).y;
+            if (!TextOverlinePainter.TryComputeGeometry(
+                    element.contentRect, measuredWidth, textBlockHeight, element.resolvedStyle.fontSize,
+                    element.resolvedStyle.unityTextAlign, out var from, out var to, out var lineWidth))
+            {
+                return;
+            }
+            TextOverlinePainter.Stroke(mgc.painter2D, from, to, lineWidth, element.resolvedStyle.color);
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Styling/TextOverlineBinding.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Styling/TextOverlineBinding.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2775d7ae19b34af995acda6c3e843e17

--- a/Packages/com.velvet.core/Runtime/Styling/TextOverlinePainter.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/TextOverlinePainter.cs
@@ -1,0 +1,130 @@
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace Velvet
+{
+    // Pure geometry for the `overline` text-decoration's painted rule (see TextOverlineBinding for the
+    // generateVisualContent attach/detach that consumes it). Painter-free so ComputeGeometry is
+    // unit-testable headless — a Painter2D cannot be read back — mirroring DashedBorderPainter's own split
+    // between pure math (ComputeSegments) and the live-Painter2D stroke call (StrokeDashed).
+    internal static class TextOverlinePainter
+    {
+        // The rule sits this far below the FIRST line's top edge, as a fraction of font size. UI Toolkit
+        // exposes no public, synchronously-reachable ascent metric for an arbitrary Font/FontAsset (the
+        // per-glyph vertex hook, PostProcessTextVertices, runs job-dependent and out of sync with
+        // generateVisualContent), so this is a documented approximation rather than a measured ascent line:
+        // most fonts carry some internal leading above the ascender within their em-square, and CSS specifies
+        // overline at the ascent line, not the very top of the line box — nudging down by 15% of the font
+        // size lands near that ascent line for typical font metrics without needing per-font data.
+        private const float TopOffsetFraction = 0.15f;
+
+        // Typical browsers stroke an underline/overline at roughly 1/16th of the font size; floored at 1px
+        // so a small font size never thins the rule to an invisible sub-pixel stroke.
+        private const float ThicknessDivisor = 16f;
+        private const float MinThicknessPx = 1f;
+
+        // Exposed separately from TryComputeGeometry so a caller (or a test) can pin the thickness rule on
+        // its own, independent of a content rect.
+        public static float ResolveThickness(float fontSize) => Mathf.Max(MinThicknessPx, fontSize / ThicknessDivisor);
+
+        // Computes the rule's endpoints and stroke width, in the element-local space generateVisualContent
+        // paints in (the same space contentRect itself is expressed in). Width is the text's natural
+        // single-line-equivalent width clamped to the content box (v1 scope: one rule above the FIRST line
+        // only — per-line metrics of wrapped text are not reachable here, see the type remarks on
+        // TextOverlineBinding). textBlockHeight is the whole (possibly wrapped, multi-line) text block's
+        // measured height — needed by ResolveFirstLineTop to find where a Middle/Lower-anchored block (and so
+        // its first line) sits, exactly the way measuredWidth feeds ResolveStartX for the horizontal anchor.
+        // Both measurements are supplied by the caller (Draw), never taken here, so this stays a pure
+        // function — a Painter2D cannot be read back, and MeasureTextSize needs a live TextElement, so neither
+        // belongs in a function a headless unit test must be able to call directly. Returns false (nothing to
+        // draw) for a degenerate content box; the caller skips painting in that case.
+        public static bool TryComputeGeometry(Rect contentRect, float measuredWidth, float textBlockHeight,
+            float fontSize, TextAnchor align, out Vector2 from, out Vector2 to, out float lineWidth)
+        {
+            from = default;
+            to = default;
+            lineWidth = 0f;
+            if (contentRect.width <= 0f || contentRect.height <= 0f
+                || float.IsNaN(contentRect.width) || float.IsNaN(contentRect.height))
+            {
+                return false;
+            }
+
+            var width = Mathf.Clamp(measuredWidth, 0f, contentRect.width);
+            var x0 = ResolveStartX(contentRect, width, align);
+            var firstLineTop = ResolveFirstLineTop(contentRect, textBlockHeight, align);
+            var y = firstLineTop + (fontSize * TopOffsetFraction);
+            lineWidth = ResolveThickness(fontSize);
+            from = new Vector2(x0, y);
+            to = new Vector2(x0 + width, y);
+            return true;
+        }
+
+        // Honors -unity-text-align for the run's horizontal start exactly like the engine's own text run:
+        // left starts at the content box's own left edge, center splits the leftover space evenly, right
+        // ends flush with the content box's right edge.
+        private static float ResolveStartX(Rect contentRect, float width, TextAnchor align)
+        {
+            switch (align)
+            {
+                case TextAnchor.UpperCenter:
+                case TextAnchor.MiddleCenter:
+                case TextAnchor.LowerCenter:
+                    return contentRect.xMin + ((contentRect.width - width) * 0.5f);
+                case TextAnchor.UpperRight:
+                case TextAnchor.MiddleRight:
+                case TextAnchor.LowerRight:
+                    return contentRect.xMax - width;
+                default: // UpperLeft / MiddleLeft / LowerLeft
+                    return contentRect.xMin;
+            }
+        }
+
+        // Honors -unity-text-align's VERTICAL component for where the text BLOCK sits in the content box, then
+        // returns the FIRST line's top edge within it (v1 scope: the rule sits above the first line only, see
+        // the type remarks on TextOverlineBinding). Velvet's own text-center/-left/-right/-start/-end utilities
+        // all resolve to a middle-* anchor (see _typography.uss), which is also UI Toolkit's own unstyled
+        // default, so the Middle branch is the common case, not an edge case: an Upper* anchor top-aligns the
+        // block to the content box (first line's top == contentRect.yMin, the only case v0 ever computed); a
+        // Middle* anchor centers the whole block, so it spans from contentRect.center.y - textBlockHeight / 2
+        // to + textBlockHeight / 2 — the first of those is the first line's top; a Lower* anchor bottom-aligns
+        // the block (block bottom == contentRect.yMax), so the first line's top is textBlockHeight above that.
+        // Lines stack downward within the block regardless of how the block itself is anchored, so "first
+        // line's top" is always the block's own top edge, one formula per anchor group.
+        private static float ResolveFirstLineTop(Rect contentRect, float textBlockHeight, TextAnchor align)
+        {
+            switch (align)
+            {
+                case TextAnchor.MiddleLeft:
+                case TextAnchor.MiddleCenter:
+                case TextAnchor.MiddleRight:
+                    return contentRect.center.y - (textBlockHeight * 0.5f);
+                case TextAnchor.LowerLeft:
+                case TextAnchor.LowerCenter:
+                case TextAnchor.LowerRight:
+                    return contentRect.yMax - textBlockHeight;
+                default: // UpperLeft / UpperCenter / UpperRight
+                    return contentRect.yMin;
+            }
+        }
+
+        // Strokes the already-computed rule onto a live Painter2D. A no-op for a transparent color or a
+        // degenerate width, mirroring DashedBorderPainter.StrokeDashed's own guards. Butt caps (not round)
+        // so the painted length matches the computed width exactly — a round cap would bleed half the line
+        // width past each end.
+        public static void Stroke(Painter2D painter, Vector2 from, Vector2 to, float lineWidth, Color color)
+        {
+            if (color.a <= 0.004f || lineWidth <= 0.01f)
+            {
+                return;
+            }
+            painter.strokeColor = color;
+            painter.lineWidth = lineWidth;
+            painter.lineCap = LineCap.Butt;
+            painter.BeginPath();
+            painter.MoveTo(from);
+            painter.LineTo(to);
+            painter.Stroke();
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Styling/TextOverlinePainter.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Styling/TextOverlinePainter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: cd897d75e0e74787bf86f4d30cc8b205


### PR DESCRIPTION
Part of #96.

Adds `overline` to the text-decoration axis (`underline` / `line-through` / `no-underline`), completing the decoration triad. UI Toolkit rich text has no overline tag (only `<u>` / `<s>`), so unlike the other decoration values — which rewrite the display string — `overline` is **painted**: a solid rule stroked above the leaf `TextElement`'s first line via `generateVisualContent`.

## What changed

- **`TextOverlinePainter`** (new) — pure geometry, fully unit-testable without a panel:
  - `TryComputeGeometry` guards degenerate rects (NaN / zero) and clamps the rule to the content box.
  - Thickness = `max(1px, fontSize / 16)`, matching the typical browser ratio.
  - Honors **both** components of `-unity-text-align`: the horizontal start (left/center/right × natural text width) and, for middle/lower vertical anchors, where the first line actually sits (via a measured text-block height).
- **`TextOverlineBinding` / `TextOverlineSilhouette`** (new) — attach/detach a prepend-ordered `generateVisualContent` hook; both paths mark dirty-repaint internally. Draw takes two `MeasureTextSize` readings (natural width, plus height at exactly `contentRect.width`) so wrapped text anchors correctly.
- **`StyleTextEffectClass` / `StyleTextEffectResolver`** — `overline` parses into the existing single-valued decoration axis, cascades from ancestors, and resets through `no-underline` like the other values. `ApplyToElement` attaches/detaches the binding off the resolved decoration.
- **Cleanup** — bindings are torn down at every element exit: `FiberElementCleaner` (unmount/pool), `FiberNodePatcher` (Text→null patch), and a `Reconciler.Dispose` sweep, so no `generateVisualContent` delegate survives its element.

## Deviations from CSS (documented in `Documentation~/fonts.md`)

- The decoration axis stays **single-valued** by this subsystem's pre-existing design: `underline overline` resolves to the last token instead of composing both lines.
- v1 paints one rule above the **first line only** — a wrapped label's later lines carry no rule of their own yet.

## Tests

- 13 unit tests on the painter geometry (nonzero-origin rect exercises the vertical-anchor formulas; NaN/zero guards; thickness floor; all 9 `TextAnchor` values).
- PlayMode pixel-band readback on a real RenderTexture panel proves an actual painted rule above the glyphs.
- EditMode panel tests pin cascade, reset via `no-underline`, patch-path detach (Text→null), and pool-reuse scrubbing.
