### PR TITLE
fix(velvet): deploy both generator artifacts from either build script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,11 +24,12 @@ The Roslyn source generators live under `Packages/com.velvet.core/Generators~/` 
 ```bash
 cd Packages/com.velvet.core/Generators~
 dotnet test Velvet.SourceGenerators.sln -c Release   # run generator unit tests
-./build.sh                                            # rebuild + deploy the DLLs to Runtime/Plugins
 ```
 
-The compiled DLLs under `Packages/com.velvet.core/Runtime/Plugins/` are committed. After changing
-generator source, rebuild with `./build.sh` and commit the updated DLLs.
+The compiled DLLs under `Packages/com.velvet.core/Runtime/Plugins/` are committed, so a change to
+generator source is only complete once they are rebuilt and committed too. Build and DLL-shipping
+steps live in [Generators~/README.md](Packages/com.velvet.core/Generators~/README.md) — `./build.sh`
+on macOS / Linux, `./build.ps1` on Windows.
 
 ## Continuous integration
 

--- a/Packages/com.velvet.core/Documentation~/memoization.md
+++ b/Packages/com.velvet.core/Documentation~/memoization.md
@@ -54,5 +54,5 @@ For a complete list including the `ReactiveScopeAnalyzer` and `PurityAnalyzer` d
 
 ## See also
 
-- [`Generators~/README.md`](https://github.com/s4k10503/velvet/blob/main/Packages/com.velvet.core/Generators~/README.md) — contributor guide for building, testing, and shipping the Source Generator DLL
+- [`Generators~/README.md`](https://github.com/s4k10503/velvet/blob/main/Packages/com.velvet.core/Generators~/README.md) — contributor guide for building, testing, and shipping the generator and code-fix assemblies
 - `[Component(Memoize = true)]` — component-level memoization (`React.memo` equivalent)

--- a/Packages/com.velvet.core/Generators~/README.md
+++ b/Packages/com.velvet.core/Generators~/README.md
@@ -11,6 +11,8 @@ Run the following inside the `Generators~/` directory:
 ./build.ps1   # Windows
 ```
 
+On Windows, run `build.ps1` from PowerShell 7 (`pwsh`) and close Unity and any IDE first: Windows PowerShell 5.1's default execution policy refuses unsigned scripts, and Windows cannot overwrite an analyzer assembly a Roslyn host still holds open.
+
 Either script rebuilds and deploys both shipped assemblies, leaving the tree in the same state:
 
 - `../Runtime/Plugins/Generators/Velvet.SourceGenerators.dll`
@@ -76,6 +78,6 @@ This README is now scoped to **contributor concerns** (build / test / DLL shippi
 
 Which paths trigger it is stated in the repository's `CLAUDE.md`; the reason `Runtime/**` is among them is that the two drift guards read the runtime sources, so a PR that only renames a hook or reshapes its signature must still run this job.
 
-**CI does not check the committed DLLs under `../Runtime/Plugins/` at all.** It tests the sources; it never compares the deployed assemblies against a rebuild, so a PR that edits generator sources and forgets to rerun `build.sh` goes green while Unity keeps consuming the stale binaries. Rebuilding and committing them is the contributor's responsibility.
+**CI does not check the committed DLLs under `../Runtime/Plugins/` at all.** It tests the sources; it never compares the deployed assemblies against a rebuild, so a PR that edits generator sources and forgets to rerun the build script goes green while Unity keeps consuming the stale binaries. Rebuilding and committing them is the contributor's responsibility.
 
 A plain `git diff --exit-code` on the deployed DLLs would not close that gap either: the build embeds the git `HEAD` commit id in the assembly, so rebuilding at commit *N* never reproduces the DLL committed *in* commit *N* (it was necessarily built at *N-1*). The build is otherwise deterministic — repeated rebuilds of unchanged sources at the same `HEAD` are byte-identical.

--- a/Packages/com.velvet.core/Generators~/README.md
+++ b/Packages/com.velvet.core/Generators~/README.md
@@ -11,12 +11,10 @@ Run the following inside the `Generators~/` directory:
 ./build.ps1   # Windows
 ```
 
-`build.sh` rebuilds and deploys both shipped assemblies:
+Either script rebuilds and deploys both shipped assemblies, leaving the tree in the same state:
 
 - `../Runtime/Plugins/Generators/Velvet.SourceGenerators.dll`
 - `../Runtime/Plugins/Analyzers/Velvet.SourceGenerators.CodeFixes.dll`
-
-`build.ps1` currently deploys only the first; after changing the CodeFixes project on Windows, build and copy that assembly by hand.
 
 Commit both rebuilt DLLs. The distribution model assumes Unity users do not need to install `dotnet`.
 

--- a/Packages/com.velvet.core/Generators~/build.ps1
+++ b/Packages/com.velvet.core/Generators~/build.ps1
@@ -12,19 +12,22 @@ $CodeFixProject = 'src/Velvet.SourceGenerators.CodeFixes/Velvet.SourceGenerators
 $CodeFixDll = "src/Velvet.SourceGenerators.CodeFixes/bin/$Configuration/netstandard2.0/Velvet.SourceGenerators.CodeFixes.dll"
 $CodeFixDeployDir = '../Runtime/Plugins/Analyzers'
 
+# Both assemblies build before either is deployed: a failure in the second build
+# would otherwise leave one refreshed DLL beside one stale DLL, which is the
+# mismatch the deployed pair exists to avoid.
 Write-Host "[Velvet.SourceGenerators] dotnet build -c $Configuration"
 dotnet build $Project -c $Configuration --nologo
-if ($LASTEXITCODE -ne 0) { throw "dotnet build failed" }
+if ($LASTEXITCODE -ne 0) { throw "dotnet build failed: $Project" }
+
+Write-Host "[Velvet.SourceGenerators.CodeFixes] dotnet build -c $Configuration"
+dotnet build $CodeFixProject -c $Configuration --nologo
+if ($LASTEXITCODE -ne 0) { throw "dotnet build failed: $CodeFixProject" }
 
 if (-not (Test-Path -LiteralPath $DeployDir)) {
     New-Item -ItemType Directory -Path $DeployDir -Force | Out-Null
 }
 Copy-Item -LiteralPath $OutputDll -Destination (Join-Path $DeployDir 'Velvet.SourceGenerators.dll') -Force
 Write-Host "[Velvet.SourceGenerators] Deployed to $DeployDir/Velvet.SourceGenerators.dll"
-
-Write-Host "[Velvet.SourceGenerators.CodeFixes] dotnet build -c $Configuration"
-dotnet build $CodeFixProject -c $Configuration --nologo
-if ($LASTEXITCODE -ne 0) { throw "dotnet build failed" }
 
 if (-not (Test-Path -LiteralPath $CodeFixDeployDir)) {
     New-Item -ItemType Directory -Path $CodeFixDeployDir -Force | Out-Null

--- a/Packages/com.velvet.core/Generators~/build.ps1
+++ b/Packages/com.velvet.core/Generators~/build.ps1
@@ -8,6 +8,10 @@ $Project = 'src/Velvet.SourceGenerators/Velvet.SourceGenerators.csproj'
 $OutputDll = "src/Velvet.SourceGenerators/bin/$Configuration/netstandard2.0/Velvet.SourceGenerators.dll"
 $DeployDir = '../Runtime/Plugins/Generators'
 
+$CodeFixProject = 'src/Velvet.SourceGenerators.CodeFixes/Velvet.SourceGenerators.CodeFixes.csproj'
+$CodeFixDll = "src/Velvet.SourceGenerators.CodeFixes/bin/$Configuration/netstandard2.0/Velvet.SourceGenerators.CodeFixes.dll"
+$CodeFixDeployDir = '../Runtime/Plugins/Analyzers'
+
 Write-Host "[Velvet.SourceGenerators] dotnet build -c $Configuration"
 dotnet build $Project -c $Configuration --nologo
 if ($LASTEXITCODE -ne 0) { throw "dotnet build failed" }
@@ -17,3 +21,13 @@ if (-not (Test-Path -LiteralPath $DeployDir)) {
 }
 Copy-Item -LiteralPath $OutputDll -Destination (Join-Path $DeployDir 'Velvet.SourceGenerators.dll') -Force
 Write-Host "[Velvet.SourceGenerators] Deployed to $DeployDir/Velvet.SourceGenerators.dll"
+
+Write-Host "[Velvet.SourceGenerators.CodeFixes] dotnet build -c $Configuration"
+dotnet build $CodeFixProject -c $Configuration --nologo
+if ($LASTEXITCODE -ne 0) { throw "dotnet build failed" }
+
+if (-not (Test-Path -LiteralPath $CodeFixDeployDir)) {
+    New-Item -ItemType Directory -Path $CodeFixDeployDir -Force | Out-Null
+}
+Copy-Item -LiteralPath $CodeFixDll -Destination (Join-Path $CodeFixDeployDir 'Velvet.SourceGenerators.CodeFixes.dll') -Force
+Write-Host "[Velvet.SourceGenerators.CodeFixes] Deployed to $CodeFixDeployDir/Velvet.SourceGenerators.CodeFixes.dll"

--- a/Packages/com.velvet.core/Generators~/build.sh
+++ b/Packages/com.velvet.core/Generators~/build.sh
@@ -12,15 +12,18 @@ CODEFIX_PROJECT="src/Velvet.SourceGenerators.CodeFixes/Velvet.SourceGenerators.C
 CODEFIX_DLL="src/Velvet.SourceGenerators.CodeFixes/bin/${CONFIGURATION}/netstandard2.0/Velvet.SourceGenerators.CodeFixes.dll"
 CODEFIX_DEPLOY_DIR="../Runtime/Plugins/Analyzers"
 
+# Both assemblies build before either is deployed: a failure in the second build
+# would otherwise leave one refreshed DLL beside one stale DLL, which is the
+# mismatch the deployed pair exists to avoid.
 echo "[Velvet.SourceGenerators] dotnet build -c ${CONFIGURATION}"
 dotnet build "${PROJECT}" -c "${CONFIGURATION}" --nologo
+
+echo "[Velvet.SourceGenerators.CodeFixes] dotnet build -c ${CONFIGURATION}"
+dotnet build "${CODEFIX_PROJECT}" -c "${CONFIGURATION}" --nologo
 
 mkdir -p "${DEPLOY_DIR}"
 cp -f "${OUTPUT_DLL}" "${DEPLOY_DIR}/Velvet.SourceGenerators.dll"
 echo "[Velvet.SourceGenerators] Deployed to ${DEPLOY_DIR}/Velvet.SourceGenerators.dll"
-
-echo "[Velvet.SourceGenerators.CodeFixes] dotnet build -c ${CONFIGURATION}"
-dotnet build "${CODEFIX_PROJECT}" -c "${CONFIGURATION}" --nologo
 
 mkdir -p "${CODEFIX_DEPLOY_DIR}"
 cp -f "${CODEFIX_DLL}" "${CODEFIX_DEPLOY_DIR}/Velvet.SourceGenerators.CodeFixes.dll"


### PR DESCRIPTION
## What

`Generators~/build.ps1` built and copied only `Velvet.SourceGenerators.dll`. A contributor on Windows following the build instructions shipped a stale `Velvet.SourceGenerators.CodeFixes.dll` while believing both had been rebuilt. It now builds the code-fixes project and copies its output to `Runtime/Plugins/Analyzers/`, mirroring `build.sh`.

Both scripts also deployed each assembly right after building it, so a failure in the second build left a refreshed generator DLL beside a stale code-fix DLL — the same mismatch, reached from the other side. Both now build both projects and deploy only once both succeed.

## Verification

Run under `pwsh` 7.6.4 (macOS), since the acceptance criteria rule out a change that has only been reasoned about:

- The pre-fix script leaves `Analyzers/Velvet.SourceGenerators.CodeFixes.dll` missing after a clean wipe; the fixed script deploys both.
- Running the fixed `build.ps1` and then `build.sh` from a wiped state produces **byte-identical** DLLs — same sha256 for both files — so the two scripts leave the tree in the same state, not merely a similar one.
- With a deliberately broken code-fixes project: the previous ordering deploys the generator DLL anyway; the new ordering deploys neither.

The committed DLLs are unchanged — no generator source moved.

## Docs

`Generators~/README.md` owns the build steps. Its standing caveat that `build.ps1` deploys only the first assembly is gone, its CI paragraph no longer names `build.sh` specifically as the script one forgets to rerun, and it now states the two Windows preconditions the scripts cannot enforce themselves: an execution policy that permits unsigned scripts, and no Roslyn host holding the analyzer assemblies open. `CONTRIBUTING.md` links that guide instead of restating a bash-only rebuild step, and `Documentation~/memoization.md` describes the guide as covering both shipped assemblies rather than one DLL.

No `Documentation~` guide documents the generator build scripts, so the doc impact is exactly the files above.

## CHANGELOG

Not updated. The package's runtime behavior is unchanged; this is contributor tooling, which this CHANGELOG has never carried.

Closes #157