### PR TITLE
fix(velvet): restore focus when a focus scope root itself holds focus at unmount

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -24,6 +24,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   as `object`/interfaces holding boxed values, and the sign-of-zero distinction for nullable floats.
   IL2CPP (AOT) players keep the reflection implementation.
 
+### Fixed
+
+- A `FocusScope` with `restoreFocus: true` did not hand focus back to the prior element when the
+  scope's ROOT element itself (rather than a descendant) held focus at unmount: the guard used
+  `VisualElement.Contains`, which does not count an element as containing itself, so a focused root
+  read as "focus already left the scope" and the restore was skipped. The guard now uses a
+  self-inclusive check, so a directly-focusable scope root restores focus the same way a focused
+  descendant already did.
+
 ## [1.6.0] - 2026-07-25
 
 ### Added

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberElementCleaner.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberElementCleaner.cs
@@ -363,8 +363,7 @@ namespace Velvet
                 // BEFORE this element physically leaves the tree (UI Toolkit clears the focused element
                 // the moment it detaches — the same ordering RescueFocusFromWorldSpaceHost exists for).
                 if (focusScopeBinding.Settings.RestoreFocus
-                    && element.panel?.focusController?.focusedElement is VisualElement held
-                    && element.Contains(held))
+                    && FiberFocusNavigator.IsFocusedElementWithin(element, out _))
                 {
                     var restore = focusScopeBinding.RestoreTarget;
                     if (restore != null && restore.panel != null && restore.canGrabFocus)

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberFocusNavigator.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberFocusNavigator.cs
@@ -774,6 +774,18 @@ namespace Velvet
             return false;
         }
 
+        // True when `root`'s panel currently has a focused element that is `root` itself or one of its
+        // descendants — the shared "does this subtree currently hold focus" check needed by every path
+        // that must undo something ONLY while it still holds focus (a focus anchor's release, a reverted
+        // landing's settle, UseFocusRing's unmount correction). Returns the held element via `held` (null
+        // when the result is false) so a caller that also needs it — e.g. to Blur it — does not re-read
+        // focusController a second time.
+        internal static bool IsFocusedElementWithin(VisualElement root, out VisualElement? held)
+        {
+            held = root.panel?.focusController?.focusedElement as VisualElement;
+            return held != null && (held == root || root.Contains(held));
+        }
+
         // Walks the parent chain from `element` (inclusive) to the first registered scope root. Physical
         // containment is deliberately the membership definition — robust at event time, across pool reuse,
         // and against the logical-tree caveats that limit userData-based resolution for bare portal children.

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/FocusScopeTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/FocusScopeTests.cs
@@ -127,6 +127,46 @@ namespace Velvet.Tests
         }
 
         [Component]
+        private static VNode RestoreScopeRootFocusableHost()
+        {
+            var (showScope, setShowScope) = Hooks.UseState(true);
+            s_setShowScope = setShowScope;
+            return V.Div(children: new VNode[]
+            {
+                V.Button(name: "opener"),
+                showScope
+                    ? V.FocusScope(name: "scope", key: "scope", restoreFocus: true,
+                        props: new FiberElementProps { Focusable = true },
+                        children: new VNode[]
+                        {
+                            V.Button(name: "inner"),
+                        })
+                    : null,
+            });
+        }
+
+        [Test]
+        public void Given_AFocusScopeWithRestoreFocus_When_TheScopeRootItselfHoldsFocusAndUnmounts_Then_TheElementFocusCameFromRegainsFocus()
+        {
+            // Arrange — focus enters the scope root element ITSELF (not a descendant) FROM the opener: the
+            // root is made focusable directly, exercising the restore guard's own-root case rather than a
+            // contained child's.
+            Mount(RestoreScopeRootFocusableHost);
+            var opener = Q("opener");
+            opener.Focus();
+            Q("scope").Focus();
+            Assume.That(_host.Panel.focusController.focusedElement, Is.EqualTo(Q("scope")),
+                "Precondition: the scope root itself holds focus");
+
+            // Act
+            s_setShowScope.Invoke(false);
+            _mounted.FlushStateForTest();
+
+            // Assert
+            Assert.That(_host.Panel.focusController.focusedElement, Is.EqualTo(opener));
+        }
+
+        [Component]
         private static VNode AutoFocusScopeHost() => V.Div(children: new VNode[]
         {
             V.FocusScope(name: "scope", autoFocus: true, children: new VNode[]


### PR DESCRIPTION
A `FocusScope` with `restoreFocus: true` skipped the focus hand-back when the scope's root element itself (rather than a descendant) held focus at unmount. The guard used `VisualElement.Contains`, which does not treat an element as containing itself, so a focused root read as "focus already left the scope" and the restore silently never ran.

The guard now routes through the shared self-inclusive containment predicate (`FiberFocusNavigator.IsFocusedElementWithin`), matching every other focus-target check in the reconciler. A directly-focusable scope root is reachable through `FiberElementProps.Focusable`, so this is an observable fix, recorded in the CHANGELOG.

Includes a regression test that focuses the scope root itself and asserts focus returns to the prior element; it fails without the guard change. EditMode 3267 and PlayMode 91 pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)