### PR TITLE
fix(velvet): resolve a wrapped Motion's variant enter/exit against its own element

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -31,10 +31,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   own enter/exit tween is bound to must stay put — wrap it in a z-managed `Div` instead, which an
   `AnimatePresence` keyed child built that way (an animated, top-most modal) can do: its enter,
   `PopLayout` exit pin, and exit-cancel all target the real, relocated element for its whole
-  lifetime, not a placeholder standing in its declared slot. The `variants` enter/exit classes still
-  resolve only when the direct presence child is the Motion itself, not this wrapped shape — only
-  the transition's timing and its `onEnterComplete` callback are guaranteed for a wrapped Motion
-  today. Comparison is scoped to direct siblings under one immediate parent only; there is no CSS
+  lifetime, not a placeholder standing in its declared slot. The `variants` enter/exit classes
+  resolve against the wrapped Motion's own element, so the wrapped shape animates identically to a
+  direct Motion child. Comparison is scoped to direct siblings under one immediate parent only; there is no CSS
   stacking-context nesting (opacity, transform, filter, and isolation do not open a new context
   here). A `peer-` source that is itself z-managed is not found by a `peer-` consumer (its
   placeholder carries none of its marker classes) — the reverse, a z-managed consumer resolving an
@@ -107,6 +106,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A `V.Motion` nested under a transparent wrapper inside an `AnimatePresence` keyed child — a
+  z-managed `Div` (the animated top-most modal shape, since `z-*` is a documented no-op on a
+  Motion itself) or a `ContextProvider` — now has its named `variants` enter/exit classes applied,
+  resolved against the Motion's own element, where the resting `variants[animate]` classes live.
+  Previously variant resolution required the keyed child itself to be the Motion, so only the
+  transition's timing and `onEnterComplete` were honored for the wrapped shape: a wrapped modal
+  faded/scaled only when its transition carried timing-preset classes, never its declared
+  variants. Exit-cancel (the key re-added mid-exit) likewise restores the resting variant on the
+  Motion's own element now. Deliberate consequence: a wrapped Motion no longer also plays the
+  classic preset alongside a variant enter/exit — a variant-driven animation manages its state
+  through variant classes alone, exactly as a direct Motion child always has (a configuration
+  without an `exit` label keeps its classic preset exit on the wrapper, same as before). Style the
+  Motion, not the wrapper, for anything that should animate with the variants.
 - `V.Portal(layer:)`/`V.WorldSpace` synthetic event bubbling now stops when a handler calls
   `StopPropagation()` partway up the logical ancestor chain, instead of continuing to invoke
   every remaining ancestor regardless. Also fixes nested portals/world-space (one mounted inside

--- a/Packages/com.velvet.core/Documentation~/styling-z-index.md
+++ b/Packages/com.velvet.core/Documentation~/styling-z-index.md
@@ -72,9 +72,10 @@ physically reorders the declaring children list itself. Instead:
   this way (the common "animated, top-most modal" shape) enters and exits against the *real*,
   relocated element for its whole lifetime, including a `PopLayout` exit's out-of-flow pin; a
   cancelled exit (the key re-added mid-animation) restores it the same way an ordinary, non-`z-*`
-  presence child does. The `variants` enter/exit *classes* still resolve only when the direct
-  presence child *is* the Motion itself (not this wrapped shape) — only the transition's timing and
-  its `onEnterComplete` callback are guaranteed for a wrapped Motion today.
+  presence child does. The `variants` enter/exit *classes* resolve against the wrapped Motion's own
+  element — the same element its resting `variants[animate]` classes live on — so the wrapped shape
+  animates identically to a direct Motion child. Style the Motion, not the wrapper, for anything
+  that should animate with the variants: the wrapper itself does not fade with a variant swap.
 - **Negative z never escapes the element's own parent's background.** UI Toolkit has exactly one
   paint traversal; a child can only paint after its own parent's background within that walk.
   Escaping "behind the parent" would mean hoisting the child to become the parent's own preceding

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodeFactory.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodeFactory.cs
@@ -232,6 +232,13 @@ namespace Velvet
                     var motionAmbient = _ctx.ComponentContextStack.Get(MotionContext.ActiveLabel);
                     var appliedClasses = MotionVariantResolver.ResolveApplied(motionNode, motionAmbient, out var variantClasses);
                     var element = _ctx.FiberElementFactory.CreateMotion(motionNode, appliedClasses);
+                    // The presence expansion dispatches this anchor Motion's variant enter/exit against the
+                    // Motion's OWN element (the resting variant classes live here, not on a wrapper) — record
+                    // it for the expansion that is emitting this keyed child right now.
+                    if (ReferenceEquals(motionNode, _ctx.PresenceAnchorMotion))
+                    {
+                        _ctx.PresenceAnchorMotionElement = element;
+                    }
                     // See the ElementNode case's comment on this same assignment (reserved userData
                     // slot for cross-panel synthetic event dispatch's VE-to-logical-fiber reverse index).
                     element.userData = _ctx.FiberStack.Current;

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
@@ -457,6 +457,14 @@ namespace Velvet
 
         private void PatchMotion(VisualElement element, MotionNode oldNode, MotionNode newNode)
         {
+            // Mirror the create path's anchor-element recording: a presence keyed child that REUSES its
+            // element (a ghost's old-side reproduction, a cancelled exit's re-entry) reaches its Motion
+            // through this patch, and the expansion still needs the Motion's own element to dispatch
+            // variant enter/exit against.
+            if (ReferenceEquals(newNode, _ctx.PresenceAnchorMotion))
+            {
+                _ctx.PresenceAnchorMotionElement = element;
+            }
             // Effective label = own Animate, else the inherited MotionContext label (read BEFORE we push this
             // node's label for its own children).
             var motionAmbient = _ctx.ComponentContextStack.Get(MotionContext.ActiveLabel);
@@ -563,13 +571,14 @@ namespace Velvet
             // identity — that field is set for every current AnimatePresence child, including a plain
             // PERSISTING one this swap must still drive when its ambient label changes, e.g. a coordinator
             // orchestrating a presence-managed child). A Motion's own resolved variant only actually changes
-            // (the precondition above) while ReferenceEquals(node, motion) && Variants != null, which is
-            // exactly GeneralPathReconciler's own isVariantMotion — and its explicit enter dispatch for that
-            // shape either runs on a fresh CREATE (never reaches PatchMotion) or, for a still-exiting /
-            // cancelled-exit reproduction, plays no competing animation of its own (CancelExit's reversal, or
-            // no-op) — so the one real overlap is a GHOST re-patched on a LATER render while still exiting
-            // (skipping the ghost dispatch's own CancelEnter, which only runs the FIRST time
-            // state.Exiting.Add(key) succeeds): IsExiting catches exactly that window.
+            // (the precondition above) while it carries Variants of its own — the shape whose enter/exit
+            // GeneralPathReconciler dispatches explicitly against this very element (isVariantMotion; a
+            // wrapped anchor Motion's dispatch also lands here, on the Motion's own element, not on its
+            // wrapper) — and that explicit dispatch either runs on a fresh CREATE (never reaches PatchMotion)
+            // or, for a still-exiting / cancelled-exit reproduction, plays no competing animation of its own
+            // (CancelExit's reversal, or no-op) — so the one real overlap is a GHOST re-patched on a LATER
+            // render while still exiting (skipping the ghost dispatch's own CancelEnter, which only runs the
+            // FIRST time state.Exiting.Add(key) succeeds): IsExiting catches exactly that window.
             if (newNode.Transition != null && !_ctx.StyleAnimationScheduler.IsExiting(element)
                 && !SequenceEqual(oldVariantClasses, newVariantClasses))
             {

--- a/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
@@ -969,7 +969,8 @@ namespace Velvet
                     {
                         EmitPresenceChildAsAnchor(node, FiberNodeFactory.FindFirstMotionDescendant(node),
                             key, presenceKey, result, isNewSide: false, parent, slotStart,
-                            oldFibers, newFibers, providers, oldProvidersForPairing, ref newProviderIndex, commit);
+                            oldFibers, newFibers, providers, oldProvidersForPairing, ref newProviderIndex, commit,
+                            out _);
                     }
                 }
                 return;
@@ -1082,6 +1083,10 @@ namespace Velvet
                             // (other retirements must spare live ghosts), and a still-listed entry would spare
                             // this sweep's own target. prevCommitted is a copy, so the loop is unaffected.
                             RemovePresenceCommittedEntry(state.Committed, key);
+                            // The key's leaves are leaving the DOM for good — its memoized Motion element
+                            // must retire with them, or a pooled element could be resurrected as a later
+                            // dispatch target.
+                            state.MotionElements.Remove(key);
                             FiberTreeReturn.ReturnRetiredTree(FiberTreeReturn.NormalizeToArray(node), boundaryFiber);
                             continue;
                         }
@@ -1095,13 +1100,24 @@ namespace Velvet
                             removedInstantThisRender = true;
                             // Same as the finished-exit drop above: leave the committed set, then retire.
                             RemovePresenceCommittedEntry(state.Committed, key);
+                            // Same memoized-element retirement as the finished-exit drop above.
+                            state.MotionElements.Remove(key);
                             FiberTreeReturn.ReturnRetiredTree(FiberTreeReturn.NormalizeToArray(node), boundaryFiber);
                             continue;
                         }
 
                         var ghostAnchor = EmitPresenceChildAsAnchor(node, ghostMotionNode, key, presenceKey, result,
                             isNewSide: true, parent, slotStart,
-                            oldFibers, newFibers, providers, oldProvidersForPairing, ref newProviderIndex, commit);
+                            oldFibers, newFibers, providers, oldProvidersForPairing, ref newProviderIndex, commit,
+                            out var ghostMotionElement);
+                        // A ghost reproduces the SAME committed node on both diff sides, so the patch that
+                        // would re-record the Motion's element bails on reference equality — fall back to
+                        // the per-key memo the live emissions kept (see PresenceBoundaryState.MotionElements).
+                        if (commit != null)
+                        {
+                            if (ghostMotionElement != null) state.MotionElements[key!] = ghostMotionElement;
+                            else state.MotionElements.TryGetValue(key!, out ghostMotionElement);
+                        }
 
                         // Track the live ghost anchor so the drop path (exit complete) can dispose the subtree
                         // fibers under it — see DisposeExitedGhostFibers.
@@ -1110,6 +1126,12 @@ namespace Velvet
                         if (commit != null && ghostAnchor != null && state.Exiting.Add(key))
                         {
                             _ctx.StyleAnimationScheduler.CancelEnter(ghostAnchor);
+                            // A wrapped Motion's variant enter ran on its own element, not the anchor —
+                            // cancel there too (idempotent when both are the same element).
+                            if (ghostMotionElement != null && !ReferenceEquals(ghostMotionElement, ghostAnchor))
+                            {
+                                _ctx.StyleAnimationScheduler.CancelEnter(ghostMotionElement);
+                            }
                             if (presence.Mode == AnimatePresenceMode.PopLayout)
                             {
                                 PinExitingChildOutOfFlow(ghostAnchor);
@@ -1118,10 +1140,15 @@ namespace Velvet
                             var capturedState = state;
                             var capturedBoundary = boundaryFiber;
                             var capturedOnExitComplete = presence.OnExitComplete;
-                            // `exit`: when the direct Motion child declares an exit variant label, animate from the
-                            // resting variants[animate] to variants[exit]; otherwise use the transition's ExitFrom/ExitTo.
-                            var variantExit = TryResolveVariantExit(node, ghostMotionNode);
+                            // `exit`: when the resolved Motion declares an exit variant label, animate from the
+                            // resting variants[animate] to variants[exit]; otherwise use the transition's
+                            // ExitFrom/ExitTo. The variant swap targets the Motion's OWN element (where the
+                            // resting variant classes live), which for a wrapped Motion is not the anchor —
+                            // without a resolved element the variant path is unavailable and the classic,
+                            // anchor-targeted transition plays instead.
+                            var variantExit = ghostMotionElement != null ? TryResolveVariantExit(ghostMotionNode) : null;
                             var exitTransition = variantExit ?? ghostTransition;
+                            var exitTarget = variantExit != null ? ghostMotionElement! : ghostAnchor;
                             // For a variant exit the From classes ARE the resting variants[animate]; if this exit is
                             // cancelled (the key is re-added before it finishes) the element must return to that resting
                             // variant rather than be left without it (interrupt handling).
@@ -1183,7 +1210,7 @@ namespace Velvet
                                         + "component (e.g. via V.Mount) rather than reconciling it onto a bare element.");
                                 }
                             }
-                            _ctx.StyleAnimationScheduler.PlayExit(ghostAnchor, exitTransition, () =>
+                            _ctx.StyleAnimationScheduler.PlayExit(exitTarget, exitTransition, () =>
                             {
                                 // See passSettled's own comment above the loop: a synchronous completion (fired
                                 // from inside this very PlayExit call) is queued instead of run inline.
@@ -1214,7 +1241,15 @@ namespace Velvet
                     var motion = FiberNodeFactory.FindFirstMotionDescendant(node);
                     var anchor = EmitPresenceChildAsAnchor(node, motion, key, presenceKey, result, isNewSide: true,
                         parent, slotStart, oldFibers, newFibers, providers, oldProvidersForPairing,
-                        ref newProviderIndex, commit);
+                        ref newProviderIndex, commit, out var motionElement);
+                    // Same memo discipline as the ghost path: record when this emission resolved the
+                    // element (create or genuine patch), fall back to the memo when a no-op re-render's
+                    // reference-equal patch bailed before recording.
+                    if (commit != null)
+                    {
+                        if (motionElement != null) state.MotionElements[key!] = motionElement;
+                        else state.MotionElements.TryGetValue(key!, out motionElement);
+                    }
 
                     if (commit != null && anchor != null)
                     {
@@ -1252,6 +1287,12 @@ namespace Velvet
                         if (wasExiting)
                         {
                             _ctx.StyleAnimationScheduler.CancelExit(anchor);
+                            // A wrapped Motion's variant exit ran on its own element, not the anchor — the
+                            // cancel (whose reversal restores the resting variant) must land there too.
+                            if (motionElement != null && !ReferenceEquals(motionElement, anchor))
+                            {
+                                _ctx.StyleAnimationScheduler.CancelExit(motionElement);
+                            }
                             if (presence.Mode == AnimatePresenceMode.PopLayout)
                             {
                                 // The anchor's OWN class list, not motion's: PinExitingChildOutOfFlow pinned
@@ -1271,13 +1312,16 @@ namespace Velvet
                                 // very first mount; later additions always animate.
                                 if (!firstRender || presence.Initial)
                                 {
-                                    // A variant Motion (direct child carrying variants + animate) manages its resting
-                                    // state through variant classes: variants[animate] is applied at mount and restored
-                                    // by CancelExit on an exit-cancel. So it only ever plays a VARIANT enter (when an
-                                    // `initial` label is declared) and must NOT fall through to the classic preset
-                                    // enter — the default StyleTransition.Fade would replay a fade-in on top of the
-                                    // resting variant on every add / interrupt.
-                                    var isVariantMotion = ReferenceEquals(node, motion)
+                                    // A variant Motion (carrying variants + animate) manages its resting state
+                                    // through variant classes: variants[animate] is applied at mount and restored
+                                    // by CancelExit on an exit-cancel. So it only ever plays a VARIANT enter (when
+                                    // an `initial` label is declared) and must NOT fall through to the classic
+                                    // preset enter — the default StyleTransition.Fade would replay a fade-in on
+                                    // top of the resting variant on every add / interrupt. The variant swap
+                                    // targets the Motion's OWN element (where those resting classes live), which
+                                    // for a wrapped Motion is not the anchor; without a resolved element the
+                                    // variant path is unavailable and the classic enter plays on the anchor.
+                                    var isVariantMotion = motionElement != null
                                         && motion.Variants != null && motion.Animate != null;
                                     // A cancelled exit reproduces the SAME still-attached element —
                                     // not a first mount — so `initial` does not reapply: CancelExit
@@ -1291,7 +1335,7 @@ namespace Velvet
                                         // `initial`: enter from variants[initial] to variants[animate]
                                         // (kept as the persistent resting state).
                                         var t = motion.Transition;
-                                        _ctx.StyleAnimationScheduler.PlayVariantEnter(anchor, fromClasses, toClasses,
+                                        _ctx.StyleAnimationScheduler.PlayVariantEnter(motionElement, fromClasses, toClasses,
                                             t, motion.OnEnterComplete, presence.StaggerDelaySec(visualIndex, newKeyed.Count));
                                     }
                                     else if (isVariantMotion)
@@ -1570,6 +1614,11 @@ namespace Velvet
         // Saved and RESTORED (not just cleared) around the call so a nested AnimatePresence inside this keyed
         // child's own subtree — which sets its own anchor for ITS keyed children — does not leave the outer
         // anchor cleared once its own expansion returns and this child's subtree keeps unwinding.
+        // anchorMotionElement: the anchor Motion's own live element, as recorded by CreateElement /
+        // PatchMotion during this very expansion — the target the caller's variant enter/exit classes must
+        // land on (the resting variant classes live there, not on a wrapper anchor). Null when the emission
+        // did not reach the Motion (or there is none); callers fall back to the classic, anchor-targeted
+        // transition then.
         private VisualElement? EmitPresenceChildAsAnchor(
             VNode? node,
             MotionNode? anchorMotion,
@@ -1584,18 +1633,24 @@ namespace Velvet
             List<ContextProviderNode>? providers,
             List<ContextProviderNode>? oldProvidersForPairing,
             ref int newProviderIndex,
-            GeneralCommitState? commit)
+            GeneralCommitState? commit,
+            out VisualElement? anchorMotionElement)
         {
             var previousAnchor = _ctx.PresenceAnchorMotion;
+            var previousAnchorElement = _ctx.PresenceAnchorMotionElement;
             _ctx.PresenceAnchorMotion = anchorMotion;
+            _ctx.PresenceAnchorMotionElement = null;
             try
             {
-                return EmitPresenceChild(node, key, presenceScope, result, isNewSide, parent, slotStart,
+                var emitted = EmitPresenceChild(node, key, presenceScope, result, isNewSide, parent, slotStart,
                     oldFibers, newFibers, providers, oldProvidersForPairing, ref newProviderIndex, commit);
+                anchorMotionElement = _ctx.PresenceAnchorMotionElement;
+                return emitted;
             }
             finally
             {
                 _ctx.PresenceAnchorMotion = previousAnchor;
+                _ctx.PresenceAnchorMotionElement = previousAnchorElement;
             }
         }
 
@@ -1623,12 +1678,13 @@ namespace Velvet
 
         // Builds the exit transition for an `exit` variant: the element animates from its resting
         // variants[Animate] (ExitFromClass) to variants[Exit] (ExitToClass), keeping this Motion's
-        // transition timing, before unmount. Returns null (caller falls back to the classic transition) unless this
-        // is the direct Motion child (node == motion, so anchor IS its element) and it sets its own
-        // Exit + Animate + Variants with a non-empty exit class.
-        internal static StyleTransitionConfig? TryResolveVariantExit(VNode? node, MotionNode? motion)
+        // transition timing, before unmount. Returns null (caller falls back to the classic transition)
+        // unless the Motion sets its own Exit + Animate + Variants with a non-empty exit class. The caller
+        // supplies the element the swap targets — the Motion's own, so a wrapped Motion's exit variant
+        // animates the same element its resting variant classes live on.
+        internal static StyleTransitionConfig? TryResolveVariantExit(MotionNode? motion)
         {
-            if (!ReferenceEquals(node, motion) || motion?.Exit == null || motion.Animate == null || motion.Variants == null
+            if (motion?.Exit == null || motion.Animate == null || motion.Variants == null
                 || !motion.Variants.TryGetValue(motion.Exit, out var exitClass) || string.IsNullOrEmpty(exitClass))
             {
                 return null;

--- a/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
@@ -778,6 +778,14 @@ namespace Velvet
             // explicitly via DisposeFibersUnder — otherwise a same-key re-entry restores a zombie fiber whose
             // local state updates never re-render.
             public readonly Dictionary<string, VisualElement> ExitAnchors = new();
+
+            // The anchor Motion's OWN element per live key — the target its variant enter/exit classes land
+            // on. A ghost's emission reproduces the SAME committed node instance on both diff sides, so the
+            // patch that would re-record the element (PresenceAnchorMotionElement) bails on reference
+            // equality and never runs; this per-key memo, written whenever an emission DOES record the
+            // element, is what the ghost's exit dispatch falls back to. Entries retire with their key
+            // (exit-complete drop / instant removal) so a pooled element is never resurrected as a target.
+            public readonly Dictionary<string, VisualElement> MotionElements = new();
         }
 
         // Keyed by (boundary fiber, parent element, scoped position key). The parent element is part of the
@@ -805,6 +813,15 @@ namespace Velvet
         // deeper, sitting under a non-anchor wrapper, or a sibling keyed child) is not presence-managed at all
         // and must keep its own mount enter.
         internal MotionNode? PresenceAnchorMotion;
+
+        // The live element CreateElement / PatchMotion resolved for PresenceAnchorMotion during the
+        // current EmitPresenceChild expansion (same set/restore discipline). Needed because variant
+        // enter/exit classes must land on the Motion's OWN element — where the resting
+        // variants[animate] classes live — not on the keyed child's top-level anchor: for a wrapped
+        // Motion (a z-managed Div or a Provider between the presence and the Motion) those are
+        // different elements, and classes applied to the wrapper would double-apply against the
+        // Motion's resting set and be clobbered by the wrapper's own class patching.
+        internal VisualElement? PresenceAnchorMotionElement;
 
         // Removes all DOM-less AnimatePresence state keyed by boundary. Invoked from
         // ComponentRegistry when the boundary fiber is unregistered, so a boundary that

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/AnimatePresencePopLayoutTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/AnimatePresencePopLayoutTests.cs
@@ -32,6 +32,7 @@ namespace Velvet.Tests
 
         private static SetStore s_store;
         private static AnimatePresenceMode s_mode;
+        private static bool s_classicTransition;
         private static readonly Dictionary<string, string> s_fade = new()
         {
             ["visible"] = "opacity-100",
@@ -48,6 +49,7 @@ namespace Velvet.Tests
             _window.Show();
             s_store = null;
             s_mode = AnimatePresenceMode.PopLayout;
+            s_classicTransition = false;
         }
 
         [TearDown]
@@ -102,13 +104,16 @@ namespace Velvet.Tests
             var children = new List<VNode>();
             foreach (var key in keys)
             {
+                // A classic preset when the test asks for one (its enter/exit dispatches against the keyed
+                // child's anchor — the shape that pins anchor-resolution regressions), else the variant
+                // trio (whose class swaps dispatch against the Motion's own element instead).
+                var motion = s_classicTransition
+                    ? V.Motion(className: "w-[60px] h-[24px]", transition: StyleTransition.Fade)
+                    : V.Motion(className: "w-[60px] h-[24px]",
+                        variants: s_fade, animate: "visible", exit: "hidden",
+                        transition: new StyleTransitionConfig { DurationSec = 0.3f });
                 children.Add(V.Div(name: "item-" + key, key: key.ToString(), className: "absolute z-10",
-                    children: new VNode[]
-                    {
-                        V.Motion(className: "w-[60px] h-[24px]",
-                            variants: s_fade, animate: "visible", exit: "hidden",
-                            transition: new StyleTransitionConfig { DurationSec = 0.3f }),
-                    }));
+                    children: new VNode[] { motion }));
             }
             return V.Div(name: "presence-host", className: "relative", children: new VNode[]
             {
@@ -180,6 +185,10 @@ namespace Velvet.Tests
             // Arrange — mount with "b" absent (its own Div/Motion never render this pass), mirroring the
             // "modal added to an already-mounted AnimatePresence" shape — the single most common
             // AnimatePresence+z use case — where the Initial flag's first-mount suppression does not apply.
+            // A CLASSIC preset drives the enter so the dispatch targets the keyed child's anchor — the
+            // very resolution this test pins (a variant Motion's enter targets the Motion's own element
+            // instead, sidestepping the anchor entirely).
+            s_classicTransition = true;
             using var store = new SetStore();
             s_store = store;
             store.Set("ac");

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/AnimatePresenceWrappedMotionVariantTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/AnimatePresenceWrappedMotionVariantTests.cs
@@ -1,0 +1,201 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine.UIElements;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins variant enter/exit resolution for a Motion that sits UNDER a transparent wrapper inside an
+    /// AnimatePresence keyed child — a z-managed Div (the animated top-most modal shape, since z-* is a
+    /// documented no-op on a Motion itself) or a ContextProvider. The presence anchor walk already
+    /// resolves the descendant Motion for timing and onEnterComplete; the named variants' enter/exit
+    /// CLASSES must resolve against that same Motion's own element (where the resting variants[animate]
+    /// classes live), not be silently dropped because the keyed child node is not the Motion itself.
+    /// </summary>
+    [TestFixture]
+    internal sealed class AnimatePresenceWrappedMotionVariantTests
+    {
+        private readonly record struct SetState(string Keys);
+
+        private sealed class SetStore : Store<SetState>
+        {
+            public SetStore() : base(new SetState("a")) { }
+            public void Set(string keys) => SetState(_ => new SetState(keys));
+            protected override void ResetCore() => SetState(_ => new SetState("a"));
+        }
+
+        private static SetStore s_store;
+        private static readonly ComponentContext<string> ThemeContext = ComponentContext<string>.Create("light");
+        private static readonly Dictionary<string, string> s_fade = new()
+        {
+            ["hidden"] = "opacity-0",
+            ["visible"] = "opacity-100",
+        };
+
+        private VisualElement _root;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _root = new VisualElement();
+            s_store = null;
+        }
+
+        private static VNode VariantMotion(string key)
+            => V.Motion(name: "inner-" + key,
+                variants: s_fade, initial: "hidden", animate: "visible", exit: "hidden",
+                transition: new StyleTransitionConfig { DurationSec = 0.3f });
+
+        [Component]
+        private static VNode ZWrappedPresenceHost()
+        {
+            var keys = Hooks.UseStore(s_store, s => s.Keys);
+            var children = new List<VNode>();
+            foreach (var key in keys)
+            {
+                var k = key.ToString();
+                children.Add(V.Div(key: k, name: "wrapper-" + k, className: "absolute z-10",
+                    children: new VNode[] { VariantMotion(k) }));
+            }
+            return V.Div(name: "host", className: "relative", children: new VNode[]
+            {
+                V.AnimatePresence(key: "presence", children: children.ToArray()),
+            });
+        }
+
+        [Component]
+        private static VNode ProviderWrappedPresenceHost()
+        {
+            var keys = Hooks.UseStore(s_store, s => s.Keys);
+            var children = new List<VNode>();
+            foreach (var key in keys)
+            {
+                var k = key.ToString();
+                children.Add(V.Provider(ThemeContext, "dark", key: k,
+                    children: new VNode[] { VariantMotion(k) }));
+            }
+            return V.Div(name: "host", children: new VNode[]
+            {
+                V.AnimatePresence(key: "presence", children: children.ToArray()),
+            });
+        }
+
+        // The variant enter's synchronous strip-to-initial is the observable EditMode evidence (the
+        // scheduler never fires the swap back to the resting classes), mirroring
+        // MotionPresenceEnterGateTests' oracle.
+
+        [Test]
+        public void Given_AZWrappedVariantMotion_When_Mounted_Then_TheInnerMotionStartsAtItsInitialVariant()
+        {
+            // Arrange
+            using var store = new SetStore();
+            s_store = store;
+
+            // Act
+            using var mounted = V.Mount(_root, V.Component(ZWrappedPresenceHost, key: "host"));
+
+            // Assert — the variant enter played against the Motion's own element: it carries
+            // variants[initial] instead of resting at variants[animate].
+            Assert.That(_root.Q<VisualElement>("inner-a").ClassListContains("opacity-0"), Is.True,
+                "The z-wrapped Motion's variant enter resolves against its own element");
+        }
+
+        [Test]
+        public void Given_AProviderWrappedVariantMotion_When_Mounted_Then_TheInnerMotionStartsAtItsInitialVariant()
+        {
+            // Arrange
+            using var store = new SetStore();
+            s_store = store;
+
+            // Act
+            using var mounted = V.Mount(_root, V.Component(ProviderWrappedPresenceHost, key: "host"));
+
+            // Assert
+            Assert.That(_root.Q<VisualElement>("inner-a").ClassListContains("opacity-0"), Is.True,
+                "The Provider-wrapped Motion's variant enter resolves against its own element");
+        }
+
+        // A VARIANT exit cancels the in-flight enter, applies its from-classes — the resting
+        // variants[animate] — and sets transition-property: all inline on its target, all
+        // synchronously (only the swap to variants[exit] is scheduler-driven). The INNER element
+        // resting at variants[animate] with the initial classes gone AND carrying the variant swap's
+        // transition-property is the observable evidence the exit resolved the declared variants and
+        // targeted the Motion: the silent classic fallback leaves the inner element untouched — frozen
+        // at the enter's variants[initial] pose (or, with no enter fix either, resting with no
+        // transition-property at all).
+
+        private static (bool op0, bool op100, bool tpAll) VariantExitEvidence(VisualElement inner)
+        {
+            var tp = inner.style.transitionProperty;
+            var tpAll = tp.keyword != StyleKeyword.Null && tp.value.Count > 0 && tp.value[0].ToString() == "all";
+            return (inner.ClassListContains("opacity-0"), inner.ClassListContains("opacity-100"), tpAll);
+        }
+
+        [Test]
+        public void Given_AZWrappedVariantMotion_When_TheKeyIsRemoved_Then_TheVariantExitTargetsTheInnerMotion()
+        {
+            // Arrange
+            using var store = new SetStore();
+            s_store = store;
+            using var mounted = V.Mount(_root, V.Component(ZWrappedPresenceHost, key: "host"));
+            var scheduler = mounted.Root.Reconciler.Context.BatchScheduler;
+
+            // Act — remove the key; the ghost's exit must start on the Motion's own element.
+            store.Set("");
+            scheduler.DrainImmediateForTest();
+
+            // Assert
+            Assert.AreEqual((false, true, true), VariantExitEvidence(_root.Q<VisualElement>("inner-a")),
+                "The z-wrapped Motion's variant exit resolves against its own element");
+        }
+
+        [Test]
+        public void Given_AProviderWrappedVariantMotion_When_TheKeyIsRemoved_Then_TheVariantExitTargetsTheInnerMotion()
+        {
+            // Arrange
+            using var store = new SetStore();
+            s_store = store;
+            using var mounted = V.Mount(_root, V.Component(ProviderWrappedPresenceHost, key: "host"));
+            var scheduler = mounted.Root.Reconciler.Context.BatchScheduler;
+
+            // Act
+            store.Set("");
+            scheduler.DrainImmediateForTest();
+
+            // Assert
+            Assert.AreEqual((false, true, true), VariantExitEvidence(_root.Q<VisualElement>("inner-a")),
+                "The Provider-wrapped Motion's variant exit resolves against its own element");
+        }
+
+        [Test]
+        public void Given_AZWrappedVariantMotionMidExit_When_TheKeyIsReAdded_Then_TheInnerMotionRestsAtItsAnimateVariant()
+        {
+            // Arrange — the exit must be cancelled ON THE MOTION'S ELEMENT (a cancel aimed only at the
+            // wrapper would leave the inner exit running to completion, whose ghost-drop then removes the
+            // freshly re-entered child).
+            using var store = new SetStore();
+            s_store = store;
+            using var mounted = V.Mount(_root, V.Component(ZWrappedPresenceHost, key: "host"));
+            var scheduler = mounted.Root.Reconciler.Context.BatchScheduler;
+            store.Set("");
+            scheduler.DrainImmediateForTest();
+            Assume.That(_root.Q<VisualElement>("inner-a"), Is.Not.Null,
+                "Precondition: the exiting ghost is still mounted");
+
+            // Act — cancel the exit by re-adding the key.
+            store.Set("a");
+            scheduler.DrainImmediateForTest();
+
+            // Assert — the cancel reverses the inner element toward its resting variant (initial is not
+            // replayed on the still-attached element) AND scrubs the exit's inline transition styles (an
+            // off-panel cancel clears immediately) — a cancel that misses the inner element would leave
+            // both the pending exit and its inline duration alive there.
+            var inner = _root.Q<VisualElement>("inner-a");
+            Assert.AreEqual((false, true, true),
+                (inner.ClassListContains("opacity-0"), inner.ClassListContains("opacity-100"),
+                    inner.style.transitionDuration.keyword == StyleKeyword.Null),
+                "Cancelling a wrapped Motion's variant exit restores its resting variant and clears the exit");
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/AnimatePresenceWrappedMotionVariantTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/AnimatePresenceWrappedMotionVariantTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: dd6385c2df1454f5cbfe0d8dcc804edf

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/MotionVariantPropagationTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/MotionVariantPropagationTests.cs
@@ -158,11 +158,11 @@ namespace Velvet.Tests
         [Test]
         public void Given_AMotionWithExit_When_ResolvingExitTransition_Then_ItAnimatesFromAnimateToExitVariant()
         {
-            // Arrange — a direct Motion child with an `exit` label.
+            // Arrange — a Motion with an `exit` label.
             MotionNode motion = V.Motion(variants: Fade, animate: "visible", exit: "hidden");
 
-            // Act — resolve the exit transition (node == motion: the direct-child case).
-            var cfg = GeneralPathReconciler.TryResolveVariantExit(motion, motion);
+            // Act
+            var cfg = GeneralPathReconciler.TryResolveVariantExit(motion);
 
             // Assert — it leaves the resting variants[animate] and animates to variants[exit].
             Assert.That((cfg.ExitFromClass, cfg.ExitToClass), Is.EqualTo(("opacity-100", "opacity-0")));


### PR DESCRIPTION
## Summary

A `V.Motion` nested under a transparent wrapper inside an `AnimatePresence` keyed child — a
z-managed `Div` (the animated top-most modal shape, since `z-*` is a documented no-op on a Motion
itself) or a `ContextProvider` — never had its named `variants` enter/exit classes applied. Variant
resolution gated on the keyed child node being the Motion itself (`ReferenceEquals(node, motion)`),
so the wrapped shape silently fell through to the classic preset path: only the transition's timing
and `onEnterComplete` were honored, a modal faded/scaled only when its transition carried
timing-preset classes, and an exit-cancel never restored the Motion's resting variant.

## Where the classes now land

Variant enter/exit classes resolve against the **Motion's own element** — the element its resting
`variants[animate]` classes already live on (applied at create) — matching how variants attach to
the motion component itself upstream. Applying them to the wrapper instead would double-apply
against the Motion's resting set and be clobbered by the wrapper's own class patching.

Mechanics:

- `ReconcilerContext.PresenceAnchorMotionElement` records the anchor Motion's live element during
  each `EmitPresenceChild` expansion (written by `CreateElement` and `PatchMotion`, same
  set/restore discipline as `PresenceAnchorMotion`).
- A ghost's emission reproduces the same committed node instance on both diff sides, so its patch
  bails on reference equality before recording — a per-key memo on `PresenceBoundaryState`
  (`MotionElements`, retired with the key on exit-complete drop / instant removal) is what the
  ghost's exit dispatch falls back to.
- Enter (`PlayVariantEnter`), exit (`PlayExit` with the variant config), and both interruption
  cancels (`CancelEnter` at exit start, `CancelExit` at re-entry) all target the resolved Motion
  element; the classic preset path still targets the keyed child's anchor, and a Motion the
  emission could not resolve falls back to it.
- `TryResolveVariantExit` drops its direct-child gate (the caller now supplies the target element).

`Documentation~/styling-z-index.md` and the CHANGELOG's z-index entry lose their wrapped-shape
caveat.

## Tests

New `AnimatePresenceWrappedMotionVariantTests` (EditMode), all verified RED against the old gates
(and the re-entry cancel against a drop-the-inner-cancel mutant):

- z-wrapped / Provider-wrapped enter: the inner Motion starts at `variants[initial]`.
- z-wrapped / Provider-wrapped exit: the exit cancels the inner enter and rests the inner element
  at `variants[animate]` (the variant exit's from-state) — the classic fallback left it frozen at
  the initial pose.
- z-wrapped exit-cancel: re-adding the key mid-exit restores the inner element's resting variant.

`AnimatePresencePopLayoutTests`' enter-dispatch regression now drives a classic preset through the
z-managed shape: the anchor-resolution behavior it pins (real element vs placeholder) is the
classic path's concern, and a variant Motion's enter no longer targets the anchor at all — the
previous fixture accidentally pinned the wrapped shape's classic-preset fallback.

Full EditMode and PlayMode suites green.

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)