### PR TITLE
refactor(velvet): pass the time-sliced budget instead of reading a test-settable static

### DIFF
--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberLane.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberLane.cs
@@ -21,12 +21,6 @@ namespace Velvet
         // paused commit never runs UseLayoutEffect against a not-yet-attached UseRef.
         internal const double TimeSlicedBudgetMs = 5;
 
-        // Test-only override for the time-sliced budget. Negative means "no override" (production value).
-        // EditMode tests set this to a tiny value to force a deterministic pause after one node, because the
-        // real 5 ms budget rarely overruns on a small list and the UIToolkit scheduler does not advance in
-        // EditMode. Mirrors the existing test-controlled IsInDiscreteEvent static.
-        internal static double TimeSlicedBudgetOverrideForTest = -1;
-
         // The highest-priority pending lane on the fiber (lowest enum value wins); Transition when the
         // lane queue is empty. Shared by ScheduleRerender's escalation check.
         internal static FiberUpdatePriority GetHighestPendingPriority(ComponentFiber fiber)
@@ -45,17 +39,13 @@ namespace Velvet
         internal static bool SchedulesOnImmediateTier(FiberUpdatePriority priority)
             => priority is FiberUpdatePriority.Urgent or FiberUpdatePriority.Normal;
 
-        // Frame budget for a flush of priority. Transition and Deferred get the time-sliced
-        // budget so a large flat-list diff can pause/resume across frames; Urgent and Normal run synchronously
+        // Frame budget for a flush of priority. Transition and Deferred slice against timeSlicedBudgetMs so a
+        // large flat-list diff can pause/resume across frames; Urgent and Normal run synchronously
         // (user-input-driven updates are never interrupted). Only the reconciler fast path acts on
         // a non-zero budget — see TimeSlicedBudgetMs.
-        internal static double BudgetForLane(FiberUpdatePriority priority)
-        {
-            if (priority is not (FiberUpdatePriority.Transition or FiberUpdatePriority.Deferred))
-            {
-                return FrameBudgetMs;
-            }
-            return TimeSlicedBudgetOverrideForTest >= 0 ? TimeSlicedBudgetOverrideForTest : TimeSlicedBudgetMs;
-        }
+        internal static double BudgetForLane(FiberUpdatePriority priority, double timeSlicedBudgetMs)
+            => priority is FiberUpdatePriority.Transition or FiberUpdatePriority.Deferred
+                ? timeSlicedBudgetMs
+                : FrameBudgetMs;
     }
 }

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberWorkLoop.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberWorkLoop.cs
@@ -163,7 +163,12 @@ namespace Velvet
         // instead try-catches each effect individually and emits via Debug.LogException.
         // Returns immediately if the fiber is not mounted or not dirty.
         // fiber: Fiber whose pending lane updates should be flushed.
-        public static void FlushState(ComponentFiber fiber)
+        public static void FlushState(ComponentFiber fiber) => FlushState(fiber, FiberLane.TimeSlicedBudgetMs);
+
+        // The time-sliced budget travels on the call rather than being read from FiberLane, so a caller that
+        // needs one flush to park deterministically cannot leave that budget set for an unrelated later flush
+        // to inherit.
+        internal static void FlushState(ComponentFiber fiber, double timeSlicedBudgetMs)
         {
             if (!fiber.IsMounted) return;
             if (!fiber.IsDirty)
@@ -231,7 +236,7 @@ namespace Velvet
             if (fiber.LaneQueue.Count > 0)
             {
                 var flushingLane = fiber.LaneQueue.Min;
-                flushBudget = FiberLane.BudgetForLane(flushingLane);
+                flushBudget = FiberLane.BudgetForLane(flushingLane, timeSlicedBudgetMs);
                 // A non-empty read above means Lanes was already allocated (Queue is only ever populated
                 // through EnsureLanes()), so the backing field is safe to mutate directly here — the
                 // fiber.LaneQueue accessor itself only ever hands back a read-only copy of the mask.

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ReconcilerAbortSafetyTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ReconcilerAbortSafetyTests.cs
@@ -214,7 +214,6 @@ namespace Velvet.Tests
         [SetUp]
         public void SetUp()
         {
-            FiberLane.TimeSlicedBudgetOverrideForTest = -1;
             _root = new VisualElement();
             FiberPortalRegistry.Clear();
             s_fallbackShown = false;
@@ -229,7 +228,6 @@ namespace Velvet.Tests
         [TearDown]
         public void TearDown()
         {
-            FiberLane.TimeSlicedBudgetOverrideForTest = -1;
             FiberPortalRegistry.Clear();
         }
 
@@ -252,10 +250,9 @@ namespace Velvet.Tests
             // placeholder (enqueuing it) as the pass's very last entry — so that SAME tick's own top-level
             // finally (Reconciler.ContinueReconcile) is what drains it: the boundary catches the Portal
             // child's throw and calls SetAborted() on the shared context.
-            FiberLane.TimeSlicedBudgetOverrideForTest = 0.0001;
             s_portalAdded = true;
             s_listFiber.ScheduleRerenderForTest(FiberUpdatePriority.Transition);
-            FiberWorkLoop.FlushState(s_listFiber);
+            s_listFiber.FlushStateWithTinyBudgetForTest();
             Assume.That(s_listFiber.HasPendingReconcileWorkForTest(), Is.True,
                 "Precondition: the tiny budget parked the grow mid-commit");
             s_listFiber.DrainTimeSlicedReconcileForTest();
@@ -265,7 +262,6 @@ namespace Velvet.Tests
             // Act (2) — an unrelated fiber sharing the same mounted tree (and so the same ReconcilerContext)
             // re-renders normally, synchronously, well after the time-sliced pass above fully completed and
             // returned.
-            FiberLane.TimeSlicedBudgetOverrideForTest = -1;
             s_setCounterText.Invoke("updated");
             mounted.FlushStateForTest();
 
@@ -290,10 +286,9 @@ namespace Velvet.Tests
             // Act — the pass parks per-item under the tiny budget, so the brand-new trailing item (and the
             // keyed Fragment inside it) is expanded by a continuation tick, and that SAME tick's own
             // top-level completion is the only boundary this pass ever gets.
-            FiberLane.TimeSlicedBudgetOverrideForTest = 0.0001;
             s_keyedFragmentAdded = true;
             s_listFiber.ScheduleRerenderForTest(FiberUpdatePriority.Transition);
-            FiberWorkLoop.FlushState(s_listFiber);
+            s_listFiber.FlushStateWithTinyBudgetForTest();
             Assume.That(s_listFiber.HasPendingReconcileWorkForTest(), Is.True,
                 "Precondition: the tiny budget parked the grow mid-commit");
             s_listFiber.DrainTimeSlicedReconcileForTest();

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/TimeSlicedFiberTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/TimeSlicedFiberTests.cs
@@ -11,10 +11,11 @@ namespace Velvet.Tests
     /// cover the integration.
     /// <list type="bullet">
     /// <item><see cref="FiberLane.BudgetForLane"/> gives the Urgent and Normal lanes a zero budget (they run
-    /// synchronously and are never interrupted) and the Transition and Deferred lanes a non-zero time-sliced
-    /// budget so a large flat-list diff can pause.</item>
+    /// synchronously and are never interrupted) and hands the Transition and Deferred lanes the time-sliced
+    /// budget its caller supplied, so a large flat-list diff can pause.</item>
     /// <item>A Transition flush threads the time-sliced budget onto the fiber so the resume continues at the same
-    /// budget; a Normal flush runs synchronously with a zero budget and never parks.</item>
+    /// budget — including a budget a caller supplied in place of the default; a Normal flush runs synchronously
+    /// with a zero budget and never parks.</item>
     /// <item>A Transition flush over a large flat list parks mid-commit with only part of the new list committed,
     /// and the resume drains the remainder to completion.</item>
     /// <item>An immediate-tier flush no-ops while a reconcile is on the stack (the resume reentrancy guard) and
@@ -31,10 +32,9 @@ namespace Velvet.Tests
     /// </summary>
     /// <remarks>
     /// The UIToolkit scheduler does not advance in EditMode, so a parked slice is resumed manually via
-    /// <see cref="MountedTreeTestExtensions.DrainTimeSlicedReconcileForTest"/>, and a tiny budget is forced via
-    /// <see cref="FiberLane.TimeSlicedBudgetOverrideForTest"/> so a pause is deterministic regardless of host
-    /// speed. The override and the discrete-event flag are reset in <see cref="SetUp"/> and <see cref="TearDown"/>
-    /// so a forced budget never leaks into another test.
+    /// <see cref="MountedTreeTestExtensions.DrainTimeSlicedReconcileForTest"/>, and a pause is made deterministic
+    /// regardless of host speed by flushing through
+    /// <see cref="MountedTreeTestExtensions.FlushStateWithTinyBudgetForTest"/>.
     /// </remarks>
     [TestFixture]
     internal sealed class TimeSlicedFiberTests
@@ -45,7 +45,6 @@ namespace Velvet.Tests
         public void SetUp()
         {
             FiberWorkLoop.IsInDiscreteEvent = false;
-            FiberLane.TimeSlicedBudgetOverrideForTest = -1;
             _root = new VisualElement();
             ResetFlatList();
             ResetProbe();
@@ -57,7 +56,6 @@ namespace Velvet.Tests
         [TearDown]
         public void TearDown()
         {
-            FiberLane.TimeSlicedBudgetOverrideForTest = -1;
             FiberWorkLoop.IsInDiscreteEvent = false;
         }
 
@@ -66,10 +64,11 @@ namespace Velvet.Tests
         [Test]
         public void Given_UrgentAndNormalLanes_When_BudgetQueried_Then_AreSynchronous()
         {
-            // Act + Assert — Urgent and Normal are user-input-driven and run synchronously (zero budget)
+            // Act + Assert — Urgent and Normal are user-input-driven and run synchronously whatever time-sliced
+            // budget the flush carries
             Assert.That(
-                (FiberLane.BudgetForLane(FiberUpdatePriority.Urgent),
-                    FiberLane.BudgetForLane(FiberUpdatePriority.Normal)),
+                (FiberLane.BudgetForLane(FiberUpdatePriority.Urgent, ProbeTimeSlicedBudgetMs),
+                    FiberLane.BudgetForLane(FiberUpdatePriority.Normal, ProbeTimeSlicedBudgetMs)),
                 Is.EqualTo((0.0, 0.0)),
                 "The Urgent and Normal lanes run synchronously with a zero budget");
         }
@@ -77,13 +76,18 @@ namespace Velvet.Tests
         [Test]
         public void Given_TransitionAndDeferredLanes_When_BudgetQueried_Then_AreTimeSliced()
         {
-            // Act + Assert — Transition and Deferred get the non-zero time-sliced budget so a large diff can pause
+            // Act + Assert — Transition and Deferred slice against the budget the flush carries, so a large diff
+            // can pause
             Assert.That(
-                FiberLane.BudgetForLane(FiberUpdatePriority.Transition) > 0.0
-                    && FiberLane.BudgetForLane(FiberUpdatePriority.Deferred) > 0.0,
-                Is.True,
-                "The Transition and Deferred lanes get a non-zero time-sliced budget");
+                (FiberLane.BudgetForLane(FiberUpdatePriority.Transition, ProbeTimeSlicedBudgetMs),
+                    FiberLane.BudgetForLane(FiberUpdatePriority.Deferred, ProbeTimeSlicedBudgetMs)),
+                Is.EqualTo((ProbeTimeSlicedBudgetMs, ProbeTimeSlicedBudgetMs)),
+                "The Transition and Deferred lanes slice against the time-sliced budget the flush carries");
         }
+
+        // Distinct from both the synchronous budget (0) and the production default, so a routing that ignored
+        // its argument cannot coincide with the expected value.
+        private const double ProbeTimeSlicedBudgetMs = 7;
 
         #endregion
 
@@ -104,6 +108,26 @@ namespace Velvet.Tests
             // Assert
             Assert.That(fiber.PendingReconcileBudgetMs, Is.GreaterThan(0.0),
                 "A Transition flush threads the time-sliced budget so the resume continues at the same budget");
+        }
+
+        [Test]
+        public void Given_TransitionFlushUnderATinyBudget_When_Flushed_Then_ThreadsThatBudgetNotTheDefault()
+        {
+            // Arrange
+            s_flatListCount = 1;
+            using var mounted = V.Mount(_root, V.Component(FlatListRender, key: "list"));
+            var fiber = s_flatListFiber;
+
+            // Act
+            fiber.ScheduleRerenderForTest(FiberUpdatePriority.Transition);
+            fiber.FlushStateWithTinyBudgetForTest();
+
+            // Assert — every fixture that forces a park depends on this; without it those fixtures would run at
+            // the production budget, never park, and report Inconclusive on their park precondition rather than
+            // failing
+            Assert.That(fiber.PendingReconcileBudgetMs,
+                Is.EqualTo(MountedTreeTestExtensions.TinyTimeSlicedBudgetMs),
+                "A flush carries the caller's own time-sliced budget through to the fiber's resume budget");
         }
 
         [Test]
@@ -148,10 +172,9 @@ namespace Velvet.Tests
             var fiber = s_flatListFiber;
 
             // Act — a tiny budget forces a pause after one node so the park is deterministic in EditMode
-            FiberLane.TimeSlicedBudgetOverrideForTest = 0.0001;
             s_flatListCount = 40;
             fiber.ScheduleRerenderForTest(FiberUpdatePriority.Transition);
-            FiberWorkLoop.FlushState(fiber);
+            fiber.FlushStateWithTinyBudgetForTest();
 
             // Assert
             Assert.That((fiber.HasPendingReconcileWorkForTest(), _root.childCount < 40), Is.EqualTo((true, true)),
@@ -165,10 +188,9 @@ namespace Velvet.Tests
             s_flatListCount = 3;
             using var mounted = V.Mount(_root, V.Component(FlatListRender, key: "list"));
             var fiber = s_flatListFiber;
-            FiberLane.TimeSlicedBudgetOverrideForTest = 0.0001;
             s_flatListCount = 40;
             fiber.ScheduleRerenderForTest(FiberUpdatePriority.Transition);
-            FiberWorkLoop.FlushState(fiber);
+            fiber.FlushStateWithTinyBudgetForTest();
             Assume.That(fiber.HasPendingReconcileWorkForTest(), Is.True, "Precondition: the flush parked mid-commit");
 
             // Act
@@ -237,10 +259,9 @@ namespace Velvet.Tests
             s_refOrderingRefWasNullAtEffect = false;
 
             // Act
-            FiberLane.TimeSlicedBudgetOverrideForTest = 0.0001;
             s_refOrderingCount = 40;
             fiber.ScheduleRerenderForTest(FiberUpdatePriority.Transition);
-            FiberWorkLoop.FlushState(fiber);
+            fiber.FlushStateWithTinyBudgetForTest();
             Assume.That(fiber.HasPendingReconcileWorkForTest(), Is.True, "Precondition: the commit paused mid-flight");
 
             // Assert
@@ -257,10 +278,9 @@ namespace Velvet.Tests
             var fiber = s_refOrderingFiber;
             s_refOrderingEffectRan = false;
             s_refOrderingRefWasNullAtEffect = false;
-            FiberLane.TimeSlicedBudgetOverrideForTest = 0.0001;
             s_refOrderingCount = 40;
             fiber.ScheduleRerenderForTest(FiberUpdatePriority.Transition);
-            FiberWorkLoop.FlushState(fiber);
+            fiber.FlushStateWithTinyBudgetForTest();
             Assume.That(fiber.HasPendingReconcileWorkForTest(), Is.True, "Precondition: the commit paused mid-flight");
 
             // Act
@@ -285,14 +305,12 @@ namespace Velvet.Tests
             using var mounted = V.Mount(_root, V.Component(SiblingHostRender, key: "host"));
             var host = _root.Q(name: "sibling-host");
             Assume.That(host.childCount, Is.EqualTo(6), "Precondition: the initial mount is 3 (A) + 3 (B)");
-            FiberLane.TimeSlicedBudgetOverrideForTest = 0.0001;
             s_siblingBCount = 30;
             s_siblingBFiber.ScheduleRerenderForTest(FiberUpdatePriority.Transition);
-            FiberWorkLoop.FlushState(s_siblingBFiber);
+            s_siblingBFiber.FlushStateWithTinyBudgetForTest();
             Assume.That(s_siblingBFiber.HasPendingReconcileWorkForTest(), Is.True, "Precondition: B parks at A's slot count");
 
             // Act — A grows by 2 synchronously (Normal lane), which must re-base parked B's captured slotStart
-            FiberLane.TimeSlicedBudgetOverrideForTest = -1;
             s_siblingACount = 5;
             s_siblingAFiber.ScheduleRerenderForTest(FiberUpdatePriority.Normal);
             FiberWorkLoop.FlushState(s_siblingAFiber);
@@ -312,14 +330,12 @@ namespace Velvet.Tests
             using var mounted = V.Mount(_root, V.Component(SiblingHostRender, key: "host"));
             var host = _root.Q(name: "sibling-host");
             Assume.That(host.childCount, Is.EqualTo(8), "Precondition: the initial mount is 5 (A) + 3 (B)");
-            FiberLane.TimeSlicedBudgetOverrideForTest = 0.0001;
             s_siblingBCount = 30;
             s_siblingBFiber.ScheduleRerenderForTest(FiberUpdatePriority.Transition);
-            FiberWorkLoop.FlushState(s_siblingBFiber);
+            s_siblingBFiber.FlushStateWithTinyBudgetForTest();
             Assume.That(s_siblingBFiber.HasPendingReconcileWorkForTest(), Is.True, "Precondition: B parks at slotStart = 5");
 
             // Act — A shrinks 5 -> 2 synchronously, so B's parked slotStart must re-base by -3
-            FiberLane.TimeSlicedBudgetOverrideForTest = -1;
             s_siblingACount = 2;
             s_siblingAFiber.ScheduleRerenderForTest(FiberUpdatePriority.Normal);
             FiberWorkLoop.FlushState(s_siblingAFiber);
@@ -341,18 +357,16 @@ namespace Velvet.Tests
             using var mounted = V.Mount(_root, V.Component(ThreeSiblingHostRender, key: "host"));
             var host = _root.Q(name: "three-sibling-host");
             Assume.That(host.childCount, Is.EqualTo(42), "Precondition: the initial mount is 2 (A) + 20 (B) + 20 (C)");
-            FiberLane.TimeSlicedBudgetOverrideForTest = 0.0001;
             s_siblingBReversed = true;
             s_siblingBFiber.ScheduleRerenderForTest(FiberUpdatePriority.Transition);
-            FiberWorkLoop.FlushState(s_siblingBFiber);
+            s_siblingBFiber.FlushStateWithTinyBudgetForTest();
             Assume.That(s_siblingBFiber.HasPendingReconcileWorkForTest(), Is.True, "Precondition: B parks");
             s_siblingCReversed = true;
             s_siblingCFiber.ScheduleRerenderForTest(FiberUpdatePriority.Transition);
-            FiberWorkLoop.FlushState(s_siblingCFiber);
+            s_siblingCFiber.FlushStateWithTinyBudgetForTest();
             Assume.That(s_siblingCFiber.HasPendingReconcileWorkForTest(), Is.True, "Precondition: C parks");
 
             // Act — A grows 2 -> 4 synchronously while both B and C are parked
-            FiberLane.TimeSlicedBudgetOverrideForTest = -1;
             s_siblingACount = 4;
             s_siblingAFiber.ScheduleRerenderForTest(FiberUpdatePriority.Normal);
             FiberWorkLoop.FlushState(s_siblingAFiber);
@@ -377,16 +391,14 @@ namespace Velvet.Tests
             using var mounted = V.Mount(_root, V.Component(ThreeSiblingHostRender, key: "host"));
             var host = _root.Q(name: "three-sibling-host");
             Assume.That(host.childCount, Is.EqualTo(42), "Precondition: the initial mount is 2 (A) + 20 (B) + 20 (C)");
-            FiberLane.TimeSlicedBudgetOverrideForTest = 0.0001;
             s_siblingBCount = 30;
             s_siblingBFiber.ScheduleRerenderForTest(FiberUpdatePriority.Transition);
-            FiberWorkLoop.FlushState(s_siblingBFiber);
+            s_siblingBFiber.FlushStateWithTinyBudgetForTest();
             Assume.That(s_siblingBFiber.HasPendingReconcileWorkForTest(), Is.True, "Precondition: B parks mid-commit");
 
             // Act — A grows 2 -> 5 synchronously; B's parked SlotLimit (= C's MountSlotStart) must re-base by +3
             // too, or the resumed Common-phase seam check rejects B's own trailing rows as out-of-range and
             // re-creates them at the C boundary instead of patching them in place.
-            FiberLane.TimeSlicedBudgetOverrideForTest = -1;
             s_siblingACount = 5;
             s_siblingAFiber.ScheduleRerenderForTest(FiberUpdatePriority.Normal);
             FiberWorkLoop.FlushState(s_siblingAFiber);
@@ -408,17 +420,16 @@ namespace Velvet.Tests
             using var mounted = V.Mount(_root, V.Component(SiblingHostRender, key: "host"));
             var host = _root.Q(name: "sibling-host");
             Assume.That(host.childCount, Is.EqualTo(5), "Precondition: the initial mount is 2 (A) + 3 (B)");
-            FiberLane.TimeSlicedBudgetOverrideForTest = 0.0001;
             s_siblingBCount = 30;
             s_siblingBFiber.ScheduleRerenderForTest(FiberUpdatePriority.Transition);
-            FiberWorkLoop.FlushState(s_siblingBFiber);
+            s_siblingBFiber.FlushStateWithTinyBudgetForTest();
             Assume.That(s_siblingBFiber.HasPendingReconcileWorkForTest(), Is.True, "Precondition: B parks at A's original slot count");
 
             // Act — A grows 2 -> 25 on the Transition lane so A itself parks and commits its +23 delta across
             // several slices; driving A to completion exercises both the partial and incremental propagation paths
             s_siblingACount = 25;
             s_siblingAFiber.ScheduleRerenderForTest(FiberUpdatePriority.Transition);
-            FiberWorkLoop.FlushState(s_siblingAFiber);
+            s_siblingAFiber.FlushStateWithTinyBudgetForTest();
             Assume.That(s_siblingAFiber.HasPendingReconcileWorkForTest(), Is.True, "Precondition: A itself parks");
             s_siblingAFiber.DrainTimeSlicedReconcileForTest();
             s_siblingBFiber.DrainTimeSlicedReconcileForTest();
@@ -438,16 +449,14 @@ namespace Velvet.Tests
             using var mounted = V.Mount(_root, V.Component(SiblingHostRender, key: "host"));
             var host = _root.Q(name: "sibling-host");
             Assume.That(host.childCount, Is.EqualTo(5), "Precondition: the initial mount is 2 (A) + 3 (B)");
-            FiberLane.TimeSlicedBudgetOverrideForTest = 0.0001;
             s_siblingACount = 20;
             s_siblingAFiber.ScheduleRerenderForTest(FiberUpdatePriority.Transition);
-            FiberWorkLoop.FlushState(s_siblingAFiber);
+            s_siblingAFiber.FlushStateWithTinyBudgetForTest();
             Assume.That(s_siblingAFiber.HasPendingReconcileWorkForTest(), Is.True, "Precondition: A parked mid-grow");
 
             // Act — A re-renders AGAIN (Normal lane) while still parked. RenderAndReconcile force-drains the parked
             // grow before the new render; the drain's child-count delta must propagate to B (else B's MountSlotStart
             // is stale and its rows land inside A's grown prefix).
-            FiberLane.TimeSlicedBudgetOverrideForTest = -1;
             s_siblingACount = 25;
             s_siblingAFiber.ScheduleRerenderForTest(FiberUpdatePriority.Normal);
             FiberWorkLoop.FlushState(s_siblingAFiber);
@@ -472,14 +481,12 @@ namespace Velvet.Tests
             Assume.That(host.childCount, Is.EqualTo(4), "Precondition: Outer div (1) + B (3)");
             var innerDiv = host.Q(name: "inner-div");
             Assume.That(innerDiv.childCount, Is.EqualTo(2), "Precondition: the inner div holds 2 leaves");
-            FiberLane.TimeSlicedBudgetOverrideForTest = 0.0001;
             s_siblingBCount = 30;
             s_siblingBFiber.ScheduleRerenderForTest(FiberUpdatePriority.Transition);
-            FiberWorkLoop.FlushState(s_siblingBFiber);
+            s_siblingBFiber.FlushStateWithTinyBudgetForTest();
             Assume.That(s_siblingBFiber.HasPendingReconcileWorkForTest(), Is.True, "Precondition: B parks at slotStart = 1");
 
             // Act — the inner grows synchronously; the host-level child count (the div itself) is unchanged
-            FiberLane.TimeSlicedBudgetOverrideForTest = -1;
             s_nestedInnerCount = 6;
             s_nestedInnerFiber.ScheduleRerenderForTest(FiberUpdatePriority.Normal);
             FiberWorkLoop.FlushState(s_nestedInnerFiber);
@@ -513,10 +520,9 @@ namespace Velvet.Tests
 
             // Act — re-render to sorted order on the Transition lane under a tiny budget so the keyed reorder parks
             // mid-pass, then drain every parked slice to completion.
-            FiberLane.TimeSlicedBudgetOverrideForTest = 0.0001;
             s_rotationSorted = true;
             fiber.ScheduleRerenderForTest(FiberUpdatePriority.Transition);
-            FiberWorkLoop.FlushState(fiber);
+            fiber.FlushStateWithTinyBudgetForTest();
             fiber.DrainTimeSlicedReconcileForTest();
 
             // Assert — every leaf sits at its sorted slot; the time-sliced reorder must not transpose any pair.

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/TimeSlicedReconcilerTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/TimeSlicedReconcilerTests.cs
@@ -763,10 +763,10 @@ namespace Velvet.Tests
     /// Registry-form <c>V.Portal(targetId:)</c> is used throughout: its target resolves at CREATE time, and its
     /// drain-time resolution falls through to the exact same nested-Reconcile call as the layer
     /// (<c>V.Portal(layer:)</c>) and <c>V.WorldSpace</c> arms once the target is known, so this one form
-    /// exercises the shared fix for all three. The tiny <see cref="FiberLane.TimeSlicedBudgetOverrideForTest"/>
-    /// forces a deterministic pause after one node (the UIToolkit scheduler does not advance in EditMode), and a
-    /// parked slice is driven to completion manually via
-    /// <see cref="MountedTreeTestExtensions.DrainTimeSlicedReconcileForTest"/>.
+    /// exercises the shared fix for all three.
+    /// <see cref="MountedTreeTestExtensions.FlushStateWithTinyBudgetForTest"/> forces a deterministic pause after
+    /// one node (the UIToolkit scheduler does not advance in EditMode), and a parked slice is driven to
+    /// completion manually via <see cref="MountedTreeTestExtensions.DrainTimeSlicedReconcileForTest"/>.
     /// </remarks>
     [TestFixture]
     internal sealed class TimeSlicedPortalDrainParkTests
@@ -777,7 +777,6 @@ namespace Velvet.Tests
         public void SetUp()
         {
             FiberWorkLoop.IsInDiscreteEvent = false;
-            FiberLane.TimeSlicedBudgetOverrideForTest = -1;
             _root = new VisualElement();
             FiberPortalRegistry.Clear();
             ResetIndexedList();
@@ -787,7 +786,6 @@ namespace Velvet.Tests
         [TearDown]
         public void TearDown()
         {
-            FiberLane.TimeSlicedBudgetOverrideForTest = -1;
             FiberWorkLoop.IsInDiscreteEvent = false;
             FiberPortalRegistry.Clear();
         }
@@ -807,10 +805,9 @@ namespace Velvet.Tests
             // (the Portal) both enqueues the deferred mount AND exhausts the budget, so this SAME FlushState call
             // parks with the Portal still queued — its own top-level finally (Reconciler.Reconcile) drains that
             // queue before FlushState returns, re-entering ChildReconciler.Reconcile on this fiber's own instance.
-            FiberLane.TimeSlicedBudgetOverrideForTest = 0.0001;
             s_indexedTotalCount = 41;
             fiber.ScheduleRerenderForTest(FiberUpdatePriority.Transition);
-            FiberWorkLoop.FlushState(fiber);
+            fiber.FlushStateWithTinyBudgetForTest();
             fiber.DrainTimeSlicedReconcileForTest();
 
             // Assert — RED without the fix: the same-pass drain's nested Reconcile call wipes PendingIndexedState
@@ -832,10 +829,9 @@ namespace Velvet.Tests
             Assume.That(_root.childCount, Is.EqualTo(0), "Precondition: the initial mount renders no rows");
 
             // Act — same tiny-budget grow as the unkeyed case, on the keyed path.
-            FiberLane.TimeSlicedBudgetOverrideForTest = 0.0001;
             s_keyedTotalCount = 41;
             fiber.ScheduleRerenderForTest(FiberUpdatePriority.Transition);
-            FiberWorkLoop.FlushState(fiber);
+            fiber.FlushStateWithTinyBudgetForTest();
             fiber.DrainTimeSlicedReconcileForTest();
 
             // Assert — RED without the fix: DiscardPendingKeyedState (invoked by the same entry-clear) also

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ZIndexStackingTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ZIndexStackingTests.cs
@@ -57,9 +57,6 @@ namespace Velvet.Tests
         [SetUp]
         public void SetUp()
         {
-            // Defensive reset (mirrors TimeSlicedFiberTests' own SetUp/TearDown pair) so a tiny budget forced
-            // by an earlier failing test can never leak into this one.
-            FiberLane.TimeSlicedBudgetOverrideForTest = -1;
             s_churnStore = null;
             s_reuseStore = null;
             s_teardownStore = null;
@@ -87,12 +84,6 @@ namespace Velvet.Tests
             s_crossParkKeyedBFiber = null;
             s_drainZManaged = false;
             s_drainFiber = null;
-        }
-
-        [TearDown]
-        public void TearDown()
-        {
-            FiberLane.TimeSlicedBudgetOverrideForTest = -1;
         }
 
         // Finds the front (z >= 0) or back (negative z) layer container directly under parent, or null when
@@ -748,13 +739,11 @@ namespace Velvet.Tests
             // the tiny budget parks immediately after — all within this ONE top-level Reconcile() call, whose
             // own finally-drain then creates the FIRST back container, physically shifting every trailing item
             // (and item0's own placeholder) by +1.
-            FiberLane.TimeSlicedBudgetOverrideForTest = 0.0001;
             s_zParkZManaged = true;
             s_zParkFiber.ScheduleRerenderForTest(FiberUpdatePriority.Transition);
-            FiberWorkLoop.FlushState(s_zParkFiber);
+            s_zParkFiber.FlushStateWithTinyBudgetForTest();
             Assume.That(s_zParkFiber.HasPendingReconcileWorkForTest(), Is.True,
                 "Precondition: the tiny budget parked the pass right after item0's own iteration");
-            FiberLane.TimeSlicedBudgetOverrideForTest = -1;
             s_zParkFiber.DrainTimeSlicedReconcileForTest();
 
             // Assert — every trailing item resumed and patched at its correct (post-shift) physical index.
@@ -767,8 +756,8 @@ namespace Velvet.Tests
         [Test]
         public void Given_ATimeSlicedPassParksRightAfterTheLastBackContainerMemberLeaves_When_TheSameFinallyDrainRemovesTheContainer_Then_TheParkedSlotStartIsRebasedSoTrailingItemsResumeAtCorrectIndices()
         {
-            // Arrange — mount with item0 ALREADY z-managed (synchronous: budget=0 at mount regardless of the
-            // override, which is only ever set below), so the back container exists cleanly beforehand.
+            // Arrange — mount with item0 ALREADY z-managed (synchronous: the mount runs on a zero budget, which
+            // the tiny-budget flush below does not reach), so the back container exists cleanly beforehand.
             s_zParkZManaged = true;
             var root = new VisualElement();
             using var mounted = V.Mount(root, V.Component(ZParkHost, key: "root"));
@@ -780,13 +769,11 @@ namespace Velvet.Tests
             // container for a teardown check, then the tiny budget parks immediately after — all within this
             // ONE top-level Reconcile() call, whose own finally-drain then REMOVES the now-empty back
             // container, physically shifting every trailing item back by -1.
-            FiberLane.TimeSlicedBudgetOverrideForTest = 0.0001;
             s_zParkZManaged = false;
             s_zParkFiber.ScheduleRerenderForTest(FiberUpdatePriority.Transition);
-            FiberWorkLoop.FlushState(s_zParkFiber);
+            s_zParkFiber.FlushStateWithTinyBudgetForTest();
             Assume.That(s_zParkFiber.HasPendingReconcileWorkForTest(), Is.True,
                 "Precondition: the tiny budget parked the pass right after item0's own iteration");
-            FiberLane.TimeSlicedBudgetOverrideForTest = -1;
             s_zParkFiber.DrainTimeSlicedReconcileForTest();
 
             // Assert — mirrors the creation-direction test above, in the opposite (-1) direction: every trailing
@@ -985,10 +972,9 @@ namespace Velvet.Tests
             // Act — A re-renders under a tiny Transition budget and parks mid-commit; the pass is left
             // parked (registered in ParkedBaselineFibers) here, deliberately NOT drained yet, while B's
             // own render below runs.
-            FiberLane.TimeSlicedBudgetOverrideForTest = 0.0001;
             s_crossParkACount = 60;
             s_crossParkAFiber.ScheduleRerenderForTest(FiberUpdatePriority.Transition);
-            FiberWorkLoop.FlushState(s_crossParkAFiber);
+            s_crossParkAFiber.FlushStateWithTinyBudgetForTest();
             Assume.That(s_crossParkAFiber.HasPendingReconcileWorkForTest(), Is.True,
                 "Precondition: A's own tiny-budget pass parked mid-commit");
             Assume.That(ctx.ParkedBaselineFibers.Contains(s_crossParkAFiber), Is.True,
@@ -999,7 +985,6 @@ namespace Velvet.Tests
             // container while A is STILL parked. RebaseParkedSlotsForContainerChange's ParkedBaselineFibers
             // loop — not A's own self-park rebase, which only ever fires from A's OWN drain — must be what
             // rebases A here.
-            FiberLane.TimeSlicedBudgetOverrideForTest = -1;
             s_crossParkBZManaged = true;
             s_crossParkBFiber.ScheduleRerenderForTest(FiberUpdatePriority.Normal);
             FiberWorkLoop.FlushState(s_crossParkBFiber);
@@ -1039,10 +1024,9 @@ namespace Velvet.Tests
             // Act — A re-renders under a tiny Transition budget and parks mid-commit; the pass is left
             // parked (registered in ParkedBaselineFibers) here, deliberately NOT drained yet, while B's
             // own render below runs.
-            FiberLane.TimeSlicedBudgetOverrideForTest = 0.0001;
             s_crossParkACount = 60;
             s_crossParkAFiber.ScheduleRerenderForTest(FiberUpdatePriority.Transition);
-            FiberWorkLoop.FlushState(s_crossParkAFiber);
+            s_crossParkAFiber.FlushStateWithTinyBudgetForTest();
             Assume.That(s_crossParkAFiber.HasPendingReconcileWorkForTest(), Is.True,
                 "Precondition: A's own tiny-budget pass parked mid-commit");
             Assume.That(ctx.ParkedBaselineFibers.Contains(s_crossParkAFiber), Is.True,
@@ -1052,7 +1036,6 @@ namespace Velvet.Tests
             // ordinary: the shared host's ONLY back-container member leaves, so B's own top-level drain
             // REMOVES the now-empty container while A is STILL parked — the teardown-direction
             // counterpart of the creation test above.
-            FiberLane.TimeSlicedBudgetOverrideForTest = -1;
             s_crossParkBZManaged = false;
             s_crossParkBFiber.ScheduleRerenderForTest(FiberUpdatePriority.Normal);
             FiberWorkLoop.FlushState(s_crossParkBFiber);
@@ -1136,10 +1119,9 @@ namespace Velvet.Tests
             // Act — A re-renders under a tiny Transition budget and parks mid-commit; the pass is left
             // parked (registered in ParkedBaselineFibers) here, deliberately NOT drained yet, while B's
             // own render below runs.
-            FiberLane.TimeSlicedBudgetOverrideForTest = 0.0001;
             s_crossParkKeyedACount = 60;
             s_crossParkKeyedAFiber.ScheduleRerenderForTest(FiberUpdatePriority.Transition);
-            FiberWorkLoop.FlushState(s_crossParkKeyedAFiber);
+            s_crossParkKeyedAFiber.FlushStateWithTinyBudgetForTest();
             Assume.That(s_crossParkKeyedAFiber.HasPendingReconcileWorkForTest(), Is.True,
                 "Precondition: A's own tiny-budget pass parked mid-commit");
             Assume.That(ctx.ParkedBaselineFibers.Contains(s_crossParkKeyedAFiber), Is.True,
@@ -1148,7 +1130,6 @@ namespace Velvet.Tests
             // Act — B re-renders synchronously (Normal lane), turning its own first item z-managed: the
             // shared host's FIRST negative-z child ever, so B's own top-level drain creates the back
             // container while A is STILL parked.
-            FiberLane.TimeSlicedBudgetOverrideForTest = -1;
             s_crossParkKeyedBZManaged = true;
             s_crossParkKeyedBFiber.ScheduleRerenderForTest(FiberUpdatePriority.Normal);
             FiberWorkLoop.FlushState(s_crossParkKeyedBFiber);
@@ -1183,10 +1164,9 @@ namespace Velvet.Tests
 
             // Act — A re-renders under a tiny Transition budget and parks mid-commit; left parked while
             // B's own render below runs.
-            FiberLane.TimeSlicedBudgetOverrideForTest = 0.0001;
             s_crossParkKeyedACount = 60;
             s_crossParkKeyedAFiber.ScheduleRerenderForTest(FiberUpdatePriority.Transition);
-            FiberWorkLoop.FlushState(s_crossParkKeyedAFiber);
+            s_crossParkKeyedAFiber.FlushStateWithTinyBudgetForTest();
             Assume.That(s_crossParkKeyedAFiber.HasPendingReconcileWorkForTest(), Is.True,
                 "Precondition: A's own tiny-budget pass parked mid-commit");
             Assume.That(ctx.ParkedBaselineFibers.Contains(s_crossParkKeyedAFiber), Is.True,
@@ -1195,7 +1175,6 @@ namespace Velvet.Tests
             // Act — B re-renders synchronously (Normal lane), flipping its own first item back to
             // ordinary: the shared host's ONLY back-container member leaves, so B's own top-level drain
             // REMOVES the now-empty container while A is STILL parked.
-            FiberLane.TimeSlicedBudgetOverrideForTest = -1;
             s_crossParkKeyedBZManaged = false;
             s_crossParkKeyedBFiber.ScheduleRerenderForTest(FiberUpdatePriority.Normal);
             FiberWorkLoop.FlushState(s_crossParkKeyedBFiber);
@@ -1247,13 +1226,11 @@ namespace Velvet.Tests
             // its deferred z-mount enqueue, since no back container exists yet) runs entirely inside a
             // RESUMED slice, never inside the one Reconciler.Reconcile call whose own top-level finally
             // already drains.
-            FiberLane.TimeSlicedBudgetOverrideForTest = 0.0001;
             s_drainZManaged = true;
             s_drainFiber.ScheduleRerenderForTest(FiberUpdatePriority.Transition);
-            FiberWorkLoop.FlushState(s_drainFiber);
+            s_drainFiber.FlushStateWithTinyBudgetForTest();
             Assume.That(s_drainFiber.HasPendingReconcileWorkForTest(), Is.True,
                 "Precondition: the tiny budget parked the pass right after item0's own iteration");
-            FiberLane.TimeSlicedBudgetOverrideForTest = -1;
             s_drainFiber.DrainTimeSlicedReconcileForTest();
 
             // Assert — RED without draining at a resumed slice's own completion: nothing ever creates the
@@ -1281,18 +1258,16 @@ namespace Velvet.Tests
 
             // Act — tick 1 (via FlushState): item0 parks first, which is what registers the fiber in
             // ParkedBaselineFibers BEFORE its own later container-creating tick runs.
-            FiberLane.TimeSlicedBudgetOverrideForTest = 0.0001;
             s_drainZManaged = true;
             s_drainFiber.ScheduleRerenderForTest(FiberUpdatePriority.Transition);
-            FiberWorkLoop.FlushState(s_drainFiber);
+            s_drainFiber.FlushStateWithTinyBudgetForTest();
             Assume.That(s_drainFiber.HasPendingReconcileWorkForTest(), Is.True,
                 "Precondition: the tiny budget parked the pass right after item0's own iteration");
             Assume.That(ctx.ParkedBaselineFibers.Contains(s_drainFiber), Is.True,
                 "Precondition: the fiber is registered as a parked baseline before its own container-creating tick");
 
-            // Act — tick 2 (a single manual resume; the budget stays deliberately tiny THROUGH this tick —
-            // reset only below, after it, unlike the drain test above's own immediate reset): processes
-            // item1, creating the shared parent's first back container INSIDE this same tick's own drain,
+            // Act — tick 2 (a single manual resume, which continues at the tiny budget tick 1 captured on the
+            // fiber): processes item1, creating the shared parent's first back container INSIDE this tick's drain,
             // then re-parks immediately after (item2..item9 remain) — so the fiber is STILL registered in
             // ParkedBaselineFibers at the exact moment RebaseParkedSlotsForContainerChange runs, alongside
             // its own current.RebasePendingSlotStartIfTargeting call on the very same PendingIndexedState.
@@ -1302,9 +1277,8 @@ namespace Velvet.Tests
             Assume.That(s_drainFiber.HasPendingReconcileWorkForTest(), Is.True,
                 "Precondition: the same tick re-parked (item2..item9 still pending) while still registered");
 
-            // Act — drain the remainder; the remaining ticks' own budget has no bearing on the double-rebase
-            // this test targets, which is already fully determined by tick 2 above.
-            FiberLane.TimeSlicedBudgetOverrideForTest = -1;
+            // Act — drain the remainder; the double-rebase this test targets is already fully determined by
+            // tick 2 above.
             s_drainFiber.DrainTimeSlicedReconcileForTest();
 
             // Assert — RED without the fix: the container-creating tick's own +1 delta is applied twice to

--- a/Packages/com.velvet.core/TestUtilities/MountedTreeTestExtensions.cs
+++ b/Packages/com.velvet.core/TestUtilities/MountedTreeTestExtensions.cs
@@ -50,6 +50,24 @@ namespace Velvet.TestUtilities
             FiberWorkLoop.ScheduleRerender(fiber, priority);
         }
 
+        // Small enough that the very first budget check of a reconcile pass already reads over it. Internal so a
+        // fixture can pin that this exact value — not the production default — is what a flush threaded.
+        internal const double TinyTimeSlicedBudgetMs = 0.0001;
+
+        /// <summary>
+        /// Flushes <paramref name="fiber"/>'s highest pending lane with a time-sliced budget too small to admit
+        /// a single node, so a Transition / Deferred flush parks after its first iteration regardless of host
+        /// speed — the real budget rarely overruns on a list small enough for a test to build, and the UIToolkit
+        /// scheduler does not advance in EditMode. The budget travels on this one call: it is captured on the
+        /// fiber as the resume budget (so <see cref="DrainTimeSlicedReconcileForTest"/> continues at the same
+        /// tiny budget) and is invisible to every other fiber's flush.
+        /// Test-only. Must not be used from production code.
+        /// </summary>
+        public static void FlushStateWithTinyBudgetForTest(this ComponentFiber fiber)
+        {
+            FiberWorkLoop.FlushState(fiber, TinyTimeSlicedBudgetMs);
+        }
+
         /// <summary>
         /// True while a time-sliced reconcile started by <paramref name="fiber"/> is paused with work still
         /// pending (the fast-path diff exceeded its frame budget and parked). Test-only.


### PR DESCRIPTION
## What

`FiberLane.TimeSlicedBudgetOverrideForTest` was not a hook a test called — it was a mutable static that production read on every scheduling decision:

```csharp
return TimeSlicedBudgetOverrideForTest >= 0 ? TimeSlicedBudgetOverrideForTest : TimeSlicedBudgetMs;
```

Two consequences, different in kind from an ordinary test-only member. It **leaked silently**: 47 assignment sites restored by hand in teardown, so a test that threw before restoring re-timed every later flush in the run, and nothing reported it. And it **shipped**: the field and the comparison were in the player build.

`BudgetForLane` now takes the budget as a parameter. The work loop supplies it, with a one-line forwarder passing the single default. The value lives on the stack for one flush; the resume budget was already captured on the fiber, so the continue path needed no arrangement.

Tests reach it through one `TestUtilities` helper. All 47 assignment sites collapsed to 26 flush calls, and every teardown reset vanished with the mechanism rather than being left as a dead assignment.

## Why a parameter rather than the alternatives

A **disposable scope** restoring the static on throw fixes the leak only — the static and the branch still ship. **Reflection**, the shape used for the class-name cache, removes the accessor but leaves the field and its comparison in the player build; that helper hides state production owns for its own reasons, whereas this state existed only for tests. A **conditional-compilation guard** keeps the leak in the editor, which is exactly where the tests run. A **field on the reconciler context** was the serious contender — per-mounted-tree, so it cannot outlive its mount — but it still ships a mutable field nothing in production writes, and a parameter leaves no state to be left set at all.

## Verification

Neutered two ways, exercising different code paths:

| neuter | result |
|---|---|
| the injection silently stops applying | 3 failed, incl. `Expected: 0.0001d But was: 5.0d` |
| time-slicing disabled outright | 4 failed, adding the fully-synchronous path |

A new test fails with the diagnosis rather than a symptom — that a flush carries the caller's own budget through to the fiber's resume budget — because the conversion's own failure mode is "the injection stops being applied", and every other test in the cluster reports that as a parked-or-not symptom.

EditMode 3469 passed / 0 failed / 0 inconclusive / 3 pre-existing skips. PlayMode 121/121. Generators 292/292.

## Docs and CHANGELOG

No guide mentions time-slicing, frame budgets or lanes. Two fixture remarks that named the removed field now name the helper.

No CHANGELOG entry: both types are internal, and the player build losing a dead field and a never-taken branch is not user-visible behaviour.

## Also

`FiberLane`'s comment claimed the override "mirrors the existing test-controlled `IsInDiscreteEvent` static". That static is production-controlled — a scope type sets and restores it around every discrete handler — so the comment invited the reader to treat it as another test knob. It went with the field.

Closes #191