### PR TITLE
refactor(velvet): drain the class-name parse cache from a test helper, not from V

### DIFF
--- a/Packages/com.velvet.core/Runtime/Component/V.cs
+++ b/Packages/com.velvet.core/Runtime/Component/V.cs
@@ -39,11 +39,6 @@ namespace Velvet
         internal const int MaxClassNameCacheSize = 256;
 
 #if UNITY_EDITOR
-        /// <summary>Test-only: drains the cache to isolate cache-bound regression coverage.</summary>
-        internal static void ClearClassNameCacheForTesting() => s_classNameCache.Clear();
-#endif
-
-#if UNITY_EDITOR
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
         private static void ResetStaticFields()
         {

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/StyleManipulatorReconcileBenchmarks.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/StyleManipulatorReconcileBenchmarks.cs
@@ -1,10 +1,8 @@
-// The class-name parse cache's drain hook is editor-only, and the unchanged-class measurement below
-// depends on it to put two content-identical trees on the class diff's content-compare path.
-#if UNITY_EDITOR
 using System;
 using NUnit.Framework;
 using Unity.PerformanceTesting;
 using UnityEngine.UIElements;
+using Velvet.TestUtilities;
 
 namespace Velvet.Tests.Performance
 {
@@ -80,7 +78,7 @@ namespace Velvet.Tests.Performance
             // strings would hand back the very same arrays and the class diff would exit at its
             // identity check. Draining the cache reproduces what a component that rebuilds its VNode
             // tree every render actually hands the reconciler.
-            V.ClearClassNameCacheForTesting();
+            ClassNameCacheTestAccess.ClearForTest();
             var repeat = BuildRows("red");
             _reconciler.Reconcile(_root, Array.Empty<VNode>(), mounted);
 
@@ -255,4 +253,3 @@ namespace Velvet.Tests.Performance
         }
     }
 }
-#endif

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/ParseClassNamesCacheTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/ParseClassNamesCacheTests.cs
@@ -1,6 +1,7 @@
 using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
+using Velvet.TestUtilities;
 
 namespace Velvet.Tests
 {
@@ -13,6 +14,7 @@ namespace Velvet.Tests
     /// <item>A cached array holds the space-split tokens of its key.</item>
     /// <item>When the cache reaches its size bound the next distinct key logs a warning and clears the cache,
     /// then caches the triggering key, so previously cached keys re-parse to fresh instances afterward.</item>
+    /// <item>Draining the cache makes an already-parsed string parse to a fresh array instance.</item>
     /// </list>
     /// Also specifies the contract of the <see cref="StyleClassNames"/> class-name builder
     /// (<see cref="StyleClassNames.Class"/> joins its parts with a single space, skips <c>null</c>/empty parts,
@@ -26,7 +28,8 @@ namespace Velvet.Tests
     /// </summary>
     /// <remarks>
     /// The cache is process-wide static, so <see cref="SetUp"/> drains it via
-    /// <c>V.ClearClassNameCacheForTesting()</c> to keep other fixtures' entries from pushing past the bound.
+    /// <see cref="ClassNameCacheTestAccess.ClearForTest"/> to keep other fixtures' entries from pushing past
+    /// the bound.
     /// </remarks>
     [TestFixture]
     internal sealed class ParseClassNamesCacheTests
@@ -34,7 +37,7 @@ namespace Velvet.Tests
         [SetUp]
         public void SetUp()
         {
-            V.ClearClassNameCacheForTesting();
+            ClassNameCacheTestAccess.ClearForTest();
         }
 
         #region Cache behavior
@@ -148,6 +151,24 @@ namespace Velvet.Tests
 
             // Assert
             Assert.That(firstAfterOverflow, Is.Not.SameAs(firstBeforeOverflow));
+        }
+
+        #endregion
+
+        #region Cache drain
+
+        [Test]
+        public void Given_ParsedString_When_CacheDrained_Then_SameStringReParsesToFreshInstance()
+        {
+            // Arrange
+            var beforeDrain = V.ParseClassNames("drain-probe drain-probe--active");
+
+            // Act
+            ClassNameCacheTestAccess.ClearForTest();
+            var afterDrain = V.ParseClassNames("drain-probe drain-probe--active");
+
+            // Assert
+            Assert.That(afterDrain, Is.Not.SameAs(beforeDrain));
         }
 
         #endregion

--- a/Packages/com.velvet.core/TestUtilities/ClassNameCacheTestAccess.cs
+++ b/Packages/com.velvet.core/TestUtilities/ClassNameCacheTestAccess.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections;
+using System.Reflection;
+
+namespace Velvet.TestUtilities
+{
+    /// <summary>
+    /// Drains <c>V</c>'s process-wide class-name parse cache. Reached by reflection because production types
+    /// carry no test-only members.
+    /// </summary>
+    public static class ClassNameCacheTestAccess
+    {
+        private const string CacheFieldName = "s_classNameCache";
+
+        /// <summary>
+        /// Empties the cache, so a string parsed before the call parses to a fresh array after it.
+        /// </summary>
+        /// <exception cref="MissingFieldException">
+        /// The cache field was renamed or removed. Throwing is the point: callers drain to keep their own
+        /// entries below the cache's size bound, or to push content-identical trees off the reference-identity
+        /// fast path, and a clear that quietly reached nothing would leave both asserting on the wrong state.
+        /// </exception>
+        public static void ClearForTest()
+        {
+            var field = typeof(V).GetField(CacheFieldName, BindingFlags.Static | BindingFlags.NonPublic);
+            if (field == null)
+            {
+                throw new MissingFieldException(typeof(V).FullName, CacheFieldName);
+            }
+            // The non-generic view avoids pinning the cache's value type, which is not what this reaches for.
+            ((IDictionary)field.GetValue(null)!).Clear();
+        }
+    }
+}

--- a/Packages/com.velvet.core/TestUtilities/ClassNameCacheTestAccess.cs.meta
+++ b/Packages/com.velvet.core/TestUtilities/ClassNameCacheTestAccess.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 88e1e151e9ab845b2ab31877203238d7


### PR DESCRIPTION
## What

`V.ClearClassNameCacheForTesting()` was a test-only member on `V`, the framework's primary factory surface. This repository's convention is that production types carry no `*ForTest` members — a test that needs private state reaches it by reflection from inside the test assembly.

It is replaced by `TestUtilities/ClassNameCacheTestAccess.ClearForTest()`, which reaches the private field by reflection and **throws when the field cannot be found**, matching how the other reflection-based helpers in that folder handle a renamed or removed member.

A correction to the issue as filed: the member was `internal`, and `InternalsVisibleTo` is granted only to Velvet's own test assemblies, `Velvet.Editor` and the code-gen assembly. A consumer never saw it. The pollution was real but internal-facing, so the argument for this change is the convention itself rather than the consumer-facing cost the issue claimed.

## Why the helper throws rather than degrading

The helper's whole correctness is "it reaches the same field". A version that silently does nothing when the field moves would be worse than the member it replaces, because the cache-bound assertions it exists to serve would start passing for the wrong reason.

Both failure modes are demonstrated:

| helper mutated to | result |
|---|---|
| wrong field name, throwing (what a rename looks like) | **20 failed** — `MissingFieldException` naming the field |
| wrong field name, returning quietly | **2 failed** — the cache-bound tests pass a stale instance where a fresh one is required |

The second is the interesting one: with no effective drain, a pre-existing bound assertion fails, which is exactly the cross-fixture interaction that made a full-suite run necessary rather than a filtered one.

## Also removed

`StyleManipulatorReconcileBenchmarks` carried a whole-file `#if UNITY_EDITOR` guard justified by the drain hook being editor-only. Reflection reads the field in players too, so both the guard and the comment explaining it are gone — leaving them would have left a false statement in the file.

## Verification

EditMode 3468 passed / 0 failed / 0 inconclusive / 3 pre-existing skips. PlayMode 121/121, including all four benchmark cases. Generators 292/292.

Not measured: removing the editor guard means that benchmark file now compiles for player targets, and neither this change nor CI builds a standalone player test runner. The reasoning is that the reflected field is not editor-guarded and the linker does not strip fields of a retained type, but it is reasoning rather than a measurement.

## Scope

Ten further `*ForTest` members remain on production types — seven on the node pool, two on the batch scheduler, one on the lane type. They are not touched here. The scheduler's pair is a documented API that `CLAUDE.md` names as the sanctioned EditMode flush, so removing it is a documentation change too, not a silent cleanup.

Closes #189