### PR TITLE
chore(velvet): commit the loop machinery as project configuration

### DIFF
--- a/.claude/agents/velvet-implementer.md
+++ b/.claude/agents/velvet-implementer.md
@@ -1,0 +1,60 @@
+---
+name: velvet-implementer
+description: Implements a change in this repository against its conventions, with RED/GREEN evidence and full-suite verification. Use for any task that edits Runtime, Generators~, or test code.
+skills:
+  - unity-tests
+color: green
+hooks:
+  PreToolUse:
+    - matcher: Bash
+      hooks:
+        - type: command
+          command: ${CLAUDE_PROJECT_DIR}/.claude/hooks/block-shared-git-state.sh
+---
+
+You implement one change in the Velvet repository and report on it. You do not push.
+
+## Working discipline
+
+You are given a git worktree. Other agents hold other worktrees of this same repository at the same time. **Never run `git checkout`, `git switch`, or `git stash`, and never touch a path outside your worktree** — those move state other agents depend on.
+
+Commit when the work is done, with a Conventional Commit message scoped `velvet`. **Do not push.** Report and stop; the coordinator pushes.
+
+If you conclude partway that the design you were given is wrong, **stop and say so with evidence** rather than building something you do not believe in. That is a useful outcome, not a failure.
+
+## Evidence, not assertion
+
+A change is not done because it compiles or because the suite is green. It is done when you can show it doing something it did not do before.
+
+- **Prove each new test RED without your fix and GREEN with it.** Quote the actual failure text. A test that passes both ways proves nothing, and this repo has shipped several — the usual cause is a fixture whose scaffolding repairs the very thing the test is meant to catch.
+- Run the **full** EditMode and PlayMode suites before reporting, not a filtered subset. A change that looks local often is not.
+- Report counts as measured. If something is unverified, say which and why.
+
+Use the `unity-tests` skill for how to run them and how to read the results — it carries the traps that otherwise produce confident wrong answers.
+
+## Test conventions
+
+- `Given_..._When_..._Then_...` naming, `// Arrange` / `// Act` / `// Assert` sections, **exactly one assert per test**, `internal sealed` fixtures.
+- `Assume.That` is only for a fact about a **different, already-tested** component, or a genuine environment precondition. It must never gate the behaviour the test exists to pin: a regression would then report Inconclusive, which the runner does not count as a failure.
+- Deciding between deleting an `Assume` and folding it: delete it and ask whether the assertion alone still fails on the broken behaviour. If yes, deletion is fine. **If no, it must be folded** into the assertion as a tuple comparing the gated state and the state under test at once — deleting it would turn an inconclusive into a silent pass.
+- No `*ForTest` members on production types. Reach private state by reflection inside the test.
+
+## Comments and documentation
+
+A comment states **why**, never what, and states it once. Every sentence must survive the deletion test: delete it, and if a competent reader of the surrounding code plus the remaining sentences still gets it right, it was carrying nothing.
+
+Reliably fails that test: restating the declaration below the comment; a consequence that follows from a constraint already stated; arguing that a non-problem is not a problem; re-explaining a sibling file's mechanism instead of naming it.
+
+Reliably passes, at whatever length it needs: engine behaviour that had to be measured or decompiled; an ordering constraint; an invariant a future edit could break silently; a rejected alternative and the one reason it was rejected.
+
+Never put an issue or PR number in a comment. Everything in this repository is written in English.
+
+A change to behaviour a guide describes updates that guide in the same change. Documentation is single-source-of-truth: a fact lives in exactly one document and the others link to it. The same applies to comments — name a sibling's mechanism rather than re-explaining it.
+
+Judge whether `Packages/com.velvet.core/CHANGELOG.md` needs an entry under `[Unreleased]` and state your judgement either way. User-visible behaviour belongs there; pure refactors and contributor tooling do not.
+
+## Reporting
+
+Say what you changed, the RED evidence with its failure text, the suite counts, your documentation and CHANGELOG judgements, and — separately — **anything you found but did not fix**. That last section is often the most valuable thing in the report; do not omit a defect because it was out of scope.
+
+If a claim in your instructions turned out to be wrong, say so plainly and show what you measured instead. That has happened repeatedly and is always worth more than politely working around it.

--- a/.claude/agents/velvet-reviewer.md
+++ b/.claude/agents/velvet-reviewer.md
@@ -1,0 +1,38 @@
+---
+name: velvet-reviewer
+description: Adversarially reviews a commit or branch in this repository, read-only, and reports defects that would make a user's behaviour wrong. Use before opening a PR and after each round of fixes.
+disallowedTools: Write, Edit, NotebookEdit
+color: cyan
+hooks:
+  PreToolUse:
+    - matcher: Bash
+      hooks:
+        - type: command
+          command: ${CLAUDE_PROJECT_DIR}/.claude/hooks/block-shared-git-state.sh
+---
+
+You review a change in the Velvet repository and report what is wrong with it. You find defects; you do not fix them.
+
+## Constraints
+
+**Read-only.** Do not edit, commit, or stage. Do not run `git checkout`, `git switch`, or `git stash` — other agents hold worktrees of this repository and those commands move state they depend on.
+
+**Do not run Unity** unless told the machine is free. Another agent is usually running the suite, and concurrent instances make unrelated tests fail, which wastes both your time and theirs. Reason from the sources instead. Where the engine's own behaviour is the question, decompile it — the assemblies are under the editor install, and this repo's convention is that an infeasibility claim only stands after a decompile check, not after reading documentation.
+
+Run `git status --short` and **read any untracked file** rather than assuming it is harmless. Review agents in this repo have left scratch fixtures behind.
+
+## What to look for, in priority order
+
+1. **A claim in the change that is false.** Commit messages, comments, CHANGELOG entries and guides all assert things. Check them against the code rather than accepting them. Several of this repo's worst defects were a correct fix shipped beside a sentence describing behaviour it did not have.
+2. **A test that cannot fail.** Establish for each new test that it goes red without the fix, *for the stated reason*. Common shapes here: an assertion satisfied by the broken behaviour, a fixture whose scaffolding repairs what the test is meant to catch, an `Assume` that turns a regression into an inconclusive, a threshold so tight it only holds on one platform, and a benchmark whose fixture never drives the code it claims to measure.
+3. **Correctness in states the change did not consider.** Enumerate them explicitly — first run versus steady state, on-panel versus off, an element leaving the tree, a pooled element reused, a variant toggled while something is mid-flight, several of them at once. State ghosting across pool reuse is this repository's recurring bug.
+4. **A mirror that has drifted.** C# that restates a fact the stylesheets or the engine own is the source of several shipped bugs. If the change adds one, say so; if it relies on one, check it still holds.
+5. **Convention.** One assert per test, Given/When/Then, `internal sealed` fixtures, English throughout, no issue numbers in comments, and the comment deletion test — every sentence must fail to be deletable.
+
+## Reporting
+
+Rank by severity. Each finding needs the **concrete failure scenario**: the inputs or state that produce the wrong outcome, and what the outcome is. A finding without one is a hypothesis, and this repo has lost time to plausible-sounding hypotheses that turned out to be wrong.
+
+Say plainly when something is right. If a design decision you attacked survives, one line saying so is worth more than silence, because it tells the coordinator that area has been examined. Do not pad a report to look thorough — "I attacked X, Y and Z and could not break them" is a complete and useful answer.
+
+Distinguish a defect from a preference. If it works and you would have written it differently, that is not a finding.

--- a/.claude/hooks/block-shared-git-state.sh
+++ b/.claude/hooks/block-shared-git-state.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Blocks git commands that move state shared across worktrees.
+#
+# Several agents hold worktrees of this repository at once. `checkout`, `switch`
+# and `stash` act on state they share, so one agent running them silently
+# retargets another's branch — this has cost recovery work twice. Reading the
+# rule in a prompt did not prevent it; refusing the command does.
+set -uo pipefail
+
+payload=$(cat)
+
+command=$(printf '%s' "$payload" | python3 -c '
+import json, sys
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+inp = d.get("tool_input") or {}
+sys.stdout.write(inp.get("command", "") if isinstance(inp, dict) else "")
+' 2>/dev/null) || exit 0
+
+[ -n "$command" ] || exit 0
+
+# `git checkout -- <path>` and `git checkout <path>` restore files without
+# moving HEAD, and are how an agent reverts a probe. Only the branch-moving
+# forms are refused.
+if printf '%s' "$command" | grep -Eq '(^|[;&|]|[[:space:]])git[[:space:]]+(switch|stash)([[:space:]]|$)'; then
+    printf 'Refused: `git switch` and `git stash` move state other worktrees share. Work in the worktree you were given; if you need a different base, say so and stop.\n' >&2
+    exit 2
+fi
+
+if printf '%s' "$command" | grep -Eq '(^|[;&|]|[[:space:]])git[[:space:]]+checkout([[:space:]]|$)' \
+   && ! printf '%s' "$command" | grep -Eq 'git[[:space:]]+checkout[[:space:]]+(--[[:space:]]|[^-][^[:space:]]*\.[[:alnum:]]|[A-Za-z0-9_./-]+/)'; then
+    printf 'Refused: `git checkout` of a branch moves state other worktrees share. Restoring a file (`git checkout -- <path>`) is allowed; changing branch is not.\n' >&2
+    exit 2
+fi
+
+exit 0

--- a/.claude/hooks/report-gitignored-write.py
+++ b/.claude/hooks/report-gitignored-write.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Report a just-written file that .gitignore excludes.
+
+An excluded file never reaches a fresh clone, yet every local run keeps passing on the copy that is
+present here — so the suite that would have caught the gap is the one that stops existing in CI. That
+is how the generator solution came to have no test coverage at all: nothing downstream can see it,
+because the failing configuration is the one nobody runs. `git check-ignore` answers it at the moment
+the file appears, which is the only cheap place to ask.
+"""
+
+import json
+import os
+import subprocess
+import sys
+
+# Build output is excluded on purpose; only a file that wants tracking is worth interrupting for.
+TRACKABLE_SUFFIXES = (
+    ".cs", ".uss", ".uxml", ".asmdef", ".csproj", ".sln",
+    ".md", ".json", ".yml", ".yaml", ".sh", ".ps1", ".py",
+)
+
+
+def main():
+    try:
+        payload = json.load(sys.stdin)
+    except ValueError:
+        return 0
+
+    path = (payload.get("tool_input") or {}).get("file_path")
+    if not path or not path.endswith(TRACKABLE_SUFFIXES):
+        return 0
+
+    root = os.environ.get("CLAUDE_PROJECT_DIR") or payload.get("cwd") or "."
+    try:
+        check = subprocess.run(
+            ["git", "-C", root, "check-ignore", "-v", "--", path],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+        )
+    except OSError:
+        return 0
+
+    # Anything but a match — no git, a path outside the work tree, a tracked file — is not the case
+    # this asks about, and staying silent is what keeps the hook usable on every write.
+    if check.returncode != 0:
+        return 0
+
+    rule = check.stdout.decode("utf-8", "replace").split("\t")[0].strip()
+    detail = (
+        "`{}` is excluded by .gitignore ({}), so a fresh clone will not have it and CI cannot see it "
+        "— while every local run keeps passing on the copy present here. The write itself succeeded. "
+        "Decide which is true before continuing: the ignore rule is too broad and wants narrowing, or "
+        "the file is genuinely generated and belongs nowhere. Force-adding it without narrowing the "
+        "rule leaves the trap set for the next file.".format(path, rule)
+    )
+    # Two audiences, two channels, per the hook output spec. `additionalContext` is injected as a
+    # system reminder and deliberately does not appear in the transcript; `systemMessage` is what the
+    # person watching sees. Exit 2 is not an option here — PostToolUse cannot block, because the tool
+    # has already run, so the spec ignores it.
+    json.dump(
+        {
+            "systemMessage": "gitignored write — {} matches {}".format(path, rule),
+            "hookSpecificOutput": {
+                "hookEventName": "PostToolUse",
+                "additionalContext": detail,
+            },
+        },
+        sys.stdout,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/hooks/report-untracked-scratch.sh
+++ b/.claude/hooks/report-untracked-scratch.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Reports what a subagent left in the working tree, into the parent's context.
+#
+# Two failures this guards. A read-only agent creating a probe fixture and not
+# removing it — self-reported cleanup has been wrong before, and the leftover
+# reads as production code to the next session. And a source file .gitignore
+# excludes, which stays untracked while every local run passes because the file
+# is there.
+set -uo pipefail
+
+cd "${CLAUDE_PROJECT_DIR:-.}" 2>/dev/null || exit 0
+command -v git >/dev/null 2>&1 || exit 0
+git rev-parse --git-dir >/dev/null 2>&1 || exit 0
+
+untracked=$(git status --porcelain --untracked-files=all 2>/dev/null \
+    | awk '/^\?\?/ { print substr($0, 4) }' \
+    | grep -v '^Library/' \
+    | head -20)
+
+# An ignored source file is the dangerous case; build output is ignored on purpose.
+ignored=$(git status --porcelain --ignored=matching --untracked-files=all 2>/dev/null \
+    | awk '/^!!/ { print substr($0, 4) }' \
+    | grep -E '\.(cs|uss|uxml|asmdef|csproj|sln|md)$' \
+    | grep -vE '^(Library|Temp|obj|Logs)/' \
+    | head -20)
+
+[ -z "$untracked" ] && [ -z "$ignored" ] && exit 0
+
+python3 - "$untracked" "$ignored" <<'PY'
+import json, sys
+untracked, ignored = sys.argv[1], sys.argv[2]
+parts, headline = [], []
+if untracked:
+    n = len(untracked.splitlines())
+    headline.append("{} untracked".format(n))
+    parts.append(
+        "Untracked files remain in the working tree. Read each before deciding "
+        "it is harmless — a probe fixture left behind reads as production code "
+        "to the next session, and an agent's own report that it cleaned up has "
+        "been wrong before:\n" + untracked
+    )
+if ignored:
+    n = len(ignored.splitlines())
+    headline.append("{} gitignored source".format(n))
+    parts.append(
+        "Source files here are EXCLUDED by .gitignore, so they cannot reach CI "
+        "while every local run stays green because the files are present "
+        "locally:\n" + ignored
+    )
+# systemMessage is the transcript channel; additionalContext is the model's and does not display.
+print(json.dumps({
+    "systemMessage": "subagent left files behind — " + ", ".join(headline),
+    "hookSpecificOutput": {
+        "hookEventName": "SubagentStop",
+        "additionalContext": "\n\n".join(parts),
+    },
+}))
+PY
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,27 @@
+{
+  "hooks": {
+    "SubagentStop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/report-untracked-scratch.sh",
+            "timeout": 15000
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/report-gitignored-write.py\"",
+            "timeout": 10000
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/unity-tests/SKILL.md
+++ b/.claude/skills/unity-tests/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: unity-tests
+description: Run Velvet's EditMode or PlayMode suites headlessly and read the results correctly. Use whenever a change needs verifying against the test suite, or when a reported pass/fail count needs to be trusted.
+---
+
+# Running the Unity suites
+
+The editor must be closed — it holds the project lock.
+
+```bash
+UNITY=/Applications/Unity/Hub/Editor/6000.3.11f1/Unity.app/Contents/MacOS/Unity
+"$UNITY" -runTests -batchmode -projectPath "$PWD" -testPlatform EditMode \
+  -testResults /tmp/results.xml -logFile /tmp/run.log
+```
+
+`-testPlatform PlayMode` for the other suite. `-testFilter "Velvet.Tests.SomeFixture"` narrows it; semicolons separate several, and it matches fully-qualified class or method names.
+
+## Traps that produce wrong answers
+
+**Never pass `-nographics`.** Any test that mounts a real panel — an `EditorWindow.rootVisualElement`, or anything reading `resolvedStyle` or firing pointer/focus events — fails with "No graphic device is available". Graphics-free tests pass with graphics on, so there is no reason to use the flag.
+
+**Check for a running instance with a pattern that cannot match its own command line.** `pgrep -f "MacOS/Unity -runTests"` matches the waiting shell itself and deadlocks against a machine that is actually idle. Use:
+
+```bash
+ps -Ao command= | grep -c '^/Applications/.*/MacOS/Uni[t]y -runTests'
+```
+
+Concurrent Unity instances make unrelated tests fail. A failure measured while another run was in flight is not evidence; re-measure on a quiet machine before concluding anything.
+
+**Compile errors appear only in the log**, never in the XML: `grep "error CS" /tmp/run.log`. A run that failed to compile still writes an XML, so a missing failure count is not proof of success.
+
+**Counts come only from the XML**: `grep -o 'passed="[0-9]*"\|failed="[0-9]*"\|inconclusive="[0-9]*"' /tmp/results.xml | head -3`.
+
+**`inconclusive` is not counted as a failure by the runner.** A non-zero count means a test skipped rather than reported — usually an `Assume` gating the behaviour under test. Treat it as a failure and find the test.
+
+## Reading a result you intend to report
+
+- EditMode batchmode does not run layout. A test that reads `resolvedStyle` must force it through the panel's `ApplyStyles`/`UpdateForRepaint`, or it silently measures nothing. Assertions on measured values belong in PlayMode.
+- A threshold derived from font metrics or layout lands differently on the CI runner than locally. Assert against declared values where possible.
+- Before reporting "no allocations", confirm the instrument works: `GC.GetAllocatedBytesForCurrentThread()` and `GC.GetTotalMemory` both report 0 under Unity's Mono regardless of what happens. Only `Unity.PerformanceTesting`'s `.GC()` recorder measures it.
+- A benchmark measures only the path its fixture drives. Confirm the code under test actually runs in it before citing it as evidence.
+
+## The generator suite
+
+Separate dotnet solution, no Unity licence needed:
+
+```bash
+cd Packages/com.velvet.core/Generators~ && dotnet test Velvet.SourceGenerators.sln -c Release
+```
+
+`./build.sh` rebuilds and redeploys the committed DLLs and regenerates the derived stylesheet table. Run it after changing generator or stylesheet sources, and commit what it produces.


### PR DESCRIPTION
## What

Three failures in recent work were caught by reading rather than by anything mechanical, and two of them had already been written down as rules — followed once, forgotten the second time. A rule in prose is enforced only when it is read. A hook cannot be forgotten.

This adds `.claude/` as committed project configuration, so every session inherits the same machinery instead of it living in one person's user settings.

## The three hooks

**`block-shared-git-state.sh`** refuses `git switch`, `git stash` and branch `checkout` inside the implementer and reviewer agents. Several agents hold worktrees of this repository at once, and those commands act on state they share — one agent running them silently retargets another's branch. That has cost recovery work twice. `git checkout -- <path>` stays allowed, since that is how an agent reverts a probe.

**`report-gitignored-write.py`** reports a source file `.gitignore` excludes, at the moment it is written. This failure is invisible to every test by construction: the generator solution failed to load on a fresh clone because its project file was never tracked, so **its whole suite had never run in CI** — while every local run stayed green on the copy present locally. The tests that would have caught it were the thing that went missing.

**`report-untracked-scratch.sh`** reports what a subagent leaves in the tree when it stops. A read-only reviewer that creates a probe fixture and does not remove it leaves something that reads as production code to the next session, and an agent's own claim to have cleaned up has been wrong before.

Each reports through both documented channels — `systemMessage` for the transcript, `additionalContext` for the model. Exit 2 is deliberately not used on the write hook: `PostToolUse` cannot block, because the tool has already run, and the specification ignores it there.

## The two agents

`velvet-reviewer` is read-only **by configuration rather than by instruction** — `disallowedTools` removes the edit tools outright, so the constraint does not depend on the prompt being read.

`velvet-implementer` preloads the test-running skill and carries the conventions that reviews keep having to enforce: RED/GREEN evidence with the actual failure text, full-suite runs rather than filtered subsets, the fold-versus-delete rule for `Assume`, the comment deletion test, and an explicit obligation to report what was found and not fixed.

## The skill

`unity-tests` carries the traps that otherwise produce confident wrong answers — the graphics flag that silently turns a suite into skips, the process check that matches its own command line and deadlocks against an idle machine, compile errors that appear only in the log, `inconclusive` not being counted as a failure, EditMode not running layout, and the allocation APIs that report zero under Mono regardless of what happens.

## Verified

Every hook was exercised against real inputs before committing: the git guard refuses all five branch-moving forms and permits all six file-restoring and read-only ones; the write hook fires on an ignored `.csproj` and stays silent on a normal source file; the subagent hook reports both untracked and ignored files and stays silent on a clean tree. The write hook was also confirmed firing end-to-end during a real write.