### PR TITLE
fix(velvet): resolve the transition guard by declaration order instead of unioning

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -23,10 +23,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   those transitions cover a property it drives — decided from the element's class list, so a
   `transition-transform` or `transition-all` element no longer paints a translate that trails the
   driver for the whole play and then eases in, while a `transition-colors` element running a
-  fade/slide keeps its hover fade. A class that supplies only a duration (`transition-filter`, a
-  bare `duration-*`) leaves `transition-property` at UI Toolkit's `all` default and so counts as
-  covering everything. Overlapping plays each hold their own claim, so the first to settle cannot
-  un-suspend the second.
+  fade/slide keeps its hover fade. The class list is read the way the cascade reads it:
+  `transition-property` holds one value, so the utilities that set it do not combine and the
+  last-declared one present wins outright — `transition-all transition-colors` transitions the
+  colours only, and `transition-all transition-none` transitions nothing. `transition-filter` names
+  `filter`, which no driver writes, so it never triggers a suspension. A bare `duration-*` with no
+  such utility leaves `transition-property` at UI Toolkit's `all` default and so counts as covering
+  everything. Overlapping plays each hold their own claim, so the first to settle cannot un-suspend
+  the second.
 - `space-x-reverse` / `space-y-reverse` are recognized alongside the existing `space-x-*` /
   `space-y-*` aliases: each is a per-axis marker that moves the gap-polyfill margin to the axis's
   trailing physical edge (`margin-right` / `margin-bottom`) instead of the leading one, matching

--- a/Packages/com.velvet.core/Documentation~/motion.md
+++ b/Packages/com.velvet.core/Documentation~/motion.md
@@ -228,16 +228,22 @@ the plan are built in one synchronous call, off-panel, before any style resoluti
   writes the exact value the curve or the physics calls for on that frame, so a transition utility
   naming that same property restarts a native transition on every one of those writes and leaves
   the painted value trailing for the whole play, easing in at the end instead of landing. Whether
-  that applies is decided from the element's **class list**: `transition-transform` names
-  translate/scale/rotate, `transition-colors` names the three colours, `transition-colors-scale`
-  and `transition-colors-scale-opacity` add those, and `transition-all` names everything. Anything
-  that supplies only a duration — `transition-filter`, or a bare `duration-*` — leaves
-  `transition-property` at its UI Toolkit default of `all`, so those elements transition
-  *everything* natively and a play on them always suspends. An element with no transition utility
-  at all has a 0s duration and transitions nothing, so nothing suspends. A play suspends only where
-  its own channels intersect that set — a `transition-colors` element running a fade/slide keeps
-  its hover fade, while the same play on a `transition-transform`, `transition-all` or
-  `transition-filter` element suspends. Two blind spots: the check runs once at play start, so a
+  that applies is decided from the element's **class list**, resolved the way the cascade resolves
+  it: `transition-property` holds one value, so the utilities that set it do not combine — the
+  **last-declared** one present on the element wins outright and the rest contribute nothing. The
+  bundled order is `transition-transform`, `transition-filter`, `transition-all`,
+  `transition-none`, `transition-opacity`, `transition-colors`, `transition-colors-scale`,
+  `transition-colors-scale-opacity`, then the scheduler-applied `anim-*` presets. So
+  `transition-all transition-colors` transitions the colours only, and
+  `transition-all transition-none` transitions nothing, whichever order the class strings appear
+  in. `transition-filter` names `filter`, which no driver writes, so it never triggers a
+  suspension. With none of those utilities present, a `duration-*` class — or the inline
+  `duration-[…]` form — leaves `transition-property` at UI Toolkit's default of `all`, so those
+  elements transition *everything* natively and a play on them always suspends; with no duration
+  either, the element transitions nothing and nothing suspends. A play suspends only where its own
+  channels intersect the resolved set — a `transition-colors` element running a fade/slide keeps
+  its hover fade, while the same play on a `transition-transform` or `transition-all` element
+  suspends. Two blind spots: the check runs once at play start, so a
   variant turning on `transition-all` mid-play is not picked up until the next play, and a
   whole-property transition written as an inline style by something other than a `duration-*`
   utility is not seen.

--- a/Packages/com.velvet.core/Generators~/README.md
+++ b/Packages/com.velvet.core/Generators~/README.md
@@ -57,9 +57,10 @@ Generators~/
 │   ├── Velvet.StyleTable.csproj              (force-added — the root .gitignore ignores *.csproj)
 │   ├── Program.cs                            (CLI: --styles <dir> --output <file>)
 │   ├── UssStyleSheetParser.cs                (rules and declarations, straight off the text)
+│   ├── UssCascadeOrder.cs                    (the @import order the importer flattens the sheets to)
 │   ├── UssSelector.cs                        (which selector shapes the table can model)
 │   ├── UssPropertyVocabulary.cs              (UI Toolkit longhands + the shorthands that expand into them)
-│   ├── UssProblem.cs                         (USS001-008 — why a derivation refused to write)
+│   ├── UssProblem.cs                         (USS001-USS011 — why a derivation refused to write)
 │   ├── StyleUtilityTableBuilder.cs           (stylesheets → class → property set)
 │   └── StyleUtilityTableEmitter.cs           (property set → C# source)
 └── tests/Velvet.SourceGenerators.Tests/      (abridged)
@@ -88,7 +89,7 @@ It is a build-time tool rather than a source generator because the answer is a f
 
 Committing generated source is only safe with a guard, and `BundledStyleSheetCensusTests` is it: it re-derives from the stylesheets and compares against the committed file. Unlike the two DLLs — which embed the git `HEAD` commit id and so can never be byte-compared against a rebuild — the emitted C# is deterministic, so the comparison is exact. `generators.yml` triggers on `Runtime/**`, so a stylesheet edit runs it whether or not any code changed.
 
-Failures are reported as `USS001`-`USS008` and refuse to write the table. They are deliberately outside the `VEL###` space the analyzers use: nothing can suppress a build-script failure through an `.editorconfig` severity, and sharing the namespace would invite someone to try. Each code marks an assumption the table depends on — that `:root` declares only custom properties, that a utility declares no custom property, that every property name resolves to the pinned UI Toolkit vocabulary, that one class carries one gate — so the assumption cannot rot silently.
+Failures are reported as `USS001`-`USS011` and refuse to write the table. They are deliberately outside the `VEL###` space the analyzers use: nothing can suppress a build-script failure through an `.editorconfig` severity, and sharing the namespace would invite someone to try. Each code marks an assumption the table depends on — that `:root` declares only custom properties, that a utility declares no custom property, that every property name resolves to the pinned UI Toolkit vocabulary, that one class carries one gate, that the sheets arrive in the aggregator's `@import` order, that no gated rule declares `transition-property` — so the assumption cannot rot silently.
 
 Four partials declare no rules and are expected to: `StyleUtilities.uss` is nothing but `@import`, and `_gap.uss`, `_presets.uss` and `_states.uss` describe utility families Velvet realises in C# rather than in USS (each says so in its own header). Their classes are therefore absent from the table, which from the table's side looks identical to a class that sets nothing — `BundledStyleSheetCensusTests` pins the list so the distinction stays visible.
 

--- a/Packages/com.velvet.core/Generators~/src/Velvet.StyleTable/Program.cs
+++ b/Packages/com.velvet.core/Generators~/src/Velvet.StyleTable/Program.cs
@@ -1,7 +1,5 @@
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 
 namespace Velvet.StyleTable
 {
@@ -38,7 +36,7 @@ namespace Velvet.StyleTable
                 return UsageError;
             }
 
-            var sheets = StyleSheetsIn(stylesDirectory);
+            var sheets = UssCascadeOrder.SheetsIn(stylesDirectory);
             var result = StyleUtilityTableBuilder.Build(sheets);
             if (result.Problems.Length > 0)
             {
@@ -59,12 +57,6 @@ namespace Velvet.StyleTable
                 $"stylesheet(s) -> {outputPath}{(changed ? "" : " (unchanged)")}");
             return Ok;
         }
-
-        public static IReadOnlyList<UssSourceText> StyleSheetsIn(string directory) =>
-            Directory.EnumerateFiles(directory, "*.uss")
-                .OrderBy(path => path, StringComparer.Ordinal)
-                .Select(path => new UssSourceText(path, File.ReadAllText(path)))
-                .ToList();
 
         /// <summary>
         /// Leaves the file alone when the derivation reproduced it, so a no-op build does not restamp an asset

--- a/Packages/com.velvet.core/Generators~/src/Velvet.StyleTable/StyleUtilityTableBuilder.cs
+++ b/Packages/com.velvet.core/Generators~/src/Velvet.StyleTable/StyleUtilityTableBuilder.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.IO;
 using System.Linq;
 
 namespace Velvet.StyleTable
@@ -13,7 +14,14 @@ namespace Velvet.StyleTable
         /// <summary>Bit width of the generated property set. Two 64-bit words.</summary>
         public const int PropertySetCapacity = 128;
 
-        public static StyleUtilityTableResult Build(IReadOnlyCollection<UssSourceText> sheets)
+        private const string TransitionProperty = "transition-property";
+
+        /// <summary>
+        /// Derives the table from <paramref name="sheets"/>, which arrive in cascade order and are not
+        /// re-sorted here — the transition table records position, so the order IS part of the answer. A
+        /// caller that hands them over in some other order is caught by the <c>@import</c> cross-check.
+        /// </summary>
+        public static StyleUtilityTableResult Build(IReadOnlyList<UssSourceText> sheets)
         {
             var problems = ImmutableArray.CreateBuilder<UssProblem>();
             var longhands = UssPropertyVocabulary.OrderedLonghands;
@@ -24,7 +32,10 @@ namespace Velvet.StyleTable
                     $"The longhand vocabulary holds {longhands.Length} properties but a property set holds " +
                     $"{PropertySetCapacity}. Emit another backing word in StyleLonghandSet."));
                 return new StyleUtilityTableResult(
-                    new StyleUtilityTable(longhands, ImmutableArray<StyleUtilityTableEntry>.Empty),
+                    new StyleUtilityTable(
+                        longhands,
+                        ImmutableArray<StyleUtilityTableEntry>.Empty,
+                        ImmutableArray<StyleTransitionTableEntry>.Empty),
                     problems.ToImmutable());
             }
 
@@ -41,10 +52,14 @@ namespace Velvet.StyleTable
                 bitOf[longhands[i].UssName] = i;
             }
 
+            var parsed = sheets.Select(s => UssStyleSheetParser.Parse(s.Path, s.Text)).ToList();
+            ReportOrderThatContradictsTheImports(parsed, problems);
+
             var accumulated = new Dictionary<string, MutableEntry>(StringComparer.Ordinal);
-            foreach (var source in sheets.OrderBy(s => s.Path, StringComparer.Ordinal))
+            var transitions = new List<StyleTransitionTableEntry>();
+            foreach (var sheet in parsed)
             {
-                CollectSheet(UssStyleSheetParser.Parse(source.Path, source.Text), bitOf, accumulated, problems);
+                CollectSheet(sheet, bitOf, accumulated, transitions, problems);
             }
 
             var entries = accumulated.Values
@@ -53,14 +68,84 @@ namespace Velvet.StyleTable
                 .ToImmutableArray();
 
             return new StyleUtilityTableResult(
-                new StyleUtilityTable(longhands, entries),
+                new StyleUtilityTable(longhands, entries, transitions.ToImmutableArray()),
                 problems.ToImmutable());
+        }
+
+        /// <summary>
+        /// Checks the order the sheets arrived in against the aggregator's <c>@import</c> list, which is the
+        /// order the importer concatenates them in. Skipped when no sheet imports anything, so a derivation
+        /// over one hand-written stylesheet has no aggregator to answer to.
+        /// </summary>
+        private static void ReportOrderThatContradictsTheImports(
+            IReadOnlyList<UssSheet> parsed, ImmutableArray<UssProblem>.Builder problems)
+        {
+            var imported = parsed
+                .SelectMany(sheet => sheet.AtRules)
+                .SelectMany(atRule => UssCascadeOrder.ImportedNames(atRule.Text))
+                .Select(Path.GetFileName)
+                .ToList();
+            if (imported.Count == 0)
+            {
+                return;
+            }
+
+            var supplied = parsed
+                .Where(sheet => sheet.AtRules.IsEmpty)
+                .Select(sheet => Path.GetFileName(sheet.Path))
+                .ToList();
+            if (!supplied.SequenceEqual(imported, StringComparer.Ordinal))
+            {
+                problems.Add(new UssProblem(
+                    UssProblemCode.StyleSheetOrderMismatch,
+                    $"The sheets were supplied as [{string.Join(", ", supplied)}] but the @import list reads " +
+                    $"[{string.Join(", ", imported)}]. Cascade order is the order they arrive in, so a sheet " +
+                    "the aggregator does not import — or one supplied out of import order — would be recorded " +
+                    "as beating rules it actually loses to."));
+                return;
+            }
+            ReportAggregatorSuppliedAheadOfItsImports(parsed, problems);
+        }
+
+        /// <summary>
+        /// Checks that each aggregator arrived after every partial it imports, which is where the importer
+        /// puts it: an imported sheet is spliced in ahead of the importing sheet's own rules.
+        /// </summary>
+        private static void ReportAggregatorSuppliedAheadOfItsImports(
+            IReadOnlyList<UssSheet> parsed, ImmutableArray<UssProblem>.Builder problems)
+        {
+            for (var position = 0; position < parsed.Count; position++)
+            {
+                var imports = parsed[position].AtRules
+                    .SelectMany(atRule => UssCascadeOrder.ImportedNames(atRule.Text))
+                    .Select(Path.GetFileName)
+                    .ToList();
+                if (imports.Count == 0)
+                {
+                    continue;
+                }
+                var lastImport = parsed
+                    .Select((sheet, index) => (Name: Path.GetFileName(sheet.Path), Index: index))
+                    .Where(candidate => imports.Contains(candidate.Name, StringComparer.Ordinal))
+                    .Select(candidate => candidate.Index)
+                    .Max();
+                if (lastImport < position)
+                {
+                    continue;
+                }
+                problems.Add(new UssProblem(
+                    UssProblemCode.StyleSheetOrderMismatch,
+                    $"'{Path.GetFileName(parsed[position].Path)}' was supplied ahead of a partial it imports. " +
+                    "An aggregator's own rules outrank every partial's, so supplying it first would record it " +
+                    "as losing ties it wins."));
+            }
         }
 
         private static void CollectSheet(
             UssSheet sheet,
             Dictionary<string, int> bitOf,
             Dictionary<string, MutableEntry> accumulated,
+            List<StyleTransitionTableEntry> transitions,
             ImmutableArray<UssProblem>.Builder problems)
         {
             foreach (var error in sheet.Errors)
@@ -88,7 +173,7 @@ namespace Velvet.StyleTable
             {
                 foreach (var target in UssSelector.Classify(rule.Selector))
                 {
-                    CollectRule(sheet, rule, target, bitOf, accumulated, problems);
+                    CollectRule(sheet, rule, target, bitOf, accumulated, transitions, problems);
                 }
             }
         }
@@ -99,6 +184,7 @@ namespace Velvet.StyleTable
             UssSelectorTarget target,
             Dictionary<string, int> bitOf,
             Dictionary<string, MutableEntry> accumulated,
+            List<StyleTransitionTableEntry> transitions,
             ImmutableArray<UssProblem>.Builder problems)
         {
             switch (target.Kind)
@@ -172,6 +258,85 @@ namespace Velvet.StyleTable
                 {
                     entry.Set(bitOf[longhand]);
                 }
+                if (!string.Equals(declaration.Property, TransitionProperty, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+                if (target.Gate != UssGate.None)
+                {
+                    problems.Add(sheet.ProblemAt(
+                        UssProblemCode.GatedTransitionProperty,
+                        $"Utility class '{target.ClassName}' declares transition-property under gate " +
+                        $"'{target.Gate}'. MotionNativeTransitionGuard answers from an element's class list " +
+                        "alone, where a gate's state is unknowable, so it would keep answering from the " +
+                        "ungated declarations and suspend an element this rule had already stopped " +
+                        "transitioning.",
+                        declaration.Offset));
+                    continue;
+                }
+                CollectTransitionDeclaration(sheet, target.ClassName, declaration, bitOf, transitions, problems);
+            }
+        }
+
+        /// <summary>
+        /// Records what a <c>transition-property</c> declaration names, at the position it was declared. A
+        /// class that declares it more than once moves to the later position, by the rule
+        /// <c>MotionNativeTransitionGuard.DeclaredSlots</c> states.
+        /// </summary>
+        private static void CollectTransitionDeclaration(
+            UssSheet sheet,
+            string className,
+            UssDeclaration declaration,
+            Dictionary<string, int> bitOf,
+            List<StyleTransitionTableEntry> transitions,
+            ImmutableArray<UssProblem>.Builder problems)
+        {
+            var word0 = 0UL;
+            var word1 = 0UL;
+            foreach (var token in declaration.Value.Split(','))
+            {
+                var name = token.Trim();
+                if (name.Length == 0 || string.Equals(name, "none", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+                if (string.Equals(name, "all", StringComparison.Ordinal)
+                    || string.Equals(name, "initial", StringComparison.Ordinal))
+                {
+                    foreach (var bit in bitOf.Values)
+                    {
+                        Set(bit, ref word0, ref word1);
+                    }
+                    continue;
+                }
+                if (!UssPropertyVocabulary.TryResolve(name, out var longhands))
+                {
+                    problems.Add(sheet.ProblemAt(
+                        UssProblemCode.UnknownTransitionProperty,
+                        $"Utility class '{className}' transitions '{name}', which is neither a UI Toolkit " +
+                        "property nor the all/none keyword. A name the engine does not know transitions " +
+                        "nothing, so recording it would describe a transition that never runs.",
+                        declaration.Offset));
+                    return;
+                }
+                foreach (var longhand in longhands)
+                {
+                    Set(bitOf[longhand], ref word0, ref word1);
+                }
+            }
+            transitions.RemoveAll(entry => string.Equals(entry.ClassName, className, StringComparison.Ordinal));
+            transitions.Add(new StyleTransitionTableEntry(className, word0, word1));
+        }
+
+        private static void Set(int bit, ref ulong word0, ref ulong word1)
+        {
+            if (bit < 64)
+            {
+                word0 |= 1UL << bit;
+            }
+            else
+            {
+                word1 |= 1UL << (bit - 64);
             }
         }
 
@@ -241,14 +406,33 @@ namespace Velvet.StyleTable
         public ulong Word1 { get; }
     }
 
+    /// <summary>One utility's <c>transition-property</c> declaration: the properties its value names.</summary>
+    internal readonly struct StyleTransitionTableEntry
+    {
+        public StyleTransitionTableEntry(string className, ulong word0, ulong word1)
+        {
+            ClassName = className;
+            Word0 = word0;
+            Word1 = word1;
+        }
+
+        public string ClassName { get; }
+
+        public ulong Word0 { get; }
+
+        public ulong Word1 { get; }
+    }
+
     internal sealed class StyleUtilityTable
     {
         public StyleUtilityTable(
             ImmutableArray<UssLonghand> longhands,
-            ImmutableArray<StyleUtilityTableEntry> entries)
+            ImmutableArray<StyleUtilityTableEntry> entries,
+            ImmutableArray<StyleTransitionTableEntry> transitions)
         {
             Longhands = longhands;
             Entries = entries;
+            Transitions = transitions;
         }
 
         /// <summary>The longhand vocabulary in bit order: index <c>i</c> is bit <c>i</c> of a property set.</summary>
@@ -256,6 +440,9 @@ namespace Velvet.StyleTable
 
         /// <summary>One entry per utility class, ordered by class name.</summary>
         public ImmutableArray<StyleUtilityTableEntry> Entries { get; }
+
+        /// <summary>The utilities that declare <c>transition-property</c>, in cascade order.</summary>
+        public ImmutableArray<StyleTransitionTableEntry> Transitions { get; }
     }
 
     internal readonly struct StyleUtilityTableResult

--- a/Packages/com.velvet.core/Generators~/src/Velvet.StyleTable/StyleUtilityTableEmitter.cs
+++ b/Packages/com.velvet.core/Generators~/src/Velvet.StyleTable/StyleUtilityTableEmitter.cs
@@ -143,7 +143,7 @@ namespace Velvet
         {
 ";
 
-        private const string Footer = @"        };
+        private const string AfterClassMap = @"        };
 
         /// <summary>How many bundled utility classes carry a USS rule.</summary>
         public static int Count => ByClassName.Count;
@@ -157,6 +157,50 @@ namespace Velvet
                 return true;
             }
             rule = default;
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// The bundled utilities that declare <c>transition-property</c>, in cascade order, with the properties
+    /// each one's value names. <c>MotionNativeTransitionGuard.DeclaredSlots</c> is the only consumer and
+    /// states what the order means.
+    /// </summary>
+    /// <remarks>
+    /// Only ungated rules reach here: the derivation refuses a gated <c>transition-property</c> rather than
+    /// record one, since no reader working from a class list can tell whether the gate holds.
+    /// </remarks>
+    internal static class StyleTransitionUtilities
+    {
+        private static readonly StyleLonghandSet[] Declared =
+        {
+";
+
+        private const string AfterTransitionSets = @"        };
+
+        private static readonly Dictionary<string, int> ByClassName =
+            new Dictionary<string, int>({TRANSITION_COUNT}, StringComparer.Ordinal)
+        {
+";
+
+        private const string Footer = @"        };
+
+        /// <summary>How many bundled utilities declare <c>transition-property</c>.</summary>
+        public static int Count => ByClassName.Count;
+
+        /// <summary>
+        /// The cascade position of <paramref name=""className""/> among the utilities that declare
+        /// <c>transition-property</c>, and the properties its declaration names.
+        /// </summary>
+        public static bool TryGet(string className, out int cascadePosition, out StyleLonghandSet properties)
+        {
+            if (className != null && ByClassName.TryGetValue(className, out cascadePosition))
+            {
+                properties = Declared[cascadePosition];
+                return true;
+            }
+            cascadePosition = -1;
+            properties = StyleLonghandSet.Empty;
             return false;
         }
     }
@@ -180,8 +224,36 @@ namespace Velvet
             AppendRules(sb, rules);
             sb.Append(AfterRules.Replace("{ENTRY_COUNT}", Number(table.Entries.Length)));
             AppendClassMap(sb, table, ruleOfEntry);
+            sb.Append(AfterClassMap);
+            AppendTransitionSets(sb, table);
+            sb.Append(AfterTransitionSets.Replace("{TRANSITION_COUNT}", Number(table.Transitions.Length)));
+            AppendTransitionClassMap(sb, table);
             sb.Append(Footer);
             return sb.ToString();
+        }
+
+        private static void AppendTransitionSets(StringBuilder sb, StyleUtilityTable table)
+        {
+            foreach (var transition in table.Transitions)
+            {
+                sb.Append("            new StyleLonghandSet(0x")
+                    .Append(transition.Word0.ToString("X16", CultureInfo.InvariantCulture))
+                    .Append("UL, 0x")
+                    .Append(transition.Word1.ToString("X16", CultureInfo.InvariantCulture))
+                    .Append("UL),\n");
+            }
+        }
+
+        private static void AppendTransitionClassMap(StringBuilder sb, StyleUtilityTable table)
+        {
+            for (var i = 0; i < table.Transitions.Length; i++)
+            {
+                sb.Append("            { \"")
+                    .Append(table.Transitions[i].ClassName)
+                    .Append("\", ")
+                    .Append(Number(i))
+                    .Append(" },\n");
+            }
         }
 
         /// <summary>

--- a/Packages/com.velvet.core/Generators~/src/Velvet.StyleTable/UssCascadeOrder.cs
+++ b/Packages/com.velvet.core/Generators~/src/Velvet.StyleTable/UssCascadeOrder.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace Velvet.StyleTable
+{
+    /// <summary>
+    /// Reads a stylesheet directory in the order the importer flattens it to: the partials an aggregator
+    /// <c>@import</c>s, in that list's order, then the aggregator itself.
+    /// </summary>
+    /// <remarks>
+    /// An imported sheet is spliced in AHEAD of the importing sheet's own rules, so the aggregator holds the
+    /// last position and its rules outrank every partial's. Placing it first instead would invert that the day
+    /// the aggregator stops being nothing but <c>@import</c> statements, and nothing about its current content
+    /// would have made the inversion visible.
+    ///
+    /// Name order is not cascade order and is not close to it — <c>_animations.uss</c> sorts first and is
+    /// imported last — so a derivation that records which of two rules wins cannot read the directory
+    /// alphabetically. A file no aggregator imports lands after everything, where
+    /// <see cref="StyleUtilityTableBuilder"/> reports it rather than letting it claim a position the importer
+    /// never gives it.
+    /// </remarks>
+    internal static class UssCascadeOrder
+    {
+        private static readonly Regex ImportStatement = new Regex(@"@import\s+url\(""([^""]+)""\)");
+
+        /// <summary>The names an aggregator imports, in declaration order.</summary>
+        public static IEnumerable<string> ImportedNames(string aggregatorText) =>
+            ImportStatement.Matches(aggregatorText).Cast<Match>().Select(match => match.Groups[1].Value);
+
+        public static bool DeclaresImport(string sheetText) => ImportStatement.IsMatch(sheetText);
+
+        public static IReadOnlyList<UssSourceText> SheetsIn(string directory)
+        {
+            var pending = Directory.EnumerateFiles(directory, "*.uss")
+                .OrderBy(path => path, StringComparer.Ordinal)
+                .Select(path => new UssSourceText(path, File.ReadAllText(path)))
+                .ToList();
+
+            var ordered = new List<UssSourceText>();
+            foreach (var aggregator in pending.Where(sheet => DeclaresImport(sheet.Text)).ToList())
+            {
+                foreach (var imported in ImportedNames(aggregator.Text))
+                {
+                    Take(pending, Path.GetFileName(imported), ordered);
+                }
+                Take(pending, Path.GetFileName(aggregator.Path), ordered);
+            }
+            ordered.AddRange(pending);
+            return ordered;
+        }
+
+        private static void Take(List<UssSourceText> pending, string fileName, List<UssSourceText> ordered)
+        {
+            var index = pending.FindIndex(
+                sheet => string.Equals(Path.GetFileName(sheet.Path), fileName, StringComparison.Ordinal));
+            if (index >= 0)
+            {
+                ordered.Add(pending[index]);
+                pending.RemoveAt(index);
+            }
+        }
+    }
+}

--- a/Packages/com.velvet.core/Generators~/src/Velvet.StyleTable/UssProblem.cs
+++ b/Packages/com.velvet.core/Generators~/src/Velvet.StyleTable/UssProblem.cs
@@ -35,6 +35,15 @@ namespace Velvet.StyleTable
 
         /// <summary>The derivation was handed no stylesheet to read.</summary>
         public const string NoStyleSheets = "USS008";
+
+        /// <summary>The sheets were supplied in an order the aggregator's <c>@import</c> list contradicts.</summary>
+        public const string StyleSheetOrderMismatch = "USS009";
+
+        /// <summary>A <c>transition-property</c> value named something the engine has no property for.</summary>
+        public const string UnknownTransitionProperty = "USS010";
+
+        /// <summary>A gated rule declared <c>transition-property</c>.</summary>
+        public const string GatedTransitionProperty = "USS011";
     }
 
     /// <summary>One reason the table could not be derived, located in the stylesheet that caused it.</summary>

--- a/Packages/com.velvet.core/Generators~/src/Velvet.StyleTable/UssStyleSheetParser.cs
+++ b/Packages/com.velvet.core/Generators~/src/Velvet.StyleTable/UssStyleSheetParser.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Text;
 
 namespace Velvet.StyleTable
 {
@@ -104,7 +105,10 @@ namespace Velvet.StyleTable
                     index++;
                 }
 
-                var declaration = text.Substring(declarationStart, index - declarationStart).Trim();
+                // The scan above steps OVER a comment to find the terminating ';', so the text it cut still
+                // contains one. Values are read, not just property names, and a comment inside a value would
+                // otherwise reach the vocabulary as a token.
+                var declaration = StripComments(text.Substring(declarationStart, index - declarationStart)).Trim();
                 index++;
                 if (declaration.Length == 0)
                 {
@@ -121,9 +125,35 @@ namespace Velvet.StyleTable
                 }
 
                 declarations.Add(new UssDeclaration(
-                    declaration.Substring(0, colon).Trim(), declarationStart));
+                    declaration.Substring(0, colon).Trim(),
+                    declaration.Substring(colon + 1).Trim(),
+                    declarationStart));
             }
             return declarations.ToImmutable();
+        }
+
+        private static string StripComments(string declaration)
+        {
+            var open = declaration.IndexOf("/*", StringComparison.Ordinal);
+            if (open < 0)
+            {
+                return declaration;
+            }
+            var stripped = new StringBuilder(declaration.Length);
+            var index = 0;
+            while (open >= 0)
+            {
+                stripped.Append(declaration, index, open - index);
+                var close = declaration.IndexOf("*/", open + 2, StringComparison.Ordinal);
+                if (close < 0)
+                {
+                    return stripped.ToString();
+                }
+                index = close + 2;
+                open = declaration.IndexOf("/*", index, StringComparison.Ordinal);
+            }
+            stripped.Append(declaration, index, declaration.Length - index);
+            return stripped.ToString();
         }
 
         /// <summary>
@@ -283,13 +313,21 @@ namespace Velvet.StyleTable
 
     internal readonly struct UssDeclaration
     {
-        public UssDeclaration(string property, int offset)
+        public UssDeclaration(string property, string value, int offset)
         {
             Property = property;
+            Value = value;
             Offset = offset;
         }
 
         public string Property { get; }
+
+        /// <summary>
+        /// The text right of the colon, uninterpreted. Only <c>transition-property</c> needs it: its value is
+        /// itself a list of property names, so which properties an element transitions cannot be answered from
+        /// the declared property alone.
+        /// </summary>
+        public string Value { get; }
 
         public int Offset { get; }
     }

--- a/Packages/com.velvet.core/Generators~/tests/Velvet.SourceGenerators.Tests/BundledStyleSheetCensusTests.cs
+++ b/Packages/com.velvet.core/Generators~/tests/Velvet.SourceGenerators.Tests/BundledStyleSheetCensusTests.cs
@@ -28,6 +28,7 @@ namespace Velvet.SourceGenerators.Tests
         private const int SurveyedSingleClassRuleCount = 2094;
         private const int SurveyedDistinctPropertyNameCount = 63;
         private const int SurveyedUtilityClassCount = 2138;
+        private const int SurveyedTransitionUtilityCount = 36;
 
         private static readonly Census Surveyed = Census.OfBundledStyleSheets();
 
@@ -86,6 +87,82 @@ namespace Velvet.SourceGenerators.Tests
 
             // Assert
             Assert.Equal(new[] { "background-color" }, shared);
+        }
+
+        [Fact]
+        public void Given_TheDerivedTable_When_Compiled_Then_ItRecordsEveryTransitionPropertyDeclaration()
+        {
+            // Arrange
+            var sheets = BundledStyleSheets();
+            Assume.NotEmpty(sheets, "the bundled stylesheets were located");
+
+            // Act
+            var count = StyleTableTestHelper.Load(StyleTableTestHelper.Derive(sheets)).TransitionCount;
+
+            // Assert
+            Assert.Equal(SurveyedTransitionUtilityCount, count);
+        }
+
+        [Fact]
+        public void Given_TheDerivedTable_When_Compiled_Then_TheTransitionUtilitiesAreInTheOrderTheSheetsDeclareThem()
+        {
+            // Arrange — transition-none sits between transition-all and the property-specific utilities rather
+            // than ahead of both, which is the deviation from the reference cascade BundledStyleSheetOrderTests
+            // exempts.
+            var sheets = BundledStyleSheets();
+            Assume.NotEmpty(sheets, "the bundled stylesheets were located");
+            var probe = StyleTableTestHelper.Load(StyleTableTestHelper.Derive(sheets));
+
+            // Act
+            var ordered = probe.TransitionUtilitiesInCascadeOrder()
+                .Where(name => name.StartsWith("transition-", StringComparison.Ordinal))
+                .ToArray();
+
+            // Assert
+            Assert.Equal(
+                new[]
+                {
+                    "transition-transform", "transition-filter", "transition-all", "transition-none",
+                    "transition-opacity", "transition-colors", "transition-colors-scale",
+                    "transition-colors-scale-opacity",
+                },
+                ordered);
+        }
+
+        [Fact]
+        public void Given_TheDerivedTable_When_Compiled_Then_EveryAnimationPresetOutranksEveryTransitionUtility()
+        {
+            // Arrange — _animations.uss is imported last so a scheduler-applied preset replaces whatever
+            // transition-* the element already carried for the length of the play.
+            var sheets = BundledStyleSheets();
+            Assume.NotEmpty(sheets, "the bundled stylesheets were located");
+            var ordered = StyleTableTestHelper.Load(StyleTableTestHelper.Derive(sheets))
+                .TransitionUtilitiesInCascadeOrder();
+
+            // Act
+            var firstPreset = ordered
+                .TakeWhile(name => !name.StartsWith("anim-", StringComparison.Ordinal))
+                .Count();
+
+            // Assert
+            Assert.Equal(
+                ordered.Count(name => !name.StartsWith("anim-", StringComparison.Ordinal)),
+                firstPreset);
+        }
+
+        [Fact]
+        public void Given_TheDerivedTable_When_Compiled_Then_TransitionFilterNamesFilterAlone()
+        {
+            // Arrange
+            var sheets = BundledStyleSheets();
+            Assume.NotEmpty(sheets, "the bundled stylesheets were located");
+
+            // Act
+            var properties = StyleTableTestHelper.Load(StyleTableTestHelper.Derive(sheets))
+                .TransitionPropertiesOf("transition-filter");
+
+            // Assert
+            Assert.Equal(new[] { "filter" }, properties);
         }
 
         [Fact]
@@ -344,14 +421,20 @@ namespace Velvet.SourceGenerators.Tests
         private static string CommittedTablePath() =>
             Path.Combine(SolutionPaths.RuntimeRoot(), "Styling", "StyleUtilityProperties.g.cs");
 
+        /// <summary>
+        /// In cascade order, the same as the build script supplies them: the derivation records which of two
+        /// utilities setting one property wins, so a differently ordered input would derive a different table.
+        /// </summary>
         private static StyleSheetInput[] BundledStyleSheets() =>
-            BundledStyleSheetPaths()
-                .Select(path => new StyleSheetInput(path, File.ReadAllText(path)))
+            UssCascadeOrder.SheetsIn(BundledStyleSheetDirectory())
+                .Select(sheet => new StyleSheetInput(sheet.Path, sheet.Text))
                 .ToArray();
 
         private static IEnumerable<string> BundledStyleSheetPaths() =>
-            Directory.EnumerateFiles(Path.Combine(SolutionPaths.RuntimeRoot(), "Styles"), "*.uss")
-                .OrderBy(path => path, StringComparer.Ordinal);
+            UssCascadeOrder.SheetsIn(BundledStyleSheetDirectory()).Select(sheet => sheet.Path);
+
+        private static string BundledStyleSheetDirectory() =>
+            Path.Combine(SolutionPaths.RuntimeRoot(), "Styles");
 
         /// <summary>The surveyed shapes, named so a histogram failure says which shape moved.</summary>
         private enum SelectorShape

--- a/Packages/com.velvet.core/Generators~/tests/Velvet.SourceGenerators.Tests/BundledStyleSheetOrderTests.cs
+++ b/Packages/com.velvet.core/Generators~/tests/Velvet.SourceGenerators.Tests/BundledStyleSheetOrderTests.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text.RegularExpressions;
 using Velvet.StyleTable;
 using Xunit;
 
@@ -123,9 +122,10 @@ namespace Velvet.SourceGenerators.Tests
         {
             var utilities = new List<Utility>();
             var order = 0;
-            foreach (var path in PartialsInImportOrder())
+            foreach (var source in UssCascadeOrder.SheetsIn(
+                Path.Combine(SolutionPaths.RuntimeRoot(), "Styles")))
             {
-                var sheet = UssStyleSheetParser.Parse(path, File.ReadAllText(path));
+                var sheet = UssStyleSheetParser.Parse(source.Path, source.Text);
                 foreach (var rule in sheet.Rules)
                 {
                     var properties = new HashSet<string>(StringComparer.Ordinal);
@@ -147,20 +147,6 @@ namespace Velvet.SourceGenerators.Tests
                 }
             }
             return utilities;
-        }
-
-        /// <summary>
-        /// The partials in the aggregator's @import order, which is the order the importer concatenates them
-        /// in and therefore the order the cascade resolves ties by.
-        /// </summary>
-        private static IEnumerable<string> PartialsInImportOrder()
-        {
-            var styles = Path.Combine(SolutionPaths.RuntimeRoot(), "Styles");
-            var aggregator = File.ReadAllText(Path.Combine(styles, "StyleUtilities.uss"));
-            foreach (Match match in Regex.Matches(aggregator, @"@import\s+url\(""([^""]+)""\)"))
-            {
-                yield return Path.Combine(styles, match.Groups[1].Value);
-            }
         }
 
         private sealed class Utility

--- a/Packages/com.velvet.core/Generators~/tests/Velvet.SourceGenerators.Tests/DocumentationDiagnosticTableTests.cs
+++ b/Packages/com.velvet.core/Generators~/tests/Velvet.SourceGenerators.Tests/DocumentationDiagnosticTableTests.cs
@@ -1,23 +1,28 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
 using Microsoft.CodeAnalysis;
+using Velvet.StyleTable;
 using Xunit;
 
 namespace Velvet.SourceGenerators.Tests
 {
     /// <summary>
-    /// Doc-drift guard for the VEL### diagnostic IDs: memoization.md's table and Generators~/README.md's
-    /// summary line must not talk about an ID the generator/analyzer assembly does not actually define —
-    /// the class of bug that once left the docs describing a contiguous "VEL001-011" range while the real
-    /// IDs are the non-contiguous VEL001-009 / VEL100-101.
+    /// Doc-drift guard for the diagnostic identifiers: memoization.md's table and Generators~/README.md must
+    /// not talk about a VEL### ID the generator/analyzer assembly does not define, nor about a USS### range
+    /// wider or narrower than the derivation's own codes — the class of bug that once left the docs
+    /// describing a contiguous "VEL001-011" range while the real IDs are the non-contiguous VEL001-009 /
+    /// VEL100-101.
     /// </summary>
     public sealed class DocumentationDiagnosticTableTests
     {
         private static readonly Regex DiagnosticIdPattern = new(@"VEL\d{3}", RegexOptions.Compiled);
+
+        private static readonly Regex UssProblemCodePattern = new(@"USS\d{3}", RegexOptions.Compiled);
 
         // "Velvet.Memoize" is the [MemoizeMethod]-attribute diagnostic category (VEL001-009). memoization.md's
         // table intentionally documents only this category and points elsewhere (AnalyzerReleases.Unshipped.md)
@@ -55,6 +60,43 @@ namespace Velvet.SourceGenerators.Tests
                 "Generators~/README.md mentions VEL IDs with no matching DiagnosticDescriptor: " +
                 $"[{string.Join(", ", undefinedInReadme)}]");
         }
+
+        [Fact]
+        public void GeneratorsReadme_ComparedAgainstTheUssProblemCodes_NamesTheRealRangeEndpoints()
+        {
+            // The README writes the derivation's failure codes as a range rather than a table, so the two IDs
+            // it may name are the lowest and highest that exist.
+            var defined = UssProblemCodes();
+            var mentioned = UssProblemCodePattern.Matches(File.ReadAllText(GeneratorsReadmePath()))
+                .Select(match => match.Value)
+                .Distinct()
+                .OrderBy(id => id, StringComparer.Ordinal)
+                .ToArray();
+
+            Assert.Equal(new[] { defined.First(), defined.Last() }, mentioned);
+        }
+
+        [Fact]
+        public void UssProblemCodes_WhenOrdered_Then_TheyRunContiguouslyFromTheFirst()
+        {
+            // Naming only the endpoints is honest documentation only while nothing is missing between them.
+            var defined = UssProblemCodes();
+            var contiguous = Enumerable.Range(1, defined.Count)
+                .Select(number => "USS" + number.ToString("000", CultureInfo.InvariantCulture))
+                .ToList();
+
+            Assert.Equal(contiguous, defined);
+        }
+
+        /// <summary>Every code the derivation can report, in ordinal order.</summary>
+        private static List<string> UssProblemCodes() =>
+            typeof(UssProblem).Assembly
+                .GetType("Velvet.StyleTable.UssProblemCode")!
+                .GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
+                .Where(field => field.IsLiteral && field.FieldType == typeof(string))
+                .Select(field => (string)field.GetRawConstantValue()!)
+                .OrderBy(code => code, StringComparer.Ordinal)
+                .ToList();
 
         private static HashSet<string> ExtractIds(string text) =>
             DiagnosticIdPattern.Matches(text).Select(m => m.Value).ToHashSet();

--- a/Packages/com.velvet.core/Generators~/tests/Velvet.SourceGenerators.Tests/StyleTableTestHelper.cs
+++ b/Packages/com.velvet.core/Generators~/tests/Velvet.SourceGenerators.Tests/StyleTableTestHelper.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
@@ -103,12 +104,14 @@ namespace Velvet.SourceGenerators.Tests
         private readonly Type _properties;
         private readonly Type _longhand;
         private readonly Type _rule;
+        private readonly Type _transitions;
 
         public StyleTableProbe(Assembly assembly)
         {
             _properties = Required(assembly, "Velvet.StyleUtilityProperties");
             _longhand = Required(assembly, "Velvet.StyleLonghand");
             _rule = Required(assembly, "Velvet.StyleUtilityRule");
+            _transitions = Required(assembly, "Velvet.StyleTransitionUtilities");
         }
 
         public int Count => (int)_properties.GetProperty("Count", BindingFlags.Public | BindingFlags.Static)!
@@ -127,7 +130,12 @@ namespace Velvet.SourceGenerators.Tests
                 throw new InvalidOperationException($"The table defines no rule for '{className}'.");
             }
 
-            var set = _rule.GetProperty("Properties")!.GetValue(rule)!;
+            return LonghandNames(_rule.GetProperty("Properties")!.GetValue(rule)!);
+        }
+
+        /// <summary>The USS longhand names a <c>StyleLonghandSet</c> holds, sorted.</summary>
+        private IReadOnlyList<string> LonghandNames(object set)
+        {
             var contains = set.GetType().GetMethod("Contains")!;
             var identifierToUss = UssPropertyVocabulary.Longhands
                 .ToDictionary(l => l.Identifier, l => l.UssName, StringComparer.Ordinal);
@@ -151,6 +159,49 @@ namespace Velvet.SourceGenerators.Tests
                 throw new InvalidOperationException($"The table defines no rule for '{className}'.");
             }
             return _rule.GetProperty("Gate")!.GetValue(rule)!.ToString()!;
+        }
+
+        /// <summary>How many bundled utilities declare <c>transition-property</c>.</summary>
+        public int TransitionCount =>
+            (int)_transitions.GetProperty("Count", BindingFlags.Public | BindingFlags.Static)!.GetValue(null)!;
+
+        /// <summary>The utilities that declare <c>transition-property</c>, in cascade order.</summary>
+        public IReadOnlyList<string> TransitionUtilitiesInCascadeOrder()
+        {
+            var byClassName = (IEnumerable)_transitions
+                .GetField("ByClassName", BindingFlags.NonPublic | BindingFlags.Static)!
+                .GetValue(null)!;
+            var byPosition = new SortedDictionary<int, string>();
+            foreach (var pair in byClassName)
+            {
+                var type = pair.GetType();
+                byPosition.Add(
+                    (int)type.GetProperty("Value")!.GetValue(pair)!,
+                    (string)type.GetProperty("Key")!.GetValue(pair)!);
+            }
+            return byPosition.Values.ToList();
+        }
+
+        /// <summary>The USS longhand names <paramref name="className"/>'s transition-property value covers.</summary>
+        public IReadOnlyList<string> TransitionPropertiesOf(string className)
+        {
+            if (!TryGetTransition(className, out _, out var set))
+            {
+                throw new InvalidOperationException($"'{className}' declares no transition-property.");
+            }
+            return LonghandNames(set!);
+        }
+
+        public bool DeclaresTransition(string className) => TryGetTransition(className, out _, out _);
+
+        private bool TryGetTransition(string className, out int cascadePosition, out object? properties)
+        {
+            var tryGet = _transitions.GetMethod("TryGet", BindingFlags.Public | BindingFlags.Static)!;
+            var arguments = new object?[] { className, null, null };
+            var found = (bool)tryGet.Invoke(null, arguments)!;
+            cascadePosition = (int)arguments[1]!;
+            properties = arguments[2];
+            return found;
         }
 
         private bool TryGet(string className, out object? rule)

--- a/Packages/com.velvet.core/Generators~/tests/Velvet.SourceGenerators.Tests/StyleUtilityTableTests.cs
+++ b/Packages/com.velvet.core/Generators~/tests/Velvet.SourceGenerators.Tests/StyleUtilityTableTests.cs
@@ -263,15 +263,190 @@ namespace Velvet.SourceGenerators.Tests
         [Fact]
         public void Given_AnImportStatement_When_TheTableIsDerived_Then_NothingIsReported()
         {
-            // Arrange
+            // Arrange — the partial an aggregator names, then the aggregator, which is where the importer
+            // splices it: an imported sheet precedes the importing sheet's own rules.
             var run = StyleTableTestHelper.Derive(
-                StyleSheetInput.Uss("@import url(\"_tokens.uss\");\n.opacity-50 { opacity: 0.5; }"));
+                new StyleSheetInput("/styles/_tokens.uss", ".opacity-50 { opacity: 0.5; }"),
+                new StyleSheetInput("/styles/StyleUtilities.uss", "@import url(\"_tokens.uss\");"));
 
             // Act
             var codes = run.ProblemCodes;
 
             // Assert
             Assert.Empty(codes);
+        }
+
+        [Fact]
+        public void Given_AnAggregatorSuppliedAheadOfItsImports_When_TheTableIsDerived_Then_TheOrderMismatchIsReported()
+        {
+            // Arrange — an aggregator's own rules outrank every partial's, so a first position would record it
+            // as losing ties it wins.
+            var run = StyleTableTestHelper.Derive(
+                new StyleSheetInput(
+                    "/styles/StyleUtilities.uss",
+                    "@import url(\"_tokens.uss\");\n.opacity-75 { opacity: 0.75; }"),
+                new StyleSheetInput("/styles/_tokens.uss", ".opacity-50 { opacity: 0.5; }"));
+
+            // Act
+            var codes = run.ProblemCodes;
+
+            // Assert
+            Assert.Equal(new[] { UssProblemCode.StyleSheetOrderMismatch }, codes);
+        }
+
+        [Fact]
+        public void Given_APartialNoAggregatorImports_When_TheTableIsDerived_Then_TheOrderMismatchIsReported()
+        {
+            // Arrange
+            var run = StyleTableTestHelper.Derive(
+                new StyleSheetInput("/styles/_tokens.uss", ".opacity-50 { opacity: 0.5; }"),
+                new StyleSheetInput("/styles/_stray.uss", ".opacity-25 { opacity: 0.25; }"),
+                new StyleSheetInput("/styles/StyleUtilities.uss", "@import url(\"_tokens.uss\");"));
+
+            // Act
+            var codes = run.ProblemCodes;
+
+            // Assert
+            Assert.Equal(new[] { UssProblemCode.StyleSheetOrderMismatch }, codes);
+        }
+
+        [Fact]
+        public void Given_PartialsSuppliedAgainstTheImportOrder_When_TheTableIsDerived_Then_TheOrderMismatchIsReported()
+        {
+            // Arrange
+            var run = StyleTableTestHelper.Derive(
+                new StyleSheetInput("/styles/_effects.uss", ".opacity-25 { opacity: 0.25; }"),
+                new StyleSheetInput("/styles/_tokens.uss", ".opacity-50 { opacity: 0.5; }"),
+                new StyleSheetInput(
+                    "/styles/StyleUtilities.uss",
+                    "@import url(\"_tokens.uss\");\n@import url(\"_effects.uss\");"));
+
+            // Act
+            var codes = run.ProblemCodes;
+
+            // Assert
+            Assert.Equal(new[] { UssProblemCode.StyleSheetOrderMismatch }, codes);
+        }
+
+        [Fact]
+        public void Given_TwoUtilitiesSettingTransitionProperty_When_TheTableIsDerived_Then_TheLaterOneIsOrderedAfter()
+        {
+            // Arrange
+            var run = StyleTableTestHelper.Derive(StyleSheetInput.Uss(@"
+.transition-transform { transition-property: translate, scale, rotate; }
+.transition-colors { transition-property: color; }"));
+
+            // Act
+            var ordered = StyleTableTestHelper.Load(run).TransitionUtilitiesInCascadeOrder();
+
+            // Assert
+            Assert.Equal(new[] { "transition-transform", "transition-colors" }, ordered);
+        }
+
+        [Fact]
+        public void Given_AClassSettingTransitionPropertyTwice_When_TheTableIsDerived_Then_TheLaterValueWins()
+        {
+            // Arrange
+            var run = StyleTableTestHelper.Derive(StyleSheetInput.Uss(
+                ".util { transition-property: opacity; transition-property: scale; }"));
+
+            // Act
+            var properties = StyleTableTestHelper.Load(run).TransitionPropertiesOf("util");
+
+            // Assert
+            Assert.Equal(new[] { "scale" }, properties);
+        }
+
+        [Fact]
+        public void Given_ATransitionPropertyNamingAShorthand_When_TheTableIsDerived_Then_ItExpandsToTheLonghands()
+        {
+            // Arrange
+            var run = StyleTableTestHelper.Derive(
+                StyleSheetInput.Uss(".util { transition-property: border-color; }"));
+
+            // Act
+            var properties = StyleTableTestHelper.Load(run).TransitionPropertiesOf("util");
+
+            // Assert
+            Assert.Equal(
+                new[]
+                {
+                    "border-bottom-color", "border-left-color", "border-right-color", "border-top-color",
+                },
+                properties);
+        }
+
+        [Fact]
+        public void Given_TransitionPropertyNone_When_TheTableIsDerived_Then_ItNamesNoProperty()
+        {
+            // Arrange
+            var run = StyleTableTestHelper.Derive(
+                StyleSheetInput.Uss(".util { transition-property: none; }"));
+
+            // Act
+            var properties = StyleTableTestHelper.Load(run).TransitionPropertiesOf("util");
+
+            // Assert
+            Assert.Empty(properties);
+        }
+
+        [Fact]
+        public void Given_TransitionPropertyAll_When_TheTableIsDerived_Then_ItNamesEveryLonghand()
+        {
+            // Arrange
+            var run = StyleTableTestHelper.Derive(
+                StyleSheetInput.Uss(".util { transition-property: all; }"));
+            var probe = StyleTableTestHelper.Load(run);
+
+            // Act
+            var covered = probe.TransitionPropertiesOf("util").Count;
+
+            // Assert
+            Assert.Equal(probe.LonghandCount, covered);
+        }
+
+        [Fact]
+        public void Given_AGatedTransitionPropertyDeclaration_When_TheTableIsDerived_Then_ItIsReported()
+        {
+            // Arrange — skipping it silently would leave the guard answering from the ungated declarations for
+            // an element whose gated rule had already replaced them.
+            var run = StyleTableTestHelper.Derive(
+                StyleSheetInput.Uss(".util:hover { transition-property: opacity; }"));
+
+            // Act
+            var codes = run.ProblemCodes;
+
+            // Assert
+            Assert.Equal(new[] { UssProblemCode.GatedTransitionProperty }, codes);
+        }
+
+        [Fact]
+        public void Given_ATransitionPropertyValueCarryingAComment_When_TheTableIsDerived_Then_TheCommentIsNotAToken()
+        {
+            // Arrange
+            var run = StyleTableTestHelper.Derive(
+                StyleSheetInput.Uss(".util { transition-property: opacity /* the fade */; }"));
+
+            // Act
+            var properties = StyleTableTestHelper.Load(run).TransitionPropertiesOf("util");
+
+            // Assert
+            Assert.Equal(new[] { "opacity" }, properties);
+        }
+
+        [Fact]
+        public void Given_ATransitionPropertyNamingAnUnknownProperty_When_TheTableIsDerived_Then_ItIsReported()
+        {
+            // Arrange — `transform` is a CSS property UI Toolkit has no storage for; a list naming it
+            // transitions nothing.
+            var run = StyleTableTestHelper.Derive(
+                StyleSheetInput.Uss(".util { transition-property: transform; }"));
+
+            // Act
+            var codes = run.ProblemCodes;
+
+            // Assert
+            Assert.Equal(new[] { UssProblemCode.UnknownTransitionProperty }, codes);
         }
 
         [Theory]

--- a/Packages/com.velvet.core/Runtime/Styling/MotionNativeTransitionGuard.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/MotionNativeTransitionGuard.cs
@@ -6,8 +6,8 @@ using UnityEngine.UIElements;
 namespace Velvet
 {
     /// <summary>
-    /// The style slots a per-frame Motion driver can write, grouped the way the bundled <c>transition-*</c>
-    /// utilities group them, so a play's driven set and an element's declared set intersect directly.
+    /// The style slots a per-frame Motion driver can write, at the granularity a play can report driving one,
+    /// so a play's driven set and an element's declared set intersect directly.
     /// </summary>
     [Flags]
     internal enum MotionTransitionSlots
@@ -17,11 +17,10 @@ namespace Velvet
         Translate = 1 << 1,
         Scale = 1 << 2,
         Rotate = 1 << 3,
-        // background-color / color / border-color move together: every transition utility that names one names
-        // all three, and no driver channel writes them independently of that grouping.
+        // A play's colour channels are resolved from its own delta, so a driver reports "writes colours"
+        // without saying which; splitting the declared side finer could not change an intersection result.
         Color = 1 << 4,
-        // Every length-valued property. Only `transition-all` covers these, so a finer split would never change
-        // an intersection result.
+        // Every length-valued property, grouped for the same reason as Color.
         Length = 1 << 5,
         All = Opacity | Translate | Scale | Rotate | Color | Length,
     }
@@ -41,13 +40,13 @@ namespace Velvet
     /// UI Toolkit's <c>transition-property</c> is a positive list with no "everything except these" spelling, and
     /// the RESOLVED list cannot be read before the element is on a panel, so the suspension is necessarily
     /// element-wide: for its duration the element's OTHER transitions land instantly too. That cost is only
-    /// worth paying where the conflict is real, so the decision is made from the element's own CLASS LIST — the
-    /// transition utilities are a small closed set with known property sets, and reading class strings is how
-    /// the rest of this feature derives its answers off-panel. A play suspends only when the slots it drives
-    /// intersect what those classes leave transitionable (see <see cref="DeclaredSlots"/>): a
-    /// <c>transition-colors</c> element running an opacity/translate play keeps its hover fade, while the same
-    /// play on a <c>transition-transform</c> or <c>transition-all</c> element does suspend, because there the
-    /// class covers the very slots the driver is writing.
+    /// worth paying where the conflict is real, so the decision is made from the element's own CLASS LIST,
+    /// resolved against the table <c>Generators~/src/Velvet.StyleTable</c> derives from the bundled
+    /// stylesheets. A play suspends only when the slots it drives intersect what those classes leave
+    /// transitionable (see <see cref="DeclaredSlots"/>): a <c>transition-colors</c> element running an
+    /// opacity/translate play keeps its hover fade, while the same play on a <c>transition-transform</c> or
+    /// <c>transition-all</c> element does suspend, because there the class covers the very slots the driver is
+    /// writing.
     /// </para>
     /// <para>
     /// Suspension is tracked by OWNER because two drivers can write one element at once (a scheduler variant
@@ -99,12 +98,11 @@ namespace Velvet
         /// <remarks>
         /// UI Toolkit's INITIAL <c>transition-property</c> is <c>all</c> and its initial duration is 0s, so an
         /// element transitions everything as soon as anything gives it a duration — and nothing at all until
-        /// then. That makes the answer three-way rather than a union: a <c>transition-*</c> utility that
-        /// declares a property list (mirroring <c>_state_variants.uss</c> / <c>_effects.uss</c>) pins the set;
-        /// otherwise a duration-only source (<c>transition-filter</c>, which deliberately sets duration and
-        /// timing alone, or any <c>duration-*</c> utility, including the bracket form the resolver applies as an
-        /// inline value rather than a class) leaves the initial <c>all</c> standing; otherwise there is no
-        /// duration and nothing transitions.
+        /// then. The classes that set <c>transition-property</c> do not combine: it holds one value, so the
+        /// LAST of them declared wins outright and the earlier ones contribute nothing, which is the ordering
+        /// <see cref="StyleTransitionUtilities"/> records. Failing one of those, a duration from any source —
+        /// a <c>duration-*</c> utility, or the bracket form the resolver applies as an inline value rather than
+        /// a class — leaves the initial <c>all</c> standing. Failing that too, nothing transitions.
         /// <para>
         /// Two residual blind spots, both accepted rather than fixed: an inline whole-property value written by
         /// something other than a duration utility (the scheduler's own tween swap sets one, though never on a
@@ -114,56 +112,99 @@ namespace Velvet
         /// </remarks>
         internal static MotionTransitionSlots DeclaredSlots(VisualElement element)
         {
-            var declaredByUtility = MotionTransitionSlots.None;
-            var sawPropertyUtility = false;
-            var sawDurationOnly = false;
+            var winningPosition = -1;
+            var declared = StyleLonghandSet.Empty;
+            var sawDuration = false;
             foreach (var core in element.GetClasses())
             {
-                if (string.IsNullOrEmpty(core))
+                if (StyleTransitionUtilities.TryGet(core, out var position, out var properties))
                 {
+                    if (position > winningPosition)
+                    {
+                        winningPosition = position;
+                        declared = properties;
+                    }
                     continue;
                 }
-                if (core.StartsWith("duration-", StringComparison.Ordinal))
-                {
-                    sawDurationOnly = true;
-                    continue;
-                }
-                var declared = core switch
-                {
-                    "transition-all" => MotionTransitionSlots.All,
-                    "transition-none" => MotionTransitionSlots.None,
-                    "transition-opacity" => MotionTransitionSlots.Opacity,
-                    "transition-colors" => MotionTransitionSlots.Color,
-                    "transition-colors-scale" => MotionTransitionSlots.Color | MotionTransitionSlots.Scale,
-                    "transition-colors-scale-opacity"
-                        => MotionTransitionSlots.Color | MotionTransitionSlots.Scale | MotionTransitionSlots.Opacity,
-                    "transition-transform"
-                        => MotionTransitionSlots.Translate | MotionTransitionSlots.Scale | MotionTransitionSlots.Rotate,
-                    // Sets duration and timing only, so it leaves transition-property at its initial `all`.
-                    "transition-filter" => MotionTransitionSlots.None,
-                    _ => (MotionTransitionSlots?)null,
-                };
-                if (declared == null)
-                {
-                    continue;
-                }
-                if (core == "transition-filter")
-                {
-                    sawDurationOnly = true;
-                    continue;
-                }
-                sawPropertyUtility = true;
-                declaredByUtility |= declared.Value;
+                sawDuration = sawDuration
+                    || (StyleUtilityProperties.TryGet(core, out var rule)
+                        && rule.Gate == StyleUtilityGate.None
+                        && rule.Properties.Contains(StyleLonghand.TransitionDuration));
             }
-            if (sawPropertyUtility)
+            if (winningPosition >= 0)
             {
-                return declaredByUtility;
+                return SlotsOf(declared);
             }
             // duration-[400ms] resolves to an inline value rather than a class, so the class scan cannot see it;
             // the inline slot can.
-            return sawDurationOnly || element.style.transitionDuration.keyword != StyleKeyword.Null
+            return sawDuration || element.style.transitionDuration.keyword != StyleKeyword.Null
                 ? MotionTransitionSlots.All
                 : MotionTransitionSlots.None;
+        }
+
+        // Every property the matching driver channel can write, which is what the grouped slot stands for.
+        // Both sets track MotionSpringClassParser's channel resolution: a property it can put in a delta and
+        // neither set names is a property a play would drive without ever asking the engine to stand down.
+        private static readonly StyleLonghandSet s_colorProperties = SetOf(
+            StyleLonghand.BackgroundColor,
+            StyleLonghand.Color,
+            StyleLonghand.BorderTopColor,
+            StyleLonghand.BorderRightColor,
+            StyleLonghand.BorderBottomColor,
+            StyleLonghand.BorderLeftColor);
+
+        private static readonly StyleLonghandSet s_lengthProperties = SetOf(
+            StyleLonghand.Width,
+            StyleLonghand.Height,
+            StyleLonghand.MinWidth,
+            StyleLonghand.MinHeight,
+            StyleLonghand.MaxWidth,
+            StyleLonghand.MaxHeight,
+            StyleLonghand.Top,
+            StyleLonghand.Right,
+            StyleLonghand.Bottom,
+            StyleLonghand.Left,
+            StyleLonghand.PaddingTop,
+            StyleLonghand.PaddingRight,
+            StyleLonghand.PaddingBottom,
+            StyleLonghand.PaddingLeft,
+            StyleLonghand.MarginTop,
+            StyleLonghand.MarginRight,
+            StyleLonghand.MarginBottom,
+            StyleLonghand.MarginLeft,
+            StyleLonghand.BorderTopLeftRadius,
+            StyleLonghand.BorderTopRightRadius,
+            StyleLonghand.BorderBottomLeftRadius,
+            StyleLonghand.BorderBottomRightRadius,
+            StyleLonghand.BorderTopWidth,
+            StyleLonghand.BorderRightWidth,
+            StyleLonghand.BorderBottomWidth,
+            StyleLonghand.BorderLeftWidth,
+            StyleLonghand.FlexBasis,
+            StyleLonghand.FontSize,
+            StyleLonghand.LetterSpacing);
+
+        /// <summary>The driver channels that would contend for the properties a declaration names.</summary>
+        private static MotionTransitionSlots SlotsOf(StyleLonghandSet declared)
+        {
+            var slots = MotionTransitionSlots.None;
+            if (declared.Contains(StyleLonghand.Opacity)) slots |= MotionTransitionSlots.Opacity;
+            if (declared.Contains(StyleLonghand.Translate)) slots |= MotionTransitionSlots.Translate;
+            if (declared.Contains(StyleLonghand.Scale)) slots |= MotionTransitionSlots.Scale;
+            if (declared.Contains(StyleLonghand.Rotate)) slots |= MotionTransitionSlots.Rotate;
+            if (declared.Overlaps(s_colorProperties)) slots |= MotionTransitionSlots.Color;
+            if (declared.Overlaps(s_lengthProperties)) slots |= MotionTransitionSlots.Length;
+            return slots;
+        }
+
+        private static StyleLonghandSet SetOf(params StyleLonghand[] longhands)
+        {
+            var set = StyleLonghandSet.Empty;
+            foreach (var longhand in longhands)
+            {
+                set = set.Union(StyleLonghandSet.Of(longhand));
+            }
+            return set;
         }
 
         /// <summary>Drops one owner, handing the element back to the cascade once the LAST owner has let go.</summary>

--- a/Packages/com.velvet.core/Runtime/Styling/StyleUtilityProperties.g.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleUtilityProperties.g.cs
@@ -2554,4 +2554,116 @@ namespace Velvet
             return false;
         }
     }
+
+    /// <summary>
+    /// The bundled utilities that declare <c>transition-property</c>, in cascade order, with the properties
+    /// each one's value names. <c>MotionNativeTransitionGuard.DeclaredSlots</c> is the only consumer and
+    /// states what the order means.
+    /// </summary>
+    /// <remarks>
+    /// Only ungated rules reach here: the derivation refuses a gated <c>transition-property</c> rather than
+    /// record one, since no reader working from a class list can tell whether the gate holds.
+    /// </remarks>
+    internal static class StyleTransitionUtilities
+    {
+        private static readonly StyleLonghandSet[] Declared =
+        {
+            new StyleLonghandSet(0x0000000000000000UL, 0x0000000000080600UL),
+            new StyleLonghandSet(0x0000400000000000UL, 0x0000000000000000UL),
+            new StyleLonghandSet(0xFFFFFFFFFFFFFFFFUL, 0x0000000000FFFFFFUL),
+            new StyleLonghandSet(0x0000000000000000UL, 0x0000000000000000UL),
+            new StyleLonghandSet(0x0000000000000000UL, 0x0000000000000002UL),
+            new StyleLonghandSet(0x0000085441000000UL, 0x0000000000000000UL),
+            new StyleLonghandSet(0x0000085441000000UL, 0x0000000000000400UL),
+            new StyleLonghandSet(0x0000085441000000UL, 0x0000000000000402UL),
+            new StyleLonghandSet(0x0000000000000000UL, 0x0000000000000002UL),
+            new StyleLonghandSet(0x0000000000000000UL, 0x0000000000000002UL),
+            new StyleLonghandSet(0x0000000000000000UL, 0x0000000000000002UL),
+            new StyleLonghandSet(0x0000000000000000UL, 0x0000000000000002UL),
+            new StyleLonghandSet(0x0000000000000000UL, 0x0000000000080002UL),
+            new StyleLonghandSet(0x0000000000000000UL, 0x0000000000080002UL),
+            new StyleLonghandSet(0x0000000000000000UL, 0x0000000000080002UL),
+            new StyleLonghandSet(0x0000000000000000UL, 0x0000000000080002UL),
+            new StyleLonghandSet(0x0000000000000000UL, 0x0000000000080002UL),
+            new StyleLonghandSet(0x0000000000000000UL, 0x0000000000080002UL),
+            new StyleLonghandSet(0x0000000000000000UL, 0x0000000000080002UL),
+            new StyleLonghandSet(0x0000000000000000UL, 0x0000000000080002UL),
+            new StyleLonghandSet(0x0000000000000000UL, 0x0000000000080002UL),
+            new StyleLonghandSet(0x0000000000000000UL, 0x0000000000080002UL),
+            new StyleLonghandSet(0x0000000000000000UL, 0x0000000000080002UL),
+            new StyleLonghandSet(0x0000000000000000UL, 0x0000000000080002UL),
+            new StyleLonghandSet(0x0000000000000000UL, 0x0000000000080002UL),
+            new StyleLonghandSet(0x0000000000000000UL, 0x0000000000080002UL),
+            new StyleLonghandSet(0x0000000000000000UL, 0x0000000000080002UL),
+            new StyleLonghandSet(0x0000000000000000UL, 0x0000000000080002UL),
+            new StyleLonghandSet(0x0000000000000000UL, 0x0000000000000402UL),
+            new StyleLonghandSet(0x0000000000000000UL, 0x0000000000000402UL),
+            new StyleLonghandSet(0x0000000000000000UL, 0x0000000000000402UL),
+            new StyleLonghandSet(0x0000000000000000UL, 0x0000000000000402UL),
+            new StyleLonghandSet(0x0000000000000000UL, 0x0000000000080002UL),
+            new StyleLonghandSet(0x0000000000000000UL, 0x0000000000080002UL),
+            new StyleLonghandSet(0x0000000000000000UL, 0x0000000000080002UL),
+            new StyleLonghandSet(0x0000000000000000UL, 0x0000000000080002UL),
+        };
+
+        private static readonly Dictionary<string, int> ByClassName =
+            new Dictionary<string, int>(36, StringComparer.Ordinal)
+        {
+            { "transition-transform", 0 },
+            { "transition-filter", 1 },
+            { "transition-all", 2 },
+            { "transition-none", 3 },
+            { "transition-opacity", 4 },
+            { "transition-colors", 5 },
+            { "transition-colors-scale", 6 },
+            { "transition-colors-scale-opacity", 7 },
+            { "anim-fade-enter-from", 8 },
+            { "anim-fade-enter-to", 9 },
+            { "anim-fade-exit-from", 10 },
+            { "anim-fade-exit-to", 11 },
+            { "anim-slide-up-enter-from", 12 },
+            { "anim-slide-up-enter-to", 13 },
+            { "anim-slide-up-exit-from", 14 },
+            { "anim-slide-up-exit-to", 15 },
+            { "anim-slide-down-enter-from", 16 },
+            { "anim-slide-down-enter-to", 17 },
+            { "anim-slide-down-exit-from", 18 },
+            { "anim-slide-down-exit-to", 19 },
+            { "anim-slide-left-enter-from", 20 },
+            { "anim-slide-left-enter-to", 21 },
+            { "anim-slide-left-exit-from", 22 },
+            { "anim-slide-left-exit-to", 23 },
+            { "anim-slide-right-enter-from", 24 },
+            { "anim-slide-right-enter-to", 25 },
+            { "anim-slide-right-exit-from", 26 },
+            { "anim-slide-right-exit-to", 27 },
+            { "anim-scale-enter-from", 28 },
+            { "anim-scale-enter-to", 29 },
+            { "anim-scale-exit-from", 30 },
+            { "anim-scale-exit-to", 31 },
+            { "anim-fade-slide-up-enter-from", 32 },
+            { "anim-fade-slide-up-enter-to", 33 },
+            { "anim-fade-slide-up-exit-from", 34 },
+            { "anim-fade-slide-up-exit-to", 35 },
+        };
+
+        /// <summary>How many bundled utilities declare <c>transition-property</c>.</summary>
+        public static int Count => ByClassName.Count;
+
+        /// <summary>
+        /// The cascade position of <paramref name="className"/> among the utilities that declare
+        /// <c>transition-property</c>, and the properties its declaration names.
+        /// </summary>
+        public static bool TryGet(string className, out int cascadePosition, out StyleLonghandSet properties)
+        {
+            if (className != null && ByClassName.TryGetValue(className, out cascadePosition))
+            {
+                properties = Declared[cascadePosition];
+                return true;
+            }
+            cascadePosition = -1;
+            properties = StyleLonghandSet.Empty;
+            return false;
+        }
+    }
 }

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/MotionNativeTransitionGuardCascadeTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/MotionNativeTransitionGuardCascadeTests.cs
@@ -1,0 +1,161 @@
+using System;
+using System.Linq;
+using NUnit.Framework;
+using UnityEngine.UIElements;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Holds <see cref="MotionNativeTransitionGuard.DeclaredSlots"/> against UI Toolkit's own answer: each case
+    /// puts a class list on a real panel carrying the bundled stylesheet, then compares the guard's slots with
+    /// the slots named by the <c>transition-property</c> the cascade actually resolved.
+    /// </summary>
+    [TestFixture]
+    internal sealed class MotionNativeTransitionGuardCascadeTests : PanelTestBase
+    {
+        protected override void LoadStyleSheets() =>
+            _window.rootVisualElement.LoadBundledStyleUtilitiesForTest();
+
+        /// <summary>
+        /// Classes go straight onto a bare element rather than through a VNode, so the class-list order is the
+        /// order written at the call site and a guard answering from it would be visible.
+        /// </summary>
+        private VisualElement Resolve(params string[] classNames)
+        {
+            var element = new VisualElement();
+            foreach (var className in classNames)
+            {
+                element.AddToClassList(className);
+            }
+            _window.rootVisualElement.Add(element);
+            ForcePanelUpdate(element.panel);
+            return element;
+        }
+
+        /// <summary>The slots a driver would contend for, read off the resolved <c>transition-property</c>.</summary>
+        private static MotionTransitionSlots CascadeSlots(VisualElement element)
+        {
+            var slots = MotionTransitionSlots.None;
+            foreach (var property in element.resolvedStyle.transitionProperty)
+            {
+                slots |= SlotOf(property.ToString() ?? string.Empty);
+            }
+            return slots;
+        }
+
+        // No per-frame driver writes filter, so a list naming it contends for nothing, exactly as an empty list
+        // does. An unmapped name throws rather than defaulting: silently contributing nothing would let a new
+        // utility widen the cascade without any case here going red.
+        private static MotionTransitionSlots SlotOf(string ussProperty) => ussProperty switch
+        {
+            "all" => MotionTransitionSlots.All,
+            "opacity" => MotionTransitionSlots.Opacity,
+            "translate" => MotionTransitionSlots.Translate,
+            "scale" => MotionTransitionSlots.Scale,
+            "rotate" => MotionTransitionSlots.Rotate,
+            "color" => MotionTransitionSlots.Color,
+            "background-color" => MotionTransitionSlots.Color,
+            "border-color" => MotionTransitionSlots.Color,
+            "border-top-color" => MotionTransitionSlots.Color,
+            "border-right-color" => MotionTransitionSlots.Color,
+            "border-bottom-color" => MotionTransitionSlots.Color,
+            "border-left-color" => MotionTransitionSlots.Color,
+            // transition-property: none resolves to one entry that names no property, whose ToString is null;
+            // there is no empty resolved list to read instead.
+            "" => MotionTransitionSlots.None,
+            "filter" => MotionTransitionSlots.None,
+            _ => throw new NotSupportedException(
+                $"The cascade resolved transition-property to '{ussProperty}', which this oracle does not map."),
+        };
+
+        [Test]
+        public void Given_TransitionAllThenTransitionNone_When_TheGuardIsAsked_Then_ItAgreesWithTheCascade()
+        {
+            // Arrange
+            var element = Resolve("transition-all", "transition-none");
+            Assume.That(element.panel, Is.Not.Null, "Precondition: the element is on a real panel");
+
+            // Act
+            var declared = MotionNativeTransitionGuard.DeclaredSlots(element);
+
+            // Assert
+            Assert.That(declared, Is.EqualTo(CascadeSlots(element)));
+        }
+
+        [Test]
+        public void Given_TransitionTransformThenTransitionColors_When_TheGuardIsAsked_Then_ItAgreesWithTheCascade()
+        {
+            // Arrange
+            var element = Resolve("transition-transform", "transition-colors");
+            Assume.That(element.panel, Is.Not.Null, "Precondition: the element is on a real panel");
+
+            // Act
+            var declared = MotionNativeTransitionGuard.DeclaredSlots(element);
+
+            // Assert
+            Assert.That(declared, Is.EqualTo(CascadeSlots(element)));
+        }
+
+        [Test]
+        public void Given_TransitionAllThenTransitionColors_When_TheGuardIsAsked_Then_ItAgreesWithTheCascade()
+        {
+            // Arrange
+            var element = Resolve("transition-all", "transition-colors");
+            Assume.That(element.panel, Is.Not.Null, "Precondition: the element is on a real panel");
+
+            // Act
+            var declared = MotionNativeTransitionGuard.DeclaredSlots(element);
+
+            // Assert
+            Assert.That(declared, Is.EqualTo(CascadeSlots(element)));
+        }
+
+        [Test]
+        public void Given_TransitionFilter_When_TheGuardIsAsked_Then_ItAgreesWithTheCascade()
+        {
+            // Arrange
+            var element = Resolve("transition-filter");
+            Assume.That(element.panel, Is.Not.Null, "Precondition: the element is on a real panel");
+
+            // Act
+            var declared = MotionNativeTransitionGuard.DeclaredSlots(element);
+
+            // Assert
+            Assert.That(declared, Is.EqualTo(CascadeSlots(element)));
+        }
+
+        [Test]
+        public void Given_TransitionColorsWrittenBeforeTransitionTransform_When_TheGuardIsAsked_Then_ItAgreesWithTheCascade()
+        {
+            // Arrange — the same pair as above with the class-list order reversed; the cascade answer is
+            // unchanged, because the stylesheet's declaration order decides it and the class list does not.
+            var element = Resolve("transition-colors", "transition-transform");
+            Assume.That(element.panel, Is.Not.Null, "Precondition: the element is on a real panel");
+
+            // Act
+            var declared = MotionNativeTransitionGuard.DeclaredSlots(element);
+
+            // Assert
+            Assert.That(declared, Is.EqualTo(CascadeSlots(element)));
+        }
+
+        [Test]
+        public void Given_ATransitionFilterElement_When_AnOpacityPlayConsultsTheGuard_Then_TheResolvedTransitionStillNamesFilter()
+        {
+            // Arrange
+            var element = Resolve("transition-filter");
+            Assume.That(element.panel, Is.Not.Null, "Precondition: the element is on a real panel");
+
+            // Act
+            MotionNativeTransitionGuard.SuspendIfIntercepted(element, new object(), MotionTransitionSlots.Opacity);
+            ForcePanelUpdate(element.panel);
+
+            // Assert — StyleFilterTransitionDriver reads this list to decide whether it owns a filter change;
+            // without filter in it the change becomes an instant write for as long as the play lasts.
+            Assert.That(
+                element.resolvedStyle.transitionProperty.Select(p => p.ToString()).ToArray(),
+                Contains.Item("filter"));
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/MotionNativeTransitionGuardCascadeTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/MotionNativeTransitionGuardCascadeTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 40bea93ba0e57446abe4af18c53f5a4d

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/MotionNativeTransitionGuardSuspensionTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/MotionNativeTransitionGuardSuspensionTests.cs
@@ -1,0 +1,111 @@
+using NUnit.Framework;
+using UnityEngine.UIElements;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// The observable half of <see cref="MotionNativeTransitionGuard"/>: whether a play suspends the element's
+    /// native transitions, which is the only thing its declared-slot answer is consulted for. Suspension is
+    /// element-wide, so suspending an element whose cascade transitions nothing the play drives makes its
+    /// unrelated transitions land instantly for the play's whole duration.
+    /// </summary>
+    [TestFixture]
+    internal sealed class MotionNativeTransitionGuardSuspensionTests
+    {
+        private static VisualElement Classed(params string[] classNames)
+        {
+            var element = new VisualElement();
+            foreach (var className in classNames)
+            {
+                element.AddToClassList(className);
+            }
+            return element;
+        }
+
+        private static bool Suspends(VisualElement element, MotionTransitionSlots drivenSlots)
+        {
+            MotionNativeTransitionGuard.SuspendIfIntercepted(element, new object(), drivenSlots);
+            return element.style.transitionProperty.keyword != StyleKeyword.Null;
+        }
+
+        [Test]
+        public void Given_TransitionAllThenTransitionNone_When_AnOpacityPlayRuns_Then_NothingIsSuspended()
+        {
+            // Arrange — the cascade leaves this element transitioning nothing at all.
+            var element = Classed("transition-all", "transition-none");
+
+            // Act
+            var suspended = Suspends(element, MotionTransitionSlots.Opacity);
+
+            // Assert
+            Assert.That(suspended, Is.False);
+        }
+
+        [Test]
+        public void Given_TransitionTransformThenTransitionColors_When_ATranslatePlayRuns_Then_NothingIsSuspended()
+        {
+            // Arrange — the later transition-colors replaces the transform list outright, so no transform
+            // property is transitioning for a translate play to fight.
+            var element = Classed("transition-transform", "transition-colors");
+
+            // Act
+            var suspended = Suspends(element, MotionTransitionSlots.Translate);
+
+            // Assert
+            Assert.That(suspended, Is.False);
+        }
+
+        [Test]
+        public void Given_TransitionAllThenTransitionColors_When_AnOpacityPlayRuns_Then_NothingIsSuspended()
+        {
+            // Arrange — transition-colors is declared later than transition-all, so opacity is not in the
+            // resolved list.
+            var element = Classed("transition-all", "transition-colors");
+
+            // Act
+            var suspended = Suspends(element, MotionTransitionSlots.Opacity);
+
+            // Assert
+            Assert.That(suspended, Is.False);
+        }
+
+        [Test]
+        public void Given_TransitionFilter_When_AnOpacityPlayRuns_Then_NothingIsSuspended()
+        {
+            // Arrange — the class pins transition-property to filter, which no driver writes.
+            var element = Classed("transition-filter");
+
+            // Act
+            var suspended = Suspends(element, MotionTransitionSlots.Opacity);
+
+            // Assert
+            Assert.That(suspended, Is.False);
+        }
+
+        [Test]
+        public void Given_TransitionColors_When_AColorPlayRuns_Then_TheElementIsSuspended()
+        {
+            // Arrange — the case the guard exists for: the class transitions exactly what the play writes.
+            var element = Classed("transition-colors");
+
+            // Act
+            var suspended = Suspends(element, MotionTransitionSlots.Color);
+
+            // Assert
+            Assert.That(suspended, Is.True);
+        }
+
+        [Test]
+        public void Given_ADurationOnlyUtility_When_AnOpacityPlayRuns_Then_TheElementIsSuspended()
+        {
+            // Arrange — a duration with no property utility leaves transition-property at its initial `all`.
+            var element = Classed("duration-300");
+
+            // Act
+            var suspended = Suspends(element, MotionTransitionSlots.Opacity);
+
+            // Assert
+            Assert.That(suspended, Is.True);
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/MotionNativeTransitionGuardSuspensionTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/MotionNativeTransitionGuardSuspensionTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0ed65e2a691304bb7bc5be9bfa765d07

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/MotionPropertyChannelTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/MotionPropertyChannelTests.cs
@@ -576,10 +576,11 @@ namespace Velvet.Tests
         }
 
         [Test]
-        public void Given_ADurationOnlyTransitionUtility_When_APlayDrivesTheElement_Then_TheNativeTransitionIsSuspended()
+        public void Given_ATransitionFilterUtility_When_APlayDrivesTheElement_Then_ItsTransitionIsUntouched()
         {
-            // Arrange — .transition-filter sets duration and timing ONLY, so transition-property is left at UI
-            // Toolkit's initial `all` and the element natively transitions every animatable property.
+            // Arrange — .transition-filter pins transition-property to `filter`, which no driver channel
+            // writes. Suspending would overwrite the very list StyleFilterTransitionDriver reads to decide it
+            // owns a filter change, so filter-* changes would land instantly for the whole play.
             var element = new VisualElement();
             element.AddToClassList("transition-filter");
 
@@ -587,9 +588,8 @@ namespace Velvet.Tests
             var state = CreateHalfway(element, new[] { "bg-black" }, new[] { "bg-white" });
 
             // Assert
-            var declared = element.style.transitionProperty.value;
-            Assert.That(state != null && declared is { Count: 1 } && StylePropertyName.IsNullOrEmpty(declared[0]),
-                Is.True);
+            Assert.That((state != null, element.style.transitionProperty.keyword),
+                Is.EqualTo((true, StyleKeyword.Null)));
         }
 
         [Test]


### PR DESCRIPTION
## What

`MotionNativeTransitionGuard` decides which properties UI Toolkit's own USS transitions are driving, so a motion driver can suspend them rather than fight the engine. It mirrored the bundled stylesheet in C#, and the mirror had drifted two ways.

**It unioned every recognised `transition-*` class on the element.** USS does not: `transition-property` is one property and the last declaration wins. So the guard answered `All` for `transition-all transition-none`, which transitions nothing, and named the transform channels for `transition-transform transition-colors`, which resolves to colours alone.

**`transition-filter` was mapped to "duration and timing only"**, commented that it leaves `transition-property` at the initial `all`. The stylesheet declares `transition-property: filter`.

## Consequence

Every disagreement was in the same direction — the guard suspended a transition that should have kept running. Suspension writes inline `transition-property: none`, which is element-wide and lasts the play's whole duration including delay and stagger, so every other native transition on that element landed instantly.

The `transition-filter` case was worse than a lost fade. The filter transition driver probes the *resolved* `transition-property` for `filter` to decide it owns a filter change; suspension overwrote it with `none`, so every `blur-*` or `brightness-*` change on such an element became an instant write until the play settled. The guard disabled the feature the class exists for.

## How it resolves now

The build-time stylesheet tool emits a second table into the committed generated file: the utilities that declare `transition-property`, indexed by cascade position, each carrying the property set its value names. The guard takes the highest position present. No class-name list survives in it, and "duration-only" is read off the derived property sets rather than a name prefix.

Cascade position is `@import` order, which is not close to name order — the animations partial sorts first and is imported last. Verified against the engine rather than assumed: imported sheets are spliced in ahead of the importing sheet, and the match sort orders by sheet index then rule order.

Two derivation assumptions are now enforced rather than trusted. An aggregator supplied ahead of a partial it imports is rejected, since that would invert the cascade the moment the aggregator stops being pure `@import`. And a **gated** rule declaring `transition-property` is rejected outright: the guard answers from an element's class list, where a gate's state is unknowable, so it would keep answering from the ungated declarations and suspend an element whose own hover rule had already stopped transitioning.

## Verification

The oracle is `resolvedStyle.transitionProperty` read off a real panel with the bundled sheet loaded — not the table the guard is built from. Red before, green after:

| classes | cascade resolves | old guard |
|---|---|---|
| `transition-all transition-none` | nothing | `All` |
| `transition-transform transition-colors` | `Color` | transform channels + `Color` |
| `transition-all transition-colors` | `Color` | `All` |
| `transition-filter` | `None` | `All` |

Plus the observable half for each: suspended when it must not be. And a panel test asserting the resolved list still names `filter` after a suspension attempt.

One pre-existing test encoded the false premise in its own arrangement and was retargeted; the genuine duration-only path stays covered by its sibling.

Generator suite 292 passed. EditMode 3430 passed / 0 failed / 3 pre-existing skips. PlayMode 99/99.

## Docs and CHANGELOG

`Documentation~/motion.md` restated the union model and the duration-only claim; both rewritten to the last-declared-wins rule. `Documentation~/styling-filters.md` already stated the rule correctly — the C# was the drifted copy, so that guide is unchanged.

The CHANGELOG entry for the suspension feature is **amended** rather than a Fixed entry added: the feature is still under `[Unreleased]`, so no released version ever had the wrong behavior.

## Known limitation, unchanged

`duration-0` still counts as "a duration is present" and so reports every property as transitioning. The derived table carries property names, not values. Pre-existing and untouched.