### PR TITLE
refactor(velvet): replace the fiber lane SortedSet with an inline bit mask

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Scheduling a fiber re-render no longer allocates a per-fiber sorted set for the pending-lane
+  queue; the four update priorities now live in an inline bit mask with identical enrollment,
+  drain-order, and starvation-promotion semantics.
 - Recycling a pooled primitive widget (`Label`/`Button`/`Toggle`/`Slider`/`TextField`) no longer
   allocates a class-list array on every pool return; the element reset path now uses fixed-arity
   overloads so steady-state list churn stays allocation-free.

--- a/Packages/com.velvet.core/Runtime/Component/ComponentFiber.cs
+++ b/Packages/com.velvet.core/Runtime/Component/ComponentFiber.cs
@@ -4,12 +4,95 @@ using System.Collections.Generic;
 namespace Velvet
 {
     /// <summary>
+    /// Bitmask over the four <see cref="FiberUpdatePriority"/> values, used as the per-fiber pending-lane
+    /// set. The priority space is fixed at exactly 4 members (Urgent=0 .. Transition=3), and this type sits
+    /// on the scheduler's hottest path (<see cref="FiberWorkLoop.ScheduleRerender"/> /
+    /// <see cref="FiberWorkLoop.FlushState"/> run on every hook-driven update), so membership is tracked with
+    /// a single byte rather than a general-purpose ordered-set container: no per-enrollment node allocation,
+    /// no comparer indirection.
+    /// </summary>
+    internal struct FiberLaneSet
+    {
+        private byte _mask;
+
+        /// <summary>Number of lanes currently enrolled (0-4).</summary>
+        internal readonly int Count
+        {
+            get
+            {
+                var count = 0;
+                for (var bit = 0; bit < 4; bit++)
+                {
+                    if ((_mask & (1 << bit)) != 0)
+                    {
+                        count++;
+                    }
+                }
+                return count;
+            }
+        }
+
+        /// <summary>
+        /// The numerically-lowest (highest-priority) enrolled lane. Undefined on an empty set by contract —
+        /// every call site guards with <see cref="Count"/> or <see cref="Contains"/> before reading Min — but
+        /// resolves to <c>default</c> (Urgent) rather than throwing, so a caller that skips the guard fails
+        /// open into a plausible-looking value instead of an exception on the render hot path.
+        /// </summary>
+        internal readonly FiberUpdatePriority Min
+        {
+            get
+            {
+                for (var bit = 0; bit < 4; bit++)
+                {
+                    if ((_mask & (1 << bit)) != 0)
+                    {
+                        return (FiberUpdatePriority)bit;
+                    }
+                }
+                return default;
+            }
+        }
+
+        internal readonly bool Contains(FiberUpdatePriority priority) => (_mask & (1 << (int)priority)) != 0;
+
+        /// <summary>
+        /// Enrolls <paramref name="priority"/>. Returns true iff it was not already enrolled — callers key
+        /// first-enrollment-vs-coalesced-re-add decisions (e.g. the transition-starvation clock reset in
+        /// <see cref="FiberWorkLoop.ScheduleRerender"/>) off this return value.
+        /// </summary>
+        internal bool Add(FiberUpdatePriority priority)
+        {
+            var bit = (byte)(1 << (int)priority);
+            if ((_mask & bit) != 0)
+            {
+                return false;
+            }
+            _mask |= bit;
+            return true;
+        }
+
+        /// <summary>Un-enrolls <paramref name="priority"/>. Returns true iff it had been enrolled.</summary>
+        internal bool Remove(FiberUpdatePriority priority)
+        {
+            var bit = (byte)(1 << (int)priority);
+            if ((_mask & bit) == 0)
+            {
+                return false;
+            }
+            _mask &= (byte)~bit;
+            return true;
+        }
+
+        internal void Clear() => _mask = 0;
+    }
+
+    /// <summary>
     /// Auxiliary structure that represents the Lane scheduling state on a Fiber.
     /// A minimal model of the per-fiber and per-subtree pending-update lane bitsets.
     /// </summary>
     internal sealed class LaneState
     {
-        public SortedSet<FiberUpdatePriority>? Queue;
+        public FiberLaneSet Queue;
         public bool IsInTransition;
         public int TransitionStarvationCounter;
         // The settle sweep keys off the Transition label's presence, which starvation promotion erases
@@ -20,7 +103,7 @@ namespace Velvet
 
         public void Clear()
         {
-            Queue?.Clear();
+            Queue.Clear();
             IsInTransition = false;
             TransitionStarvationCounter = 0;
             HasPromotedTransition = false;
@@ -230,12 +313,15 @@ namespace Velvet
 
         internal LaneState EnsureLanes() => Lanes ??= new LaneState();
 
-        /// <summary>Null-safe getter / lazy-init setter for Lane operations (used by FiberWorkLoop).</summary>
-        internal SortedSet<FiberUpdatePriority>? LaneQueue
-        {
-            get => Lanes?.Queue;
-            set => EnsureLanes().Queue = value;
-        }
+        /// <summary>
+        /// Null-safe read of the pending-lane mask (used by FiberWorkLoop / FiberLane's query paths). An
+        /// unallocated <see cref="Lanes"/> (fiber currently clean) reads as an empty <see cref="FiberLaneSet"/>
+        /// without allocating, preserving the lazy-init invariant. This is a read-only view: FiberLaneSet's
+        /// Add/Remove/Clear mutate the struct in place and a property getter can only hand back a copy of it
+        /// (CS1612), so enrollment/removal call sites go through <see cref="EnsureLanes"/> / <see cref="Lanes"/>
+        /// directly against the backing <see cref="LaneState.Queue"/> field instead of through this accessor.
+        /// </summary>
+        internal FiberLaneSet LaneQueue => Lanes?.Queue ?? default;
 
         /// <summary>
         /// True while any <see cref="Hooks.UseTransition"/> slot on this fiber is pending. Derived from the

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberBatchScheduler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberBatchScheduler.cs
@@ -199,12 +199,15 @@ namespace Velvet
                     for (var i = 0; i < _drainBuffer.Count; i++)
                     {
                         var dropped = _drainBuffer[i];
-                        dropped.LaneQueue?.Remove(FiberUpdatePriority.Urgent);
-                        dropped.LaneQueue?.Remove(FiberUpdatePriority.Normal);
+                        // Direct field access through Lanes (not the dropped.LaneQueue read accessor): a
+                        // FiberLaneSet handed back by a property getter is a copy, so Remove() through it
+                        // would mutate a throwaway value instead of the backing queue.
+                        dropped.Lanes?.Queue.Remove(FiberUpdatePriority.Urgent);
+                        dropped.Lanes?.Queue.Remove(FiberUpdatePriority.Normal);
                         // The promoted marker retires with the dropped Normal it rode, or it would keep
                         // skipping the settle sweep for as long as any surviving lane stays queued.
                         dropped.HasPromotedTransition = false;
-                        if (dropped.LaneQueue == null || dropped.LaneQueue.Count == 0)
+                        if (dropped.LaneQueue.Count == 0)
                         {
                             dropped.IsDirty = false;
                             dropped.ClearAllTransitionPending();

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberLane.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberLane.cs
@@ -31,7 +31,7 @@ namespace Velvet
         // lane queue is empty. Shared by ScheduleRerender's escalation check.
         internal static FiberUpdatePriority GetHighestPendingPriority(ComponentFiber fiber)
         {
-            if (fiber.LaneQueue == null || fiber.LaneQueue.Count == 0)
+            if (fiber.LaneQueue.Count == 0)
             {
                 return FiberUpdatePriority.Transition;
             }

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberRenderer.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberRenderer.cs
@@ -130,13 +130,16 @@ namespace Velvet
         // stranded and silently dropped by FlushState's not-dirty early-return.
         internal static void SettleSubsumedFiber(ComponentFiber fiber)
         {
-            fiber.LaneQueue?.Clear();
+            // Direct field access through Lanes (not the fiber.LaneQueue read accessor): EnsureLanes would
+            // allocate a LaneState for the lane-less majority of subsumed fibers (every non-memoized child
+            // re-render lands here), defeating the documented lazy-allocation invariant, and a FiberLaneSet
+            // handed back by a property getter is a copy — Clear() through it would mutate a throwaway
+            // value instead of the backing queue.
+            fiber.Lanes?.Queue.Clear();
             // The subsuming render committed the fiber's latest (eagerly-written) state, so any
             // starvation-promoted work is satisfied too — a marker left true on the now-clean fiber
             // would mis-time a LATER transition's settle (its sweep would be skipped while other lanes
-            // queue). Direct field access: the proxy setter's EnsureLanes would allocate a LaneState
-            // for the lane-less majority of subsumed fibers (every non-memoized child re-render lands
-            // here), defeating the documented lazy-allocation invariant.
+            // queue).
             if (fiber.Lanes != null)
             {
                 fiber.Lanes.HasPromotedTransition = false;

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberWorkLoop.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberWorkLoop.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 
 namespace Velvet
 {
@@ -90,13 +89,14 @@ namespace Velvet
 
         internal static void ScheduleRerender(ComponentFiber fiber, FiberUpdatePriority priority)
         {
-            fiber.LaneQueue ??= new SortedSet<FiberUpdatePriority>();
-
             // Record the current highest priority before adding.
             // If the same Lane already exists, Add returns false (coalesced).
             var prevHighest = FiberLane.GetHighestPendingPriority(fiber);
 
-            var enrolled = fiber.LaneQueue.Add(priority);
+            // Goes through EnsureLanes()/Lanes directly (not the fiber.LaneQueue read accessor): FiberLaneSet
+            // is a struct, so a property getter can only hand back a copy — Add must mutate the backing
+            // LaneState.Queue field in place to enroll for real.
+            var enrolled = fiber.EnsureLanes().Queue.Add(priority);
 
             // A coalesced re-add must NOT restart the starvation clock: it measures how long the lane
             // has been continuously pending, so sustained re-scheduling (e.g. a per-frame
@@ -228,11 +228,14 @@ namespace Velvet
             // lane (e.g. a context-driven flush) the reconcile runs synchronously.
             var flushBudget = FiberLane.FrameBudgetMs;
 
-            if (fiber.LaneQueue != null && fiber.LaneQueue.Count > 0)
+            if (fiber.LaneQueue.Count > 0)
             {
                 var flushingLane = fiber.LaneQueue.Min;
                 flushBudget = FiberLane.BudgetForLane(flushingLane);
-                fiber.LaneQueue.Remove(flushingLane);
+                // A non-empty read above means Lanes was already allocated (Queue is only ever populated
+                // through EnsureLanes()), so the backing field is safe to mutate directly here — the
+                // fiber.LaneQueue accessor itself only ever hands back a read-only copy of the mask.
+                fiber.Lanes!.Queue.Remove(flushingLane);
 
                 // The promoted marker retires at the drain that commits its content — a
                 // starvation-promoted lane rides the Normal label (see HasPromotedTransition).
@@ -253,7 +256,7 @@ namespace Velvet
                 // The Transition label alone is not the settled signal — starvation promotion erases it
                 // while the promoted work is still queued (possibly parked behind an Urgent drain), so
                 // the promoted marker must ALSO be clear before the pending flags may sweep.
-                if (fiber.LaneQueue == null || fiber.LaneQueue.Count == 0
+                if (fiber.LaneQueue.Count == 0
                     || (!fiber.LaneQueue.Contains(FiberUpdatePriority.Transition) && !fiber.HasPromotedTransition))
                 {
                     fiber.ClearAllTransitionPending();
@@ -399,7 +402,7 @@ namespace Velvet
 
         private static void PromoteStarvedTransitionLane(ComponentFiber fiber)
         {
-            if (fiber.LaneQueue == null || !fiber.LaneQueue.Contains(FiberUpdatePriority.Transition))
+            if (!fiber.LaneQueue.Contains(FiberUpdatePriority.Transition))
             {
                 fiber.TransitionStarvationCounter = 0;
                 return;
@@ -419,8 +422,10 @@ namespace Velvet
                 // higher-priority traffic is. The promoted marker keeps the settle sweep honest about
                 // the erased Transition label (see HasPromotedTransition), so isPending still clears at
                 // (not before) the commit that renders the promoted content.
-                fiber.LaneQueue.Remove(FiberUpdatePriority.Transition);
-                fiber.LaneQueue.Add(FiberUpdatePriority.Normal);
+                // Contains(Transition) above guarantees Lanes was already allocated; mutate the backing
+                // field directly, as the fiber.LaneQueue accessor only hands back a read-only copy.
+                fiber.Lanes!.Queue.Remove(FiberUpdatePriority.Transition);
+                fiber.Lanes.Queue.Add(FiberUpdatePriority.Normal);
                 fiber.HasPromotedTransition = true;
                 fiber.TransitionStarvationCounter = 0;
             }
@@ -519,7 +524,6 @@ namespace Velvet
                 // queued, and completing the async action inside that window must not clear isPending
                 // ahead of the commit that renders the transition's content.
                 if (fiber.IsDisposed
-                    || fiber.LaneQueue == null
                     || (!fiber.LaneQueue.Contains(FiberUpdatePriority.Transition) && !fiber.HasPromotedTransition))
                 {
                     slot.IsPending = false;

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/AncestorDescendantStoreRerenderTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/AncestorDescendantStoreRerenderTests.cs
@@ -544,7 +544,7 @@ namespace Velvet.Tests
                 "The subsumed child is removed from the delayed tier (its lane is honored by the re-expansion, not dropped)");
             Assert.IsFalse(s_childFiber.IsDirty,
                 "The subsumed child's dirty flag is cleared by the re-expansion");
-            Assert.IsTrue(s_childFiber.LaneQueue == null || s_childFiber.LaneQueue.Count == 0,
+            Assert.IsTrue(s_childFiber.LaneQueue.Count == 0,
                 "The subsumed child's lane queue is settled, not left holding a stranded Transition lane");
         }
 

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/UpdatePriorityTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/UpdatePriorityTests.cs
@@ -737,7 +737,7 @@ namespace Velvet.Tests
             s_btnSetValue.Invoke("direct");
 
             // Assert
-            Assume.That(s_btnFiber.LaneQueue, Is.Not.Null, "Precondition: an update is queued on the fiber");
+            Assume.That(s_btnFiber.LaneQueue.Count, Is.GreaterThan(0), "Precondition: an update is queued on the fiber");
             Assert.AreEqual((1, FiberUpdatePriority.Normal), (s_btnRenderCount, s_btnFiber.LaneQueue.Min),
                 "Outside a discrete event, a setState stays on the Normal lane and does not flush synchronously");
         }
@@ -948,10 +948,10 @@ namespace Velvet.Tests
                 {
                     setValue.Invoke("clicked");
                     // Capture the lane the handler scheduled, before the end-of-event sync flush drains it. Read
-                    // Min only when something is queued: SortedSet.Min returns default==Urgent on an empty set,
-                    // which would let a dropped enqueue pass the assertion falsely.
+                    // Min only when something is queued: FiberLaneSet.Min returns default==Urgent on an empty
+                    // set, which would let a dropped enqueue pass the assertion falsely.
                     var queue = s_btnFiber.LaneQueue;
-                    s_btnLaneInHandler = queue != null && queue.Count > 0 ? queue.Min : (FiberUpdatePriority?)null;
+                    s_btnLaneInHandler = queue.Count > 0 ? queue.Min : (FiberUpdatePriority?)null;
                 },
                 key: "btn");
         }
@@ -968,9 +968,9 @@ namespace Velvet.Tests
                 {
                     setOn.Invoke(next);
                     // Capture the scheduled lane before the end-of-event sync flush drains it. Read Min only when
-                    // something is queued (SortedSet.Min returns default==Urgent on an empty set).
+                    // something is queued (FiberLaneSet.Min returns default==Urgent on an empty set).
                     var queue = s_btnFiber.LaneQueue;
-                    s_btnLaneInHandler = queue != null && queue.Count > 0 ? queue.Min : (FiberUpdatePriority?)null;
+                    s_btnLaneInHandler = queue.Count > 0 ? queue.Min : (FiberUpdatePriority?)null;
                 },
                 key: "tg");
         }


### PR DESCRIPTION
Replaces the per-fiber `SortedSet<FiberUpdatePriority>` lane queue with `FiberLaneSet`, an inline byte-mask struct. Four fixed priorities never needed a red-black tree: the mask provides `Add`/`Remove`/`Contains`/`Min`/`Count` with identical semantics — including `Add` reporting first-enrollment, which gates the transition-starvation clock — while removing the per-fiber set allocation and comparer overhead from the scheduling hot path.

Mutating call sites route through the `LaneState` backing field (a struct-returning property hands back copies; the compiler rejects mutation through it), read sites keep the property. Former null checks collapse to empty-mask checks, verified line-by-line as behaviorally identical, and the lazy `LaneState` allocation timing is unchanged. Two scheduler-test assertions that would have become vacuous on a struct (`Is.Not.Null`) are strengthened to pending-count checks.

Full EditMode (3262) + PlayMode (91) suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)