### PR TITLE
fix(velvet): resolve inter-child spacing from the child container's own layout

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -88,6 +88,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **BREAKING:** `gap-*` / `space-*` and `divide-*` on a composite widget picked their physical edge
+  from the widget's own flex-direction instead of from the container the spaced children are actually
+  in. A composite widget — `ScrollView`, `Foldout`, `Tab`, `TabView`, `TwoPaneSplitView`,
+  `RadioButtonGroup`, `ToggleButtonGroup`, `PopupWindow`, and anything else that redirects —
+  reconciles its children into an inner box, so a `flex-row-reverse` / `flex-col-reverse` class on one
+  reverses only the widget's own box (a ScrollView's viewport and scrollers, a Foldout's toggle above
+  its content) while the content still paints in source order; the gap margin and the divider border
+  moved to the trailing edge anyway, leaving every visually adjacent pair unseparated and a margin or
+  a rule stranded on an outer edge. Both manipulators now read the direction from the inner box, which
+  is already the container they iterate and write to, and the container they name is decided by the
+  redirect itself rather than by a widget type — so it holds for anything mounted through
+  `V.Custom<T>` too. `flex-wrap` is read from there as well, so a `flex-wrap` written on such a widget
+  — which wraps only the widget, never its content — no longer switches the content to the four-side
+  half-margin polyfill: adjacent children keep the same separation through the leading-margin path,
+  without that path's negative container margin bleeding `gap/2` outward *inside* the widget, over the
+  box that clips or frames the content. A plain `gap-*` now follows the inner box's own direction
+  (vertical for a default `ScrollView`) rather than the widget's. **This changes existing layouts with
+  no compile error**: a class string that used to space horizontally may now space vertically, or move
+  its margin from one edge to the other. Plain elements parent their own children, so nothing changes
+  for them; nest a plain container inside the widget and put the direction or wrap class there when
+  the content needs one.
+  Two consequences worth knowing. Off-panel, where no resolved style exists, an inner box now defaults
+  to the engine's column rather than to `.flex`'s row, so the off-panel and on-panel answers agree —
+  *except* for a widget whose own built-in USS lays its inner box out as a row (a horizontally
+  scrolling `ScrollView`, a `TwoPaneSplitView`, a `ToggleButtonGroup`), which only a live panel can
+  report. On those, the first application runs before the widget attaches and writes the column edge,
+  moving to the row edge on the first geometry event — a one-frame flash that did not exist before.
+  And the manipulators now also watch the inner box for geometry changes, since
+  `GeometryChangedEvent` neither bubbles nor trickles and a re-layout confined to that box used to
+  reach nothing.
+- Two latent bugs on composite widgets other than `ScrollView` are fixed by the same change, because
+  the manipulators' "is this element still my child" test compared against the widget instead of the
+  box its children are in and so was permanently false. `gap-*` reset **all four margins on every
+  tracked child** on any change to its inputs, including out-of-flow children whose margin it is
+  supposed to leave alone — visibly shifting an `AnimatePresence` exit ghost mid-flight. A skewed
+  container (`skew-x-*` / `skew-y-*`) re-captured the *previous* pass's shear as each child's own
+  baseline translate every pass, so removing the skew restored a stale shear instead of the child's
+  original position.
 - **BREAKING:** `"flex flex-col md:flex-row"` — the documented "stack on narrow screens, row on wide
   ones" idiom — laid out as a column at every width. A responsive or state variant adds the BARE
   utility to the live class list, so above the breakpoint the element carried both `flex-col` and

--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -89,43 +89,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **BREAKING:** `gap-*` / `space-*` and `divide-*` on a composite widget picked their physical edge
-  from the widget's own flex-direction instead of from the container the spaced children are actually
-  in. A composite widget — `ScrollView`, `Foldout`, `Tab`, `TabView`, `TwoPaneSplitView`,
-  `RadioButtonGroup`, `ToggleButtonGroup`, `PopupWindow`, and anything else that redirects —
-  reconciles its children into an inner box, so a `flex-row-reverse` / `flex-col-reverse` class on one
-  reverses only the widget's own box (a ScrollView's viewport and scrollers, a Foldout's toggle above
-  its content) while the content still paints in source order; the gap margin and the divider border
-  moved to the trailing edge anyway, leaving every visually adjacent pair unseparated and a margin or
-  a rule stranded on an outer edge. Both manipulators now read the direction from the inner box, which
-  is already the container they iterate and write to, and the container they name is decided by the
-  redirect itself rather than by a widget type — so it holds for anything mounted through
-  `V.Custom<T>` too. `flex-wrap` is read from there as well, so a `flex-wrap` written on such a widget
-  — which wraps only the widget, never its content — no longer switches the content to the four-side
-  half-margin polyfill: adjacent children keep the same separation through the leading-margin path,
-  without that path's negative container margin bleeding `gap/2` outward *inside* the widget, over the
-  box that clips or frames the content. A plain `gap-*` now follows the inner box's own direction
-  (vertical for a default `ScrollView`) rather than the widget's. **This changes existing layouts with
-  no compile error**: a class string that used to space horizontally may now space vertically, or move
-  its margin from one edge to the other. Plain elements parent their own children, so nothing changes
-  for them; nest a plain container inside the widget and put the direction or wrap class there when
-  the content needs one.
-  Two consequences worth knowing. Off-panel, where no resolved style exists, an inner box now defaults
-  to the engine's column rather than to `.flex`'s row, so the off-panel and on-panel answers agree —
-  *except* for a widget whose own built-in USS lays its inner box out as a row (a horizontally
-  scrolling `ScrollView`, a `TwoPaneSplitView`, a `ToggleButtonGroup`), which only a live panel can
-  report. On those, the first application runs before the widget attaches and writes the column edge,
-  moving to the row edge on the first geometry event — a one-frame flash that did not exist before.
-  And the manipulators now also watch the inner box for geometry changes, since
-  `GeometryChangedEvent` neither bubbles nor trickles and a re-layout confined to that box used to
-  reach nothing.
-- Two latent bugs on composite widgets other than `ScrollView` are fixed by the same change, because
-  the manipulators' "is this element still my child" test compared against the widget instead of the
-  box its children are in and so was permanently false. `gap-*` reset **all four margins on every
-  tracked child** on any change to its inputs, including out-of-flow children whose margin it is
-  supposed to leave alone — visibly shifting an `AnimatePresence` exit ghost mid-flight. A skewed
-  container (`skew-x-*` / `skew-y-*`) re-captured the *previous* pass's shear as each child's own
-  baseline translate every pass, so removing the skew restored a stale shear instead of the child's
-  original position.
+  from the widget's own flex-direction instead of from the container the spaced children are in. A
+  composite widget — `ScrollView`, `Foldout`, `Tab`, `TabView`, `TwoPaneSplitView`, `RadioButtonGroup`,
+  `ToggleButtonGroup`, `PopupWindow`, and anything else that redirects — reconciles its children into
+  an inner box, so a `flex-row-reverse` / `flex-col-reverse` class on one reverses only the widget's
+  own box (a ScrollView's viewport and scrollers, a Foldout's toggle above its content) while the
+  content still paints in source order. The gap margin and the divider border moved to the trailing
+  edge anyway, leaving every visually adjacent pair unseparated and a margin or a rule stranded on an
+  outer edge. Both manipulators now read the direction from the inner box, and which container that is
+  is decided by the redirect rather than by a widget type, so it holds for anything mounted through
+  `V.Custom<T>`. `flex-wrap` is read from there too, so a `flex-wrap` on such a widget — which wraps
+  the widget, not its content — no longer switches the content to the four-side half-margin polyfill,
+  whose negative container margin bleeds `gap/2` outward *inside* the widget over the box that clips
+  the content. A plain `gap-*` now follows the inner box's direction (vertical for a default
+  `ScrollView`). **This changes existing layouts with no compile error**: a class string that used to
+  space horizontally may now space vertically, or move its margin to the opposite edge. Plain elements
+  parent their own children and are unaffected; nest a plain container inside the widget and put the
+  direction or wrap class there when the content needs one.
+  Off-panel, an inner box now defaults to the engine's column rather than `.flex`'s row so that the
+  off-panel and on-panel answers agree — *except* on a widget whose built-in USS lays its inner box out
+  as a row (a horizontally scrolling `ScrollView`, a `TwoPaneSplitView`, a `ToggleButtonGroup`), which
+  only a live panel reports. Those now flash for one frame: the first application writes the column
+  edge before attach and moves to the row edge on the first geometry event. The manipulators also watch
+  the inner box for geometry changes now, since `GeometryChangedEvent` neither bubbles nor trickles.
+- Two latent bugs on composite widgets other than `ScrollView`, from the same root: the manipulators'
+  "is this element still my child" test compared against the widget rather than the box its children
+  are in, and so was permanently false. `gap-*` reset **all four margins on every tracked child** on
+  any input change, including the out-of-flow children it must leave alone — visibly shifting an
+  `AnimatePresence` exit ghost mid-flight. A skewed container (`skew-x-*` / `skew-y-*`) re-captured the
+  *previous* pass's shear as each child's baseline translate, so removing the skew restored a stale
+  shear instead of the child's original position.
 - **BREAKING:** `"flex flex-col md:flex-row"` — the documented "stack on narrow screens, row on wide
   ones" idiom — laid out as a column at every width. A responsive or state variant adds the BARE
   utility to the live class list, so above the breakpoint the element carried both `flex-col` and

--- a/Packages/com.velvet.core/Documentation~/styling-flexbox-and-gap.md
+++ b/Packages/com.velvet.core/Documentation~/styling-flexbox-and-gap.md
@@ -192,10 +192,52 @@ manipulator's own events. It is re-applied from three sources:
    children, so an add / remove / reorder during a reconcile pass immediately re-spaces. This is also
    the path that makes it correct in EditMode, where layout never ticks.
 2. **`GeometryChangedEvent`.** Catches child mutations driven by an *unrelated* reconcile pass at
-   runtime (e.g. a nested component re-render that adds a child under this container).
+   runtime (e.g. a nested component re-render that adds a child under this container). Registered on
+   the attached element **and**, when it differs, on the inner box the verdict is read from (below):
+   `GeometryChangedEvent` neither bubbles nor trickles, so a re-layout confined to the inner box — a
+   widget reconfiguring itself, its own USS changing — reaches nothing registered on the widget.
 3. **`AttachToPanelEvent`.** Re-resolves plain `gap-*`'s axis, and every axis's reversed-edge flip,
    once `resolvedStyle.flexDirection` is valid — needed for the one case no class marker can cover
-   (below).
+   (below). Registered on the attached element only: the inner box lives inside its subtree and
+   attaches in the same pass, so doubling it would re-resolve the same state twice.
+
+**Which element the verdict is read from: the container the children are actually in.** Both
+manipulators are attached to the element the class string is written on, but they resolve, iterate and
+read from the element that element's children are *reconciled into*. For a plain element the two are
+the same element. A **composite widget** is where they part: it redirects its children into an inner box,
+so a direction (or `flex-wrap`) class written on one lays out the **widget's own** box — a `ScrollView`'s
+viewport and scrollers, a `Foldout`'s toggle above its content — and leaves the content it wraps
+untouched. The spacing follows the content, not the class's own element: in
+`V.ScrollView("flex flex-row-reverse gap-x-4", …)` the gap stays on the leading edge, because the content
+is not painted in reverse order; and in `V.ScrollView("flex flex-row gap-4", …)` a plain `gap-4` spaces
+**vertically**, the axis its content actually stacks on. Velvet does not pick the widgets this applies to
+from a list: `V.Custom<T>` mounts any `VisualElement` subclass with children, so the rule is keyed on the
+redirect itself. The engine's own redirecting widgets — the ones you are most likely to hit — include
+`ScrollView`, `Foldout`, `Tab`, `TabView`, `TwoPaneSplitView`, `RadioButtonGroup`, `ToggleButtonGroup`
+and `PopupWindow`; the collection views (`ListView`, `TreeView`, `MultiColumnListView`) parent nothing at
+all and build their rows themselves, so nothing here spaces them.
+
+A class string only ever reaches the element it is written on, so none of the five direction classes can
+land on an inner box: a composite widget's verdict always comes from the `resolvedStyle` fallback below,
+and its direction is whatever the widget's own built-in USS gives it. Off-panel, where `resolvedStyle`
+is unavailable, an inner box falls back to the **engine's** default (column) rather than to `.flex`'s
+row — the row default exists to mirror what `.flex` means on an element an author wrote a class on, and
+no class reaches here, so the engine's own default is what will actually lay the box out. For most
+widgets that makes the off-panel answer equal the on-panel one, which matters because most of this
+behavior is asserted off-panel.
+
+**The residue, where the two do not agree:** a widget whose own USS *overrides* the engine default, so
+its inner box is a **row**. A horizontally scrolling `ScrollView`, a `TwoPaneSplitView` and a
+`ToggleButtonGroup` are the ones checked; the list is not closed, since any widget's built-in USS may do
+this. Only `resolvedStyle`, and so only a live panel, has the answer for those — off-panel they still
+resolve as a column. The visible cost is a frame: the first application runs before the widget attaches,
+writes the column edge, and moves to the row edge on the first geometry event. The same residue applies
+to `flex-wrap` on an inner box whose built-in USS wraps, which is the worse of the two — wrap is the only
+mode that writes the container's own margin.
+
+No **direction or wrap** utility reaches inside a composite widget to lay its content out; the spacing
+utilities themselves do reach the inner box's children, which is the whole point of the paragraphs above.
+Nest a plain container inside the widget and put the direction class there when the content needs one.
 
 **Direction source: a single resolved verdict from the class list, by USS precedence, not
 `resolvedStyle` — on a panel included.** `flex` / `flex-row` / `flex-col` / `flex-row-reverse` /
@@ -262,17 +304,30 @@ Under wrap, any two adjacent items (either axis, including across wrapped lines)
 `gap/2 + gap/2 == gap`, and the container's negative margin cancels the children's outer-edge
 half-margins so content stays flush to the container edge. A reversed container (e.g.
 `flex-row-reverse flex-wrap`) still uses this same symmetric half-margin polyfill — direction never
-changes which edges wrap spaces, only non-wrap's single leading/trailing edge choice. Wrap is detected
-the same way direction is, and for the same staleness reason: the `flex-wrap` / `flex-nowrap` /
-`flex-wrap-reverse` class markers first (by `_layout.uss` declaration order — `flex-wrap-reverse`
-beats `flex-nowrap` beats `flex-wrap` when more than one is present); when none of those three are
-present, `flex` / `flex-row` / `flex-col` / `flex-row-reverse` / `flex-col-reverse` — none of which
-touch `flex-wrap` themselves — mean Yoga's own default (no wrap) applies, so an OFF-state toggle like
-`wrapped ? "flex flex-wrap gap-4" : "flex gap-4"` still converges without a wrap class in its OFF
-state; `resolvedStyle.flexWrap` is the fallback only when none of those eight classes are on the
-element at all. Getting this wrong is worse than getting direction wrong: wrap is the only mode that
+changes which edges wrap spaces, only non-wrap's single leading/trailing edge choice. Wrap is read
+from the same element the direction is (see "Which element the verdict is read from" above), and in the
+same shape, for the same staleness reason: the `flex-wrap` / `flex-nowrap` / `flex-wrap-reverse` class
+markers first (by `_layout.uss` declaration order — `flex-wrap-reverse` beats `flex-nowrap` beats
+`flex-wrap` when more than one is present), then `resolvedStyle.flexWrap` whenever none of those three
+is present. Unlike the direction scan there is no further "a direction class implies a default" tier:
+`flex` / `flex-row(-reverse)` / `flex-col(-reverse)` set `flex-direction` only and say nothing about
+`flex-wrap`, so counting them as evidence of no-wrap would take the `resolvedStyle` fallback away from
+nearly every real container — almost all of them carry a direction class — and misread a genuinely
+wrapping inline-styled one as non-wrapping. It also means removing a `flex-wrap` class does not
+converge on its own: with no marker left, the verdict drops to `resolvedStyle.flexWrap`, which can read
+one pass stale, so the half-margin path can survive the flip until the next style pass or geometry
+event. Spell the OFF state `flex-nowrap` — `wrapped ? "flex flex-wrap gap-4" : "flex flex-nowrap gap-4"`
+— and the marker tier answers immediately.
+Getting this wrong is worse than getting direction wrong: wrap is the only mode that
 writes the CONTAINER's own margin, so a stuck stale "wrap" verdict leaves a fixed-size container
 bleeding its negative margin outward over its siblings until something unrelated forces a re-apply.
+
+A corollary of reading wrap from the inner box: a `flex-wrap` class on a **composite widget** wraps the
+widget, never its content, and no wrap utility reaches the inner box — so on one of those the half-margin
+path is **unreachable from class strings**. It is still reachable by anything that sets the inner box's
+own `flex-wrap` directly (a custom stylesheet rule matching it, a `refCallback` reaching in), and by a
+widget whose built-in USS wraps. Wrap the content in a plain container inside the widget to get a
+wrapping gap from a class string.
 
 `grid` also sets `flex-direction: row` (and `flex-wrap: wrap`) in `_layout.uss`, but a `grid` /
 `grid-cols-*` class routes an element's gap through the separate grid manipulator entirely —

--- a/Packages/com.velvet.core/Documentation~/styling-flexbox-and-gap.md
+++ b/Packages/com.velvet.core/Documentation~/styling-flexbox-and-gap.md
@@ -193,50 +193,43 @@ manipulator's own events. It is re-applied from three sources:
    the path that makes it correct in EditMode, where layout never ticks.
 2. **`GeometryChangedEvent`.** Catches child mutations driven by an *unrelated* reconcile pass at
    runtime (e.g. a nested component re-render that adds a child under this container). Registered on
-   the attached element **and**, when it differs, on the inner box the verdict is read from (below):
-   `GeometryChangedEvent` neither bubbles nor trickles, so a re-layout confined to the inner box — a
-   widget reconfiguring itself, its own USS changing — reaches nothing registered on the widget.
+   the attached element **and**, when it differs, on the inner box the verdict is read from (below),
+   because `GeometryChangedEvent` neither bubbles nor trickles.
 3. **`AttachToPanelEvent`.** Re-resolves plain `gap-*`'s axis, and every axis's reversed-edge flip,
    once `resolvedStyle.flexDirection` is valid — needed for the one case no class marker can cover
-   (below). Registered on the attached element only: the inner box lives inside its subtree and
-   attaches in the same pass, so doubling it would re-resolve the same state twice.
+   (below). Registered on the attached element only, since the inner box attaches in its subtree pass.
 
 **Which element the verdict is read from: the container the children are actually in.** Both
 manipulators are attached to the element the class string is written on, but they resolve, iterate and
-read from the element that element's children are *reconciled into*. For a plain element the two are
-the same element. A **composite widget** is where they part: it redirects its children into an inner box,
-so a direction (or `flex-wrap`) class written on one lays out the **widget's own** box — a `ScrollView`'s
-viewport and scrollers, a `Foldout`'s toggle above its content — and leaves the content it wraps
-untouched. The spacing follows the content, not the class's own element: in
-`V.ScrollView("flex flex-row-reverse gap-x-4", …)` the gap stays on the leading edge, because the content
-is not painted in reverse order; and in `V.ScrollView("flex flex-row gap-4", …)` a plain `gap-4` spaces
-**vertically**, the axis its content actually stacks on. Velvet does not pick the widgets this applies to
-from a list: `V.Custom<T>` mounts any `VisualElement` subclass with children, so the rule is keyed on the
-redirect itself. The engine's own redirecting widgets — the ones you are most likely to hit — include
-`ScrollView`, `Foldout`, `Tab`, `TabView`, `TwoPaneSplitView`, `RadioButtonGroup`, `ToggleButtonGroup`
-and `PopupWindow`; the collection views (`ListView`, `TreeView`, `MultiColumnListView`) parent nothing at
-all and build their rows themselves, so nothing here spaces them.
+read from the element that element's children are *reconciled into*. For a plain element those are the
+same. A **composite widget** redirects its children into an inner box, so a direction (or `flex-wrap`)
+class on one lays out the **widget's own** box — a `ScrollView`'s viewport and scrollers, a `Foldout`'s
+toggle above its content — and leaves the content untouched. The spacing follows the content: in
+`V.ScrollView("flex flex-row-reverse gap-x-4", …)` the gap stays on the leading edge, and in
+`V.ScrollView("flex flex-row gap-4", …)` a plain `gap-4` spaces **vertically**, the axis its content
+actually stacks on. The rule is keyed on the redirect itself, not on a list of widgets — `V.Custom<T>`
+mounts any `VisualElement` subclass with children. The engine's redirecting widgets include `ScrollView`,
+`Foldout`, `Tab`, `TabView`, `TwoPaneSplitView`, `RadioButtonGroup`, `ToggleButtonGroup` and
+`PopupWindow`; the collection views (`ListView`, `TreeView`, `MultiColumnListView`) parent nothing and
+build their rows themselves, so nothing here spaces them.
 
-A class string only ever reaches the element it is written on, so none of the five direction classes can
-land on an inner box: a composite widget's verdict always comes from the `resolvedStyle` fallback below,
-and its direction is whatever the widget's own built-in USS gives it. Off-panel, where `resolvedStyle`
-is unavailable, an inner box falls back to the **engine's** default (column) rather than to `.flex`'s
-row — the row default exists to mirror what `.flex` means on an element an author wrote a class on, and
-no class reaches here, so the engine's own default is what will actually lay the box out. For most
+A class string only reaches the element it is written on, so no direction class can land on an inner box:
+its verdict comes from the `resolvedStyle` fallback below, over whatever the widget's own built-in USS
+gives it. Off-panel an inner box falls back to the **engine's** default (column) rather than to `.flex`'s
+row, since the row default mirrors what `.flex` means on an element an author wrote a class on. For most
 widgets that makes the off-panel answer equal the on-panel one, which matters because most of this
 behavior is asserted off-panel.
 
-**The residue, where the two do not agree:** a widget whose own USS *overrides* the engine default, so
-its inner box is a **row**. A horizontally scrolling `ScrollView`, a `TwoPaneSplitView` and a
-`ToggleButtonGroup` are the ones checked; the list is not closed, since any widget's built-in USS may do
-this. Only `resolvedStyle`, and so only a live panel, has the answer for those — off-panel they still
-resolve as a column. The visible cost is a frame: the first application runs before the widget attaches,
-writes the column edge, and moves to the row edge on the first geometry event. The same residue applies
-to `flex-wrap` on an inner box whose built-in USS wraps, which is the worse of the two — wrap is the only
-mode that writes the container's own margin.
+**The residue, where the two disagree:** a widget whose own USS overrides the engine default, so its
+inner box is a **row** — a horizontally scrolling `ScrollView`, a `TwoPaneSplitView`, a
+`ToggleButtonGroup`, and any other whose built-in USS does the same. Only a live panel has the answer
+there; off-panel they still resolve as a column. That costs a frame: the first application runs before
+the widget attaches, writes the column edge, and moves to the row edge on the first geometry event. The
+same residue applies to `flex-wrap` on an inner box whose built-in USS wraps, and is worse there — wrap
+is the only mode that writes the container's own margin.
 
 No **direction or wrap** utility reaches inside a composite widget to lay its content out; the spacing
-utilities themselves do reach the inner box's children, which is the whole point of the paragraphs above.
+utilities do reach the inner box's children, which is the point of the paragraphs above.
 Nest a plain container inside the widget and put the direction class there when the content needs one.
 
 **Direction source: a single resolved verdict from the class list, by USS precedence, not
@@ -310,24 +303,21 @@ same shape, for the same staleness reason: the `flex-wrap` / `flex-nowrap` / `fl
 markers first (by `_layout.uss` declaration order — `flex-wrap-reverse` beats `flex-nowrap` beats
 `flex-wrap` when more than one is present), then `resolvedStyle.flexWrap` whenever none of those three
 is present. Unlike the direction scan there is no further "a direction class implies a default" tier:
-`flex` / `flex-row(-reverse)` / `flex-col(-reverse)` set `flex-direction` only and say nothing about
-`flex-wrap`, so counting them as evidence of no-wrap would take the `resolvedStyle` fallback away from
-nearly every real container — almost all of them carry a direction class — and misread a genuinely
-wrapping inline-styled one as non-wrapping. It also means removing a `flex-wrap` class does not
-converge on its own: with no marker left, the verdict drops to `resolvedStyle.flexWrap`, which can read
-one pass stale, so the half-margin path can survive the flip until the next style pass or geometry
-event. Spell the OFF state `flex-nowrap` — `wrapped ? "flex flex-wrap gap-4" : "flex flex-nowrap gap-4"`
-— and the marker tier answers immediately.
+`flex` / `flex-row(-reverse)` / `flex-col(-reverse)` say nothing about `flex-wrap`, and since nearly
+every real container carries one, counting them as evidence of no-wrap would take the `resolvedStyle`
+fallback away from almost all of them and misread a genuinely wrapping inline-styled one as
+non-wrapping. One consequence: removing a `flex-wrap` class does not converge on its own, because the
+verdict drops to `resolvedStyle.flexWrap`, which can read one pass stale. Spell the OFF state
+`flex-nowrap` — `wrapped ? "flex flex-wrap gap-4" : "flex flex-nowrap gap-4"` — and the marker tier
+answers immediately.
 Getting this wrong is worse than getting direction wrong: wrap is the only mode that
 writes the CONTAINER's own margin, so a stuck stale "wrap" verdict leaves a fixed-size container
 bleeding its negative margin outward over its siblings until something unrelated forces a re-apply.
 
-A corollary of reading wrap from the inner box: a `flex-wrap` class on a **composite widget** wraps the
-widget, never its content, and no wrap utility reaches the inner box — so on one of those the half-margin
-path is **unreachable from class strings**. It is still reachable by anything that sets the inner box's
-own `flex-wrap` directly (a custom stylesheet rule matching it, a `refCallback` reaching in), and by a
-widget whose built-in USS wraps. Wrap the content in a plain container inside the widget to get a
-wrapping gap from a class string.
+A corollary on a **composite widget**: a `flex-wrap` class wraps the widget, never its content, so the
+half-margin path is **unreachable from class strings** there. It is still reachable by anything setting
+the inner box's own `flex-wrap` (a custom stylesheet rule, a `refCallback` reaching in) and by a widget
+whose built-in USS wraps. Nest a plain container inside the widget for a wrapping gap from a class.
 
 `grid` also sets `flex-direction: row` (and `flex-wrap: wrap`) in `_layout.uss`, but a `grid` /
 `grid-cols-*` class routes an element's gap through the separate grid manipulator entirely —

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
@@ -2775,21 +2775,15 @@ namespace Velvet
 
         #region Helpers
 
-        // The element a child added to this one actually lands under: its contentContainer, or the
-        // element itself when it does not redirect. This is the same rule VisualElement.Add follows, and it
-        // is keyed on the redirect rather than on a widget type so it holds for every composite a caller can
-        // reach. V.Custom<T> mounts ANY VisualElement subclass with children, so the redirecting widgets are
-        // not a closed set Velvet chooses: ScrollView, Foldout, TabView, Tab and TwoPaneSplitView all parent
-        // their children in an inner container, and all of them place a real reconciled child list there.
-        // Everything downstream — where children are reconciled, and which box the layout manipulators read
-        // their direction / wrap from and write a container margin to — has to name that same element or it
-        // describes a layout the children are not in.
+        // The element a child added to this one actually lands under — the rule VisualElement.Add follows.
+        // Keyed on the redirect, not on a widget type: V.Custom<T> mounts ANY VisualElement subclass with
+        // children, so the composites that redirect are not a set Velvet gets to choose. Every caller that
+        // names "the children's container" must name this same element — the reconcile target, and the box
+        // the layout manipulators read direction / wrap from and write a container margin to.
         //
-        // A null contentContainer (ListView, which parents nothing and builds its rows from its own item
-        // source) answers with the element. That is not a workaround for a crash: VisualElement is null-safe
-        // throughout for this — childCount reads 0, the indexer yields nothing — so a caller walking "the
-        // children" of one simply finds none. Insert quietly does nothing there, which is why nothing should
-        // be reconciled into such a widget in the first place.
+        // A null contentContainer (the collection views, which build their rows themselves) answers with the
+        // element. Not a crash guard: VisualElement is null-safe throughout — childCount reads 0, the indexer
+        // yields nothing. Insert quietly does nothing there, so nothing should be reconciled into one.
         internal static VisualElement GetChildContainer(VisualElement element)
         {
             var content = element.contentContainer;

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
@@ -2775,15 +2775,25 @@ namespace Velvet
 
         #region Helpers
 
-        // Returns contentContainer when the element is a ScrollView; otherwise returns the element itself.
+        // The element a child added to this one actually lands under: its contentContainer, or the
+        // element itself when it does not redirect. This is the same rule VisualElement.Add follows, and it
+        // is keyed on the redirect rather than on a widget type so it holds for every composite a caller can
+        // reach. V.Custom<T> mounts ANY VisualElement subclass with children, so the redirecting widgets are
+        // not a closed set Velvet chooses: ScrollView, Foldout, TabView, Tab and TwoPaneSplitView all parent
+        // their children in an inner container, and all of them place a real reconciled child list there.
+        // Everything downstream — where children are reconciled, and which box the layout manipulators read
+        // their direction / wrap from and write a container margin to — has to name that same element or it
+        // describes a layout the children are not in.
+        //
+        // A null contentContainer (ListView, which parents nothing and builds its rows from its own item
+        // source) answers with the element. That is not a workaround for a crash: VisualElement is null-safe
+        // throughout for this — childCount reads 0, the indexer yields nothing — so a caller walking "the
+        // children" of one simply finds none. Insert quietly does nothing there, which is why nothing should
+        // be reconciled into such a widget in the first place.
         internal static VisualElement GetChildContainer(VisualElement element)
         {
-            if (element is ScrollView scrollView)
-            {
-                return scrollView.contentContainer;
-            }
-
-            return element;
+            var content = element.contentContainer;
+            return content ?? element;
         }
 
         #endregion

--- a/Packages/com.velvet.core/Runtime/Styling/StyleChildVariantManipulator.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleChildVariantManipulator.cs
@@ -21,8 +21,8 @@ namespace Velvet
     // AttachToPanelEvent. A signature makes a redundant Apply a no-op.
     //
     // Child container. Like gap / divide it resolves and iterates FiberNodePatcher.GetChildContainer(target)
-    // (a ScrollView's contentContainer; else self), so the payload lands on the reconciled content and never
-    // on a ScrollView's internal hierarchy.
+    // (a composite widget's inner box; else self), so the payload lands on the reconciled content and never
+    // on the widget's internal hierarchy.
     //
     // Out-of-flow children (position: absolute) are excluded from the walk via StyleOutOfFlowChild, the same
     // way gap / divide exclude them. This is a deliberate deviation from literal CSS `> *` (which DOES match
@@ -106,7 +106,7 @@ namespace Velvet
 
         private void OnGeometryChanged(GeometryChangedEvent evt) => Apply();
 
-        // The container children are reconciled into (a ScrollView's contentContainer; else self).
+        // The container children are reconciled into (a composite widget's inner box; else self).
         private VisualElement? ChildContainer
             => target == null ? null : FiberNodePatcher.GetChildContainer(target);
 

--- a/Packages/com.velvet.core/Runtime/Styling/StyleDivideManipulator.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleDivideManipulator.cs
@@ -34,11 +34,9 @@ namespace Velvet
     // the dashed / dotted stroke on the child's own generateVisualContent — so switching between solid and
     // dashed is layout-identical and only the paint differs.
     //
-    // Child container. Like the gap manipulator it resolves and iterates
-    // FiberNodePatcher.GetChildContainer(target) (a composite widget's inner box; else self), so the
-    // divider lands on the reconciled content and never on the widget's internal hierarchy. The direction
-    // verdict comes from that same child container too — a direction class on such a widget reverses the
-    // widget's own box, not the content the dividers separate.
+    // Child container. Like the gap manipulator it iterates, and resolves its direction from,
+    // FiberNodePatcher.GetChildContainer(target) — a composite widget's inner box; else self. A direction
+    // class on such a widget reverses the widget's own box, not the content the dividers separate.
     //
     // Limitations: an explicit per-child border on the SAME edge the divider draws on (e.g. border-l on a
     // child of a divide-x row) is OVERWRITTEN — this manipulator owns that edge, exactly as the gap
@@ -78,8 +76,7 @@ namespace Velvet
         private int _lastSignature;
         private bool _hasSignature;
 
-        // The inner box this manipulator additionally watches for geometry changes, when the child
-        // container is not the target itself. Null for a plain element. See ObserveChildContainer.
+        // Null unless the child container is a separate element — see ObserveChildContainer.
         private VisualElement? _observed;
 
         public StyleDivideManipulator(DivideSpec spec, ReconcilerContext ctx)
@@ -116,10 +113,7 @@ namespace Velvet
             }
         }
 
-        // Watches a child container that is NOT the target, for the reason StyleGapManipulator's own
-        // ObserveChildContainer gives: the direction verdict is read from a composite widget's inner box,
-        // and GeometryChangedEvent neither bubbles nor trickles, so a re-layout confined to that box
-        // reaches nothing registered on the target.
+        // GeometryChangedEvent neither bubbles nor trickles — see StyleGapManipulator.ObserveChildContainer.
         private void ObserveChildContainer()
         {
             var container = ChildContainer;

--- a/Packages/com.velvet.core/Runtime/Styling/StyleDivideManipulator.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleDivideManipulator.cs
@@ -35,8 +35,10 @@ namespace Velvet
     // dashed is layout-identical and only the paint differs.
     //
     // Child container. Like the gap manipulator it resolves and iterates
-    // FiberNodePatcher.GetChildContainer(target) (a ScrollView's contentContainer; else self), so the
-    // divider lands on the reconciled content and never on a ScrollView's internal hierarchy.
+    // FiberNodePatcher.GetChildContainer(target) (a composite widget's inner box; else self), so the
+    // divider lands on the reconciled content and never on the widget's internal hierarchy. The direction
+    // verdict comes from that same child container too — a direction class on such a widget reverses the
+    // widget's own box, not the content the dividers separate.
     //
     // Limitations: an explicit per-child border on the SAME edge the divider draws on (e.g. border-l on a
     // child of a divide-x row) is OVERWRITTEN — this manipulator owns that edge, exactly as the gap
@@ -76,6 +78,10 @@ namespace Velvet
         private int _lastSignature;
         private bool _hasSignature;
 
+        // The inner box this manipulator additionally watches for geometry changes, when the child
+        // container is not the target itself. Null for a plain element. See ObserveChildContainer.
+        private VisualElement? _observed;
+
         public StyleDivideManipulator(DivideSpec spec, ReconcilerContext ctx)
         {
             _spec = spec;
@@ -94,6 +100,7 @@ namespace Velvet
         {
             target.RegisterCallback<AttachToPanelEvent>(OnAttach);
             target.RegisterCallback<GeometryChangedEvent>(OnGeometryChanged);
+            ObserveChildContainer();
             Apply();
         }
 
@@ -102,6 +109,26 @@ namespace Velvet
             Clear();
             target.UnregisterCallback<AttachToPanelEvent>(OnAttach);
             target.UnregisterCallback<GeometryChangedEvent>(OnGeometryChanged);
+            if (_observed != null)
+            {
+                _observed.UnregisterCallback<GeometryChangedEvent>(OnGeometryChanged);
+                _observed = null;
+            }
+        }
+
+        // Watches a child container that is NOT the target, for the reason StyleGapManipulator's own
+        // ObserveChildContainer gives: the direction verdict is read from a composite widget's inner box,
+        // and GeometryChangedEvent neither bubbles nor trickles, so a re-layout confined to that box
+        // reaches nothing registered on the target.
+        private void ObserveChildContainer()
+        {
+            var container = ChildContainer;
+            if (container == null || ReferenceEquals(container, target))
+            {
+                return;
+            }
+            _observed = container;
+            container.RegisterCallback<GeometryChangedEvent>(OnGeometryChanged);
         }
 
         private void OnAttach(AttachToPanelEvent evt)
@@ -126,7 +153,7 @@ namespace Velvet
                 return;
             }
 
-            var edge = ResolveEdge();
+            var edge = ResolveEdge(container);
             var signature = ComputeSignature(container, edge);
             if (_hasSignature && signature == _lastSignature)
             {
@@ -226,9 +253,9 @@ namespace Velvet
         // flip is per-axis: a horizontal divide never reacts to column-reverse, and a vertical divide never
         // reacts to row-reverse — StyleFlexDirectionResolver returns ONE mutually-exclusive verdict per call,
         // so there is no stale leftover from a different family to react to.
-        private DivideEdge ResolveEdge()
+        private DivideEdge ResolveEdge(VisualElement container)
         {
-            var direction = StyleFlexDirectionResolver.Resolve(target);
+            var direction = StyleFlexDirectionResolver.Resolve(container, !ReferenceEquals(container, target));
             if (_spec.Axis == DivideAxis.Horizontal)
             {
                 return (_spec.Reverse || direction == FlexDirection.RowReverse) ? DivideEdge.Right : DivideEdge.Left;

--- a/Packages/com.velvet.core/Runtime/Styling/StyleFlexDirectionResolver.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleFlexDirectionResolver.cs
@@ -9,6 +9,20 @@ namespace Velvet
     // one; a manipulator that picked its edge from the axis alone would put its margin / border on an outer
     // edge of the container and leave the boundary between the visually adjacent pair unmarked.
     //
+    // The element handed in is the CHILD CONTAINER — the one the spaced children are actually parented to,
+    // which is FiberNodePatcher.GetChildContainer's answer. It is deliberately NOT the element a manipulator
+    // is attached to. A composite widget (ScrollView, Foldout, TabView, Tab, TwoPaneSplitView) redirects its
+    // children into an inner box, so a direction class written on the widget lays out the WIDGET's own box —
+    // a ScrollView's viewport and scrollers, a Foldout's toggle above its content — while the children being
+    // spaced sit one level down under the inner box's own direction. An edge picked from the attached
+    // element would then move the margin / border to the trailing side of a pair that is not painted in
+    // reverse order at all. For a plain element the two are the same element, so this is the same read.
+    //
+    // Consequence for every redirecting widget: a class string only ever reaches the element it is written
+    // on, so none of the five direction classes can land on an inner box and its verdict always comes from
+    // the resolvedStyle fallback (or, off-panel, the widgetOwned default) below. That is the honest answer —
+    // what lays an inner box out is the widget's own built-in USS, which no Velvet utility reaches.
+    //
     // The five direction/display classes are consulted FIRST — even on a panel — in the SAME precedence USS
     // itself uses when more than one matches the element (equal specificity, so the LAST declared RULE wins):
     // _layout.uss declares .flex, .grid, .flex-col, .flex-col-reverse, .flex-row, .flex-row-reverse in that
@@ -49,36 +63,49 @@ namespace Velvet
     // answer than omitting it does.
     internal static class StyleFlexDirectionResolver
     {
-        public static FlexDirection Resolve(VisualElement element)
+        // widgetOwned marks a child container that is a widget's own inner box rather than the element the
+        // class string was written on — see the header. It selects the off-panel default only.
+        public static FlexDirection Resolve(VisualElement childContainer, bool widgetOwned)
         {
-            if (element.ClassListContains("flex-row-reverse"))
+            if (childContainer.ClassListContains("flex-row-reverse"))
             {
                 return FlexDirection.RowReverse;
             }
-            if (element.ClassListContains("flex-row"))
+            if (childContainer.ClassListContains("flex-row"))
             {
                 return FlexDirection.Row;
             }
-            if (element.ClassListContains("flex-col-reverse"))
+            if (childContainer.ClassListContains("flex-col-reverse"))
             {
                 return FlexDirection.ColumnReverse;
             }
-            if (element.ClassListContains("flex-col"))
+            if (childContainer.ClassListContains("flex-col"))
             {
                 return FlexDirection.Column;
             }
-            if (element.ClassListContains("flex"))
+            if (childContainer.ClassListContains("flex"))
             {
                 return FlexDirection.Row;
             }
-            if (element.panel != null)
+            if (childContainer.panel != null)
             {
-                return element.resolvedStyle.flexDirection;
+                return childContainer.resolvedStyle.flexDirection;
             }
-            // No direction/display class and no panel to resolve against: mirror the .flex=row default — the
-            // one place this deliberately disagrees with the raw engine, whose own default is column (see
-            // Documentation~/styling-flexbox-and-gap.md, "The engine's raw flex default is a column, not a
-            // row").
+            // No direction/display class and no panel to resolve against. A widget's own inner box takes the
+            // ENGINE's default, column: the row default below exists only to mirror what .flex means on an
+            // element an author wrote a class string on, and no class string ever reaches here, so there is
+            // no such intent to mirror — what will actually lay this box out is the widget's own USS over
+            // Yoga's raw column default. Answering row instead would make the off-panel verdict disagree
+            // with the on-panel one for the same tree, and each would then pin the other's bug. A widget
+            // whose USS overrides that default (a horizontally scrolling ScrollView, a horizontal
+            // TwoPaneSplitView) is exactly what the resolvedStyle branch above is for, and needs a panel.
+            if (widgetOwned)
+            {
+                return FlexDirection.Column;
+            }
+            // Mirror the .flex=row default — the one place this deliberately disagrees with the raw engine,
+            // whose own default is column (see Documentation~/styling-flexbox-and-gap.md, "The engine's raw
+            // flex default is a column, not a row").
             return FlexDirection.Row;
         }
     }

--- a/Packages/com.velvet.core/Runtime/Styling/StyleFlexDirectionResolver.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleFlexDirectionResolver.cs
@@ -9,19 +9,15 @@ namespace Velvet
     // one; a manipulator that picked its edge from the axis alone would put its margin / border on an outer
     // edge of the container and leave the boundary between the visually adjacent pair unmarked.
     //
-    // The element handed in is the CHILD CONTAINER — the one the spaced children are actually parented to,
-    // which is FiberNodePatcher.GetChildContainer's answer. It is deliberately NOT the element a manipulator
-    // is attached to. A composite widget (ScrollView, Foldout, TabView, Tab, TwoPaneSplitView) redirects its
-    // children into an inner box, so a direction class written on the widget lays out the WIDGET's own box —
-    // a ScrollView's viewport and scrollers, a Foldout's toggle above its content — while the children being
-    // spaced sit one level down under the inner box's own direction. An edge picked from the attached
-    // element would then move the margin / border to the trailing side of a pair that is not painted in
-    // reverse order at all. For a plain element the two are the same element, so this is the same read.
+    // The element handed in is the CHILD CONTAINER (FiberNodePatcher.GetChildContainer), NOT the element a
+    // manipulator is attached to. A composite widget redirects its children into an inner box, so a
+    // direction class on the widget lays out the widget's own box — a ScrollView's viewport and scrollers —
+    // while the spaced children sit one level down under the inner box's direction. For a plain element the
+    // two are the same element.
     //
-    // Consequence for every redirecting widget: a class string only ever reaches the element it is written
-    // on, so none of the five direction classes can land on an inner box and its verdict always comes from
-    // the resolvedStyle fallback (or, off-panel, the widgetOwned default) below. That is the honest answer —
-    // what lays an inner box out is the widget's own built-in USS, which no Velvet utility reaches.
+    // A class string only reaches the element it is written on, so none of the five direction classes can
+    // land on an inner box: its verdict always comes from the resolvedStyle fallback (off-panel, the
+    // widgetOwned default) below, and what lays it out is the widget's own built-in USS.
     //
     // The five direction/display classes are consulted FIRST — even on a panel — in the SAME precedence USS
     // itself uses when more than one matches the element (equal specificity, so the LAST declared RULE wins):
@@ -63,8 +59,7 @@ namespace Velvet
     // answer than omitting it does.
     internal static class StyleFlexDirectionResolver
     {
-        // widgetOwned marks a child container that is a widget's own inner box rather than the element the
-        // class string was written on — see the header. It selects the off-panel default only.
+        // widgetOwned marks a widget's own inner box; it selects the off-panel default only.
         public static FlexDirection Resolve(VisualElement childContainer, bool widgetOwned)
         {
             if (childContainer.ClassListContains("flex-row-reverse"))
@@ -91,14 +86,12 @@ namespace Velvet
             {
                 return childContainer.resolvedStyle.flexDirection;
             }
-            // No direction/display class and no panel to resolve against. A widget's own inner box takes the
-            // ENGINE's default, column: the row default below exists only to mirror what .flex means on an
-            // element an author wrote a class string on, and no class string ever reaches here, so there is
-            // no such intent to mirror — what will actually lay this box out is the widget's own USS over
-            // Yoga's raw column default. Answering row instead would make the off-panel verdict disagree
-            // with the on-panel one for the same tree, and each would then pin the other's bug. A widget
-            // whose USS overrides that default (a horizontally scrolling ScrollView, a horizontal
-            // TwoPaneSplitView) is exactly what the resolvedStyle branch above is for, and needs a panel.
+            // No direction/display class and no panel. An inner box takes the ENGINE's default, column: the
+            // row default below mirrors what .flex means on an element an author wrote a class on, and no
+            // class reaches an inner box — what lays it out is the widget's own USS over Yoga's column.
+            // Answering row here would make the off-panel verdict disagree with the on-panel one for the
+            // same tree, so each could pin the other's bug. A widget whose USS overrides that default (a
+            // horizontally scrolling ScrollView, a TwoPaneSplitView) needs the panel branch above.
             if (widgetOwned)
             {
                 return FlexDirection.Column;

--- a/Packages/com.velvet.core/Runtime/Styling/StyleGapManipulator.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleGapManipulator.cs
@@ -33,16 +33,11 @@ namespace Velvet
     // reconciler attaches one per gap container, keeps it in ReconcilerContext.GapManipulators,
     // and removes it on cleanup / dispose. UnregisterCallbacksFromTarget clears the
     // margins it wrote so removing the gap class (or unmounting) leaves no residue.
-    // Child container. The manipulator is attached to the gap ELEMENT, but its
-    // children are reconciled into FiberNodePatcher.GetChildContainer(element) — for a composite widget
-    // (ScrollView, Foldout, TabView, Tab, TwoPaneSplitView) that is an inner box, not the widget itself,
-    // which wraps its own chrome around it. The manipulator therefore resolves and iterates
-    // that same child container (ChildContainer); the wrap path's negative margin is
-    // written on the child container too, so gap lands on the reconciled content and never on the widget's
-    // internal hierarchy. The direction (ResolveEdge) and wrap (IsWrap) verdicts are read from
-    // that same child container for the same reason: a direction or wrap class on the widget governs the
-    // WIDGET's own box, so choosing an edge or a spacing strategy from it would describe a layout the
-    // spaced children are not in.
+    // Child container. The manipulator is attached to the gap ELEMENT, but its children are reconciled
+    // into FiberNodePatcher.GetChildContainer(element) — a composite widget's inner box, not the widget.
+    // Everything naming a container names that one: the iteration, the wrap path's negative margin, and
+    // the direction / wrap verdicts (ResolveEdge, IsWrap). A direction or wrap class on the widget governs
+    // the WIDGET's box, which is not the box the spaced children are in.
     // Re-application. The spacing depends on the child set and, for every axis, the resolved
     // direction, both of which change outside this manipulator's own events. It is re-applied
     // from three sources: (1) the reconciler calls Apply right after it reconciles the
@@ -75,9 +70,8 @@ namespace Velvet
     // sides of EVERY child and -gap/2 on all four sides of the CHILD CONTAINER. Adjacent items
     // (in either axis, including across wrapped lines) are then separated by gap/2 + gap/2 == gap,
     // and the container's negative margin pulls content flush to its edge.
-    // Wrap is detected from the child container's own wrap class markers first, and from
-    // resolvedStyle.flexWrap only when none of them is present — see IsWrap. The half-margin path
-    // writes layout-independent margins, so it is fully resolved (and assertable) without a layout tick.
+    // Wrap is detected from the child container — see IsWrap. The half-margin path writes
+    // layout-independent margins, so it is fully resolved (and assertable) without a layout tick.
     // Direction never changes which edges wrap spaces (always symmetric), only non-wrap's edge choice.
     // Residual gaps versus native CSS gap (documented, not solved):
     // An explicit per-child margin on the SAME logical edge as the gap (e.g. ml-2 on a
@@ -120,10 +114,7 @@ namespace Velvet
         // that array to the element's live class list once a variant has toggled any layout gate class onto
         // it, which is what carries the marker across a breakpoint.
         // StyleFlexDirectionResolver, by contrast, reads the live child container's classList
-        // unconditionally, because unlike the gap spec itself the direction can change out from under the
-        // manipulator without a matching gap-config patch. The two halves of this feature therefore reach
-        // the live list by different routes on principle, not by accident — each is authoritative for what
-        // it answers.
+        // unconditionally: unlike the gap spec, the direction can change with no matching gap-config patch.
         private bool _xReverse;
         private bool _yReverse;
 
@@ -162,8 +153,7 @@ namespace Velvet
         private int _lastSignature;
         private bool _hasSignature;
 
-        // The inner box this manipulator additionally watches for geometry changes, when the child
-        // container is not the target itself. Null for a plain element. See ObserveChildContainer.
+        // Null unless the child container is a separate element — see ObserveChildContainer.
         private VisualElement? _observed;
 
         public StyleGapManipulator(float gap, GapAxis axis, bool xReverse, bool yReverse)
@@ -208,14 +198,10 @@ namespace Velvet
             }
         }
 
-        // Watches a child container that is NOT the target — a composite widget's inner box. The direction
-        // and wrap verdicts are read from that box, and GeometryChangedEvent neither bubbles nor trickles,
-        // so a re-layout confined to it (the widget reconfiguring itself, its own USS changing) reaches no
-        // callback on the target and would leave the verdict stale with nothing left to correct it.
-        // AttachToPanelEvent is deliberately not doubled: the inner box lives inside the target's own
-        // subtree and attaches in the same pass, so the target's handler already re-resolves then. The
-        // element is remembered rather than re-derived at teardown, so unregistration always releases
-        // whatever registration was made on.
+        // GeometryChangedEvent neither bubbles nor trickles, so a re-layout confined to a composite widget's
+        // inner box — the box the verdicts come from — reaches nothing registered on the target.
+        // AttachToPanelEvent is not doubled: the inner box attaches in the target's own subtree pass.
+        // The element is remembered, not re-derived, so teardown releases what registration took.
         private void ObserveChildContainer()
         {
             var container = ChildContainer;
@@ -542,28 +528,21 @@ namespace Velvet
         }
 
         // True when the child container wraps (selects the four-side half-margin path). Read from the child
-        // container for the same reason the direction is (see StyleFlexDirectionResolver): whether the
-        // spaced children wrap is a property of the box they sit in, and a wrap class on a composite widget
-        // sets only the widget's own. Unlike the direction resolve this needs no separate default for a
-        // widget's inner box: the final fallback here is already the engine's own (no wrap), so an inner box
-        // with no wrap class off-panel answers the same as it will once a panel resolves it — with the same
-        // residue the direction resolve has, an inner box whose own built-in USS sets flex-wrap, which only
-        // resolvedStyle (and so only a live panel) can report. That residue bites harder here than it does
+        // container, like the direction (see StyleFlexDirectionResolver): a wrap class on a composite widget
+        // sets only the widget's own. This needs no engine-default variant for an inner box the way the
+        // direction resolve does — the fallback below is already the engine's own no-wrap. The residue is
+        // an inner box whose built-in USS wraps, which only a live panel reports; it bites harder here than
         // for direction, since wrap is the only mode that writes the container's own margin.
-        // The flex-wrap / flex-nowrap / flex-wrap-reverse class markers are
-        // consulted first, in _layout.uss's own declaration order (flex-wrap, flex-nowrap,
-        // flex-wrap-reverse — so flex-wrap-reverse beats flex-nowrap beats flex-wrap when more than one is
-        // present). UNLIKE the direction resolve, there is no further "direction class implies a default"
-        // tier here: flex / flex-row(-reverse) / flex-col(-reverse) set flex-direction only — they say
-        // nothing about flex-wrap — so their presence is not evidence either way. resolvedStyle.flexWrap is
-        // the fallback whenever none of the three wrap classes is present, which is the catch-all for wrap
-        // set some other way (a custom stylesheet rule, an inline style) — nearly every real container
-        // carries a direction class, so folding direction classes into this check would take that fallback
-        // away for almost all of them, misreading a genuinely wrapping inline-styled container as
-        // non-wrapping. This fallback CAN read one pass stale on a same-rect toggle, the same
-        // risk StyleFlexDirectionResolver has — but unlike a direction flip, gaining or losing a wrapped line usually
-        // changes the container's own measured size, so the resulting GeometryChangedEvent self-corrects it
-        // in the common case; see the guide for the residual fixed-size exception.
+        // The flex-wrap / flex-nowrap / flex-wrap-reverse markers are consulted first, in _layout.uss's
+        // declaration order (flex-wrap-reverse beats flex-nowrap beats flex-wrap when more than one is
+        // present). There is no further "direction class implies a default" tier: flex / flex-row(-reverse)
+        // / flex-col(-reverse) set flex-direction only, and since nearly every real container carries one,
+        // treating them as evidence would take the resolvedStyle fallback away from almost all of them and
+        // misread a genuinely wrapping inline-styled container as non-wrapping. That fallback is the
+        // catch-all for wrap set some other way (a custom stylesheet rule, an inline style), and CAN read
+        // one pass stale on a same-rect toggle — but unlike a direction flip, gaining or losing a wrapped
+        // line usually changes the container's measured size, so the GeometryChangedEvent self-corrects it;
+        // see the guide for the residual fixed-size exception.
         private static bool IsWrap(VisualElement container)
         {
             if (container.ClassListContains("flex-wrap-reverse"))

--- a/Packages/com.velvet.core/Runtime/Styling/StyleGapManipulator.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleGapManipulator.cs
@@ -34,12 +34,15 @@ namespace Velvet
     // and removes it on cleanup / dispose. UnregisterCallbacksFromTarget clears the
     // margins it wrote so removing the gap class (or unmounting) leaves no residue.
     // Child container. The manipulator is attached to the gap ELEMENT, but its
-    // children are reconciled into FiberNodePatcher.GetChildContainer(element) — for a
-    // ScrollView that is the contentContainer, not the ScrollView itself (which
-    // wraps internal viewport / scroller elements). The manipulator therefore resolves and iterates
+    // children are reconciled into FiberNodePatcher.GetChildContainer(element) — for a composite widget
+    // (ScrollView, Foldout, TabView, Tab, TwoPaneSplitView) that is an inner box, not the widget itself,
+    // which wraps its own chrome around it. The manipulator therefore resolves and iterates
     // that same child container (ChildContainer); the wrap path's negative margin is
-    // written on the child container too, so gap lands on the reconciled content and never on a
-    // ScrollView's internal hierarchy.
+    // written on the child container too, so gap lands on the reconciled content and never on the widget's
+    // internal hierarchy. The direction (ResolveEdge) and wrap (IsWrap) verdicts are read from
+    // that same child container for the same reason: a direction or wrap class on the widget governs the
+    // WIDGET's own box, so choosing an edge or a spacing strategy from it would describe a layout the
+    // spaced children are not in.
     // Re-application. The spacing depends on the child set and, for every axis, the resolved
     // direction, both of which change outside this manipulator's own events. It is re-applied
     // from three sources: (1) the reconciler calls Apply right after it reconciles the
@@ -72,8 +75,8 @@ namespace Velvet
     // sides of EVERY child and -gap/2 on all four sides of the CHILD CONTAINER. Adjacent items
     // (in either axis, including across wrapped lines) are then separated by gap/2 + gap/2 == gap,
     // and the container's negative margin pulls content flush to its edge.
-    // Wrap is detected on-panel via resolvedStyle.flexWrap (Wrap / WrapReverse) and
-    // off-panel (EditMode) via the flex-wrap / flex-wrap-reverse class markers. The half-margin path
+    // Wrap is detected from the child container's own wrap class markers first, and from
+    // resolvedStyle.flexWrap only when none of them is present — see IsWrap. The half-margin path
     // writes layout-independent margins, so it is fully resolved (and assertable) without a layout tick.
     // Direction never changes which edges wrap spaces (always symmetric), only non-wrap's edge choice.
     // Residual gaps versus native CSS gap (documented, not solved):
@@ -116,10 +119,11 @@ namespace Velvet
         // variant-prefixed md:space-x-reverse resolves with the rest of the spec — the patcher switches
         // that array to the element's live class list once a variant has toggled any layout gate class onto
         // it, which is what carries the marker across a breakpoint.
-        // StyleFlexDirectionResolver, by contrast, reads the live element's classList unconditionally,
-        // because unlike the gap spec itself the direction can change out from under the manipulator
-        // without a matching gap-config patch. The two halves of this feature therefore reach the live list
-        // by different routes on principle, not by accident — each is authoritative for what it answers.
+        // StyleFlexDirectionResolver, by contrast, reads the live child container's classList
+        // unconditionally, because unlike the gap spec itself the direction can change out from under the
+        // manipulator without a matching gap-config patch. The two halves of this feature therefore reach
+        // the live list by different routes on principle, not by accident — each is authoritative for what
+        // it answers.
         private bool _xReverse;
         private bool _yReverse;
 
@@ -158,6 +162,10 @@ namespace Velvet
         private int _lastSignature;
         private bool _hasSignature;
 
+        // The inner box this manipulator additionally watches for geometry changes, when the child
+        // container is not the target itself. Null for a plain element. See ObserveChildContainer.
+        private VisualElement? _observed;
+
         public StyleGapManipulator(float gap, GapAxis axis, bool xReverse, bool yReverse)
         {
             _gap = gap;
@@ -184,6 +192,7 @@ namespace Velvet
         {
             target.RegisterCallback<AttachToPanelEvent>(OnAttach);
             target.RegisterCallback<GeometryChangedEvent>(OnGeometryChanged);
+            ObserveChildContainer();
             Apply();
         }
 
@@ -192,6 +201,30 @@ namespace Velvet
             Clear();
             target.UnregisterCallback<AttachToPanelEvent>(OnAttach);
             target.UnregisterCallback<GeometryChangedEvent>(OnGeometryChanged);
+            if (_observed != null)
+            {
+                _observed.UnregisterCallback<GeometryChangedEvent>(OnGeometryChanged);
+                _observed = null;
+            }
+        }
+
+        // Watches a child container that is NOT the target — a composite widget's inner box. The direction
+        // and wrap verdicts are read from that box, and GeometryChangedEvent neither bubbles nor trickles,
+        // so a re-layout confined to it (the widget reconfiguring itself, its own USS changing) reaches no
+        // callback on the target and would leave the verdict stale with nothing left to correct it.
+        // AttachToPanelEvent is deliberately not doubled: the inner box lives inside the target's own
+        // subtree and attaches in the same pass, so the target's handler already re-resolves then. The
+        // element is remembered rather than re-derived at teardown, so unregistration always releases
+        // whatever registration was made on.
+        private void ObserveChildContainer()
+        {
+            var container = ChildContainer;
+            if (container == null || ReferenceEquals(container, target))
+            {
+                return;
+            }
+            _observed = container;
+            container.RegisterCallback<GeometryChangedEvent>(OnGeometryChanged);
         }
 
         private void OnAttach(AttachToPanelEvent evt)
@@ -203,7 +236,7 @@ namespace Velvet
 
         private void OnGeometryChanged(GeometryChangedEvent evt) => Apply();
 
-        // The container children are reconciled into (a ScrollView's contentContainer; else self).
+        // The container children are reconciled into (a composite widget's inner box; else self).
         private VisualElement? ChildContainer
             => target == null ? null : FiberNodePatcher.GetChildContainer(target);
 
@@ -221,7 +254,7 @@ namespace Velvet
                 return;
             }
 
-            var wrap = IsWrap();
+            var wrap = IsWrap(container);
             var signature = ComputeSignature(container, wrap);
             if (_hasSignature && signature == _lastSignature)
             {
@@ -247,7 +280,7 @@ namespace Velvet
 
         private void ApplyLeading(VisualElement container)
         {
-            var edge = ResolveEdge();
+            var edge = ResolveEdge(container);
 
             // Clear whatever the previous pass wrote when the strategy changed: a stale wrap half-margin
             // set, or the previous leading edge after an Auto row↔column direction flip or a reverse-marker
@@ -475,7 +508,7 @@ namespace Velvet
             {
                 var hash = 17;
                 hash = hash * 31 + _gap.GetHashCode();
-                hash = hash * 31 + (wrap ? 1 : 100 + (int)ResolveEdge());
+                hash = hash * 31 + (wrap ? 1 : 100 + (int)ResolveEdge(container));
                 var count = container.childCount;
                 hash = hash * 31 + count;
                 hash = StyleOutOfFlowChild.HashChildSequence(hash, container);
@@ -492,9 +525,9 @@ namespace Velvet
         // horizontal gap never reacts to column-reverse, and a vertical gap never reacts to row-reverse —
         // StyleFlexDirectionResolver resolves ONE mutually-exclusive verdict per call, so there is no stale
         // leftover from a different family to react to.
-        private Edge ResolveEdge()
+        private Edge ResolveEdge(VisualElement container)
         {
-            var direction = StyleFlexDirectionResolver.Resolve(target);
+            var direction = StyleFlexDirectionResolver.Resolve(container, !ReferenceEquals(container, target));
             switch (_axis)
             {
                 case GapAxis.Horizontal:
@@ -508,38 +541,46 @@ namespace Velvet
             }
         }
 
-        // True when the container wraps (selects the four-side half-margin path). The flex-wrap /
-        // flex-nowrap / flex-wrap-reverse class markers are consulted first, in _layout.uss's own
-        // declaration order (flex-wrap, flex-nowrap, flex-wrap-reverse — so flex-wrap-reverse beats
-        // flex-nowrap beats flex-wrap when more than one is present). UNLIKE the direction resolve, there is
-        // no further "direction class implies a default" tier here: flex / flex-row(-reverse) /
-        // flex-col(-reverse) set flex-direction only — they say nothing about flex-wrap — so their
-        // presence is not evidence either way. resolvedStyle.flexWrap is the fallback whenever none of the
-        // three wrap classes is present, which is the catch-all for wrap set some other way (a custom
-        // stylesheet rule, an inline style) — nearly every real container carries a direction class, so
-        // folding direction classes into this check (as an earlier revision of this method did) would have
-        // taken that fallback away for almost all of them, misreading a genuinely wrapping inline-styled
-        // container as non-wrapping. This fallback CAN read one pass stale on a same-rect toggle, the same
+        // True when the child container wraps (selects the four-side half-margin path). Read from the child
+        // container for the same reason the direction is (see StyleFlexDirectionResolver): whether the
+        // spaced children wrap is a property of the box they sit in, and a wrap class on a composite widget
+        // sets only the widget's own. Unlike the direction resolve this needs no separate default for a
+        // widget's inner box: the final fallback here is already the engine's own (no wrap), so an inner box
+        // with no wrap class off-panel answers the same as it will once a panel resolves it — with the same
+        // residue the direction resolve has, an inner box whose own built-in USS sets flex-wrap, which only
+        // resolvedStyle (and so only a live panel) can report. That residue bites harder here than it does
+        // for direction, since wrap is the only mode that writes the container's own margin.
+        // The flex-wrap / flex-nowrap / flex-wrap-reverse class markers are
+        // consulted first, in _layout.uss's own declaration order (flex-wrap, flex-nowrap,
+        // flex-wrap-reverse — so flex-wrap-reverse beats flex-nowrap beats flex-wrap when more than one is
+        // present). UNLIKE the direction resolve, there is no further "direction class implies a default"
+        // tier here: flex / flex-row(-reverse) / flex-col(-reverse) set flex-direction only — they say
+        // nothing about flex-wrap — so their presence is not evidence either way. resolvedStyle.flexWrap is
+        // the fallback whenever none of the three wrap classes is present, which is the catch-all for wrap
+        // set some other way (a custom stylesheet rule, an inline style) — nearly every real container
+        // carries a direction class, so folding direction classes into this check would take that fallback
+        // away for almost all of them, misreading a genuinely wrapping inline-styled container as
+        // non-wrapping. This fallback CAN read one pass stale on a same-rect toggle, the same
         // risk StyleFlexDirectionResolver has — but unlike a direction flip, gaining or losing a wrapped line usually
         // changes the container's own measured size, so the resulting GeometryChangedEvent self-corrects it
         // in the common case; see the guide for the residual fixed-size exception.
-        private bool IsWrap()
+        private static bool IsWrap(VisualElement container)
         {
-            if (target.ClassListContains("flex-wrap-reverse"))
+            if (container.ClassListContains("flex-wrap-reverse"))
             {
                 return true;
             }
-            if (target.ClassListContains("flex-nowrap"))
+            if (container.ClassListContains("flex-nowrap"))
             {
                 return false;
             }
-            if (target.ClassListContains("flex-wrap"))
+            if (container.ClassListContains("flex-wrap"))
             {
                 return true;
             }
-            if (target.panel != null)
+            if (container.panel != null)
             {
-                var wrap = target.resolvedStyle.flexWrap;
+                var wrap = container.resolvedStyle.flexWrap;
                 return wrap == Wrap.Wrap || wrap == Wrap.WrapReverse;
             }
             return false;

--- a/Packages/com.velvet.core/Runtime/Styling/StyleGridManipulator.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleGridManipulator.cs
@@ -41,7 +41,7 @@ namespace Velvet
     // container, keeps it in ReconcilerContext.GridManipulators, and removes it on cleanup / dispose.
     // UnregisterCallbacksFromTarget clears the widths + margins it wrote so removing the grid class (or
     // unmounting) leaves no residue. Like the gap manipulator it iterates FiberNodePatcher.GetChildContainer,
-    // so the sizing lands on the reconciled content and never on a ScrollView's internal hierarchy.
+    // so the sizing lands on the reconciled content and never on a composite widget's internal hierarchy.
     //
     // Out-of-flow children (position: absolute) are excluded from the column/row walk — see
     // StyleOutOfFlowChild — matching CSS Grid, whose auto-placement never assigns a cell to an

--- a/Packages/com.velvet.core/Runtime/Styling/StyleSkewChildTranslateManipulator.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleSkewChildTranslateManipulator.cs
@@ -108,7 +108,7 @@ namespace Velvet
 
         private void OnGeometryChanged(GeometryChangedEvent evt) => Apply();
 
-        // The children are reconciled into (a ScrollView's contentContainer; else the caster itself).
+        // The children are reconciled into (a composite widget's inner box; else the caster itself).
         private VisualElement? ChildContainer
             => target == null ? null : FiberNodePatcher.GetChildContainer(target);
 
@@ -124,9 +124,9 @@ namespace Velvet
             }
 
             // The shear box is the CASTER's OWN layout — the box SkewSilhouette.Draw shears the silhouette at.
-            // For a ScrollView the children live in contentContainer, whose resolved height is the full unclamped
-            // content extent, not the visible caster box; reading the box from the container would centre the
-            // shear on the content midpoint and seat every child against a line the silhouette never paints.
+            // For a composite widget the children live in its inner box — a ScrollView's content container has the
+            // full unclamped content extent, not the visible caster box; reading the box from the container would
+            // centre the shear on the content midpoint and seat every child against a line the silhouette never paints.
             // Children are still enumerated from the container, where their laid-out centroids live; for a plain
             // element the container IS the caster, so the two boxes coincide.
             var box = target.layout;

--- a/Packages/com.velvet.core/Runtime/Styling/StyleTextBalanceManipulator.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleTextBalanceManipulator.cs
@@ -91,10 +91,10 @@ namespace Velvet
     // as the target's own listeners already are. The subscription is (re-)synced at the top of every
     // Apply() call, not only from AttachToPanelEvent, so a mid-life reparent is picked up by whichever
     // event fires next regardless of exactly how UI Toolkit sequences Attach/Detach for a same-panel
-    // reparent. What remains uncovered: a resize confined entirely to a ScrollView parent's OWN
-    // contentContainer (GetChildContainer's ScrollView case) with no accompanying change to the
-    // ScrollView's own outer rect — e.g. a scrollbar toggling — since the subscription is the ScrollView
-    // itself, not its contentContainer. A grandparent-or-higher resize is NOT a separate gap: available is
+    // reparent. What remains uncovered: a resize confined entirely to a composite-widget parent's OWN inner
+    // box (GetChildContainer's redirect case, e.g. a ScrollView's content container) with no accompanying
+    // change to the widget's own outer rect — a scrollbar toggling, say — since the subscription is the
+    // widget itself, not its inner box. A grandparent-or-higher resize is NOT a separate gap: available is
     // read from the parent's own contentRect, so if the parent's rect is genuinely unaffected by a
     // grandparent change, there is nothing that needed re-deriving in the first place.
     //

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/CompositeWidgetSpacingDirectionPanelTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/CompositeWidgetSpacingDirectionPanelTests.cs
@@ -5,23 +5,17 @@ using Velvet.TestUtilities;
 namespace Velvet.Tests
 {
     /// <summary>
-    /// Pins which element the inter-child spacing manipulators take their direction verdict from when the two
-    /// candidates differ. They differ on any composite widget that redirects its children into an inner box:
-    /// a class string lands on the widget, whose own box lays out its chrome (a ScrollView's viewport and
-    /// scrollers, a Foldout's toggle above its content), while the children being spaced are reconciled one
-    /// level down. A reversed direction class therefore reverses the widget and not the content, so the
-    /// boundary between two adjacent content children is still the axis's leading edge — reading the attached
-    /// element instead moves the gap margin and the divider border to the trailing edge of content that is
-    /// painted in source order. A plain <c>gap-*</c> likewise takes its AXIS from the inner box, so a
-    /// <c>flex-row</c> on the widget does not make its column-stacked content space horizontally.
+    /// Pins which element the inter-child spacing manipulators take their direction verdict from, on a
+    /// composite widget that redirects its children into an inner box. The class string lands on the widget,
+    /// so a reversed direction class reverses the widget and not the content: the boundary between two
+    /// adjacent content children is still the axis's leading edge, and a plain <c>gap-*</c> takes its axis
+    /// from the inner box rather than from the widget.
     /// <para>
-    /// These cases need a real <see cref="UnityEditor.EditorWindow"/> panel with the bundled
-    /// <c>StyleUtilities.uss</c> attached: <c>flex-row-reverse</c> is a USS-only rule, so nothing reports the
-    /// widget as genuinely reversed without one, and an inner box's own direction — which no Velvet class can
-    /// reach — is readable only through <c>resolvedStyle</c>. The horizontally scrolling case is the one that
-    /// proves the <c>resolvedStyle</c> branch actually runs: every other inner box here resolves to a column,
-    /// which is also the off-panel default, so it alone separates "resolved" from "defaulted and lucky".
-    /// GWT, one assert per case.
+    /// A real <see cref="UnityEditor.EditorWindow"/> panel with the bundled <c>StyleUtilities.uss</c> is
+    /// required: <c>flex-row-reverse</c> is a USS-only rule, and an inner box's direction — which no Velvet
+    /// class can reach — is readable only through <c>resolvedStyle</c>. The horizontally scrolling case is
+    /// the one proving that branch runs at all; every other inner box here resolves to a column, which is
+    /// also the off-panel default. GWT, one assert per case.
     /// </para>
     /// </summary>
     [TestFixture]
@@ -40,9 +34,8 @@ namespace Velvet.Tests
             V.Label(name: "c", text: "c"),
         };
 
-        // Mounts node and resolves the panel around its widget. The manipulators re-derive from a geometry
-        // event on their own container once resolvedStyle is valid, which the EditMode player loop never
-        // delivers on its own.
+        // The geometry event is synthesized because the EditMode player loop delivers none, and the
+        // manipulators only re-derive from one once resolvedStyle is valid.
         private T MountAndResolve<T>(VNode node) where T : VisualElement
         {
             _mounted = V.Mount(_window.rootVisualElement, node);
@@ -54,8 +47,8 @@ namespace Velvet.Tests
             return widget;
         }
 
-        // V.Custom is the mount path here so one helper covers every redirecting widget, including the ones
-        // with no first-class V factory; for a ScrollView it builds the same node V.ScrollView does.
+        // V.Custom reaches the widgets with no first-class V factory; for a ScrollView it builds the same
+        // node V.ScrollView does.
         private T MountWidget<T>(string className) where T : VisualElement
             => MountAndResolve<T>(V.Custom<T>(className, ThreeLabels()));
 
@@ -70,8 +63,7 @@ namespace Velvet.Tests
             Assume.That(content.childCount, Is.EqualTo(3),
                 "Precondition: the spaced children reconcile into the content container");
 
-            // Assert — the content container is not reversed, so the gap between the first pair is the
-            // second child's leading margin.
+            // Assert — the content container is not reversed, so the boundary is a leading margin.
             Assert.That(content[1].style.marginLeft.value.value, Is.EqualTo(Space4));
         }
 
@@ -86,16 +78,14 @@ namespace Velvet.Tests
             Assume.That(content.childCount, Is.EqualTo(3),
                 "Precondition: the divided children reconcile into the content container");
 
-            // Assert — same boundary, same reasoning: the divider between the first pair is the second
-            // child's leading border.
+            // Assert — same boundary as the gap case, so a leading border.
             Assert.That(content[1].style.borderLeftWidth.value, Is.EqualTo(DivideWidth));
         }
 
         [Test]
         public void Given_ARowScrollView_When_APlainGapSpacesItsContent_Then_TheAxisFollowsTheContentContainer()
         {
-            // Arrange / Act — a plain gap-* takes its axis from the resolved direction, and the class fixes
-            // the ScrollView's own direction to a row while its content container stays a column.
+            // Arrange / Act
             var scrollView = MountWidget<ScrollView>("flex flex-row gap-4");
             var content = scrollView.contentContainer;
             Assume.That(scrollView.resolvedStyle.flexDirection, Is.EqualTo(FlexDirection.Row),
@@ -110,9 +100,8 @@ namespace Velvet.Tests
         [Test]
         public void Given_AHorizontallyScrollingScrollView_When_APlainGapSpacesItsContent_Then_TheAxisFollowsTheResolvedRow()
         {
-            // Arrange / Act — a horizontal scroll mode is the case where the inner box resolves to a ROW,
-            // against both the class on the widget (a column) and the off-panel default for an inner box
-            // (also a column). Only reading the box's resolved style can land on the row's leading edge.
+            // Arrange / Act — a horizontal scroll mode resolves the inner box to a ROW, against both the
+            // class on the widget and the off-panel default for an inner box, which are each a column.
             var scrollView = MountAndResolve<ScrollView>(V.ScrollView(
                 className: "flex flex-col gap-4",
                 onCreated: el => ((ScrollView)el).mode = ScrollViewMode.Horizontal,
@@ -130,8 +119,7 @@ namespace Velvet.Tests
         [Test]
         public void Given_AReversedRowFoldout_When_AGapSpacesItsContent_Then_TheMarginSitsOnTheLeadingEdge()
         {
-            // Arrange / Act — the same mismatch on a widget with no first-class V factory, reached through
-            // V.Custom: a Foldout redirects its children into the box below its toggle.
+            // Arrange / Act — the same mismatch on a widget that is not a ScrollView.
             var foldout = MountWidget<Foldout>("flex flex-row-reverse gap-x-4");
             var content = foldout.contentContainer;
             Assume.That(foldout.resolvedStyle.flexDirection, Is.EqualTo(FlexDirection.RowReverse),

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/CompositeWidgetSpacingDirectionPanelTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/CompositeWidgetSpacingDirectionPanelTests.cs
@@ -1,0 +1,146 @@
+using NUnit.Framework;
+using UnityEngine.UIElements;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins which element the inter-child spacing manipulators take their direction verdict from when the two
+    /// candidates differ. They differ on any composite widget that redirects its children into an inner box:
+    /// a class string lands on the widget, whose own box lays out its chrome (a ScrollView's viewport and
+    /// scrollers, a Foldout's toggle above its content), while the children being spaced are reconciled one
+    /// level down. A reversed direction class therefore reverses the widget and not the content, so the
+    /// boundary between two adjacent content children is still the axis's leading edge — reading the attached
+    /// element instead moves the gap margin and the divider border to the trailing edge of content that is
+    /// painted in source order. A plain <c>gap-*</c> likewise takes its AXIS from the inner box, so a
+    /// <c>flex-row</c> on the widget does not make its column-stacked content space horizontally.
+    /// <para>
+    /// These cases need a real <see cref="UnityEditor.EditorWindow"/> panel with the bundled
+    /// <c>StyleUtilities.uss</c> attached: <c>flex-row-reverse</c> is a USS-only rule, so nothing reports the
+    /// widget as genuinely reversed without one, and an inner box's own direction — which no Velvet class can
+    /// reach — is readable only through <c>resolvedStyle</c>. The horizontally scrolling case is the one that
+    /// proves the <c>resolvedStyle</c> branch actually runs: every other inner box here resolves to a column,
+    /// which is also the off-panel default, so it alone separates "resolved" from "defaulted and lucky".
+    /// GWT, one assert per case.
+    /// </para>
+    /// </summary>
+    [TestFixture]
+    internal sealed class CompositeWidgetSpacingDirectionPanelTests : PanelTestBase
+    {
+        // --space-4 == 16px (see _tokens.uss); a bare divide-x is a 1px border.
+        private const float Space4 = 16f;
+        private const float DivideWidth = 1f;
+
+        protected override void LoadStyleSheets() => _window.rootVisualElement.LoadBundledStyleUtilitiesForTest();
+
+        private static VNode[] ThreeLabels() => new VNode[]
+        {
+            V.Label(name: "a", text: "a"),
+            V.Label(name: "b", text: "b"),
+            V.Label(name: "c", text: "c"),
+        };
+
+        // Mounts node and resolves the panel around its widget. The manipulators re-derive from a geometry
+        // event on their own container once resolvedStyle is valid, which the EditMode player loop never
+        // delivers on its own.
+        private T MountAndResolve<T>(VNode node) where T : VisualElement
+        {
+            _mounted = V.Mount(_window.rootVisualElement, node);
+            var widget = _window.rootVisualElement.Q<T>();
+            ForcePanelUpdate(widget.panel);
+            using var evt = EventBase<GeometryChangedEvent>.GetPooled();
+            widget.SimulateEvent(evt);
+            ForcePanelUpdate(widget.panel);
+            return widget;
+        }
+
+        // V.Custom is the mount path here so one helper covers every redirecting widget, including the ones
+        // with no first-class V factory; for a ScrollView it builds the same node V.ScrollView does.
+        private T MountWidget<T>(string className) where T : VisualElement
+            => MountAndResolve<T>(V.Custom<T>(className, ThreeLabels()));
+
+        [Test]
+        public void Given_AReversedRowScrollView_When_AGapSpacesItsContent_Then_TheMarginSitsOnTheLeadingEdge()
+        {
+            // Arrange / Act
+            var scrollView = MountWidget<ScrollView>("flex flex-row-reverse gap-x-4");
+            var content = scrollView.contentContainer;
+            Assume.That(scrollView.resolvedStyle.flexDirection, Is.EqualTo(FlexDirection.RowReverse),
+                "Precondition: the panel resolved flex-row-reverse on the ScrollView's own box");
+            Assume.That(content.childCount, Is.EqualTo(3),
+                "Precondition: the spaced children reconcile into the content container");
+
+            // Assert — the content container is not reversed, so the gap between the first pair is the
+            // second child's leading margin.
+            Assert.That(content[1].style.marginLeft.value.value, Is.EqualTo(Space4));
+        }
+
+        [Test]
+        public void Given_AReversedRowScrollView_When_ADivideSeparatesItsContent_Then_TheBorderSitsOnTheLeadingEdge()
+        {
+            // Arrange / Act
+            var scrollView = MountWidget<ScrollView>("flex flex-row-reverse divide-x divide-gray-200");
+            var content = scrollView.contentContainer;
+            Assume.That(scrollView.resolvedStyle.flexDirection, Is.EqualTo(FlexDirection.RowReverse),
+                "Precondition: the panel resolved flex-row-reverse on the ScrollView's own box");
+            Assume.That(content.childCount, Is.EqualTo(3),
+                "Precondition: the divided children reconcile into the content container");
+
+            // Assert — same boundary, same reasoning: the divider between the first pair is the second
+            // child's leading border.
+            Assert.That(content[1].style.borderLeftWidth.value, Is.EqualTo(DivideWidth));
+        }
+
+        [Test]
+        public void Given_ARowScrollView_When_APlainGapSpacesItsContent_Then_TheAxisFollowsTheContentContainer()
+        {
+            // Arrange / Act — a plain gap-* takes its axis from the resolved direction, and the class fixes
+            // the ScrollView's own direction to a row while its content container stays a column.
+            var scrollView = MountWidget<ScrollView>("flex flex-row gap-4");
+            var content = scrollView.contentContainer;
+            Assume.That(scrollView.resolvedStyle.flexDirection, Is.EqualTo(FlexDirection.Row),
+                "Precondition: the panel resolved flex-row on the ScrollView's own box");
+            Assume.That(content.resolvedStyle.flexDirection, Is.EqualTo(FlexDirection.Column),
+                "Precondition: the content container lays its children out as a column");
+
+            // Assert — the gap spaces the axis the content actually stacks on.
+            Assert.That(content[1].style.marginTop.value.value, Is.EqualTo(Space4));
+        }
+
+        [Test]
+        public void Given_AHorizontallyScrollingScrollView_When_APlainGapSpacesItsContent_Then_TheAxisFollowsTheResolvedRow()
+        {
+            // Arrange / Act — a horizontal scroll mode is the case where the inner box resolves to a ROW,
+            // against both the class on the widget (a column) and the off-panel default for an inner box
+            // (also a column). Only reading the box's resolved style can land on the row's leading edge.
+            var scrollView = MountAndResolve<ScrollView>(V.ScrollView(
+                className: "flex flex-col gap-4",
+                onCreated: el => ((ScrollView)el).mode = ScrollViewMode.Horizontal,
+                children: ThreeLabels()));
+            var content = scrollView.contentContainer;
+            Assume.That(content.resolvedStyle.flexDirection, Is.EqualTo(FlexDirection.Row),
+                "Precondition: the horizontal scroll mode lays the content container out as a row");
+            Assume.That(scrollView.resolvedStyle.flexDirection, Is.EqualTo(FlexDirection.Column),
+                "Precondition: the class still resolves the ScrollView's own box to a column");
+
+            // Assert — the row's leading edge, which neither the class nor the default would have chosen.
+            Assert.That(content[1].style.marginLeft.value.value, Is.EqualTo(Space4));
+        }
+
+        [Test]
+        public void Given_AReversedRowFoldout_When_AGapSpacesItsContent_Then_TheMarginSitsOnTheLeadingEdge()
+        {
+            // Arrange / Act — the same mismatch on a widget with no first-class V factory, reached through
+            // V.Custom: a Foldout redirects its children into the box below its toggle.
+            var foldout = MountWidget<Foldout>("flex flex-row-reverse gap-x-4");
+            var content = foldout.contentContainer;
+            Assume.That(foldout.resolvedStyle.flexDirection, Is.EqualTo(FlexDirection.RowReverse),
+                "Precondition: the panel resolved flex-row-reverse on the Foldout's own box");
+            Assume.That(content.childCount, Is.EqualTo(3),
+                "Precondition: the spaced children reconcile into the Foldout's inner container");
+
+            // Assert
+            Assert.That(content[1].style.marginLeft.value.value, Is.EqualTo(Space4));
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/CompositeWidgetSpacingDirectionPanelTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/CompositeWidgetSpacingDirectionPanelTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 465c0cfc83af4436e81afba6688e0d7a

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/GapParityTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/GapParityTests.cs
@@ -42,7 +42,13 @@ namespace Velvet.Tests
     /// The manipulator writes INLINE margins (resolved to pixels from the same scale as <c>_tokens.uss</c>), so
     /// the produced spacing is observable via <c>element.style.margin*</c> without attaching to a panel or
     /// ticking layout — off-panel, both direction and wrap fall back from the class markers (the only source
-    /// available) to the same defaults their on-panel <c>resolvedStyle</c> fallback would produce. A USS
+    /// available) to the same defaults their on-panel <c>resolvedStyle</c> fallback would produce. That
+    /// agreement extends to a composite widget's inner box, which no class marker can reach: its off-panel
+    /// direction default is the engine's column rather than <c>.flex</c>'s row precisely so the two answers
+    /// match, and its wrap default was already the engine's. It does NOT extend to a widget whose own
+    /// built-in USS lays that box out as a row — a horizontally scrolling <c>ScrollView</c>, a
+    /// <c>TwoPaneSplitView</c>, a <c>ToggleButtonGroup</c> — which only a live panel reports; that case is
+    /// covered in <see cref="CompositeWidgetSpacingDirectionPanelTests"/>. A USS
     /// child-selector approach to gap would resolve only under a live panel and produce no inline margins at
     /// all, so these off-panel assertions are a meaningful discriminator against that class of implementation.
     /// </remarks>
@@ -420,6 +426,9 @@ namespace Velvet.Tests
         // landing there would shift the whole scroller instead of just the content. We assert both: content
         // is spaced, and the container margin is on the contentContainer with the ScrollView's own margin
         // left untouched.
+        // The wrap verdict is read from the content container as well, so the class that makes it wrap has
+        // to sit there: a flex-wrap in the ScrollView's own class string wraps only the ScrollView's box,
+        // which holds the viewport and the scrollers rather than the spaced children.
         [Test]
         public void Given_ScrollViewWrapGap4_When_Reconciled_Then_ContainerMarginOnContentNotScrollView()
         {
@@ -427,7 +436,10 @@ namespace Velvet.Tests
             using var scope = new ReconcilerScope();
             var tree = new VNode[]
             {
-                V.ScrollView("flex flex-row flex-wrap gap-4", Children(3)),
+                V.ScrollView(
+                    className: "flex flex-row gap-4",
+                    onCreated: el => ((ScrollView)el).contentContainer.AddToClassList("flex-wrap"),
+                    children: Children(3)),
             };
 
             // Act
@@ -474,6 +486,30 @@ namespace Velvet.Tests
             Assert.That(content[0].style.marginTop.value.value, Is.EqualTo(0f), "first content child no leading gap");
             Assert.That(content[1].style.marginTop.value.value, Is.EqualTo(Space2), "gap before 2nd content child");
             Assert.That(content[2].style.marginTop.value.value, Is.EqualTo(Space2), "gap before 3rd content child");
+        }
+
+        // The off-panel half of the plain-gap axis verdict for a redirecting widget. The direction class is on
+        // the ScrollView, which no child of the content container is laid out by, and no class marker can
+        // reach the content container itself — so the axis comes from the off-panel default for a widget's own
+        // inner box, which is the engine's column. Its on-panel twin (CompositeWidgetSpacingDirectionPanelTests)
+        // resolves the same container through resolvedStyle and must land on the same edge: a default that
+        // disagreed with the resolved answer would let an off-panel test pin what an on-panel one refutes.
+        [Test]
+        public void Given_ScrollViewRowGap4_When_ReconciledOffPanel_Then_TheAxisFollowsTheContentContainer()
+        {
+            // Arrange
+            using var scope = new ReconcilerScope();
+            var tree = new VNode[]
+            {
+                V.ScrollView("flex flex-row gap-4", Children(3)),
+            };
+
+            // Act
+            scope.Reconciler.Reconcile(scope.Root, System.Array.Empty<VNode>(), tree);
+            var content = ((ScrollView)Container(scope.Root)).contentContainer;
+
+            // Assert: vertical spacing, matching the column the content container resolves to on a panel.
+            Assert.That(content[1].style.marginTop.value.value, Is.EqualTo(Space4));
         }
 
         // Bug 2: off-panel, bare `flex gap-4` (Auto axis, no flex-row/flex-col) must resolve the ROW edge

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/GapParityTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/GapParityTests.cs
@@ -43,10 +43,9 @@ namespace Velvet.Tests
     /// the produced spacing is observable via <c>element.style.margin*</c> without attaching to a panel or
     /// ticking layout — off-panel, both direction and wrap fall back from the class markers (the only source
     /// available) to the same defaults their on-panel <c>resolvedStyle</c> fallback would produce. That
-    /// agreement extends to a composite widget's inner box, which no class marker can reach: its off-panel
-    /// direction default is the engine's column rather than <c>.flex</c>'s row precisely so the two answers
-    /// match, and its wrap default was already the engine's. It does NOT extend to a widget whose own
-    /// built-in USS lays that box out as a row — a horizontally scrolling <c>ScrollView</c>, a
+    /// agreement extends to a composite widget's inner box, whose off-panel direction default is the
+    /// engine's column rather than <c>.flex</c>'s row so that the two answers match. It does NOT extend to a
+    /// widget whose built-in USS lays that box out as a row — a horizontally scrolling <c>ScrollView</c>, a
     /// <c>TwoPaneSplitView</c>, a <c>ToggleButtonGroup</c> — which only a live panel reports; that case is
     /// covered in <see cref="CompositeWidgetSpacingDirectionPanelTests"/>. A USS
     /// child-selector approach to gap would resolve only under a live panel and produce no inline margins at
@@ -426,9 +425,8 @@ namespace Velvet.Tests
         // landing there would shift the whole scroller instead of just the content. We assert both: content
         // is spaced, and the container margin is on the contentContainer with the ScrollView's own margin
         // left untouched.
-        // The wrap verdict is read from the content container as well, so the class that makes it wrap has
-        // to sit there: a flex-wrap in the ScrollView's own class string wraps only the ScrollView's box,
-        // which holds the viewport and the scrollers rather than the spaced children.
+        // The wrap class sits on the contentContainer because that is where the wrap verdict is read from —
+        // a flex-wrap in the ScrollView's own class string wraps only the ScrollView's box.
         [Test]
         public void Given_ScrollViewWrapGap4_When_Reconciled_Then_ContainerMarginOnContentNotScrollView()
         {
@@ -488,12 +486,10 @@ namespace Velvet.Tests
             Assert.That(content[2].style.marginTop.value.value, Is.EqualTo(Space2), "gap before 3rd content child");
         }
 
-        // The off-panel half of the plain-gap axis verdict for a redirecting widget. The direction class is on
-        // the ScrollView, which no child of the content container is laid out by, and no class marker can
-        // reach the content container itself — so the axis comes from the off-panel default for a widget's own
-        // inner box, which is the engine's column. Its on-panel twin (CompositeWidgetSpacingDirectionPanelTests)
-        // resolves the same container through resolvedStyle and must land on the same edge: a default that
-        // disagreed with the resolved answer would let an off-panel test pin what an on-panel one refutes.
+        // No class marker can reach the content container, so off-panel the axis comes from the inner-box
+        // default, the engine's column. The on-panel twin in CompositeWidgetSpacingDirectionPanelTests
+        // resolves the same container and must land on the same edge — a default disagreeing with the
+        // resolved answer would let one of the two pin what the other refutes.
         [Test]
         public void Given_ScrollViewRowGap4_When_ReconciledOffPanel_Then_TheAxisFollowsTheContentContainer()
         {


### PR DESCRIPTION
## What

The gap and divide manipulators resolved the container's flex direction — and the wrap check its strategy — from the element they are attached to. But the children they space live in that element's **child container**, which is not the same element for every widget. On a composite widget a direction class sits on the widget and lays out its own box, while the spaced children live in an inner box whose direction was never read. A reversed direction class moved the margin or the divider to the trailing edge while the content was not reversed.

Both manipulators now resolve from the element whose children are actually being spaced, keyed on the redirect (`contentContainer` differing from the element) rather than on a widget type. That covers every redirecting widget rather than only `ScrollView` — `Foldout`, `Tab`, `TabView`, `TwoPaneSplitView`, `RadioButtonGroup`, `ToggleButtonGroup` and `PopupWindow` all reach the same defect through `V.Custom<T>`.

## Two bugs this repairs as a side effect

The membership predicate (`child.parent != container`) compared against the widget rather than the box its children are in, so it was permanently wrong on every redirecting widget except `ScrollView`:

- Gap's stale-margin reset cleared **all four margins on every tracked child, including out-of-flow ones it must leave alone** — visibly shifting an `AnimatePresence` exit ghost mid-flight.
- Skew's managed check never matched, so each pass re-captured the *previous pass's shear* as a child's own baseline and unskew restored a stale shear permanently.

## Off-panel default

An inner box carries no Velvet class, so its verdict comes from the resolved style — unavailable off-panel. The off-panel default for an inner box is now the engine's column rather than `.flex`'s row, since no class string can reach an inner box and what lays it out is the widget's own USS over the engine default.

That makes the off-panel and on-panel answers agree **except** for a widget whose own USS overrides the engine default — a horizontally scrolling `ScrollView`, `TwoPaneSplitView`, `ToggleButtonGroup`. On those, the first application runs pre-attach, writes the column edge, and moves to the row edge on the first geometry event: one frame, where previously there was none.

## Re-application

`GeometryChangedEvent` neither bubbles nor trickles, so a re-layout confined to the inner box reached no callback on the widget and left the verdict stale with nothing to correct it — reachable by setting a `ScrollView`'s mode through a ref. Both manipulators now also observe the child container when it differs from the target, remembering the element so teardown releases exactly what registration took. `AttachToPanelEvent` is deliberately not doubled: the inner box is inside the target's subtree and attaches in the same pass.

## Verification

Seven tests fail with production reverted and pass with it, `inconclusive="0"` so every precondition genuinely held. The new coverage includes a **Row** inner box on a panel — a horizontally scrolling `ScrollView` whose class says column and whose off-panel default says column, so only the resolved branch can land on the leading edge — and an off-panel case, so neither side of the panel boundary can pin what the other refutes.

EditMode 3418 passed / 0 failed / 3 pre-existing skips. PlayMode 99/99. Generators 208/208.

## Docs

`Documentation~/styling-flexbox-and-gap.md` states which element each verdict comes from, the residue where off-panel and on-panel still disagree, and the re-application coupling. Three sentences that were false before this change were corrected: the wrap check never had a "direction class implies no-wrap" tier; spacing utilities *do* reach inside a composite widget; and the half-margin path on a `ScrollView` is unreachable from class strings rather than unreachable outright.

Closes #171