### PR TITLE
feat(velvet): add z-* stacking utilities via same-panel layer containers

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -9,6 +9,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `z-0`…`z-50`, `z-[N]`, and their negative forms (`-z-10`, `z-[-5]`) — each also accepting the
+  important modifier (`!z-10`, `z-10!`, `!z-[5]`, `z-[5]!`, itself a no-op for this utility) —
+  bring CSS `z-index` to `absolute` descendants, compared among siblings sharing one direct parent.
+  UI Toolkit ties paint order, pointer-pick order, and Yoga flex placement to a single physical
+  child list, so physically reordering children for paint would also reorder their layout and
+  corrupt the reconciler's own diff of every other sibling on the very next render. Instead, a
+  z-marked absolute element's real content relocates into a lazily-created per-stacking-parent
+  layer container — one for non-negative z (painted last) and one for negative z (painted first, so
+  it still sits behind ordinary siblings, though never behind its own parent's background, which is
+  a genuine engine dead end: UI Toolkit has one paint traversal, and a child can only paint after
+  its own parent's background) — while a hidden, zero-footprint placeholder holds the element's
+  declared slot for the reconciler, structural variants (`first:`/`last:`/`odd:`/`even:`/`nth-child`),
+  and Tab order, reusing the Portal placeholder pipeline and `SilhouetteBoundsSpacer`'s
+  reconciler-invisible-child convention; a resort's own detach-and-reinsert (a mount-order tie, a
+  sign flip, or a patch-time z change) rescues and restores focus when the moving element holds it,
+  so interacting with a focused element never silently drops focus. `z-*` on an in-flow
+  (non-`absolute`) element is a documented no-op — Yoga has no flex `order` analog, so reordering an
+  in-flow child for paint would also reorder its layout position — and so is `z-*` on `V.Motion`
+  (now with a warning): a Motion's create path never relocates it, since the element identity its
+  own enter/exit tween is bound to must stay put — wrap it in a z-managed `Div` instead, which an
+  `AnimatePresence` keyed child built that way (an animated, top-most modal) can do: its enter,
+  `PopLayout` exit pin, and exit-cancel all target the real, relocated element for its whole
+  lifetime, not a placeholder standing in its declared slot. The `variants` enter/exit classes still
+  resolve only when the direct presence child is the Motion itself, not this wrapped shape — only
+  the transition's timing and its `onEnterComplete` callback are guaranteed for a wrapped Motion
+  today. Comparison is scoped to direct siblings under one immediate parent only; there is no CSS
+  stacking-context nesting (opacity, transform, filter, and isolation do not open a new context
+  here). A `peer-` source that is itself z-managed is not found by a `peer-` consumer (its
+  placeholder carries none of its marker classes) — the reverse, a z-managed consumer resolving an
+  ordinary `peer-`/`group-` source, works.
 - `text-balance` approximates CSS `text-wrap: balance` on a `TextElement` (Label / Button / …). UI
   Toolkit's text engine exposes no line-break hook, so `StyleTextBalanceManipulator` narrows the box
   instead: it binary-searches the public `TextElement.MeasureTextSize` — the same method the engine's own

--- a/Packages/com.velvet.core/Documentation~/README.md
+++ b/Packages/com.velvet.core/Documentation~/README.md
@@ -10,6 +10,7 @@ For the package overview and installation instructions, see the repository root 
 | [react-migration.md](react-migration.md) | Naming alignment and API mapping for developers coming from React |
 | [memoization.md](memoization.md) | The `[Memoize]` attribute — usage, constraints, and diagnostic IDs (Source Generator-driven partial-method memoization) |
 | [styling-flexbox-and-gap.md](styling-flexbox-and-gap.md) | Flexbox direction (`flex` defaults to column, not row) and `gap-*` gotchas (single-axis, trailing margin) vs Tailwind |
+| [styling-z-index.md](styling-z-index.md) | `z-*` stacking for `absolute` descendants — the layer-container + placeholder mechanism, sibling-scope-only comparison, and the in-flow/negative-z/`peer-` deviations from CSS |
 | [styling-variants.md](styling-variants.md) | The variant set (state / theme `dark:` / responsive `sm:`…`2xl:` / relational `group-`·`peer-` / stacked) and container queries (`@container`, the `container-type: inline-size` equivalent) |
 | [styling-filters.md](styling-filters.md) | Filter utilities (`blur-*` … `sepia-*`, the shader-backed full-range `brightness-*`/`saturate-*`) and the `VelvetFilters` custom filter registry (`filter-[name:args]`) |
 | [scene-view.md](scene-view.md) | `V.SceneView` — a camera's output as an element (`<canvas>` parity): the framework-owned RenderTexture contract, styling composition, live sampling |

--- a/Packages/com.velvet.core/Documentation~/styling-z-index.md
+++ b/Packages/com.velvet.core/Documentation~/styling-z-index.md
@@ -1,0 +1,104 @@
+# Styling notes: z-index stacking
+
+Velvet's `z-*` utilities bring CSS `z-index` to `position: absolute` descendants, compared among
+sibling elements that share one direct parent. Unity UI Toolkit has no `z-index` property (and no
+flex `order` analog either) — paint order, pointer-pick order, and Yoga's own flex layout
+placement are all tied to a single physical child list, so this is a framework-level feature, not
+a USS rule.
+
+```csharp
+V.Div(className: "relative w-64 h-64", children: new VNode[]
+{
+    V.Div(className: "absolute inset-0 bg-blue-500"),
+    V.Div(className: "absolute inset-0 z-10 bg-red-500"),   // paints in front
+    V.Div(className: "absolute inset-0 -z-10 bg-gray-200"), // paints behind the other two
+});
+```
+
+## The scope gate: `absolute` + `z-*`
+
+`z-*` only takes effect on an element that is **also** out of flow — either the `absolute` utility
+class, or `V.Anchored` (which forces `position: absolute` itself). On an in-flow element `z-*` is a
+**documented no-op** — see [Scope cuts](#scope-cuts) for why.
+
+| Utility | Resolved z |
+|---|---|
+| `z-0` / `z-10` / `z-20` / `z-30` / `z-40` / `z-50` | Tailwind's fixed named scale |
+| `-z-10` … `-z-50` | negated named scale |
+| `z-[N]` / `z-[-N]` | arbitrary integer (the bracket carries its own sign) |
+
+The named scale is fixed — `z-15` is not a thing, `z-[15]` is, mirroring real Tailwind. Each form
+also accepts the important modifier (`!z-10`, `z-10!`, `!z-[5]`, `z-[5]!`) like any other utility;
+the modifier itself is a no-op here — z-index is a physical relocation, not a style-cascade layer
+`!important` arbitrates.
+
+## How it works
+
+Unity's `VisualElement.hierarchy` moves the same node in the Yoga layout tree that it moves for
+paint — physically reordering children for stacking would also reorder their flex layout, and
+would corrupt the reconciler's own diff of every *other* sibling on the very next render (the
+reconciler assumes a live child's physical index tracks its logical one). So `z-*` never
+physically reorders the declaring children list itself. Instead:
+
+- The first `z-*` element of each sign (non-negative / negative) under a stacking parent lazily
+  creates a **layer container** — a plain, reconciler-invisible `VisualElement` sized to the
+  parent's own content box. The **front** layer (non-negative z) is always the parent's last
+  child; the **back** layer (negative z) is always its *first* child, so it still paints behind
+  the ordinary children even though it is created later.
+- A z-marked element's real content relocates into its layer container, sorted by resolved z
+  (mount order breaks ties), while a hidden, zero-footprint **placeholder** — a real, displayed,
+  zero-size element (not `display: none`, which would drop it from the focus ring) — is left at
+  its declared position so the reconciler, `first:`/`last:`/`odd:`/`even:`/`nth-child` structural
+  variants, and Tab order all still see it there.
+- Because the layer container is geometrically coincident with the stacking parent's own content
+  box, a relocated `absolute` child's `left`/`top` (already parent-relative in UI Toolkit) resolve
+  to the exact same on-screen position whether the child sits at its declared slot or inside the
+  container — no coordinate re-projection needed.
+- The mechanism reuses the same deferred-mount pipeline `V.Portal` already relies on (creating or
+  growing a layer container only runs from the same post-reconcile-pass safe point a Portal mount
+  resolves from) and the same reconciler-invisible-child convention the internal filter
+  bounds-spacer uses, so the existing diff/patch code for ordinary children is unaffected.
+
+## Scope cuts
+
+- **In-flow `z-*` is a no-op.** The classic "overlapping cards with a negative margin and `z-10`,
+  no `.absolute`" pattern needs `.absolute` too — reordering an in-flow child for paint would also
+  reorder its Yoga layout position (there is no separate flex `order` to reorder instead), so
+  Velvet does not attempt it.
+- **`z-*` on `V.Motion` is also a no-op — now with a warning.** A Motion's create path never
+  relocates it into a layer container: the element identity its own enter/exit tween is bound to
+  must stay put, the same reason `shadow-*` and `clip-path-*` are already documented no-ops on a
+  Motion. Wrap the Motion around a z-managed `Div` instead — an `AnimatePresence` keyed child built
+  this way (the common "animated, top-most modal" shape) enters and exits against the *real*,
+  relocated element for its whole lifetime, including a `PopLayout` exit's out-of-flow pin; a
+  cancelled exit (the key re-added mid-animation) restores it the same way an ordinary, non-`z-*`
+  presence child does. The `variants` enter/exit *classes* still resolve only when the direct
+  presence child *is* the Motion itself (not this wrapped shape) — only the transition's timing and
+  its `onEnterComplete` callback are guaranteed for a wrapped Motion today.
+- **Negative z never escapes the element's own parent's background.** UI Toolkit has exactly one
+  paint traversal; a child can only paint after its own parent's background within that walk.
+  Escaping "behind the parent" would mean hoisting the child to become the parent's own preceding
+  *sibling*, which breaks containing-block/clipping semantics (an `overflow-hidden` parent would
+  no longer clip it) — a genuine engine dead end, not a missing feature.
+- **Comparison is sibling-scope only.** Velvet does not implement full CSS stacking-context
+  formation or nesting (`opacity < 1`, `transform`, `filter`, `isolation`, … as stacking-context
+  triggers elsewhere in the spec). Every z comparison is against the direct siblings sharing one
+  immediate parent, matching the dominant real-world use case rather than full spec fidelity.
+- **Tab order follows the declared position, not the layer.** The placeholder is a real Tab stop
+  at the element's declared slot; Tab reaching it forwards focus into the relocated element, and
+  Tab leaving the relocated element's own subtree redirects to the declared position's next
+  sibling — so `z-*` never changes keyboard navigation order.
+- **A resort preserves focus.** Every z transition (a mount-order tie resolving, a sign flip, a
+  patch-time z change) detaches and re-inserts the real element — UI Toolkit clears
+  `FocusController.focusedElement` the instant an element leaves its panel's visual tree, even for
+  an immediate same-panel reattachment — so the relocation rescues and restores focus when the
+  moving element (or a descendant of it) holds it, instead of silently dropping it mid-interaction.
+- **`group-`/`peer-` mostly cross the layer boundary, with one gap.** A z-managed element's
+  physical parent is its layer container, one hop different from its logical parent.
+  `group-*:` ancestor lookups are unaffected (the container is a transparent hop on the way up).
+  A `peer-*:` **consumer** that is itself z-managed still resolves an ordinary preceding `peer`
+  source correctly (the search walks from the consumer's declared position, not its physical one).
+  The reverse does not: a `peer-*:` **source** that is itself z-managed is not found by an
+  ordinary consumer, because the source's placeholder — the only thing physically sitting among
+  the consumer's preceding siblings — carries none of the source's marker classes. Give a z-managed
+  peer source an ordinary (non-`peer`) wrapper if a consumer needs to react to it.

--- a/Packages/com.velvet.core/Runtime/Reconciler/ChildReconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ChildReconciler.cs
@@ -314,8 +314,11 @@ namespace Velvet
                         // context, like any ordinary sibling) — only its CONTAINER placement was deferred,
                         // because placeholder.parent (the stacking parent) is only knowable now. No target
                         // resolution, no nested Reconcile, no PortalState entry: resolve the layer placement
-                        // and move on to the next queued entry.
-                        FiberZLayerCoordinator.ResolveQueuedMount(_ctx, placeholder, zLayerMount);
+                        // and move on to the next queued entry. `this` is passed through so a first-of-its-
+                        // sign container creation can rebase a park THIS SAME instance's Reconcile() call just
+                        // captured (see RebasePendingSlotStartIfTargeting) — invisible to any other lookup
+                        // until this whole top-level call returns.
+                        FiberZLayerCoordinator.ResolveQueuedMount(_ctx, placeholder, zLayerMount, this);
                         continue;
                     default:
                         // Only PortalNode / WorldSpaceNode enqueue deferred mounts; anything else is
@@ -328,8 +331,19 @@ namespace Velvet
                 var resolvedTarget = target!;
                 // Exclude a trailing filter bounds-spacer (a skewed / shadowed + filtered target carries one):
                 // portal children must land BEFORE it so it stays last and the recorded slot start does not
-                // drift when the spacer self-heals to the end.
-                var slotStart = SilhouetteBoundsSpacer.NonSpacerChildCount(resolvedTarget);
+                // drift when the spacer self-heals to the end. NonSpacerChildCount is a PHYSICAL count (it still
+                // counts a leading back z-layer container, if the target already carries one from an earlier
+                // relocation directly under it) — Reconcile's own entry point (this method's caller for an
+                // ordinary child list, and every subsequent patch of this same slot range) always re-adds
+                // LeadingOffset to convert a LOGICAL slotStart into a physical one, so passing the already-
+                // physical value here would fold the offset a second time and misplace every child after the
+                // first (a keyed insert can even index past childCount and throw). Subtracting it back out here,
+                // once, is the single point every consumer of the stored PortalState.SlotStart agrees on: a
+                // LOGICAL basis, re-derived fresh at each use (LeadingOffset reads the target's live physical
+                // structure, never a cached copy) so it stays correct even if the target's own leading container
+                // appears or disappears between this mount and a later patch.
+                var physicalSlotStart = SilhouetteBoundsSpacer.NonSpacerChildCount(resolvedTarget);
+                var slotStart = physicalSlotStart - FiberZLayerCoordinator.LeadingOffset(resolvedTarget);
                 // Restore the context that enclosed the Portal's tree position (captured at enqueue) so the
                 // children mount under their enclosing Providers / MotionContext rather than an empty cursor.
                 // The children's own reconcile pushes/pops on top of these and balances out, so popping the
@@ -380,12 +394,17 @@ namespace Velvet
                         f.DetachedMountContext = detachedContext;
                     }
                 }
-                var slotLength = SilhouetteBoundsSpacer.NonSpacerChildCount(resolvedTarget) - slotStart;
+                // The growth this mount contributed, in PHYSICAL terms (both operands share that basis, so the
+                // leading offset — constant across this call, since a nested z-layer mount targeting this same
+                // resolvedTarget only ever ENQUEUES here rather than resolving inline — cancels out of the
+                // difference either way); slotStart itself is stored LOGICAL, per the comment above.
+                var slotLength = SilhouetteBoundsSpacer.NonSpacerChildCount(resolvedTarget) - physicalSlotStart;
                 _ctx.PortalState[placeholder] = new PortalSlotInfo(resolvedTarget, slotStart, slotLength);
             }
             // Same safe (post-pass, no diff in flight) context as the drain above: a container that lost its
-            // last member this pass tears down here, never synchronously mid-diff.
-            FiberZLayerCoordinator.DrainTeardowns(_ctx);
+            // last member this pass tears down here, never synchronously mid-diff. `this` mirrors
+            // ResolveQueuedMount's own reason above (a self-caused park from THIS instance's own pass).
+            FiberZLayerCoordinator.DrainTeardowns(_ctx, this);
         }
 
         // Resumes a suspended IndexedReconcile.
@@ -444,6 +463,35 @@ namespace Velvet
         // is preserved unshifted.
         private static int ShiftSlotLimit(int slotLimit, int delta)
             => slotLimit == int.MaxValue ? slotLimit : slotLimit + delta;
+
+        // Rebases this instance's own parked state by delta, but only when its captured Parent is `parent` —
+        // called by FiberZLayerCoordinator when a back z-layer container is created or torn down (see
+        // FiberZLayerCoordinator.RebaseParkedSlotsForContainerChange). That mutation runs from
+        // DrainPendingPortalMounts, itself called from THIS instance's own top-level finally — Reconciler.
+        // Reconcile's on a fiber's first suspension, or Reconciler.ContinueReconcile's on a later resume tick
+        // that re-parks in the same tick it drains — so a park this SAME call just captured (its own
+        // placeholder insert queued the very mount this drain now resolves) is still sitting on this
+        // instance. On a first suspension that is also invisible to any cross-fiber sweep:
+        // ReconcilerContext.ParkedBaselineFibers only gains this fiber once Reconcile() itself has fully
+        // returned (FiberCommitWork.ReturnOldTreeAfterReconcile), strictly AFTER that drain finishes. On a
+        // later resume tick the fiber may ALREADY be registered there too (nothing removes it until
+        // HasPendingWork goes false) — RebaseParkedSlotsForContainerChange's own loop excludes this instance
+        // by identity so the two call sites never double-apply to the same captured state. Unlike
+        // RebasePendingSlotStart (which the caller already knows targets this instance's parked parent, from
+        // the inline-sibling walk), this call site has no such guarantee — a parked state here may belong to
+        // an unrelated parent entirely — so the Parent match is checked first.
+        internal void RebasePendingSlotStartIfTargeting(VisualElement parent, int delta)
+        {
+            if (delta == 0) return;
+            if (PendingIndexedState.HasValue && ReferenceEquals(PendingIndexedState.Value.Parent, parent))
+            {
+                RebasePendingSlotStart(delta);
+            }
+            else if (PendingKeyedState != null && ReferenceEquals(PendingKeyedState.Parent, parent))
+            {
+                RebasePendingSlotStart(delta);
+            }
+        }
 
         // Discards a suspended KeyedReconcile state and returns the held Pool buffers.
         // Invoked on a new Reconcile or during Dispose.

--- a/Packages/com.velvet.core/Runtime/Reconciler/ChildReconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ChildReconciler.cs
@@ -136,6 +136,27 @@ namespace Velvet
         {
             if (_ctx.IsAborted) return;
 
+            // A back z-layer container, when present, is parent's own leading child (physically preceding
+            // the ordinary children it must paint behind) — the one structural asymmetry against every other
+            // reconciler-invisible child (SilhouetteBoundsSpacer's own spacer, and the front z-layer
+            // container, are both trailing). Every caller's incoming slotStart/slotLimit is computed in
+            // purely logical terms (0 for a fresh range, or a sum of PRECEDING SIBLING FIBERS' own rendered
+            // counts for a shared-parent inline tenant) — entirely blind to this leading child — so folding
+            // the offset in ONCE here, at the single choke point every fresh (non-resumed) entry funnels
+            // through, corrects every downstream absolute-index computation without touching any of them
+            // individually (symmetrical to how NonSpacerChildCount centralizes the trailing side). A resumed
+            // time-sliced pass (ContinueIndexed/ContinueKeyed) never re-enters here — its saved slotStart
+            // already has this baked in from when it first ran — so this can never double-apply.
+            if (parent != null)
+            {
+                var leadingOffset = FiberZLayerCoordinator.LeadingOffset(parent);
+                if (leadingOffset != 0)
+                {
+                    slotStart += leadingOffset;
+                    if (slotLimit != int.MaxValue) slotLimit += leadingOffset;
+                }
+            }
+
             // New entries discard any prior suspended state. ContinueXxx calls ReconcileXxxFrom
             // directly and bypasses this path, so discarding here does not break a Continue run.
             // Nested calls entered via PatchNode during ContinueXxx also pass through here, but at
@@ -287,6 +308,15 @@ namespace Velvet
                         }
                         break;
                     }
+                    case ZLayerMountNode zLayerMount:
+                        // Not a host mount: the real element is already fully built (CreateElement / a
+                        // patch-time none-to-z transition ran its whole child reconcile inline, under live
+                        // context, like any ordinary sibling) — only its CONTAINER placement was deferred,
+                        // because placeholder.parent (the stacking parent) is only knowable now. No target
+                        // resolution, no nested Reconcile, no PortalState entry: resolve the layer placement
+                        // and move on to the next queued entry.
+                        FiberZLayerCoordinator.ResolveQueuedMount(_ctx, placeholder, zLayerMount);
+                        continue;
                     default:
                         // Only PortalNode / WorldSpaceNode enqueue deferred mounts; anything else is
                         // a missing branch for a new node kind and must fail loudly rather than
@@ -353,6 +383,9 @@ namespace Velvet
                 var slotLength = SilhouetteBoundsSpacer.NonSpacerChildCount(resolvedTarget) - slotStart;
                 _ctx.PortalState[placeholder] = new PortalSlotInfo(resolvedTarget, slotStart, slotLength);
             }
+            // Same safe (post-pass, no diff in flight) context as the drain above: a container that lost its
+            // last member this pass tears down here, never synchronously mid-diff.
+            FiberZLayerCoordinator.DrainTeardowns(_ctx);
         }
 
         // Resumes a suspended IndexedReconcile.

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberCommitWork.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberCommitWork.cs
@@ -1,4 +1,6 @@
 #nullable enable
+using UnityEngine.UIElements;
+
 namespace Velvet
 {
     // The commit phase for a function-component fiber: applies the rendered
@@ -35,6 +37,23 @@ namespace Velvet
             }
             return limit;
         }
+
+        // The fiber's shared MountPoint child count, blind to a z-layer container's own physical presence.
+        // FiberZLayerCoordinator creates or removes a container on the SAME parent a caller measures
+        // before/after its own Reconcile / ContinueReconcile call (the container drain runs from inside
+        // that same call's safe post-pass point), so a raw childCount read attributes the container's
+        // leading/trailing +-1 to this fiber's own committed-row delta and leaks a physical offset into
+        // MountSlotCount / a following sibling's MountSlotStart — both already logical quantities the entry
+        // gate (ChildReconciler.Reconcile) re-adds LeadingOffset to on every fresh entry, so that offset
+        // would then apply twice. NonSpacerChildCount only trims the TRAILING spacer run (a front
+        // container, a bounds-spacer) — a leading back container stays counted by its contract — so the
+        // leading side must be subtracted separately for a container appearing or disappearing during the
+        // measured interval to cancel out of the delta symmetrically in either direction.
+        internal static int LogicalMountPointChildCount(VisualElement? mountPoint)
+            => mountPoint != null
+                ? SilhouetteBoundsSpacer.NonSpacerChildCount(mountPoint)
+                    - FiberZLayerCoordinator.LeadingOffset(mountPoint)
+                : 0;
 
         // Propagates an inline-mount fiber's committed child-count change to the siblings that share its
         // MountPoint. Updates the fiber's own slot count, then shifts every following sibling's
@@ -74,9 +93,9 @@ namespace Velvet
         {
             if (fiber.IsInlineMounted)
             {
-                var beforeDrain = fiber.MountPoint?.childCount ?? 0;
+                var beforeDrain = LogicalMountPointChildCount(fiber.MountPoint);
                 fiber.Reconciler!.ContinueReconcile(frameBudgetMs: 0);
-                var afterDrain = fiber.MountPoint?.childCount ?? 0;
+                var afterDrain = LogicalMountPointChildCount(fiber.MountPoint);
                 PropagateInlineSlotShift(fiber, afterDrain - beforeDrain);
             }
             else
@@ -119,13 +138,13 @@ namespace Velvet
                 // fibers own their entire MountPoint and don't participate in sibling shifts.
                 if (fiber.IsInlineMounted)
                 {
-                    var beforeChildCount = fiber.MountPoint?.childCount ?? 0;
+                    var beforeChildCount = LogicalMountPointChildCount(fiber.MountPoint);
                     // Bound the reconcile to this fiber's slot range so a desync rebuild cannot delete a
                     // following sibling's committed rows — the next inline-mount sibling's MountSlotStart is
                     // where this fiber's rows end.
                     var slotLimit = NextInlineSiblingSlotStart(fiber);
                     fiber.Reconciler!.Reconcile(fiber.MountPoint, oldTree, newTree, frameBudgetMs, slotStart, slotLimit);
-                    var afterChildCount = fiber.MountPoint?.childCount ?? 0;
+                    var afterChildCount = LogicalMountPointChildCount(fiber.MountPoint);
                     PropagateInlineSlotShift(fiber, afterChildCount - beforeChildCount);
                 }
                 else

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberElementCleaner.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberElementCleaner.cs
@@ -464,9 +464,16 @@ namespace Velvet
                 return;
             }
 
-            var slotEnd = portalInfo.SlotStart + portalInfo.SlotLength;
+            // PortalState.SlotStart is stored LOGICAL (ChildReconciler.DrainPendingPortalMounts /
+            // FiberNodePatcher.PatchPortalChildren both keep it in that basis so Reconcile's own leading-offset
+            // entry gate folds it exactly once) — this walk indexes target's children PHYSICALLY and never goes
+            // through that entry gate, so it converts once here instead, re-deriving the live offset rather than
+            // trusting a stale copy (see FiberZLayerCoordinator.LeadingOffset's own doc on why it must always be
+            // read fresh).
+            var physicalSlotStart = portalInfo.SlotStart + FiberZLayerCoordinator.LeadingOffset(target);
+            var slotEnd = physicalSlotStart + portalInfo.SlotLength;
             if (slotEnd > target.childCount) slotEnd = target.childCount;
-            for (var i = slotEnd - 1; i >= portalInfo.SlotStart; i--)
+            for (var i = slotEnd - 1; i >= physicalSlotStart; i--)
             {
                 var child = target.ElementAt(i);
                 var poolable = PoolableOccupantOf(child);
@@ -531,6 +538,17 @@ namespace Velvet
             {
                 var child = element.ElementAt(i);
                 if (child == excluded)
+                {
+                    continue;
+                }
+
+                // A z-layer container's own members are z-managed REAL elements, each with a placeholder
+                // sitting elsewhere in this SAME child list (both are direct children of `element` whenever
+                // it is a stacking-context parent being torn down) — CleanupZLayerPlaceholder already reaches
+                // and fully cleans up every member via its placeholder in this very loop. Descending into the
+                // container here too would run the full CleanupElementResources + DisposeFibersUnder sequence
+                // on each member a second time.
+                if (FiberZLayerCoordinator.IsLayerContainer(child))
                 {
                     continue;
                 }

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberElementCleaner.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberElementCleaner.cs
@@ -500,6 +500,23 @@ namespace Velvet
             PanelHostFactory.Destroy(record);
         }
 
+        // Tears down the real element owned by a departing z-layer placeholder — mirrors CleanupPortal: the
+        // real element is not a DOM descendant of the placeholder (it lives in a layer container elsewhere
+        // under the same stacking parent), so the ordinary CleanupDescendants walk below would never reach
+        // it on its own. A no-op when element is not (or no longer) a z-layer placeholder.
+        private void CleanupZLayerPlaceholder(VisualElement element)
+        {
+            var real = FiberZLayerCoordinator.TakeReal(_ctx, element);
+            if (real == null)
+            {
+                return;
+            }
+            var poolable = PoolableOccupantOf(real);
+            CleanupElement(real);
+            // TakeReal already detached `real` from its layer container; nothing left to remove from the DOM.
+            ReturnOccupantToPool(real, poolable);
+        }
+
         // Recursively cleans up the descendants of an element. DOM operations are the caller's
         // responsibility. Applies the same processing order as CleanupElement to each
         // child, preventing silent bugs caused by asymmetric wrapper handling.
@@ -552,6 +569,7 @@ namespace Velvet
             RescueFocusFromWorldSpaceHost(element);
             CleanupPortal(element);
             CleanupWorldSpaceHost(element);
+            CleanupZLayerPlaceholder(element);
             CleanupDescendants(element, innerElement);
         }
 

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberFocusNavigator.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberFocusNavigator.cs
@@ -460,7 +460,7 @@ namespace Velvet
             NavigationMoveEvent evt, IPanel panel, VisualElement panelRoot, VisualElement focused, bool forward,
             ReconcilerContext ctx)
         {
-            var real = FindEnclosingZLayerReal(focused, ctx, out var placeholder);
+            var real = FindEnclosingZLayerReal(focused, ctx, out var placeholder, out var container);
             if (real == null)
             {
                 return false;
@@ -474,8 +474,32 @@ namespace Velvet
                 return false;
             }
 
+            // The placeholder's own physical ring-neighbour can BE the layer container itself (or a landing
+            // inside it, on ANY co-tenant's real — not only this element's own): a trailing front container
+            // sits right after its stacking parent's last ordinary slot, so when the z-managed element is
+            // that parent's logically LAST child (forward) — or, symmetrically, a leading back container's
+            // FIRST child (backward) — the very next ring step from the placeholder re-enters the container
+            // instead of escaping past it. With 2+ z-managed siblings sharing that container, this can land on
+            // a DIFFERENT member's real (physically adjacent within the same container) rather than this
+            // element's own, which the OLD "inside real's own subtree" test would wrongly accept as an escape
+            // — so the walk is scoped to the whole CONTAINER (any co-tenant's real), not just `real`. A
+            // landing on a NEIGHBOUR's PLACEHOLDER is unaffected: a placeholder lives in the stacking parent's
+            // own slot range, never as a child of the container (see InsertSorted / Place), so it is never
+            // "inside container" and the walk correctly stops there — the legitimate adjacent-sibling handoff
+            // (OnFocusIn forwards from a placeholder to its own real) that the existing backward test relies
+            // on. Keep walking past any container landing until it is genuinely outside the container
+            // entirely, bounded exactly like the SingleTabStop exit walk above so a pathological ring cannot
+            // spin this forever; a ring with nothing else reachable (every walk stays inside the container, or
+            // wraps back to the placeholder itself) falls through to "no valid exit".
             var landing = ring.GetNextFocusable(placeholder, direction) as VisualElement;
-            if (landing == null || ReferenceEquals(landing, placeholder) || !landing.canGrabFocus)
+            var guard = MaxRingWalk;
+            while (landing != null && (ReferenceEquals(landing, container) || container.Contains(landing)) && guard-- > 0)
+            {
+                landing = ring.GetNextFocusable(landing, direction) as VisualElement;
+            }
+
+            if (landing == null || ReferenceEquals(landing, placeholder) || !landing.canGrabFocus
+                || ReferenceEquals(landing, container) || container.Contains(landing))
             {
                 return false;
             }
@@ -484,20 +508,23 @@ namespace Velvet
         }
 
         // Walks UP from `element` (inclusive) for the nearest ancestor currently registered as a z-managed
-        // real element (ReconcilerContext.ZLayerMembers), returning it and its placeholder. Physical
-        // containment, mirroring FindEnclosingScopeRoot's own walk — robust across pool reuse and independent
-        // of any logical-tree bookkeeping.
-        private static VisualElement? FindEnclosingZLayerReal(VisualElement element, ReconcilerContext ctx, out VisualElement? placeholder)
+        // real element (ReconcilerContext.ZLayerMembers), returning it, its placeholder, and the layer
+        // container it currently lives in. Physical containment, mirroring FindEnclosingScopeRoot's own walk
+        // — robust across pool reuse and independent of any logical-tree bookkeeping.
+        private static VisualElement? FindEnclosingZLayerReal(
+            VisualElement element, ReconcilerContext ctx, out VisualElement? placeholder, out VisualElement? container)
         {
             for (var current = element; current != null; current = current.parent)
             {
                 if (ctx.ZLayerMembers.TryGetValue(current, out var member))
                 {
                     placeholder = member.Placeholder;
+                    container = member.Container;
                     return current;
                 }
             }
             placeholder = null;
+            container = null;
             return null;
         }
 

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberFocusNavigator.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberFocusNavigator.cs
@@ -306,6 +306,17 @@ namespace Velvet
                 return;
             }
 
+            // Same-panel counterpart: focus sits inside a z-relocated element's subtree (its real element
+            // physically lives in a layer container, elsewhere in the same panel) and this move would leave
+            // that subtree — redirect to the panel-ring neighbour of its PLACEHOLDER (its declared position)
+            // instead of wherever the layer container happens to sit physically. Reached only when neither
+            // Contain nor SingleTabStop claims this focus (both returned above), mirroring the chained escape's
+            // own scope precedence.
+            if (TryZLayerExit(evt, panel!, panelRoot, focused, forward, ctx))
+            {
+                return;
+            }
+
             // Entering a SingleTabStop scope from outside: the group is one tab stop, so the move lands on
             // the member last used, else the group's first member — from either direction (the WAI-ARIA
             // composite contract; a backward move's raw prediction would be the group's ring-LAST).
@@ -438,6 +449,58 @@ namespace Velvet
             return null;
         }
 
+        // Same-panel counterpart to TryChainedEscape. `focused` sits inside a z-relocated real element's
+        // subtree, so the engine's own ring prediction reflects where that element physically paints (its
+        // layer container), not its declared position. A prediction that STAYS inside the real element's own
+        // subtree is left alone (moving between two focusables both inside it never crosses its boundary);
+        // only a prediction that would LEAVE it gets redirected, to the panel ring's neighbour of the
+        // element's PLACEHOLDER — its logical position — instead. No panel hop (same panel throughout), so
+        // this redirects synchronously, unlike the cross-panel chained escape.
+        private static bool TryZLayerExit(
+            NavigationMoveEvent evt, IPanel panel, VisualElement panelRoot, VisualElement focused, bool forward,
+            ReconcilerContext ctx)
+        {
+            var real = FindEnclosingZLayerReal(focused, ctx, out var placeholder);
+            if (real == null)
+            {
+                return false;
+            }
+
+            var direction = ToRingDirection(forward);
+            var ring = new VisualElementFocusRing(panelRoot);
+            var predicted = ring.GetNextFocusable(focused, direction) as VisualElement;
+            if (predicted != null && real.Contains(predicted))
+            {
+                return false;
+            }
+
+            var landing = ring.GetNextFocusable(placeholder, direction) as VisualElement;
+            if (landing == null || ReferenceEquals(landing, placeholder) || !landing.canGrabFocus)
+            {
+                return false;
+            }
+            Redirect(evt, panel, ResolveScopeEntryTarget(landing, ctx));
+            return true;
+        }
+
+        // Walks UP from `element` (inclusive) for the nearest ancestor currently registered as a z-managed
+        // real element (ReconcilerContext.ZLayerMembers), returning it and its placeholder. Physical
+        // containment, mirroring FindEnclosingScopeRoot's own walk — robust across pool reuse and independent
+        // of any logical-tree bookkeeping.
+        private static VisualElement? FindEnclosingZLayerReal(VisualElement element, ReconcilerContext ctx, out VisualElement? placeholder)
+        {
+            for (var current = element; current != null; current = current.parent)
+            {
+                if (ctx.ZLayerMembers.TryGetValue(current, out var member))
+                {
+                    placeholder = member.Placeholder;
+                    return current;
+                }
+            }
+            placeholder = null;
+            return null;
+        }
+
         private static void OnFocusIn(FocusInEvent evt, ReconcilerContext ctx)
         {
             if (evt.target is not VisualElement target)
@@ -469,6 +532,31 @@ namespace Velvet
                     {
                         ResolveScopeEntryTarget(entry, ctx).Focus();
                     }
+                }
+                return;
+            }
+
+            // z-layer placeholder forwarding: Tab reached the proxy stand-in at a z-relocated element's
+            // logical position — same panel, so no host-panel hop is needed, just the chained case's
+            // forwarding shape minus the panel-boundary machinery. Contain snap-back is checked first for the
+            // same reason the chained branch above checks it first.
+            if (ctx.ZLayerPlaceholders.TryGetValue(target, out var real))
+            {
+                if (TrySnapBackToContainScope(target, evt.relatedTarget as VisualElement, ctx))
+                {
+                    return;
+                }
+                if (real.canGrabFocus)
+                {
+                    ResolveScopeEntryTarget(real, ctx).Focus();
+                    return;
+                }
+                var backward = evt.direction == VisualElementFocusChangeDirection.left;
+                var entry = new VisualElementFocusRing(real).GetNextFocusable(null,
+                    backward ? VisualElementFocusChangeDirection.left : VisualElementFocusChangeDirection.right) as VisualElement;
+                if (entry != null)
+                {
+                    ResolveScopeEntryTarget(entry, ctx).Focus();
                 }
                 return;
             }

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodeFactory.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodeFactory.cs
@@ -186,28 +186,44 @@ namespace Velvet
                         _patcher.Appliers.ApplyDragOverlay(element, elementNode.Props.DragOverlay);
                     }
 
+                    VisualElement outer;
                     if (elementNode.WrapElement != null)
                     {
                         var wrapper = elementNode.WrapElement(element);
                         if (wrapper != null && wrapper != element)
                         {
                             _ctx.WrapperToInnerMap[wrapper] = element;
-                            return wrapper;
+                            outer = wrapper;
                         }
-                        return element;
+                        else
+                        {
+                            outer = element;
+                        }
+                    }
+                    else
+                    {
+                        // No explicit wrapElement: a clip-path-* class auto-wraps the element in a stencil-
+                        // masking container, else a ring-* class wraps it in a native-border overlay
+                        // container. Clip takes precedence: the two are mutually exclusive (one structural
+                        // wrapper per element). The shadow is NOT here — it is a wrapper-less paint attached
+                        // above (a clipped element renders no shadow because the shadow paint self-suppresses
+                        // on an active clip).
+                        var clipWrapped = _patcher.Appliers.ApplyClipPathOnCreate(element, elementNode.ClassNames);
+                        outer = !ReferenceEquals(clipWrapped, element)
+                            ? clipWrapped
+                            : _patcher.Appliers.ApplyRingOnCreate(element, elementNode.ClassNames);
                     }
 
-                    // No explicit wrapElement: a clip-path-* class auto-wraps the element in a stencil-
-                    // masking container, else a ring-* class wraps it in a native-border overlay container.
-                    // Clip takes precedence: the two are mutually exclusive (one structural wrapper per
-                    // element). The shadow is NOT here — it is a wrapper-less paint attached above (a clipped
-                    // element renders no shadow because the shadow paint self-suppresses on an active clip).
-                    var clipWrapped = _patcher.Appliers.ApplyClipPathOnCreate(element, elementNode.ClassNames);
-                    if (!ReferenceEquals(clipWrapped, element))
+                    // z-* scope gate: only an ALSO-absolute element with an explicit z-* class routes into a
+                    // layer container; everything else (the overwhelming majority) returns `outer` unchanged
+                    // at the cost of one cheap prefix scan. Gated on the OUTERMOST element — a clip-path-*/
+                    // ring/wrapElement wrapper is what physically occupies the slot, so it (not the inner
+                    // `element`) is what must relocate.
+                    if (FiberZLayerCoordinator.TryClassify(elementNode.ClassNames, elementNode.Props, out var resolvedZ))
                     {
-                        return clipWrapped;
+                        return FiberZLayerCoordinator.EnqueueMount(_ctx, outer, resolvedZ);
                     }
-                    return _patcher.Appliers.ApplyRingOnCreate(element, elementNode.ClassNames);
+                    return outer;
                 }
                 case MotionNode motionNode:
                 {

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodeFactory.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodeFactory.cs
@@ -364,6 +364,17 @@ namespace Velvet
                             "A clip-path-* utility on a Motion is ignored: it would break AnimatePresence enter/exit "
                             + "(same constraint as shadow-*). Wrap the Motion around a clipped Div instead.");
                     }
+                    // z-* is ignored on a Motion: this create path never consults FiberZLayerCoordinator at all
+                    // (only the ElementNode case above does), so a Motion never relocates into a layer container
+                    // — TryClassify's out-of-flow half runs off the declared class list / Anchored prop alone
+                    // (no live element needed), so it can be evaluated here for diagnostics purposes even though
+                    // this path never acts on it. Warn like the shadow-*/clip-path-* gates above.
+                    if (FiberZLayerCoordinator.TryClassify(appliedClasses, motionNode.Props, out _))
+                    {
+                        FiberLogger.LogWarning("Motion",
+                            "A z-* utility on a Motion is ignored: z-* does not apply to Motion elements. "
+                            + "Wrap the Motion around a z-managed Div instead.");
+                    }
                     // Exit tweens are scheduled only by the AnimatePresence expansion — something has to defer
                     // the unmount for a removal to animate against, and AnimatePresence is what does that — so
                     // exit outside one is genuinely inert. Warn like the shadow-*/clip-path-* gates above. Initial
@@ -736,8 +747,8 @@ namespace Velvet
         }
 
         // Walks node and returns the first MotionNode descendant
-        // reachable through transparent wrappers — ContextProviderNode and
-        // FragmentNode. Returns the node itself when it is already a MotionNode, or
+        // reachable through transparent wrappers — ContextProviderNode, FragmentNode, and a z-managed
+        // ElementNode. Returns the node itself when it is already a MotionNode, or
         // null when no MotionNode exists in this transparent-wrapper chain. Used by
         // ResolveAnimatePresenceMotion and AnimatePresence's else-branch
         // (Initial=false) where no warning should be emitted — so a Provider-wrapped Motion
@@ -750,11 +761,22 @@ namespace Velvet
             {
                 return motion;
             }
-            // The only transparent wrappers whose children can carry the Motion: a Provider or a Fragment.
+            // The transparent wrappers whose children can carry the Motion: a Provider, a Fragment, or a
+            // z-managed ElementNode. The z-managed case is a narrow, deliberate carve-out — z-* is a
+            // documented no-op on a Motion itself (FiberNodeFactory's own create-time warning), so the ONLY
+            // way to combine z-* with an AnimatePresence-driven Motion is to wrap it in a z-managed Div; that
+            // wrapper exists purely to satisfy the out-of-flow scope gate, not as an opaque animation
+            // boundary the author intended, so treating it like Provider/Fragment for this walk is exactly
+            // the same "structurally forced, not a user choice" reasoning. An ORDINARY (non-z) ElementNode is
+            // deliberately NOT walked into: unlike Provider/Fragment it emits its own real DOM element, so
+            // silently treating any Motion nested anywhere inside it as the presence anchor would surprise a
+            // caller who wrapped a Motion in a plain structural Div for unrelated styling reasons.
             var children = node switch
             {
                 ContextProviderNode provider => provider.Children,
                 FragmentNode fragment => fragment.Children,
+                ElementNode elementNode when FiberZLayerCoordinator.TryClassify(elementNode.ClassNames, elementNode.Props, out _)
+                    => elementNode.Children,
                 _ => null,
             };
             if (children != null)

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
@@ -2323,13 +2323,20 @@ namespace Velvet
             // sibling index, not the wrapper's 1-child interior. On initial mount the element is not parented
             // yet, so the container post-children pass applies it once placed.
             var outer = ResolveOuter(element);
-            if (outer.parent != null)
+            // A z-managed outer's PHYSICAL parent is its layer container (its position there is relative to
+            // unrelated same-layer siblings, not this element's true siblings) — TryGetLogicalPosition
+            // resolves to the stacking parent + the placeholder's slot instead; an ordinary outer resolves to
+            // its own parent/index unchanged, same as the previous outer.parent / outer.parent.IndexOf(outer).
+            if (!FiberZLayerCoordinator.TryGetLogicalPosition(_ctx, outer, out var logicalParent, out var logicalIndex))
             {
-                // Exclude the trailing filter bounds-spacer(s) from the sibling count: they are internal
-                // render-bounds children, not part of the logical child list a first:/last:/nth match sees.
-                EvaluateStructural(element, outer.parent.IndexOf(outer),
-                    SilhouetteBoundsSpacer.NonSpacerChildCount(outer.parent), rules);
+                return;
             }
+            // Exclude the trailing filter bounds-spacer(s) AND a leading back z-layer container (either may
+            // be present) from the sibling count: neither is part of the logical child list a
+            // first:/last:/nth match sees.
+            var leadingOffset = FiberZLayerCoordinator.LeadingOffset(logicalParent!);
+            EvaluateStructural(element, logicalIndex - leadingOffset,
+                SilhouetteBoundsSpacer.NonSpacerChildCount(logicalParent!) - leadingOffset, rules);
         }
 
         // Applies / clears each structural rule's payload for an element at the given sibling position.
@@ -2357,11 +2364,21 @@ namespace Velvet
 
             // The trailing filter bounds-spacer(s) are internal render-bounds children, not logical siblings:
             // exclude them from the count and skip evaluating them so first:/last:/nth match the real children.
-            var count = SilhouetteBoundsSpacer.NonSpacerChildCount(container);
+            // A leading back z-layer container (FiberZLayerCoordinator), when present, is symmetrically
+            // excluded: NonSpacerChildCount only trims the trailing side, so the scan start and the count are
+            // both corrected by LeadingOffset here — otherwise every ordinary child's structural position
+            // computes one slot too high and the sibling count is inflated by one.
+            var leadingOffset = FiberZLayerCoordinator.LeadingOffset(container);
+            var count = SilhouetteBoundsSpacer.NonSpacerChildCount(container) - leadingOffset;
             for (var i = 0; i < count; i++)
             {
-                // The slot may hold a shadow / clip-path WRAPPER; the structural rules are keyed by the inner.
-                var inner = ResolveWrapped(container.ElementAt(i));
+                var slotOccupant = container.ElementAt(i + leadingOffset);
+                // A z-managed child's slot holds its PLACEHOLDER, not the element the rules were registered
+                // against (ApplyStructuralVariantConfig keys by the real element / its own wrapper) — resolve
+                // through the z-registry first, then the ordinary wrapper unwrap (the slot may ALSO hold a
+                // shadow / clip-path WRAPPER either way).
+                var inner = ResolveWrapped(
+                    _ctx.ZLayerPlaceholders.TryGetValue(slotOccupant, out var real) ? real : slotOccupant);
                 if (_ctx.StructuralVariants.TryGetValue(inner, out var rules))
                 {
                     EvaluateStructural(inner, i, count, rules);

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
@@ -57,7 +57,22 @@ namespace Velvet
             switch (oldNode)
             {
                 case ElementNode oldElem when newNode is ElementNode newElem:
-                    PatchElement(element, oldElem, newElem);
+                    // z-* candidacy is a runtime property of the CLASS LIST, not the VNode type (unlike
+                    // Portal/WorldSpace, which dispatch on a distinct type below) — CanPatch already says
+                    // "patch in place" for any two ElementNodes of the same ElementType/wrapper-presence
+                    // regardless of z-classes, so the four transitions (still z / z-to-none / none-to-z /
+                    // z-changed) must be intercepted HERE, before the ordinary element patch, or `element`
+                    // (a z-managed slot's PLACEHOLDER, whenever oldElem was z-managed) would be patched as if
+                    // it were the real content.
+                    if (!FiberZLayerCoordinator.TryClassify(oldElem.ClassNames, oldElem.Props, out _)
+                        && !FiberZLayerCoordinator.TryClassify(newElem.ClassNames, newElem.Props, out _))
+                    {
+                        PatchElement(element, oldElem, newElem);
+                    }
+                    else
+                    {
+                        PatchZLayerElement(element, oldElem, newElem);
+                    }
                     break;
                 case TextNode oldText when newNode is TextNode newText:
                     // Invariant: TextNode is always mapped to Label by CreateElement.
@@ -264,6 +279,58 @@ namespace Velvet
             // are mutually exclusive — one wrapper per element). The shadow is now a paint, so a ring composes
             // with it rather than competing for the wrapper.
             _appliers.ApplyRingOnPatch(element, newNode.ClassNames, suppress: clipActive, allowWrap: true);
+        }
+
+        // Applies the oldNode -> newNode diff when EITHER side is z-managed (FiberZLayerCoordinator.
+        // TryClassify), covering the three reachable transitions (the caller already excludes "neither side is
+        // z-managed", which falls through to the ordinary PatchElement):
+        //   still z-managed (z -> z, possibly a different resolved value): `element` is the PLACEHOLDER;
+        //     the real element is patched normally, then repositioned only if its resolved z (or front/back
+        //     sign) actually changed.
+        //   z -> none: `element` is the PLACEHOLDER; the real element is patched normally, then relocated
+        //     back into the placeholder's own slot, replacing it.
+        //   none -> z: `element` IS the real, still-ordinary element; it is patched normally in place, then
+        //     relocated out into its layer, leaving a fresh placeholder at its old slot.
+        // Every branch patches the REAL element (props/children/styles) before any relocation, so a size or
+        // content change that a coordinate-neutral reposition depends on is already reflected.
+        // Contract-preserving: exactly like PatchElement, the net effect on `element`'s own parent's
+        // childCount/order is zero in every branch — a same-index swap (mirroring PatchNode's own MemoNode-
+        // branch precedent) or a pure container-membership move — so ProcessKeyedNode / CommitLeaf's post-
+        // patch re-fetch at the same slot (already written to tolerate a WrapElement-style reference swap)
+        // picks up the new occupant without any change to those call sites.
+        private void PatchZLayerElement(VisualElement element, ElementNode oldNode, ElementNode newNode)
+        {
+            var oldIsZ = FiberZLayerCoordinator.TryClassify(oldNode.ClassNames, oldNode.Props, out _);
+            var newIsZ = FiberZLayerCoordinator.TryClassify(newNode.ClassNames, newNode.Props, out var newResolvedZ);
+
+            if (!oldIsZ)
+            {
+                // none -> z: `element` is still the ordinary, in-flow element.
+                PatchElement(element, oldNode, newNode);
+                FiberZLayerCoordinator.RelocateFromOrdinarySlot(_ctx, element, newResolvedZ);
+                return;
+            }
+
+            // `element` is the placeholder for both remaining branches (oldIsZ is true): the real element
+            // lives elsewhere and must be resolved before it can be patched.
+            if (!_ctx.ZLayerPlaceholders.TryGetValue(element, out var real))
+            {
+                // Defensive: a live tree should never reach a z-managed placeholder with no registered real
+                // element. Patching the placeholder itself would be wrong (it is not the declared content),
+                // so at minimum do not silently drop the node's props/children.
+                PatchElement(element, oldNode, newNode);
+                return;
+            }
+
+            PatchElement(real, oldNode, newNode);
+            if (newIsZ)
+            {
+                FiberZLayerCoordinator.Reposition(_ctx, element, real, newResolvedZ);
+            }
+            else
+            {
+                FiberZLayerCoordinator.RelocateToOrdinarySlot(_ctx, element, real);
+            }
         }
 
         // The ordered post-children effect-pass sequence shared by PatchElement and PatchMotion, kept in

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberWorkLoop.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberWorkLoop.cs
@@ -321,9 +321,14 @@ namespace Velvet
                 // stale against the rows this slice just inserted / removed.
                 if (fiber.IsInlineMounted)
                 {
-                    var beforeChildCount = fiber.MountPoint?.childCount ?? 0;
+                    // Logical (container-blind) count, not raw childCount: this same ContinueReconcile call
+                    // now also drains any Portal / z-layer mount this slice enqueued (see Reconciler.
+                    // ContinueReconcile), and a first-of-its-sign container the drain creates or removes would
+                    // otherwise leak its own +-1 into this fiber's delta exactly like FiberCommitWork.
+                    // ReconcileIntoSlotRange's own measurement — see LogicalMountPointChildCount.
+                    var beforeChildCount = FiberCommitWork.LogicalMountPointChildCount(fiber.MountPoint);
                     fiber.Reconciler.ContinueReconcile(fiber.PendingReconcileBudgetMs);
-                    var afterChildCount = fiber.MountPoint?.childCount ?? 0;
+                    var afterChildCount = FiberCommitWork.LogicalMountPointChildCount(fiber.MountPoint);
                     FiberCommitWork.PropagateInlineSlotShift(fiber, afterChildCount - beforeChildCount);
                 }
                 else

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberZLayerCoordinator.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberZLayerCoordinator.cs
@@ -20,6 +20,14 @@ namespace Velvet
         // container did not exist yet for a sign flip on an already-z-managed element); null for a genuinely
         // new entry (a fresh mount, or a none-to-z transition), which is assigned one on resolution.
         public ulong? Order;
+
+        // Carries a focus rescue forward across the SAME deferred reposition Order does, for the identical
+        // reason: Reposition/RelocateFromOrdinarySlot capture this BEFORE their own detach (the only point Real
+        // is still attached to a live panel to read FocusController.focusedElement from), then this queued entry
+        // is the sole surviving reference by the time ResolveQueuedMount finally re-attaches Real — see
+        // FiberZLayerCoordinator.CaptureFocusForRescue / RestoreRescuedFocus. Null when nothing was focused (the
+        // common case) or for a genuinely fresh mount (nothing to rescue — the element never existed before).
+        public VisualElement? RescueFocus;
     }
 
     // Owns the reconciler-side mechanics of the z-* stacking feature: classifying which absolute elements
@@ -79,27 +87,49 @@ namespace Velvet
         internal static int LeadingOffset(VisualElement parent)
             => parent.childCount > 0 && parent[0].ClassListContains(BackMarkerClass) ? 1 : 0;
 
-        // A hidden, zero-footprint stand-in left at a z-managed element's logical slot while its real
-        // element lives in a layer container. Carries focusable/tabIndex so it can act as a same-panel Tab
-        // proxy (FiberFocusNavigator) — set unconditionally (not opt-in): keeping Tab order following the
+        // A zero-footprint stand-in left at a z-managed element's logical slot while its real element
+        // lives in a layer container. Carries focusable/tabIndex so it can act as a same-panel Tab proxy
+        // (FiberFocusNavigator) — set unconditionally (not opt-in): keeping Tab order following the
         // logical position has no downside, unlike PanelFocusOrder's genuine cross-panel behavior change.
+        // display:None is NOT used here, unlike an Isolated portal placeholder (ConfigureChainedPlaceholder's
+        // reset branch) — display:None excludes an element from VisualElementFocusRing's ring entirely, which
+        // would make every focus redirect below silently unreachable (Tab could never land on this
+        // placeholder, and a ring query anchored on it would not resolve). Mirrors
+        // ConfigureChainedPlaceholder's own chained-branch styling instead: absolute (zero-size, out of flex
+        // flow and the gap/grid/divide/child-variant index walks, which already skip out-of-flow children)
+        // while staying displayed, so the engine's own ring keeps a ring position for it.
         internal static VisualElement CreatePlaceholder()
         {
             var placeholder = new VisualElement
             {
-                style = { display = DisplayStyle.None },
                 focusable = true,
                 tabIndex = 0,
             };
+            placeholder.style.position = Position.Absolute;
+            placeholder.style.width = 0f;
+            placeholder.style.height = 0f;
             return placeholder;
         }
 
         // Mount-time entry (FiberNodeFactory.CreateElement): `real` is fully built but not yet attached
         // anywhere (CreateElement never knows its own parent), so placement must wait for the drain, where
         // placeholder.parent is finally resolvable. Returns the placeholder to install at the ordinary slot.
+        // ZLayerPlaceholders[placeholder] is registered HERE, before the physical relocation this method
+        // defers, NOT only later inside Place: AnimatePresence's own enter dispatch (GeneralPathReconciler.
+        // EmitPresenceChild) resolves this exact mapping synchronously, during THIS SAME reconcile pass —
+        // for a brand-new mount, that resolution runs before the drain (the only place Place would otherwise
+        // populate it), so without this the enter would tween a zero-size placeholder instead of `real`.
+        // ZLayerMembers (which needs the layer CONTAINER — not yet known, since GetOrCreateContainer runs
+        // only from the drain) is deliberately left for Place to set once resolved; every other
+        // ZLayerPlaceholders consumer already tolerates a "registered but not yet physically relocated"
+        // entry: TakeReal (a same-pass Suspense/error-boundary rollback) reads real's absent ZLayerMembers
+        // entry as "nothing to detach yet" and still cleans real up correctly, and PatchZLayerElement /
+        // FiberFocusNavigator only ever read this map for an ALREADY z-managed element on a LATER pass, once
+        // this one has committed.
         internal static VisualElement EnqueueMount(ReconcilerContext ctx, VisualElement real, int resolvedZ)
         {
             var placeholder = CreatePlaceholder();
+            ctx.ZLayerPlaceholders[placeholder] = real;
             ctx.PendingPortalMounts.Enqueue(
                 (placeholder, new ZLayerMountNode { Real = real, ResolvedZ = resolvedZ }, null, null, null));
             return placeholder;
@@ -108,7 +138,11 @@ namespace Velvet
         // Drain-time resolution of a queued mount (ChildReconciler.DrainPendingPortalMounts's new case arm).
         // By now placeholder.parent is set (the caller already inserted it at the ordinary slot like any
         // other created element), so the stacking parent — and therefore its container — is finally known.
-        internal static void ResolveQueuedMount(ReconcilerContext ctx, VisualElement placeholder, ZLayerMountNode node)
+        // `current` is the ChildReconciler instance whose own top-level Reconcile() finally is running this
+        // drain (see RebaseParkedSlotsForContainerChange) — threaded through only so GetOrCreateContainer can
+        // rebase a same-pass self-park; it plays no other part in resolving this mount.
+        internal static void ResolveQueuedMount(
+            ReconcilerContext ctx, VisualElement placeholder, ZLayerMountNode node, ChildReconciler current)
         {
             var stackingParent = placeholder.parent;
             if (stackingParent == null)
@@ -117,8 +151,8 @@ namespace Velvet
                 // this drained — mirrors DrainPendingPortalMounts' own placeholder.parent == null skip.
                 return;
             }
-            var container = GetOrCreateContainer(ctx, stackingParent, node.ResolvedZ);
-            Place(ctx, placeholder, container, stackingParent, node.Real, node.ResolvedZ, node.Order);
+            var container = GetOrCreateContainer(ctx, stackingParent, node.ResolvedZ, current);
+            Place(ctx, placeholder, container, stackingParent, node.Real, node.ResolvedZ, node.Order, node.RescueFocus);
         }
 
         // Patch-time: an already z-managed element's resolved z (or its front/back sign) changed. A no-op
@@ -132,6 +166,13 @@ namespace Velvet
             {
                 return;
             }
+            // Captured before ANY branch below: every one of them physically detaches `real` from its current
+            // parent at some point (the same-container branch's own InsertSorted, DetachFromContainer for a
+            // cross-container move, or the deferred sign-flip) — UI Toolkit clears FocusController.focusedElement
+            // the instant an element leaves its panel's visual tree (see
+            // FiberElementCleaner.RescueFocusFromWorldSpaceHost's own comment on the same behavior), even across
+            // an immediate same-panel reattachment, so this must run while `real` is still attached to read it.
+            var rescue = CaptureFocusForRescue(real);
             var stackingParent = member.StackingParent;
             var existing = TryGetExistingContainer(ctx, stackingParent, newResolvedZ);
             if (existing != null)
@@ -140,13 +181,14 @@ namespace Velvet
                 {
                     DetachFromContainer(ctx, member.Container, real);
                 }
-                Place(ctx, placeholder, existing, stackingParent, real, newResolvedZ, member.Order);
+                Place(ctx, placeholder, existing, stackingParent, real, newResolvedZ, member.Order, rescue);
                 return;
             }
             DetachFromContainer(ctx, member.Container, real);
             ctx.ZLayerMembers.Remove(real);
             ctx.PendingPortalMounts.Enqueue(
-                (placeholder, new ZLayerMountNode { Real = real, ResolvedZ = newResolvedZ, Order = member.Order },
+                (placeholder, new ZLayerMountNode
+                    { Real = real, ResolvedZ = newResolvedZ, Order = member.Order, RescueFocus = rescue },
                     null, null, null));
         }
 
@@ -159,6 +201,9 @@ namespace Velvet
         {
             var stackingParent = real.parent!;
             var idx = stackingParent.IndexOf(real);
+            // Captured before the detach two lines below drops it — see Reposition's own comment on why this
+            // must run while `real` is still attached.
+            var rescue = CaptureFocusForRescue(real);
             var placeholder = CreatePlaceholder();
             stackingParent.Insert(idx, placeholder);
             real.RemoveFromHierarchy();
@@ -166,12 +211,17 @@ namespace Velvet
             var existing = TryGetExistingContainer(ctx, stackingParent, resolvedZ);
             if (existing != null)
             {
-                Place(ctx, placeholder, existing, stackingParent, real, resolvedZ);
+                Place(ctx, placeholder, existing, stackingParent, real, resolvedZ, rescueFocus: rescue);
             }
             else
             {
+                // `placeholder` is new (this is a none-to-z transition), so it needs the same eager
+                // registration EnqueueMount's own doc comment explains — a same-render consumer must not see
+                // this pair as unregistered just because the destination layer happens to need creating.
+                ctx.ZLayerPlaceholders[placeholder] = real;
                 ctx.PendingPortalMounts.Enqueue(
-                    (placeholder, new ZLayerMountNode { Real = real, ResolvedZ = resolvedZ }, null, null, null));
+                    (placeholder, new ZLayerMountNode { Real = real, ResolvedZ = resolvedZ, RescueFocus = rescue },
+                        null, null, null));
             }
             return placeholder;
         }
@@ -180,6 +230,10 @@ namespace Velvet
         // ordinary slot `placeholder` occupies, replacing it (same in-place-swap contract as above).
         internal static void RelocateToOrdinarySlot(ReconcilerContext ctx, VisualElement placeholder, VisualElement real)
         {
+            // Captured before the container detach below drops it — see Reposition's own comment on why this
+            // must run while `real` is still attached. Restored once `real` is back in its ordinary slot below
+            // (RelocateToOrdinarySlot has no deferred branch, so this always resolves synchronously).
+            var rescue = CaptureFocusForRescue(real);
             if (ctx.ZLayerMembers.TryGetValue(real, out var member))
             {
                 DetachFromContainer(ctx, member.Container, real);
@@ -191,6 +245,7 @@ namespace Velvet
             var idx = stackingParent.IndexOf(placeholder);
             stackingParent.Insert(idx, real);
             stackingParent.Remove(placeholder);
+            RestoreRescuedFocus(rescue);
         }
 
         // Cleanup entry (FiberElementCleaner.CleanupZLayerPlaceholder, mirroring CleanupPortal): detaches and
@@ -229,8 +284,10 @@ namespace Velvet
         }
 
         // Runs at the same post-pass safe point as DrainPendingPortalMounts: any container whose membership
-        // changed this pass and is now empty is removed from its stacking parent and forgotten.
-        internal static void DrainTeardowns(ReconcilerContext ctx)
+        // changed this pass and is now empty is removed from its stacking parent and forgotten. `current` is
+        // threaded through for the same reason as ResolveQueuedMount's own parameter — see
+        // RebaseParkedSlotsForContainerChange.
+        internal static void DrainTeardowns(ReconcilerContext ctx, ChildReconciler current)
         {
             if (ctx.PendingZLayerTeardownChecks.Count == 0)
             {
@@ -243,7 +300,16 @@ namespace Velvet
                     continue;
                 }
                 var stackingParent = container.parent;
+                // The marker class survives Remove (a detach, not a destroy), so reading it after is just as
+                // valid — checked here only because only a BACK container's removal is a LEADING-child change
+                // (LeadingOffset's whole reason to exist); a front container is trailing, so removing it never
+                // shifts any ordinary/placeholder index.
+                var wasBack = container.ClassListContains(BackMarkerClass);
                 stackingParent.Remove(container);
+                if (wasBack)
+                {
+                    RebaseParkedSlotsForContainerChange(ctx, stackingParent, -1, current);
+                }
                 if (!ctx.ZLayerHosts.TryGetValue(stackingParent, out var record))
                 {
                     continue;
@@ -260,15 +326,44 @@ namespace Velvet
 
         // Places (inserts sorted, records bookkeeping) `real` into `container`, assigning a fresh mount-order
         // tiebreak unless one is supplied (a reposition/relocation carries its element's existing order
-        // forward — see ZLayerMember.Order's own "assigned once" contract).
+        // forward — see ZLayerMember.Order's own "assigned once" contract). rescueFocus mirrors that same
+        // "carry an already-captured value forward" shape for a focus rescue (see ZLayerMountNode.RescueFocus):
+        // restored here, once, since InsertSorted just below is what actually reattaches `real` to a panel,
+        // regardless of which caller (a synchronous reposition, or a deferred drain resolution) reached this.
         private static void Place(
             ReconcilerContext ctx, VisualElement placeholder, VisualElement container, VisualElement stackingParent,
-            VisualElement real, int resolvedZ, ulong? existingOrder = null)
+            VisualElement real, int resolvedZ, ulong? existingOrder = null, VisualElement? rescueFocus = null)
         {
             var order = existingOrder ?? ctx.NextZOrder++;
             InsertSorted(ctx, container, real, resolvedZ, order);
             ctx.ZLayerPlaceholders[placeholder] = real;
             ctx.ZLayerMembers[real] = new ZLayerMember(placeholder, container, stackingParent, resolvedZ, order);
+            RestoreRescuedFocus(rescueFocus);
+        }
+
+        // Captures the panel's currently focused element when it is `moving` itself, or is contained within its
+        // subtree, immediately before `moving` physically detaches from its current parent — UI Toolkit clears
+        // FocusController.focusedElement the instant an element leaves its panel's visual tree (see
+        // FiberElementCleaner.RescueFocusFromWorldSpaceHost's own comment on this exact behavior), even when the
+        // very next statement reattaches it elsewhere in the SAME panel. Unlike that world-space rescue (which
+        // redirects focus elsewhere because the host is being destroyed), `moving` survives every z transition
+        // with its identity intact, so the caller can simply re-Focus() this SAME captured element once it is
+        // back in the tree — see RestoreRescuedFocus.
+        private static VisualElement? CaptureFocusForRescue(VisualElement moving)
+        {
+            var focused = moving.panel?.focusController?.focusedElement as VisualElement;
+            return focused != null && (ReferenceEquals(focused, moving) || moving.Contains(focused)) ? focused : null;
+        }
+
+        // Restores focus captured by CaptureFocusForRescue once the moved element is back in a panel. A no-op
+        // when nothing was captured (the common case: the moving element held no focus) or the captured element
+        // can no longer grab focus (a concurrent unmount elsewhere in the same pass).
+        private static void RestoreRescuedFocus(VisualElement? rescued)
+        {
+            if (rescued != null && rescued.panel != null && rescued.canGrabFocus)
+            {
+                rescued.Focus();
+            }
         }
 
         // The already-existing container for `resolvedZ`'s sign under `stackingParent`, or null. A pure
@@ -286,8 +381,11 @@ namespace Velvet
         // The container for `resolvedZ`'s sign under `stackingParent`, creating (and physically attaching)
         // it on first use. Only ever called from a safe (post-pass) context — creating one changes
         // `stackingParent`'s own child list, which a live diff over that same parent may still be indexing
-        // by absolute position.
-        private static VisualElement GetOrCreateContainer(ReconcilerContext ctx, VisualElement stackingParent, int resolvedZ)
+        // by absolute position. `current` is the ChildReconciler instance running this drain — threaded
+        // through only for the back-container branch's rebase (see RebaseParkedSlotsForContainerChange); the
+        // front branch never needs it (trailing, no LeadingOffset impact).
+        private static VisualElement GetOrCreateContainer(
+            ReconcilerContext ctx, VisualElement stackingParent, int resolvedZ, ChildReconciler current)
         {
             if (!ctx.ZLayerHosts.TryGetValue(stackingParent, out var record))
             {
@@ -304,6 +402,11 @@ namespace Velvet
                     // own trailing-only spacer convention), which is what LeadingOffset exists to reconcile
                     // against every ordinary-child index computation.
                     stackingParent.Insert(0, record.Back);
+                    // A time-sliced pass — this same drain's own instance, mid-unwind through its own park, or
+                    // any other fiber already parked from an earlier pass — may have captured a slotStart/
+                    // slotLimit over this exact stackingParent before this LEADING insert existed. Every such
+                    // pass is now off by one in the corresponding direction.
+                    RebaseParkedSlotsForContainerChange(ctx, stackingParent, +1, current);
                 }
                 return record.Back;
             }
@@ -317,6 +420,52 @@ namespace Velvet
                 stackingParent.Add(record.Front);
             }
             return record.Front;
+        }
+
+        // Rebases every time-sliced pass parked over `stackingParent` by delta, once a back container's
+        // creation or removal has just shifted every LEADING index there by that same amount. Two
+        // populations can be parked against the SAME stackingParent at this moment, and they are NOT always
+        // disjoint by fiber:
+        //   `current` — the ChildReconciler instance whose OWN top-level Reconcile()/ContinueReconcile() call
+        //     is unwinding through THIS SAME drain (both always run DrainPendingPortalMounts, hence
+        //     DrainTeardowns, from their own top-level finally before returning). A self-caused park — this
+        //     slice's own placeholder insert queued the very mount (or, for the negative direction, its own
+        //     patch synchronously emptied the container) this drain now resolves — is invisible to any
+        //     cross-fiber registry ONLY on a fiber's very FIRST suspension: FiberCommitWork adds a fiber to
+        //     ParkedBaselineFibers once its Reconcile() call has fully returned, strictly AFTER that first
+        //     drain finishes. But an INTERMEDIATE resume tick (FiberWorkLoop.ContinueReconcile driving an
+        //     already-parked fiber) runs with that SAME fiber already sitting in ParkedBaselineFibers from its
+        //     earlier suspension — nothing removes it until HasPendingWork finally goes false — so if that
+        //     tick both creates/removes a container under its OWN MountPoint and immediately re-parks, `current`
+        //     and the loop below would otherwise match the identical fiber twice. RebasePendingSlotStartIfTargeting
+        //     checks Parent match itself, since (unlike FiberCommitWork.PropagateInlineSlotShift's inline-sibling
+        //     walk) nothing here already guarantees `current` is even parked over THIS stackingParent.
+        //   ReconcilerContext.ParkedBaselineFibers — every fiber left parked by an earlier pass, MINUS
+        //     whichever one owns `current` (excluded below) — the same ctx-wide registry
+        //     FiberTreeReturn.MarkOwnerRoots already sweeps wholesale for its own cross-fiber mark. A fiber's
+        //     own Reconcile call always targets fiber.MountPoint as `parent`
+        //     (FiberCommitWork.ReconcileIntoSlotRange), so MountPoint identity is exactly the "this fiber's
+        //     parked state targets stackingParent" test — no separate per-parent index needs maintaining
+        //     alongside it.
+        private static void RebaseParkedSlotsForContainerChange(
+            ReconcilerContext ctx, VisualElement stackingParent, int delta, ChildReconciler current)
+        {
+            current.RebasePendingSlotStartIfTargeting(stackingParent, delta);
+            foreach (var fiber in ctx.ParkedBaselineFibers)
+            {
+                // `current`'s own owning fiber, when it is itself one of the parked entries this loop would
+                // otherwise reach (see this method's own doc), was already rebased by the direct call above —
+                // matching it again here would apply delta to the very same PendingIndexedState/
+                // PendingKeyedState instance a second time.
+                if (ReferenceEquals(fiber.Reconciler?.ChildReconciler, current))
+                {
+                    continue;
+                }
+                if (ReferenceEquals(fiber.MountPoint, stackingParent))
+                {
+                    fiber.Reconciler?.RebasePendingSlotStart(delta);
+                }
+            }
         }
 
         private static VisualElement CreateContainer(string markerClass)

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberZLayerCoordinator.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberZLayerCoordinator.cs
@@ -1,0 +1,373 @@
+#nullable enable
+using UnityEngine.UIElements;
+
+namespace Velvet
+{
+    // Internal-only carrier that shuttles a fully-built z-managed element through the EXISTING
+    // ReconcilerContext.PendingPortalMounts queue so its container placement resolves from the same
+    // post-pass safe context Portal mounts already use (ChildReconciler.DrainPendingPortalMounts). Never
+    // appears in an actual VNode tree — synthesized in FiberNodeFactory.CreateElement / FiberNodePatcher and
+    // immediately enqueued, so RequiresInlineExpansion / CanPatch / ExpandInlineRecursive never see it: the
+    // element it carries is already an ordinary ElementNode as far as the rest of the reconciler is
+    // concerned, and this node's only job is to reach ResolveQueuedMount with the placeholder it was queued
+    // against.
+    internal sealed class ZLayerMountNode : VNode
+    {
+        public VisualElement Real = null!;
+        public int ResolvedZ;
+
+        // Carries an already-assigned mount-order tiebreak forward across a deferred reposition (the target
+        // container did not exist yet for a sign flip on an already-z-managed element); null for a genuinely
+        // new entry (a fresh mount, or a none-to-z transition), which is assigned one on resolution.
+        public ulong? Order;
+    }
+
+    // Owns the reconciler-side mechanics of the z-* stacking feature: classifying which absolute elements
+    // are z-managed, the lazily-created per-stacking-parent front/back layer containers, sorted insertion
+    // within a layer, and the four patch-time transitions (z stays z / z->none / none->z / z changes within
+    // z) that must preserve the real element's identity across a physical relocation. Called from
+    // FiberNodeFactory (mount), FiberNodePatcher (patch), FiberElementCleaner (unmount), and ChildReconciler
+    // (the leading-offset gate + the deferred-mount drain arm). No state of its own — everything lives in
+    // ReconcilerContext, mirroring PanelHostFactory/AnchoredDriver's own ctx-parameter style.
+    //
+    // Safety invariant threaded through every method below: mutating a LAYER CONTAINER's own children
+    // (insert / remove / reorder a member) never touches the stacking parent's child list and is always
+    // safe, from any call site, at any time. Mutating the stacking parent's OWN children — creating a
+    // container for the first time, or removing one once empty — changes physical indices a live
+    // Indexed/Keyed diff over that same parent may still be iterating by absolute position (worse for a
+    // LEADING back container, which shifts every ordinary sibling after it), so that half is always
+    // deferred to the same post-pass point Portal's own deferred mount already resolves from
+    // (EnqueueMount/ResolveQueuedMount for creation, PendingZLayerTeardownChecks/DrainTeardowns for removal).
+    internal static class FiberZLayerCoordinator
+    {
+        internal const string FrontMarkerClass = "velvet-z-layer-front";
+        internal const string BackMarkerClass = "velvet-z-layer-back";
+
+        // True when child is one of the two layer containers this stacking parent may carry. Consulted by
+        // SilhouetteBoundsSpacer.IsSpacer, the single centralized predicate every "real child" count/index
+        // site in the reconciler already goes through.
+        internal static bool IsLayerContainer(VisualElement child)
+            => child.ClassListContains(FrontMarkerClass) || child.ClassListContains(BackMarkerClass);
+
+        // The z-* scope gate: an element is z-managed only when it carries an explicit z-* utility class AND
+        // is ALSO out-of-flow — either the "absolute" utility class (StyleOutOfFlowChild's off-panel/class-
+        // based half: z-* on an in-flow element is a documented no-op, decided here before the element has
+        // any live position to read) or V.Anchored's Props.Anchored (which forces position:absolute via
+        // AnchoredDriver.Attach as a plain inline style, never through the utility class, so the classNames
+        // array alone would otherwise never see it). Cheap prefix-gated (HasZIndexClass short-circuits the
+        // common case with no z class at all).
+        internal static bool TryClassify(string[] classNames, FiberElementProps? props, out int resolvedZ)
+        {
+            resolvedZ = 0;
+            if (!StyleZIndexClass.HasZIndexClass(classNames))
+            {
+                return false;
+            }
+            if (!StyleOutOfFlowChild.IsOutOfFlowClass(classNames) && props?.Anchored == null)
+            {
+                return false;
+            }
+            return StyleZIndexClass.TryExtract(classNames, out resolvedZ);
+        }
+
+        // How many of `parent`'s LEADING children are its own back-layer container (0 or 1). Folded into
+        // wherever a fresh (non-resumed) slotStart originates — ChildReconciler.Reconcile's single entry
+        // point — so every downstream ordinary-child index computation is already correct without touching
+        // any of them individually. A resumed time-sliced pass never re-enters through that same point (its
+        // saved slotStart already has this baked in from when it first ran), so this must never be applied
+        // twice for the same logical pass.
+        internal static int LeadingOffset(VisualElement parent)
+            => parent.childCount > 0 && parent[0].ClassListContains(BackMarkerClass) ? 1 : 0;
+
+        // A hidden, zero-footprint stand-in left at a z-managed element's logical slot while its real
+        // element lives in a layer container. Carries focusable/tabIndex so it can act as a same-panel Tab
+        // proxy (FiberFocusNavigator) — set unconditionally (not opt-in): keeping Tab order following the
+        // logical position has no downside, unlike PanelFocusOrder's genuine cross-panel behavior change.
+        internal static VisualElement CreatePlaceholder()
+        {
+            var placeholder = new VisualElement
+            {
+                style = { display = DisplayStyle.None },
+                focusable = true,
+                tabIndex = 0,
+            };
+            return placeholder;
+        }
+
+        // Mount-time entry (FiberNodeFactory.CreateElement): `real` is fully built but not yet attached
+        // anywhere (CreateElement never knows its own parent), so placement must wait for the drain, where
+        // placeholder.parent is finally resolvable. Returns the placeholder to install at the ordinary slot.
+        internal static VisualElement EnqueueMount(ReconcilerContext ctx, VisualElement real, int resolvedZ)
+        {
+            var placeholder = CreatePlaceholder();
+            ctx.PendingPortalMounts.Enqueue(
+                (placeholder, new ZLayerMountNode { Real = real, ResolvedZ = resolvedZ }, null, null, null));
+            return placeholder;
+        }
+
+        // Drain-time resolution of a queued mount (ChildReconciler.DrainPendingPortalMounts's new case arm).
+        // By now placeholder.parent is set (the caller already inserted it at the ordinary slot like any
+        // other created element), so the stacking parent — and therefore its container — is finally known.
+        internal static void ResolveQueuedMount(ReconcilerContext ctx, VisualElement placeholder, ZLayerMountNode node)
+        {
+            var stackingParent = placeholder.parent;
+            if (stackingParent == null)
+            {
+                // The placeholder's own subtree was rolled back (a Suspense/error-boundary abort) before
+                // this drained — mirrors DrainPendingPortalMounts' own placeholder.parent == null skip.
+                return;
+            }
+            var container = GetOrCreateContainer(ctx, stackingParent, node.ResolvedZ);
+            Place(ctx, placeholder, container, stackingParent, node.Real, node.ResolvedZ, node.Order);
+        }
+
+        // Patch-time: an already z-managed element's resolved z (or its front/back sign) changed. A no-op
+        // when the resolved value is unchanged — ordering is a mount/patch-time invariant maintained
+        // incrementally, never a periodic resort. Safe to call synchronously when the destination layer
+        // already exists (a pure container-membership move); defers to the drain only for the rarer case
+        // where this parent's FIRST member of the opposite sign has just appeared.
+        internal static void Reposition(ReconcilerContext ctx, VisualElement placeholder, VisualElement real, int newResolvedZ)
+        {
+            if (!ctx.ZLayerMembers.TryGetValue(real, out var member) || member.ResolvedZ == newResolvedZ)
+            {
+                return;
+            }
+            var stackingParent = member.StackingParent;
+            var existing = TryGetExistingContainer(ctx, stackingParent, newResolvedZ);
+            if (existing != null)
+            {
+                if (!ReferenceEquals(existing, member.Container))
+                {
+                    DetachFromContainer(ctx, member.Container, real);
+                }
+                Place(ctx, placeholder, existing, stackingParent, real, newResolvedZ, member.Order);
+                return;
+            }
+            DetachFromContainer(ctx, member.Container, real);
+            ctx.ZLayerMembers.Remove(real);
+            ctx.PendingPortalMounts.Enqueue(
+                (placeholder, new ZLayerMountNode { Real = real, ResolvedZ = newResolvedZ, Order = member.Order },
+                    null, null, null));
+        }
+
+        // Patch-time none-to-z: `real` is still ordinary (physically at its declared slot under
+        // `stackingParent`); relocates it out, leaving `placeholder` in its place at the SAME physical
+        // index (an in-place swap, like a WrapElement type-flip — parent childCount/order is unchanged, so
+        // the caller's post-patch re-fetch-at-the-same-index picks up the new occupant). Synchronous when
+        // the destination layer already exists; defers only when it must be created for the first time.
+        internal static VisualElement RelocateFromOrdinarySlot(ReconcilerContext ctx, VisualElement real, int resolvedZ)
+        {
+            var stackingParent = real.parent!;
+            var idx = stackingParent.IndexOf(real);
+            var placeholder = CreatePlaceholder();
+            stackingParent.Insert(idx, placeholder);
+            real.RemoveFromHierarchy();
+
+            var existing = TryGetExistingContainer(ctx, stackingParent, resolvedZ);
+            if (existing != null)
+            {
+                Place(ctx, placeholder, existing, stackingParent, real, resolvedZ);
+            }
+            else
+            {
+                ctx.PendingPortalMounts.Enqueue(
+                    (placeholder, new ZLayerMountNode { Real = real, ResolvedZ = resolvedZ }, null, null, null));
+            }
+            return placeholder;
+        }
+
+        // Patch-time z-to-none: `real` (found via `placeholder`) leaves its layer and returns to the
+        // ordinary slot `placeholder` occupies, replacing it (same in-place-swap contract as above).
+        internal static void RelocateToOrdinarySlot(ReconcilerContext ctx, VisualElement placeholder, VisualElement real)
+        {
+            if (ctx.ZLayerMembers.TryGetValue(real, out var member))
+            {
+                DetachFromContainer(ctx, member.Container, real);
+                ctx.ZLayerMembers.Remove(real);
+            }
+            ctx.ZLayerPlaceholders.Remove(placeholder);
+
+            var stackingParent = placeholder.parent!;
+            var idx = stackingParent.IndexOf(placeholder);
+            stackingParent.Insert(idx, real);
+            stackingParent.Remove(placeholder);
+        }
+
+        // Cleanup entry (FiberElementCleaner.CleanupZLayerPlaceholder, mirroring CleanupPortal): detaches and
+        // forgets the real element owned by a departing placeholder, returning it so the caller performs the
+        // ordinary resource-cleanup + pool-return sequence it already owns for any removed element. Returns
+        // null when `placeholder` is not (or is no longer) a z-layer placeholder.
+        internal static VisualElement? TakeReal(ReconcilerContext ctx, VisualElement placeholder)
+        {
+            if (!ctx.ZLayerPlaceholders.Remove(placeholder, out var real))
+            {
+                return null;
+            }
+            if (ctx.ZLayerMembers.TryGetValue(real, out var member))
+            {
+                DetachFromContainer(ctx, member.Container, real);
+                ctx.ZLayerMembers.Remove(real);
+            }
+            return real;
+        }
+
+        // The (logical parent, logical index) a peer-/group- source search must walk from: a z-managed
+        // element's PLACEHOLDER position (its declared position among its true siblings), not its current
+        // physical parent (the layer container, whose "preceding siblings" are unrelated same-layer
+        // members). Ordinary elements resolve to their own physical parent/index unchanged.
+        internal static bool TryGetLogicalPosition(ReconcilerContext ctx, VisualElement element, out VisualElement? parent, out int index)
+        {
+            if (ctx.ZLayerMembers.TryGetValue(element, out var member))
+            {
+                parent = member.StackingParent;
+                index = parent.IndexOf(member.Placeholder);
+                return index >= 0;
+            }
+            parent = element.parent;
+            index = parent?.IndexOf(element) ?? -1;
+            return parent != null && index >= 0;
+        }
+
+        // Runs at the same post-pass safe point as DrainPendingPortalMounts: any container whose membership
+        // changed this pass and is now empty is removed from its stacking parent and forgotten.
+        internal static void DrainTeardowns(ReconcilerContext ctx)
+        {
+            if (ctx.PendingZLayerTeardownChecks.Count == 0)
+            {
+                return;
+            }
+            foreach (var container in ctx.PendingZLayerTeardownChecks)
+            {
+                if (container.childCount > 0 || container.parent == null)
+                {
+                    continue;
+                }
+                var stackingParent = container.parent;
+                stackingParent.Remove(container);
+                if (!ctx.ZLayerHosts.TryGetValue(stackingParent, out var record))
+                {
+                    continue;
+                }
+                if (ReferenceEquals(record.Front, container)) record.Front = null;
+                if (ReferenceEquals(record.Back, container)) record.Back = null;
+                if (record.Front == null && record.Back == null)
+                {
+                    ctx.ZLayerHosts.Remove(stackingParent);
+                }
+            }
+            ctx.PendingZLayerTeardownChecks.Clear();
+        }
+
+        // Places (inserts sorted, records bookkeeping) `real` into `container`, assigning a fresh mount-order
+        // tiebreak unless one is supplied (a reposition/relocation carries its element's existing order
+        // forward — see ZLayerMember.Order's own "assigned once" contract).
+        private static void Place(
+            ReconcilerContext ctx, VisualElement placeholder, VisualElement container, VisualElement stackingParent,
+            VisualElement real, int resolvedZ, ulong? existingOrder = null)
+        {
+            var order = existingOrder ?? ctx.NextZOrder++;
+            InsertSorted(ctx, container, real, resolvedZ, order);
+            ctx.ZLayerPlaceholders[placeholder] = real;
+            ctx.ZLayerMembers[real] = new ZLayerMember(placeholder, container, stackingParent, resolvedZ, order);
+        }
+
+        // The already-existing container for `resolvedZ`'s sign under `stackingParent`, or null. A pure
+        // dictionary read — never mutates `stackingParent`'s children, so it is always safe to call, from
+        // anywhere, including synchronously mid-diff.
+        private static VisualElement? TryGetExistingContainer(ReconcilerContext ctx, VisualElement stackingParent, int resolvedZ)
+        {
+            if (!ctx.ZLayerHosts.TryGetValue(stackingParent, out var record))
+            {
+                return null;
+            }
+            return resolvedZ < 0 ? record.Back : record.Front;
+        }
+
+        // The container for `resolvedZ`'s sign under `stackingParent`, creating (and physically attaching)
+        // it on first use. Only ever called from a safe (post-pass) context — creating one changes
+        // `stackingParent`'s own child list, which a live diff over that same parent may still be indexing
+        // by absolute position.
+        private static VisualElement GetOrCreateContainer(ReconcilerContext ctx, VisualElement stackingParent, int resolvedZ)
+        {
+            if (!ctx.ZLayerHosts.TryGetValue(stackingParent, out var record))
+            {
+                record = new ZLayerHostRecord();
+                ctx.ZLayerHosts[stackingParent] = record;
+            }
+            if (resolvedZ < 0)
+            {
+                if (record.Back == null)
+                {
+                    record.Back = CreateContainer(BackMarkerClass);
+                    // The back layer must physically PRECEDE the parent's ordinary children to paint behind
+                    // them — the one structural asymmetry against the front layer (SilhouetteBoundsSpacer's
+                    // own trailing-only spacer convention), which is what LeadingOffset exists to reconcile
+                    // against every ordinary-child index computation.
+                    stackingParent.Insert(0, record.Back);
+                }
+                return record.Back;
+            }
+            if (record.Front == null)
+            {
+                record.Front = CreateContainer(FrontMarkerClass);
+                // Trailing, like SilhouetteBoundsSpacer's own spacer — Add (not Insert at NonSpacerChildCount)
+                // is correct here specifically because IsLayerContainer now makes IsSpacer recognize this
+                // container too, so a co-existing bounds-spacer's own "after all rendered children" invariant
+                // tolerates either relative order between the two trailing spacers.
+                stackingParent.Add(record.Front);
+            }
+            return record.Front;
+        }
+
+        private static VisualElement CreateContainer(string markerClass)
+        {
+            var container = new VisualElement { pickingMode = PickingMode.Ignore };
+            container.AddToClassList(markerClass);
+            container.style.position = Position.Absolute;
+            container.style.left = 0;
+            container.style.top = 0;
+            container.style.right = 0;
+            container.style.bottom = 0;
+            return container;
+        }
+
+        // Inserts (or repositions) `real` at its sorted position within `container`: resolved z ascending,
+        // ties broken by mount order. Only ever mutates `container`'s own children — never `container`'s
+        // parent — so this is safe from any call site, synchronous or deferred.
+        private static void InsertSorted(ReconcilerContext ctx, VisualElement container, VisualElement real, int resolvedZ, ulong order)
+        {
+            if (real.parent != null)
+            {
+                real.RemoveFromHierarchy();
+            }
+            var insertAt = container.childCount;
+            for (var i = 0; i < container.childCount; i++)
+            {
+                var sibling = container.ElementAt(i);
+                if (!ctx.ZLayerMembers.TryGetValue(sibling, out var siblingInfo))
+                {
+                    continue;
+                }
+                if (siblingInfo.ResolvedZ > resolvedZ
+                    || (siblingInfo.ResolvedZ == resolvedZ && siblingInfo.Order > order))
+                {
+                    insertAt = i;
+                    break;
+                }
+            }
+            container.Insert(insertAt, real);
+        }
+
+        // Detaches `real` from `container` (a no-op if it has already moved) and marks the container for an
+        // emptiness re-check at the next safe drain point — never removed here: that would mutate the
+        // STACKING PARENT's own children, unsafe mid-pass (see the type's own safety-invariant note).
+        private static void DetachFromContainer(ReconcilerContext ctx, VisualElement container, VisualElement real)
+        {
+            if (ReferenceEquals(real.parent, container))
+            {
+                real.RemoveFromHierarchy();
+            }
+            ctx.PendingZLayerTeardownChecks.Add(container);
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberZLayerCoordinator.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberZLayerCoordinator.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 29dcf1ae7e7804c80a870383f6d96ed6

--- a/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
@@ -1254,7 +1254,11 @@ namespace Velvet
                             _ctx.StyleAnimationScheduler.CancelExit(anchor);
                             if (presence.Mode == AnimatePresenceMode.PopLayout)
                             {
-                                RestorePopLayoutChildToFlow(anchor, motion?.ClassNames);
+                                // The anchor's OWN class list, not motion's: PinExitingChildOutOfFlow pinned
+                                // `anchor` (this keyed child's own top-level element), which for a Div wrapping
+                                // a Motion (the z-managed shape) is a DIFFERENT element — with a different
+                                // class list — than the nested Motion FindFirstMotionDescendant resolved.
+                                RestorePopLayoutChildToFlow(anchor, (node as BaseElementNode)?.ClassNames);
                             }
                         }
 
@@ -1436,11 +1440,14 @@ namespace Velvet
         // Nulling width/height erases whatever geometry a resolver-applied arbitrary-value class (w-[..],
         // h-[..]) owns — those live in the SAME inline slots this method clears and have no USS rule to fall
         // back to, unlike a named utility (w-full) whose class rule keeps applying underneath. classNames is
-        // the re-added Motion's OWN class array (not anchor.GetClasses(): arbitrary-value tokens resolve
+        // the re-added ANCHOR's OWN class array (not anchor.GetClasses(): arbitrary-value tokens resolve
         // straight to inline style and are deliberately never added to the USS class list, so the element's
-        // class list itself never contains them). The caller resolves it from the CURRENT node — already
-        // patched by EmitPresenceChild, which runs before this restore — so a re-add that also changed props
-        // re-applies the new value rather than a stale pre-pin one.
+        // class list itself never contains them) — the anchor's own declared classes, not necessarily the
+        // Motion's: PinExitingChildOutOfFlow always pins the ANCHOR (the keyed child's own top-level
+        // element), which for a z-managed presence child wrapping a Motion in a Div is the Div, with its own,
+        // separate class list from the nested Motion's. The caller resolves it from the CURRENT node —
+        // already patched by EmitPresenceChild, which runs before this restore — so a re-add that also
+        // changed props re-applies the new value rather than a stale pre-pin one.
         //
         // CancelExit (the caller's previous statement) deliberately leaves transition-property: all /
         // transition-duration active on this exact element so the variant's OWN reversal (e.g. opacity
@@ -1535,7 +1542,20 @@ namespace Velvet
 
             if (commit != null && commit.NewElements.Count > startIdx)
             {
-                return commit.NewElements[startIdx].element;
+                var committed = commit.NewElements[startIdx].element;
+                // A z-managed keyed child's first committed element is its PLACEHOLDER — the real content's
+                // own layer-container placement is deferred to the post-pass drain (FiberZLayerCoordinator),
+                // which has not run yet at this exact synchronous point — every caller of this method
+                // dispatches enter/exit animation and PopLayout pinning against the returned anchor, so
+                // resolving through the registry here, once, means the REAL element is what actually tweens
+                // (and what PinExitingChildOutOfFlow pins) instead of a zero-size proxy that visibly does
+                // nothing. This resolves correctly even for a BRAND-NEW mount reached this same synchronous
+                // pass: FiberZLayerCoordinator.EnqueueMount (and RelocateFromOrdinarySlot's own deferred
+                // branch) register the placeholder->real pair the instant the placeholder is created — well
+                // before the drain that alone would place the real element in its layer container — precisely
+                // so this lookup never has to fall back to the placeholder for a child this method's own
+                // caller is about to explicitly animate.
+                return _ctx.ZLayerPlaceholders.TryGetValue(committed, out var real) ? real : committed;
             }
             return null;
         }

--- a/Packages/com.velvet.core/Runtime/Reconciler/Reconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Reconciler.cs
@@ -630,6 +630,12 @@ namespace Velvet
             _ctx.ChildVariantManipulators.Clear();
             _ctx.PortalState.Clear();
             _ctx.PendingPortalMounts.Clear();
+            // ZLayerHosts/ZLayerMembers are pure side-tables (dropped by ClearAllSideTables below); these two
+            // are not — a placeholder->real entry always accompanies a live container membership, and a
+            // pending teardown check references a container that may still be attached — so both are dropped
+            // explicitly here, mirroring PortalState/PendingPortalMounts above.
+            _ctx.ZLayerPlaceholders.Clear();
+            _ctx.PendingZLayerTeardownChecks.Clear();
             // Same-panel registry-portal targets are ordinary, user-owned elements that commonly
             // outlive this reconciler (unlike the framework-owned hosts destroyed wholesale below), so
             // each bridge is detached explicitly rather than left to die with a GameObject — see

--- a/Packages/com.velvet.core/Runtime/Reconciler/Reconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Reconciler.cs
@@ -42,6 +42,16 @@ namespace Velvet
 
         internal ReconcilerContext Context => _ctx;
 
+        /// <summary>
+        /// This Reconciler's own <see cref="ChildReconciler"/> instance. Exposed so
+        /// <see cref="FiberZLayerCoordinator.RebaseParkedSlotsForContainerChange"/> can tell whether a fiber
+        /// found via <see cref="ReconcilerContext.ParkedBaselineFibers"/> is the SAME fiber already being
+        /// rebased directly (the caller's own <c>current</c> parameter), rather than a genuinely different,
+        /// unrelated parked fiber — the two are otherwise indistinguishable by fiber identity alone from
+        /// inside that method, which never sees a fiber, only a ChildReconciler.
+        /// </summary>
+        internal ChildReconciler ChildReconciler => _childReconciler;
+
         public Reconciler()
             : this(new ReconcilerContext(), ownsContext: true)
         {
@@ -245,16 +255,29 @@ namespace Velvet
             if (_ctx.IsDisposed || !HasPendingWork) { return; }
             using var _ = s_continueReconcileMarker.Auto();
 
-            // A resume continues the same pass an earlier time-slice suspended; it is NOT a fresh
-            // top-level entry, so it must not run the top-level reset (abort / EffectiveKeys /
-            // portal drain) that Reconcile's isTopLevel finally performs — clearing those mid-pass
-            // would discard state sibling subtrees still need. That reset block lives only in
-            // Reconcile, so incrementing the shared depth here can never trigger it. The bracket
-            // exists so the reconcile-active probe (FiberBatchScheduler.FlushImmediate) reports
-            // SharedReconcileDepth > 0 while a resume is on the stack: a resume is scheduled via
-            // schedule.Execute, not through the batch Drain, so _draining is false during it, and
-            // without the probe a discrete event dispatched synchronously inside a slice would
-            // re-enter the reconciler on the stack.
+            // A resume continues the same pass an earlier time-slice suspended, so while genuinely
+            // nested inside an ancestor's still-unwinding pass (e.g. FiberCommitWork.DrainPendingWork
+            // force-completing a parked inline fiber from inside another fiber's live expansion) it must
+            // not run the top-level reset (abort / EffectiveKeys / DeclaringResolveMisses / portal drain)
+            // that Reconcile's own isTopLevel finally performs — clearing those mid-pass would discard
+            // state sibling subtrees still need, and the ancestor's own eventual top-level finally runs
+            // them once already. But a resume driven by the scheduler tick (FiberWorkLoop.ContinueReconcile,
+            // on its own frame-boundary callback) is NOT nested in anything, and any Portal / z-layer mount
+            // THIS slice enqueued needs the exact same safe post-pass drain a fresh top-level Reconcile call
+            // already gets — leaving it queued until some unrelated fiber's next top-level Reconcile happens
+            // to run would strand a z-managed element's real content (or a Portal's children) unattached
+            // for however long that takes. isTopLevel is the SAME "genuinely outermost" test Reconcile.
+            // Reconcile uses (SharedReconcileDepth read before this call's own increment), so the drain
+            // below is gated identically: it fires once per genuine completion and never while nested,
+            // so DrainPendingWork's own force-drain cannot double-fire it ahead of the ancestor's finally.
+            // The bracket around SharedReconcileDepth itself is unconditional regardless (both branches
+            // need it): it is what lets the reconcile-active probe (FiberBatchScheduler.FlushImmediate)
+            // report SharedReconcileDepth > 0 while a resume is on the stack — a resume is scheduled via
+            // schedule.Execute, not through the batch Drain, so _draining is false during it, and without
+            // the probe a discrete event dispatched synchronously inside a slice would re-enter the
+            // reconciler on the stack.
+            var isTopLevel = _ctx.SharedReconcileDepth == 0;
+
             _ctx.SharedReconcileDepth++;
             // A resume slice rents and returns pooled objects like the original pass, so it gets the
             // same release staging bracket (nested entries are depth-counted inside VNodePool).
@@ -274,8 +297,47 @@ namespace Velvet
             }
             finally
             {
-                VNodePool.EndReleaseScope();
                 _ctx.SharedReconcileDepth--;
+                if (isTopLevel)
+                {
+                    // Mirrors Reconcile's own top-level finally: consumed here, before the drain, so a
+                    // boundary caught earlier in THIS resumed slice cannot make the drain's own nested
+                    // Reconcile calls (fresh top-level entries themselves) see IsAborted already true and
+                    // silently no-op via ChildReconciler.Reconcile's own entry guard. Left unset (false) on
+                    // a nested resume — the ancestor's own eventual top-level finally is what consumes it.
+                    LastTopLevelWasAborted = _ctx.IsAborted;
+                    _ctx.IsAborted = false;
+                }
+                try
+                {
+                    if (isTopLevel)
+                    {
+                        _childReconciler.DrainPendingPortalMounts();
+                    }
+                }
+                finally
+                {
+                    // Mirrors Reconcile's own top-level finally, statement for statement: a continuation
+                    // that completes a pass IS that pass's genuine top-level boundary, so every per-pass
+                    // reset must happen here too or it leaks on the SHARED context until some unrelated
+                    // fiber's fresh Reconcile happens to run. IsAborted gets the same belt-and-suspenders
+                    // second reset (consuming an abort raised DURING this drain itself — a boundary inside
+                    // a Portal's / a z-layer mount's children); DeclaringResolveMisses stays scoped to one
+                    // pass so a late-arriving declaring panel is retried instead of staying permanently
+                    // unresolvable; EffectiveKeys entries registered by subtrees expanded in a resumed
+                    // slice (a new item's keyed Fragment) must not accumulate for the tree's lifetime; and
+                    // the deferred inline old-tree returns must reach the pool at the same boundary a
+                    // fresh pass would give them.
+                    if (isTopLevel)
+                    {
+                        _ctx.PendingPortalMounts.Clear();
+                        _ctx.IsAborted = false;
+                        _ctx.DeclaringResolveMisses.Clear();
+                        _ctx.EffectiveKeys.Clear();
+                        FiberTreeReturn.DrainDeferredInlineOldTreeReturns(_ctx);
+                    }
+                    VNodePool.EndReleaseScope();
+                }
             }
         }
 

--- a/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
@@ -51,6 +51,22 @@ namespace Velvet
         }
     }
 
+    // The front (non-negative z) and back (negative z) layer containers a stacking-context parent lazily
+    // grows, one of each on first use. Either may be null (no member of that sign has mounted yet).
+    internal sealed class ZLayerHostRecord
+    {
+        public VisualElement? Front;
+        public VisualElement? Back;
+    }
+
+    // Per-z-managed-element bookkeeping: which placeholder stands in its logical slot, which layer container
+    // currently holds it, the stacking parent both are scoped to, its last resolved z, and the monotonic
+    // mount-order tiebreak for same-z siblings (assigned once, at first entry, then stable — re-sorting on
+    // every patch would contradict "no periodic resort"). Keyed by the REAL element in
+    // ReconcilerContext.ZLayerMembers; the reverse index (placeholder -> real) is ZLayerPlaceholders.
+    internal readonly record struct ZLayerMember(
+        VisualElement Placeholder, VisualElement Container, VisualElement StackingParent, int ResolvedZ, ulong Order);
+
     // Shared helpers for maintaining the multi-Portal slot range invariant.
     internal static class PortalSlotTracker
     {
@@ -472,6 +488,43 @@ namespace Velvet
         public Queue<(VisualElement Placeholder, VNode Node, VisualElement? Target,
             List<KeyValuePair<object, object>> ContextSnapshot, ComponentFiber? LogicalParent)> PendingPortalMounts { get; } = new();
 
+        // Per-stacking-context-parent z-layer containers (FiberZLayerCoordinator), lazily created on first
+        // z-marked absolute child. NOT a pure side-table: the record's Front/Back reference live VisualElement
+        // containers that are ordinary (if empty) children of the key until FiberZLayerCoordinator.DrainTeardowns
+        // removes them — but the dictionary ENTRY itself is dropped exactly like a pure side-table (a plain
+        // Remove) once both containers are gone, since the containers' own subtree teardown already runs
+        // through the ordinary recursive cleanup that reaches them as ordinary children of a departing parent.
+        public Dictionary<VisualElement, ZLayerHostRecord> ZLayerHosts { get; } = new();
+
+        // Placeholder -> real element, for a z-managed slot currently routed into its layer container. Mirrors
+        // PortalState's placeholder-keyed role: FiberElementCleaner's CleanupZLayerPlaceholder consults this
+        // (keyed by the PLACEHOLDER, which is what a normal slot removal or subtree teardown physically
+        // reaches) to find and tear down the real element living elsewhere in the tree. NOT a pure side-table
+        // — removing an entry here always accompanies detaching the real element from its container.
+        public Dictionary<VisualElement, VisualElement> ZLayerPlaceholders { get; } = new();
+
+        // Real element -> its z-layer bookkeeping. A pure side-table (its own teardown is a plain Remove — the
+        // container detach and placeholder bookkeeping live in ZLayerPlaceholders/ZLayerHosts instead), so it
+        // is enrolled in _pureElementSideTables: a departing real element (however it is reached — its own
+        // placeholder's cleanup, or the ordinary recursive walk into its layer container) drops its entry the
+        // same way MotionAppliedClasses/TextEffects/etc. do.
+        public Dictionary<VisualElement, ZLayerMember> ZLayerMembers { get; } = new();
+
+        // Layer containers whose membership changed this pass and so need an emptiness re-check once the pass
+        // is over. Container PRESENCE changes (creating one for the first time, or removing one once its last
+        // member left) touch the stacking parent's OWN child list — safe only from the same post-pass drain
+        // context DrainPendingPortalMounts already runs from, never synchronously mid-diff (a mid-pass removal
+        // of a LEADING back container would shift every ordinary sibling index a live Common/Keyed loop is
+        // still iterating by absolute position). Pure membership changes within an ALREADY-EXISTING container
+        // never touch this set — they run synchronously, from anywhere. Drained (and cleared) by
+        // FiberZLayerCoordinator.DrainTeardowns, called from the same Reconciler.Reconcile top-level finally as
+        // DrainPendingPortalMounts.
+        public HashSet<VisualElement> PendingZLayerTeardownChecks { get; } = new();
+
+        // Monotonic tiebreak counter for same-resolved-z siblings under one layer container, handed out once
+        // per element at its first entry into a layer (see ZLayerMember.Order).
+        internal ulong NextZOrder;
+
         // Guards FiberCrossPanelPointerRouter.AttachToMainPanel against attaching twice on the same
         // main panel — V.Mount is idempotent-safe to call from a component's own render (uncommon but
         // not disallowed) and the router's TrickleDown listeners must not stack.
@@ -888,6 +941,8 @@ namespace Velvet
                 TextEffects,
                 TextRawText,
                 TextWhitespaceOwned,
+                ZLayerHosts,
+                ZLayerMembers,
             };
         }
     }

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/AnimatePresencePopLayoutTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/AnimatePresencePopLayoutTests.cs
@@ -89,6 +89,150 @@ namespace Velvet.Tests
             return mounted;
         }
 
+        // "item-b" itself is z-managed (absolute + z-10): its real content relocates into "presence-host"'s own
+        // front layer container, with a Motion child (found via FindFirstMotionDescendant, since the presence
+        // child's own node is the Div wrapper, not a MotionNode) driving the actual enter/exit variants — an
+        // "animated top-most modal" shape. The wrapper Div carries the name and the key; the z-layer placeholder
+        // FiberZLayerCoordinator.CreatePlaceholder builds carries no name at all, so a query by name always
+        // resolves the real element regardless of which one the animation machinery held as its own anchor.
+        [Component]
+        private static VNode ZManagedPresenceList()
+        {
+            var keys = Hooks.UseStore(s_store, s => s.Keys);
+            var children = new List<VNode>();
+            foreach (var key in keys)
+            {
+                children.Add(V.Div(name: "item-" + key, key: key.ToString(), className: "absolute z-10",
+                    children: new VNode[]
+                    {
+                        V.Motion(className: "w-[60px] h-[24px]",
+                            variants: s_fade, animate: "visible", exit: "hidden",
+                            transition: new StyleTransitionConfig { DurationSec = 0.3f }),
+                    }));
+            }
+            return V.Div(name: "presence-host", className: "relative", children: new VNode[]
+            {
+                V.AnimatePresence(key: "presence", mode: s_mode, children: children.ToArray()),
+            });
+        }
+
+        // The z-* scope gate classifies "item-b" from its class NAME array alone (no live style needed), but
+        // the bundled utility sheet is attached anyway so "absolute"/"relative" also resolve visually, matching
+        // real usage (see ZIndexPanelTests.Mount's own comment on this same attach).
+        private MountedTree MountZManagedLaidOut()
+        {
+            var sheet = AssetDatabase.LoadAssetAtPath<StyleSheet>(
+                "Packages/com.velvet.core/Runtime/Styles/StyleUtilities.uss");
+            Assume.That(sheet, Is.Not.Null, "Precondition: the bundled StyleUtilities.uss loads");
+            _window.rootVisualElement.styleSheets.Add(sheet);
+            var mounted = V.Mount(_window.rootVisualElement, V.Component(ZManagedPresenceList, key: "list"));
+            EditorPanelTestHelpers.ForcePanelUpdate(_window.rootVisualElement.panel);
+            return mounted;
+        }
+
+        [Test]
+        public void Given_AZManagedKeyedChild_When_ItsPopLayoutExitStarts_Then_TheRealElementNotThePlaceholderIsPinned()
+        {
+            // Arrange — "item-b" is a z-managed absolute Div; force a real layout pass so its pre-exit rect is
+            // finite before the exit starts (the pin bails out silently on a non-finite rect either way, which
+            // would make this test uninformative regardless of the fix).
+            using var store = new SetStore();
+            s_store = store;
+            using var mounted = MountZManagedLaidOut();
+            var ctx = mounted.Root.Reconciler.Context;
+            var scheduler = ctx.BatchScheduler;
+            var item = _window.rootVisualElement.Q<VisualElement>("item-b");
+            Assume.That(ctx.ZLayerMembers.ContainsKey(item), Is.True,
+                "Precondition: item-b actually relocated into its layer container");
+            Assume.That(float.IsFinite(item.layout.width), Is.True,
+                "Precondition: item-b's pre-exit rect is finite");
+
+            // Act — remove the middle child; PopLayout pins the exiting ghost's anchor out of flow.
+            store.Set("ac");
+            scheduler.DrainImmediateForTest();
+
+            // Assert — the pin landed on the REAL element (found by name — the placeholder carries no name at
+            // all), not silently on a zero-size placeholder the animation dispatch held as its anchor instead.
+            Assert.That(_window.rootVisualElement.Q<VisualElement>("item-b").style.position.value,
+                Is.EqualTo(Position.Absolute));
+        }
+
+        [Test]
+        public void Given_AZManagedElementWrappingMotion_When_FindFirstMotionDescendantRuns_Then_ReturnsTheNestedMotion()
+        {
+            // Arrange — a z-managed (absolute + z-10) Div wrapping a Motion: the only shape that can combine
+            // z-* with an AnimatePresence-driven Motion, since z-* on a Motion itself is a documented no-op.
+            var motion = V.Motion(transition: StyleTransition.FadeSlideUp);
+            var wrapper = V.Div(className: "absolute z-10", children: new VNode[] { motion });
+
+            // Act
+            var resolved = FiberNodeFactory.FindFirstMotionDescendant(wrapper);
+
+            // Assert — the walk descends into the z-managed wrapper's own children, exactly as it already does
+            // for the transparent Provider/Fragment wrappers, so AnimatePresence's enter/exit dispatch can read
+            // Transition + OnEnterComplete off the same node this method surfaces for an ordinary (non-z) wrap.
+            Assert.That(resolved, Is.SameAs(motion));
+        }
+
+        [Test]
+        public void Given_ANewlyAddedZManagedPresenceChild_When_ItEntersAndDrains_Then_TheEnterDispatchTargetsTheRealElement()
+        {
+            // Arrange — mount with "b" absent (its own Div/Motion never render this pass), mirroring the
+            // "modal added to an already-mounted AnimatePresence" shape — the single most common
+            // AnimatePresence+z use case — where the Initial flag's first-mount suppression does not apply.
+            using var store = new SetStore();
+            s_store = store;
+            store.Set("ac");
+            using var mounted = MountZManagedLaidOut();
+            var scheduler = mounted.Root.Reconciler.Context.BatchScheduler;
+            Assume.That(_window.rootVisualElement.Q<VisualElement>("item-b"), Is.Null,
+                "Precondition: item-b has not mounted yet");
+
+            // Act — add "b"; its EnqueueMount and this render's enter dispatch both run inside this SAME
+            // synchronous pass, before the post-pass drain that (without eagerly registering the pair at
+            // enqueue time) would be the only place ZLayerPlaceholders learns about it.
+            store.Set("abc");
+            scheduler.DrainImmediateForTest();
+
+            // Assert — PlayEnter's own transition-duration inline write (applied synchronously, not deferred)
+            // landed on the REAL element found by name, so the enter's anchor was resolved through the
+            // registry to `real`, not left as the zero-size placeholder EmitPresenceChild would otherwise have
+            // returned at this still-synchronous point.
+            var real = _window.rootVisualElement.Q<VisualElement>("item-b");
+            Assert.That(real.style.transitionDuration.keyword, Is.Not.EqualTo(StyleKeyword.Null));
+        }
+
+        [Test]
+        public void Given_AZManagedPopLayoutExitInFlight_When_TheKeyReturnsBeforeItFinishes_Then_TheRealElementRejoinsFlowWithoutStrayGeometry()
+        {
+            // Arrange — item-b's exit has started (pinned on the REAL element via the registry); its 0.3s
+            // duration has not elapsed (the EditMode scheduler never ticks a scheduled swap on its own).
+            using var store = new SetStore();
+            s_store = store;
+            using var mounted = MountZManagedLaidOut();
+            var ctx = mounted.Root.Reconciler.Context;
+            var scheduler = ctx.BatchScheduler;
+            store.Set("ac");
+            scheduler.DrainImmediateForTest();
+            var pinnedBeforeCancel = _window.rootVisualElement.Q<VisualElement>("item-b");
+            Assume.That(pinnedBeforeCancel.style.position.value, Is.EqualTo(Position.Absolute),
+                "Precondition: the exiting real element is pinned out of flow");
+
+            // Act — re-add the key before the exit finishes, cancelling it.
+            store.Set("abc");
+            scheduler.DrainImmediateForTest();
+
+            // Assert — the cancel clears item-b's own pin (position back to Null, rejoining the front layer
+            // container's normal flow) AND leaves its width untouched by the nested Motion's own w-[60px]
+            // class: RestorePopLayoutChildToFlow reapplies the ANCHOR's own declared classes (item-b's
+            // "absolute z-10", neither an arbitrary-value token), not the differently-classed Motion nested
+            // inside it — a stray reapply from the wrong element's class list would otherwise leave a
+            // concrete (non-Null) width behind.
+            var restored = _window.rootVisualElement.Q<VisualElement>("item-b");
+            Assert.That((restored.style.position.keyword, restored.style.width.keyword),
+                Is.EqualTo((StyleKeyword.Null, StyleKeyword.Null)));
+        }
+
         [Test]
         public void Given_APopLayoutModeChild_When_ItStartsExiting_Then_ItsInlinePositionBecomesAbsolute()
         {

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ContinueReconcileAbortLeakTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ContinueReconcileAbortLeakTests.cs
@@ -1,0 +1,190 @@
+using System;
+using NUnit.Framework;
+using UnityEngine.UIElements;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Specifies that <see cref="Reconciler.ContinueReconcile"/>'s own top-level completion point consumes
+    /// <see cref="ReconcilerContext.IsAborted"/> exactly like <see cref="Reconciler.Reconcile"/>'s does —
+    /// reading it into <see cref="Reconciler.LastTopLevelWasAborted"/> and resetting it (twice, around the
+    /// Portal / z-layer drain) rather than leaving it untouched. Without this, an Error Boundary catching
+    /// inside a Portal that a RESUMED time-sliced slice enqueued leaves the shared flag true after
+    /// ContinueReconcile returns; the very next unrelated fiber's own top-level Reconcile — sharing the same
+    /// ReconcilerContext — then hits ChildReconciler.Reconcile's entry guard (<c>if (_ctx.IsAborted) return;</c>)
+    /// and silently no-ops its entire pass. The same boundary must also apply the REST of a pass's
+    /// per-pass resets (scoped-key registrations, declaring-panel resolution misses, deferred old-tree
+    /// pool returns) — a pass that happens to complete in a resumed slice is still that pass's genuine
+    /// end, and anything skipped there leaks on the shared context until some unrelated fiber's own
+    /// fresh top-level pass happens to clean it.
+    /// </summary>
+    [TestFixture]
+    internal sealed class ContinueReconcileAbortLeakTests
+    {
+        private VisualElement _root;
+        private static bool s_fallbackShown;
+        private static int s_listCount;
+        private static bool s_portalAdded;
+        private static bool s_keyedFragmentAdded;
+        private static ComponentFiber s_listFiber;
+        private static string s_counterText;
+        private static StateUpdater<string> s_setCounterText;
+
+        [SetUp]
+        public void SetUp()
+        {
+            FiberLane.TimeSlicedBudgetOverrideForTest = -1;
+            _root = new VisualElement();
+            FiberPortalRegistry.Clear();
+            s_fallbackShown = false;
+            s_listCount = 3;
+            s_portalAdded = false;
+            s_keyedFragmentAdded = false;
+            s_listFiber = null;
+            s_counterText = "initial";
+            s_setCounterText = default;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            FiberLane.TimeSlicedBudgetOverrideForTest = -1;
+            FiberPortalRegistry.Clear();
+        }
+
+        [Test]
+        public void Given_ATimeSlicedResumeDrainsAPortalWhoseErrorBoundaryCatches_When_AnUnrelatedFiberLaterReRenders_Then_ItsChangeStillCommits()
+        {
+            // Arrange — a target the Portal resolves at enqueue time, and a host with two INDEPENDENT
+            // inline-mounted sibling fibers sharing one ReconcilerContext (mirrors TimeSlicedFiberTests' own
+            // SiblingHostRender shape): "list" (a flat, keyed, time-sliceable array that grows a brand-new
+            // trailing Portal — wrapping an error boundary around a throwing child — only below) and
+            // "counter" (an ordinary, unrelated fiber whose own later re-render this test observes).
+            var portalTarget = new VisualElement();
+            FiberPortalRegistry.Register("continue-reconcile-abort-leak-target", portalTarget);
+            using var mounted = V.Mount(_root, V.Component(Host, key: "host"));
+            Assume.That(s_listFiber.HasPendingReconcileWorkForTest(), Is.False,
+                "Precondition: the initial mount is synchronous (zero budget)");
+
+            // Act (1) — add the trailing Portal under a tiny time-sliced budget: the pass parks on the
+            // existing (unchanged) keyed prefix one item per tick, then a RESUMED tick creates the Portal's
+            // placeholder (enqueuing it) as the pass's very last entry — so that SAME tick's own top-level
+            // finally (Reconciler.ContinueReconcile) is what drains it: the boundary catches the Portal
+            // child's throw and calls SetAborted() on the shared context.
+            FiberLane.TimeSlicedBudgetOverrideForTest = 0.0001;
+            s_portalAdded = true;
+            s_listFiber.ScheduleRerenderForTest(FiberUpdatePriority.Transition);
+            FiberWorkLoop.FlushState(s_listFiber);
+            Assume.That(s_listFiber.HasPendingReconcileWorkForTest(), Is.True,
+                "Precondition: the tiny budget parked the grow mid-commit");
+            s_listFiber.DrainTimeSlicedReconcileForTest();
+            Assume.That(s_fallbackShown, Is.True,
+                "Precondition: the Portal's error boundary actually caught the throw");
+
+            // Act (2) — an unrelated fiber sharing the same mounted tree (and so the same ReconcilerContext)
+            // re-renders normally, synchronously, well after the time-sliced pass above fully completed and
+            // returned.
+            FiberLane.TimeSlicedBudgetOverrideForTest = -1;
+            s_setCounterText.Invoke("updated");
+            mounted.FlushStateForTest();
+
+            // Assert — RED without the fix: a stale IsAborted left over from the Portal drain makes
+            // ChildReconciler.Reconcile's entry guard silently no-op this fiber's entire reconcile, leaving
+            // the old text in place instead of committing the update.
+            Assert.That(_root.Q<Label>("counter-label").text, Is.EqualTo("updated"));
+        }
+
+        [Test]
+        public void Given_AResumedSliceExpandsAKeyedFragmentSubtree_When_ThePassCompletesThroughItsOwnContinuation_Then_TheSharedContextCarriesNoStaleScopedKeyEntries()
+        {
+            // Arrange — same two-fiber host; the growth below appends an item whose subtree contains a
+            // KEYED Fragment, so the scoped-key registration the expansion performs lands during a RESUMED
+            // slice (the initial mount's own top-level pass — which does clear the table at its end — is
+            // long finished by then).
+            using var mounted = V.Mount(_root, V.Component(Host, key: "host"));
+            var ctx = mounted.Root.Reconciler.Context;
+            Assume.That(ctx.EffectiveKeys.Count, Is.EqualTo(0),
+                "Precondition: the synchronous initial mount left no scoped-key entries behind");
+
+            // Act — the pass parks per-item under the tiny budget, so the brand-new trailing item (and the
+            // keyed Fragment inside it) is expanded by a continuation tick, and that SAME tick's own
+            // top-level completion is the only boundary this pass ever gets.
+            FiberLane.TimeSlicedBudgetOverrideForTest = 0.0001;
+            s_keyedFragmentAdded = true;
+            s_listFiber.ScheduleRerenderForTest(FiberUpdatePriority.Transition);
+            FiberWorkLoop.FlushState(s_listFiber);
+            Assume.That(s_listFiber.HasPendingReconcileWorkForTest(), Is.True,
+                "Precondition: the tiny budget parked the grow mid-commit");
+            s_listFiber.DrainTimeSlicedReconcileForTest();
+            Assume.That(_root.Q<Label>("keyed-fragment-leaf"), Is.Not.Null,
+                "Precondition: the keyed Fragment's subtree really was expanded and committed");
+
+            // Assert — RED without the continuation boundary clearing the table: the entries registered by
+            // the resumed slice's expansion outlive the pass on the shared context (nothing else runs), so
+            // the count stays nonzero here instead of resetting at the pass's genuine end.
+            Assert.That(ctx.EffectiveKeys.Count, Is.EqualTo(0));
+        }
+
+        [Component]
+        private static VNode Host() => V.Div(children: new VNode[]
+        {
+            V.Component(ListRender, key: "list"),
+            V.Component(CounterRender, key: "counter"),
+        });
+
+        [Component]
+        private static VNode ListRender()
+        {
+            s_listFiber = FiberAmbientStack.Current;
+            var total = s_listCount + (s_portalAdded || s_keyedFragmentAdded ? 1 : 0);
+            var children = new VNode[total];
+            for (var i = 0; i < s_listCount; i++)
+            {
+                children[i] = V.Label(text: "item-" + i, key: "item" + i);
+            }
+            if (s_portalAdded)
+            {
+                children[s_listCount] = V.Portal("continue-reconcile-abort-leak-target", key: "portal",
+                    children: new VNode[] { V.Component(BoundaryWrappingThrowerRender, key: "throwing-child") });
+            }
+            else if (s_keyedFragmentAdded)
+            {
+                children[s_listCount] = V.Div(key: "kf-wrap", children: new VNode[]
+                {
+                    V.Fragment(key: "kf", children: new VNode[]
+                    {
+                        V.Label(name: "keyed-fragment-leaf", text: "kf-leaf"),
+                    }),
+                });
+            }
+            return V.Fragment(children: children);
+        }
+
+        [Component]
+        private static VNode CounterRender()
+        {
+            var (text, setText) = Hooks.UseState(s_counterText);
+            s_setCounterText = setText;
+            return V.Label(name: "counter-label", text: text);
+        }
+
+        #region BoundaryWrappingThrower component (boundary + Hooks.UseFallback wrapping a throwing child)
+
+        [Component(IsErrorBoundary = true)]
+        private static VNode BoundaryWrappingThrowerRender()
+        {
+            Hooks.UseFallback(_ =>
+            {
+                s_fallbackShown = true;
+                return V.Label(text: "caught");
+            });
+            return V.Component(ThrowingChildRender, key: "throwing-child-inner");
+        }
+
+        [Component]
+        private static VNode ThrowingChildRender() => throw new Exception("boom-child");
+
+        #endregion
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ContinueReconcileAbortLeakTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ContinueReconcileAbortLeakTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 114dbffad824347aba2a89ee62c95904

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/PortalTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/PortalTests.cs
@@ -656,5 +656,40 @@ namespace Velvet.Tests
         }
 
         #endregion
+
+        #region Target already carries a z-layer container
+
+        [Test]
+        public void Given_APortalTargetThatAlreadyHasABackZLayerContainer_When_KeyedChildrenMount_Then_TheyLandAtTheCorrectPhysicalIndices()
+        {
+            // Arrange — the target already carries a leading back z-layer container (as a negative-z absolute
+            // element relocated directly under it would leave behind), so NonSpacerChildCount(target) already
+            // counts it: the drain's own slotStart computation is already physically correct and must not be
+            // folded a second time by Reconcile's leading-offset entry gate, or a keyed tail-add indexes past
+            // childCount and throws.
+            var target = new VisualElement();
+            var backContainer = new VisualElement();
+            backContainer.AddToClassList(FiberZLayerCoordinator.BackMarkerClass);
+            target.Add(backContainer);
+            FiberPortalRegistry.Register("z-managed-target", target);
+            var children = new VNode[]
+            {
+                V.Portal("z-managed-target", children: new VNode[]
+                {
+                    V.Label(key: "a", text: "A"),
+                    V.Label(key: "b", text: "B"),
+                }),
+            };
+
+            // Act — without the fix, this throws (List.Insert index > Count) before ever reaching the assert.
+            _reconciler.Reconcile(_root, Array.Empty<VNode>(), children);
+
+            // Assert — both keyed labels land right after the back container, in declared order.
+            Assert.That(
+                (target.childCount, ((Label)target.ElementAt(1)).text, ((Label)target.ElementAt(2)).text),
+                Is.EqualTo((3, "A", "B")));
+        }
+
+        #endregion
     }
 }

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ZIndexPanelTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ZIndexPanelTests.cs
@@ -1,0 +1,449 @@
+using NUnit.Framework;
+using UnityEditor;
+using UnityEngine.UIElements;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Specifies the <c>z-*</c> stacking feature's behavior on a real (headless) editor panel: the parts that
+    /// need resolved layout or the engine's own focus ring — coordinate neutrality (relocating an absolute
+    /// child into its layer container must not move it, since the container is coincident with the stacking
+    /// parent's own content box), focus order (a z-relocated element's placeholder is a real, displayed,
+    /// zero-size proxy tab stop, so Tab order follows the DECLARED position, not wherever the layer container
+    /// physically paints), and event bubbling (a relocated element's physical ancestor chain still passes
+    /// through its own stacking parent, one hop deeper via the container). GWT, one assert per case.
+    /// </summary>
+    [TestFixture]
+    internal sealed class ZIndexPanelTests
+    {
+        private sealed class ToggleStore<T> : Store<T>
+        {
+            private readonly T _initial;
+            public ToggleStore(T initial) : base(initial) => _initial = initial;
+            public void Set(T value) => SetState(_ => value);
+            protected override void ResetCore() => SetState(_ => _initial);
+        }
+
+        private static ToggleStore<bool> s_coordinateStore;
+        private static ToggleStore<bool> s_resortZStore;
+        private static ToggleStore<bool> s_resortZContainerStore;
+
+        private HeadlessEditorPanelHost _host;
+        private MountedTree _mounted;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _host = new HeadlessEditorPanelHost();
+            s_coordinateStore = null;
+            s_resortZStore = null;
+            s_resortZContainerStore = null;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _mounted?.Dispose();
+            _mounted = null;
+            _host?.Dispose();
+            _host = null;
+        }
+
+        // Focus-ring membership (and resolvedStyle / worldBound) requires a resolved style pass, which
+        // batchmode never runs on its own. The bundled utility sheet must be attached explicitly: the
+        // z-* scope gate recognizes the "absolute" CLASS token at reconcile time, but the element only
+        // actually leaves flow when the `.absolute { position: absolute; }` USS rule resolves — without
+        // the sheet this fixture would relocate elements that never really were absolute.
+        private void Mount(System.Func<VNode> body)
+        {
+            var sheet = AssetDatabase.LoadAssetAtPath<StyleSheet>(
+                "Packages/com.velvet.core/Runtime/Styles/StyleUtilities.uss");
+            Assume.That(sheet, Is.Not.Null, "Precondition: the bundled StyleUtilities.uss loads");
+            _host.Root.styleSheets.Add(sheet);
+            _mounted = V.Mount(_host.Root, V.Component(body, key: "root"));
+            EditorPanelTestHelpers.ForcePanelUpdate(_host.Panel);
+        }
+
+        private static void SendMove(VisualElement target, NavigationMoveEvent.Direction direction)
+        {
+            using var move = NavigationMoveEvent.GetPooled(direction);
+            move.target = target;
+            target.SendEvent(move);
+        }
+
+        #region Coordinate neutrality
+
+        [Component]
+        private static VNode CoordinateHost()
+        {
+            var withZ = Hooks.UseStore(s_coordinateStore, x => x);
+            var cls = "absolute left-[24px] top-[16px] w-[10px] h-[10px]" + (withZ ? " z-10" : "");
+            return V.Div(name: "parent", className: "relative w-[200px] h-[200px]", children: new VNode[]
+            {
+                V.Div(name: "sibling", className: "w-[50px] h-[50px]"),
+                V.Div(name: "child", className: cls),
+            });
+        }
+
+        [Test]
+        public void Given_AnAbsoluteChildWithAFixedOffset_When_ItGainsAZClass_Then_ItsResolvedWorldPositionIsUnchanged()
+        {
+            // Arrange
+            using var store = new ToggleStore<bool>(false);
+            s_coordinateStore = store;
+            Mount(CoordinateHost);
+            Assume.That(_host.Root.Q<VisualElement>("child")?.resolvedStyle.position,
+                Is.EqualTo(Position.Absolute),
+                "Precondition: the child mounted as a genuinely out-of-flow absolute sibling");
+            var before = _host.Root.Q<VisualElement>("child").worldBound;
+
+            // Act — relocates the same element into the front layer container.
+            store.Set(true);
+            _mounted.FlushStateForTest();
+            EditorPanelTestHelpers.ForcePanelUpdate(_host.Panel);
+            Assume.That(_mounted.Root.Reconciler.Context.ZLayerMembers.ContainsKey(_host.Root.Q<VisualElement>("child")),
+                Is.True, "Precondition: the child actually relocated into a z-layer container");
+
+            // Assert — the layer container is coincident with the stacking parent's own content box, so the
+            // child's left/top (parent-relative) resolve to the identical world rect.
+            Assert.That(_host.Root.Q<VisualElement>("child").worldBound, Is.EqualTo(before));
+        }
+
+        #endregion
+
+        #region Focus order
+
+        [Component]
+        private static VNode FocusOrderHost() => V.Div(name: "parent", className: "relative", children: new VNode[]
+        {
+            V.Button(name: "before"),
+            V.Button(name: "zmanaged", className: "absolute z-10"),
+            V.Button(name: "after"),
+        });
+
+        [Test]
+        public void Given_AZManagedButtonAmongOrdinaryButtons_When_TabDispatchesFromItsDeclaredPredecessor_Then_FocusLandsOnItAtItsLogicalPosition()
+        {
+            // Arrange
+            Mount(FocusOrderHost);
+            var before = _host.Root.Q<Button>("before");
+            before.Focus();
+            Assume.That(_host.Panel.focusController.focusedElement, Is.EqualTo(before),
+                "Precondition: the declared predecessor holds focus");
+
+            // Act — the engine's own move lands on the placeholder (physically right after "before"); the
+            // FocusIn forwarding hands focus into the real z-managed element.
+            SendMove(before, NavigationMoveEvent.Direction.Next);
+            Assume.That(_mounted.Root.Reconciler.Context.ZLayerMembers.ContainsKey(_host.Root.Q<Button>("zmanaged")),
+                Is.True, "Precondition: the z-managed button actually relocated into a layer container");
+
+            // Assert
+            Assert.That(_host.Panel.focusController.focusedElement, Is.EqualTo(_host.Root.Q<Button>("zmanaged")));
+        }
+
+        [Test]
+        public void Given_FocusInsideAZManagedButton_When_TabDispatchesForward_Then_FocusContinuesToItsDeclaredSuccessorNotWhereverTheLayerPaints()
+        {
+            // Arrange — the layer container is trailing (the button physically paints as the parent's LAST
+            // child), so the engine's own ring would otherwise have nothing (or something unrelated) after it.
+            Mount(FocusOrderHost);
+            var zmanaged = _host.Root.Q<Button>("zmanaged");
+            zmanaged.Focus();
+            Assume.That(_host.Panel.focusController.focusedElement, Is.EqualTo(zmanaged),
+                "Precondition: the z-managed button holds focus");
+
+            // Act
+            SendMove(zmanaged, NavigationMoveEvent.Direction.Next);
+            Assume.That(_mounted.Root.Reconciler.Context.ZLayerMembers.ContainsKey(zmanaged),
+                Is.True, "Precondition: the z-managed button actually relocated into a layer container");
+
+            // Assert — focus continues to "after", the TRUE next sibling at the element's declared position.
+            Assert.That(_host.Panel.focusController.focusedElement, Is.EqualTo(_host.Root.Q<Button>("after")));
+        }
+
+        #endregion
+
+        #region Event bubbling
+
+        [Component]
+        private static VNode BubbleHost() => V.Div(name: "ancestor", children: new VNode[]
+        {
+            V.Div(name: "parent", className: "relative", children: new VNode[]
+            {
+                V.Div(name: "ordinary"),
+                V.Div(name: "zchild", className: "absolute z-10"),
+            }),
+        });
+
+        [Test]
+        public void Given_AZManagedElement_When_ItReceivesAPointerDownEvent_Then_TheEventBubblesToAnAncestorAboveTheStackingParent()
+        {
+            // Arrange
+            Mount(BubbleHost);
+            var received = 0;
+            _host.Root.Q<VisualElement>("ancestor").RegisterCallback<PointerDownEvent>(_ => received++);
+            Assume.That(_host.Root.Q<VisualElement>("zchild").parent?.ClassListContains(FiberZLayerCoordinator.FrontMarkerClass),
+                Is.True, "Precondition: zchild's real element physically relocated into the front layer container");
+
+            // Act — dispatched through the real panel: zchild -> its layer container -> the stacking parent
+            // ("parent") -> "ancestor", one hop deeper than an ordinary sibling but never leaving the panel.
+            _host.Root.Q<VisualElement>("zchild").SendPointerDownEvent(UnityEngine.Vector2.zero);
+
+            // Assert
+            Assert.That(received, Is.EqualTo(1));
+        }
+
+        #endregion
+
+        #region Focus preservation across a z resort
+
+        [Component]
+        private static VNode ResortZHost()
+        {
+            var bumped = Hooks.UseStore(s_resortZStore, x => x);
+            return V.Div(name: "parent", className: "relative", children: new VNode[]
+            {
+                V.Button(name: "zmanaged", className: "absolute " + (bumped ? "z-20" : "z-10")),
+            });
+        }
+
+        [Test]
+        public void Given_FocusInsideAZManagedButton_When_ItsZChanges_Then_ItStillHoldsFocusAfterTheResort()
+        {
+            // Arrange
+            using var store = new ToggleStore<bool>(false);
+            s_resortZStore = store;
+            Mount(ResortZHost);
+            var button = _host.Root.Q<Button>("zmanaged");
+            button.Focus();
+            Assume.That(_host.Panel.focusController.focusedElement, Is.EqualTo(button),
+                "Precondition: the z-managed button holds focus before the resort");
+
+            // Act — bumps z-10 -> z-20: Reposition detaches and re-inserts the same real element within the
+            // same front container (InsertSorted's own unconditional RemoveFromHierarchy).
+            store.Set(true);
+            _mounted.FlushStateForTest();
+            EditorPanelTestHelpers.ForcePanelUpdate(_host.Panel);
+
+            // Assert
+            Assert.That(_host.Panel.focusController.focusedElement, Is.EqualTo(button));
+        }
+
+        [Component]
+        private static VNode ResortZContainerHost()
+        {
+            var bumped = Hooks.UseStore(s_resortZContainerStore, x => x);
+            return V.Div(name: "parent", className: "relative", children: new VNode[]
+            {
+                V.Div(name: "zdiv", className: "absolute " + (bumped ? "z-20" : "z-10"), children: new VNode[]
+                {
+                    V.Button(name: "inner"),
+                }),
+            });
+        }
+
+        [Test]
+        public void Given_FocusInsideAButtonNestedInAZManagedDiv_When_TheDivsZChanges_Then_TheInnerButtonStillHoldsFocusAfterTheResort()
+        {
+            // Arrange — the focused element is a DESCENDANT of the z-managed element, not the z-managed
+            // element itself (every other resort test in this file focuses the z-managed element directly,
+            // which only pins CaptureFocusForRescue's ReferenceEquals(focused, moving) branch, never its
+            // moving.Contains(focused) branch).
+            using var store = new ToggleStore<bool>(false);
+            s_resortZContainerStore = store;
+            Mount(ResortZContainerHost);
+            var inner = _host.Root.Q<Button>("inner");
+            inner.Focus();
+            Assume.That(_host.Panel.focusController.focusedElement, Is.EqualTo(inner),
+                "Precondition: the inner button holds focus before the resort");
+
+            // Act — bumps z-10 -> z-20: Reposition detaches and re-inserts the z-managed div (and its whole
+            // subtree, "inner" included) within the same front container.
+            store.Set(true);
+            _mounted.FlushStateForTest();
+            EditorPanelTestHelpers.ForcePanelUpdate(_host.Panel);
+
+            // Assert
+            Assert.That(_host.Panel.focusController.focusedElement, Is.EqualTo(inner));
+        }
+
+        #endregion
+
+        #region Adjacent z-managed siblings backward focus exit
+
+        [Component]
+        private static VNode AdjacentZHost() => V.Div(name: "parent", className: "relative", children: new VNode[]
+        {
+            V.Button(name: "first", className: "absolute z-10"),
+            V.Button(name: "second", className: "absolute z-20"),
+        });
+
+        [Test]
+        public void Given_TwoAdjacentZManagedButtons_When_FocusOnTheSecondNavigatesPrevious_Then_FocusLandsOnTheFirstsRealButton()
+        {
+            // Arrange
+            Mount(AdjacentZHost);
+            var second = _host.Root.Q<Button>("second");
+            second.Focus();
+            Assume.That(_host.Panel.focusController.focusedElement, Is.EqualTo(second),
+                "Precondition: the second z-managed button holds focus");
+
+            // Act — TryZLayerExit's own ring prediction lands on the first's PLACEHOLDER (the panel-ring
+            // neighbour of "second"'s own placeholder); OnFocusIn's existing z-layer-placeholder forwarding
+            // branch chains a second redirect from there onto the first's real button.
+            SendMove(second, NavigationMoveEvent.Direction.Previous);
+
+            // Assert
+            Assert.That(_host.Panel.focusController.focusedElement, Is.EqualTo(_host.Root.Q<Button>("first")));
+        }
+
+        #endregion
+
+        #region Focus exit past the stacking parent's own boundary
+
+        // "zlast" is the stacking parent's own LOGICALLY LAST child, so its placeholder's physical
+        // ring-neighbour is the trailing front container itself (real's own layer), not another ordinary
+        // sibling the way FocusOrderHost's "after" is.
+        [Component]
+        private static VNode ZExitForwardHost() => V.Div(name: "ancestor", children: new VNode[]
+        {
+            V.Div(name: "parent", className: "relative", children: new VNode[]
+            {
+                V.Button(name: "before"),
+                V.Button(name: "zlast", className: "absolute z-10"),
+            }),
+            V.Button(name: "outerAfter"),
+        });
+
+        [Test]
+        public void Given_AZManagedButtonIsTheStackingParentsLastLogicalChild_When_TabDispatchesForward_Then_FocusExitsPastTheStackingParentToTheOrdinaryAncestorSuccessor()
+        {
+            // Arrange
+            Mount(ZExitForwardHost);
+            var zlast = _host.Root.Q<Button>("zlast");
+            zlast.Focus();
+            Assume.That(_host.Panel.focusController.focusedElement, Is.EqualTo(zlast),
+                "Precondition: the z-managed button holds focus");
+
+            // Act — the naive one-step ring walk from "zlast"'s placeholder re-enters the trailing front
+            // container (its own physical ring-neighbour), landing back on "zlast" itself.
+            SendMove(zlast, NavigationMoveEvent.Direction.Next);
+            Assume.That(_mounted.Root.Reconciler.Context.ZLayerMembers.ContainsKey(zlast), Is.True,
+                "Precondition: the z-managed button actually relocated into the front layer container");
+
+            // Assert — RED without the fix: the redirect lands back on "zlast" itself (a no-op) instead of
+            // escaping past "parent" to "outerAfter", the true next stop under the shared ancestor.
+            Assert.That(_host.Panel.focusController.focusedElement, Is.EqualTo(_host.Root.Q<Button>("outerAfter")));
+        }
+
+        // "zfirst" is the stacking parent's own LOGICALLY FIRST child and negative-z, so its placeholder's
+        // physical ring-neighbour going backward is the LEADING back container itself — the symmetric
+        // mirror of the forward/trailing-front-container case above.
+        [Component]
+        private static VNode ZExitBackwardHost() => V.Div(name: "ancestor", children: new VNode[]
+        {
+            V.Button(name: "outerBefore"),
+            V.Div(name: "parent", className: "relative", children: new VNode[]
+            {
+                V.Button(name: "zfirst", className: "absolute -z-10"),
+                V.Button(name: "after"),
+            }),
+        });
+
+        [Test]
+        public void Given_ANegativeZButtonIsTheStackingParentsFirstLogicalChild_When_TabDispatchesBackward_Then_FocusExitsPastTheStackingParentToTheOrdinaryAncestorPredecessor()
+        {
+            // Arrange
+            Mount(ZExitBackwardHost);
+            var zfirst = _host.Root.Q<Button>("zfirst");
+            zfirst.Focus();
+            Assume.That(_host.Panel.focusController.focusedElement, Is.EqualTo(zfirst),
+                "Precondition: the z-managed button holds focus");
+
+            // Act — the naive one-step ring walk from "zfirst"'s placeholder re-enters the leading back
+            // container (its own physical ring-neighbour going backward), landing back on "zfirst" itself.
+            SendMove(zfirst, NavigationMoveEvent.Direction.Previous);
+            Assume.That(_mounted.Root.Reconciler.Context.ZLayerMembers.ContainsKey(zfirst), Is.True,
+                "Precondition: the z-managed button actually relocated into the back layer container");
+
+            // Assert — RED without the fix: the redirect lands back on "zfirst" itself (a no-op) instead of
+            // escaping past "parent" to "outerBefore", the true previous stop under the shared ancestor.
+            Assert.That(_host.Panel.focusController.focusedElement, Is.EqualTo(_host.Root.Q<Button>("outerBefore")));
+        }
+
+        #endregion
+
+        #region Focus exit past a co-tenant sharing the same layer container
+
+        // "zb" is "parent"'s own LOGICALLY LAST child, but its LOWER z (10, vs "za"'s 20) sorts it
+        // PHYSICALLY FIRST within the shared front container — the declaration/physical-order mismatch that
+        // exposes a co-tenant landing: the very next ring step past "zb" itself is "za" (the OTHER
+        // z-managed sibling sharing that SAME container), not something genuinely outside it.
+        [Component]
+        private static VNode ZExitCoTenantForwardHost() => V.Div(name: "ancestor", children: new VNode[]
+        {
+            V.Div(name: "parent", className: "relative", children: new VNode[]
+            {
+                V.Button(name: "before"),
+                V.Button(name: "za", className: "absolute z-20"),
+                V.Button(name: "zb", className: "absolute z-10"),
+            }),
+            V.Button(name: "outerAfter"),
+        });
+
+        [Test]
+        public void Given_AZManagedButtonsRingNeighbourIsACoTenantInTheSameContainer_When_TabDispatchesForward_Then_FocusStillExitsPastTheStackingParent()
+        {
+            // Arrange — "za" and "zb" share the front container ("za" sorts after "zb": z-20 > z-10), so
+            // "zb"'s very next physical ring step lands on "za", not outside the container.
+            Mount(ZExitCoTenantForwardHost);
+            var zb = _host.Root.Q<Button>("zb");
+            zb.Focus();
+            Assume.That(_host.Panel.focusController.focusedElement, Is.EqualTo(zb),
+                "Precondition: \"zb\" holds focus");
+
+            // Act
+            SendMove(zb, NavigationMoveEvent.Direction.Next);
+            Assume.That(_mounted.Root.Reconciler.Context.ZLayerMembers.ContainsKey(zb), Is.True,
+                "Precondition: \"zb\" actually relocated into the shared front layer container");
+
+            // Assert — RED without the fix: the walk stops the instant it steps past "zb" itself, landing on
+            // "za" (a co-tenant sharing the SAME container) instead of continuing until it is genuinely
+            // outside the whole container — past "parent" — onto "outerAfter".
+            Assert.That(_host.Panel.focusController.focusedElement, Is.EqualTo(_host.Root.Q<Button>("outerAfter")));
+        }
+
+        #endregion
+
+        #region No valid exit
+
+        [Component]
+        private static VNode ZExitNoTargetHost() => V.Div(name: "parent", className: "relative", children: new VNode[]
+        {
+            V.Button(name: "zonly", className: "absolute z-10"),
+        });
+
+        [Test]
+        public void Given_AZManagedButtonIsTheOnlyFocusableInThePanel_When_TabDispatchesForward_Then_FocusStaysOnItInstead()
+        {
+            // Arrange — nothing else exists anywhere in the panel to escape to.
+            Mount(ZExitNoTargetHost);
+            var zonly = _host.Root.Q<Button>("zonly");
+            zonly.Focus();
+            Assume.That(_host.Panel.focusController.focusedElement, Is.EqualTo(zonly),
+                "Precondition: the z-managed (and only) button holds focus");
+
+            // Act — TryZLayerExit's own walk stays inside the container or wraps back onto the placeholder
+            // itself every step, so it falls through to "no valid exit" (returns false) instead of
+            // redirecting anywhere.
+            SendMove(zonly, NavigationMoveEvent.Direction.Next);
+
+            // Assert — graceful no-move: focus stays exactly where it was instead of the walk finding a
+            // spurious target or the panel throwing/looping.
+            Assert.That(_host.Panel.focusController.focusedElement, Is.EqualTo(zonly));
+        }
+
+        #endregion
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ZIndexPanelTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ZIndexPanelTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 968fa69ac747c43f6882355bad2bf0c5

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ZIndexStackingTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ZIndexStackingTests.cs
@@ -1,0 +1,1449 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine.UIElements;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Specifies the reconciler-side mechanics of the <c>z-*</c> stacking feature (FiberZLayerCoordinator /
+    /// StyleZIndexClass): a z-marked <c>absolute</c> element's real content relocates into a lazily-created
+    /// per-stacking-parent layer container (front for z &gt;= 0, back — the parent's own LEADING child, so it
+    /// paints behind ordinary siblings — for negative z), while a hidden placeholder holds its logical slot for
+    /// the reconciler, structural variants, and focus order. None of this needs a live panel: physical DOM
+    /// structure, element identity across patches, and reconciler slot-range correctness are all observable on
+    /// a bare (unattached) tree. GWT, one assert per case.
+    /// </summary>
+    [TestFixture]
+    internal sealed class ZIndexStackingTests
+    {
+        // A minimal reusable Store for tests that only need to flip one value and re-render.
+        private sealed class ToggleStore<T> : Store<T>
+        {
+            private readonly T _initial;
+            public ToggleStore(T initial) : base(initial) => _initial = initial;
+            public void Set(T value) => SetState(_ => value);
+            protected override void ResetCore() => SetState(_ => _initial);
+        }
+
+        private static ToggleStore<string> s_churnStore;
+        private static ToggleStore<int> s_reuseStore;
+        private static ToggleStore<bool> s_teardownStore;
+        private static ToggleStore<bool> s_zToNoneStore;
+        private static ToggleStore<bool> s_noneToZStore;
+        private static ToggleStore<bool> s_resortStore;
+        private static ToggleStore<bool> s_typeFlipStore;
+        private static ToggleStore<bool> s_signFlipStore;
+        private static ToggleStore<bool> s_moveStore;
+        private static bool s_zParkZManaged;
+        private static ComponentFiber s_zParkFiber;
+        private static ToggleStore<bool> s_structuralSweepStore;
+        private static ToggleStore<bool> s_structuralPatchStore;
+        private static bool s_crossFiberAZManaged;
+        private static string s_crossFiberBName;
+        private static ComponentFiber s_crossFiberAFiber;
+        private static ComponentFiber s_crossFiberBFiber;
+        private static int s_crossParkACount;
+        private static bool s_crossParkBZManaged;
+        private static ComponentFiber s_crossParkAFiber;
+        private static ComponentFiber s_crossParkBFiber;
+        private static int s_crossParkKeyedACount;
+        private static bool s_crossParkKeyedBZManaged;
+        private static ComponentFiber s_crossParkKeyedAFiber;
+        private static ComponentFiber s_crossParkKeyedBFiber;
+        private static bool s_drainZManaged;
+        private static ComponentFiber s_drainFiber;
+
+        [SetUp]
+        public void SetUp()
+        {
+            // Defensive reset (mirrors TimeSlicedFiberTests' own SetUp/TearDown pair) so a tiny budget forced
+            // by an earlier failing test can never leak into this one.
+            FiberLane.TimeSlicedBudgetOverrideForTest = -1;
+            s_churnStore = null;
+            s_reuseStore = null;
+            s_teardownStore = null;
+            s_zToNoneStore = null;
+            s_noneToZStore = null;
+            s_resortStore = null;
+            s_typeFlipStore = null;
+            s_signFlipStore = null;
+            s_moveStore = null;
+            s_zParkZManaged = false;
+            s_zParkFiber = null;
+            s_structuralSweepStore = null;
+            s_structuralPatchStore = null;
+            s_crossFiberAZManaged = false;
+            s_crossFiberBName = null;
+            s_crossFiberAFiber = null;
+            s_crossFiberBFiber = null;
+            s_crossParkACount = 0;
+            s_crossParkBZManaged = false;
+            s_crossParkAFiber = null;
+            s_crossParkBFiber = null;
+            s_crossParkKeyedACount = 0;
+            s_crossParkKeyedBZManaged = false;
+            s_crossParkKeyedAFiber = null;
+            s_crossParkKeyedBFiber = null;
+            s_drainZManaged = false;
+            s_drainFiber = null;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            FiberLane.TimeSlicedBudgetOverrideForTest = -1;
+        }
+
+        // Finds the front (z >= 0) or back (negative z) layer container directly under parent, or null when
+        // no z-managed child of that sign has mounted yet.
+        private static VisualElement FindLayerContainer(VisualElement parent, bool front)
+        {
+            var marker = front ? FiberZLayerCoordinator.FrontMarkerClass : FiberZLayerCoordinator.BackMarkerClass;
+            foreach (var child in parent.Children())
+            {
+                if (child.ClassListContains(marker))
+                {
+                    return child;
+                }
+            }
+            return null;
+        }
+
+        #region Physical order
+
+        [Test]
+        public void Given_MultipleAbsoluteSiblingsWithDifferentPositiveZ_When_Mounted_Then_TheyArePhysicallySortedByZUnderTheFrontLayer()
+        {
+            // Arrange / Act — declared out of ascending order; the front layer must still sort them.
+            var root = new VisualElement();
+            using var mounted = V.Mount(root, V.Div(name: "parent", className: "relative", children: new VNode[]
+            {
+                V.Div(name: "ordinary"),
+                V.Div(name: "z30", className: "absolute z-30"),
+                V.Div(name: "z10", className: "absolute z-10"),
+                V.Div(name: "z20", className: "absolute z-20"),
+            }));
+            var front = FindLayerContainer(root.Q<VisualElement>("parent"), front: true);
+            Assume.That(front, Is.Not.Null, "Precondition: a front z-layer container was created");
+
+            // Assert
+            Assert.That((front.ElementAt(0).name, front.ElementAt(1).name, front.ElementAt(2).name),
+                Is.EqualTo(("z10", "z20", "z30")));
+        }
+
+        [Test]
+        public void Given_ANegativeZAbsoluteSibling_When_Mounted_Then_ItPhysicallyPrecedesTheOrdinaryChildren()
+        {
+            // Arrange / Act
+            var root = new VisualElement();
+            using var mounted = V.Mount(root, V.Div(name: "parent", className: "relative", children: new VNode[]
+            {
+                V.Div(name: "ordinary1"),
+                V.Div(name: "negz", className: "absolute -z-10"),
+                V.Div(name: "ordinary2"),
+            }));
+            var parent = root.Q<VisualElement>("parent");
+
+            // Assert — the back layer container is parent's own first physical child.
+            Assert.That(parent.ElementAt(0), Is.SameAs(FindLayerContainer(parent, front: false)));
+        }
+
+        [Test]
+        public void Given_ANegativeZChild_When_Mounted_Then_ItNeverEscapesToBeforeItsOwnStackingParent()
+        {
+            // Arrange / Act — negative z is a genuine engine dead end (one paint traversal; a child can only
+            // paint after its own parent's background): the back layer is always the stacking parent's OWN
+            // leading child, never hoisted to become the parent's preceding sibling under the grandparent.
+            var root = new VisualElement();
+            using var mounted = V.Mount(root, V.Div(name: "grandparent", children: new VNode[]
+            {
+                V.Div(name: "before"),
+                V.Div(name: "parent", className: "relative", children: new VNode[]
+                {
+                    V.Div(name: "ordinary"),
+                    V.Div(name: "negz", className: "absolute -z-10"),
+                }),
+            }));
+            Assume.That(FindLayerContainer(root.Q<VisualElement>("parent"), front: false), Is.Not.Null,
+                "Precondition: a back container exists under parent");
+
+            // Assert — "before" is still the grandparent's first child; "parent" was never reordered around it.
+            Assert.That(root.Q<VisualElement>("grandparent").ElementAt(0).name, Is.EqualTo("before"));
+        }
+
+        [Test]
+        public void Given_AnInFlowElementWithAZClassButNoAbsolute_When_Mounted_Then_NoLayerContainerIsEverCreated()
+        {
+            // Arrange / Act — z-10 without "absolute": the scope gate requires ALSO being out-of-flow, so this
+            // is a documented no-op.
+            var root = new VisualElement();
+            using var mounted = V.Mount(root, V.Div(name: "parent", children: new VNode[]
+            {
+                V.Div(name: "child", className: "z-10"),
+            }));
+
+            // Assert
+            Assert.That(FindLayerContainer(root.Q<VisualElement>("parent"), front: true), Is.Null);
+        }
+
+        [Component]
+        private static VNode TypeFlipHost()
+        {
+            var showButton = Hooks.UseStore(s_typeFlipStore, x => x);
+            var children = showButton
+                ? new VNode[] { V.Button(name: "button"), V.Div(name: "negz", className: "absolute -z-10") }
+                : new VNode[] { V.Div(name: "negz", className: "absolute -z-10") };
+            return V.Div(name: "parent", className: "relative", children: children);
+        }
+
+        [Test]
+        public void Given_AParentWhoseOnlyChildIsANegativeZElement_When_TheNextRenderPrependsAnOrdinaryElement_Then_TheBackContainerStaysTheParentsFirstPhysicalChild()
+        {
+            // Arrange — the back container is parent's only physical child besides negz's own placeholder;
+            // declaring a new leading Button forces a positional type-flip at slot 0 (Button replaces negz
+            // there), transiently leaving the back container as parent's SOLE remaining child mid-diff.
+            using var store = new ToggleStore<bool>(false);
+            s_typeFlipStore = store;
+            var root = new VisualElement();
+            using var mounted = V.Mount(root, V.Component(TypeFlipHost, key: "root"));
+            var parent = root.Q<VisualElement>("parent");
+            Assume.That(FindLayerContainer(parent, front: false), Is.Not.Null,
+                "Precondition: the back layer container exists");
+
+            // Act — declares [Button, negz]: a positional type-flip at slot 0.
+            store.Set(true);
+            mounted.FlushStateForTest();
+
+            // Assert — the back container is still parent's first physical child, not displaced behind Button.
+            Assert.That(parent.ElementAt(0), Is.SameAs(FindLayerContainer(parent, front: false)));
+        }
+
+        #endregion
+
+        #region Reconciler slot-range integrity
+
+        [Component]
+        private static VNode ChurnList()
+        {
+            var keys = Hooks.UseStore(s_churnStore, x => x);
+            var children = new List<VNode> { V.Div(name: "zchild", key: "z", className: "absolute -z-10") };
+            foreach (var key in keys)
+            {
+                children.Add(V.Button(name: "item-" + key, key: key.ToString(), text: key.ToString()));
+            }
+            return V.Div(name: "list", className: "relative", children: children.ToArray());
+        }
+
+        [Test]
+        public void Given_ABackZMarkedChildAmongKeyedSiblings_When_TheSiblingsReorderAddAndRemoveAcrossMultipleRerenders_Then_TheyStillCommitTheLatestDeclaredOrder()
+        {
+            // Arrange — a back-managed sibling (the leading-offset case) interspersed among keyed buttons.
+            using var store = new ToggleStore<string>("abc");
+            s_churnStore = store;
+            var root = new VisualElement();
+            using var mounted = V.Mount(root, V.Component(ChurnList, key: "root"));
+            var list = root.Q<VisualElement>("list");
+            Assume.That(FindLayerContainer(list, front: false), Is.Not.Null,
+                "Precondition: the back layer container exists");
+
+            // Act — reorder, then insert, then remove ordinary keyed siblings across successive re-renders
+            // while the leading back-layer container stays present the whole time: an insertion/removal shifts
+            // every subsequent index differently than a pure LIS reorder, so both need their own coverage here,
+            // not just the reorder the original regression pinned.
+            store.Set("cba");
+            mounted.FlushStateForTest();
+            store.Set("bac");
+            mounted.FlushStateForTest();
+            store.Set("bacd"); // insert "d" at the tail
+            mounted.FlushStateForTest();
+            store.Set("acd"); // remove "b" from the middle
+            mounted.FlushStateForTest();
+
+            // Assert — the ordinary siblings' physical order matches the latest declared order: their own
+            // slot-range math was never corrupted by the interspersed leading container, across reorder,
+            // insert, and remove alike.
+            var names = list.Query<Button>().ToList().ConvertAll(b => b.name);
+            Assert.That(names, Is.EqualTo(new[] { "item-a", "item-c", "item-d" }));
+        }
+
+        #endregion
+
+        #region Cleanup
+
+        // 0 = z-managed button, 1 = empty (unmounted, pool-returned), 2 = plain button (rents the pool).
+        [Component]
+        private static VNode ReuseHost()
+        {
+            var phase = Hooks.UseStore(s_reuseStore, x => x);
+            var children = phase switch
+            {
+                0 => new VNode[] { V.Button(name: "b", className: "absolute z-10") },
+                1 => System.Array.Empty<VNode>(),
+                _ => new VNode[] { V.Button(name: "b") },
+            };
+            return V.Div(name: "parent", className: "relative", children: children);
+        }
+
+        [Test]
+        public void Given_AZManagedButtonWasPooled_When_APlainButtonRentsTheSamePooledInstance_Then_ItCarriesNoZLayerMembership()
+        {
+            // Arrange — a z-managed button unmounts (fully removed, pool-returned).
+            using var store = new ToggleStore<int>(0);
+            s_reuseStore = store;
+            var root = new VisualElement();
+            using var mounted = V.Mount(root, V.Component(ReuseHost, key: "root"));
+            var ctx = mounted.Root.Reconciler.Context;
+            var original = root.Q<Button>("b");
+            store.Set(1);
+            mounted.FlushStateForTest();
+            Assume.That(ctx.ZLayerMembers.Count, Is.EqualTo(0),
+                "Precondition: unmounting tore down the z-managed button's registration");
+
+            // Act — a plain (non-z) button mounts, renting the same pooled Button instance back.
+            store.Set(2);
+            mounted.FlushStateForTest();
+            var rented = root.Q<Button>("b");
+
+            // Assert — folded into one tuple: the plain button actually rented the SAME pooled instance (not a
+            // fresh one) AND that instance carries no leftover z-layer registration. A bare
+            // ContainsKey(rented)==false assert alone would pass vacuously on a fresh (non-pooled) instance, and
+            // a separate Assume for the pooling fact would report Inconclusive instead of Failed on a cleanup
+            // regression.
+            Assert.That((ReferenceEquals(rented, original), ctx.ZLayerMembers.ContainsKey(rented)),
+                Is.EqualTo((true, false)));
+        }
+
+        [Component]
+        private static VNode TeardownHost()
+        {
+            var show = Hooks.UseStore(s_teardownStore, x => x);
+            return V.Div(name: "parent", className: "relative", children: show
+                ? new VNode[] { V.Div(name: "zchild", className: "absolute z-10") }
+                : System.Array.Empty<VNode>());
+        }
+
+        [Test]
+        public void Given_TheLastZMarkedChildUnderAParent_When_ItUnmounts_Then_TheLayerContainerIsRemoved()
+        {
+            // Arrange
+            using var store = new ToggleStore<bool>(true);
+            s_teardownStore = store;
+            var root = new VisualElement();
+            using var mounted = V.Mount(root, V.Component(TeardownHost, key: "root"));
+            var parent = root.Q<VisualElement>("parent");
+            Assume.That(FindLayerContainer(parent, front: true), Is.Not.Null,
+                "Precondition: the front layer container exists");
+
+            // Act
+            store.Set(false);
+            mounted.FlushStateForTest();
+
+            // Assert
+            Assert.That(FindLayerContainer(parent, front: true), Is.Null);
+        }
+
+        #endregion
+
+        #region Patch transitions preserve element identity
+
+        [Component]
+        private static VNode ZToNoneHost()
+        {
+            var withZ = Hooks.UseStore(s_zToNoneStore, x => x);
+            return V.Div(name: "parent", className: "relative", children: new VNode[]
+            {
+                V.Div(name: "child", className: withZ ? "absolute z-10" : "absolute"),
+            });
+        }
+
+        [Test]
+        public void Given_AZManagedElement_When_ItsClassChangesToPlainAbsolute_Then_TheSameElementInstanceReturnsToItsOrdinarySlot()
+        {
+            // Arrange
+            using var store = new ToggleStore<bool>(true);
+            s_zToNoneStore = store;
+            var root = new VisualElement();
+            using var mounted = V.Mount(root, V.Component(ZToNoneHost, key: "root"));
+            var child = root.Q<VisualElement>("child");
+            var ctx = mounted.Root.Reconciler.Context;
+            Assume.That(ctx.ZLayerMembers.ContainsKey(child), Is.True, "Precondition: the child is z-managed");
+
+            // Act
+            store.Set(false);
+            mounted.FlushStateForTest();
+
+            // Assert — the SAME instance now occupies the parent's ordinary slot directly.
+            Assert.That(ReferenceEquals(root.Q<VisualElement>("parent").ElementAt(0), child), Is.True);
+        }
+
+        [Component]
+        private static VNode NoneToZHost()
+        {
+            var withZ = Hooks.UseStore(s_noneToZStore, x => x);
+            return V.Div(name: "parent", className: "relative", children: new VNode[]
+            {
+                V.Div(name: "child", className: withZ ? "absolute z-10" : "absolute"),
+            });
+        }
+
+        [Test]
+        public void Given_AnOrdinaryAbsoluteElement_When_ItGainsAZClass_Then_TheSameElementInstanceRelocatesIntoTheLayer()
+        {
+            // Arrange
+            using var store = new ToggleStore<bool>(false);
+            s_noneToZStore = store;
+            var root = new VisualElement();
+            using var mounted = V.Mount(root, V.Component(NoneToZHost, key: "root"));
+            var child = root.Q<VisualElement>("child");
+            var ctx = mounted.Root.Reconciler.Context;
+            Assume.That(ReferenceEquals(root.Q<VisualElement>("parent").ElementAt(0), child), Is.True,
+                "Precondition: the child starts as an ordinary direct child");
+
+            // Act
+            store.Set(true);
+            mounted.FlushStateForTest();
+
+            // Assert — the SAME instance is now registered as z-managed (relocated into the front layer).
+            Assert.That(ctx.ZLayerMembers.ContainsKey(child), Is.True);
+        }
+
+        [Component]
+        private static VNode ResortHost()
+        {
+            var swapped = Hooks.UseStore(s_resortStore, x => x);
+            return V.Div(name: "parent", className: "relative", children: new VNode[]
+            {
+                V.Div(name: "a", className: "absolute " + (swapped ? "z-30" : "z-10")),
+                V.Div(name: "b", className: "absolute " + (swapped ? "z-10" : "z-30")),
+            });
+        }
+
+        [Test]
+        public void Given_TwoZManagedSiblings_When_TheirRelativeZOrderSwaps_Then_TheSameElementInstancesResortWithoutRemounting()
+        {
+            // Arrange — a (z-10) sorts before b (z-30).
+            using var store = new ToggleStore<bool>(false);
+            s_resortStore = store;
+            var root = new VisualElement();
+            using var mounted = V.Mount(root, V.Component(ResortHost, key: "root"));
+            var a = root.Q<VisualElement>("a");
+            var b = root.Q<VisualElement>("b");
+            var front = FindLayerContainer(root.Q<VisualElement>("parent"), front: true);
+            Assume.That(ReferenceEquals(front.ElementAt(0), a) && ReferenceEquals(front.ElementAt(1), b), Is.True,
+                "Precondition: a (z-10) sorts before b (z-30)");
+
+            // Act — swap: a becomes z-30, b becomes z-10.
+            store.Set(true);
+            mounted.FlushStateForTest();
+
+            // Assert — the front container's order flips, using the SAME two element instances.
+            Assert.That(ReferenceEquals(front.ElementAt(0), b) && ReferenceEquals(front.ElementAt(1), a), Is.True);
+        }
+
+        [Component]
+        private static VNode SignFlipHost()
+        {
+            var flipped = Hooks.UseStore(s_signFlipStore, x => x);
+            return V.Div(name: "parent", className: "relative", children: new VNode[]
+            {
+                V.Div(name: "child", className: "absolute " + (flipped ? "-z-10" : "z-10")),
+            });
+        }
+
+        [Test]
+        public void Given_AZManagedElement_When_ItsSignFlipsToAContainerThatDoesNotYetExist_Then_ItsMountOrderTiebreakCarriesForwardUnchanged()
+        {
+            // Arrange — z-10 only: the front container exists, no back container has ever been created.
+            using var store = new ToggleStore<bool>(false);
+            s_signFlipStore = store;
+            var root = new VisualElement();
+            using var mounted = V.Mount(root, V.Component(SignFlipHost, key: "root"));
+            var ctx = mounted.Root.Reconciler.Context;
+            var child = root.Q<VisualElement>("child");
+            Assume.That(ctx.ZLayerMembers.ContainsKey(child), Is.True,
+                "Precondition: child mounted z-managed under z-10");
+            var originalOrder = ctx.ZLayerMembers[child].Order;
+            Assume.That(FindLayerContainer(root.Q<VisualElement>("parent"), front: false), Is.Null,
+                "Precondition: no back container exists yet");
+
+            // Act — flip to -z-10: Reposition finds no existing back container for this parent and defers
+            // through the same enqueue/drain path a fresh mount uses, carrying the element's mount-order
+            // tiebreak forward instead of reassigning a fresh one.
+            store.Set(true);
+            mounted.FlushStateForTest();
+
+            // Assert — folded into one tuple: the flip actually created a fresh back container (the deferred/
+            // enqueue branch ran, not a same-container Reposition no-op — which would leave Order untouched and
+            // pass vacuously) AND the SAME order value survived the deferred round-trip (a fresh assignment
+            // would differ).
+            Assert.That(
+                (FindLayerContainer(root.Q<VisualElement>("parent"), front: false) != null, ctx.ZLayerMembers[child].Order),
+                Is.EqualTo((true, originalOrder)));
+        }
+
+        #endregion
+
+        #region Relational variants across the layer boundary
+
+        [Test]
+        public void Given_AZManagedConsumerAndAnOrdinaryPeerSource_When_ResolvingTheLogicalPeerSearchOrigin_Then_ItStillFindsTheOrdinarySource()
+        {
+            // Arrange — parent: [source(ordinary, "peer"), consumer(z-managed)]. The consumer's real element
+            // physically lives in the front layer container, whose preceding siblings are unrelated same-layer
+            // members, not "source" — the fix routes the search through the consumer's PLACEHOLDER position.
+            var root = new VisualElement();
+            using var mounted = V.Mount(root, V.Div(name: "parent", className: "relative", children: new VNode[]
+            {
+                V.Div(name: "source", className: "peer"),
+                V.Div(name: "consumer", className: "absolute z-10"),
+            }));
+            var ctx = mounted.Root.Reconciler.Context;
+
+            // Act
+            var found = StyleRelationalVariantManipulator.FindPrevSiblingWithClass(
+                root.Q<VisualElement>("consumer"), "peer", ctx);
+
+            // Assert
+            Assert.That(found, Is.SameAs(root.Q<VisualElement>("source")));
+        }
+
+        [Test]
+        public void Given_AZManagedPeerSourceAndAnOrdinaryConsumer_When_ResolvingThePeerSearch_Then_TheRelocatedSourceIsNotFound()
+        {
+            // Arrange — parent: [source(z-managed, "peer"), consumer(ordinary)]. Documented gap: a relocated
+            // SOURCE's placeholder carries none of its marker classes, and the search only ever inspects
+            // physical siblings, so it does not resolve here (real CSS would; Velvet does not, for this
+            // specific relocated-source shape).
+            var root = new VisualElement();
+            using var mounted = V.Mount(root, V.Div(name: "parent", className: "relative", children: new VNode[]
+            {
+                V.Div(name: "source", className: "peer absolute z-10"),
+                V.Div(name: "consumer"),
+            }));
+            var ctx = mounted.Root.Reconciler.Context;
+
+            // Act
+            var found = StyleRelationalVariantManipulator.FindPrevSiblingWithClass(
+                root.Q<VisualElement>("consumer"), "peer", ctx);
+
+            // Assert
+            Assert.That(found, Is.Null);
+        }
+
+        #endregion
+
+        #region Per-parent isolation
+
+        [Test]
+        public void Given_TwoSiblingStackingParentsEachWithZManagedChildren_When_Mounted_Then_TheirLayerContainersAndOrderingDoNotCrossTalk()
+        {
+            // Arrange / Act — two INDEPENDENT stacking parents, each growing its own container; per-parent
+            // keying (ZLayerHosts is keyed by the stacking parent element, not a single global registry) must
+            // keep them from cross-talking.
+            var root = new VisualElement();
+            using var mounted = V.Mount(root, V.Div(name: "wrapper", children: new VNode[]
+            {
+                V.Div(name: "parentA", className: "relative", children: new VNode[]
+                {
+                    V.Div(name: "a1", className: "absolute z-30"),
+                    V.Div(name: "a2", className: "absolute z-10"),
+                }),
+                V.Div(name: "parentB", className: "relative", children: new VNode[]
+                {
+                    V.Div(name: "b1", className: "absolute z-20"),
+                }),
+            }));
+            var frontA = FindLayerContainer(root.Q<VisualElement>("parentA"), front: true);
+            var frontB = FindLayerContainer(root.Q<VisualElement>("parentB"), front: true);
+            Assume.That(frontA, Is.Not.SameAs(frontB), "Precondition: each stacking parent grew its own container");
+
+            // Assert — parentA's container holds only its own two children, correctly sorted, unaffected by
+            // parentB's own separate single member.
+            Assert.That((frontA.childCount, frontA.ElementAt(0).name, frontA.ElementAt(1).name),
+                Is.EqualTo((2, "a2", "a1")));
+        }
+
+        #endregion
+
+        #region V.Anchored without the "absolute" class
+
+        [Test]
+        public void Given_AnAnchoredElementWithNoAbsoluteClass_When_ItCarriesAZClass_Then_ItStillRelocatesIntoTheLayerContainer()
+        {
+            // Arrange / Act — V.Anchored forces position:absolute via AnchoredDriver.Attach as a plain inline
+            // style (never through the "absolute" utility class), so TryClassify's out-of-flow half must accept
+            // Props.Anchored on its own. AnchoredDriver.Sync bails cleanly with no live panel (element.panel ==
+            // null), so this needs no host panel, like every other test in this fixture.
+            var root = new VisualElement();
+            using var mounted = V.Mount(root, V.Div(name: "parent", className: "relative", children: new VNode[]
+            {
+                V.Anchored(target: null, name: "child", className: "z-10"),
+            }));
+            var ctx = mounted.Root.Reconciler.Context;
+            var child = root.Q<VisualElement>("child");
+            Assume.That(child.ClassListContains("absolute"), Is.False,
+                "Precondition: the child carries no \"absolute\" utility class");
+
+            // Assert — TryClassify's Props.Anchored half classified it anyway.
+            Assert.That(ctx.ZLayerMembers.ContainsKey(child), Is.True);
+        }
+
+        #endregion
+
+        #region Keyed reorder moves the z-managed item itself
+
+        [Component]
+        private static VNode MoveZManagedHost()
+        {
+            var moved = Hooks.UseStore(s_moveStore, x => x);
+            var zChild = V.Div(name: "zchild", key: "z", className: "absolute z-10");
+            var a = V.Button(name: "a", key: "a");
+            var b = V.Button(name: "b", key: "b");
+            var children = moved ? new VNode[] { a, b, zChild } : new VNode[] { zChild, a, b };
+            return V.Div(name: "list", className: "relative", children: children);
+        }
+
+        [Test]
+        public void Given_AKeyedReorder_When_TheZManagedItemMovesToADifferentLogicalIndex_Then_ThePlaceholderTracksItAndTheRealElementStaysRegistered()
+        {
+            // Arrange — the z-managed child starts FIRST among three keyed siblings.
+            using var store = new ToggleStore<bool>(false);
+            s_moveStore = store;
+            var root = new VisualElement();
+            using var mounted = V.Mount(root, V.Component(MoveZManagedHost, key: "root"));
+            var ctx = mounted.Root.Reconciler.Context;
+            var zchild = root.Q<VisualElement>("zchild");
+            Assume.That(ctx.ZLayerMembers.ContainsKey(zchild), Is.True,
+                "Precondition: the z-managed child is registered before the move");
+
+            // Act — the keyed reorder moves the z-managed item to the LAST logical position.
+            store.Set(true);
+            mounted.FlushStateForTest();
+
+            // Assert — the SAME real element instance is still registered, now with its placeholder physically
+            // last among the LOGICAL (non-spacer) children — list's own trailing front layer container is not
+            // itself a logical child, so the last logical slot is NonSpacerChildCount - 1, not childCount - 1;
+            // default (false/null Placeholder) if the registration itself was lost, so this also proves the
+            // "stays registered" half.
+            var list = root.Q<VisualElement>("list");
+            ctx.ZLayerMembers.TryGetValue(zchild, out var memberAfter);
+            var lastLogicalIndex = SilhouetteBoundsSpacer.NonSpacerChildCount(list) - 1;
+            var stillRegisteredAtTrackedPosition = memberAfter.Placeholder != null
+                && ReferenceEquals(list.ElementAt(lastLogicalIndex), memberAfter.Placeholder);
+            Assert.That(stillRegisteredAtTrackedPosition, Is.True);
+        }
+
+        #endregion
+
+        #region Nested stacking parents
+
+        [Test]
+        public void Given_AZManagedElementWhoseRealContentContainsItsOwnZManagedDescendant_When_Mounted_Then_BothLayersResolveIndependently()
+        {
+            // Arrange / Act — "mid" is z-managed under "outer"; its own child "innerParent" is a SEPARATE
+            // stacking parent for "inner" — an independent nested layer, unrelated to "mid"'s own relocation.
+            var root = new VisualElement();
+            using var mounted = V.Mount(root, V.Div(name: "outer", className: "relative", children: new VNode[]
+            {
+                V.Div(name: "mid", className: "absolute z-10", children: new VNode[]
+                {
+                    V.Div(name: "innerParent", className: "relative", children: new VNode[]
+                    {
+                        V.Div(name: "inner", className: "absolute z-20"),
+                    }),
+                }),
+            }));
+            var outerFront = FindLayerContainer(root.Q<VisualElement>("outer"), front: true);
+            Assume.That(outerFront, Is.Not.Null, "Precondition: outer's own front container exists");
+            var innerParent = root.Q<VisualElement>("innerParent");
+            var innerFront = FindLayerContainer(innerParent, front: true);
+
+            // Assert — innerParent (reached inside mid's relocated real content) grew its OWN front container,
+            // holding "inner", independent of mid's own relocation under outer.
+            Assert.That(innerFront != null && ReferenceEquals(innerFront.ElementAt(0), root.Q<VisualElement>("inner")),
+                Is.True);
+        }
+
+        #endregion
+
+        #region Motion incompatibility
+
+        [Test]
+        public void Given_AMotionWithAnAbsoluteAndZClass_When_Mounted_Then_ItWarnsThatZIsIgnored()
+        {
+            // Arrange — the warning is expected (LogAssert fails the test if it never fires). A plain Regex
+            // (no IgnoreCase) mirrors ShadowWrapTests / ClipPathWrapTests' own Motion-incompatibility pins.
+            UnityEngine.TestTools.LogAssert.Expect(UnityEngine.LogType.Warning,
+                new System.Text.RegularExpressions.Regex(@"z-\* utility on a Motion is ignored"));
+
+            // Act — z-* + absolute would classify as z-managed on a plain element; on a Motion it must not (the
+            // MotionNode create path never consults the z classifier at all).
+            var root = new VisualElement();
+            using var mounted = V.Mount(root, V.Motion(name: "m", className: "absolute z-10"));
+
+            // Assert — the element mounted ordinary and unrelocated; the expected warning above is enforced by
+            // LogAssert at test end (an Assert.Pass would bypass that unmatched-expectation check).
+            Assert.That(mounted.Root.Reconciler.Context.ZLayerMembers.ContainsKey(root.Q<VisualElement>("m")), Is.False);
+        }
+
+        #endregion
+
+        #region Time-sliced staleness of the baked leading offset
+
+        // item0 alone toggles between plain and z-managed (negative, so a BACK container is at stake); item1
+        // through item9 stay ordinary. Every child is a fresh VNode each render (no ILPP memo, no shared
+        // instances), so no Common-phase iteration ever takes the ReferenceEquals fast path — matching
+        // TimeSlicedFiberTests' own FlatListRender shape, which is what makes "a tiny budget parks after
+        // exactly one node" a deterministic guarantee rather than a timing race. The fiber's own top-level
+        // output is the Fragment directly (no wrapping Div) so root itself — not some nested element — is the
+        // stacking parent and the reconcile the tiny budget parks takes the time-sliceable fast path at all
+        // (a nested ReconcileChildren call, the shape an intervening wrapper Div would force, always runs at
+        // frameBudgetMs=0 regardless of the caller's own budget).
+        [Component]
+        private static VNode ZParkHost()
+        {
+            s_zParkFiber = FiberAmbientStack.Current;
+            var zManaged = s_zParkZManaged;
+            var children = new VNode[10];
+            children[0] = V.Div(name: "item0", className: zManaged ? "absolute -z-10" : null);
+            for (var i = 1; i < 10; i++)
+            {
+                children[i] = V.Div(name: "item" + i);
+            }
+            return V.Fragment(children: children);
+        }
+
+        // The "itemN" (N >= 1) direct children of root, in physical order, joined into one comparable string —
+        // a back container (unnamed) and item0's own placeholder (also unnamed) are both naturally excluded, so
+        // this reads purely as "where did item1..item9 end up, and under what name".
+        private static string TrailingItemOrder(VisualElement root)
+        {
+            var names = new List<string>();
+            foreach (var child in root.Children())
+            {
+                if (child.name is { Length: > 0 } n && n != "item0")
+                {
+                    names.Add(n);
+                }
+            }
+            return string.Join(",", names);
+        }
+
+        private const string ExpectedTrailingItemOrder =
+            "item1,item2,item3,item4,item5,item6,item7,item8,item9";
+
+        [Test]
+        public void Given_ATimeSlicedPassParksRightAfterQueuingTheFirstBackContainerMember_When_TheSameFinallyDrainCreatesTheContainer_Then_TheParkedSlotStartIsRebasedSoTrailingItemsResumeAtCorrectIndices()
+        {
+            // Arrange — mount fully ordinary: no z anywhere yet, so no back container exists.
+            s_zParkZManaged = false;
+            var root = new VisualElement();
+            using var mounted = V.Mount(root, V.Component(ZParkHost, key: "root"));
+            Assume.That(FindLayerContainer(root, front: false), Is.Null,
+                "Precondition: no back container exists before the timed re-render");
+
+            // Act — item0 turns z-managed under a tiny forced budget: the Common-phase loop patches item0's
+            // class, relocates it out (enqueuing the deferred z-mount) since no back container exists yet, then
+            // the tiny budget parks immediately after — all within this ONE top-level Reconcile() call, whose
+            // own finally-drain then creates the FIRST back container, physically shifting every trailing item
+            // (and item0's own placeholder) by +1.
+            FiberLane.TimeSlicedBudgetOverrideForTest = 0.0001;
+            s_zParkZManaged = true;
+            s_zParkFiber.ScheduleRerenderForTest(FiberUpdatePriority.Transition);
+            FiberWorkLoop.FlushState(s_zParkFiber);
+            Assume.That(s_zParkFiber.HasPendingReconcileWorkForTest(), Is.True,
+                "Precondition: the tiny budget parked the pass right after item0's own iteration");
+            FiberLane.TimeSlicedBudgetOverrideForTest = -1;
+            s_zParkFiber.DrainTimeSlicedReconcileForTest();
+
+            // Assert — every trailing item resumed and patched at its correct (post-shift) physical index.
+            // RED without the fix: the resumed slice keeps reading one slot short of where the container's
+            // insertion actually left each row, so each iteration patches (and renames, via PatchCommon) the
+            // WRONG physical element — a cascading off-by-one that leaves a stale/duplicated name in this join.
+            Assert.That(TrailingItemOrder(root), Is.EqualTo(ExpectedTrailingItemOrder));
+        }
+
+        [Test]
+        public void Given_ATimeSlicedPassParksRightAfterTheLastBackContainerMemberLeaves_When_TheSameFinallyDrainRemovesTheContainer_Then_TheParkedSlotStartIsRebasedSoTrailingItemsResumeAtCorrectIndices()
+        {
+            // Arrange — mount with item0 ALREADY z-managed (synchronous: budget=0 at mount regardless of the
+            // override, which is only ever set below), so the back container exists cleanly beforehand.
+            s_zParkZManaged = true;
+            var root = new VisualElement();
+            using var mounted = V.Mount(root, V.Component(ZParkHost, key: "root"));
+            Assume.That(FindLayerContainer(root, front: false), Is.Not.Null,
+                "Precondition: the back container exists before the timed re-render");
+
+            // Act — item0 turns back to ordinary under a tiny forced budget: the Common-phase loop patches
+            // item0's class, synchronously detaches it from the (now-empty) back container and marks the
+            // container for a teardown check, then the tiny budget parks immediately after — all within this
+            // ONE top-level Reconcile() call, whose own finally-drain then REMOVES the now-empty back
+            // container, physically shifting every trailing item back by -1.
+            FiberLane.TimeSlicedBudgetOverrideForTest = 0.0001;
+            s_zParkZManaged = false;
+            s_zParkFiber.ScheduleRerenderForTest(FiberUpdatePriority.Transition);
+            FiberWorkLoop.FlushState(s_zParkFiber);
+            Assume.That(s_zParkFiber.HasPendingReconcileWorkForTest(), Is.True,
+                "Precondition: the tiny budget parked the pass right after item0's own iteration");
+            FiberLane.TimeSlicedBudgetOverrideForTest = -1;
+            s_zParkFiber.DrainTimeSlicedReconcileForTest();
+
+            // Assert — mirrors the creation-direction test above, in the opposite (-1) direction: every trailing
+            // item resumed at its correct (post-shift) physical index instead of one slot past it.
+            Assert.That(TrailingItemOrder(root), Is.EqualTo(ExpectedTrailingItemOrder));
+        }
+
+        #endregion
+
+        #region Cross-fiber MountSlotStart contamination from container churn
+
+        // A parent Div hosting two independent inline-mounted sibling fibers (mirrors TimeSlicedFiberTests'
+        // own SiblingHostRender two-fiber shape). A's own re-render can turn its own first item z-managed,
+        // creating (or, symmetrically, emptying) the shared parent's back container from INSIDE A's own
+        // Reconcile() call; B's own INDEPENDENT later re-render must still patch its own items at their
+        // correct physical slots. No time-slicing anywhere in this region — the leak this pins is a plain
+        // childCount measurement around a synchronous Reconcile call, not a parked-state concern.
+        [Component]
+        private static VNode CrossFiberSiblingHost() => V.Div(
+            name: "cross-fiber-host", className: "relative", children: new VNode[]
+            {
+                V.Component(CrossFiberARender, key: "a"),
+                V.Component(CrossFiberBRender, key: "b"),
+            });
+
+        [Component]
+        private static VNode CrossFiberARender()
+        {
+            s_crossFiberAFiber = FiberAmbientStack.Current;
+            return V.Fragment(children: new VNode[]
+            {
+                V.Div(name: "a0", className: s_crossFiberAZManaged ? "absolute -z-10" : null),
+                V.Div(name: "a1"),
+            });
+        }
+
+        [Component]
+        private static VNode CrossFiberBRender()
+        {
+            s_crossFiberBFiber = FiberAmbientStack.Current;
+            return V.Fragment(children: new VNode[]
+            {
+                V.Div(name: s_crossFiberBName),
+                V.Div(name: "b1"),
+            });
+        }
+
+        // Every "b*"-named child under host, in physical order, joined into one comparable string — mirrors
+        // TrailingItemOrder's own name-filtered join. A's own item names are excluded so a stale, untouched
+        // "a0"/"a1" a mis-slotted patch left behind cannot masquerade as one of B's own entries.
+        private static string CrossFiberBOrder(VisualElement host)
+        {
+            var names = new List<string>();
+            foreach (var child in host.Children())
+            {
+                if (child.name is { Length: > 0 } n && n != "a0" && n != "a1")
+                {
+                    names.Add(n);
+                }
+            }
+            return string.Join(",", names);
+        }
+
+        [Test]
+        public void Given_AnInlineSiblingFiberTurnsItsOwnFirstItemZManaged_When_AnIndependentSiblingFiberLaterReRendersItsOwnItems_Then_TheLaterSiblingsItemsPatchAtTheirCorrectPhysicalSlots()
+        {
+            // Arrange — mount fully ordinary: no z anywhere yet, so A's transition below creates the
+            // shared host's very first back container.
+            s_crossFiberAZManaged = false;
+            s_crossFiberBName = "b0";
+            var root = new VisualElement();
+            using var mounted = V.Mount(root, V.Component(CrossFiberSiblingHost, key: "root"));
+            var host = root.Q<VisualElement>("cross-fiber-host");
+            Assume.That(FindLayerContainer(host, front: false), Is.Null,
+                "Precondition: no back container exists before A's own transition");
+
+            // Act — A turns its own first item z-managed: A's own Reconcile() call's top-level finally
+            // creates the back container synchronously within that SAME call, before A's own before/after
+            // childCount measurement (ReconcileIntoSlotRange) completes.
+            s_crossFiberAZManaged = true;
+            s_crossFiberAFiber.ScheduleRerenderForTest(FiberUpdatePriority.Normal);
+            FiberWorkLoop.FlushState(s_crossFiberAFiber);
+            Assume.That(FindLayerContainer(host, front: false), Is.Not.Null,
+                "Precondition: A's own transition actually created the shared host's first back container");
+
+            // Act — B re-renders independently, renaming its own first item.
+            s_crossFiberBName = "b0-renamed";
+            s_crossFiberBFiber.ScheduleRerenderForTest(FiberUpdatePriority.Normal);
+            FiberWorkLoop.FlushState(s_crossFiberBFiber);
+
+            // Assert — RED without the fix: A's own transition leaks the container's +1 into B's
+            // MountSlotStart, so B's diff runs one physical slot high — it patches the element that is
+            // actually its own "b1" with "b0"'s new name and creates a duplicate "b1" past the end,
+            // leaving a stale, untouched "b0" behind instead of the single renamed item in order.
+            Assert.That(CrossFiberBOrder(host), Is.EqualTo("b0-renamed,b1"));
+        }
+
+        [Test]
+        public void Given_AnInlineSiblingFiberRemovesItsOwnZClass_When_AnIndependentSiblingFiberLaterReRendersItsOwnItems_Then_TheLaterSiblingsItemsStillPatchAtTheirCorrectPhysicalSlots()
+        {
+            // Arrange — mount with A's first item ALREADY z-managed, so the back container exists cleanly
+            // from the synchronous mount, before either fiber's own contamination-prone re-render runs.
+            s_crossFiberAZManaged = true;
+            s_crossFiberBName = "b0";
+            var root = new VisualElement();
+            using var mounted = V.Mount(root, V.Component(CrossFiberSiblingHost, key: "root"));
+            var host = root.Q<VisualElement>("cross-fiber-host");
+            Assume.That(FindLayerContainer(host, front: false), Is.Not.Null,
+                "Precondition: the back container exists before A's own teardown");
+
+            // Act — A removes its own item's z class: A's own Reconcile() call's top-level finally REMOVES
+            // the now-empty back container synchronously within that SAME call — the teardown-direction
+            // counterpart of the creation above.
+            s_crossFiberAZManaged = false;
+            s_crossFiberAFiber.ScheduleRerenderForTest(FiberUpdatePriority.Normal);
+            FiberWorkLoop.FlushState(s_crossFiberAFiber);
+            Assume.That(FindLayerContainer(host, front: false), Is.Null,
+                "Precondition: A's own teardown actually removed the now-empty back container");
+
+            // Act — B re-renders independently, renaming its own first item.
+            s_crossFiberBName = "b0-renamed";
+            s_crossFiberBFiber.ScheduleRerenderForTest(FiberUpdatePriority.Normal);
+            FiberWorkLoop.FlushState(s_crossFiberBFiber);
+
+            // Assert — the teardown (-1) direction stays consistent with the creation (+1) direction
+            // above: nothing breaks after the un-contamination.
+            Assert.That(CrossFiberBOrder(host), Is.EqualTo("b0-renamed,b1"));
+        }
+
+        #endregion
+
+        #region Cross-fiber parked-baseline rebase
+
+        // A large flat list of fresh VNodes each render (no ILPP memo, no shared instances — mirrors
+        // ZParkHost / TimeSlicedFiberTests' own FlatLeafFragment), so a tiny forced budget deterministically
+        // parks after only the first node or two rather than racing host speed.
+        [Component]
+        private static VNode CrossParkSiblingHost() => V.Div(
+            name: "cross-park-host", className: "relative", children: new VNode[]
+            {
+                V.Component(CrossParkARender, key: "a"),
+                V.Component(CrossParkBRender, key: "b"),
+            });
+
+        [Component]
+        private static VNode CrossParkARender()
+        {
+            s_crossParkAFiber = FiberAmbientStack.Current;
+            var children = new VNode[s_crossParkACount];
+            for (var i = 0; i < s_crossParkACount; i++)
+            {
+                children[i] = V.Div(name: "cpa" + i);
+            }
+            return V.Fragment(children: children);
+        }
+
+        [Component]
+        private static VNode CrossParkBRender()
+        {
+            s_crossParkBFiber = FiberAmbientStack.Current;
+            return V.Fragment(children: new VNode[]
+            {
+                V.Div(name: "cpb0", className: s_crossParkBZManaged ? "absolute -z-10" : null),
+                V.Div(name: "cpb1"),
+            });
+        }
+
+        // Every "cpa*"-named child under host, in physical order, joined into one comparable string.
+        private static string CrossParkAOrder(VisualElement host)
+        {
+            var names = new List<string>();
+            foreach (var child in host.Children())
+            {
+                if (child.name is { Length: > 0 } n && n.StartsWith("cpa", System.StringComparison.Ordinal))
+                {
+                    names.Add(n);
+                }
+            }
+            return string.Join(",", names);
+        }
+
+        [Test]
+        public void Given_AFiberParkedAndRegisteredAcrossPasses_When_AnIndependentSiblingCreatesTheSharedParentsFirstBackContainer_Then_TheParkedFiberResumesAtRebasedPhysicalIndices()
+        {
+            // Arrange — A mounts with a large flat list; B mounts ordinary (no z yet), so no back
+            // container exists when A's own park (below) begins.
+            s_crossParkACount = 30;
+            s_crossParkBZManaged = false;
+            var root = new VisualElement();
+            using var mounted = V.Mount(root, V.Component(CrossParkSiblingHost, key: "root"));
+            var host = root.Q<VisualElement>("cross-park-host");
+            Assume.That(FindLayerContainer(host, front: false), Is.Null,
+                "Precondition: no back container exists before B's own z-transition");
+            var ctx = mounted.Root.Reconciler.Context;
+
+            // Act — A re-renders under a tiny Transition budget and parks mid-commit; the pass is left
+            // parked (registered in ParkedBaselineFibers) here, deliberately NOT drained yet, while B's
+            // own render below runs.
+            FiberLane.TimeSlicedBudgetOverrideForTest = 0.0001;
+            s_crossParkACount = 60;
+            s_crossParkAFiber.ScheduleRerenderForTest(FiberUpdatePriority.Transition);
+            FiberWorkLoop.FlushState(s_crossParkAFiber);
+            Assume.That(s_crossParkAFiber.HasPendingReconcileWorkForTest(), Is.True,
+                "Precondition: A's own tiny-budget pass parked mid-commit");
+            Assume.That(ctx.ParkedBaselineFibers.Contains(s_crossParkAFiber), Is.True,
+                "Precondition: A is registered as a cross-fiber parked baseline while still parked");
+
+            // Act — B re-renders synchronously (Normal lane), turning its own first item z-managed: the
+            // shared host's FIRST negative-z child ever, so B's own top-level drain creates the back
+            // container while A is STILL parked. RebaseParkedSlotsForContainerChange's ParkedBaselineFibers
+            // loop — not A's own self-park rebase, which only ever fires from A's OWN drain — must be what
+            // rebases A here.
+            FiberLane.TimeSlicedBudgetOverrideForTest = -1;
+            s_crossParkBZManaged = true;
+            s_crossParkBFiber.ScheduleRerenderForTest(FiberUpdatePriority.Normal);
+            FiberWorkLoop.FlushState(s_crossParkBFiber);
+            Assume.That(FindLayerContainer(host, front: false), Is.Not.Null,
+                "Precondition: B's own render actually created the shared host's first back container");
+
+            // Act — drive A's still-parked pass to completion.
+            s_crossParkAFiber.DrainTimeSlicedReconcileForTest();
+
+            // Assert — every one of A's 60 items landed at its correct (post-shift) physical slot in
+            // order. RED without the ParkedBaselineFibers rebase branch: A's resume writes one slot short
+            // of where the container's insertion actually left each row, scrambling the tail it still had
+            // to create. A's own MountSlotStart is never touched by B's commit (A is declared BEFORE B, so
+            // PropagateInlineSlotShift's forward-only sibling walk never reaches it) — this pins the
+            // parked PendingIndexedState rebase specifically, independent of ComponentFiber.MountSlotStart
+            // propagation.
+            var expected = new List<string>();
+            for (var i = 0; i < 60; i++) { expected.Add("cpa" + i); }
+            Assert.That(CrossParkAOrder(host), Is.EqualTo(string.Join(",", expected)));
+        }
+
+        [Test]
+        public void Given_AFiberParkedAndRegisteredAcrossPasses_When_AnIndependentSiblingRemovesTheSharedParentsOnlyBackContainer_Then_TheParkedFiberResumesAtRebasedPhysicalIndices()
+        {
+            // Arrange — the teardown-direction mirror of the creation test above: B mounts ALREADY
+            // z-managed, so the shared host's back container exists cleanly from the synchronous initial
+            // mount, before A's own park (below) begins.
+            s_crossParkACount = 3;
+            s_crossParkBZManaged = true;
+            var root = new VisualElement();
+            using var mounted = V.Mount(root, V.Component(CrossParkSiblingHost, key: "root"));
+            var host = root.Q<VisualElement>("cross-park-host");
+            Assume.That(FindLayerContainer(host, front: false), Is.Not.Null,
+                "Precondition: the back container exists before B's own teardown");
+            var ctx = mounted.Root.Reconciler.Context;
+
+            // Act — A re-renders under a tiny Transition budget and parks mid-commit; the pass is left
+            // parked (registered in ParkedBaselineFibers) here, deliberately NOT drained yet, while B's
+            // own render below runs.
+            FiberLane.TimeSlicedBudgetOverrideForTest = 0.0001;
+            s_crossParkACount = 60;
+            s_crossParkAFiber.ScheduleRerenderForTest(FiberUpdatePriority.Transition);
+            FiberWorkLoop.FlushState(s_crossParkAFiber);
+            Assume.That(s_crossParkAFiber.HasPendingReconcileWorkForTest(), Is.True,
+                "Precondition: A's own tiny-budget pass parked mid-commit");
+            Assume.That(ctx.ParkedBaselineFibers.Contains(s_crossParkAFiber), Is.True,
+                "Precondition: A is registered as a cross-fiber parked baseline while still parked");
+
+            // Act — B re-renders synchronously (Normal lane), flipping its own first item back to
+            // ordinary: the shared host's ONLY back-container member leaves, so B's own top-level drain
+            // REMOVES the now-empty container while A is STILL parked — the teardown-direction
+            // counterpart of the creation test above.
+            FiberLane.TimeSlicedBudgetOverrideForTest = -1;
+            s_crossParkBZManaged = false;
+            s_crossParkBFiber.ScheduleRerenderForTest(FiberUpdatePriority.Normal);
+            FiberWorkLoop.FlushState(s_crossParkBFiber);
+            Assume.That(FindLayerContainer(host, front: false), Is.Null,
+                "Precondition: B's own render actually removed the shared host's now-empty back container");
+
+            // Act — drive A's still-parked pass to completion.
+            s_crossParkAFiber.DrainTimeSlicedReconcileForTest();
+
+            // Assert — every one of A's 60 items landed at its correct (post-shift-back) physical slot in
+            // order — the -1 teardown direction stays consistent with the +1 creation direction above.
+            var expected = new List<string>();
+            for (var i = 0; i < 60; i++) { expected.Add("cpa" + i); }
+            Assert.That(CrossParkAOrder(host), Is.EqualTo(string.Join(",", expected)));
+        }
+
+        // Keyed mirror of CrossParkARender/CrossParkSiblingHost: every one of A's own children carries an
+        // explicit key, so its park goes through PendingKeyedState (ContinueKeyed) instead of
+        // PendingIndexedState (ContinueIndexed) — RebasePendingSlotStartIfTargeting's OTHER branch, never
+        // exercised by the positional cross-fiber tests above.
+        [Component]
+        private static VNode CrossParkKeyedSiblingHost() => V.Div(
+            name: "cross-park-keyed-host", className: "relative", children: new VNode[]
+            {
+                V.Component(CrossParkKeyedARender, key: "a"),
+                V.Component(CrossParkKeyedBRender, key: "b"),
+            });
+
+        [Component]
+        private static VNode CrossParkKeyedARender()
+        {
+            s_crossParkKeyedAFiber = FiberAmbientStack.Current;
+            var children = new VNode[s_crossParkKeyedACount];
+            for (var i = 0; i < s_crossParkKeyedACount; i++)
+            {
+                children[i] = V.Div(name: "cpka" + i, key: "cpka" + i);
+            }
+            return V.Fragment(children: children);
+        }
+
+        [Component]
+        private static VNode CrossParkKeyedBRender()
+        {
+            s_crossParkKeyedBFiber = FiberAmbientStack.Current;
+            return V.Fragment(children: new VNode[]
+            {
+                V.Div(name: "cpkb0", className: s_crossParkKeyedBZManaged ? "absolute -z-10" : null),
+                V.Div(name: "cpkb1"),
+            });
+        }
+
+        // Every "cpka*"-named child under host, in physical order, joined into one comparable string.
+        private static string CrossParkKeyedAOrder(VisualElement host)
+        {
+            var names = new List<string>();
+            foreach (var child in host.Children())
+            {
+                if (child.name is { Length: > 0 } n && n.StartsWith("cpka", System.StringComparison.Ordinal))
+                {
+                    names.Add(n);
+                }
+            }
+            return string.Join(",", names);
+        }
+
+        [Test]
+        public void Given_AKeyedFiberParkedAndRegisteredAcrossPasses_When_AnIndependentSiblingCreatesTheSharedParentsFirstBackContainer_Then_TheParkedFiberResumesAtRebasedPhysicalIndices()
+        {
+            // Arrange — A mounts with a large KEYED flat list, so its own park exercises
+            // RebasePendingSlotStart's PendingKeyedState branch (via ContinueKeyed) instead of the
+            // positional test's PendingIndexedState/ContinueIndexed; B mounts ordinary (no z yet).
+            s_crossParkKeyedACount = 30;
+            s_crossParkKeyedBZManaged = false;
+            var root = new VisualElement();
+            using var mounted = V.Mount(root, V.Component(CrossParkKeyedSiblingHost, key: "root"));
+            var host = root.Q<VisualElement>("cross-park-keyed-host");
+            Assume.That(FindLayerContainer(host, front: false), Is.Null,
+                "Precondition: no back container exists before B's own z-transition");
+            var ctx = mounted.Root.Reconciler.Context;
+
+            // Act — A re-renders under a tiny Transition budget and parks mid-commit; the pass is left
+            // parked (registered in ParkedBaselineFibers) here, deliberately NOT drained yet, while B's
+            // own render below runs.
+            FiberLane.TimeSlicedBudgetOverrideForTest = 0.0001;
+            s_crossParkKeyedACount = 60;
+            s_crossParkKeyedAFiber.ScheduleRerenderForTest(FiberUpdatePriority.Transition);
+            FiberWorkLoop.FlushState(s_crossParkKeyedAFiber);
+            Assume.That(s_crossParkKeyedAFiber.HasPendingReconcileWorkForTest(), Is.True,
+                "Precondition: A's own tiny-budget pass parked mid-commit");
+            Assume.That(ctx.ParkedBaselineFibers.Contains(s_crossParkKeyedAFiber), Is.True,
+                "Precondition: A is registered as a cross-fiber parked baseline while still parked");
+
+            // Act — B re-renders synchronously (Normal lane), turning its own first item z-managed: the
+            // shared host's FIRST negative-z child ever, so B's own top-level drain creates the back
+            // container while A is STILL parked.
+            FiberLane.TimeSlicedBudgetOverrideForTest = -1;
+            s_crossParkKeyedBZManaged = true;
+            s_crossParkKeyedBFiber.ScheduleRerenderForTest(FiberUpdatePriority.Normal);
+            FiberWorkLoop.FlushState(s_crossParkKeyedBFiber);
+            Assume.That(FindLayerContainer(host, front: false), Is.Not.Null,
+                "Precondition: B's own render actually created the shared host's first back container");
+
+            // Act — drive A's still-parked pass to completion.
+            s_crossParkKeyedAFiber.DrainTimeSlicedReconcileForTest();
+
+            // Assert — every one of A's 60 items landed at its correct (post-shift) physical slot in
+            // order. RED without the PendingKeyedState branch of the ParkedBaselineFibers rebase: A's
+            // resume writes one slot short of where the container's insertion actually left each row.
+            var expected = new List<string>();
+            for (var i = 0; i < 60; i++) { expected.Add("cpka" + i); }
+            Assert.That(CrossParkKeyedAOrder(host), Is.EqualTo(string.Join(",", expected)));
+        }
+
+        [Test]
+        public void Given_AKeyedFiberParkedAndRegisteredAcrossPasses_When_AnIndependentSiblingRemovesTheSharedParentsOnlyBackContainer_Then_TheParkedFiberResumesAtRebasedPhysicalIndices()
+        {
+            // Arrange — the teardown-direction mirror of the keyed creation test above, completing the
+            // {positional, keyed} x {creation, teardown} matrix: B mounts ALREADY z-managed so the back
+            // container exists before A's keyed park begins.
+            s_crossParkKeyedACount = 30;
+            s_crossParkKeyedBZManaged = true;
+            var root = new VisualElement();
+            using var mounted = V.Mount(root, V.Component(CrossParkKeyedSiblingHost, key: "root"));
+            var host = root.Q<VisualElement>("cross-park-keyed-host");
+            Assume.That(FindLayerContainer(host, front: false), Is.Not.Null,
+                "Precondition: the back container exists before B's own teardown");
+            var ctx = mounted.Root.Reconciler.Context;
+
+            // Act — A re-renders under a tiny Transition budget and parks mid-commit; left parked while
+            // B's own render below runs.
+            FiberLane.TimeSlicedBudgetOverrideForTest = 0.0001;
+            s_crossParkKeyedACount = 60;
+            s_crossParkKeyedAFiber.ScheduleRerenderForTest(FiberUpdatePriority.Transition);
+            FiberWorkLoop.FlushState(s_crossParkKeyedAFiber);
+            Assume.That(s_crossParkKeyedAFiber.HasPendingReconcileWorkForTest(), Is.True,
+                "Precondition: A's own tiny-budget pass parked mid-commit");
+            Assume.That(ctx.ParkedBaselineFibers.Contains(s_crossParkKeyedAFiber), Is.True,
+                "Precondition: A is registered as a cross-fiber parked baseline while still parked");
+
+            // Act — B re-renders synchronously (Normal lane), flipping its own first item back to
+            // ordinary: the shared host's ONLY back-container member leaves, so B's own top-level drain
+            // REMOVES the now-empty container while A is STILL parked.
+            FiberLane.TimeSlicedBudgetOverrideForTest = -1;
+            s_crossParkKeyedBZManaged = false;
+            s_crossParkKeyedBFiber.ScheduleRerenderForTest(FiberUpdatePriority.Normal);
+            FiberWorkLoop.FlushState(s_crossParkKeyedBFiber);
+            Assume.That(FindLayerContainer(host, front: false), Is.Null,
+                "Precondition: B's own render actually removed the shared host's now-empty back container");
+
+            // Act — drive A's still-parked pass to completion.
+            s_crossParkKeyedAFiber.DrainTimeSlicedReconcileForTest();
+
+            // Assert — the -1 teardown direction stays consistent with the +1 creation direction for the
+            // keyed branch too: every one of A's 60 items landed at its correct (post-shift-back) slot.
+            var expected = new List<string>();
+            for (var i = 0; i < 60; i++) { expected.Add("cpka" + i); }
+            Assert.That(CrossParkKeyedAOrder(host), Is.EqualTo(string.Join(",", expected)));
+        }
+
+        #endregion
+
+        #region Draining a resumed slice's own deferred z-layer mount
+
+        [Component]
+        private static VNode DrainZLayerHost()
+        {
+            s_drainFiber = FiberAmbientStack.Current;
+            var zManaged = s_drainZManaged;
+            var children = new VNode[10];
+            children[0] = V.Div(name: "item0");
+            children[1] = V.Div(name: "item1", className: zManaged ? "absolute -z-10" : null);
+            for (var i = 2; i < 10; i++)
+            {
+                children[i] = V.Div(name: "item" + i);
+            }
+            return V.Fragment(children: children);
+        }
+
+        [Test]
+        public void Given_ATransitionPassParksBeforeReachingANewZManagedItem_When_TheZTransitionRunsEntirelyInTheResumedSlice_Then_ItsRealContentIsAttachedInTheBackContainerAfterThePassCompletes()
+        {
+            // Arrange — mount fully ordinary.
+            s_drainZManaged = false;
+            var root = new VisualElement();
+            using var mounted = V.Mount(root, V.Component(DrainZLayerHost, key: "root"));
+            var item1 = root.Q<VisualElement>("item1");
+            Assume.That(FindLayerContainer(root, front: false), Is.Null,
+                "Precondition: no back container exists before the timed re-render");
+
+            // Act — item1 turns z-managed under a tiny forced budget: the first slice parks right after
+            // item0's own iteration, BEFORE the diff even reaches item1 — so item1's own transition (and
+            // its deferred z-mount enqueue, since no back container exists yet) runs entirely inside a
+            // RESUMED slice, never inside the one Reconciler.Reconcile call whose own top-level finally
+            // already drains.
+            FiberLane.TimeSlicedBudgetOverrideForTest = 0.0001;
+            s_drainZManaged = true;
+            s_drainFiber.ScheduleRerenderForTest(FiberUpdatePriority.Transition);
+            FiberWorkLoop.FlushState(s_drainFiber);
+            Assume.That(s_drainFiber.HasPendingReconcileWorkForTest(), Is.True,
+                "Precondition: the tiny budget parked the pass right after item0's own iteration");
+            FiberLane.TimeSlicedBudgetOverrideForTest = -1;
+            s_drainFiber.DrainTimeSlicedReconcileForTest();
+
+            // Assert — RED without draining at a resumed slice's own completion: nothing ever creates the
+            // back container (creation itself lives behind the drain) and item1's real content stays
+            // orphaned (parent null), so BOTH sides must be pinned non-null — a bare reference comparison
+            // would let null == null pass for exactly the broken state.
+            Assert.That(item1.parent, Is.Not.Null.And.SameAs(FindLayerContainer(root, front: false)));
+        }
+
+        #endregion
+
+        #region Self-park double-rebase on a container-creating resume tick
+
+        [Test]
+        public void Given_AParkedFibersOwnResumeTickCreatesItsContainerAndReParks_When_ItFinishes_Then_TrailingItemsLandAtCorrectIndices()
+        {
+            // Arrange — mount fully ordinary (reuses DrainZLayerHost: item1 is the one the toggle below
+            // turns z-managed).
+            s_drainZManaged = false;
+            var root = new VisualElement();
+            using var mounted = V.Mount(root, V.Component(DrainZLayerHost, key: "root"));
+            var ctx = mounted.Root.Reconciler.Context;
+            Assume.That(FindLayerContainer(root, front: false), Is.Null,
+                "Precondition: no back container exists before the timed re-render");
+
+            // Act — tick 1 (via FlushState): item0 parks first, which is what registers the fiber in
+            // ParkedBaselineFibers BEFORE its own later container-creating tick runs.
+            FiberLane.TimeSlicedBudgetOverrideForTest = 0.0001;
+            s_drainZManaged = true;
+            s_drainFiber.ScheduleRerenderForTest(FiberUpdatePriority.Transition);
+            FiberWorkLoop.FlushState(s_drainFiber);
+            Assume.That(s_drainFiber.HasPendingReconcileWorkForTest(), Is.True,
+                "Precondition: the tiny budget parked the pass right after item0's own iteration");
+            Assume.That(ctx.ParkedBaselineFibers.Contains(s_drainFiber), Is.True,
+                "Precondition: the fiber is registered as a parked baseline before its own container-creating tick");
+
+            // Act — tick 2 (a single manual resume; the budget stays deliberately tiny THROUGH this tick —
+            // reset only below, after it, unlike the drain test above's own immediate reset): processes
+            // item1, creating the shared parent's first back container INSIDE this same tick's own drain,
+            // then re-parks immediately after (item2..item9 remain) — so the fiber is STILL registered in
+            // ParkedBaselineFibers at the exact moment RebaseParkedSlotsForContainerChange runs, alongside
+            // its own current.RebasePendingSlotStartIfTargeting call on the very same PendingIndexedState.
+            FiberWorkLoop.ContinueReconcile(s_drainFiber);
+            Assume.That(FindLayerContainer(root, front: false), Is.Not.Null,
+                "Precondition: this single resume tick actually created the shared parent's first back container");
+            Assume.That(s_drainFiber.HasPendingReconcileWorkForTest(), Is.True,
+                "Precondition: the same tick re-parked (item2..item9 still pending) while still registered");
+
+            // Act — drain the remainder; the remaining ticks' own budget has no bearing on the double-rebase
+            // this test targets, which is already fully determined by tick 2 above.
+            FiberLane.TimeSlicedBudgetOverrideForTest = -1;
+            s_drainFiber.DrainTimeSlicedReconcileForTest();
+
+            // Assert — RED without the fix: the container-creating tick's own +1 delta is applied twice to
+            // the very same PendingIndexedState (current's own self-rebase, then the SAME fiber matched
+            // again in the ParkedBaselineFibers loop, since nothing yet removed it from that registry), so
+            // every trailing item resumes two physical slots ahead of where the container's single
+            // insertion actually left it.
+            Assert.That(TrailingItemOrder(root), Is.EqualTo("item2,item3,item4,item5,item6,item7,item8,item9"));
+        }
+
+        #endregion
+
+        #region Structural variants across a stacking parent
+
+        // negz is declared LAST (not first) so "ordinary"/"second" are genuinely the 1st/2nd LOGICAL siblings
+        // — GetOrCreateContainer always inserts a back container at the stacking parent's own PHYSICAL index 0
+        // regardless of where among the siblings the negative-z element itself was declared, so this still
+        // makes the back container physically precede both of them. appendThird changes ONLY the child COUNT
+        // (a brand-new, structural-class-free sibling), never ordinary/second's own className — so their own
+        // ApplyStructuralVariantConfig never re-fires; only "parent"'s own post-children container sweep
+        // (ApplyStructuralVariants) re-derives their positions when this toggles.
+        [Component]
+        private static VNode StructuralSweepHost()
+        {
+            var appendThird = Hooks.UseStore(s_structuralSweepStore, x => x);
+            var children = new List<VNode>
+            {
+                V.Div(name: "ordinary", className: "first:bg-mark"),
+                V.Div(name: "second", className: "[&:nth-child(2)]:bg-mark"),
+                V.Div(name: "negz", className: "absolute -z-10"),
+            };
+            if (appendThird)
+            {
+                children.Add(V.Div(name: "third"));
+            }
+            return V.Div(name: "parent", className: "relative", children: children.ToArray());
+        }
+
+        [Test]
+        public void Given_OrdinarySiblingsCarryingFirstAndNthChildVariants_When_ANewSiblingIsAppendedAfterABackContainerAlreadyExists_Then_TheContainerSweepStillExcludesTheContainerFromTheirPositions()
+        {
+            // Arrange — mount with the back container already created. A FRESH mount's own post-children sweep
+            // runs BEFORE the finally-drain that creates the container (FiberZLayerCoordinator.
+            // GetOrCreateContainer), so this first sweep computes ordinary/second's positions with no container
+            // to subtract yet — correct at that instant, but not a pin of the subtraction itself; only a LATER
+            // sweep, re-triggered with the container already physically present, exercises that.
+            using var store = new ToggleStore<bool>(false);
+            s_structuralSweepStore = store;
+            var root = new VisualElement();
+            using var mounted = V.Mount(root, V.Component(StructuralSweepHost, key: "root"));
+            Assume.That(
+                (FindLayerContainer(root.Q<VisualElement>("parent"), front: false) != null,
+                    root.Q<VisualElement>("ordinary").ClassListContains("bg-mark")),
+                Is.EqualTo((true, true)),
+                "Precondition: the back container exists and ordinary already carries its mount-time payload");
+
+            // Act — append an unrelated new sibling: "parent" itself re-patches (a genuine child-count change),
+            // so its own post-children pass re-derives every position via the container sweep
+            // (FiberNodePatcher.ApplyStructuralVariants) — this time with the back container already present.
+            store.Set(true);
+            mounted.FlushStateForTest();
+
+            // Assert — RED without subtracting LeadingOffset: the re-derived sweep would read "ordinary" as
+            // sibling index 1 (the back container counted as index 0) and "second" as index 2, matching neither
+            // first: nor nth-child(2) (which expects 0-based index 1) — un-applying the payload each correctly
+            // held after the mount.
+            Assert.That(
+                (root.Q<VisualElement>("ordinary").ClassListContains("bg-mark"),
+                    root.Q<VisualElement>("second").ClassListContains("bg-mark")),
+                Is.EqualTo((true, true)));
+        }
+
+        // "ordinary" is its OWN inline-mounted child component (declared before negz, so it is genuinely
+        // logical sibling 0), so its LATER re-render (triggered by its own store subscription) reconciles
+        // directly against "parent" (its shared MountPoint, via ChildReconciler.Reconcile's slot-range
+        // addressing) without StructuralPatchParentHost itself ever re-rendering. That is deliberate: "parent"
+        // itself getting patched would ALSO re-run its own post-children container sweep (ApplyStructuralVariants
+        // — the same hunk StructuralSweepHost above exercises), which would re-derive (and so silently mask a
+        // broken) LeadingOffset subtraction in ApplyStructuralVariantConfig moments later in the very same
+        // patch. Only isolating "ordinary"'s own re-render like this exercises ApplyStructuralVariantConfig's
+        // immediate-evaluation branch on its own.
+        [Component]
+        private static VNode StructuralPatchParentHost() => V.Div(name: "parent", className: "relative", children: new VNode[]
+        {
+            V.Component(StructuralPatchOrdinaryRender, key: "ordinary"),
+            V.Div(name: "negz", className: "absolute -z-10"),
+        });
+
+        [Component]
+        private static VNode StructuralPatchOrdinaryRender()
+        {
+            var apply = Hooks.UseStore(s_structuralPatchStore, x => x);
+            return V.Div(name: "ordinary", className: apply ? "first:bg-mark" : null);
+        }
+
+        [Test]
+        public void Given_AnOrdinarySiblingPatchedWithAFirstVariant_When_ABackContainerAlreadyExists_Then_ItsImmediateEvaluationExcludesTheContainer()
+        {
+            // Arrange — mount with the back container already created; "ordinary" has no structural class yet.
+            using var store = new ToggleStore<bool>(false);
+            s_structuralPatchStore = store;
+            var root = new VisualElement();
+            using var mounted = V.Mount(root, V.Component(StructuralPatchParentHost, key: "root"));
+            Assume.That(FindLayerContainer(root.Q<VisualElement>("parent"), front: false), Is.Not.Null,
+                "Precondition: the back container already exists before the patch");
+
+            // Act — "ordinary"'s own fiber re-renders (StructuralPatchParentHost's own fiber is never marked
+            // dirty and stays untouched), patching its className to add first: while it is already parented —
+            // routing through ApplyStructuralVariantConfig's immediate-evaluation branch alone.
+            store.Set(true);
+            mounted.FlushStateForTest();
+
+            // Assert — RED without subtracting LeadingOffset in ApplyStructuralVariantConfig specifically: the
+            // immediate evaluation would read "ordinary"'s raw physical index (1, the back container counted as
+            // index 0) against the raw count, never matching first: (which expects index 0).
+            Assert.That(root.Q<VisualElement>("ordinary").ClassListContains("bg-mark"), Is.True);
+        }
+
+        [Test]
+        public void Given_AZManagedElementCarryingLastVariant_When_ItIsLogicallyTheLastDeclaredChild_Then_ItsRealElementGetsThePayload()
+        {
+            // Arrange/Act — "zlast"'s placeholder sits at parent's own last ordinary slot (its real content
+            // lives in the trailing front layer container instead); last: must resolve against the
+            // PLACEHOLDER's logical position (FiberNodePatcher.ApplyStructuralVariants' ZLayerPlaceholders
+            // resolution), not the real element's physical position inside the layer container.
+            var root = new VisualElement();
+            using var mounted = V.Mount(root, V.Div(name: "parent", className: "relative", children: new VNode[]
+            {
+                V.Div(name: "ordinary"),
+                V.Div(name: "zlast", className: "absolute z-10 last:bg-mark"),
+            }));
+            var ctx = mounted.Root.Reconciler.Context;
+            Assume.That(ctx.ZLayerMembers.ContainsKey(root.Q<VisualElement>("zlast")), Is.True,
+                "Precondition: zlast actually relocated into the front layer container");
+
+            // Assert
+            Assert.That(root.Q<VisualElement>("zlast").ClassListContains("bg-mark"), Is.True);
+        }
+
+        #endregion
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ZIndexStackingTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ZIndexStackingTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 997fefa4372d946a199c48e8401f811f

--- a/Packages/com.velvet.core/Runtime/Styling/SilhouetteBoundsSpacer.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/SilhouetteBoundsSpacer.cs
@@ -123,10 +123,27 @@ namespace Velvet
         // The container's child count excluding the trailing bounds-spacer(s). The spacers are always kept
         // last, so the real children occupy [0, this) — the range the child reconciler and structural
         // variants must treat as the whole child list.
+        // Floored at the LEADING run of z-layer containers (FiberZLayerCoordinator's own back container is the
+        // one reconciler-invisible child ever placed leading, never trailing): IsSpacer also recognizes a layer
+        // container, so an unguarded trailing trim would eat it too whenever it is (even transiently, mid-diff)
+        // the parent's LAST child — e.g. the instant an interspersed ordinary sibling's own placeholder is
+        // removed and the back container is momentarily all that is left. Once eaten from the count, an
+        // ordinary insert clamped against that undercount lands BEFORE the back container instead of after it,
+        // permanently misplacing it (it stops being the parent's leading child, corrupting LeadingOffset for
+        // this parent from then on). Scanning the leading run first — not calling into the reconciler layer —
+        // keeps the Styling -> Reconciler dependency direction this file already has via IsLayerContainer, one
+        // level further. A front (trailing) container reached by this same leading scan only when it happens to
+        // be the parent's OWN sole child protects it identically; every other trailing case (the ordinary,
+        // overwhelming majority) is unaffected since the floor is 0 there.
         internal static int NonSpacerChildCount(VisualElement container)
         {
             var n = container.childCount;
-            while (n > 0 && IsSpacer(container[n - 1]))
+            var floor = 0;
+            while (floor < n && FiberZLayerCoordinator.IsLayerContainer(container[floor]))
+            {
+                floor++;
+            }
+            while (n > floor && IsSpacer(container[n - 1]))
             {
                 n--;
             }

--- a/Packages/com.velvet.core/Runtime/Styling/SilhouetteBoundsSpacer.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/SilhouetteBoundsSpacer.cs
@@ -91,9 +91,15 @@ namespace Velvet
             }
         }
 
-        // True when child is a bounds-spacer (the internal, reconciler-invisible render-bounds child).
+        // True when child is a bounds-spacer (the internal, reconciler-invisible render-bounds child) OR a
+        // z-index layer container (FiberZLayerCoordinator's front/back containers, which are equally
+        // reconciler-invisible — a z-marked absolute child's real element lives inside one instead of at its
+        // logical slot). NonSpacerChildCount below is the single centralized consumer every "real child"
+        // count/index site already goes through, so broadening this one predicate makes the whole reconciler
+        // treat both z-layer containers as invisible without touching any of those call sites.
         internal static bool IsSpacer(VisualElement child)
-            => child != null && child.ClassListContains(MarkerClass);
+            => child != null
+                && (child.ClassListContains(MarkerClass) || FiberZLayerCoordinator.IsLayerContainer(child));
 
         // True when spacer is a child of caster and no RENDERED (non-spacer) child follows it — the placement
         // invariant that keeps it outside the child reconciler's [0, renderedChildCount) index range.

--- a/Packages/com.velvet.core/Runtime/Styling/StyleArbitraryValueResolver.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleArbitraryValueResolver.cs
@@ -26,10 +26,15 @@ namespace Velvet
         // so its '!' is accepted but inert. Returns the input unchanged when no modifier is present.
         //
         // Scope: this is wired into the per-class dispatch (USS-class + inline-layer utilities). The
-        // array-scanned subsystem utilities (shadow-*, font-*, gap-*, divide-*, clip-path-*, leading-*) do
-        // NOT participate in the USS/inline cascade that !important arbitrates — they are custom-drawn or
-        // resolved to inline that already wins — so the important form is not recognized for them; use the
-        // plain form. (Adding the bang there would be a no-op elevation by definition.)
+        // array-scanned subsystem utilities (shadow-*, font-*, gap-*, divide-*, clip-path-*, leading-*, z-*)
+        // do NOT participate in the USS/inline cascade that !important arbitrates — they are custom-drawn,
+        // resolved to inline that already wins, or (z-*) a physical relocation — so the bang never has a
+        // cascade effect anywhere in this family; use the plain form (adding it would be a no-op elevation
+        // by definition). font-*, leading-*, and z-* still route their own classification gate through this
+        // method (StyleFontClass.IsArbitraryFontClass / StyleTextEffectClass.IsArbitraryLeadingClass /
+        // StyleZIndexClass.TryParse), so a bang'd token still classifies as the family instead of silently
+        // falling through; gap-*/divide-*/shadow-*/clip-path-* have no such gate and do not recognize the
+        // bang at all.
         public static string StripImportant(string className, out bool important)
         {
             important = false;

--- a/Packages/com.velvet.core/Runtime/Styling/StyleOutOfFlowChild.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleOutOfFlowChild.cs
@@ -33,5 +33,27 @@ namespace Velvet
             }
             return child.ClassListContains("absolute");
         }
+
+        // The off-panel (class-only) half of IsOutOfFlow's test, exposed standalone for callers that only have
+        // a VNode's declared classNames — not a live element — at reconcile time (the z-* scope gate: z-* takes
+        // effect only on an element that is ALSO position:absolute, decided before the element's class list has
+        // ever been attached to anything). Recognizes only the "absolute" utility class, the same limitation
+        // IsOutOfFlow's own off-panel fallback already has (an inline Styles.Position override is invisible
+        // here either way).
+        internal static bool IsOutOfFlowClass(string[] classNames)
+        {
+            if (classNames == null)
+            {
+                return false;
+            }
+            foreach (var cls in classNames)
+            {
+                if (cls == "absolute")
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Styling/StyleRelationalVariantManipulator.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleRelationalVariantManipulator.cs
@@ -171,18 +171,23 @@ namespace Velvet
             return null;
         }
 
-        internal static VisualElement? FindPrevSiblingWithClass(VisualElement element, string cls)
+        // ctx resolves the LOGICAL search origin for a z-relocated consumer (FiberZLayerCoordinator.
+        // TryGetLogicalPosition): a z-managed element's physical parent is its layer container, whose
+        // "preceding siblings" are unrelated same-layer members, not this element's declared siblings — the
+        // search must walk from its PLACEHOLDER's position instead. An ordinary element resolves to its own
+        // parent/index unchanged. Does NOT cover the reverse direction (the peer/group SOURCE itself being
+        // z-relocated): a relocated source's placeholder carries none of its marker classes and this search
+        // only ever inspects physical siblings, so that case is a documented gap, not fixed here.
+        internal static VisualElement? FindPrevSiblingWithClass(VisualElement element, string cls, ReconcilerContext ctx)
         {
-            var parent = element.parent;
-            if (parent == null)
+            if (!FiberZLayerCoordinator.TryGetLogicalPosition(ctx, element, out var parent, out var index))
             {
                 return null;
             }
 
-            var index = parent.IndexOf(element);
             for (var i = index - 1; i >= 0; i--)
             {
-                var sibling = parent.ElementAt(i);
+                var sibling = parent!.ElementAt(i);
                 if (sibling.ClassListContains(cls))
                 {
                     return sibling;
@@ -238,7 +243,7 @@ namespace Velvet
                 if (_aChecked) { _aChecked = false; Apply(_checked, false, StyleLayerPriority.PeerChecked); }
 
                 var source = _isPeer
-                    ? FindPrevSiblingWithClass(target, SourceClass)
+                    ? FindPrevSiblingWithClass(target, SourceClass, _owner._ctx)
                     : FindAncestorWithClass(target, SourceClass);
                 if (source == null || !HasAnyState())
                 {

--- a/Packages/com.velvet.core/Runtime/Styling/StyleStackedVariantManipulator.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleStackedVariantManipulator.cs
@@ -208,7 +208,7 @@ namespace Velvet
             var sourceClass = StyleRelationalVariantManipulator.SourceClassFor(!isGroup, _innerName);
             var source = isGroup
                 ? StyleRelationalVariantManipulator.FindAncestorWithClass(target, sourceClass)
-                : StyleRelationalVariantManipulator.FindPrevSiblingWithClass(target, sourceClass);
+                : StyleRelationalVariantManipulator.FindPrevSiblingWithClass(target, sourceClass, _ctx);
             if (source == null)
             {
                 return;

--- a/Packages/com.velvet.core/Runtime/Styling/StyleZIndexClass.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleZIndexClass.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Globalization;
 
 namespace Velvet
@@ -12,8 +11,9 @@ namespace Velvet
     internal static class StyleZIndexClass
     {
         // Cheap early-out gate: true when ANY class looks like a z-* utility (after stripping a leading "-").
-        // No parsing and no allocation — used to skip the full TryExtract scan on the vast majority of
-        // elements that carry no z class at all.
+        // Routed through StripImportant first (mirrors StyleFontClass.IsArbitraryFontClass) so this gate agrees
+        // with TryParse on what counts as "a z-* utility" — otherwise "!z-10" would fail this early-out and
+        // TryExtract would never even attempt it, silently leaving an important-modified z-* class unclassified.
         public static bool HasZIndexClass(string[] classNames)
         {
             if (classNames == null)
@@ -26,8 +26,13 @@ namespace Velvet
                 {
                     continue;
                 }
-                var offset = cls[0] == '-' ? 1 : 0;
-                if (cls.Length >= offset + 2 && cls[offset] == 'z' && cls[offset + 1] == '-')
+                var core = StyleArbitraryValueResolver.StripImportant(cls, out _);
+                if (string.IsNullOrEmpty(core))
+                {
+                    continue;
+                }
+                var offset = core[0] == '-' ? 1 : 0;
+                if (core.Length >= offset + 2 && core[offset] == 'z' && core[offset + 1] == '-')
                 {
                     return true;
                 }
@@ -65,6 +70,19 @@ namespace Velvet
         public static bool TryParse(string cls, out int z)
         {
             z = 0;
+            if (string.IsNullOrEmpty(cls))
+            {
+                return false;
+            }
+            // Stripped first (house convention — see StyleFontClass.IsArbitraryFontClass / StyleTextEffectClass's
+            // own leading-* parse / MotionSpringClassParser.TryParseAxisValue): "!z-10", "z-10!", "!z-[5]", and
+            // "z-[5]!" all classify like their bare form. The bang itself stays a no-op here regardless — z-index
+            // is a physical relocation, not a style-cascade layer !important arbitrates (StripImportant's own
+            // Scope comment already documents this for the array-scanned utility families) — this only makes the
+            // parser recognize the four bang'd spellings instead of silently dropping the element from z
+            // management. A dash embedded AFTER a leading "-" (e.g. "-!z-10") is not a shape StripImportant
+            // recognizes (it only strips a bang at the very first or very last character), so that stays rejected.
+            cls = StyleArbitraryValueResolver.StripImportant(cls, out _);
             if (string.IsNullOrEmpty(cls))
             {
                 return false;

--- a/Packages/com.velvet.core/Runtime/Styling/StyleZIndexClass.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleZIndexClass.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Globalization;
+
+namespace Velvet
+{
+    // Parses Velvet's z-* utility classes into a resolved stacking value for FiberZLayerCoordinator. Mirrors
+    // StyleGapClass/StyleGridClass: a cheap prefix-scan gate (HasZIndexClass) before the full TryExtract parse.
+    // Supports the fixed Tailwind scale (z-0/10/20/30/40/50), its negated form (-z-10 … -z-50, Tailwind's
+    // negative-value convention: the sign prefixes the whole class), and the arbitrary bracket form (z-[999],
+    // z-[-5] — the bracket already carries a signed integer, so no outer "-" is recognized for it: z-index has
+    // no separate magnitude/direction split the way a length utility does).
+    internal static class StyleZIndexClass
+    {
+        // Cheap early-out gate: true when ANY class looks like a z-* utility (after stripping a leading "-").
+        // No parsing and no allocation — used to skip the full TryExtract scan on the vast majority of
+        // elements that carry no z class at all.
+        public static bool HasZIndexClass(string[] classNames)
+        {
+            if (classNames == null)
+            {
+                return false;
+            }
+            foreach (var cls in classNames)
+            {
+                if (string.IsNullOrEmpty(cls))
+                {
+                    continue;
+                }
+                var offset = cls[0] == '-' ? 1 : 0;
+                if (cls.Length >= offset + 2 && cls[offset] == 'z' && cls[offset + 1] == '-')
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        // Scans classNames for the last z-* utility (later classes win, matching CSS cascade order) and
+        // returns its resolved value. Returns false when no z utility is present or every z-looking token
+        // failed to parse (e.g. a user class that merely starts with "z-").
+        public static bool TryExtract(string[] classNames, out int z)
+        {
+            z = 0;
+            if (classNames == null)
+            {
+                return false;
+            }
+
+            var found = false;
+            foreach (var cls in classNames)
+            {
+                if (TryParse(cls, out var parsed))
+                {
+                    z = parsed;
+                    found = true;
+                }
+            }
+            return found;
+        }
+
+        // z-0/10/20/30/40/50 (Tailwind's fixed named scale), -z-0/10/20/30/40/50 (the negated form), or
+        // z-[<int>] (arbitrary, the bracket's own sign — z-[-5] is how a negative arbitrary value is spelled,
+        // not -z-[5]). Anything else (including a non-numeric bracket, or a bare "z-" prefix that is not one
+        // of these three shapes) returns false.
+        public static bool TryParse(string cls, out int z)
+        {
+            z = 0;
+            if (string.IsNullOrEmpty(cls))
+            {
+                return false;
+            }
+
+            if (cls.Length > 3 && cls[0] == 'z' && cls[1] == '-' && cls[2] == '['
+                && cls[cls.Length - 1] == ']')
+            {
+                var inner = cls.Substring(3, cls.Length - 4);
+                return inner.Length > 0
+                    && int.TryParse(inner, NumberStyles.Integer, CultureInfo.InvariantCulture, out z);
+            }
+
+            var negate = cls[0] == '-';
+            var offset = negate ? 1 : 0;
+            if (cls.Length <= offset + 2 || cls[offset] != 'z' || cls[offset + 1] != '-')
+            {
+                return false;
+            }
+            if (!TryNamedLevel(cls.Substring(offset + 2), out var level))
+            {
+                return false;
+            }
+            z = negate ? -level : level;
+            return true;
+        }
+
+        // The fixed non-arbitrary levels Tailwind's z-index utility defines. Anything outside this set needs
+        // the z-[N] bracket form (mirrors real Tailwind — z-15 is not a thing, z-[15] is).
+        private static bool TryNamedLevel(string suffix, out int level)
+        {
+            switch (suffix)
+            {
+                case "0": level = 0; return true;
+                case "10": level = 10; return true;
+                case "20": level = 20; return true;
+                case "30": level = 30; return true;
+                case "40": level = 40; return true;
+                case "50": level = 50; return true;
+                default: level = 0; return false;
+            }
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Styling/StyleZIndexClass.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleZIndexClass.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 84155b88096df4fdba985d4389231288

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/SilhouetteBoundsSpacerTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/SilhouetteBoundsSpacerTests.cs
@@ -113,6 +113,55 @@ namespace Velvet.Tests
         }
 
         [Test]
+        public void Given_ALeadingBackZLayerContainerIsMomentarilyTheOnlyOtherChildBesidesATrailingSpacer_When_Counted_Then_TheBackContainerIsNotAlsoTrimmedAwayAsASpacer()
+        {
+            // Arrange — a leading back z-layer container (FiberZLayerCoordinator's own convention: the ONE
+            // reconciler-invisible child ever placed leading, never trailing) immediately followed by a
+            // trailing bounds-spacer, with no ordinary child between them — the exact transient shape the
+            // leading floor guards against (every ordinary sibling's own placeholder momentarily absent).
+            // IsSpacer recognizes BOTH kinds of reconciler-invisible child, so an unguarded trailing trim would
+            // walk straight through the back container too and return 0, undercounting it out of the physical
+            // range entirely (a later ordinary insert clamped against that undercount would land BEFORE the
+            // back container instead of after it, permanently misplacing it).
+            var container = new VisualElement();
+            var back = new VisualElement();
+            back.AddToClassList(FiberZLayerCoordinator.BackMarkerClass);
+            container.Add(back);
+            var spacer = new VisualElement();
+            spacer.AddToClassList(SilhouetteBoundsSpacer.MarkerClass);
+            container.Add(spacer);
+
+            // Act / Assert — only the trailing spacer is excluded; the back container itself still counts.
+            Assert.That(SilhouetteBoundsSpacer.NonSpacerChildCount(container), Is.EqualTo(1));
+        }
+
+        [Test]
+        public void Given_ABackContainerAndAFrontContainerAndATrailingBoundsSpacerAllCoexist_When_Counted_Then_OnlyTheTwoTrailingReconcilerInvisibleChildrenAreExcluded()
+        {
+            // Arrange — the full 3-way combo a stacking parent carrying both z-layer containers AND a
+            // filtered caster's own bounds-spacer can reach simultaneously: a leading back container (never
+            // trimmed — it stays counted by its own contract), one ordinary rendered child, then the two
+            // TRAILING reconciler-invisible children (front container, bounds-spacer), deliberately in THIS
+            // relative order since GetOrCreateContainer's own comment notes the two trailing spacers
+            // tolerate either order between them.
+            var container = new VisualElement();
+            var back = new VisualElement();
+            back.AddToClassList(FiberZLayerCoordinator.BackMarkerClass);
+            container.Add(back);
+            container.Add(new VisualElement());
+            var front = new VisualElement();
+            front.AddToClassList(FiberZLayerCoordinator.FrontMarkerClass);
+            container.Add(front);
+            var spacer = new VisualElement();
+            spacer.AddToClassList(SilhouetteBoundsSpacer.MarkerClass);
+            container.Add(spacer);
+
+            // Act / Assert — the back container and the ordinary child stay counted; both trailing
+            // reconciler-invisible children (front container, bounds-spacer) are excluded: 2 total.
+            Assert.That(SilhouetteBoundsSpacer.NonSpacerChildCount(container), Is.EqualTo(2));
+        }
+
+        [Test]
         public void Given_AllSidesScaleBorder_When_InsetParsed_Then_LeftMatchesTheScale()
         {
             SilhouetteBoundsSpacer.BorderInset(new[] { "border-8" }, out var left, out _);

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/StyleZIndexClassTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/StyleZIndexClassTests.cs
@@ -1,0 +1,244 @@
+using NUnit.Framework;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Specifies the <c>z-*</c> utility parser (StyleZIndexClass): the fixed named scale
+    /// (<c>z-0</c>…<c>z-50</c>), its negated form (<c>-z-10</c>), the arbitrary bracket form
+    /// (<c>z-[999]</c>, <c>z-[-5]</c>), the cascade (last-wins), and rejection of anything that only
+    /// looks like a z-* token (an unrecognized named level, a non-integer bracket, a bare "z-"
+    /// prefix). GWT, one assert per case.
+    /// </summary>
+    [TestFixture]
+    internal sealed class StyleZIndexClassTests
+    {
+        [Test]
+        public void Given_AClassListWithNoZToken_When_CheckedForAZIndexClass_Then_ItReportsNone()
+        {
+            // Arrange
+            var classes = new[] { "flex", "items-center", "absolute" };
+
+            // Act
+            var has = StyleZIndexClass.HasZIndexClass(classes);
+
+            // Assert
+            Assert.That(has, Is.False);
+        }
+
+        [Test]
+        public void Given_AClassListWithAZToken_When_CheckedForAZIndexClass_Then_ItReportsPresent()
+        {
+            // Arrange
+            var classes = new[] { "absolute", "z-10" };
+
+            // Act
+            var has = StyleZIndexClass.HasZIndexClass(classes);
+
+            // Assert
+            Assert.That(has, Is.True);
+        }
+
+        [Test]
+        public void Given_ANegatedZTokenOnly_When_CheckedForAZIndexClass_Then_ItReportsPresent()
+        {
+            // Arrange — the prefix scan strips a leading dash before checking for "z-".
+            var classes = new[] { "-z-20" };
+
+            // Act
+            var has = StyleZIndexClass.HasZIndexClass(classes);
+
+            // Assert
+            Assert.That(has, Is.True);
+        }
+
+        [Test]
+        public void Given_ZZero_When_Parsed_Then_ItResolvesToZero()
+        {
+            // Arrange / Act
+            var ok = StyleZIndexClass.TryParse("z-0", out var z);
+
+            // Assert
+            Assert.That((ok, z), Is.EqualTo((true, 0)));
+        }
+
+        [Test]
+        public void Given_ZFifty_When_Parsed_Then_ItResolvesToFifty()
+        {
+            // Arrange / Act
+            StyleZIndexClass.TryParse("z-50", out var z);
+
+            // Assert
+            Assert.That(z, Is.EqualTo(50));
+        }
+
+        [Test]
+        public void Given_AMidScaleNamedLevel_When_Parsed_Then_ItResolvesToThatLevel()
+        {
+            // Arrange / Act
+            StyleZIndexClass.TryParse("z-30", out var z);
+
+            // Assert
+            Assert.That(z, Is.EqualTo(30));
+        }
+
+        [Test]
+        public void Given_ANegatedNamedLevel_When_Parsed_Then_TheResolvedValueIsNegative()
+        {
+            // Arrange / Act — Tailwind's negative-value convention: the sign prefixes the whole class.
+            StyleZIndexClass.TryParse("-z-10", out var z);
+
+            // Assert
+            Assert.That(z, Is.EqualTo(-10));
+        }
+
+        [Test]
+        public void Given_APositiveArbitraryBracketValue_When_Parsed_Then_ItResolvesToThatInteger()
+        {
+            // Arrange / Act
+            StyleZIndexClass.TryParse("z-[999]", out var z);
+
+            // Assert
+            Assert.That(z, Is.EqualTo(999));
+        }
+
+        [Test]
+        public void Given_ANegativeArbitraryBracketValue_When_Parsed_Then_ItResolvesToTheNegativeInteger()
+        {
+            // Arrange — the bracket itself carries the sign; there is no separate "-z-[5]" form.
+            StyleZIndexClass.TryParse("z-[-5]", out var z);
+
+            // Assert
+            Assert.That(z, Is.EqualTo(-5));
+        }
+
+        [Test]
+        public void Given_ANonIntegerBracketValue_When_Parsed_Then_ItIsRejected()
+        {
+            // Arrange / Act
+            var ok = StyleZIndexClass.TryParse("z-[abc]", out _);
+
+            // Assert
+            Assert.That(ok, Is.False);
+        }
+
+        [Test]
+        public void Given_AnUnrecognizedNamedLevel_When_Parsed_Then_ItIsRejected()
+        {
+            // Arrange — z-15 is not on the fixed scale; only z-[15] would express it.
+            var ok = StyleZIndexClass.TryParse("z-15", out _);
+
+            // Assert
+            Assert.That(ok, Is.False);
+        }
+
+        [Test]
+        public void Given_ZAuto_When_Parsed_Then_ItIsRejected()
+        {
+            // Arrange — z-auto is not part of Velvet's simplified two-layer numeric scale.
+            var ok = StyleZIndexClass.TryParse("z-auto", out _);
+
+            // Assert
+            Assert.That(ok, Is.False);
+        }
+
+        [Test]
+        public void Given_AUserClassThatMerelyStartsWithZDash_When_Parsed_Then_ItIsRejected()
+        {
+            // Arrange — "z-boost" passes the cheap prefix scan but is not a real z utility.
+            var ok = StyleZIndexClass.TryParse("z-boost", out _);
+
+            // Assert
+            Assert.That(ok, Is.False);
+        }
+
+        [Test]
+        public void Given_TwoZClassesInCascadeOrder_When_Extracted_Then_TheLaterClassWins()
+        {
+            // Arrange — CSS cascade: later classes win.
+            var classes = new[] { "z-10", "z-40" };
+
+            // Act
+            StyleZIndexClass.TryExtract(classes, out var z);
+
+            // Assert
+            Assert.That(z, Is.EqualTo(40));
+        }
+
+        [Test]
+        public void Given_OnlyAnUnparseableZLookingToken_When_Extracted_Then_NoZValueIsFound()
+        {
+            // Arrange — every z-looking token in the list fails to parse.
+            var classes = new[] { "flex", "z-boost" };
+
+            // Act
+            var found = StyleZIndexClass.TryExtract(classes, out _);
+
+            // Assert
+            Assert.That(found, Is.False);
+        }
+
+        [Test]
+        public void Given_ALeadingImportantBangOnANamedLevel_When_CheckedForAZIndexClass_Then_ItReportsPresent()
+        {
+            // Arrange
+            var classes = new[] { "!z-10" };
+
+            // Act
+            var has = StyleZIndexClass.HasZIndexClass(classes);
+
+            // Assert
+            Assert.That(has, Is.True);
+        }
+
+        [Test]
+        public void Given_ALeadingImportantBangOnANamedLevel_When_Parsed_Then_ItResolvesTheSameLevel()
+        {
+            // Arrange / Act — the bang is a no-op for this non-cascade utility; it must not block parsing.
+            StyleZIndexClass.TryParse("!z-10", out var z);
+
+            // Assert
+            Assert.That(z, Is.EqualTo(10));
+        }
+
+        [Test]
+        public void Given_ATrailingImportantBangOnANamedLevel_When_Parsed_Then_ItResolvesTheSameLevel()
+        {
+            // Arrange / Act
+            StyleZIndexClass.TryParse("z-10!", out var z);
+
+            // Assert
+            Assert.That(z, Is.EqualTo(10));
+        }
+
+        [Test]
+        public void Given_ALeadingImportantBangOnAnArbitraryBracketValue_When_Parsed_Then_ItResolvesTheBracketInteger()
+        {
+            // Arrange / Act
+            StyleZIndexClass.TryParse("!z-[5]", out var z);
+
+            // Assert
+            Assert.That(z, Is.EqualTo(5));
+        }
+
+        [Test]
+        public void Given_ATrailingImportantBangOnAnArbitraryBracketValue_When_Parsed_Then_ItResolvesTheBracketInteger()
+        {
+            // Arrange / Act
+            StyleZIndexClass.TryParse("z-[5]!", out var z);
+
+            // Assert
+            Assert.That(z, Is.EqualTo(5));
+        }
+
+        [Test]
+        public void Given_ANegatedTokenWithAnEmbeddedBang_When_Parsed_Then_ItIsRejected()
+        {
+            // Arrange / Act — the bang sits after the leading dash, a shape StripImportant does not recognize
+            // (it only strips a bang at the very first or very last character), so this stays rejected.
+            var ok = StyleZIndexClass.TryParse("-!z-10", out _);
+
+            // Assert
+            Assert.That(ok, Is.False);
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/StyleZIndexClassTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/StyleZIndexClassTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d257240b4ce384c2391bc25b84e5c059


### PR DESCRIPTION
Closes #94.

Adds CSS `z-index` (`z-0`…`z-50`, `z-[N]`, negative forms, important-modifier forms) for `position:absolute` elements, compared among siblings sharing one direct parent.

## Why not a plain reorder

UI Toolkit ties paint order, pointer-pick order, and Yoga flex placement to a single physical child list, and the reconciler's slot math treats physical index == logical index as an invariant. Physically reordering children for paint would corrupt both. Instead:

- A z-marked absolute element's **real content relocates** into a lazily-created per-stacking-parent **layer container** — front (trailing) for non-negative z, back (leading, physical index 0) for negative z — sorted by resolved z, ties by mount order.
- A hidden zero-footprint **placeholder** holds the element's declared slot for the reconciler, structural variants (`first:`/`nth-child`/…), and Tab order, reusing the Portal placeholder pipeline and `SilhouetteBoundsSpacer`'s reconciler-invisible-child convention.
- The back container being a *leading* child is bridged in exactly three seams: the reconcile entry gate folds `LeadingOffset` into `slotStart`; the sibling-fiber propagation delta measures logical (container-blind) counts; parked time-sliced states are rebased when a container appears/disappears mid-park.

## Semantics shipped

- Coordinate-neutral relocation (containers are inset-0 over the stacking parent; an absolute child's resolved position is identical with and without `z-*`).
- Tab order follows the **declared** position: placeholders are ring-addressable proxies that forward focus both ways, exits walk past the layer container entirely, and a resort's detach-and-reinsert rescues and restores focus held by the moving element or its descendants.
- Events bubble through the layer container to ancestors above the stacking parent; picking hits the topmost painted element.
- `AnimatePresence` keyed children built as z-managed wrappers animate the **real** element (enter, `PopLayout` exit pin, exit-cancel), not the placeholder.
- Patch transitions (`z→z` resort, `z→none`, `none→z`) preserve element identity; cleanup/pool-reuse scrub every registry (unmount, `Reconciler.Dispose`, pool reset).

## Documented deviations (`Documentation~/styling-z-index.md`)

- `z-*` on an in-flow (non-absolute) element is a no-op (Yoga has no flex `order` analog); on `V.Motion` it warns and stays inert — wrap the Motion in a z-managed Div instead (named `variants` classes still require the Motion as the direct presence child; transition timing and `onEnterComplete` are honored for the wrapped shape).
- Negative z never escapes its own parent's background (single paint traversal — engine dead end).
- Sibling scope only; no CSS stacking-context nesting.
- A `peer-` source that is itself z-managed is not found by consumers (the reverse direction works).

## Hardening that fell out of the review passes

- `ContinueReconcile`'s top-level completion now mirrors `Reconcile`'s finally statement for statement (portal drain, abort consumption, `DeclaringResolveMisses`/`EffectiveKeys` clears, deferred old-tree returns) — previously a pass completing in a resumed time-sliced slice skipped all of it, leaking abort state and scoped-key entries on the shared context.
- The sibling-fiber slot-shift delta is now blind to layer-container churn in both directions (front and back).
- `NonSpacerChildCount`'s trailing trim floors at the leading container run, so a transiently-sole back container can never be miscounted.
- Portal `slotStart` bookkeeping is stored logical-basis and converted at the one physical consumer.

## Tests

61 new tests across `ZIndexStackingTests` / `ZIndexPanelTests` / `StyleZIndexClassTests` / `ContinueReconcileAbortLeakTests` / additions to `PortalTests`, `AnimatePresencePopLayoutTests`, `SilhouetteBoundsSpacerTests`: parser matrix, physical-order and back-layer pins, reconciler-untouched churn regressions, pool-reuse ghosting, patch transitions, coordinate neutrality, focus (forward/backward/co-tenant/descendant-rescue/no-exit), event bubbling, structural variants with containers present, cross-fiber and multi-tick time-sliced rebase matrices ({positional, keyed} × {creation, teardown}), presence enter/exit/cancel targeting, and the continuation-boundary resets. Every mechanism fix was verified red-without-fix against the real suite.
