### PR TITLE
fix(velvet): preserve a parked time-sliced pass across the portal drain

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -119,6 +119,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   worked for children present at the very first mount (or, for `V.Portal(targetId:)`, a registry
   target's one-time late-registration heal); anything mounted by a later patch of an
   already-mounted portal reached its physical ancestors but never its logical ones.
+- A time-sliced (`Transition`/`Deferred` priority) reconcile that enqueues a `V.Portal`/`V.WorldSpace`
+  mount and then pauses on budget exhaustion no longer has that paused state destroyed by its own
+  same-pass drain. The drain resolves the portal's target children through the very same reconciler
+  instance, whose entry unconditionally cleared any paused state as though it were leftover from a
+  finished pass — silently truncating the list (the remaining rows were never created, with no error)
+  instead of resuming once drained.
 
 ## [1.5.0] - 2026-07-19
 

--- a/Packages/com.velvet.core/Runtime/Reconciler/ChildReconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ChildReconciler.cs
@@ -370,6 +370,30 @@ namespace Velvet
                         childFibersBefore.Add(f);
                     }
                 }
+                // The nested Reconcile below re-enters ChildReconciler.Reconcile on THIS SAME instance, whose
+                // entry unconditionally discards PendingIndexedState/PendingKeyedState as stale state left by a
+                // finished pass — correct for a genuine fresh top-level call, but wrong here: this drain runs
+                // from the OUTER pass's own top-level finally (Reconciler.Reconcile / Reconciler.ContinueReconcile),
+                // so when that outer pass just parked (budget exhausted mid-list, with a Portal enqueued right
+                // before parking), the entry-clear below would destroy the park before the caller ever observes
+                // HasPendingWork — the continuation then never resumes and the remaining rows silently never
+                // commit. Move the parked state out of the instance fields first — never through
+                // DiscardPendingKeyedState, which returns PendingKeyedState's pooled buffers to the shared pool;
+                // a nested keyed Pass 2 below can rent the exact same pool types and would be handed back, and
+                // mutate, the very buffers this parked state still owns — so the nested entry-clear becomes a
+                // no-op, then restore both fields verbatim once this one nested call returns. Always safe to
+                // restore unconditionally: the call below never carries a frameBudgetMs argument (defaults to 0),
+                // and at budget 0 ReconcileIndexedFrom's `budgeted` gate is false while ReconcileKeyed routes to
+                // the fully synchronous ReconcileKeyedSync — neither can ever set new pending state of its own, so
+                // there is nothing legitimate from the nested call itself to preserve instead. Scoped to just this
+                // call (not the whole drain loop) so FiberZLayerCoordinator's own rebase of a self-caused park
+                // (RebaseParkedSlotsForContainerChange, triggered only between loop iterations or after the loop
+                // via DrainTeardowns, never while this call is on the stack) still sees the real parked state
+                // everywhere else in the drain.
+                var parkedIndexed = PendingIndexedState;
+                var parkedKeyed = PendingKeyedState;
+                PendingIndexedState = null;
+                PendingKeyedState = null;
                 try
                 {
                     Reconcile(resolvedTarget, Array.Empty<VNode>(), children, slotStart: slotStart);
@@ -383,6 +407,8 @@ namespace Velvet
                             stack.PopRaw(contextSnapshot[s].Key);
                         }
                     }
+                    PendingIndexedState = parkedIndexed;
+                    PendingKeyedState = parkedKeyed;
                 }
                 if (drainAnchor != null)
                 {

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/TimeSlicedPortalDrainParkTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/TimeSlicedPortalDrainParkTests.cs
@@ -1,0 +1,171 @@
+using NUnit.Framework;
+using UnityEngine.UIElements;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Specifies that a time-sliced (Transition-lane) reconcile which enqueues a <see cref="V.Portal"/> mount
+    /// and then parks (frame budget exhausted) survives its own top-level finally draining that Portal in the
+    /// SAME pass. The drain's Portal-target resolution re-enters <c>ChildReconciler.Reconcile</c> on the SAME
+    /// instance, whose entry unconditionally discards the just-parked state as though it were stale leftovers
+    /// from a finished pass; without pinning it across that nested call, the wipe destroys the continuation
+    /// before the caller ever observes <see cref="Reconciler.HasPendingWork"/> — the remaining rows are then
+    /// silently never created (a truncated commit, no error).
+    /// <list type="bullet">
+    /// <item>An unkeyed (Indexed-path) grow that creates a Portal as its very first new row, then parks under a
+    /// tiny budget with that Portal still queued, still resumes and commits every trailing row once drained —
+    /// and the Portal's own content mounts exactly once.</item>
+    /// <item>The same shape on the keyed path (every row, including the Portal, carries a key) exercises
+    /// <c>PendingKeyedState</c> instead of <c>PendingIndexedState</c> — the entry-clear this bug is about
+    /// discards both unconditionally, regardless of which one is actually parked.</item>
+    /// </list>
+    /// </summary>
+    /// <remarks>
+    /// Registry-form <c>V.Portal(targetId:)</c> is used throughout: its target resolves at CREATE time, and its
+    /// drain-time resolution falls through to the exact same nested-Reconcile call as the layer
+    /// (<c>V.Portal(layer:)</c>) and <c>V.WorldSpace</c> arms once the target is known, so this one form
+    /// exercises the shared fix for all three. The tiny <see cref="FiberLane.TimeSlicedBudgetOverrideForTest"/>
+    /// forces a deterministic pause after one node (the UIToolkit scheduler does not advance in EditMode), and a
+    /// parked slice is driven to completion manually via
+    /// <see cref="MountedTreeTestExtensions.DrainTimeSlicedReconcileForTest"/>.
+    /// </remarks>
+    [TestFixture]
+    internal sealed class TimeSlicedPortalDrainParkTests
+    {
+        private VisualElement _root;
+
+        [SetUp]
+        public void SetUp()
+        {
+            FiberWorkLoop.IsInDiscreteEvent = false;
+            FiberLane.TimeSlicedBudgetOverrideForTest = -1;
+            _root = new VisualElement();
+            FiberPortalRegistry.Clear();
+            ResetIndexedList();
+            ResetKeyedList();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            FiberLane.TimeSlicedBudgetOverrideForTest = -1;
+            FiberWorkLoop.IsInDiscreteEvent = false;
+            FiberPortalRegistry.Clear();
+        }
+
+        [Test]
+        public void Given_UnkeyedGrowEnqueuesPortalThenParks_When_DrainedAfterSamePassPortalDrain_Then_ResumesAndCommitsFullList()
+        {
+            // Arrange — initial mount is empty (no Portal, no rows), so the grow below creates the Portal fresh
+            // (not a patch) as the reconcile's very first Add-phase iteration.
+            var target = new VisualElement();
+            FiberPortalRegistry.Register("indexed-park-target", target);
+            using var mounted = V.Mount(_root, V.Component(IndexedListRender, key: "list"));
+            var fiber = s_indexedListFiber;
+            Assume.That(_root.childCount, Is.EqualTo(0), "Precondition: the initial mount renders no rows");
+
+            // Act — grow to a Portal row + 40 trailing rows under a tiny budget: the very first Add iteration
+            // (the Portal) both enqueues the deferred mount AND exhausts the budget, so this SAME FlushState call
+            // parks with the Portal still queued — its own top-level finally (Reconciler.Reconcile) drains that
+            // queue before FlushState returns, re-entering ChildReconciler.Reconcile on this fiber's own instance.
+            FiberLane.TimeSlicedBudgetOverrideForTest = 0.0001;
+            s_indexedTotalCount = 41;
+            fiber.ScheduleRerenderForTest(FiberUpdatePriority.Transition);
+            FiberWorkLoop.FlushState(fiber);
+            fiber.DrainTimeSlicedReconcileForTest();
+
+            // Assert — RED without the fix: the same-pass drain's nested Reconcile call wipes PendingIndexedState
+            // the instant it is set, so HasPendingWork already reads false when FlushState returns; the drain
+            // above is then a no-op and the list stays truncated at 1 (only the Portal placeholder) forever.
+            Assert.That((_root.childCount, target.childCount), Is.EqualTo((41, 1)),
+                "The parked pass resumes through the same-pass Portal drain and commits every trailing row, with the Portal's content mounted exactly once");
+        }
+
+        [Test]
+        public void Given_KeyedGrowEnqueuesPortalThenParks_When_DrainedAfterSamePassPortalDrain_Then_ResumesAndCommitsFullList()
+        {
+            // Arrange — same shape, but every row (including the Portal) carries a key, so the reconcile takes
+            // the Keyed path and parks into PendingKeyedState instead of PendingIndexedState.
+            var target = new VisualElement();
+            FiberPortalRegistry.Register("keyed-park-target", target);
+            using var mounted = V.Mount(_root, V.Component(KeyedListRender, key: "list"));
+            var fiber = s_keyedListFiber;
+            Assume.That(_root.childCount, Is.EqualTo(0), "Precondition: the initial mount renders no rows");
+
+            // Act — same tiny-budget grow as the unkeyed case, on the keyed path.
+            FiberLane.TimeSlicedBudgetOverrideForTest = 0.0001;
+            s_keyedTotalCount = 41;
+            fiber.ScheduleRerenderForTest(FiberUpdatePriority.Transition);
+            FiberWorkLoop.FlushState(fiber);
+            fiber.DrainTimeSlicedReconcileForTest();
+
+            // Assert — RED without the fix: DiscardPendingKeyedState (invoked by the same entry-clear) also
+            // returns PendingKeyedState's pooled buffers to the shared pool, so the wipe is destructive twice
+            // over here; the list stays truncated at 1 (only the Portal placeholder) forever.
+            Assert.That((_root.childCount, target.childCount), Is.EqualTo((41, 1)),
+                "The parked keyed pass resumes through the same-pass Portal drain and commits every trailing row, with the Portal's content mounted exactly once");
+        }
+
+        #region Indexed list component (unkeyed; Portal occupies index 0 once the count is nonzero)
+
+        private static int s_indexedTotalCount;
+        private static ComponentFiber s_indexedListFiber;
+
+        private static void ResetIndexedList()
+        {
+            s_indexedTotalCount = 0;
+            s_indexedListFiber = null;
+        }
+
+        [Component]
+        private static VNode IndexedListRender()
+        {
+            s_indexedListFiber = FiberAmbientStack.Current;
+            var total = s_indexedTotalCount;
+            var children = new VNode[total];
+            if (total > 0)
+            {
+                children[0] = V.Portal("indexed-park-target", children: new VNode[] { V.Label(text: "portal-content") });
+                for (var i = 1; i < total; i++)
+                {
+                    children[i] = V.Label(text: $"row-{i}");
+                }
+            }
+            return V.Fragment(children: children);
+        }
+
+        #endregion
+
+        #region Keyed list component (every row, including the Portal, carries a key)
+
+        private static int s_keyedTotalCount;
+        private static ComponentFiber s_keyedListFiber;
+
+        private static void ResetKeyedList()
+        {
+            s_keyedTotalCount = 0;
+            s_keyedListFiber = null;
+        }
+
+        [Component]
+        private static VNode KeyedListRender()
+        {
+            s_keyedListFiber = FiberAmbientStack.Current;
+            var total = s_keyedTotalCount;
+            var children = new VNode[total];
+            if (total > 0)
+            {
+                children[0] = V.Portal("keyed-park-target", key: "portal",
+                    children: new VNode[] { V.Label(text: "portal-content") });
+                for (var i = 1; i < total; i++)
+                {
+                    children[i] = V.Label(text: $"row-{i}", key: $"row{i}");
+                }
+            }
+            return V.Fragment(children: children);
+        }
+
+        #endregion
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/TimeSlicedPortalDrainParkTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/TimeSlicedPortalDrainParkTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 18820df8f058d428a88ef9a250e4de05


### PR DESCRIPTION
Closes #114.

A time-sliced (Transition/Deferred lane) pass that enqueues a `V.Portal` / `V.WorldSpace` mount and then parks (budget exhausted) had its freshly-saved continuation state destroyed by the same call's own top-level drain: the drain's resolution arm runs a nested `Reconcile` on the **same `ChildReconciler` instance**, and that entry unconditionally discards `PendingIndexedState` / `PendingKeyedState` as stale. `HasPendingWork` then read false before the caller ever observed the park, so no continuation was scheduled and the remaining rows of the list were silently never created — truncated commit, no error, no log.

## Fix

Scoped to the one nested call inside `DrainPendingPortalMounts`: move the parked state out of the instance fields first (never through `DiscardPendingKeyedState`, whose buffer release would hand the parked pass's still-live pooled buffers to any nested keyed pass in the same drain), run the nested reconcile with both fields null so its entry-clear is a no-op, and restore both fields verbatim in the existing `finally`.

Restoring unconditionally is safe because the nested call can never produce pending state of its own: it carries no frame budget (defaults to 0), and at budget 0 the indexed path's park gate is closed while the keyed path routes to the fully synchronous implementation — an invariant `IReconcilerHost.ReconcileChildren`'s contract already documents for every deeper re-entry.

The null window is deliberately per-call, not drain-wide: the z-layer arm's parked-slot rebase (which must read the *real* parked state when a layer container appears mid-drain) runs only between loop iterations, never while the nested call is on the stack, so it keeps seeing the true state.

## Tests

Two deterministic regressions on the existing time-slice harness (`TimeSlicedPortalDrainParkTests`), unkeyed (indexed park) and keyed (keyed park): a grow pass whose very first added row is a registry portal, parked immediately after the enqueue by a tiny forced budget, then driven to completion — asserting the full list committed and the portal content mounted exactly once. Both were verified red with the fix neutered (exactly these two fail; the pass truncates at 1 of 41 rows) and green with it restored.
