### PR TITLE
fix(velvet): support space-*-reverse and fix gap direction on reversed flex containers

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -27,6 +27,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   bare `duration-*`) leaves `transition-property` at UI Toolkit's `all` default and so counts as
   covering everything. Overlapping plays each hold their own claim, so the first to settle cannot
   un-suspend the second.
+- `space-x-reverse` / `space-y-reverse` are recognized alongside the existing `space-x-*` /
+  `space-y-*` aliases: each is a per-axis marker that moves the gap-polyfill margin to the axis's
+  trailing physical edge (`margin-right` / `margin-bottom`) instead of the leading one, matching
+  Tailwind's own `space-*-reverse` semantics. See `Documentation~/styling-flexbox-and-gap.md` for
+  the combination rule with a `flex-row-reverse` / `flex-col-reverse` container (OR, not XOR) and
+  the one case where the marker ends up a no-op.
 
 ### Changed
 
@@ -103,6 +109,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the cancel path. The write is therefore skipped when the element is off-panel, keeping the
   (always-detached) pool return free of the inline entry the trailing null would then tear down
   again; what changed is that the reset no longer depends on that call ordering.
+- `gap-*` (and its `space-x-*`/`space-y-*` aliases) placed its margin on the wrong physical edge
+  inside a `flex-row-reverse` / `flex-col-reverse` container: `StyleGapManipulator` folded
+  `RowReverse` into `Row` and `ColumnReverse` into `Column` when picking the leading edge, so a
+  plain `gap-4` (no reverse marker at all) wrote a leading `margin-left`/`margin-top` that showed up
+  as extra space on the container's OUTER edge, with no gap on the visually-adjacent boundary it was
+  reversed away from. Off-panel (EditMode, and the pre-attach mount pass), a `flex-col-reverse`
+  container's axis itself resolved wrong (the class-marker fallback checked only the literal string
+  `"flex-col"`, which `"flex-col-reverse"` never matches), so the gap landed on the wrong AXIS
+  entirely, not just the wrong edge. `gap-*` is now direction-correct on a reversed container without
+  needing a `space-*-reverse` marker — see `Documentation~/styling-flexbox-and-gap.md` for how
+  direction is resolved. This is a visible behavior change for any app that was compensating for the
+  old misplaced margin.
 - A `FocusScope` with `restoreFocus: true` did not hand focus back to the prior element when the
   scope's ROOT element itself (rather than a descendant) held focus at unmount: the guard used
   `VisualElement.Contains`, which does not count an element as containing itself, so a focused root

--- a/Packages/com.velvet.core/Documentation~/README.md
+++ b/Packages/com.velvet.core/Documentation~/README.md
@@ -9,7 +9,7 @@ For the package overview and installation instructions, see the repository root 
 |------|----------|
 | [react-migration.md](react-migration.md) | Naming alignment and API mapping for developers coming from React |
 | [memoization.md](memoization.md) | The `[MemoizeMethod]` attribute — usage, constraints, and diagnostic IDs (Source Generator-driven partial-method memoization) |
-| [styling-flexbox-and-gap.md](styling-flexbox-and-gap.md) | Flexbox direction (`flex` defaults to column, not row) and `gap-*` gotchas (single-axis, trailing margin) vs Tailwind |
+| [styling-flexbox-and-gap.md](styling-flexbox-and-gap.md) | Flexbox direction (`flex` defaults to column, not row) and `gap-*` gotchas vs Tailwind — the leading-margin polyfill, its edge flip on `flex-row-reverse` / `flex-col-reverse` (and `space-x-reverse` / `space-y-reverse`), and the wrap half-margin hybrid |
 | [styling-z-index.md](styling-z-index.md) | `z-*` stacking for `absolute` descendants — the layer-container + placeholder mechanism, sibling-scope-only comparison, and the in-flow/negative-z/`peer-` deviations from CSS |
 | [styling-variants.md](styling-variants.md) | The variant set (state / theme `dark:` / responsive `sm:`…`2xl:` / relational `group-`·`peer-` / stacked) and container queries (`@container`, the `container-type: inline-size` equivalent) |
 | [styling-filters.md](styling-filters.md) | Filter utilities (`blur-*` … `sepia-*`, the shader-backed full-range `brightness-*`/`saturate-*`) and the `VelvetFilters` custom filter registry (`filter-[name:args]`) |

--- a/Packages/com.velvet.core/Documentation~/styling-flexbox-and-gap.md
+++ b/Packages/com.velvet.core/Documentation~/styling-flexbox-and-gap.md
@@ -48,9 +48,9 @@ strictly **between** children, exactly like CSS `gap`: no leading, trailing, or 
 
 | Utility | Axis | Effect |
 |---|---|---|
-| `gap-*`   | follows `flex-direction` | row → horizontal (`margin-left`), column → vertical (`margin-top`) |
-| `gap-x-*` | always horizontal | `margin-left` between columns |
-| `gap-y-*` | always vertical | `margin-top` between rows |
+| `gap-*`   | follows `flex-direction` | row → horizontal, column → vertical; the leading edge of that axis (`margin-left` / `margin-top`) — or the trailing edge (`margin-right` / `margin-bottom`) on a reversed container, see "Reversed containers" below |
+| `gap-x-*` | always horizontal | `margin-left` between columns, or `margin-right` on a `flex-row-reverse` container |
+| `gap-y-*` | always vertical | `margin-top` between rows, or `margin-bottom` on a `flex-col-reverse` container |
 
 ```csharp
 // Horizontal spacing between columns, no trailing gap after the last item.
@@ -70,26 +70,103 @@ emits any rules; see `Runtime/Styling/StyleGapManipulator.cs` and `Runtime/Styli
 
 Tailwind's `space-x-*` / `space-y-*` are accepted as aliases of `gap-x-*` / `gap-y-*` (same scale,
 same manipulator) — they realize the same "leading margin on every child but the first" spacing a
-`space-* > * + *` margin rule would inside a flex container. `space-*-reverse` has no equivalent
-and is not supported.
+`space-* > * + *` margin rule would inside a flex container. `space-x-reverse` / `space-y-reverse`
+are accepted too — see "Reversed containers" below for what they do and the one case where they are
+a no-op.
+
+### Reversed containers (`flex-row-reverse` / `flex-col-reverse`) and `space-*-reverse`
+
+A `flex-row-reverse` / `flex-col-reverse` container moves a gap's margin to the axis's **trailing**
+physical edge (`margin-right` / `margin-bottom`) instead of the leading one (`margin-left` /
+`margin-top`) — this applies to **every** gap on that axis, including a plain `gap-4` with no
+`space-*-reverse` marker at all, because native CSS `gap` has no leading/trailing distinction to
+begin with: it spaces consecutive children the same way regardless of direction, so matching it
+here means the polyfill's margin has to move to whichever physical edge is the "between children"
+edge for the resolved direction. `space-x-reverse` / `space-y-reverse` are Tailwind's own,
+direction-independent way to ask for the same trailing edge — they are an **absolute** per-axis
+marker ("put the margin on the trailing edge") that Tailwind itself never conditions on
+`flex-direction`, so a marker and a detected reverse direction on the same axis combine with **OR**,
+not XOR: `flex-row-reverse space-x-4 space-x-reverse` still lands trailing rather than the marker
+cancelling the direction back to leading. The flip is per axis — a `gap-x-*` / `space-x-*` never
+reacts to `flex-col-reverse`, and a `gap-y-*` / `space-y-*` never reacts to `flex-row-reverse`.
+
+One deliberate consequence: because `space-x-*` / `space-y-*` are realized through this same
+CSS-`gap` polyfill, and `gap` is already direction-correct on its own (per the paragraph above),
+`space-x-4` **alone** — with no `space-x-reverse` — is already direction-correct on a
+`flex-row-reverse` container. That makes `space-x-reverse` a **compatibility no-op** there: adding
+it changes nothing, because the direction already produced the trailing edge without it. This is a
+deviation from plain CSS (where `space-x-*` has no native realization at all, so Tailwind's own
+`> * + *` margin rule needs the marker to ever move off the leading edge); it exists here only
+because Velvet's `space-*` and `gap-*` share one direction-aware implementation.
 
 ### How re-spacing stays correct
 
-The spacing depends on the child set and (for plain `gap-*`) the resolved direction, both of which
-can change outside the manipulator's own events. It is re-applied from three sources:
+The spacing depends on the child set and, for every axis (not just plain `gap-*`'s axis choice — a
+`gap-x-*` / `gap-y-*`'s reversed-edge flip too), the resolved direction. Both can change outside the
+manipulator's own events. It is re-applied from three sources:
 
 1. **Reconcile.** The reconciler calls the manipulator right after it reconciles the container's
    children, so an add / remove / reorder during a reconcile pass immediately re-spaces. This is also
    the path that makes it correct in EditMode, where layout never ticks.
 2. **`GeometryChangedEvent`.** Catches child mutations driven by an *unrelated* reconcile pass at
    runtime (e.g. a nested component re-render that adds a child under this container).
-3. **`AttachToPanelEvent`.** Re-resolves plain `gap-*`'s axis once `resolvedStyle.flexDirection` is
-   valid. Off-panel (EditMode, pre-attach) it falls back to the `flex-row` / `flex-col` class marker,
-   defaulting to **row** (matching Tailwind's `flex` and the framework's `.flex` intent) when neither is
-   present; `flex-col` still forces a column. On a panel the resolved direction is authoritative either
-   way, so this off-panel default only affects pre-layout assertions (and EditMode).
+3. **`AttachToPanelEvent`.** Re-resolves plain `gap-*`'s axis, and every axis's reversed-edge flip,
+   once `resolvedStyle.flexDirection` is valid — needed for the one case no class marker can cover
+   (below).
 
-## `flex-wrap`: both axes are spaced (half-margin hybrid)
+**Direction source: a single resolved verdict from the class list, by USS precedence, not
+`resolvedStyle` — on a panel included.** `flex` / `flex-row` / `flex-col` / `flex-row-reverse` /
+`flex-col-reverse` are all direction-bearing (`flex` sets `flex-direction: row`, same as a bare
+`flex-row`), and `_layout.uss` declares them in that order — `flex-row`, `flex-col`,
+`flex-row-reverse`, `flex-col-reverse` — so at equal specificity (one class selector each) a
+*later*-declared rule always overrides an earlier one when an element carries more than one of them at
+once, which is routine once a responsive/state variant is involved (`flex flex-col md:flex-row-reverse`
+leaves BOTH `flex-col` and `flex-row-reverse` on the live class list above the breakpoint).
+`StyleGapManipulator.ResolveDirection` reproduces that exact precedence — checking
+`flex-col-reverse`, then `flex-row-reverse`, then `flex-col`, then `flex-row`/`flex`, in that order —
+and resolves it into ONE mutually-exclusive verdict (axis + reversed-or-not together), rather than an
+axis check and a reversed check answered independently: a `gap-x-4` container patched straight from
+`flex-row-reverse` to `flex-col-reverse` (no row-family class survives the patch) needs the reversed
+bit to come from a fresh read of whichever family the CURRENT verdict is, not a stale answer cached
+from the row family that is no longer even present. (`grid` sets `flex-direction: row` too, but is
+deliberately excluded from this scan: a `grid` present in the RECONCILED class array routes the
+element's gap through the separate grid manipulator instead, suppressing this one entirely — see
+"`flex-wrap` and `grid`" below. A variant-gated class such as `md:grid` can still land on the LIVE
+class list outside that reconciled array, a pre-existing gap in the suppression check rather than
+something this change introduces, but it does not change the answer here either way: `grid` implies
+Row, which coincides with this scan's own fallback default, so omitting it never produces a different
+result.)
+
+Classes are consulted before `resolvedStyle`, even on a panel: the direction classes are USS-only
+rules with no equivalent C# inline `flex-direction` write, so `resolvedStyle.flexDirection` only
+catches up after the panel's *next* style pass, and a same-rect direction toggle (children reorder;
+the container itself never resizes) fires no `GeometryChangedEvent` to trigger a re-derive. A
+manipulator that trusted `resolvedStyle` here could converge on the *first* toggle (its initial layout
+pass happens to touch the rect) and then never converge on a later toggle back — leaving a gap margin
+wrong indefinitely. The class list, by contrast, is already the *final* one at the moment a
+class-driven patch reaches the manipulator, so reading it directly is both correct and immediate, with
+no dependency on a style pass or a geometry event. One consequence: a Velvet direction class, when
+present, now **outranks** `flex-direction` set some other way (a custom stylesheet rule, an inline
+style) on the SAME element, rather than composing with it — `resolvedStyle` is read only as the
+fallback for the case no class can cover: `flex-direction` set that other way with *none* of the five
+direction/display classes present on the element at all. That fallback case still needs a live panel
+(`AttachToPanelEvent` above) and still cannot self-correct on a same-rect toggle with no intervening
+reconcile pass, since nothing would tell the manipulator to look again. With no direction class AND no
+panel to resolve against (EditMode, pre-attach), the default is **row** — the one place this
+deliberately disagrees with the raw engine, whose own unstyled default is column (see "The engine's
+raw flex default" above); mirroring `.flex`'s intent here matters more than mirroring Yoga's raw
+default, since `.flex` alone is the common case this default exists for.
+
+One more asymmetry worth knowing: a plain `gap-*` (the Auto axis) DOES react to a `space-*-reverse`
+marker on whichever axis it resolves to, even though real Tailwind `gap` has no reverse-marker concept
+at all (only its `space-*` polyfill does, since native `gap` never needed one) — this is a consequence
+of Velvet routing `gap-*` and `space-*` through one shared, direction-aware implementation rather than
+a divergence you would predict from Tailwind's own model. `flex flex-col gap-4 space-y-reverse`
+demonstrates it: `gap-4` resolves to the vertical axis (via `flex-col`), and `space-y-reverse` is on
+that SAME axis, so the plain gap lands on `margin-bottom` instead of `margin-top` — an (irrelevant)
+`space-x-reverse` on the same element would not apply, since it targets the other axis.
+
+## `flex-wrap` and `grid`: both axes are spaced (half-margin hybrid)
 
 CSS `gap` under `flex-wrap` spaces **both** axes — between items in a line *and* between wrapped
 lines. A single leading-edge margin can only space the main axis, so the manipulator switches
@@ -102,9 +179,25 @@ strategy when the container wraps:
 
 Under wrap, any two adjacent items (either axis, including across wrapped lines) are separated by
 `gap/2 + gap/2 == gap`, and the container's negative margin cancels the children's outer-edge
-half-margins so content stays flush to the container edge. Wrap is detected from
-`resolvedStyle.flexWrap` on a panel and from the `flex-wrap` class off-panel (EditMode); the
-half-margin values are layout-independent, so they resolve without a layout tick.
+half-margins so content stays flush to the container edge. A reversed container (e.g.
+`flex-row-reverse flex-wrap`) still uses this same symmetric half-margin polyfill — direction never
+changes which edges wrap spaces, only non-wrap's single leading/trailing edge choice. Wrap is detected
+the same way direction is, and for the same staleness reason: the `flex-wrap` / `flex-nowrap` /
+`flex-wrap-reverse` class markers first (by `_layout.uss` declaration order — `flex-wrap-reverse`
+beats `flex-nowrap` beats `flex-wrap` when more than one is present); when none of those three are
+present, `flex` / `flex-row` / `flex-col` / `flex-row-reverse` / `flex-col-reverse` — none of which
+touch `flex-wrap` themselves — mean Yoga's own default (no wrap) applies, so an OFF-state toggle like
+`wrapped ? "flex flex-wrap gap-4" : "flex gap-4"` still converges without a wrap class in its OFF
+state; `resolvedStyle.flexWrap` is the fallback only when none of those eight classes are on the
+element at all. Getting this wrong is worse than getting direction wrong: wrap is the only mode that
+writes the CONTAINER's own margin, so a stuck stale "wrap" verdict leaves a fixed-size container
+bleeding its negative margin outward over its siblings until something unrelated forces a re-apply.
+
+`grid` also sets `flex-direction: row` (and `flex-wrap: wrap`) in `_layout.uss`, but a `grid` /
+`grid-cols-*` class routes an element's gap through the separate grid manipulator entirely —
+`StyleGapManipulator` is suppressed and removed for that element rather than ever computing a
+direction or wrap verdict for it, so neither class scan needs to (or does) recognize `grid` at all;
+see `StyleGapManipulator.ResolveDirection`'s own comment for the mechanics.
 
 ```csharp
 // Wrapping grid: gap-4 now spaces BOTH the row direction and between wrapped rows.
@@ -129,13 +222,15 @@ row/column layout is **exact**; the remaining gaps are called out here and in
   **different** edge than the gap are preserved, so `mt-2` on a child under a non-wrap `gap-x-4` row
   is untouched. (Under the wrap half-margin path every side belongs to the gap, so any explicit child
   margin is overwritten on all four sides.)
-- **First child's leading-edge margin is erased.** The non-wrap path forces the **first** child's
-  leading-edge margin (`margin-left` for a row, `margin-top` for a column) to `Null` on every pass — the
-  first child must have no leading gap to match CSS `gap` (no outer-edge spacing). So an explicit margin
-  on the first child's gap edge (e.g. `ml-2` on the first child of a `gap-x-4` row) is **erased**: the
-  manipulator cannot distinguish an intentional first-child margin from a stale gap value it wrote on a
-  previous pass. The first child's *other* edges, and all edges of non-first children's *cross* axis, are
-  untouched. Workaround: use container padding for a leading inset, or an inner wrapper.
+- **First child's spacing-edge margin is erased.** The non-wrap path forces the **first** child's
+  spacing-edge margin to `Null` on every pass — `margin-left` / `margin-top` normally, or `margin-right` /
+  `margin-bottom` on a reversed container (the SAME edge `gap` writes on every other child — see
+  "Reversed containers" above). The first child must carry no gap on that edge to match CSS `gap` (no
+  outer-edge spacing). So an explicit margin on the first child's gap edge (e.g. `ml-2` on the first
+  child of a `gap-x-4` row) is **erased**: the manipulator cannot distinguish an intentional first-child
+  margin from a stale gap value it wrote on a previous pass. The first child's *other* edges, and all
+  edges of non-first children's *cross* axis, are untouched. Workaround: use container padding for a
+  leading inset, or an inner wrapper.
 - **Wrap path overwrites (and loses) the container's own margin.** The wrap half-margin path writes the
   container's own four margins to `-gap/2`, so an explicit container margin (e.g. `m-4` on the same
   element that carries `flex-wrap gap-4`) is **overwritten** while gap is active — and `Clear` resets the

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
@@ -1811,21 +1811,25 @@ namespace Velvet
         {
             private readonly float _gap;
             private readonly GapAxis _axis;
+            private readonly bool _xReverse;
+            private readonly bool _yReverse;
 
-            internal GapOp(float gap, GapAxis axis)
+            internal GapOp(float gap, GapAxis axis, bool xReverse, bool yReverse)
             {
                 _gap = gap;
                 _axis = axis;
+                _xReverse = xReverse;
+                _yReverse = yReverse;
             }
 
             public Dictionary<VisualElement, StyleGapManipulator> Table(ReconcilerContext ctx)
                 => ctx.GapManipulators;
 
             public StyleGapManipulator Create(ReconcilerContext ctx)
-                => new StyleGapManipulator(_gap, _axis);
+                => new StyleGapManipulator(_gap, _axis, _xReverse, _yReverse);
 
             public void Update(StyleGapManipulator manipulator)
-                => manipulator.UpdateGap(_gap, _axis);
+                => manipulator.UpdateGap(_gap, _axis, _xReverse, _yReverse);
         }
 
         private readonly struct DivideOp : IManipulatorOp<StyleDivideManipulator>
@@ -2596,8 +2600,9 @@ namespace Velvet
             }
 
             var hasGap = StyleGapClass.TryExtract(classNames, out var gap, out var axis);
+            StyleGapClass.ExtractReverseMarkers(classNames, out var xReverse, out var yReverse);
 
-            Configure<GapOp, StyleGapManipulator>(element, hasGap, new GapOp(gap, axis));
+            Configure<GapOp, StyleGapManipulator>(element, hasGap, new GapOp(gap, axis, xReverse, yReverse));
         }
 
         // Configures the element's StyleDivideManipulator from the divide-x / divide-y (+ width / color)

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/AnimatePresencePopLayoutTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/AnimatePresencePopLayoutTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using NUnit.Framework;
+using UnityEditor;
 using UnityEditor.UIElements.TestFramework;
 using UnityEngine;
 using UnityEngine.UIElements;
@@ -464,6 +465,130 @@ namespace Velvet.Tests
 
             // Assert — the survivor now leads the row (no leading gap margin, no reserved slot).
             Assert.That(Root.Q<VisualElement>("item-b").layout.x, Is.EqualTo(0f).Within(0.5f));
+        }
+    }
+
+    /// <summary>
+    /// PopLayout inside an actual <c>flex-row-reverse</c> container (as opposed to a
+    /// <c>space-x-reverse</c> marker on a non-reversed row): the gap emulation's margin lands on the
+    /// TRAILING edge (<c>margin-right</c>), the one edge <see cref="GeneralPathReconciler.PinExitingChildOutOfFlow"/>
+    /// does NOT subtract (it only reads <c>marginLeft</c>/<c>marginTop</c>) — reasoning says the pin still
+    /// reproduces the exact last laid-out position because that subtraction is 0, so this locks it with a
+    /// test instead of trusting the reasoning. Runs in its OWN isolated <c>EditorPanelSimulator</c> with the
+    /// bundled <c>StyleUtilities.uss</c> attached (<c>flex-row-reverse</c> is a USS-only rule — see
+    /// <c>Documentation~/styling-flexbox-and-gap.md</c>), kept separate from
+    /// <see cref="AnimatePresencePopLayoutFlowTests"/> so attaching a stylesheet here cannot perturb that
+    /// fixture's existing (deliberately stylesheet-less) assertions.
+    /// </summary>
+    [TestFixture]
+    internal sealed class AnimatePresencePopLayoutReversedRowTests
+    {
+        private const string StyleSheetPath = "Packages/com.velvet.core/Runtime/Styles/StyleUtilities.uss";
+
+        private static readonly Dictionary<string, string> s_fade = new()
+        {
+            ["hidden"] = "opacity-0",
+            ["visible"] = "opacity-100",
+        };
+
+        private readonly record struct SetState(string Keys);
+
+        private sealed class SetStore : Store<SetState>
+        {
+            public SetStore(string initial) : base(new SetState(initial)) { }
+            public void Set(string keys) => SetState(_ => new SetState(keys));
+            protected override void ResetCore() => SetState(_ => new SetState("ab"));
+        }
+
+        private static SetStore s_store;
+
+        private EditorPanelSimulator _sim;
+
+        [SetUp]
+        public void SetUp()
+        {
+            PanelSimulator.ResetCurrentTime();
+            _sim = new EditorPanelSimulator { panelSize = new Vector2(800, 600) };
+            _sim.ResetTimePerSimulatedFrameToDefault();
+            var sheet = AssetDatabase.LoadAssetAtPath<StyleSheet>(StyleSheetPath);
+            Assume.That(sheet, Is.Not.Null, "Precondition: the bundled StyleUtilities.uss loads");
+            _sim.rootVisualElement.styleSheets.Add(sheet);
+            s_store = null;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _sim?.Dispose();
+            _sim = null;
+        }
+
+        private VisualElement Root => _sim.rootVisualElement;
+
+        private void Tick() => _sim.FrameUpdateMs(16);
+
+        [Component]
+        private static VNode PopRowReversed()
+        {
+            var keys = Hooks.UseStore(s_store, s => s.Keys);
+            var children = new List<VNode>();
+            foreach (var key in keys)
+            {
+                children.Add(V.Motion(name: "item-" + key, key: key.ToString(), className: "h-[20px] w-[40px]",
+                    variants: s_fade, animate: "visible", exit: "hidden",
+                    transition: new StyleTransitionConfig { DurationSec = 0.3f }));
+            }
+            return V.Div(name: "row", className: "flex flex-row-reverse gap-x-2", children: new VNode[]
+            {
+                V.AnimatePresence(key: "presence", initial: false,
+                    mode: AnimatePresenceMode.PopLayout, children: children.ToArray()),
+            });
+        }
+
+        [Test]
+        public void Given_ATrailingGapMarginedChildInAReversedRow_When_ItsPopLayoutExitStarts_Then_ItStaysAtItsLastLaidOutPosition()
+        {
+            // Arrange — [a,b] under an actual flex-row-reverse container: b (not a — the first child never
+            // carries a gap margin) carries margin-right (trailing), not margin-left, so
+            // PinExitingChildOutOfFlow's marginLeft/marginTop-only subtraction sees a zero leading margin on
+            // the very element it pins.
+            using var store = new SetStore("ab");
+            s_store = store;
+            using var mounted = V.Mount(Root, V.Component(PopRowReversed, key: "row"));
+            var scheduler = mounted.Root.Reconciler.Context.BatchScheduler;
+            Tick();
+            Tick();
+            var b = Root.Q<VisualElement>("item-b");
+            var xBefore = b.layout.x;
+            Assume.That(b.style.marginRight.value.value, Is.GreaterThan(0f),
+                "Precondition: b carries the trailing gap margin in the reversed container");
+
+            // Act — remove b (the child whose OWN margin is the trailing one) and let PopLayout pin it.
+            store.Set("a");
+            scheduler.DrainImmediateForTest();
+            Tick();
+
+            // Assert — the pinned ghost (b) has not moved from its last laid-out position.
+            Assert.That(b.layout.x, Is.EqualTo(xBefore).Within(0.5f));
+        }
+
+        // The pin test above deliberately keeps its trailing-margin check as an Assume (the pin, not the
+        // edge, is its subject — a tolerance comparison belongs on the pin assertion, not welded onto a
+        // precondition). If the edge-flip regressed, that Assume would report Inconclusive rather than
+        // Failed, which would not reliably turn CI red. This test asserts the same arrangement directly, so
+        // a regression here fails loudly instead of merely invalidating a precondition elsewhere.
+        [Test]
+        public void Given_AFlexRowReverseGapContainer_When_Reconciled_Then_TheSecondChildCarriesTheTrailingMargin()
+        {
+            // Arrange / Act
+            using var store = new SetStore("ab");
+            s_store = store;
+            using var mounted = V.Mount(Root, V.Component(PopRowReversed, key: "row"));
+            Tick();
+            Tick();
+
+            // Assert — gap-x-2 == 8px (see _tokens.uss).
+            Assert.That(Root.Q<VisualElement>("item-b").style.marginRight.value.value, Is.EqualTo(8f));
         }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Styles/_gap.uss
+++ b/Packages/com.velvet.core/Runtime/Styles/_gap.uss
@@ -6,9 +6,12 @@
  * (`.gap-* > *`) cannot follow `flex-direction` and cannot cancel the margin on
  * the last child (a trailing gap). Velvet therefore implements `gap-*` at the
  * FRAMEWORK level instead: it owns the ordered child list, so a per-container
- * `StyleGapManipulator` writes the inter-child leading margin (margin-left for a
- * row, margin-top for a column) on every child EXCEPT the first — spacing
- * strictly BETWEEN children, matching CSS `gap`. See:
+ * `StyleGapManipulator` writes the inter-child margin on every child EXCEPT the
+ * first — spacing strictly BETWEEN children, matching CSS `gap`. That margin
+ * lands on the LEADING edge of the resolved axis (margin-left for a row,
+ * margin-top for a column) normally, or the TRAILING edge (margin-right /
+ * margin-bottom) on a `flex-row-reverse` / `flex-col-reverse` container — see
+ * "Reversed containers" in the guide below. See:
  *   - Runtime/Styling/StyleGapManipulator.cs (the polyfill + residual edge cases)
  *   - Runtime/Styling/StyleGapClass.cs (class → pixel scale, mirrors _tokens.uss)
  *   - Documentation~/styling-flexbox-and-gap.md

--- a/Packages/com.velvet.core/Runtime/Styling/StyleGapClass.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleGapClass.cs
@@ -26,7 +26,11 @@ namespace Velvet
             // space-x-*/space-y-* alias onto the gap axes: Velvet realizes inter-child
             // spacing as a leading margin on every child but the first (the gap manipulator), which
             // is exactly what the `space-* > * + *` margin rule produces for a flex container.
-            // (Deviations: takes effect only inside a flex container, and space-*-reverse is unsupported.)
+            // (Deviation: takes effect only inside a flex container.) The space-x-reverse /
+            // space-y-reverse markers carry no pixel value of their own, so they decline here the same as
+            // any other unrecognized suffix ("reverse" matches neither the arbitrary-pixel nor the preset
+            // scale parse below) — StyleGapManipulator reads them separately via ExtractReverseMarkers,
+            // since they flip which edge the gap lands on rather than contributing a gap value themselves.
             if (cls.StartsWith("space-x-", StringComparison.Ordinal))
             {
                 axis = GapAxis.Horizontal;
@@ -91,6 +95,32 @@ namespace Velvet
                 }
             }
             return false;
+        }
+
+        // Scans classNames for the space-x-reverse / space-y-reverse markers. Tailwind's markers are
+        // absolute ("put the margin on the trailing edge") and never consult flex-direction themselves —
+        // StyleGapManipulator is the one that OR's a marker with a detected row-reverse/column-reverse, so
+        // the idiomatic flex-row-reverse space-x-4 space-x-reverse combination still lands trailing rather
+        // than cancelling back to leading.
+        public static void ExtractReverseMarkers(string[] classNames, out bool xReverse, out bool yReverse)
+        {
+            xReverse = false;
+            yReverse = false;
+            if (classNames == null)
+            {
+                return;
+            }
+            foreach (var cls in classNames)
+            {
+                if (cls == "space-x-reverse")
+                {
+                    xReverse = true;
+                }
+                else if (cls == "space-y-reverse")
+                {
+                    yReverse = true;
+                }
+            }
         }
 
         // Scans classNames for the last gap utility (later classes win, matching CSS

--- a/Packages/com.velvet.core/Runtime/Styling/StyleGapManipulator.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleGapManipulator.cs
@@ -3,14 +3,16 @@ using UnityEngine.UIElements;
 
 namespace Velvet
 {
-    // The axis a gap spaces children along.
+    // The axis a gap spaces children along. Within an axis, StyleGapManipulator still picks the leading
+    // vs. trailing physical edge (margin-left/-top vs. margin-right/-bottom) from the resolved direction
+    // and any reverse marker — see StyleGapManipulator.ResolveEdge.
     internal enum GapAxis
     {
         // Plain gap-*: follow the container's resolved flex-direction.
         Auto,
-        // gap-x-*: always horizontal (margin-left between columns).
+        // gap-x-*/space-x-*: always horizontal, between columns.
         Horizontal,
-        // gap-y-*: always vertical (margin-top between rows).
+        // gap-y-*/space-y-*: always vertical, between rows.
         Vertical,
     }
 
@@ -20,7 +22,13 @@ namespace Velvet
     // follow flex-direction. Velvet owns the ordered child list, so this manipulator writes the
     // inter-child leading margin (margin-left for a row, margin-top for a column) on every
     // child EXCEPT the first — spacing BETWEEN children only, matching CSS gap: no leading,
-    // trailing, or outer-edge margin.
+    // trailing, or outer-edge margin. A row-reverse / column-reverse container (or a
+    // space-x-reverse / space-y-reverse marker) moves that same inter-child margin to the axis's
+    // TRAILING physical edge (margin-right / margin-bottom) instead — native CSS gap has no leading/
+    // trailing distinction at all (it spaces between children regardless of direction), so this is what
+    // reproduces that direction-agnostic behavior through a physical-margin polyfill: Yoga (like CSS
+    // flexbox) resolves the "leading" flex-margin for a reversed main axis to the physical trailing edge,
+    // so writing margin-right there is the leading-margin equivalent, not an extra trailing gap.
     // Lifecycle mirrors the other style manipulators (StyleVariantManipulator): the
     // reconciler attaches one per gap container, keeps it in ReconcilerContext.GapManipulators,
     // and removes it on cleanup / dispose. UnregisterCallbacksFromTarget clears the
@@ -32,15 +40,16 @@ namespace Velvet
     // that same child container (ChildContainer); the wrap path's negative margin is
     // written on the child container too, so gap lands on the reconciled content and never on a
     // ScrollView's internal hierarchy.
-    // Re-application. The spacing depends on the child set and (for GapAxis.Auto) the
-    // resolved direction, both of which change outside this manipulator's own events. It is re-applied
+    // Re-application. The spacing depends on the child set and, for every axis, the resolved
+    // direction, both of which change outside this manipulator's own events. It is re-applied
     // from three sources: (1) the reconciler calls Apply right after it reconciles the
     // container's children (the panel-independent path that also covers EditMode, where layout never
     // ticks); (2) GeometryChangedEvent catches child add / remove / reorder driven by an
-    // unrelated reconcile pass at runtime; (3) AttachToPanelEvent re-resolves
-    // GapAxis.Auto once resolvedStyle.flexDirection is valid. A signature
-    // (_lastSignature) makes repeated Apply calls with no relevant change
-    // — notably the GeometryChanged feedback the manipulator's own margin writes provoke — into no-ops.
+    // unrelated reconcile pass at runtime; (3) AttachToPanelEvent re-resolves once resolvedStyle is
+    // valid, for the one case no class can cover (see ResolveDirection: the five direction/display
+    // classes are the PRIMARY direction source, even on a panel — resolvedStyle is only the fallback).
+    // A signature (_lastSignature) makes repeated Apply calls with no relevant change — notably the
+    // GeometryChanged feedback the manipulator's own margin writes provoke — into no-ops.
     // Reparent / removal. The manipulator tracks every element it wrote a margin to
     // (_margined); on each Apply / Clear any tracked element
     // that is no longer a current child has its gap margins reset first, so a child moved out of (or
@@ -63,8 +72,9 @@ namespace Velvet
     // (in either axis, including across wrapped lines) are then separated by gap/2 + gap/2 == gap,
     // and the container's negative margin pulls content flush to its edge.
     // Wrap is detected on-panel via resolvedStyle.flexWrap (Wrap / WrapReverse) and
-    // off-panel (EditMode) via the flex-wrap class marker. The half-margin path writes
-    // layout-independent margins, so it is fully resolved (and assertable) without a layout tick.
+    // off-panel (EditMode) via the flex-wrap / flex-wrap-reverse class markers. The half-margin path
+    // writes layout-independent margins, so it is fully resolved (and assertable) without a layout tick.
+    // Direction never changes which edges wrap spaces (always symmetric), only non-wrap's edge choice.
     // Residual gaps versus native CSS gap (documented, not solved):
     // An explicit per-child margin on the SAME logical edge as the gap (e.g. ml-2 on a
     // child under a gap-x-4 row) is OVERWRITTEN — this manipulator owns the margin edge(s) it
@@ -95,10 +105,29 @@ namespace Velvet
         private float _gap;
         private GapAxis _axis;
 
+        // The space-x-reverse / space-y-reverse markers (StyleGapClass.ExtractReverseMarkers). Each is an
+        // ABSOLUTE per-axis instruction — "put the margin on the trailing physical edge" — that Tailwind
+        // never conditions on flex-direction, so ResolveEdge OR's a marker with a detected row-reverse /
+        // column-reverse rather than XOR'ing: the idiomatic flex-row-reverse space-x-4 space-x-reverse still
+        // lands trailing instead of cancelling back to leading.
+        // Source asymmetry (by design, not an oversight): these markers are extracted from the VNode's
+        // OWN classNames array at gap-config time (FiberNodePatcher.ApplyGapManipulator), the same source
+        // StyleGapClass.TryExtract already reads the gap value and axis from — so a variant-prefixed
+        // md:space-x-reverse resolves however the variant system resolves md: classes generally (it either
+        // is or isn't in THIS render's classNames, before any manipulator ever runs). ResolveDirection
+        // below, by contrast, reads the live element's classList, because unlike the gap spec itself the
+        // direction can change out from under the manipulator without a matching gap-config patch (see
+        // ResolveDirection). The two halves of this feature therefore consult different lists on principle,
+        // not by accident — each is authoritative for what it answers.
+        private bool _xReverse;
+        private bool _yReverse;
+
         // Which margins are currently written, so a later pass (axis flip, mode flip, gap removal,
         // detach) clears exactly what was applied without disturbing other margins. Leading == one
         // inter-child edge (non-wrap); HalfMargin == four-side child margins + container negative margin.
-        private enum Edge { None, Left, Top }
+        // Right/Bottom are the trailing physical edges a row-reverse / column-reverse container (or a
+        // reverse marker) resolves to instead of Left/Top.
+        private enum Edge { None, Left, Top, Right, Bottom }
         private enum Mode { None, Leading, HalfMargin }
 
         // (mode, edge) transition table read by ApplyLeading / ApplyHalfMargin / Clear: re-running the SAME
@@ -128,18 +157,24 @@ namespace Velvet
         private int _lastSignature;
         private bool _hasSignature;
 
-        public StyleGapManipulator(float gap, GapAxis axis)
+        public StyleGapManipulator(float gap, GapAxis axis, bool xReverse, bool yReverse)
         {
             _gap = gap;
             _axis = axis;
+            _xReverse = xReverse;
+            _yReverse = yReverse;
         }
 
-        // Swaps the gap value / axis and re-applies, clearing the old edge first if it changed.
-        public void UpdateGap(float gap, GapAxis axis)
+        // Swaps the gap value / axis / reverse markers and re-applies, clearing the old edge first if it
+        // changed.
+        public void UpdateGap(float gap, GapAxis axis, bool xReverse, bool yReverse)
         {
             _gap = gap;
             _axis = axis;
-            // Force a re-apply: gap/axis changed even when the child set did not, so invalidate the cache.
+            _xReverse = xReverse;
+            _yReverse = yReverse;
+            // Force a re-apply: gap/axis/markers changed even when the child set did not, so invalidate the
+            // cache.
             _hasSignature = false;
             Apply();
         }
@@ -214,7 +249,8 @@ namespace Velvet
             var edge = ResolveEdge();
 
             // Clear whatever the previous pass wrote when the strategy changed: a stale wrap half-margin
-            // set, or the opposite leading edge after an Auto row↔column direction flip.
+            // set, or the previous leading edge after an Auto row↔column direction flip or a reverse-marker
+            // change (any of the four edges may be the one abandoned).
             if (_mode == Mode.HalfMargin)
             {
                 ClearHalfMargin(container);
@@ -242,13 +278,23 @@ namespace Velvet
                     continue;
                 }
                 var value = logicalIndex == 0 ? new StyleLength(StyleKeyword.Null) : new StyleLength(_gap);
-                if (edge == Edge.Left)
+                // Four explicit cases (matching ClearEdge's shape below) rather than a Left/Right/Top +
+                // default: ResolveEdge never returns Edge.None, but an explicit case makes that invariant
+                // visible here instead of silently folding None into Bottom.
+                switch (edge)
                 {
-                    child.style.marginLeft = value;
-                }
-                else
-                {
-                    child.style.marginTop = value;
+                    case Edge.Left:
+                        child.style.marginLeft = value;
+                        break;
+                    case Edge.Right:
+                        child.style.marginRight = value;
+                        break;
+                    case Edge.Top:
+                        child.style.marginTop = value;
+                        break;
+                    case Edge.Bottom:
+                        child.style.marginBottom = value;
+                        break;
                 }
                 _margined.Add(child);
                 logicalIndex++;
@@ -319,6 +365,13 @@ namespace Velvet
             _hasSignature = false;
         }
 
+        // Unlike ApplyLeading, this does NOT skip out-of-flow children — it clears the ABANDONED edge on
+        // every current child unconditionally, including a PopLayout ghost mid-exit. That ghost's margin on
+        // the OLD edge is frozen into the left/top PinExitingChildOutOfFlow already computed for it (see
+        // that method), so an edge flip landing here WHILE it is still mid-exit would null the same margin
+        // its pinned position assumed stays put, visibly shifting it. This window already existed for the
+        // original Left<->Top axis flip (a row<->column re-render mid-exit); the reverse-driven Left<->Right
+        // / Top<->Bottom flips this file adds are the same shape of risk, not a new one.
         private void ClearEdge(VisualElement container, Edge edge)
         {
             if (container == null)
@@ -329,13 +382,20 @@ namespace Velvet
             var count = container.childCount;
             for (var i = 0; i < count; i++)
             {
-                if (edge == Edge.Left)
+                switch (edge)
                 {
-                    container[i].style.marginLeft = nullLength;
-                }
-                else if (edge == Edge.Top)
-                {
-                    container[i].style.marginTop = nullLength;
+                    case Edge.Left:
+                        container[i].style.marginLeft = nullLength;
+                        break;
+                    case Edge.Right:
+                        container[i].style.marginRight = nullLength;
+                        break;
+                    case Edge.Top:
+                        container[i].style.marginTop = nullLength;
+                        break;
+                    case Edge.Bottom:
+                        container[i].style.marginBottom = nullLength;
+                        break;
                 }
             }
         }
@@ -404,14 +464,17 @@ namespace Velvet
         // A cheap order-sensitive hash of the inputs that change the applied margins: gap value, mode,
         // resolved edge, and the current child identity sequence. Apply() early-returns when this matches
         // the last application, so redundant re-applies (the GeometryChanged feedback its own writes
-        // trigger, or reconcile passes that did not touch the child set) do no work.
+        // trigger, or reconcile passes that did not touch the child set) do no work. The non-wrap bucket
+        // must fold in the resolved EDGE, not just an axis bit — Left→Right or Top→Bottom is a same-axis
+        // flip (a reverse marker or direction toggling without the row/column axis itself changing), and a
+        // signature collision here would skip the re-apply that moves the margin to the new edge.
         private int ComputeSignature(VisualElement container, bool wrap)
         {
             unchecked
             {
                 var hash = 17;
                 hash = hash * 31 + _gap.GetHashCode();
-                hash = hash * 31 + (wrap ? 1 : ResolveEdge() == Edge.Left ? 2 : 3);
+                hash = hash * 31 + (wrap ? 1 : 100 + (int)ResolveEdge());
                 var count = container.childCount;
                 hash = hash * 31 + count;
                 hash = StyleOutOfFlowChild.HashChildSequence(hash, container);
@@ -419,51 +482,138 @@ namespace Velvet
             }
         }
 
-        // Chooses the leading edge from the axis. GapAxis.Auto follows the resolved
-        // flex-direction when the element is on a panel; off-panel (EditMode, pre-attach) it
-        // falls back to the flex-row / flex-col class markers, defaulting to row (the .flex
-        // default direction) when neither is present.
+        // Chooses the edge from the axis and the resolved direction. GapAxis.Horizontal / Vertical fix the
+        // AXIS (gap-x-*/gap-y-*/space-x-*/space-y-*); GapAxis.Auto (plain gap-*) follows the resolved axis.
+        // Independently, each axis flips to its trailing edge (Left→Right, Top→Bottom) when EITHER its own
+        // reverse marker is set OR the resolved direction is reversed on that SAME axis — the marker and a
+        // detected row-reverse/column-reverse OR together (both mean "trailing"), never XOR, so
+        // flex-row-reverse space-x-4 space-x-reverse still lands trailing. The flip is per-axis: a
+        // horizontal gap never reacts to column-reverse, and a vertical gap never reacts to row-reverse —
+        // ResolveDirection resolves ONE mutually-exclusive verdict per call, so there is no stale leftover
+        // from a different family to react to.
         private Edge ResolveEdge()
         {
+            var direction = ResolveDirection();
             switch (_axis)
             {
                 case GapAxis.Horizontal:
-                    return Edge.Left;
+                    return (_xReverse || direction == Direction.RowReverse) ? Edge.Right : Edge.Left;
                 case GapAxis.Vertical:
-                    return Edge.Top;
+                    return (_yReverse || direction == Direction.ColumnReverse) ? Edge.Bottom : Edge.Top;
                 default:
-                    return IsRow() ? Edge.Left : Edge.Top;
+                    return direction == Direction.Row || direction == Direction.RowReverse
+                        ? ((_xReverse || direction == Direction.RowReverse) ? Edge.Right : Edge.Left)
+                        : ((_yReverse || direction == Direction.ColumnReverse) ? Edge.Bottom : Edge.Top);
             }
         }
 
-        private bool IsRow()
+        // The container's resolved flex-direction, collapsed to the four values that matter here (axis +
+        // reversed-or-not). A single mutually-exclusive verdict — rather than an axis check and a
+        // reversed-family check answered independently — is required for correctness, not just tidiness:
+        // gap-x-4 patched straight from flex-row-reverse to flex-col-reverse (no row-family class survives
+        // the patch) must forget RowReverse entirely and see ColumnReverse fresh, which a same-family-only
+        // check cannot do since it never looks at the other family at all.
+        private enum Direction { Row, RowReverse, Column, ColumnReverse }
+
+        // Resolves the direction: the five direction/display classes are consulted FIRST — even on a panel —
+        // in the SAME precedence USS itself uses when more than one matches the element (equal specificity,
+        // so the LAST declared RULE wins): _layout.uss declares .flex-row, .flex-col, .flex-row-reverse,
+        // .flex-col-reverse in that source order, so flex-col-reverse beats flex-row-reverse beats flex-col
+        // beats flex-row beats the bare .flex row default, regardless of which classes ended up on the
+        // element or in what order — a responsive/state variant routinely leaves TWO direction classes on
+        // the live list at once (e.g. "flex flex-col md:flex-row-reverse" above the breakpoint), and only
+        // checking one family (row OR column) would silently pick the wrong one. This also single-sources
+        // why classes beat resolvedStyle.flexDirection generally: flex-row(-reverse) / flex-col(-reverse)
+        // are USS-only rules with no C# inline flex-direction write, so resolvedStyle only catches up after
+        // the panel's NEXT style pass, and a same-rect direction toggle (children reorder; the container
+        // itself never resizes) fires no GeometryChangedEvent to trigger a re-derive — a toggle driven
+        // through resolvedStyle could converge once by luck (an unrelated rect change) and never again.
+        // The class list, by contrast, is already the FINAL one by the time ApplyGapManipulator runs
+        // (SyncClassDrivenStyling patches it during PatchBaseElement, before the post-children passes that
+        // include the gap manipulator), so it is synchronously correct exactly when this needs it.
+        // resolvedStyle is the fallback for the one case no class can cover: flex-direction set some other
+        // way (a custom stylesheet rule, an inline style) with NONE of the five classes on the element — a
+        // direction class, when present, always outranks a custom stylesheet or inline flexDirection.
+        // .grid also sets flex-direction: row in _layout.uss, but is deliberately NOT part of this scan:
+        // FiberNodePatcher.ApplyGapManipulator checks StyleGridClass.HasGridClass against the reconciled
+        // classNames array before this manipulator is ever created or updated, and that check matches the
+        // literal string "grid" too, so a "grid" present in THAT array suppresses the manipulator — its gap
+        // is owned by StyleGridManipulator instead. (This does not make "grid" provably unreachable on the
+        // LIVE class list this method actually reads: a variant-gated class, e.g. a responsive md:grid,
+        // is added straight to the live element by the conditional-variant manipulator once its breakpoint
+        // is met, outside the reconciled classNames array HasGridClass checked — a pre-existing gap in that
+        // suppression, not something introduced here. It happens not to matter: "grid" implies Row, which
+        // coincides with this method's own eventual fallback default, so omitting the check never produces
+        // a different answer — it just reaches the same answer by a different path.)
+        private Direction ResolveDirection()
         {
+            if (target.ClassListContains("flex-col-reverse"))
+            {
+                return Direction.ColumnReverse;
+            }
+            if (target.ClassListContains("flex-row-reverse"))
+            {
+                return Direction.RowReverse;
+            }
+            if (target.ClassListContains("flex-col"))
+            {
+                return Direction.Column;
+            }
+            if (target.ClassListContains("flex-row") || target.ClassListContains("flex"))
+            {
+                return Direction.Row;
+            }
             if (target.panel != null)
             {
-                var dir = target.resolvedStyle.flexDirection;
-                return dir == FlexDirection.Row || dir == FlexDirection.RowReverse;
+                return target.resolvedStyle.flexDirection switch
+                {
+                    FlexDirection.RowReverse => Direction.RowReverse,
+                    FlexDirection.Column => Direction.Column,
+                    FlexDirection.ColumnReverse => Direction.ColumnReverse,
+                    _ => Direction.Row,
+                };
             }
-            // Off-panel: resolvedStyle is not yet meaningful. Mirror the .flex=row default:
-            // plain gap (Auto axis) resolves to a ROW unless flex-col explicitly forces column.
-            // flex-col still wins; flex-row is the same as the default here.
-            if (target.ClassListContains("flex-col"))
+            // No direction/display class and no panel to resolve against: mirror the .flex=row default —
+            // the one place this deliberately disagrees with the raw engine, whose own default is column
+            // (see this file's own guide, "The engine's raw flex default is a column, not a row").
+            return Direction.Row;
+        }
+
+        // True when the container wraps (selects the four-side half-margin path). The flex-wrap /
+        // flex-nowrap / flex-wrap-reverse class markers are consulted first, in _layout.uss's own
+        // declaration order (flex-wrap, flex-nowrap, …, flex-wrap-reverse — so flex-wrap-reverse beats
+        // flex-nowrap beats flex-wrap when more than one is present). UNLIKE ResolveDirection, there is no
+        // further "direction class implies a default" tier here: flex / flex-row(-reverse) /
+        // flex-col(-reverse) set flex-direction only — they say nothing about flex-wrap — so their
+        // presence is not evidence either way. resolvedStyle.flexWrap is the fallback whenever none of the
+        // three wrap classes is present, which is the catch-all for wrap set some other way (a custom
+        // stylesheet rule, an inline style) — nearly every real container carries a direction class, so
+        // folding direction classes into this check (as an earlier revision of this method did) would have
+        // taken that fallback away for almost all of them, misreading a genuinely wrapping inline-styled
+        // container as non-wrapping. This fallback CAN read one pass stale on a same-rect toggle, the same
+        // risk ResolveDirection has — but unlike a direction flip, gaining or losing a wrapped line usually
+        // changes the container's own measured size, so the resulting GeometryChangedEvent self-corrects it
+        // in the common case; see the guide for the residual fixed-size exception.
+        private bool IsWrap()
+        {
+            if (target.ClassListContains("flex-wrap-reverse"))
+            {
+                return true;
+            }
+            if (target.ClassListContains("flex-nowrap"))
             {
                 return false;
             }
-            return true;
-        }
-
-        // True when the container wraps (selects the four-side half-margin path). On a panel this reads
-        // resolvedStyle.flexWrap (Wrap or WrapReverse); off-panel (EditMode) it falls
-        // back to the flex-wrap class marker, mirroring IsRow's off-panel idiom.
-        private bool IsWrap()
-        {
+            if (target.ClassListContains("flex-wrap"))
+            {
+                return true;
+            }
             if (target.panel != null)
             {
                 var wrap = target.resolvedStyle.flexWrap;
                 return wrap == Wrap.Wrap || wrap == Wrap.WrapReverse;
             }
-            return target.ClassListContains("flex-wrap");
+            return false;
         }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Styling/StyleOutOfFlowChild.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleOutOfFlowChild.cs
@@ -17,7 +17,7 @@ namespace Velvet
         // On a panel this reads the resolved position (reflects both an inline override — the way a PopLayout
         // pin sets it — and a class-driven one). Off-panel (EditMode, pre-attach) resolvedStyle is not yet
         // meaningful, so this falls back to the .absolute utility class marker, mirroring the off-panel idiom
-        // StyleGapManipulator.IsRow/IsWrap already use for flex-direction / flex-wrap.
+        // StyleGapManipulator.ResolveDirection/IsWrap already use for flex-direction / flex-wrap.
         internal static bool IsOutOfFlow(VisualElement child)
         {
             // The filter bounds-spacer is always out of flow (position:absolute) and must never occupy a

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/GapParityTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/GapParityTests.cs
@@ -1,7 +1,11 @@
 using System.Collections;
 using System.Reflection;
 using NUnit.Framework;
+using UnityEditor;
+using UnityEditor.UIElements.TestFramework;
+using UnityEngine;
 using UnityEngine.UIElements;
+using UnityEngine.UIElements.TestFramework;
 
 using Velvet;
 using Velvet.TestUtilities;
@@ -19,23 +23,26 @@ namespace Velvet.Tests
     /// that alone, so the manipulator switches to the classic wrap-compatible half-margin polyfill instead:
     /// <c>gap/2</c> on all four sides of every child and <c>-gap/2</c> on all four sides of the container. This
     /// also covers a handful of hardening regressions (gap on a contentContainer-redirecting element like
-    /// ScrollView must land on the reconciled content, not the element itself; the off-panel Auto-axis default
-    /// is row, not column; the wrap container's own negative margin must survive a later <c>DiffStyles</c> pass
-    /// since gap is applied AFTER style diffing; a child moved out of a gap container must carry no residual
-    /// gap margin; <see cref="StyleGapManipulator.Apply"/> must no-op when nothing relevant changed so the
-    /// GeometryChanged feedback its own writes provoke does not re-churn), and the RUNTIME axis flip: an
-    /// Auto-axis gap resolves its edge from the direction class marker off-panel, so a re-render that swaps
-    /// <c>flex-row</c> ↔ <c>flex-col</c> must move the inter-child margin to the new edge AND clear the edge it
-    /// abandoned. Also specifies the <c>space-x-*</c> / <c>space-y-*</c> alias onto the same gap machinery
-    /// (<c>space-*</c> is CSS's own inter-child-margin selector, <c>&gt; * + *</c>, which UITK has no equivalent
-    /// for) — the alias maps onto <see cref="GapAxis"/> and the <c>--space-*</c> scale exactly like <c>gap-x-*</c>
-    /// / <c>gap-y-*</c>, and the cheap <see cref="StyleGapClass.HasGapClass"/> gate must recognize it too, or it
-    /// never reaches the manipulator — plus the <c>gap-x-[…]</c> / <c>gap-[…]</c> JIT arbitrary-value form.
+    /// ScrollView must land on the reconciled content, not the element itself; the Auto-axis default with no
+    /// direction class is row, not column; the wrap container's own negative margin must survive a later
+    /// <c>DiffStyles</c> pass since gap is applied AFTER style diffing; a child moved out of a gap container
+    /// must carry no residual gap margin; <see cref="StyleGapManipulator.Apply"/> must no-op when nothing
+    /// relevant changed so the GeometryChanged feedback its own writes provoke does not re-churn), and the
+    /// RUNTIME axis flip: an Auto-axis gap resolves its edge from the direction class marker — the class list
+    /// is consulted before <c>resolvedStyle</c> even on a panel, see <see cref="StyleGapManipulator.ResolveDirection"/>
+    /// — so a re-render that swaps <c>flex-row</c> ↔ <c>flex-col</c> must move the inter-child margin to the new
+    /// edge AND clear the edge it abandoned. Also specifies the <c>space-x-*</c> / <c>space-y-*</c> alias onto
+    /// the same gap machinery (<c>space-*</c> is CSS's own inter-child-margin selector, <c>&gt; * + *</c>, which
+    /// UITK has no equivalent for) — the alias maps onto <see cref="GapAxis"/> and the <c>--space-*</c> scale
+    /// exactly like <c>gap-x-*</c> / <c>gap-y-*</c>, and the cheap <see cref="StyleGapClass.HasGapClass"/> gate
+    /// must recognize it too, or it never reaches the manipulator — plus the <c>gap-x-[…]</c> / <c>gap-[…]</c>
+    /// JIT arbitrary-value form.
     /// </summary>
     /// <remarks>
     /// The manipulator writes INLINE margins (resolved to pixels from the same scale as <c>_tokens.uss</c>), so
     /// the produced spacing is observable via <c>element.style.margin*</c> without attaching to a panel or
-    /// ticking layout — wrap is likewise detected off-panel via the <c>flex-wrap</c> class marker. A USS
+    /// ticking layout — off-panel, both direction and wrap fall back from the class markers (the only source
+    /// available) to the same defaults their on-panel <c>resolvedStyle</c> fallback would produce. A USS
     /// child-selector approach to gap would resolve only under a live panel and produce no inline margins at
     /// all, so these off-panel assertions are a meaningful discriminator against that class of implementation.
     /// </remarks>
@@ -311,6 +318,24 @@ namespace Velvet.Tests
             AssertFourSideMargin(container[0], Half4, "child[0]");
             AssertFourSideMargin(container[2], Half4, "child[2]");
             AssertFourSideMargin(container, -Half4, "container");
+        }
+
+        [Test]
+        public void Given_FlexWrapReverseGap4_When_ReconciledOffPanel_Then_StillUsesTheHalfMarginPolyfill()
+        {
+            // Arrange — flex-wrap-reverse is a DIFFERENT string than flex-wrap, so the off-panel class-marker
+            // fallback must recognize it too (the same shape of miss the flex-col / flex-col-reverse fix
+            // addressed for direction) — otherwise a flex-wrap-reverse container would wrongly resolve to
+            // non-wrap off-panel and use the single leading-edge margin instead of the half-margin polyfill.
+            using var scope = new ReconcilerScope();
+            var tree = new VNode[] { Row("flex flex-row flex-wrap-reverse gap-4", 3) };
+
+            // Act
+            scope.Reconciler.Reconcile(scope.Root, System.Array.Empty<VNode>(), tree);
+            var container = Container(scope.Root);
+
+            // Assert
+            AssertFourSideMargin(container[0], Half4, "child[0] under flex-wrap-reverse");
         }
 
         [Test]
@@ -604,6 +629,37 @@ namespace Velvet.Tests
                 "the newly added child gets the gap");
         }
 
+        // The signature-widening regression guard: ComputeSignature must encode all four edges distinctly.
+        // A class-driven direction toggle reaches the manipulator through UpdateGap, which unconditionally
+        // forces a re-apply (bypassing the cached signature) — so the ONLY place a collapsed edge encoding
+        // can matter is a re-application that does NOT go through UpdateGap, i.e. exactly what a
+        // GeometryChangedEvent-triggered Apply() call is. This drives that path directly: change the class
+        // list on the live element (not through the reconciler, so UpdateGap never runs), then call Apply()
+        // via reflection the same way OnGeometryChanged would — a stale cached signature that collapsed Top
+        // and Bottom into one bucket would make this a no-op and leave the abandoned margin in place.
+        [Test]
+        public void Given_AClassListChangeWithNoConfigChange_When_ApplyReruns_Then_TheMarginMovesToTheNewEdge()
+        {
+            // Arrange — establish the Top edge off-panel via a real reconcile.
+            using var scope = new ReconcilerScope();
+            var tree = new VNode[] { Row("flex flex-col gap-4", 3) };
+            scope.Reconciler.Reconcile(scope.Root, System.Array.Empty<VNode>(), tree);
+            var container = Container(scope.Root);
+            var manipulator = GetGapManipulator(scope.Reconciler, container);
+            Assume.That(container[1].style.marginTop.value.value, Is.EqualTo(Space4),
+                "Precondition: the column gap settled on the leading (top) edge");
+
+            // Act — flip the class list DIRECTLY (never through UpdateGap, so gap/axis/markers are
+            // unchanged and the cached signature is the only thing standing between this call and the new
+            // edge), then re-run Apply() the way a GeometryChangedEvent would.
+            container.RemoveFromClassList("flex-col");
+            container.AddToClassList("flex-col-reverse");
+            InvokeApply(manipulator);
+
+            // Assert — the stale leading (top) margin is cleared once Apply() re-derives the new edge.
+            Assert.That(container[1].style.marginTop.keyword, Is.EqualTo(StyleKeyword.Null));
+        }
+
         [Test]
         public void Given_AnAutoGapRow_When_Mounted_Then_TheSecondChildHasAHorizontalLeadingMargin()
         {
@@ -737,13 +793,282 @@ namespace Velvet.Tests
         }
 
         [Test]
-        public void Given_SpaceXReverse_When_Parsed_Then_DeclinesToParse()
+        public void Given_SpaceXReverse_When_Parsed_Then_DeclinesToParseAsAGapValue()
         {
-            // Act — space-x-reverse has no gap analog; it is an intentional no-op (locked here).
+            // Act — space-x-reverse carries no pixel gap value of its own (TryParse is the pixel-value
+            // parser); it is now recognized separately as a reverse marker (see the tests below), not
+            // dropped as an unsupported no-op.
             var ok = StyleGapClass.TryParse("space-x-reverse", out _, out _);
 
             // Assert
             Assert.That(ok, Is.False);
+        }
+
+        [Test]
+        public void Given_SpaceXReverse_When_ReverseMarkersExtracted_Then_TheHorizontalMarkerIsRecognized()
+        {
+            // Act — space-x-reverse is no longer an unsupported no-op: StyleGapManipulator reads it through
+            // this extractor instead of the pixel-value TryParse.
+            StyleGapClass.ExtractReverseMarkers(new[] { "space-x-reverse" }, out var xReverse, out var yReverse);
+
+            // Assert
+            Assert.That((xReverse, yReverse), Is.EqualTo((true, false)));
+        }
+
+        [Test]
+        public void Given_SpaceYReverse_When_ReverseMarkersExtracted_Then_TheVerticalMarkerIsRecognized()
+        {
+            // Act
+            StyleGapClass.ExtractReverseMarkers(new[] { "space-y-reverse" }, out var xReverse, out var yReverse);
+
+            // Assert
+            Assert.That((xReverse, yReverse), Is.EqualTo((false, true)));
+        }
+
+        [Test]
+        public void Given_NoReverseMarkerClass_When_ReverseMarkersExtracted_Then_BothMarkersAreFalse()
+        {
+            // Act
+            StyleGapClass.ExtractReverseMarkers(new[] { "flex", "flex-row", "gap-4" }, out var xReverse, out var yReverse);
+
+            // Assert
+            Assert.That((xReverse, yReverse), Is.EqualTo((false, false)));
+        }
+
+        // --- End-to-end: the reverse marker / row-reverse / col-reverse edge flip, driven through the
+        // reconciler exactly like the rest of this file's off-panel oracle (inline margins, no panel needed
+        // — StyleGapManipulator's off-panel fallback reads the flex-row-reverse / flex-col-reverse / space-*-
+        // reverse class markers directly, matching the on-panel resolvedStyle.flexDirection reads exactly). ---
+
+        [Test]
+        public void Given_FlexRowSpaceXReverse_When_Reconciled_Then_SecondChildCarriesTheTrailingMargin()
+        {
+            // Arrange — space-x-4 space-x-reverse on a (non-reversed) row: the marker alone, with no
+            // row-reverse container, still moves the gap to the trailing physical edge (margin-right).
+            using var scope = new ReconcilerScope();
+            var tree = new VNode[] { Row("flex flex-row space-x-4 space-x-reverse", 3) };
+
+            // Act
+            scope.Reconciler.Reconcile(scope.Root, System.Array.Empty<VNode>(), tree);
+            var container = Container(scope.Root);
+
+            // Assert
+            Assert.That(container[1].style.marginRight.value.value, Is.EqualTo(Space4));
+        }
+
+        [Test]
+        public void Given_FlexRowSpaceXReverse_When_Reconciled_Then_ThirdChildCarriesTheTrailingMargin()
+        {
+            // Arrange — same container; the LAST child (not just the second) also carries the trailing
+            // margin, matching the ordinary leading-margin contract (every child but the first).
+            using var scope = new ReconcilerScope();
+            var tree = new VNode[] { Row("flex flex-row space-x-4 space-x-reverse", 3) };
+
+            // Act
+            scope.Reconciler.Reconcile(scope.Root, System.Array.Empty<VNode>(), tree);
+            var container = Container(scope.Root);
+
+            // Assert
+            Assert.That(container[2].style.marginRight.value.value, Is.EqualTo(Space4));
+        }
+
+        [Test]
+        public void Given_ALeadingMarginRow_When_SpaceXReverseIsAddedByPatch_Then_TheStaleLeadingMarginIsCleared()
+        {
+            // Arrange — first reconcile establishes the LEADING (margin-left) edge with no reverse marker.
+            using var scope = new ReconcilerScope();
+            var tree1 = new VNode[] { Row("flex flex-row space-x-4", 3) };
+            scope.Reconciler.Reconcile(scope.Root, System.Array.Empty<VNode>(), tree1);
+            var container = Container(scope.Root);
+            Assume.That(container[1].style.marginLeft.value.value, Is.EqualTo(Space4),
+                "Precondition: the leading (margin-left) edge is established before the marker is added");
+
+            // Act — patch in space-x-reverse: the edge flips from Left to Right, so the manipulator must
+            // clear the now-abandoned leading margin, not just add the new trailing one.
+            var tree2 = new VNode[] { Row("flex flex-row space-x-4 space-x-reverse", 3) };
+            scope.Reconciler.Reconcile(scope.Root, tree1, tree2);
+
+            // Assert — the stale margin-left is cleared (this is the missing-clear case: ApplyLeading's
+            // "_applied != edge" check must cover ALL four edges, not just Left vs Top).
+            Assert.That(container[1].style.marginLeft.keyword, Is.EqualTo(StyleKeyword.Null));
+        }
+
+        [Test]
+        public void Given_FlexRowReverseGap4_When_ReconciledOffPanel_Then_ResolvesTheTrailingHorizontalEdge()
+        {
+            // Arrange — plain gap-4 (Auto axis) on a flex-row-reverse container: the row-reverse direction
+            // alone (no space-*-reverse marker) must move the margin to the trailing edge (margin-right).
+            // This is the parity bug independent of the issue as filed: plain gap-4 was already wrong on a
+            // row-reverse container.
+            using var scope = new ReconcilerScope();
+            var tree = new VNode[] { Row("flex flex-row-reverse gap-4", 3) };
+
+            // Act
+            scope.Reconciler.Reconcile(scope.Root, System.Array.Empty<VNode>(), tree);
+            var container = Container(scope.Root);
+
+            // Assert
+            Assert.That(container[1].style.marginRight.value.value, Is.EqualTo(Space4));
+        }
+
+        [Test]
+        public void Given_FlexColReverseGap4_When_ReconciledOffPanel_Then_ResolvesTheTrailingVerticalEdge()
+        {
+            // Arrange — plain gap-4 on a flex-col-reverse container. Off-panel, this exercises TWO bugs at
+            // once: the axis-detection fallback used to check only "flex-col" (a different string than
+            // "flex-col-reverse"), resolving the wrong axis entirely, and the edge itself must land on the
+            // trailing margin-bottom, not margin-top.
+            using var scope = new ReconcilerScope();
+            var tree = new VNode[] { Row("flex flex-col-reverse gap-4", 3) };
+
+            // Act
+            scope.Reconciler.Reconcile(scope.Root, System.Array.Empty<VNode>(), tree);
+            var container = Container(scope.Root);
+
+            // Assert
+            Assert.That(container[1].style.marginBottom.value.value, Is.EqualTo(Space4));
+        }
+
+        [Test]
+        public void Given_FlexRowReverseWithSpaceXReverse_When_Reconciled_Then_StillResolvesTheTrailingEdge()
+        {
+            // Arrange — the idiomatic Tailwind combination: a row-reverse container's own direction AND the
+            // space-x-reverse marker both independently mean "trailing edge". They must OR together (both
+            // pointing the same way keeps it trailing) rather than XOR (which would cancel back to leading).
+            using var scope = new ReconcilerScope();
+            var tree = new VNode[] { Row("flex flex-row-reverse space-x-4 space-x-reverse", 3) };
+
+            // Act
+            scope.Reconciler.Reconcile(scope.Root, System.Array.Empty<VNode>(), tree);
+            var container = Container(scope.Root);
+
+            // Assert
+            Assert.That(container[1].style.marginRight.value.value, Is.EqualTo(Space4));
+        }
+
+        [Test]
+        public void Given_FlexColGapY4WithSpaceXReverse_When_Reconciled_Then_TheHorizontalMarkerDoesNotAffectTheVerticalAxis()
+        {
+            // Arrange — space-x-reverse must not flip a VERTICAL gap: the flip is per-axis, so a plain
+            // vertical gap-y-4 on a non-reversed column stays on the leading (margin-top) edge even with an
+            // (irrelevant, cross-axis) space-x-reverse marker present.
+            using var scope = new ReconcilerScope();
+            var tree = new VNode[] { Row("flex flex-col gap-y-4 space-x-reverse", 3) };
+
+            // Act
+            scope.Reconciler.Reconcile(scope.Root, System.Array.Empty<VNode>(), tree);
+            var container = Container(scope.Root);
+
+            // Assert
+            Assert.That(container[1].style.marginTop.value.value, Is.EqualTo(Space4));
+        }
+
+        [Test]
+        public void Given_FlexColReverseGapX4_When_Reconciled_Then_TheHorizontalGapStaysOnTheLeadingEdge()
+        {
+            // Arrange — the direction half of per-axis independence: gap-x-4 (explicit Horizontal axis) on
+            // a flex-col-reverse container must NOT flip, because flex-col-reverse only reverses the
+            // VERTICAL axis. The gap stays on margin-left.
+            using var scope = new ReconcilerScope();
+            var tree = new VNode[] { Row("flex flex-col-reverse gap-x-4", 3) };
+
+            // Act
+            scope.Reconciler.Reconcile(scope.Root, System.Array.Empty<VNode>(), tree);
+            var container = Container(scope.Root);
+
+            // Assert
+            Assert.That(container[1].style.marginLeft.value.value, Is.EqualTo(Space4));
+        }
+
+        [Test]
+        public void Given_FlexRowReverseGapY4_When_Reconciled_Then_TheVerticalGapStaysOnTheLeadingEdge()
+        {
+            // Arrange — the symmetric direction half: gap-y-4 (explicit Vertical axis) on a
+            // flex-row-reverse container must NOT flip, because flex-row-reverse only reverses the
+            // HORIZONTAL axis. The gap stays on margin-top.
+            using var scope = new ReconcilerScope();
+            var tree = new VNode[] { Row("flex flex-row-reverse gap-y-4", 3) };
+
+            // Act
+            scope.Reconciler.Reconcile(scope.Root, System.Array.Empty<VNode>(), tree);
+            var container = Container(scope.Root);
+
+            // Assert
+            Assert.That(container[1].style.marginTop.value.value, Is.EqualTo(Space4));
+        }
+
+        [Test]
+        public void Given_FlexColSpaceYReverse_When_Reconciled_Then_TheSecondChildCarriesTheTrailingVerticalMargin()
+        {
+            // Arrange — space-y-reverse end to end (only the extractor was covered elsewhere): the vertical
+            // twin of space-x-reverse, moving the gap emulation's margin to margin-bottom.
+            using var scope = new ReconcilerScope();
+            var tree = new VNode[] { Row("flex flex-col space-y-4 space-y-reverse", 3) };
+
+            // Act
+            scope.Reconciler.Reconcile(scope.Root, System.Array.Empty<VNode>(), tree);
+            var container = Container(scope.Root);
+
+            // Assert
+            Assert.That(container[1].style.marginBottom.value.value, Is.EqualTo(Space4));
+        }
+
+        [Test]
+        public void Given_ATrailingMarginRow_When_SpaceXReverseIsRemovedByPatch_Then_TheStaleTrailingMarginIsCleared()
+        {
+            // Arrange — the mirror image of the earlier Left→Right clear test: establish the TRAILING
+            // (margin-right) edge first, then patch the marker away so the edge flips back to leading.
+            using var scope = new ReconcilerScope();
+            var tree1 = new VNode[] { Row("flex flex-row space-x-4 space-x-reverse", 3) };
+            scope.Reconciler.Reconcile(scope.Root, System.Array.Empty<VNode>(), tree1);
+            var container = Container(scope.Root);
+            Assume.That(container[1].style.marginRight.value.value, Is.EqualTo(Space4),
+                "Precondition: the trailing (margin-right) edge is established before the marker is removed");
+
+            // Act — patch away space-x-reverse: the edge flips from Right back to Left, so the manipulator
+            // must clear the now-abandoned trailing margin, not just add the new leading one.
+            var tree2 = new VNode[] { Row("flex flex-row space-x-4", 3) };
+            scope.Reconciler.Reconcile(scope.Root, tree1, tree2);
+
+            // Assert — the stale margin-right is cleared.
+            Assert.That(container[1].style.marginRight.keyword, Is.EqualTo(StyleKeyword.Null));
+        }
+
+        [Test]
+        public void Given_FlexRowReverseWrapGap4_When_Reconciled_Then_StillUsesTheSymmetricHalfMarginPolyfill()
+        {
+            // Arrange — flex-wrap always wins over direction: a reversed container that also wraps must
+            // still use the four-side half-margin polyfill (symmetric on every side), never ResolveEdge's
+            // leading/trailing split, since wrapping needs both axes spaced regardless of direction.
+            using var scope = new ReconcilerScope();
+            var tree = new VNode[] { Row("flex flex-row-reverse flex-wrap gap-4", 3) };
+
+            // Act
+            scope.Reconciler.Reconcile(scope.Root, System.Array.Empty<VNode>(), tree);
+            var container = Container(scope.Root);
+
+            // Assert
+            AssertFourSideMargin(container[0], Half4, "child[0] in a reversed wrapping container");
+        }
+
+        [Test]
+        public void Given_AnElementCarryingBothFlexColAndFlexRowReverse_When_Reconciled_Then_TheLaterDeclaredClassWins()
+        {
+            // Arrange — two direction classes on one element is routine once responsive/state variants are
+            // involved (a base flex-col plus a variant-applied md:flex-row-reverse both land in the SAME
+            // live class list once the breakpoint is met). _layout.uss declares .flex-col before
+            // .flex-row-reverse, so at equal specificity the LATER rule wins the USS cascade regardless of
+            // which class was written first or which one a naive "row family vs column family" check
+            // happens to look at — the gap must resolve exactly as real USS would: horizontal, trailing.
+            using var scope = new ReconcilerScope();
+            var tree = new VNode[] { Row("flex-col flex-row-reverse gap-4", 3) };
+
+            // Act
+            scope.Reconciler.Reconcile(scope.Root, System.Array.Empty<VNode>(), tree);
+            var container = Container(scope.Root);
+
+            // Assert
+            Assert.That(container[1].style.marginRight.value.value, Is.EqualTo(Space4));
         }
 
         [Test]
@@ -779,6 +1104,382 @@ namespace Velvet.Tests
 
             // Assert
             Assert.That(scope.Root[0][1].style.marginLeft.value.value, Is.EqualTo(12f));
+        }
+    }
+
+    /// <summary>
+    /// On-panel coverage for the row-reverse / col-reverse gap edge flip, using a real
+    /// <see cref="UnityEditor.EditorWindow"/> panel (<see cref="PanelTestBase"/>) rather than the simulated
+    /// one <see cref="GapReverseRuntimeFlipTests"/> below uses. <c>flex-row-reverse</c> /
+    /// <c>flex-col-reverse</c> are USS-only rules (<c>_layout.uss</c>) with no C# parse path of their own —
+    /// <c>resolvedStyle.flexDirection</c> never actually reports <c>RowReverse</c> without the bundled
+    /// <c>StyleUtilities.uss</c> attached to a real panel. Since <see cref="StyleGapManipulator.ResolveDirection"/>
+    /// reads the class markers before resolvedStyle even on a panel, the first test below is class-marker
+    /// coverage on a panel, not resolvedStyle coverage — the second test is the one that actually proves the
+    /// resolvedStyle FALLBACK, by withholding every direction/display class entirely.
+    /// </summary>
+    [TestFixture]
+    internal sealed class GapReversePanelTests : PanelTestBase
+    {
+        private const string StyleSheetPath = "Packages/com.velvet.core/Runtime/Styles/StyleUtilities.uss";
+        private const float Space4 = 16f;
+
+        protected override void LoadStyleSheets()
+        {
+            var sheet = AssetDatabase.LoadAssetAtPath<StyleSheet>(StyleSheetPath);
+            Assume.That(sheet, Is.Not.Null, "Precondition: the bundled StyleUtilities.uss loads");
+            _window.rootVisualElement.styleSheets.Add(sheet);
+        }
+
+        [Test]
+        public void Given_AFlexRowReverseGapContainer_When_PanelResolves_Then_TheSecondChildCarriesTheTrailingMargin()
+        {
+            // Arrange
+            _mounted = V.Mount(_window.rootVisualElement,
+                V.Div(name: "row", className: "flex flex-row-reverse gap-x-4", children: new VNode[]
+                {
+                    V.Label(name: "a", text: "a"),
+                    V.Label(name: "b", text: "b"),
+                }));
+            var row = _window.rootVisualElement.Q<VisualElement>("row");
+            ForcePanelUpdate(row.panel);
+            using var evt = EventBase<GeometryChangedEvent>.GetPooled();
+            row.SimulateEvent(evt);
+            Assume.That(row.resolvedStyle.flexDirection, Is.EqualTo(FlexDirection.RowReverse),
+                "Precondition: the panel resolved flex-row-reverse from the bundled USS");
+
+            // Assert
+            var b = _window.rootVisualElement.Q<Label>("b");
+            Assert.That(b.resolvedStyle.marginRight, Is.EqualTo(Space4));
+        }
+
+        [Test]
+        public void Given_ADirectionSetOnlyThroughResolvedStyle_When_PanelResolves_Then_TheGapStillFollowsIt()
+        {
+            // Arrange — flex-direction set via an inline style (standing in for a custom stylesheet rule),
+            // with NONE of the five direction/display classes (flex / flex-row(-reverse) /
+            // flex-col(-reverse)) anywhere on the element — the one case ResolveDirection's class scan
+            // cannot answer, so it must fall through to resolvedStyle. A VisualElement is a flex container
+            // by Yoga's own default regardless of a "flex" class, so the inline flex-direction alone is
+            // enough to produce a real RowReverse layout.
+            _mounted = V.Mount(_window.rootVisualElement,
+                V.Div(name: "row", className: "gap-x-4",
+                    refCallback: el => { el.style.flexDirection = FlexDirection.RowReverse; return null; },
+                    children: new VNode[]
+                    {
+                        V.Label(name: "a", text: "a"),
+                        V.Label(name: "b", text: "b"),
+                    }));
+            var row = _window.rootVisualElement.Q<VisualElement>("row");
+            ForcePanelUpdate(row.panel);
+            using var evt = EventBase<GeometryChangedEvent>.GetPooled();
+            row.SimulateEvent(evt);
+            Assume.That(row.resolvedStyle.flexDirection, Is.EqualTo(FlexDirection.RowReverse),
+                "Precondition: the panel resolved the inline flex-direction with no direction class present");
+
+            // Assert
+            var b = _window.rootVisualElement.Q<Label>("b");
+            Assert.That(b.resolvedStyle.marginRight, Is.EqualTo(Space4));
+        }
+    }
+
+    /// <summary>
+    /// The on-panel convergence regression guard for a class-driven direction toggle. <c>flex-row-reverse</c>
+    /// / <c>flex-col-reverse</c> are USS-only rules with no C# inline <c>flex-direction</c> write, so
+    /// <c>resolvedStyle.flexDirection</c> only catches up after the panel's NEXT style pass — and a
+    /// same-rect direction toggle (children reorder, the container itself never resizes) fires no
+    /// <c>GeometryChangedEvent</c> to trigger a re-derive. A manipulator that consulted resolvedStyle for
+    /// this would converge on the FIRST toggle (the initial layout pass happens to change the rect) but
+    /// never on a LATER toggle back — the margin would stay wrong indefinitely, with nothing left to
+    /// correct it. <see cref="StyleGapManipulator"/> avoids this by preferring the flex-row(-reverse) /
+    /// flex-col(-reverse) class markers over resolvedStyle (they are the FINAL class list by the time
+    /// <c>UpdateGap</c> runs, unlike resolvedStyle), so <c>UpdateGap</c>'s own unconditional forced re-apply
+    /// converges immediately, without needing any geometry event at all. This test proves exactly that: it
+    /// ticks the panel after the toggle but deliberately does NOT synthesize a <c>GeometryChangedEvent</c> —
+    /// a version that relied on one (or on resolvedStyle) would never converge here.
+    /// </summary>
+    [TestFixture]
+    internal sealed class GapReverseRuntimeFlipTests
+    {
+        private const string StyleSheetPath = "Packages/com.velvet.core/Runtime/Styles/StyleUtilities.uss";
+
+        private readonly record struct DirectionState(bool Reversed);
+
+        private sealed class DirectionStore : Store<DirectionState>
+        {
+            public DirectionStore() : base(new DirectionState(false)) { }
+            public void Set(bool reversed) => SetState(_ => new DirectionState(reversed));
+            protected override void ResetCore() => SetState(_ => new DirectionState(false));
+        }
+
+        private static DirectionStore s_store;
+
+        // A raw class-string store for the scenarios below that need more than a two-state boolean:
+        // the bare-flex round trip and the axis-and-edge-both-flip case both toggle between class
+        // strings that are not simple mirror images of each other.
+        private readonly record struct ClassNameState(string ClassName);
+
+        private sealed class ClassNameStore : Store<ClassNameState>
+        {
+            public ClassNameStore(string initial) : base(new ClassNameState(initial)) { }
+            public void Set(string className) => SetState(_ => new ClassNameState(className));
+            protected override void ResetCore() => SetState(_ => new ClassNameState(string.Empty));
+        }
+
+        private static ClassNameStore s_classNameStore;
+
+        private EditorPanelSimulator _sim;
+
+        [SetUp]
+        public void SetUp()
+        {
+            PanelSimulator.ResetCurrentTime();
+            _sim = new EditorPanelSimulator { panelSize = new Vector2(200, 200) };
+            _sim.ResetTimePerSimulatedFrameToDefault();
+            var sheet = AssetDatabase.LoadAssetAtPath<StyleSheet>(StyleSheetPath);
+            Assume.That(sheet, Is.Not.Null, "Precondition: the bundled StyleUtilities.uss loads");
+            _sim.rootVisualElement.styleSheets.Add(sheet);
+            s_store = null;
+            s_classNameStore = null;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _sim?.Dispose();
+            _sim = null;
+        }
+
+        private VisualElement Root => _sim.rootVisualElement;
+
+        private void Tick() => _sim.FrameUpdateMs(16);
+
+        [Component]
+        private static VNode ColumnGapRow()
+        {
+            var reversed = Hooks.UseStore(s_store, s => s.Reversed);
+            var dir = reversed ? "flex-col-reverse" : "flex-col";
+            return V.Div(name: "col", className: $"flex {dir} gap-4", children: new VNode[]
+            {
+                V.Label(name: "a", text: "a"),
+                V.Label(name: "b", text: "b"),
+            });
+        }
+
+        [Test]
+        public void Given_AColumnGapContainer_When_FlippedToColumnReverse_Then_TheStaleTopMarginIsClearedWithNoSynthesizedEvent()
+        {
+            // Arrange — establish the leading (margin-top) edge on a settled column container.
+            using var store = new DirectionStore();
+            s_store = store;
+            using var mounted = V.Mount(Root, V.Component(ColumnGapRow, key: "col"));
+            var scheduler = mounted.Root.Reconciler.Context.BatchScheduler;
+            Tick();
+            Tick();
+            var b = Root.Q<Label>("b");
+            Assume.That(b.style.marginTop.value.value, Is.EqualTo(16f),
+                "Precondition: the column gap settled on the leading (top) edge");
+
+            // Act — flip to flex-col-reverse and just tick the panel; deliberately NO synthesized
+            // GeometryChangedEvent. Production must converge through UpdateGap's own forced re-apply
+            // (which now reads the class marker, already final at patch time) rather than depending on an
+            // event that a same-rect direction toggle never actually fires.
+            store.Set(true);
+            scheduler.DrainImmediateForTest();
+            Tick();
+            Tick();
+
+            // Assert — the abandoned leading margin is cleared without any manufactured event.
+            Assert.That(b.style.marginTop.keyword, Is.EqualTo(StyleKeyword.Null));
+        }
+
+        [Test]
+        public void Given_AColumnReverseGapContainer_When_FlippedBackToColumn_Then_TheStaleBottomMarginIsClearedWithNoSynthesizedEvent()
+        {
+            // Arrange — the round trip: start REVERSED (so the very first layout pass, which happens to
+            // change the rect from nothing to something, cannot be the thing that makes this converge) and
+            // settle on the trailing (margin-bottom) edge.
+            using var store = new DirectionStore();
+            s_store = store;
+            store.Set(true);
+            using var mounted = V.Mount(Root, V.Component(ColumnGapRow, key: "col"));
+            var scheduler = mounted.Root.Reconciler.Context.BatchScheduler;
+            Tick();
+            Tick();
+            var b = Root.Q<Label>("b");
+            Assume.That(b.style.marginBottom.value.value, Is.EqualTo(16f),
+                "Precondition: the column-reverse gap settled on the trailing (bottom) edge");
+
+            // Act — flip BACK to flex-col (no longer reversed) and just tick; no synthesized event. This is
+            // the exact toggle direction the reviewed regression left unconverged: a resolvedStyle-only
+            // read has no rect change to piggyback a natural GeometryChangedEvent on here.
+            store.Set(false);
+            scheduler.DrainImmediateForTest();
+            Tick();
+            Tick();
+
+            // Assert — the abandoned trailing margin is cleared without any manufactured event.
+            Assert.That(b.style.marginBottom.keyword, Is.EqualTo(StyleKeyword.Null));
+        }
+
+        [Component]
+        private static VNode ClassDrivenGapRow()
+        {
+            var className = Hooks.UseStore(s_classNameStore, s => s.ClassName);
+            return V.Div(name: "row", className: className, children: new VNode[]
+            {
+                V.Label(name: "a", text: "a"),
+                V.Label(name: "b", text: "b"),
+            });
+        }
+
+        // Bare `flex` is itself a direction-bearing class (_layout.uss: `.flex { flex-direction: row; }`,
+        // the stylesheet's own recommended spelling for a row), so it must be part of the class scan, not
+        // just flex-row(-reverse) / flex-col(-reverse) — otherwise the idiomatic
+        // `reversed ? "flex flex-row-reverse gap-4" : "flex gap-4"` toggle has no marker at all in its OFF
+        // state and falls through to a possibly-stale resolvedStyle.
+
+        [Test]
+        public void Given_ABareFlexGapRow_When_ToggledToRowReverse_Then_TheMarginMovesToTheTrailingEdge()
+        {
+            // Arrange — plain "flex gap-4": no flex-row class, just the direction-bearing bare flex.
+            using var store = new ClassNameStore("flex gap-4");
+            s_classNameStore = store;
+            using var mounted = V.Mount(Root, V.Component(ClassDrivenGapRow, key: "row"));
+            var scheduler = mounted.Root.Reconciler.Context.BatchScheduler;
+            Tick();
+            Tick();
+            var b = Root.Q<Label>("b");
+            Assume.That(b.style.marginLeft.value.value, Is.EqualTo(16f),
+                "Precondition: the bare-flex row settled on the leading (left) edge");
+
+            // Act — toggle to flex-row-reverse; no synthesized event.
+            store.Set("flex flex-row-reverse gap-4");
+            scheduler.DrainImmediateForTest();
+            Tick();
+            Tick();
+
+            // Assert — the margin moved to the trailing edge.
+            Assert.That(b.style.marginRight.value.value, Is.EqualTo(16f));
+        }
+
+        [Test]
+        public void Given_ABareFlexRowReverseGapRow_When_ToggledBackToPlainFlex_Then_TheStaleTrailingMarginIsCleared()
+        {
+            // Arrange — the failing direction: start reversed (a marker present in both the axis and the
+            // reversed sense), then toggle to bare "flex", which carries NO reversed marker at all — the
+            // OFF state of the reviewed idiom.
+            using var store = new ClassNameStore("flex flex-row-reverse gap-4");
+            s_classNameStore = store;
+            using var mounted = V.Mount(Root, V.Component(ClassDrivenGapRow, key: "row"));
+            var scheduler = mounted.Root.Reconciler.Context.BatchScheduler;
+            Tick();
+            Tick();
+            var b = Root.Q<Label>("b");
+            Assume.That(b.style.marginRight.value.value, Is.EqualTo(16f),
+                "Precondition: the reversed row settled on the trailing (right) edge");
+
+            // Act — toggle to bare flex (no synthesized event). Without the class-marker-first fix, this
+            // falls through to resolvedStyle, which is still stale RowReverse at UpdateGap time and never
+            // gets a geometry event to correct it (a same-rect direction toggle moves no rect).
+            store.Set("flex gap-4");
+            scheduler.DrainImmediateForTest();
+            Tick();
+            Tick();
+
+            // Assert — the stale trailing margin is cleared.
+            Assert.That(b.style.marginRight.keyword, Is.EqualTo(StyleKeyword.Null));
+        }
+
+        [Test]
+        public void Given_AColumnReverseGapRow_When_ToggledToBareFlex_Then_TheAxisAndEdgeBothConvergeToLeft()
+        {
+            // Arrange — the "worse" variant: flex-col-reverse carries NEITHER a row-family class, so
+            // toggling to bare "flex" must flip BOTH the axis (column -> row) and the reversed bit
+            // (reversed -> not) — a single margin-left assertion proves both at once, since getting EITHER
+            // one wrong leaves the left margin at 0 or Null instead of the gap value.
+            using var store = new ClassNameStore("flex-col-reverse gap-4");
+            s_classNameStore = store;
+            using var mounted = V.Mount(Root, V.Component(ClassDrivenGapRow, key: "row"));
+            var scheduler = mounted.Root.Reconciler.Context.BatchScheduler;
+            Tick();
+            Tick();
+            var b = Root.Q<Label>("b");
+            Assume.That(b.style.marginBottom.value.value, Is.EqualTo(16f),
+                "Precondition: the column-reverse row settled on the trailing (bottom) edge");
+
+            // Act — toggle to bare flex (no synthesized event).
+            store.Set("flex gap-4");
+            scheduler.DrainImmediateForTest();
+            Tick();
+            Tick();
+
+            // Assert — both axis and edge converged to the plain row's leading (left) edge.
+            Assert.That(b.style.marginLeft.value.value, Is.EqualTo(16f));
+        }
+
+        [Test]
+        public void Given_AGapXRowReverseContainer_When_ToggledToColumnReverse_Then_TheMarginMovesFromRightToLeft()
+        {
+            // Arrange — the cross-axis hole: an explicit gap-x-4 (Horizontal axis) container starts
+            // flex-row-reverse (trailing = margin-right), then patches straight to flex-col-reverse — no
+            // row-family class survives the patch at all, so a same-family-only check (as opposed to one
+            // resolved verdict) would find nothing to update and keep the stale Right edge.
+            using var store = new ClassNameStore("flex-row-reverse gap-x-4");
+            s_classNameStore = store;
+            using var mounted = V.Mount(Root, V.Component(ClassDrivenGapRow, key: "row"));
+            var scheduler = mounted.Root.Reconciler.Context.BatchScheduler;
+            Tick();
+            Tick();
+            var b = Root.Q<Label>("b");
+            Assume.That(b.style.marginRight.value.value, Is.EqualTo(16f),
+                "Precondition: the row-reverse container settled on the trailing (right) edge");
+
+            // Act — patch straight to flex-col-reverse (no synthesized event); gap-x-4 stays horizontal
+            // regardless, but flex-row-reverse is gone so the reversed bit must re-derive from scratch.
+            store.Set("flex-col-reverse gap-x-4");
+            scheduler.DrainImmediateForTest();
+            Tick();
+            Tick();
+
+            // Assert — the margin moved back to the leading (left) edge; flex-col-reverse does not reverse
+            // the horizontal axis.
+            Assert.That(b.style.marginLeft.value.value, Is.EqualTo(16f));
+        }
+
+        [Component]
+        private static VNode InlineWrapRow()
+        {
+            // "flex flex-row" is present (the realistic, idiomatic shape — nearly every real container
+            // carries a direction class) and NO flex-wrap class at all: IsWrap's resolvedStyle fallback is
+            // the only source that can possibly answer, exactly the "wrap set some other way" case a
+            // direction class must NOT paper over.
+            var children = new VNode[3];
+            for (var i = 0; i < 3; i++)
+            {
+                children[i] = V.Div(name: "child-" + i, className: "w-[40px] h-[20px]");
+            }
+            return V.Div(name: "row", className: "flex flex-row w-[60px] gap-4",
+                refCallback: el => { el.style.flexWrap = Wrap.Wrap; return null; },
+                children: children);
+        }
+
+        [Test]
+        public void Given_AnInlineFlexWrapWithNoWrapClass_When_ThePanelSettles_Then_TheHalfMarginPolyfillAppliesWithoutASynthesizedEvent()
+        {
+            // Arrange/Act — a 60px-wide row with three 40px children set to wrap only via an inline style
+            // (no flex-wrap class at all): wrapping genuinely changes the container's own measured height
+            // (one line of content vs. three stacked lines), unlike a same-size direction toggle, so the
+            // resulting GeometryChangedEvent is a REAL one this test deliberately never synthesizes.
+            using var mounted = V.Mount(Root, V.Component(InlineWrapRow, key: "row"));
+            Tick();
+            Tick();
+            Tick();
+
+            // Assert — the container carries the wrap path's own negative half-margin, proving the
+            // resolvedStyle fallback (not a class) correctly detected wrapping and self-corrected.
+            var row = Root.Q<VisualElement>("row");
+            Assert.That(row.style.marginRight.value.value, Is.EqualTo(-8f));
         }
     }
 }


### PR DESCRIPTION
## What & why

`space-x-reverse` / `space-y-reverse` were unsupported. Adding them surfaced two real bugs in the same code, both of which are fixed here.

**Plain `gap-*` put its margin on the wrong edge inside a reversed container.** The manipulator folded the reversed directions into their forward counterparts when picking which edge carries the inter-child margin, so on `flex-row-reverse` a plain `gap-4` — with no reverse marker anywhere — wrote a leading margin that showed up as space on the container's *outer* edge, while the boundary between the two visually adjacent children got nothing. That is a violation of what `gap` means, not just a Tailwind mismatch. I confirmed it by rendering before and after: the before image shows the first pair touching and a stray margin at the far edge; the after image shows even spacing with no outer margin.

**Off-panel, a `flex-col-reverse` container resolved the wrong axis entirely** — the class fallback compared against the literal `flex-col`, which `flex-col-reverse` never equals — so the gap landed on the horizontal axis on a column container.

**Direction is now resolved once, from the class list, in the stylesheet's own declaration order** (`flex-col-reverse`, then `flex-row-reverse`, then `flex-col`, then `flex-row` / `flex`), falling back to the resolved style only when no direction class is present. Reading the class list rather than the resolved style is what makes a toggle converge: the direction comes from a class rule, so at reconcile time the resolved value still holds the pre-flip direction, and a flip between two same-size directions moves no rect, so no geometry event ever arrives to correct it. Reproducing the stylesheet's order matters because responsive and state variants add their bare utility to the live class list, so two direction classes coexist routinely and the later-declared one wins.

The reverse marker and a detected reversed direction combine as OR, per axis: the marker means "use the other edge" unconditionally, so `flex-row-reverse space-x-4 space-x-reverse` must not flip back. One consequence is worth stating and is documented: because Velvet realizes `space-*` through the direction-aware gap polyfill, `space-x-4` alone is already correct on a reversed container, which makes the marker a compatibility no-op there.

Wrap detection keeps its existing fallback to the resolved value, so an element whose wrap comes from an inline style or a custom sheet is still honoured.

## Checklist

- [x] Tests pass locally (EditMode / PlayMode / generator tests as applicable) — EditMode 3357 passed / 0 failed after rebasing onto the manipulator-consolidation and filter changes that touch the same file, PlayMode 91 / 91
- [x] New regression tests were verified red without the change and green with it — seven separate demonstrations, each reverting one part and confirming exactly the expected tests fail: the edge logic, the off-panel axis, the class-priority order, the cross-axis case, the signature encoding that made a vertical flip a silent no-op, the resolved-style fallback, and the wrap literal
- [x] Docs are updated for every fact this change touches (guides, READMEs, CLAUDE.md) — or this PR has no doc impact
- [x] CHANGELOG updated for behavior/perf changes (pure refactors are omitted by convention) — including that this moves spacing for any app that compensated for the old placement
- [x] Known gaps or deliberate deferrals discovered here are filed as issues with acceptance criteria — the divider utilities have the same direction blindness (#161), the stylesheet's declaration order makes the documented responsive direction idiom non-functional (#163), and a variant-gated grid class does not suppress this manipulator (#165)

Closes #152