### PR TITLE
feat(velvet): let Velvet's tween own filter transitions and interpolate user custom filters

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -30,6 +30,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `transition-filter` now declares `transition-property: filter`, so Velvet's tween owns the motion
+  outright. Previously it left `transition-property` at its initial whole-property value, under which
+  the engine's inline-filter setter runs an inline write as its own animation that no API can cancel:
+  every frame the tween wrote restarted that animation over the same value, and what was painted
+  lagged the tween that was supposed to drive it. The resolved value is now what decides which
+  animator runs — a value naming `filter`, alone or among other property names, leaves the setter on
+  its plain direct-write path so the tween can paint its own frames; a whole-property value hands the
+  change to the engine and the tween stands down; anything else keeps the change instant, except a
+  value naming `background-size` or `-unity-background-scale-mode`, which is what the setter actually
+  gates on and so animates a filter change with nothing in the declaration mentioning filters. The tween
+  re-checks that value on every frame, so a `transition-property` rewritten mid-tween (a Motion play,
+  a class swap) hands over once instead of restarting the engine's animation on every tick. Because
+  every `transition-*` utility sets the same property, `transition-filter` does not combine with
+  another one — the later-declared utility wins — and it transitions only `filter`.
+- A user-authored `filter-[name:args]` custom filter now interpolates under `transition-filter` when
+  both sides are the same registered definition with the same number of arguments and matching
+  argument types per slot: a color argument cross-fades and a float argument lerps. Previously a user
+  custom on either side always forced an instant write. One added or removed on its own now fades
+  from the neutral its own `FilterParameterDeclaration.interpolationDefaultValue` declares — the same
+  value the engine pads its filter-list transitions with — and another filter may be added or removed
+  alongside one that pairs, so `filter-[glow:1]` → `blur-4 filter-[glow:2]` fades the blur in while
+  the glow lerps. A user custom still snaps when it cannot be paired: a different definition on each
+  side, a differing argument count, a slot whose type differs across the change, and two or more
+  distinct user customs when a filter is added or removed (they all compose last, leaving no order to
+  place them in). A definition destroyed mid-tween now drops out of the frames the tween paints
+  instead of throwing, mirroring how the compose path already skips dead definitions.
 - Scheduling a fiber re-render no longer allocates a per-fiber sorted set for the pending-lane
   queue; the four update priorities now live in an inline bit mask with identical enrollment,
   drain-order, and starvation-promotion semantics.
@@ -61,6 +87,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   receives the navigation attempt, and a cancellation token on the async overload) is covered for the same
   reason. A lambda's own parameters are supplied per invocation and are never treated as dependencies, and a
   lambda wider than the hook's widest overload is still not read as that hook's factory.
+- `Documentation~/styling-filters.md` claimed that UI Toolkit's transition system cannot repaint an
+  inline `filter` at all, and that `transition-all` and `transition-property: filter` therefore leave
+  a filter change snapping. Both were wrong: the engine animates an inline filter under a
+  whole-property `transition-property`, and pinning the property does not stop it repainting. The
+  guide now describes the measured behavior — which of the two animators runs, and why — instead.
+- The pooled-element inline-style reset neutralised the transition longhands only at the end of its
+  scrub, so on an element still attached to a panel every clear before that point — `filter`,
+  `opacity`, the transforms, the colors, the geometry longhands — became a running animation that
+  kept painting the value the reset had just removed, and the trailing nulls restored the
+  matched-rules value rather than disabling the transition, so nothing cancelled them. The reset now
+  writes a zero transition duration before its inline scrub, which makes every clear in that scrub
+  cancel instead of animate. No shipped caller could reach the defect: they all detach before
+  resetting, and a detached element is not style-initialized, which already takes every clear down
+  the cancel path. The write is therefore skipped when the element is off-panel, keeping the
+  (always-detached) pool return free of the inline entry the trailing null would then tear down
+  again; what changed is that the reset no longer depends on that call ordering.
 - A `FocusScope` with `restoreFocus: true` did not hand focus back to the prior element when the
   scope's ROOT element itself (rather than a descendant) held focus at unmount: the guard used
   `VisualElement.Contains`, which does not count an element as containing itself, so a focused root

--- a/Packages/com.velvet.core/Documentation~/styling-filters.md
+++ b/Packages/com.velvet.core/Documentation~/styling-filters.md
@@ -41,11 +41,10 @@ hue-rotate, invert, saturate, sepia) regardless of class order, matching how bro
 multi-function `filter` value.
 
 Filter utilities work everywhere other utilities do: under variants
-(`hover:blur-sm`, `dark:grayscale`), with the important modifier, and inside recipes. Unlike most
-inline properties, `filter` is **not** tweened by `transition-all` / `transition-property: filter`
-— UI Toolkit's native transition system cannot repaint an inline filter list at all, so those
-utilities leave a filter change snapping instead of animating. Animating a filter change needs the
-dedicated `transition-filter` opt-in described below.
+(`hover:blur-sm`, `dark:grayscale`), with the important modifier, and inside recipes. A filter change
+animates like any other property: `transition-all`, a bare `duration-*`, and the dedicated
+`transition-filter` class all tween it — see [Transitions](#transitions) for which of the two
+animators runs and why it matters.
 
 ## Custom filters: `VelvetFilters` + `filter-[name:args]`
 
@@ -94,25 +93,83 @@ unrecognized utility.
 
 ### Transitions
 
-UI Toolkit's native transition system cannot repaint an inline `filter` list at all — pinning
-`transition-property` to `filter` (or including it via `transition-all`) only applies the very
-first frame of a change and then stops repainting, an engine limitation, not a Velvet gap. So
-animating a filter change is a dedicated opt-in, not a side effect of the general `transition-*`
-utilities: add the `transition-filter` class. It deliberately sets only `transition-duration` /
-`transition-timing-function` (never `transition-property: filter`, which would just hit the same
-repaint bug) and a scheduler-driven tween (`StyleFilterTransitionDriver`) lerps the filter's
-parameters itself, writing a fresh inline list every frame so the engine actually repaints it.
-`duration-*` / `ease-*` still override the resolved duration/timing the class carries.
+A filter change animates under any transition utility whose resolved `transition-property` covers
+`filter` — `transition-all`, or a bare `duration-*` (whose `transition-property` stays at its
+initial whole-property value). No opt-in class is required for that, matching CSS. The
+`transition-filter` class exists because **which animator runs** is decided by that same resolved
+value, and the two animators do not have the same capabilities:
 
-What interpolates under `transition-filter`: every native filter type (`blur`, `contrast`,
+| Resolved `transition-property` | Set by | Who animates |
+|---|---|---|
+| covers every property (`all`) | `transition-all`, a bare `duration-*` | UI Toolkit's own transition system |
+| contains `filter` | `transition-filter` | Velvet's scheduler-driven tween (`StyleFilterTransitionDriver`) |
+| names neither | `transition-colors`, `transition-transform`, `transition-none` | nobody — the change is instant |
+| names `background-size` or `-unity-background-scale-mode` | hand-authored USS only | UI Toolkit's, even with no filter named — see the warning below |
+
+The split is forced by the engine: writing an inline `filter` under a whole-property
+`transition-property` makes the setter run the write as its own animation, and there is no API to
+cancel one, so a Velvet tween writing a frame per tick would only be fighting it. A value that names
+`filter` leaves that setter on its plain direct-write path, which is what lets the tween paint its
+own frames. `transition-filter` sets exactly that, plus a default duration and curve; `duration-*` /
+`ease-*` still override those.
+
+> **`transition-filter` does not combine with another `transition-*` utility.** They all set the
+> same `transition-property`, and at equal specificity the one declared later in the bundled sheet
+> wins outright rather than merging — `transition-filter transition-colors` resolves to the colors
+> list, which silently takes filter changes back to instant. Note also that pinning the property
+> means `transition-filter` transitions *only* `filter`: the element's colours, transforms and
+> geometry stop transitioning, which is what CSS does too. Put the other properties' transitions on a
+> different element.
+>
+> Hand-authoring a `transition-property` that names `filter` alongside other properties does work —
+> the tween accepts any list containing `filter` — but three things have to line up. The element must
+> still carry `transition-filter`, because that class is what registers the tween binding; the
+> stylesheet has to load after the bundled utilities to win the cascade; and the list must name
+> neither `background-size` nor `-unity-background-scale-mode`.
+>
+> That last one is not a typo. The engine's inline-filter setter decides whether to animate by
+> matching the transition list against **`background-size`** — never against `filter` — and it accepts
+> any shorthand covering it, which `-unity-background-scale-mode` is. So a list naming `filter` and
+> either of those two puts Velvet's tween and a native animation on the same property at once, and a
+> list naming either of them *without* `filter` animates your filters with nothing in the declaration
+> mentioning filters. Neither case is diagnosed. Everything above is measured on Unity 6000.3; a
+> future engine fix would invert it, which is what the `Group D` tests in
+> `FilterTransitionPanelTests` exist to catch.
+
+Under `transition-filter`, Velvet's tween interpolates every native filter type (`blur`, `contrast`,
 `grayscale`, `hue-rotate`, `invert`, `sepia`) and the two first-party built-in customs
-(`brightness`, `saturate`) lerp their parameters — `transition-filter duration-300` tweens
-`blur-0` → `blur-md` (or `brightness-100` → `brightness-150`) smoothly. A filter present on only
-one side of the change fades in/out from its neutral (identity) value, matching CSS's implicit
-list padding, unless the same channel repeats within one list — an ambiguous pairing that falls
-back to an instant write, like CSS. A user-authored `filter-[name:args]` custom filter is the one
-exception: its parameters bind opaque shader material state, so it always snaps instantly — even
-under `transition-filter` — rather than cross-fading.
+(`brightness`, `saturate`), so `transition-filter duration-300` tweens `blur-0` → `blur-md` (or
+`brightness-100` → `brightness-150`) smoothly. Under a whole-property value the engine interpolates
+the inline filter list itself instead, on its own terms — which are not always Velvet's. `contrast`
+is the visible case: Velvet fades an added or removed `contrast-*` from CSS's identity of `1`, while
+the engine pads it from the `0` its own declaration states, so the same class change ramps from
+neutral under `transition-filter` and from fully flat under `transition-all`. Reach for `transition-filter` when you need
+the behavior Velvet's tween defines:
+
+- **User custom filters interpolate** when both sides are the *same registered definition* with the
+  same number of arguments and matching argument types per slot — `filter-[glow:#f00:2]` →
+  `hover:filter-[glow:#00f:6]` cross-fades the color and lerps the amount. Another filter may be
+  added or removed alongside one that pairs: `filter-[glow:1]` → `hover:blur-4 filter-[glow:2]`
+  fades the blur in while the glow lerps.
+- **A filter on only one side** of the change fades in/out from its neutral value, matching CSS's
+  implicit list padding. For a user custom that neutral is the one *your definition declares* — each
+  `FilterParameterDeclaration.interpolationDefaultValue`, the same value the engine pads its own
+  filter-list transitions with — so `filter-[glow:2]` appearing on hover fades up from the glow's
+  declared default rather than from zero. Declare those defaults deliberately; a slot left at the
+  struct default fades from `0`.
+- A user custom **snaps** when it cannot be paired: a different definition on each side (different
+  shaders have no correspondence to interpolate along), a differing argument count, a slot that is a
+  color on one side and a float on the other, or two or more *distinct* user customs when a filter is
+  added or removed (every user custom composes last, so there is no order to place two of them in).
+- A repeat of the same channel within one list is an ambiguous pairing and falls back to an instant
+  write, like CSS.
+- A definition **destroyed mid-tween** drops out of the frames the tween paints instead of throwing;
+  the remaining filters keep animating. The value the tween settles on is the one composed when it
+  started, so a dead definition is cleared from the element by the next compose rather than at settle.
+- One cosmetic edge: clearing an inline filter list leaves the old value readable (an engine bug the
+  reconciler already works around when pooling), so the change immediately after a tween that cleared
+  its filters can compose one pass at a filter's declared neutral before settling. A neutral that is a
+  visual no-op — which is what a neutral should be — makes this invisible.
 
 `duration-0` (or any zero-duration resolution) and an off-panel change both write the target
 value instantly, matching CSS's zero-duration behavior.

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberElementPoolReset.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberElementPoolReset.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using UnityEngine.UIElements;
 
 namespace Velvet
@@ -77,6 +78,23 @@ namespace Velvet
         {
             if (element == null) return;
 
+            // Clearing ANY inline property restores the matched-rules value THROUGH the transition system, so
+            // while the element is still on a panel every clear below can become a running animation instead —
+            // one that keeps painting what the reset just removed, and that the transition-longhand nulls at
+            // the end of the scrub cannot stop (nulling restores the matched-rules value rather than disabling
+            // the transition). Writing a transition longhand recomputes that data, and a zero total time
+            // contributes no transition at all, so the clears cancel instead of animating. Must precede the
+            // scrub to cover all of it. Scoped to that INLINE scrub: the name / enabled-state resets after it
+            // change which rules match, and whatever the next styles pass transitions from that is its own.
+            // A detached element is not style-initialized, which already takes every clear down the cancel
+            // path — which is why no shipped caller can reach the defect, since they all detach first.
+            // Skipping the write there also keeps the pool return free of the managed entry it would otherwise
+            // create for the trailing null to tear down again.
+            if (element.panel != null)
+            {
+                element.style.transitionDuration = new StyleList<TimeValue>(s_zeroDuration);
+            }
+
             ResetInlineStyle(element.style);
 
             element.userData = null;
@@ -91,6 +109,11 @@ namespace Velvet
             element.viewDataKey = null;
             element.SetEnabled(true);
         }
+
+        // Source for the zero transition duration written above. Shared because the inline-style write path
+        // copies a list value into its own storage instead of aliasing the one handed to it, and this runs
+        // once per recycled element on the reconciler's steady-state hot path.
+        private static readonly List<TimeValue> s_zeroDuration = new() { new TimeValue(0f) };
 
         private static void ResetInlineStyle(IStyle style)
         {

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberFilterTransitionApplier.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberFilterTransitionApplier.cs
@@ -2,9 +2,9 @@ using UnityEngine.UIElements;
 
 namespace Velvet
 {
-    // The wrapper-less opt-in that makes a later inline filter change (a hover variant, a reconcile-diff
-    // value swap) animate instead of snapping. The binding only ENABLES the tween; the filter itself is
-    // applied by the arbitrary-value resolver, which the tween's write hook sits inside.
+    // Owns the lifecycle of the per-element binding that lets a later inline filter change (a hover variant,
+    // a reconcile-diff value swap) animate instead of snapping. Wrapper-less: the filter itself is applied by
+    // the arbitrary-value resolver, which the tween's write hook sits inside.
     internal sealed class FiberFilterTransitionApplier
     {
         private readonly ReconcilerContext _ctx;
@@ -14,11 +14,11 @@ namespace Velvet
             _ctx = ctx;
         }
 
-        // Create-time entry point: when classNames carries the transition-filter opt-in, registers the tween
-        // binding so a later filter change (a hover variant, a reconcile-diff value swap) animates instead of
-        // snapping. Wrapper-less — the tween drives the element's own inline filter. The binding only ENABLES
-        // the tween; the filter itself is applied by the arbitrary-value resolver, which the tween's write hook
-        // (StyleFilterTransitionDriver.TryStartOrRedirect) sits inside.
+        // Create-time entry point: when classNames carries transition-filter, registers the tween binding so a
+        // later filter change (a hover variant, a reconcile-diff value swap) animates instead of snapping.
+        // Wrapper-less — the tween drives the element's own inline filter. The binding is only the driver's
+        // handle on the element; the filter itself is applied by the arbitrary-value resolver, which the
+        // tween's write hook (StyleFilterTransitionDriver.TryStartOrRedirect) sits inside.
         internal void ApplyFilterTransitionOnCreate(VisualElement element, string[] classNames)
         {
             if (!HasFilterTransitionClass(classNames))
@@ -30,9 +30,9 @@ namespace Velvet
             StyleFilterTransitionDriver.Register(element, binding);
         }
 
-        // Patch-time reconciliation of the transition-filter opt-in against the new class list: attach the
-        // binding when the class first appears, keep it while present, tear it down when removed. NOTE: on the
-        // very patch that ADDS transition-filter, a filter value that changes in the same diff still applies
+        // Patch-time reconciliation of the binding against the new class list: attach it when transition-filter
+        // first appears, keep it while present, tear it down when removed. NOTE: on the very patch that ADDS
+        // the class, a filter value that changes in the same diff still applies
         // INSTANTLY — SyncClassDrivenStyling (which resolves and writes the filter) runs before this pass, so
         // the tween binding is not enabled yet when the write happens. This matches CSS, which does not
         // retroactively animate a value that changed in the same paint the transition first became active;
@@ -59,10 +59,14 @@ namespace Velvet
             _ctx.FilterTransitionBindings.Remove(element);
         }
 
-        // True when the class list carries the transition-filter opt-in in the base classes OR any state
-        // variant (peeling variant layers to the leaf, mirroring CarriesFilter). Scoped to the literal
-        // transition-filter token only — transition-all sets a real transition-property and rides UI Toolkit's
-        // native transition system, which cannot repaint an inline filter, so it is deliberately NOT an opt-in.
+        // True when the class list carries transition-filter in the base classes OR any state variant (peeling
+        // variant layers to the leaf, mirroring CarriesFilter). Scoped to that one token because it is the only
+        // utility that can resolve transition-property to a list naming filter, which is the only value
+        // StyleFilterTransitionDriver's probe accepts: .transition-all is declared later in the bundled sheet
+        // at equal specificity, so it always wins the cascade over this class, and every other transition-*
+        // names unrelated properties. Registering wider would put a binding on the element-creation path for a
+        // tween the probe would reject on every write. The probe still has the final say — this only decides
+        // where a binding exists for it to consult.
         private static bool HasFilterTransitionClass(string[] classNames)
         {
             if (classNames == null)

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodeFactory.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodeFactory.cs
@@ -122,7 +122,7 @@ namespace Velvet
                     // animate-* motion (gradient pan / hue cycle) drives the element's own inline style; runs
                     // after the gradient so a pan mode sees the baked gradient already applied.
                     _patcher.Appliers.ApplyAnimateOnCreate(element, elementNode.ClassNames);
-                    // transition-filter opt-in: register the tween binding so a later filter change animates.
+                    // transition-filter: register the tween binding so a later filter change animates.
                     // The mount's own filter is already applied instantly above (the binding is not enabled
                     // yet), matching CSS's no-transition-on-initial-value.
                     _patcher.Appliers.ApplyFilterTransitionOnCreate(element, elementNode.ClassNames);
@@ -254,8 +254,8 @@ namespace Velvet
                     _patcher.ApplyHasVariantManipulators(element);
                     _patcher.Appliers.ApplyGradientOnCreate(element, appliedClasses);
                     _patcher.Appliers.ApplyAnimateOnCreate(element, appliedClasses);
-                    // transition-filter opt-in on a Motion host: a Motion can carry filter utilities + the
-                    // opt-in class just like a plain element, so register the tween binding here too.
+                    // transition-filter on a Motion host: a Motion can carry filter utilities + that class
+                    // just like a plain element, so register the tween binding here too.
                     _patcher.Appliers.ApplyFilterTransitionOnCreate(element, appliedClasses);
                     // Motion does NOT paint a drop shadow: the animation scheduler hides a subtree's shadow
                     // paints for the lifetime of an enter / exit (the opacity-blind shadow would otherwise

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
@@ -393,7 +393,7 @@ namespace Velvet
             StyleTextEffectResolver.Apply(_ctx, element, classNames);
             _appliers.ApplyGradientOnPatch(element, classNames, skewable: gradientSkewable);
             _appliers.ApplyAnimateOnPatch(element, classNames);
-            // transition-filter opt-in: attach/keep/detach the tween binding against the new class list. The
+            // transition-filter: attach/keep/detach the tween binding against the new class list. The
             // shared hook for both the element and Motion patch paths (a filter can be Motion-hosted).
             _appliers.ApplyFilterTransitionOnPatch(element, classNames);
             // Here, not in the Particles-settings diff: the spacer follows the class list (a filter comes and

--- a/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
@@ -395,7 +395,7 @@ namespace Velvet
         // side-tables); FiberElementCleaner / Reconciler.Dispose call StyleAnimateDriver.Detach.
         public Dictionary<VisualElement, StyleAnimateBinding> AnimationBindings { get; } = new();
 
-        // Per-element filter-* transition (transition-filter opt-in), keyed by the element itself — the tween
+        // Per-element filter-* transition (the transition-filter class), keyed by the element itself — the tween
         // drives the element's own inline filter with no wrapper. The binding holds a one-shot scheduled tick,
         // so cleanup must PAUSE it (unlike the pure side-tables); FiberElementCleaner / Reconciler.Dispose call
         // StyleFilterTransitionDriver.Detach. The driver's own ConditionalWeakTable is the lookup the resolver

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/PooledElementStyleGhostTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/PooledElementStyleGhostTests.cs
@@ -26,6 +26,10 @@ namespace Velvet.Tests
     /// The structural cases pin the FULL reset surface: every inline style property the reset scrubs is compared
     /// against a freshly constructed element, in both directions, so dropping a scrubbed property from the helper
     /// (reintroducing a ghost) or scrubbing a new one without extending the pinned contract list fails a test.
+    /// One case additionally resets an element that is still ATTACHED to a panel: clearing an inline filter goes
+    /// through the transition system, so the scrub must not turn itself into a running animation that keeps
+    /// painting what it just removed. Today's callers detach before resetting, which suppresses that path on its
+    /// own; the case pins the helper independently of that ordering.
     /// </summary>
     [TestFixture]
     internal sealed class PooledElementStyleGhostTests : VariantCleanupTestsBase
@@ -46,6 +50,67 @@ namespace Velvet.Tests
 
             // Assert — the letterSpacing is cleared, so the recycled label cannot ghost it onto the next consumer.
             Assert.AreEqual(StyleKeyword.Null, label.style.letterSpacing.keyword);
+        }
+
+        [Test]
+        public void Given_AnAttachedElementWithAFilterCoveringTransition_When_ResetForReuse_Then_NothingKeepsPaintingTheFilter()
+        {
+            // Arrange — an element on a real panel carrying a settled inline filter under a live whole-property
+            // transition (what transition-all / a bare duration-* resolves to). Clearing an inline filter goes
+            // through the transition system, so the clear can become a running animation that keeps painting
+            // the filter the reset just removed; the reset must hold regardless of whether its caller detached
+            // the element first. The fake clock makes the painted mid-animation value load-independent.
+            using var host = new HeadlessEditorPanelHost();
+            var now = 100.0;
+            EditorPanelTestHelpers.SetPanelTimeFunction(host.Panel, () => now);
+            var element = new VisualElement();
+            element.style.transitionDuration = new StyleList<TimeValue>(new List<TimeValue> { new TimeValue(0.3f) });
+            host.Root.Add(element);
+            EditorPanelTestHelpers.ForcePanelUpdate(host.Panel);
+            var blur = new FilterFunction(FilterFunctionType.Blur);
+            blur.AddParameter(new FilterParameter(12f));
+            element.style.filter = new List<FilterFunction> { blur };
+            now += 1.0;
+            EditorPanelTestHelpers.DriveAnimationsOnce(host.Panel);
+            Assume.That(element.resolvedStyle.filter, Is.Not.Empty,
+                "Precondition: the element paints its inline filter before the reset");
+
+            // Act — the shared pool reset runs, then the panel paints a frame.
+            FiberElementPoolReset.ResetCommonState(element);
+            now += 0.15;
+            EditorPanelTestHelpers.DriveAnimationsOnce(host.Panel);
+
+            // Assert — nothing is painting a filter any more.
+            Assert.That(element.resolvedStyle.filter, Is.Empty);
+        }
+
+        [Test]
+        public void Given_AnAttachedElementWithATransitionedOpacity_When_ResetForReuse_Then_TheOpacityIsAlreadyBack()
+        {
+            // Arrange — filter is not special: EVERY inline clear in the scrub restores its matched-rules value
+            // through the transition system, so the neutralising write has to land before the whole scrub, not
+            // merely before the filter clear. opacity is the probe because it is cleared early in the scrub, so
+            // a write placed later would leave this one animating.
+            using var host = new HeadlessEditorPanelHost();
+            var now = 100.0;
+            EditorPanelTestHelpers.SetPanelTimeFunction(host.Panel, () => now);
+            var element = new VisualElement();
+            element.style.transitionDuration = new StyleList<TimeValue>(new List<TimeValue> { new TimeValue(0.3f) });
+            host.Root.Add(element);
+            EditorPanelTestHelpers.ForcePanelUpdate(host.Panel);
+            element.style.opacity = 0.2f;
+            now += 1.0;
+            EditorPanelTestHelpers.DriveAnimationsOnce(host.Panel);
+            Assume.That(element.resolvedStyle.opacity, Is.EqualTo(0.2f).Within(1e-3f),
+                "Precondition: the element paints its inline opacity before the reset");
+
+            // Act
+            FiberElementPoolReset.ResetCommonState(element);
+            now += 0.15;
+            EditorPanelTestHelpers.DriveAnimationsOnce(host.Panel);
+
+            // Assert — fully back to the default, not part-way through fading back to it.
+            Assert.That(element.resolvedStyle.opacity, Is.EqualTo(1f).Within(1e-3f));
         }
 
         // Integration: reconcile remove → recreate a plain label from the pool

--- a/Packages/com.velvet.core/Runtime/Styles/_effects.uss
+++ b/Packages/com.velvet.core/Runtime/Styles/_effects.uss
@@ -51,14 +51,25 @@
     transition-timing-function: ease-in-out;
 }
 
-/* transition-filter — opt-in for animating filter-* changes (blur-*, brightness-*, ...).
+/* transition-filter — hands filter-* changes (blur-*, brightness-*, ...) to Velvet's own tween rather
+ * than to the engine's native filter animation, which transition-all / a bare duration-* would get.
  *
- * Deliberately sets NO transition-property: filter. UI Toolkit stops repainting an inline filter once its
- * transition-property is [filter], so a native transition would freeze the effect after the first frame.
- * Instead this carries only the duration + timing-function, which a scheduler-tween driver reads to lerp the
- * filter's parameters itself (StyleFilterTransitionDriver). duration-* / ease-* still override, declared later.
+ * transition-property is pinned to `filter` so the scheduler-driven tween (StyleFilterTransitionDriver)
+ * owns the motion outright. The inline-filter setter runs a write as an UNCANCELLABLE native animation
+ * whenever the resolved transition-property covers every property, and takes a plain direct-write path
+ * when it names filter; only the latter lets a per-frame tween write paint what it wrote, so leaving
+ * this at the initial `all` would have each tween frame restart a native chase over the same value.
+ * (What the setter actually matches the list against is `background-size` — or any shorthand covering
+ * it, which `-unity-background-scale-mode` is — so that equivalence is measured on this editor rather
+ * than definitional. A list naming filter AND either of those two would satisfy the tween's probe and
+ * the setter's animating path at once; a list naming either WITHOUT filter animates the filter with
+ * nothing in it mentioning filters.)
+ * Pinning one property also means this class transitions ONLY filter, and it does not combine with
+ * another transition-* utility: they set the same property, so the later-declared one wins outright.
+ * duration-* / ease-* still override, declared later.
  */
 .transition-filter {
+    transition-property: filter;
     transition-duration: var(--duration-normal);
     transition-timing-function: ease-in-out;
 }

--- a/Packages/com.velvet.core/Runtime/Styling/BuiltInFilterDefinitions.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/BuiltInFilterDefinitions.cs
@@ -40,8 +40,9 @@ namespace Velvet
 
         internal static bool IsSaturate(FilterFunctionDefinition? def) => def != null && ReferenceEquals(def, s_saturate);
 
-        // True for either first-party built-in definition — the ones that interpolate like a native float
-        // filter, as opposed to a user filter-[name:args] custom whose parameters carry no tween semantics.
+        // True for either first-party built-in definition. Used to tell Velvet's own brightness/saturate
+        // customs apart from a user filter-[name:args] one; both kinds interpolate, but only the user kind is
+        // limited to one distinct definition per add/remove transition (they share a canonical compose slot).
         internal static bool IsBuiltIn(FilterFunctionDefinition? def) => IsBrightness(def) || IsSaturate(def);
 
         // A cached definition is reusable only while both it and the material its single pass binds are live.

--- a/Packages/com.velvet.core/Runtime/Styling/StyleArbitraryValueResolver.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleArbitraryValueResolver.cs
@@ -1019,10 +1019,11 @@ namespace Velvet
                     (functions ??= new List<FilterFunction>()).Add(BuildCustomFilter(custom));
                 }
             }
-            // The transition-filter opt-in tween owns the write when active; it reads the current inline list as
-            // its from-side, so it must run BEFORE the instant write below (never observing its own write). It
-            // returns false — deferring to the instant write — for a non-opting element, off-panel, zero
-            // duration, or a non-interpolable change.
+            // Velvet's filter tween owns the write when it runs; it reads the current inline list as its
+            // from-side, so it must run BEFORE the instant write below (never observing its own write). It
+            // returns false — deferring to the instant write — for an element with no tween binding, off-panel,
+            // zero duration, a resolved transition-property that does not name filter (the engine's own
+            // animation runs the change, or there is no transition), or a non-interpolable change.
             if (functions == null)
             {
                 if (!StyleFilterTransitionDriver.TryStartOrRedirect(element, null))

--- a/Packages/com.velvet.core/Runtime/Styling/StyleFilterTransitionDriver.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleFilterTransitionDriver.cs
@@ -7,9 +7,9 @@ using UnityEngine.UIElements;
 
 namespace Velvet
 {
-    // Per-element state for a filter-* transition (opt-in via the transition-filter class). Holds the
-    // one-shot tick that lerps the inline filter's parameters from the current applied value to the newly
-    // composed one, the precomputed aligned interpolation slots, and the exact static list to settle to.
+    // Per-element state for a Velvet-driven filter-* transition. Holds the one-shot tick that lerps the
+    // inline filter's parameters from the current applied value to the newly composed one, the precomputed
+    // aligned interpolation slots, and the exact static list to settle to.
     internal sealed class StyleFilterTransitionBinding
     {
         // The one-shot tick, null when idle/settled. Scheduled on the PANEL ROOT (not the element) so a keyed
@@ -29,10 +29,26 @@ namespace Velvet
     }
 
     // Drives filter-* transitions (blur / brightness / contrast / …) via the scheduler tween Velvet already
-    // uses for animate-hue. UI Toolkit cannot CSS-transition the inline filter — a [filter] transition-property
-    // stops it repainting the filter after the first frame — so the transition-filter utility deliberately sets
-    // only duration + timing and this driver lerps the filter parameters itself, writing a fresh inline list per
-    // frame (same repaint-dirtying reason as the Hue arm of StyleAnimateDriver).
+    // uses for animate-hue, lerping the filter parameters itself and writing a fresh inline list per frame
+    // (same repaint-dirtying reason as the Hue arm of StyleAnimateDriver).
+    //
+    // Velvet takes over when the resolved transition-property CONTAINS filter — what .transition-filter pins,
+    // and equally true of a hand-authored list naming filter among others. Under a whole-property value the
+    // inline-filter setter runs the write as its own native animation (which no public API can cancel), so the
+    // tween stands down there and the engine animates it. That decision is TryStartOrRedirect's resolvedStyle
+    // probe, not the class list, and the tick re-checks it every frame so a value that changes mid-tween hands
+    // over instead of fighting.
+    //
+    // NB the setter does not test the transition list against `filter` at all: it tests it against
+    // `background-size`, and takes its animating path when an entry equals that or is a shorthand covering it.
+    // Three values therefore trip it — a whole-property value, `background-size`, and the
+    // `-unity-background-scale-mode` shorthand. The probe's rule is an OBSERVED equivalence, measured on this
+    // editor, not a restatement of the engine's own condition: it holds only because the values Velvet's own
+    // utilities produce never name those. Two consequences, neither diagnosed anywhere. A hand-authored list
+    // naming filter AND either of those two satisfies the probe and the setter at once, so both animators run
+    // the same property. And a list naming one of them WITHOUT filter animates the change natively even though
+    // nothing about it mentions filter, so "names neither, therefore discrete" holds only for lists that also
+    // avoid the background-size family.
     //
     // The write hook (TryStartOrRedirect) sits inside StyleArbitraryValueResolver.ApplyCombinedFilter — the sole
     // site that composes and writes style.filter — so it covers every filter path (base blur-md, arbitrary
@@ -61,9 +77,10 @@ namespace Velvet
         internal readonly struct Channel
         {
             public readonly FilterFunctionType Type;
-            // The bound definition for a first-party built-in Custom function (brightness/saturate); null for a
-            // native filter type. ApplyFrame rebuilds the function through it so a rebuilt Custom rebinds its
-            // shader material instead of collapsing to a definition-less Custom that renders nothing.
+            // The bound definition for a Custom function — first-party brightness/saturate or a user
+            // filter-[name:args]; null for a native filter type. ApplyFrame rebuilds the function through it so
+            // a rebuilt Custom rebinds its shader material instead of collapsing to a definition-less Custom
+            // that renders nothing.
             public readonly FilterFunctionDefinition? Definition;
             public readonly FilterParameter[] From;
             public readonly FilterParameter[] To;
@@ -88,11 +105,12 @@ namespace Velvet
 
         // The write hook, called from ApplyCombinedFilter with the freshly composed target list (null = clear).
         // Returns true iff it took ownership of the write (started or redirected a tween); false lets the
-        // resolver perform its instant write. Everything a non-opting element pays is the first line's lookup.
+        // resolver perform its instant write. An element with no binding pays only the first line's lookup.
         internal static bool TryStartOrRedirect(VisualElement element, List<FilterFunction>? to)
         {
-            // A binding exists only while the reconciler sees transition-filter on the element, so its presence
-            // IS the opt-in gate — a non-opting element pays only this lookup.
+            // The binding is the driver's per-element state, not the decision: the reconciler creates one
+            // wherever a transition-filter class appears, and the resolvedStyle probe below rules on whether
+            // this particular change is the tween's to run.
             if (!s_bindings.TryGetValue(element, out var b))
             {
                 return false;
@@ -114,6 +132,18 @@ namespace Velvet
                 Cancel(b);
                 return false;
             }
+            // The RESOLVED transition-property — not the class list — decides which animator owns the change.
+            // A list CONTAINING filter (alongside any number of other properties) keeps the inline-filter
+            // setter on its plain direct-write path, the only path where a per-frame tween write actually
+            // paints what it wrote. A whole-property value instead makes that setter run the write as a native
+            // animation that nothing can cancel, so the tween stands down and lets it animate. Any other list
+            // leaves the change discrete — EXCEPT one naming the background-size family, which trips the same
+            // native animation without mentioning filter at all (see the note on the class).
+            if (!ResolvedTransitionNamesFilter(element))
+            {
+                Cancel(b);
+                return false;
+            }
             var easing = element.resolvedStyle.transitionTimingFunction.FirstOrDefault().mode;
 
             // Read the CURRENT applied list as the from-side. During an in-flight tween this is last frame's
@@ -121,7 +151,7 @@ namespace Velvet
             var from = element.style.filter.value;
             if (!TryBuildChannels(from, to, out var channels))
             {
-                // Non-interpolable (a user custom filter, or an ambiguous add/remove) → discrete instant write.
+                // Non-interpolable (an ambiguous add/remove, mismatched slots) → discrete instant write.
                 Cancel(b);
                 return false;
             }
@@ -147,6 +177,37 @@ namespace Velvet
             return true;
         }
 
+        // The USS name of the filter property, as it appears in a resolved transition-property list.
+        private const string FilterPropertyName = "filter";
+
+        // Indexed rather than foreach'd: the resolved list is typed as an interface, so enumerating it boxes an
+        // enumerator — once per tick per animating element, since the tick re-checks this every frame. The
+        // backing value is a list today; the enumerated fallback keeps the answer correct rather than silently
+        // disabling the tween should that ever stop being true.
+        private static bool ResolvedTransitionNamesFilter(VisualElement element)
+        {
+            var resolved = element.resolvedStyle.transitionProperty;
+            if (resolved is IList<StylePropertyName> properties)
+            {
+                for (var k = 0; k < properties.Count; k++)
+                {
+                    if (properties[k].ToString() == FilterPropertyName)
+                    {
+                        return true;
+                    }
+                }
+                return false;
+            }
+            foreach (var property in resolved)
+            {
+                if (property.ToString() == FilterPropertyName)
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
         // Applies one frame at progress t (pre-easing). Pure: builds a FRESH list every call (UI Toolkit's
         // inline-filter setter dirties the element for repaint only when the backing list REFERENCE changes,
         // so a reused list would paint the first frame then freeze). Public so tests drive specific phases
@@ -157,8 +218,17 @@ namespace Velvet
             var list = new List<FilterFunction>(b.Channels.Length);
             foreach (var channel in b.Channels)
             {
-                // A first-party built-in Custom (brightness/saturate) must be rebuilt through its definition so
-                // it rebinds its shader; a native type is rebuilt by its FilterFunctionType.
+                // A Custom channel whose definition was destroyed mid-tween compares equal to null (a dead
+                // asset). The engine's FilterFunction constructor throws on one, and a Custom rebuilt without
+                // its definition would render nothing anyway, so drop the channel — the same degrade the
+                // resolver takes when a registered definition dies under it.
+                if (channel.Type == FilterFunctionType.Custom && channel.Definition == null)
+                {
+                    continue;
+                }
+                // A Custom (the first-party brightness/saturate, or a user filter-[name:args]) must be rebuilt
+                // through its definition so it rebinds its shader; a native type is rebuilt by its
+                // FilterFunctionType.
                 var fn = channel.Definition != null
                     ? new FilterFunction(channel.Definition)
                     : new FilterFunction(channel.Type);
@@ -178,27 +248,39 @@ namespace Velvet
             {
                 var elapsed = Time.realtimeSinceStartupAsDouble - b.StartTime;
                 var progress = b.DurationSec > 0f ? (float)(elapsed / b.DurationSec) : 1f;
-                if (progress >= 1f)
+                // The resolved transition-property can stop naming filter WHILE the tween runs — a class swap
+                // the reconciler keeps bound, or an inline transition-property written by a Motion play. From
+                // that moment every frame write is taken over by the setter's own animation and restarted from
+                // the painted value, so the paint would crawl behind a target that moves each tick. Hand over
+                // by settling once instead.
+                if (progress >= 1f || !ResolvedTransitionNamesFilter(element))
                 {
-                    // Settle to the EXACT composed static list so the tween lands on the resolver's own value.
-                    if (b.Target != null)
-                    {
-                        element.style.filter = b.Target;
-                    }
-                    else
-                    {
-                        element.style.filter = StyleKeyword.Null;
-                    }
-                    b.Scheduled?.Pause();
-                    b.Scheduled = null;
+                    Settle(element, b);
                     return;
                 }
                 ApplyFrame(element, b, progress);
             }).Every(StyleAnimateDriver.TickMs);
         }
 
+        // Writes the EXACT composed static list the tween was heading for (null = clear the inline filter) and
+        // stops ticking. The target is the resolver's own value, so the tween lands where a plain instant write
+        // would have. NOTE the target is the list composed when the tween started: a definition destroyed since
+        // then is still in it, and is skipped by the resolver's next compose rather than here.
+        private static void Settle(VisualElement element, StyleFilterTransitionBinding b)
+        {
+            if (b.Target != null)
+            {
+                element.style.filter = b.Target;
+            }
+            else
+            {
+                element.style.filter = StyleKeyword.Null;
+            }
+            Cancel(b);
+        }
+
         // Pauses + drops the tick, keeping the binding registered (idle). Used when a change resolves to an
-        // instant write (off-panel / zero-duration / non-interpolable) and by Detach.
+        // instant write (off-panel / zero-duration / not the tween's to run / non-interpolable) and by Detach.
         private static void Cancel(StyleFilterTransitionBinding b)
         {
             b.Scheduled?.Pause();
@@ -214,14 +296,7 @@ namespace Velvet
         {
             if (b.Scheduled != null && element.panel != null)
             {
-                if (b.Target != null)
-                {
-                    element.style.filter = b.Target;
-                }
-                else
-                {
-                    element.style.filter = StyleKeyword.Null;
-                }
+                Settle(element, b);
             }
             Cancel(b);
             Unregister(element);
@@ -230,11 +305,11 @@ namespace Velvet
         #region Channel alignment
 
         // Builds the aligned interpolation slots for from→to (both always in canonical filter order). Returns
-        // false — meaning "not interpolable, write instantly" — for a user filter-[name:args] custom or an
-        // ambiguous add/remove (a channel that appears more than once, which cannot be paired by identity
-        // alone). The first-party brightness/saturate customs DO interpolate: each is a single float amount, so
-        // they pair like a native filter, keyed by their definition to stay distinct from one another. A null
-        // from is treated as an empty list (a freshly-mounted element with no inline filter reads null, not []).
+        // false — meaning "not interpolable, write instantly" — for an ambiguous add/remove (a channel that
+        // appears more than once, which cannot be paired by identity alone), for an add/remove carrying two or
+        // more distinct user customs (they share one canonical rank, so the merge cannot order them), and for a
+        // slot pair whose parameters do not line up. A null from is treated as an empty list (a freshly-mounted
+        // element with no inline filter reads null, not []).
         internal static bool TryBuildChannels(List<FilterFunction>? from, List<FilterFunction>? to,
             out Channel[] channels)
         {
@@ -245,14 +320,11 @@ namespace Velvet
             {
                 return false;
             }
-            // A user custom filter binds opaque shader material state; a numeric cross-fade is meaningless. The
-            // first-party brightness/saturate customs are excluded — they interpolate like a native filter.
-            if (ContainsUserCustom(from) || ContainsUserCustom(to))
-            {
-                return false;
-            }
 
             // Fast path: identical channel sequence — the common case (a value change on the same filter set).
+            // A user filter-[name:args] custom rides this path too: SameChannel already pairs customs by
+            // reference-equal definition, so the slots that survive here are the same shader with the same
+            // declared parameters, and interpolating those arguments is what animating the filter means.
             if (SameChannelSequence(from, to))
             {
                 var paired = new Channel[fromCount];
@@ -260,7 +332,7 @@ namespace Velvet
                 {
                     var f = from![k];
                     var t = to![k];
-                    if (f.parameterCount != t.parameterCount)
+                    if (f.parameterCount != t.parameterCount || !ParameterTypesAlign(f, t))
                     {
                         return false;
                     }
@@ -276,6 +348,15 @@ namespace Velvet
             {
                 return false;
             }
+            // The merge below is a sorted merge over CanonicalRank, which gives EVERY user filter-[name:args]
+            // custom the same last rank. One distinct user custom is still the only channel at that rank, so
+            // both lists stay strictly ordered and the merge is well defined; two or more tie, and the merge
+            // would emit them in an order the resolver does not compose in. Snap only that case — an unpaired
+            // user custom fades from its own declared neutral like any other channel (see IdentityParams).
+            if (!AtMostOneUserCustomDefinition(from, to))
+            {
+                return false;
+            }
 
             var merged = new List<Channel>(fromCount + toCount);
             int i = 0, j = 0;
@@ -287,7 +368,7 @@ namespace Velvet
                     var t = to![j];
                     if (SameChannel(f, t))
                     {
-                        if (f.parameterCount != t.parameterCount)
+                        if (f.parameterCount != t.parameterCount || !ParameterTypesAlign(f, t))
                         {
                             return false;
                         }
@@ -331,26 +412,61 @@ namespace Velvet
         private static FilterFunctionDefinition? DefinitionOf(FilterFunction f)
             => f.type == FilterFunctionType.Custom ? f.customDefinition : null;
 
-        // A USER custom (filter-[name:args]) forces an instant write; a first-party brightness/saturate custom
-        // does not, since it interpolates like a native float filter.
-        private static bool ContainsUserCustom(List<FilterFunction>? list)
+        // Two paired functions interpolate only when each slot holds the same kind of value: a definition may
+        // declare a color slot where its counterpart declares a float, and lerping across those is meaningless.
+        private static bool ParameterTypesAlign(FilterFunction a, FilterFunction b)
+        {
+            for (var k = 0; k < a.parameterCount; k++)
+            {
+                if (a.GetParameter(k).type != b.GetParameter(k).type)
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        // A USER custom (filter-[name:args]), as opposed to a first-party brightness/saturate custom. Only the
+        // add/remove merge distinguishes them: it has no per-name ordering for user customs.
+        private static bool IsUserCustom(FilterFunction f)
+            => f.type == FilterFunctionType.Custom && !BuiltInFilterDefinitions.IsBuiltIn(f.customDefinition);
+
+        // True when the two lists hold AT MOST ONE distinct user-custom definition between them; false once a
+        // second appears, which is the case that ties CanonicalRank. Definitions are compared by reference, the
+        // same identity SameChannel pairs on.
+        private static bool AtMostOneUserCustomDefinition(List<FilterFunction>? from, List<FilterFunction>? to)
+        {
+            FilterFunctionDefinition? definition = null;
+            return ScanUserCustoms(from, ref definition) && ScanUserCustoms(to, ref definition);
+        }
+
+        private static bool ScanUserCustoms(List<FilterFunction>? list, ref FilterFunctionDefinition? definition)
         {
             if (list == null)
             {
-                return false;
+                return true;
             }
             foreach (var f in list)
             {
-                if (f.type == FilterFunctionType.Custom && !BuiltInFilterDefinitions.IsBuiltIn(f.customDefinition))
+                if (!IsUserCustom(f))
                 {
-                    return true;
+                    continue;
+                }
+                if (definition == null)
+                {
+                    definition = f.customDefinition;
+                }
+                else if (!ReferenceEquals(definition, f.customDefinition))
+                {
+                    return false;
                 }
             }
-            return false;
+            return true;
         }
 
-        // Two functions share a channel when they are the same native filter type, or both the SAME first-party
-        // custom — brightness and saturate are distinct channels even though both are FilterFunctionType.Custom.
+        // Two functions share a channel when they are the same native filter type, or both Custom bound to the
+        // SAME definition — brightness, saturate and each user filter-[name:args] are distinct channels even
+        // though all of them are FilterFunctionType.Custom.
         private static bool SameChannel(FilterFunction a, FilterFunction b)
         {
             if (a.type != b.type)
@@ -400,8 +516,9 @@ namespace Velvet
 
         // Canonical composition order of the filter channels (mirrors s_filterOrder in the resolver): the two
         // first-party customs slot by their definition — brightness right after blur, saturate right after
-        // invert — so an add/remove merge keeps the same order the resolver composes in. Only consulted after
-        // user customs and repeated channels are ruled out.
+        // invert — so an add/remove merge keeps the same order the resolver composes in. A user custom ranks
+        // last, matching the resolver composing every user custom after the built-ins; the caller admits at
+        // most one distinct user custom precisely because they all share that one rank.
         private static int CanonicalRank(FilterFunction f)
         {
             if (f.type == FilterFunctionType.Custom)
@@ -433,19 +550,36 @@ namespace Velvet
             return arr;
         }
 
-        // The neutral parameters for a filter — the value at which it is a no-op. The multiplicative filters
-        // (contrast, and the first-party brightness/saturate customs) are off at 1; every other float filter
-        // (blur, grayscale, hue-rotate, invert, sepia) is off at 0; a color parameter's identity is white.
+        // The neutral parameters for a filter — the value at which it is a no-op, which a channel present on
+        // only one side fades from or to. A CUSTOM function declares its own per-slot neutral, and that
+        // declaration is the same value the engine pads a filter-list transition with, so it is read straight
+        // off the definition rather than guessed from the function's shape. For a native type the neutral
+        // follows the CSS definition: contrast is off at 1, every other float filter (blur, grayscale,
+        // hue-rotate, invert, sepia) is off at 0, and a color parameter's identity is white.
         private static FilterParameter[] IdentityParams(FilterFunction f)
         {
             var count = f.parameterCount;
             var arr = new FilterParameter[count];
-            var floatIdentity = f.type == FilterFunctionType.Contrast
-                || BuiltInFilterDefinitions.IsBuiltIn(f.customDefinition) ? 1f : 0f;
+            var declarations = f.type == FilterFunctionType.Custom ? f.customDefinition?.parameters : null;
+            var floatIdentity = f.type == FilterFunctionType.Contrast ? 1f : 0f;
             for (var k = 0; k < count; k++)
             {
-                var p = f.GetParameter(k);
-                arr[k] = p.type == FilterParameterType.Color
+                // A declaration shorter than the live parameter list leaves that slot without a declared
+                // neutral; fall back to the native rule for its type. NOTE the ?. above is a plain reference
+                // check — it does NOT use the engine's destroyed-object equality, so a destroyed-but-uncollected
+                // definition still reaches this. That is safe only because reading the parameter declarations
+                // touches managed fields; anything here that reaches native state must test the definition with
+                // == null instead (as the frame apply does).
+                if (declarations != null && k < declarations.Length)
+                {
+                    var declared = declarations[k].interpolationDefaultValue;
+                    if (declared.type == f.GetParameter(k).type)
+                    {
+                        arr[k] = declared;
+                        continue;
+                    }
+                }
+                arr[k] = f.GetParameter(k).type == FilterParameterType.Color
                     ? new FilterParameter(Color.white)
                     : new FilterParameter(floatIdentity);
             }

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/FilterTransitionPanelTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/FilterTransitionPanelTests.cs
@@ -1,31 +1,89 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using UnityEditor;
+using UnityEngine;
 using UnityEngine.UIElements;
 using Velvet.TestUtilities;
+using Object = UnityEngine.Object;
 
 namespace Velvet.Tests
 {
     /// <summary>
-    /// Coverage for the transition-filter opt-in tween (<see cref="StyleFilterTransitionDriver"/>), which lerps
-    /// the inline filter's parameters because UI Toolkit cannot CSS-transition an inline filter.
+    /// Coverage for the filter-* transition tween (<see cref="StyleFilterTransitionDriver"/>), which lerps the
+    /// inline filter's parameters itself whenever the resolved <c>transition-property</c> CONTAINS
+    /// <c>filter</c> — the shape under which the engine's inline-filter setter leaves a write on its plain
+    /// direct-write path instead of running it as its own uncancellable animation.
     /// Group A drives the pure <see cref="StyleFilterTransitionDriver.ApplyFrame"/> at explicit phases (the
     /// scheduler never ticks in EditMode; filter is geometry-independent, so no panel is needed to interpolate).
     /// Group B mounts a real <see cref="EditorWindow"/> panel with the bundled stylesheet so the transition-*
-    /// longhands resolve, then exercises the real write hook through the arbitrary-value resolver. GWT, one
-    /// assert each.
+    /// longhands resolve, then exercises the real write hook through the arbitrary-value resolver; the cases
+    /// that must distinguish "Velvet's write landed" from "the engine swallowed it and animated instead" assert
+    /// on <c>resolvedStyle.filter</c> (what is painted) rather than <c>style.filter</c> (what was written), and
+    /// drive the panel's animation phase on a fake clock so the reading is load-independent. GWT, one assert
+    /// each.
     /// </summary>
     [TestFixture]
     internal sealed class FilterTransitionPanelTests : PanelTestBase
     {
         private const string StyleSheetPath = "Packages/com.velvet.core/Runtime/Styles/StyleUtilities.uss";
 
+        // Fake panel clock: the engine's animation phase reads elapsed time exclusively through the panel's
+        // time function, so stepping this by hand makes every painted mid-animation value deterministic.
+        private double _now;
+        private readonly List<Object> _spawned = new();
+
         protected override void LoadStyleSheets()
         {
             var sheet = AssetDatabase.LoadAssetAtPath<StyleSheet>(StyleSheetPath);
             Assume.That(sheet, Is.Not.Null, "Precondition: the bundled StyleUtilities.uss loads");
             _window.rootVisualElement.styleSheets.Add(sheet);
+            _now = 100.0;
+            EditorPanelTestHelpers.SetPanelTimeFunction(_window.rootVisualElement.panel, () => _now);
+        }
+
+        public override void TearDown()
+        {
+            base.TearDown();
+            foreach (var obj in _spawned)
+            {
+                if (obj != null)
+                {
+                    Object.DestroyImmediate(obj);
+                }
+            }
+            _spawned.Clear();
+        }
+
+        // A user-authored custom filter definition (NOT one of the first-party brightness/saturate ones), with
+        // one declared parameter slot per supplied default — the slot types drive what may interpolate.
+        private FilterFunctionDefinition CreateUserDefinition(params FilterParameter[] parameterDefaults)
+        {
+            var def = ScriptableObject.CreateInstance<FilterFunctionDefinition>();
+            var declarations = new FilterParameterDeclaration[parameterDefaults.Length];
+            for (var i = 0; i < parameterDefaults.Length; i++)
+            {
+                declarations[i] = new FilterParameterDeclaration
+                {
+                    name = "p" + i,
+                    interpolationDefaultValue = parameterDefaults[i],
+                };
+            }
+            def.parameters = declarations;
+            _spawned.Add(def);
+            return def;
+        }
+
+        // A single-function list holding a user custom bound to def, carrying the supplied arguments.
+        private static List<FilterFunction> CustomList(FilterFunctionDefinition def, params FilterParameter[] args)
+        {
+            var fn = new FilterFunction(def);
+            foreach (var arg in args)
+            {
+                fn.AddParameter(arg);
+            }
+            return new List<FilterFunction> { fn };
         }
 
         // A single-blur inline filter list, the simplest interpolable filter (one float parameter).
@@ -38,8 +96,8 @@ namespace Velvet.Tests
 
         // A single brightness inline filter list. brightness renders as a FIRST-PARTY custom-filter function
         // (FilterFunctionType.Custom bound to BuiltInFilterDefinitions.Brightness), so it exercises the driver's
-        // built-in-custom interpolation path — distinct from a user filter-[name:args] custom, which stays a
-        // discrete instant write.
+        // Custom interpolation path through a definition Velvet itself owns, rather than a user
+        // filter-[name:args] one.
         private static List<FilterFunction> BrightnessList(float amount)
         {
             var fn = new FilterFunction(BuiltInFilterDefinitions.Brightness);
@@ -60,6 +118,18 @@ namespace Velvet.Tests
         // so it flows through ApplyCombinedFilter's transition hook.
         private static void ApplyBlur(VisualElement element, float px)
             => StyleArbitraryValueResolver.Apply(element, new ArbitraryStyle(ArbitraryProperty.FilterBlur, px, LengthUnit.Pixel));
+
+        // Advances the fake clock and runs the panel's animation phase, the pair a live panel performs once per
+        // frame. What resolvedStyle reports afterwards is what would be painted.
+        private void AdvanceAndPaint(IPanel panel, double seconds)
+        {
+            _now += seconds;
+            EditorPanelTestHelpers.DriveAnimationsOnce(panel);
+        }
+
+        // The float parameter of the element's single PAINTED filter function.
+        private static float PaintedFloat(VisualElement element)
+            => element.resolvedStyle.filter.First().GetParameter(0).floatValue;
 
         #region Group A — pure ApplyFrame
 
@@ -162,6 +232,226 @@ namespace Velvet.Tests
 
             // Assert — RED if Ease ignores the mode and lerps linearly (which would land at 3).
             Assert.That(element.style.filter.value[0].GetParameter(0).floatValue, Is.LessThan(3f));
+        }
+
+        #endregion
+
+        #region Group A2 — user custom filters (filter-[name:args])
+
+        [Test]
+        public void Given_TwoListsOfOneUserCustom_When_ChannelsBuilt_Then_TheCustomAligns()
+        {
+            // Arrange — the same user definition on both sides, one float argument each. The two functions are
+            // the same shader with the same declared slots, so lerping the arguments is exactly what animating
+            // that filter means.
+            var def = CreateUserDefinition(new FilterParameter(0f));
+
+            // Act
+            var built = StyleFilterTransitionDriver.TryBuildChannels(
+                CustomList(def, new FilterParameter(0f)), CustomList(def, new FilterParameter(1f)),
+                out var channels);
+
+            // Assert — one interpolable channel (RED while any user custom forces an instant write).
+            Assert.That((built, channels.Length), Is.EqualTo((true, 1)));
+        }
+
+        [Test]
+        public void Given_AUserCustomTween_When_FrameAtMid_Then_TheArgumentIsHalfway()
+        {
+            // Arrange — a user custom whose single float argument runs 0 → 1.
+            var element = new VisualElement();
+            var def = CreateUserDefinition(new FilterParameter(0f));
+            var to = CustomList(def, new FilterParameter(1f));
+            StyleFilterTransitionDriver.TryBuildChannels(CustomList(def, new FilterParameter(0f)), to, out var channels);
+            var binding = new StyleFilterTransitionBinding { Channels = channels, Easing = EasingMode.Linear, Target = to };
+            Assume.That(channels.Length, Is.EqualTo(1), "Precondition: the custom aligned into one channel");
+
+            // Act
+            StyleFilterTransitionDriver.ApplyFrame(element, binding, 0.5f);
+
+            // Assert — the rebuilt function still carries its definition (a definition-less Custom renders
+            // nothing) and its argument sits halfway.
+            var fn = element.style.filter.value[0];
+            Assert.That((ReferenceEquals(fn.customDefinition, def), fn.GetParameter(0).floatValue),
+                Is.EqualTo((true, 0.5f)));
+        }
+
+        [Test]
+        public void Given_AUserCustomWithAColorArgument_When_FrameAtMid_Then_TheColorIsHalfway()
+        {
+            // Arrange — a color slot interpolates like any other: the lerp helper handles colors and a color
+            // argument is as continuous as a float one.
+            var element = new VisualElement();
+            var def = CreateUserDefinition(new FilterParameter(Color.black));
+            var to = CustomList(def, new FilterParameter(Color.white));
+            StyleFilterTransitionDriver.TryBuildChannels(CustomList(def, new FilterParameter(Color.black)), to, out var channels);
+            var binding = new StyleFilterTransitionBinding { Channels = channels, Easing = EasingMode.Linear, Target = to };
+
+            // Act
+            StyleFilterTransitionDriver.ApplyFrame(element, binding, 0.5f);
+
+            // Assert — one channel painting mid-grey, not a snap to either end. The count travels in the assert
+            // rather than an Assume so an inadmissible color slot (which leaves no channel at all) fails here
+            // instead of reporting inconclusive.
+            var list = element.style.filter.value;
+            Assert.That((list.Count, list.Count == 1 && Mathf.Approximately(list[0].GetParameter(0).colorValue.r, 0.5f)),
+                Is.EqualTo((1, true)));
+        }
+
+        [Test]
+        public void Given_TwoDifferentUserCustoms_When_ChannelsBuilt_Then_ItSnaps()
+        {
+            // Arrange — different definitions are different shaders; there is no correspondence between their
+            // arguments to interpolate along.
+            var a = CreateUserDefinition(new FilterParameter(0f));
+            var b = CreateUserDefinition(new FilterParameter(0f));
+
+            // Act
+            var built = StyleFilterTransitionDriver.TryBuildChannels(
+                CustomList(a, new FilterParameter(0f)), CustomList(b, new FilterParameter(1f)), out _);
+
+            // Assert — an instant write.
+            Assert.That(built, Is.False);
+        }
+
+        [Test]
+        public void Given_AUserCustomWithDifferingArity_When_ChannelsBuilt_Then_ItSnaps()
+        {
+            // Arrange — the same definition but a different number of supplied arguments: the slots do not
+            // line up pairwise, so there is nothing well-defined to lerp.
+            var def = CreateUserDefinition(new FilterParameter(0f), new FilterParameter(0f));
+
+            // Act
+            var built = StyleFilterTransitionDriver.TryBuildChannels(
+                CustomList(def, new FilterParameter(0f)),
+                CustomList(def, new FilterParameter(0f), new FilterParameter(1f)), out _);
+
+            // Assert
+            Assert.That(built, Is.False);
+        }
+
+        [Test]
+        public void Given_AUserCustomWithAMismatchedArgumentType_When_ChannelsBuilt_Then_ItSnaps()
+        {
+            // Arrange — same definition and arity, but one side supplies a color where the other supplies a
+            // float; lerping across the two kinds is meaningless.
+            var def = CreateUserDefinition(new FilterParameter(0f));
+
+            // Act
+            var built = StyleFilterTransitionDriver.TryBuildChannels(
+                CustomList(def, new FilterParameter(0f)), CustomList(def, new FilterParameter(Color.white)), out _);
+
+            // Assert
+            Assert.That(built, Is.False);
+        }
+
+        [Test]
+        public void Given_AUserCustomAddedOnOneSide_When_FrameAtMid_Then_ItFadesFromItsDeclaredNeutral()
+        {
+            // Arrange — a user custom present only in the to-list is padded from a neutral, and a user shader's
+            // neutral is the one its own declaration states (the same value the engine pads its filter-list
+            // transitions with). The declared 0.4 is chosen so the painted midpoint tells reading the
+            // declaration (0.7) apart from assuming a native filter's zero (0.5).
+            var element = new VisualElement();
+            var def = CreateUserDefinition(new FilterParameter(0.4f));
+            var to = new List<FilterFunction>(BlurList(12f));
+            to.AddRange(CustomList(def, new FilterParameter(1f)));
+            StyleFilterTransitionDriver.TryBuildChannels(BlurList(0f), to, out var channels);
+            var binding = new StyleFilterTransitionBinding { Channels = channels, Easing = EasingMode.Linear, Target = to };
+
+            // Act
+            StyleFilterTransitionDriver.ApplyFrame(element, binding, 0.5f);
+
+            // Assert — halfway from the declared 0.4 to 1. RED while an added user custom snaps (no channels at
+            // all), and RED if the neutral is guessed from the function's shape instead of read (0.5).
+            var list = element.style.filter.value;
+            Assert.That((list.Count, list.Count == 2 && Mathf.Approximately(list[1].GetParameter(0).floatValue, 0.7f)),
+                Is.EqualTo((2, true)));
+        }
+
+        [Test]
+        public void Given_ABuiltInCustomAddedOnOneSide_When_FrameAtMid_Then_ItFadesFromOne()
+        {
+            // Arrange — brightness declares 1 as its neutral (brightness(1) is the CSS no-op), so reading the
+            // declaration has to keep yielding the multiplicative identity rather than the 0 a blur fades from.
+            Assume.That(BuiltInFilterDefinitions.Brightness, Is.Not.Null,
+                "Precondition: the brightness shader resolved into a definition");
+            var element = new VisualElement();
+            var to = BrightnessList(1.5f);
+            StyleFilterTransitionDriver.TryBuildChannels(null, to, out var channels);
+            var binding = new StyleFilterTransitionBinding { Channels = channels, Easing = EasingMode.Linear, Target = to };
+
+            // Act
+            StyleFilterTransitionDriver.ApplyFrame(element, binding, 0.5f);
+
+            // Assert — halfway from 1 to 1.5, not from 0.
+            Assert.That(element.style.filter.value[0].GetParameter(0).floatValue, Is.EqualTo(1.25f).Within(1e-5f));
+        }
+
+        [Test]
+        public void Given_ABlurAddedBesideAPairedUserCustom_When_ChannelsBuilt_Then_BothChannelsAlign()
+        {
+            // Arrange — base filter-[custom:1], hover blur-4 filter-[custom:2]: the custom pairs on both sides
+            // and only the blur is added. The custom needs no invented identity, and with a single distinct
+            // user custom the canonical ranks stay strictly ordered, so the merge places both correctly.
+            var def = CreateUserDefinition(new FilterParameter(0f));
+            var to = new List<FilterFunction>(BlurList(4f));
+            to.AddRange(CustomList(def, new FilterParameter(2f)));
+
+            // Act
+            var built = StyleFilterTransitionDriver.TryBuildChannels(
+                CustomList(def, new FilterParameter(1f)), to, out var channels);
+
+            // Assert — blur first (canonical order), then the custom (RED while any user custom bars the merge).
+            // Joined rather than compared as arrays: a tuple assert compares each slot with Equals, which for
+            // an array is reference identity.
+            Assert.That((built, string.Join(",", channels.Select(c => c.Type))),
+                Is.EqualTo((true, "Blur,Custom")));
+        }
+
+        [Test]
+        public void Given_TwoDistinctUserCustomsAcrossAnAddOrRemove_When_ChannelsBuilt_Then_ItSnaps()
+        {
+            // Arrange — two different user definitions share the same last canonical rank, so the sorted merge
+            // has no tiebreak and would emit them in an order the resolver does not compose in.
+            var a = CreateUserDefinition(new FilterParameter(0f));
+            var b = CreateUserDefinition(new FilterParameter(0f));
+            var from = new List<FilterFunction>(CustomList(a, new FilterParameter(1f)));
+            from.AddRange(CustomList(b, new FilterParameter(1f)));
+            var to = new List<FilterFunction>(BlurList(4f));
+            to.AddRange(CustomList(a, new FilterParameter(2f)));
+            to.AddRange(CustomList(b, new FilterParameter(2f)));
+
+            // Act
+            var built = StyleFilterTransitionDriver.TryBuildChannels(from, to, out _);
+
+            // Assert
+            Assert.That(built, Is.False);
+        }
+
+        [Test]
+        public void Given_AUserCustomDefinitionDestroyedMidTween_When_FrameApplied_Then_TheChannelIsOmitted()
+        {
+            // Arrange — a blur + user custom tween whose definition is destroyed while the tween is in flight.
+            // The engine's filter-function constructor throws on a dead definition, and a Custom rebuilt
+            // without one would render nothing anyway.
+            var element = new VisualElement();
+            var def = CreateUserDefinition(new FilterParameter(0f));
+            var from = new List<FilterFunction>(BlurList(0f));
+            from.AddRange(CustomList(def, new FilterParameter(0f)));
+            var to = new List<FilterFunction>(BlurList(12f));
+            to.AddRange(CustomList(def, new FilterParameter(1f)));
+            StyleFilterTransitionDriver.TryBuildChannels(from, to, out var channels);
+            var binding = new StyleFilterTransitionBinding { Channels = channels, Easing = EasingMode.Linear, Target = to };
+            Object.DestroyImmediate(def);
+
+            // Act
+            StyleFilterTransitionDriver.ApplyFrame(element, binding, 0.5f);
+
+            // Assert — the surviving blur still paints and the dead channel is dropped rather than throwing.
+            // Both facts travel in the assert (rather than an Assume that the pair aligned) so a regression
+            // making the pair inadmissible — which leaves an empty list — fails here instead of skipping.
+            Assert.That(element.style.filter.value.Select(f => f.type), Is.EqualTo(new[] { FilterFunctionType.Blur }));
         }
 
         #endregion
@@ -270,6 +560,197 @@ namespace Velvet.Tests
 
             // Assert — the cancelled tween settles to its target instead of freezing at the mid-frame value.
             Assert.That(element.style.filter.value[0].GetParameter(0).floatValue, Is.EqualTo(12f));
+        }
+
+        #endregion
+
+        #region Group C — what the panel actually paints
+
+        [Test]
+        public void Given_TransitionFilterMidTween_When_TheFrameIsPainted_Then_ThePaintedFilterIsTheTweenValue()
+        {
+            // Arrange — a tween to blur-12 stepped to its own midpoint. The inline value alone cannot tell
+            // whether the write landed: under a whole-property transition-property the engine swallows each
+            // write and re-targets its own animation, leaving the PAINTED value near zero while the inline
+            // value reads exactly 6.
+            var element = MountResolved("transition-filter duration-300");
+            var binding = _mounted.Root.Reconciler.Context.FilterTransitionBindings[element];
+            ApplyBlur(element, 12f);
+            StyleFilterTransitionDriver.ApplyFrame(element, binding, 0.5f);
+            Assume.That(element.style.filter.value[0].GetParameter(0).floatValue, Is.EqualTo(6f),
+                "Precondition: the tween wrote its own midpoint");
+
+            // Act — the panel paints a frame, 150 ms after the write.
+            AdvanceAndPaint(element.panel, 0.15);
+
+            // Assert — the paint shows what the tween wrote, unmoved.
+            Assert.That(PaintedFloat(element), Is.EqualTo(6f));
+        }
+
+        [Test]
+        public void Given_TransitionColorsOverridingTheOptIn_When_FilterChanges_Then_InstantWrite()
+        {
+            // Arrange — transition-colors is declared after transition-filter in the bundled sheet, so at equal
+            // specificity it wins transition-property while the opt-in class still registers a binding. The
+            // resolved property names no filter, so this must stay a discrete change: guards the driver's probe
+            // against matching any non-empty transition list.
+            var element = MountResolved("transition-filter transition-colors");
+            Assume.That(_mounted.Root.Reconciler.Context.FilterTransitionBindings.ContainsKey(element), Is.True,
+                "Precondition: a binding is registered");
+            Assume.That(element.resolvedStyle.transitionProperty.Select(p => p.ToString()), Does.Not.Contain("filter"),
+                "Precondition: the resolved transition-property names no filter");
+
+            // Act
+            ApplyBlur(element, 12f);
+
+            // Assert — the composed value lands immediately (RED if the driver tweens on any live duration).
+            Assert.That(element.style.filter.value[0].GetParameter(0).floatValue, Is.EqualTo(12f));
+        }
+
+        [Test]
+        public void Given_TransitionAll_When_FilterChanges_Then_TheEngineAnimatesThePaintedFilter()
+        {
+            // CHARACTERIZATION PIN, not a requirement on Velvet: nothing in Velvet animates this, and the
+            // asserted midpoint is what THIS editor's inline-filter setter does with a whole-property
+            // transition. It is recorded because the whole design branches on it — the setter reaches its
+            // animating path by matching the transition list against background-size, not filter. Should that
+            // property-id ever change, this test keeps passing while the filter-naming tests below start
+            // failing, and the right response is to re-measure both rather than to patch either.
+            //
+            // Arrange
+            var element = MountResolved("transition-all duration-300");
+            Assume.That(element.resolvedStyle.transitionProperty.Select(p => p.ToString()), Does.Not.Contain("filter"),
+                "Precondition: the resolved transition-property is the whole-property value, not filter");
+
+            // Act — the change is written, then the panel paints a frame at the animation's midpoint.
+            ApplyBlur(element, 12f);
+            AdvanceAndPaint(element.panel, 0.15);
+
+            // Assert — the paint is mid-flight, neither the old value nor the target.
+            Assert.That(PaintedFloat(element), Is.EqualTo(6f).Within(0.5f));
+        }
+
+        [Test]
+        public void Given_TransitionPropertyNamingFilterAmongOthers_When_FilterChanges_Then_TheTweenRuns()
+        {
+            // Arrange — a list naming filter alongside another property leaves the inline-filter setter on the
+            // same direct-write path a lone filter does, so the tween owns the change exactly as CSS would.
+            // Pins the probe as a CONTAINS test: narrowing it to "the only name" would silently snap this.
+            var element = MountResolved("transition-filter duration-300");
+            var binding = _mounted.Root.Reconciler.Context.FilterTransitionBindings[element];
+            element.style.transitionProperty = new StyleList<StylePropertyName>(
+                new List<StylePropertyName> { new StylePropertyName("filter"), new StylePropertyName("opacity") });
+            ForcePanelUpdate(element.panel);
+            Assume.That(element.resolvedStyle.transitionProperty.Select(p => p.ToString()),
+                Is.EqualTo(new[] { "filter", "opacity" }), "Precondition: the multi-name list resolved");
+
+            // Act
+            ApplyBlur(element, 12f);
+
+            // Assert — the tween took the write.
+            Assert.That(binding.Scheduled, Is.Not.Null);
+        }
+
+        [Test]
+        public void Given_ARunningTween_When_TheTransitionPropertyStopsNamingFilter_Then_TheTickSettlesAndStops()
+        {
+            // Arrange — a live tween whose transition-property is then rewritten out from under it (what a
+            // Motion play does inline). From that moment every frame write would be taken over by the setter's
+            // own animation and restarted from the painted value, so the tick must hand over instead of
+            // ticking on. The fake clock keeps the tick's own elapsed reading irrelevant here.
+            var element = MountResolved("transition-filter duration-300");
+            var binding = _mounted.Root.Reconciler.Context.FilterTransitionBindings[element];
+            ApplyBlur(element, 12f);
+            Assume.That(binding.Scheduled, Is.Not.Null, "Precondition: a tween is running");
+            element.style.transitionProperty = new StyleList<StylePropertyName>(
+                new List<StylePropertyName> { new StylePropertyName("all") });
+            ForcePanelUpdate(element.panel);
+
+            // Act — the tick fires once after the rewrite.
+            EditorPanelTestHelpers.DriveSchedulerOnce(element.panel);
+
+            // Assert — the tick settled to its target and stopped rather than continuing to write frames.
+            Assert.That((binding.Scheduled, element.style.filter.value[0].GetParameter(0).floatValue),
+                Is.EqualTo(((IVisualElementScheduledItem)null, 12f)));
+        }
+
+        #endregion
+
+        #region Group D — what the inline-filter setter actually gates on
+
+        // These three mount WITHOUT transition-filter, so no tween binding exists and the driver returns at its
+        // first line. The resolver's instant write is then the only writer and the engine the only animator,
+        // which makes each row a single-animator, fully deterministic reading of the setter's gate.
+        //
+        // Together they pin the gap between what Velvet's probe asks ("does the list name filter?") and what
+        // the setter asks ("does the list name background-size, or a shorthand covering it?"). Today those two
+        // questions disagree, which is exactly why naming filter is safe and naming the background-size family
+        // is not. If the engine ever changes which property-id it queries, the second and third rows flip and
+        // say so loudly — they are the canary for the whole design.
+        private void MountWithInlineTransition(string className, out VisualElement element, params string[] properties)
+        {
+            element = MountResolved(className);
+            Assume.That(_mounted.Root.Reconciler.Context.FilterTransitionBindings.ContainsKey(element), Is.False,
+                "Precondition: no tween binding, so the engine is the only animator");
+            var names = new List<StylePropertyName>();
+            foreach (var property in properties)
+            {
+                names.Add(new StylePropertyName(property));
+            }
+            element.style.transitionProperty = new StyleList<StylePropertyName>(names);
+            element.style.transitionDuration = new StyleList<TimeValue>(new List<TimeValue> { new TimeValue(0.3f) });
+            // Linear so a painted midpoint is exactly half the target. These elements carry no ease-* class, so
+            // they would otherwise resolve the initial `ease` curve and land at 0.725 of the way.
+            element.style.transitionTimingFunction = new StyleList<EasingFunction>(
+                new List<EasingFunction> { new EasingFunction(EasingMode.Linear) });
+            ForcePanelUpdate(element.panel);
+        }
+
+        [Test]
+        public void Given_NoBindingAndATransitionNamingFilterAndOpacity_When_FilterChanges_Then_ThePaintIsInstant()
+        {
+            // Arrange — neither name is background-size-shaped, so the setter takes its direct-write path even
+            // though the list names filter and a live duration is resolved. This is the property that makes
+            // Velvet's tween able to paint its own frames at all.
+            MountWithInlineTransition("w-[100px] h-[40px]", out var element, "filter", "opacity");
+
+            // Act
+            ApplyBlur(element, 12f);
+            AdvanceAndPaint(element.panel, 0.15);
+
+            // Assert — the composed value is painted outright, never animated.
+            Assert.That(PaintedFloat(element), Is.EqualTo(12f));
+        }
+
+        [Test]
+        public void Given_NoBindingAndATransitionNamingBackgroundSize_When_FilterChanges_Then_TheEngineAnimatesIt()
+        {
+            // Arrange — background-size is the property-id the setter actually queries, so naming it animates
+            // the FILTER even though the list says nothing about filters.
+            MountWithInlineTransition("w-[100px] h-[40px]", out var element, "background-size");
+
+            // Act
+            ApplyBlur(element, 12f);
+            AdvanceAndPaint(element.panel, 0.15);
+
+            // Assert — exactly half way at the half-way point, so a list naming this alongside filter would
+            // put the engine's animation and Velvet's tween on the same property at once.
+            Assert.That(PaintedFloat(element), Is.EqualTo(6f).Within(1e-3f));
+        }
+
+        [Test]
+        public void Given_NoBindingAndATransitionNamingTheBackgroundScaleModeShorthand_When_FilterChanges_Then_TheEngineAnimatesIt()
+        {
+            // Arrange — the same gate also accepts any shorthand covering background-size, and
+            // -unity-background-scale-mode is one, so it is a SECOND way into the engine's filter animation.
+            MountWithInlineTransition("w-[100px] h-[40px]", out var element, "-unity-background-scale-mode");
+
+            // Act
+            ApplyBlur(element, 12f);
+            AdvanceAndPaint(element.panel, 0.15);
+
+            // Assert — exactly half way, same as naming background-size outright.
+            Assert.That(PaintedFloat(element), Is.EqualTo(6f).Within(1e-3f));
         }
 
         #endregion

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/StyleUtilitiesUssTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/StyleUtilitiesUssTests.cs
@@ -349,6 +349,20 @@ namespace Velvet.Tests
         }
 
         [Test]
+        public void Given_TransitionFilterClass_When_Resolved_Then_TransitionsFilterOnly()
+        {
+            // Arrange / Act — the utility must name filter. A whole-property value would hand the change to
+            // the inline-filter setter's own uncancellable animation instead, and Velvet's tween reads this
+            // resolved value to decide whether it owns the motion. (The driver accepts any list CONTAINING
+            // filter; this utility contributes exactly the one name.)
+            var leaf = MountAndResolve("transition-filter");
+            var properties = leaf.resolvedStyle.transitionProperty.Select(p => p.ToString()).ToArray();
+
+            // Assert
+            Assert.That(properties, Is.EqualTo(new[] { "filter" }));
+        }
+
+        [Test]
         public void Given_ArbitraryDurationMs_When_Resolved_Then_AppliesTransitionDurationInSeconds()
         {
             // duration-[400ms] carries a TIME value (not a length) and resolves to a 0.4s transition-duration.

--- a/Packages/com.velvet.core/TestUtilities/EditorPanelTestHelpers.cs
+++ b/Packages/com.velvet.core/TestUtilities/EditorPanelTestHelpers.cs
@@ -54,6 +54,23 @@ namespace Velvet.TestUtilities
         }
 
         /// <summary>
+        /// Runs the panel's animation phase once — the same call a live panel issues once per frame — so an
+        /// EditMode fixture can advance the engine's own style transitions deterministically (the batchmode
+        /// PlayerLoop never ticks them). Pair with <see cref="SetPanelTimeFunction"/>: the animation phase
+        /// reads elapsed time through the panel's time function. Internal engine surface, reached by walking
+        /// the panel's type chain for its animation-update entry point.
+        /// </summary>
+        public static void DriveAnimationsOnce(IPanel panel)
+        {
+            var update = FindPanelMethod(panel, "UpdateAnimations");
+            if (update == null)
+            {
+                throw new MissingMethodException(panel.GetType().FullName, "UpdateAnimations");
+            }
+            update.Invoke(panel, null);
+        }
+
+        /// <summary>
         /// Installs a fake clock on the panel: the scheduler and every scheduled item read time
         /// exclusively through the panel's own time function (double seconds), so an EditMode fixture
         /// can drive cadence deterministically regardless of machine load. Internal engine surface,
@@ -68,6 +85,24 @@ namespace Velvet.TestUtilities
             }
             var del = Delegate.CreateDelegate(prop.PropertyType, secondsClock.Target, secondsClock.Method);
             prop.SetValue(panel, del);
+        }
+
+        // Walks the panel's type chain for an inherited method, for the same reason FindPanelProperty
+        // walks it for a property: the engine declares these on an internal base the concrete panel type
+        // inherits, which a plain GetMethod on the concrete type misses.
+        private static MethodInfo FindPanelMethod(IPanel panel, string name)
+        {
+            for (var t = panel.GetType(); t != null; t = t.BaseType)
+            {
+                var method = t.GetMethod(name,
+                    BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly,
+                    binder: null, types: Type.EmptyTypes, modifiers: null);
+                if (method != null)
+                {
+                    return method;
+                }
+            }
+            return null;
         }
 
         // Walks the panel's type chain for an internal property: the engine members these helpers


### PR DESCRIPTION
## What & why

A filter change under `transition-filter` was tweened by Velvet's scheduler, but the class only ever set a duration — it never named a property, so the element kept the initial whole-property value and UI Toolkit's own animator claimed the write as well. Both animators ran: every frame the tween wrote, the engine restarted a fresh native animation toward it, so the painted filter trailed the tween for the whole play and eased rather than landed at the end. The class now pins the property to `filter`, which leaves the write on the direct path and gives the tween sole ownership.

Which animator runs is now decided by the resolved transition property rather than by the class: a value naming `filter` drives the tween, a whole-property value defers to the engine (which genuinely animates an inline filter — measured, not assumed), and anything else writes instantly. A running tween re-checks this every frame, so a value rewritten mid-play — by a class swap or by a Motion play's own inline write — hands over once instead of restarting the engine's animation on every remaining tick.

**User custom filters interpolate.** Previously any user-registered filter snapped, on both sides of a change. They now ride the same paired path as native ones when a single distinct definition is involved and the argument slots line up by type, and an added or removed custom fades from the neutral value its own parameter declaration states — the same value the engine pads with when it interpolates a filter list of unequal length. Two distinct customs still snap, because the composition order ranks them identically and a stable merge is not possible.

Two documentation claims were wrong and are corrected: the guide said the engine cannot repaint an inline filter at all, and that pinning the property stops it repainting after the first frame. Neither holds. The guide now describes what was measured, including the engine quirk the design depends on — its inline-filter setter tests the wrong property id, so a transition list naming `background-size` (or the scale-mode shorthand that covers it) hands filter writes to the engine even when the list also names `filter`. Three tests pin each of those routes on an element with no binding, so each is single-animator and deterministic; they also fail loudly if a future engine release fixes the quirk.

The pooled-element reset now writes a zero transition duration before its inline scrub, so every clear in the scrub cancels rather than animating. No shipped caller can reach the defect — they all detach first, and a detached element is not style-initialized — so the write is skipped off-panel and the pool return stays free of the entry the trailing null would tear down again.

## Checklist

- [x] Tests pass locally (EditMode / PlayMode / generator tests as applicable) — EditMode 3328 passed / 0 failed after rebasing onto the motion-channel change that touches the same resolver, PlayMode 91 / 91
- [x] New regression tests were verified red without the change and green with it — three demonstrations: reverting the production files reddens 11, narrowing the property probe to an exact match reddens the multi-name test, and replacing the declared-neutral read with the old guess reddens the fade test
- [x] Docs are updated for every fact this change touches (guides, READMEs, CLAUDE.md) — or this PR has no doc impact
- [x] CHANGELOG updated for behavior/perf changes (pure refactors are omitted by convention)
- [x] Known gaps or deliberate deferrals discovered here are filed as issues with acceptance criteria — three are documented rather than filed, as limits rather than defects: the interleaved case where a list names both `filter` and the quirk property is described but not pinned, what the engine does with non-blur filters under a whole-property value is unmeasured and therefore unclaimed, and a settle can leave a target holding a definition destroyed mid-tween

Closes #149