### PR TITLE
fix(velvet): make transition-starvation promotion survive re-scheduling and actually outrank its preemptors

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -107,6 +107,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A `Transition`-lane re-render can no longer be starved indefinitely by sustained higher-priority
+  work, on either of two fronts. The anti-starvation clock — which promotes a Transition lane once
+  its 30th flush pass still finds it pending — used to restart on every schedule, including a
+  coalesced re-add onto the already-pending lane, so a component that kept re-signalling
+  transition intent (e.g. a per-frame transition-tier update) kept resetting it and the promotion
+  never fired; the clock now starts once when the lane first becomes pending and runs until the
+  lane flushes, and only a genuine re-enrol after a drain restarts it. And the promotion itself
+  used to hand the lane to `Deferred`, which a sustained stream of `Normal` updates still
+  outranks — promoted work could go right back to starving; a starved lane is now promoted to
+  `Normal`, draining in the flush that reaches the threshold or right after any co-pending
+  Urgent drains, so `useTransition`'s `isPending` also clears at (not before) the commit that
+  renders the transition's content — including across that Urgent parking window, which the
+  settle sweep used to misread as the transition having settled once promotion erased the
+  Transition label. An `isPending` flag held by an **async** `startTransition`
+  still awaiting its action is additionally no longer wiped when a drain callback fires on the
+  fiber while no lane is pending (the awaiting action has not scheduled its updates yet, so an
+  empty lane queue does not mean the transition settled).
 - `V.Portal(layer:)`/`V.WorldSpace` synthetic event bubbling now stops when a handler calls
   `StopPropagation()` partway up the logical ancestor chain, instead of continuing to invoke
   every remaining ancestor regardless. Also fixes nested portals/world-space (one mounted inside

--- a/Packages/com.velvet.core/Runtime/Component/ComponentFiber.cs
+++ b/Packages/com.velvet.core/Runtime/Component/ComponentFiber.cs
@@ -12,12 +12,18 @@ namespace Velvet
         public SortedSet<FiberUpdatePriority>? Queue;
         public bool IsInTransition;
         public int TransitionStarvationCounter;
+        // The settle sweep keys off the Transition label's presence, which starvation promotion erases
+        // (relabelling the lane to Normal) while the promoted work may still be queued — e.g. parked
+        // behind a co-pending Urgent drain. Without this marker the sweep would read the erased label
+        // as "settled" and clear isPending before the promoted content commits.
+        public bool HasPromotedTransition;
 
         public void Clear()
         {
             Queue?.Clear();
             IsInTransition = false;
             TransitionStarvationCounter = 0;
+            HasPromotedTransition = false;
         }
     }
 
@@ -254,7 +260,12 @@ namespace Velvet
             }
         }
 
-        /// <summary>Clears the pending flag on every transition slot (called when the transition lane settles).</summary>
+        /// <summary>
+        /// Clears the pending flag on every settled transition slot (called when the transition lane
+        /// settles). A slot whose async action is still in flight is skipped: its awaiting action has not
+        /// scheduled its updates yet, so an empty lane queue does not mean that transition settled — its
+        /// own completion path clears the flag once the task finishes.
+        /// </summary>
         internal void ClearAllTransitionPending()
         {
             if (TransitionSlots == null)
@@ -263,6 +274,10 @@ namespace Velvet
             }
             foreach (var slot in TransitionSlots)
             {
+                if (slot.IsAsyncInFlight)
+                {
+                    continue;
+                }
                 slot.IsPending = false;
             }
         }
@@ -277,6 +292,12 @@ namespace Velvet
         {
             get => Lanes?.TransitionStarvationCounter ?? 0;
             set => EnsureLanes().TransitionStarvationCounter = value;
+        }
+
+        internal bool HasPromotedTransition
+        {
+            get => Lanes?.HasPromotedTransition ?? false;
+            set => EnsureLanes().HasPromotedTransition = value;
         }
 
         // Per-hook-kind counts from the previous render, compared against this render's counts to enforce a

--- a/Packages/com.velvet.core/Runtime/Hooks/HookSlots.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/HookSlots.cs
@@ -113,6 +113,12 @@ namespace Velvet
     internal sealed class HookTransitionSlot
     {
         public bool IsPending;
+        // An awaiting async StartTransition may hold IsPending=true on a fiber with NO pending lane (its
+        // setState calls come after the await), and a drain callback armed earlier can legitimately fire
+        // on that clean fiber — the settle-time sweep (ClearAllTransitionPending) must not read the empty
+        // lane queue as "the transition settled" and wipe the flag mid-flight. Only the async completion
+        // path clears IsPending while this is set.
+        public bool IsAsyncInFlight;
         public TransitionStarter Starter = default!;
     }
 

--- a/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseTransitionTests.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseTransitionTests.cs
@@ -231,6 +231,31 @@ namespace Velvet.Tests
         }
 
         [Test]
+        public void Given_AsyncStartTransitionAwaitingBeforeAnyUpdate_When_ACleanFiberFlushFires_Then_IsPendingStaysTrue()
+        {
+            // Arrange — the action awaits BEFORE its first setState, so the fiber has no pending lane at
+            // all while the transition is in flight.
+            using var mounted = V.Mount(_root, V.Component(TransitionRender, key: "transition"));
+            var gate = new Cysharp.Threading.Tasks.UniTaskCompletionSource();
+            Func<Cysharp.Threading.Tasks.UniTask> asyncUpdates = async () =>
+            {
+                await gate.Task;
+                s_transitionSetValue.Invoke(1);
+            };
+            s_transitionStarter.Invoke(asyncUpdates);
+            Assume.That(s_transitionFiber.IsTransitionPending, Is.True, "Precondition: the async transition is awaiting");
+
+            // Act — a drain callback armed earlier can legitimately fire on this now-clean fiber (e.g.
+            // the delayed-tier callback left over after a starvation promotion drained every lane); the
+            // not-dirty flush must not read the empty lane queue as this transition having settled.
+            mounted.FlushStateForTest();
+
+            // Assert
+            Assert.IsTrue(s_transitionFiber.IsTransitionPending,
+                "A flush on a clean fiber must not wipe an awaiting async transition's pending flag");
+        }
+
+        [Test]
         public void Given_AsyncStartTransition_When_TaskCompletesAndFlushes_Then_IsPendingClears()
         {
             // Arrange

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberBatchScheduler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberBatchScheduler.cs
@@ -183,7 +183,11 @@ namespace Velvet
                     // lanes are dropped: a fiber can be queued this deep with an unrelated
                     // Transition/Deferred lane still pending (the
                     // runaway's commits may write bystanders each pass), and wiping that lane would
-                    // strand its delayed-tier work (a StartTransition left isPending forever).
+                    // strand its delayed-tier work (a StartTransition left isPending forever). A
+                    // Transition lane that starvation-promoted to Normal DURING the runaway (the cap
+                    // exceeds the starvation threshold) is dropped with it — acceptable: state slots are
+                    // written eagerly, so the last committed render already showed the transition's
+                    // values, and the pending-flag sweep below spares an async action still in flight.
                     FiberLogger.LogError("Scheduler",
                         "Maximum update depth exceeded. A component repeatedly schedules state"
                         + " updates from its commit phase (a callback ref or an effect writing a"
@@ -197,6 +201,9 @@ namespace Velvet
                         var dropped = _drainBuffer[i];
                         dropped.LaneQueue?.Remove(FiberUpdatePriority.Urgent);
                         dropped.LaneQueue?.Remove(FiberUpdatePriority.Normal);
+                        // The promoted marker retires with the dropped Normal it rode, or it would keep
+                        // skipping the settle sweep for as long as any surviving lane stays queued.
+                        dropped.HasPromotedTransition = false;
                         if (dropped.LaneQueue == null || dropped.LaneQueue.Count == 0)
                         {
                             dropped.IsDirty = false;

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberRenderer.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberRenderer.cs
@@ -131,6 +131,16 @@ namespace Velvet
         internal static void SettleSubsumedFiber(ComponentFiber fiber)
         {
             fiber.LaneQueue?.Clear();
+            // The subsuming render committed the fiber's latest (eagerly-written) state, so any
+            // starvation-promoted work is satisfied too — a marker left true on the now-clean fiber
+            // would mis-time a LATER transition's settle (its sweep would be skipped while other lanes
+            // queue). Direct field access: the proxy setter's EnsureLanes would allocate a LaneState
+            // for the lane-less majority of subsumed fibers (every non-memoized child re-render lands
+            // here), defeating the documented lazy-allocation invariant.
+            if (fiber.Lanes != null)
+            {
+                fiber.Lanes.HasPromotedTransition = false;
+            }
             fiber.IsDirty = false;
             fiber.ClearAllTransitionPending();
             fiber.Reconciler?.Context.BatchScheduler.Remove(fiber);
@@ -200,7 +210,7 @@ namespace Velvet
             // but removing here keeps the pending set from retaining a dead fiber reference until drain.
             fiber.Reconciler?.Context.BatchScheduler.Remove(fiber);
             // For components whose LaneState has not been allocated (Lane never used), do not call Clear() to
-            // preserve zero-allocation. LaneState.Clear initializes all four queue/transition-related fields.
+            // preserve zero-allocation. LaneState.Clear initializes every queue/transition-related field.
             fiber.Lanes?.Clear();
 
             // A mid-pass unmount takes its own deferred inline baselines with it: the end-of-pass

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberUpdatePriority.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberUpdatePriority.cs
@@ -3,7 +3,7 @@ namespace Velvet
     /// <summary>
     /// Lane priority for a scheduled re-render. The lane is chosen from the scheduling context, not passed
     /// as an argument: <c>StartTransition</c> updates and <c>UseDeferredValue</c> derivations take the
-    /// Transition lane, a starved Transition lane is promoted to Deferred, and every other state update
+    /// Transition lane, a starved Transition lane is promoted to Normal, and every other state update
     /// takes the Normal lane. Lower numeric values indicate higher priority; a fiber's lane queue drains
     /// lowest-value-first.
     /// </summary>
@@ -11,14 +11,19 @@ namespace Velvet
     {
         /// <summary>Highest priority. Drains ahead of every other lane within a fiber's lane queue.</summary>
         Urgent = 0,
-        /// <summary>Default priority for state updates that are not part of a transition.</summary>
+        /// <summary>
+        /// Default priority for state updates that are not part of a transition. A starved Transition lane
+        /// is promoted to it, coalescing with the very traffic that kept preempting it, so the starved
+        /// work commits with the next Normal drain instead of waiting behind it.
+        /// </summary>
         Normal = 1,
-        /// <summary>Low priority. Its flush is delayed by a fixed delay; a starved Transition lane is promoted to it.</summary>
+        /// <summary>Low priority. Its flush is delayed by a fixed delay.</summary>
         Deferred = 2,
         /// <summary>
         /// Lowest priority. Taken by <c>StartTransition</c> updates and <c>UseDeferredValue</c> derivations.
-        /// Its flush is delayed so higher-priority lanes commit first, and it is promoted to Deferred once it
-        /// has been starved for a fixed number of flushes.
+        /// Its flush is delayed so higher-priority lanes commit first, and once it has been starved for a
+        /// fixed number of flushes it is promoted to Normal — draining in that same flush, or right after
+        /// any co-pending Urgent drains; <c>isPending</c> survives until the promoted work commits.
         /// </summary>
         Transition = 3,
     }

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberWorkLoop.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberWorkLoop.cs
@@ -14,7 +14,8 @@ namespace Velvet
         // Delay (milliseconds) for the Deferred priority.
         private const int DeferredDelayMs = 100;
 
-        // Number of FlushState invocations before promoting the Transition Lane to Deferred.
+        // The FlushState invocation at which a continuously-pending Transition lane is promoted
+        // (see PromoteStarvedTransitionLane); it survives threshold-1 preempted flushes.
         private const int TransitionStarvationThreshold = 30;
 
         // Set while a discrete user-input event handler (click, change, pointer down/up, key down/up, focus/blur)
@@ -95,10 +96,15 @@ namespace Velvet
             // If the same Lane already exists, Add returns false (coalesced).
             var prevHighest = FiberLane.GetHighestPendingPriority(fiber);
 
-            fiber.LaneQueue.Add(priority);
+            var enrolled = fiber.LaneQueue.Add(priority);
 
-            // When adding the Transition Lane, reset the starvation counter (also on a coalesced re-add).
-            if (priority == FiberUpdatePriority.Transition)
+            // A coalesced re-add must NOT restart the starvation clock: it measures how long the lane
+            // has been continuously pending, so sustained re-scheduling (e.g. a per-frame
+            // transition-tier update) cannot indefinitely defeat the promotion while higher-priority
+            // work keeps preempting the flush. The genuine-enrol reset is still required: without it a
+            // lane that drained normally would inherit the previous cycle's residual count and promote
+            // early.
+            if (priority == FiberUpdatePriority.Transition && enrolled)
             {
                 fiber.TransitionStarvationCounter = 0;
             }
@@ -228,6 +234,13 @@ namespace Velvet
                 flushBudget = FiberLane.BudgetForLane(flushingLane);
                 fiber.LaneQueue.Remove(flushingLane);
 
+                // The promoted marker retires at the drain that commits its content — a
+                // starvation-promoted lane rides the Normal label (see HasPromotedTransition).
+                if (flushingLane == FiberUpdatePriority.Normal)
+                {
+                    fiber.HasPromotedTransition = false;
+                }
+
                 if (fiber.LaneQueue.Count > 0)
                 {
                     ScheduleFlush(fiber, fiber.LaneQueue.Min);
@@ -237,7 +250,11 @@ namespace Velvet
                     fiber.IsDirty = false;
                 }
 
-                if (fiber.LaneQueue == null || fiber.LaneQueue.Count == 0 || !fiber.LaneQueue.Contains(FiberUpdatePriority.Transition))
+                // The Transition label alone is not the settled signal — starvation promotion erases it
+                // while the promoted work is still queued (possibly parked behind an Urgent drain), so
+                // the promoted marker must ALSO be clear before the pending flags may sweep.
+                if (fiber.LaneQueue == null || fiber.LaneQueue.Count == 0
+                    || (!fiber.LaneQueue.Contains(FiberUpdatePriority.Transition) && !fiber.HasPromotedTransition))
                 {
                     fiber.ClearAllTransitionPending();
                 }
@@ -392,13 +409,19 @@ namespace Velvet
 
             if (fiber.TransitionStarvationCounter >= TransitionStarvationThreshold)
             {
+                // Promote to Normal — not Deferred — so the starved work coalesces with the very traffic
+                // that kept preempting it and drains in this flush (the caller drains the queue's minimum
+                // next; co-pending Urgent drains still go first, parking the promoted lane on the
+                // immediate tier, not back behind the sustained stream that starved it). A Deferred
+                // promotion would stay below a sustained stream of Normal updates and the lane would
+                // starve on exactly as before; an expired lane must instead flush synchronously,
+                // abandoning time-slicing, so starvation is bounded no matter how relentless the
+                // higher-priority traffic is. The promoted marker keeps the settle sweep honest about
+                // the erased Transition label (see HasPromotedTransition), so isPending still clears at
+                // (not before) the commit that renders the promoted content.
                 fiber.LaneQueue.Remove(FiberUpdatePriority.Transition);
-
-                if (!fiber.LaneQueue.Contains(FiberUpdatePriority.Deferred))
-                {
-                    fiber.LaneQueue.Add(FiberUpdatePriority.Deferred);
-                }
-
+                fiber.LaneQueue.Add(FiberUpdatePriority.Normal);
+                fiber.HasPromotedTransition = true;
                 fiber.TransitionStarvationCounter = 0;
             }
         }
@@ -413,6 +436,15 @@ namespace Velvet
         public static void StartTransition(ComponentFiber fiber, HookTransitionSlot slot, Action updates)
         {
             if (updates == null) throw new ArgumentNullException(nameof(updates));
+
+            // Leave the slot's pending lifecycle alone on a disposed fiber: disposal forced IsDirty
+            // false, so the finally below would treat the transition as settled and clobber flags a
+            // still-in-flight async owner on this same slot relies on.
+            if (fiber.IsDisposed)
+            {
+                updates();
+                return;
+            }
 
             // Re-entrant call: join the outer transition. IsInTransition is already set, so the updates run
             // at Transition priority; the outer call owns the pending lifecycle (this slot's flag is left to
@@ -452,6 +484,13 @@ namespace Velvet
         {
             if (asyncUpdates == null) throw new ArgumentNullException(nameof(asyncUpdates));
 
+            // Same disposed guard as the sync overload: run the action, leave the slot's lifecycle alone.
+            if (fiber.IsDisposed)
+            {
+                await asyncUpdates();
+                return;
+            }
+
             // Re-entrant async call: join the outer transition. The outer call owns the pending lifecycle.
             if (fiber.IsInTransition)
             {
@@ -460,6 +499,10 @@ namespace Velvet
             }
 
             slot.IsPending = true;
+            // While the action is awaiting (before its setState calls land) the fiber can be entirely
+            // clean, and a drain callback armed earlier that fires on that clean fiber must not read the
+            // empty lane queue as this transition having settled (see ClearAllTransitionPending).
+            slot.IsAsyncInFlight = true;
             fiber.IsInTransition = true;
             try
             {
@@ -470,9 +513,14 @@ namespace Velvet
             finally
             {
                 fiber.IsInTransition = false;
+                slot.IsAsyncInFlight = false;
+                // The promoted marker joins the Transition-label check for the same reason the settle
+                // sweep consults it: promotion erases the label while the promoted work may still be
+                // queued, and completing the async action inside that window must not clear isPending
+                // ahead of the commit that renders the transition's content.
                 if (fiber.IsDisposed
                     || fiber.LaneQueue == null
-                    || !fiber.LaneQueue.Contains(FiberUpdatePriority.Transition))
+                    || (!fiber.LaneQueue.Contains(FiberUpdatePriority.Transition) && !fiber.HasPromotedTransition))
                 {
                     slot.IsPending = false;
                 }

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/UpdatePriorityTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/UpdatePriorityTests.cs
@@ -17,7 +17,8 @@ namespace Velvet.Tests
     /// Transition enroll on the delayed tier. Each tier's drain flushes only its own lanes.</item>
     /// <item>An Urgent lane drains and clears the dirty flag; once the queue is empty a further flush is a no-op.</item>
     /// <item>Deferred updates require a delayed flush and coalesce on the same fiber; Transition updates require a
-    /// flush and coalesce, and a starved Transition lane is eventually promoted and processed.</item>
+    /// flush and coalesce, and a starved Transition lane is promoted to Normal — and drained — by the flush that
+    /// reaches the starvation threshold, however often the lane was re-scheduled while pending.</item>
     /// <item>A fiber's lane queue drains lowest-value-first, one lane per flush; an Urgent update added to an
     /// already-Deferred fiber also enrolls it on the immediate tier so a synchronous immediate flush can commit it.</item>
     /// <item>A render-phase setState re-runs Render() synchronously within the same commit, leaves no pending
@@ -329,11 +330,12 @@ namespace Velvet.Tests
         }
 
         [Test]
-        public void Given_StarvedTransition_When_NormalUpdatesExceedThreshold_Then_TransitionIsPromotedAndProcessed()
+        public void Given_StarvedTransition_When_NormalUpdatesReachThreshold_Then_TransitionIsPromotedAndDrainedInThatFlush()
         {
             // Arrange
             s_simpleInitial = "initial";
             using var mounted = V.Mount(_root, V.Component(SimpleRender, key: "simple"));
+            Assume.That(s_simpleRenderCount, Is.EqualTo(1), "Precondition: the mount rendered once");
             s_simpleStartTransition.Invoke(() => s_simpleSetValue.Invoke("transition-update"));
             const int threshold = 30;
             for (var i = 0; i < threshold - 1; i++)
@@ -341,16 +343,159 @@ namespace Velvet.Tests
                 s_simpleSetValue.Invoke($"normal-{i}");
                 mounted.FlushStateForTest();
             }
-            s_simpleSetValue.Invoke($"normal-{threshold - 1}");
-            mounted.FlushStateForTest();
             var renderCountBeforeFinal = s_simpleRenderCount;
 
-            // Act
+            // Act — the flush that reaches the threshold promotes the starved lane to Normal and drains
+            // it in the same pass; a mere hand-off to another still-outranked lane would keep losing to
+            // the sustained Normal traffic.
+            s_simpleSetValue.Invoke($"normal-{threshold - 1}");
             mounted.FlushStateForTest();
 
             // Assert
-            Assert.Greater(s_simpleRenderCount, renderCountBeforeFinal,
-                "After starvation promotion, the Transition lane is processed and Render runs");
+            Assert.AreEqual((renderCountBeforeFinal + 1, false), (s_simpleRenderCount, s_simpleFiber.IsDirty),
+                "The threshold flush renders once (the promoted lane coalesces with the preempting Normal) "
+                + "and leaves no lane pending");
+        }
+
+        [Test]
+        public void Given_SustainedTransitionRescheduling_When_NormalPreemptionReachesThreshold_Then_TransitionLaneIsPromoted()
+        {
+            // Arrange
+            s_simpleInitial = "initial";
+            using var mounted = V.Mount(_root, V.Component(SimpleRender, key: "simple"));
+            Assume.That(s_simpleRenderCount, Is.EqualTo(1), "Precondition: the mount rendered once");
+            const int threshold = 30;
+
+            // Act — the first pass genuinely enrols the Transition lane; every later pass re-signals
+            // transition intent as a coalesced re-add onto the still-pending lane, while a fresh Normal
+            // update preempts each flush, so the Transition lane never drains on its own. The starvation
+            // clock measures continuous pendency, so the coalesced re-adds must not restart it: the
+            // threshold flush must still promote and drain the starved lane.
+            for (var i = 0; i < threshold; i++)
+            {
+                s_simpleStartTransition.Invoke(() => s_simpleSetValue.Invoke($"transition-{i}"));
+                s_simpleSetValue.Invoke($"normal-{i}");
+                mounted.FlushStateForTest();
+            }
+
+            // Assert — the threshold flush promoted the starved lane to Normal and drained it in the
+            // same pass, leaving nothing pending (a promote that merely re-queued it on a still-outranked
+            // lane would keep starving under the sustained Normal traffic).
+            Assert.AreEqual((false, false),
+                (s_simpleFiber.LaneQueue.Contains(FiberUpdatePriority.Transition), s_simpleFiber.IsDirty),
+                "Sustained Transition re-scheduling under Normal preemption must not defeat the "
+                + "starvation promotion — the threshold flush drains the starved lane");
+        }
+
+        [Test]
+        public void Given_StarvedTransitionUnderDeferredPreemption_When_ThresholdReached_Then_PromotedLaneOutranksThePreemptor()
+        {
+            // Arrange — starve the Transition lane behind a re-added Deferred lane each pass (Deferred
+            // outranks Transition, so each flush drains the Deferred preemptor and Transition survives).
+            s_simpleInitial = "initial";
+            using var mounted = V.Mount(_root, V.Component(SimpleRender, key: "simple"));
+            Assume.That(s_simpleRenderCount, Is.EqualTo(1), "Precondition: the mount rendered once");
+            s_simpleStartTransition.Invoke(() => s_simpleSetValue.Invoke("transition-update"));
+            const int threshold = 30;
+            for (var i = 0; i < threshold - 1; i++)
+            {
+                s_simpleFiber.ScheduleRerenderForTest(FiberUpdatePriority.Deferred);
+                mounted.FlushStateForTest();
+            }
+
+            // Act — the threshold flush must drain the PROMOTED lane, which now outranks the re-added
+            // Deferred preemptor; the preemptor is what stays pending.
+            s_simpleFiber.ScheduleRerenderForTest(FiberUpdatePriority.Deferred);
+            mounted.FlushStateForTest();
+
+            // Assert — distinguishes a genuine promotion from a drop of the starved lane: a drop would
+            // let this flush drain the Deferred preemptor instead, emptying the queue.
+            Assert.AreEqual((true, true),
+                (s_simpleFiber.LaneQueue.Contains(FiberUpdatePriority.Deferred), s_simpleFiber.IsDirty),
+                "The promoted lane outranks the Deferred preemptor — the threshold flush drains the "
+                + "promoted Normal and leaves the preemptor pending");
+        }
+
+        [Test]
+        public void Given_StarvedTransitionUnderDeferredPreemption_When_ThePromotedLaneDrains_Then_IsPendingClearsDespiteThePendingPreemptor()
+        {
+            // Arrange — same starvation shape as the preemptor-ordering test above.
+            s_simpleInitial = "initial";
+            using var mounted = V.Mount(_root, V.Component(SimpleRender, key: "simple"));
+            Assume.That(s_simpleRenderCount, Is.EqualTo(1), "Precondition: the mount rendered once");
+            s_simpleStartTransition.Invoke(() => s_simpleSetValue.Invoke("transition-update"));
+            const int threshold = 30;
+            for (var i = 0; i < threshold - 1; i++)
+            {
+                s_simpleFiber.ScheduleRerenderForTest(FiberUpdatePriority.Deferred);
+                mounted.FlushStateForTest();
+            }
+            s_simpleFiber.ScheduleRerenderForTest(FiberUpdatePriority.Deferred);
+
+            // Act — the threshold flush promotes and drains the starved lane while the Deferred
+            // preemptor stays queued.
+            mounted.FlushStateForTest();
+
+            // Assert — the promoted marker must retire with the drain that committed its content: a
+            // marker left set would skip the settle sweep for as long as any other lane stays queued,
+            // holding isPending past its own commit.
+            Assert.IsFalse(s_simpleFiber.IsTransitionPending,
+                "isPending clears at the promoted drain even while the Deferred preemptor is still queued");
+        }
+
+        [Test]
+        public void Given_StarvedTransitionPromotedBehindUrgent_When_ThresholdFlushDrainsUrgent_Then_IsPendingSurvives()
+        {
+            // Arrange
+            s_simpleInitial = "initial";
+            using var mounted = V.Mount(_root, V.Component(SimpleRender, key: "simple"));
+            Assume.That(s_simpleRenderCount, Is.EqualTo(1), "Precondition: the mount rendered once");
+            s_simpleStartTransition.Invoke(() => s_simpleSetValue.Invoke("transition-update"));
+            const int threshold = 30;
+            for (var i = 0; i < threshold - 1; i++)
+            {
+                s_simpleSetValue.Invoke($"normal-{i}");
+                mounted.FlushStateForTest();
+            }
+
+            // Act — the threshold flush finds an Urgent co-pending: promotion erases the Transition label
+            // (relabelling the lane to Normal), the flush drains Urgent first, and the promoted work stays
+            // queued one more pass.
+            s_simpleFiber.ScheduleRerenderForTest(FiberUpdatePriority.Urgent);
+            mounted.FlushStateForTest();
+
+            // Assert — the settle sweep must not read the erased Transition label as settled: isPending
+            // survives until the commit that renders the promoted content.
+            Assert.AreEqual((true, true),
+                (s_simpleFiber.IsTransitionPending, s_simpleFiber.LaneQueue.Contains(FiberUpdatePriority.Normal)),
+                "isPending survives the Urgent drain while the promoted lane is still queued");
+        }
+
+        [Test]
+        public void Given_StarvedTransitionPromotedBehindUrgent_When_ThePromotedLaneDrains_Then_IsPendingClears()
+        {
+            // Arrange — same shape as the survival test above, driven one flush further.
+            s_simpleInitial = "initial";
+            using var mounted = V.Mount(_root, V.Component(SimpleRender, key: "simple"));
+            Assume.That(s_simpleRenderCount, Is.EqualTo(1), "Precondition: the mount rendered once");
+            s_simpleStartTransition.Invoke(() => s_simpleSetValue.Invoke("transition-update"));
+            const int threshold = 30;
+            for (var i = 0; i < threshold - 1; i++)
+            {
+                s_simpleSetValue.Invoke($"normal-{i}");
+                mounted.FlushStateForTest();
+            }
+            s_simpleFiber.ScheduleRerenderForTest(FiberUpdatePriority.Urgent);
+            mounted.FlushStateForTest();
+            Assume.That(s_simpleFiber.IsTransitionPending, Is.True,
+                "Precondition: isPending survived the Urgent drain");
+
+            // Act — drain the promoted lane: this is the commit that renders the promoted content.
+            mounted.FlushStateForTest();
+
+            // Assert — the promoted marker retires with its drain; the sweep must not skip forever.
+            Assert.IsFalse(s_simpleFiber.IsTransitionPending,
+                "isPending clears at the commit that drains the promoted lane");
         }
 
         #endregion


### PR DESCRIPTION
## Summary

A `Transition`-lane re-render could be starved indefinitely by sustained higher-priority work, on
two independent fronts:

1. **The starvation clock restarted on every schedule.** `ScheduleRerender` reset
   `TransitionStarvationCounter` on every Transition schedule — including a coalesced re-add onto
   an already-pending lane — so a component that re-signalled transition intent more often than
   every 30 flush passes kept restarting the clock and `PromoteStarvedTransitionLane` never fired.
   The clock now measures how long the lane has been **continuously pending**: it starts once when
   the lane genuinely enters the queue and runs until the lane flushes. A coalesced re-add no
   longer restarts it; the genuine-enrol reset is kept so a lane that drained normally does not
   inherit the previous cycle's residual count and promote early.

2. **The promotion itself could not win.** Promoting to `Deferred` (2) still loses to a sustained
   stream of `Normal` (1) updates — the exact traffic that caused the starvation — so promoted
   work could go straight back to starving. A starved lane is now promoted to `Normal`, draining
   in the flush that reaches the threshold or right after any co-pending Urgent drains,
   synchronously (an expired lane abandons time-slicing).

`useTransition.isPending` timing hardens with this:

- Promotion erases the Transition label while the promoted work may still be queued (parked behind
  an Urgent drain), and the settle sweep used to misread that as the transition having settled. A
  promoted-lane marker now keeps `isPending` alive until the commit that renders the promoted
  content — across the drain sweep, the async-completion check, the runaway drop, and the
  subsumed-fiber settle.
- An **async** `startTransition` still awaiting its action (setState calls come after the await)
  legitimately holds `isPending = true` on a fiber with no pending lane; the settle sweep used to
  wipe it when any drain callback fired on that clean fiber. Transition slots now track the async
  in-flight window and the sweep skips them; only the action's own completion clears the flag.

## Behavior decided

The issue left open whether reset-on-schedule was intended ("continuous waiting since the last
explicit intent") or a defect ("how long the lane has been continuously non-empty"). Resolved as
the latter: the promotion exists to bound how long pending transition work can be preempted, and a
clock that restarts on every re-signal cannot bound anything under sustained scheduling.

## Tests

All new/rewritten tests verified RED against the pre-fix behavior (including drop-without-requeue
and marker-never-cleared mutants) and GREEN with the fix; full EditMode and PlayMode suites green.

- `Given_SustainedTransitionRescheduling_When_NormalPreemptionReachesThreshold_Then_TransitionLaneIsPromoted`:
  coalesced re-add + Normal preemption every pass; the threshold flush drains the starved lane.
- `Given_StarvedTransitionUnderDeferredPreemption_When_ThresholdReached_Then_PromotedLaneOutranksThePreemptor`:
  the promoted lane outranks a re-added Deferred preemptor.
- `Given_StarvedTransitionUnderDeferredPreemption_When_ThePromotedLaneDrains_Then_IsPendingClearsDespiteThePendingPreemptor`:
  the promoted marker retires at its commit even while another lane stays queued.
- `Given_StarvedTransitionPromotedBehindUrgent_When_ThresholdFlushDrainsUrgent_Then_IsPendingSurvives`
  / `..._When_ThePromotedLaneDrains_Then_IsPendingClears`: `isPending` spans the Urgent parking
  window and clears at the promoted commit.
- `Given_StarvedTransition_When_NormalUpdatesReachThreshold_Then_TransitionIsPromotedAndDrainedInThatFlush`
  (rewritten): the threshold flush renders once and leaves no lane pending.
- `Given_AsyncStartTransitionAwaitingBeforeAnyUpdate_When_ACleanFiberFlushFires_Then_IsPendingStaysTrue`:
  a flush on a clean fiber does not wipe an awaiting async transition's pending flag.

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)