### PR TITLE
refactor(velvet): restructure the inline-expansion walk and the indexed reconcile path

### DIFF
--- a/Packages/com.velvet.core/Runtime/Reconciler/ChildReconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ChildReconciler.cs
@@ -598,6 +598,38 @@ namespace Velvet
 
         #region Indexed Pass
 
+        // Inputs fixed for the whole indexed reconcile. A readonly struct passed `in`, NOT a heap state
+        // object like the keyed path's KeyedReconcileState: the unkeyed diff is the framework's hottest
+        // list update and almost always runs at a zero budget with nothing to park, so a per-reconcile
+        // allocation here would be paid by every plain list render. The resumable cursor (phase + index)
+        // deliberately stays out of this struct — it lives in the dispatcher's locals while running and in
+        // IndexedReconcileState while parked.
+        private readonly struct IndexedPassInputs
+        {
+            public readonly VisualElement Parent;
+            public readonly VNode?[] OldNodes;
+            public readonly VNode?[] NewNodes;
+            public readonly int SlotStart;
+            public readonly int SlotLimit;
+
+            public IndexedPassInputs(
+                VisualElement parent, VNode?[] oldNodes, VNode?[] newNodes, int slotStart, int slotLimit)
+            {
+                Parent = parent;
+                OldNodes = oldNodes;
+                NewNodes = newNodes;
+                SlotStart = slotStart;
+                SlotLimit = slotLimit;
+            }
+
+            // Derived on demand rather than stored, so the shared-prefix length has exactly one definition
+            // for the dispatcher and all three phases.
+            public int CommonLength => Math.Min(OldNodes.Length, NewNodes.Length);
+        }
+
+        // State-machine dispatcher for indexed reconciliation, mirroring ReconcileKeyedFrom: each phase is
+        // its own method, the successor phase and its start index are assigned here, and a phase that
+        // yields has already parked its own resume point.
         private void ReconcileIndexedFrom(
             VisualElement? parent,
             VNode?[] oldNodes,
@@ -620,127 +652,170 @@ namespace Velvet
 
             if (parent == null) return;
 
-            var commonLength = Math.Min(oldNodes.Length, newNodes.Length);
-            var budgeted = frameBudgetMs > 0;
+            var inputs = new IndexedPassInputs(parent, oldNodes, newNodes, slotStart, slotLimit);
 
-            if (budgeted)
+            if (frameBudgetMs > 0)
             {
                 _stopwatch ??= new Stopwatch();
                 _stopwatch.Restart();
             }
 
-            #region Phase: Common
-
-            if (startPhase == IndexedReconcilePhase.Common)
+            var phase = startPhase;
+            var index = startIndex;
+            while (phase != IndexedReconcilePhase.Done)
             {
-                for (var i = startIndex; i < commonLength; i++)
+                switch (phase)
                 {
-                    if (_ctx.IsAborted) return;
+                    case IndexedReconcilePhase.Common:
+                        if (!CommonPhase(in inputs, index, frameBudgetMs)) return;
+                        phase = IndexedReconcilePhase.Remove;
+                        index = RemovePhaseStartSentinel;
+                        break;
+                    case IndexedReconcilePhase.Remove:
+                        if (!RemovePhase(in inputs, index, frameBudgetMs)) return;
+                        phase = IndexedReconcilePhase.Add;
+                        index = inputs.CommonLength;
+                        break;
+                    case IndexedReconcilePhase.Add:
+                        if (!AddPhase(in inputs, index, frameBudgetMs)) return;
+                        phase = IndexedReconcilePhase.Done;
+                        break;
+                    default:
+                        throw new InvalidOperationException(
+                            $"[ChildReconciler] Unhandled IndexedReconcilePhase: {phase}");
+                }
+                // An error-boundary abort parks nothing and must end the pass here — unlike a yield, which
+                // already parked its own resume point, an aborted phase reports completion so this is the
+                // only place that can stop the machine before it advances into the next phase's work.
+                if (_ctx.IsAborted) return;
+            }
+        }
 
-                    // Identical VNode instances are guaranteed to be diff-free. Skipping the DOM
-                    // lookup and DiffProps invocation suppresses outlier GC allocations on the
-                    // no-change path.
-                    if (ReferenceEquals(oldNodes[i], newNodes[i]))
-                    {
-                        if (budgeted && _stopwatch!.Elapsed.TotalMilliseconds > frameBudgetMs)
-                        {
-                            PendingIndexedState = new IndexedReconcileState(
-                                parent, oldNodes, newNodes,
-                                IndexedReconcilePhase.Common, resumeIndex: i + 1, slotStart: slotStart, slotLimit: slotLimit);
-                            _stopwatch.Stop();
-                            return;
-                        }
-                        continue;
-                    }
+        // Parks the resume point for a phase that ran out of budget. Only ever called where the caller has
+        // proven another iteration remains, so HasPendingWork never reports a resume that has nothing left.
+        private void ParkIndexedResume(
+            in IndexedPassInputs inputs, IndexedReconcilePhase resumePhase, int resumeIndex)
+        {
+            PendingIndexedState = new IndexedReconcileState(
+                inputs.Parent, inputs.OldNodes, inputs.NewNodes,
+                resumePhase, resumeIndex, slotStart: inputs.SlotStart, slotLimit: inputs.SlotLimit);
+            _stopwatch!.Stop();
+        }
 
-                    // DOM-desync recovery: the baseline (oldNodes) is a positional prefix of the live children,
-                    // but a transient AnimatePresence overlap (an exit ghost whose VE was dropped, or a key
-                    // re-entered mid-exit) can leave the live container SHORTER than the baseline claims, so the
-                    // slot this index expects no longer exists. Rather than over-index parent.ElementAt, create the
-                    // model's child to converge the DOM toward the (authoritative) new tree; the missing tail is
-                    // built the same way and the Remove phase skips the absent slots.
-                    // Bound by slotLimit (this fiber's range end), not just childCount: for a non-last inline
-                    // tenant childCount includes the following sibling's rows, so an unbounded check would treat a
-                    // sibling row as this fiber's and PATCH it. Out of range → create within this fiber's range.
-                    var slotExists = slotStart + i < Math.Min(SilhouetteBoundsSpacer.NonSpacerChildCount(parent), slotLimit);
-                    if (PatchOrReplaceAtSlot(parent, slotStart, i, oldNodes[i], newNodes[i],
-                            slotExists, clampInsertIndex: true, checkAbortAfterCreate: true))
-                    {
-                        return;
-                    }
+        // Returns false only on a yield (this phase parked its resume point); true when the phase is done
+        // with the range — including when an abort cut it short, which the dispatcher detects separately.
+        private bool CommonPhase(in IndexedPassInputs inputs, int startIndex, double frameBudgetMs)
+        {
+            var parent = inputs.Parent;
+            var oldNodes = inputs.OldNodes;
+            var newNodes = inputs.NewNodes;
+            var slotStart = inputs.SlotStart;
+            var slotLimit = inputs.SlotLimit;
+            var commonLength = inputs.CommonLength;
+            var budgeted = frameBudgetMs > 0;
 
+            for (var i = startIndex; i < commonLength; i++)
+            {
+                if (_ctx.IsAborted) return true;
+
+                // Identical VNode instances are guaranteed to be diff-free. Skipping the DOM
+                // lookup and DiffProps invocation suppresses outlier GC allocations on the
+                // no-change path.
+                if (ReferenceEquals(oldNodes[i], newNodes[i]))
+                {
                     if (budgeted && _stopwatch!.Elapsed.TotalMilliseconds > frameBudgetMs)
                     {
-                        PendingIndexedState = new IndexedReconcileState(
-                            parent, oldNodes, newNodes,
-                            IndexedReconcilePhase.Common, resumeIndex: i + 1, slotStart: slotStart, slotLimit: slotLimit);
-                        _stopwatch.Stop();
-                        return;
+                        ParkIndexedResume(in inputs, IndexedReconcilePhase.Common, resumeIndex: i + 1);
+                        return false;
                     }
+                    continue;
                 }
 
-                startPhase = IndexedReconcilePhase.Remove;
-                startIndex = RemovePhaseStartSentinel;
-            }
-
-            #endregion
-
-            #region Phase: Remove
-
-            if (startPhase == IndexedReconcilePhase.Remove)
-            {
-                // Removal proceeds from the tail, so the resume index is "the tail index to process".
-                // RemovePhaseStartSentinel signals phase start (which begins from oldNodes.Length-1).
-                var removeStart = startIndex == RemovePhaseStartSentinel ? oldNodes.Length - 1 : startIndex;
-                for (var i = removeStart; i >= commonLength; i--)
+                // DOM-desync recovery: the baseline (oldNodes) is a positional prefix of the live children,
+                // but a transient AnimatePresence overlap (an exit ghost whose VE was dropped, or a key
+                // re-entered mid-exit) can leave the live container SHORTER than the baseline claims, so the
+                // slot this index expects no longer exists. Rather than over-index parent.ElementAt, create the
+                // model's child to converge the DOM toward the (authoritative) new tree; the missing tail is
+                // built the same way and the Remove phase skips the absent slots.
+                // Bound by slotLimit (this fiber's range end), not just childCount: for a non-last inline
+                // tenant childCount includes the following sibling's rows, so an unbounded check would treat a
+                // sibling row as this fiber's and PATCH it. Out of range → create within this fiber's range.
+                var slotExists = slotStart + i < Math.Min(SilhouetteBoundsSpacer.NonSpacerChildCount(parent), slotLimit);
+                if (PatchOrReplaceAtSlot(parent, slotStart, i, oldNodes[i], newNodes[i],
+                        slotExists, clampInsertIndex: true, checkAbortAfterCreate: true))
                 {
-                    if (_ctx.IsAborted) return;
-
-                    // DOM-desync recovery (see the Common phase): when the live container is shorter than the
-                    // baseline claims, the tail slot to remove may not exist — skip it instead of over-indexing.
-                    // NonSpacerChildCount so a trailing filter bounds-spacer is never the slot removal targets.
-                    if (slotStart + i >= SilhouetteBoundsSpacer.NonSpacerChildCount(parent))
-                    {
-                        continue;
-                    }
-                    _cleaner.RemoveElement(parent, slotStart + i);
-
-                    if (budgeted && _stopwatch!.Elapsed.TotalMilliseconds > frameBudgetMs)
-                    {
-                        var nextRemoveIndex = i - 1;
-                        if (nextRemoveIndex >= commonLength)
-                        {
-                            // Save pending only when another iteration remains.
-                            // nextRemoveIndex == RemovePhaseStartSentinel (-1) signals "phase start",
-                            // so the nextRemoveIndex >= commonLength check is required to avoid that collision.
-                            PendingIndexedState = new IndexedReconcileState(
-                                parent, oldNodes, newNodes,
-                                IndexedReconcilePhase.Remove, resumeIndex: nextRemoveIndex, slotStart: slotStart, slotLimit: slotLimit);
-                            _stopwatch.Stop();
-                            return;
-                        }
-                        // nextRemoveIndex < commonLength: no Remove iterations remain, so saving pending is unnecessary.
-                        // Fall through to the Add phase as-is, even though _stopwatch already shows a budget overrun.
-                        // The Add phase runs a budget check after the first element, so the overrun is bounded
-                        // to "one element" at worst (intentional).
-                    }
+                    return true;
                 }
 
-                startPhase = IndexedReconcilePhase.Add;
-                startIndex = commonLength;
+                if (budgeted && _stopwatch!.Elapsed.TotalMilliseconds > frameBudgetMs)
+                {
+                    ParkIndexedResume(in inputs, IndexedReconcilePhase.Common, resumeIndex: i + 1);
+                    return false;
+                }
             }
 
-            #endregion
+            return true;
+        }
 
-            #region Phase: Add
+        // Removal proceeds from the tail, so the resume index is "the tail index to process" and
+        // RemovePhaseStartSentinel means "begin at oldNodes.Length - 1". Decoding the sentinel and the
+        // guard against re-encoding it (below) describe the same encoding and must move together.
+        private bool RemovePhase(in IndexedPassInputs inputs, int startIndex, double frameBudgetMs)
+        {
+            var parent = inputs.Parent;
+            var slotStart = inputs.SlotStart;
+            var commonLength = inputs.CommonLength;
+            var budgeted = frameBudgetMs > 0;
 
-            // At this point startPhase is always Add (Common/Remove fall-through or Add resume).
+            var removeStart = startIndex == RemovePhaseStartSentinel ? inputs.OldNodes.Length - 1 : startIndex;
+            for (var i = removeStart; i >= commonLength; i--)
+            {
+                if (_ctx.IsAborted) return true;
+
+                // DOM-desync recovery (see the Common phase): when the live container is shorter than the
+                // baseline claims, the tail slot to remove may not exist — skip it instead of over-indexing.
+                // NonSpacerChildCount so a trailing filter bounds-spacer is never the slot removal targets.
+                if (slotStart + i >= SilhouetteBoundsSpacer.NonSpacerChildCount(parent))
+                {
+                    continue;
+                }
+                _cleaner.RemoveElement(parent, slotStart + i);
+
+                if (budgeted && _stopwatch!.Elapsed.TotalMilliseconds > frameBudgetMs)
+                {
+                    var nextRemoveIndex = i - 1;
+                    if (nextRemoveIndex >= commonLength)
+                    {
+                        // Park only when another iteration remains. nextRemoveIndex ==
+                        // RemovePhaseStartSentinel (-1) is this phase's own "begin at the tail" encoding,
+                        // so parking that value would restart the whole phase instead of resuming it —
+                        // the nextRemoveIndex >= commonLength test is what keeps the two apart.
+                        ParkIndexedResume(in inputs, IndexedReconcilePhase.Remove, nextRemoveIndex);
+                        return false;
+                    }
+                    // nextRemoveIndex < commonLength: no Remove iterations remain, so nothing is parked and
+                    // the pass falls into Add already over budget. Deliberate, not an oversight — Add runs a
+                    // budget check after its first element, bounding the overrun to one element. Do not
+                    // "fix" this into a yield.
+                }
+            }
+
+            return true;
+        }
+
+        private bool AddPhase(in IndexedPassInputs inputs, int startIndex, double frameBudgetMs)
+        {
+            var parent = inputs.Parent;
+            var newNodes = inputs.NewNodes;
+            var slotStart = inputs.SlotStart;
+            var budgeted = frameBudgetMs > 0;
+
             for (var i = startIndex; i < newNodes.Length; i++)
             {
-                if (_ctx.IsAborted) return;
+                if (_ctx.IsAborted) return true;
 
                 var newElement = _factory.CreateElement(newNodes[i]);
-                if (_ctx.IsAborted) return;
+                if (_ctx.IsAborted) return true;
                 // Insert at the absolute slot to avoid colliding with siblings outside this fiber's
                 // range when slotStart > 0. When the range covers the entire children list, this is
                 // equivalent to Add (slotStart + i == parent.childCount at this point). Clamp to childCount so a
@@ -753,19 +828,16 @@ namespace Velvet
                     var nextAddIndex = i + 1;
                     if (nextAddIndex < newNodes.Length)
                     {
-                        // Save pending only when another iteration remains.
+                        // Park only when another iteration remains.
                         // No pending is needed when the final element has already been processed.
-                        PendingIndexedState = new IndexedReconcileState(
-                            parent, oldNodes, newNodes,
-                            IndexedReconcilePhase.Add, resumeIndex: nextAddIndex, slotStart: slotStart, slotLimit: slotLimit);
-                        _stopwatch.Stop();
-                        return;
+                        ParkIndexedResume(in inputs, IndexedReconcilePhase.Add, nextAddIndex);
+                        return false;
                     }
                     // nextAddIndex >= newNodes.Length: all Add iterations done → fall through.
                 }
             }
 
-            #endregion
+            return true;
         }
 
         #endregion

--- a/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
@@ -49,7 +49,7 @@ namespace Velvet
         // (neither needs live context). This is a depth-first descent that reconciles + renders
         // each node under live context, then places its host element on the way back up; the
         // flat fast path (pure-leaf containers) keeps the time-sliced Indexed/Keyed machinery.
-        private sealed class GeneralCommitState
+        internal sealed class GeneralCommitState
         {
             public VisualElement? Parent;
             public int SlotStart;
@@ -132,17 +132,23 @@ namespace Velvet
                 // Live-context walk: emit + commit each new leaf under its ancestor Providers.
                 var positionCounters = pool.RentPositionCounter();
                 var prevFlag = _ctx.ContextValueChanged;
-                var newProviderIndex = 0;
+                var walk = pool.RentInlineWalk();
+                walk.IsNewSide = true;
+                walk.Parent = parent;
+                walk.SlotStart = slotStart;
+                walk.OldFibers = oldFibers;
+                walk.NewFibers = newFibers;
+                walk.OldProvidersForPairing = oldProviders;
+                walk.Commit = commit;
                 try
                 {
-                    ExpandInlineRecursive(newChildren, result: null, isNewSide: true, parent, slotStart,
-                        oldFibers, newFibers, providers: null, oldProvidersForPairing: oldProviders,
-                        positionCounters, ref newProviderIndex, fragmentKeyScope: null, commit);
+                    ExpandInlineRecursive(walk, newChildren, positionCounters, fragmentKeyScope: null);
                 }
                 finally
                 {
                     _ctx.ContextValueChanged = prevFlag;
                     pool.ReturnPositionCounter(positionCounters);
+                    pool.ReturnInlineWalk(walk);
                 }
 
                 // Orphan effect cleanups run BEFORE the DOM-removal pass (Finalize → RemoveElement),
@@ -364,6 +370,56 @@ namespace Velvet
 
         #region Inline expansion
 
+        // Rented from ReconcilerBufferPool once per outer walk and returned at that walk's exit, never
+        // per recursion.
+        //
+        // Do NOT hold a single cached instance on this class: the walk re-enters itself through the commit
+        // (CommitLeaf -> PatchNode -> ReconcileChildren -> ChildReconciler.Reconcile -> back here), so the
+        // nested walk would overwrite the outer one's fields mid-descent.
+        //
+        // Do NOT fold this into GeneralCommitState either: the old-side structural walk runs with a null
+        // Commit and still needs every other field here.
+        //
+        // Providers is read only on the old-side branch and OldProvidersForPairing only on the new-side
+        // branch, and no recursion flips IsNewSide — so one copy of each per walk is exact. ReconcileGeneral
+        // cannot break that by construction: it always walks the new side and has no old-side Providers
+        // parameter to hand over. ExpandInlineForReconcile takes both lists from its caller, so that is the
+        // entry carrying the runtime check.
+        internal sealed class InlineWalk
+        {
+            // Flat structural output (old-side / fast-path expansion). Null on the general commit path,
+            // where Commit is what receives each emitted leaf instead.
+            public List<VNode>? Result;
+            public bool IsNewSide;
+            public VisualElement? Parent;
+            public int SlotStart;
+            public List<ComponentFiber> OldFibers = null!;
+            public HashSet<ComponentFiber> NewFibers = null!;
+            public List<ContextProviderNode>? Providers;
+            public List<ContextProviderNode>? OldProvidersForPairing;
+            public GeneralCommitState? Commit;
+            // Expansion-order position of the next new-side Provider, paired against
+            // OldProvidersForPairing. Monotonic for the whole walk: nothing rewinds it, including a
+            // Suspense rollback that discards a primary subtree the counter has already advanced through.
+            public int NewProviderIndex;
+
+            // Every field a walk may set is scrubbed here: a stale reference surviving into the next
+            // rent would silently splice one walk's destination or fiber accumulators into another's.
+            public void Clear()
+            {
+                Result = null;
+                IsNewSide = false;
+                Parent = null;
+                SlotStart = 0;
+                OldFibers = null!;
+                NewFibers = null!;
+                Providers = null;
+                OldProvidersForPairing = null;
+                Commit = null;
+                NewProviderIndex = 0;
+            }
+        }
+
         // A node type that forces the live-context inline-expansion slow path: a ComponentNode renders, a
         // Provider/Fragment is transparent, a Suspense/Memo/AnimatePresence expands inline (wrapper-less),
         // and a null is filtered. Both the fast/slow routing in NeedsExpansion and the early-out inside
@@ -405,6 +461,8 @@ namespace Velvet
             List<ContextProviderNode>? providers = null,
             List<ContextProviderNode>? oldProvidersForPairing = null)
         {
+            AssertProviderListMatchesSide(isNewSide, providers, oldProvidersForPairing);
+
             if (nodes == null || nodes.Length == 0) return Array.Empty<VNode>();
 
             // Fast path: no inline expansion required. ComponentNode is always expanded inline
@@ -428,10 +486,18 @@ namespace Velvet
             var buffer = _ctx.BufferPool.RentNodeList();
             var positionCounters = _ctx.BufferPool.RentPositionCounter();
             var prevFlag = _ctx.ContextValueChanged;
-            var newProviderIndex = 0;
+            var walk = _ctx.BufferPool.RentInlineWalk();
+            walk.Result = buffer;
+            walk.IsNewSide = isNewSide;
+            walk.Parent = parent;
+            walk.SlotStart = slotStart;
+            walk.OldFibers = oldFibers;
+            walk.NewFibers = newFibers;
+            walk.Providers = providers;
+            walk.OldProvidersForPairing = oldProvidersForPairing;
             try
             {
-                ExpandInlineRecursive(nodes, buffer, isNewSide, parent, slotStart, oldFibers, newFibers, providers, oldProvidersForPairing, positionCounters, ref newProviderIndex, fragmentKeyScope: null);
+                ExpandInlineRecursive(walk, nodes, positionCounters, fragmentKeyScope: null);
                 return buffer.Count == 0 ? Array.Empty<VNode>() : buffer.ToArray();
             }
             finally
@@ -439,24 +505,42 @@ namespace Velvet
                 if (isNewSide) _ctx.ContextValueChanged = prevFlag;
                 _ctx.BufferPool.ReturnNodeList(buffer);
                 _ctx.BufferPool.ReturnPositionCounter(positionCounters);
+                _ctx.BufferPool.ReturnInlineWalk(walk);
             }
         }
 
-        private void ExpandInlineRecursive(
-            VNode?[] nodes,
-            List<VNode>? result,
+        // The walk keeps one Providers / OldProvidersForPairing pair for its whole descent, which is exact
+        // only because each list is consumed on exactly one side (Providers collects old-side Providers;
+        // OldProvidersForPairing is read when a new-side Provider pushes) and no recursion flips the side.
+        // A caller that hands in the off-side list is expressing an intent this walk silently drops, so
+        // fail loudly here rather than at the far end of a diff that quietly used the wrong Providers.
+        // Checked ahead of the empty-input and flat-leaf early-outs: the caller's intent is just as wrong
+        // when the container happens to hold nothing that needs expanding.
+        private static void AssertProviderListMatchesSide(
             bool isNewSide,
-            VisualElement? parent,
-            int slotStart,
-            List<ComponentFiber> oldFibers,
-            HashSet<ComponentFiber> newFibers,
             List<ContextProviderNode>? providers,
-            List<ContextProviderNode>? oldProvidersForPairing,
-            Dictionary<object, int> positionCounters,
-            ref int newProviderIndex,
-            string? fragmentKeyScope,
-            GeneralCommitState? commit = null)
+            List<ContextProviderNode>? oldProvidersForPairing)
         {
+            UnityEngine.Debug.Assert(
+                isNewSide ? providers == null : oldProvidersForPairing == null,
+                "[Velvet] GeneralPathReconciler.ExpandInlineForReconcile: the new side only reads "
+                + "oldProvidersForPairing and the old side only fills providers; the list for the other "
+                + "side is never consumed.");
+        }
+
+        private void ExpandInlineRecursive(
+            InlineWalk walk,
+            VNode?[] nodes,
+            Dictionary<object, int> positionCounters,
+            string? fragmentKeyScope)
+        {
+            var result = walk.Result;
+            var isNewSide = walk.IsNewSide;
+            var parent = walk.Parent;
+            var slotStart = walk.SlotStart;
+            var newFibers = walk.NewFibers;
+            var commit = walk.Commit;
+
             for (var nodeIndex = 0; nodeIndex < nodes.Length; nodeIndex++)
             {
                 var node = nodes[nodeIndex];
@@ -469,16 +553,16 @@ namespace Velvet
                         {
                             var childScope = FiberKeying.FragmentChildScope(
                                 fragmentKeyScope, fragment.Key, nodeIndex);
-                            ExpandInlineRecursive(fragment.Children, result, isNewSide, parent, slotStart, oldFibers, newFibers, providers, oldProvidersForPairing, positionCounters, ref newProviderIndex, childScope, commit);
+                            ExpandInlineRecursive(walk, fragment.Children, positionCounters, childScope);
                         }
                         break;
                     case ContextProviderNode provider when !isNewSide:
-                        providers?.Add(provider);
+                        walk.Providers?.Add(provider);
                         if (provider.Children != null)
                         {
                             var providerScope = FiberKeying.ProviderChildScope(
                                 fragmentKeyScope, provider.Key, nodeIndex);
-                            ExpandInlineRecursive(provider.Children, result, isNewSide: false, parent, slotStart, oldFibers, newFibers, providers, null, positionCounters, ref newProviderIndex, providerScope, commit);
+                            ExpandInlineRecursive(walk, provider.Children, positionCounters, providerScope);
                         }
                         break;
                     case ContextProviderNode provider:
@@ -486,7 +570,8 @@ namespace Velvet
                         provider.PushContext(_ctx.ComponentContextStack);
                         try
                         {
-                            var pairIndex = newProviderIndex++;
+                            var oldProvidersForPairing = walk.OldProvidersForPairing;
+                            var pairIndex = walk.NewProviderIndex++;
                             if (oldProvidersForPairing != null
                                 && pairIndex < oldProvidersForPairing.Count
                                 && provider.HasValueChanged(oldProvidersForPairing[pairIndex]))
@@ -497,7 +582,7 @@ namespace Velvet
                             {
                                 var providerScope = FiberKeying.ProviderChildScope(
                                     fragmentKeyScope, provider.Key, nodeIndex);
-                                ExpandInlineRecursive(provider.Children, result, isNewSide: true, parent, slotStart, oldFibers, newFibers, providers: null, oldProvidersForPairing, positionCounters, ref newProviderIndex, providerScope, commit);
+                                ExpandInlineRecursive(walk, provider.Children, positionCounters, providerScope);
                             }
                         }
                         finally
@@ -574,7 +659,7 @@ namespace Velvet
                                 {
                                     var componentScope = FiberKeying.ComponentChildScope(
                                         fragmentKeyScope, component.Key, nodeIndex);
-                                    ExpandInlineRecursive(fiber.PreviousTree, result, isNewSide: true, parent, slotStart, oldFibers, newFibers, providers: null, oldProvidersForPairing, childCounters, ref newProviderIndex, componentScope, commit);
+                                    ExpandInlineRecursive(walk, fiber.PreviousTree, childCounters, componentScope);
                                 }
                                 finally
                                 {
@@ -603,7 +688,7 @@ namespace Velvet
                                     {
                                         var componentScope = FiberKeying.ComponentChildScope(
                                             fragmentKeyScope, component.Key, nodeIndex);
-                                        ExpandInlineRecursive(fiber.PreviousTree, result, isNewSide: false, parent, slotStart, oldFibers, newFibers, providers, null, childCounters, ref newProviderIndex, componentScope, commit);
+                                        ExpandInlineRecursive(walk, fiber.PreviousTree, childCounters, componentScope);
                                     }
                                     finally
                                     {
@@ -615,7 +700,7 @@ namespace Velvet
                                 // parent in oldFibers so the orphan sweep's forward walk tears the
                                 // subtree down bottom-up — a descendant's effect cleanups complete
                                 // before an ancestor's, matching the commit-phase deletion order.
-                                oldFibers.Add(fiber);
+                                walk.OldFibers.Add(fiber);
                             }
                         }
                         break;
@@ -634,14 +719,10 @@ namespace Velvet
                         // wrapper-less in the parent's slot range. The inner renders in live context
                         // (the enclosing Provider is still pushed on the new side), so no pre-captured
                         // snapshot is needed.
-                        ExpandMemoInline(memo, result, isNewSide, parent, slotStart, oldFibers,
-                            newFibers, providers, oldProvidersForPairing, ref newProviderIndex,
-                            fragmentKeyScope, nodeIndex, commit);
+                        ExpandMemoInline(walk, memo, fragmentKeyScope, nodeIndex);
                         break;
                     case SuspenseNode suspense:
-                        ExpandSuspenseInline(suspense, result, isNewSide, parent, slotStart, oldFibers,
-                            newFibers, providers, oldProvidersForPairing, ref newProviderIndex,
-                            fragmentKeyScope, nodeIndex, commit);
+                        ExpandSuspenseInline(walk, suspense, fragmentKeyScope, nodeIndex);
                         break;
                     case AnimatePresenceNode presence:
                         // DOM-less: AnimatePresence emits no wrapper. Its keyed children expand directly
@@ -654,9 +735,7 @@ namespace Velvet
                         _ctx.PresenceExpansionDepth++;
                         try
                         {
-                            ExpandAnimatePresenceInline(presence, result, isNewSide, parent, slotStart,
-                                oldFibers, newFibers, providers, oldProvidersForPairing, ref newProviderIndex,
-                                fragmentKeyScope, nodeIndex, commit);
+                            ExpandAnimatePresenceInline(walk, presence, fragmentKeyScope, nodeIndex);
                         }
                         finally
                         {
@@ -687,19 +766,10 @@ namespace Velvet
         // changed. The resolved inner is expanded recursively so a Suspense / Component / Provider
         // inner is handled wrapper-less in the parent's slot range.
         private void ExpandMemoInline(
+            InlineWalk walk,
             MemoNode memo,
-            List<VNode>? result,
-            bool isNewSide,
-            VisualElement? parent,
-            int slotStart,
-            List<ComponentFiber> oldFibers,
-            HashSet<ComponentFiber> newFibers,
-            List<ContextProviderNode>? providers,
-            List<ContextProviderNode>? oldProvidersForPairing,
-            ref int newProviderIndex,
             string? fragmentKeyScope,
-            int nodeIndex,
-            GeneralCommitState? commit = null)
+            int nodeIndex)
         {
             var memoScope = FiberKeying.MemoScope(fragmentKeyScope, nodeIndex);
             var cacheKey = FiberKeying.MemoCacheKey(memo.Key, memoScope);
@@ -721,9 +791,7 @@ namespace Velvet
                 // Recurse under this memo's own scope so a nested Memo's position key (or an inner
                 // Component's slot key) cannot collide with this memo's scope — e.g. an outer and an
                 // inner unkeyed Memo both at node index 0 would otherwise share cacheKey "{scope}/m0".
-                ExpandInlineRecursive(new[] { inner }, result, isNewSide, parent, slotStart,
-                    oldFibers, newFibers, providers, oldProvidersForPairing, counters,
-                    ref newProviderIndex, memoScope, commit);
+                ExpandInlineRecursive(walk, new[] { inner }, counters, memoScope);
             }
             finally
             {
@@ -776,27 +844,21 @@ namespace Velvet
         // position) so the old-side structural walk reproduces the committed subtree for the diff.
         // Primary and fallback children use distinct fragment scopes so their fibers never collide.
         private void ExpandSuspenseInline(
+            InlineWalk walk,
             SuspenseNode suspense,
-            List<VNode>? result,
-            bool isNewSide,
-            VisualElement? parent,
-            int slotStart,
-            List<ComponentFiber> oldFibers,
-            HashSet<ComponentFiber> newFibers,
-            List<ContextProviderNode>? providers,
-            List<ContextProviderNode>? oldProvidersForPairing,
-            ref int newProviderIndex,
             string? fragmentKeyScope,
-            int nodeIndex,
-            GeneralCommitState? commit = null)
+            int nodeIndex)
         {
+            var result = walk.Result;
+            var newFibers = walk.NewFibers;
+            var commit = walk.Commit;
             var boundaryFiber = _ctx.FiberStack.Current;
             var suspenseKey = FiberKeying.SuspenseKey(fragmentKeyScope, suspense.Key, nodeIndex);
             var primaryScope = FiberKeying.SuspenseSubtreeScope(suspenseKey, isFallback: false);
             var fallbackScope = FiberKeying.SuspenseSubtreeScope(suspenseKey, isFallback: true);
             var stateKey = (boundaryFiber, suspenseKey);
 
-            if (isNewSide)
+            if (walk.IsNewSide)
             {
                 if (boundaryFiber != null) boundaryFiber.IsSuspenseBoundary = true;
                 var preCount = commit != null ? commit.NewElements.Count : result!.Count;
@@ -812,9 +874,7 @@ namespace Velvet
                         var counters = _ctx.BufferPool.RentPositionCounter();
                         try
                         {
-                            ExpandInlineRecursive(suspense.Children, result, isNewSide: true, parent, slotStart,
-                                oldFibers, newFibers, providers: null, oldProvidersForPairing, counters,
-                                ref newProviderIndex, primaryScope, commit);
+                            ExpandInlineRecursive(walk, suspense.Children, counters, primaryScope);
                         }
                         catch (FiberSuspendSignal)
                         {
@@ -874,9 +934,7 @@ namespace Velvet
                             var fbCounters = _ctx.BufferPool.RentPositionCounter();
                             try
                             {
-                                ExpandInlineRecursive(new[] { suspense.Fallback }, result, isNewSide: true, parent,
-                                    slotStart, oldFibers, newFibers, providers: null, oldProvidersForPairing,
-                                    fbCounters, ref newProviderIndex, fallbackScope, commit);
+                                ExpandInlineRecursive(walk, new[] { suspense.Fallback }, fbCounters, fallbackScope);
                             }
                             finally
                             {
@@ -909,9 +967,8 @@ namespace Velvet
                     var counters = _ctx.BufferPool.RentPositionCounter();
                     try
                     {
-                        ExpandInlineRecursive(nodesToExpand, result, isNewSide: false, parent, slotStart,
-                            oldFibers, newFibers, providers, null, counters, ref newProviderIndex,
-                            wasFallback ? fallbackScope : primaryScope, commit);
+                        ExpandInlineRecursive(walk, nodesToExpand, counters,
+                            wasFallback ? fallbackScope : primaryScope);
                     }
                     finally
                     {
@@ -951,27 +1008,20 @@ namespace Velvet
         }
 
         private void ExpandAnimatePresenceInline(
+            InlineWalk walk,
             AnimatePresenceNode presence,
-            List<VNode>? result,
-            bool isNewSide,
-            VisualElement? parent,
-            int slotStart,
-            List<ComponentFiber> oldFibers,
-            HashSet<ComponentFiber> newFibers,
-            List<ContextProviderNode>? providers,
-            List<ContextProviderNode>? oldProvidersForPairing,
-            ref int newProviderIndex,
             string? fragmentKeyScope,
-            int nodeIndex,
-            GeneralCommitState? commit)
+            int nodeIndex)
         {
+            var parent = walk.Parent;
+            var commit = walk.Commit;
             var boundaryFiber = _ctx.FiberStack.Current;
             var presenceKey = FiberKeying.PresenceKey(fragmentKeyScope, presence.Key, nodeIndex);
             // Parent is part of the key so an AnimatePresence nested inside a real element does not collide
             // with an outer one at the same (fiber, scope, index). See ReconcilerContext.PresenceStates.
             var stateKey = (boundaryFiber, parent, presenceKey);
 
-            if (!isNewSide)
+            if (!walk.IsNewSide)
             {
                 // Old side: reproduce the committed leaf composition (including exiting ghosts) so the
                 // diff's old leaves match the live DOM. No state mutation, no animation.
@@ -979,10 +1029,8 @@ namespace Velvet
                 {
                     foreach (var (key, node) in oldState.Committed)
                     {
-                        EmitPresenceChildAsAnchor(node, FiberNodeFactory.FindFirstMotionDescendant(node),
-                            key, presenceKey, result, isNewSide: false, parent, slotStart,
-                            oldFibers, newFibers, providers, oldProvidersForPairing, ref newProviderIndex, commit,
-                            out _);
+                        EmitPresenceChildAsAnchor(walk, node,
+                            FiberNodeFactory.FindFirstMotionDescendant(node), key, presenceKey, out _);
                     }
                 }
                 return;
@@ -1075,16 +1123,14 @@ namespace Velvet
                 {
                     if (!newKeySet.Contains(key))
                     {
-                        ExpandPresenceGhostEntry(key, node, presenceKey, result, parent, slotStart,
-                            oldFibers, newFibers, providers, oldProvidersForPairing, ref newProviderIndex,
-                            commit, state, boundaryFiber, presence, nextCommitted, ref exitIndex, exitCount,
+                        ExpandPresenceGhostEntry(walk, key, node, presenceKey,
+                            state, boundaryFiber, presence, nextCommitted, ref exitIndex, exitCount,
                             ref removedInstantThisRender, exitPass);
                         continue;
                     }
 
-                    ExpandPresenceEnterEntry(key, node, presenceKey, result, parent, slotStart,
-                        oldFibers, newFibers, providers, oldProvidersForPairing, ref newProviderIndex,
-                        commit, state, boundaryFiber, presence, prevCommitted, nextCommitted, newKeyed,
+                    ExpandPresenceEnterEntry(walk, key, node, presenceKey,
+                        state, boundaryFiber, presence, prevCommitted, nextCommitted, newKeyed,
                         blockEnters, firstRender, ref visualIndex);
                 }
 
@@ -1141,18 +1187,10 @@ namespace Velvet
         // exit is dropped (not emitted → the diff removes its leaves); a child without an exit animation is
         // removed immediately; otherwise the child stays mounted in its old slot and its exit is started once.
         private void ExpandPresenceGhostEntry(
+            InlineWalk walk,
             string key,
             VNode node,
             string? presenceKey,
-            List<VNode>? result,
-            VisualElement? parent,
-            int slotStart,
-            List<ComponentFiber> oldFibers,
-            HashSet<ComponentFiber> newFibers,
-            List<ContextProviderNode>? providers,
-            List<ContextProviderNode>? oldProvidersForPairing,
-            ref int newProviderIndex,
-            GeneralCommitState? commit,
             ReconcilerContext.PresenceBoundaryState state,
             ComponentFiber? boundaryFiber,
             AnimatePresenceNode presence,
@@ -1162,6 +1200,7 @@ namespace Velvet
             ref bool removedInstantThisRender,
             ExitCompletionGate exitPass)
         {
+            var commit = walk.Commit;
             if (state.ExitComplete.Contains(key))
             {
                 state.Exiting.Remove(key);
@@ -1200,9 +1239,7 @@ namespace Velvet
                 return;
             }
 
-            var ghostAnchor = EmitPresenceChildAsAnchor(node, ghostMotionNode, key, presenceKey, result,
-                isNewSide: true, parent, slotStart,
-                oldFibers, newFibers, providers, oldProvidersForPairing, ref newProviderIndex, commit,
+            var ghostAnchor = EmitPresenceChildAsAnchor(walk, node, ghostMotionNode, key, presenceKey,
                 out var ghostMotionElement);
             // A ghost reproduces the SAME committed node on both diff sides, so the patch that
             // would re-record the Motion's element bails on reference equality — fall back to
@@ -1322,18 +1359,10 @@ namespace Velvet
         // whose exit was cancelled or already completed, or a first-time add). Emits the child, reconciles
         // exit/enter bookkeeping against its previous ghost state (if any), and dispatches its enter animation.
         private void ExpandPresenceEnterEntry(
+            InlineWalk walk,
             string key,
             VNode node,
             string? presenceKey,
-            List<VNode>? result,
-            VisualElement? parent,
-            int slotStart,
-            List<ComponentFiber> oldFibers,
-            HashSet<ComponentFiber> newFibers,
-            List<ContextProviderNode>? providers,
-            List<ContextProviderNode>? oldProvidersForPairing,
-            ref int newProviderIndex,
-            GeneralCommitState? commit,
             ReconcilerContext.PresenceBoundaryState state,
             ComponentFiber? boundaryFiber,
             AnimatePresenceNode presence,
@@ -1344,6 +1373,7 @@ namespace Velvet
             bool firstRender,
             ref int visualIndex)
         {
+            var commit = walk.Commit;
             // Withhold a brand-new child under mode="wait" while exits are in flight (see above). The
             // linear prevCommitted scan is bounded: this only runs when blockEnters is set, and wait-mode
             // targets single-child swaps, so prevCommitted holds ~1 entry.
@@ -1358,9 +1388,8 @@ namespace Velvet
             // gate, so CreateElement can tell this SAME node (which the dispatch below is about to
             // explicitly animate) apart from every OTHER Motion the emission below might create.
             var motion = FiberNodeFactory.FindFirstMotionDescendant(node);
-            var anchor = EmitPresenceChildAsAnchor(node, motion, key, presenceKey, result, isNewSide: true,
-                parent, slotStart, oldFibers, newFibers, providers, oldProvidersForPairing,
-                ref newProviderIndex, commit, out var motionElement);
+            var anchor = EmitPresenceChildAsAnchor(walk, node, motion, key, presenceKey,
+                out var motionElement);
             // Same memo discipline as the ghost path: record when this emission resolved the
             // element (create or genuine patch), fall back to the memo when a no-op re-render's
             // reference-equal patch bailed before recording.
@@ -1662,28 +1691,18 @@ namespace Velvet
         // emitted into GeneralCommitState.NewElements — for enter / exit animation, or null on
         // the structural (old-side) walk or when the child emitted nothing.
         private VisualElement? EmitPresenceChild(
+            InlineWalk walk,
             VNode? node,
             string? key,
-            string? presenceScope,
-            List<VNode>? result,
-            bool isNewSide,
-            VisualElement? parent,
-            int slotStart,
-            List<ComponentFiber> oldFibers,
-            HashSet<ComponentFiber> newFibers,
-            List<ContextProviderNode>? providers,
-            List<ContextProviderNode>? oldProvidersForPairing,
-            ref int newProviderIndex,
-            GeneralCommitState? commit)
+            string? presenceScope)
         {
-            var startIdx = commit != null ? commit.NewElements.Count : result!.Count;
+            var commit = walk.Commit;
+            var startIdx = commit != null ? commit.NewElements.Count : walk.Result!.Count;
             var childScope = FiberKeying.PresenceChildScope(presenceScope, key);
             var counters = _ctx.BufferPool.RentPositionCounter();
             try
             {
-                ExpandInlineRecursive(new[] { node }, result, isNewSide, parent, slotStart,
-                    oldFibers, newFibers, providers, oldProvidersForPairing, counters,
-                    ref newProviderIndex, childScope, commit);
+                ExpandInlineRecursive(walk, new[] { node }, counters, childScope);
             }
             finally
             {
@@ -1726,20 +1745,11 @@ namespace Velvet
         // did not reach the Motion (or there is none); callers fall back to the classic, anchor-targeted
         // transition then.
         private VisualElement? EmitPresenceChildAsAnchor(
+            InlineWalk walk,
             VNode? node,
             MotionNode? anchorMotion,
             string? key,
             string? presenceScope,
-            List<VNode>? result,
-            bool isNewSide,
-            VisualElement? parent,
-            int slotStart,
-            List<ComponentFiber> oldFibers,
-            HashSet<ComponentFiber> newFibers,
-            List<ContextProviderNode>? providers,
-            List<ContextProviderNode>? oldProvidersForPairing,
-            ref int newProviderIndex,
-            GeneralCommitState? commit,
             out VisualElement? anchorMotionElement)
         {
             var previousAnchor = _ctx.PresenceAnchorMotion;
@@ -1748,8 +1758,7 @@ namespace Velvet
             _ctx.PresenceAnchorMotionElement = null;
             try
             {
-                var emitted = EmitPresenceChild(node, key, presenceScope, result, isNewSide, parent, slotStart,
-                    oldFibers, newFibers, providers, oldProvidersForPairing, ref newProviderIndex, commit);
+                var emitted = EmitPresenceChild(walk, node, key, presenceScope);
                 anchorMotionElement = _ctx.PresenceAnchorMotionElement;
                 return emitted;
             }

--- a/Packages/com.velvet.core/Runtime/Reconciler/ReconcileState.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ReconcileState.cs
@@ -7,9 +7,15 @@ namespace Velvet
 {
     internal enum IndexedReconcilePhase
     {
+        // Patch (or replace) each slot the old and new lists share.
         Common,
+        // Remove the old tail beyond the shared length, from the end inward.
         Remove,
+        // Create and insert the new tail beyond the shared length.
         Add,
+        // All phases complete. Terminates the dispatch loop; never parked in
+        // IndexedReconcileState.ResumePhase, which only ever holds a phase that has work left.
+        Done,
     }
 
     internal readonly struct IndexedReconcileState

--- a/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerBufferPool.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerBufferPool.cs
@@ -130,6 +130,15 @@ namespace Velvet
 
         #endregion
 
+        #region GeneralPathReconciler — inline-expansion walk state
+
+        private readonly ClearablePool<GeneralPathReconciler.InlineWalk> _inlineWalkPool = new(w => w.Clear());
+
+        public GeneralPathReconciler.InlineWalk RentInlineWalk() => _inlineWalkPool.Rent();
+        public void ReturnInlineWalk(GeneralPathReconciler.InlineWalk walk) => _inlineWalkPool.Return(walk);
+
+        #endregion
+
         #region FiberNodeFactory.BuildKeyedMapCopy — indexByKey
 
         private readonly ClearablePool<Dictionary<string, int>> _indexByKeyMapPool = new(m => m.Clear());

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/BenchmarkHelpers.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/BenchmarkHelpers.cs
@@ -2,6 +2,11 @@ namespace Velvet.Tests.Performance
 {
     internal static class BenchmarkHelpers
     {
+        // Context instance shared by every expansion child so a Provider push/pop pair surrounds each
+        // one. A single instance is enough: the benchmark measures the walk, not context resolution.
+        private static readonly ComponentContext<string> s_expansionContext =
+            ComponentContext<string>.Create("default");
+
         internal static VNode[] BuildLabelNodes(int count, string prefix = "item-")
         {
             var nodes = new VNode[count];
@@ -24,5 +29,46 @@ namespace Velvet.Tests.Performance
             }
             return nodes;
         }
+
+        // Children whose every node type forces the inline-expansion walk: Provider (transparent, pushes
+        // context), Fragment (transparent), Component (renders, emits no element of its own). Keep all
+        // three — a flat host-leaf array routes to the Indexed/Keyed fast path and never enters the
+        // expansion walk at all, so a Label-only benchmark measures none of this code.
+        internal static VNode[] BuildExpansionNodes(int count, string prefix = "expand-")
+        {
+            var nodes = new VNode[count];
+            for (int i = 0; i < count; i++)
+            {
+                // Constant value across every built array. A changed value makes the walk dispatch a
+                // context-propagation traversal, and this fixture reconciles onto a bare VisualElement
+                // with no root fiber to propagate from — the assertion that fires there is logged, and an
+                // unhandled log fails the test outright.
+                nodes[i] = V.Provider(s_expansionContext, "scoped", new VNode?[]
+                {
+                    V.Fragment(new VNode?[]
+                    {
+                        V.Component(RenderExpansionRow, new ExpansionRowProps(i, prefix), key: $"row-{i}"),
+                    }),
+                });
+            }
+            return nodes;
+        }
+
+        // Reference type with value equality so the auto-memoization keyed on props behaves the way a
+        // real component's props do (a record struct would box on every V.Component call).
+        internal sealed record ExpansionRowProps(int Index, string Prefix);
+
+        // The Div's own child must stay a component, not a Label: committing this row re-enters the
+        // reconciler for the Div's children, and only a child that needs expanding makes that re-entry
+        // rent a SECOND walk while the outer one is still live. That nesting is the whole reason the walk
+        // state is rented per entry instead of cached on the reconciler, so a Label-only Div would leave
+        // the hazard unmeasured.
+        [Component]
+        private static VNode RenderExpansionRow(ExpansionRowProps props)
+            => V.Div(children: new VNode?[] { V.Component(RenderExpansionLeaf, props, key: "leaf") });
+
+        [Component]
+        private static VNode RenderExpansionLeaf(ExpansionRowProps props)
+            => V.Label(text: $"{props.Prefix}{props.Index}");
     }
 }

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/ReconcilerPerformanceBenchmarks.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/ReconcilerPerformanceBenchmarks.cs
@@ -252,6 +252,51 @@ namespace Velvet.Tests.Performance
 
         #endregion
 
+        #region B-1-c-3: Time-sliced indexed diff, driven to completion through the resume entry
+
+        // Every other benchmark passes a zero frame budget, which routes the indexed diff straight
+        // through its non-budgeted path and never parks state. These two force a yield per element so
+        // the parked-state save/restore and the ContinueIndexed resume entry are what gets measured.
+        [Test, Performance]
+        public void Reconcile_BudgetedIndexed_AllChange_200Elements()
+        {
+            var oldNodes = BenchmarkHelpers.BuildLabelNodes(200, prefix: "old-");
+            var newNodes = BenchmarkHelpers.BuildLabelNodes(200, prefix: "new-");
+            _reconciler.Reconcile(_root, Array.Empty<VNode>(), oldNodes);
+
+            Measure.Method(() =>
+            {
+                ReconcileToCompletionUnderBudget(oldNodes, newNodes);
+                ReconcileToCompletionUnderBudget(newNodes, oldNodes);
+            })
+            .GC()
+            .WarmupCount(5)
+            .MeasurementCount(20)
+            .Run();
+        }
+
+        // Grow then shrink, so the Remove and Add phases are entered through both the phase fall-through
+        // and the resume entry — the Common phase alone would leave two thirds of the machine unmeasured.
+        [Test, Performance]
+        public void Reconcile_BudgetedIndexed_GrowShrink_100To200Elements()
+        {
+            var smallNodes = BenchmarkHelpers.BuildLabelNodes(100);
+            var largeNodes = BenchmarkHelpers.BuildLabelNodes(200);
+            _reconciler.Reconcile(_root, Array.Empty<VNode>(), smallNodes);
+
+            Measure.Method(() =>
+            {
+                ReconcileToCompletionUnderBudget(smallNodes, largeNodes);
+                ReconcileToCompletionUnderBudget(largeNodes, smallNodes);
+            })
+            .GC()
+            .WarmupCount(5)
+            .MeasurementCount(20)
+            .Run();
+        }
+
+        #endregion
+
         #region B-1-d: Pooled-widget recycle (mount -> unmount -> remount)
 
         // Pins the primitive-element pool's recycle path: VNodePool.ReturnLabel / ReturnButton (invoked
@@ -286,6 +331,20 @@ namespace Velvet.Tests.Performance
         #endregion
 
         #region Helpers
+
+        // The smallest positive budget: every element overruns it, so the diff yields after each one and
+        // the whole list commits through ContinueReconcile. A realistic multi-millisecond budget would
+        // finish a 200-element list in a single slice and measure the straight-line path instead.
+        private const double YieldPerElementBudgetMs = 1e-6;
+
+        private void ReconcileToCompletionUnderBudget(VNode[] oldNodes, VNode[] newNodes)
+        {
+            _reconciler.Reconcile(_root, oldNodes, newNodes, YieldPerElementBudgetMs);
+            while (_reconciler.HasPendingWork)
+            {
+                _reconciler.ContinueReconcile(YieldPerElementBudgetMs);
+            }
+        }
 
         /// <summary>
         /// Initial mount on the long-lived Reconciler path. Production reuses one Reconciler per Page/Component,

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/ReconcilerPerformanceBenchmarks.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/ReconcilerPerformanceBenchmarks.cs
@@ -208,6 +208,50 @@ namespace Velvet.Tests.Performance
 
         #endregion
 
+        #region B-1-c-2: Re-reconcile — inline-expansion path (Provider / Fragment / Component)
+
+        // Pins the general (inline-expansion) walk, which the Label-only benchmarks above never reach:
+        // a flat host-leaf array routes to the Indexed/Keyed fast path, so the expansion walk early-outs
+        // before its first recursion. The allocation column is the load-bearing one — the walk's own
+        // per-call state is pooled, so a steady-state re-reconcile must not allocate for it.
+        [Test, Performance]
+        public void Reconcile_Expansion_NoChange_100Nodes()
+        {
+            var nodes = BenchmarkHelpers.BuildExpansionNodes(100);
+            _reconciler.Reconcile(_root, Array.Empty<VNode>(), nodes);
+
+            Measure.Method(() =>
+            {
+                _reconciler.Reconcile(_root, nodes, nodes);
+            })
+            .GC()
+            .WarmupCount(5)
+            .MeasurementCount(20)
+            .Run();
+        }
+
+        // Same walk with every emitted leaf changing, so each recursion also runs the commit
+        // (CommitLeaf -> PatchNode) rather than only the structural descent.
+        [Test, Performance]
+        public void Reconcile_Expansion_AllChange_100Nodes()
+        {
+            var oldNodes = BenchmarkHelpers.BuildExpansionNodes(100, prefix: "old-");
+            var newNodes = BenchmarkHelpers.BuildExpansionNodes(100, prefix: "new-");
+            _reconciler.Reconcile(_root, Array.Empty<VNode>(), oldNodes);
+
+            Measure.Method(() =>
+            {
+                _reconciler.Reconcile(_root, oldNodes, newNodes);
+                _reconciler.Reconcile(_root, newNodes, oldNodes);
+            })
+            .GC()
+            .WarmupCount(5)
+            .MeasurementCount(20)
+            .Run();
+        }
+
+        #endregion
+
         #region B-1-d: Pooled-widget recycle (mount -> unmount -> remount)
 
         // Pins the primitive-element pool's recycle path: VNodePool.ReturnLabel / ReturnButton (invoked


### PR DESCRIPTION
## What & why

Two structural changes to the reconciler, no behavior change in either.

**The inline-expansion walk** threaded thirteen parameters plus a by-reference counter through its recursion, and four helper methods re-declared twelve or thirteen of the same ones — so any new piece of walk state meant editing five signatures and every call site. Seven of those values are invariant for the whole walk, and they now travel in one context object rented from the existing reconciler buffer pool at each outer entry and returned in that entry's `finally`. Renting rather than caching is required: the walk re-enters itself through the commit path, so a single shared instance would be clobbered by a nested walk. Per-call values stay explicit parameters. Two provider lists moved in on the invariant that a walk never flips between the old and new side; the entry that takes both lists from its caller asserts it, and the other entry cannot violate it because it has no parameter through which a caller could pass the wrong-side list.

**The indexed (unkeyed) child path** kept its three phases inline in one long method, falling through by reassigning its own phase and index parameters, while the keyed path next to it dispatches a phase per method from a switch. The indexed path now mirrors that shape. It does not copy the keyed path's state object: that one is a heap allocation per keyed reconcile, and the unkeyed diff is the hottest path in the framework, so the inputs travel in a stack struct passed by reference instead. Every resume and interrupt point is preserved verbatim — the fresh-versus-resumed entry guard, the remove phase's start sentinel and the guard against a decrement colliding with it, the deliberate over-budget fall-through into the add phase, and the distinction between aborting (which parks nothing) and yielding (which parks and resumes).

## Benchmarks

The existing suite reached neither path: it builds text leaves, so the expansion path early-outs entirely, and every benchmark passes a zero frame budget, so the indexed path's resume machinery never runs. Four benchmarks were added — a re-reconcile over provider/fragment/component nesting that genuinely rents a nested walk while the outer one is live, and two budgeted list diffs driven to completion through the resume entry.

**Allocation is identical between the two arms** on every column that is reproducible per code version, across every run.

**Timing could not be resolved at this rig's precision, and the honest answer is that no cost is measurable.** An earlier reading suggested the changed paths were uniformly slower by a small margin. Re-measuring with a three-arm design — base, base plus the walk-context change, and both — showed that pattern was an artifact of the measurement, not the code: runs of one arm had been grouped in time so machine state was absorbed into the arm, and the two arms were switched by rewriting different numbers of files, which put an arm-correlated re-import cost into the comparison. Correcting both, and rotating arm order across cycles, the deltas split evenly between faster and slower.

The floor was established by comparing two arms that execute byte-identical code for the benchmark in question (the walk-context change cannot run on text-leaf rows): that null comparison spans roughly three percent of standard deviation with excursions to seven. No measured delta on the changed paths exceeds it. Thirty-three of thirty-three accepted runs were taken with no other editor process on the machine; five runs were discarded and the reason recorded.

One gap worth stating: the indexed path has no true null in this fixture, since every benchmark in it routes through that path. Its numbers sit inside the floor measured for the other change, which is the best available proxy rather than a direct one.

## Checklist

- [x] Tests pass locally (EditMode / PlayMode / generator tests as applicable) — EditMode 3267 passed / 0 failed, PlayMode 95 passed / 0 failed, including the time-sliced, abort-safety and z-index fixtures that cover the resume machinery
- [x] New regression tests were verified red without the change and green with it — n/a: no behavior change, so no new regression test; the added coverage is benchmarks, and the correctness net is the existing time-sliced suite
- [x] Docs are updated for every fact this change touches (guides, READMEs, CLAUDE.md) — or this PR has no doc impact
- [x] CHANGELOG updated for behavior/perf changes (pure refactors are omitted by convention)
- [x] Known gaps or deliberate deferrals discovered here are filed as issues with acceptance criteria

Closes #146
Closes #147