### PR TITLE
chore(velvet): correct CLAUDE.md, fail on inconclusive, and record what no check can enforce

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,6 +107,14 @@ jobs:
           artifactsPath: ${{ matrix.testMode }}-results
           githubToken: ${{ secrets.GITHUB_TOKEN }}
 
+      # Unity exits 0 on an inconclusive case and game-ci's reporter reads only
+      # passed/failed/skipped off <test-run>, so a test whose Assume stopped holding
+      # would leave this job green. always() reports both tallies on a run that also
+      # has failures.
+      - name: Assert no inconclusive results
+        if: always()
+        run: python3 scripts/assert-no-inconclusive.py "${{ matrix.testMode }}-results"
+
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,11 +70,19 @@ Tests are **colocated** with the code: `Runtime/<Area>/Tests/Editor/` and `.../T
 
 **Test convention for this repo:** Given/When/Then naming (`Given_..._When_..._Then_...`) for method names, with `// Arrange`/`// Act`/`// Assert` sections in the body, **exactly one assert per test**, and `Assume.That` for preconditions. Verify a regression test is RED without the fix and GREEN with it. Test fixtures are `internal sealed class` (the Unity Test Framework discovers internal fixtures; bases are `internal`/`public abstract`). Comments must not carry issue/PR numbers — state the reason in terms of behavior so it is self-contained. Templates: `ButtonChildPoolReuseTests.cs`, `ClickDrivenHookLifecycleTests.cs`.
 
+Four ways a green test has lied here:
+
+- An `Assume` that gates the behavior under test is folded into the assertion — one comparison over a tuple of the gated state and the state under test — rather than deleted; deletion is correct only when the assertion alone would still fail on the broken behavior.
+- A threshold compared against a measured value is platform-dependent, since font metrics and layout land differently on a CI runner than on a developer machine: assert declared values, and where a measured one must take part, let the floating-point margin separate the right outcome from the wrong one rather than a hand-picked pixel budget.
+- `GC.GetAllocatedBytesForCurrentThread()` and `GC.GetTotalMemory()` both report 0 under Unity's Mono while allocation is happening, so "no allocations" holds only after a canary that allocates a known amount moves the instrument — `Unity.PerformanceTesting`'s `.GC()` recorder is the one that measures.
+- A benchmark is evidence only for the code its fixture drives — a paint change measured free on the manipulator-reconcile fixture, whose class strings never take the paint path it changed — so confirm the code under test runs in a fixture before citing its numbers.
+
 ## Conventions
 
 - Commits use Conventional Commits with the `velvet` scope (e.g. `fix(velvet): …`, `feat(velvet): …`, `refactor(velvet): …`).
 - Everything in this repo is written in English: code, comments, commit messages, and PR titles/bodies. PR descriptions state what changed and why — never the local workflow that produced the change (audit/review process, agent tooling, session details).
 - A PR that adds, changes, or removes a feature updates the corresponding `Documentation~` guide (and the `Documentation~/README.md` index table) in the same PR. If the change has no doc impact, say so explicitly in the PR body. `DocumentationDriftTests` (EditMode) and the Generators~ diagnostic-table tests catch API references and diagnostic IDs that no longer exist, but they cannot verify that a behavior description is still accurate — that stays the PR author's responsibility.
+- A fact the bundled stylesheets own — the longhands a utility writes, where it sits in the cascade — is derived from them rather than restated in C#: `Generators~/src/Velvet.StyleTable` reads `Runtime/Styles/*.uss` and emits `Runtime/Styling/StyleUtilityProperties.g.cs`. Where a mirror is genuinely unavoidable it is pinned by a test that fails when the stylesheet moves, because an unpinned one drifts silently — a guard that unioned property sets where the cascade takes only the last declaration suspended the transitions it existed to protect.
 - Documentation is single-source-of-truth: a given fact (the hooks table, the factory list, the diagnostic-ID table, a feature's behavior description) lives in exactly one owning document. Other documents link to it and add at most a one-line summary instead of restating it. Duplicated statements are how docs drift — when the fact changes, only one copy gets updated. This holds for comments too: name a sibling's mechanism ("same ownership rule as `StyleGapManipulator`"), never re-explain it.
 
 ## Comment length

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,12 +19,13 @@ Unity test runs require the editor to be **closed** (it holds the project lock).
 UNITY=/Applications/Unity/Hub/Editor/6000.3.11f1/Unity.app/Contents/MacOS/Unity
 "$UNITY" -runTests -batchmode -projectPath "$PWD" -testPlatform EditMode \
   -testResults /tmp/results.xml -logFile /tmp/run.log
+python3 scripts/assert-no-inconclusive.py /tmp/results.xml
 ```
 
 - **Run a subset / single fixture:** add `-testFilter "Velvet.Tests.SomeFixture"` (semicolon-separates multiple; matches fully-qualified class or method names).
 - **PlayMode:** `-testPlatform PlayMode`.
 - **Do NOT pass `-nographics`.** Everything that needs a real panel (an `EditorWindow.rootVisualElement`, or anything reading `resolvedStyle` / firing pointer/focus events) goes through `TestGraphics.IgnoreIfHeadless`, so the flag does not fail those tests — it **skips** them, and the run reports green having exercised none of the panel behavior. Graphics-free tests all pass with graphics on, so the flag buys nothing and costs the half of the suite that is hardest to get right.
-- Results land in the JUnit-style XML (`grep -o 'passed="[0-9]*"\|failed="[0-9]*"'`); compile errors appear only in the `-logFile` (`grep "error CS"`).
+- Results land in the JUnit-style XML (`grep -o 'passed="[0-9]*"\|failed="[0-9]*"'`); compile errors appear only in the `-logFile` (`grep "error CS"`). Neither the exit code nor any reporter treats an inconclusive case as a failure, which is why the run ends with `assert-no-inconclusive.py` — CI runs the same script.
 - Interactively, the same suites run from **Window ▸ General ▸ Test Runner**.
 
 ### Source generators (separate .NET solution)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ UNITY=/Applications/Unity/Hub/Editor/6000.3.11f1/Unity.app/Contents/MacOS/Unity
 
 - **Run a subset / single fixture:** add `-testFilter "Velvet.Tests.SomeFixture"` (semicolon-separates multiple; matches fully-qualified class or method names).
 - **PlayMode:** `-testPlatform PlayMode`.
-- **Do NOT pass `-nographics`.** Tests that mount a real panel (an `EditorWindow.rootVisualElement`, or anything reading `resolvedStyle` / firing pointer/focus events) fail with "No graphic device is available" under `-nographics`. Graphics-free tests still pass with graphics on, so just always omit the flag.
+- **Do NOT pass `-nographics`.** Everything that needs a real panel (an `EditorWindow.rootVisualElement`, or anything reading `resolvedStyle` / firing pointer/focus events) goes through `TestGraphics.IgnoreIfHeadless`, so the flag does not fail those tests — it **skips** them, and the run reports green having exercised none of the panel behavior. Graphics-free tests all pass with graphics on, so the flag buys nothing and costs the half of the suite that is hardest to get right.
 - Results land in the JUnit-style XML (`grep -o 'passed="[0-9]*"\|failed="[0-9]*"'`); compile errors appear only in the `-logFile` (`grep "error CS"`).
 - Interactively, the same suites run from **Window ▸ General ▸ Test Runner**.
 
@@ -34,24 +34,25 @@ The Roslyn analyzers/generators under `Packages/com.velvet.core/Generators~/` ar
 ```bash
 cd Packages/com.velvet.core/Generators~
 dotnet test Velvet.SourceGenerators.sln -c Release   # generator unit tests (no Unity license needed)
-./build.sh                                            # rebuild + redeploy DLLs to Runtime/Plugins, then commit them
 ```
 
-CI is split by what a change can affect: `.github/workflows/generators.yml` runs `source-generators` (no license) for `Generators~/**` changes and for `Runtime/**` changes (the analyzer's hook-name lists are pinned against the runtime sources, so a rename there must run the generator suite), and `.github/workflows/test.yml` runs `unity-tests` (EditMode/PlayMode, **skipped unless a `UNITY_LICENSE` secret is set** — see CONTRIBUTING.md) only for package/project changes; docs and markdown trigger neither. Docs (`docs/`) are DocFX-generated from XML comments via `docs/build.sh`.
+A generator change is complete only once the redeployed DLLs are committed with it; `Generators~/README.md` owns the build and deploy steps.
+
+CI is split by what a change can affect: `.github/workflows/generators.yml` runs `source-generators` (no license) for `Generators~/**` changes and for `Runtime/**` changes (its drift guards re-derive the hook surface and the generator test stub's signatures from the runtime sources, so a rename there must run the generator suite), and `.github/workflows/test.yml` runs `unity-tests` (EditMode/PlayMode, **skipped unless a `UNITY_LICENSE` secret is set** — see CONTRIBUTING.md) only for package/project changes; docs and markdown trigger neither. Docs (`docs/`) are DocFX-generated from XML comments via `docs/build.sh`.
 
 ## Architecture (the parts that span many files)
 
 The render pipeline, in dependency order under `Runtime/`:
 
-1. **`Component/`** — the `V.*` factories build an immutable **`VNode`** tree (`VNodeTypes.cs`); `V.Mount` attaches it. `V.Component(Foo.Render)` wraps a `[Component] static VNode Foo()`. `V.List` / `V.When` / `V.Fragment` / `V.Provider` are the JSX-construct equivalents. `VNodePool.cs` pools the poolable primitives.
+1. **`Component/`** — the `V.*` factories build an immutable **`VNode`** tree (`VNodeTypes.cs`); `V.Mount` attaches it. `V.Component(Foo.Render)` wraps the `[Component] static VNode Render()` declared on a static class `Foo`. `V.List` / `V.When` / `V.Fragment` / `V.Provider` are the JSX-construct equivalents. `VNodePool.cs` pools the poolable primitives.
 2. **`Reconciler/`** — diffs the new VNode tree against the live fiber tree and patches the underlying `VisualElement`s. Key seams: `FiberRenderer` (mount/flush/dispose), `ChildReconciler` (keyed/positional diff + `FlattenAndFilter`, which drops `null` children — so `cond ? node : null` is the idiomatic "render nothing"), `FiberBatchScheduler` (lane-based, coalesced frame-boundary drains), `FiberNodeFactory`/`FiberNodePatcher` (create/patch + attach styling manipulators), `FiberElementCleaner` + `FiberPrimitiveElementPool`/`FiberElementPoolReset` (resource cleanup + reset-before-pool — a recurring bug class is state ghosting across pool reuse, so a reset helper must scrub **every** field a node may have set).
 3. **`Hooks/`** — `Hooks.cs` is the public surface (`UseState`/`UseEffect`/`UseStore`/`UseRef`/…). Hook state lives on the `ComponentFiber`; `StateUpdater<T>` (the setter) is reference-stable across renders and supports the functional form `setX.Invoke(prev => next)`.
 4. **`Store/`** — `Store<T>` (Zustand-style immutable state + subscribers); `UseStore(store, selector)` subscribes synchronously at render and unsubscribes on unmount.
 5. **`Styling/`** — utility-first className resolution (no per-component USS). `StyleRecipe`/`StyleSlotRecipe` are the cva/tailwind-variants equivalent; `StyleArbitraryValueResolver` handles `w-[120px]`-style JIT values; variant **manipulators** (`StyleVariantManipulator` = `hover:`/`focus:`/`active:`, `StyleConditionalVariantManipulator` = `dark:`/`sm:`…, `StyleRelationalVariantManipulator` = `group-`/`peer-`, `StyleGapManipulator`) attach as UI Toolkit `Manipulator`s and are tracked in `ReconcilerContext` so cleanup can remove them.
-6. **`Routing/`** — React-Router-style `Router`/`Outlet`/navigation hooks.
+6. **`Routing/`** — React-Router-style routing: the router, the route matcher and the navigation hooks. The `V.Outlet` factory itself sits with every other factory in `Component/V.cs`.
 
 **Two memoization axes (independent), both `[Component]` knobs in `Component/ComponentAttribute.cs`:**
-- `Compiler` (default `true`) = the **React Compiler equivalent**: the ILPP under `CodeGen/` (`CompilerWeaver`, driven by `VelvetCompilerILPostProcessor`) weaves auto-memoization of a component's VNode construction keyed on its hook inputs + props. It processes **every assembly that references `Velvet`** (including samples), bailing gracefully (no diagnostic) on memo-unsafe hooks. Opt a component out with `[Component(Compiler = false)]`.
+- `Compiler` (default `true`) = the **React Compiler equivalent**: the ILPP under `CodeGen/` (`CompilerWeaver`, driven by `VelvetCompilerILPostProcessor`) weaves auto-memoization of a component's VNode construction keyed on its hook inputs + props. It processes the `Velvet` assembly and **every assembly that references it**, skipping only the `*.CodeGen.Tests` assemblies and anything handed to it without PE or PDB data, and bails gracefully (no diagnostic) on memo-unsafe hooks. Opt a component out with `[Component(Compiler = false)]`.
 - `Memoize` (default `false`) = the **`React.memo` equivalent**: a props-bail at the reconcile boundary (skip a parent-driven re-render when props are shallow-equal). The component's own store/state updates still re-render it. Note auto-memo is keyed on props too, so an unstable callback prop (fresh delegate each render) defeats both axes — stabilize with `UseCallback`.
 
 Do not confuse either axis with the standalone method-level `[MemoizeMethod]` attribute (`Component/MemoizeMethodAttribute.cs`): that is an unrelated source-generator marker that wraps a partial method's body in `V.Memoized(factory, deps)` (see `Documentation~/memoization.md`). Shared name root, independent mechanism.
@@ -64,7 +65,7 @@ Tests are **colocated** with the code: `Runtime/<Area>/Tests/Editor/` and `.../T
 
 - `SimulateClick()` / `SimulateChange()` / `SimulateEvent<TEvent>()` — fire events through an element's callback registry without a live panel (the only way to exercise the discrete-event commit path, e.g. `button.SimulateClick()` which runs the handler + a synchronous `FlushImmediate`).
 - `DrainImmediateForTest()` (on `FiberBatchScheduler` via `mounted.Root.Reconciler.Context.BatchScheduler`) and `FlushEffectsForTest()` / `FlushStateForTest()` — the EditMode scheduler/PlayerLoop does not tick, so flush manually.
-- EditMode batchmode does not run layout; force it via the panel's `ApplyStyles`/`UpdateForRepaint` (reflection) when a test reads `resolvedStyle` (see `StyleUtilitiesUssTests`, `ResponsiveBreakpointPanelTests`).
+- EditMode batchmode drives neither layout, the panel scheduler, nor animations. `EditorPanelTestHelpers` reaches each of them by reflection — a styles/layout pass so `resolvedStyle` populates, one scheduler tick, one animation tick, and a substitute panel clock — and `PanelTestBase` packages the host window, the headless guard and that layout pass for a fixture that needs a real panel. Read `TestUtilities/` before hand-rolling any of it.
 
 **Test convention for this repo:** Given/When/Then naming (`Given_..._When_..._Then_...`) for method names, with `// Arrange`/`// Act`/`// Assert` sections in the body, **exactly one assert per test**, and `Assume.That` for preconditions. Verify a regression test is RED without the fix and GREEN with it. Test fixtures are `internal sealed class` (the Unity Test Framework discovers internal fixtures; bases are `internal`/`public abstract`). Comments must not carry issue/PR numbers — state the reason in terms of behavior so it is self-contained. Templates: `ButtonChildPoolReuseTests.cs`, `ClickDrivenHookLifecycleTests.cs`.
 

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/DocumentationDriftTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/DocumentationDriftTests.cs
@@ -9,7 +9,7 @@ using NUnit.Framework;
 namespace Velvet.Tests
 {
     /// <summary>
-    /// Machine-checks the shipped Documentation~ guides (plus both README.md files) against the actual
+    /// Machine-checks the shipped Documentation~ guides (plus both README.md files and CLAUDE.md) against the actual
     /// runtime API surface, so a doc referencing a renamed/removed <c>V.*</c> factory or <c>Hooks.*</c> hook,
     /// or an index that has drifted from the files on disk, fails a test instead of shipping silently wrong.
     /// Each check pins a failure mode that has actually shipped: a guide referencing a never-implemented
@@ -43,6 +43,7 @@ namespace Velvet.Tests
             }
             yield return (Path.GetFullPath("README.md"), "README.md (repo root)");
             yield return (Path.GetFullPath("Packages/com.velvet.core/README.md"), "Packages/com.velvet.core/README.md");
+            yield return (Path.GetFullPath("CLAUDE.md"), "CLAUDE.md");
         }
 
         [Test]

--- a/scripts/assert-no-inconclusive.py
+++ b/scripts/assert-no-inconclusive.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Fail a Unity test run that reported an Inconclusive case.
+
+Nothing else treats Inconclusive as a failure. Unity's runner exits 0, and game-ci's reporter
+reads only passed/failed/skipped off the <test-run> element, so a test whose Assume stopped
+holding reports green over the behavior it exists to pin.
+"""
+
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+USAGE = "usage: assert-no-inconclusive.py RESULTS_XML_OR_DIRECTORY [...]"
+
+
+def result_files(arguments):
+    files = []
+    for argument in arguments:
+        path = Path(argument)
+        if path.is_dir():
+            files.extend(sorted(path.rglob("*.xml")))
+        elif path.is_file():
+            files.append(path)
+        else:
+            print("{}: no such file or directory".format(path), file=sys.stderr)
+    return files
+
+
+def inconclusive_in(path):
+    """None when the file is not a test run. The root tally decides; the names are for the report."""
+    root = ET.parse(str(path)).getroot()
+    if root.tag != "test-run":
+        return None
+    count = int(root.get("inconclusive", "0"))
+    names = [
+        case.get("fullname") or case.get("name") or "<unnamed>"
+        for case in root.iter("test-case")
+        if case.get("result") == "Inconclusive"
+    ]
+    return count, names
+
+
+def main(arguments):
+    if not arguments:
+        print(USAGE, file=sys.stderr)
+        return 2
+
+    runs = 0
+    total = 0
+    offenders = []
+    for path in result_files(arguments):
+        try:
+            parsed = inconclusive_in(path)
+        except ET.ParseError as error:
+            print("{}: unreadable test results ({})".format(path, error), file=sys.stderr)
+            return 2
+        if parsed is None:
+            continue
+        runs += 1
+        count, names = parsed
+        if count:
+            total += count
+            offenders.append((path, names))
+
+    # A run that wrote no results is the same hole as a silent inconclusive: nothing was verified.
+    if runs == 0:
+        print("no test run found under: {}".format(" ".join(arguments)), file=sys.stderr)
+        return 2
+
+    if not offenders:
+        print("checked {} test run(s): no inconclusive cases".format(runs))
+        return 0
+
+    print("{} test(s) reported Inconclusive:".format(total), file=sys.stderr)
+    for path, names in offenders:
+        print("  {}".format(path), file=sys.stderr)
+        for name in names:
+            print("    {}".format(name), file=sys.stderr)
+    print(
+        "An Assume that gates the behavior under test belongs inside the assertion, comparing the "
+        "gated state and the state under test at once, so a regression fails instead of skipping.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
Three commits, independent and separately revertible.

## 1. `CLAUDE.md` had five false claims, and nothing was checking it

It is the only markdown in this repository that `DocumentationDriftTests` does not scan, and it names about 25 internal types. The errors that had accumulated:

- The instruction for forcing layout in a test told the reader to reimplement reflection that now lives in `TestUtilities` — 19 fixtures inherit the helper that wraps it, and three later helpers were missing from the description entirely. An agent following the file wrote code that already existed.
- The `-nographics` warning described a failure mode that no longer happens. Graphics-dependent tests now skip rather than fail, which makes the advice **more** load-bearing, not less: the outcome is a green run that exercised nothing.
- The component idiom named the wrong member, the ILPP description named assemblies that do not exist, and one factory was filed under the wrong directory.

`CLAUDE.md` is now in the drift guard's file set. That guard resolves `V.*` and backticked `Use*` names only, so it would not have caught any of these five — it is cheap insurance against one class of drift, not a substitute for keeping type names scarce.

## 2. A test run with inconclusive results now fails

Unity's JUnit-style XML does not count `inconclusive` as a failure, so a test that gates the behaviour it exists to pin behind `Assume` reports Inconclusive when that behaviour regresses — and CI goes green over a broken feature.

This defect was found and fixed **twice in recent work**, once in the motion driver fixtures and once in the class-projection fixtures. The second occurrence is what makes this mechanical rather than another convention: the rule was already written down.

Both suites report zero inconclusive today, so the guard starts clean rather than with a backlog to grandfather.

## 3. Four rules that no check can enforce

Kept to one sentence each, because everything mechanisable was mechanised instead:

- The fold-versus-delete distinction for `Assume` — the part that was gotten wrong on the second occurrence, after the general rule was already known.
- A threshold on a measured value is platform-dependent. One shipped a red CI on a locally-green suite.
- Verify the instrument before trusting a zero: two allocation APIs report 0 under Mono regardless of what happens.
- A benchmark measures only the path its fixture drives. One was cited as evidence that a change was free, while its fixture never executed the code in question.

Plus the rule that a fact the bundled stylesheets own is derived from them rather than restated in C#. Two shipped bugs came from mirrors that drifted, one of which disabled the feature its class exists for.