### PR TITLE
refactor(velvet): center compile-time tooling comments on rationale

### DIFF
--- a/Packages/com.velvet.core/CodeGen/CompilerWeaver.cs
+++ b/Packages/com.velvet.core/CodeGen/CompilerWeaver.cs
@@ -406,8 +406,8 @@ namespace Velvet.CodeGen
 
             // Injecting a raw `Ret` for the cache-hit path or wrapping a `Ret` inside
             // a `try`/`finally`/`catch` would bypass the `Leave` protocol that CLR
-            // requires for protected regions, producing invalid IL. Bail out and let
-            // the SG (or a future Leave-aware weaver) handle these shapes.
+            // requires for protected regions, producing invalid IL. Bail out; a future
+            // Leave-aware version of this weaver could handle these shapes instead.
             if (body.HasExceptionHandlers
                 && IsInsideAnyHandler(body, lastHookBoundary, returns))
             {

--- a/Packages/com.velvet.core/CodeGen/MetadataRegistrationWeaver.cs
+++ b/Packages/com.velvet.core/CodeGen/MetadataRegistrationWeaver.cs
@@ -9,8 +9,8 @@ namespace Velvet.CodeGen
     // Build-time transform that injects Velvet.ComponentMethodRegistry registration calls into the
     // module initializer (<Module>.cctor) for every [Component] method that opts into
     // Error Boundary, the props-bail, or a DisplayName override. This replaces the Roslyn source
-    // generator's [ModuleInitializer] hook: the epic decision is that everything expressible in IL moves
-    // to the ILPostProcessor, leaving the Source Generator to API generation and analyzers only.
+    // generator's [ModuleInitializer] hook: everything expressible in IL belongs in the
+    // ILPostProcessor, leaving the Source Generator to API generation and analyzers only.
     // The registry is a process-global, IL2CPP / metadata-stripping-resilient string map keyed on
     // (DeclaringType.FullName, MethodName). The declaring type name is emitted in the runtime
     // Type.FullName form — '+' between an outer type and a nested one, and the Cecil `{arity}
@@ -177,8 +177,8 @@ namespace Velvet.CodeGen
         private static string RuntimeFullName(TypeReference type)
             => type.FullName.Replace('/', '+');
 
-        // Returns the last ret in body, or null when none exists. Registration calls
-        // are inserted before it so a pre-existing module-initializer body keeps its own ending.
+        // Registration calls are inserted before the returned ret, so a pre-existing
+        // module-initializer body keeps its own ending.
         private static Instruction? FindLastReturn(MethodBody body)
         {
             for (var i = body.Instructions.Count - 1; i >= 0; i--)

--- a/Packages/com.velvet.core/CodeGen/VelvetCompilerILPostProcessor.cs
+++ b/Packages/com.velvet.core/CodeGen/VelvetCompilerILPostProcessor.cs
@@ -8,12 +8,12 @@ using Unity.CompilationPipeline.Common.ILPostProcessing;
 
 namespace Velvet.CodeGen
 {
-    // ILPostProcessor host that delegates to CompilerWeaver, which weaves inner
-    // auto-memoization into analyzable [Component] bodies. The assembly is rewritten only when the
-    // weaver reports a change; otherwise the original assembly is passed through untouched.
-    // The ILPostProcessor runs in the external Unity.ILPP.Runner process,
-    // so UnityEngine.Debug.Log is unavailable. All diagnostics are
-    // surfaced through DiagnosticMessage.
+    // ILPostProcessor host that delegates to CompilerWeaver (inner auto-memoization of analyzable
+    // [Component] bodies) and MetadataRegistrationWeaver (Error Boundary / props-bail / DisplayName
+    // registration calls). The assembly is rewritten only when either weaver reports a change;
+    // otherwise the original assembly is passed through untouched. The ILPostProcessor runs in the
+    // external Unity.ILPP.Runner process, so UnityEngine.Debug.Log is unavailable. All diagnostics
+    // are surfaced through DiagnosticMessage.
     internal sealed class VelvetCompilerILPostProcessor : ILPostProcessor
     {
         private const string VelvetAssemblyName = "Velvet";

--- a/Packages/com.velvet.core/Generators~/src/Velvet.SourceGenerators.CodeFixes/Vel100FillMissingDepsCodeFixProvider.cs
+++ b/Packages/com.velvet.core/Generators~/src/Velvet.SourceGenerators.CodeFixes/Vel100FillMissingDepsCodeFixProvider.cs
@@ -15,10 +15,11 @@ namespace Velvet.SourceGenerators.CodeFixes
 {
     /// <summary>
     /// Quick fix for VEL100: appends the missing closure-captured local to the deps array literal of a
-    /// deps-comparing hook (<c>UseEffect</c> / <c>UseLayoutEffect</c> / <c>UseCallback</c> /
-    /// <c>UseImperativeHandle</c>). Only handles the simple <c>new[]</c> / <c>new T[] { ... }</c> deps
-    /// initializer forms that the analyzer flags (loose <c>params</c> deps are left untouched). Preserves the
-    /// leading trivia of the previous element so multi-line deps stay aligned.
+    /// deps-comparing hook (<c>UseEffect</c> / <c>UseLayoutEffect</c> / <c>UseCallback</c> / <c>UseMemo</c> /
+    /// <c>UseImperativeHandle</c>, or the V DSL's <c>V.Memoized</c> / <c>V.MemoizedWithKey</c>). Only handles
+    /// the simple <c>new[]</c> / <c>new T[] { ... }</c> deps initializer forms that the analyzer flags (loose
+    /// <c>params</c> deps are left untouched). Preserves the leading trivia of the previous element so
+    /// multi-line deps stay aligned.
     /// </summary>
     [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(Vel100FillMissingDepsCodeFixProvider))]
     [Shared]

--- a/Packages/com.velvet.core/Generators~/src/Velvet.SourceGenerators/AutoDeps/DepsHookDescriptor.cs
+++ b/Packages/com.velvet.core/Generators~/src/Velvet.SourceGenerators/AutoDeps/DepsHookDescriptor.cs
@@ -57,8 +57,8 @@ namespace Velvet.SourceGenerators.AutoDeps
                     descriptor = new DepsHookDescriptor(VelvetWellKnownNames.HooksTypeFullName, factoryArgIndex: 0, depsArgIndex: 1, depsAreParams: true);
                     return true;
                 case VelvetWellKnownNames.UseMemoMethodName:
-                    // UseMemo(Func<T> factory, params object[] deps) — the value-memoization hook. Its factory
-                    // is parameterless, so it flows through the deps-comparison pipeline like UseCallback.
+                    // UseMemo's factory is parameterless, so it flows through the deps-comparison
+                    // pipeline the same way UseCallback's does.
                     descriptor = new DepsHookDescriptor(VelvetWellKnownNames.HooksTypeFullName, factoryArgIndex: 0, depsArgIndex: 1, depsAreParams: true);
                     return true;
                 case VelvetWellKnownNames.UseImperativeHandleMethodName:

--- a/Packages/com.velvet.core/Generators~/src/Velvet.SourceGenerators/AutoDeps/UseEffectExhaustiveDepsAnalyzer.cs
+++ b/Packages/com.velvet.core/Generators~/src/Velvet.SourceGenerators/AutoDeps/UseEffectExhaustiveDepsAnalyzer.cs
@@ -16,7 +16,8 @@ namespace Velvet.SourceGenerators.AutoDeps
     /// Compares closure-captured values (locals, instance fields, and properties) inside a deps-comparing
     /// hook's lambda factory against the elements listed in the hook's <c>deps</c> argument and reports
     /// <see cref="MemoizeDiagnostics.Vel100UseEffectMissingDep"/> when a captured value is missing.
-    /// Covers <c>UseEffect</c> / <c>UseLayoutEffect</c> / <c>UseCallback</c> / <c>UseImperativeHandle</c>.
+    /// Covers <c>UseEffect</c> / <c>UseLayoutEffect</c> / <c>UseCallback</c> / <c>UseMemo</c> /
+    /// <c>UseImperativeHandle</c>, and the V DSL's <c>V.Memoized</c> / <c>V.MemoizedWithKey</c>.
     /// </summary>
     /// <remarks>
     /// The match is conservative: only <c>new[] { ... }</c> / <c>new T[] { ... }</c> deps initializers and
@@ -135,7 +136,7 @@ namespace Velvet.SourceGenerators.AutoDeps
                 // collapse to `a` and the missing `a.b.c` goes unreported. Closing that gap needs
                 // path-sensitive analysis, which risks warning on correct code (false positives). A lint must
                 // prioritise precision (zero false positives) over completeness, so the conservative
-                // root-collapse is kept on purpose rather than matching ESLint's exact path-tracking.
+                // root-collapse is kept on purpose rather than adding exact path-tracking.
                 if (element is MemberAccessExpressionSyntax memberAccess)
                 {
                     var current = memberAccess;

--- a/Packages/com.velvet.core/Generators~/src/Velvet.SourceGenerators/MemoizeMethodGenerator.cs
+++ b/Packages/com.velvet.core/Generators~/src/Velvet.SourceGenerators/MemoizeMethodGenerator.cs
@@ -485,7 +485,7 @@ namespace Velvet.SourceGenerators
             {
                 return hintName;
             }
-            // Build the suffix from the upper 4 bytes (32 bits) of SHA256. The collision probability within the same trunk is 1/2^32,
+            // Build the suffix from the first 4 bytes (32 bits) of SHA256. The collision probability within the same trunk is 1/2^32,
             // which is negligible in practice. If a collision still happens, the Add failure has no effect on the outcome, so we ignore the return value.
             var hash = ComputeShortHash(content);
             var dotIndex = hintName.IndexOf('.');

--- a/Packages/com.velvet.core/Generators~/src/Velvet.SourceGenerators/Purity/SideEffectWalker.cs
+++ b/Packages/com.velvet.core/Generators~/src/Velvet.SourceGenerators/Purity/SideEffectWalker.cs
@@ -220,9 +220,9 @@ namespace Velvet.SourceGenerators.PurityAnalysis
                 return;
             }
 
-            // Call-graph propagation: recurse into the callee body when budget remains.
-            // Pure callees absorb silently. Impure callees propagate as KnownImpureCall.
-            // Unknown callees fall through to UnknownCall so the caller still sees at least one reason.
+            // The switch below only returns for Pure/Impure; an Unknown callee result falls through to the
+            // UnknownCall add at the bottom, so the caller always sees at least one reason when propagation
+            // through the callee is inconclusive.
             if (_remainingDepth > 0 && _compilation is not null && _visited is not null)
             {
                 _visited.Add(target);

--- a/Packages/com.velvet.core/Generators~/src/Velvet.SourceGenerators/ReactiveScope/LocalDataFlowResolver.cs
+++ b/Packages/com.velvet.core/Generators~/src/Velvet.SourceGenerators/ReactiveScope/LocalDataFlowResolver.cs
@@ -30,7 +30,9 @@ namespace Velvet.SourceGenerators.ReactiveScope
 
         /// <summary>
         /// Recursively expands any <see cref="ILocalSymbol"/>s in the input symbol set into base symbols.
-        /// Cycles are cut by a visited set; the cycling local passes through unexpanded.
+        /// Cycles are cut by a visited set: a local already being expanded on the current path is skipped
+        /// rather than re-expanded, so every member of a self- or mutually-referential assignment chain
+        /// contributes nothing to the result instead of looping forever.
         /// </summary>
         public ImmutableArray<ISymbol> Resolve(ImmutableArray<ISymbol> symbols)
         {

--- a/Packages/com.velvet.core/Generators~/src/Velvet.SourceGenerators/ReactiveScope/ReactiveScopeAnalyzer.cs
+++ b/Packages/com.velvet.core/Generators~/src/Velvet.SourceGenerators/ReactiveScope/ReactiveScopeAnalyzer.cs
@@ -236,7 +236,8 @@ namespace Velvet.SourceGenerators.ReactiveScope
         }
 
         /// <summary>
-        /// Enumerates the sub-expressions we want to analyze (returns / assignments / member accesses, etc.).
+        /// Enumerates the sub-expressions we want to analyze: return values, invocations, object creations,
+        /// conditional/switch expressions, and binary operations.
         /// We pick meaningful units rather than leaf nodes so that cache slots are sliced per expression.
         /// </summary>
         private static IEnumerable<IOperation> EnumerateInterestingOperations(IOperation root)
@@ -267,8 +268,10 @@ namespace Velvet.SourceGenerators.ReactiveScope
         }
 
         /// <summary>
-        /// Checks the given expression for calls where <see cref="PurityAnalyzer"/> returns Impure / Unknown,
-        /// or for virtual / abstract / dynamic paths.
+        /// Checks the given expression for anything that would make treating it as a pure function of its
+        /// dependencies unsound: calls where <see cref="PurityAnalyzer"/> returns Impure / Unknown, virtual /
+        /// abstract / dynamic dispatch, and directly observable side effects (field/property/array/ref-out
+        /// assignment, event subscription, lock, await).
         /// Returns the conservative fallback reason set if any are found; otherwise null.
         /// </summary>
         private static ImmutableArray<ScopeDiagnostic>? CheckExpressionPurity(

--- a/Packages/com.velvet.core/Generators~/src/Velvet.SourceGenerators/ReactiveScope/ReactiveScopeResult.cs
+++ b/Packages/com.velvet.core/Generators~/src/Velvet.SourceGenerators/ReactiveScope/ReactiveScopeResult.cs
@@ -84,8 +84,8 @@ namespace Velvet.SourceGenerators.ReactiveScope
         /// </summary>
         /// <remarks>
         /// <see cref="ISymbol"/> references <see cref="Compilation"/>, so placing it directly onto an <c>IncrementalValuesProvider</c>
-        /// would pin the Compilation and break the cache.
-        /// Convert to a cache-safe value type (e.g. (DisplayString, SymbolKind, ContainingType)) before propagating it through the pipeline.
+        /// would pin the Compilation and break the cache. <see cref="ReactiveScopeAnalyzer.GetAccessPath"/> converts each symbol
+        /// into the cache-safe <see cref="DependencyAccessPath"/> before propagating it through a pipeline.
         /// </remarks>
         public ImmutableArray<ISymbol>? Dependencies { get; }
 

--- a/Packages/com.velvet.core/Generators~/src/Velvet.SourceGenerators/ReactiveScope/SymbolCollector.cs
+++ b/Packages/com.velvet.core/Generators~/src/Velvet.SourceGenerators/ReactiveScope/SymbolCollector.cs
@@ -11,7 +11,7 @@ namespace Velvet.SourceGenerators.ReactiveScope
     /// Visits the IOperation tree and collects referenced symbols relevant to Render() (parameter / field / property / local).
     /// On entering a lambda / local function / foreach scope, pushes the scope-local set onto a stack so locals and parameters
     /// that belong to it are excluded from the final result.
-    /// readonly static fields and consts are treated as immutable and excluded.
+    /// readonly fields and consts are treated as immutable and excluded.
     /// </summary>
     internal sealed class SymbolCollector : OperationWalker
     {

--- a/Packages/com.velvet.core/Generators~/src/Velvet.SourceGenerators/RulesOfHooks/RulesOfHooksAnalyzer.cs
+++ b/Packages/com.velvet.core/Generators~/src/Velvet.SourceGenerators/RulesOfHooks/RulesOfHooksAnalyzer.cs
@@ -19,8 +19,10 @@ namespace Velvet.SourceGenerators.RulesOfHooks
     /// Two passes: a syntax-ancestor walk flags hooks inside a control-flow construct, and a control-flow
     /// analysis pass (<see cref="TryReportConditionalEarlyExit"/>) flags a hook that follows a conditional early
     /// return (<c>if (x) return; UseState(...);</c>) — a case the syntax walk cannot see. A conditional
-    /// <c>throw</c> is not treated as a skip (it aborts the render rather than skipping the hook). The
-    /// MemoizeMethod codegen's transitive scan handles custom-hook detection at compile time.
+    /// <c>throw</c> is not treated as a skip (it aborts the render rather than skipping the hook). This
+    /// analyzer's naming-convention check is a syntax-only signal; the auto-memoization IL weaver
+    /// (CompilerWeaver, under CodeGen/) is what actually verifies a called method transitively composes
+    /// a hook.
     /// </remarks>
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     internal sealed class RulesOfHooksAnalyzer : DiagnosticAnalyzer

--- a/Packages/com.velvet.core/Runtime/Component/ComponentMethodRegistry.cs
+++ b/Packages/com.velvet.core/Runtime/Component/ComponentMethodRegistry.cs
@@ -8,9 +8,9 @@ namespace Velvet
 {
     /// <summary>
     /// Process-global registry of methods annotated with <c>[Component(IsErrorBoundary = true)]</c>
-    /// and <c>[Component(DisplayName = "...")]</c>. Populated by Source-Generator-emitted
-    /// <c>[ModuleInitializer]</c> hooks at startup; consumed by <c>V.Component</c> on every render
-    /// and by hook-rule violation paths.
+    /// and <c>[Component(DisplayName = "...")]</c>. Populated at startup by registration calls
+    /// <c>MetadataRegistrationWeaver</c> injects into the assembly's module initializer at build time;
+    /// consumed by <c>V.Component</c> on every render and by hook-rule violation paths.
     /// </summary>
     /// <remarks>
     /// The registry keys on <c>(declaringTypeFullName, methodName)</c>. Component's contract is
@@ -27,12 +27,13 @@ namespace Velvet
         private static readonly ConcurrentDictionary<MethodInfo, bool> s_memoizeCache = new();
 
         /// <summary>
-        /// Registers a component method as an Error Boundary. Invoked from generator-emitted <c>[ModuleInitializer]</c> hooks.
+        /// Registers a component method as an Error Boundary. Invoked from the module-initializer calls
+        /// <c>MetadataRegistrationWeaver</c> injects at build time.
         /// Idempotent: re-registering the same method is a no-op.
         /// </summary>
         /// <param name="declaringTypeFullName">Fully qualified type name of the class containing the component method.</param>
         /// <param name="methodName">Name of the static <c>[Component(IsErrorBoundary = true)]</c> method.</param>
-        // Hidden from IntelliSense: this entry point is for source-generator emitted code, not user code.
+        // Hidden from IntelliSense: this entry point is for weaver-injected code, not user code.
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static void RegisterErrorBoundary(string declaringTypeFullName, string methodName)
         {
@@ -40,9 +41,9 @@ namespace Velvet
         }
 
         /// <summary>
-        /// Registers the <c>DisplayName</c> override for a component method. Invoked from generator-emitted
-        /// <c>[ModuleInitializer]</c> hooks only when the <c>[Component]</c> attribute supplies a non-empty
-        /// <c>DisplayName</c>. Idempotent: re-registering the same method overwrites the previous value.
+        /// Registers the <c>DisplayName</c> override for a component method. Invoked from the module-initializer
+        /// calls <c>MetadataRegistrationWeaver</c> injects, only when the <c>[Component]</c> attribute supplies a
+        /// non-empty <c>DisplayName</c>. Idempotent: re-registering the same method overwrites the previous value.
         /// </summary>
         /// <param name="declaringTypeFullName">Fully qualified type name of the class containing the component method.</param>
         /// <param name="methodName">Name of the static <c>[Component(DisplayName = "...")]</c> method.</param>
@@ -55,9 +56,9 @@ namespace Velvet
 
         /// <summary>
         /// Registers a component method as props-bail-opted-in (<c>[Component(Memoize = true)]</c>). Invoked
-        /// from generator-emitted <c>[ModuleInitializer]</c> hooks. Idempotent: re-registering is a no-op.
-        /// This is the IL2CPP / metadata-stripping-resilient path for <see cref="IsMemoized"/>; when present
-        /// it is preferred over the reflection fallback.
+        /// from the module-initializer calls <c>MetadataRegistrationWeaver</c> injects. Idempotent: re-registering
+        /// is a no-op. This is the IL2CPP / metadata-stripping-resilient path for <see cref="IsMemoized"/>; when
+        /// present it is preferred over the reflection fallback.
         /// </summary>
         /// <param name="declaringTypeFullName">Fully qualified type name of the class containing the component method.</param>
         /// <param name="methodName">Name of the static <c>[Component(Memoize = true)]</c> method.</param>
@@ -78,11 +79,12 @@ namespace Velvet
         }
 
         /// <summary>
-        /// Returns <c>true</c> if <paramref name="method"/> was registered as an Error Boundary by an emitted module initializer.
+        /// Returns <c>true</c> if <paramref name="method"/> was registered as an Error Boundary via the woven module initializer.
         /// </summary>
         // MethodInfo-keyed cache layered on top of the string-keyed registry: the string form is required
-        // because the SG cannot reference MethodInfo at compile time, but per-render lookups against MethodInfo
-        // identity are O(1) on a RuntimeMethodHandle compare and avoid two ordinal string-equals on every hit.
+        // because the weaver only has IL-level type metadata to work with, not a runtime MethodInfo, but
+        // per-render lookups against MethodInfo identity are O(1) on a RuntimeMethodHandle compare and avoid
+        // two ordinal string-equals on every hit.
         internal static bool IsErrorBoundary(MethodInfo? method)
         {
             if (method is null) return false;
@@ -92,10 +94,10 @@ namespace Velvet
 
         /// <summary>
         /// Returns <c>true</c> if <paramref name="method"/> carries <c>[Component(Memoize = true)]</c>
-        /// (props-bail opt-in). Prefers the SG-emitted string registry (<see cref="RegisterMemoize"/>) — the
+        /// (props-bail opt-in). Prefers the weaver-populated string registry (<see cref="RegisterMemoize"/>) — the
         /// IL2CPP / metadata-stripping-resilient path, matching how <see cref="IsErrorBoundary"/> resolves —
         /// and falls back to reflecting <see cref="ComponentAttribute"/> off the method when the registry has
-        /// no entry (e.g. before the generator has been rebuilt to emit Memoize registrations). The result is
+        /// no entry (e.g. before the assembly has been rewoven to include Memoize registrations). The result is
         /// cached per <see cref="MethodInfo"/> so the lookup cost is paid once per component method, not per render.
         /// </summary>
         internal static bool IsMemoized(MethodInfo? method)
@@ -112,7 +114,7 @@ namespace Velvet
             });
         }
 
-        // Shared key resolution: tries the live `Type.FullName` first, then falls back to the SG-emitted
+        // Shared key resolution: tries the live `Type.FullName` first, then falls back to the weaver-emitted
         // open form for closed generics where `FullName` either gains a type-arg suffix or returns null.
         private static bool TryLookupByMethod<TValue>(
             MethodInfo method,
@@ -132,7 +134,7 @@ namespace Velvet
                 return true;
             }
 
-            // Closed generic fallback: SG-emitted keys always use the open form (`Foo`1`, `Outer`1+Inner`).
+            // Closed generic fallback: weaver-emitted keys always use the open form (`Foo`1`, `Outer`1+Inner`).
             // At runtime, `Type.FullName` returns either:
             //   - closed instantiation: `Foo`1[[System.Int32, ...]]` (suffix mismatch)
             //   - any closed generic in declaring chain: `null` (BCL quirk for nested-in-generic)
@@ -159,7 +161,7 @@ namespace Velvet
             return false;
         }
 
-        // Reconstructs the SG-style open-form FullName by walking DeclaringType: each generic segment uses its
+        // Reconstructs the weaver's open-form FullName by walking DeclaringType: each generic segment uses its
         // open-definition MetadataName (e.g. `Foo`1`), nested types are joined with `+`, namespace from outermost.
         private static string BuildOpenFormFullName(Type t)
         {


### PR DESCRIPTION
Final part of the per-subsystem pass converting What-narration comments to the Why-only house convention, covering the IL post-processor and the analyzer/generator solution (27 files read, 13 touched), plus the runtime registry their comments misattributed. Comment-only change — zero code tokens touched (verified by a comment-stripping token comparison), generator unit tests 186/186, EditMode 3236 and PlayMode 90 green on this tree.

- Corrected a systematic attribution error: the runtime method registry and an analyzer both credited source-generator emission for registration and transitive hook scanning that actually live in the IL post-processor's weavers; the attribute types whose expansion genuinely is source-generated keep their attribution.
- Fixed stale or wrong mechanism claims: a data-flow doc said a cycling local passes through unexpanded (it contributes nothing), an operation-enumeration doc listed operations its switch never visits, two dependency-hook coverage lists omitted three supported shapes, a byte-slice comment said upper when the code reads the first bytes, and a field-filter comment was narrower than the filter.
- Removed the one product-comparison reference and a stale forward-looking note describing work that had since been built (now pointing at the real mechanism).