### PR TITLE
test(velvet): guard the generator test stub against drift from the runtime surface

### DIFF
--- a/.github/workflows/generators.yml
+++ b/.github/workflows/generators.yml
@@ -2,9 +2,9 @@ name: Source generators
 
 # The Roslyn generators are a standalone dotnet solution, so changes under
 # Generators~ (or this workflow) trigger it. The runtime sources are listed too:
-# the hook-surface drift guard re-derives the hook and type surface by parsing
-# them, so a rename there — not a generator edit — is exactly what must fail
-# this job. Generator changes reach the Unity side as committed DLLs under
+# the drift guards re-derive the hook surface and the test stub's signatures by
+# parsing them, so a rename or a reshaped signature there — not a generator
+# edit — is exactly what must fail this job. Generator changes reach the Unity side as committed DLLs under
 # Runtime/Plugins, which the Unity test workflow picks up on its own paths; that
 # workflow keeps excluding Generators~, so a generator-only change still runs
 # here alone.

--- a/Packages/com.velvet.core/Generators~/README.md
+++ b/Packages/com.velvet.core/Generators~/README.md
@@ -30,6 +30,7 @@ dotnet test Velvet.SourceGenerators.sln
 - `MemoOverloadGeneratorTests` — snapshot comparison that verifies the generated `V.Memoized<T1..T8>` output
 - `MemoizeMethodGeneratorTests` — verifies `[MemoizeMethod]`-driven `V.Memoized(...)` wrapper expansion and its diagnostics (see [Documentation~/memoization.md](../Documentation~/memoization.md) for what they mean and the complete list)
 - `HookSurfaceDriftTests` — pins the analyzer's hook-name and type-name strings to the runtime surface by parsing `../Runtime/` with Roslyn (syntax only, no Unity assemblies). Nothing else notices a hook rename or a newly added deps-comparing hook on this side of the compile boundary, so the guard turns both into a red test instead of silently narrowed exhaustive-deps coverage
+- `StubSurfaceDriftTests` — pins the Velvet stub in `GeneratorTestHelper` (the surface every analyzer and generator test compiles its sample user code against) to the runtime signatures, using the same syntax-only parse. It fails on a divergent parameter type, return type, generic constraint, modifier or optionality, and on a runtime overload the stub names but does not model; without it the suite can verify a diagnostic for a call shape no user can write
 
 ## Directory layout
 
@@ -55,7 +56,9 @@ Generators~/
     ├── MemoOverloadGeneratorTests.cs
     ├── MemoizeMethodGeneratorTests.cs
     ├── HookSurfaceDriftTests.cs               (pins the analyzer name lists to ../Runtime/)
-    ├── GeneratorTestHelper.cs
+    ├── StubSurfaceDriftTests.cs               (pins the Velvet stub's signatures to ../Runtime/)
+    ├── RuntimeSourceIndex.cs                  (the shared syntax-only parse of ../Runtime/)
+    ├── GeneratorTestHelper.cs                 (the Velvet stub the test sources compile against)
     └── Snapshots/                            (verified golden files)
         ├── Memoized_Arity*/MemoizedWithKey_Arity*    (MemoOverloadGenerator)
         └── Memoize/                          (MemoizeMethodGenerator)
@@ -73,7 +76,7 @@ This README is now scoped to **contributor concerns** (build / test / DLL shippi
 
 `.github/workflows/generators.yml` has a single job with one build/test step: check out, install the .NET SDK pinned by `global.json`, then `dotnet test Velvet.SourceGenerators.sln -c Release --nologo` (which restores and builds as part of the run). No Unity license is required.
 
-Which paths trigger it is stated in the repository's `CLAUDE.md`; the reason `Runtime/**` is among them is that `HookSurfaceDriftTests` reads the runtime sources, so a PR that only renames a hook must still run this job.
+Which paths trigger it is stated in the repository's `CLAUDE.md`; the reason `Runtime/**` is among them is that the two drift guards read the runtime sources, so a PR that only renames a hook or reshapes its signature must still run this job.
 
 **CI does not check the committed DLLs under `../Runtime/Plugins/` at all.** It tests the sources; it never compares the deployed assemblies against a rebuild, so a PR that edits generator sources and forgets to rerun `build.sh` goes green while Unity keeps consuming the stale binaries. Rebuilding and committing them is the contributor's responsibility.
 

--- a/Packages/com.velvet.core/Generators~/tests/Velvet.SourceGenerators.Tests/Assume.cs
+++ b/Packages/com.velvet.core/Generators~/tests/Velvet.SourceGenerators.Tests/Assume.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+
+namespace Velvet.SourceGenerators.Tests
+{
+    /// <summary>
+    /// Preconditions for guards that assert an emptiness ("nothing diverges"). Such a guard passes on an empty
+    /// input for the same reason it passes on a correct one, so the inputs it filters must be proven non-empty
+    /// separately or the whole fixture is decorative.
+    /// </summary>
+    internal static class Assume
+    {
+        public static void NotEmpty<T>(IReadOnlyCollection<T> values, string what)
+        {
+            if (values.Count == 0)
+            {
+                throw new InvalidOperationException(
+                    $"Precondition failed: {what}. There is nothing to compare against, which would make " +
+                    "this guard pass vacuously.");
+            }
+        }
+    }
+}

--- a/Packages/com.velvet.core/Generators~/tests/Velvet.SourceGenerators.Tests/GeneratorTestHelper.cs
+++ b/Packages/com.velvet.core/Generators~/tests/Velvet.SourceGenerators.Tests/GeneratorTestHelper.cs
@@ -13,6 +13,13 @@ namespace Velvet.SourceGenerators.Tests
     /// of the required Velvet types to drive the generator. Helper for retrieving MemoizeMethodGenerator
     /// execution results.
     /// </summary>
+    /// <remarks>
+    /// The stub is a subset, never a variant: it may leave a runtime type or member out, but whatever it does
+    /// declare carries the runtime's exact signature, so a diagnostic verified here is verified for a call
+    /// shape a user can actually write. <see cref="StubSurfaceDriftTests"/> re-derives the runtime signatures
+    /// from source and fails on any divergence this file introduces, including a runtime overload the stub
+    /// declares the name of but not the shape of.
+    /// </remarks>
     internal static class GeneratorTestHelper
     {
         internal const string VelvetStubSource = @"
@@ -21,20 +28,27 @@ namespace Velvet
     [global::System.AttributeUsage(global::System.AttributeTargets.Method, Inherited = false)]
     public sealed class MemoizeMethodAttribute : global::System.Attribute { }
 
-    [global::System.AttributeUsage(global::System.AttributeTargets.Method | global::System.AttributeTargets.Constructor, Inherited = false)]
+    [global::System.AttributeUsage(global::System.AttributeTargets.Method, Inherited = false)]
     public sealed class PureAttribute : global::System.Attribute { }
 
     [global::System.AttributeUsage(global::System.AttributeTargets.Method, Inherited = false)]
     public sealed class ComponentAttribute : global::System.Attribute
     {
-        public bool IsErrorBoundary { get; set; } = false;
-        public bool Memoize { get; set; } = false;
-        public string DisplayName { get; set; }
+        public bool IsErrorBoundary { get; init; } = false;
+        public bool Memoize { get; init; } = false;
+        public bool Compiler { get; init; } = true;
+        public string DisplayName { get; init; }
     }
 
     public class VNode
     {
-        [global::Velvet.PureAttribute] public VNode() { }
+        public string Key { get; internal set; }
+    }
+
+    public sealed class MemoNode : VNode
+    {
+        public required global::System.Func<VNode> Factory { get; init; }
+        public object[] Dependencies { get; init; }
     }
 
     public sealed class MutableRef<T>
@@ -43,15 +57,20 @@ namespace Velvet
         public T Current { get; set; }
     }
 
+    public sealed class Ref<T> where T : class { }
+
+    public sealed class ComponentContext<T> { }
+
+    public readonly struct StateUpdater<T>
+    {
+        public void Invoke(T next) { }
+        public void Invoke(global::System.Func<T, T> updater) { }
+    }
+
+    public readonly struct TransitionStarter { }
+
     public sealed class NavigationAttempt { }
     public sealed class RouteBlockerState { }
-
-    public sealed class MemoNode : VNode
-    {
-        public string Key;
-        public global::System.Func<VNode> Factory;
-        public object[] Dependencies;
-    }
 
     public static partial class V
     {
@@ -80,29 +99,47 @@ namespace Velvet
         }
         public static void StoreMemoizedVNode(int slotIndex, object[] deps, VNode result) { }
 
-        // Static API stubs for the positional hooks a functional-component test fixture may call.
-        // params on the deps argument mirrors the runtime Hooks signatures so loose-arg deps typecheck.
-        public static void UseEffect(global::System.Func<global::System.Action> factory, object[] deps) { }
-        public static void UseLayoutEffect(global::System.Func<global::System.Action> factory, object[] deps) { }
-        public static void UseInsertionEffect(global::System.Func<global::System.Action> factory, object[] deps) { }
+        // Static API stubs for the positional hooks a functional-component test fixture may call. Every
+        // overload the runtime declares of a name appearing here is modelled, so a fixture cannot pick a
+        // shape that only exists because the narrower overloads are missing.
+        public static void UseEffect(global::System.Func<global::System.Action> factory, object[] deps = null) { }
+        public static void UseEffect(global::System.Func<global::System.IDisposable> factory, object[] deps = null) { }
+        public static void UseLayoutEffect(global::System.Func<global::System.Action> factory, object[] deps = null) { }
+        public static void UseLayoutEffect(global::System.Func<global::System.IDisposable> factory, object[] deps = null) { }
+        public static void UseInsertionEffect(global::System.Func<global::System.Action> factory, object[] deps = null) { }
+        public static void UseInsertionEffect(global::System.Func<global::System.IDisposable> factory, object[] deps = null) { }
+        public static T UseCallback<T>(T callback) where T : global::System.Delegate => callback;
         public static T UseCallback<T>(T callback, params object[] deps) where T : global::System.Delegate => callback;
+        public static T UseMemo<T>(global::System.Func<T> factory) => factory();
         public static T UseMemo<T>(global::System.Func<T> factory, params object[] deps) => factory();
         public static global::Velvet.RouteBlockerState UseBlocker(
             global::System.Func<global::Velvet.NavigationAttempt, bool> shouldBlock, params object[] deps) => null;
         public static global::Velvet.RouteBlockerState UseBlocker(
             global::System.Func<global::Velvet.NavigationAttempt, global::System.Threading.CancellationToken,
                 global::Cysharp.Threading.Tasks.UniTask<bool>> shouldBlock, params object[] deps) => null;
-        public static (T value, global::System.Action<T> setValue) UseState<T>(T initial) =>
+        public static (T value, global::Velvet.StateUpdater<T> setValue) UseState<T>(T initial) =>
+            (initial, default);
+        public static (T value, global::Velvet.StateUpdater<T> setValue) UseState<T>(global::System.Func<T> initialFactory) =>
+            (default, default);
+        public static (TState state, global::System.Action<TAction> dispatch) UseReducer<TState, TAction>(
+            global::System.Func<TState, TAction, TState> reducer, TState initial) =>
             (initial, _ => { });
-        public static (TState state, global::System.Action<TAction> dispatch) UseReducer<TState, TAction>(global::System.Func<TState, TAction, TState> reducer, TState initial) =>
-            (initial, _ => { });
-        public static T UseContext<T>(object contextRef) where T : class => null;
-        public static (bool isPending, global::System.Action<global::System.Action> startTransition) UseTransition() =>
-            (false, _ => { });
-        public static T UseRef<T>(T initial) where T : class => initial;
+        public static (TState state, global::System.Action<TAction> dispatch) UseReducer<TArg, TState, TAction>(
+            global::System.Func<TState, TAction, TState> reducer, TArg initialArg, global::System.Func<TArg, TState> init) =>
+            (default, _ => { });
+        public static T UseContext<T>(global::Velvet.ComponentContext<T> context) => default;
+        public static (bool isPending, global::Velvet.TransitionStarter startTransition) UseTransition() =>
+            (false, default);
+        public static global::Velvet.Ref<T> UseRef<T>() where T : class => null;
+        public static global::Velvet.Ref<T> UseRef<T>(global::System.Func<T> initialFactory) where T : class => null;
         public static global::Velvet.MutableRef<T> UseMutableRef<T>(T initial) =>
             new global::Velvet.MutableRef<T>(initial);
-        public static void UseImperativeHandle<T>(object refTarget, global::System.Func<T> factory, params object[] deps) { }
+        public static global::Velvet.MutableRef<T> UseMutableRef<T>(global::System.Func<T> initialFactory) =>
+            new global::Velvet.MutableRef<T>(default);
+        public static void UseImperativeHandle<THandle>(
+            global::Velvet.Ref<THandle> handleRef, global::System.Func<THandle> factory) where THandle : class { }
+        public static void UseImperativeHandle<THandle>(
+            global::Velvet.Ref<THandle> handleRef, global::System.Func<THandle> factory, params object[] deps) where THandle : class { }
     }
 }
 

--- a/Packages/com.velvet.core/Generators~/tests/Velvet.SourceGenerators.Tests/HookSurfaceDriftTests.cs
+++ b/Packages/com.velvet.core/Generators~/tests/Velvet.SourceGenerators.Tests/HookSurfaceDriftTests.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Reflection;
 using Microsoft.CodeAnalysis;
@@ -80,7 +79,7 @@ namespace Velvet.SourceGenerators.Tests
                 "names the runtime namespace, which is not a type or method declaration",
         };
 
-        private static readonly Lazy<RuntimeSourceIndex> Runtime = new(RuntimeSourceIndex.Build);
+        private static RuntimeSourceIndex Runtime => RuntimeSourceIndex.Shared;
 
         [Fact]
         public void Given_WellKnownMethodNameConstants_When_ResolvedAgainstRuntimeSource_Then_EachNamesADeclaredMethod()
@@ -88,7 +87,7 @@ namespace Velvet.SourceGenerators.Tests
             // Arrange
             var constants = ConstantsWithSuffix(MethodNameSuffix);
             var declared = HookHostTypes
-                .SelectMany(type => Runtime.Value.PublicMethodNamesOf(type))
+                .SelectMany(type => Runtime.PublicMethodNamesOf(type))
                 .ToHashSet(StringComparer.Ordinal);
             Assume.NotEmpty(constants, $"no '{MethodNameSuffix}' constants found on {nameof(VelvetWellKnownNames)}");
             Assume.NotEmpty(declared, "no public methods parsed off the runtime hook host types");
@@ -112,7 +111,7 @@ namespace Velvet.SourceGenerators.Tests
         {
             // Arrange
             var constants = ConstantsWithSuffix(TypeNameSuffix);
-            var declared = Runtime.Value.DeclaredTypeFullNames;
+            var declared = Runtime.DeclaredTypeFullNames;
             Assume.NotEmpty(constants, $"no '{TypeNameSuffix}' constants found on {nameof(VelvetWellKnownNames)}");
             Assume.NotEmpty(declared, "no type declarations parsed off the runtime sources");
 
@@ -313,7 +312,7 @@ namespace Velvet.SourceGenerators.Tests
         {
             foreach (var type in HookHostTypes)
             {
-                foreach (var declared in Runtime.Value.PublicMethodsOf(type))
+                foreach (var declared in Runtime.PublicMethodsOf(type))
                 {
                     var overload = TryDescribe(declared);
                     if (overload is not null) yield return overload.Value;
@@ -454,137 +453,5 @@ namespace Velvet.SourceGenerators.Tests
             int DepsArgIndex,
             bool DepsAreParams,
             int FactoryParameterCount);
-
-        private readonly record struct MethodDeclaration(string ContainingTypeFullName, MethodDeclarationSyntax Method);
-
-        /// <summary>
-        /// Namespace-qualified index of the type and public-method declarations in the Velvet runtime sources.
-        /// </summary>
-        private sealed class RuntimeSourceIndex
-        {
-            // The Unity build defines this; parsing with and without it keeps editor-only declarations visible.
-            private static readonly string[] EditorPreprocessorSymbols = { "UNITY_EDITOR" };
-
-            private readonly List<MethodDeclaration> _methods;
-
-            private RuntimeSourceIndex(HashSet<string> types, List<MethodDeclaration> methods)
-            {
-                DeclaredTypeFullNames = types;
-                _methods = methods;
-            }
-
-            public IReadOnlySet<string> DeclaredTypeFullNames { get; }
-
-            public IEnumerable<MethodDeclaration> PublicMethodsOf(string containingTypeFullName) =>
-                _methods.Where(m => m.ContainingTypeFullName == containingTypeFullName);
-
-            public IEnumerable<string> PublicMethodNamesOf(string containingTypeFullName) =>
-                PublicMethodsOf(containingTypeFullName).Select(m => m.Method.Identifier.ValueText);
-
-            public static RuntimeSourceIndex Build()
-            {
-                var types = new HashSet<string>(StringComparer.Ordinal);
-                var methods = new List<MethodDeclaration>();
-
-                foreach (var file in RuntimeSourceFiles())
-                {
-                    var text = File.ReadAllText(file);
-                    Collect(CSharpSyntaxTree.ParseText(text, DefaultParseOptions), types, methods);
-                    Collect(CSharpSyntaxTree.ParseText(text, EditorParseOptions), types, methods);
-                }
-
-                return new RuntimeSourceIndex(types, methods);
-            }
-
-            private static CSharpParseOptions DefaultParseOptions =>
-                CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest);
-
-            private static CSharpParseOptions EditorParseOptions =>
-                DefaultParseOptions.WithPreprocessorSymbols(EditorPreprocessorSymbols);
-
-            private static void Collect(SyntaxTree tree, HashSet<string> types, List<MethodDeclaration> methods)
-            {
-                var root = tree.GetRoot();
-
-                // Enums and delegates carry no methods but can still be named by a well-known-name constant.
-                foreach (var declaration in root.DescendantNodes().OfType<BaseTypeDeclarationSyntax>())
-                {
-                    AddNames(types, declaration, declaration.Identifier.ValueText);
-                }
-                foreach (var declaration in root.DescendantNodes().OfType<DelegateDeclarationSyntax>())
-                {
-                    AddNames(types, declaration, declaration.Identifier.ValueText);
-                }
-
-                foreach (var declaration in root.DescendantNodes().OfType<TypeDeclarationSyntax>())
-                {
-                    var displayName = QualifiedName(declaration, declaration.Identifier.ValueText, nestingSeparator: ".");
-                    foreach (var method in declaration.Members.OfType<MethodDeclarationSyntax>())
-                    {
-                        if (!method.Modifiers.Any(SyntaxKind.PublicKeyword)) continue;
-                        methods.Add(new MethodDeclaration(displayName, method));
-                    }
-                }
-            }
-
-            // A nested type is spelled Outer.Inner by the analyzer's display-string comparisons and Outer+Inner
-            // by the attribute lookups' metadata names; both forms are indexed so either resolves.
-            private static void AddNames(HashSet<string> types, SyntaxNode declaration, string identifier)
-            {
-                types.Add(QualifiedName(declaration, identifier, nestingSeparator: "."));
-                types.Add(QualifiedName(declaration, identifier, nestingSeparator: "+"));
-            }
-
-            private static string QualifiedName(SyntaxNode declaration, string identifier, string nestingSeparator)
-            {
-                var typeSegments = new List<string> { identifier };
-                var containingNamespace = string.Empty;
-                foreach (var ancestor in declaration.Ancestors())
-                {
-                    switch (ancestor)
-                    {
-                        case BaseTypeDeclarationSyntax outer:
-                            typeSegments.Insert(0, outer.Identifier.ValueText);
-                            break;
-                        case BaseNamespaceDeclarationSyntax ns:
-                            containingNamespace = ns.Name.ToString() +
-                                (containingNamespace.Length == 0 ? string.Empty : "." + containingNamespace);
-                            break;
-                    }
-                }
-
-                var nested = string.Join(nestingSeparator, typeSegments);
-                return containingNamespace.Length == 0 ? nested : containingNamespace + "." + nested;
-            }
-
-            // Colocated tests declare their own fixtures and would let a stub stand in for a renamed runtime
-            // type, so only production sources are indexed.
-            private static List<string> RuntimeSourceFiles()
-            {
-                var root = SolutionPaths.RuntimeRoot();
-                var files = Directory
-                    .EnumerateFiles(root, "*.cs", SearchOption.AllDirectories)
-                    .Where(path => !path.Split(Path.DirectorySeparatorChar).Contains("Tests"))
-                    .ToList();
-                if (files.Count == 0)
-                {
-                    throw new InvalidOperationException($"No runtime C# sources found under '{root}'.");
-                }
-                return files;
-            }
-        }
-
-        private static class Assume
-        {
-            public static void NotEmpty<T>(IReadOnlyCollection<T> values, string what)
-            {
-                if (values.Count == 0)
-                {
-                    throw new InvalidOperationException(
-                        $"Precondition failed: {what}. There is nothing to compare against, which would make " +
-                        "this guard pass vacuously.");
-                }
-            }
-        }
     }
 }

--- a/Packages/com.velvet.core/Generators~/tests/Velvet.SourceGenerators.Tests/RuntimeSourceIndex.cs
+++ b/Packages/com.velvet.core/Generators~/tests/Velvet.SourceGenerators.Tests/RuntimeSourceIndex.cs
@@ -1,0 +1,164 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Velvet.SourceGenerators.Tests
+{
+    /// <summary>One public method declaration parsed off the runtime sources, with its declaring type.</summary>
+    internal readonly record struct MethodDeclaration(string ContainingTypeFullName, MethodDeclarationSyntax Method);
+
+    /// <summary>
+    /// Namespace-qualified index of the type and public-member declarations in the Velvet runtime sources.
+    /// </summary>
+    /// <remarks>
+    /// The parse is syntax only: no assembly references, no build ordering, and no dependency on a
+    /// Unity-produced artifact CI does not have. That is what lets a guard on this side of the compile
+    /// boundary re-derive the runtime surface at all. The cost is that nothing here is semantically resolved —
+    /// a type name is whatever the source spells, so two types sharing a simple name are indistinguishable to
+    /// a caller comparing simple names.
+    /// </remarks>
+    internal sealed class RuntimeSourceIndex
+    {
+        // The Unity build defines this; parsing with and without it keeps editor-only declarations visible.
+        private static readonly string[] EditorPreprocessorSymbols = { "UNITY_EDITOR" };
+
+        private static readonly Lazy<RuntimeSourceIndex> Instance = new(Build);
+
+        private readonly List<TypeDeclaration> _types;
+
+        private RuntimeSourceIndex(HashSet<string> typeNames, List<TypeDeclaration> types)
+        {
+            DeclaredTypeFullNames = typeNames;
+            _types = types;
+        }
+
+        /// <summary>
+        /// Index shared by every fixture that re-derives the runtime surface. Parsing the whole runtime tree
+        /// twice per file is slow enough that each fixture building its own is felt in the suite's runtime.
+        /// </summary>
+        public static RuntimeSourceIndex Shared => Instance.Value;
+
+        /// <summary>Every declared type, in both the display (<c>Outer.Inner</c>) and metadata (<c>Outer+Inner</c>) spelling.</summary>
+        public IReadOnlySet<string> DeclaredTypeFullNames { get; }
+
+        /// <summary>
+        /// Every declaration of a type, which is more than one when it is <c>partial</c> or when a
+        /// preprocessor branch redeclares it. A caller comparing a declaration against the runtime must accept
+        /// a match against any of them.
+        /// </summary>
+        public IEnumerable<TypeDeclarationSyntax> TypeDeclarationsOf(string containingTypeFullName) =>
+            _types.Where(t => t.FullName == containingTypeFullName).Select(t => t.Declaration);
+
+        public IEnumerable<MemberDeclarationSyntax> PublicMembersOf(string containingTypeFullName) =>
+            TypeDeclarationsOf(containingTypeFullName)
+                .SelectMany(declaration => declaration.Members)
+                .Where(member => member.Modifiers.Any(SyntaxKind.PublicKeyword));
+
+        public IEnumerable<MethodDeclaration> PublicMethodsOf(string containingTypeFullName) =>
+            PublicMembersOf(containingTypeFullName)
+                .OfType<MethodDeclarationSyntax>()
+                .Select(method => new MethodDeclaration(containingTypeFullName, method));
+
+        public IEnumerable<string> PublicMethodNamesOf(string containingTypeFullName) =>
+            PublicMethodsOf(containingTypeFullName).Select(m => m.Method.Identifier.ValueText);
+
+        public static RuntimeSourceIndex Build()
+        {
+            var typeNames = new HashSet<string>(StringComparer.Ordinal);
+            var types = new List<TypeDeclaration>();
+
+            foreach (var file in RuntimeSourceFiles())
+            {
+                var text = File.ReadAllText(file);
+                Collect(CSharpSyntaxTree.ParseText(text, DefaultParseOptions), typeNames, types);
+                Collect(CSharpSyntaxTree.ParseText(text, EditorParseOptions), typeNames, types);
+            }
+
+            return new RuntimeSourceIndex(typeNames, types);
+        }
+
+        private static CSharpParseOptions DefaultParseOptions =>
+            CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest);
+
+        private static CSharpParseOptions EditorParseOptions =>
+            DefaultParseOptions.WithPreprocessorSymbols(EditorPreprocessorSymbols);
+
+        private static void Collect(SyntaxTree tree, HashSet<string> typeNames, List<TypeDeclaration> types)
+        {
+            var root = tree.GetRoot();
+
+            // Enums and delegates carry no members but can still be named by a well-known-name constant.
+            foreach (var declaration in root.DescendantNodes().OfType<BaseTypeDeclarationSyntax>())
+            {
+                AddNames(typeNames, declaration, declaration.Identifier.ValueText);
+            }
+            foreach (var declaration in root.DescendantNodes().OfType<DelegateDeclarationSyntax>())
+            {
+                AddNames(typeNames, declaration, declaration.Identifier.ValueText);
+            }
+
+            foreach (var declaration in root.DescendantNodes().OfType<TypeDeclarationSyntax>())
+            {
+                var displayName = QualifiedName(declaration, declaration.Identifier.ValueText, nestingSeparator: ".");
+                types.Add(new TypeDeclaration(displayName, declaration));
+            }
+        }
+
+        // A nested type is spelled Outer.Inner by the analyzer's display-string comparisons and Outer+Inner
+        // by the attribute lookups' metadata names; both forms are indexed so either resolves.
+        private static void AddNames(HashSet<string> typeNames, SyntaxNode declaration, string identifier)
+        {
+            typeNames.Add(QualifiedName(declaration, identifier, nestingSeparator: "."));
+            typeNames.Add(QualifiedName(declaration, identifier, nestingSeparator: "+"));
+        }
+
+        /// <summary>
+        /// The namespace- and nesting-qualified name a declaration is indexed under. Public because a caller
+        /// looking a declaration up must derive its name exactly this way; deriving it independently is how a
+        /// lookup silently misses and a guard built on it passes with nothing compared.
+        /// </summary>
+        public static string QualifiedName(SyntaxNode declaration, string identifier, string nestingSeparator)
+        {
+            var typeSegments = new List<string> { identifier };
+            var containingNamespace = string.Empty;
+            foreach (var ancestor in declaration.Ancestors())
+            {
+                switch (ancestor)
+                {
+                    case BaseTypeDeclarationSyntax outer:
+                        typeSegments.Insert(0, outer.Identifier.ValueText);
+                        break;
+                    case BaseNamespaceDeclarationSyntax ns:
+                        containingNamespace = ns.Name.ToString() +
+                            (containingNamespace.Length == 0 ? string.Empty : "." + containingNamespace);
+                        break;
+                }
+            }
+
+            var nested = string.Join(nestingSeparator, typeSegments);
+            return containingNamespace.Length == 0 ? nested : containingNamespace + "." + nested;
+        }
+
+        // Colocated tests declare their own fixtures and would let a stub stand in for a renamed runtime
+        // type, so only production sources are indexed.
+        private static List<string> RuntimeSourceFiles()
+        {
+            var root = SolutionPaths.RuntimeRoot();
+            var files = Directory
+                .EnumerateFiles(root, "*.cs", SearchOption.AllDirectories)
+                .Where(path => !path.Split(Path.DirectorySeparatorChar).Contains("Tests"))
+                .ToList();
+            if (files.Count == 0)
+            {
+                throw new InvalidOperationException($"No runtime C# sources found under '{root}'.");
+            }
+            return files;
+        }
+
+        private readonly record struct TypeDeclaration(string FullName, TypeDeclarationSyntax Declaration);
+    }
+}

--- a/Packages/com.velvet.core/Generators~/tests/Velvet.SourceGenerators.Tests/StubSurfaceDriftTests.cs
+++ b/Packages/com.velvet.core/Generators~/tests/Velvet.SourceGenerators.Tests/StubSurfaceDriftTests.cs
@@ -1,0 +1,412 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit;
+
+namespace Velvet.SourceGenerators.Tests
+{
+    /// <summary>
+    /// Pins <see cref="GeneratorTestHelper.VelvetStubSource"/> to the runtime it stands in for. Analyzer and
+    /// generator tests compile their sample user code against that stub, so a stubbed signature that disagrees
+    /// with the real one makes the whole suite green against a surface nobody can call: a diagnostic gets
+    /// "verified" for an argument list, a return shape or a constraint set no user could ever write. This
+    /// fixture re-derives the real signatures by parsing the runtime sources with Roslyn — syntax only, the
+    /// same parse the hook-name guard uses, since this solution cannot reference the Unity assemblies — and
+    /// fails on any divergence, naming the member.
+    /// </summary>
+    /// <remarks>
+    /// The stub is a subset, not a variant: leaving a runtime type or member out is allowed and unchecked,
+    /// because the stub only has to model what the analyzers look at. What is checked is everything it does
+    /// declare — its modifiers, parameter types and names, return type, generic parameters, constraints,
+    /// optionality and <c>params</c> form — plus, for any method or constructor name it declares, that it
+    /// models every runtime overload of that name. That last rule is what stops a fixture from picking a call
+    /// shape that only resolves because the narrower overloads are missing.
+    /// <para>
+    /// Comparison limits, each chosen because the stub cannot model the thing at all:
+    /// </para>
+    /// <list type="bullet">
+    /// <item>Types are compared by simple name: the parse is syntactic, so <c>Velvet.Ref</c> and any other
+    /// <c>Ref</c> in scope are indistinguishable. Nothing on this surface collides today.</item>
+    /// <item>Nullable reference annotations are erased on both sides. The stub compiles in a
+    /// nullable-oblivious compilation, so it cannot carry them, and no analyzer reads them.</item>
+    /// <item>Base types and implemented interfaces are not compared. The runtime's are Unity- or
+    /// runtime-internal types (<c>IHookRefSetter</c>, <c>VisualElement</c>) that cannot cross this
+    /// boundary.</item>
+    /// <item>Attributes, accessor bodies and member bodies are not compared — the stub is deliberately inert.</item>
+    /// <item>Operators, indexers and nested types are not extracted. The stub declares none, so a lookup for
+    /// one would find nothing on either side rather than mismatch.</item>
+    /// </list>
+    /// </remarks>
+    public sealed class StubSurfaceDriftTests
+    {
+        /// <summary>
+        /// Divergences the stub keeps on purpose, each with the reason it cannot or need not be modelled
+        /// faithfully. Recorded so an intentional simplification is a decision in code rather than an absence
+        /// nobody can distinguish from an oversight. A type key covers that type's own declaration; a
+        /// <c>Type.Member</c> key covers every overload of that member name.
+        /// </summary>
+        private static readonly Dictionary<string, string> StubSimplifications = new()
+        {
+            ["Cysharp.Threading.Tasks.UniTask"] =
+                "UniTask lives in an external package the netstandard test project has no reference to, and " +
+                "UseBlocker's async overload is part of the deps-comparison surface, so a placeholder of the " +
+                "same name and arity stands in — that keeps the overload's true parameter types, and therefore " +
+                "its predicate arity, exercised end to end",
+            ["Velvet.VNode"] =
+                "the runtime's VNode is abstract and every concrete node carries required members; the stub " +
+                "makes it instantiable so a fixture can hand a VNode-shaped value to a memoized factory " +
+                "without modelling the node hierarchy. No analyzer inspects the type's abstractness",
+        };
+
+        private static readonly Lazy<StubComparison> Comparison = new(Compare);
+
+        [Fact]
+        public void Given_StubTypes_When_ResolvedAgainstRuntimeSource_Then_EachNamesADeclaredType()
+        {
+            // Arrange
+            var comparison = Comparison.Value;
+            Assume.NotEmpty(comparison.StubTypeNames, "no type declarations parsed off the Velvet stub");
+            Assume.NotEmpty(RuntimeSourceIndex.Shared.DeclaredTypeFullNames, "no types parsed off the runtime sources");
+
+            // Act
+            var unresolved = Reportable(comparison, DivergenceKind.UnknownType);
+
+            // Assert
+            Assert.True(unresolved.Count == 0,
+                "The Velvet stub declares types the runtime sources do not: " +
+                $"[{string.Join("; ", unresolved)}]. A fixture compiling against one of them is exercising a " +
+                $"type that does not exist. Correct the stub, or record it in {nameof(StubSimplifications)} " +
+                "with the reason it cannot be modelled.");
+        }
+
+        [Fact]
+        public void Given_StubDeclarations_When_ComparedAgainstRuntimeSource_Then_EachMatchesTheRuntimeSignature()
+        {
+            // Arrange
+            var comparison = Comparison.Value;
+            Assume.NotEmpty(comparison.StubMemberNames, "no public members parsed off the Velvet stub");
+            Assume.NotEmpty(comparison.RuntimeMemberNames, "no public members parsed off the stubbed runtime types");
+
+            // Act
+            var mismatched = Reportable(comparison, DivergenceKind.Signature);
+
+            // Assert
+            Assert.True(mismatched.Count == 0,
+                "These Velvet stub declarations do not match the runtime declaration they stand in for: " +
+                $"[{string.Join("; ", mismatched)}]. Every analyzer and generator test compiles its sample " +
+                "user code against the stub, so a diagnostic verified against a divergent signature is " +
+                $"verified for a call shape no user can write. Correct the stub, or record it in " +
+                $"{nameof(StubSimplifications)} with the reason.");
+        }
+
+        [Fact]
+        public void Given_RuntimeOverloads_When_TheStubDeclaresTheirName_Then_EachIsModelled()
+        {
+            // Arrange
+            var comparison = Comparison.Value;
+            Assume.NotEmpty(comparison.OverloadableRuntimeMemberNames,
+                "no overloadable runtime members matched a name the stub declares");
+
+            // Act
+            var unmodelled = Reportable(comparison, DivergenceKind.MissingOverload);
+
+            // Assert
+            Assert.True(unmodelled.Count == 0,
+                "The runtime declares these overloads of a member the Velvet stub already models by name, but " +
+                $"the stub does not model them: [{string.Join("; ", unmodelled)}]. With a narrower overload " +
+                "missing, overload resolution in a fixture's sample source lands on a candidate that would " +
+                "lose — or be ambiguous — against the real surface. Add it, or record it in " +
+                $"{nameof(StubSimplifications)} with the reason.");
+        }
+
+        [Fact]
+        public void Given_RecordedStubSimplifications_When_ComparedAgainstRuntimeSource_Then_EachStillDiverges()
+        {
+            // Arrange
+            var comparison = Comparison.Value;
+            Assume.NotEmpty(comparison.StubTypeNames, "no type declarations parsed off the Velvet stub");
+
+            // Act
+            var settled = StubSimplifications
+                .Where(entry => comparison.Divergences.All(d => d.Key != entry.Key))
+                .Select(entry => $"{entry.Key} (recorded as: {entry.Value})")
+                .OrderBy(x => x, StringComparer.Ordinal)
+                .ToList();
+
+            // Assert
+            Assert.True(settled.Count == 0,
+                $"{nameof(StubSimplifications)} records divergences the stub no longer has: " +
+                $"[{string.Join("; ", settled)}]. A record that no longer applies suppresses the next real " +
+                "divergence to appear under the same name.");
+        }
+
+        private static List<string> Reportable(StubComparison comparison, DivergenceKind kind) =>
+            comparison.Divergences
+                .Where(d => d.Kind == kind && !StubSimplifications.ContainsKey(d.Key))
+                .Select(d => d.Description)
+                .OrderBy(x => x, StringComparer.Ordinal)
+                .ToList();
+
+        /// <summary>
+        /// Every way the stub and the runtime disagree, before the recorded simplifications are subtracted, so
+        /// the staleness fact can tell a record that still applies from one that has been fixed.
+        /// </summary>
+        private static StubComparison Compare()
+        {
+            var runtime = RuntimeSourceIndex.Shared;
+            var divergences = new List<Divergence>();
+            var stubTypeNames = new List<string>();
+            var stubMemberNames = new List<string>();
+            var runtimeMemberNames = new List<string>();
+            var overloadableRuntimeMemberNames = new List<string>();
+
+            foreach (var (fullName, stubDeclaration) in StubTypeDeclarations())
+            {
+                stubTypeNames.Add(fullName);
+
+                var runtimeDeclarations = runtime.TypeDeclarationsOf(fullName).ToList();
+                if (runtimeDeclarations.Count == 0)
+                {
+                    divergences.Add(new Divergence(fullName, DivergenceKind.UnknownType,
+                        $"{fullName} is declared by the stub but by no runtime source file"));
+                    continue;
+                }
+
+                var runtimeTypeForms = runtimeDeclarations.Select(CanonicalType).Distinct(StringComparer.Ordinal).ToList();
+                var stubTypeForm = CanonicalType(stubDeclaration);
+                if (!runtimeTypeForms.Contains(stubTypeForm, StringComparer.Ordinal))
+                {
+                    divergences.Add(new Divergence(fullName, DivergenceKind.Signature,
+                        $"{fullName}: stub declares '{stubTypeForm}', runtime declares " +
+                        $"[{string.Join(" | ", runtimeTypeForms)}]"));
+                }
+
+                var runtimeMembers = runtime.PublicMembersOf(fullName).SelectMany(Signatures).Distinct().ToList();
+                var stubMembers = PublicMembersOf(stubDeclaration).SelectMany(Signatures).ToList();
+                runtimeMemberNames.AddRange(runtimeMembers.Select(m => $"{fullName}.{m.Name}"));
+                stubMemberNames.AddRange(stubMembers.Select(m => $"{fullName}.{m.Name}"));
+
+                foreach (var stubMember in stubMembers)
+                {
+                    var key = $"{fullName}.{stubMember.Name}";
+                    var candidates = runtimeMembers.Where(m => m.Name == stubMember.Name).ToList();
+                    if (candidates.Count == 0)
+                    {
+                        divergences.Add(new Divergence(key, DivergenceKind.Signature,
+                            $"{key}: stub declares '{stubMember.Form}', the runtime declares no public member " +
+                            "of that name"));
+                    }
+                    else if (!candidates.Any(c => c.Form == stubMember.Form))
+                    {
+                        divergences.Add(new Divergence(key, DivergenceKind.Signature,
+                            $"{key}: stub declares '{stubMember.Form}', runtime declares " +
+                            $"[{string.Join(" | ", candidates.Select(c => c.Form))}]"));
+                    }
+                }
+
+                foreach (var name in stubMembers.Where(m => m.IsOverloadable).Select(m => m.Name).Distinct())
+                {
+                    var stubForms = stubMembers.Where(m => m.Name == name).Select(m => m.Form).ToHashSet(StringComparer.Ordinal);
+                    var runtimeOverloads = runtimeMembers.Where(m => m.IsOverloadable && m.Name == name).ToList();
+                    overloadableRuntimeMemberNames.AddRange(runtimeOverloads.Select(_ => $"{fullName}.{name}"));
+                    foreach (var missing in runtimeOverloads.Where(m => !stubForms.Contains(m.Form)))
+                    {
+                        divergences.Add(new Divergence($"{fullName}.{name}", DivergenceKind.MissingOverload,
+                            $"{fullName}.{name}: the runtime also declares '{missing.Form}'"));
+                    }
+                }
+            }
+
+            return new StubComparison(
+                divergences, stubTypeNames, stubMemberNames, runtimeMemberNames, overloadableRuntimeMemberNames);
+        }
+
+        /// <summary>
+        /// The stub's type declarations, keyed the way <see cref="RuntimeSourceIndex"/> keys the runtime's. A
+        /// stub that no longer parses would otherwise present as a surface with nothing to compare.
+        /// </summary>
+        private static List<(string FullName, TypeDeclarationSyntax Declaration)> StubTypeDeclarations()
+        {
+            var tree = CSharpSyntaxTree.ParseText(
+                GeneratorTestHelper.VelvetStubSource,
+                CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest));
+
+            var errors = tree.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).ToList();
+            if (errors.Count > 0)
+            {
+                throw new InvalidOperationException(
+                    $"{nameof(GeneratorTestHelper.VelvetStubSource)} does not parse: " +
+                    string.Join("; ", errors.Select(e => e.ToString())));
+            }
+
+            return tree.GetRoot()
+                .DescendantNodes()
+                .OfType<TypeDeclarationSyntax>()
+                .Select(declaration => (
+                    RuntimeSourceIndex.QualifiedName(declaration, declaration.Identifier.ValueText, nestingSeparator: "."),
+                    declaration))
+                .ToList();
+        }
+
+        private static IEnumerable<MemberDeclarationSyntax> PublicMembersOf(TypeDeclarationSyntax declaration) =>
+            declaration.Members.Where(member => member.Modifiers.Any(SyntaxKind.PublicKeyword));
+
+        private static string CanonicalType(TypeDeclarationSyntax declaration) =>
+            $"{Modifiers(declaration.Modifiers)}{declaration.Keyword.ValueText} {declaration.Identifier.ValueText}" +
+            $"{TypeParameters(declaration.TypeParameterList)}{Constraints(declaration.ConstraintClauses)}";
+
+        private static IEnumerable<MemberSignature> Signatures(MemberDeclarationSyntax member)
+        {
+            switch (member)
+            {
+                case MethodDeclarationSyntax method:
+                    yield return new MemberSignature(
+                        method.Identifier.ValueText,
+                        IsOverloadable: true,
+                        $"{Modifiers(method.Modifiers)}{TypeName(method.ReturnType)} " +
+                        $"{method.Identifier.ValueText}{TypeParameters(method.TypeParameterList)}" +
+                        $"({Parameters(method.ParameterList)}){Constraints(method.ConstraintClauses)}");
+                    break;
+                case ConstructorDeclarationSyntax constructor:
+                    yield return new MemberSignature(
+                        constructor.Identifier.ValueText,
+                        IsOverloadable: true,
+                        $"{Modifiers(constructor.Modifiers)}{constructor.Identifier.ValueText}" +
+                        $"({Parameters(constructor.ParameterList)})");
+                    break;
+                case PropertyDeclarationSyntax property:
+                    yield return new MemberSignature(
+                        property.Identifier.ValueText,
+                        IsOverloadable: false,
+                        $"{Modifiers(property.Modifiers)}{TypeName(property.Type)} " +
+                        $"{property.Identifier.ValueText} {{ {Accessors(property)} }}");
+                    break;
+                case FieldDeclarationSyntax field:
+                    foreach (var variable in field.Declaration.Variables)
+                    {
+                        yield return new MemberSignature(
+                            variable.Identifier.ValueText,
+                            IsOverloadable: false,
+                            $"{Modifiers(field.Modifiers)}{TypeName(field.Declaration.Type)} " +
+                            $"{variable.Identifier.ValueText}");
+                    }
+                    break;
+                case EventFieldDeclarationSyntax @event:
+                    foreach (var variable in @event.Declaration.Variables)
+                    {
+                        yield return new MemberSignature(
+                            variable.Identifier.ValueText,
+                            IsOverloadable: false,
+                            $"{Modifiers(@event.Modifiers)}event {TypeName(@event.Declaration.Type)} " +
+                            $"{variable.Identifier.ValueText}");
+                    }
+                    break;
+            }
+        }
+
+        // `partial` splits a declaration across files rather than describing its surface, so it is dropped;
+        // every other modifier (static / sealed / abstract / readonly / required / accessibility) is compared.
+        private static string Modifiers(SyntaxTokenList modifiers)
+        {
+            var kept = modifiers
+                .Where(modifier => !modifier.IsKind(SyntaxKind.PartialKeyword))
+                .Select(modifier => modifier.ValueText)
+                .ToList();
+            return kept.Count == 0 ? string.Empty : string.Join(" ", kept) + " ";
+        }
+
+        // An expression-bodied property is a getter; the stub declares none, but reading one as no accessors
+        // at all would silently equal a stub property that declares none either.
+        private static string Accessors(PropertyDeclarationSyntax property) =>
+            property.AccessorList is null
+                ? "get;"
+                : string.Concat(property.AccessorList.Accessors
+                    .Select(accessor => $"{Modifiers(accessor.Modifiers)}{accessor.Keyword.ValueText};"));
+
+        private static string TypeParameters(TypeParameterListSyntax? list) =>
+            list is null
+                ? string.Empty
+                : "<" + string.Join(", ", list.Parameters.Select(p =>
+                    (p.VarianceKeyword.IsKind(SyntaxKind.None) ? string.Empty : p.VarianceKeyword.ValueText + " ")
+                    + p.Identifier.ValueText)) + ">";
+
+        private static string Constraints(SyntaxList<TypeParameterConstraintClauseSyntax> clauses) =>
+            clauses.Count == 0
+                ? string.Empty
+                : " " + string.Join(" ", clauses.Select(clause =>
+                    $"where {clause.Name.Identifier.ValueText} : " +
+                    string.Join(", ", clause.Constraints.Select(ConstraintText))));
+
+        private static string ConstraintText(TypeParameterConstraintSyntax constraint) =>
+            constraint switch
+            {
+                TypeConstraintSyntax type => TypeName(type.Type),
+                ClassOrStructConstraintSyntax classOrStruct => classOrStruct.ClassOrStructKeyword.ValueText,
+                ConstructorConstraintSyntax => "new()",
+                DefaultConstraintSyntax => "default",
+                _ => Collapse(constraint.ToString()),
+            };
+
+        private static string Parameters(ParameterListSyntax list) =>
+            string.Join(", ", list.Parameters.Select(parameter =>
+                $"{Modifiers(parameter.Modifiers)}{TypeName(parameter.Type)} {parameter.Identifier.ValueText}"
+                + (parameter.Default is null ? string.Empty : $" = {Collapse(parameter.Default.Value.ToString())}")));
+
+        /// <summary>
+        /// A type reduced to what both sides can express: namespace qualification dropped (the stub writes
+        /// <c>global::</c>-rooted names where the runtime writes imported ones) and nullable reference
+        /// annotations erased (the stub's compilation is nullable-oblivious).
+        /// </summary>
+        private static string TypeName(TypeSyntax? type) =>
+            type switch
+            {
+                null => "<none>",
+                NullableTypeSyntax nullable => TypeName(nullable.ElementType),
+                ArrayTypeSyntax array => TypeName(array.ElementType) + string.Concat(
+                    array.RankSpecifiers.Select(rank => "[" + new string(',', rank.Rank - 1) + "]")),
+                PredefinedTypeSyntax predefined => predefined.Keyword.ValueText,
+                QualifiedNameSyntax qualified => TypeName(qualified.Right),
+                AliasQualifiedNameSyntax alias => TypeName(alias.Name),
+                GenericNameSyntax generic => generic.Identifier.ValueText + "<"
+                    + string.Join(", ", generic.TypeArgumentList.Arguments.Select(TypeName)) + ">",
+                IdentifierNameSyntax identifier => identifier.Identifier.ValueText,
+                TupleTypeSyntax tuple => "(" + string.Join(", ", tuple.Elements.Select(element =>
+                    TypeName(element.Type)
+                    + (element.Identifier.IsKind(SyntaxKind.None) ? string.Empty : " " + element.Identifier.ValueText)))
+                    + ")",
+                RefTypeSyntax reference => "ref " + TypeName(reference.Type),
+                _ => Collapse(type.ToString()),
+            };
+
+        private static string Collapse(string text) =>
+            string.Join(" ", text.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries));
+
+        private enum DivergenceKind
+        {
+            UnknownType,
+            Signature,
+            MissingOverload,
+        }
+
+        /// <summary><paramref name="Key"/> is what <see cref="StubSimplifications"/> records against.</summary>
+        private readonly record struct Divergence(string Key, DivergenceKind Kind, string Description);
+
+        /// <summary>One declared member reduced to the form both sides are compared in.</summary>
+        private readonly record struct MemberSignature(string Name, bool IsOverloadable, string Form);
+
+        /// <summary>
+        /// The comparison plus the populations it ran over. Every fact here asserts that a filtered list is
+        /// empty, which an empty population satisfies for the wrong reason, so the counts are carried out of
+        /// the single pass rather than recomputed per fact.
+        /// </summary>
+        private sealed record StubComparison(
+            IReadOnlyList<Divergence> Divergences,
+            IReadOnlyList<string> StubTypeNames,
+            IReadOnlyList<string> StubMemberNames,
+            IReadOnlyList<string> RuntimeMemberNames,
+            IReadOnlyList<string> OverloadableRuntimeMemberNames);
+    }
+}

--- a/Packages/com.velvet.core/Generators~/tests/Velvet.SourceGenerators.Tests/UseEffectExhaustiveDepsAnalyzerTests.cs
+++ b/Packages/com.velvet.core/Generators~/tests/Velvet.SourceGenerators.Tests/UseEffectExhaustiveDepsAnalyzerTests.cs
@@ -9,9 +9,9 @@ namespace Velvet.SourceGenerators.Tests
     /// <summary>Tests for <see cref="UseEffectExhaustiveDepsAnalyzer"/>.</summary>
     /// <remarks>
     /// All test sources use the <c>() =&gt; () =&gt; { ... }</c> nested-lambda shape so they typecheck against
-    /// the Velvet stub's <c>UseEffect(Func&lt;Action&gt; factory, object[] deps)</c> signature; the inner
-    /// lambda is the cleanup action. The analyzer descends into the outer lambda's tree and inspects every
-    /// captured local regardless of nesting depth.
+    /// <c>UseEffect(Func&lt;Action&gt; factory, object[] deps)</c>; the inner lambda is the cleanup action.
+    /// The analyzer descends into the outer lambda's tree and inspects every captured local regardless of
+    /// nesting depth.
     /// </remarks>
     public sealed class UseEffectExhaustiveDepsAnalyzerTests
     {
@@ -120,10 +120,9 @@ namespace MyApp.Pages
         }
 
         [Fact]
-        public void DoesNotReport_When_Captured_Local_Is_Action_Setter_From_Hook()
+        public void DoesNotReport_When_Captured_Local_Is_Setter_From_Hook()
         {
-            // Stable hook returns (Action / Action<T>) are exempted: the setter from UseState is a stable
-            // reference across renders and need not be in deps.
+            // The setter from UseState is a stable reference across renders and need not be in deps.
             const string source = @"
 namespace MyApp.Pages
 {
@@ -132,7 +131,7 @@ namespace MyApp.Pages
         public static void Render()
         {
             var (value, setValue) = global::Velvet.Hooks.UseState(0);
-            global::Velvet.Hooks.UseEffect(() => () => setValue(1), new object[] { });
+            global::Velvet.Hooks.UseEffect(() => () => setValue.Invoke(1), new object[] { });
         }
     }
 }";
@@ -840,7 +839,7 @@ namespace MyApp.Pages
     {
         public static void Render()
         {
-            var (onTick, setOnTick) = global::Velvet.Hooks.UseState<System.Action>(null);
+            var (onTick, setOnTick) = global::Velvet.Hooks.UseState<System.Action>(default(System.Action));
             global::Velvet.Hooks.UseEffect(() => () => onTick(), new object[] { });
         }
     }
@@ -864,7 +863,7 @@ namespace MyApp.Pages
         public static void Render()
         {
             var (count, setCount) = global::Velvet.Hooks.UseState(0);
-            global::Velvet.Hooks.UseEffect(() => () => { System.Console.WriteLine(count); setCount(1); }, new object[] { count });
+            global::Velvet.Hooks.UseEffect(() => () => { System.Console.WriteLine(count); setCount.Invoke(1); }, new object[] { count });
         }
     }
 }";


### PR DESCRIPTION
## What & why

The generator test project cannot reference the Unity assemblies, so it compiles its fixtures against a hand-written stub of the Velvet surface. That stub had drifted, which meant analyzer and generator tests were green against an API that does not exist — a diagnostic could be "verified" for a call shape no user can write, and one hook's stub return type made a `.Current` read impossible to exercise at all.

This adds a guard that parses the stub and compares every declaration against the runtime sources, using the same syntax-only Roslyn parse the existing hook-name guard uses — no assembly reference across the compile boundary, no shared runtime code. Four checks: stub types resolve to a runtime type; every stub declaration matches the runtime's on modifiers, parameter types and names, return type, generic parameters, constraints, optionality and `params`; every runtime overload of a name the stub already declares is modelled; and a recorded simplification that no longer diverges fails as stale.

Overload completeness is scoped to names the stub already declares, because the stub is a subset by design. Two divergences are kept deliberately and recorded with their reasons: an awaitable placeholder standing in for a type the test project cannot reference (it carries the real overload's arity, which is what the analyzer reads), and an instantiable node type where the runtime's is abstract (no analyzer inspects abstractness, and modelling it faithfully would force every fixture to build the concrete node hierarchy).

The divergences the guard found are corrected, and the two analyzer test sources that depended on a fictional shape are updated rather than deleted: one invoked a state setter as a delegate, which the real type does not permit. A second edit pins a call to its intended overload — the previous form compiled and resolved unambiguously, but to the lazy-factory overload rather than the value one once the missing overload was added, so the call was silently rebinding rather than failing.

Two items in the filed issue turned out to be wrong, and following them literally would have introduced new divergence: the constraint it reported was already correct, and one hook genuinely does return what the issue called a mistake. Both were left alone; what the issue missed — a missing overload on that same hook, a wrong return type on another, an attribute's targets, and one more missing overload — is fixed.

## Checklist

- [x] Tests pass locally (EditMode / PlayMode / generator tests as applicable) — generator suite 208 passed / 0 failed (baseline 204 plus the four new checks); no runtime or generator source changed, so the Unity suites have nothing to prove here
- [x] New regression tests were verified red without the change and green with it — six divergences injected one at a time (a dropped optional marker, a changed parameter type, a deleted overload, a loosened constraint, an unknown stub type, and a settled record), each captured with its failure message; and gutting the stub fails all four checks with an explicit "would pass vacuously" precondition rather than passing
- [x] Docs are updated for every fact this change touches (guides, READMEs, CLAUDE.md) — or this PR has no doc impact
- [x] CHANGELOG updated for behavior/perf changes (pure refactors are omitted by convention) — no entry: this is test-side only with no shipped behaviour change
- [x] Known gaps or deliberate deferrals discovered here are filed as issues with acceptance criteria — the guard deliberately does not compare base types, interfaces, attributes, member bodies, or nullable annotations, each stated in the fixture with its reason; absence of a runtime member from the stub stays allowed, since the stub is a subset by design

Closes #156