### PR TITLE
fix(velvet): balance text inside a declared max-width by writing width instead of max-width

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -199,14 +199,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   children with no spacing at all: the arriving gap manipulator wrote its margins before the departing
   grid manipulator cleared the margins IT had written, and that clear took the new ones with it.
   Whichever of the two is departing now releases its writes first.
-- Removing a `text-balance` class from an element whose max-width comes from a VARIANT
-  (`dark:max-w-[80px] text-balance` with the dark theme active) left the element with no max-width at
-  all. `text-balance` borrows that inline slot while it is attached and nulls it on detach, and the
-  restore re-derived the value by scanning the element's class list — which skips variant tokens, since
-  a variant's payload is not a utility of the element itself. Nothing else re-asserts that layer, so the
-  width was gone for good. The restore now reads the recorded value directly and no longer cares how the
-  token was spelled. A max-width from the element's own `max-w-[…]` utility was already restored
-  correctly and is unchanged.
+- Removing a `text-balance` class from an element whose size comes from a VARIANT
+  (`dark:w-[80px] text-balance` with the dark theme active) left the element with no such value at all.
+  `text-balance` borrows one inline slot while it is attached and nulls it on detach, and the restore
+  re-derived the value by scanning the element's class list — which skips variant tokens, since a
+  variant's payload is not a utility of the element itself. Nothing else re-asserts that layer, so the
+  value was gone for good. The restore now reads the recorded value directly and no longer cares how the
+  token was spelled. A value from the element's own bracket utility was already restored correctly and is
+  unchanged.
+- `text-balance` no longer violates a declared `max-width`, and no longer destroys a co-present sizing
+  utility. It writes the element's inline **`width`** now instead of its `max-width`: the engine clamps
+  that write to whatever `max-width` the element declares, so the ceiling holds by construction, and the
+  declared `max-width` — no longer the slot balance overwrites — stays readable, so the search is bounded
+  by it and the text is balanced *inside* the ceiling rather than cut off by it. Previously the balanced
+  width came from the parent's content width alone, so a `text-balance max-w-[120px]` label in a
+  380px-wide parent rendered ~284px, and a `max-w-*` utility beside `text-balance` was erased outright
+  whenever balance declined to act (empty text, or text that fits one line). Every spelling of a ceiling
+  now behaves identically and applies on every pass: `max-w-[…]`, a variant's `dark:max-w-[80px]`, the USS
+  scale forms (`max-w-32`, `max-w-full`), and percentages. `max-w-0` releases the box instead of widening
+  past it. **Balanced labels carrying a max-width now render narrower**, since they previously rendered
+  wider than they asked to be.
+- **`text-balance` now stands down on an element that declares its own width.** Any `w-*` or `size-*`
+  class — `w-full` included, in every spelling: scale, bracket, fraction, `!`-important, and one a variant
+  supplies — leaves the box exactly as declared, as does a child of a `grid` container, whose width the
+  grid writes. `w-auto` declares nothing and does not count. Balance is approximated by narrowing the box,
+  so a declared width leaves nothing to narrow, and the width is the contract other layout depends on.
+  **`w-full text-balance` no longer balances** — drop the `w-full`, since a column child already fills its
+  parent. `w-32 text-balance` now renders at 128px rather than at a balanced width. See
+  `Documentation~/fonts.md`.
 - On an element that already carries a clip — a base `clip-path-*`, or one from a state, theme,
   responsive or relational variant — a `clip-path-*` payload carried by a structural (`first:`),
   `has-[.class]:`, `data-`/`aria-` or `supports-` variant now re-resolves the mask when it toggles.

--- a/Packages/com.velvet.core/Documentation~/fonts.md
+++ b/Packages/com.velvet.core/Documentation~/fonts.md
@@ -178,59 +178,63 @@ included — is already a real value, so there is nothing for a descendant to re
 `normal-case` / `no-underline` / an explicit `whitespace-*` class do.
 
 **`text-balance`** approximates CSS `text-wrap: balance` even though UI Toolkit's text engine exposes no
-line-break hook at all (there is no way to influence *where* a line wraps). `StyleTextBalanceManipulator`
-sidesteps that by not touching line breaks: it binary-searches the public
-`TextElement.MeasureTextSize(text, width, widthMode, height, heightMode)` — the same method the engine's
-own autosize pass already calls — for the **narrowest inline `maxWidth`** that keeps the measured height
-at or under the height a normal (unbalanced) layout would take at the element's available width. Since
-font metrics are constant across candidates, comparing heights stands in for comparing line counts: a
-width narrow enough to add a line always measures taller and is rejected. The result reads more evenly
-than a near-empty last line, the same visual goal as the real CSS feature.
+line-break hook (there is no way to influence *where* a line wraps). Instead of moving line breaks inside
+a fixed box, `StyleTextBalanceManipulator` narrows the box: it binary-searches
+`TextElement.MeasureTextSize` — the same method the engine's own autosize pass calls — for the narrowest
+inline **`width`** that still measures the height a normal, unbalanced layout would take at the available
+width. Comparing heights stands in for comparing line counts, since font metrics are constant across
+candidates.
 
-Two deviations from CSS, both documented on the manipulator itself and worth knowing before reaching for
-this class:
+**What it honours.** `text-balance` writes the element's inline `width` and never its `max-width`:
+
+- **A declared `max-width` is a ceiling it balances inside.** Every spelling counts — `max-w-[120px]`, a
+  variant's `dark:max-w-[80px]`, the USS scale forms (`max-w-32`, `max-w-full`), and percentages — and all
+  of them apply on every pass. The engine also clamps the written width to that ceiling, so it holds even
+  if the search were wrong. `max-w-0` leaves nothing to redistribute, so the box is released and the
+  ceiling applies on its own.
+- **A declared `width` turns `text-balance` off for that element.** We approximate balance by narrowing
+  the box, so a declared width leaves nothing to narrow — and the width is the contract other layout
+  depends on, while balance is a refinement nothing breaks without. Any `w-*` or `size-*` class does it,
+  in every spelling: scale, bracket, fraction, `!`-important, and one a variant supplies. `w-auto` does
+  not, since `width: auto` is the default and declares nothing. **`w-full text-balance` therefore does
+  not balance**; a column child already fills its parent, so drop the `w-full`. The same applies to a
+  child of a `grid` container, whose width the grid itself writes.
+
+Two deviations from CSS, both worth knowing before reaching for this class:
 
 - **The box can shrink.** Real `text-wrap: balance` never resizes the element — only where its lines
-  break. This approximation instead narrows the box via `maxWidth`, so anything sized from that box (a
-  background, alignment relative to it) reads against a smaller box than an unbalanced sibling would
-  have. Applied only when the text actually wraps to 2+ lines (see below), so a single-line label's box
-  is never touched.
-- **`maxWidth` is measured against the PARENT's content width**, not the element's own — reading the
-  element's own already-narrowed width back would ratchet it narrower every pass instead of converging.
-  This is exact when the element is its parent's sole / stretch-to-fill child (the common
-  paragraph/heading usage) and an over-estimate when siblings share the row or the element carries its
-  own narrower `max-w-*`. An over-estimate only makes balancing less aggressive (it never widens the box
-  past what normal layout already gives it), so the deviation is a conservative under-balance, never a
-  wrong one. `text-balance` otherwise owns the element's inline `maxWidth` outright while its class is
-  present — a co-present `max-w-*` utility on the same element is overwritten, the same ownership rule
-  `grid-cols-*` applies to a column's width — and that ownership is enforced every patch (not just once at
-  attach), so a `max-w-*` value that changes in the same render as a still-present `text-balance` is
-  re-overwritten before the render ends. Removing the `text-balance` class instead RESTORES a co-present
-  `max-w-*` utility's own value rather than leaving `maxWidth` cleared.
+  break — so anything sized from this box (a background, alignment relative to it) reads against a
+  smaller box than an unbalanced sibling would have. Only when the text wraps to 2+ lines (see below).
+- **The search measures against the PARENT's content width**, since the element's own is this feature's
+  output. That is exact for a sole / stretch-to-fill child, and an over-estimate when siblings share the
+  row: the balanced box plus those siblings can exceed the row, so it overflows slightly and flex-shrink
+  shares the loss across every box in it — a sibling can end up a pixel or so under its declared width.
+  Keep a balanced label out of a tight row if that matters. A **hug-width parent**
+  (auto width, e.g. an `items-start` row) defeats the indirection entirely: the parent's width follows the
+  element's, so the search input narrows every pass. With a fixed ceiling it converges, settling narrower
+  than one pass would give; with a percentage ceiling (`max-w-[50%]`) it oscillates — the bound decays
+  until the box is released, the release re-widens the parent, and the next pass starts over. Give such a
+  parent a definite width.
 
 **Prerequisite — needs a wrapping white-space too:** Velvet's `Label` ships with no bundled base
 white-space rule, so its engine default is `nowrap`. `text-balance` alone is therefore a **silent no-op**
 on a default `Label` — pair it with `text-wrap` / `whitespace-normal` (or another wrapping white-space)
 for it to have any effect.
 
-**Single-line gate:** CSS balance is a no-op on one line, and since this approximation instead shrinks the
-box, applying it to single-line text would shrink that box for no CSS-parity benefit. The manipulator
-only writes a narrower `maxWidth` when the natural height at the available width exceeds the text's
-unconstrained single-line height (2+ lines); otherwise any previously-applied `maxWidth` is cleared. An
-element with `white-space: nowrap` reaches the same "single line" outcome through this same comparison
-(`MeasureTextSize` already measures against the element's own resolved white-space), so no separate check
-is needed for it — this is also why the prerequisite above is silent rather than a thrown error: nowrap
-text always measures as "single line" and the gate above clears (or never writes) a `maxWidth` for it.
+**Single-line gate:** CSS balance is a no-op on one line, and narrowing a single-line box would shrink it
+for no parity benefit, so a width is written only when the text wraps at the ceiling-clamped available
+width. Otherwise — empty text included — the slot goes back to the element's own cascade, dropping a
+previously balanced width and restoring a co-present `w-*` value. A `white-space: nowrap` element reaches
+the same verdict through the same comparison, which is why the prerequisite above is silent rather than an
+error.
 
 **Staleness:** the manipulator re-derives on attach; on its own `GeometryChangedEvent`; on a listener on
-the PARENT's `GeometryChangedEvent` (needed because the manipulator's own `maxWidth` write pins the
+the PARENT's `GeometryChangedEvent` (needed because the manipulator's own `width` write pins the
 element's resolved size, so an ancestor WIDENING never changes the element's own rect and would otherwise
 never re-fire the search — listening on the parent directly, the same element the available width is read
 from, closes that gap); and on the `ChangeEvent<string>` UI Toolkit raises whenever `.text` is reassigned
 on a live element (covers a text swap that happens to keep the same wrapped box size, and therefore raises
-no geometry event, from going stale). What's left uncovered: a resize confined entirely to a `ScrollView`
-parent's own content viewport with no accompanying change to the `ScrollView`'s own outer rect (e.g. a
-scrollbar toggling) — a narrower edge case than the ancestor-resize gap the parent listener closes.
+no geometry event, from going stale).
 
 **Not expressible in UI Toolkit (no USS property — intentionally absent):**
 

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
@@ -2603,8 +2603,11 @@ namespace Velvet
         // re-scan for it.
         // Divide and text-balance are in no such handoff: divide writes only the border width and color of
         // the one edge it draws on (and nulls that same pair on teardown), text-balance writes only the
-        // element's own max-width, and neither gap nor grid writes a border at all — so the three write
-        // sets are disjoint and the position of these two in the sequence is not load-bearing.
+        // element's OWN width, and neither gap nor grid writes a border at all — so the three write sets
+        // are disjoint and the position of these two in the sequence is not load-bearing. Grid writes its
+        // CHILDREN's widths, which is the one slot text-balance also writes, and the handoff for that is
+        // the child's own: a text-balance element inside a grid container stands down entirely (see
+        // StyleTextBalanceManipulator's grid-parent check).
         private void ApplyResolvedLayoutManipulators(VisualElement element, string[] classNames)
         {
             if (StyleGridClass.HasGridClass(classNames))
@@ -2722,19 +2725,9 @@ namespace Velvet
                 new GridOp(new GridSpec(columns, columnGap, rowGap)));
         }
 
-        // Configures the element's StyleTextBalanceManipulator from the `text-balance` token in
-        // classNames. Unlike Gap/Grid/Divide, text-balance carries no per-element spec value to diff (it
-        // is a bare flag the manipulator re-derives entirely from its own events) — but it still needs an
-        // "update existing manipulator" branch that runs every patch: Refresh() forces a full re-derive so
-        // text-balance re-wins its inline maxWidth slot even when a co-present max-w-* utility's inline
-        // write — applied earlier in this SAME patch by DiffClassList/ApplyClassNames — changed value
-        // without anything the manipulator's own events would otherwise catch. Mirrors
-        // ApplyGapManipulator's timing — call AFTER the container's children have been reconciled
-        // (harmless here since text-balance does not read children, but keeps every per-element style
-        // manipulator attached at the same, single, well-known point in the pass).
-        // Kept outside the shared Configure step: its teardown owes the element an extra restore of the
-        // shared inline maxWidth slot, and the shared body has no way to signal that tail step. Folding
-        // it in would add a teardown hook the eight other families would carry for nothing.
+        // Carries no per-element spec to diff, unlike Gap/Grid/Divide — the manipulator re-derives
+        // everything itself. Kept outside the shared Configure step because its teardown owes the element a
+        // restore of the shared inline width slot, which the shared body has no way to signal.
         private void ApplyTextBalanceManipulator(VisualElement element, string[] classNames)
         {
             // Fast early-out for the ~99% of elements with no text-balance class and no existing manipulator.
@@ -2744,17 +2737,11 @@ namespace Velvet
                 {
                     element.RemoveManipulator(stale);
                     _ctx.TextBalanceManipulators.Remove(element);
-                    // Detach unconditionally nulls the shared maxWidth slot text-balance owned while
-                    // present, so a co-present max-w-* utility's own value has to be put back — otherwise
-                    // removing JUST the text-balance token would also erase an unrelated max-width the
-                    // element still carries, permanently (the class diff only re-applies a token on a
-                    // removal, so nothing else would ever re-assert it).
-                    // Restored from the arbitrary-value LAYER MAP, not by re-scanning a class array: a
-                    // max-w-[600px] is inline-resolved, so it never enters the USS class list, and the
-                    // array this method is gated from may be the live class list (see ResolveLayoutClasses)
-                    // — which would silently restore nothing. The map is authoritative on both paths, and
-                    // covers a variant-registered layer as well.
-                    StyleArbitraryValueResolver.ReapplyLayeredValue(element, ArbitraryProperty.MaxWidth);
+                    // Detach nulls the borrowed width slot, taking a w-[..] or size-[..] applied in this
+                    // same patch with it — the class diff re-applies a token only on a change. The layer
+                    // map rather than a class array: a w-[600px] never enters the class list, and the array
+                    // here may be the live one (see ResolveLayoutClasses), which carries no bracket tokens.
+                    StyleArbitraryValueResolver.ReapplyWidthSlot(element);
                 }
                 return;
             }
@@ -2765,7 +2752,7 @@ namespace Velvet
             }
             else
             {
-                var manipulator = new StyleTextBalanceManipulator();
+                var manipulator = new StyleTextBalanceManipulator(_ctx);
                 element.AddManipulator(manipulator);
                 _ctx.TextBalanceManipulators[element] = manipulator;
             }

--- a/Packages/com.velvet.core/Runtime/Styling/StyleArbitraryValueResolver.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleArbitraryValueResolver.cs
@@ -759,18 +759,18 @@ namespace Velvet
         // form of ReapplyLayeredValues above.
         //
         // For a manipulator that borrows a shared inline slot and nulls it outright on detach
-        // (StyleTextBalanceManipulator and max-width): the authored value it clobbered is still recorded
+        // (StyleTextBalanceManipulator and width): the authored value it clobbered is still recorded
         // here, so re-resolving the one slot restores exactly what the cascade says it should hold — and
         // does so regardless of how that value got there. A restore driven by re-scanning the element's
         // class list is only as complete as that list: it cannot see a layer a VARIANT registered
-        // (dark:max-w-[80px]), whose payload is not a token of the element's own.
+        // (dark:w-[80px]), whose payload is not a token of the element's own.
         //
         // A property with no surviving layer clears the inline value — the same fallback Clear itself takes
         // once it removes the last layer.
         //
         // No filter-family exemption, unlike the whole-map form: this re-resolves whatever property it is
         // handed, so a filter one would recompose the filter list and restart an in-flight transition tween.
-        // Today's only caller passes a max-width; a caller that wants a filter property has to weigh that.
+        // Today's only caller passes a width; a caller that wants a filter property has to weigh that.
         internal static void ReapplyLayeredValue(VisualElement element, ArbitraryProperty property)
         {
             if (element == null || !s_layers.TryGetValue(element, out var map))
@@ -779,6 +779,30 @@ namespace Velvet
             }
             ResolveAndApply(element, property, map);
         }
+
+        // Re-asserts every layer that writes the inline WIDTH slot, for a caller handing that slot back
+        // after borrowing it. Width first and Size second, because Size writes width and height together
+        // while re-resolving Width on an element with no Width layer CLEARS the slot — which would wipe a
+        // Size restore done first. Size is skipped when no Size layer exists, since clearing that one nulls
+        // the height too, and the height may have come from a layer of its own.
+        // An element carrying both layers ends up with the Size one, which cannot reproduce class-string
+        // order; that ambiguity belongs to the resolver and needs a pathological w-[..] size-[..] pair.
+        internal static void ReapplyWidthSlot(VisualElement element)
+        {
+            ReapplyLayeredValue(element, ArbitraryProperty.Width);
+            if (HasLayer(element, ArbitraryProperty.Size))
+            {
+                ReapplyLayeredValue(element, ArbitraryProperty.Size);
+            }
+        }
+
+        // Whether any layer is registered for property. Uncontaminated for a caller asking about a slot it
+        // writes directly rather than through Apply — no manipulator registers a layer.
+        internal static bool HasLayer(VisualElement element, ArbitraryProperty property)
+            => element != null
+                && s_layers.TryGetValue(element, out var map)
+                && map.TryGetValue(property, out var layers)
+                && layers.Count > 0;
 
         // Drops all arbitrary-value layers tracked for element. Called when the element is
         // cleaned up / returned to a pool so a later reuse does not inherit a prior consumer's layers.

--- a/Packages/com.velvet.core/Runtime/Styling/StyleTextBalanceClass.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleTextBalanceClass.cs
@@ -1,11 +1,42 @@
+using System;
+using UnityEngine.UIElements;
+
 namespace Velvet
 {
-    // Recognizes the `text-balance` utility for StyleTextBalanceManipulator. Unlike gap-* /
-    // grid-cols-*, text-balance carries no scale or arbitrary-value form — it is a bare, parameterless
-    // flag — so the classifier is a single exact-match scan rather than a prefix + TryExtract pair.
+    // Recognizes the `text-balance` utility for StyleTextBalanceManipulator, plus the one question about
+    // OTHER classes its behavior depends on (DeclaresOwnWidth). text-balance carries no scale or
+    // arbitrary-value form, so its own classifier is an exact match rather than a prefix + TryExtract pair.
     internal static class StyleTextBalanceClass
     {
         private const string ClassName = "text-balance";
+
+        // Bundled prefixes that write the `width` longhand — the slot the manipulator borrows. `basis-` is
+        // excluded: flex-basis sizes the main axis, which is the HEIGHT in UI Toolkit's default column
+        // direction, so it would be a false positive on most elements. Inset shorthands likewise size a box
+        // only while it is absolutely positioned, which has no in-flow parent width to balance against.
+        private static readonly string[] WidthDeclaringPrefixes = { "w-", "size-" };
+
+        // `width: auto` IS the default, so this declares nothing to stand down for.
+        private const string AutoWidthClass = "w-auto";
+
+        // Single-token half of DeclaresOwnWidth, so the token set has ONE definition: the scan below and
+        // the variant-payload gate (StyleVariantPayload) both resolve the family through here. A variant
+        // payload lands bare, which is the form this matches.
+        public static bool IsWidthDeclaringToken(string cls)
+        {
+            if (string.IsNullOrEmpty(cls) || cls == AutoWidthClass)
+            {
+                return false;
+            }
+            foreach (var prefix in WidthDeclaringPrefixes)
+            {
+                if (cls.StartsWith(prefix, StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
 
         // Single-token half of HasTextBalanceClass. Its own predicate so the token name has ONE
         // definition — both the array scan below and the variant-payload gate (StyleVariantPayload)
@@ -23,6 +54,41 @@ namespace Velvet
             foreach (var cls in classNames)
             {
                 if (IsTextBalanceToken(cls))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        // The two halves of "the element's own cascade sizes its width", split by cost because the caller
+        // runs one on every derive and the other only behind its signature guard. No style read can answer
+        // the question at all — the manipulator owns the inline width slot — and both of these are
+        // uncontaminated, since balance writes style.width directly and registers no layer.
+
+        // The bracket forms (w-[200px], !w-[200px], dark:size-[40px]), which resolve to inline style and so
+        // never enter the class list. Two dictionary lookups, no allocation.
+        public static bool DeclaresWidthLayer(VisualElement element)
+            => element != null
+                && (StyleArbitraryValueResolver.HasLayer(element, ArbitraryProperty.Width)
+                    || StyleArbitraryValueResolver.HasLayer(element, ArbitraryProperty.Size));
+
+        // The USS forms, read from the LIVE class list, which is where a variant's payload and a
+        // bang-stripped `!w-32` also land. Walking it boxes an enumerator, so the caller keeps this behind
+        // its early-out; every path that can change the answer forces a full derive anyway — a patch
+        // through Refresh, and a variant payload through the layout re-sync its width token triggers.
+        // NOT covered: an app writing the class imperatively (element.AddToClassList("w-40")). Nothing
+        // observes that, and it cannot move the manipulator's signature either, so a width added that way
+        // while balance holds a value is ignored until something unrelated forces a derive.
+        public static bool DeclaresWidthClass(VisualElement element)
+        {
+            if (element == null)
+            {
+                return false;
+            }
+            foreach (var cls in element.GetClasses())
+            {
+                if (IsWidthDeclaringToken(cls))
                 {
                     return true;
                 }

--- a/Packages/com.velvet.core/Runtime/Styling/StyleTextBalanceManipulator.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleTextBalanceManipulator.cs
@@ -3,140 +3,85 @@ using UnityEngine.UIElements;
 
 namespace Velvet
 {
-    // Framework-level approximation of CSS `text-wrap: balance` for a TextElement (Label / Button / …)
-    // carrying the `text-balance` class. UI Toolkit's text engine exposes no line-break hook — there is
-    // no way to influence WHERE a line wraps — so balance cannot be realized the way a browser does it
-    // (re-flowing line breaks within a fixed box). Instead this manipulator narrows the box itself:
-    // TextElement.MeasureTextSize(text, width, widthMode, height, heightMode) is the same public method
-    // the engine's own measure callback (TextElement.DoMeasure) already calls every autosize pass, so a
-    // bounded binary search over it — a handful of calls — costs the same order of work UI Toolkit
-    // already pays, and:
-    //   1. measures the natural height at the element's available width (the height a normal, unbalanced
-    //      layout would take);
-    //   2. binary-searches the NARROWEST width that keeps the measured height at or under that natural
-    //      height (font metrics are constant across candidates, so comparing HEIGHTS is a stand-in for
-    //      comparing line counts — a narrower width that adds a line always measures taller);
-    //   3. writes that width as an inline `maxWidth`, so the box shrinks and the same text redistributes
-    //      across its existing line count more evenly instead of leaving a near-empty last line.
+    // Approximates CSS `text-wrap: balance` on a TextElement carrying `text-balance`. UI Toolkit's text
+    // engine exposes no line-break hook, so rather than moving line breaks inside a fixed box this narrows
+    // the box: a bounded binary search over TextElement.MeasureTextSize — the same method the engine's own
+    // measure pass calls — for the narrowest inline `width` whose measured height still matches the height
+    // a normal layout takes at the available width. Font metrics are constant across candidates, so
+    // comparing heights stands in for comparing line counts. Resizing the box at all is a deviation from
+    // CSS; see Documentation~/fonts.md.
     //
-    // Deviation from CSS (documented, not solved): real `text-wrap: balance` never changes the box's own
-    // width — only where lines break inside it. Our approximation narrows the box via `maxWidth`, so the
-    // element's outer width (and anything sized from it — a background, a sibling relying on its bounds)
-    // can shrink on balanced multi-line text, and text alignment then reads relative to that SMALLER box
-    // rather than the original one. See Documentation~/fonts.md for the full writeup.
+    // `width` rather than `maxWidth`, for two engine facts: the engine clamps a written width to the
+    // element's own max-width, so a declared ceiling holds whatever this manipulator computes; and
+    // resolvedStyle.maxWidth then reports the cascade instead of this manipulator's own output, which is
+    // what makes the ceiling readable at all.
     //
-    // The available-width problem. The width to balance AGAINST is the box's width BEFORE this
-    // manipulator's own constraint — but this manipulator is the thing that writes the element's OWN
-    // maxWidth, so target.contentRect.width is self-contaminated the moment a narrower maxWidth has
-    // already taken effect: re-deriving "natural" from an already-balanced width would ratchet narrower
-    // every pass instead of converging. StyleGridManipulator sidesteps the analogous problem by reading a
-    // width it never writes (the container's, while it sizes the CHILDREN) — this manipulator mirrors
-    // that discipline by reading the PARENT's contentRect (never written by this manipulator) minus the
-    // target's own resolved horizontal margin, instead of the target's own contentRect. This is exact
-    // when the target is the parent's sole / stretch-to-fill child (the common paragraph/heading case)
-    // and an OVER-estimate when siblings share the row or the target carries its own narrower width /
-    // max-width utility — but an over-estimate only makes the search less aggressive (maxWidth resolves
-    // wide enough to never bind, so the box falls back to whatever flex would have given it anyway); it
-    // never widens the box past what normal layout would already produce, so the deviation is a
-    // conservative under-balance, not a wrong one. text-balance therefore OWNS the element's inline
-    // maxWidth outright while its class is present — like StyleGridManipulator owns a column's width — so
-    // a co-present max-w-* utility's inline write is overwritten. Unlike a one-time attach-time overwrite,
-    // this ownership is enforced every patch: FiberNodePatcher.ApplyTextBalanceManipulator calls Refresh()
-    // on an already-attached manipulator on every pass where the class remains present (mirroring
-    // StyleGridManipulator.UpdateSpec / StyleGapManipulator.UpdateGap), so a same-patch max-w-* write that
-    // lands earlier in the same pass (DiffClassList / ApplyClassNames apply class-driven inline styles
-    // before this manipulator runs) is always re-overwritten before the patch ends, rather than sitting
-    // exposed until an unrelated geometry event happens to fire. Ownership ends when the text-balance
-    // class itself is removed: the teardown that clears the inline maxWidth then restores a co-present
-    // max-w-* utility's own value by re-resolving that one slot from the arbitrary-value layer map
-    // (StyleArbitraryValueResolver.ReapplyLayeredValue) — serving the same purpose as the
-    // shared-inline-slot restore FiberAnimateMotionApplier.RestoreSharedInlineSlot performs after
-    // detaching a Hue/Pulse motion — so removing just the text-balance token does not also erase an
-    // unrelated max-width the element still carries. The map rather than a scan of the element's class
-    // list, because a max-w-[600px] resolves to inline style and so never appears in that list at all.
+    // Available width comes from the PARENT's contentRect, through FiberNodePatcher.GetChildContainer,
+    // which follows UI Toolkit's own contentContainer redirect and so answers with a composite widget's
+    // inner box. For a RECONCILED child that redirect has already happened — the reconciler adds into the
+    // inner box, so the element's parent IS it — which makes the call idempotent here and the element this
+    // subscribes to the same one it measures. The target's own contentRect is never the source: that is
+    // this manipulator's output.
     //
-    // Single-line gate. CSS balance is a visual no-op on a single line. Since this approximation instead
-    // shrinks the box, applying it to a single line would shrink a label to its tight text width and
-    // change its box (background, centering-within-box) for no CSS-parity benefit — so Apply only writes
-    // a narrower maxWidth when the text actually wraps (natural height at the available width exceeds the
-    // unconstrained single-line height); otherwise any previously-written inline maxWidth is cleared.
-    // Feeding a nowrap element through the same comparison naturally reaches the same "single line"
-    // verdict without a separate white-space check, because MeasureTextSize already accounts for the
-    // element's own resolved white-space when it measures.
+    // A hug-width parent defeats that indirection, since the parent's width follows the target's: the
+    // search input then narrows every pass. With a fixed ceiling it converges. With a PERCENTAGE ceiling
+    // it oscillates instead — the bound decays to a release, the released box re-widens the parent, and
+    // the next pass starts over — so that combination needs a parent with a definite width.
     //
-    // Prerequisite: Velvet's Label ships with no bundled base white-space rule, so its engine default is
-    // nowrap. text-balance alone is therefore a silent no-op on a default Label — it also needs
-    // `text-wrap` / `whitespace-normal` (or another wrap-enabling white-space) applied, or MeasureTextSize
-    // reaches the single-line gate above on every measurement regardless of the text's length.
+    // Balance stands down entirely when something else owns the box: a declared width, releasing the slot
+    // back to it, or a grid parent, whose StyleGridManipulator writes this same child.style.width and is
+    // left to hold it. Both are re-checked per derive rather than delivered per patch, because a variant
+    // payload lands on the element outside any patch of its own.
     //
-    // Re-application / staleness. Re-derives on: AttachToPanelEvent (first resolve, and re-resolve after
-    // a reparent that lands on an already-appropriately-sized rect with no fresh GeometryChangedEvent);
-    // GeometryChangedEvent on the TARGET (the target's own resolved rect changed — covers the feedback its
-    // own maxWidth write provokes, guarded below); GeometryChangedEvent on the PARENT (see the
-    // ancestor-resize discussion below); and ChangeEvent<string> (TextElement dispatches this whenever
-    // `.text` is set to a new value WHILE attached to a panel — see TextElement's
-    // INotifyValueChanged<string>.value setter — so a text swap that happens to keep the exact same
-    // wrapped box size, and would therefore raise no GeometryChangedEvent, is still caught).
+    // Ownership of the inline width lasts only while a balanced value sits in it. Every release re-resolves
+    // the slot from the arbitrary-value layer map, which matters for a w-[..] applied in the same patch
+    // that ends the ownership; a USS-spelled width needs nothing, since clearing the inline value reveals
+    // the class again.
     //
-    // The ancestor-resize problem. Listening on the target alone is not enough: the maxWidth THIS
-    // manipulator writes pins the target's own resolved size, so once it is narrower than the parent, an
-    // ancestor WIDENING never changes the target's own rect at all (it stays clamped at the old maxWidth)
-    // — no GeometryChangedEvent fires on the target, and the search stays stuck at the old, now-too-narrow
-    // value forever; a narrowing ancestor that does not yet cross the clamped value is missed the same
-    // way. Grid/Gap do not have this problem because they listen on the exact element whose contentRect
-    // their own sizing reads (their own target IS the container); here that element is the PARENT (see
-    // the available-width discussion above), so this manipulator additionally subscribes
-    // GeometryChangedEvent on textElement.parent directly — the plain hierarchy parent, not
-    // FiberNodePatcher.GetChildContainer(parent), to keep the subscribe/unsubscribe bookkeeping as simple
-    // as the target's own listeners already are. The subscription is (re-)synced at the top of every
-    // Apply() call, not only from AttachToPanelEvent, so a mid-life reparent is picked up by whichever
-    // event fires next regardless of exactly how UI Toolkit sequences Attach/Detach for a same-panel
-    // reparent. What remains uncovered: a resize confined entirely to a composite-widget parent's OWN inner
-    // box (GetChildContainer's redirect case, e.g. a ScrollView's content container) with no accompanying
-    // change to the widget's own outer rect — a scrollbar toggling, say — since the subscription is the
-    // widget itself, not its inner box. A grandparent-or-higher resize is NOT a separate gap: available is
-    // read from the parent's own contentRect, so if the parent's rect is genuinely unaffected by a
-    // grandparent change, there is nothing that needed re-deriving in the first place.
+    // Single-line gate: CSS balance is a no-op on one line, and narrowing a single-line box would shrink it
+    // for no parity benefit. Measured at the ceiling-clamped width, so text that fits the parent but wraps
+    // inside the ceiling still balances. A nowrap element reaches the same verdict through the same
+    // comparison, since MeasureTextSize honors the element's own resolved white-space.
     //
-    // Feedback-loop guard. A signature over the available width (rounded), the text's hash, and the
-    // resolved font size makes a GeometryChangedEvent that this manipulator's own maxWidth write provoked
-    // — with none of those inputs actually different — a no-op regardless of which of the two
-    // GeometryChangedEvent listeners fired it, mirroring StyleGridManipulator's documented discipline
-    // exactly.
+    // Prerequisite: Velvet's Label ships no base white-space rule, so its engine default is nowrap and
+    // `text-balance` alone is a silent no-op — it needs `text-wrap` / `whitespace-normal` alongside.
     //
-    // Lifecycle mirrors the other per-element style manipulators (StyleGapManipulator /
-    // StyleGridManipulator): the reconciler attaches one per text-balance element, keeps it in
-    // ReconcilerContext.TextBalanceManipulators, and removes it on cleanup / dispose.
-    // UnregisterCallbacksFromTarget clears the inline maxWidth it wrote (and drops the parent
-    // subscription above) so removing the class or unmounting leaves no residue on the TARGET; a class
-    // removal additionally has the reconciler restore a co-present max-w-* utility right after, per the
-    // ownership paragraph above (a full unmount has no "current class list" to restore against, so it
-    // does not). FiberElementPoolReset also nulls maxWidth generically on every pooled element as a
-    // second line of defense against a pooled Label ghosting a prior consumer's balanced width.
+    // Re-derives on attach, on its own and its PARENT's GeometryChangedEvent, and on ChangeEvent<string>
+    // (a text swap that keeps the same box size raises no geometry event). The parent subscription is what
+    // catches an ancestor WIDENING: the written width pins the target's own rect, so nothing fires on the
+    // target. A signature over the clamped available width, the text and the font size absorbs the
+    // GeometryChangedEvent this manipulator's own write provokes.
+    //
+    // Lifecycle mirrors StyleGapManipulator / StyleGridManipulator: the reconciler attaches one per
+    // element, tracks it in ReconcilerContext.TextBalanceManipulators, and removes it on cleanup. Detach
+    // clears the inline width and the reconciler restores a co-present w-* right after; a full unmount
+    // does not, since the element's layer record is dropped and FiberElementPoolReset nulls width anyway.
     internal sealed class StyleTextBalanceManipulator : Manipulator
     {
-        // Bounded binary-search depth: enough precision to land within a fraction of a pixel of the true
-        // narrowest width without an unbounded measure-call budget.
         private const int MaxIterations = 8;
 
-        // Floor for the search range, expressed as a fraction of the available width, so the search never
-        // measures a degenerate near-zero width. A too-narrow candidate simply measures TALLER than the
-        // natural height and is rejected by the comparison, so this floor only bounds the search range —
-        // it does not need to equal the longest word's width for correctness.
+        // Search floor as a fraction of the available width. Bounds the range only — a too-narrow
+        // candidate measures taller and is rejected anyway, so it need not equal the longest word.
         private const float MinWidthFraction = 0.1f;
 
-        // Sub-pixel tolerance on height comparisons, mirroring StyleGridManipulator's WrapSafetyPx: absorbs
-        // float rounding so an unchanged wrap outcome does not misregister as "one line taller".
+        // Absorbs float rounding so an unchanged wrap outcome does not misregister as "one line taller",
+        // mirroring StyleGridManipulator's WrapSafetyPx.
         private const float HeightEpsilonPx = 0.5f;
+
+        // A ceiling at or below this leaves nothing to redistribute, and keeps the search from being
+        // entered with a floor above its own upper bound.
+        private const float MinBalanceableWidthPx = 1f;
+
+        // Answers whether the target's parent is a grid container, whose manipulator writes the same slot.
+        private readonly ReconcilerContext _ctx;
 
         private int _lastSignature;
         private bool _hasSignature;
 
-        // The parent currently subscribed for OnParentGeometryChanged — see the class doc's
-        // ancestor-resize discussion. Tracked (rather than re-derived on every check) so SyncParentSubscription
-        // can cheaply no-op when the parent has not changed, and so it can unregister the exact callback it
-        // registered when the parent DOES change (or the manipulator detaches).
+        // Tracked so the callback can be unregistered from the exact element it was registered on.
         private VisualElement? _subscribedParent;
+
+        internal StyleTextBalanceManipulator(ReconcilerContext ctx) => _ctx = ctx;
 
         protected override void RegisterCallbacksOnTarget()
         {
@@ -154,13 +99,7 @@ namespace Velvet
             target.UnregisterCallback<ChangeEvent<string>>(OnTextChanged);
         }
 
-        // Forces the next Apply() to fully re-derive even when nothing this manipulator's own signature
-        // tracks has changed — mirrors StyleGridManipulator.UpdateSpec / StyleGapManipulator.UpdateGap.
-        // FiberNodePatcher.ApplyTextBalanceManipulator calls this on an already-attached manipulator every
-        // patch the text-balance class remains present, so a co-present max-w-* utility's inline write —
-        // applied earlier in the SAME patch by DiffClassList / ApplyClassNames — is always re-overwritten
-        // before the patch ends, instead of silently winning the shared maxWidth slot until an unrelated
-        // geometry event happens to fire.
+        // Forces a full re-derive, mirroring StyleGridManipulator.UpdateSpec / StyleGapManipulator.UpdateGap.
         public void Refresh()
         {
             _hasSignature = false;
@@ -177,15 +116,10 @@ namespace Velvet
 
         private void OnTextChanged(ChangeEvent<string> evt) => Apply();
 
-        // Re-fires Apply() when the PARENT's own resolved rect changes — the half of ancestor-resize
-        // staleness the target's own GeometryChangedEvent cannot see once a narrower inline maxWidth pins
-        // the target's size (see the class doc's ancestor-resize discussion).
         private void OnParentGeometryChanged(GeometryChangedEvent evt) => Apply();
 
-        // Keeps the parent subscription in sync with the CURRENT hierarchy parent. Called at the top of
-        // every Apply() — not only from AttachToPanelEvent — so a mid-life reparent is picked up by
-        // whichever event happens to fire next, without needing to know whether UI Toolkit raises
-        // Attach/Detach for a same-panel reparent. Cheap no-op when the parent has not changed.
+        // Re-pointed from every Apply, not only from AttachToPanelEvent, so a mid-life reparent is caught
+        // without depending on how UI Toolkit sequences Attach/Detach for a same-panel reparent.
         private void SyncParentSubscription(VisualElement? parent)
         {
             if (ReferenceEquals(parent, _subscribedParent))
@@ -197,8 +131,6 @@ namespace Velvet
             _subscribedParent?.RegisterCallback<GeometryChangedEvent>(OnParentGeometryChanged);
         }
 
-        // Recomputes the balanced width from the current text / available width / font size, early-out
-        // when nothing relevant to the last application has changed.
         private void Apply()
         {
             if (target is not TextElement textElement)
@@ -207,22 +139,26 @@ namespace Velvet
             }
 
             var parent = textElement.parent;
-            // Re-sync BEFORE the parent-null early-out (not just from AttachToPanelEvent) so every Apply()
-            // call — from whichever event triggered it — keeps the subscription pointed at the CURRENT
-            // parent. See the class doc's ancestor-resize discussion.
             SyncParentSubscription(parent);
             if (parent == null)
             {
-                // Off-panel / detached: nothing meaningful to measure against yet. Defer to the next
-                // AttachToPanelEvent / GeometryChangedEvent, mirroring StyleGridManipulator's off-panel
-                // deferral (it re-arms _hasSignature so a later resolve is never skipped as a false repeat).
+                // Re-arms so a later resolve is never skipped as a false repeat, mirroring
+                // StyleGridManipulator's off-panel deferral.
                 _hasSignature = false;
                 return;
             }
 
-            // The PARENT's content width is never written by this manipulator (only the target's OWN
-            // maxWidth is), so — unlike target.contentRect.width — it cannot be self-contaminated by a
-            // previous pass's narrower write. See the available-width discussion in the class doc comment.
+            if (StyleTextBalanceClass.DeclaresWidthLayer(textElement))
+            {
+                // In FRONT of the signature guard: two dictionary lookups, no allocation. This is what
+                // sees an inline-resolved variant width (md:w-[200px]) on both edges — its layer flips
+                // without moving anything else this manipulator watches, and the release below re-arms the
+                // signature so the OFF edge re-balances.
+                ReleaseWidth(textElement);
+                _hasSignature = false;
+                return;
+            }
+
             var container = FiberNodePatcher.GetChildContainer(parent);
             var available = container.contentRect.width
                 - textElement.resolvedStyle.marginLeft - textElement.resolvedStyle.marginRight;
@@ -233,6 +169,13 @@ namespace Velvet
                 return;
             }
 
+            // Clamped before the signature is computed, so a ceiling change that can alter the outcome
+            // re-derives and one that cannot leaves the signature untouched.
+            if (TryGetDeclaredCeiling(textElement, out var ceiling))
+            {
+                available = Mathf.Min(available, ceiling);
+            }
+
             var text = textElement.text ?? string.Empty;
             var fontSize = textElement.resolvedStyle.fontSize;
             var signature = ComputeSignature(available, text, fontSize);
@@ -241,42 +184,63 @@ namespace Velvet
                 return;
             }
 
+            // Behind the signature guard because the class walk below allocates; see DeclaresWidthClass
+            // for which paths deliver a change and the one that does not.
+            if (IsSizedByGridParent(parent))
+            {
+                // Left untouched rather than released: the grid writes this same slot with no layer behind
+                // it, so clearing it would destroy the column width rather than a value of ours. The grid
+                // cannot repair a write of ours either — its own re-derive is gated on the container's
+                // contentRect WIDTH, which a child re-wrapping does not move.
+                _hasSignature = false;
+                return;
+            }
+
+            if (StyleTextBalanceClass.DeclaresWidthClass(textElement))
+            {
+                // Released rather than skipped, so a declaration arriving while a balanced value is held
+                // takes effect at once.
+                ReleaseWidth(textElement);
+                _hasSignature = false;
+                return;
+            }
+
             if (string.IsNullOrEmpty(text))
             {
-                ClearMaxWidth(textElement);
+                ReleaseWidth(textElement);
                 _lastSignature = signature;
                 _hasSignature = true;
                 return;
             }
 
-            // The text's own preferred size with no width constraint at all — the single-line reference
-            // (or however many hard line breaks it already carries, but no SOFT wrap on top of those).
+            if (available < MinBalanceableWidthPx)
+            {
+                // The engine applies a ceiling this narrow to the released box on its own.
+                ReleaseWidth(textElement);
+                _lastSignature = signature;
+                _hasSignature = true;
+                return;
+            }
+
+            // Unconstrained: the single-line reference, carrying any hard line breaks but no soft wrap.
             var singleLineHeight = textElement.MeasureTextSize(
                 text, float.NaN, VisualElement.MeasureMode.Undefined,
                 float.NaN, VisualElement.MeasureMode.Undefined).y;
-            // The height a normal (unbalanced) layout would take at the full available width.
             var naturalHeight = textElement.MeasureTextSize(
                 text, available, VisualElement.MeasureMode.Exactly,
                 float.NaN, VisualElement.MeasureMode.Undefined).y;
 
             if (naturalHeight <= 0f || float.IsNaN(naturalHeight))
             {
-                // Degenerate measurement (e.g. the font has not resolved yet): return WITHOUT recording
-                // _lastSignature/_hasSignature for this signature. Caching a verdict derived from a
-                // degenerate height would make a later, valid measurement with the same available
-                // width/text/font-size early-out forever at the top-of-method signature check — the
-                // signature alone cannot distinguish "genuinely unchanged" from "the font resolved since".
-                // Leaving _hasSignature as-is lets the next triggering event retry from scratch.
+                // The font has not resolved yet. Recording this signature would make the later, valid
+                // measurement early-out forever, since the signature cannot tell "unchanged" from "the
+                // font resolved since".
                 return;
             }
 
             if (naturalHeight <= singleLineHeight + HeightEpsilonPx)
             {
-                // Single line at the available width (includes an element whose resolved white-space is
-                // nowrap, since MeasureTextSize already measures against the element's own resolved
-                // style): CSS balance is a visual no-op here, and our box-narrowing approximation would
-                // only shrink the box for no parity benefit, so leave it alone.
-                ClearMaxWidth(textElement);
+                ReleaseWidth(textElement);
                 _lastSignature = signature;
                 _hasSignature = true;
                 return;
@@ -284,15 +248,14 @@ namespace Velvet
 
             var minWidth = Mathf.Max(1f, available * MinWidthFraction);
             var narrowest = FindNarrowestWidth(textElement, text, minWidth, available, naturalHeight);
-            textElement.style.maxWidth = new StyleLength(narrowest);
+            textElement.style.width = new StyleLength(narrowest);
 
             _lastSignature = signature;
             _hasSignature = true;
         }
 
-        // Binary search over [lo, hi] for the narrowest width whose measured height still fits under
-        // naturalHeight. hi (the available width) is always feasible by construction (its own measured
-        // height IS naturalHeight), so it is a safe fallback if the loop's precision never beats it.
+        // hi is feasible by construction — its own measured height IS naturalHeight — so it is a safe
+        // fallback when the loop's precision never beats it.
         private static float FindNarrowestWidth(
             TextElement textElement, string text, float lo, float hi, float naturalHeight)
         {
@@ -305,9 +268,6 @@ namespace Velvet
                     float.NaN, VisualElement.MeasureMode.Undefined).y;
                 if (height <= naturalHeight + HeightEpsilonPx)
                 {
-                    // Still fits the natural line count at this narrower width: it is feasible, so record
-                    // it and keep searching narrower. A too-narrow candidate instead measures TALLER (an
-                    // extra wrapped line) and falls into the else branch, which the search rejects.
                     best = mid;
                     hi = mid;
                 }
@@ -319,29 +279,68 @@ namespace Velvet
             return best;
         }
 
-        private static void ClearMaxWidth(TextElement textElement)
+        private static void ClearWidth(TextElement textElement)
         {
-            textElement.style.maxWidth = new StyleLength(StyleKeyword.Null);
+            textElement.style.width = new StyleLength(StyleKeyword.Null);
         }
 
-        // Clears the inline maxWidth this manipulator wrote and drops the parent subscription (invoked on
-        // detach / removal). Putting a co-present max-w-* value BACK is the caller's job (see the class
-        // doc's ownership paragraph): this manipulator knows only that it borrowed the slot, not what the
-        // element's cascade says belongs in it. The caller restores on a class removal and skips it on a
-        // full unmount, where the element's whole layer record is dropped moments later regardless.
+        // The null covers an element with no arbitrary layers at all, for which the re-assert early-returns;
+        // the re-assert covers a w-[..] or size-[..] whose inline write the null would otherwise take with
+        // it, including one a variant registered.
+        private static void ReleaseWidth(TextElement textElement)
+        {
+            ClearWidth(textElement);
+            StyleArbitraryValueResolver.ReapplyWidthSlot(textElement);
+        }
+
+        // Uncontaminated because this manipulator writes `width`, so every spelling — bracket, variant,
+        // USS scale, percentage — reads back here. An absent max-width reports the None keyword while a
+        // declared zero reports a value, so the two never blur; Auto is a third keyword no max-width
+        // utility can currently produce, and would read as a ceiling of whatever value accompanies it.
+        private static bool TryGetDeclaredCeiling(VisualElement element, out float ceilingPx)
+        {
+            var declared = element.resolvedStyle.maxWidth;
+            ceilingPx = declared.value;
+            return declared.keyword != StyleKeyword.None;
+        }
+
+        // StyleGridManipulator writes its children's own style.width. Asks the registry of attached grid
+        // manipulators rather than re-deriving the grid's class condition, so the two cannot drift apart.
+        // Walks ancestors because the grid sizes the children of GetChildContainer(target), and on any
+        // widget carrying a contentContainer redirect — ScrollView, Foldout, TabView, … — that inner box
+        // sits below the element the manipulator is keyed on; the match is that container being this
+        // element's own parent, so no unrelated ancestor grid can claim it.
+        private bool IsSizedByGridParent(VisualElement parent)
+        {
+            if (_ctx.GridManipulators.Count == 0)
+            {
+                return false;
+            }
+            for (var ancestor = parent; ancestor != null; ancestor = ancestor.parent)
+            {
+                if (_ctx.GridManipulators.ContainsKey(ancestor)
+                    && ReferenceEquals(FiberNodePatcher.GetChildContainer(ancestor), parent))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        // Stops at the clear: only the caller can tell a class removal, which owes the element its
+        // co-present w-* back, from an unmount, whose layer record is dropped moments later.
         private void Clear()
         {
             if (target is TextElement textElement)
             {
-                ClearMaxWidth(textElement);
+                ClearWidth(textElement);
             }
             SyncParentSubscription(null);
             _hasSignature = false;
         }
 
-        // A hash of the inputs that change the balanced width: the available width (rounded to skip float
-        // jitter), the full text (a length-only signature would miss a same-length text swap), and the
-        // resolved font size (a size change re-wraps the same text differently).
+        // The available width is already ceiling-clamped, so a ceiling change that can alter the outcome
+        // changes the signature. The full text rather than its length, which would miss a same-length swap.
         private static int ComputeSignature(float available, string text, float fontSize)
         {
             unchecked

--- a/Packages/com.velvet.core/Runtime/Styling/StyleVariantPayload.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleVariantPayload.cs
@@ -28,6 +28,12 @@ namespace Velvet
             // `md:grid md:grid-cols-3` re-derives the grid from its FINAL token set instead of first
             // building a one-column grid from the half-applied one.
             var layoutGateChanged = false;
+            // A USS-spelled width payload has to re-sync the layout manipulators: it decides whether
+            // text-balance stands down, and it loses to balance's own inline width, so it moves nothing the
+            // engine would raise a geometry event for. Kept out of the gate set above because it needs only
+            // the trigger, not the per-patch live-list routing that set also turns on. The inline-resolved
+            // spellings need nothing here — the manipulator's own layer probe sees both of their edges.
+            var reSyncOnly = false;
 
             foreach (var payload in payloads)
             {
@@ -77,11 +83,13 @@ namespace Velvet
                 {
                     target.AddToClassList(core);
                     layoutGateChanged |= TrackLayoutGate(ctx, target, core, true);
+                    reSyncOnly |= StyleTextBalanceClass.IsWidthDeclaringToken(core);
                 }
                 else
                 {
                     target.RemoveFromClassList(core);
                     layoutGateChanged |= TrackLayoutGate(ctx, target, core, false);
+                    reSyncOnly |= StyleTextBalanceClass.IsWidthDeclaringToken(core);
                 }
 
                 // A clip-path payload (hover:clip-path-[…], dark:/first:clip-path-[…], …) was just toggled as a class,
@@ -94,7 +102,7 @@ namespace Velvet
                 }
             }
 
-            if (layoutGateChanged)
+            if (layoutGateChanged || reSyncOnly)
             {
                 // A gap / grid / divide / text-balance class just appeared on (or left) the live class list
                 // without passing through the reconciler, so the manipulators those tokens gate must be
@@ -113,6 +121,11 @@ namespace Velvet
         // The utility tokens whose mere PRESENCE decides whether a layout manipulator exists on an element
         // (FiberNodePatcher.ApplyLayoutManipulators). Each family answers for its own prefix set so this
         // gate cannot drift from the array scans the manipulator passes run.
+        //
+        // Deliberately NOT the same set as the re-sync trigger: entering this one also routes the element
+        // to the live-class-list path on every later patch, which costs an array per patch, and that is
+        // only worth paying for a token a manipulator pass has to READ back out of the class array. A width
+        // payload needs the trigger and nothing else — text-balance reads the live list directly.
         private static bool IsLayoutGateToken(string core)
             => StyleGapClass.IsGapToken(core)
                 || StyleGridClass.IsGridToken(core)

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/TextBalanceParityTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/TextBalanceParityTests.cs
@@ -10,8 +10,8 @@ namespace Velvet.Tests
     /// <summary>
     /// Specifies the <c>text-balance</c> classifier + <see cref="StyleTextBalanceManipulator"/> lifecycle
     /// contract: the manipulator attaches exactly when the class is present, detaches when the class is
-    /// removed (clearing any inline <c>maxWidth</c> it may have written), and a pooled <see cref="Label"/>
-    /// carries neither a ghost manipulator nor a ghost <c>maxWidth</c> value into its next consumer.
+    /// removed (clearing any inline <c>width</c> it may have written), and a pooled <see cref="Label"/>
+    /// carries neither a ghost manipulator nor a ghost <c>width</c> value into its next consumer.
     /// </summary>
     /// <remarks>
     /// EditMode has no resolved layout (<c>ReconcilerScope.Root</c> is never attached to a panel), so
@@ -19,7 +19,7 @@ namespace Velvet.Tests
     /// width to measure against) — exactly like <see cref="StyleGridManipulator"/>'s off-panel column
     /// width. These tests therefore pin the wiring (attach / detach / pool hygiene) only; the actual
     /// measure-and-narrow behavior needs a real panel and is covered by the PlayMode spec
-    /// (<c>TextBalancePlaybackTests</c>). A stale <c>maxWidth</c> is seeded by hand where a test needs one,
+    /// (<c>TextBalancePlaybackTests</c>). A stale <c>width</c> is seeded by hand where a test needs one,
     /// standing in for what a prior LIVE computation would have written.
     /// </remarks>
     [TestFixture]
@@ -80,7 +80,7 @@ namespace Velvet.Tests
         }
 
         [Test]
-        public void Given_TextBalanceManipulator_When_ClassPatchedAway_Then_InlineMaxWidthCleared()
+        public void Given_TextBalanceManipulator_When_ClassPatchedAway_Then_InlineWidthCleared()
         {
             // Arrange
             using var scope = new ReconcilerScope();
@@ -90,25 +90,25 @@ namespace Velvet.Tests
             Assume.That(label, Is.Not.Null, "Precondition: the label mounted");
             // Off-panel Apply() defers (no resolved parent width to measure against), so seed the value a
             // LIVE computation would have written, pinning the detach path independently of layout.
-            label.style.maxWidth = new StyleLength(50f);
+            label.style.width = new StyleLength(50f);
 
             // Act — patch the same label without the text-balance class.
             var tree2 = new VNode[] { V.Label(text: "hello") };
             scope.Reconciler.Reconcile(scope.Root, tree1, tree2);
 
             // Assert
-            Assert.That(label.style.maxWidth.keyword, Is.EqualTo(StyleKeyword.Null));
+            Assert.That(label.style.width.keyword, Is.EqualTo(StyleKeyword.Null));
         }
 
         // Pins the END-TO-END pool-reuse pipeline, not the manipulator's OWN Clear() in isolation: a full
-        // removal also runs FiberElementPoolReset's generic maxWidth null (applied to every pooled
+        // removal also runs FiberElementPoolReset's generic width null (applied to every pooled
         // element regardless of text-balance), so a green result here does not by itself prove the
         // manipulator's own Clear() ran at all — the generic reset alone would produce the same outcome.
-        // Given_TextBalanceManipulator_When_ClassPatchedAway_Then_InlineMaxWidthCleared below is the
+        // Given_TextBalanceManipulator_When_ClassPatchedAway_Then_InlineWidthCleared above is the
         // manipulator-specific pin: a same-element class-removal PATCH never returns the element to the
         // pool, so it isolates Clear() from the generic reset.
         [Test]
-        public void Given_ATextBalanceLabelWithAStaleMaxWidth_When_RemovedAndPooledThenRecreated_Then_NoStaleMaxWidthGhosts()
+        public void Given_ATextBalanceLabelWithAStaleWidth_When_RemovedAndPooledThenRecreated_Then_NoStaleWidthGhosts()
         {
             // Arrange
             using var scope = new ReconcilerScope();
@@ -117,9 +117,9 @@ namespace Velvet.Tests
             var original = scope.Root.Q<Label>();
             Assume.That(original, Is.Not.Null, "Precondition: the label mounted");
             // Simulate a prior LIVE balance computation's result (off-panel Apply() never writes one itself).
-            original.style.maxWidth = new StyleLength(42f);
+            original.style.width = new StyleLength(42f);
 
-            // Act — remove (returns the label to the pool with the stale maxWidth still on it), then
+            // Act — remove (returns the label to the pool with the stale width still on it), then
             // recreate a text-balance label at the same position, renting the SAME pooled instance back.
             scope.Reconciler.Reconcile(scope.Root, tree1, System.Array.Empty<VNode>());
             Assume.That(VNodePool.LabelPoolCountForTesting, Is.EqualTo(1),
@@ -131,7 +131,7 @@ namespace Velvet.Tests
                 "Precondition: the same pooled Label instance was rented back");
 
             // Assert
-            Assert.That(recreated.style.maxWidth.keyword, Is.EqualTo(StyleKeyword.Null));
+            Assert.That(recreated.style.width.keyword, Is.EqualTo(StyleKeyword.Null));
         }
 
         [Test]
@@ -175,25 +175,45 @@ namespace Velvet.Tests
         }
 
         [Test]
-        public void Given_ATextBalanceLabelWithACoPresentMaxWidthUtility_When_TextBalanceClassPatchedAway_Then_TheUtilitysMaxWidthIsRestored()
+        public void Given_ATextBalanceLabelWithACoPresentWidthUtility_When_TextBalanceClassPatchedAway_Then_TheUtilitysWidthIsRestored()
         {
             // Arrange
             using var scope = new ReconcilerScope();
-            var tree1 = new VNode[] { V.Label(className: "text-balance max-w-[50px]", text: "hello") };
+            var tree1 = new VNode[] { V.Label(className: "text-balance w-[50px]", text: "hello") };
             scope.Reconciler.Reconcile(scope.Root, System.Array.Empty<VNode>(), tree1);
             var label = scope.Root.Q<Label>();
             Assume.That(label, Is.Not.Null, "Precondition: the label mounted");
-            Assume.That(label.style.maxWidth.value.value, Is.EqualTo(50f),
-                "Precondition: the co-present max-w-[50px] utility resolved its own value at mount");
+            Assume.That(label.style.width.value.value, Is.EqualTo(50f),
+                "Precondition: the co-present w-[50px] utility resolved its own value at mount");
 
-            // Act — patch away JUST the text-balance token; the max-w-[50px] utility stays in the class list.
-            var tree2 = new VNode[] { V.Label(className: "max-w-[50px]", text: "hello") };
+            // Act — patch away JUST the text-balance token; the w-[50px] utility stays in the class list.
+            var tree2 = new VNode[] { V.Label(className: "w-[50px]", text: "hello") };
             scope.Reconciler.Reconcile(scope.Root, tree1, tree2);
 
             // Assert — the utility's own value survives text-balance's teardown instead of being left
-            // cleared by it (StyleTextBalanceManipulator.Clear unconditionally nulls maxWidth first; the
+            // cleared by it (StyleTextBalanceManipulator.Clear unconditionally nulls the width first; the
             // reconciler must restore the co-present utility's value right after).
-            Assert.That(label.style.maxWidth.value.value, Is.EqualTo(50f));
+            Assert.That(label.style.width.value.value, Is.EqualTo(50f));
+        }
+
+        [Test]
+        public void Given_ATextBalanceLabelWithACoPresentSizeShorthand_When_TextBalanceClassPatchedAway_Then_TheShorthandsWidthIsRestored()
+        {
+            // Arrange — the teardown restore has the same shape as the manipulator's own release, so it
+            // owes `size-[..]` the same treatment: its layer is keyed Size while the slot cleared is width.
+            using var scope = new ReconcilerScope();
+            var tree1 = new VNode[] { V.Label(className: "text-balance size-[40px]", text: "hello") };
+            scope.Reconciler.Reconcile(scope.Root, System.Array.Empty<VNode>(), tree1);
+            var label = scope.Root.Q<Label>();
+            Assume.That(label.style.width.value.value, Is.EqualTo(40f),
+                "Precondition: the co-present size-[40px] utility resolved its own width at mount");
+
+            // Act
+            var tree2 = new VNode[] { V.Label(className: "size-[40px]", text: "hello") };
+            scope.Reconciler.Reconcile(scope.Root, tree1, tree2);
+
+            // Assert
+            Assert.That(label.style.width.value.value, Is.EqualTo(40f));
         }
 
         private static int GetManipulatorCount(Reconciler reconciler)

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/VariantGatedLayoutManipulatorPanelTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/VariantGatedLayoutManipulatorPanelTests.cs
@@ -236,7 +236,7 @@ namespace Velvet.Tests
         [Test]
         public void Given_ADarkGatedTextBalanceApplied_When_TheThemeTurnsLight_Then_TheTextBalanceManipulatorIsRemoved()
         {
-            // Arrange — text-balance owns a shared inline max-width slot, so its teardown is bespoke rather
+            // Arrange — text-balance owns a shared inline width slot, so its teardown is bespoke rather
             // than the shared configure step; the off-edge has to reach it just as the on-edge did.
             using var scope = new ReconcilerScope();
             var tree = new VNode[] { V.Label(className: "dark:text-balance", text: "hello") };
@@ -253,18 +253,39 @@ namespace Velvet.Tests
         }
 
         [Test]
-        public void Given_ADarkGatedTextBalanceBesideAMaxWidth_When_TheThemeTurnsLight_Then_TheUtilitysMaxWidthIsRestored()
+        public void Given_ADarkGatedWidth_When_TheThemeTurnsDark_Then_TheElementIsNotTrackedForLiveClassResolution()
         {
-            // Arrange — the variant analogue of the literal co-present-max-width contract: text-balance
-            // borrows the element's max-width slot and nulls it on detach, so the utility's own value has
-            // to come back. max-w-[50px] is inline-resolved, so it is exactly the kind of token that never
-            // appears on the live class list the variant path re-derives from.
+            // Arrange — a width payload has to re-sync the layout manipulators, since it decides whether
+            // text-balance stands down. It must not join the variant-layout tracking table while doing so:
+            // membership there routes the element through a fresh class ARRAY on every later patch, which
+            // is only worth paying where a manipulator pass reads a token back out of that array.
             using var scope = new ReconcilerScope();
-            var tree = new VNode[] { V.Label(className: "max-w-[50px] dark:text-balance", text: "hello") };
+            var tree = new VNode[] { V.Label(className: "text-balance dark:w-40", text: "hello") };
             scope.Reconciler.Reconcile(scope.Root, System.Array.Empty<VNode>(), tree);
             var label = scope.Root.Q<Label>();
-            Assume.That(label.style.maxWidth.value.value, Is.EqualTo(50f),
-                "Precondition: the co-present max-w-[50px] utility resolved its own value at mount");
+
+            // Act
+            VelvetTheme.IsDark = true;
+            Assume.That(label.ClassListContains("w-40"), Is.True,
+                "Precondition: the dark payload put the width class on the live class list");
+
+            // Assert
+            Assert.That(scope.Reconciler.Context.VariantLayoutClasses.ContainsKey(label), Is.False);
+        }
+
+        [Test]
+        public void Given_ADarkGatedTextBalanceBesideAWidth_When_TheThemeTurnsLight_Then_TheUtilitysWidthIsRestored()
+        {
+            // Arrange — the variant analogue of the literal co-present-width contract: text-balance
+            // borrows the element's width slot and nulls it on detach, so the utility's own value has
+            // to come back. w-[50px] is inline-resolved, so it is exactly the kind of token that never
+            // appears on the live class list the variant path re-derives from.
+            using var scope = new ReconcilerScope();
+            var tree = new VNode[] { V.Label(className: "w-[50px] dark:text-balance", text: "hello") };
+            scope.Reconciler.Reconcile(scope.Root, System.Array.Empty<VNode>(), tree);
+            var label = scope.Root.Q<Label>();
+            Assume.That(label.style.width.value.value, Is.EqualTo(50f),
+                "Precondition: the co-present w-[50px] utility resolved its own value at mount");
             VelvetTheme.IsDark = true;
             Assume.That(scope.Reconciler.Context.TextBalanceManipulators.Count, Is.EqualTo(1),
                 "Precondition: the dark payload attached the manipulator that borrows the slot");
@@ -273,54 +294,54 @@ namespace Velvet.Tests
             VelvetTheme.IsDark = false;
 
             // Assert
-            Assert.That(label.style.maxWidth.value.value, Is.EqualTo(50f));
+            Assert.That(label.style.width.value.value, Is.EqualTo(50f));
         }
 
         [Test]
-        public void Given_ATrackedElementWithALiteralTextBalanceBesideAMaxWidth_When_TextBalanceIsRenderedAway_Then_TheUtilitysMaxWidthIsRestored()
+        public void Given_ATrackedElementWithALiteralTextBalanceBesideAWidth_When_TextBalanceIsRenderedAway_Then_TheUtilitysWidthIsRestored()
         {
             // Arrange — no variant gates text-balance here; the dark:gap-4 is only there to put the element
             // in the variant-applied table, which is what switches its layout gates onto the live class
             // list. The teardown then runs on an ordinary re-render, with no variant toggle involved.
             using var scope = new ReconcilerScope();
-            var tree1 = new VNode[] { V.Label(className: "max-w-[50px] text-balance dark:gap-4", text: "hello") };
+            var tree1 = new VNode[] { V.Label(className: "w-[50px] text-balance dark:gap-4", text: "hello") };
             scope.Reconciler.Reconcile(scope.Root, System.Array.Empty<VNode>(), tree1);
             var label = scope.Root.Q<Label>();
-            Assume.That(label.style.maxWidth.value.value, Is.EqualTo(50f),
-                "Precondition: the co-present max-w-[50px] utility resolved its own value at mount");
+            Assume.That(label.style.width.value.value, Is.EqualTo(50f),
+                "Precondition: the co-present w-[50px] utility resolved its own value at mount");
             VelvetTheme.IsDark = true;
             Assume.That(label.ClassListContains("gap-4"), Is.True,
                 "Precondition: the dark payload put a layout gate class on the live class list");
 
             // Act — re-render without the text-balance token, everything else unchanged.
-            var tree2 = new VNode[] { V.Label(className: "max-w-[50px] dark:gap-4", text: "hello") };
+            var tree2 = new VNode[] { V.Label(className: "w-[50px] dark:gap-4", text: "hello") };
             scope.Reconciler.Reconcile(scope.Root, tree1, tree2);
 
             // Assert
-            Assert.That(label.style.maxWidth.value.value, Is.EqualTo(50f));
+            Assert.That(label.style.width.value.value, Is.EqualTo(50f));
         }
 
         [Test]
-        public void Given_ATextBalanceBesideAVariantSuppliedMaxWidth_When_TextBalanceIsRenderedAway_Then_TheVariantsMaxWidthIsRestored()
+        public void Given_ATextBalanceBesideAVariantSuppliedWidth_When_TextBalanceIsRenderedAway_Then_TheVariantsWidthIsRestored()
         {
-            // Arrange — the max-width here is supplied by the dark: layer, not by a utility of the
+            // Arrange — the width here is supplied by the dark: layer, not by a utility of the
             // element's own. That is the case no class-list scan can restore, on either array: a variant
             // token is skipped, because its payload is not a token the element itself carries. Nothing
             // gates layout on this element, so it also proves the restore on the ordinary reconcile path.
             using var scope = new ReconcilerScope();
-            var tree1 = new VNode[] { V.Label(className: "dark:max-w-[80px] text-balance", text: "hello") };
+            var tree1 = new VNode[] { V.Label(className: "dark:w-[80px] text-balance", text: "hello") };
             scope.Reconciler.Reconcile(scope.Root, System.Array.Empty<VNode>(), tree1);
             var label = scope.Root.Q<Label>();
             VelvetTheme.IsDark = true;
-            Assume.That(label.style.maxWidth.value.value, Is.EqualTo(80f),
-                "Precondition: the dark payload resolved its own max-width before text-balance is removed");
+            Assume.That(label.style.width.value.value, Is.EqualTo(80f),
+                "Precondition: the dark payload resolved its own width before text-balance is removed");
 
             // Act — remove just the text-balance token; the dark: layer is untouched.
-            var tree2 = new VNode[] { V.Label(className: "dark:max-w-[80px]", text: "hello") };
+            var tree2 = new VNode[] { V.Label(className: "dark:w-[80px]", text: "hello") };
             scope.Reconciler.Reconcile(scope.Root, tree1, tree2);
 
             // Assert
-            Assert.That(label.style.maxWidth.value.value, Is.EqualTo(80f));
+            Assert.That(label.style.width.value.value, Is.EqualTo(80f));
         }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/PlayMode/TextBalancePlaybackTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/PlayMode/TextBalancePlaybackTests.cs
@@ -193,9 +193,10 @@ namespace Velvet.Tests
 
             // Assert — the single-line gate measures at the ceiling-clamped width, so this text counts as
             // wrapping and gets balanced. Measuring at the parent's width instead would dismiss it as
-            // single-line and leave the box sitting at exactly the ceiling; the margin keeps that verdict
-            // distinguishable from a search that merely returned its own upper bound.
-            Assert.That(balanced.resolvedStyle.width, Is.LessThan(CoPresentMaxWidthPx - 5f));
+            // single-line and leave the box sitting at EXACTLY the ceiling, so the bound only has to clear
+            // that value: how far under it a balanced width lands is font metrics, which differ per
+            // platform, and must not be part of the assertion.
+            Assert.That(balanced.resolvedStyle.width, Is.LessThan(CoPresentMaxWidthPx - 0.5f));
         }
 
         [UnityTest]
@@ -668,7 +669,7 @@ namespace Velvet.Tests
             var tree = V.Div(className: $"w-[{WrapperWidthPx}px]", refCallback: s_rowRef, children: new VNode[]
             {
                 V.Label(name: "balanced", text: LongWrapText, className: "text-balance", refCallback: s_wrapWithFontRef),
-                V.Div(name: "sibling", className: "w-[100px] h-[10px]"),
+                V.Div(name: "sibling", className: "w-[200px] h-[10px]"),
             });
             _mounted = V.Mount(_host.Root, tree);
             yield return WaitRealtime(0.5);
@@ -677,9 +678,11 @@ namespace Velvet.Tests
             Assume.That(balanced.resolvedStyle.height, Is.GreaterThan(balanced.resolvedStyle.fontSize * 1.5f),
                 "Precondition: the text wrapped, so balance wrote a real width into the row");
 
-            // Assert — the sibling ends up under its declared 100px: the row overflows and flex-shrink
-            // shares the loss across both boxes.
-            Assert.That(sibling.resolvedStyle.width, Is.LessThan(100f));
+            // Assert — the sibling ends up under its declared 200px: the row overflows and flex-shrink
+            // shares the loss across both boxes. The sibling is wide enough that any balanced width
+            // overflows the row by a large margin, so the outcome does not depend on where a platform's
+            // font metrics put that width.
+            Assert.That(sibling.resolvedStyle.width, Is.LessThan(200f));
         }
 
         [UnityTest]

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/PlayMode/TextBalancePlaybackTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/PlayMode/TextBalancePlaybackTests.cs
@@ -22,7 +22,8 @@ namespace Velvet.Tests
     /// that was never loaded onto this panel. No stylesheet is needed for the `w-[Npx]` wrapper width or
     /// the `text-balance` class either: both are arbitrary-value / classifier tokens Velvet resolves in
     /// C#, independent of any USS asset (mirrors <c>BuiltInFilterShaderPlaybackTests</c>' own
-    /// stylesheet-less `w-[100px]` usage).
+    /// stylesheet-less `w-[100px]` usage). The one exception is the `max-w-32` case, which exists only as
+    /// a USS rule and so asks its mount helper for the bundled stylesheet.
     /// </remarks>
     internal sealed class TextBalancePlaybackTests
     {
@@ -40,6 +41,14 @@ namespace Velvet.Tests
             return null;
         };
 
+        // The wrapper's direction, supplied inline for the same reason the font is: no stylesheet is
+        // loaded, so `flex-row` would be an inert class name and the engine's own default is a column.
+        private static readonly Func<VisualElement, Action> s_rowRef = element =>
+        {
+            element.style.flexDirection = FlexDirection.Row;
+            return null;
+        };
+
         // Many short words so the wrap point has real work to do at any wrapper width used below (100px
         // up to ~350px) — reused by the state-driven tests, which each need long-wrapping text at a
         // width chosen after mount rather than at construction time like MountPair's own literal.
@@ -47,16 +56,34 @@ namespace Velvet.Tests
             "inside a narrow box so the balance search over its width has real work to do and a " +
             "clearly uneven last line to fix";
 
+        // Wraps to several lines at the bound below, yet fits comfortably on ONE line at the wrapper's own
+        // width — the case where the two widths disagree about whether the text wraps at all.
+        private const string MediumWrapText = "A heading that fits one line here";
+
+        // A wrapper far wider than anything the sizing utilities below ask for, so a label that ignored one
+        // resolves visibly wider instead of landing on it by coincidence.
+        private const int WrapperWidthPx = 380;
+
+        // The arbitrary (inline-resolved) bound and its class, spelled once.
+        private const int CoPresentMaxWidthPx = 120;
+        private const string CoPresentMaxWidthClass = "max-w-[120px]";
+
+        // The USS scale bound: `.max-w-32 { max-width: var(--space-32); }` with `--space-32: 128px`. Only
+        // reachable through the bundled stylesheet, and only through the element's RESOLVED style — there
+        // is no arbitrary-value layer behind a scale class.
+        private const int ScaleMaxWidthPx = 128;
+        private const string ScaleMaxWidthClass = "max-w-32";
+
         private static StateUpdater<bool> s_setWrapperWide;
         private static StateUpdater<string> s_setSwapText;
-        private static StateUpdater<bool> s_setAddMaxWidth;
+        private static StateUpdater<bool> s_setAddCeiling;
 
         [UnitySetUp]
         public IEnumerator UnitySetUp()
         {
             s_setWrapperWide = default;
             s_setSwapText = default;
-            s_setAddMaxWidth = default;
+            s_setAddCeiling = default;
             yield break;
         }
 
@@ -67,6 +94,7 @@ namespace Velvet.Tests
             _mounted = null;
             _host?.Dispose();
             _host = null;
+            VelvetTheme.IsDark = false;
             yield return null;
         }
 
@@ -89,6 +117,85 @@ namespace Velvet.Tests
             });
             _mounted = V.Mount(_host.Root, tree);
             yield return WaitRealtime(0.5);
+        }
+
+        // Mounts one balanced label carrying an extra sizing utility — a ceiling or a declared width —
+        // inside a wrapper wider than anything that utility asks for, then waits for layout to settle.
+        // loadUtilities attaches the bundled stylesheet, which the USS scale forms need and the
+        // arbitrary-value forms resolve without.
+        private IEnumerator MountWithSizingClass(string panelName, string text, string boundClass, bool loadUtilities = false)
+        {
+            _host = new RenderTexturePanelHost(panelName, 400, 400);
+            if (loadUtilities)
+            {
+                _host.Root.LoadBundledStyleUtilitiesForTest();
+            }
+            var tree = V.Div(className: $"w-[{WrapperWidthPx}px]", children: new VNode[]
+            {
+                V.Label(name: "balanced", text: text,
+                    className: $"text-balance {boundClass}", refCallback: s_wrapWithFontRef),
+            });
+            _mounted = V.Mount(_host.Root, tree);
+            yield return WaitRealtime(0.5);
+        }
+
+        [UnityTest]
+        public IEnumerator Given_ABalancedLabelBesideAnArbitraryMaxWidth_When_ItsTextWraps_Then_TheBalancedBoxStaysInsideThatCeiling()
+        {
+            // Arrange / Act — text long enough to wrap at either width, so balance genuinely runs and
+            // writes a width of its own rather than releasing the slot.
+            yield return MountWithSizingClass("TextBalanceArbitraryCeilingPanel", LongWrapText, CoPresentMaxWidthClass);
+            var balanced = _host.Root.Q<Label>("balanced");
+            Assume.That(balanced.resolvedStyle.height, Is.GreaterThan(balanced.resolvedStyle.fontSize * 1.5f),
+                "Precondition: the text wrapped, so balance wrote a real (not released) width");
+
+            // Assert — a declared max-width is a ceiling the balanced width must fit inside, the way CSS
+            // balances lines INSIDE the box max-width already allows; deriving it from the parent's width
+            // alone overshoots the ceiling outright.
+            Assert.That(balanced.resolvedStyle.width, Is.LessThanOrEqualTo(CoPresentMaxWidthPx + 0.5f));
+        }
+
+        [UnityTest]
+        public IEnumerator Given_ABalancedLabelBesideAScaleMaxWidth_When_ItsTextWraps_Then_TheBalancedBoxStaysInsideThatCeiling()
+        {
+            // Arrange / Act — the same ceiling contract for a max-width that exists ONLY as a USS class:
+            // it registers no arbitrary-value layer, so the ceiling has to come from the element's own
+            // resolved style instead.
+            yield return MountWithSizingClass("TextBalanceScaleCeilingPanel", LongWrapText, ScaleMaxWidthClass, loadUtilities: true);
+            var balanced = _host.Root.Q<Label>("balanced");
+            Assume.That(balanced.resolvedStyle.height, Is.GreaterThan(balanced.resolvedStyle.fontSize * 1.5f),
+                "Precondition: the text wrapped, so balance wrote a real (not released) width");
+
+            // Assert — the two spellings of a ceiling behave identically; a bracket-only clamp would be
+            // harder to predict than uniformly ignoring the ceiling.
+            Assert.That(balanced.resolvedStyle.width, Is.LessThanOrEqualTo(ScaleMaxWidthPx + 0.5f));
+        }
+
+        [UnityTest]
+        public IEnumerator Given_ABalancedLabelWhoseTextFitsTheParentButWrapsInsideItsCeiling_When_ItSettles_Then_BalanceRunsAnyway()
+        {
+            // Arrange — one wrapper, two labels with the same text: a probe carrying neither balance nor a
+            // ceiling, which shows that the text does fit one line at the wrapper's own width, and the
+            // subject, whose ceiling is narrow enough that the same text wraps inside it.
+            _host = new RenderTexturePanelHost("TextBalanceCeilingGatePanel", 400, 400);
+            var tree = V.Div(className: $"w-[{WrapperWidthPx}px]", children: new VNode[]
+            {
+                V.Label(name: "probe", text: MediumWrapText, refCallback: s_wrapWithFontRef),
+                V.Label(name: "balanced", text: MediumWrapText,
+                    className: $"text-balance {CoPresentMaxWidthClass}", refCallback: s_wrapWithFontRef),
+            });
+            _mounted = V.Mount(_host.Root, tree);
+            yield return WaitRealtime(0.5);
+            var probe = _host.Root.Q<Label>("probe");
+            var balanced = _host.Root.Q<Label>("balanced");
+            Assume.That(probe.resolvedStyle.height, Is.LessThan(probe.resolvedStyle.fontSize * 1.8f),
+                "Precondition: the text fits one line at the wrapper's own width, so only the ceiling makes it wrap");
+
+            // Assert — the single-line gate measures at the ceiling-clamped width, so this text counts as
+            // wrapping and gets balanced. Measuring at the parent's width instead would dismiss it as
+            // single-line and leave the box sitting at exactly the ceiling; the margin keeps that verdict
+            // distinguishable from a search that merely returned its own upper bound.
+            Assert.That(balanced.resolvedStyle.width, Is.LessThan(CoPresentMaxWidthPx - 5f));
         }
 
         [UnityTest]
@@ -153,7 +260,7 @@ namespace Velvet.Tests
         }
 
         [UnityTest]
-        public IEnumerator Given_ABalancedLabel_When_ItsWrapperWidensAfterMount_Then_ItRebalancesToAWiderMaxWidth()
+        public IEnumerator Given_ABalancedLabel_When_ItsWrapperWidensAfterMount_Then_ItRebalancesToAWiderBox()
         {
             // Arrange
             _host = new RenderTexturePanelHost("TextBalanceWidenPanel", 400, 400);
@@ -163,7 +270,7 @@ namespace Velvet.Tests
             Assume.That(balanced, Is.Not.Null, "Precondition: the label mounted");
             var narrowWidth = balanced.resolvedStyle.width;
             Assume.That(balanced.resolvedStyle.height, Is.GreaterThan(balanced.resolvedStyle.fontSize * 1.5f),
-                "Precondition: the text wrapped multi-line at the narrow wrapper, so balance wrote a real narrower maxWidth");
+                "Precondition: the text wrapped multi-line at the narrow wrapper, so balance wrote a real narrower width");
 
             // Act — widen the wrapper, an ANCESTOR of the label, not the label itself.
             s_setWrapperWide.Invoke(true);
@@ -172,30 +279,31 @@ namespace Velvet.Tests
             Assume.That(balanced.resolvedStyle.height, Is.GreaterThan(balanced.resolvedStyle.fontSize * 1.5f),
                 "Precondition: the text still wraps multi-line at the wider wrapper, so this is a real re-balance and not the single-line clear path");
 
-            // Assert — the manipulator's own maxWidth write pins the target's size, so only a listener on
+            // Assert — the manipulator's own width write pins the target's size, so only a listener on
             // the PARENT's own GeometryChangedEvent (not just the target's) can catch an ancestor widening
             // and re-run the search; without it the label stays stuck at the narrow value forever.
             Assert.That(balanced.resolvedStyle.width, Is.GreaterThan(narrowWidth));
         }
 
         // The label's own text toggles between a short single-line string and LongWrapText, at a fixed
-        // wrapper width — state-driven so the CHANGE happens after mount via TextElement's ChangeEvent<string>.
+        // wrapper width wide enough that a balanced value and the released box are far apart — state-driven
+        // so the CHANGE happens after mount via TextElement's ChangeEvent<string>.
         [Component]
         private static VNode TextSwapHost()
         {
             var (text, setText) = Hooks.UseState("Hi");
             s_setSwapText = setText;
-            return V.Div(className: "w-[140px]", children: new VNode[]
+            return V.Div(className: $"w-[{WrapperWidthPx}px]", children: new VNode[]
             {
                 V.Label(name: "balanced", text: text, className: "text-balance", refCallback: s_wrapWithFontRef),
             });
         }
 
         [UnityTest]
-        public IEnumerator Given_ABalancedLabel_When_ItsTextChangesToAWrappingStringAfterMount_Then_TheInlineMaxWidthAppears()
+        public IEnumerator Given_ABalancedLabel_When_ItsTextChangesToAWrappingStringAfterMount_Then_TheInlineWidthAppears()
         {
             // Arrange — mounts short enough to sit on one line, which the multi-line gate leaves entirely
-            // unconstrained: no inline maxWidth exists yet, giving the swap below a clean edge to observe.
+            // unconstrained: no inline width exists yet, giving the swap below a clean edge to observe.
             _host = new RenderTexturePanelHost("TextBalanceTextSwapPanel", 400, 400);
             _mounted = V.Mount(_host.Root, V.Component(TextSwapHost, key: "root"));
             yield return WaitRealtime(0.5);
@@ -203,7 +311,7 @@ namespace Velvet.Tests
             Assume.That(balanced, Is.Not.Null, "Precondition: the label mounted");
             Assume.That(balanced.resolvedStyle.height, Is.LessThan(balanced.resolvedStyle.fontSize * 1.8f),
                 "Precondition: the short initial text stayed on a single line");
-            Assume.That(balanced.style.maxWidth.keyword, Is.EqualTo(StyleKeyword.Null),
+            Assume.That(balanced.style.width.keyword, Is.EqualTo(StyleKeyword.Null),
                 "Precondition: a single-line label carries no balanced constraint to begin with");
 
             // Act — swap in text long enough to wrap at the SAME (unchanged) wrapper width.
@@ -214,54 +322,409 @@ namespace Velvet.Tests
                 "Precondition: the new text actually wrapped onto multiple lines");
 
             // Assert — a text change re-triggers the balance computation THROUGH SOME PATH: the multi-line
-            // gate flips from "leave unconstrained" to "write the searched bound", so an inline maxWidth
+            // gate flips from "leave unconstrained" to "write the searched bound", so an inline width
             // appearing at all proves the swap re-ran the search. This swap changes the label's resolved
             // height, so the geometry listener alone would also re-run it — the text-change notification
             // is NOT isolated here (isolating it needs a same-height swap, whose construction depends on
             // font metrics too fragile to pin). The magnitude of the resulting width is deliberately not
             // asserted either — how densely text packs at the wrapper's width is font-metric trivia, not
             // the re-trigger contract under test.
-            Assert.That(balanced.style.maxWidth.keyword, Is.Not.EqualTo(StyleKeyword.Null));
+            Assert.That(balanced.style.width.keyword, Is.Not.EqualTo(StyleKeyword.Null));
         }
 
-        // The label's classNames toggles a co-present max-w-[400px] utility on/off alongside the
-        // ever-present text-balance token — state-driven so the utility's own inline write lands in a
-        // LATER patch than the one that first established the manipulator's own balanced value.
+        // The label's classNames gains a USS ceiling class AFTER mount — state-driven so the ceiling
+        // arrives in a later patch than the one that first established the balanced width, which is the
+        // case a ceiling read taken once at the first derive can never see.
         [Component]
-        private static VNode OwnershipHost()
+        private static VNode LateCeilingHost()
         {
-            var (addMaxWidth, setAddMaxWidth) = Hooks.UseState(false);
-            s_setAddMaxWidth = setAddMaxWidth;
-            var cls = addMaxWidth ? "text-balance max-w-[400px]" : "text-balance";
-            return V.Div(className: "w-[100px]", children: new VNode[]
+            var (addCeiling, setAddCeiling) = Hooks.UseState(false);
+            s_setAddCeiling = setAddCeiling;
+            var cls = addCeiling ? $"text-balance {ScaleMaxWidthClass}" : "text-balance";
+            return V.Div(className: $"w-[{WrapperWidthPx}px]", children: new VNode[]
             {
                 V.Label(name: "balanced", text: LongWrapText, className: cls, refCallback: s_wrapWithFontRef),
             });
         }
 
         [UnityTest]
-        public IEnumerator Given_ABalancedLabel_When_AMaxWidthUtilityIsAddedInALaterPatch_Then_BalanceKeepsOwningTheInlineMaxWidth()
+        public IEnumerator Given_ABalancedLabelAlreadyHoldingAWidth_When_ACeilingArrivesInALaterPatch_Then_TheBoxMovesInsideIt()
         {
-            // Arrange — mounts with text-balance alone so its own computed maxWidth is already established
-            // before the utility ever enters the class list.
-            _host = new RenderTexturePanelHost("TextBalanceOwnershipPanel", 400, 400);
-            _mounted = V.Mount(_host.Root, V.Component(OwnershipHost, key: "root"));
+            // Arrange — mounts with text-balance alone, so a balanced width is established and held before
+            // any ceiling exists at all.
+            _host = new RenderTexturePanelHost("TextBalanceLateCeilingPanel", 400, 400);
+            _host.Root.LoadBundledStyleUtilitiesForTest();
+            _mounted = V.Mount(_host.Root, V.Component(LateCeilingHost, key: "root"));
             yield return WaitRealtime(0.5);
             var balanced = _host.Root.Q<Label>("balanced");
-            Assume.That(balanced, Is.Not.Null, "Precondition: the label mounted");
-            Assume.That(balanced.resolvedStyle.height, Is.GreaterThan(balanced.resolvedStyle.fontSize * 1.5f),
-                "Precondition: the text wrapped, so text-balance wrote a real (not cleared) maxWidth");
-            var balancedMaxWidth = balanced.style.maxWidth.value.value;
+            Assume.That(balanced.resolvedStyle.width, Is.GreaterThan(ScaleMaxWidthPx),
+                "Precondition: balance is holding a width wider than the ceiling that is about to arrive");
 
-            // Act — patch in a co-present max-w-[400px] utility on the SAME element, in the SAME render
-            // that first applies it: DiffClassList's inline write and the manipulator's own Refresh() both
-            // touch style.maxWidth in this one patch.
-            s_setAddMaxWidth.Invoke(true);
+            // Act — the ceiling class enters the class list while that width is held.
+            s_setAddCeiling.Invoke(true);
             yield return WaitRealtime(0.6);
 
-            // Assert — text-balance re-asserts every patch while its class is present, so the utility's
-            // own 400px write never survives past the same patch that introduced it.
-            Assert.That(balanced.style.maxWidth.value.value, Is.EqualTo(balancedMaxWidth).Within(0.5f));
+            // Assert — a ceiling is read fresh on every pass, so one that appears mid-life binds like one
+            // present at mount. Reading it once and caching cannot see this, since a label whose text
+            // always wraps never releases the slot that would trigger a re-read.
+            Assert.That(balanced.resolvedStyle.width, Is.LessThanOrEqualTo(ScaleMaxWidthPx + 0.5f));
+        }
+
+        [UnityTest]
+        public IEnumerator Given_ABalancedLabelAlreadyHoldingAWidth_When_AVariantSwapsInANarrowerCeiling_Then_TheBoxMovesInsideIt()
+        {
+            // Arrange — a USS base ceiling, and a dark: payload that narrows it. The theme flip changes
+            // the ceiling while the balanced width is held, with no re-render at all. The payload is an
+            // arbitrary value rather than another scale class because two USS classes resolve against each
+            // other by stylesheet source order, which no variant can reorder.
+            _host = new RenderTexturePanelHost("TextBalanceVariantCeilingPanel", 400, 400);
+            _host.Root.LoadBundledStyleUtilitiesForTest();
+            var tree = V.Div(className: $"w-[{WrapperWidthPx}px]", children: new VNode[]
+            {
+                V.Label(name: "balanced", text: LongWrapText,
+                    className: $"text-balance {ScaleMaxWidthClass} dark:max-w-[80px]", refCallback: s_wrapWithFontRef),
+            });
+            _mounted = V.Mount(_host.Root, tree);
+            yield return WaitRealtime(0.5);
+            var balanced = _host.Root.Q<Label>("balanced");
+            Assume.That(balanced.resolvedStyle.width, Is.GreaterThan(80.5f),
+                "Precondition: the base ceiling is the one binding, so balance holds a width above the narrower one");
+
+            // Act
+            VelvetTheme.IsDark = true;
+            yield return WaitRealtime(0.6);
+
+            // Assert
+            Assert.That(balanced.resolvedStyle.width, Is.LessThanOrEqualTo(80.5f));
+        }
+
+        [UnityTest]
+        public IEnumerator Given_AVariantCeilingOverABaseOne_When_TheVariantIsRemoved_Then_TheBaseCeilingStillBinds()
+        {
+            // Arrange — the dark: layer supplies the narrower ceiling over a base USS one. Removing it must
+            // fall back to the base rather than to "no ceiling at all", which is the widening direction of
+            // the same currency contract the two tests above cover in the narrowing one.
+            _host = new RenderTexturePanelHost("TextBalanceCeilingFallbackPanel", 400, 400);
+            _host.Root.LoadBundledStyleUtilitiesForTest();
+            VelvetTheme.IsDark = true;
+            var tree = V.Div(className: $"w-[{WrapperWidthPx}px]", children: new VNode[]
+            {
+                V.Label(name: "balanced", text: LongWrapText,
+                    className: $"text-balance {ScaleMaxWidthClass} dark:max-w-[80px]", refCallback: s_wrapWithFontRef),
+            });
+            _mounted = V.Mount(_host.Root, tree);
+            yield return WaitRealtime(0.5);
+            var balanced = _host.Root.Q<Label>("balanced");
+            Assume.That(balanced.resolvedStyle.width, Is.LessThanOrEqualTo(80.5f),
+                "Precondition: the dark layer's narrower ceiling is the one binding to begin with");
+
+            // Act
+            VelvetTheme.IsDark = false;
+            yield return WaitRealtime(0.6);
+
+            // Assert
+            Assert.That(balanced.resolvedStyle.width, Is.LessThanOrEqualTo(ScaleMaxWidthPx + 0.5f));
+        }
+
+        [UnityTest]
+        public IEnumerator Given_ABalancedLabelHoldingAWidth_When_ItsTextShrinksToOneLine_Then_TheBoxIsHandedBack()
+        {
+            // Arrange — the relocated release contract: balance borrows the WIDTH slot now, so a label that
+            // stops needing a balanced value must hand that slot back or stay pinned at it forever.
+            _host = new RenderTexturePanelHost("TextBalanceReleaseWidthPanel", 400, 400);
+            _mounted = V.Mount(_host.Root, V.Component(TextSwapHost, key: "root"));
+            yield return WaitRealtime(0.5);
+            var balanced = _host.Root.Q<Label>("balanced");
+            s_setSwapText.Invoke(LongWrapText);
+            yield return WaitRealtime(0.6);
+            var wrapperWidth = balanced.parent.resolvedStyle.width;
+            Assume.That(balanced.resolvedStyle.width, Is.LessThan(wrapperWidth - 0.5f),
+                "Precondition: balance is holding a width narrower than the wrapper");
+
+            // Act — back to text that fits one line, which is a gate balance declines to act on.
+            s_setSwapText.Invoke("Hi");
+            yield return WaitRealtime(0.6);
+
+            // Assert — the box returns to what the cascade gives it, rather than staying at the width
+            // balance wrote while it still had a reason to.
+            Assert.That(balanced.resolvedStyle.width, Is.EqualTo(wrapperWidth).Within(0.5f));
+        }
+
+        // Two cells of a grid, one balanced. `grid-cols-2` carries no bare `grid` token, so this also
+        // pins that the stand-down follows the grid manipulator rather than the marker class.
+        private IEnumerator MountGridCells(string containerClass)
+        {
+            _host = new RenderTexturePanelHost("TextBalanceGridChildPanel", 400, 400);
+            var tree = V.Div(className: containerClass, children: new VNode[]
+            {
+                V.Label(name: "plain", text: LongWrapText, refCallback: s_wrapWithFontRef),
+                V.Label(name: "balanced", text: "Hi", className: "text-balance", refCallback: s_wrapWithFontRef),
+            });
+            _mounted = V.Mount(_host.Root, tree);
+            yield return WaitRealtime(0.5);
+        }
+
+        [UnityTest]
+        public IEnumerator Given_ALabelInsideAGridContainer_When_ItsTextIsSetDirectly_Then_TheGridsColumnWidthSurvives()
+        {
+            // Arrange
+            yield return MountGridCells($"grid-cols-2 w-[{WrapperWidthPx}px]");
+            var plain = _host.Root.Q<Label>("plain");
+            var balanced = _host.Root.Q<Label>("balanced");
+            Assume.That(plain.resolvedStyle.width, Is.LessThan(WrapperWidthPx),
+                "Precondition: the grid sized its children into columns narrower than the container");
+
+            // Act — assigned straight onto the element, which is the trigger that reaches balance without
+            // reaching the grid: TextElement raises ChangeEvent<string> synchronously, while the grid's own
+            // re-derive is gated on a container width that a child re-wrapping never moves.
+            balanced.text = LongWrapText;
+            yield return WaitRealtime(0.6);
+
+            // Assert — the grid owns this slot, so balance stands down instead of taking the column.
+            Assert.That(balanced.resolvedStyle.width, Is.EqualTo(plain.resolvedStyle.width).Within(0.5f));
+        }
+
+        [UnityTest]
+        public IEnumerator Given_ABalancedLabelInsideACompositeWidget_When_Balanced_Then_ItMeasuresAgainstTheInnerBox()
+        {
+            // Arrange — a ScrollView redirects its children into an inner box, so the label's parent is
+            // that box and not the widget. Both the measurement and the parent subscription use it.
+            _host = new RenderTexturePanelHost("TextBalanceCompositeWidgetPanel", 400, 400);
+            var tree = V.ScrollView(className: $"w-[{WrapperWidthPx}px] h-[200px]", children: new VNode[]
+            {
+                V.Label(name: "balanced", text: LongWrapText, className: "text-balance", refCallback: s_wrapWithFontRef),
+            });
+            _mounted = V.Mount(_host.Root, tree);
+            yield return WaitRealtime(0.5);
+            var balanced = _host.Root.Q<Label>("balanced");
+            Assume.That(balanced.resolvedStyle.height, Is.GreaterThan(balanced.resolvedStyle.fontSize * 1.5f),
+                "Precondition: the text wrapped inside the widget's inner box");
+
+            // Assert — a box narrower than the inner box it measured against, which only happens if the
+            // available width resolved through the redirect instead of coming out as nothing.
+            Assert.That(balanced.resolvedStyle.width,
+                Is.LessThan(balanced.parent.resolvedStyle.width - 0.5f));
+        }
+
+        [UnityTest]
+        public IEnumerator Given_ALabelInsideAScrollViewGrid_When_ItsTextIsSetDirectly_Then_TheGridsColumnWidthSurvives()
+        {
+            // Arrange — a ScrollView grid sizes the children of its contentContainer, so the manipulator is
+            // keyed on an element that is NOT the children's parent.
+            _host = new RenderTexturePanelHost("TextBalanceScrollGridPanel", 400, 400);
+            var tree = V.ScrollView(className: $"grid-cols-2 w-[{WrapperWidthPx}px] h-[200px]", children: new VNode[]
+            {
+                V.Label(name: "plain", text: LongWrapText, refCallback: s_wrapWithFontRef),
+                V.Label(name: "balanced", text: "Hi", className: "text-balance", refCallback: s_wrapWithFontRef),
+            });
+            _mounted = V.Mount(_host.Root, tree);
+            yield return WaitRealtime(0.5);
+            var plain = _host.Root.Q<Label>("plain");
+            var balanced = _host.Root.Q<Label>("balanced");
+            Assume.That(plain.resolvedStyle.width, Is.LessThan(WrapperWidthPx),
+                "Precondition: the grid sized the contentContainer's children into columns");
+
+            // Act
+            balanced.text = LongWrapText;
+            yield return WaitRealtime(0.6);
+
+            // Assert
+            Assert.That(balanced.resolvedStyle.width, Is.EqualTo(plain.resolvedStyle.width).Within(0.5f));
+        }
+
+        [UnityTest]
+        public IEnumerator Given_ABalancedLabelHoldingAWidth_When_ItsTextBecomesEmpty_Then_TheBoxIsHandedBack()
+        {
+            // Arrange — the empty-text gate has its own release branch, reached before any measurement.
+            _host = new RenderTexturePanelHost("TextBalanceReleaseEmptyPanel", 400, 400);
+            _mounted = V.Mount(_host.Root, V.Component(TextSwapHost, key: "root"));
+            yield return WaitRealtime(0.5);
+            var balanced = _host.Root.Q<Label>("balanced");
+            s_setSwapText.Invoke(LongWrapText);
+            yield return WaitRealtime(0.6);
+            var wrapperWidth = balanced.parent.resolvedStyle.width;
+            Assume.That(balanced.resolvedStyle.width, Is.LessThan(wrapperWidth - 0.5f),
+                "Precondition: balance is holding a width narrower than the wrapper");
+
+            // Act
+            s_setSwapText.Invoke(string.Empty);
+            yield return WaitRealtime(0.6);
+
+            // Assert
+            Assert.That(balanced.resolvedStyle.width, Is.EqualTo(wrapperWidth).Within(0.5f));
+        }
+
+        [UnityTest]
+        public IEnumerator Given_ABalancedLabelHoldingAWidth_When_AVariantWidthIsToggledOn_Then_TheDeclaredWidthTakesOver()
+        {
+            // Arrange — balance settles on a width of its own BEFORE the declaration exists. A USS-spelled
+            // variant width then loses to that inline value, so it moves no resolved width and raises no
+            // geometry event: only the layout re-sync its gate token triggers can deliver it.
+            yield return MountWithSizingClass("TextBalanceLateVariantWidthPanel", LongWrapText, "dark:w-40", loadUtilities: true);
+            var balanced = _host.Root.Q<Label>("balanced");
+            Assume.That(balanced.resolvedStyle.width, Is.GreaterThan(200f),
+                "Precondition: balance is holding a width well above the one the variant will declare");
+
+            // Act
+            VelvetTheme.IsDark = true;
+            yield return WaitRealtime(0.6);
+
+            // Assert — `.w-40 { width: var(--space-40); }` with `--space-40: 160px`.
+            Assert.That(balanced.resolvedStyle.width, Is.EqualTo(160f).Within(0.5f));
+        }
+
+        [UnityTest]
+        public IEnumerator Given_ABalancedLabel_When_AnInlineResolvedVariantWidthIsToggledOnAndOff_Then_ItBalancesAgain()
+        {
+            // Arrange — a bracket variant width takes the inline-resolved branch, which fires no layout
+            // re-sync at all: only the layer probe sees either edge of it.
+            yield return MountWithSizingClass("TextBalanceVariantLayerEdgePanel", LongWrapText, "dark:w-[200px]");
+            var balanced = _host.Root.Q<Label>("balanced");
+            VelvetTheme.IsDark = true;
+            yield return WaitRealtime(0.6);
+            Assume.That(balanced.resolvedStyle.width, Is.EqualTo(200f).Within(0.5f),
+                "Precondition: the variant's width took the box over while it was active");
+
+            // Act — the OFF edge removes the layer, which nothing else reports.
+            VelvetTheme.IsDark = false;
+            yield return WaitRealtime(0.6);
+
+            // Assert — back to a balanced box rather than the full wrapper it would stretch to unbalanced.
+            Assert.That(balanced.resolvedStyle.width, Is.LessThan(WrapperWidthPx - 0.5f));
+        }
+
+        [UnityTest]
+        public IEnumerator Given_ALabelDeclaringAnArbitraryWidth_When_Balanced_Then_TheDeclaredWidthIsLeftAlone()
+        {
+            // Arrange / Act — a browser balances INSIDE a fixed box; this approximation can only resize the
+            // box, so on an element the author has sized there is no honest approximation left and balance
+            // stands down rather than overruling the declaration.
+            yield return MountWithSizingClass("TextBalanceDeclaredWidthPanel", LongWrapText, "w-[200px]");
+            var balanced = _host.Root.Q<Label>("balanced");
+            Assume.That(balanced.resolvedStyle.height, Is.GreaterThan(balanced.resolvedStyle.fontSize * 1.5f),
+                "Precondition: the text wraps at the declared width, so balance had a real candidate to write");
+
+            // Assert
+            Assert.That(balanced.resolvedStyle.width, Is.EqualTo(200f).Within(0.5f));
+        }
+
+        [UnityTest]
+        public IEnumerator Given_ALabelDeclaringAVariantWidth_When_ThatVariantIsActive_Then_TheDeclaredWidthIsLeftAlone()
+        {
+            // Arrange — a variant-prefixed token never starts with `w-`, so only the payload it writes onto
+            // the live class list identifies it as a width declaration.
+            VelvetTheme.IsDark = true;
+
+            // Act
+            yield return MountWithSizingClass("TextBalanceVariantWidthPanel", LongWrapText, "dark:w-40", loadUtilities: true);
+            var balanced = _host.Root.Q<Label>("balanced");
+            Assume.That(balanced.resolvedStyle.height, Is.GreaterThan(balanced.resolvedStyle.fontSize * 1.5f),
+                "Precondition: the text wraps at the declared width, so balance had a real candidate to write");
+
+            // Assert — `.w-40 { width: var(--space-40); }` with `--space-40: 160px`.
+            Assert.That(balanced.resolvedStyle.width, Is.EqualTo(160f).Within(0.5f));
+        }
+
+        [UnityTest]
+        public IEnumerator Given_ALabelDeclaringAnImportantWidth_When_Balanced_Then_TheDeclaredWidthIsLeftAlone()
+        {
+            // Arrange / Act — the bang form registers its layer at a higher priority and never reaches the
+            // class list under either spelling.
+            yield return MountWithSizingClass("TextBalanceImportantWidthPanel", LongWrapText, "!w-[200px]");
+            var balanced = _host.Root.Q<Label>("balanced");
+            Assume.That(balanced.resolvedStyle.height, Is.GreaterThan(balanced.resolvedStyle.fontSize * 1.5f),
+                "Precondition: the text wraps at the declared width, so balance had a real candidate to write");
+
+            // Assert
+            Assert.That(balanced.resolvedStyle.width, Is.EqualTo(200f).Within(0.5f));
+        }
+
+        [UnityTest]
+        public IEnumerator Given_AVariantTrackedLabelDeclaringABracketWidth_When_Balanced_Then_TheDeclaredWidthIsLeftAlone()
+        {
+            // Arrange / Act — the `dark:gap-4` puts the element on the variant-gated path, where the layout
+            // families read the LIVE class list; a bracket width resolves to inline style and never appears
+            // there, so only the recorded layer still sees it.
+            VelvetTheme.IsDark = true;
+            yield return MountWithSizingClass("TextBalanceTrackedBracketWidthPanel", LongWrapText, "w-[200px] dark:gap-4");
+            var balanced = _host.Root.Q<Label>("balanced");
+            Assume.That(balanced.resolvedStyle.height, Is.GreaterThan(balanced.resolvedStyle.fontSize * 1.5f),
+                "Precondition: the text wraps at the declared width, so balance had a real candidate to write");
+
+            // Assert
+            Assert.That(balanced.resolvedStyle.width, Is.EqualTo(200f).Within(0.5f));
+        }
+
+        [UnityTest]
+        public IEnumerator Given_ABalancedLabelSharingARowWithASibling_When_Balanced_Then_TheSiblingGivesUpSomeWidth()
+        {
+            // Arrange — the over-estimate the class doc calls harmless is not, in a row: the search
+            // measures against the whole row, so the balanced box plus its sibling exceed it. Measured to
+            // be the same under either write slot, because Yoga folds a child's max-width into the MEASURE
+            // constraint before computing a flex basis, and wrapping text measured under that cap returns
+            // the cap itself — the same basis a width sets outright. So this pins a consequence of
+            // measuring against the parent, not of the slot.
+            _host = new RenderTexturePanelHost("TextBalanceRowSiblingPanel", 400, 400);
+            var tree = V.Div(className: $"w-[{WrapperWidthPx}px]", refCallback: s_rowRef, children: new VNode[]
+            {
+                V.Label(name: "balanced", text: LongWrapText, className: "text-balance", refCallback: s_wrapWithFontRef),
+                V.Div(name: "sibling", className: "w-[100px] h-[10px]"),
+            });
+            _mounted = V.Mount(_host.Root, tree);
+            yield return WaitRealtime(0.5);
+            var balanced = _host.Root.Q<Label>("balanced");
+            var sibling = _host.Root.Q<VisualElement>("sibling");
+            Assume.That(balanced.resolvedStyle.height, Is.GreaterThan(balanced.resolvedStyle.fontSize * 1.5f),
+                "Precondition: the text wrapped, so balance wrote a real width into the row");
+
+            // Assert — the sibling ends up under its declared 100px: the row overflows and flex-shrink
+            // shares the loss across both boxes.
+            Assert.That(sibling.resolvedStyle.width, Is.LessThan(100f));
+        }
+
+        [UnityTest]
+        public IEnumerator Given_ALabelDeclaringASizeShorthand_When_Balanced_Then_TheDeclaredWidthIsLeftAlone()
+        {
+            // Arrange / Act — `size-[..]` is the one declaration whose layer key is not the slot it writes:
+            // it registers under Size and writes width AND height, so restoring only Width hands back an
+            // element with no width at all.
+            yield return MountWithSizingClass("TextBalanceSizeShorthandPanel", LongWrapText, "size-[40px]");
+            var balanced = _host.Root.Q<Label>("balanced");
+            Assume.That(balanced.resolvedStyle.height, Is.EqualTo(40f).Within(0.5f),
+                "Precondition: the shorthand's height took effect, so its width is the half under test");
+
+            // Assert
+            Assert.That(balanced.resolvedStyle.width, Is.EqualTo(40f).Within(0.5f));
+        }
+
+        [UnityTest]
+        public IEnumerator Given_ABalancedLabelDeclaringOnlyAHeight_When_ItReleasesTheWidthSlot_Then_TheHeightSurvives()
+        {
+            // Arrange / Act — the mirror hazard: re-asserting Size on an element that has no Size layer
+            // would null the height along with the width, and this height comes from a layer of its own.
+            // Short text, so the single-line gate releases the slot.
+            yield return MountWithSizingClass("TextBalanceHeightOnlyPanel", "Hi", "h-[100px]");
+            var balanced = _host.Root.Q<Label>("balanced");
+            Assume.That(balanced.resolvedStyle.width, Is.EqualTo(WrapperWidthPx).Within(0.5f),
+                "Precondition: the width slot was released, so the box stretches to the wrapper");
+
+            // Assert
+            Assert.That(balanced.resolvedStyle.height, Is.EqualTo(100f).Within(0.5f));
+        }
+
+        [UnityTest]
+        public IEnumerator Given_ALabelDeclaringAScaleWidth_When_Balanced_Then_TheDeclaredWidthIsLeftAlone()
+        {
+            // Arrange / Act — the same contract for a width that exists only as a USS class. Both spellings
+            // are read from the class tokens, so neither is honored more than the other.
+            yield return MountWithSizingClass("TextBalanceDeclaredScaleWidthPanel", LongWrapText, "w-40", loadUtilities: true);
+            var balanced = _host.Root.Q<Label>("balanced");
+            Assume.That(balanced.resolvedStyle.height, Is.GreaterThan(balanced.resolvedStyle.fontSize * 1.5f),
+                "Precondition: the text wraps at the declared width, so balance had a real candidate to write");
+
+            // Assert — `.w-40 { width: var(--space-40); }` with `--space-40: 160px`, far enough from any
+            // width the search would have produced that a font-metric shift cannot blur the two.
+            Assert.That(balanced.resolvedStyle.width, Is.EqualTo(160f).Within(0.5f));
         }
     }
 }


### PR DESCRIPTION
## What

Two defects, one root.

**The slot was destroyed, not borrowed.** The text-balance manipulator cleared the element's inline max-width unconditionally on two branches — empty text, and text that already fits one line — with nothing putting back the value it had borrowed. A co-present `max-w-[…]` was gone for the whole lifetime of the attachment, not just at teardown.

**A declared `max-width` was not honored.** The search measured against the parent's content width, so `text-balance max-w-[120px]` in a 380px wrapper resolved around 284px where a browser renders 120. `max-width` is a ceiling that `text-wrap: balance` operates inside.

## Why the write slot moved

Honoring the ceiling means reading it, and reading `resolvedStyle.maxWidth` while *writing* max-width is self-referential — the read returns the manipulator's own output. The first attempt worked around that with a cache invalidated on release, which is dead for the main case: a paragraph whose text always wraps never releases, so a ceiling arriving later, or changing across a breakpoint, was never picked up.

Balance now writes `style.width`. Measured on a panel, the two produce identical layout in a column wrapper, in a flex row beside a sibling, and under shrink pressure — and the engine clamps width to max-width, so **a declared ceiling cannot be violated even when the clamp is wrong**. The ceiling read is one `resolvedStyle.maxWidth` per pass covering every spelling, with no cache, no flag and no staleness.

## What it costs, and what it does not

Owning the width slot means an author's own declared width would be overwritten, so balance **stands down** when one is present — detected as presence, not value, so bracket, scale, variant and important spellings read alike. `w-full text-balance` therefore does not balance: we approximate balance by narrowing the box, and a declared width leaves nothing to narrow. That is stated in the guide as the rule it follows from, not as a case to memorise.

The grid manipulator writes the same slot, so balance stands down for a grid parent too, found by walking to the ancestor whose child container is the element's parent — which covers a grid on any widget that redirects its children, not only a ScrollView.

## Verification

Each fix is red without it, on a panel where layout actually resolves:

| reverted | expected | actual |
|---|---|---|
| write slot (late ceiling) | ≤ 128.5 | 284.0 |
| declared-width gate | 200.0 / 256.0 | 284.0 |
| release clear (empty and single-line) | 380.0 | 284.0 |
| variant gate token | 160.0 | 284.0 |
| grid stand-down | 190.0 | 284.0 |
| `size-[…]` restore | 40.0 | 380.0 |

The `size-[…]` case is the one this change set most nearly reintroduced: that layer registers under `Size` but writes both width and height, so restoring only `Width` half-destroyed the declaration. Re-resolving `Size` unconditionally would have been the same bug one property over — it would null a height from an element's own `h-[…]` layer — so it is gated on the layer existing, with a test pinning the height survives.

EditMode 3420 passed / 0 failed / 3 pre-existing skips. PlayMode 119/119.

## Docs

`Documentation~/fonts.md` states what the manipulator honours and what it does not. Three claims that were false are gone: that the over-estimate is "never a wrong one" (untrue for exactly the max-width case), that a percentage ceiling converges under a hug-width parent (it oscillates — bound decays, box releases, parent re-widens, restart), and that a resize confined to a ScrollView's inner box is uncovered (the subscription is on that box).

One limitation is documented rather than fixed: an imperative `AddToClassList("w-40")` is not observed, because nothing reports it and it cannot move the manipulator's signature.

Closes #175