### PR TITLE
refactor(velvet): center Reconciler comments on rationale

### DIFF
--- a/Packages/com.velvet.core/Runtime/Reconciler/AnchoredDriver.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/AnchoredDriver.cs
@@ -32,8 +32,7 @@ namespace Velvet
     /// the element's own PARENT-relative space (subtracting <c>element.parent.worldBound.position</c> — UI
     /// Toolkit resolves <c>position: absolute</c> <c>left</c>/<c>top</c> against the immediate parent, not the
     /// panel root, unlike CSS's nearest-positioned-ancestor walk), and writes the result as inline
-    /// <c>left</c>/<c>top</c> — drei's
-    /// <c>&lt;Html&gt;</c> parity (screen-space projection; unlike <c>V.WorldSpace</c>, which renders content
+    /// <c>left</c>/<c>top</c> — a screen-space projection (unlike <c>V.WorldSpace</c>, which renders content
     /// INTO the 3D scene and is depth-tested for free, this is ordinary 2D UI with no inherent scene depth —
     /// <see cref="AnchoredSettings.Occlude"/> opts into an explicit physics stand-in for that test).
     /// <c>RuntimePanelUtils.CameraTransformWorldToPanel</c> is correct here specifically
@@ -149,7 +148,7 @@ namespace Velvet
                 return;
             }
 
-            // View-space depth test (drei's own isObjectBehindCamera equivalent): a target behind the camera
+            // View-space depth test: a target behind the camera
             // plane projects through WorldToScreenPoint with its x/y mirrored, which CameraTransformWorldToPanel
             // would otherwise turn into a wildly wrong on-screen position rather than an obviously-off-screen
             // one — including when HideWhenBehindCamera is false, so that opt-out does not attempt this
@@ -189,7 +188,7 @@ namespace Velvet
                 return;
             }
 
-            // Opt-in physics stand-in for scene depth (drei's <Html occlude> parity): a solid collider
+            // Opt-in physics stand-in for scene depth: a solid collider
             // between the camera and the target hides the element instead of painting it through scene
             // geometry. Linecast's endpoint sits exactly at the target's own pivot, so a target whose own
             // collider encloses that pivot will typically self-occlude — scope OccludeLayerMask to scene
@@ -243,7 +242,7 @@ namespace Velvet
             var distanceFactor = binding.Settings.DistanceFactor;
             if (distanceFactor.HasValue)
             {
-                // drei's <Html distanceFactor> parity: flat screen-space content has no inherent size in
+                // Flat screen-space content has no inherent size in
                 // the scene, so faking perspective falloff means scaling it inversely with camera distance
                 // — distanceFactor is the reference distance at which scale is exactly 1. toTarget (from the
                 // behind-camera test above) already holds camera-to-target; reused here rather than a

--- a/Packages/com.velvet.core/Runtime/Reconciler/ChildReconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ChildReconciler.cs
@@ -93,17 +93,16 @@ namespace Velvet
         //     explains why: an inline fiber under a torn-down host is otherwise invisible to the
         //     normal orphan sweep and "would survive to be re-paired as a zombie on a same-key
         //     re-entry" — which is exactly what create-then-remove reintroduces.
-        //   newElement is ALWAYS inserted, abort or not (#48): _ctx.IsAborted only ever becomes true
+        //   newElement is ALWAYS inserted, abort or not: _ctx.IsAborted only ever becomes true
         //     via FiberErrorBoundary.TryCatch -> SetAborted, which fires exclusively on TryShowFallback's
         //     SUCCESS path (fiber.Reconciler.Reconcile(fiber.MountPoint, ..., fallbackTree) returned
         //     without throwing and FallbackContentFailed is false) — i.e. by the time CreateElement
         //     returns, newElement already holds a fully, successfully rendered subtree (the boundary's
         //     fallback content in place of whatever threw beneath it), not a half-built one. Discarding
-        //     it and leaving the slot empty was strictly worse than what React does: an error boundary
-        //     that catches never leaves the DOM with nothing where its fallback should be (render never
-        //     touches the committed tree — see ReactFiberThrow.js's throwException, which only tags
-        //     fibers for the commit phase to later process; Velvet has no such phase split, so the
-        //     nearest equivalent is "don't throw away content the boundary already finished building").
+        //     it and leaving the slot empty would be strictly worse: an error boundary that catches must
+        //     never leave the DOM with nothing where its fallback should be. Velvet has no render/commit
+        //     phase split that could defer this decision, so the nearest equivalent is "don't throw away
+        //     content the boundary already finished building".
         //     checkAbortAfterCreate's true meaning is narrower: stop scanning further siblings in THIS
         //     pass, because the boundary already resolved the failure and any later slot's patch/replace
         //     would be racing a reconcile the caller no longer owns end-to-end.

--- a/Packages/com.velvet.core/Runtime/Reconciler/DndActiveDrag.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/DndActiveDrag.cs
@@ -175,7 +175,7 @@ namespace Velvet
             }
             else if (_activation.Distance <= 0f)
             {
-                // Unconstrained (DragActivation.None): dnd-kit's raw PointerSensor — the press IS the drag.
+                // Unconstrained (DragActivation.None): the press IS the drag.
                 Activate();
                 return;
             }
@@ -393,8 +393,8 @@ namespace Velvet
             _appliedActiveClasses.Add((element, binding.ActiveClasses));
         }
 
-        // Candidacy pairs a droppable with its NEAREST enclosing DndContext (dnd-kit keeps nested
-        // contexts isolated): subtree containment alone would leak an inner scope's droppables into an
+        // Candidacy pairs a droppable with its NEAREST enclosing DndContext, keeping nested contexts
+        // isolated: subtree containment alone would leak an inner scope's droppables into an
         // outer scope's drag, handing the outer callbacks drop ids they never registered.
         private bool IsCollisionCandidate(VisualElement element, DndDroppableBinding binding)
             => !binding.Settings.Disabled

--- a/Packages/com.velvet.core/Runtime/Reconciler/DndCollisions.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/DndCollisions.cs
@@ -4,16 +4,15 @@ using UnityEngine;
 namespace Velvet
 {
     /// <summary>
-    /// The built-in collision strategies — dnd-kit's <c>rectIntersection</c> / <c>closestCenter</c> /
-    /// <c>pointerWithin</c>. All are pure functions over a <see cref="DndCollisionQuery"/> (no panel
-    /// access), returning a single winning id or null. Documented deviation from dnd-kit: a strategy
-    /// returns one winner, not a ranked collision list — the context only ever consumes the first
-    /// collision anyway, and the delegate's return can be extended compatibly later. None of them
-    /// consider occlusion (dnd-kit parity — its strategies are rect-based too).
+    /// The built-in collision strategies: <see cref="RectIntersection"/>, <see cref="ClosestCenter"/>, and
+    /// <see cref="PointerWithin"/>. All are pure functions over a <see cref="DndCollisionQuery"/> (no panel
+    /// access), returning a single winning id or null rather than a ranked collision list — the context
+    /// only ever consumes the first collision anyway, and the delegate's return can be extended compatibly
+    /// later. None of them consider occlusion; all are rect-based only.
     /// </summary>
     public static class DndCollisions
     {
-        /// <summary>Largest ActiveRect-droppable intersection area wins (the dnd-kit default). Ties
+        /// <summary>Largest ActiveRect-droppable intersection area wins. Ties
         /// resolve by registration order (first candidate wins).</summary>
         public static readonly DndCollisionDetection RectIntersection = (in DndCollisionQuery query) =>
         {

--- a/Packages/com.velvet.core/Runtime/Reconciler/DndDriver.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/DndDriver.cs
@@ -194,8 +194,8 @@ namespace Velvet
             positioner.style.height = StyleKeyword.Null;
         }
 
-        // One overlay per mounted tree: the first registered positioner wins (dnd-kit renders one
-        // DragOverlay per DndContext; several in one Velvet tree would fight over one pointer).
+        // One overlay per mounted tree: the first registered positioner wins — several in one
+        // Velvet tree would fight over one pointer.
         public static DndOverlayBinding? FindOverlay(ReconcilerContext ctx, out VisualElement? positioner)
         {
             foreach (var (element, binding) in ctx.DragOverlayBindings)

--- a/Packages/com.velvet.core/Runtime/Reconciler/DndTypes.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/DndTypes.cs
@@ -20,11 +20,10 @@ namespace Velvet
     /// <summary>
     /// Constraint before a press becomes a drag, so clicks keep working on draggable elements.
     /// <see cref="Distance"/> is panel px of travel before activation. A <see cref="DelaySec"/> &gt; 0
-    /// switches to hold-to-drag mode (dnd-kit's either/or): activation happens after the hold, aborted if
-    /// the observed travel exceeds <see cref="Tolerance"/> first. The default is Distance = 4 — a
-    /// documented deviation from dnd-kit's unconstrained PointerSensor default, because a zero threshold
-    /// would race UI Toolkit's own Clickable capture-at-down and kill clicks on draggable buttons;
-    /// <see cref="None"/> restores the raw dnd-kit behavior.
+    /// switches from distance-based to hold-to-drag activation: activation happens after the hold,
+    /// aborted if the observed travel exceeds <see cref="Tolerance"/> first. The default is Distance = 4,
+    /// not 0, because a zero threshold would race UI Toolkit's own Clickable capture-at-down and kill
+    /// clicks on draggable buttons; <see cref="None"/> restores unconstrained (zero-threshold) activation.
     /// </summary>
     public sealed record DragActivation(float Distance = 4f, float DelaySec = 0f, float Tolerance = 5f)
     {
@@ -79,8 +78,8 @@ namespace Velvet
     public readonly struct DndCollisionQuery
     {
         /// <summary>The source's activation-time <c>worldBound</c> translated by the current pointer
-        /// delta (dnd-kit's translated-initial-rect semantics) — correct even under
-        /// <see cref="DragMovement.None"/>, where the source element itself never moves.</summary>
+        /// delta — correct even under <see cref="DragMovement.None"/>, where the source element itself
+        /// never moves.</summary>
         public Rect ActiveRect { get; }
         /// <summary>Current pointer position, panel space.</summary>
         public Vector2 PointerPosition { get; }
@@ -99,7 +98,7 @@ namespace Velvet
     public delegate string? DndCollisionDetection(in DndCollisionQuery query);
 
     /// <summary>
-    /// Drag-and-drop scope configuration — dnd-kit's <c>DndContext</c> props. All callbacks are optional;
+    /// Drag-and-drop scope configuration. All callbacks are optional;
     /// <see cref="CollisionDetection"/> null means <see cref="DndCollisions.RectIntersection"/>;
     /// <see cref="Activation"/> is the scope-wide default a per-draggable override wins over.
     /// </summary>
@@ -111,7 +110,7 @@ namespace Velvet
         DndCollisionDetection? CollisionDetection = null,
         DragActivation? Activation = null);
 
-    /// <summary>Drag-source configuration — dnd-kit's <c>useDraggable</c> options. The element carrying
+    /// <summary>Drag-source configuration. The element carrying
     /// the setting is the drag node itself.</summary>
     public sealed record DraggableSettings(
         string Id,
@@ -121,10 +120,10 @@ namespace Velvet
         DragActivation? Activation = null,
         string? WhileDraggingClass = null);
 
-    /// <summary>Drop-target configuration — dnd-kit's <c>useDroppable</c> options.
+    /// <summary>Drop-target configuration.
     /// <see cref="WhileOverClass"/> applies while this target is the winning collision;
     /// <see cref="WhileDragActiveClass"/> applies to every enabled candidate while any drag is live in
-    /// scope (dnd-kit's droppable <c>active</c> cue).</summary>
+    /// scope.</summary>
     public sealed record DroppableSettings(
         string Id,
         object? Data = null,

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberAmbientStack.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberAmbientStack.cs
@@ -6,8 +6,8 @@ namespace Velvet
     // Ambient context that holds the currently rendering ComponentFiber in a thread-static stack.
     // A component calls Push at the start of Render and Pop at the end.
     // The Hooks static class resolves the fiber via this stack's Current.
-    // Distinct in role from ReconcilerContext.FiberStack (used for parent/child tracking); intentionally
-    // separated for separation of concerns.
+    // Distinct in role from ReconcilerContext.FiberStack, which tracks parent/child relationships rather
+    // than the ambient current-fiber lookup Hooks needs.
     internal static class FiberAmbientStack
     {
         [ThreadStatic]

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberBatchScheduler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberBatchScheduler.cs
@@ -16,7 +16,7 @@ namespace Velvet
     // preserved — only the scheduler-callback count collapses to one per tier.
     internal sealed class FiberBatchScheduler
     {
-        // Cap on the drain-until-quiet passes one DrainImmediate performs — React's
+        // Cap on the drain-until-quiet passes one DrainImmediate performs — the
         // "Maximum update depth exceeded" limit (one initial pass plus this many nested ones):
         // each pass exists for commit-phase writes (a callback ref or an event dispatched during
         // a commit re-enqueues its fiber mid-drain), and a component whose commit writes a NEW
@@ -65,8 +65,7 @@ namespace Velvet
         private Action<bool>? _onDrainBegin;
         private Action? _onDrainEnd;
         // Flushes any pending passive effects from a prior commit, wired by the owning Reconciler. Run before a
-        // synchronous discrete-event drain so those effects commit before the new update's render — React's
-        // flushPassiveEffects-before-update.
+        // synchronous discrete-event drain so those effects commit before the new update's render.
         private Action? _flushPassiveEffects;
 
         // True when an immediate drain has just established snapshot pins that a pending delayed drain should
@@ -119,8 +118,8 @@ namespace Velvet
             _onDrainEnd = onDrainEnd;
         }
 
-        // Registers the pending-passive-effect flush run before a synchronous discrete-event drain (React's
-        // flushPassiveEffects-before-update). Called once by the owning Reconciler.
+        // Registers the pending-passive-effect flush run before a synchronous discrete-event drain.
+        // Called once by the owning Reconciler.
         internal void SetPassiveEffectFlush(Action flush) => _flushPassiveEffects = flush;
 
         // Enqueues fiber for a batched flush at the next frame boundary
@@ -164,8 +163,8 @@ namespace Velvet
             // Commit-phase state writes (a callback ref invoked during the patch, an event
             // dispatched from a detach) re-enqueue their fiber mid-drain. Keep draining until the
             // queue is quiet so the follow-up render commits before this frame callback yields —
-            // React's "setState during the commit schedules a follow-up pass before paint". Each
-            // pass opens a fresh tearing-guard wave (a commit write moved state forward, so its
+            // a state update issued during the commit still schedules a follow-up pass before paint.
+            // Each pass opens a fresh tearing-guard wave (a commit write moved state forward, so its
             // first UseStore read re-pins the now-current snapshot). _immediateScheduled stays SET
             // for the whole loop: the loop itself consumes every mid-drain enqueue, so registering
             // another frame callback for one would only fire an empty drain next frame (dead
@@ -176,12 +175,13 @@ namespace Velvet
             {
                 if (totalPasses > NestedUpdateLimit)
                 {
-                    // Runaway commit-phase loop (a component writing a NEW value on every pass).
-                    // React throws here; a throw from the frame callback cannot reach an error
-                    // boundary and would only re-arm next frame, burning the full cap every frame
-                    // forever — so the runaway update is DROPPED instead and the UI keeps the last
-                    // committed state. Only the IMMEDIATE-tier lanes are dropped: a fiber can be
-                    // queued this deep with an unrelated Transition/Deferred lane still pending (the
+                    // Runaway commit-phase loop (a component writing a NEW value on every pass) — the
+                    // kind of bug that would ordinarily deserve a hard failure, but a throw from the
+                    // frame callback cannot reach an error boundary and would only re-arm next frame,
+                    // burning the full cap every frame forever — so the runaway update is DROPPED
+                    // instead and the UI keeps the last committed state. Only the IMMEDIATE-tier
+                    // lanes are dropped: a fiber can be queued this deep with an unrelated
+                    // Transition/Deferred lane still pending (the
                     // runaway's commits may write bystanders each pass), and wiping that lane would
                     // strand its delayed-tier work (a StartTransition left isPending forever).
                     FiberLogger.LogError("Scheduler",
@@ -357,10 +357,10 @@ namespace Velvet
             DrainImmediate();
         }
 
-        // Flushes a prior commit's pending passive effects (React's flushPassiveEffects-before-update), driven
-        // by the discrete-event boundary so an effect runs before that event's render — NOT from the mount /
-        // commit-phase FlushImmediate callers, which must leave passive effects pending for the scheduler tick.
-        // Gated like FlushImmediate so it never re-enters a live drain / reconcile.
+        // Flushes a prior commit's pending passive effects, driven by the discrete-event boundary so an
+        // effect runs before that event's render — NOT from the mount / commit-phase FlushImmediate
+        // callers, which must leave passive effects pending for the scheduler tick. Gated like
+        // FlushImmediate so it never re-enters a live drain / reconcile.
         internal void FlushPendingPassiveEffects()
         {
             if (_draining || (_reconcileActiveProbe?.Invoke() ?? false)) return;

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberBeginWork.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberBeginWork.cs
@@ -15,8 +15,6 @@ namespace Velvet
         // updates; an unconditional render-phase setState would otherwise loop forever.
         internal const int RenderPhaseUpdateLimit = 25;
 
-        // Reads state via hooks and invokes the function body that declares the VNode tree.
-        // The body is stored in ComponentFiber.Body.
         internal static VNode Render(ComponentFiber fiber) => fiber.Body!();
 
         internal static void ResetHookIndex(ComponentFiber fiber)
@@ -120,7 +118,6 @@ namespace Velvet
         // discarded attempt cannot break callback referential stability or force a memo rebuild.
         internal static void CommitSettledHookDeps(ComponentFiber fiber)
         {
-            // The settled attempt's context reads become the committed dependency list (list swap).
             fiber.CommitStagedDependencies();
             HookEffectExecutor.CommitEffectDeps(fiber.LayoutEffects);
             HookEffectExecutor.CommitEffectDeps(fiber.InsertionEffects);

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberContextSpine.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberContextSpine.cs
@@ -16,7 +16,7 @@ namespace Velvet
     // spine fiber — WITHOUT re-running any ancestor body (that is the bailout: clean ancestors contribute
     // their committed Provider values for free). The target then renders with a correct live cursor and
     // Hooks.UseContext<T> reads the top of the stack.
-    // The provider-enclosure search mirrors ChildReconciler.ExpandInlineRecursive: position keys
+    // The provider-enclosure search mirrors GeneralPathReconciler.ExpandInlineRecursive: position keys
     // for unkeyed ComponentNodes are per-identity counters within one reconcile scope (a fiber body
     // output, or one element's children reconcile), Fragment/Provider continue the current scope, an
     // element node opens a fresh scope for its children, and a Memo resolves to its committed inner.
@@ -368,7 +368,7 @@ namespace Velvet
 
                     case AnimatePresenceNode presence:
                     {
-                        // AnimatePresence is DOM-less: ChildReconciler.ExpandAnimatePresenceInline expands each
+                        // AnimatePresence is DOM-less: GeneralPathReconciler.ExpandAnimatePresenceInline expands each
                         // keyed child directly into the parent's slot range, each under its own PresenceChildScope
                         // with a FRESH position counter (EmitPresenceChild rents one per child). A wrapper-hosted
                         // spine child therefore registers under THIS ancestor by its own slotKey, exactly like an

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberCrossPanelInput.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberCrossPanelInput.cs
@@ -44,12 +44,13 @@ namespace Velvet
     //     is an ordinary, already-live user element that normally outlives this reconciler, unlike a
     //     framework-owned host root.
     //
-    // Mirrors React's own root-level event delegation (a single listener per event type at the DOM
-    // root, walking Fiber.return instead of the DOM to build the dispatch order — see
-    // DOMPluginEventSystem.js's accumulateSinglePhaseListeners) with one deliberate adaptation: Velvet
-    // does NOT move every event to root-level delegation. Ordinary same-panel bubbling stays exactly as
-    // UI Toolkit's own native dispatch already does it (FiberEventBindingManager.Bind's direct
-    // RegisterCallback<T> registrations on each element), since that already agrees with the logical
+    // Uses a single root-level listener per event type that walks the physical parent chain,
+    // redirecting through a fiber's logical parent only at a nested portal / world-space boundary
+    // (see NextLogicalAncestor), to build its dispatch order, but with one
+    // deliberate adaptation: Velvet does NOT move every event to root-level delegation. Ordinary
+    // same-panel bubbling stays exactly as UI Toolkit's own native dispatch already does it
+    // (FiberEventBindingManager.Bind's direct RegisterCallback<T> registrations on each element),
+    // since that already agrees with the logical
     // tree everywhere except at a portal/world-space boundary. This dispatcher only takes over at the
     // seams where physical bubbling structurally cannot reach the logical chain: a host panel's root
     // (nothing physical above it at all), and a same-panel registry target (something physical above

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberDiscreteEventScope.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberDiscreteEventScope.cs
@@ -9,8 +9,9 @@ namespace Velvet
     /// flushes the owning context's immediate batch synchronously so the update commits in the same frame.
     /// The flag is restored before the flush so updates scheduled by effects that run during the flush take
     /// the Normal lane; they still commit within this same synchronous flush (the drain loops until its
-    /// queue is quiet — React's setState-in-commit semantics — with the maximum-update-depth cap bounding a
-    /// runaway feedback pair), just without escalating the discrete Urgent classification. Shared by
+    /// queue is quiet, so a state update issued during commit still commits within the same flush, with
+    /// the maximum-update-depth cap bounding a runaway feedback pair), just without escalating the
+    /// discrete Urgent classification. Shared by
     /// <c>FiberEventBindingManager</c> (clicks, value changes, discrete pointer/key bindings) and the
     /// drag-and-drop session (<c>OnDragStart</c>/<c>OnDragEnd</c>/<c>OnDragCancel</c>), so a drag commit
     /// behaves exactly like a click handler's.
@@ -30,7 +31,7 @@ namespace Velvet
                 FiberWorkLoop.IsInDiscreteEvent = wasInDiscreteEvent;
                 if (!wasInDiscreteEvent)
                 {
-                    // React flushes a prior commit's pending passive effects before a discrete update's render,
+                    // Pending passive effects from a prior commit are flushed before a discrete update's render,
                     // so the effect runs before this event's re-render. Scoped to the discrete boundary (not the
                     // mount / commit-phase FlushImmediate callers, which keep passive effects pending). The
                     // event's own flush still runs even if a runaway passive-effect loop throws its guard.

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberEffects.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberEffects.cs
@@ -46,15 +46,15 @@ namespace Velvet
 
         private static void CommitSubtreeEffectsNow(ComponentFiber fiber, bool mountDoubleInvoke)
         {
-            // React commits ALL layout-effect cleanups (the mutation phase) across a whole subtree before ANY
+            // Commit ALL layout-effect cleanups (the mutation phase) across a whole subtree before ANY
             // layout-effect setup (the layout phase). This root fiber and the inline children MountInline
             // deferred onto the drain stack form one subtree, so their layout effects run as one cleanup pass
             // then one setup pass with the root interleaved between: the root's cleanup runs before a child's
             // setup, so a child setup that writes shared state can no longer be observed by the root's cleanup —
-            // React's [child.cleanup, root.cleanup, child.setup, root.setup]. Committing each child fully before
+            // [child.cleanup, root.cleanup, child.setup, root.setup]. Committing each child fully before
             // the root began (the child's setup ahead of the root's cleanup) inverted that pair. Imperative
             // handles and layout setups belong to the setup pass; insertion effects run in the cleanup pass
-            // (React runs them during mutation).
+            // (they belong to the mutation phase too).
             var stack = fiber.Reconciler?.Context.DeferredInlineLayoutEffectFibers;
             List<(ComponentFiber Fiber, bool IsMount)>? inlineBatch = null;
             if (stack is { Count: > 0 })
@@ -70,8 +70,8 @@ namespace Velvet
             HookEffectExecutor.RunFactoriesAndClear(fiber, fiber.PendingLayoutEffects, mountDoubleInvoke);
 
             // A setup (a child's or this root's) that mounted more inline children pushed them onto the drain
-            // stack: they are a subsequent pass, committed after this root's layout phase — React runs
-            // effect-mounted work in a follow-up commit, not the current one.
+            // stack: they are a subsequent pass, committed after this root's layout phase — work newly
+            // mounted from inside an effect commits in a follow-up commit, not the current one.
             DrainDeferredInlineLayoutEffects(fiber);
             ScheduleRunEffects(fiber, mountDoubleInvoke);
         }
@@ -111,7 +111,8 @@ namespace Velvet
         // batch interleaved with its own root, then calls this to pick up any fibers a setup mounted. The outer
         // loop re-drains because an inline setup can synchronously push MORE deferred fibers (e.g. a
         // UseLayoutEffect that mounts another inline child) — each such push is a fresh subtree, committed after
-        // the one that mounted it, matching how React runs effect-mounted work in a follow-up commit.
+        // the one that mounted it, the same follow-up-commit treatment as any other work mounted from inside
+        // an effect.
         private static void DrainDeferredInlineLayoutEffects(ComponentFiber rootFiber)
         {
             var stack = rootFiber.Reconciler?.Context.DeferredInlineLayoutEffectFibers;
@@ -128,7 +129,7 @@ namespace Velvet
         // parents), and runs the layout-effect CLEANUP pass over that order into `ordered` — per fiber, its
         // insertion effects then its layout-effect cleanups. The caller feeds the same `ordered` list to
         // RunInlineLayoutSetups for the SETUP pass; splitting the two lets CommitSubtreeEffectsNow interleave
-        // its root fiber's own cleanup/setup between them, so React's all-cleanups-before-all-setups holds
+        // its root fiber's own cleanup/setup between them, so the all-cleanups-before-all-setups invariant holds
         // across the root/child boundary and not just within the child batch. Ordering off a snapshot and
         // running after is equivalent to running mid-walk: an effect that synchronously pushes MORE deferred
         // fibers lands on the stack and is picked up by the caller's re-drain, not this already-captured batch.
@@ -162,7 +163,7 @@ namespace Velvet
             OrderByNearestStagedAncestorPostOrder(deduped, pushedSet, static e => e.Fiber, ordered);
             bufferPool.ReturnFiberSet(pushedSet);
 
-            // Cleanup pass — React's mutation phase. Running every cleanup before any setup is the point of the
+            // Cleanup pass — the mutation phase. Running every cleanup before any setup is the point of the
             // split: a later fiber's cleanup must not observe state an earlier fiber's setup wrote. Insertion
             // effects belong to the mutation phase too; imperative handles and layout setups defer to the setup
             // pass so a parent setup can observe a child's already-committed handle.
@@ -430,8 +431,8 @@ namespace Velvet
         }
 
         // Context overload: the batch scheduler drives this before a synchronous discrete-event flush so a
-        // prior commit's pending passive effects run before the new update's render — React's
-        // flushPassiveEffects-before-update. A no-op when nothing is pending.
+        // prior commit's pending passive effects run before the new update's render. A no-op when nothing
+        // is pending.
         internal static void FlushPendingPassiveEffects(ReconcilerContext context)
         {
             // An effect setup may setState and stage a fresh batch synchronously; drain until quiescent.

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberElementCleaner.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberElementCleaner.cs
@@ -3,8 +3,8 @@ using UnityEngine.UIElements;
 
 namespace Velvet
 {
-    // Responsible for removing DOM elements and releasing their resources.
-    // Recursively cleans up event bindings, components, animations, and descendants.
+    // Element-exit teardown: every path that removes an element from the DOM funnels through here so
+    // the ~25 per-element resource categories are released exactly once (see CleanupElementResources).
     internal sealed class FiberElementCleaner
     {
         private readonly ReconcilerContext _ctx;
@@ -151,7 +151,6 @@ namespace Velvet
             }
         }
 
-        // Recursively cleans up the element's events, components, animations, and descendants.
         // DOM operations (RemoveAt / RemoveFromHierarchy) are performed by the caller.
         public void CleanupElement(VisualElement element)
         {

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberElementProps.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberElementProps.cs
@@ -58,7 +58,7 @@ namespace Velvet
         private bool? _delegatesFocus;
 
         /// <summary>
-        /// Focus-scope behavior for this container element (React Aria's FocusScope parity). Attachable to
+        /// Focus-scope behavior for this container element. Attachable to
         /// ANY container — the modal Div you already have can be the scope; <c>V.FocusScope</c> is sugar for
         /// when no container exists yet.
         /// </summary>
@@ -66,18 +66,18 @@ namespace Velvet
         private FocusScopeSettings? _focusScope;
 
         /// <summary>
-        /// Drag-and-drop scope configuration for this container element (dnd-kit's DndContext parity).
+        /// Drag-and-drop scope configuration for this container element.
         /// Draggables and droppables pair with their nearest ancestor scope at event time.
         /// </summary>
         public DndContextSettings? DndContext { get => _dndContext; set { ThrowIfReadOnly(); _dndContext = value; } }
         private DndContextSettings? _dndContext;
 
-        /// <summary>Drag-source configuration (dnd-kit's useDraggable parity) — the element carrying it
+        /// <summary>Drag-source configuration — the element carrying it
         /// is the drag node itself.</summary>
         public DraggableSettings? Draggable { get => _draggable; set { ThrowIfReadOnly(); _draggable = value; } }
         private DraggableSettings? _draggable;
 
-        /// <summary>Drop-target configuration (dnd-kit's useDroppable parity).</summary>
+        /// <summary>Drop-target configuration.</summary>
         public DroppableSettings? Droppable { get => _droppable; set { ThrowIfReadOnly(); _droppable = value; } }
         private DroppableSettings? _droppable;
 
@@ -204,8 +204,8 @@ namespace Velvet
     }
 
     /// <summary>
-    /// Focus-management behavior for a container subtree — React Aria's FocusScope parity:
-    /// <see cref="Contain"/>/<see cref="RestoreFocus"/>/<see cref="AutoFocus"/> map 1:1;
+    /// Focus-management behavior for a container subtree: <see cref="Contain"/>, <see cref="RestoreFocus"/>,
+    /// and <see cref="AutoFocus"/> are straightforward toggles;
     /// <see cref="SingleTabStop"/> is the WAI-ARIA composite-widget (roving) contract adapted to UI Toolkit,
     /// where arrow/dpad movement inside the group is already engine-native 2D navigation. Record structural
     /// equality simplifies DiffProps.
@@ -218,7 +218,7 @@ namespace Velvet
     /// it first entered the scope (skipped if that element is gone, detached, or cannot grab focus).</param>
     /// <param name="AutoFocus">On mount (the scope's FIRST attach-to-panel, never a re-attach such as a
     /// keyed reorder's), focus the scope's first focusable descendant (skipped when focus is already
-    /// inside the scope) — matching React's mount-once autoFocus.</param>
+    /// inside the scope).</param>
     /// <param name="SingleTabStop">The subtree behaves as one Tab stop: Tab from inside exits past the
     /// remaining members (wrapping within the nearest containing scope, if any); Tab entering from outside
     /// — in either direction — lands on the last-focused member, else the scope's first. Members keep

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberErrorBoundary.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberErrorBoundary.cs
@@ -10,19 +10,14 @@ namespace Velvet
     // plumbing it relies on stays on FiberRenderer (the render core) and is called back into here.
     internal static class FiberErrorBoundary
     {
-        // Hook for when an exception occurs during Render() or Reconcile.
-        // Walks up the Fiber tree to find the nearest Error Boundary and attempts to catch.
-        // If no boundary catches it, logs via Debug.LogException.
-        // Error Boundaries catch only errors in their child subtree.
-        // A fiber's own Render() exception is not caught by itself, and is delegated to a parent (or higher) boundary.
+        // Error Boundaries catch only errors in their child subtree — a fiber's own Render() exception is
+        // not caught by itself, and is delegated to a parent (or higher) boundary instead.
         internal static void OnRenderError(ComponentFiber fiber, Exception exception)
             => ComponentBoundarySearch.PropagateException(fiber, exception);
 
-        // Fallback path for a function-style Error Boundary. Invokes the factory registered via
-        // Hooks.UseFallback within the Render of a [Component(IsErrorBoundary = true)]
-        // component and returns the fallback VNode. Builds an ErrorInfo with the
-        // throwing fiber's ComponentStack. Returns null if no factory is registered,
-        // propagating to a higher boundary.
+        // Fallback path for a function-style Error Boundary: invokes the factory registered via
+        // Hooks.UseFallback within the Render of a [Component(IsErrorBoundary = true)] component.
+        // Returns null when no factory is registered, so the caller keeps propagating to a higher boundary.
         private static VNode? RenderFallback(ComponentFiber fiber, ComponentFiber? throwingFiber, Exception exception)
         {
             if (fiber?.FallbackFactory == null) return null;
@@ -109,16 +104,13 @@ namespace Velvet
 
         // Attempts to display a fallback UI via this fiber's own RenderFallback; returns true on success.
         // Delegation to a parent boundary is performed by the caller (ComponentBoundarySearch.PropagateException)
-        // by walking the Fiber tree.
-        // Opt-in contract: only components with IsErrorBoundary=true are eligible to catch.
-        // Returns false unless the candidate fiber has IsErrorBoundary=true.
+        // by walking the Fiber tree. Opt-in contract: only a fiber with IsErrorBoundary=true is eligible
+        // to catch — every other candidate returns false immediately, even if reached via some other path.
         // fiber: Candidate Error Boundary fiber.
         // exception: Exception thrown by a descendant render that should be caught.
         // True when the fallback was rendered successfully and the exception is consumed; false to continue propagation.
         public static bool TryCatch(ComponentFiber fiber, ComponentFiber? throwingFiber, Exception exception)
         {
-            // Opt-in contract: even if a Fiber returning IsErrorBoundary=false has TryCatch invoked through some
-            // path, it does not catch.
             if (!fiber.IsErrorBoundary || fiber.Reconciler == null) return false;
             // A fiber whose own fallback content throws re-enters here (the content's per-fiber render
             // catch routes back to this same boundary via ComponentBoundarySearch.PropagateException).

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberEventBindingManager.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberEventBindingManager.cs
@@ -5,7 +5,6 @@ using UnityEngine.UIElements;
 
 namespace Velvet
 {
-    // Manages event registration / unregistration.
     // Uses an "unbind all → bind all" diff strategy. Event count is typically 1-3, so this is lightweight enough.
     // Unity internally reuses functor pools, so GC pressure is also low.
     internal sealed class FiberEventBindingManager
@@ -140,8 +139,6 @@ namespace Velvet
             _bindingsByElement.Remove(element);
         }
 
-        // Checks whether the bindings already registered on the element match the new event array.
-        // If they match, re-binding is not necessary.
         // Order-sensitive: assumes the insertion order of _boundDelegates matches newEvents.
         // Currently only called from PatchCommon, where Bind invocation order guarantees this.
         public bool HasSameBindings(VisualElement element, FiberEventBinding[] newEvents)
@@ -179,7 +176,6 @@ namespace Velvet
             return true;
         }
 
-        // Unbinds every event from every element.
         public void Clear()
         {
             foreach (var kvp in _unbindActions)

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberFocusNavigator.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberFocusNavigator.cs
@@ -31,7 +31,7 @@ namespace Velvet
         public VisualElement? LastFocusedMember;
         public VisualElement? RestoreTarget;
         public bool RestoreCaptured;
-        // AutoFocus is mount-once, matching React: the latch is set on the scope's FIRST attach no matter
+        // AutoFocus is mount-once: the latch is set on the scope's FIRST attach no matter
         // what the setting held then, so neither a keyed reorder's re-attach nor a post-mount settings
         // flip can ever fire it again.
         public bool AutoFocusFired;
@@ -591,7 +591,7 @@ namespace Velvet
             // Contain snap-back: focus left a contained scope through a path the sequential interception
             // cannot see (a spatial 2D move, or a pointer press outside) — pull it back inside within the
             // same event flush. A landing INSIDE any contain scope stands instead: the scope receiving
-            // focus claims it (React Aria's newest-scope activation — a stacked dialog must be able to
+            // focus claims it (the newest scope wins — a stacked dialog must be able to
             // take focus from the modal underneath), and because a snap-back's own landing is by
             // construction inside a contain scope, the recursion is structurally terminal — no re-entrancy
             // flag needed (one would not work anyway: UI Toolkit QUEUES focus events raised from inside a
@@ -836,7 +836,7 @@ namespace Velvet
             binding.OnAttach = _ =>
             {
                 FiberFocusNavigator.EnsureAttached(element, ctx);
-                // Mount-once, matching React's autoFocus (it acts on mount, never again): the latch is
+                // Mount-once (it acts on mount, never again): the latch is
                 // taken on the FIRST attach regardless of the setting's value at that moment, so a
                 // post-mount settings flip cannot re-arm it for a later physical re-attach (a keyed
                 // reorder moves the subtree via RemoveAt + Insert, whose transient detach also clears

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberMemoCache.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberMemoCache.cs
@@ -12,7 +12,6 @@ namespace Velvet
         // Convenience overload for callers that don't need the cache-hit flags.
         public VNode GetOrCompute(string cacheKey, MemoNode memo) => GetOrComputeWithHitInfo(cacheKey, memo).result;
 
-        // Returns the cached VNode or computes a new one, along with cache-hit information.
         // Used by PatchNode to skip child-tree rebuilds on a cache hit.
         public (VNode result, bool wasHit, VNode? previousCached) GetOrComputeWithHitInfo(string cacheKey, MemoNode memo)
         {
@@ -52,10 +51,9 @@ namespace Velvet
 
         public void Clear() => _cache.Clear();
 
-        // Returns every cached inner tree to the VNode pool, then clears. Called at reconciler
-        // disposal: the whole mounted tree is torn down with it, so there is no committed successor
-        // to spare (a cached inner shared with an already-retired committed tree is a harmless
-        // overlap — pool returns are idempotent).
+        // Called at reconciler disposal: the whole mounted tree is torn down with it, so there is no
+        // committed successor to spare (a cached inner shared with an already-retired committed tree is
+        // a harmless overlap — pool returns are idempotent).
         public void DisposeAndReturnCachedTrees()
         {
             foreach (var entry in _cache.Values)

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodeFactory.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodeFactory.cs
@@ -76,7 +76,7 @@ namespace Velvet
                     if (elementNode.Children != null)
                     {
                         var childContainer = FiberNodePatcher.GetChildContainer(element);
-                        // ReconcileChildren (= ChildReconciler.ExpandInlineRecursive) inline-expands
+                        // ReconcileChildren (= GeneralPathReconciler.ExpandInlineRecursive) inline-expands
                         // ComponentNode / ContextProviderNode / FragmentNode so children appear as
                         // direct siblings under <paramref name="childContainer"/>. These node kinds
                         // produce no DOM element of their own. The same path is used
@@ -379,8 +379,8 @@ namespace Velvet
                     // the unmount for a removal to animate against, and AnimatePresence is what does that — so
                     // exit outside one is genuinely inert. Warn like the shadow-*/clip-path-* gates above. Initial
                     // is NOT warned here (see the standalone enter below): unlike exit, a mount-time enter needs
-                    // no deferred unmount to play against, so it works on any Motion, matching Framer parity
-                    // (initial/animate apply to any motion.* component; only AnimatePresence is exit-only).
+                    // no deferred unmount to play against, so it works on any Motion (initial/animate apply
+                    // anywhere; only exit is AnimatePresence-only).
                     if (_ctx.PresenceExpansionDepth == 0 && motionNode.Exit != null)
                     {
                         FiberLogger.LogWarning("Motion",
@@ -423,7 +423,7 @@ namespace Velvet
                                 + "enter. An inherited animate label does not yet drive one.");
                         }
                     }
-                    // Shared-element layout animation (Framer's layoutId) on a freshly-created element —
+                    // Shared-element layout animation (layoutId) on a freshly-created element —
                     // the same-key-type-flip case PatchMotion's own registration cannot reach (a type
                     // flip tears down the OLD element and creates a genuinely NEW one for the SAME id,
                     // never routing through PatchMotion at all). MotionLayoutIdDriver.OnPatched already
@@ -440,7 +440,7 @@ namespace Velvet
                 }
                 case AnimatePresenceNode:
                     // AnimatePresence is DOM-less: it never becomes a single element.
-                    // ChildReconciler.ExpandAnimatePresenceInline expands its keyed children directly into
+                    // GeneralPathReconciler.ExpandAnimatePresenceInline expands its keyed children directly into
                     // the parent's slot range, so CreateElement is never invoked on it.
                     throw new System.InvalidOperationException(
                         "[FiberNodeFactory] AnimatePresenceNode is DOM-less and must be inline-expanded, not created as an element.");
@@ -528,7 +528,7 @@ namespace Velvet
                     // resolved inner is a ComponentNode, or a ComponentNode that is a direct child of
                     // an AnimatePresence keyed entry. ComponentNodes reached during a
                     // ChildReconciler.Reconcile pass (top-level or nested under an element) are
-                    // inline-mounted (no wrapper VE) by ChildReconciler.ExpandInlineRecursive, so this
+                    // inline-mounted (no wrapper VE) by GeneralPathReconciler.ExpandInlineRecursive, so this
                     // case is unreachable for them.
                     // A Component does not emit a DOM element; its rendered tree attaches
                     // directly to the parent. Velvet needs an anchor element for fiber tracking,
@@ -547,7 +547,7 @@ namespace Velvet
                     // list reached through MemoNode's resolved inner) tracks for this Provider entry —
                     // the wrapper element is a deliberate choice, as documented on ContextProviderNode.
                     //
-                    // ChildReconciler.ExpandInlineRecursive expands Provider inline (no wrapper) during
+                    // GeneralPathReconciler.ExpandInlineRecursive expands Provider inline (no wrapper) during
                     // a Reconcile pass, so this case is unreachable for slot-based reconciliation; it is
                     // reached only when CreateElement is invoked directly on a Provider VNode — e.g. a
                     // MemoNode resolved inner.

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
@@ -556,9 +556,9 @@ namespace Velvet
             // Runtime variant swap: PatchBaseElement above already synced the class list to the final resting
             // state (appliedNew) via a plain, instant diff. When the effective label actually changed WHICH
             // variant classes are applied AND this Motion declares a Transition, replay that same swap as a
-            // VISUAL tween on the scheduler instead — Framer applies `transition` to every animate update, not
-            // just the first. A null Transition keeps today's plain, instant diff (Velvet does not imitate
-            // Framer's implicit default transition).
+            // VISUAL tween on the scheduler instead — a transition should apply to every animate update, not
+            // just the first. A null Transition keeps today's plain, instant diff (Velvet applies no implicit
+            // default transition).
             // Gated off an element the scheduler already treats as EXITING (not off PresenceAnchorMotion
             // identity — that field is set for every current AnimatePresence child, including a plain
             // PERSISTING one this swap must still drive when its ambient label changes, e.g. a coordinator
@@ -589,12 +589,12 @@ namespace Velvet
             // (absent by this rule) binding.
             _appliers.ApplyRingOnPatch(element, appliedNew, suppress: false, allowWrap: false);
 
-            // Shared-element layout animation (Framer's layoutId): independent of the variant swap
+            // Shared-element layout animation (layoutId): independent of the variant swap
             // above — runs from the ACTUAL resolved-rect delta, not a class-defined from/to pair — so
             // it fires whether or not this patch also changed Variants/Animate. Falls back to
             // StyleTransitionConfig's own documented spring defaults (Stiffness 100 / Damping 10 /
             // Mass 1) when this Motion declares no Transition, since a layoutId tween needs SOME spring
-            // shape to animate with and Velvet does not imitate Framer's implicit default transition
+            // shape to animate with and Velvet applies no implicit default transition
             // for the variant swap either.
             if (newNode.LayoutId != null)
             {
@@ -929,7 +929,7 @@ namespace Velvet
         // FiberNodeFactory.CreateElement's ContextProviderNode case. Used when the
         // Provider is reached as a node-typed keyed entry (e.g. inside an AnimatePresence subtree,
         // or as a MemoNode's resolved inner) — paths where
-        // ChildReconciler.ExpandInlineRecursive's inline Provider expansion does not apply.
+        // GeneralPathReconciler.ExpandInlineRecursive's inline Provider expansion does not apply.
         internal void PatchContextProvider(VisualElement wrapper, ContextProviderNode oldNode, ContextProviderNode newNode)
         {
             newNode.PushContext(_ctx.ComponentContextStack);

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberRenderer.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberRenderer.cs
@@ -75,7 +75,7 @@ namespace Velvet
 
         // Inline-mount variant for wrapper-less fibers. The fiber's render output is held on the
         // fiber's ComponentFiber.PreviousTree for the caller (typically
-        // ChildReconciler.ExpandInlineRecursive) to incorporate into the parent expansion;
+        // GeneralPathReconciler.ExpandInlineRecursive) to incorporate into the parent expansion;
         // no Reconcile is issued from the fiber itself. The caller is responsible for placing the
         // output VEs into parent.children at slotStart.
         // Subsequent setState-triggered re-renders use the fiber's own Reconciler with slot-range
@@ -147,7 +147,7 @@ namespace Velvet
         // ComponentNode's fiber.Parent stays null even though ComponentRegistry itself is unambiguously
         // running inside a real, non-orphaned context. Falling back to bootstrapping a fresh, unrelated
         // Reconciler+ReconcilerContext there silently detaches the fiber from the caller's registries /
-        // FiberStack / IsAborted flag (see #51). Left null only by V.Mount's direct root-fiber path,
+        // FiberStack / IsAborted flag. Left null only by V.Mount's direct root-fiber path,
         // which has no context to join and must bootstrap its own (this fiber becomes the owner).
         private static void SetupMount(ComponentFiber fiber, VisualElement? mountPoint, ReconcilerContext? sharedContext = null)
         {

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberStrictMode.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberStrictMode.cs
@@ -10,7 +10,6 @@ namespace Velvet
     /// surface impure renders and non-symmetric effect cleanup. Exposed as a single editor-wide switch and
     /// compiled out of player builds entirely.
     /// </summary>
-    /// <remarks>Equivalent to React's StrictMode for users migrating from React.</remarks>
     public static class FiberStrictMode
     {
         /// <summary>

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberSuspendSignal.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberSuspendSignal.cs
@@ -2,12 +2,10 @@ using System;
 
 namespace Velvet
 {
-    // Sentinel exception thrown by Use<T> against a pending async resource.
-    // RenderAndReconcile catches it and asks the nearest Suspense Boundary to display the fallback.
-    // Uses only a singleton instance to distinguish from regular exceptions, and does not retain a stack trace.
-    // A pending async read aborts the in-progress render by throwing this signal, which unwinds the
-    // stack up to the nearest Suspense Boundary so it can show its fallback until the resource settles.
-    // This class must be caught only by Velvet's internal RenderAndReconcile and never by user code.
+    // Sentinel exception thrown by Use<T> against a pending async resource; unwinds the render stack
+    // until RenderAndReconcile catches it and shows the nearest Suspense boundary's fallback until the
+    // resource settles. Singleton instance with no retained stack trace, since it exists only as a
+    // control-flow signal. Must be caught only by Velvet's internal RenderAndReconcile, never by user code.
     internal sealed class FiberSuspendSignal : Exception
     {
         public static readonly FiberSuspendSignal Instance = new();

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberTreeTraversal.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberTreeTraversal.cs
@@ -8,8 +8,6 @@ namespace Velvet
     // reliably even across memoized subtrees.
     internal static class FiberTreeTraversal
     {
-        // Generic visitor that walks fibers under root via iterative DFS and applies
-        // visitor to each fiber.
         // Uses an explicit Stack rather than recursion to avoid StackOverflowException on deeply nested
         // component trees. root itself is also visited.
         // Sibling nodes are processed in reverse order due to Stack LIFO, but all current callers
@@ -32,10 +30,8 @@ namespace Velvet
             }
         }
 
-        // Walks fibers under root and schedules every consumer that registered a
-        // dependency on contextKey (via UseContext) for re-render.
-        // Only fibers that read the changed context are
-        // scheduled. Each scheduled consumer re-renders later (setState lane) and reads the new value LIVE
+        // Schedules for re-render every fiber that registered a dependency on contextKey (via UseContext).
+        // Each scheduled consumer re-renders later (setState lane) and reads the new value LIVE
         // from the context cursor — the spine of enclosing Providers is reconstructed onto the cursor by
         // FiberContextSpine before its body runs — so no per-fiber snapshot is distributed
         // here. The reconstruction always reflects the nearest Provider, so an inner Provider that masks

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberWorkLoop.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberWorkLoop.cs
@@ -53,8 +53,8 @@ namespace Velvet
             // re-run; the state slot already holds the new value by the time this is called. The
             // gate is the render-phase window, NOT IsRendering: a write landing later in the same
             // flush (a callback ref invoked during the patch, an event dispatched from a detach) is
-            // a commit-phase update that falls through to the regular schedule below — React's
-            // "setState in a commit schedules a follow-up pass" — where the flag would be consumed
+            // a commit-phase update that falls through to the regular schedule below (a state update
+            // issued during commit schedules a follow-up pass) — where the flag would be consumed
             // by nobody and cleared, silently dropping the write. A setter for a *different* fiber
             // that fires during this fiber's render also falls through.
             if (fiber.IsInRenderPhase && ReferenceEquals(FiberAmbientStack.Current, fiber))
@@ -97,7 +97,7 @@ namespace Velvet
 
             fiber.LaneQueue.Add(priority);
 
-            // When adding the Transition Lane anew, reset the starvation counter.
+            // When adding the Transition Lane, reset the starvation counter (also on a coalesced re-add).
             if (priority == FiberUpdatePriority.Transition)
             {
                 fiber.TransitionStarvationCounter = 0;

--- a/Packages/com.velvet.core/Runtime/Reconciler/IReconcilerHost.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/IReconcilerHost.cs
@@ -24,7 +24,7 @@ namespace Velvet
         // propagated snapshot reflects it. Used by FiberNodePatcher's
         // ContextProviderNode case when the keyed Provider entry's value changes
         // between renders (e.g. inside an AnimatePresence subtree, where the Provider stays in the
-        // keyed map rather than being inline-expanded by ChildReconciler.ExpandInlineRecursive).
+        // keyed map rather than being inline-expanded by GeneralPathReconciler.ExpandInlineRecursive).
         void NotifyContextValueChange(ContextProviderNode newProvider);
 
         // Implementations must always invoke ChildReconciler.Reconcile with

--- a/Packages/com.velvet.core/Runtime/Reconciler/ReconcileKeying.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ReconcileKeying.cs
@@ -87,9 +87,6 @@ namespace Velvet
         // CanPatch decision — whether an old and new node share enough identity to patch the existing
         // element in place rather than remove + recreate. Shared by the keyed/indexed fast path and the
         // general-path CommitLeaf.
-        // Same type (both ElementNode) AND same ElementType AND matching wrapper presence → true.
-        // Same type (both TextNode) → true.
-        // Otherwise → false.
         internal static bool CanPatch(VNode? oldNode, VNode? newNode)
         {
             if (oldNode == null || newNode == null)

--- a/Packages/com.velvet.core/Runtime/Reconciler/Reconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Reconciler.cs
@@ -92,7 +92,7 @@ namespace Velvet
                 // Lets the batch scheduler block a synchronous discrete-event flush while any reconcile
                 // pass (including a time-sliced resume that runs outside the batch Drain) is on the stack.
                 _ctx.BatchScheduler.SetReconcileActiveProbe(() => _ctx.SharedReconcileDepth > 0);
-                // React flushes pending passive effects before a new discrete-event update; wire the scheduler
+                // Pending passive effects must be flushed before a new discrete-event update; wire the scheduler
                 // to drain them at that boundary so an effect from a prior commit runs before the next render.
                 _ctx.BatchScheduler.SetPassiveEffectFlush(() => FiberEffects.FlushPendingPassiveEffects(_ctx));
                 // Brackets each drain to drive (1) the UseStore cross-tier tearing guard — pinning is active only

--- a/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerBufferPool.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerBufferPool.cs
@@ -68,7 +68,7 @@ namespace Velvet
 
         #endregion
 
-        #region For DOM-less AnimatePresence (ChildReconciler.ExpandAnimatePresenceInline) + BuildKeyedMapCopy
+        #region For DOM-less AnimatePresence (GeneralPathReconciler.ExpandAnimatePresenceInline) + BuildKeyedMapCopy
 
         private readonly ClearablePool<List<(string key, VNode node)>> _presenceListPool = new(l => l.Clear());
         private readonly ClearablePool<HashSet<string>> _presenceKeyPool = new(s => s.Clear());

--- a/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
@@ -688,7 +688,7 @@ namespace Velvet
 
         // Callback-ref bookkeeping per element (BaseElementNode.RefCallback): the callback identity
         // that installed the current ref plus its returned cleanup. The identity is stored so a
-        // patch can tell a STABLE ref apart from a swapped one — matching React, a ref cycles
+        // patch can tell a STABLE ref apart from a swapped one — a ref cycles
         // (cleanup, then setup) only when its identity changes or the element remounts. The cleanup
         // fires when the element detaches from the DOM, releasing resources such as resetting
         // Ref<T>.Current to null.
@@ -731,7 +731,7 @@ namespace Velvet
         // the boundary's re-render, which re-attempts the primary subtree and commits the reveal in one pass
         // (a resolved resource schedules the boundary itself, not the suspended child — committing
         // the child independently would write into the slot range the fallback occupies). Maintained by
-        // ChildReconciler.ExpandSuspenseInline; read by FiberWorkLoop.FlushState.
+        // GeneralPathReconciler.ExpandSuspenseInline; read by FiberWorkLoop.FlushState.
         internal HashSet<ComponentFiber> SuspendedBoundaries { get; } = new();
 
         // Removes all wrapper-less Suspense boundary state keyed by boundary.

--- a/Packages/com.velvet.core/Runtime/Reconciler/WrapperInfrastructure.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/WrapperInfrastructure.cs
@@ -17,8 +17,6 @@ namespace Velvet
             _ctx = ctx;
         }
 
-        // Returns the inner real element when the input is a wrapper container.
-        // Otherwise returns the input unchanged.
         internal VisualElement ResolveWrapped(VisualElement domElement)
             => _ctx.WrapperToInnerMap.GetValueOrDefault(domElement, domElement);
 
@@ -49,7 +47,7 @@ namespace Velvet
         // are paint-only; this wrapper is not): only flexGrow/flexShrink are forwarded — an inner
         // with a percentage width in a row parent, or one relying on the parent's default
         // cross-axis stretch, sizes against the wrapper instead of the real parent and can
-        // shrink-wrap. Documented in the velvet-ui skill; fixing it for one layer must fix both.
+        // shrink-wrap. Both wrapper layers share this limitation, so fixing it for one must fix both.
         internal static VisualElement CreatePassthroughWrapper(string ussClass)
         {
             var wrapper = new VisualElement
@@ -80,8 +78,8 @@ namespace Velvet
                 return;
             }
             var index = parent.IndexOf(wrapper);
-            element.RemoveFromHierarchy(); // out of the wrapper
-            wrapper.RemoveFromHierarchy(); // wrapper leaves the parent
+            element.RemoveFromHierarchy();
+            wrapper.RemoveFromHierarchy();
             parent.Insert(index, element);
         }
 


### PR DESCRIPTION
Part of the per-subsystem pass converting What-narration comments to the Why-only house convention, over the codebase's densest subsystem (57 files read, 31 touched; the large majority of its comments are load-bearing invariant prose and are untouched). Comment-only apart from one preprocessor region label — zero code tokens touched (verified by a comment-stripping token comparison of every file), EditMode 3236 and PlayMode 90 green on this tree.

- Deleted a stale decision-table comment that contradicted the patchability switch below it (it claimed two node kinds patch; the switch accepts twelve), plus 10 other pure restatements.
- Fixed a systematic stale attribution left by an earlier class split: 14 comments (and one region label) credited a sibling class for methods that live on the general-path reconciler, each verified against the sole real definition site.
- Neutralized the remaining external framework references (event-delegation, effect-ordering, presence, anchoring) while keeping every timing/ordering fact — including re-deriving one event-walk description from the actual code after the neutralization had inverted its emphasis (the walk is physical-parent-first, redirecting through logical parents only at portal boundaries).
- Removed one bare issue-number reference and a pointer to a file that exists only outside this repository, restating both facts self-containedly.