### PR TITLE
fix(velvet): keep a variant Motion's resting pose across presence interruptions

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -106,6 +106,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A variant Motion's resting `variants[animate]` classes now survive both presence interruption
+  windows that used to strip them. Cancelling an in-flight variant enter (an exit starting
+  mid-enter) restores the resting classes the enter's strip had removed — previously a
+  configuration without an `exit` label played its classic exit on an element missing its resting
+  variant. And a re-entry landing after a completed variant exit's class swap but before its drop
+  render found the still-attached element parked at `variants[exit]` with nothing restoring it;
+  the re-entry now puts the resting pose back — including un-pinning a `PopLayout` exit's
+  out-of-flow geometry — before the enter branches run, so it starts from the same state a fresh
+  mount would. A completed tween exit also clears its inline `transition-*` styles now (as the
+  enter completion always has), so an element that outlives its drop no longer tweens unrelated
+  later class changes through the exit's leftover timing.
 - A `V.Motion` nested under a transparent wrapper inside an `AnimatePresence` keyed child — a
   z-managed `Div` (the animated top-most modal shape, since `z-*` is a documented no-op on a
   Motion itself) or a `ContextProvider` — now has its named `variants` enter/exit classes applied,

--- a/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
@@ -1276,7 +1276,9 @@ namespace Velvet
                         // path — dispose them via the tracked anchor before re-pairing, else this same-render
                         // re-entry resurrects them as a zombie. A cancel-exit instead reproduces the SAME still-
                         // attached element (anchor == the stale one), so just drop the now-current reference.
-                        if (state.ExitAnchors.TryGetValue(key, out var staleAnchor) && !ReferenceEquals(staleAnchor, anchor))
+                        var freshReplacement =
+                            state.ExitAnchors.TryGetValue(key, out var staleAnchor) && !ReferenceEquals(staleAnchor, anchor);
+                        if (freshReplacement)
                         {
                             DisposeExitedGhostFibers(state, key);
                         }
@@ -1300,6 +1302,39 @@ namespace Velvet
                                 // a Motion (the z-managed shape) is a DIFFERENT element — with a different
                                 // class list — than the nested Motion FindFirstMotionDescendant resolved.
                                 RestorePopLayoutChildToFlow(anchor, (node as BaseElementNode)?.ClassNames);
+                            }
+                        }
+                        else if (wasExitComplete)
+                        {
+                            // A COMPLETED exit's re-entry (the drop render was preempted) reproduces a
+                            // still-attached element that nothing downstream un-parks: there is no pending
+                            // animation left to cancel, so the interruption restores the wasExiting branch
+                            // handles never run. Reverse the exit-time mutations here so the enter branches
+                            // start from the same state a fresh mount would.
+                            if (presence.Mode == AnimatePresenceMode.PopLayout && !freshReplacement)
+                            {
+                                // The out-of-flow pin outlives its exit (only the drop would have removed the
+                                // element). Skipped for a fresh replacement: the pin lives on the discarded
+                                // ghost, and nulling a never-pinned element's geometry slots would erase
+                                // resolver-applied inline values a transparent-wrapper child cannot re-resolve.
+                                RestorePopLayoutChildToFlow(anchor, (node as BaseElementNode)?.ClassNames);
+                            }
+                            if (motionElement != null)
+                            {
+                                // The completed swap left the element AT variants[exit] with the resting
+                                // variants[animate] stripped; the no-initial enter branch below plays nothing
+                                // and the class diff cannot help (MotionAppliedClasses still records the
+                                // resting set as applied). Resolved from the RE-ADDED node's variants — the
+                                // ghost node is already retired, so the exact applied arrays are gone; a
+                                // re-add that also changed the variants map may leave the old exit class
+                                // behind, or skip this restoration entirely when the exit label no longer
+                                // resolves — the same staleness any heuristic over the new declaration has.
+                                var completedExit = TryResolveVariantExit(motion);
+                                if (completedExit != null)
+                                {
+                                    StyleAnimationClassUtils.RemoveClasses(motionElement, completedExit.ExitToClasses);
+                                    StyleAnimationClassUtils.AddClasses(motionElement, completedExit.ExitFromClasses);
+                                }
                             }
                         }
 

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/MotionVariantInterruptionPoseTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/MotionVariantInterruptionPoseTests.cs
@@ -1,0 +1,192 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine.UIElements;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins the resting-variant pose across presence interruptions of a variant Motion. A variant
+    /// Motion's resting state is its <c>variants[animate]</c> classes, and two interruption windows
+    /// used to strip it: an exit starting mid-enter cancelled the enter without restoring the resting
+    /// classes the enter's strip had removed (visible whenever a classic, non-variant exit follows),
+    /// and a re-entry landing after a completed exit's class swap — but before its drop render — found
+    /// the still-attached element at <c>variants[exit]</c> with nothing downstream putting the resting
+    /// pose back.
+    /// </summary>
+    [TestFixture]
+    internal sealed class MotionVariantInterruptionPoseTests
+    {
+        private readonly record struct SetState(string Keys);
+
+        private sealed class SetStore : Store<SetState>
+        {
+            public SetStore() : base(new SetState("a")) { }
+            public void Set(string keys) => SetState(_ => new SetState(keys));
+            protected override void ResetCore() => SetState(_ => new SetState("a"));
+        }
+
+        private static SetStore s_store;
+        private static readonly Dictionary<string, string> s_fade = new()
+        {
+            ["hidden"] = "opacity-0",
+            ["visible"] = "opacity-100",
+        };
+        // Color classes on purpose: MotionSpringClassParser recognizes no spring-animatable channel in
+        // them, so a spring exit over this pair completes SYNCHRONOUSLY (the swap lands, no tick) —
+        // the only EditMode-reachable way to park a presence key in its completed-exit window.
+        private static readonly Dictionary<string, string> s_recolor = new()
+        {
+            ["hidden"] = "bg-red-500",
+            ["visible"] = "bg-blue-500",
+        };
+        // A third label distinct from the exit's: with initial == exit the initial→animate replay would
+        // wash the exit residue out coincidentally, hiding a missing restoration.
+        private static readonly Dictionary<string, string> s_recolorWithStart = new()
+        {
+            ["hidden"] = "bg-red-500",
+            ["start"] = "bg-green-500",
+            ["visible"] = "bg-blue-500",
+        };
+
+        private VisualElement _root;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _root = new VisualElement();
+            s_store = null;
+        }
+
+        [Component]
+        private static VNode EnterInterruptHost()
+        {
+            var keys = Hooks.UseStore(s_store, s => s.Keys);
+            var children = new List<VNode>();
+            foreach (var key in keys)
+            {
+                // initial + animate, NO exit label: the exit that interrupts the enter is the classic
+                // preset path, which re-adds no variant classes of its own.
+                children.Add(V.Motion(name: "item-" + key, key: key.ToString(),
+                    variants: s_fade, initial: "hidden", animate: "visible",
+                    transition: new StyleTransitionConfig { DurationSec = 0.3f }));
+            }
+            return V.Div(name: "host", children: new VNode[]
+            {
+                V.AnimatePresence(key: "presence", children: children.ToArray()),
+            });
+        }
+
+        [Component]
+        private static VNode CompletedExitHost()
+        {
+            var keys = Hooks.UseStore(s_store, s => s.Keys);
+            var children = new List<VNode>();
+            foreach (var key in keys)
+            {
+                children.Add(V.Motion(name: "item-" + key, key: key.ToString(),
+                    variants: s_recolor, animate: "visible", exit: "hidden",
+                    transition: new StyleTransitionConfig { Type = TransitionType.Spring }));
+            }
+            return V.Div(name: "host", children: new VNode[]
+            {
+                V.AnimatePresence(key: "presence", children: children.ToArray()),
+            });
+        }
+
+        [Component]
+        private static VNode CompletedExitWithInitialHost()
+        {
+            var keys = Hooks.UseStore(s_store, s => s.Keys);
+            var children = new List<VNode>();
+            foreach (var key in keys)
+            {
+                children.Add(V.Motion(name: "item-" + key, key: key.ToString(),
+                    variants: s_recolorWithStart, initial: "start", animate: "visible", exit: "hidden",
+                    transition: new StyleTransitionConfig { Type = TransitionType.Spring }));
+            }
+            return V.Div(name: "host", children: new VNode[]
+            {
+                V.AnimatePresence(key: "presence", children: children.ToArray()),
+            });
+        }
+
+        [Test]
+        public void Given_AVariantEnterInFlight_When_AClassicExitInterruptsIt_Then_TheRestingVariantIsRestored()
+        {
+            // Arrange — mount plays the initial→animate enter; its strip leaves the element at
+            // variants[initial] until the (scheduler-driven) swap, which EditMode never fires.
+            using var store = new SetStore();
+            s_store = store;
+            using var mounted = V.Mount(_root, V.Component(EnterInterruptHost, key: "host"));
+            var scheduler = mounted.Root.Reconciler.Context.BatchScheduler;
+            Assume.That(_root.Q<VisualElement>("item-a").ClassListContains("opacity-0"), Is.True,
+                "Precondition: the enter is in flight at its initial pose");
+
+            // Act — remove the key: the exit cancels the in-flight enter, and with no exit label the
+            // CLASSIC exit follows, which has no variant from-classes to re-add.
+            store.Set("");
+            scheduler.DrainImmediateForTest();
+
+            // Assert — the enter's cancel must restore the resting variants[animate] it had stripped,
+            // so the ghost plays its exit from the resting pose instead of a bare, variant-less one.
+            var item = _root.Q<VisualElement>("item-a");
+            Assert.AreEqual((false, true),
+                (item.ClassListContains("opacity-0"), item.ClassListContains("opacity-100")),
+                "Cancelling an in-flight variant enter restores the resting variant");
+        }
+
+        [Test]
+        public void Given_ACompletedVariantExit_When_TheKeyIsReAddedBeforeTheDropRender_Then_TheRestingVariantIsRestored()
+        {
+            // Arrange — remove the key with ONE flush (not a drain): the spring exit completes
+            // synchronously (the swap lands the element at variants[exit]) and schedules the ghost-drop
+            // re-render, which this single flush deliberately leaves pending.
+            using var store = new SetStore();
+            s_store = store;
+            using var mounted = V.Mount(_root, V.Component(CompletedExitHost, key: "host"));
+            store.Set("");
+            mounted.FlushStateForTest();
+            Assume.That(_root.Q<VisualElement>("item-a")?.ClassListContains("bg-red-500"), Is.True,
+                "Precondition: the completed exit parked the still-attached element at variants[exit]");
+
+            // Act — re-add the key inside the completed-exit window; the re-entry reproduces the SAME
+            // still-attached element.
+            store.Set("a");
+            mounted.FlushStateForTest();
+
+            // Assert — the re-entry must put the resting pose back: no pending animation is left to
+            // cancel, and the class diff cannot restore it (the resting set is still recorded as applied).
+            var item = _root.Q<VisualElement>("item-a");
+            Assert.AreEqual((false, true),
+                (item.ClassListContains("bg-red-500"), item.ClassListContains("bg-blue-500")),
+                "A re-entry after a completed exit restores the resting variant");
+        }
+
+        [Test]
+        public void Given_ACompletedVariantExitWithInitial_When_TheKeyIsReAddedBeforeTheDropRender_Then_TheExitPoseIsFullyReplaced()
+        {
+            // Arrange — same completed-exit window as above, with an `initial` label DISTINCT from the
+            // exit's: the re-entry replays initial→animate, and only an explicit restoration removes the
+            // exit classes first (the replay's own strip touches the resting label, not the exit's).
+            using var store = new SetStore();
+            s_store = store;
+            using var mounted = V.Mount(_root, V.Component(CompletedExitWithInitialHost, key: "host"));
+            store.Set("");
+            mounted.FlushStateForTest();
+            Assume.That(_root.Q<VisualElement>("item-a")?.ClassListContains("bg-red-500"), Is.True,
+                "Precondition: the completed exit parked the still-attached element at variants[exit]");
+
+            // Act
+            store.Set("a");
+            mounted.FlushStateForTest();
+
+            // Assert — the exit residue is gone and the (synchronously settled) spring replay landed the
+            // element at its resting variant.
+            var item = _root.Q<VisualElement>("item-a");
+            Assert.AreEqual((false, true),
+                (item.ClassListContains("bg-red-500"), item.ClassListContains("bg-blue-500")),
+                "The re-entry replaces the exit pose before replaying the enter");
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/MotionVariantInterruptionPoseTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/MotionVariantInterruptionPoseTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 15eb7b93ac4ab45c4af74306528d11e5

--- a/Packages/com.velvet.core/Runtime/Styling/StyleAnimationScheduler.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleAnimationScheduler.cs
@@ -110,9 +110,11 @@ namespace Velvet
 
             if (type == TransitionType.Spring)
             {
+                // restingClasses mirrors the tween path's variant-enter pending: the to-classes are the
+                // persistent resting state, and a cancel must restore them (see PlayEnterInternal).
                 StartSpringVariant(element, fromClasses ?? System.Array.Empty<string>(), toClasses ?? System.Array.Empty<string>(),
                     delaySec, stiffness, damping, mass, onComplete, additionalDelaySec,
-                    restingClasses: null, isExit: false);
+                    restingClasses: toClasses ?? System.Array.Empty<string>(), isExit: false);
                 return;
             }
 
@@ -120,7 +122,7 @@ namespace Velvet
             {
                 StartBezierVariant(element, fromClasses ?? System.Array.Empty<string>(), toClasses ?? System.Array.Empty<string>(),
                     delaySec, bezierX1, bezierY1, bezierX2, bezierY2, durationSec, onComplete, additionalDelaySec,
-                    restingClasses: null, isExit: false);
+                    restingClasses: toClasses ?? System.Array.Empty<string>(), isExit: false);
                 return;
             }
 
@@ -159,6 +161,11 @@ namespace Velvet
             {
                 FromClasses = fromClasses,
                 ToClasses = toClasses,
+                // A variant enter's to-classes ARE the persistent resting state the strip above just
+                // removed — a cancel (an exit starting mid-enter, a teardown) must put them back, or the
+                // element is left without its resting variant for whatever follows (a classic exit with no
+                // variant from-classes to re-add them would play out on a stripped element).
+                RestingClasses = variantMode ? toClasses : null,
                 DurationList = durationList,
                 DelayList = delayList,
                 AnimatingElement = element,
@@ -404,6 +411,12 @@ namespace Velvet
                         if (_pendingExits.Remove(element, out var completed))
                         {
                             EndShadowCoFade(completed);
+                            // Clear BEFORE returning the lists (mirrors the enter completion): the inline
+                            // slots retain the list references, and a completed exit's element can outlive
+                            // its drop (a re-entry preempting the drop render) — leaving them set would make
+                            // later class changes tween unexpectedly, and a re-rented list would silently
+                            // mutate this element's timing through the retained reference.
+                            ClearTransitionStyles(element);
                             ReturnDurationList(completed.DurationList);
                             ReturnDelayList(completed.DelayList);
                             onComplete?.Invoke();
@@ -467,7 +480,9 @@ namespace Velvet
         // touches (opacity / translate / scale / rotate) into a from/to pair each, and a per-frame physics tick
         // (StartSpringTick) drives them via inline styles until they settle — replacing the tween's fixed-
         // duration completion timeout with a dynamic settle check.
-        // restingClasses: non-null only for a variant exit (restoreFromOnCancel) — see PendingAnimation.RestingClasses.
+        // restingClasses: the persistent resting set a cancel must restore — a variant exit's from-classes
+        // (restoreFromOnCancel) or a variant enter's to-classes; null for preset plays, whose classes are
+        // all transient. See PendingAnimation.RestingClasses.
         // isExit: selects both the exit-shaped self-cancel (mirrors calling the PUBLIC CancelExit rather than
         // CancelEnter below) and which bookkeeping map (_pendingExits / _pendingEnters) this play registers
         // into — a separate map parameter would only ever repeat that same choice, so isExit alone decides it.
@@ -1428,10 +1443,11 @@ namespace Velvet
             public IVisualElementScheduledItem? TimeoutItem;
             public string[]? FromClasses;
             public string[]? ToClasses;
-            // Classes to RE-ADD when this animation is cancelled (interrupted). Set for a variant-driven exit
-            // whose FromClasses ARE the persistent resting state (variants[animate]): cancelling such an exit
-            // must return the element to its resting variant (interrupt behavior), not strip it. Null for
-            // preset exits / enters, whose FromClasses are transient and correctly removed on cancel.
+            // Classes to RE-ADD when this animation is cancelled (interrupted). Set for variant-driven
+            // plays, whose class set includes the persistent resting state (variants[animate]) — an exit's
+            // FromClasses, an enter's ToClasses: cancelling such a play must return the element to its
+            // resting variant (interrupt behavior), not strip it. Null for preset exits / enters, whose
+            // classes are all transient and correctly removed on cancel.
             public string[]? RestingClasses;
             public List<TimeValue>? DurationList;
             public List<TimeValue>? DelayList;


### PR DESCRIPTION
## Summary

Two presence interruption windows stripped a variant Motion's resting `variants[animate]` classes
(both confirmed during the wrapped-Motion variant review, both pre-existing for the direct shape):

1. **An exit starting mid-enter.** Cancelling an in-flight variant enter removed the from/to
   classes without re-adding the resting set the enter's strip had taken. A variant exit
   self-healed (its from-classes ARE the resting set), but a configuration without an `exit` label
   played its classic exit on an element missing its resting variant. Variant enter pendings now
   carry `RestingClasses` (tween, spring, and bezier alike), so the cancel's existing restore
   heals them.

2. **A re-entry after a completed exit, before its drop render.** The completed swap parks the
   still-attached element at `variants[exit]` with resting stripped, and nothing downstream
   restored it: there is no pending animation left to cancel, the no-initial enter branch plays
   nothing, and the class diff cannot help (the resting set is still recorded as applied). The
   re-entry now reverses the exit-time mutations — the class pose and a `PopLayout` out-of-flow
   pin — before the enter branches run, so it starts from the same state a fresh mount would. The
   restore is skipped for a fresh replacement element (never pinned; nulling its geometry could
   erase resolver-applied inline values a transparent-wrapper child cannot re-resolve).

Also: a completed tween exit now clears its inline `transition-*` styles (mirroring the enter
completion), so an element that outlives its drop neither tweens unrelated later class changes
through the exit's leftover timing nor retains a pooled `TimeValue` list by reference.

## Tests

New `MotionVariantInterruptionPoseTests` (EditMode), each verified RED without its fix:

- An in-flight variant enter interrupted by a classic exit: the resting variant is restored.
- A completed variant exit re-added before the drop render (spring over color-only variants — the
  one synchronously-completing exit shape EditMode can park in that window): the resting variant
  is restored.
- The same window with an `initial` label distinct from the exit's: the exit residue is fully
  replaced before the enter replay (a coincidentally-shared label would mask a missing
  restoration).

Full EditMode and PlayMode suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)