### PR TITLE
docs(velvet): add a deletion test for comment length

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,4 +73,29 @@ Tests are **colocated** with the code: `Runtime/<Area>/Tests/Editor/` and `.../T
 - Commits use Conventional Commits with the `velvet` scope (e.g. `fix(velvet): …`, `feat(velvet): …`, `refactor(velvet): …`).
 - Everything in this repo is written in English: code, comments, commit messages, and PR titles/bodies. PR descriptions state what changed and why — never the local workflow that produced the change (audit/review process, agent tooling, session details).
 - A PR that adds, changes, or removes a feature updates the corresponding `Documentation~` guide (and the `Documentation~/README.md` index table) in the same PR. If the change has no doc impact, say so explicitly in the PR body. `DocumentationDriftTests` (EditMode) and the Generators~ diagnostic-table tests catch API references and diagnostic IDs that no longer exist, but they cannot verify that a behavior description is still accurate — that stays the PR author's responsibility.
-- Documentation is single-source-of-truth: a given fact (the hooks table, the factory list, the diagnostic-ID table, a feature's behavior description) lives in exactly one owning document. Other documents link to it and add at most a one-line summary instead of restating it. Duplicated statements are how docs drift — when the fact changes, only one copy gets updated.
+- Documentation is single-source-of-truth: a given fact (the hooks table, the factory list, the diagnostic-ID table, a feature's behavior description) lives in exactly one owning document. Other documents link to it and add at most a one-line summary instead of restating it. Duplicated statements are how docs drift — when the fact changes, only one copy gets updated. This holds for comments too: name a sibling's mechanism ("same ownership rule as `StyleGapManipulator`"), never re-explain it.
+
+## Comment length
+
+A comment states why, never what — and states it once. Length is not capped, but every sentence must survive the **deletion test**: delete it; if a competent reader of the surrounding code plus the remaining sentences would still get it right, the sentence was carrying nothing. Delete it for real.
+
+Four things reliably fail the test and should not be written:
+
+- a restatement of the declaration below the comment — its name, signature, or next lines;
+- a consequence that follows from a constraint already stated above it;
+- an argument that a non-problem is not a problem;
+- a sibling file's mechanism re-explained instead of named.
+
+Four things pass, and stay however long they need to be:
+
+- engine behavior that had to be measured, decompiled, or read out of Unity's source;
+- an ordering constraint between passes, writes, or events;
+- an invariant a future edit could silently break;
+- a rejected alternative and the one reason it was rejected.
+
+Two checks that need no judgement:
+
+- A comment's first sentence may not open by restating the identifier it sits above. `// Resolves the direction:` over `ResolveDirection()` is dead text — open with the constraint.
+- A block over 12 lines is a review trigger, not an error: the PR states what its load-bearing facts are. Long is fine; unexamined-long is not.
+
+Prose in `Documentation~` is held to the same test. A guide for a polyfill tends to justify the polyfill at length; state what the behavior is and where it deviates, not why the deviation is defensible.


### PR DESCRIPTION
## What

The repo's rule that a comment states why and never what has been followed. Nothing bounded how long the why could take, and it shows.

Measured over `Runtime/**` excluding tests, and `Generators~/src/**`:

| | comment lines | code lines | ratio |
|---|---|---|---|
| `Runtime` (production) | 17,322 | 36,147 | **0.479** |
| `Generators~/src` | 536 | 2,954 | **0.181** |

Same repository, same author, same convention, 2.6× apart. Classifying the thirty longest blocks at clause level puts **41%** of their words on facts a reader could not derive, **25%** on restating the declaration below the comment, **25%** on consequences that follow from a constraint already stated, and **9%** on connective padding. The corpus is roughly 2.4× its load-bearing content.

The trend runs the wrong way. Comment lines added per code line added: 0.356 at the initial import, 0.503 through mid-July, **0.675** over the last week — several individual days ship more comment lines than code lines.

Blocks over 12 lines are 5.2% of blocks and **23%** of all comment lines, so that is where the leverage is. And 6.4% of all comment words sit inside an eight-word sequence that also appears verbatim in another file — the single-source-of-truth rule the guides follow was never extended to comments.

## The rule

A per-sentence **deletion test**, plus one mechanical check and one review trigger. Both lists — what fails and what passes — are explicit, so an engine quirk that needs a paragraph keeps its paragraph.

A length ceiling was considered and rejected: it measures fact *count* rather than words per fact. `FiberNodePatcher.cs:348` is 29 lines and 65% load-bearing — an ordering table where every entry is a real constraint — while a 28-line block elsewhere is 30% load-bearing. A ceiling treats them alike and makes the author of the first delete something true. The 12-line trigger captures the same leverage by demanding examination rather than truncation.

The guides get the same test. Their worst offenders all document a framework-level polyfill for a missing engine capability, and they spend their length justifying the polyfill rather than stating its behavior.

## Scope

This is the rule only. It prevents the next 20k words; it does not remove the current 195k. Bringing the existing worst offenders down is separate work — the top 20 files hold 45% of all comment lines, so it is tractable, but it is a sweep and belongs in its own PR.