### PR TITLE
refactor(velvet): center Store comments on rationale

### DIFF
--- a/Packages/com.velvet.core/Runtime/Store/Store.cs
+++ b/Packages/com.velvet.core/Runtime/Store/Store.cs
@@ -9,7 +9,6 @@ namespace Velvet
     /// synchronous subscribers notified on every change.
     /// </summary>
     /// <remarks>
-    /// <para>Equivalent to a Zustand store for users migrating from Zustand.</para>
     /// Threading: a store is single-threaded. All reads, mutations (<see cref="SetState"/> /
     /// <see cref="Mutate"/>), and subscription changes must occur on the Unity main thread
     /// (PlayerLoop). The store performs no internal locking; it assumes a single-threaded model.
@@ -48,12 +47,14 @@ namespace Velvet
         #region Infrastructure
 
         /// <summary>
-        /// Logger. null suppresses logs.
+        /// Logger captured from <see cref="StoreLogger.Default"/> at construction. See <see cref="StoreLogger"/>
+        /// to suppress output in tests.
         /// </summary>
         protected StoreLogger Logger { get; }
 
         /// <summary>
-        /// CancellationToken for async operations.
+        /// Cancelled when the store is disposed. Subclasses can thread this through async work so
+        /// in-flight operations observe disposal.
         /// </summary>
         protected CancellationToken CancellationToken
             => _cancellationTokenSource.Token;
@@ -97,14 +98,14 @@ namespace Velvet
         protected bool SetState(Func<TState, TState> updater)
             => TryApply(updater, force: false);
 
-        // The single write path through the state cell: guards disposal, applies the updater, and notifies.
-        // When force is false an Object.is-unchanged result is suppressed; when true it always notifies.
-        // Returns whether a notification was raised.
+        // Sole write path into the state cell: SetState and Mutate both funnel through here, so the
+        // disposal guard and equality check apply to every mutation.
         //
-        // Disposal-order race guard: VContainer / V.Mount cleanup paths can call setState from a UseEffect
-        // cleanup that runs after the store has been disposed (e.g. app shutdown where the singleton store is
-        // disposed before AppRouterInitializer tears down the mounted tree). A state update on an unmounted
-        // component is treated as a no-op, so a setState after disposal is silently ignored rather than throwing.
+        // Disposal-order race guard: during app shutdown, a DI container's LIFO singleton teardown can
+        // dispose this store before the code that tears down the mounted tree runs, so a V.Mount UseEffect
+        // cleanup can still call setState on an already-disposed store. A state update on an unmounted
+        // component is treated as a no-op, so a setState after disposal is silently ignored rather than
+        // throwing.
         //
         // Reference (Object.is) equality is used deliberately: a value-equal but distinct record instance must
         // still notify subscribers. EqualityComparer<T>.Default would invoke record value-equality and suppress
@@ -227,8 +228,8 @@ namespace Velvet
         /// when the store has been disposed; concrete stores implement <see cref="ResetCore"/>.
         /// </summary>
         /// <remarks>
-        /// During app shutdown / scene unload, VContainer disposes singletons LIFO, so a child
-        /// store can be disposed before a parent store's Reset chain reaches it. The same disposal
+        /// During app shutdown / scene unload, a DI container's LIFO singleton teardown can dispose a child
+        /// store before a parent store's Reset chain reaches it. The same disposal
         /// race also fires when V.Mount's UseEffect cleanup runs after the store has been disposed.
         /// Centralizing the guard here ensures every <see cref="Store{TState}"/> subclass — including
         /// those whose <see cref="ResetCore"/> touches disposable internal resources — is automatically
@@ -250,7 +251,7 @@ namespace Velvet
         #region Dispose
 
         /// <summary>
-        /// Releases resources in the order: CTS cancel → state notifier.
+        /// Releases resources in the order: CTS cancel → state notifier → OnDispose.
         /// </summary>
         public void Dispose()
         {

--- a/Packages/com.velvet.core/Runtime/Store/StoreShallowEqualityComparer.cs
+++ b/Packages/com.velvet.core/Runtime/Store/StoreShallowEqualityComparer.cs
@@ -4,8 +4,9 @@ namespace Velvet
 {
     /// <summary>
     /// Shallow equality comparers for selector return values that are sequences.
-    /// Reference-equal elements at matching positions and matching
-    /// lengths are considered equal; deep equality is intentionally not performed.
+    /// Elements are compared with <c>Object.is</c> semantics (see <see cref="Sequence{T}"/> for the
+    /// exact per-type rules) at matching positions with matching lengths; deep equality is
+    /// intentionally not performed.
     /// </summary>
     /// <remarks>
     /// Use this for selectors that return an array/list slice, where a fresh list instance with the
@@ -19,8 +20,9 @@ namespace Velvet
         /// <summary>
         /// Returns a comparer that treats two <see cref="IReadOnlyList{T}"/> as equal when their
         /// lengths match and each element pair is <c>Object.is</c>-equal: reference identity for reference
-        /// types, bit-pattern equality for float/double, and boxed value equality for other value types.
-        /// A fresh-but-value-equal reference-type element therefore counts as changed.
+        /// types (strings compare by ordinal value instead), bit-pattern equality for float/double, and
+        /// boxed value equality for other value types. A fresh-but-value-equal reference-type element
+        /// (other than a string) therefore counts as changed.
         /// </summary>
         public static IEqualityComparer<IReadOnlyList<T>> Sequence<T>() => SequenceComparer<T>.Instance;
 

--- a/Packages/com.velvet.core/Runtime/Store/StoreStateNotifier.cs
+++ b/Packages/com.velvet.core/Runtime/Store/StoreStateNotifier.cs
@@ -3,11 +3,10 @@ using System.Collections.Generic;
 
 namespace Velvet
 {
-    // Holds the current state value and a hand-rolled set of listeners (not an observable stream). Listeners
-    // registered through Subscribe are notified of each value pushed through
-    // Notify; the current value is not replayed on subscribe (subsequent-only).
-    // Callers that need the current value read Value directly, and callers that need
-    // immediate delivery invoke their listener themselves before subscribing.
+    // Hand-rolled listener set, not an observable stream (no operators/buffering). Subscribe only
+    // receives values pushed by later Notify calls; the current value is not replayed at subscribe
+    // time — callers that need it read Value directly, and callers that need immediate delivery
+    // invoke their listener themselves before subscribing.
     // Notification iterates an immutable snapshot of the listener set, rebuilt only when the set
     // changes (copy-on-write), so Notify allocates nothing in the steady state. A
     // listener that subscribes or unsubscribes re-entrantly during a notification does not
@@ -18,7 +17,6 @@ namespace Velvet
     // Single-threaded: no internal locking. All calls (Notify / Subscribe /
     // Dispose) must occur on the owning Store<TState>'s thread (the Unity
     // main thread).
-    // T: State value type.
     internal sealed class StoreStateNotifier<T> : IDisposable
     {
         private readonly List<Action<T>> _listeners = new();
@@ -32,7 +30,7 @@ namespace Velvet
 
         public T Value { get; private set; }
 
-        // Updates the current value and notifies every listener. No-op after disposal.
+        // No-op after disposal.
         public void Notify(T value)
         {
             if (_disposed) return;
@@ -48,8 +46,7 @@ namespace Velvet
             }
         }
 
-        // Registers a listener for subsequent values; the current value is not replayed. Returns a
-        // disposable that removes the listener.
+        // Returns a no-op disposable after disposal instead of throwing.
         public IDisposable Subscribe(Action<T> listener)
         {
             if (_disposed) return NoopDisposable.Instance;
@@ -58,7 +55,7 @@ namespace Velvet
             return new Subscription(this, listener);
         }
 
-        // Clears all listeners. Subsequent Notify calls are no-ops.
+        // Subsequent Notify calls are no-ops.
         public void Dispose()
         {
             if (_disposed) return;


### PR DESCRIPTION
Part of the per-subsystem pass converting What-narration comments to the Why-only house convention. Comment-only change — zero code tokens touched (verified by a comment-stripping token comparison), EditMode 3236 and PlayMode 90 green on this tree.

- Deleted 2 comments that restated the adjacent code; converted 6 more to state only the constraint (the single-write-funnel invariant, subscribe-after-dispose semantics), with 5 XML-doc corrections.
- Corrected three factually wrong claims: the logger doc claimed null suppresses logs (disposal logging calls it unconditionally — suppression actually goes through the swappable default logger), the shallow comparer docs claimed unconditional reference identity for reference types (strings compare by ordinal value), and the dispose doc omitted its final teardown step.
- Removed the remaining external library references, and replaced a comment example that cited a type this repository does not contain with the actual in-repo teardown path.