### PR TITLE
refactor(velvet): route eight manipulator families through one configure step

### DIFF
--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
@@ -1643,11 +1643,235 @@ namespace Velvet
 
         #endregion
 
+        #region Manipulator Configure
+
+        // One manipulator family's tracking table, constructor and update call. Implementations must be
+        // structs: Configure is constrained to a struct so every instantiation is specialized and each
+        // member below binds to a direct call. A class implementation, or a delegate parameter in place of
+        // this interface, would allocate once per element per patch on a path that runs for every styled
+        // element in the tree.
+        // Create takes the context because most families' manipulators resolve their payloads through
+        // it; gap and grid write only their own target's child margins and ignore it.
+        private interface IManipulatorOp<TManip> where TManip : Manipulator
+        {
+            Dictionary<VisualElement, TManip> Table(ReconcilerContext ctx);
+            TManip Create(ReconcilerContext ctx);
+            void Update(TManip manipulator);
+        }
+
+        // Creates, updates or tears down element's manipulator of the family described by op. wanted is
+        // the family's own verdict on whether the current class list still asks for the manipulator;
+        // each caller computes it from its own token scan (an emptiness check, a parse result, or the
+        // prefix scan it already ran to early-out).
+        // The table entry is dropped only AFTER the element has released the manipulator. These tables
+        // are the index FiberElementCleaner detaches from, so an entry cleared ahead of a detach that
+        // throws or re-enters would strand an attached manipulator nothing can reach.
+        // `default` is a legal op ONLY where wanted is statically false: a default op carries zeroed
+        // fields, so a computed wanted that turns out true would build a manipulator out of them.
+        // op is taken by value. `where TOp : struct` does not promise the concrete type is readonly, so
+        // an `in` parameter would make each member call below copy defensively rather than copying once
+        // at the call site.
+        private void Configure<TOp, TManip>(VisualElement element, bool wanted, TOp op)
+            where TOp : struct, IManipulatorOp<TManip>
+            where TManip : Manipulator
+        {
+            var table = op.Table(_ctx);
+            if (table.TryGetValue(element, out var existing))
+            {
+                if (wanted)
+                {
+                    // Keep this unconditional — never gate it on "the spec is unchanged". Gap / divide /
+                    // grid re-derive against the CURRENT child set and text-balance re-wins a shared
+                    // inline slot, both of which move without any class token changing.
+                    op.Update(existing);
+                }
+                else
+                {
+                    element.RemoveManipulator(existing);
+                    table.Remove(element);
+                }
+            }
+            else if (wanted)
+            {
+                var manipulator = op.Create(_ctx);
+                element.AddManipulator(manipulator);
+                table[element] = manipulator;
+            }
+        }
+
+        private readonly struct VariantOp : IManipulatorOp<StyleVariantManipulator>
+        {
+            private readonly string[] _hover;
+            private readonly string[] _focus;
+            private readonly string[] _focusVisible;
+            private readonly string[] _active;
+            private readonly string[] _checked;
+
+            internal VariantOp(string[] hover, string[] focus, string[] focusVisible, string[] active,
+                string[] @checked)
+            {
+                _hover = hover;
+                _focus = focus;
+                _focusVisible = focusVisible;
+                _active = active;
+                _checked = @checked;
+            }
+
+            public Dictionary<VisualElement, StyleVariantManipulator> Table(ReconcilerContext ctx)
+                => ctx.VariantManipulators;
+
+            public StyleVariantManipulator Create(ReconcilerContext ctx)
+                => new StyleVariantManipulator(ctx, _hover, _focus, _focusVisible, _active, _checked);
+
+            public void Update(StyleVariantManipulator manipulator)
+                => manipulator.UpdatePayloads(_hover, _focus, _focusVisible, _active, _checked);
+        }
+
+        private readonly struct ConditionalVariantOp : IManipulatorOp<StyleConditionalVariantManipulator>
+        {
+            private readonly string[][] _responsive;
+            private readonly string[] _dark;
+
+            internal ConditionalVariantOp(string[][] responsive, string[] dark)
+            {
+                _responsive = responsive;
+                _dark = dark;
+            }
+
+            public Dictionary<VisualElement, StyleConditionalVariantManipulator> Table(ReconcilerContext ctx)
+                => ctx.ConditionalVariantManipulators;
+
+            public StyleConditionalVariantManipulator Create(ReconcilerContext ctx)
+                => new StyleConditionalVariantManipulator(ctx, _responsive, _dark);
+
+            public void Update(StyleConditionalVariantManipulator manipulator)
+                => manipulator.UpdatePayloads(_responsive, _dark);
+        }
+
+        private readonly struct RelationalVariantOp : IManipulatorOp<StyleRelationalVariantManipulator>
+        {
+            private readonly List<RelationalBindingConfig>? _configs;
+
+            internal RelationalVariantOp(List<RelationalBindingConfig>? configs)
+            {
+                _configs = configs;
+            }
+
+            public Dictionary<VisualElement, StyleRelationalVariantManipulator> Table(ReconcilerContext ctx)
+                => ctx.RelationalVariantManipulators;
+
+            public StyleRelationalVariantManipulator Create(ReconcilerContext ctx)
+                => new StyleRelationalVariantManipulator(ctx, _configs);
+
+            public void Update(StyleRelationalVariantManipulator manipulator)
+                => manipulator.UpdatePayloads(_configs);
+        }
+
+        private readonly struct HasVariantOp : IManipulatorOp<StyleHasVariantManipulator>
+        {
+            private readonly string[] _checked;
+            private readonly string[] _focus;
+
+            internal HasVariantOp(string[] @checked, string[] focus)
+            {
+                _checked = @checked;
+                _focus = focus;
+            }
+
+            public Dictionary<VisualElement, StyleHasVariantManipulator> Table(ReconcilerContext ctx)
+                => ctx.HasVariantManipulators;
+
+            public StyleHasVariantManipulator Create(ReconcilerContext ctx)
+                => new StyleHasVariantManipulator(ctx, _checked, _focus);
+
+            public void Update(StyleHasVariantManipulator manipulator)
+                => manipulator.UpdatePayloads(_checked, _focus);
+        }
+
+        private readonly struct ChildVariantOp : IManipulatorOp<StyleChildVariantManipulator>
+        {
+            private readonly string[] _payloads;
+
+            internal ChildVariantOp(string[] payloads)
+            {
+                _payloads = payloads;
+            }
+
+            public Dictionary<VisualElement, StyleChildVariantManipulator> Table(ReconcilerContext ctx)
+                => ctx.ChildVariantManipulators;
+
+            public StyleChildVariantManipulator Create(ReconcilerContext ctx)
+                => new StyleChildVariantManipulator(ctx, _payloads);
+
+            public void Update(StyleChildVariantManipulator manipulator)
+                => manipulator.UpdatePayloads(_payloads);
+        }
+
+        private readonly struct GapOp : IManipulatorOp<StyleGapManipulator>
+        {
+            private readonly float _gap;
+            private readonly GapAxis _axis;
+
+            internal GapOp(float gap, GapAxis axis)
+            {
+                _gap = gap;
+                _axis = axis;
+            }
+
+            public Dictionary<VisualElement, StyleGapManipulator> Table(ReconcilerContext ctx)
+                => ctx.GapManipulators;
+
+            public StyleGapManipulator Create(ReconcilerContext ctx)
+                => new StyleGapManipulator(_gap, _axis);
+
+            public void Update(StyleGapManipulator manipulator)
+                => manipulator.UpdateGap(_gap, _axis);
+        }
+
+        private readonly struct DivideOp : IManipulatorOp<StyleDivideManipulator>
+        {
+            private readonly DivideSpec _spec;
+
+            internal DivideOp(DivideSpec spec)
+            {
+                _spec = spec;
+            }
+
+            public Dictionary<VisualElement, StyleDivideManipulator> Table(ReconcilerContext ctx)
+                => ctx.DivideManipulators;
+
+            public StyleDivideManipulator Create(ReconcilerContext ctx)
+                => new StyleDivideManipulator(_spec, ctx);
+
+            public void Update(StyleDivideManipulator manipulator)
+                => manipulator.UpdateSpec(_spec);
+        }
+
+        private readonly struct GridOp : IManipulatorOp<StyleGridManipulator>
+        {
+            private readonly GridSpec _spec;
+
+            internal GridOp(GridSpec spec)
+            {
+                _spec = spec;
+            }
+
+            public Dictionary<VisualElement, StyleGridManipulator> Table(ReconcilerContext ctx)
+                => ctx.GridManipulators;
+
+            public StyleGridManipulator Create(ReconcilerContext ctx)
+                => new StyleGridManipulator(_spec);
+
+            public void Update(StyleGridManipulator manipulator)
+                => manipulator.UpdateSpec(_spec);
+        }
+
+        #endregion
+
         #region Variant Manipulator
 
         // Configures (creates / updates / removes) the element's StyleVariantManipulator
         // from the state-variant tokens (hover:/focus:/active:) found in classNames.
-        // Mirrors ApplyGestureManipulator.
         internal void ApplyVariantManipulator(VisualElement element, string[] classNames)
         {
             var hover = ExtractVariant(classNames, StyleVariantKind.Hover);
@@ -1658,24 +1882,8 @@ namespace Velvet
             var hasAny = hover.Length > 0 || focus.Length > 0 || focusVisible.Length > 0
                 || active.Length > 0 || @checked.Length > 0;
 
-            if (_ctx.VariantManipulators.TryGetValue(element, out var existing))
-            {
-                if (hasAny)
-                {
-                    existing.UpdatePayloads(hover, focus, focusVisible, active, @checked);
-                }
-                else
-                {
-                    element.RemoveManipulator(existing);
-                    _ctx.VariantManipulators.Remove(element);
-                }
-            }
-            else if (hasAny)
-            {
-                var manipulator = new StyleVariantManipulator(_ctx, hover, focus, focusVisible, active, @checked);
-                element.AddManipulator(manipulator);
-                _ctx.VariantManipulators[element] = manipulator;
-            }
+            Configure<VariantOp, StyleVariantManipulator>(element, hasAny,
+                new VariantOp(hover, focus, focusVisible, active, @checked));
         }
 
         private static string[] ExtractVariant(string[] classNames, StyleVariantKind kind)
@@ -1698,8 +1906,7 @@ namespace Velvet
         }
 
         // Configures the element's StyleConditionalVariantManipulator from the responsive
-        // (sm:/md:/lg:/xl:/2xl:) and dark: tokens in classNames. Mirrors
-        // ApplyVariantManipulator.
+        // (sm:/md:/lg:/xl:/2xl:) and dark: tokens in classNames.
         internal void ApplyConditionalVariantManipulator(VisualElement element, string[] classNames)
         {
             var responsive = new[]
@@ -1718,51 +1925,19 @@ namespace Velvet
                 hasAny = responsive[i].Length > 0;
             }
 
-            if (_ctx.ConditionalVariantManipulators.TryGetValue(element, out var existing))
-            {
-                if (hasAny)
-                {
-                    existing.UpdatePayloads(responsive, dark);
-                }
-                else
-                {
-                    element.RemoveManipulator(existing);
-                    _ctx.ConditionalVariantManipulators.Remove(element);
-                }
-            }
-            else if (hasAny)
-            {
-                var manipulator = new StyleConditionalVariantManipulator(_ctx, responsive, dark);
-                element.AddManipulator(manipulator);
-                _ctx.ConditionalVariantManipulators[element] = manipulator;
-            }
+            Configure<ConditionalVariantOp, StyleConditionalVariantManipulator>(element, hasAny,
+                new ConditionalVariantOp(responsive, dark));
         }
 
         // Configures the element's StyleRelationalVariantManipulator from the group-*/peer- tokens (incl. the
-        // named group-*/name · peer-*/name forms) in classNames. Mirrors ApplyVariantManipulator.
+        // named group-*/name · peer-*/name forms) in classNames.
         internal void ApplyRelationalVariantManipulator(VisualElement element, string[] classNames)
         {
             var configs = BuildRelationalConfigs(classNames);
             var hasAny = configs != null && configs.Count > 0;
 
-            if (_ctx.RelationalVariantManipulators.TryGetValue(element, out var existing))
-            {
-                if (hasAny)
-                {
-                    existing.UpdatePayloads(configs);
-                }
-                else
-                {
-                    element.RemoveManipulator(existing);
-                    _ctx.RelationalVariantManipulators.Remove(element);
-                }
-            }
-            else if (hasAny)
-            {
-                var manipulator = new StyleRelationalVariantManipulator(_ctx, configs);
-                element.AddManipulator(manipulator);
-                _ctx.RelationalVariantManipulators[element] = manipulator;
-            }
+            Configure<RelationalVariantOp, StyleRelationalVariantManipulator>(element, hasAny,
+                new RelationalVariantOp(configs));
         }
 
         // Groups the relational tokens by (relation, name) into one binding config each — so the unnamed
@@ -1835,33 +2010,17 @@ namespace Velvet
         }
 
         // Configures (creates / updates / removes) the element's StyleHasVariantManipulator from the
-        // event-driven has- tokens (has-[:checked]: / has-[:focus]:) in classNames. Mirrors
-        // ApplyVariantManipulator. The has-[.class]: form is handled separately by
-        // ApplyHasClassVariantConfig (a side-table, not an event manipulator).
+        // event-driven has- tokens (has-[:checked]: / has-[:focus]:) in classNames. The has-[.class]:
+        // form is handled separately by ApplyHasClassVariantConfig (a side-table, not an event
+        // manipulator).
         internal void ApplyHasVariantManipulator(VisualElement element, string[] classNames)
         {
             var @checked = ExtractHas(classNames, StyleHasKind.Checked);
             var focus = ExtractHas(classNames, StyleHasKind.Focus);
             var hasAny = @checked.Length > 0 || focus.Length > 0;
 
-            if (_ctx.HasVariantManipulators.TryGetValue(element, out var existing))
-            {
-                if (hasAny)
-                {
-                    existing.UpdatePayloads(@checked, focus);
-                }
-                else
-                {
-                    element.RemoveManipulator(existing);
-                    _ctx.HasVariantManipulators.Remove(element);
-                }
-            }
-            else if (hasAny)
-            {
-                var manipulator = new StyleHasVariantManipulator(_ctx, @checked, focus);
-                element.AddManipulator(manipulator);
-                _ctx.HasVariantManipulators[element] = manipulator;
-            }
+            Configure<HasVariantOp, StyleHasVariantManipulator>(element, hasAny,
+                new HasVariantOp(@checked, focus));
         }
 
         // Collects the payloads of every has-[:checked]: / has-[:focus]: token of the given kind. A payload
@@ -2401,11 +2560,7 @@ namespace Velvet
             // Fast early-out for the ~99% of elements with no [&>*]: class and no existing manipulator.
             if (!StyleChildVariantClass.HasChildVariantClass(classNames))
             {
-                if (_ctx.ChildVariantManipulators.TryGetValue(element, out var stale))
-                {
-                    element.RemoveManipulator(stale);
-                    _ctx.ChildVariantManipulators.Remove(element);
-                }
+                Configure<ChildVariantOp, StyleChildVariantManipulator>(element, wanted: false, default);
                 return;
             }
 
@@ -2413,30 +2568,14 @@ namespace Velvet
             // structural / has- / attribute- / supports-), so the real gate is TryExtract, not the prefix scan.
             var hasPayloads = StyleChildVariantClass.TryExtract(classNames, out var payloads);
 
-            if (_ctx.ChildVariantManipulators.TryGetValue(element, out var existing))
-            {
-                if (hasPayloads)
-                {
-                    existing.UpdatePayloads(payloads);
-                }
-                else
-                {
-                    element.RemoveManipulator(existing);
-                    _ctx.ChildVariantManipulators.Remove(element);
-                }
-            }
-            else if (hasPayloads)
-            {
-                var manipulator = new StyleChildVariantManipulator(_ctx, payloads);
-                element.AddManipulator(manipulator);
-                _ctx.ChildVariantManipulators[element] = manipulator;
-            }
+            Configure<ChildVariantOp, StyleChildVariantManipulator>(element, hasPayloads,
+                new ChildVariantOp(payloads));
         }
 
-        // Configures the element's StyleGapManipulator from the gap-* / gap-x-*
-        // / gap-y-* token in classNames and (re-)applies it so the inter-child
-        // margins reflect the current child set. Mirrors ApplyVariantManipulator. Call this
-        // AFTER the container's children have been reconciled so the manipulator sees the final child list.
+        // Configures the element's StyleGapManipulator from the gap-* / gap-x-* / gap-y-* token in
+        // classNames and (re-)applies it so the inter-child margins reflect the current child set. Call
+        // this AFTER the container's children have been reconciled so the manipulator sees the final
+        // child list.
         internal void ApplyGapManipulator(VisualElement element, string[] classNames)
         {
             // A grid container routes its gap through StyleGridManipulator (the grid owns the children's
@@ -2444,11 +2583,7 @@ namespace Velvet
             // Suppress the gap manipulator entirely when a grid-cols-* spec is present.
             if (StyleGridClass.HasGridClass(classNames))
             {
-                if (_ctx.GapManipulators.TryGetValue(element, out var gridOwned))
-                {
-                    element.RemoveManipulator(gridOwned);
-                    _ctx.GapManipulators.Remove(element);
-                }
+                Configure<GapOp, StyleGapManipulator>(element, wanted: false, default);
                 return;
             }
 
@@ -2456,34 +2591,13 @@ namespace Velvet
             // cheap prefix scan (no dictionary lookup, no substring) before the full TryExtract parse.
             if (!StyleGapClass.HasGapClass(classNames))
             {
-                if (_ctx.GapManipulators.TryGetValue(element, out var stale))
-                {
-                    element.RemoveManipulator(stale);
-                    _ctx.GapManipulators.Remove(element);
-                }
+                Configure<GapOp, StyleGapManipulator>(element, wanted: false, default);
                 return;
             }
 
             var hasGap = StyleGapClass.TryExtract(classNames, out var gap, out var axis);
 
-            if (_ctx.GapManipulators.TryGetValue(element, out var existing))
-            {
-                if (hasGap)
-                {
-                    existing.UpdateGap(gap, axis);
-                }
-                else
-                {
-                    element.RemoveManipulator(existing);
-                    _ctx.GapManipulators.Remove(element);
-                }
-            }
-            else if (hasGap)
-            {
-                var manipulator = new StyleGapManipulator(gap, axis);
-                element.AddManipulator(manipulator);
-                _ctx.GapManipulators[element] = manipulator;
-            }
+            Configure<GapOp, StyleGapManipulator>(element, hasGap, new GapOp(gap, axis));
         }
 
         // Configures the element's StyleDivideManipulator from the divide-x / divide-y (+ width / color)
@@ -2495,34 +2609,13 @@ namespace Velvet
             // Fast early-out for the ~99% of elements with no divide class and no existing manipulator.
             if (!StyleDivideClass.HasDivideClass(classNames))
             {
-                if (_ctx.DivideManipulators.TryGetValue(element, out var stale))
-                {
-                    element.RemoveManipulator(stale);
-                    _ctx.DivideManipulators.Remove(element);
-                }
+                Configure<DivideOp, StyleDivideManipulator>(element, wanted: false, default);
                 return;
             }
 
             var hasDivide = StyleDivideClass.TryExtract(classNames, out var spec);
 
-            if (_ctx.DivideManipulators.TryGetValue(element, out var existing))
-            {
-                if (hasDivide)
-                {
-                    existing.UpdateSpec(spec);
-                }
-                else
-                {
-                    element.RemoveManipulator(existing);
-                    _ctx.DivideManipulators.Remove(element);
-                }
-            }
-            else if (hasDivide)
-            {
-                var manipulator = new StyleDivideManipulator(spec, _ctx);
-                element.AddManipulator(manipulator);
-                _ctx.DivideManipulators[element] = manipulator;
-            }
+            Configure<DivideOp, StyleDivideManipulator>(element, hasDivide, new DivideOp(spec));
         }
 
         // Configures the element's StyleGridManipulator from the grid-cols-* token (and the gap-* it owns) in
@@ -2534,36 +2627,15 @@ namespace Velvet
             // Fast early-out for the ~99% of elements with no grid-cols class and no existing manipulator.
             if (!StyleGridClass.HasGridClass(classNames))
             {
-                if (_ctx.GridManipulators.TryGetValue(element, out var stale))
-                {
-                    element.RemoveManipulator(stale);
-                    _ctx.GridManipulators.Remove(element);
-                }
+                Configure<GridOp, StyleGridManipulator>(element, wanted: false, default);
                 return;
             }
 
             var hasGrid = StyleGridClass.TryExtract(classNames, out var columns);
             StyleGridClass.ExtractGaps(classNames, out var columnGap, out var rowGap);
-            var spec = new GridSpec(columns, columnGap, rowGap);
 
-            if (_ctx.GridManipulators.TryGetValue(element, out var existing))
-            {
-                if (hasGrid)
-                {
-                    existing.UpdateSpec(spec);
-                }
-                else
-                {
-                    element.RemoveManipulator(existing);
-                    _ctx.GridManipulators.Remove(element);
-                }
-            }
-            else if (hasGrid)
-            {
-                var manipulator = new StyleGridManipulator(spec);
-                element.AddManipulator(manipulator);
-                _ctx.GridManipulators[element] = manipulator;
-            }
+            Configure<GridOp, StyleGridManipulator>(element, hasGrid,
+                new GridOp(new GridSpec(columns, columnGap, rowGap)));
         }
 
         // Configures the element's StyleTextBalanceManipulator from the `text-balance` token in
@@ -2576,6 +2648,9 @@ namespace Velvet
         // ApplyGapManipulator's timing — call AFTER the container's children have been reconciled
         // (harmless here since text-balance does not read children, but keeps every per-element style
         // manipulator attached at the same, single, well-known point in the pass).
+        // Kept outside the shared Configure step: its teardown owes the element an extra restore of the
+        // shared inline maxWidth slot, and the shared body has no way to signal that tail step. Folding
+        // it in would add a teardown hook the eight other families would carry for nothing.
         internal void ApplyTextBalanceManipulator(VisualElement element, string[] classNames)
         {
             // Fast early-out for the ~99% of elements with no text-balance class and no existing manipulator.

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
@@ -1680,9 +1680,9 @@ namespace Velvet
             {
                 if (wanted)
                 {
-                    // Keep this unconditional — never gate it on "the spec is unchanged". Gap / divide /
-                    // grid re-derive against the CURRENT child set and text-balance re-wins a shared
-                    // inline slot, both of which move without any class token changing.
+                    // Keep this unconditional — never gate it on "the spec is unchanged". Gap, divide and
+                    // grid re-derive against the CURRENT child set, which moves without any class token
+                    // changing.
                     op.Update(existing);
                 }
                 else

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/StyleManipulatorReconcileBenchmarks.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/StyleManipulatorReconcileBenchmarks.cs
@@ -1,0 +1,181 @@
+// The class-name parse cache's drain hook is editor-only, and the unchanged-class measurement below
+// depends on it to put two content-identical trees on the class diff's content-compare path.
+#if UNITY_EDITOR
+using System;
+using NUnit.Framework;
+using Unity.PerformanceTesting;
+using UnityEngine.UIElements;
+
+namespace Velvet.Tests.Performance
+{
+    /// <summary>
+    /// Benchmarks the per-element style-manipulator configure pass: the state / conditional /
+    /// relational / has- variant families (re-derived only when the class list changed CONTENT) and
+    /// the child-variant / gap / divide / grid / text-balance families (re-applied on every patch,
+    /// because they re-derive against the current child set).
+    /// A class-less tree never enters any of those blocks — every family early-outs on the first
+    /// token scan — so the label-only reconciler benchmarks cannot detect a cost added there. The
+    /// rows here carry live tokens of all nine families, which makes this fixture the measurement
+    /// that gates changes to the configure pass. Between them the four cases drive all three
+    /// branches: create, update and teardown.
+    /// </summary>
+    internal sealed class StyleManipulatorReconcileBenchmarks
+    {
+        private const int k_Rows = 100;
+        private const int k_WarmupCount = 5;
+        private const int k_MeasurementCount = 20;
+
+        // grid-cols-* suppresses the gap manipulator (the grid owns the child margins), so the gap
+        // family is exercised on the row containers and its suppression path on the grid containers.
+        private const string k_GridClass = "grid grid-cols-3 gap-4";
+
+        // The stripped counterparts keep the element type and child count of their decorated twins so
+        // a reconcile between the two is a pure class change: same elements, no create or destroy.
+        private const string k_StrippedRowClass = "flex flex-row";
+        private const string k_StrippedGridClass = "flex flex-col";
+
+        private Reconciler _reconciler = null!;
+        private VisualElement _root = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _reconciler = new Reconciler();
+            _root = new VisualElement();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _reconciler.Dispose();
+        }
+
+        // Element creation runs the create branch of every family.
+        [Test, Performance]
+        public void Mount_100StyledRows()
+        {
+            var rows = BuildRows("red");
+
+            Measure.Method(() =>
+                {
+                    _reconciler.Reconcile(_root, Array.Empty<VNode>(), rows);
+                    _reconciler.Reconcile(_root, rows, Array.Empty<VNode>());
+                })
+                .GC()
+                .WarmupCount(k_WarmupCount)
+                .MeasurementCount(k_MeasurementCount)
+                .Run();
+        }
+
+        // Distinct VNode instances carrying the same tokens in freshly parsed arrays: the reference
+        // skips in ChildReconciler and DiffClassList both miss, so every element is patched and the
+        // class diff runs its full content comparison — which reports no change, leaving the four
+        // variant families unvisited. What remains is the every-patch cost of child-variant / gap /
+        // divide / grid / text-balance.
+        [Test, Performance]
+        public void Reconcile_UnchangedClassList_100StyledRows()
+        {
+            var mounted = BuildRows("red");
+            // Parsed class-name arrays are cached by string CONTENT, so a second build from the same
+            // strings would hand back the very same arrays and the class diff would exit at its
+            // identity check. Draining the cache reproduces what a component that rebuilds its VNode
+            // tree every render actually hands the reconciler.
+            V.ClearClassNameCacheForTesting();
+            var repeat = BuildRows("red");
+            _reconciler.Reconcile(_root, Array.Empty<VNode>(), mounted);
+
+            Measure.Method(() => _reconciler.Reconcile(_root, mounted, repeat))
+                .GC()
+                .WarmupCount(k_WarmupCount)
+                .MeasurementCount(k_MeasurementCount)
+                .Run();
+        }
+
+        // Only the variant PAYLOADS differ between the two trees, and no variant token ever enters
+        // the USS class list, so the class diff itself does almost nothing while all four variant
+        // families take their update branch on every row: the warm path a consolidation of the
+        // configure shape has to leave untouched.
+        [Test, Performance]
+        public void Reconcile_ChangedClassList_100StyledRows()
+        {
+            var oldRows = BuildRows("red");
+            var newRows = BuildRows("blue");
+            _reconciler.Reconcile(_root, Array.Empty<VNode>(), oldRows);
+
+            Measure.Method(() => _reconciler.Reconcile(_root, oldRows, newRows))
+                .GC()
+                .WarmupCount(k_WarmupCount)
+                .MeasurementCount(k_MeasurementCount)
+                .Run();
+        }
+
+        // Losing a utility class while staying mounted: every family finds its manipulator in the
+        // table, no longer wanted, and has to detach it from the still-live element and drop the
+        // table entry. A wholesale unmount cannot stand in for this — that path runs through
+        // FiberElementCleaner and never reaches the configure step at all.
+        // Measured as a round trip because a single strip only tears down on its first iteration;
+        // re-decorating first puts every iteration back on the teardown branch.
+        [Test, Performance]
+        public void Reconcile_StripAndRestoreClassList_100StyledRows()
+        {
+            var decorated = BuildRows("red");
+            var stripped = BuildStrippedRows();
+            _reconciler.Reconcile(_root, Array.Empty<VNode>(), stripped);
+
+            Measure.Method(() =>
+                {
+                    _reconciler.Reconcile(_root, stripped, decorated);
+                    _reconciler.Reconcile(_root, decorated, stripped);
+                })
+                .GC()
+                .WarmupCount(k_WarmupCount)
+                .MeasurementCount(k_MeasurementCount)
+                .Run();
+        }
+
+        private static VNode[] BuildRows(string tint)
+        {
+            var rowClass = RowClass(tint);
+            var leafClass = LeafClass(tint);
+            var rows = new VNode[k_Rows];
+            for (var i = 0; i < k_Rows; i++)
+            {
+                rows[i] = V.Div(rowClass,
+                    V.Div(k_GridClass,
+                        V.Label(className: leafClass, text: "cell-a"),
+                        V.Label(className: leafClass, text: "cell-b")),
+                    V.Label(className: leafClass, text: "tail"));
+            }
+            return rows;
+        }
+
+        private static VNode[] BuildStrippedRows()
+        {
+            var rows = new VNode[k_Rows];
+            for (var i = 0; i < k_Rows; i++)
+            {
+                rows[i] = V.Div(k_StrippedRowClass,
+                    V.Div(k_StrippedGridClass,
+                        V.Label(text: "cell-a"),
+                        V.Label(text: "cell-b")),
+                    V.Label(text: "tail"));
+            }
+            return rows;
+        }
+
+        // One token of every family whose manipulator hangs off the container: state variants,
+        // responsive + dark conditionals, group-/peer- relationals, event-driven has-, the [&>*]:
+        // child combinator, gap and divide. `tint` varies only the variant payloads.
+        private static string RowClass(string tint) =>
+            "flex flex-row group gap-4 divide-y divide-gray-200 [&>*]:mt-2 "
+            + $"hover:bg-{tint}-500 focus:bg-{tint}-400 active:bg-{tint}-300 "
+            + $"sm:p-2 md:p-3 lg:p-4 dark:bg-{tint}-500 "
+            + "group-hover:opacity-50 peer-hover:opacity-75 "
+            + $"has-[:checked]:bg-{tint}-500 has-[:focus]:text-{tint}-500";
+
+        // Leaves carry text-balance plus a single variant family, the shape most elements in a real
+        // tree have.
+        private static string LeafClass(string tint) => $"text-balance hover:text-{tint}-500";
+    }
+}
+#endif

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/StyleManipulatorReconcileBenchmarks.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/StyleManipulatorReconcileBenchmarks.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1113938f93cac40b992bacecf963cd33


### PR DESCRIPTION
## What & why

`FiberNodePatcher` repeated the same configure-or-teardown shape once per manipulator family: look the manipulator up in a per-element table, update it if it is still wanted, detach and forget it if it is not, construct and record it if it is newly wanted. Adding a family meant copying the shape again, and a fix to the shape had to be applied to every copy.

Eight of the nine families now share one body, parameterised by a readonly struct that supplies the family's table, constructor and update call. The struct is passed by value under a `struct` type constraint, so each call site resolves to a direct, non-virtual call on a stack value — no delegate, no boxing, no interface receiver. Text-balance stays separate: its teardown owes a restore of a shared inline slot that the shared body has no way to signal.

Behavior is unchanged for all eight families: the same "still wanted" predicate, the same pre-scan early-outs in the same order (including the grid check that suppresses the gap manipulator before the gap scan runs), the same detach-before-table-write ordering, and the same unconditional update — gap, divide and grid re-derive against the current child set on every patch, so gating the update on an unchanged spec would silently regress them.

The existing benchmarks never reached this code — they build text leaves, whose class lists are empty, so every family exits at its first token scan. Three new benchmarks cover it: a re-reconcile with an unchanged class list (the five families that run on every patch), one with a changed class list (the four gated on a class-content change), and a strip-and-restore round trip that drives the teardown branch while the element stays mounted. Measured on an otherwise idle machine across three independent before/after pairs, allocation counts are identical to the byte in every case, and the changed-class and unchanged-class timings overlap completely between the two arms.

## Checklist

- [x] Tests pass locally (EditMode / PlayMode / generator tests as applicable) — EditMode 3267 passed / 0 failed, PlayMode 95 passed / 0 failed
- [x] New regression tests were verified red without the change and green with it — n/a: no behavior change, so no new regression test. The per-family parity fixtures (gap, grid, divide, child-variant, text-balance, variant cleanup) stay green, and several of them assert manipulator-table contents by reflection, so a dropped detach fails loudly
- [x] Docs are updated for every fact this change touches (guides, READMEs, CLAUDE.md) — or this PR has no doc impact
- [x] CHANGELOG updated for behavior/perf changes (pure refactors are omitted by convention)
- [x] Known gaps or deliberate deferrals discovered here are filed as issues with acceptance criteria — one deliberate deferral, stated rather than filed: the conditional-variant family still allocates its payload array unconditionally, which is a behavior-visible change and does not belong in a no-op refactor

Closes #145