### PR TITLE
fix(velvet): anchor the generated-project-file ignores to the project root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,8 +22,11 @@
 .vs/
 .idea/
 .vscode/
-*.csproj
-*.sln
+# Unity regenerates these at the project root. Anchored so the hand-authored projects
+# under Generators~ and docs/ stay committed — an unanchored rule drops a new one
+# silently and only fails on a fresh clone.
+/*.csproj
+/*.sln
 *.user
 *.userprefs
 *.unityproj


### PR DESCRIPTION
## What

`.gitignore` matched `*.csproj` and `*.sln` anywhere in the tree. Unity regenerates those at the **project root**, but the same patterns also cover the hand-authored projects under `Packages/com.velvet.core/Generators~/` and `docs/`, which are sources.

The three that exist today were force-added, so the rule looked harmless. It is not: a project file added normally stays untracked, and the failure surfaces only on a fresh clone — every local run stays green because the file is present locally, while CI cannot load the solution at all.

Anchoring both patterns to the root keeps Unity's regenerated files ignored and lets the authored ones be committed the ordinary way.

## Verification

With the change in place:

- `Assembly-CSharp.csproj` and `velvet.sln` at the root still match, attributed to the anchored rules.
- `Generators~/src/**/**.csproj`, `Generators~/Velvet.SourceGenerators.sln` and `docs/Velvet.Docs.csproj` no longer match.

The four project files already tracked are unaffected — a tracked path ignores `.gitignore` — so this changes nothing about the current tree and only removes the trap for the next one.