### PR TITLE
chore(velvet): add a pull request template with the completion checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+## What & why
+
+<!-- What changed and why. -->
+
+## Checklist
+
+- [ ] Tests pass locally (EditMode / PlayMode / generator tests as applicable)
+- [ ] New regression tests were verified red without the change and green with it
+- [ ] Docs are updated for every fact this change touches (guides, READMEs, CLAUDE.md) — or this PR has no doc impact
+- [ ] CHANGELOG updated for behavior/perf changes (pure refactors are omitted by convention)
+- [ ] Known gaps or deliberate deferrals discovered here are filed as issues with acceptance criteria


### PR DESCRIPTION
Adds `.github/PULL_REQUEST_TEMPLATE.md` so every PR opens with the full definition of done: local test runs, red-verified regression tests, doc sync (or an explicit no-doc-impact statement), the CHANGELOG convention, and issue filing for known gaps discovered during the work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)