### PR TITLE
perf(velvet): eliminate hot-path allocations in pool reset, UseFrame tick, and Memoize props-bail

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Recycling a pooled primitive widget (`Label`/`Button`/`Toggle`/`Slider`/`TextField`) no longer
+  allocates a class-list array on every pool return; the element reset path now uses fixed-arity
+  overloads so steady-state list churn stays allocation-free.
+- `UseFrame` dispatch no longer allocates a snapshot array every ticked frame; the dispatcher reuses
+  a grow-only buffer guarded against re-entrant ticks, so a panel with stable subscribers ticks with
+  zero allocations.
+- The `Memoize` props-bail comparison compiles a cached, typed per-props-type comparer on JIT
+  platforms instead of reading members through reflection, removing the per-render boxing of
+  value-type props while preserving `Object.is` member semantics exactly — including members declared
+  as `object`/interfaces holding boxed values, and the sign-of-zero distinction for nullable floats.
+  IL2CPP (AOT) players keep the reflection implementation.
+
 ## [1.6.0] - 2026-07-25
 
 ### Added

--- a/Packages/com.velvet.core/Runtime/Component/ComponentPropsComparer.cs
+++ b/Packages/com.velvet.core/Runtime/Component/ComponentPropsComparer.cs
@@ -1,6 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+#if !ENABLE_IL2CPP
+using System.Linq.Expressions;
+#endif
 
 namespace Velvet
 {
@@ -14,14 +17,42 @@ namespace Velvet
     // The member set (public instance properties + fields) is reflected once per props type and
     // cached. Equality protocol: same reference is equal; null vs non-null is not equal; differing
     // runtime types are not equal; otherwise every member is compared by identity equality.
+    //
+    // This predicate runs on every parent-driven re-render attempt of a Memoize=true component, so
+    // per-call PropertyInfo/FieldInfo.GetValue reflection — and the boxing it does for each
+    // value-type member on both sides of the comparison — is a hot-path cost that eats into the
+    // savings Memoize exists to provide. Where the runtime can JIT, member reads and the per-member
+    // ObjectIs.AreEqual<T> call are compiled once per props type into a cached delegate via
+    // System.Linq.Expressions, so the generated IL passes typed values straight through instead of
+    // boxing them to object.
+    // Expression.Compile() emits and JITs IL at compile time; the IL2CPP AOT backend has no JIT to
+    // target, so a compiled expression there either runs through a slow interpreter or fails
+    // outright — neither is acceptable for a hot-path predicate. IL2CPP players therefore use the
+    // reflection implementation unconditionally.
     // Not thread-safe — the Velvet Reconciler is main-thread only.
     internal static class ComponentPropsComparer
     {
         private static readonly Dictionary<Type, MemberInfo[]> s_memberCache = new();
 
+#if !ENABLE_IL2CPP
+        private static readonly Dictionary<Type, Func<object, object, bool>> s_compiledComparerCache = new();
+
+        private static readonly MethodInfo s_areEqualOpenMethod =
+            typeof(ObjectIs).GetMethod(nameof(ObjectIs.AreEqual), BindingFlags.Public | BindingFlags.Static)!;
+
+        private static readonly MethodInfo s_areEqualObjectsMethod =
+            typeof(ObjectIs).GetMethod(nameof(ObjectIs.AreEqualObjects), BindingFlags.Public | BindingFlags.Static)!;
+#endif
+
 #if UNITY_EDITOR
         [UnityEngine.RuntimeInitializeOnLoadMethod(UnityEngine.RuntimeInitializeLoadType.SubsystemRegistration)]
-        private static void ResetCache() => s_memberCache.Clear();
+        private static void ResetCache()
+        {
+            s_memberCache.Clear();
+#if !ENABLE_IL2CPP
+            s_compiledComparerCache.Clear();
+#endif
+        }
 #endif
 
         public static bool ShallowEquals(object? prev, object? next)
@@ -48,6 +79,7 @@ namespace Velvet
                 return ObjectIs.AreEqualObjects(prev, next);
             }
 
+#if ENABLE_IL2CPP
             var members = GetMembers(type);
             for (var i = 0; i < members.Length; i++)
             {
@@ -60,6 +92,9 @@ namespace Velvet
             }
 
             return true;
+#else
+            return GetCompiledComparer(type)(prev, next);
+#endif
         }
 
         private static MemberInfo[] GetMembers(Type type)
@@ -93,11 +128,98 @@ namespace Velvet
             return result;
         }
 
+#if ENABLE_IL2CPP
         private static object? ReadMember(MemberInfo member, object instance) => member switch
         {
             PropertyInfo p => p.GetValue(instance),
             FieldInfo f => f.GetValue(instance),
             _ => null,
         };
+#else
+        private static Func<object, object, bool> GetCompiledComparer(Type type)
+        {
+            if (s_compiledComparerCache.TryGetValue(type, out var cached))
+            {
+                return cached;
+            }
+
+            var comparer = BuildComparer(type, GetMembers(type));
+            s_compiledComparerCache[type] = comparer;
+            return comparer;
+        }
+
+        // Builds a delegate equivalent to the AOT reflection path: read each cached member
+        // from both sides and AND together per-member equality expressions (see BuildMemberEquality),
+        // short-circuiting on the first mismatch. Closing a generic comparison over the member's
+        // DECLARED type (via MakeGenericMethod) rather than always going through the boxed
+        // AreEqualObjects overload lets the compiled IL pass typed member values straight to the
+        // comparison instead of boxing each one into an object first — BuildMemberEquality is what
+        // keeps that shortcut from diverging from the reflection path's runtime-type dispatch.
+        private static Func<object, object, bool> BuildComparer(Type type, MemberInfo[] members)
+        {
+            var prevParam = Expression.Parameter(typeof(object), "prev");
+            var nextParam = Expression.Parameter(typeof(object), "next");
+            var prevTyped = Expression.Convert(prevParam, type);
+            var nextTyped = Expression.Convert(nextParam, type);
+
+            Expression body = Expression.Constant(true);
+            for (var i = 0; i < members.Length; i++)
+            {
+                var member = members[i];
+                var memberType = member is PropertyInfo property ? property.PropertyType : ((FieldInfo)member).FieldType;
+                var prevAccess = Expression.MakeMemberAccess(prevTyped, member);
+                var nextAccess = Expression.MakeMemberAccess(nextTyped, member);
+                var equalityExpression = BuildMemberEquality(memberType, prevAccess, nextAccess);
+                body = i == 0 ? equalityExpression : Expression.AndAlso(body, equalityExpression);
+            }
+
+            var lambda = Expression.Lambda<Func<object, object, bool>>(body, prevParam, nextParam);
+            return lambda.Compile();
+        }
+
+        // Routes each member to the expression shape that keeps the compiled path's outcome identical
+        // to the reflection path, which always calls AreEqualObjects on the boxed RUNTIME type:
+        // - A member declared as object, an interface, System.ValueType, or System.Enum can hold a
+        //   boxed value type or a string at runtime. Closing AreEqual<T> over that DECLARED type (T =
+        //   object / the interface / ValueType / Enum) would hit AreEqual's non-value-type branch —
+        //   ReferenceEquals — instead of unboxing, which is over-strict versus the reflection path
+        //   (equal-content boxed floats/ints/strings would compare unequal). Routing to
+        //   AreEqualObjects(object, object) matches the reflection path exactly: the member read is
+        //   already a reference-typed value (an implicit upcast, no extra boxing), and AreEqualObjects
+        //   re-derives the runtime type itself the same way the reflection path's GetType() does.
+        // - A Nullable<U> member is lifted (HasValue compared first, AreEqual<U> on the unwrapped
+        //   values only when both have one) rather than closing AreEqual<Nullable<U>> directly, because
+        //   AreEqual<T> falls back to EqualityComparer<T>.Default for any T it does not special-case,
+        //   and EqualityComparer<Nullable<U>>.Default treats +0f and -0f as equal for U = float/double —
+        //   violating Object.is. The CLR unwraps a boxed nullable to a plain U before the reflection
+        //   path's AreEqualObjects ever sees it, so closing AreEqual<U> over the underlying type here
+        //   mirrors that unwrap and keeps the two paths agreeing.
+        private static Expression BuildMemberEquality(Type memberType, Expression prevAccess, Expression nextAccess)
+        {
+            if (memberType == typeof(object) || memberType.IsInterface
+                || memberType == typeof(System.ValueType) || memberType == typeof(System.Enum))
+            {
+                return Expression.Call(s_areEqualObjectsMethod, prevAccess, nextAccess);
+            }
+
+            if (memberType.IsGenericType && memberType.GetGenericTypeDefinition() == typeof(Nullable<>))
+            {
+                var underlyingType = Nullable.GetUnderlyingType(memberType)!;
+                var hasValueProperty = memberType.GetProperty(nameof(Nullable<int>.HasValue))!;
+                var valueProperty = memberType.GetProperty(nameof(Nullable<int>.Value))!;
+                var prevHasValue = Expression.Property(prevAccess, hasValueProperty);
+                var nextHasValue = Expression.Property(nextAccess, hasValueProperty);
+                var valuesEqual = Expression.Call(
+                    s_areEqualOpenMethod.MakeGenericMethod(underlyingType),
+                    Expression.Property(prevAccess, valueProperty),
+                    Expression.Property(nextAccess, valueProperty));
+                return Expression.AndAlso(
+                    Expression.Equal(prevHasValue, nextHasValue),
+                    Expression.OrElse(Expression.Not(prevHasValue), valuesEqual));
+            }
+
+            return Expression.Call(s_areEqualOpenMethod.MakeGenericMethod(memberType), prevAccess, nextAccess);
+        }
+#endif
     }
 }

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/ComponentPropsComparerTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/ComponentPropsComparerTests.cs
@@ -25,6 +25,30 @@ namespace Velvet.Tests
         private sealed record SimpleProps(string Id, int Value);
         private sealed record RefMemberProps(object Handle);
         private sealed record FloatProps(float X);
+        private sealed record NullableFloatProps(float? X);
+
+        private readonly struct Point
+        {
+            public Point(int x, int y)
+            {
+                X = x;
+                Y = y;
+            }
+
+            public int X { get; }
+            public int Y { get; }
+        }
+
+        private sealed record StructMemberProps(Point Location);
+
+        // A record's own EqualityContract getter is synthesized as non-public, so it never reaches
+        // the comparer's reflected member set through BindingFlags.Public alone; this type carries a
+        // public member of the same name to exercise the comparer's explicit name-based exclusion.
+        private sealed class ExplicitEqualityContractMember
+        {
+            public int Value { get; init; }
+            public string EqualityContract { get; init; } = string.Empty;
+        }
 
         [Test]
         public void Given_SameReference_When_ShallowEquals_Then_IsEqual()
@@ -148,6 +172,110 @@ namespace Velvet.Tests
 
             // Act + Assert
             Assert.That(ComponentPropsComparer.ShallowEquals(a, b), Is.False);
+        }
+
+        [Test]
+        public void Given_StructMemberWithEqualValues_When_ShallowEquals_Then_IsEqual()
+        {
+            // Arrange — distinct struct instances with equal field values
+            var a = new StructMemberProps(new Point(1, 2));
+            var b = new StructMemberProps(new Point(1, 2));
+
+            // Act + Assert
+            Assert.That(ComponentPropsComparer.ShallowEquals(a, b), Is.True);
+        }
+
+        [Test]
+        public void Given_StructMemberWithDifferentValues_When_ShallowEquals_Then_IsNotEqual()
+        {
+            // Arrange
+            var a = new StructMemberProps(new Point(1, 2));
+            var b = new StructMemberProps(new Point(1, 3));
+
+            // Act + Assert
+            Assert.That(ComponentPropsComparer.ShallowEquals(a, b), Is.False);
+        }
+
+        [Test]
+        public void Given_MembersDifferOnlyInEqualityContract_When_ShallowEquals_Then_IsEqual()
+        {
+            // Arrange — the EqualityContract member is excluded by name, so it must not affect the outcome
+            var a = new ExplicitEqualityContractMember { Value = 1, EqualityContract = "A" };
+            var b = new ExplicitEqualityContractMember { Value = 1, EqualityContract = "B" };
+
+            // Act + Assert
+            Assert.That(ComponentPropsComparer.ShallowEquals(a, b), Is.True);
+        }
+
+        [Test]
+        public void Given_ObjectMemberHoldingEqualValueBoxedFloatsInDistinctBoxes_When_ShallowEquals_Then_IsEqual()
+        {
+            // Arrange — two separate boxing conversions of the same float value
+            var a = new RefMemberProps(1.5f);
+            var b = new RefMemberProps(1.5f);
+            Assume.That(ReferenceEquals(a.Handle, b.Handle), Is.False, "Precondition: the boxed floats are distinct instances");
+
+            // Act + Assert
+            Assert.That(ComponentPropsComparer.ShallowEquals(a, b), Is.True,
+                "An object-declared member holding a boxed float compares by unboxed value, not by box identity");
+        }
+
+        [Test]
+        public void Given_ObjectMemberHoldingEqualContentDistinctStringInstances_When_ShallowEquals_Then_IsEqual()
+        {
+            // Arrange — distinct string instances with equal content, held in an object-declared member
+            var a = new RefMemberProps(string.Concat("i", "d"));
+            var b = new RefMemberProps(string.Concat("i", "d"));
+            Assume.That(ReferenceEquals(a.Handle, b.Handle), Is.False, "Precondition: the string instances are distinct");
+
+            // Act + Assert
+            Assert.That(ComponentPropsComparer.ShallowEquals(a, b), Is.True,
+                "An object-declared member holding a string compares by content, matching the reflection path");
+        }
+
+        [Test]
+        public void Given_ObjectMemberHoldingBoxedFloatNaNBothSides_When_ShallowEquals_Then_IsEqual()
+        {
+            // Arrange — two separate boxing conversions of NaN
+            var a = new RefMemberProps(float.NaN);
+            var b = new RefMemberProps(float.NaN);
+
+            // Act + Assert
+            Assert.That(ComponentPropsComparer.ShallowEquals(a, b), Is.True,
+                "An object-declared member holding boxed NaN is Object.is-equal to itself, matching the reflection path");
+        }
+
+        [Test]
+        public void Given_NullableFloatMemberPositiveZeroVsNegativeZero_When_ShallowEquals_Then_IsNotEqual()
+        {
+            // Arrange — Object.is distinguishes +0 from -0 through a Nullable<float> member
+            var a = new NullableFloatProps(0f);
+            var b = new NullableFloatProps(-0f);
+
+            // Act + Assert
+            Assert.That(ComponentPropsComparer.ShallowEquals(a, b), Is.False);
+        }
+
+        [Test]
+        public void Given_NullableFloatMemberBothNull_When_ShallowEquals_Then_IsEqual()
+        {
+            // Arrange
+            var a = new NullableFloatProps(null);
+            var b = new NullableFloatProps(null);
+
+            // Act + Assert
+            Assert.That(ComponentPropsComparer.ShallowEquals(a, b), Is.True);
+        }
+
+        [Test]
+        public void Given_NullableFloatMemberNaNBothSides_When_ShallowEquals_Then_IsEqual()
+        {
+            // Arrange
+            var a = new NullableFloatProps(float.NaN);
+            var b = new NullableFloatProps(float.NaN);
+
+            // Act + Assert
+            Assert.That(ComponentPropsComparer.ShallowEquals(a, b), Is.True);
         }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Hooks/UseFrameDispatcher.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/UseFrameDispatcher.cs
@@ -58,6 +58,14 @@ namespace Velvet
         private readonly List<Subscription> _subscriptions = new();
         private IVisualElementScheduledItem? _tick;
         private long _nextSequence;
+        // Reused snapshot buffer for Tick's own iteration (see Tick). Grow-only: it is resized up to
+        // the panel's high-water-mark subscriber count and never shrunk, so a steady-state panel (no
+        // new UseFrame hosts mounting) ticks with zero allocation. Never read outside Tick itself: it
+        // is a scratch field, not state, and is left in its default (all-null, matching Length) shape
+        // between ticks. Nullable so Tick can null it out for the duration of its own invocation loop
+        // (see the reentrancy guard there) — a null field is how a nested Tick call on this same
+        // instance is told to allocate its own buffer instead of aliasing the in-flight one.
+        private Subscription?[]? _tickSnapshot = Array.Empty<Subscription>();
 
         private UseFrameDispatcher(IPanel panel)
         {
@@ -83,7 +91,7 @@ namespace Velvet
 
         internal void Unsubscribe(Subscription subscription)
         {
-            // Setting Active=false (not just removing from the list) matters because Tick's foreach below
+            // Setting Active=false (not just removing from the list) matters because Tick's loop below
             // runs over a SNAPSHOT taken at the start of that tick: a callback that synchronously disposes
             // a later-sorted sibling this same tick (an error boundary's fallback swap unmounting it
             // mid-iteration) can reach this Unsubscribe call before the snapshot's own walk gets to that
@@ -109,36 +117,97 @@ namespace Velvet
                 var byPriority = a.Priority.CompareTo(b.Priority);
                 return byPriority != 0 ? byPriority : a.Sequence.CompareTo(b.Sequence);
             });
-            // Snapshot via ToArray: a callback that itself mounts/unmounts a UseFrame sibling (adding
-            // or removing a Subscription mid-tick) must not perturb this pass's own iteration.
-            foreach (var subscription in _subscriptions.ToArray())
+            // Snapshot into a reused buffer: a callback that itself
+            // mounts/unmounts a UseFrame sibling (adding or removing a Subscription mid-tick) must not
+            // perturb this pass's own iteration, but the snapshot itself need not be a fresh
+            // allocation every tick — nothing on this path re-enters Tick for the SAME dispatcher while
+            // this pass is still running. The one confirmed mid-tick escalation (an error boundary's
+            // fallback swap, triggered synchronously from a throwing callback via
+            // Hooks.UseFrame's own try/catch) only ever mutates _subscriptions (Unsubscribe) through
+            // this call stack; Subscribe's `_tick ??=` short-circuits while _tick is already armed, and
+            // nothing else on this path drives the panel's scheduler synchronously, so a second,
+            // concurrent Tick call on this same instance never happens. A single reused array is
+            // therefore safe: growing it (never shrinking) covers the panel's high-water-mark
+            // subscriber count, and clearing it in the finally below keeps a paused/unmounted
+            // subscription from being held alive by this scratch field between ticks.
+            //
+            // The analysis above is not enforced by any runtime check, so the buffer is still guarded
+            // against reentrancy rather than trusted unconditionally: the field is captured into a
+            // local and nulled out before the invocation loop runs, so a nested Tick that DID somehow
+            // reach this same instance (a future call path this analysis failed to anticipate) would
+            // find the field null and allocate its own buffer instead of aliasing this pass's in-flight
+            // one. This costs one extra field read/write on the already-taken hot path — no allocation,
+            // so steady state stays zero-alloc — and the finally below restores the field from the
+            // local only if it is still null, i.e. only if no nested Tick claimed it in the meantime.
+            var count = _subscriptions.Count;
+            var snapshot = _tickSnapshot;
+            _tickSnapshot = null;
+            // The grow/copy phase lives inside the try: if the array allocation ever fails, the
+            // finally must still restore whatever buffer this pass holds, or the field would be
+            // abandoned at null and the next tick forced to reallocate.
+            try
             {
-                // LastTimeMs is not refreshed while inactive, so a pause accumulates real elapsed time
-                // rather than freezing it — reactivating hands the next callback a dt spanning the WHOLE
-                // paused interval (still clamped below like any other). The only currently-reachable pause
-                // is a same-frame keyed-reorder detach+reattach (zero elapsed time either way), so this
-                // choice is unobserved today; it is deliberate, not an oversight, should a future pause
-                // ever span real time.
-                if (!subscription.Active) continue;
-
-                // Per-subscription delta (see Subscription.LastTimeMs) rather than one dt shared by the
-                // whole panel: a subscription with no baseline yet only records one here and skips
-                // invoking this pass, matching a freshly-armed engine scheduled item's own zero-delta
-                // first fire — the callback only ever observes a real elapsed span it was actually
-                // present for.
-                if (subscription.LastTimeMs is not { } lastMs)
+                if (snapshot is null || snapshot.Length < count)
                 {
-                    subscription.LastTimeMs = ts.now;
-                    continue;
+                    snapshot = new Subscription?[count];
                 }
-                var dt = (ts.now - lastMs) / 1000f;
-                subscription.LastTimeMs = ts.now;
-                // Mirrors the per-subscriber cadence guard this replaced: a zero delta (same-frame
-                // flush) is skipped so the callback only ever observes positive, frame-sized seconds,
-                // and a hitch spike is clamped the way Time.deltaTime clamps its own.
-                if (dt <= 0f) continue;
-                dt = Mathf.Min(dt, Time.maximumDeltaTime);
-                subscription.Callback(dt);
+                for (var i = 0; i < count; i++)
+                {
+                    snapshot[i] = _subscriptions[i];
+                }
+
+                for (var i = 0; i < count; i++)
+                {
+                    var subscription = snapshot[i]!;
+                    // LastTimeMs is not refreshed while inactive, so a pause accumulates real elapsed time
+                    // rather than freezing it — reactivating hands the next callback a dt spanning the WHOLE
+                    // paused interval (still clamped below like any other). The only currently-reachable pause
+                    // is a same-frame keyed-reorder detach+reattach (zero elapsed time either way), so this
+                    // choice is unobserved today; it is deliberate, not an oversight, should a future pause
+                    // ever span real time.
+                    if (!subscription.Active) continue;
+
+                    // Per-subscription delta (see Subscription.LastTimeMs) rather than one dt shared by the
+                    // whole panel: a subscription with no baseline yet only records one here and skips
+                    // invoking this pass, matching a freshly-armed engine scheduled item's own zero-delta
+                    // first fire — the callback only ever observes a real elapsed span it was actually
+                    // present for.
+                    if (subscription.LastTimeMs is not { } lastMs)
+                    {
+                        subscription.LastTimeMs = ts.now;
+                        continue;
+                    }
+                    var dt = (ts.now - lastMs) / 1000f;
+                    subscription.LastTimeMs = ts.now;
+                    // Per-subscriber cadence guard: a zero delta (same-frame
+                    // flush) is skipped so the callback only ever observes positive, frame-sized seconds,
+                    // and a hitch spike is clamped the way Time.deltaTime clamps its own.
+                    if (dt <= 0f) continue;
+                    dt = Mathf.Min(dt, Time.maximumDeltaTime);
+                    subscription.Callback(dt);
+                }
+            }
+            finally
+            {
+                // Scrubbed rather than left dangling: a stale reference here would hold a disposed
+                // subscription's Callback closure (and everything it captures) alive on this instance
+                // field until the buffer slot is next overwritten, well past the subscription's own
+                // unmount.
+                if (snapshot != null)
+                {
+                    var scrub = count < snapshot.Length ? count : snapshot.Length;
+                    for (var i = 0; i < scrub; i++)
+                    {
+                        snapshot[i] = null;
+                    }
+                }
+                // Restore only if the field is still null: a nested Tick that ran synchronously during
+                // the invocation loop above would have found the field null (per the reentrancy guard),
+                // allocated its own buffer, and already restored it through this same line by the time
+                // this outer call resumes here. In that case this pass's buffer is simply dropped rather
+                // than overwriting the nested call's — both are equivalently-sized scratch space and
+                // only one can occupy the field going forward.
+                _tickSnapshot ??= snapshot;
             }
         }
     }

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberElementPoolReset.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberElementPoolReset.cs
@@ -32,25 +32,42 @@ namespace Velvet
         // USS class (see Unity reference TextElement.cs:178). Passing the base classes in
         // constructor-call order (base first, subclass last) keeps the resulting class list identical
         // to a freshly constructed instance.
+        // Fixed-arity overloads cover every call shape in this codebase (two USS classes for
+        // Label/Button/Toggle, three for Slider/TextField, whose constructor chains run one field
+        // class deeper). Do not collapse them into a `params` signature: this runs once per recycled
+        // element on the reconciler's steady-state hot path, and a params array would put a heap
+        // allocation on every widget pool-return.
         // element: Pooled element to reset. Null is a no-op.
-        // baseUssClasses: USS classes required by Unity built-in styling. Order is preserved.
-        public static void ResetClassListAndCommon(VisualElement element, params string[] baseUssClasses)
+        public static void ResetClassListAndCommon(VisualElement element, string ussClassA, string ussClassB)
         {
             if (element == null) return;
 
             element.ClearClassList();
-            if (baseUssClasses != null)
-            {
-                foreach (var ussClass in baseUssClasses)
-                {
-                    if (!string.IsNullOrEmpty(ussClass))
-                    {
-                        element.AddToClassList(ussClass);
-                    }
-                }
-            }
+            AddClassIfNotEmpty(element, ussClassA);
+            AddClassIfNotEmpty(element, ussClassB);
 
             ResetCommonState(element);
+        }
+
+        // element: Pooled element to reset. Null is a no-op.
+        public static void ResetClassListAndCommon(VisualElement element, string ussClassA, string ussClassB, string ussClassC)
+        {
+            if (element == null) return;
+
+            element.ClearClassList();
+            AddClassIfNotEmpty(element, ussClassA);
+            AddClassIfNotEmpty(element, ussClassB);
+            AddClassIfNotEmpty(element, ussClassC);
+
+            ResetCommonState(element);
+        }
+
+        private static void AddClassIfNotEmpty(VisualElement element, string ussClass)
+        {
+            if (!string.IsNullOrEmpty(ussClass))
+            {
+                element.AddToClassList(ussClass);
+            }
         }
 
         // Resets the element's UIToolkit-side state shared by all pooled widgets.

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/BenchmarkHelpers.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/BenchmarkHelpers.cs
@@ -11,5 +11,18 @@ namespace Velvet.Tests.Performance
             }
             return nodes;
         }
+
+        // Mixed Label/Button leaves for benchmarks exercising VNodePool's per-widget-type recycle path
+        // (both types are poolable primitives, so an unmount round-trips each through its own pool).
+        internal static VNode[] BuildLabelAndButtonNodes(int countEach)
+        {
+            var nodes = new VNode[countEach * 2];
+            for (int i = 0; i < countEach; i++)
+            {
+                nodes[i] = V.Label(text: $"label-{i}");
+                nodes[countEach + i] = V.Button(text: $"button-{i}");
+            }
+            return nodes;
+        }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/ReconcilerPerformanceBenchmarks.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/ReconcilerPerformanceBenchmarks.cs
@@ -208,6 +208,39 @@ namespace Velvet.Tests.Performance
 
         #endregion
 
+        #region B-1-d: Pooled-widget recycle (mount -> unmount -> remount)
+
+        // Pins the primitive-element pool's recycle path: VNodePool.ReturnLabel / ReturnButton (invoked
+        // when RemoveElement/RemoveElementDirect reclaims an unmounted Label/Button) run
+        // FiberLabelPoolHelper/FiberButtonPoolHelper's ResetXForReuse, which calls
+        // FiberElementPoolReset.ResetClassListAndCommon on every single recycle — a per-recycle heap
+        // allocation anywhere on that path is what this measurement exists to catch. Held at 10 of each (well under
+        // either pool's own 32-instance cap) so every element genuinely round-trips through
+        // Rent/Return across the measured region instead of being dropped uncounted by a full pool.
+        [Test, Performance]
+        public void PooledWidgetRecycle_LabelsAndButtons_10Elements()
+        {
+            var nodes = BenchmarkHelpers.BuildLabelAndButtonNodes(10);
+            var empty = Array.Empty<VNode>();
+
+            // Warms both pools first so the measured region only ever rents/returns already-pooled
+            // instances, not the `new Label()` / `new Button()` construction cost of filling them.
+            _reconciler.Reconcile(_root, empty, nodes);
+            _reconciler.Reconcile(_root, nodes, empty);
+
+            Measure.Method(() =>
+            {
+                _reconciler.Reconcile(_root, empty, nodes);
+                _reconciler.Reconcile(_root, nodes, empty);
+            })
+            .GC()
+            .WarmupCount(5)
+            .MeasurementCount(20)
+            .Run();
+        }
+
+        #endregion
+
         #region Helpers
 
         /// <summary>


### PR DESCRIPTION
Eliminates three heap-allocation sources on the reconciler's steady-state hot paths, found by a benchmark-gap audit and verified by adversarial review:

- **Pooled widget recycle**: `FiberElementPoolReset.ResetClassListAndCommon` took `params string[]`, allocating an array on every `Label`/`Button`/`Toggle`/`Slider`/`TextField` pool return. Replaced with fixed-arity overloads; a new PlayMode GC benchmark pins the recycle path.
- **UseFrame tick**: the dispatcher snapshotted subscribers with `List.ToArray()` every ticked frame. It now reuses a grow-only buffer with an unconditional reentrancy guard and exception-safe restore, so steady-state panels tick allocation-free while preserving the exact snapshot contract (mid-tick subscribes don't fire that tick; mid-tick unsubscribes still do).
- **Memoize props-bail**: `ComponentPropsComparer` read members via `PropertyInfo/FieldInfo.GetValue`, boxing every value-typed prop per comparison on the very path `Memoize` exists to make cheap. On JIT platforms it now compiles one cached typed comparer per props type, routing per member to preserve `Object.is` semantics exactly — members declared `object`/interface/`ValueType`/`Enum` go through the boxed runtime-type dispatch, `Nullable<T>` is lifted so the sign-of-zero distinction survives, and everything else calls the typed comparison directly. IL2CPP (AOT) players keep the reflection implementation unchanged. Semantics were cross-verified empirically (44 scenarios, compiled vs reflection path) and the new comparer tests were confirmed red without the routing logic.

Full EditMode (3262) + PlayMode (91) suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
