### PR TITLE
refactor(velvet): center Styling comments on rationale

### DIFF
--- a/Packages/com.velvet.core/Runtime/Styling/ClipPathVectorImageBaker.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/ClipPathVectorImageBaker.cs
@@ -152,8 +152,7 @@ namespace Velvet
             }
         }
 
-        // Resolves circle()/ellipse() center and per-axis radii. A circle is an ellipse with
-        // rx == ry; its single radius lives in the spec's X slot.
+        // A circle is an ellipse with rx == ry; its single radius lives in the spec's X slot.
         private static void ResolveRadialGeometry(ClipPathSpec spec, float width, float height,
             out float cx, out float cy, out float rx, out float ry)
         {

--- a/Packages/com.velvet.core/Runtime/Styling/CubicBezierEvaluator.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/CubicBezierEvaluator.cs
@@ -33,9 +33,9 @@ namespace Velvet
         // bisection instead of taking a wild step.
         private const float MinSlope = 1e-6f;
 
-        // The fallback curve for an invalid x1/x2 — Tailwind's own default, and the same default
-        // StyleTransitionConfig.BezierX1..Y2 already carry, so a rejected value degrades to what an
-        // unconfigured Motion would have played anyway rather than an arbitrary hardcoded curve.
+        // The fallback curve for an invalid x1/x2 is the same default StyleTransitionConfig.BezierX1..Y2
+        // already carry, so a rejected value degrades to what an unconfigured Motion would have played
+        // anyway rather than an arbitrary hardcoded curve.
         private const float DefaultX1 = 0.4f;
         private const float DefaultY1 = 0f;
         private const float DefaultX2 = 0.2f;

--- a/Packages/com.velvet.core/Runtime/Styling/DashedBorderPainter.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/DashedBorderPainter.cs
@@ -22,16 +22,16 @@ namespace Velvet
     // last point back to point 0 (a full border); an open polyline leaves the raw ends (a divide edge).
     internal static class DashedBorderPainter
     {
-        private const float DashLengthFactor = 3f; // dash run ≈ 3× the line width
-        private const float DashGapFactor = 2f;    // gap between dashes ≈ 2× the line width
-        private const float DotSpacingFactor = 2f; // centre-to-centre dot spacing ≈ 2× the line width
+        private const float DashLengthFactor = 3f;
+        private const float DashGapFactor = 2f;
+        private const float DotSpacingFactor = 2f;
 
         // Reused across draws so a steady-state repaint allocates nothing. UI Toolkit generateVisualContent
         // callbacks run sequentially on the main thread, so a single shared buffer is safe (no re-entrancy).
         private static readonly List<(Vector2 From, Vector2 To)> s_segments = new();
 
-        // Walks the polyline and strokes the dashes / dots onto the painter. A no-op for Solid (the native
-        // border draws that), a transparent color, or a degenerate width.
+        // A no-op for Solid (the native border already draws that), a near-transparent color, or a
+        // hairline width — callers do not pre-filter for the latter two.
         public static void StrokeDashed(Painter2D painter, IReadOnlyList<Vector2> polyline, bool closed,
             float lineWidth, Color color, BorderLineStyle style)
         {

--- a/Packages/com.velvet.core/Runtime/Styling/DropShadowBaker.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/DropShadowBaker.cs
@@ -96,12 +96,12 @@ namespace Velvet
                 Mathf.RoundToInt(skewXDeg * 100f));
             if (s_silhouetteCache.TryGetValue(key, out var tex) && tex != null)
             {
-                TouchSilhouette(key); // bump recency on a cache hit
+                TouchSilhouette(key);
                 return tex;
             }
 
             tex = BakeSilhouetteTexture(mat, corner, blur, spread, targetWidth, targetHeight, skewXDeg);
-            StoreSilhouette(key, tex); // insert + evict-if-over-cap (a null bake is not cached)
+            StoreSilhouette(key, tex);
             return tex;
         }
 

--- a/Packages/com.velvet.core/Runtime/Styling/MotionLayoutIdDriver.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/MotionLayoutIdDriver.cs
@@ -4,21 +4,19 @@ using UnityEngine.UIElements;
 
 namespace Velvet
 {
-    // Framer Motion's layoutId parity: FLIP (First-Last-Invert-Play) shared-element layout animation.
-    // When a V.Motion(layoutId:) patches at a resolved layout rect different from the rect the SAME id
-    // last settled at — including across a DIFFERENT physical element entirely, e.g. after a same-key
-    // type flip or a move to a different parent — it tweens from the old rect to the new one instead of
-    // jump-cutting: capture the OLD rect, let this frame's layout settle at the NEW one, compute the
-    // delta, apply it as an inline inverse transform (Invert), then spring that inverse back to zero
-    // (Play). Reuses MotionSpringDriver's existing panel-independent physics channels (translate x/y,
-    // uniform scale) — the same machinery every other spring-driven Motion transition already shares —
-    // rather than building a second driver.
+    // Shared-element layout animation via FLIP (First-Last-Invert-Play). When a V.Motion(layoutId:)
+    // patches at a resolved layout rect different from the rect the SAME id last settled at —
+    // including across a DIFFERENT physical element entirely, e.g. after a same-key type flip or a
+    // move to a different parent — it tweens from the old rect to the new one instead of jump-cutting:
+    // capture the OLD rect, let this frame's layout settle at the NEW one, compute the delta, apply it
+    // as an inline inverse transform (Invert), then spring that inverse back to zero (Play). Reuses
+    // MotionSpringDriver's existing panel-independent physics channels (translate x/y, uniform scale)
+    // — the same machinery every other spring-driven Motion transition already shares — rather than
+    // building a second driver.
     //
-    // Scope: uniform scale only. MotionSpringDriver.SpringChannel.Scale drives a single Vector2(v, v);
-    // a non-uniform rect change (width and height scale by different factors) averages the two axis
-    // scale factors instead of distorting the element on two independent axes — Framer Motion itself
-    // falls back to the same kind of approximation (via `layout="preserve-aspect"` guidance) when an
-    // element's own aspect ratio changes across the animated rects.
+    // Scope: uniform scale only. MotionSpringDriver.SpringChannel.Scale drives a single Vector2(v, v),
+    // so a non-uniform rect change (width and height scale by different factors) averages the two axis
+    // scale factors into one uniform factor instead of distorting the element on two independent axes.
     internal static class MotionLayoutIdDriver
     {
         // Called from FiberNodePatcher.PatchMotion for a MotionNode carrying a LayoutId, once the

--- a/Packages/com.velvet.core/Runtime/Styling/MotionSpringDriver.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/MotionSpringDriver.cs
@@ -64,9 +64,9 @@ namespace Velvet
     /// </summary>
     internal static class MotionSpringDriver
     {
-        // Rest epsilons, chosen per channel's natural scale (Framer Motion's own defaults — 0.01 — are tuned for
-        // a roughly 0..1 range; a channel in pixels or degrees needs a proportionally larger pair or it would
-        // spend many extra (imperceptible) ticks converging on a threshold far tighter than the value's scale).
+        // Rest epsilons, chosen per channel's natural scale (a 0.01 threshold is tuned for a roughly 0..1 range;
+        // a channel in pixels or degrees needs a proportionally larger pair or it would spend many extra
+        // (imperceptible) ticks converging on a threshold far tighter than the value's scale).
         private const float NormalizedRestDelta = 0.001f; // opacity / uniform scale (~0..1 / ~1 range)
         private const float NormalizedRestSpeed = 0.001f;
         private const float PixelRestDelta = 0.1f; // translate x/y (pixels)

--- a/Packages/com.velvet.core/Runtime/Styling/SilhouetteBoundsSpacer.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/SilhouetteBoundsSpacer.cs
@@ -306,7 +306,6 @@ namespace Velvet
             return new Rect(aabbLocal.xMin - borderLeft, aabbLocal.yMin - borderTop, aabbLocal.width, aabbLocal.height);
         }
 
-        // Axis-aligned union of two rects.
         internal static Rect Union(Rect a, Rect b)
         {
             var xMin = Mathf.Min(a.xMin, b.xMin);

--- a/Packages/com.velvet.core/Runtime/Styling/SpringIntegrator.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/SpringIntegrator.cs
@@ -15,8 +15,8 @@ namespace Velvet
     /// Retargeting mid-flight (calling <see cref="Step"/> with a different <c>target</c> than the previous
     /// call) is intentionally just a normal call: <see cref="Value"/> / <see cref="Velocity"/> are never reset
     /// between calls, so the SAME instance keeps its current value and velocity — the physical continuity an
-    /// interrupted spring needs (e.g. an AnimatePresence exit that gets cancelled hands off to a reversal
-    /// spring built from wherever the exit currently was, not from a fresh rest state).
+    /// interrupted spring needs (e.g. a cancelled exit transition hands off to a reversal spring built from
+    /// wherever the exit currently was, not from a fresh rest state).
     /// <para>
     /// A mutable struct, not a class: <see cref="SpringChannel"/> embeds one inline (as a plain, non-readonly
     /// field — see its own doc) instead of holding a separate heap reference, so a spring channel costs one
@@ -69,9 +69,9 @@ namespace Velvet
 
         /// <summary>
         /// True once the spring is close enough to <paramref name="target"/>, in both position and speed, to
-        /// treat as settled. The default epsilons (Framer Motion's own defaults) suit a roughly 0..1-scale value
-        /// (opacity, a uniform scale factor); a caller animating a pixel or degree-scale channel should pass a
-        /// larger, scale-appropriate pair (see <see cref="MotionSpringDriver"/>'s per-channel epsilons).
+        /// treat as settled. The default epsilons (0.01) suit a roughly 0..1-scale value (opacity, a uniform
+        /// scale factor); a caller animating a pixel or degree-scale channel should pass a larger,
+        /// scale-appropriate pair (see <see cref="MotionSpringDriver"/>'s per-channel epsilons).
         /// </summary>
         public bool IsSettled(float target, float restDelta = 0.01f, float restSpeed = 0.01f)
         {

--- a/Packages/com.velvet.core/Runtime/Styling/StyleAnimationScheduler.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleAnimationScheduler.cs
@@ -6,20 +6,17 @@ using UnityEngine.UIElements;
 
 namespace Velvet
 {
-    // Manages the animation lifecycle for AnimatePresenceNode.
-    // schedule.Execute-based class swapping plus timeout management.
-    // transition-duration and transition-timing-function are set as inline styles, with C# as the
-    // Single Source of Truth.
+    // transition-duration and transition-timing-function are set as inline styles rather than in USS, with
+    // C# as the Single Source of Truth for every play's timing.
     internal sealed class StyleAnimationScheduler
     {
-        // Grace time after a CSS transition completes (ms).
         // UIToolkit's schedule.Execute runs on the next frame, so 50ms is set to absorb the
         // 60fps (16ms) - 30fps (33ms) frame delay.
         private const long AnimationGraceMs = 50;
         private const float MaxDurationSec = 10f;
         private const int MaxPoolSize = 16;
 
-        // Static cache from EasingMode to List<EasingFunction>. EasingMode values are finite, so caching is safe.
+        // EasingMode values are finite, so caching is safe.
         private static readonly Dictionary<EasingMode, List<EasingFunction>> s_easingCache = new();
 
 #if UNITY_EDITOR
@@ -34,14 +31,9 @@ namespace Velvet
         private readonly Stack<List<TimeValue>> _durationPool = new();
         private readonly Stack<List<TimeValue>> _delayPool = new();
 
-        // Starts the mount animation.
-        // 1. Adds EnterFromClass and sets duration / easing as inline styles.
-        // 2. On the next frame, removes EnterFromClass and adds EnterToClass (firing the CSS transition).
-        // 3. After the duration, removes EnterToClass and clears inline styles (clean state).
-        // additionalDelaySec:
-        // Extra delay (seconds) added on top of the StyleTransitionConfig delay.
-        // Used by AnimatePresenceNode.StaggerSec to sequentially delay child elements.
-        // 0 (default) means no extra delay.
+        // The next-frame class swap (EnterFromClass -> EnterToClass) is what fires the CSS transition.
+        // additionalDelaySec: extra delay (seconds) added on top of the StyleTransitionConfig delay, used by
+        // AnimatePresenceNode.StaggerSec to sequentially delay child elements. 0 (default) means no extra delay.
         public void PlayEnter(VisualElement? element, StyleTransitionConfig? config, Action? onComplete = null, float additionalDelaySec = 0f)
         {
             if (element == null || config == null)
@@ -103,8 +95,8 @@ namespace Velvet
         // type/stiffness/damping/mass: the enclosing StyleTransitionConfig's spring knobs (Tween/100/10/1 by
         // default — the caller passes the config's own values through, since this overload takes the
         // already-unpacked timing primitives rather than the config itself).
-        // bezierX1/bezierY1/bezierX2/bezierY2: the config's cubic-bezier control points (Tailwind's own default
-        // curve by default), meaningful only when type is Bezier — passed through the same way.
+        // bezierX1/bezierY1/bezierX2/bezierY2: the config's cubic-bezier control points (cubic-bezier(0.4, 0,
+        // 0.2, 1) by default), meaningful only when type is Bezier — passed through the same way.
         public void PlayVariantEnter(VisualElement? element, string[]? fromClasses, string[]? toClasses,
             float durationSec, EasingMode easing, float delaySec, Action? onComplete = null, float additionalDelaySec = 0f,
             IReadOnlyList<StylePropertyTransition>? propertyOverrides = null,
@@ -281,18 +273,14 @@ namespace Velvet
             }
         }
 
-        // Starts the unmount animation.
-        // 1. Adds ExitFromClass and sets duration / easing as inline styles.
-        // 2. On the next frame, removes ExitFromClass and adds ExitToClass (firing the CSS transition).
-        // 3. After the duration, invokes onComplete (the element is removed).
-        // restoreFromOnCancel:
-        // When true, the exit's FromClasses are the persistent resting state (a variant exit's
-        // variants[animate]); cancelling the exit (the key is re-added mid-exit) re-applies them so the
+        // The next-frame class swap (ExitFromClass -> ExitToClass) is what fires the CSS transition; onComplete
+        // runs after the duration (the caller removes the element).
+        // restoreFromOnCancel: when true, the exit's FromClasses are the persistent resting state (a variant
+        // exit's variants[animate]); cancelling the exit (the key is re-added mid-exit) re-applies them so the
         // element returns to its resting variant instead of being left without it. Default false (preset exits,
         // whose FromClasses are transient).
-        // additionalDelaySec:
-        // Extra delay before the exit transition fires, on top of config.DelaySec. Used for exit
-        // staggering (each removed child delayed by stagger × its index), mirroring the enter stagger.
+        // additionalDelaySec: extra delay before the exit transition fires, on top of config.DelaySec. Used for
+        // exit staggering (each removed child delayed by stagger × its index), mirroring the enter stagger.
         public void PlayExit(VisualElement? element, StyleTransitionConfig? config, Action? onComplete,
             bool restoreFromOnCancel = false, float additionalDelaySec = 0f)
         {
@@ -940,7 +928,6 @@ namespace Velvet
             return false;
         }
 
-        // Sets transition-duration and transition-timing-function as inline styles.
         // C# becomes the Single Source of Truth, so they need not be defined in USS.
         // GC tuning: the EasingFunction list is cached statically per EasingMode; TimeValue lists are
         // reused via per-instance pools.
@@ -1367,8 +1354,7 @@ namespace Velvet
 
         private void ClearTransitionStyles(VisualElement element)
         {
-            // Cleared via the implicit conversion from StyleKeyword to StyleList<T>.
-            // The clear releases UIElements' internal list reference, making pool return safe.
+            // Releases UIElements' internal list reference, making pool return safe.
             element.style.transitionDuration = StyleKeyword.Null;
             element.style.transitionTimingFunction = StyleKeyword.Null;
             element.style.transitionDelay = StyleKeyword.Null;
@@ -1435,8 +1421,7 @@ namespace Velvet
             }
         }
 
-        // State of an in-progress animation. Fields are sufficient since this is a private sealed class.
-        // Created and referenced only inside StyleAnimationScheduler.
+        // Fields are sufficient since this is a private sealed class.
         private sealed class PendingAnimation
         {
             public IVisualElementScheduledItem? ScheduledItem;

--- a/Packages/com.velvet.core/Runtime/Styling/StyleArbitraryModel.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleArbitraryModel.cs
@@ -59,11 +59,10 @@ namespace Velvet
         public const int GroupFocusWithin = 36;
         public const int PeerFocusWithin = 37;
         public const int PeerChecked = 38;
-        // Element-local interaction states. Tailwind's default variant order emits `checked` BEFORE
-        // hover/focus/active, so on a same-property tie an interaction state (emitted later) wins over
-        // `checked:` — the checked layer therefore ranks BELOW them (but still above the relational
-        // group-/peer- layers). Getting this backwards would let a checked control's `checked:` value beat a
-        // concurrent `hover:` / `focus:` / `active:` value, which Tailwind does not.
+        // Element-local interaction states. checked: ranks BELOW hover/focus/active on a same-property tie
+        // — the reference cascade emits checked before the interaction states, and later-emitted wins a
+        // tie — so a checked control's `checked:` value never beats a concurrent `hover:` / `focus:` /
+        // `active:` value (but still above the relational group-/peer- layers).
         public const int Checked = 39;
         public const int Hover = 40;
         public const int Focus = 50;

--- a/Packages/com.velvet.core/Runtime/Styling/StyleArbitraryValueResolver.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleArbitraryValueResolver.cs
@@ -9,16 +9,13 @@ namespace Velvet
 {
 
     // Parses utility-class arbitrary-value syntax (e.g. h-[15%], min-w-[60px], -mt-[20px],
-    // text-[#fff], bg-[#1e1e1e]) and applies the result as an inline style.
-    // Uses inline styles instead of USS classes to reduce reliance on USS files.
-    // text-[...] is overloaded: a color value sets the text color, otherwise the
+    // text-[#fff], bg-[#1e1e1e]) and applies the result as an inline style. Resolved to inline (not USS
+    // classes) because an arbitrary bracket value is unbounded — there is no USS selector that could be
+    // pre-declared for it. text-[...] is overloaded: a color value sets the text color, otherwise the
     // value is a font size. bg-[#color] sets the background color (the bg-[addr:...] image
     // form is handled by StyleBackgroundImageResolver).
     internal static class StyleArbitraryValueResolver
     {
-        // Determines whether className matches an arbitrary-value pattern (prefix-[value]) and returns the parsed result.
-        // Negative values (-mt-[20px]) are also supported.
-        // Parses using IndexOf + string operations rather than regex for speed.
         // Strips the important modifier and reports whether it was present: a leading '!' (!bg-red-500)
         // or a trailing '!' (bg-red-500!). The bare core is returned so the caller routes
         // it normally; when important, the caller elevates the (inline-resolvable) utility to the Important
@@ -66,6 +63,7 @@ namespace Velvet
         public static bool IsInlineResolved(string core)
             => core.IndexOf('[') >= 0 || StyleColorValueParser.HasColorOpacityModifier(core) || MayBeStaticScale(core);
 
+        // Parses using IndexOf + string operations rather than regex — a per-class hot path.
         public static bool TryParse(string className, out ArbitraryStyle result)
         {
             result = default;
@@ -105,7 +103,6 @@ namespace Velvet
                 return false; // prefix is at least 2 chars (e.g. "h-").
             }
 
-            // The last character must be ']'.
             if (className.Length < bracketStart + 2 || className[className.Length - 1] != ']')
             {
                 return false;
@@ -934,8 +931,6 @@ namespace Velvet
         // skipped. An empty result clears the inline filter.
         private static readonly ArbitraryProperty[] s_filterOrder =
         {
-            // Canonical CSS filter order (blur, brightness, contrast, grayscale, hue-rotate, invert,
-            // saturate, sepia) so stacked filters compose identically to the browser.
             ArbitraryProperty.FilterBlur,
             ArbitraryProperty.FilterBrightness,
             ArbitraryProperty.FilterContrast,
@@ -1453,7 +1448,6 @@ namespace Velvet
             }
             else
             {
-                // No unit suffix → Pixel.
                 parsed = float.TryParse(
                     valueStr,
                     NumberStyles.Float,

--- a/Packages/com.velvet.core/Runtime/Styling/StyleChildVariantManipulator.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleChildVariantManipulator.cs
@@ -126,8 +126,8 @@ namespace Velvet
                 return;
             }
 
-            // Reset any previously-applied element that is no longer a current child before re-applying, so a
-            // child moved or removed out of this container drops the class / inline style it carried.
+            // Must run before _applied.Clear() below: it reads the pre-clear _applied list to find children
+            // that left the container.
             ResetStaleApplied(container);
             _applied.Clear();
 

--- a/Packages/com.velvet.core/Runtime/Styling/StyleDivideManipulator.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleDivideManipulator.cs
@@ -118,7 +118,8 @@ namespace Velvet
                 return;
             }
 
-            // Reset any previously-bordered element that is no longer a current child before re-applying.
+            // Must run before _bordered.Clear() below: it reads the pre-clear _bordered list to find children
+            // that left the container.
             ResetStaleBordered(container);
 
             var edge = _spec.Axis == DivideAxis.Horizontal ? Edge.Left : Edge.Top;
@@ -237,7 +238,6 @@ namespace Velvet
             }
         }
 
-        // Detaches (and drops) a child's dashed-divider paint, if any.
         private void DetachDash(VisualElement child)
         {
             if (_ctx.DivideDashBindings.TryGetValue(child, out var binding))

--- a/Packages/com.velvet.core/Runtime/Styling/StyleFilterValueParser.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleFilterValueParser.cs
@@ -41,19 +41,18 @@ namespace Velvet
             ["0"] = 0f, ["15"] = 15f, ["30"] = 30f, ["60"] = 60f, ["90"] = 90f, ["180"] = 180f,
         };
 
-        // brightness multiplier presets (the full Tailwind scale). brightness renders through a first-party
-        // custom-filter shader that multiplies unclamped, so the over-bright values (105/110/125/150/200)
-        // genuinely brighten — the whole point of the shader over the old Tint approximation, which could
-        // never exceed identity.
+        // brightness multiplier presets. brightness renders through a first-party custom-filter shader that
+        // multiplies unclamped, so the over-bright values (105/110/125/150/200) genuinely brighten — the
+        // whole point of the shader over the old Tint approximation, which could never exceed identity.
         private static readonly Dictionary<string, float> s_brightnessPreset = new()
         {
             ["0"] = 0f, ["50"] = 0.5f, ["75"] = 0.75f, ["90"] = 0.9f, ["95"] = 0.95f, ["100"] = 1f,
             ["105"] = 1.05f, ["110"] = 1.1f, ["125"] = 1.25f, ["150"] = 1.5f, ["200"] = 2f,
         };
 
-        // saturate presets as a saturation fraction (the full Tailwind scale). saturate renders through a
-        // first-party custom-filter shader that lerps toward luminance unclamped, so the over-saturate values
-        // (150 / 200) push past the original colour, which the old grayscale(1-N) approximation could not do.
+        // saturate presets as a saturation fraction. saturate renders through a first-party custom-filter
+        // shader that lerps toward luminance unclamped, so the over-saturate values (150 / 200) push past
+        // the original colour, which the old grayscale(1-N) approximation could not do.
         private static readonly Dictionary<string, float> s_saturatePreset = new()
         {
             ["0"] = 0f, ["50"] = 0.5f, ["100"] = 1f, ["150"] = 1.5f, ["200"] = 2f,

--- a/Packages/com.velvet.core/Runtime/Styling/StyleGapManipulator.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleGapManipulator.cs
@@ -178,8 +178,8 @@ namespace Velvet
                 return;
             }
 
-            // Reset any previously-margined element that is no longer a current child before re-applying,
-            // so a child moved or removed out of this container drops its inline gap margin.
+            // Must run before _margined.Clear() (inside ApplyHalfMargin / ApplyLeading below): it reads the
+            // pre-clear _margined list to find children that left the container.
             ResetStaleMargined(container);
 
             if (wrap)

--- a/Packages/com.velvet.core/Runtime/Styling/StyleRingClass.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleRingClass.cs
@@ -46,7 +46,7 @@ namespace Velvet
         // The DEFAULT ring is 3px blue-500; the bare `ring` and a width-only `ring-2` use it (color applied at
         // 0.5 alpha, see DefaultRingColor). An explicit `ring-<color>` is opaque and does not go through here.
         private const float DefaultRingWidth = 3f;
-        // The default ring's alpha. Tailwind renders a ring with no explicit color at blue-500 / 0.5, not full
+        // The default ring's alpha. A ring with no explicit color renders at blue-500 / 0.5, not full
         // opacity; an explicit ring color stays opaque, and the outline default (below) is unaffected.
         private const float DefaultRingAlpha = 0.5f;
         // Bare `outline` (outline-style: solid) — Velvet picks a thin default width; outline-{N} overrides.
@@ -71,7 +71,7 @@ namespace Velvet
             return s_blue500;
         }
 
-        // A color-less ring: blue-500 at 0.5 alpha (Tailwind's default --tw-ring-color).
+        // A color-less ring: blue-500 at 0.5 alpha.
         private static Color DefaultRingColor()
         {
             var c = DefaultBandColor();

--- a/Packages/com.velvet.core/Runtime/Styling/StyleSkewChildTranslateManipulator.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleSkewChildTranslateManipulator.cs
@@ -146,7 +146,6 @@ namespace Velvet
                 return;
             }
 
-            // Relinquish any tracked child the manipulator no longer owns before re-seating the rest.
             DropUnmanaged(container);
 
             var count = container.childCount;

--- a/Packages/com.velvet.core/Runtime/Styling/StyleTextBalanceClass.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleTextBalanceClass.cs
@@ -1,6 +1,6 @@
 namespace Velvet
 {
-    // Recognizes Tailwind's `text-balance` utility for StyleTextBalanceManipulator. Unlike gap-* /
+    // Recognizes the `text-balance` utility for StyleTextBalanceManipulator. Unlike gap-* /
     // grid-cols-*, text-balance carries no scale or arbitrary-value form — it is a bare, parameterless
     // flag — so the classifier is a single exact-match scan rather than a prefix + TryExtract pair.
     internal static class StyleTextBalanceClass

--- a/Packages/com.velvet.core/Runtime/Styling/StyleTextEffectClass.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleTextEffectClass.cs
@@ -47,12 +47,12 @@ namespace Velvet
     // Which unit a resolved Leading value carries: Em multiplies whatever font-size is in effect at the
     // point the rich-text tag is generated (every named leading-* preset); Pixel is an absolute length
     // (leading-[Npx]). Unlike TextTransformKind/TextDecorationKind/WhitespaceCollapseKind, this axis has
-    // deliberately no explicit-reset member: Tailwind defines no leading-auto utility below leading-none, and
-    // every named preset — including leading-none's own multiplier of 1 — is already a real, meaningful
-    // value rather than a sentinel standing in for "reset to nothing" the way normal-case / no-underline /
-    // an explicit whitespace-* class are. A None member here would have no Parse case that ever produces it
-    // and no caller that would ever need it, so it is left out rather than added purely for symmetry with
-    // the other three axes.
+    // deliberately no explicit-reset member: the leading-* utility scale defines no reset value below
+    // leading-none, and every named preset — including leading-none's own multiplier of 1 — is already a
+    // real, meaningful value rather than a sentinel standing in for "reset to nothing" the way normal-case /
+    // no-underline / an explicit whitespace-* class are. A None member here would have no Parse case that
+    // ever produces it and no caller that would ever need it, so it is left out rather than added purely
+    // for symmetry with the other three axes.
     internal enum LeadingUnit
     {
         Em,
@@ -131,7 +131,7 @@ namespace Velvet
     // owns the per-element side-tables and the cascade (walking ancestors for the nearest non-null axis).
     internal static class StyleTextEffectClass
     {
-        // leading-* named presets -> em multiplier (Tailwind's own scale). Applied verbatim as the rich-text
+        // leading-* named presets -> em multiplier. Applied verbatim as the rich-text
         // tag's <line-height=Nem> value — the ENGINE resolves the em against whatever font-size is in effect
         // at that point in the string, so this table needs no font-size-aware pre-baking the way
         // tracking-*'s em scale does in _typography.uss (see fonts.md).

--- a/Packages/com.velvet.core/Runtime/Styling/StyleTransitionConfig.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleTransitionConfig.cs
@@ -39,26 +39,23 @@ namespace Velvet
         /// tween whose easing is an EXACT numeric cubic-bezier curve (<see cref="TransitionType.Bezier"/>). See
         /// <see cref="TransitionType"/> for the full contract, including what each does and does not animate.
         /// </summary>
-        /// <remarks>Equivalent to setting Framer Motion's <c>transition.type</c> to <c>"tween"</c> / <c>"spring"</c>
-        /// for users migrating from Framer Motion — except Velvet defaults to <c>Tween</c> where Framer defaults
-        /// transform-like values to a spring; spring is opt-in here.</remarks>
         public TransitionType Type { get; init; } = TransitionType.Tween;
 
         /// <summary>
         /// Spring stiffness (only meaningful when <see cref="Type"/> is <see cref="TransitionType.Spring"/>).
-        /// Higher values snap toward the target faster. Framer Motion's default (100).
+        /// Higher values snap toward the target faster.
         /// </summary>
         public float Stiffness { get; init; } = 100f;
 
         /// <summary>
         /// Spring damping (only meaningful when <see cref="Type"/> is <see cref="TransitionType.Spring"/>).
-        /// Higher values settle with less oscillation. Framer Motion's default (10).
+        /// Higher values settle with less oscillation.
         /// </summary>
         public float Damping { get; init; } = 10f;
 
         /// <summary>
         /// Spring mass (only meaningful when <see cref="Type"/> is <see cref="TransitionType.Spring"/>).
-        /// Higher values feel heavier / slower to accelerate. Framer Motion's default (1).
+        /// Higher values feel heavier / slower to accelerate.
         /// </summary>
         public float Mass { get; init; } = 1f;
 
@@ -67,7 +64,7 @@ namespace Velvet
         /// CSS <c>cubic-bezier(x1,y1,x2,y2)</c> parameter order. X must stay in [0,1] (a timing function must be
         /// monotone in time); a value outside that range is invalid per the <c>cubic-bezier()</c> spec and
         /// degrades to the default curve below with a one-shot warning, rather than being silently clamped.
-        /// Defaults to Tailwind's own default curve, <c>cubic-bezier(0.4, 0, 0.2, 1)</c> — the exact curve the
+        /// Defaults to <c>cubic-bezier(0.4, 0, 0.2, 1)</c> — the exact curve the
         /// bundled USS only approximates with the <c>ease-in-out</c> keyword.
         /// </summary>
         public float BezierX1 { get; init; } = 0.4f;
@@ -156,19 +153,16 @@ namespace Velvet
         /// (<c>V.AnimatePresence(staggerSec:)</c>), this orchestrates a PLAIN parent → child label propagation —
         /// no AnimatePresence boundary is required; toggling this Motion's <c>animate</c> prop is enough. A
         /// descendant with its OWN explicit <c>animate</c> opts out of both the label inheritance and this
-        /// stagger — it is driven by its own render, not this propagation (matching Framer Motion, where an
-        /// explicit <c>animate</c> override disconnects a component from its parent's variant propagation). The
+        /// stagger — it is driven by its own render, not this propagation. The
         /// stagger index is transitive: an inheriting descendant with no stagger config of its own passes this
         /// orchestration through to ITS OWN inheriting children, who continue claiming from the SAME sequence.
         /// </summary>
-        /// <remarks>Equivalent to Framer Motion's <c>transition.staggerChildren</c> for users migrating from Framer Motion.</remarks>
         public float StaggerChildrenSec { get; init; }
 
         /// <summary>
         /// A fixed delay (seconds) added before any inheriting descendant's staggered delay — see
         /// <see cref="StaggerChildrenSec"/> for the full propagation contract. 0 (default) means no fixed delay.
         /// </summary>
-        /// <remarks>Equivalent to Framer Motion's <c>transition.delayChildren</c> for users migrating from Framer Motion.</remarks>
         public float DelayChildrenSec { get; init; }
 
         /// <summary>
@@ -176,7 +170,6 @@ namespace Velvet
         /// <see cref="StaggerChildrenSec"/>) when its active label changes. Defaults to
         /// <see cref="TransitionWhen.Together"/>.
         /// </summary>
-        /// <remarks>Equivalent to Framer Motion's <c>transition.when</c> for users migrating from Framer Motion.</remarks>
         public TransitionWhen When { get; init; } = TransitionWhen.Together;
 
         /// <summary>
@@ -372,7 +365,6 @@ namespace Velvet
     /// Sequences a Motion's own class swap against its inheriting descendants' swaps — see
     /// <see cref="StyleTransitionConfig.When"/> and <see cref="StyleTransitionConfig.StaggerChildrenSec"/>.
     /// </summary>
-    /// <remarks>Equivalent to Framer Motion's <c>transition.when</c> for users migrating from Framer Motion.</remarks>
     public enum TransitionWhen
     {
         /// <summary>
@@ -392,7 +384,7 @@ namespace Velvet
         BeforeChildren,
 
         /// <summary>
-        /// In Framer Motion, this Motion's own transition would wait for every inheriting descendant to finish
+        /// The name implies this Motion's own transition would wait for every inheriting descendant to finish
         /// first. Not implemented: Velvet applies this Motion's own class swap before its descendants are even
         /// visited during the reconcile walk, so the descendant count / durations needed to delay THIS swap are
         /// not known in time. Setting this value logs a warning and behaves like <see cref="Together"/> (no

--- a/Packages/com.velvet.core/Runtime/Styling/StyleVariantClass.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleVariantClass.cs
@@ -11,8 +11,6 @@ namespace Velvet
     /// (the curated <c>disabled-*</c> utilities). Responsive (<c>sm:</c>/<c>md:</c>), <c>dark:</c>, and
     /// <c>group</c>/<c>peer</c> are tracked separately (they need a breakpoint / theme / structural
     /// signal source).
-    /// <para/>
-    /// Equivalent to Tailwind CSS's state-variant prefixes for users migrating from Tailwind.
     /// </remarks>
     public enum StyleVariantKind
     {

--- a/Packages/com.velvet.core/Runtime/Styling/StyleZIndexClass.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleZIndexClass.cs
@@ -4,8 +4,8 @@ namespace Velvet
 {
     // Parses Velvet's z-* utility classes into a resolved stacking value for FiberZLayerCoordinator. Mirrors
     // StyleGapClass/StyleGridClass: a cheap prefix-scan gate (HasZIndexClass) before the full TryExtract parse.
-    // Supports the fixed Tailwind scale (z-0/10/20/30/40/50), its negated form (-z-10 … -z-50, Tailwind's
-    // negative-value convention: the sign prefixes the whole class), and the arbitrary bracket form (z-[999],
+    // Supports the fixed named scale (z-0/10/20/30/40/50), its negated form (-z-10 … -z-50, the
+    // sign prefixes the whole class), and the arbitrary bracket form (z-[999],
     // z-[-5] — the bracket already carries a signed integer, so no outer "-" is recognized for it: z-index has
     // no separate magnitude/direction split the way a length utility does).
     internal static class StyleZIndexClass
@@ -63,7 +63,7 @@ namespace Velvet
             return found;
         }
 
-        // z-0/10/20/30/40/50 (Tailwind's fixed named scale), -z-0/10/20/30/40/50 (the negated form), or
+        // z-0/10/20/30/40/50 (the fixed named scale), -z-0/10/20/30/40/50 (the negated form), or
         // z-[<int>] (arbitrary, the bracket's own sign — z-[-5] is how a negative arbitrary value is spelled,
         // not -z-[5]). Anything else (including a non-numeric bracket, or a bare "z-" prefix that is not one
         // of these three shapes) returns false.
@@ -110,8 +110,8 @@ namespace Velvet
             return true;
         }
 
-        // The fixed non-arbitrary levels Tailwind's z-index utility defines. Anything outside this set needs
-        // the z-[N] bracket form (mirrors real Tailwind — z-15 is not a thing, z-[15] is).
+        // The fixed non-arbitrary levels the z-index utility scale defines. Anything outside this set needs
+        // the z-[N] bracket form (z-15 is not a thing, z-[15] is).
         private static bool TryNamedLevel(string suffix, out int level)
         {
             switch (suffix)

--- a/Packages/com.velvet.core/Runtime/Styling/VelvetFontWeight.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/VelvetFontWeight.cs
@@ -10,7 +10,6 @@ namespace Velvet
     /// in a <see cref="VelvetFontFamily"/>. When no such asset exists Velvet folds the weight to the
     /// nearest binary value (<c>&gt;= 600</c> → bold, otherwise normal); see <see cref="VelvetFonts"/>.
     /// </summary>
-    /// <remarks>Equivalent to Tailwind CSS's <c>font-weight</c> utility scale for users migrating from Tailwind.</remarks>
     public enum VelvetFontWeight
     {
         Thin = 100,

--- a/Packages/com.velvet.core/Runtime/Styling/VelvetTheme.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/VelvetTheme.cs
@@ -10,7 +10,6 @@ namespace Velvet
     /// Set <see cref="IsDark"/> from your app (e.g. on a settings toggle); every mounted element with
     /// a <c>dark:</c> variant re-evaluates its payload when the value changes.
     /// </summary>
-    /// <remarks>Equivalent to Tailwind CSS's class-based dark-mode strategy for users migrating from Tailwind.</remarks>
     public static class VelvetTheme
     {
         private static bool _isDark;


### PR DESCRIPTION
Part of a per-subsystem pass converting What-narration comments to the Why-only house convention. Comment-only change — zero code tokens touched (verified by a comment-stripping token comparison of every file), EditMode 3234 and PlayMode 90 both green on this tree.

- Deleted 17 comments that restated the adjacent code (call-site duplicates of the callee's own doc, constant labels, step narration); converted ~40 more to state only the constraint/rationale, including 14 XML-doc tightenings.
- Removed the external framework name-drops that had accumulated across 12 files' comments, restating each as the actual behavior or the concrete default value it referenced.
- Relocated one misattributed doc comment to the method it actually describes.

The large majority of comments in the subsystem were already Why-centered and are untouched.