### PR TITLE
refactor(velvet): center Component comments on rationale

### DIFF
--- a/Packages/com.velvet.core/Runtime/Component/ComponentBoundarySearch.cs
+++ b/Packages/com.velvet.core/Runtime/Component/ComponentBoundarySearch.cs
@@ -4,11 +4,11 @@ using UnityEngine;
 
 namespace Velvet
 {
-    // Walks up the Fiber tree to find an Error Boundary and propagates exceptions to it.
+    // Locates Error and Suspense boundaries by walking the Fiber tree, and propagates exceptions
+    // to the nearest Error Boundary.
     internal static class ComponentBoundarySearch
     {
-        // Walks ancestors of the given fiber and returns the nearest Suspense Boundary.
-        // Includes the fiber itself if it is a boundary. Returns null if not found.
+        // Inclusive of fiber itself.
         internal static ComponentFiber? FindNearestSuspenseBoundary(ComponentFiber fiber)
         {
             for (var current = fiber; current != null; current = current.Parent)
@@ -20,7 +20,7 @@ namespace Velvet
 
 
         // True when fiber's own async slots hold a pending resource (does not walk
-        // descendants). Used by ChildReconciler.ExpandSuspenseInline to scan a Suspense's
+        // descendants). Used by GeneralPathReconciler.ExpandSuspenseInline to scan a Suspense's
         // primary subtree per-fiber while skipping nested boundaries' subtrees.
         internal static bool HasPendingAsyncSlot(ComponentFiber fiber)
         {
@@ -32,9 +32,7 @@ namespace Velvet
             return false;
         }
 
-        // Propagates an exception to the fiber's ancestor Error Boundary.
-        // If a boundary that can catch the exception is found, processing completes there.
-        // Otherwise, falls back to logging via Debug.LogException.
+        // Exclusive of fiber itself (starts at fiber.Parent).
         // fiber is nullable: a caller with no owning component fiber (e.g. AnimatePresence reconciled onto
         // a bare element) has nothing to walk from and falls straight through to the log.
         internal static void PropagateException(ComponentFiber? fiber, Exception exception)

--- a/Packages/com.velvet.core/Runtime/Component/ComponentFiber.cs
+++ b/Packages/com.velvet.core/Runtime/Component/ComponentFiber.cs
@@ -77,7 +77,7 @@ namespace Velvet
 
         /// <summary>
         /// True while this fiber is a primary (hidden) child of a wrapper-less Suspense boundary that
-        /// is currently showing its fallback. Set by <c>ChildReconciler.ExpandSuspenseInline</c> when
+        /// is currently showing its fallback. Set by <c>GeneralPathReconciler.ExpandSuspenseInline</c> when
         /// the boundary suspends and cleared when it reveals. <see cref="FiberWorkLoop.FlushState"/>'s
         /// offscreen guard defers a lane flush for offscreen fibers (their slot is occupied by the
         /// fallback) while still allowing the visible fallback subtree to flush (the
@@ -218,7 +218,6 @@ namespace Velvet
 
         /// <summary>
         /// Scheduling state holding the Lane queue / Transition state.
-        /// A minimal model of the per-fiber and per-subtree pending-update lane bitsets.
         /// Allocated only on demand (lazy init preserves zero-allocation for most components).
         /// </summary>
         internal LaneState? Lanes { get; set; }
@@ -341,7 +340,7 @@ namespace Velvet
         /// inline-mounted mode (<see cref="IsInlineMounted"/>=true) it is a parent VE shared with
         /// sibling fibers, with the sub-range
         /// <c>[<see cref="MountSlotStart"/>, <see cref="MountSlotStart"/> + <see cref="MountSlotCount"/>)</c>
-        /// owned by this fiber. The host VisualElement backing this fiber.
+        /// owned by this fiber.
         /// </summary>
         internal UnityEngine.UIElements.VisualElement? MountPoint { get; set; }
 

--- a/Packages/com.velvet.core/Runtime/Component/ComponentRegistry.cs
+++ b/Packages/com.velvet.core/Runtime/Component/ComponentRegistry.cs
@@ -4,7 +4,6 @@ using UnityEngine.UIElements;
 
 namespace Velvet
 {
-    // Component instance management.
     // Within the Reconciler, manages creation / reuse / disposal of ComponentNode.
     // The cache key is (VisualElement anchor, object slotKey, object identity). Two
     // mounting modes share this key:
@@ -59,7 +58,7 @@ namespace Velvet
             return GetOrCreateCore(node, wrapper, positionKey: null, mountPoint: wrapper, slotStart: 0, isInline: false);
         }
 
-        // Inline-mounted GetOrCreate. Fiber identity is anchored on its parent parentFiber
+        // Fiber identity is anchored on its parent parentFiber
         // by tree position (positionKey) — independent of any VisualElement, so the same
         // fiber resolves regardless of which host container its output lands in (a child
         // fiber's identity is (parent fiber, key, position)). The fiber's rendered output occupies the
@@ -278,7 +277,7 @@ namespace Velvet
         }
 
         // Disposes an inline-mounted fiber identified by reference and removes its registry entry.
-        // Called by ChildReconciler when its per-call old/new fiber-set diff detects
+        // Called by GeneralPathReconciler.SweepOrphans when its per-call old/new fiber-set diff detects
         // an orphan (ComponentNode present on the old side but absent on the new side). The orphan
         // fiber's rendered VEs were already removed from anchor.children by the reconcile's
         // Remove ops; this method releases fiber-side resources (effects, ref cleanups, hook state).
@@ -319,7 +318,7 @@ namespace Velvet
             => _wrapperIndex.TryGetValue(wrapper, out var fiber) ? fiber : null;
 
         // Inline-mounted lookup by tree-position key (parent fiber, position key, identity). Used by
-        // the old-side walk in ChildReconciler to read the previously rendered
+        // the old-side walk in GeneralPathReconciler to read the previously rendered
         // ComponentFiber.PreviousTree without triggering a re-render.
         internal ComponentFiber? TryGetFiberForInlineKey(ComponentFiber? parentFiber, object positionKey, object identity)
         {

--- a/Packages/com.velvet.core/Runtime/Component/ObjectIs.cs
+++ b/Packages/com.velvet.core/Runtime/Component/ObjectIs.cs
@@ -6,7 +6,7 @@ namespace Velvet
     // comparison. Reference types compare by reference; value types compare by value, with the
     // special-number handling described below.
     // Reference types are compared by object.ReferenceEquals, EXCEPT
-    // string, which compares by value (ordinal) — JS Object.is treats strings as primitives,
+    // string, which compares by value (ordinal) — strings are treated as primitives,
     // so a content-equal but freshly-built string bails. float and double are compared by raw
     // bit pattern so that NaN equals itself and +0 does not equal -0. Other value types
     // fall back to EqualityComparer<T>.Default because their boxed identity is unstable on
@@ -33,10 +33,10 @@ namespace Velvet
 
             if (typeof(T) == typeof(string))
             {
-                // Strings are primitives under JS Object.is (Object.is("a","a") === true), so compare by value —
-                // otherwise a dynamically-built but content-equal string (interpolation / concat / Format) would
-                // never bail and a UseState / UseStore / Provider holding it would re-render every time. This
-                // matches the boxed AreEqualObjects path. Handles nulls (string.Equals(null, null) is true).
+                // Strings are treated as primitives, so compare by value — otherwise a dynamically-built but
+                // content-equal string (interpolation / concat / Format) would never bail and a UseState /
+                // UseStore / Provider holding it would re-render every time. This matches the boxed
+                // AreEqualObjects path. Handles nulls (string.Equals(null, null) is true).
                 return string.Equals((string?)(object?)a, (string?)(object?)b, System.StringComparison.Ordinal);
             }
 
@@ -94,8 +94,8 @@ namespace Velvet
             {
                 // Strings are treated as primitive values: two content-equal strings are equal regardless of
                 // instance identity. C# strings are reference types, so compare by value (otherwise a
-                // dynamically-built but content-equal string prop would never bail). This MATCHES JS
-                // `Object.is("a","a") === true` (strings are primitives there) and the generic AreEqual<string>.
+                // dynamically-built but content-equal string prop would never bail). This matches the
+                // generic AreEqual<string> path.
                 return string.Equals((string)a, (string)b, System.StringComparison.Ordinal);
             }
 

--- a/Packages/com.velvet.core/Runtime/Component/V.Mount.cs
+++ b/Packages/com.velvet.core/Runtime/Component/V.Mount.cs
@@ -43,10 +43,8 @@ namespace Velvet
         }
 
 #if UNITY_EDITOR
-        // Picks a human-readable DevTools label for a mounted root. The root fiber's own Body is the
-        // V.Mount lambda (an unnamed closure), so the label is derived from the supplied tree instead:
-        // the root component's function name, else the root element's name, else the target's name,
-        // else a generic fallback.
+        // The root fiber's own Body is the V.Mount lambda (an unnamed closure), so the label is
+        // derived from the supplied tree instead.
         private static string ResolveDevToolsLabel(VNode tree, VisualElement target)
         {
             if (tree is ComponentNode component)

--- a/Packages/com.velvet.core/Runtime/Component/V.cs
+++ b/Packages/com.velvet.core/Runtime/Component/V.cs
@@ -56,7 +56,7 @@ namespace Velvet
         #region Host element factories
 
         /// <summary>
-        /// Creates a VisualElement (generic container). Equivalent to HTML's div.
+        /// Creates a VisualElement (generic container).
         /// Long form: every prop is a named optional parameter. For the shorthand
         /// <c>V.Div("class", child1, child2)</c> form, see the <c>params</c> overload.
         /// </summary>
@@ -1400,7 +1400,7 @@ namespace Velvet
         /// memoizes a function-style component by props equality.
         /// </summary>
         /// <param name="factory">Factory invoked to produce the cached VNode when <paramref name="deps"/> change.</param>
-        /// <param name="deps">Dependency values. When equal to the previous render (each dependency compared with <c>Object.is</c>), the cached VNode is reused.</param>
+        /// <param name="deps">Dependency values. When equal to the previous render (each dependency compared via <see cref="ObjectIs.AreEqualDeps"/> — reference-type elements by identity, strings and primitives by value, floats by raw bit pattern), the cached VNode is reused.</param>
         /// <returns>The created <see cref="MemoNode"/>.</returns>
         public static MemoNode Memoized(Func<VNode> factory, params object?[]? deps)
         {
@@ -1524,8 +1524,8 @@ namespace Velvet
 
         /// <summary>
         /// Renders <paramref name="children"/> into a framework-owned world-space panel positioned by
-        /// a scene transform — UI that lives among 3D content and is depth-tested against it (the drei
-        /// <c>&lt;Html&gt;</c> parity point), unlike the always-on-top screen-space layers. The host
+        /// a scene transform — UI that lives among 3D content and is depth-tested against it, unlike
+        /// the always-on-top screen-space layers. The host
         /// (GameObject + world-space panel) is created on mount, follows <paramref name="position"/> /
         /// <paramref name="rotation"/> updates, and is destroyed on unmount. Children stay part of the
         /// logical tree: context and state cross, and an <c>events:</c> handler on a logical ancestor
@@ -1563,8 +1563,8 @@ namespace Velvet
         }
 
         /// <summary>
-        /// Screen-space element that tracks a 3D scene Transform's projected position every frame — drei's
-        /// <c>&lt;Html&gt;</c> parity (default screen-space projection mode). This is ordinary 2D UI with no
+        /// Screen-space element that tracks a 3D scene Transform's projected position every frame (the
+        /// default screen-space projection mode). This is ordinary 2D UI with no
         /// inherent scene depth (unlike <see cref="WorldSpace"/>, which renders content INTO the 3D scene and
         /// is occluded by it for free) — <paramref name="occlude"/> opts into an explicit physics stand-in for
         /// that test. Forces <c>position: absolute</c> inline (dynamic left/top positioning has no other way
@@ -1588,7 +1588,7 @@ namespace Velvet
         /// <param name="occludeLayerMask">Which colliders count as occluders when <paramref name="occlude"/>
         /// is true. Null (default) resolves to <see cref="Physics.DefaultRaycastLayers"/>.</param>
         /// <param name="distanceFactor">When set, scales the element by this value divided by its current
-        /// distance to the camera — drei's <c>&lt;Html distanceFactor&gt;</c> parity, faking perspective size
+        /// distance to the camera, faking perspective size
         /// falloff for otherwise-flat screen-space content. Null (default) leaves the element unscaled and
         /// never touches <c>style.scale</c>, so it composes with a <c>scale-*</c> class or a Motion scale
         /// variant on the same element; a non-null value OWNS that style slot every tick instead and will
@@ -1642,8 +1642,8 @@ namespace Velvet
         }
 
         /// <summary>
-        /// Container element whose subtree is a focus scope — React Aria's FocusScope. Deviation
-        /// (documented): Aria's scope is renderless (sentinel spans); Velvet's is a real VisualElement,
+        /// Container element whose subtree is a focus scope. Deviation
+        /// (documented): a renderless, sentinel-span scope is common elsewhere; Velvet's is a real VisualElement,
         /// because UI Toolkit containment needs a subtree root for the scoped focus ring and the
         /// membership test. Any existing container can be a scope via props
         /// (<see cref="FiberElementProps.FocusScope"/>) — this factory is convenience for when no
@@ -1698,7 +1698,7 @@ namespace Velvet
         }
 
         /// <summary>
-        /// Drag-and-drop scope — dnd-kit's DndContext. A real container element (the FocusScope
+        /// Drag-and-drop scope. A real container element (the FocusScope
         /// precedent: the element is the stable scope identity and cleanup anchor). Draggables and
         /// droppables pair with their nearest ancestor scope at event time; one drag may be active per
         /// mounted tree at a time. Any existing container can be a scope via props
@@ -1756,7 +1756,7 @@ namespace Velvet
         }
 
         /// <summary>
-        /// Drag source — dnd-kit's useDraggable. The element itself is the drag node; it must sit (at
+        /// Drag source. The element itself is the drag node; it must sit (at
         /// any depth) under a <see cref="DndContext"/> scope.
         /// </summary>
         /// <param name="id">Identity reported to the scope callbacks. An element that is both draggable
@@ -1812,16 +1812,15 @@ namespace Velvet
         }
 
         /// <summary>
-        /// Drop target — dnd-kit's useDroppable. Collides with the active drag's rect under the scope's
-        /// collision strategy; accept-filtering stays app logic in the scope callbacks (dnd-kit core
-        /// behavior).
+        /// Drop target. Collides with the active drag's rect under the scope's
+        /// collision strategy; accept-filtering stays app logic in the scope callbacks.
         /// </summary>
         /// <param name="id">Identity reported to the scope callbacks.</param>
         /// <param name="dropData">Arbitrary payload carried into the callbacks.</param>
         /// <param name="disabled">A disabled droppable never collides.</param>
         /// <param name="whileOverClass">Classes applied while this target is the winning collision.</param>
         /// <param name="whileDragActiveClass">Classes applied to every enabled candidate while any drag
-        /// is live in scope (dnd-kit's droppable "active" cue).</param>
+        /// is live in scope.</param>
         /// <returns>The created <see cref="ElementNode"/>.</returns>
         public static ElementNode Droppable(
             string id,
@@ -1864,11 +1863,11 @@ namespace Velvet
         }
 
         /// <summary>
-        /// Portal-rendered drag preview — dnd-kit's DragOverlay. Expands to
+        /// Portal-rendered drag preview. Expands to
         /// <c>V.Portal(UILayer.Overlay)</c> hosting a framework-positioned, picking-ignored positioner
         /// that is sized to the drag source at activation and tracks the pointer while a drag is active
         /// (hidden otherwise). Render preview content conditionally from state set in
-        /// <c>onDragStart</c>/<c>onDragEnd</c> — dnd-kit's activeId recipe. Inherits
+        /// <c>onDragStart</c>/<c>onDragEnd</c>. Inherits
         /// <c>V.Portal(layer:)</c>'s editor-context degradation.
         /// </summary>
         /// <param name="children">The preview content.</param>
@@ -1955,8 +1954,6 @@ namespace Velvet
         /// <remarks>
         /// AnimatePresence emits no element of its own — its keyed children expand directly into the parent.
         /// Put flex / wrap / gap on the <em>parent</em> element.
-        /// Equivalent to Framer Motion's <c>AnimatePresence</c> (with <c>mode="wait"</c> and
-        /// <c>onExitComplete</c>) for users migrating from Framer Motion.
         /// </remarks>
         public static AnimatePresenceNode AnimatePresence(
             VNode?[]? children = null,
@@ -2024,19 +2021,14 @@ namespace Velvet
         /// <param name="initial">Mount-time starting variant label. When this Motion also sets
         /// <paramref name="animate"/> + <paramref name="variants"/>, the enter starts at <c>variants[initial]</c>
         /// and transitions to <c>variants[animate]</c> (its persistent resting state) using this Motion's
-        /// transition timing — whether this Motion is the DIRECT child of an AnimatePresence or mounts standalone
-        /// (Framer parity: <c>initial</c>/<c>animate</c> apply to any motion.* component).</param>
+        /// transition timing — whether this Motion is the DIRECT child of an AnimatePresence or mounts
+        /// standalone.</param>
         /// <param name="exit">Exit variant label. When this Motion is the DIRECT child of an
         /// AnimatePresence and also sets <paramref name="animate"/> + <paramref name="variants"/>, removal animates
         /// from <c>variants[animate]</c> to <c>variants[exit]</c> (using this Motion's transition timing) before the
         /// element unmounts. Unlike <paramref name="initial"/>, this needs AnimatePresence to defer the unmount —
         /// set outside one, it is inert and logs a warning.</param>
         /// <returns>The created <see cref="MotionNode"/>.</returns>
-        /// <remarks>
-        /// Equivalent to Framer Motion's <c>motion.&lt;tag&gt;</c> component (with its <c>variants</c>,
-        /// <c>initial</c>, <c>animate</c>, and <c>exit</c> props, and parent→child context propagation) for
-        /// users migrating from Framer Motion.
-        /// </remarks>
         public static MotionNode Motion(
             string? className = null,
             string? key = null,

--- a/Packages/com.velvet.core/Runtime/Component/VNodePool.cs
+++ b/Packages/com.velvet.core/Runtime/Component/VNodePool.cs
@@ -271,7 +271,6 @@ namespace Velvet
             return label;
         }
 
-        // Returns a Label to the pool after resetting its UIToolkit-side state.
         // Called by FiberElementCleaner after the label has been removed from the DOM
         // hierarchy and Velvet-managed resources have been released.
         public static void ReturnLabel(Label label) => s_labelPool.Return(label);
@@ -286,7 +285,6 @@ namespace Velvet
 
         public static Button RentButton() => s_buttonPool.Rent();
 
-        // Returns a Button to the pool after resetting its UIToolkit-side state.
         // Called by FiberElementCleaner after the button has been removed from the DOM
         // hierarchy and Velvet-managed resources (event bindings, gesture manipulators) have been released.
         public static void ReturnButton(Button button) => s_buttonPool.Return(button);
@@ -326,7 +324,6 @@ namespace Velvet
 
         public static TextField RentTextField() => s_textFieldPool.Rent();
 
-        // Returns a TextField to the pool after resetting its security-critical input state.
         public static void ReturnTextField(TextField textField) => s_textFieldPool.Return(textField);
 
         #endregion

--- a/Packages/com.velvet.core/Runtime/Component/VNodeTypes.cs
+++ b/Packages/com.velvet.core/Runtime/Component/VNodeTypes.cs
@@ -71,7 +71,6 @@ namespace Velvet
 
         /// <summary>
         /// Function that wraps the element with a wrapper container.
-        /// Input: the created VisualElement → output: the wrapper VisualElement.
         /// The Reconciler places the wrapper in the DOM and tracks the inner real element in a dictionary for patching.
         /// Primary use case: wrapping a button with a DropShadow container.
         /// </summary>
@@ -93,8 +92,9 @@ namespace Velvet
         /// <summary>
         /// Callback invoked when the enter animation completes.
         /// Fires for a variant <see cref="Initial"/>/<see cref="Animate"/> enter whether this Motion sits under
-        /// AnimatePresence or mounts standalone. Invoked immediately when StyleTransitionConfig.None.
-        /// When initial=false, fires synchronously inside CreateElement.
+        /// AnimatePresence or mounts standalone. Invoked immediately when StyleTransitionConfig.None,
+        /// and also synchronously inside Reconcile when the enter animation is skipped entirely (a
+        /// presence-suppressed first mount, or a variant Motion with no resolvable initial state).
         /// On asynchronous animation completion via schedule.Execute, called outside of Reconcile, so SetState()
         /// is safe.
         /// </summary>
@@ -117,7 +117,7 @@ namespace Velvet
         /// <see cref="Variants"/>, the enter starts the element at <c>variants[Initial]</c> and transitions to
         /// <c>variants[Animate]</c> (which it then rests at, persistently) using the <see cref="Transition"/>
         /// timing. Works the same whether this Motion is the direct child of an AnimatePresence or mounts
-        /// standalone — Framer parity: <c>initial</c>/<c>animate</c> apply to any motion.* component; AnimatePresence
+        /// standalone — <c>initial</c>/<c>animate</c> apply to any Motion node; AnimatePresence
         /// is only required for <see cref="Exit"/>. Null = no variant initial state.
         /// </summary>
         public string? Initial { get; init; }
@@ -133,7 +133,7 @@ namespace Velvet
         public string? Exit { get; init; }
 
         /// <summary>
-        /// Shared-element layout animation identity (Framer Motion's <c>layoutId</c> parity). When a Motion
+        /// Shared-element layout animation identity. When a Motion
         /// carrying this same string patches at a resolved layout rect (position and/or size) different from
         /// the rect the SAME id last settled at — including a different physical element entirely, e.g. after
         /// a same-key type flip or a move to a different parent — it tweens from the old rect to the new one
@@ -245,7 +245,7 @@ namespace Velvet
         public required Func<VNode> Factory { get; init; }
 
         /// <summary>
-        /// Dependency array. Compared element-wise with <c>Object.is</c> semantics
+        /// Dependency array. Compared element-wise with identity-equality semantics
         /// (<see cref="ObjectIs.AreEqualDeps"/>): reference-type elements by identity (a fresh-but-equal record
         /// counts as changed), strings/primitives by value, floats by raw bit pattern. NOT a structural
         /// <c>SequenceEqual</c> — there is no recursion into element contents.
@@ -342,7 +342,6 @@ namespace Velvet
     /// <summary>
     /// How an <see cref="AnimatePresenceNode"/> sequences exit and enter when its keyed children change.
     /// </summary>
-    /// <remarks>Equivalent to Framer Motion's <c>AnimatePresence mode</c> prop for users migrating from Framer Motion.</remarks>
     public enum AnimatePresenceMode
     {
         /// <summary>
@@ -400,14 +399,12 @@ namespace Velvet
         /// A fixed delay (seconds) added before ANY child animates. Combined with
         /// the per-child stagger: child i is delayed by <c>DelayChildrenSec + StaggerSec * staggerIndex(i)</c>.
         /// </summary>
-        /// <remarks>Equivalent to Framer Motion's <c>delayChildren</c> for users migrating from Framer Motion.</remarks>
         public float DelayChildrenSec { get; init; }
 
         /// <summary>
         /// Direction the stagger sweeps. <c>1</c> (default) staggers
         /// first-to-last; <c>-1</c> staggers last-to-first (the last child animates first).
         /// </summary>
-        /// <remarks>Equivalent to Framer Motion's <c>staggerDirection</c> for users migrating from Framer Motion.</remarks>
         public int StaggerDirection { get; init; } = 1;
 
         /// <summary>
@@ -433,7 +430,6 @@ namespace Velvet
         /// Not fired when an exit is cancelled by the key re-entering,
         /// nor for children removed without an exit animation.
         /// </summary>
-        /// <remarks>Equivalent to Framer Motion's <c>onExitComplete</c> for users migrating from Framer Motion.</remarks>
         public Action? OnExitComplete { get; init; }
     }
 


### PR DESCRIPTION
Part of the per-subsystem pass converting What-narration comments to the Why-only house convention. Comment-only change — zero code tokens touched (verified by a comment-stripping token comparison), EditMode 3236 and PlayMode 90 green on this tree.

- Deleted 7 comments restating adjacent code; converted 9 more to state only the non-obvious contract (the inclusive/exclusive boundary-walk pair is now stated explicitly on both methods), with 23 XML-doc tightenings across the public factory surface.
- Corrected stale attributions: several comments still credited a sibling class for methods that live on the general-path reconciler after an earlier split, and one claim about enter-completion firing synchronously inside element creation could not have type-checked against the property it cited — replaced with the two real synchronous cases.
- Removed the external framework name-drops from the public XML docs while keeping each behavioral spec anchored (dependency equality now links the exact in-repo comparison rule instead of naming an external algorithm).