### PR TITLE
test(velvet): fold recognition preconditions into the motion driver assertions

### DIFF
--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/BezierTweenDriverTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/BezierTweenDriverTests.cs
@@ -31,7 +31,10 @@ namespace Velvet.Tests
     /// same WebKit UnitBezier Newton/bisection algorithm every browser's <c>cubic-bezier()</c> is built on. The
     /// warn-once static is reset before/after every test (reflection, mirroring DropShadowBakeTests) so the
     /// out-of-range cases stay deterministic regardless of run order or of another fixture having already tripped
-    /// the same one-shot flag. GWT, one assert per case (Assume for preconditions).
+    /// the same one-shot flag. GWT, one assert per case: every fact a case depends on — channel recognition
+    /// or a captured intermediate reading — folds into that single assertion via a nullable/NaN/tuple
+    /// sentinel, so a regression in any of them turns the case red instead of skipping it (see
+    /// <see cref="MotionPropertyChannelTests"/> for the pattern this fixture follows).
     /// </remarks>
     [TestFixture]
     internal sealed class BezierTweenDriverTests
@@ -83,21 +86,28 @@ namespace Velvet.Tests
             var element = new VisualElement();
             var plan = MotionSpringClassParser.Resolve(new[] { "opacity-0" }, new[] { "opacity-100" });
             var state = BezierTweenDriver.Create(plan, X1, Y1, X2, Y2, durationSec: 1f);
-            Assume.That(state, Is.Not.Null, "Precondition: the plan resolves an opacity channel");
-            BezierTweenDriver.ApplyCurrentValues(element, state!);
-            Assume.That(element.style.opacity.value, Is.EqualTo(0f), "Precondition: starts at the from-value");
+            if (state != null)
+            {
+                BezierTweenDriver.ApplyCurrentValues(element, state);
+            }
 
-            // Act — a handful of early ticks, then many more later ticks.
-            for (var i = 0; i < 5; i++)
+            // Act — a handful of early ticks, then many more later ticks. The sentinel readings survive when
+            // no channel resolved, so both stay equal and fail below instead of the case being skipped.
+            var earlyOpacity = -1f;
+            var laterOpacity = -1f;
+            if (state != null)
             {
-                BezierTweenDriver.Step(element, state!, FixedDeltaSec);
+                for (var i = 0; i < 5; i++)
+                {
+                    BezierTweenDriver.Step(element, state, FixedDeltaSec);
+                }
+                earlyOpacity = element.style.opacity.value;
+                for (var i = 0; i < 40; i++)
+                {
+                    BezierTweenDriver.Step(element, state, FixedDeltaSec);
+                }
+                laterOpacity = element.style.opacity.value;
             }
-            var earlyOpacity = element.style.opacity.value;
-            for (var i = 0; i < 40; i++)
-            {
-                BezierTweenDriver.Step(element, state!, FixedDeltaSec);
-            }
-            var laterOpacity = element.style.opacity.value;
 
             // Assert — opacity has moved further toward the target (1) as more ticks run.
             Assert.That(laterOpacity, Is.GreaterThan(earlyOpacity));
@@ -110,44 +120,61 @@ namespace Velvet.Tests
             var element = new VisualElement();
             var plan = MotionSpringClassParser.Resolve(new[] { "opacity-0" }, new[] { "opacity-100" });
             var state = BezierTweenDriver.Create(plan, X1, Y1, X2, Y2, durationSec: 0.3f);
-            Assume.That(state, Is.Not.Null, "Precondition: the plan resolves an opacity channel");
-            BezierTweenDriver.ApplyCurrentValues(element, state!);
-
-            // Act — step until elapsed reaches the fixed duration (the cap only guards against a regression that
-            // never completes).
-            var completed = false;
-            for (var i = 0; i < 600 && !completed; i++)
+            if (state != null)
             {
-                completed = BezierTweenDriver.Step(element, state!, FixedDeltaSec);
+                BezierTweenDriver.ApplyCurrentValues(element, state);
             }
-            Assume.That(completed, Is.True, "Precondition: the tween completed within the tick budget");
 
-            // Assert — the t>=1 early-return is exact, so the value rests EXACTLY at the target (tighter than a
-            // spring's convergence-based settle).
-            Assert.That(element.style.opacity.value, Is.EqualTo(1f));
+            // Act — step until elapsed reaches the fixed duration (the cap only guards against a regression
+            // that never completes). NaN stands in for either failure mode (no channel resolved, or a tween
+            // that never completed), so both fail the exact-value comparison rather than skipping the case.
+            var restingOpacity = float.NaN;
+            if (state != null)
+            {
+                var completed = false;
+                for (var i = 0; i < 600 && !completed; i++)
+                {
+                    completed = BezierTweenDriver.Step(element, state, FixedDeltaSec);
+                }
+                if (completed)
+                {
+                    restingOpacity = element.style.opacity.value;
+                }
+            }
+
+            // Assert — the t>=1 early-return is exact, so the value rests EXACTLY at the target (tighter than
+            // a spring's convergence-based settle).
+            Assert.That(restingOpacity, Is.EqualTo(1f));
         }
 
         [Test]
         public void Given_ASettledBezierChannel_When_InlineOverridesCleared_Then_TheOpacityStyleIsRemoved()
         {
-            // Arrange — run the tween to completion first (Assume guards the precondition).
+            // Arrange — run the tween to completion first.
             var element = new VisualElement();
             var plan = MotionSpringClassParser.Resolve(new[] { "opacity-0" }, new[] { "opacity-100" });
             var state = BezierTweenDriver.Create(plan, X1, Y1, X2, Y2, durationSec: 0.3f);
-            Assume.That(state, Is.Not.Null, "Precondition: the plan resolves an opacity channel");
-            BezierTweenDriver.ApplyCurrentValues(element, state!);
             var completed = false;
-            for (var i = 0; i < 600 && !completed; i++)
+            if (state != null)
             {
-                completed = BezierTweenDriver.Step(element, state!, FixedDeltaSec);
+                BezierTweenDriver.ApplyCurrentValues(element, state);
+                for (var i = 0; i < 600 && !completed; i++)
+                {
+                    completed = BezierTweenDriver.Step(element, state, FixedDeltaSec);
+                }
             }
-            Assume.That(completed, Is.True, "Precondition: the tween completed within the tick budget");
+            // A style that was never driven to completion is trivially "removed", so the assertion has to see
+            // that it was held first.
+            var heldWhileTicking = completed && element.style.opacity.keyword != StyleKeyword.Null;
 
             // Act — the scheduler calls this on completion so the resting classes' own opacity takes back over.
-            BezierTweenDriver.ClearInlineOverrides(element, state!);
+            if (state != null)
+            {
+                BezierTweenDriver.ClearInlineOverrides(element, state);
+            }
 
             // Assert
-            Assert.That(element.style.opacity.keyword, Is.EqualTo(StyleKeyword.Null));
+            Assert.That((heldWhileTicking, element.style.opacity.keyword), Is.EqualTo((true, StyleKeyword.Null)));
         }
 
         [Test]
@@ -158,19 +185,30 @@ namespace Velvet.Tests
             var element = new VisualElement();
             var plan = MotionSpringClassParser.Resolve(new[] { "opacity-100" }, new[] { "opacity-0" });
             var state = BezierTweenDriver.Create(plan, X1, Y1, X2, Y2, durationSec: 1f);
-            Assume.That(state, Is.Not.Null, "Precondition: the plan resolves an opacity channel");
-            BezierTweenDriver.ApplyCurrentValues(element, state!);
-            for (var i = 0; i < 5; i++)
+            var toMidExit = float.NaN;
+            if (state != null)
             {
-                BezierTweenDriver.Step(element, state!, FixedDeltaSec);
+                BezierTweenDriver.ApplyCurrentValues(element, state);
+                for (var i = 0; i < 5; i++)
+                {
+                    BezierTweenDriver.Step(element, state, FixedDeltaSec);
+                }
+                toMidExit = state.Opacity!.To;
             }
-            Assume.That(state!.Opacity!.To, Is.EqualTo(0f), "Precondition: heading toward the exit value");
 
             // Act — an exit-cancel (the key re-entered mid-exit): retarget back toward the resting value.
-            BezierTweenDriver.Retarget(state!);
+            // NaN stands in for a plan that resolved no channel, failing the comparison below the same way a
+            // wrong target would.
+            var toAfterRetarget = float.NaN;
+            if (state != null)
+            {
+                BezierTweenDriver.Retarget(state);
+                toAfterRetarget = state.Opacity!.To;
+            }
 
-            // Assert — the channel's goal flipped to the value it originally started from (its RestingTarget).
-            Assert.That(state!.Opacity!.To, Is.EqualTo(1f));
+            // Assert — the channel was genuinely heading toward the exit value (0) before the retarget, and
+            // its goal flipped to the value it originally started from (its RestingTarget, 1) afterward.
+            Assert.That((toMidExit, toAfterRetarget), Is.EqualTo((0f, 1f)));
         }
 
         [Test]
@@ -181,19 +219,29 @@ namespace Velvet.Tests
             var element = new VisualElement();
             var plan = MotionSpringClassParser.Resolve(new[] { "opacity-100" }, new[] { "opacity-0" });
             var state = BezierTweenDriver.Create(plan, X1, Y1, X2, Y2, durationSec: 1f);
-            Assume.That(state, Is.Not.Null, "Precondition: the plan resolves an opacity channel");
-            BezierTweenDriver.ApplyCurrentValues(element, state!);
-            for (var i = 0; i < 5; i++)
+            var advancedBeforeRetarget = false;
+            if (state != null)
             {
-                BezierTweenDriver.Step(element, state!, FixedDeltaSec);
+                BezierTweenDriver.ApplyCurrentValues(element, state);
+                for (var i = 0; i < 5; i++)
+                {
+                    BezierTweenDriver.Step(element, state, FixedDeltaSec);
+                }
+                advancedBeforeRetarget = state.ElapsedSec > 0f;
             }
-            Assume.That(state!.ElapsedSec, Is.GreaterThan(0f), "Precondition: the forward tween has advanced");
 
-            // Act
-            BezierTweenDriver.Retarget(state!);
+            // Act — NaN stands in for a plan that resolved no channel, failing the comparison below the same
+            // way a clock that never reset would.
+            var elapsedAfterRetarget = float.NaN;
+            if (state != null)
+            {
+                BezierTweenDriver.Retarget(state);
+                elapsedAfterRetarget = state.ElapsedSec;
+            }
 
-            // Assert — the reversal starts from a clean clock.
-            Assert.That(state!.ElapsedSec, Is.EqualTo(0f));
+            // Assert — the forward tween had genuinely advanced before the reversal starts it from a clean
+            // clock.
+            Assert.That((advancedBeforeRetarget, elapsedAfterRetarget), Is.EqualTo((true, 0f)));
         }
 
         [Test]
@@ -205,13 +253,19 @@ namespace Velvet.Tests
             var element = new VisualElement();
             var plan = MotionSpringClassParser.Resolve(new[] { "opacity-0" }, new[] { "opacity-100" });
             var state = BezierTweenDriver.Create(plan, 0.34f, 1.56f, 0.64f, 1f, durationSec: 1f);
-            Assume.That(state, Is.Not.Null, "Precondition: the plan resolves an opacity channel");
 
             // Act — advance to 60% of the duration, where the overshoot curve is already past its target.
-            BezierTweenDriver.Step(element, state!, 0.6f);
+            // NaN stands in for a plan that resolved no channel, failing the "exceeds 1" comparison below the
+            // same way a value that never overshot would.
+            var opacity = float.NaN;
+            if (state != null)
+            {
+                BezierTweenDriver.Step(element, state, 0.6f);
+                opacity = element.style.opacity.value;
+            }
 
             // Assert — the inline value momentarily exceeds the target (1), i.e. it actually overshoots.
-            Assert.That(element.style.opacity.value, Is.GreaterThan(1f));
+            Assert.That(opacity, Is.GreaterThan(1f));
         }
 
         [Test]

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/MotionSpringDriverTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/MotionSpringDriverTests.cs
@@ -32,7 +32,10 @@ namespace Velvet.Tests
     /// setup is asserted directly (no tick needed to observe it), and the recurring tick's own math — along with
     /// the standalone integrator and the layoutId delta math, neither of which involves a panel or VisualElement
     /// at all — is exercised by calling the driver directly in a loop instead of trying to pump a real/simulated
-    /// scheduler clock. GWT, one assert per case (Assume for preconditions).
+    /// scheduler clock. GWT, one assert per case: every fact a case depends on — channel recognition,
+    /// settle/convergence, or a captured intermediate reading — folds into that single assertion via a
+    /// nullable/NaN/tuple sentinel, so a regression in any of them turns the case red instead of skipping
+    /// it (see <see cref="MotionPropertyChannelTests"/> for the pattern this fixture follows).
     /// </remarks>
     [TestFixture]
     internal sealed class MotionSpringDriverTests
@@ -70,21 +73,28 @@ namespace Velvet.Tests
             var element = new VisualElement();
             var plan = MotionSpringClassParser.Resolve(new[] { "opacity-0" }, new[] { "opacity-100" });
             var state = MotionSpringDriver.Create(plan, stiffness: 100f, damping: 20f, mass: 1f);
-            Assume.That(state, Is.Not.Null, "Precondition: the plan resolves an opacity channel");
-            MotionSpringDriver.ApplyCurrentValues(element, state!);
-            Assume.That(element.style.opacity.value, Is.EqualTo(0f), "Precondition: starts at the from-value");
+            if (state != null)
+            {
+                MotionSpringDriver.ApplyCurrentValues(element, state);
+            }
 
-            // Act — a handful of early ticks, then many more later ticks.
-            for (var i = 0; i < 5; i++)
+            // Act — a handful of early ticks, then many more later ticks. The sentinel readings survive when
+            // no channel resolved, so both stay equal and fail below instead of the case being skipped.
+            var earlyOpacity = -1f;
+            var laterOpacity = -1f;
+            if (state != null)
             {
-                MotionSpringDriver.Step(element, state!, FixedDeltaSec);
+                for (var i = 0; i < 5; i++)
+                {
+                    MotionSpringDriver.Step(element, state, FixedDeltaSec);
+                }
+                earlyOpacity = element.style.opacity.value;
+                for (var i = 0; i < 40; i++)
+                {
+                    MotionSpringDriver.Step(element, state, FixedDeltaSec);
+                }
+                laterOpacity = element.style.opacity.value;
             }
-            var earlyOpacity = element.style.opacity.value;
-            for (var i = 0; i < 40; i++)
-            {
-                MotionSpringDriver.Step(element, state!, FixedDeltaSec);
-            }
-            var laterOpacity = element.style.opacity.value;
 
             // Assert — opacity has moved further toward the target (1) as more ticks run.
             Assert.That(laterOpacity, Is.GreaterThan(earlyOpacity));
@@ -97,44 +107,62 @@ namespace Velvet.Tests
             var element = new VisualElement();
             var plan = MotionSpringClassParser.Resolve(new[] { "opacity-0" }, new[] { "opacity-100" });
             var state = MotionSpringDriver.Create(plan, stiffness: 100f, damping: 20f, mass: 1f);
-            Assume.That(state, Is.Not.Null, "Precondition: the plan resolves an opacity channel");
-            MotionSpringDriver.ApplyCurrentValues(element, state!);
+            if (state != null)
+            {
+                MotionSpringDriver.ApplyCurrentValues(element, state);
+            }
 
             // Act — step until settled (a critically damped spring at this stiffness settles well inside this
             // budget; the cap just guards against an infinite loop if a regression stops it from ever settling).
-            var settled = false;
-            for (var i = 0; i < 600 && !settled; i++)
+            // NaN stands in for either failure mode (no channel resolved, or a spring that never converged),
+            // so both fail the tolerance comparison rather than skipping the case.
+            var restingOpacity = float.NaN;
+            if (state != null)
             {
-                settled = MotionSpringDriver.Step(element, state!, FixedDeltaSec);
+                var settled = false;
+                for (var i = 0; i < 600 && !settled; i++)
+                {
+                    settled = MotionSpringDriver.Step(element, state, FixedDeltaSec);
+                }
+                if (settled)
+                {
+                    restingOpacity = element.style.opacity.value;
+                }
             }
-            Assume.That(settled, Is.True, "Precondition: the spring settled within the tick budget");
 
             // Assert
-            Assert.That(element.style.opacity.value, Is.EqualTo(1f).Within(0.01f));
+            Assert.That(restingOpacity, Is.EqualTo(1f).Within(0.01f));
         }
 
         [Test]
         public void Given_ASettledSpringChannel_When_InlineOverridesCleared_Then_TheOpacityStyleIsRemoved()
         {
-            // Arrange — settle the spring first (Assume guards the precondition, mirroring the test above).
+            // Arrange — settle the spring first.
             var element = new VisualElement();
             var plan = MotionSpringClassParser.Resolve(new[] { "opacity-0" }, new[] { "opacity-100" });
             var state = MotionSpringDriver.Create(plan, stiffness: 100f, damping: 20f, mass: 1f);
-            Assume.That(state, Is.Not.Null, "Precondition: the plan resolves an opacity channel");
-            MotionSpringDriver.ApplyCurrentValues(element, state!);
             var settled = false;
-            for (var i = 0; i < 600 && !settled; i++)
+            if (state != null)
             {
-                settled = MotionSpringDriver.Step(element, state!, FixedDeltaSec);
+                MotionSpringDriver.ApplyCurrentValues(element, state);
+                for (var i = 0; i < 600 && !settled; i++)
+                {
+                    settled = MotionSpringDriver.Step(element, state, FixedDeltaSec);
+                }
             }
-            Assume.That(settled, Is.True, "Precondition: the spring settled within the tick budget");
+            // A style that was never driven while settling is trivially "removed", so the assertion has to
+            // see that it was held first.
+            var heldWhileSettled = settled && element.style.opacity.keyword != StyleKeyword.Null;
 
             // Act — the scheduler calls this once every channel has settled, so the (already-applied) resting
             // classes' own opacity takes back over instead of the driver's inline value.
-            MotionSpringDriver.ClearInlineOverrides(element, state!);
+            if (state != null)
+            {
+                MotionSpringDriver.ClearInlineOverrides(element, state);
+            }
 
             // Assert
-            Assert.That(element.style.opacity.keyword, Is.EqualTo(StyleKeyword.Null));
+            Assert.That((heldWhileSettled, element.style.opacity.keyword), Is.EqualTo((true, StyleKeyword.Null)));
         }
 
         [Test]
@@ -145,10 +173,10 @@ namespace Velvet.Tests
             // (shared, not a second hand-copied dictionary), so this pins that the shared table still resolves
             // the same 0.5 / 1.0 pair.
             var plan = MotionSpringClassParser.Resolve(new[] { "scale-50" }, new[] { "scale-100" });
-            Assume.That(plan.Scale, Is.Not.Null, "Precondition: the pair resolves a scale channel");
 
-            // Assert
-            Assert.That((plan.Scale!.Value.from, plan.Scale.Value.to), Is.EqualTo((0.5f, 1f)));
+            // Assert — a pair that resolved no scale channel reads as null here and fails the same
+            // comparison a wrong magnitude would.
+            Assert.That(plan.Scale, Is.EqualTo(((float, float)?)(0.5f, 1f)));
         }
 
         [Test]
@@ -159,10 +187,10 @@ namespace Velvet.Tests
             // (negating it itself for the "n"-suffixed spelling), the single source of truth this pins against
             // rather than a separately hand-expanded ± table that could drift out of sync.
             var plan = MotionSpringClassParser.Resolve(new[] { "rotate-45" }, new[] { "rotate-n45" });
-            Assume.That(plan.Rotate, Is.Not.Null, "Precondition: the pair resolves a rotate channel");
 
-            // Assert
-            Assert.That((plan.Rotate!.Value.from, plan.Rotate.Value.to), Is.EqualTo((45f, -45f)));
+            // Assert — a pair that resolved no rotate channel reads as null here and fails the same
+            // comparison a wrong magnitude would.
+            Assert.That(plan.Rotate, Is.EqualTo(((float, float)?)(45f, -45f)));
         }
 
         [Test]
@@ -173,20 +201,31 @@ namespace Velvet.Tests
             var element = new VisualElement();
             var plan = MotionSpringClassParser.Resolve(new[] { "opacity-100" }, new[] { "opacity-0" });
             var state = MotionSpringDriver.Create(plan, stiffness: 100f, damping: 20f, mass: 1f);
-            Assume.That(state, Is.Not.Null, "Precondition: the plan resolves an opacity channel");
-            MotionSpringDriver.ApplyCurrentValues(element, state!);
-            for (var i = 0; i < 5; i++)
+            var targetMidExit = float.NaN;
+            if (state != null)
             {
-                MotionSpringDriver.Step(element, state!, FixedDeltaSec);
+                MotionSpringDriver.ApplyCurrentValues(element, state);
+                for (var i = 0; i < 5; i++)
+                {
+                    MotionSpringDriver.Step(element, state, FixedDeltaSec);
+                }
+                targetMidExit = state.Opacity!.Target;
             }
-            Assume.That(state!.Opacity!.Target, Is.EqualTo(0f), "Precondition: heading toward the exit value");
 
             // Act — an exit-cancel (the key re-entered mid-exit): retarget back toward the resting value.
-            MotionSpringDriver.Retarget(state!);
+            // NaN stands in for a plan that resolved no channel, failing the comparison below the same way a
+            // wrong target would.
+            var targetAfterRetarget = float.NaN;
+            if (state != null)
+            {
+                MotionSpringDriver.Retarget(state);
+                targetAfterRetarget = state.Opacity!.Target;
+            }
 
-            // Assert — the channel's goal flipped to the value it originally started from (its RestingTarget),
+            // Assert — the channel was genuinely heading toward the exit value (0) before the retarget, and
+            // its goal flipped to the value it originally started from (its RestingTarget, 1) afterward —
             // not a fresh 0/1 default or the exit value it was still short of.
-            Assert.That(state!.Opacity!.Target, Is.EqualTo(1f));
+            Assert.That((targetMidExit, targetAfterRetarget), Is.EqualTo((0f, 1f)));
         }
 
         [Test]
@@ -242,7 +281,6 @@ namespace Velvet.Tests
             }
             var capturedValue = spring.Value;
             var capturedVelocity = spring.Velocity;
-            Assume.That(capturedVelocity, Is.Not.EqualTo(0f), "Precondition: the spring has built up velocity heading toward the first target");
 
             // Act — retarget to a wildly different value (mirrors an exit-cancel reversing back toward the
             // resting value) and take one more step; a FRESH spring seeded with the exact captured state is the
@@ -250,10 +288,13 @@ namespace Velvet.Tests
             spring.Step(FixedDeltaSec, -50f, stiffness: 100f, damping: 10f, mass: 1f);
             var reference = new SpringIntegrator(capturedValue, capturedVelocity);
             reference.Step(FixedDeltaSec, -50f, stiffness: 100f, damping: 10f, mass: 1f);
+            var valuesMatch = Mathf.Abs(spring.Value - reference.Value) <= 1e-6f;
 
-            // Assert — the retargeted spring's value matches the reference exactly: the retarget carried the
-            // SAME value/velocity forward (no discontinuity) rather than resetting either.
-            Assert.That(spring.Value, Is.EqualTo(reference.Value).Within(1e-6f));
+            // Assert — the spring had genuinely built up velocity before the retarget (otherwise "continues
+            // from its current value/velocity" would be indistinguishable from a reset to zero), and the
+            // retargeted spring's value matches the reference exactly: the retarget carried the SAME
+            // value/velocity forward (no discontinuity) rather than resetting either.
+            Assert.That((capturedVelocity != 0f, valuesMatch), Is.EqualTo((true, true)));
         }
 
         [Test]


### PR DESCRIPTION
## What

`MotionSpringDriverTests` and `BezierTweenDriverTests` gated the behavior they exist to pin behind `Assume.That(...)`. When the recognition and driver machinery regressed, those cases reported **Inconclusive** rather than **Failed** — a green-looking suite over a broken feature.

Every such precondition now folds into the single assertion, via a nullable, NaN or tuple sentinel chosen so an absent channel cannot satisfy the comparison. Both fixtures now contain zero `Assume` calls.

Two preconditions were **deleted** rather than folded: each fixture already has a dedicated unconditional case asserting the from-pose through the scheduler path, so a broken from-pose write now fails a test written for it instead of skipping one that borrowed it.

## Verification

With the opacity-channel recognition gate neutered in the parser, the two fixtures go from **0 failed / 10 inconclusive** to **10 failed / 0 inconclusive** — the exact hole this closes. Nothing else moved.

The one precondition that survived the first pass was folded too. Neutering the integrator by zeroing velocity after each physics update turns it red:

```
Expected: (True, True)
But was:  (False, True)
```

Full EditMode 3357 passed / 0 failed. Full PlayMode 99 passed / 0 failed.

## Docs and CHANGELOG

Neither. This changes no product behavior — it changes what the suite reports when the product breaks. The fixtures' own remarks were rewritten to state the invariant that now holds rather than to carve out an exception that no longer exists.

Closes #158