### PR TITLE
refactor(velvet): center Hooks comments on rationale

### DIFF
--- a/Packages/com.velvet.core/Runtime/Hooks/AnimationSequenceTypes.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/AnimationSequenceTypes.cs
@@ -3,8 +3,8 @@ using System;
 
 namespace Velvet
 {
-    // Which effect an AnimationSequenceStep carries. Internal: callers only ever construct a step through
-    // the public static factories below, never read Kind directly.
+    // Internal: callers construct a step only through the public static factories below, never by
+    // reading Kind directly.
     internal enum AnimationSequenceStepKind
     {
         To,
@@ -81,9 +81,8 @@ namespace Velvet
         /// <summary>
         /// Fires <paramref name="callback"/> synchronously on arrival, then advances immediately — never holds
         /// the cursor. Step 0's callback re-fires under the Editor's StrictMode mount double-invoke diagnostic
-        /// (same expectation as any <c>UseEffect</c> mount factory with a non-idempotent body): write it to
-        /// tolerate running twice if the sequence's own mount matters, exactly as React's own StrictMode
-        /// guidance recommends for an effect that isn't naturally idempotent.
+        /// (same expectation as any <c>UseEffect</c> mount factory with a non-idempotent body), so write it to
+        /// tolerate running twice if the sequence's own mount matters.
         /// </summary>
         /// <param name="callback">The callback to invoke. Must not be null.</param>
         public static AnimationSequenceStep Call(Action callback)

--- a/Packages/com.velvet.core/Runtime/Hooks/FocusRing.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/FocusRing.cs
@@ -5,10 +5,10 @@ using UnityEngine.UIElements;
 namespace Velvet
 {
     /// <summary>
-    /// Focus state of the element carrying <see cref="Ref"/>, returned by <c>Hooks.UseFocusRing</c> —
-    /// React Aria's <c>useFocusRing</c> parity. Rides the same element-local focus-visible heuristic as the
-    /// <c>focus-visible:</c> styling variant (a pointer press on the element suppresses the visible state
-    /// for the focus it causes), so the two surfaces cannot drift.
+    /// Focus state of the element carrying <see cref="Ref"/>, returned by <c>Hooks.UseFocusRing</c>.
+    /// Rides the same element-local focus-visible heuristic as the <c>focus-visible:</c> styling variant
+    /// (a pointer press on the element suppresses the visible state for the focus it causes), so the two
+    /// surfaces cannot drift.
     /// </summary>
     public readonly struct FocusRing
     {

--- a/Packages/com.velvet.core/Runtime/Hooks/HookEffectExecutor.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/HookEffectExecutor.cs
@@ -11,15 +11,9 @@ namespace Velvet
     // PropagateException falls back to Debug.LogException, preserving the prior log-only behavior.
     internal static class HookEffectExecutor
     {
-        // Runs every entry in the pending list with a 2-pass strategy.
-        // Pass 1: invoke all cleanups. Pass 2: invoke all factories and set the new cleanup.
-        // fiber: the owning fiber, used to route an effect throw to its nearest Error Boundary.
-        // pending: Effect slots whose factory should run this commit.
-        // mountDoubleInvoke:
-        // When true and StrictMode is enabled, runs an extra cleanup -> setup cycle after the initial setup.
-        // Set only on the mount commit; update commits pass false. The diagnostic
-        // doubles effects on mount only, so doubling on update would tear down and re-establish external
-        // resources (subscriptions / sockets) of a deps-changed effect mid-frame.
+        // mountDoubleInvoke must be false on update commits: doubling there would tear down and re-establish
+        // external resources (subscriptions / sockets) of a deps-changed effect mid-frame, not just exercise
+        // the mount-only diagnostic.
         internal static void RunPendingEffects(ComponentFiber fiber, List<HookEffectSlot>? pending, bool mountDoubleInvoke = false)
         {
             if (pending == null || pending.Count == 0) return;
@@ -28,9 +22,8 @@ namespace Velvet
             RunFactoriesAndClear(fiber, pending, mountDoubleInvoke);
         }
 
-        // Runs the factory (setup) pass for every pending slot, then clears the list. Split out from
-        // RunPendingEffects so the passive-effect drain can run a tree-wide cleanup phase
-        // across every fiber FIRST, then a tree-wide setup phase — without re-running the cleanups that
+        // Split out from RunPendingEffects so the passive-effect drain can run a tree-wide cleanup phase across
+        // every fiber FIRST, then a tree-wide setup phase — without re-running the cleanups that
         // RunPendingEffects bundles in. Callers that want the single-fiber cleanup→setup
         // pair should call RunPendingEffects instead.
         internal static void RunFactoriesAndClear(ComponentFiber fiber, List<HookEffectSlot>? pending, bool mountDoubleInvoke = false)
@@ -67,16 +60,14 @@ namespace Velvet
                 catch (Exception ex)
                 {
                     ComponentBoundarySearch.PropagateException(fiber, ex);
-                    // An error boundary's fallback can synchronously unmount fiber as part of handling ex
-                    // (the same re-entrancy HookEffectExecutor's own class comment already calls out for
-                    // RunCleanups). Stop running the remaining factories on it rather than standing up new
-                    // resources whose cleanup pass already ran and will never run again.
+                    // An error boundary's fallback can synchronously unmount fiber (the same re-entrancy
+                    // RunCleanups guards against below). Stop running the remaining factories on it rather than
+                    // standing up new resources whose cleanup pass already ran and will never run again.
                     if (fiber.IsDisposed) return;
                 }
             }
         }
 
-        // Runs only the cleanups for every entry in the pending list. Factories are not invoked.
         internal static void RunCleanups(ComponentFiber fiber, List<HookEffectSlot>? entries)
         {
             if (entries == null) return;
@@ -101,9 +92,8 @@ namespace Velvet
             }
         }
 
-        // Promotes each slot's staged HookEffectSlot.NextDeps to HookEffectSlot.LastDeps.
-        // Called once after the render-phase loop settles so the committed comparison baseline reflects the final
-        // (settled) attempt's deps rather than a discarded intermediate attempt.
+        // Called once after the render-phase loop settles, so the committed comparison baseline reflects the
+        // final (settled) attempt's deps rather than a discarded intermediate attempt.
         internal static void CommitEffectDeps(List<HookEffectSlot>? effects)
         {
             if (effects == null) return;
@@ -114,8 +104,7 @@ namespace Velvet
             }
         }
 
-        // Full cleanup: runs the cleanup for every entry in all and clears both lists.
-        // Usable for both UseLayoutEffect and UseEffect on Unmount.
+        // The unmount path for both UseLayoutEffect and UseEffect.
         internal static void CleanupAll(ComponentFiber fiber, List<HookEffectSlot>? all, List<HookEffectSlot>? pending)
         {
             if (all == null) return;

--- a/Packages/com.velvet.core/Runtime/Hooks/HookGuard.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/HookGuard.cs
@@ -4,8 +4,6 @@ namespace Velvet
 {
     internal static class HookGuard
     {
-        // Throws when a hook is invoked outside of a Render() context.
-        // Called from the Hooks static class.
         // fiber == null means there is no Current on FiberAmbientStack, i.e. we are outside Render().
         // The gate is the render-phase WINDOW (the body on the stack), not the whole flush: the
         // commit phase legitimately runs user code (callback refs) with the ambient fiber still

--- a/Packages/com.velvet.core/Runtime/Hooks/HookSetterFactory.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/HookSetterFactory.cs
@@ -2,10 +2,8 @@ using System;
 
 namespace Velvet
 {
-    // Helper that builds setter / dispatcher closures for UseState / UseReducer.
     internal static class HookSetterFactory
     {
-        // Builds a setter closure for UseState.
         // Equal-value updates do not request a re-render (identity-based bailout).
         // The caller must invoke this exactly once when the slot is created and cache the resulting
         // delegate. Calling it on every render would keep producing unnecessary closures.
@@ -23,7 +21,6 @@ namespace Velvet
             };
         }
 
-        // Builds a dispatch closure for UseReducer.
         // The reducer is updated via the slot on every render, so the latest function is always used.
         // Bailout uses identity semantics (NaN equals itself, ±0 distinguished, reference equality
         // for objects) so a record/struct reducer that returns a new instance with identical content still propagates.

--- a/Packages/com.velvet.core/Runtime/Hooks/HookSlotRegistrar.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/HookSlotRegistrar.cs
@@ -5,21 +5,18 @@ using System.Collections.Generic;
 
 namespace Velvet
 {
-    // Generic helper for the "render-guard -> null-coalesce -> bump index -> new-or-existing branch" pattern.
-    // Centralizes the logic shared by position-based slot registrations such as UseLayoutEffect / UseEffect.
+    // Centralizes the slot-registration logic shared by position-based hooks such as UseLayoutEffect / UseEffect.
     internal static class HookSlotRegistrar
     {
-        // Registers an effect slot with deps comparison.
         // The current render's deps are staged on HookEffectSlot.NextDeps and compared against the
         // committed HookEffectSlot.LastDeps; HookEffectSlot.LastDeps is promoted only
         // once the render-phase loop settles (FiberRenderer calls HookEffectExecutor.CommitEffectDeps). A
         // render-phase state-update re-run discards intermediate attempts, so leaving the baseline at the committed
         // render is what lets the settled attempt's deps be compared against the committed render rather than a
         // discarded attempt.
-        // When deduplicatePending is true, skips adding to pendingEffects
-        // if the slot is already present. Both UseEffect and UseLayoutEffect require this: the pending
-        // list persists across a render-phase state-update re-run (it is cleared once per RenderAndReconcile,
-        // not per re-run), so a slot whose deps change between attempts could otherwise be added twice.
+        // Both UseEffect and UseLayoutEffect require deduplicatePending: the pending list persists across a
+        // render-phase state-update re-run (it is cleared once per RenderAndReconcile, not per re-run), so a
+        // slot whose deps change between attempts could otherwise be added twice.
         internal static void RegisterEffect(
             ref List<HookEffectSlot>? effects,
             ref List<HookEffectSlot>? pendingEffects,

--- a/Packages/com.velvet.core/Runtime/Hooks/HookSlots.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/HookSlots.cs
@@ -1,5 +1,5 @@
-// Hook slot storage mirrors React fiber hook state: committed vs staged fields, and nullable deps
-// arrays where null means "always re-run" (UseEffect with no deps array).
+// Hook slot storage keeps committed vs staged fields separate, with a null deps array meaning
+// "always re-run" (UseEffect with no deps array).
 #nullable enable
 using System;
 using System.Collections.Generic;
@@ -168,7 +168,7 @@ namespace Velvet
 
     internal abstract class HookStateSlot
     {
-        // The committed state value when it is a VNode root (React's element-in-state pattern) —
+        // The committed state value when it is a VNode root (element-in-state caching) —
         // see HookSlotRecycleProbe.
         public abstract object? RecycleMarkRoot { get; }
     }

--- a/Packages/com.velvet.core/Runtime/Hooks/Hooks.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Hooks.cs
@@ -105,9 +105,8 @@ namespace Velvet
             return (typed.Value, typed.Setter);
         }
 
-        // Slot lookup shared by the eager and lazy overloads. Pass a non-null <paramref name="initialFactory"/>
-        // when the caller wants lazy initialization (the factory is invoked once on the first render).
-        // Otherwise the eager <paramref name="initial"/> seeds the slot.
+        // initialFactory is always null at the current call site (the eager UseState(T) overload above);
+        // UseState(Func<T>) is served by the separate UseStateFromFactory above instead of this branch.
         private static (T value, StateUpdater<T> setValue) UseStateInternalCore<T>(
             Func<T>? initialFactory, T initial, string hookName)
         {
@@ -327,8 +326,8 @@ namespace Velvet
             fiber.CallbackSlots ??= new List<HookCallbackSlot>();
             var index = fiber.Indices.HookIndex++;
 
-            // No-deps overload: returns this render's callback as-is (no memoization). Stage into Next* like the
-            // deps overload so the render-phase settle commit treats every callback slot uniformly.
+            // Stages into Next* like the deps overload, so the render-phase settle commit treats every
+            // callback slot uniformly even though this overload never memoizes.
             if (index >= fiber.CallbackSlots.Count)
             {
                 fiber.CallbackSlots.Add(new HookCallbackSlot
@@ -414,8 +413,8 @@ namespace Velvet
             fiber.MemoValueSlots ??= new List<HookMemoValueSlot>();
             var index = fiber.Indices.MemoValueHookIndex++;
 
-            // No-deps overload: recompute every render (no memoization). Stage into Next* like the deps
-            // overload so the render-phase settle commit treats every memo slot uniformly.
+            // Stages into Next* like the deps overload, so the render-phase settle commit treats every memo
+            // slot uniformly even though this overload never memoizes.
             var value = factory();
             if (index >= fiber.MemoValueSlots.Count)
             {
@@ -911,11 +910,10 @@ namespace Velvet
         /// Frames tick while the component's host is attached to a panel and pause while it is not.
         /// <paramref name="priority"/> orders callbacks within the SAME panel — lower runs earlier,
         /// equal priorities run in subscription (mount) order, and this stays true across a keyed
-        /// reorder of the host — r3f's <c>useFrame(callback, renderPriority)</c> parity. Unlike r3f, a
-        /// positive priority has no side effect beyond ordering: Unity's rendering is independent of
-        /// this scheduler, so there is no internal render call for it to take over. The latest render's
-        /// priority applies live, the same way <paramref name="onFrame"/> does — changing it does not
-        /// restart the subscription or move it among same-priority siblings.
+        /// reorder of the host. A positive priority has no side effect beyond ordering: Unity's
+        /// rendering is independent of this scheduler, so there is no internal render call for it to
+        /// take over. The latest render's priority applies live, the same way <paramref name="onFrame"/>
+        /// does — changing it does not restart the subscription or move it among same-priority siblings.
         /// </summary>
         /// <param name="onFrame">Invoked once per frame with the elapsed time in seconds (always positive).</param>
         /// <param name="priority">Lower runs earlier within the same panel this frame. Defaults to 0.</param>
@@ -1039,8 +1037,8 @@ namespace Velvet
         /// <summary>
         /// Plays an ordered <see cref="AnimationSequenceStep"/> array over time, exposing the active step's
         /// label/transition to feed straight into a coordinator <c>V.Motion(animate:, transition:)</c>.
-        /// Velvet's timeline primitive (Framer Motion's <c>useAnimate</c> parity target): the hook owns the
-        /// clock (via <see cref="UseFrame"/>) and the step walk, so a caller never hand-rolls
+        /// Velvet's timeline primitive: the hook owns the clock (via <see cref="UseFrame"/>) and the step
+        /// walk, so a caller never hand-rolls
         /// <see cref="UseEffect(Func{Action},object[])"/> plus a timer plus <see cref="UseState{T}(T)"/> to
         /// sequence a multi-stage animation. Descendant <c>V.Motion</c> nodes with no own <c>animate</c>
         /// inherit the coordinator's label exactly as they already do for any hand-toggled label change; "one
@@ -1118,7 +1116,7 @@ namespace Velvet
         #region UseFocusRing
 
         /// <summary>
-        /// React Aria's <c>useFocusRing</c> parity: exposes an element's focus state — and specifically
+        /// Exposes an element's focus state — and specifically
         /// keyboard/gamepad-visible focus, as distinct from pointer focus — as re-rendering component
         /// state. Pass <see cref="FocusRing.Ref"/> as the target element's <c>refCallback:</c>. For pure
         /// styling, the <c>focus-visible:</c> class variant already covers the same distinction without a
@@ -1128,8 +1126,8 @@ namespace Velvet
         /// When composing <see cref="FocusRing.Ref"/> with other per-element work in one callback,
         /// wrap the composed lambda in <c>Hooks.UseCallback</c>: a per-render lambda is a fresh
         /// identity each render, so every patch would cycle the ref (cleanup on a still-focused
-        /// element, then re-setup) — the same re-render feedback an inline ref writing state
-        /// produces in React.
+        /// element, then re-setup) — the same re-render feedback an inline ref that writes state on
+        /// every render would produce.
         /// </para>
         /// </summary>
         public static FocusRing UseFocusRing()
@@ -1345,8 +1343,8 @@ namespace Velvet
             // check and the handle is not part of the render output signature.
             if (IsStrictDiagnosticPass(fiber)) return;
 
-            // No-deps: refresh every render. Stage the factory / ref; the handle is built and the parent ref is
-            // written at the render-phase settle so a discarded attempt cannot expose a throwaway handle.
+            // Stages the factory / ref; the handle is built and the parent ref is written at the render-phase
+            // settle so a discarded attempt cannot expose a throwaway handle.
             if (index >= fiber.ImperativeHandleSlots.Count)
             {
                 fiber.ImperativeHandleSlots.Add(new HookImperativeHandleSlot
@@ -1666,7 +1664,6 @@ namespace Velvet
         ///   for synchronous updates or <c>startTransition.Invoke(async () =&gt; ...)</c> for async actions whose
         ///   <c>isPending</c> stays true across awaits. Nested calls join the outer transition.
         /// </returns>
-        /// <remarks>Equivalent to React's <c>useTransition</c> (<c>[isPending, startTransition]</c>) for users migrating from React.</remarks>
         public static (bool isPending, TransitionStarter startTransition) UseTransition()
         {
             var fiber = Resolve("UseTransition");
@@ -1817,8 +1814,7 @@ namespace Velvet
             catch (Exception ex)
             {
                 // Superseded (a newer call replaced slot.Cts) or the owner was disposed: the result is stale, so
-                // neither deliver onError nor mutate the slot. mutateAsync still rejects so its awaiter observes
-                // the failure; fire-and-forget mutate swallows (no awaiter — a rethrow would leak unobserved).
+                // neither deliver onError nor mutate the slot.
                 if (slot.Cts != cts || fiber.IsDisposed)
                 {
                     if (rethrowOnFailure) throw;
@@ -1828,8 +1824,6 @@ namespace Velvet
                 slot.Result.Status = MutationStatus.Error;
                 slot.OnError?.Invoke(ex, variables);
                 RequestRender(fiber);
-                // mutate() reports failures via onError / the Error status only and never raises an unhandled
-                // rejection; mutateAsync() rejects so the awaiter can catch it.
                 if (rethrowOnFailure) throw;
                 return default!;
             }
@@ -2029,11 +2023,11 @@ namespace Velvet
         #region Memoization (component-level)
 
         /// <summary>
-        /// Memoization slot accessor used exclusively by SG-generated code for
-        /// <c>[Component(Memoize = true)]</c>.
+        /// Memoization slot accessor woven in by the build-time compiler transform for
+        /// <c>[Component(Compiler = true)]</c> (the default).
         /// On each Render, advances <see cref="HookIndexTable.MemoHookIndex"/> to allocate a slot in
         /// Fiber.MemoSlots; returns the cached VNode when the previous deps are equal.
-        /// Do not call by hand (the slot index convention is a position-based API fixed by SG).
+        /// Do not call by hand (the slot index convention is a position-based API fixed by the weaver).
         /// When the return value is <c>false</c>, <paramref name="cached"/> is undefined.
         /// </summary>
         /// <param name="deps">Dependency values for this slot. Must not be null.</param>
@@ -2045,9 +2039,8 @@ namespace Velvet
         {
             if (deps == null) throw new ArgumentNullException(nameof(deps));
             var fiber = Resolve("TryGetMemoizedVNode");
-            // SG-emitted code is contracted to call this exactly once per render, so Count is at most
+            // The weaver is contracted to call this exactly once per render, so Count is at most
             // slotIndex or slotIndex+1.
-            // Append a single entry to allocate the slot at the end of the list.
             slotIndex = fiber.Indices.MemoHookIndex++;
             fiber.MemoSlots ??= new List<HookMemoSlot>();
             if (fiber.MemoSlots.Count <= slotIndex)
@@ -2075,7 +2068,7 @@ namespace Velvet
         }
 
         /// <summary>
-        /// Slot writer API called by SG-generated code on the miss path of <see cref="TryGetMemoizedVNode"/>.
+        /// Slot writer API woven in on the miss path of <see cref="TryGetMemoizedVNode"/>.
         /// The <paramref name="slotIndex"/> argument must be the value returned by the immediately
         /// preceding <see cref="TryGetMemoizedVNode"/> call.
         /// </summary>

--- a/Packages/com.velvet.core/Runtime/Hooks/IHookRefSetter.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/IHookRefSetter.cs
@@ -1,7 +1,6 @@
 #nullable enable
 namespace Velvet
 {
-    // Type-erased abstraction over Ref<T>.
     // Allows ComponentNode to accept the ref passed by the parent and store the handle produced
     // by the child's UseImperativeHandle without knowing the concrete THandle.
     // internal: consumers only need to pass a Ref<T> to V.Component<TRef>(componentRef:).

--- a/Packages/com.velvet.core/Runtime/Hooks/IHookServiceResolver.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/IHookServiceResolver.cs
@@ -2,7 +2,7 @@ namespace Velvet
 {
     /// <summary>
     /// Resolver abstraction that fetches services from the host DI container.
-    /// Decouples DI-framework-specific implementations (such as VContainer) from the framework core.
+    /// Decouples DI-framework-specific implementations from the framework core.
     /// </summary>
     public interface IHookServiceResolver
     {

--- a/Packages/com.velvet.core/Runtime/Hooks/Ref.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Ref.cs
@@ -17,7 +17,7 @@ namespace Velvet
         // must be ONE delegate instance — a method group (`refCallback: _ref.SetElement`) would
         // convert to a fresh delegate every render, so the reconciler's ref-identity gate (a ref
         // cycles only when its identity changes) could never recognize the same Ref across patches
-        // and would cycle it per render, React's object-ref contract broken by a C# conversion detail.
+        // and would cycle it per render — a C# delegate-conversion detail breaking object-ref stability.
         private readonly Action _clearAction;
         private readonly Func<VisualElement, Action> _setElement;
 
@@ -45,8 +45,7 @@ namespace Velvet
         /// Callback ref setter. Used as <c>V.Button(refCallback: _ref.SetElement)</c>.
         /// Stores the element into <see cref="Current"/>; the returned <c>Action</c> is the cleanup that
         /// resets <c>Current = null</c> on detach. The same delegate instance is returned for the
-        /// Ref's lifetime, so a patch that passes it again leaves the installed ref untouched
-        /// (React's object-ref stability).
+        /// Ref's lifetime, so a patch that passes it again leaves the installed ref untouched.
         /// For T values not derived from VisualElement, <c>element as T</c> is always null, so this is
         /// primarily used for Element-node refs.
         /// </summary>

--- a/Packages/com.velvet.core/Runtime/Hooks/UseFrameDispatcher.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/UseFrameDispatcher.cs
@@ -11,11 +11,9 @@ namespace Velvet
     /// One dispatcher per panel: a single stable scheduled tick, hosted on the panel's own root element
     /// (never itself subject to a keyed reorder), fanning out every frame to every live
     /// <see cref="Hooks.UseFrame(System.Action{float}, int)"/> subscriber in that panel, in
-    /// <c>priority</c> order (ties broken by subscription order) — r3f's
-    /// <c>useFrame(callback, renderPriority)</c> ordering parity. A positive priority carries no other
-    /// side effect here (unlike r3f, where it also hands the caller manual control of the render loop):
-    /// Unity's own rendering is independent of this scheduler, so there is no internal render call to
-    /// take over.
+    /// <c>priority</c> order (ties broken by subscription order). Priority affects only this ordering:
+    /// Unity's own rendering is independent of this scheduler, so a higher priority does not grant the
+    /// caller any control over the render loop itself.
     /// </summary>
     /// <remarks>
     /// Subscribing per-PANEL rather than per-component-HOST (the one scheduled item per component this


### PR DESCRIPTION
Part of a per-subsystem pass converting What-narration comments to the Why-only house convention. Comment-only change — zero code tokens touched (verified by a comment-stripping token comparison of every file), EditMode 3234 and PlayMode 90 both green on this tree.

- Deleted 9 comments that restated the adjacent code or method name; converted ~27 more to state only the constraint/rationale, including 11 XML-doc tightenings on the public hook surface.
- Removed the remaining external framework name-drops from comments, restating the actual behavior neutrally.
- Corrected two factually wrong claims: the memoized-VNode helpers' docs attributed them to source-generated code gated by the props-bail flag (they are woven by the build-time IL transform, gated by the default-on compiler flag), and a state-hook helper's doc claimed it was shared by the eager and lazy overloads (the lazy overload uses a separate helper).

The large majority of comments in the subsystem were already Why-centered and are untouched.