### PR TITLE
fix(velvet): match context providers by tree position so a sibling change cannot cost one its notification

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -111,7 +111,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   position has no counterpart, so a Provider appearing or disappearing elsewhere no longer displaces the
   comparison. A provider's position includes its own sibling index, which a conditional sibling rendered
   as `null` preserves; give it an explicit `key` when the index itself moves, such as a provider appended
-  after a variable number of siblings.
+  after a variable number of siblings — keying the provider pins its own place among its siblings, so an
+  unkeyed fragment or component enclosing it needs a key of its own if that is what moves.
 - The VEL100 exhaustive-deps analyzer now also covers `Hooks.UseInsertionEffect` and `Hooks.UseBlocker`.
   Both take a closure plus a deps array, but neither was listed as a deps-comparing hook, so a captured
   value missing from their deps went unreported.

--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -107,8 +107,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   an ordinary consumer is re-rendered by the surrounding walk anyway. A theme or locale change while a
   route's data is still loading, with the skeleton widgets memoized, is the everyday shape: the skeleton
   kept the old theme until the fetch resolved. Providers on the two sides of the diff are now matched by
-  their position in the tree rather than by their order of appearance, so a nearby Provider appearing or
-  disappearing no longer displaces the comparison.
+  their position in the tree first, falling back to the previous order-of-appearance matching when a
+  position has no counterpart, so a Provider appearing or disappearing elsewhere no longer displaces the
+  comparison. A provider's position includes its own sibling index, which a conditional sibling rendered
+  as `null` preserves; give it an explicit `key` when the index itself moves, such as a provider appended
+  after a variable number of siblings.
 - The VEL100 exhaustive-deps analyzer now also covers `Hooks.UseInsertionEffect` and `Hooks.UseBlocker`.
   Both take a closure plus a deps array, but neither was listed as a deps-comparing hook, so a captured
   value missing from their deps went unreported.

--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -98,6 +98,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (or plain) form as the base, or render one direction class computed in C#. The `gap-*` polyfill
   resolves its axis from the same precedence and was updated in lockstep, so spacing still follows the
   axis the container actually renders on.
+- A consumer below a `V.Provider` could keep rendering the previous context value indefinitely when the
+  set of Providers around it changed in the same render as the value. It showed up wherever a Provider
+  shares a parent with something that can add or drop a Provider of its own — a `V.Suspense` whose
+  primary subtree provides a value while the fallback is showing, a Provider inside a fallback beside one
+  in the primary, or simply a conditional `cond ? V.Provider(...) : null` sibling appearing — and only
+  below a memoized boundary (a `[Component(Memoize = true)]` consumer, or one behind `V.Memoized`), since
+  an ordinary consumer is re-rendered by the surrounding walk anyway. A theme or locale change while a
+  route's data is still loading, with the skeleton widgets memoized, is the everyday shape: the skeleton
+  kept the old theme until the fetch resolved. Providers on the two sides of the diff are now matched by
+  their position in the tree rather than by their order of appearance, so a nearby Provider appearing or
+  disappearing no longer displaces the comparison.
 - The VEL100 exhaustive-deps analyzer now also covers `Hooks.UseInsertionEffect` and `Hooks.UseBlocker`.
   Both take a closure plus a deps array, but neither was listed as a deps-comparing hook, so a captured
   value missing from their deps went unreported.

--- a/Packages/com.velvet.core/Runtime/Component/V.cs
+++ b/Packages/com.velvet.core/Runtime/Component/V.cs
@@ -1446,6 +1446,14 @@ namespace Velvet
         /// Provides a context value to the descendant subtree, visible to descendants that read the
         /// same context via <c>Hooks.UseContext</c>.
         /// </summary>
+        /// <remarks>
+        /// A value change reaches consumers by comparing this provider against the one that held the same
+        /// position last render, and an unkeyed provider is identified by its own sibling index. That covers
+        /// the ordinary cases, including a conditional sibling rendered as <c>null</c>, which keeps its slot.
+        /// Give the provider an explicit <paramref name="key"/> when the index itself can move — it follows a
+        /// variable number of siblings, or is appended after a mapped list — so it stays identified across
+        /// the shift.
+        /// </remarks>
         /// <typeparam name="T">Context value type.</typeparam>
         /// <param name="context">Context object whose value is being provided.</param>
         /// <param name="value">Value visible to descendants via <c>Hooks.UseContext(context)</c>.</param>

--- a/Packages/com.velvet.core/Runtime/Component/V.cs
+++ b/Packages/com.velvet.core/Runtime/Component/V.cs
@@ -1452,7 +1452,8 @@ namespace Velvet
         /// the ordinary cases, including a conditional sibling rendered as <c>null</c>, which keeps its slot.
         /// Give the provider an explicit <paramref name="key"/> when the index itself can move — it follows a
         /// variable number of siblings, or is appended after a mapped list — so it stays identified across
-        /// the shift.
+        /// the shift. The key pins the provider's own place among its siblings, not the path above it: if an
+        /// unkeyed fragment or component enclosing it is what moves, key the moving ancestor too.
         /// </remarks>
         /// <typeparam name="T">Context value type.</typeparam>
         /// <param name="context">Context object whose value is being provided.</param>

--- a/Packages/com.velvet.core/Runtime/Reconciler/ChildReconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ChildReconciler.cs
@@ -166,8 +166,8 @@ namespace Velvet
             // ContextProviderNode / ComponentNode / OutletNode are expanded inline (no wrapper VE
             // emitted). Old-side expansion is structural-only (no context push, no fiber render).
             // New-side expansion pushes each Provider's value onto the stack and, while it is
-            // still pushed, notifies dependent fibers if the value changed vs the corresponding
-            // old Provider (paired by expansion order), then pops — so propagation snapshots
+            // still pushed, notifies dependent fibers if the value changed vs the old Provider that
+            // held the same tree position (see ProviderPairKey), then pops — so propagation snapshots
             // include the new value. ComponentNode children render synchronously during new-side
             // expansion via ComponentRegistry.GetOrCreateInline; the fiber's PreviousTree is
             // expanded recursively in place of the ComponentNode.
@@ -179,7 +179,7 @@ namespace Velvet
             // single Reconcile call, so a sibling fiber's setState re-render (which calls
             // Reconcile with a different parent/slotStart) does not falsely orphan unrelated
             // siblings under the same anchor.
-            var oldProviders = _ctx.BufferPool.RentProviderList();
+            var oldProviders = _ctx.BufferPool.RentProviderMap();
             var oldFibers = _ctx.BufferPool.RentFiberList();
             var newFibers = _ctx.BufferPool.RentFiberSet();
             VNode?[] oldNodes;
@@ -218,7 +218,7 @@ namespace Velvet
             }
             finally
             {
-                _ctx.BufferPool.ReturnProviderList(oldProviders);
+                _ctx.BufferPool.ReturnProviderMap(oldProviders);
                 _ctx.BufferPool.ReturnFiberList(oldFibers);
                 _ctx.BufferPool.ReturnFiberSet(newFibers);
             }

--- a/Packages/com.velvet.core/Runtime/Reconciler/ChildReconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ChildReconciler.cs
@@ -179,7 +179,7 @@ namespace Velvet
             // single Reconcile call, so a sibling fiber's setState re-render (which calls
             // Reconcile with a different parent/slotStart) does not falsely orphan unrelated
             // siblings under the same anchor.
-            var oldProviders = _ctx.BufferPool.RentProviderMap();
+            var oldProviders = _ctx.BufferPool.RentProviderTable();
             var oldFibers = _ctx.BufferPool.RentFiberList();
             var newFibers = _ctx.BufferPool.RentFiberSet();
             VNode?[] oldNodes;
@@ -218,7 +218,7 @@ namespace Velvet
             }
             finally
             {
-                _ctx.BufferPool.ReturnProviderMap(oldProviders);
+                _ctx.BufferPool.ReturnProviderTable(oldProviders);
                 _ctx.BufferPool.ReturnFiberList(oldFibers);
                 _ctx.BufferPool.ReturnFiberSet(newFibers);
             }

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberKeying.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberKeying.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 
@@ -15,8 +16,70 @@ namespace Velvet
     // identity)</c> misses and either the spine reconstruction fails to recognize a child or a fiber's
     // state is reset. Centralizing the derivation here makes that lockstep structural: changing a
     // keying rule changes both walkers at once.
+
+    // Tree position of one inline-expanded ContextProviderNode, used to pair a new-side Provider with the
+    // Provider that held the same position on the old side (whose value it must be compared against to decide
+    // whether consumers need notifying). Position — not order of appearance: the two sides emit different
+    // numbers of Providers whenever a Suspense swaps primary for fallback or a conditional Provider appears,
+    // and an order-based pairing then compares every following Provider against a stranger's value.
+    // Occurrence separates Providers that genuinely share a position: nested Providers are transparent, so an
+    // inner one sits at the same node index of its parent's children and opens no scope of its own. Both sides
+    // number them in walk order (outermost first), which each reproduces identically.
+    //
+    // Equality and hashing are spelled out rather than left to a record struct: this is a dictionary key on the
+    // inline-expansion walk, hashed several times per Provider, and the compiler-generated members route every
+    // field through EqualityComparer<T>.Default — a virtual call per field that Mono does not devirtualize.
+    internal readonly struct ProviderPairKey : IEquatable<ProviderPairKey>
+    {
+        private readonly ComponentFiber? _fiber;
+        private readonly string? _scope;
+        private readonly string? _key;
+        private readonly int _index;
+        private readonly int _occurrence;
+
+        internal ProviderPairKey(ComponentFiber? fiber, string? scope, string? key, int index, int occurrence)
+        {
+            _fiber = fiber;
+            _scope = scope;
+            _key = key;
+            _index = index;
+            _occurrence = occurrence;
+        }
+
+        internal ProviderPairKey AtOccurrence(int occurrence)
+            => new(_fiber, _scope, _key, _index, occurrence);
+
+        public bool Equals(ProviderPairKey other)
+            => _index == other._index
+                && _occurrence == other._occurrence
+                && ReferenceEquals(_fiber, other._fiber)
+                && string.Equals(_scope, other._scope, StringComparison.Ordinal)
+                && string.Equals(_key, other._key, StringComparison.Ordinal);
+
+        public override bool Equals(object? obj) => obj is ProviderPairKey other && Equals(other);
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hash = _fiber?.GetHashCode() ?? 0;
+                hash = (hash * 397) ^ (_scope?.GetHashCode() ?? 0);
+                hash = (hash * 397) ^ (_key?.GetHashCode() ?? 0);
+                hash = (hash * 397) ^ _index;
+                return (hash * 397) ^ _occurrence;
+            }
+        }
+    }
+
     internal static class FiberKeying
     {
+        // The position of a ContextProviderNode found at nodeIndex of the child array currently being walked
+        // under fiber and parentScope, at occurrence 0. An explicit key replaces the positional index so a
+        // keyed Provider keeps its identity when siblings shift around it.
+        internal static ProviderPairKey ProviderPosition(
+            ComponentFiber? fiber, string? parentScope, string? providerKey, int nodeIndex)
+            => new(fiber, parentScope, providerKey, providerKey != null ? -1 : nodeIndex, 0);
+
         // Returns the per-identity position key for an unkeyed inline ComponentNode: the n-th
         // occurrence of identity within one reconcile scope. Unkeyed siblings are
         // matched between renders by their render order. Mutates counters (bumps the

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberKeying.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberKeying.cs
@@ -49,9 +49,16 @@ namespace Velvet
     // Path is a 64-bit rolling hash of those contributions rather than the composed string Scope is: composing
     // a string per level would allocate on the walk's hottest path, which today allocates nothing at all in
     // the scope-less regime. The cost of that choice is stated rather than hidden — two DIFFERENT paths that
-    // hash alike pair the wrong Providers, which for the ~100 Provider positions one walk can hold is a
-    // ~1e-16 event per reconcile. A Provider whose path is NOT found does not guess: it falls back to the
-    // walk-order pairing that predates position pairing (see GeneralPathReconciler.ProviderPairTable).
+    // hash alike pair the wrong Providers, which is usually a spurious notification but is a stale consumer
+    // when the Provider wrongly paired against carries the same context and an equal value. Every
+    // contribution, an explicit key's characters included, is folded into the full 64-bit accumulator, so the
+    // bound is uniform: ~1e-16 for the ~100 Provider positions one walk can hold. Folding a key through its
+    // 32-bit string hash instead would make sibling keys the dominant term at ~1e-6 for a 100-item keyed
+    // list — and, string hashing being deterministic within a process, a colliding pair would collide on
+    // every render rather than being a per-reconcile roll of the dice.
+    //
+    // A Provider whose path is NOT found does not guess: it falls back to the walk-order pairing that
+    // predates position pairing (see GeneralPathReconciler.ProviderPairTable).
     internal readonly struct WalkPosition
     {
         internal readonly string? Scope;
@@ -124,7 +131,14 @@ namespace Velvet
         internal static WalkPosition WalkRoot => new(null, unchecked((long)PathSeed));
 
         // One level's contribution to the structural path. An explicit key replaces the positional index —
-        // mirroring the Scope rule — so a keyed node keeps its path when siblings shift around it.
+        // mirroring the Scope rule — so a keyed node keeps this ONE level's contribution when its siblings
+        // shift around it. It does not pin the levels above: an unkeyed Fragment or Component that moves
+        // changes the parent path, and the key below it moves with it.
+        //
+        // The key is folded CHARACTER BY CHARACTER into the 64-bit accumulator, not through its 32-bit
+        // string hash: two keyed siblings differ only by their key's contribution, and routing that through
+        // 32 bits would leave a ~1e-6 collision for a 100-item keyed list — deterministic per process, so a
+        // colliding pair would mispair on every render rather than once in a blue moon.
         private static long ExtendPath(long parentPath, WalkPathKind kind, string? key, int nodeIndex)
         {
             unchecked
@@ -133,7 +147,10 @@ namespace Velvet
                 if (key != null)
                 {
                     hash = (hash ^ KeyedContributionMarker) * PathPrime;
-                    hash = (hash ^ (uint)key.GetHashCode()) * PathPrime;
+                    foreach (var ch in key)
+                    {
+                        hash = (hash ^ ch) * PathPrime;
+                    }
                 }
                 else
                 {

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberKeying.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberKeying.cs
@@ -17,43 +17,81 @@ namespace Velvet
     // state is reset. Centralizing the derivation here makes that lockstep structural: changing a
     // keying rule changes both walkers at once.
 
+    // How the child array a node sits in was opened. Part of the structural path below, so two arrays opened
+    // at the same node index by different constructs — a Suspense's primary vs its fallback, a Memo's
+    // resolved inner vs a Fragment's children — never compose to the same path.
+    internal enum WalkPathKind : byte
+    {
+        Fragment = 1,
+        Provider = 2,
+        Component = 3,
+        Memo = 4,
+        SuspensePrimary = 5,
+        SuspenseFallback = 6,
+        Presence = 7,
+        PresenceChild = 8,
+    }
+
+    // The two position coordinates the inline-expansion walk carries down one descent. Both are derived from
+    // the same contribution at every level, by one factory per construct below, so they cannot drift apart.
+    //
+    // Scope is the fiber-keying scope chain, and deliberately COLLAPSES: a Fragment / Provider / Component
+    // contributes nothing while no enclosing keyed boundary has established a scope, which is what keeps an
+    // unkeyed subtree participating in its parent's plain keyed/indexed list. The registry and
+    // FiberContextSpine depend on that exact rule.
+    //
+    // Path never collapses: every construct the descent passes through contributes, starting at the walk root.
+    // Provider pairing needs that. Under Scope alone, a Provider nested directly inside another one is
+    // indistinguishable from its parent at the top level (both null scope, both node index 0), and so are two
+    // Providers at index 0 of two different unkeyed Fragments — pairing either against the wrong side's node
+    // silently compares against a value that was never theirs.
+    //
+    // Path is a 64-bit rolling hash of those contributions rather than the composed string Scope is: composing
+    // a string per level would allocate on the walk's hottest path, which today allocates nothing at all in
+    // the scope-less regime. The cost of that choice is stated rather than hidden — two DIFFERENT paths that
+    // hash alike pair the wrong Providers, which for the ~100 Provider positions one walk can hold is a
+    // ~1e-16 event per reconcile. A Provider whose path is NOT found does not guess: it falls back to the
+    // walk-order pairing that predates position pairing (see GeneralPathReconciler.ProviderPairTable).
+    internal readonly struct WalkPosition
+    {
+        internal readonly string? Scope;
+        internal readonly long Path;
+
+        internal WalkPosition(string? scope, long path)
+        {
+            Scope = scope;
+            Path = path;
+        }
+    }
+
     // Tree position of one inline-expanded ContextProviderNode, used to pair a new-side Provider with the
     // Provider that held the same position on the old side (whose value it must be compared against to decide
     // whether consumers need notifying). Position — not order of appearance: the two sides emit different
     // numbers of Providers whenever a Suspense swaps primary for fallback or a conditional Provider appears,
     // and an order-based pairing then compares every following Provider against a stranger's value.
-    // Occurrence separates Providers that genuinely share a position: nested Providers are transparent, so an
-    // inner one sits at the same node index of its parent's children and opens no scope of its own. Both sides
-    // number them in walk order (outermost first), which each reproduces identically.
     //
     // Equality and hashing are spelled out rather than left to a record struct: this is a dictionary key on the
-    // inline-expansion walk, hashed several times per Provider, and the compiler-generated members route every
+    // inline-expansion walk, hashed once per Provider per side, and the compiler-generated members route every
     // field through EqualityComparer<T>.Default — a virtual call per field that Mono does not devirtualize.
     internal readonly struct ProviderPairKey : IEquatable<ProviderPairKey>
     {
         private readonly ComponentFiber? _fiber;
-        private readonly string? _scope;
+        private readonly long _path;
         private readonly string? _key;
         private readonly int _index;
-        private readonly int _occurrence;
 
-        internal ProviderPairKey(ComponentFiber? fiber, string? scope, string? key, int index, int occurrence)
+        internal ProviderPairKey(ComponentFiber? fiber, long path, string? key, int index)
         {
             _fiber = fiber;
-            _scope = scope;
+            _path = path;
             _key = key;
             _index = index;
-            _occurrence = occurrence;
         }
-
-        internal ProviderPairKey AtOccurrence(int occurrence)
-            => new(_fiber, _scope, _key, _index, occurrence);
 
         public bool Equals(ProviderPairKey other)
             => _index == other._index
-                && _occurrence == other._occurrence
+                && _path == other._path
                 && ReferenceEquals(_fiber, other._fiber)
-                && string.Equals(_scope, other._scope, StringComparison.Ordinal)
                 && string.Equals(_key, other._key, StringComparison.Ordinal);
 
         public override bool Equals(object? obj) => obj is ProviderPairKey other && Equals(other);
@@ -63,22 +101,95 @@ namespace Velvet
             unchecked
             {
                 var hash = _fiber?.GetHashCode() ?? 0;
-                hash = (hash * 397) ^ (_scope?.GetHashCode() ?? 0);
+                hash = (hash * 397) ^ (int)_path;
+                hash = (hash * 397) ^ (int)(_path >> 32);
                 hash = (hash * 397) ^ (_key?.GetHashCode() ?? 0);
-                hash = (hash * 397) ^ _index;
-                return (hash * 397) ^ _occurrence;
+                return (hash * 397) ^ _index;
             }
         }
     }
 
     internal static class FiberKeying
     {
+        // FNV-1a 64 offset basis and prime. Chosen for being a one-multiply-per-contribution mix with no
+        // table and no state beyond the accumulator, which is what keeps extending the path at every
+        // recursion level off the walk's cost profile.
+        private const ulong PathSeed = 14695981039346656037UL;
+        private const ulong PathPrime = 1099511628211UL;
+        // Folded in ahead of a key so an explicit key of "3" and a node index of 3 cannot compose alike.
+        private const ulong KeyedContributionMarker = 0x9E3779B97F4A7C15UL;
+
+        // The position an outer walk starts from. Scope-less (nothing has established a keyed boundary yet)
+        // with the path accumulator at its seed.
+        internal static WalkPosition WalkRoot => new(null, unchecked((long)PathSeed));
+
+        // One level's contribution to the structural path. An explicit key replaces the positional index —
+        // mirroring the Scope rule — so a keyed node keeps its path when siblings shift around it.
+        private static long ExtendPath(long parentPath, WalkPathKind kind, string? key, int nodeIndex)
+        {
+            unchecked
+            {
+                var hash = ((ulong)parentPath ^ (byte)kind) * PathPrime;
+                if (key != null)
+                {
+                    hash = (hash ^ KeyedContributionMarker) * PathPrime;
+                    hash = (hash ^ (uint)key.GetHashCode()) * PathPrime;
+                }
+                else
+                {
+                    hash = (hash ^ (uint)nodeIndex) * PathPrime;
+                }
+                return (long)hash;
+            }
+        }
+
+        // The position a FragmentNode opens for its children.
+        internal static WalkPosition FragmentChild(WalkPosition parent, string? fragmentKey, int nodeIndex)
+            => new(FragmentChildScope(parent.Scope, fragmentKey, nodeIndex),
+                ExtendPath(parent.Path, WalkPathKind.Fragment, fragmentKey, nodeIndex));
+
+        // The position a ContextProviderNode opens for its children.
+        internal static WalkPosition ProviderChild(WalkPosition parent, string? providerKey, int nodeIndex)
+            => new(ProviderChildScope(parent.Scope, providerKey, nodeIndex),
+                ExtendPath(parent.Path, WalkPathKind.Provider, providerKey, nodeIndex));
+
+        // The position an inline ComponentNode opens when its committed PreviousTree is descended.
+        internal static WalkPosition ComponentChild(WalkPosition parent, string? componentKey, int nodeIndex)
+            => new(ComponentChildScope(parent.Scope, componentKey, nodeIndex),
+                ExtendPath(parent.Path, WalkPathKind.Component, componentKey, nodeIndex));
+
+        // The position a MemoNode opens for its resolved inner. The memo's own key selects the dep-cache
+        // entry (MemoCacheKey), not the position, so only the node index contributes here.
+        internal static WalkPosition MemoInner(WalkPosition parent, int nodeIndex)
+            => new(MemoScope(parent.Scope, nodeIndex),
+                ExtendPath(parent.Path, WalkPathKind.Memo, null, nodeIndex));
+
+        // The position a Suspense's primary or fallback subtree renders under. The two branches contribute
+        // different kinds, so a Provider in the fallback is never paired against one in the primary.
+        internal static WalkPosition SuspenseSubtree(
+            WalkPosition parent, string suspenseKey, string? ownKey, int nodeIndex, bool isFallback)
+            => new(SuspenseSubtreeScope(suspenseKey, isFallback),
+                ExtendPath(parent.Path,
+                    isFallback ? WalkPathKind.SuspenseFallback : WalkPathKind.SuspensePrimary,
+                    ownKey, nodeIndex));
+
+        // The position of a DOM-less AnimatePresence itself; its Scope doubles as the boundary's state key.
+        internal static WalkPosition Presence(WalkPosition parent, string? presenceKey, int nodeIndex)
+            => new(PresenceKey(parent.Scope, presenceKey, nodeIndex),
+                ExtendPath(parent.Path, WalkPathKind.Presence, presenceKey, nodeIndex));
+
+        // The position one keyed AnimatePresence child renders under. Keyed by the child's own key, which is
+        // stable across renders, so a Provider inside it pairs across a reorder.
+        internal static WalkPosition PresenceChild(WalkPosition presence, string? childKey)
+            => new(PresenceChildScope(presence.Scope, childKey),
+                ExtendPath(presence.Path, WalkPathKind.PresenceChild, childKey, 0));
+
         // The position of a ContextProviderNode found at nodeIndex of the child array currently being walked
-        // under fiber and parentScope, at occurrence 0. An explicit key replaces the positional index so a
-        // keyed Provider keeps its identity when siblings shift around it.
+        // under fiber. An explicit key replaces the positional index so a keyed Provider keeps its identity
+        // when siblings shift around it.
         internal static ProviderPairKey ProviderPosition(
-            ComponentFiber? fiber, string? parentScope, string? providerKey, int nodeIndex)
-            => new(fiber, parentScope, providerKey, providerKey != null ? -1 : nodeIndex, 0);
+            ComponentFiber? fiber, WalkPosition position, string? providerKey, int nodeIndex)
+            => new(fiber, position.Path, providerKey, providerKey != null ? -1 : nodeIndex);
 
         // Returns the per-identity position key for an unkeyed inline ComponentNode: the n-th
         // occurrence of identity within one reconcile scope. Unkeyed siblings are

--- a/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
@@ -432,8 +432,9 @@ namespace Velvet
         // index, so `cond ? new[]{ p } : new[]{ banner, p }` moves it even though the Provider sequence itself
         // never changed. Falling back to walk order there keeps that case pairing as it always did, and makes
         // the whole scheme monotone — a position hit can only be more accurate than the ordinal it replaces,
-        // and a position miss is never worse than the behavior it replaced. Give a Provider an explicit key to
-        // pin its position through such a shift.
+        // and a position miss is never worse than the behavior it replaced. An explicit key on the Provider
+        // pins its OWN contribution through such a shift, but not the levels above it: an unkeyed Fragment or
+        // Component that moves takes the key's subtree with it.
         internal sealed class ProviderPairTable
         {
             private readonly Dictionary<ProviderPairKey, ContextProviderNode> _byPosition = new();
@@ -441,9 +442,13 @@ namespace Velvet
 
             public void Record(ProviderPairKey key, ContextProviderNode provider)
             {
-                // Two Providers cannot share a structural position (siblings differ by index or key, nesting
-                // differs by path), so this only ever guards against a path hash collision — where keeping the
-                // first preserves walk order rather than rebinding an earlier position to a later Provider.
+                // Two Providers DO share a position when siblings share one explicit key: a key replaces the
+                // node index, so the pair is genuinely indistinguishable here (and, far more remotely, on a
+                // path hash collision). Keeping the first is what walk order would have done; the second then
+                // pairs by walk order instead, and its consumers are re-notified every reconcile while the two
+                // values differ. Unlike the duplicate-key guards in the leaf and ComponentNode branches, this
+                // one does not warn: the duplicate is only visible from the OLD side here, whereas those warn
+                // where the repeated sibling is emitted.
                 _byPosition.TryAdd(key, provider);
                 _inWalkOrder.Add(provider);
             }

--- a/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
@@ -104,7 +104,7 @@ namespace Velvet
             int slotStart,
             List<ComponentFiber> oldFibers,
             HashSet<ComponentFiber> newFibers,
-            List<ContextProviderNode> oldProviders)
+            Dictionary<ProviderPairKey, ContextProviderNode> oldProviders)
         {
             var pool = _ctx.BufferPool;
             var commit = new GeneralCommitState
@@ -131,6 +131,7 @@ namespace Velvet
 
                 // Live-context walk: emit + commit each new leaf under its ancestor Providers.
                 var positionCounters = pool.RentPositionCounter();
+                var providerOccurrences = pool.RentProviderOccurrenceMap();
                 var prevFlag = _ctx.ContextValueChanged;
                 var walk = pool.RentInlineWalk();
                 walk.IsNewSide = true;
@@ -139,6 +140,7 @@ namespace Velvet
                 walk.OldFibers = oldFibers;
                 walk.NewFibers = newFibers;
                 walk.OldProvidersForPairing = oldProviders;
+                walk.ProviderOccurrences = providerOccurrences;
                 walk.Commit = commit;
                 try
                 {
@@ -148,6 +150,7 @@ namespace Velvet
                 {
                     _ctx.ContextValueChanged = prevFlag;
                     pool.ReturnPositionCounter(positionCounters);
+                    pool.ReturnProviderOccurrenceMap(providerOccurrences);
                     pool.ReturnInlineWalk(walk);
                 }
 
@@ -383,7 +386,7 @@ namespace Velvet
         // Providers is read only on the old-side branch and OldProvidersForPairing only on the new-side
         // branch, and no recursion flips IsNewSide — so one copy of each per walk is exact. ReconcileGeneral
         // cannot break that by construction: it always walks the new side and has no old-side Providers
-        // parameter to hand over. ExpandInlineForReconcile takes both lists from its caller, so that is the
+        // parameter to hand over. ExpandInlineForReconcile takes both maps from its caller, so that is the
         // entry carrying the runtime check.
         internal sealed class InlineWalk
         {
@@ -395,13 +398,15 @@ namespace Velvet
             public int SlotStart;
             public List<ComponentFiber> OldFibers = null!;
             public HashSet<ComponentFiber> NewFibers = null!;
-            public List<ContextProviderNode>? Providers;
-            public List<ContextProviderNode>? OldProvidersForPairing;
+            public Dictionary<ProviderPairKey, ContextProviderNode>? Providers;
+            public Dictionary<ProviderPairKey, ContextProviderNode>? OldProvidersForPairing;
             public GeneralCommitState? Commit;
-            // Expansion-order position of the next new-side Provider, paired against
-            // OldProvidersForPairing. Monotonic for the whole walk: nothing rewinds it, including a
-            // Suspense rollback that discards a primary subtree the counter has already advanced through.
-            public int NewProviderIndex;
+            // Per-position Provider counter, so two Providers that share one ProviderPairKey position
+            // (nested Providers, which are transparent and open no scope of their own) get distinct keys in
+            // walk order. Walk-wide, and deliberately never rewound — a Suspense rollback discards a primary
+            // subtree whose Providers already counted, but the fallback expands under its own scope, so the
+            // discarded counts belong to positions the rest of the walk never revisits.
+            public Dictionary<ProviderPairKey, int>? ProviderOccurrences;
 
             // Every field a walk may set is scrubbed here: a stale reference surviving into the next
             // rent would silently splice one walk's destination or fiber accumulators into another's.
@@ -416,7 +421,7 @@ namespace Velvet
                 Providers = null;
                 OldProvidersForPairing = null;
                 Commit = null;
-                NewProviderIndex = 0;
+                ProviderOccurrences = null;
             }
         }
 
@@ -445,9 +450,9 @@ namespace Velvet
         // Expansion variant invoked by Reconcile that inlines wrapper-less node types
         // (ContextProviderNode, FragmentNode) into the flat VNode array consumed by the
         // Indexed/Keyed reconciler. Old-side (isNewSide=false) is structural:
-        // it walks the input tree without pushing context onto the live stack. New-side
-        // (isNewSide=true) pushes each Provider's value onto the stack, then —
-        // while the value is still pushed — pairs against the corresponding old Provider via
+        // it walks the input tree without pushing context onto the live stack, recording each Provider under
+        // its ProviderPairKey. New-side (isNewSide=true) pushes each Provider's value onto the stack, then —
+        // while the value is still pushed — pairs against the old Provider that held the same position via
         // oldProvidersForPairing and dispatches NotifyContextChanged when the
         // value changed; finally pops. The push → notify → recurse → pop order guarantees the
         // propagated snapshot includes the new value.
@@ -458,10 +463,10 @@ namespace Velvet
             int slotStart,
             List<ComponentFiber> oldFibers,
             HashSet<ComponentFiber> newFibers,
-            List<ContextProviderNode>? providers = null,
-            List<ContextProviderNode>? oldProvidersForPairing = null)
+            Dictionary<ProviderPairKey, ContextProviderNode>? providers = null,
+            Dictionary<ProviderPairKey, ContextProviderNode>? oldProvidersForPairing = null)
         {
-            AssertProviderListMatchesSide(isNewSide, providers, oldProvidersForPairing);
+            AssertProviderMapMatchesSide(isNewSide, providers, oldProvidersForPairing);
 
             if (nodes == null || nodes.Length == 0) return Array.Empty<VNode>();
 
@@ -485,6 +490,7 @@ namespace Velvet
 
             var buffer = _ctx.BufferPool.RentNodeList();
             var positionCounters = _ctx.BufferPool.RentPositionCounter();
+            var providerOccurrences = _ctx.BufferPool.RentProviderOccurrenceMap();
             var prevFlag = _ctx.ContextValueChanged;
             var walk = _ctx.BufferPool.RentInlineWalk();
             walk.Result = buffer;
@@ -495,6 +501,7 @@ namespace Velvet
             walk.NewFibers = newFibers;
             walk.Providers = providers;
             walk.OldProvidersForPairing = oldProvidersForPairing;
+            walk.ProviderOccurrences = providerOccurrences;
             try
             {
                 ExpandInlineRecursive(walk, nodes, positionCounters, fragmentKeyScope: null);
@@ -505,27 +512,45 @@ namespace Velvet
                 if (isNewSide) _ctx.ContextValueChanged = prevFlag;
                 _ctx.BufferPool.ReturnNodeList(buffer);
                 _ctx.BufferPool.ReturnPositionCounter(positionCounters);
+                _ctx.BufferPool.ReturnProviderOccurrenceMap(providerOccurrences);
                 _ctx.BufferPool.ReturnInlineWalk(walk);
             }
         }
 
         // The walk keeps one Providers / OldProvidersForPairing pair for its whole descent, which is exact
-        // only because each list is consumed on exactly one side (Providers collects old-side Providers;
+        // only because each map is consumed on exactly one side (Providers collects old-side Providers;
         // OldProvidersForPairing is read when a new-side Provider pushes) and no recursion flips the side.
-        // A caller that hands in the off-side list is expressing an intent this walk silently drops, so
+        // A caller that hands in the off-side map is expressing an intent this walk silently drops, so
         // fail loudly here rather than at the far end of a diff that quietly used the wrong Providers.
         // Checked ahead of the empty-input and flat-leaf early-outs: the caller's intent is just as wrong
         // when the container happens to hold nothing that needs expanding.
-        private static void AssertProviderListMatchesSide(
+        private static void AssertProviderMapMatchesSide(
             bool isNewSide,
-            List<ContextProviderNode>? providers,
-            List<ContextProviderNode>? oldProvidersForPairing)
+            Dictionary<ProviderPairKey, ContextProviderNode>? providers,
+            Dictionary<ProviderPairKey, ContextProviderNode>? oldProvidersForPairing)
         {
             UnityEngine.Debug.Assert(
                 isNewSide ? providers == null : oldProvidersForPairing == null,
                 "[Velvet] GeneralPathReconciler.ExpandInlineForReconcile: the new side only reads "
-                + "oldProvidersForPairing and the old side only fills providers; the list for the other "
+                + "oldProvidersForPairing and the old side only fills providers; the map for the other "
                 + "side is never consumed.");
+        }
+
+        // The pairing key of the Provider being visited, and the claim on it: the position is derived from
+        // the enclosing fiber + scope + node index, and its occurrence counter advances so a second Provider
+        // at the same position takes the next key. Both sides call this at the same point of the same walk
+        // order, which is what makes a new-side lookup land on the Provider that held the position last
+        // render rather than on whichever Provider happened to be emitted the same number of steps in.
+        private ProviderPairKey TakeProviderPairKey(
+            InlineWalk walk, ContextProviderNode provider, string? fragmentKeyScope, int nodeIndex)
+        {
+            var position = FiberKeying.ProviderPosition(
+                _ctx.FiberStack.Current, fragmentKeyScope, provider.Key, nodeIndex);
+            var occurrences = walk.ProviderOccurrences;
+            if (occurrences == null) return position;
+            occurrences.TryGetValue(position, out var occurrence);
+            occurrences[position] = occurrence + 1;
+            return position.AtOccurrence(occurrence);
         }
 
         private void ExpandInlineRecursive(
@@ -557,7 +582,11 @@ namespace Velvet
                         }
                         break;
                     case ContextProviderNode provider when !isNewSide:
-                        walk.Providers?.Add(provider);
+                    {
+                        // Recorded under its position BEFORE the descent, so a nested Provider's own
+                        // occurrence is numbered after this one's on both sides.
+                        var pairKey = TakeProviderPairKey(walk, provider, fragmentKeyScope, nodeIndex);
+                        walk.Providers?.TryAdd(pairKey, provider);
                         if (provider.Children != null)
                         {
                             var providerScope = FiberKeying.ProviderChildScope(
@@ -565,16 +594,18 @@ namespace Velvet
                             ExpandInlineRecursive(walk, provider.Children, positionCounters, providerScope);
                         }
                         break;
+                    }
                     case ContextProviderNode provider:
                         // New side: push value first so the notification snapshot includes it.
                         provider.PushContext(_ctx.ComponentContextStack);
                         try
                         {
-                            var oldProvidersForPairing = walk.OldProvidersForPairing;
-                            var pairIndex = walk.NewProviderIndex++;
-                            if (oldProvidersForPairing != null
-                                && pairIndex < oldProvidersForPairing.Count
-                                && provider.HasValueChanged(oldProvidersForPairing[pairIndex]))
+                            var pairKey = TakeProviderPairKey(walk, provider, fragmentKeyScope, nodeIndex);
+                            // No old Provider at this position means this one is mounting here: its consumers
+                            // mount with it and read the live cursor, so there is nothing to notify.
+                            if (walk.OldProvidersForPairing != null
+                                && walk.OldProvidersForPairing.TryGetValue(pairKey, out var oldProvider)
+                                && provider.HasValueChanged(oldProvider))
                             {
                                 NotifyContextValueChange(provider);
                             }

--- a/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
@@ -104,7 +104,7 @@ namespace Velvet
             int slotStart,
             List<ComponentFiber> oldFibers,
             HashSet<ComponentFiber> newFibers,
-            Dictionary<ProviderPairKey, ContextProviderNode> oldProviders)
+            ProviderPairTable oldProviders)
         {
             var pool = _ctx.BufferPool;
             var commit = new GeneralCommitState
@@ -131,7 +131,6 @@ namespace Velvet
 
                 // Live-context walk: emit + commit each new leaf under its ancestor Providers.
                 var positionCounters = pool.RentPositionCounter();
-                var providerOccurrences = pool.RentProviderOccurrenceMap();
                 var prevFlag = _ctx.ContextValueChanged;
                 var walk = pool.RentInlineWalk();
                 walk.IsNewSide = true;
@@ -140,17 +139,15 @@ namespace Velvet
                 walk.OldFibers = oldFibers;
                 walk.NewFibers = newFibers;
                 walk.OldProvidersForPairing = oldProviders;
-                walk.ProviderOccurrences = providerOccurrences;
                 walk.Commit = commit;
                 try
                 {
-                    ExpandInlineRecursive(walk, newChildren, positionCounters, fragmentKeyScope: null);
+                    ExpandInlineRecursive(walk, newChildren, positionCounters, FiberKeying.WalkRoot);
                 }
                 finally
                 {
                     _ctx.ContextValueChanged = prevFlag;
                     pool.ReturnPositionCounter(positionCounters);
-                    pool.ReturnProviderOccurrenceMap(providerOccurrences);
                     pool.ReturnInlineWalk(walk);
                 }
 
@@ -386,7 +383,7 @@ namespace Velvet
         // Providers is read only on the old-side branch and OldProvidersForPairing only on the new-side
         // branch, and no recursion flips IsNewSide — so one copy of each per walk is exact. ReconcileGeneral
         // cannot break that by construction: it always walks the new side and has no old-side Providers
-        // parameter to hand over. ExpandInlineForReconcile takes both maps from its caller, so that is the
+        // parameter to hand over. ExpandInlineForReconcile takes both tables from its caller, so that is the
         // entry carrying the runtime check.
         internal sealed class InlineWalk
         {
@@ -398,15 +395,14 @@ namespace Velvet
             public int SlotStart;
             public List<ComponentFiber> OldFibers = null!;
             public HashSet<ComponentFiber> NewFibers = null!;
-            public Dictionary<ProviderPairKey, ContextProviderNode>? Providers;
-            public Dictionary<ProviderPairKey, ContextProviderNode>? OldProvidersForPairing;
+            public ProviderPairTable? Providers;
+            public ProviderPairTable? OldProvidersForPairing;
             public GeneralCommitState? Commit;
-            // Per-position Provider counter, so two Providers that share one ProviderPairKey position
-            // (nested Providers, which are transparent and open no scope of their own) get distinct keys in
-            // walk order. Walk-wide, and deliberately never rewound — a Suspense rollback discards a primary
-            // subtree whose Providers already counted, but the fallback expands under its own scope, so the
-            // discarded counts belong to positions the rest of the walk never revisits.
-            public Dictionary<ProviderPairKey, int>? ProviderOccurrences;
+            // Expansion-order position of the next new-side Provider, the fallback pairing for a Provider
+            // whose structural position has no counterpart on the old side. Monotonic for the whole walk:
+            // nothing rewinds it, including a Suspense rollback that discards a primary subtree it has
+            // already advanced through — matching the old side, which reproduces exactly one branch.
+            public int NewProviderOrdinal;
 
             // Every field a walk may set is scrubbed here: a stale reference surviving into the next
             // rent would silently splice one walk's destination or fiber accumulators into another's.
@@ -421,7 +417,47 @@ namespace Velvet
                 Providers = null;
                 OldProvidersForPairing = null;
                 Commit = null;
-                ProviderOccurrences = null;
+                NewProviderOrdinal = 0;
+            }
+        }
+
+        // The old side's Providers, recorded two ways so the new side can prefer the precise pairing without
+        // losing the one it replaces.
+        //
+        // ByPosition is the primary: a Provider is compared against whatever held its structural position last
+        // render, which is unaffected by Providers appearing or disappearing elsewhere in the walk.
+        //
+        // InWalkOrder is the fallback, and is exactly the pairing that predates ByPosition. A structural
+        // position is not stable across everything: an unkeyed Provider's own contribution is its sibling
+        // index, so `cond ? new[]{ p } : new[]{ banner, p }` moves it even though the Provider sequence itself
+        // never changed. Falling back to walk order there keeps that case pairing as it always did, and makes
+        // the whole scheme monotone — a position hit can only be more accurate than the ordinal it replaces,
+        // and a position miss is never worse than the behavior it replaced. Give a Provider an explicit key to
+        // pin its position through such a shift.
+        internal sealed class ProviderPairTable
+        {
+            private readonly Dictionary<ProviderPairKey, ContextProviderNode> _byPosition = new();
+            private readonly List<ContextProviderNode> _inWalkOrder = new();
+
+            public void Record(ProviderPairKey key, ContextProviderNode provider)
+            {
+                // Two Providers cannot share a structural position (siblings differ by index or key, nesting
+                // differs by path), so this only ever guards against a path hash collision — where keeping the
+                // first preserves walk order rather than rebinding an earlier position to a later Provider.
+                _byPosition.TryAdd(key, provider);
+                _inWalkOrder.Add(provider);
+            }
+
+            public ContextProviderNode? Match(ProviderPairKey key, int walkOrdinal)
+            {
+                if (_byPosition.TryGetValue(key, out var atPosition)) return atPosition;
+                return walkOrdinal < _inWalkOrder.Count ? _inWalkOrder[walkOrdinal] : null;
+            }
+
+            public void Clear()
+            {
+                _byPosition.Clear();
+                _inWalkOrder.Clear();
             }
         }
 
@@ -463,10 +499,10 @@ namespace Velvet
             int slotStart,
             List<ComponentFiber> oldFibers,
             HashSet<ComponentFiber> newFibers,
-            Dictionary<ProviderPairKey, ContextProviderNode>? providers = null,
-            Dictionary<ProviderPairKey, ContextProviderNode>? oldProvidersForPairing = null)
+            ProviderPairTable? providers = null,
+            ProviderPairTable? oldProvidersForPairing = null)
         {
-            AssertProviderMapMatchesSide(isNewSide, providers, oldProvidersForPairing);
+            AssertProviderTableMatchesSide(isNewSide, providers, oldProvidersForPairing);
 
             if (nodes == null || nodes.Length == 0) return Array.Empty<VNode>();
 
@@ -490,7 +526,6 @@ namespace Velvet
 
             var buffer = _ctx.BufferPool.RentNodeList();
             var positionCounters = _ctx.BufferPool.RentPositionCounter();
-            var providerOccurrences = _ctx.BufferPool.RentProviderOccurrenceMap();
             var prevFlag = _ctx.ContextValueChanged;
             var walk = _ctx.BufferPool.RentInlineWalk();
             walk.Result = buffer;
@@ -501,10 +536,9 @@ namespace Velvet
             walk.NewFibers = newFibers;
             walk.Providers = providers;
             walk.OldProvidersForPairing = oldProvidersForPairing;
-            walk.ProviderOccurrences = providerOccurrences;
             try
             {
-                ExpandInlineRecursive(walk, nodes, positionCounters, fragmentKeyScope: null);
+                ExpandInlineRecursive(walk, nodes, positionCounters, FiberKeying.WalkRoot);
                 return buffer.Count == 0 ? Array.Empty<VNode>() : buffer.ToArray();
             }
             finally
@@ -512,52 +546,34 @@ namespace Velvet
                 if (isNewSide) _ctx.ContextValueChanged = prevFlag;
                 _ctx.BufferPool.ReturnNodeList(buffer);
                 _ctx.BufferPool.ReturnPositionCounter(positionCounters);
-                _ctx.BufferPool.ReturnProviderOccurrenceMap(providerOccurrences);
                 _ctx.BufferPool.ReturnInlineWalk(walk);
             }
         }
 
         // The walk keeps one Providers / OldProvidersForPairing pair for its whole descent, which is exact
-        // only because each map is consumed on exactly one side (Providers collects old-side Providers;
+        // only because each table is consumed on exactly one side (Providers collects old-side Providers;
         // OldProvidersForPairing is read when a new-side Provider pushes) and no recursion flips the side.
-        // A caller that hands in the off-side map is expressing an intent this walk silently drops, so
+        // A caller that hands in the off-side table is expressing an intent this walk silently drops, so
         // fail loudly here rather than at the far end of a diff that quietly used the wrong Providers.
         // Checked ahead of the empty-input and flat-leaf early-outs: the caller's intent is just as wrong
         // when the container happens to hold nothing that needs expanding.
-        private static void AssertProviderMapMatchesSide(
+        private static void AssertProviderTableMatchesSide(
             bool isNewSide,
-            Dictionary<ProviderPairKey, ContextProviderNode>? providers,
-            Dictionary<ProviderPairKey, ContextProviderNode>? oldProvidersForPairing)
+            ProviderPairTable? providers,
+            ProviderPairTable? oldProvidersForPairing)
         {
             UnityEngine.Debug.Assert(
                 isNewSide ? providers == null : oldProvidersForPairing == null,
                 "[Velvet] GeneralPathReconciler.ExpandInlineForReconcile: the new side only reads "
-                + "oldProvidersForPairing and the old side only fills providers; the map for the other "
+                + "oldProvidersForPairing and the old side only fills providers; the table for the other "
                 + "side is never consumed.");
-        }
-
-        // The pairing key of the Provider being visited, and the claim on it: the position is derived from
-        // the enclosing fiber + scope + node index, and its occurrence counter advances so a second Provider
-        // at the same position takes the next key. Both sides call this at the same point of the same walk
-        // order, which is what makes a new-side lookup land on the Provider that held the position last
-        // render rather than on whichever Provider happened to be emitted the same number of steps in.
-        private ProviderPairKey TakeProviderPairKey(
-            InlineWalk walk, ContextProviderNode provider, string? fragmentKeyScope, int nodeIndex)
-        {
-            var position = FiberKeying.ProviderPosition(
-                _ctx.FiberStack.Current, fragmentKeyScope, provider.Key, nodeIndex);
-            var occurrences = walk.ProviderOccurrences;
-            if (occurrences == null) return position;
-            occurrences.TryGetValue(position, out var occurrence);
-            occurrences[position] = occurrence + 1;
-            return position.AtOccurrence(occurrence);
         }
 
         private void ExpandInlineRecursive(
             InlineWalk walk,
             VNode?[] nodes,
             Dictionary<object, int> positionCounters,
-            string? fragmentKeyScope)
+            WalkPosition position)
         {
             var result = walk.Result;
             var isNewSide = walk.IsNewSide;
@@ -576,22 +592,24 @@ namespace Velvet
                     case FragmentNode fragment:
                         if (fragment.Children != null)
                         {
-                            var childScope = FiberKeying.FragmentChildScope(
-                                fragmentKeyScope, fragment.Key, nodeIndex);
-                            ExpandInlineRecursive(walk, fragment.Children, positionCounters, childScope);
+                            var childPosition = FiberKeying.FragmentChild(
+                                position, fragment.Key, nodeIndex);
+                            ExpandInlineRecursive(walk, fragment.Children, positionCounters, childPosition);
                         }
                         break;
                     case ContextProviderNode provider when !isNewSide:
                     {
-                        // Recorded under its position BEFORE the descent, so a nested Provider's own
-                        // occurrence is numbered after this one's on both sides.
-                        var pairKey = TakeProviderPairKey(walk, provider, fragmentKeyScope, nodeIndex);
-                        walk.Providers?.TryAdd(pairKey, provider);
+                        // Recorded BEFORE the descent, so the walk order the new side counts in places an
+                        // enclosing Provider ahead of the ones it wraps.
+                        walk.Providers?.Record(
+                            FiberKeying.ProviderPosition(
+                                _ctx.FiberStack.Current, position, provider.Key, nodeIndex),
+                            provider);
                         if (provider.Children != null)
                         {
-                            var providerScope = FiberKeying.ProviderChildScope(
-                                fragmentKeyScope, provider.Key, nodeIndex);
-                            ExpandInlineRecursive(walk, provider.Children, positionCounters, providerScope);
+                            var childPosition = FiberKeying.ProviderChild(
+                                position, provider.Key, nodeIndex);
+                            ExpandInlineRecursive(walk, provider.Children, positionCounters, childPosition);
                         }
                         break;
                     }
@@ -600,20 +618,23 @@ namespace Velvet
                         provider.PushContext(_ctx.ComponentContextStack);
                         try
                         {
-                            var pairKey = TakeProviderPairKey(walk, provider, fragmentKeyScope, nodeIndex);
-                            // No old Provider at this position means this one is mounting here: its consumers
-                            // mount with it and read the live cursor, so there is nothing to notify.
-                            if (walk.OldProvidersForPairing != null
-                                && walk.OldProvidersForPairing.TryGetValue(pairKey, out var oldProvider)
-                                && provider.HasValueChanged(oldProvider))
+                            var pairKey = FiberKeying.ProviderPosition(
+                                _ctx.FiberStack.Current, position, provider.Key, nodeIndex);
+                            // Neither a structural position nor a walk-order counterpart means this Provider
+                            // is mounting here: its consumers mount with it and read the live cursor, so
+                            // there is nothing to notify.
+                            var oldProvider = walk.OldProvidersForPairing?.Match(
+                                pairKey, walk.NewProviderOrdinal);
+                            walk.NewProviderOrdinal++;
+                            if (oldProvider != null && provider.HasValueChanged(oldProvider))
                             {
                                 NotifyContextValueChange(provider);
                             }
                             if (provider.Children != null)
                             {
-                                var providerScope = FiberKeying.ProviderChildScope(
-                                    fragmentKeyScope, provider.Key, nodeIndex);
-                                ExpandInlineRecursive(walk, provider.Children, positionCounters, providerScope);
+                                var childPosition = FiberKeying.ProviderChild(
+                                    position, provider.Key, nodeIndex);
+                                ExpandInlineRecursive(walk, provider.Children, positionCounters, childPosition);
                             }
                         }
                         finally
@@ -688,9 +709,9 @@ namespace Velvet
                                 _ctx.FiberStack.Push(fiber);
                                 try
                                 {
-                                    var componentScope = FiberKeying.ComponentChildScope(
-                                        fragmentKeyScope, component.Key, nodeIndex);
-                                    ExpandInlineRecursive(walk, fiber.PreviousTree, childCounters, componentScope);
+                                    var componentPosition = FiberKeying.ComponentChild(
+                                        position, component.Key, nodeIndex);
+                                    ExpandInlineRecursive(walk, fiber.PreviousTree, childCounters, componentPosition);
                                 }
                                 finally
                                 {
@@ -717,9 +738,9 @@ namespace Velvet
                                     _ctx.FiberStack.Push(fiber);
                                     try
                                     {
-                                        var componentScope = FiberKeying.ComponentChildScope(
-                                            fragmentKeyScope, component.Key, nodeIndex);
-                                        ExpandInlineRecursive(walk, fiber.PreviousTree, childCounters, componentScope);
+                                        var componentPosition = FiberKeying.ComponentChild(
+                                            position, component.Key, nodeIndex);
+                                        ExpandInlineRecursive(walk, fiber.PreviousTree, childCounters, componentPosition);
                                     }
                                     finally
                                     {
@@ -741,7 +762,7 @@ namespace Velvet
                         // matched route during this walk's commit (live context), reading
                         // RouterContext.Location / Depth from the live stack and pushing Depth+1 around
                         // the route Component's mount. No pre-captured snapshot / owner is needed.
-                        _keying.RegisterScopedKey(node, fragmentKeyScope, nodeIndex);
+                        _keying.RegisterScopedKey(node, position.Scope, nodeIndex);
                         Emit(node, result, commit);
                         break;
                     case MemoNode memo:
@@ -750,10 +771,10 @@ namespace Velvet
                         // wrapper-less in the parent's slot range. The inner renders in live context
                         // (the enclosing Provider is still pushed on the new side), so no pre-captured
                         // snapshot is needed.
-                        ExpandMemoInline(walk, memo, fragmentKeyScope, nodeIndex);
+                        ExpandMemoInline(walk, memo, position, nodeIndex);
                         break;
                     case SuspenseNode suspense:
-                        ExpandSuspenseInline(walk, suspense, fragmentKeyScope, nodeIndex);
+                        ExpandSuspenseInline(walk, suspense, position, nodeIndex);
                         break;
                     case AnimatePresenceNode presence:
                         // DOM-less: AnimatePresence emits no wrapper. Its keyed children expand directly
@@ -766,7 +787,7 @@ namespace Velvet
                         _ctx.PresenceExpansionDepth++;
                         try
                         {
-                            ExpandAnimatePresenceInline(walk, presence, fragmentKeyScope, nodeIndex);
+                            ExpandAnimatePresenceInline(walk, presence, position, nodeIndex);
                         }
                         finally
                         {
@@ -777,11 +798,11 @@ namespace Velvet
                         // Regular element: CreateElement / PatchNode reconciles its children via the
                         // host's ReconcileChildren during this walk's commit, so descendant Components
                         // render in-scope of their ancestor Providers without a pre-captured snapshot.
-                        _keying.RegisterScopedKey(node, fragmentKeyScope, nodeIndex);
+                        _keying.RegisterScopedKey(node, position.Scope, nodeIndex);
                         Emit(node, result, commit);
                         break;
                     default:
-                        _keying.RegisterScopedKey(node, fragmentKeyScope, nodeIndex);
+                        _keying.RegisterScopedKey(node, position.Scope, nodeIndex);
                         Emit(node, result, commit);
                         break;
                 }
@@ -799,11 +820,11 @@ namespace Velvet
         private void ExpandMemoInline(
             InlineWalk walk,
             MemoNode memo,
-            string? fragmentKeyScope,
+            WalkPosition position,
             int nodeIndex)
         {
-            var memoScope = FiberKeying.MemoScope(fragmentKeyScope, nodeIndex);
-            var cacheKey = FiberKeying.MemoCacheKey(memo.Key, memoScope);
+            var innerPosition = FiberKeying.MemoInner(position, nodeIndex);
+            var cacheKey = FiberKeying.MemoCacheKey(memo.Key, innerPosition.Scope!);
             var (inner, _, previousCached) = _ctx.FiberMemoCache.GetOrComputeWithHitInfo(cacheKey, memo);
             if (previousCached != null)
             {
@@ -822,7 +843,7 @@ namespace Velvet
                 // Recurse under this memo's own scope so a nested Memo's position key (or an inner
                 // Component's slot key) cannot collide with this memo's scope — e.g. an outer and an
                 // inner unkeyed Memo both at node index 0 would otherwise share cacheKey "{scope}/m0".
-                ExpandInlineRecursive(walk, new[] { inner }, counters, memoScope);
+                ExpandInlineRecursive(walk, new[] { inner }, counters, innerPosition);
             }
             finally
             {
@@ -877,16 +898,18 @@ namespace Velvet
         private void ExpandSuspenseInline(
             InlineWalk walk,
             SuspenseNode suspense,
-            string? fragmentKeyScope,
+            WalkPosition position,
             int nodeIndex)
         {
             var result = walk.Result;
             var newFibers = walk.NewFibers;
             var commit = walk.Commit;
             var boundaryFiber = _ctx.FiberStack.Current;
-            var suspenseKey = FiberKeying.SuspenseKey(fragmentKeyScope, suspense.Key, nodeIndex);
-            var primaryScope = FiberKeying.SuspenseSubtreeScope(suspenseKey, isFallback: false);
-            var fallbackScope = FiberKeying.SuspenseSubtreeScope(suspenseKey, isFallback: true);
+            var suspenseKey = FiberKeying.SuspenseKey(position.Scope, suspense.Key, nodeIndex);
+            var primaryPosition = FiberKeying.SuspenseSubtree(
+                position, suspenseKey, suspense.Key, nodeIndex, isFallback: false);
+            var fallbackPosition = FiberKeying.SuspenseSubtree(
+                position, suspenseKey, suspense.Key, nodeIndex, isFallback: true);
             var stateKey = (boundaryFiber, suspenseKey);
 
             if (walk.IsNewSide)
@@ -905,7 +928,7 @@ namespace Velvet
                         var counters = _ctx.BufferPool.RentPositionCounter();
                         try
                         {
-                            ExpandInlineRecursive(walk, suspense.Children, counters, primaryScope);
+                            ExpandInlineRecursive(walk, suspense.Children, counters, primaryPosition);
                         }
                         catch (FiberSuspendSignal)
                         {
@@ -965,7 +988,7 @@ namespace Velvet
                             var fbCounters = _ctx.BufferPool.RentPositionCounter();
                             try
                             {
-                                ExpandInlineRecursive(walk, new[] { suspense.Fallback }, fbCounters, fallbackScope);
+                                ExpandInlineRecursive(walk, new[] { suspense.Fallback }, fbCounters, fallbackPosition);
                             }
                             finally
                             {
@@ -999,7 +1022,7 @@ namespace Velvet
                     try
                     {
                         ExpandInlineRecursive(walk, nodesToExpand, counters,
-                            wasFallback ? fallbackScope : primaryScope);
+                            wasFallback ? fallbackPosition : primaryPosition);
                     }
                     finally
                     {
@@ -1041,13 +1064,15 @@ namespace Velvet
         private void ExpandAnimatePresenceInline(
             InlineWalk walk,
             AnimatePresenceNode presence,
-            string? fragmentKeyScope,
+            WalkPosition position,
             int nodeIndex)
         {
             var parent = walk.Parent;
             var commit = walk.Commit;
             var boundaryFiber = _ctx.FiberStack.Current;
-            var presenceKey = FiberKeying.PresenceKey(fragmentKeyScope, presence.Key, nodeIndex);
+            var presencePosition = FiberKeying.Presence(position, presence.Key, nodeIndex);
+            // FiberKeying.PresenceKey always composes onto its parent, so this scope is never null.
+            var presenceKey = presencePosition.Scope!;
             // Parent is part of the key so an AnimatePresence nested inside a real element does not collide
             // with an outer one at the same (fiber, scope, index). See ReconcilerContext.PresenceStates.
             var stateKey = (boundaryFiber, parent, presenceKey);
@@ -1061,7 +1086,7 @@ namespace Velvet
                     foreach (var (key, node) in oldState.Committed)
                     {
                         EmitPresenceChildAsAnchor(walk, node,
-                            FiberNodeFactory.FindFirstMotionDescendant(node), key, presenceKey, out _);
+                            FiberNodeFactory.FindFirstMotionDescendant(node), key, presencePosition, out _);
                     }
                 }
                 return;
@@ -1156,13 +1181,13 @@ namespace Velvet
                 {
                     if (!newKeySet.Contains(key))
                     {
-                        ExpandPresenceGhostEntry(walk, key, node, presenceKey,
+                        ExpandPresenceGhostEntry(walk, key, node, presencePosition,
                             state, boundaryFiber, presence, nextCommitted, ref exitIndex, exitCount,
                             ref removedInstantThisRender, exitPass);
                         continue;
                     }
 
-                    ExpandPresenceEnterEntry(walk, key, node, presenceKey,
+                    ExpandPresenceEnterEntry(walk, key, node, presencePosition,
                         state, boundaryFiber, presence, prevCommitted, nextCommitted, newKeyed,
                         blockEnters, firstRender, ref visualIndex);
                 }
@@ -1223,7 +1248,7 @@ namespace Velvet
             InlineWalk walk,
             string key,
             VNode node,
-            string? presenceKey,
+            WalkPosition presencePosition,
             ReconcilerContext.PresenceBoundaryState state,
             ComponentFiber? boundaryFiber,
             AnimatePresenceNode presence,
@@ -1272,7 +1297,7 @@ namespace Velvet
                 return;
             }
 
-            var ghostAnchor = EmitPresenceChildAsAnchor(walk, node, ghostMotionNode, key, presenceKey,
+            var ghostAnchor = EmitPresenceChildAsAnchor(walk, node, ghostMotionNode, key, presencePosition,
                 out var ghostMotionElement);
             // A ghost reproduces the SAME committed node on both diff sides, so the patch that
             // would re-record the Motion's element bails on reference equality — fall back to
@@ -1395,7 +1420,7 @@ namespace Velvet
             InlineWalk walk,
             string key,
             VNode node,
-            string? presenceKey,
+            WalkPosition presencePosition,
             ReconcilerContext.PresenceBoundaryState state,
             ComponentFiber? boundaryFiber,
             AnimatePresenceNode presence,
@@ -1421,7 +1446,7 @@ namespace Velvet
             // gate, so CreateElement can tell this SAME node (which the dispatch below is about to
             // explicitly animate) apart from every OTHER Motion the emission below might create.
             var motion = FiberNodeFactory.FindFirstMotionDescendant(node);
-            var anchor = EmitPresenceChildAsAnchor(walk, node, motion, key, presenceKey,
+            var anchor = EmitPresenceChildAsAnchor(walk, node, motion, key, presencePosition,
                 out var motionElement);
             // Same memo discipline as the ghost path: record when this emission resolved the
             // element (create or genuine patch), fall back to the memo when a no-op re-render's
@@ -1727,15 +1752,15 @@ namespace Velvet
             InlineWalk walk,
             VNode? node,
             string? key,
-            string? presenceScope)
+            WalkPosition presencePosition)
         {
             var commit = walk.Commit;
             var startIdx = commit != null ? commit.NewElements.Count : walk.Result!.Count;
-            var childScope = FiberKeying.PresenceChildScope(presenceScope, key);
+            var childPosition = FiberKeying.PresenceChild(presencePosition, key);
             var counters = _ctx.BufferPool.RentPositionCounter();
             try
             {
-                ExpandInlineRecursive(walk, new[] { node }, counters, childScope);
+                ExpandInlineRecursive(walk, new[] { node }, counters, childPosition);
             }
             finally
             {
@@ -1782,7 +1807,7 @@ namespace Velvet
             VNode? node,
             MotionNode? anchorMotion,
             string? key,
-            string? presenceScope,
+            WalkPosition presencePosition,
             out VisualElement? anchorMotionElement)
         {
             var previousAnchor = _ctx.PresenceAnchorMotion;
@@ -1791,7 +1816,7 @@ namespace Velvet
             _ctx.PresenceAnchorMotionElement = null;
             try
             {
-                var emitted = EmitPresenceChild(walk, node, key, presenceScope);
+                var emitted = EmitPresenceChild(walk, node, key, presencePosition);
                 anchorMotionElement = _ctx.PresenceAnchorMotionElement;
                 return emitted;
             }

--- a/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerBufferPool.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerBufferPool.cs
@@ -92,14 +92,10 @@ namespace Velvet
 
         #region ChildReconciler — for inline ContextProviderNode tracking
 
-        private readonly ClearablePool<Dictionary<ProviderPairKey, ContextProviderNode>> _providerMapPool = new(m => m.Clear());
-        private readonly ClearablePool<Dictionary<ProviderPairKey, int>> _providerOccurrencePool = new(m => m.Clear());
+        private readonly ClearablePool<GeneralPathReconciler.ProviderPairTable> _providerTablePool = new(t => t.Clear());
 
-        public Dictionary<ProviderPairKey, ContextProviderNode> RentProviderMap() => _providerMapPool.Rent();
-        public void ReturnProviderMap(Dictionary<ProviderPairKey, ContextProviderNode> map) => _providerMapPool.Return(map);
-
-        public Dictionary<ProviderPairKey, int> RentProviderOccurrenceMap() => _providerOccurrencePool.Rent();
-        public void ReturnProviderOccurrenceMap(Dictionary<ProviderPairKey, int> map) => _providerOccurrencePool.Return(map);
+        public GeneralPathReconciler.ProviderPairTable RentProviderTable() => _providerTablePool.Rent();
+        public void ReturnProviderTable(GeneralPathReconciler.ProviderPairTable table) => _providerTablePool.Return(table);
 
         #endregion
 

--- a/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerBufferPool.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerBufferPool.cs
@@ -92,10 +92,14 @@ namespace Velvet
 
         #region ChildReconciler — for inline ContextProviderNode tracking
 
-        private readonly ClearablePool<List<ContextProviderNode>> _providerListPool = new(l => l.Clear());
+        private readonly ClearablePool<Dictionary<ProviderPairKey, ContextProviderNode>> _providerMapPool = new(m => m.Clear());
+        private readonly ClearablePool<Dictionary<ProviderPairKey, int>> _providerOccurrencePool = new(m => m.Clear());
 
-        public List<ContextProviderNode> RentProviderList() => _providerListPool.Rent();
-        public void ReturnProviderList(List<ContextProviderNode> list) => _providerListPool.Return(list);
+        public Dictionary<ProviderPairKey, ContextProviderNode> RentProviderMap() => _providerMapPool.Rent();
+        public void ReturnProviderMap(Dictionary<ProviderPairKey, ContextProviderNode> map) => _providerMapPool.Return(map);
+
+        public Dictionary<ProviderPairKey, int> RentProviderOccurrenceMap() => _providerOccurrencePool.Rent();
+        public void ReturnProviderOccurrenceMap(Dictionary<ProviderPairKey, int> map) => _providerOccurrencePool.Return(map);
 
         #endregion
 

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ProviderPositionPairingTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ProviderPositionPairingTests.cs
@@ -19,6 +19,9 @@ namespace Velvet.Tests
     /// <item>A Provider inside a Suspense fallback keeps notifying its consumers while the primary subtree
     /// also declares one.</item>
     /// <item>With two Providers in a fallback, the last one keeps notifying its consumers.</item>
+    /// <item>A Provider whose own sibling index moves — a preceding child appearing in a longer children
+    /// array — still notifies its consumers: a position with no counterpart on the old side falls back to
+    /// pairing in walk order rather than treating the Provider as newly mounted.</item>
     /// </list>
     /// </summary>
     /// <remarks>
@@ -120,6 +123,23 @@ namespace Velvet.Tests
                 "Each fallback Provider keeps its own position, so the last one is not pushed past the end of the old side");
         }
 
+        [Test]
+        public void Given_ProviderPrecededByAppearingSibling_When_ItsValueChanges_Then_ConsumerRendersNewValue()
+        {
+            // Arrange
+            using var mounted = V.Mount(_root, V.Component(ShiftedSiblingIndexHostRender, key: "host"));
+            Assume.That(_root.Q<Label>("consumer")?.text, Is.EqualTo("initial"),
+                "Precondition: the consumer mounted with the initial value as the only child");
+
+            // Act
+            s_setTick.Invoke(1);
+            mounted.FlushStateForTest();
+
+            // Assert
+            Assert.That(_root.Q<Label>("consumer")?.text, Is.EqualTo("updated"),
+                "A non-Provider child appearing ahead of it moves the Provider's sibling index but not its place in walk order");
+        }
+
         #region Consumer
 
         // Memoized with no props: only a context notification can re-render it, so its Label goes stale
@@ -161,6 +181,22 @@ namespace Velvet.Tests
                     V.Component(MemoizedConsumerRender, key: "consumer"),
                 }),
             });
+        }
+
+        // The children array grows by a non-Provider child ahead of the Provider, so the Provider keeps its
+        // place in walk order (still the first and only one) while its sibling index moves from 0 to 1.
+        [Component]
+        private static VNode ShiftedSiblingIndexHostRender()
+        {
+            var (tick, setTick) = Hooks.UseState(0);
+            s_setTick = setTick;
+            var themeProvider = V.Provider(ThemeContext, tick == 0 ? "initial" : "updated", new VNode[]
+            {
+                V.Component(MemoizedConsumerRender, key: "consumer"),
+            });
+            return V.Div(name: "host", children: tick == 0
+                ? new VNode[] { themeProvider }
+                : new VNode[] { V.Label(text: "banner"), themeProvider });
         }
 
         [Component]

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ProviderPositionPairingTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ProviderPositionPairingTests.cs
@@ -1,0 +1,236 @@
+using System;
+using System.Threading;
+using Cysharp.Threading.Tasks;
+using NUnit.Framework;
+using UnityEngine.UIElements;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Specifies that the inline-expansion walk compares a Provider against the Provider that held the same
+    /// tree position on the previous render, so a value change always reaches the consumers below it — even
+    /// when the number of Providers the walk emits before it differs between the two sides.
+    /// <list type="bullet">
+    /// <item>A conditional Provider appearing earlier among its siblings does not stop a later Provider's own
+    /// value change from reaching its consumers.</item>
+    /// <item>A Provider placed after a suspended Suspense keeps notifying its consumers while the boundary's
+    /// primary subtree — which contributes its own Providers to the walk before suspending — stays pending.</item>
+    /// <item>A Provider inside a Suspense fallback keeps notifying its consumers while the primary subtree
+    /// also declares one.</item>
+    /// <item>With two Providers in a fallback, the last one keeps notifying its consumers.</item>
+    /// </list>
+    /// </summary>
+    /// <remarks>
+    /// Uses the <c>[Component] static VNode</c> + <c>V.Mount</c> + static-field exposure pattern. Each host
+    /// drives every value it changes from a single <c>UseState</c> tick, so one setter call produces exactly
+    /// one re-render in which the Provider sequence and the observed Provider's value change together. The
+    /// consumer is <c>[Component(Memoize = true)]</c> with no props: it re-renders only when the context
+    /// notification marks it dirty, so a missed notification is visible as a stale Label in the tree — a plain
+    /// consumer would be re-rendered by the parent walk regardless and hide the defect. The suspending child
+    /// is driven by a <see cref="UniTaskCompletionSource{T}"/> that is deliberately left pending.
+    /// </remarks>
+    [TestFixture]
+    internal sealed class ProviderPositionPairingTests
+    {
+        private static readonly ComponentContext<string> ThemeContext = ComponentContext<string>.Create("theme-default");
+        private static readonly ComponentContext<string> OtherContext = ComponentContext<string>.Create("other-default");
+
+        private VisualElement _root;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _root = new VisualElement();
+            s_setTick = null;
+            s_pendingFactory = null;
+        }
+
+        [Test]
+        public void Given_ProviderAfterConditionalSibling_When_SiblingAppearsAsValueChanges_Then_ConsumerRendersNewValue()
+        {
+            // Arrange
+            using var mounted = V.Mount(_root, V.Component(ConditionalSiblingHostRender, key: "host"));
+            Assume.That(_root.Q<Label>("consumer")?.text, Is.EqualTo("initial"),
+                "Precondition: the consumer mounted with the initial value");
+
+            // Act
+            s_setTick.Invoke(1);
+            mounted.FlushStateForTest();
+
+            // Assert
+            Assert.That(_root.Q<Label>("consumer")?.text, Is.EqualTo("updated"),
+                "A Provider appearing before it in the same render does not cost the second Provider its own change notification");
+        }
+
+        [Test]
+        public void Given_ProviderAfterSuspendedBoundary_When_ItsValueChanges_Then_ConsumerRendersNewValue()
+        {
+            // Arrange
+            var pending = new UniTaskCompletionSource<string>();
+            s_pendingFactory = _ => pending.Task;
+            using var mounted = V.Mount(_root, V.Component(SuspenseThenProviderHostRender, key: "host"));
+            Assume.That(_root.Q<Label>("consumer")?.text, Is.EqualTo("initial"),
+                "Precondition: the consumer mounted with the initial value beside the suspended boundary");
+
+            // Act
+            s_setTick.Invoke(1);
+            mounted.FlushStateForTest();
+
+            // Assert
+            Assert.That(_root.Q<Label>("consumer")?.text, Is.EqualTo("updated"),
+                "A Provider following a still-pending Suspense observes its own previous value, not the boundary's");
+        }
+
+        [Test]
+        public void Given_ProvidersInBothSuspenseBranches_When_FallbackProviderValueChanges_Then_ConsumerRendersNewValue()
+        {
+            // Arrange
+            var pending = new UniTaskCompletionSource<string>();
+            s_pendingFactory = _ => pending.Task;
+            using var mounted = V.Mount(_root, V.Component(BothBranchesProviderHostRender, key: "host"));
+            Assume.That(_root.Q<Label>("consumer")?.text, Is.EqualTo("initial"),
+                "Precondition: the fallback's consumer mounted with the initial value");
+
+            // Act
+            s_setTick.Invoke(1);
+            mounted.FlushStateForTest();
+
+            // Assert
+            Assert.That(_root.Q<Label>("consumer")?.text, Is.EqualTo("updated"),
+                "The fallback's Provider is compared against the fallback's previous Provider, not the primary's");
+        }
+
+        [Test]
+        public void Given_TwoProvidersInSuspenseFallback_When_LastProviderValueChanges_Then_ConsumerRendersNewValue()
+        {
+            // Arrange
+            var pending = new UniTaskCompletionSource<string>();
+            s_pendingFactory = _ => pending.Task;
+            using var mounted = V.Mount(_root, V.Component(TwoFallbackProvidersHostRender, key: "host"));
+            Assume.That(_root.Q<Label>("consumer")?.text, Is.EqualTo("initial"),
+                "Precondition: the consumer under the fallback's second Provider mounted with the initial value");
+
+            // Act
+            s_setTick.Invoke(1);
+            mounted.FlushStateForTest();
+
+            // Assert
+            Assert.That(_root.Q<Label>("consumer")?.text, Is.EqualTo("updated"),
+                "Each fallback Provider keeps its own position, so the last one is not pushed past the end of the old side");
+        }
+
+        #region Consumer
+
+        // Memoized with no props: only a context notification can re-render it, so its Label goes stale
+        // exactly when the notification is missed.
+        [Component(Memoize = true)]
+        private static VNode MemoizedConsumerRender()
+            => V.Label(name: "consumer", text: Hooks.UseContext(ThemeContext));
+
+        #endregion
+
+        #region Suspending child
+
+        private static Func<CancellationToken, UniTask<string>> s_pendingFactory;
+
+        // The factory lambda captures only a static field, so its delegate identity is stable across renders
+        // and the resource is not re-fetched per render.
+        [Component]
+        private static VNode PendingChildRender()
+            => V.Label(text: Hooks.Use(ct => s_pendingFactory(ct)));
+
+        #endregion
+
+        #region Hosts (one tick drives both the Provider sequence and the observed value)
+
+        private static Action<int> s_setTick;
+
+        [Component]
+        private static VNode ConditionalSiblingHostRender()
+        {
+            var (tick, setTick) = Hooks.UseState(0);
+            s_setTick = setTick;
+            return V.Div(name: "host", children: new VNode[]
+            {
+                tick == 0
+                    ? null
+                    : V.Provider(OtherContext, "leading", new VNode[] { V.Label(text: "leading") }),
+                V.Provider(ThemeContext, tick == 0 ? "initial" : "updated", new VNode[]
+                {
+                    V.Component(MemoizedConsumerRender, key: "consumer"),
+                }),
+            });
+        }
+
+        [Component]
+        private static VNode SuspenseThenProviderHostRender()
+        {
+            var (tick, setTick) = Hooks.UseState(0);
+            s_setTick = setTick;
+            return V.Div(name: "host", children: new VNode[]
+            {
+                V.Suspense(
+                    fallback: V.Label(text: "loading"),
+                    children: new VNode[]
+                    {
+                        V.Provider(OtherContext, "primary", new VNode[]
+                        {
+                            V.Component(PendingChildRender, key: "async"),
+                        }),
+                    }),
+                V.Provider(ThemeContext, tick == 0 ? "initial" : "updated", new VNode[]
+                {
+                    V.Component(MemoizedConsumerRender, key: "consumer"),
+                }),
+            });
+        }
+
+        [Component]
+        private static VNode BothBranchesProviderHostRender()
+        {
+            var (tick, setTick) = Hooks.UseState(0);
+            s_setTick = setTick;
+            return V.Suspense(
+                fallback: V.Provider(ThemeContext, tick == 0 ? "initial" : "updated", new VNode[]
+                {
+                    V.Component(MemoizedConsumerRender, key: "consumer"),
+                }),
+                children: new VNode[]
+                {
+                    V.Provider(OtherContext, "primary", new VNode[]
+                    {
+                        V.Component(PendingChildRender, key: "async"),
+                    }),
+                });
+        }
+
+        [Component]
+        private static VNode TwoFallbackProvidersHostRender()
+        {
+            var (tick, setTick) = Hooks.UseState(0);
+            s_setTick = setTick;
+            return V.Suspense(
+                fallback: V.Fragment(new VNode[]
+                {
+                    V.Provider(OtherContext, tick == 0 ? "first" : "first-updated", new VNode[]
+                    {
+                        V.Label(text: "sibling"),
+                    }),
+                    V.Provider(ThemeContext, tick == 0 ? "initial" : "updated", new VNode[]
+                    {
+                        V.Component(MemoizedConsumerRender, key: "consumer"),
+                    }),
+                }),
+                children: new VNode[]
+                {
+                    V.Provider(OtherContext, "primary", new VNode[]
+                    {
+                        V.Component(PendingChildRender, key: "async"),
+                    }),
+                });
+        }
+
+        #endregion
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ProviderPositionPairingTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ProviderPositionPairingTests.cs
@@ -22,6 +22,13 @@ namespace Velvet.Tests
     /// <item>A Provider whose own sibling index moves — a preceding child appearing in a longer children
     /// array — still notifies its consumers: a position with no counterpart on the old side falls back to
     /// pairing in walk order rather than treating the Provider as newly mounted.</item>
+    /// <item>Two Providers each at index 0 of their own unkeyed Fragment hold distinct positions, so one of
+    /// those Fragments appearing does not displace the other Provider's comparison. Neither Fragment reaches
+    /// the fiber-keying scope chain — it stays null for both Providers — so this is the case that requires
+    /// the position to be a structural path of its own rather than that scope.</item>
+    /// <item>A Provider matched by position takes its place in walk order all the same, so a later Provider
+    /// that falls back to walk order lands on its own counterpart rather than on the one already matched
+    /// ahead of it.</item>
     /// </list>
     /// </summary>
     /// <remarks>
@@ -140,6 +147,40 @@ namespace Velvet.Tests
                 "A non-Provider child appearing ahead of it moves the Provider's sibling index but not its place in walk order");
         }
 
+        [Test]
+        public void Given_ProvidersInSeparateFragments_When_OneFragmentAppearsAsValueChanges_Then_ConsumerRendersNewValue()
+        {
+            // Arrange
+            using var mounted = V.Mount(_root, V.Component(SeparateFragmentsHostRender, key: "host"));
+            Assume.That(_root.Q<Label>("consumer")?.text, Is.EqualTo("initial"),
+                "Precondition: the consumer mounted with the initial value under the second Fragment");
+
+            // Act
+            s_setTick.Invoke(1);
+            mounted.FlushStateForTest();
+
+            // Assert
+            Assert.That(_root.Q<Label>("consumer")?.text, Is.EqualTo("updated"),
+                "Each Fragment gives the Provider under it a position of its own, which the fiber-keying scope alone does not");
+        }
+
+        [Test]
+        public void Given_ProviderMatchedByPosition_When_ALaterProviderFallsBackToWalkOrder_Then_ConsumerRendersNewValue()
+        {
+            // Arrange
+            using var mounted = V.Mount(_root, V.Component(PositionHitThenMissHostRender, key: "host"));
+            Assume.That(_root.Q<Label>("consumer")?.text, Is.EqualTo("initial"),
+                "Precondition: the consumer mounted with the initial value under the second Provider");
+
+            // Act
+            s_setTick.Invoke(1);
+            mounted.FlushStateForTest();
+
+            // Assert
+            Assert.That(_root.Q<Label>("consumer")?.text, Is.EqualTo("updated"),
+                "The Provider matched by position still takes walk-order slot 0, leaving slot 1 for the one that falls back");
+        }
+
         #region Consumer
 
         // Memoized with no props: only a context notification can re-render it, so its Label goes stale
@@ -197,6 +238,51 @@ namespace Velvet.Tests
             return V.Div(name: "host", children: tick == 0
                 ? new VNode[] { themeProvider }
                 : new VNode[] { V.Label(text: "banner"), themeProvider });
+        }
+
+        // Each Provider is the only child of its own unkeyed Fragment, so both sit at node index 0 and neither
+        // Fragment contributes to the fiber-keying scope (it stays null throughout). Only a position that
+        // descends through the Fragments themselves tells the two apart.
+        [Component]
+        private static VNode SeparateFragmentsHostRender()
+        {
+            var (tick, setTick) = Hooks.UseState(0);
+            s_setTick = setTick;
+            return V.Div(name: "host", children: new VNode[]
+            {
+                tick == 0
+                    ? null
+                    : V.Fragment(new VNode[]
+                    {
+                        V.Provider(OtherContext, "leading", new VNode[] { V.Label(text: "leading") }),
+                    }),
+                V.Fragment(new VNode[]
+                {
+                    V.Provider(ThemeContext, tick == 0 ? "initial" : "updated", new VNode[]
+                    {
+                        V.Component(MemoizedConsumerRender, key: "consumer"),
+                    }),
+                }),
+            });
+        }
+
+        // The first Provider keeps its index and so is matched by position; the second is pushed along by the
+        // appearing banner and falls back to walk order. Both provide the same context, and the first one's
+        // value is what the second one is changing TO — so pairing the second against the first reads as "no
+        // change" and notifies nobody, which is what makes the ordinal a position hit consumes observable.
+        [Component]
+        private static VNode PositionHitThenMissHostRender()
+        {
+            var (tick, setTick) = Hooks.UseState(0);
+            s_setTick = setTick;
+            var pinned = V.Provider(ThemeContext, "updated", new VNode[] { V.Label(text: "pinned") });
+            var observed = V.Provider(ThemeContext, tick == 0 ? "initial" : "updated", new VNode[]
+            {
+                V.Component(MemoizedConsumerRender, key: "consumer"),
+            });
+            return V.Div(name: "host", children: tick == 0
+                ? new VNode[] { pinned, observed }
+                : new VNode[] { pinned, V.Label(text: "banner"), observed });
         }
 
         [Component]

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ProviderPositionPairingTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ProviderPositionPairingTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 96cc4825eb3694eb388543c4f1aa1022


### PR DESCRIPTION
## What & why

Context providers were matched between the previous and current trees by a flat counter: the nth provider encountered on one side was compared against the nth on the other. Whenever the current tree momentarily held more providers than the previous one, every provider after that point was compared against the wrong one — one received a change notification it should not have, and the last fell off the end and received none at all.

A provider that gets no notification leaves memoized consumers below it rendering the previous value **indefinitely**. Non-memoized consumers are swept up by the parent's own re-render, which is why the existing context suites never caught this. In an app it looks like a theme or locale change that applies everywhere except the part of the screen that is still loading.

Four ordinary shapes reproduce it: a provider inside a suspended subtree while another sits in the fallback, a provider merely positioned after a suspense boundary, two providers in one fallback, and — with no suspense involved at all — a conditional provider appearing beside another in the same render that changes the second one's value.

Providers are now matched by their position in the tree: the enclosing fiber, a structural path from the walk root, and the provider's own key or sibling index. The path is composed at every level and never collapses, so nesting depth and distinct sibling arrays are distinguished on their own.

**Position matching alone would have regressed a case the counter got right**, so both are kept. A provider whose sibling index shifts — `[provider]` becoming `[banner, provider]` — has no counterpart at its new position, but its walk order is unchanged. The previous side is therefore recorded twice, by position and in walk order, and a position miss falls back to the order. That makes the scheme monotone: a position hit is only ever more accurate than the order it replaces, and a miss is byte-for-byte the previous behaviour, so no match the old code got right can be lost.

The residual limit is narrow and documented on the factory: a provider that shifts index *and* whose walk order changes is missed by both, and an explicit key fixes it — the key pins the provider's own contribution, though not the path above it, so if an unkeyed enclosing element is what moves, the key belongs there instead.

## Cost

Measured against main on a provider-dense benchmark where every node is a provider: +5.4% and +4.6% on the two expansion cases, with **allocation unchanged on every run**. Nothing is replaced — the walk gains the per-level path arithmetic and one dictionary operation per provider per side while keeping the previous walk-order list. The noise floor was established at 2.2–3.4% by running an identical build five times, so these sit just above it.

## Checklist

- [x] Tests pass locally (EditMode / PlayMode / generator tests as applicable) — EditMode 3364 passed / 0 failed, PlayMode 99 / 99
- [x] New regression tests were verified red without the change and green with it — seven tests run against three implementations: four are red on main, one is red only under position matching without the fallback, one is red under both prior schemes and is what pins the structural path, and one pins that a position hit still consumes an order slot, verified by applying that exact mutation and seeing precisely one test fail
- [x] Docs are updated for every fact this change touches (guides, READMEs, CLAUDE.md) — or this PR has no doc impact — no guide describes provider matching; the factory's own documentation and the CHANGELOG own it
- [x] CHANGELOG updated for behavior/perf changes (pure refactors are omitted by convention)
- [x] Known gaps or deliberate deferrals discovered here are filed as issues with acceptance criteria — two limits are stated in code rather than filed, as properties of the rule: two sibling providers sharing one explicit key collapse to one position and the second matches by order instead, and the adjacent case where a provider is replaced by one of a different context leaves consumers of the vanished context unnotified, which is a separate mechanism on a different code path