### PR TITLE
refactor(velvet): center Routing comments on rationale

### DIFF
--- a/Packages/com.velvet.core/Runtime/Routing/RouteLoaderRunner.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/RouteLoaderRunner.cs
@@ -5,9 +5,8 @@ using Cysharp.Threading.Tasks;
 
 namespace Velvet
 {
-    // Runner that manages execution of route loaders.
-    // LoaderMode.Await loaders must complete synchronously, while
-    // LoaderMode.Suspend loaders run asynchronously in the background.
+    // LoaderMode.Await loaders must complete synchronously; LoaderMode.Suspend loaders run
+    // asynchronously in the background.
     internal sealed class RouteLoaderRunner : IDisposable
     {
         private CancellationTokenSource? _cts;
@@ -37,9 +36,8 @@ namespace Velvet
         // This counter therefore tracks "all live tasks across rounds", not "tasks of the current round".
         internal int ActiveSuspendTaskCount => _activeSuspendTaskCount;
 
-        // Runs loaders for the given matches. Await loaders must complete synchronously; Suspend loaders
-        // are started in the background. On error, the error is recorded per-route in Errors; the caller
-        // is expected to inspect Errors.
+        // Per-route errors are recorded in Errors rather than the return value; the caller is expected
+        // to inspect Errors after this returns.
         public (Dictionary<string?, object> results, bool allCompleted) RunLoadersSync(
             IReadOnlyList<RouteMatch> matches,
             CancellationToken externalToken)
@@ -148,8 +146,7 @@ namespace Velvet
             }
         }
 
-        // Cancels the loaders that are currently in progress. Also runs automatically on the next
-        // RunLoadersSync call.
+        // This also runs automatically at the start of the next RunLoadersSync call.
         public void CancelPending()
         {
             if (_cts != null)
@@ -163,7 +160,7 @@ namespace Velvet
             // If the loader honors the CancellationToken, the awaited task ends with
             // OperationCanceledException and the counter naturally returns to 0.
             // If the loader ignores the ct, the async state machine remains alive and the counter
-            // does not drop (see the OnSuspendLoaderCompleted XmlDoc).
+            // does not drop until it eventually completes (see the ActiveSuspendTaskCount comment).
         }
 
         public void Dispose() => CancelPending();

--- a/Packages/com.velvet.core/Runtime/Routing/Router.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/Router.cs
@@ -10,7 +10,6 @@ namespace Velvet
     /// Navigation controller: matches paths against a route tree, runs guards / blockers / loaders, and
     /// maintains a history stack with Back/Forward. The active instance is exposed as <see cref="Current"/>.
     /// </summary>
-    /// <remarks>Models the same navigation controller role as React Router for users migrating from React Router.</remarks>
     public sealed class Router : IDisposable
     {
         private readonly RouteTree _routeTree;
@@ -334,9 +333,8 @@ namespace Velvet
             }
 
             #region Provisional history index for Back/Forward
-            // Apply the index provisionally before the Guard/Blocker checks.
-            // Required so a Guard redirect (Replace) overwrites the correct entry.
-            // Roll it back if blocked by a Blocker.
+            // The index must move before the Guard/Blocker checks so a Guard redirect (Replace)
+            // overwrites the correct entry; rolled back below if the Blocker check rejects the attempt.
             var savedHistoryIndex = _historyIndex;
             if (mode == NavigationMode.Back)
             {
@@ -413,8 +411,8 @@ namespace Velvet
             #region Blocker check
             var currentPath = CurrentLocation?.Path ?? "";
             var attempt = new NavigationAttempt { CurrentPath = currentPath, NextPath = path, NavigationMode = mode };
-            // Auto-reset the previous block state. By design, a different navigation lifts the block
-            // even if Proceed() was not called (intentional).
+            // By design, a different navigation lifts the previous block even if Proceed() was not
+            // called (intentional).
             _blockerManager.ResetAllBlocked();
 
             var blocked = await _blockerManager.CheckAsync(attempt, cancellationToken);
@@ -439,7 +437,6 @@ namespace Velvet
             #endregion
 
             #region Loading
-            // For Back/Forward navigation, skip loading when cached loader data is already in the history.
             var cachedLoaderData = (mode == NavigationMode.Back || mode == NavigationMode.Forward)
                 ? _history[_historyIndex].loaderData
                 : null;
@@ -626,7 +623,8 @@ namespace Velvet
             _history.Add((path, matches, loaderData, loaderErrors));
             _historyIndex = _history.Count - 1;
 
-            // FIFO: drop the head entry when we exceed the cap.
+            // Evicting the head entry when the cap is exceeded shifts every remaining index down by
+            // one, so _historyIndex must decrement too to keep pointing at the same logical entry.
             if (_history.Count > MaxHistoryEntries)
             {
                 _history.RemoveAt(0);

--- a/Packages/com.velvet.core/Runtime/Routing/SearchParams.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/SearchParams.cs
@@ -11,7 +11,6 @@ namespace Velvet
     /// returns to the previous query) — pass <see cref="NavigationMode.Replace"/> to overwrite the current
     /// entry instead.
     /// </summary>
-    /// <remarks>Equivalent to React Router's <c>setSearchParams(nextInit, navigateOptions)</c> for users migrating from React Router.</remarks>
     public sealed class SearchParamsSetter
     {
         internal static readonly SearchParamsSetter Shared = new();


### PR DESCRIPTION
Part of the per-subsystem pass converting What-narration comments to the Why-only house convention. Comment-only change — zero code tokens touched (verified by a comment-stripping token comparison), EditMode 3236 and PlayMode 90 green on this tree.

- Deleted 2 comments restating adjacent code and trimmed 3 lead sentences that restated member signatures, keeping only the contract each carried (loader errors surface via the error map, not the return value).
- Converted the history-cap eviction and provisional-index comments to state the actual invariants (why the index must decrement with the eviction; why it must move before the guard check and when it rolls back).
- Fixed one wrong cross-reference: the cancel path pointed at an event-dispatch comment for a claim actually documented on the live-task counter, and implied the counter never drops (it drops when the detached task eventually completes).
- Removed the two remaining external-router migration remarks; the summaries already state the behavior in this package's own vocabulary.