### PR TITLE
test(velvet): fold the park preconditions into the time-slicing assertions

### DIFF
--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ReconcilerAbortSafetyTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ReconcilerAbortSafetyTests.cs
@@ -253,8 +253,7 @@ namespace Velvet.Tests
             s_portalAdded = true;
             s_listFiber.ScheduleRerenderForTest(FiberUpdatePriority.Transition);
             s_listFiber.FlushStateWithTinyBudgetForTest();
-            Assume.That(s_listFiber.HasPendingReconcileWorkForTest(), Is.True,
-                "Precondition: the tiny budget parked the grow mid-commit");
+            var parkedMidCommit = s_listFiber.HasPendingReconcileWorkForTest();
             s_listFiber.DrainTimeSlicedReconcileForTest();
             Assume.That(s_fallbackShown, Is.True,
                 "Precondition: the Portal's error boundary actually caught the throw");
@@ -268,7 +267,7 @@ namespace Velvet.Tests
             // Assert — RED without the fix: a stale IsAborted left over from the Portal drain makes
             // ChildReconciler.Reconcile's entry guard silently no-op this fiber's entire reconcile, leaving
             // the old text in place instead of committing the update.
-            Assert.That(_root.Q<Label>("counter-label").text, Is.EqualTo("updated"));
+            Assert.That((parkedMidCommit, _root.Q<Label>("counter-label").text), Is.EqualTo((true, "updated")));
         }
 
         [Test]
@@ -289,8 +288,7 @@ namespace Velvet.Tests
             s_keyedFragmentAdded = true;
             s_listFiber.ScheduleRerenderForTest(FiberUpdatePriority.Transition);
             s_listFiber.FlushStateWithTinyBudgetForTest();
-            Assume.That(s_listFiber.HasPendingReconcileWorkForTest(), Is.True,
-                "Precondition: the tiny budget parked the grow mid-commit");
+            var parkedMidCommit = s_listFiber.HasPendingReconcileWorkForTest();
             s_listFiber.DrainTimeSlicedReconcileForTest();
             Assume.That(_root.Q<Label>("keyed-fragment-leaf"), Is.Not.Null,
                 "Precondition: the keyed Fragment's subtree really was expanded and committed");
@@ -298,7 +296,7 @@ namespace Velvet.Tests
             // Assert — RED without the continuation boundary clearing the table: the entries registered by
             // the resumed slice's expansion outlive the pass on the shared context (nothing else runs), so
             // the count stays nonzero here instead of resetting at the pass's genuine end.
-            Assert.That(ctx.EffectiveKeys.Count, Is.EqualTo(0));
+            Assert.That((parkedMidCommit, ctx.EffectiveKeys.Count), Is.EqualTo((true, 0)));
         }
 
         [Component]

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/TimeSlicedFiberTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/TimeSlicedFiberTests.cs
@@ -123,8 +123,8 @@ namespace Velvet.Tests
             fiber.FlushStateWithTinyBudgetForTest();
 
             // Assert — every fixture that forces a park depends on this; without it those fixtures would run at
-            // the production budget, never park, and report Inconclusive on their park precondition rather than
-            // failing
+            // the production budget and never park, which is why each of them compares its parked state inside
+            // its own assertion rather than gating on it
             Assert.That(fiber.PendingReconcileBudgetMs,
                 Is.EqualTo(MountedTreeTestExtensions.TinyTimeSlicedBudgetMs),
                 "A flush carries the caller's own time-sliced budget through to the fiber's resume budget");
@@ -191,14 +191,15 @@ namespace Velvet.Tests
             s_flatListCount = 40;
             fiber.ScheduleRerenderForTest(FiberUpdatePriority.Transition);
             fiber.FlushStateWithTinyBudgetForTest();
-            Assume.That(fiber.HasPendingReconcileWorkForTest(), Is.True, "Precondition: the flush parked mid-commit");
+            var parkedMidCommit = fiber.HasPendingReconcileWorkForTest();
 
             // Act
             fiber.DrainTimeSlicedReconcileForTest();
 
             // Assert
-            Assert.That((fiber.HasPendingReconcileWorkForTest(), _root.childCount), Is.EqualTo((false, 40)),
-                "The resume drains the remaining work and commits the full new list");
+            Assert.That((parkedMidCommit, fiber.HasPendingReconcileWorkForTest(), _root.childCount),
+                Is.EqualTo((true, false, 40)),
+                "The flush parks mid-commit and the resume drains the remaining work, committing the full new list");
         }
 
         #endregion
@@ -262,10 +263,10 @@ namespace Velvet.Tests
             s_refOrderingCount = 40;
             fiber.ScheduleRerenderForTest(FiberUpdatePriority.Transition);
             fiber.FlushStateWithTinyBudgetForTest();
-            Assume.That(fiber.HasPendingReconcileWorkForTest(), Is.True, "Precondition: the commit paused mid-flight");
 
-            // Assert
-            Assert.That(s_refOrderingEffectRan, Is.False,
+            // Assert — "deferred" is a claim about a commit that is still in flight, so the pause has to be part
+            // of the comparison: an effect that never ran at all reads identically on its own
+            Assert.That((fiber.HasPendingReconcileWorkForTest(), s_refOrderingEffectRan), Is.EqualTo((true, false)),
                 "UseLayoutEffect is deferred while the commit is paused (it would otherwise read a not-yet-attached ref)");
         }
 
@@ -281,14 +282,15 @@ namespace Velvet.Tests
             s_refOrderingCount = 40;
             fiber.ScheduleRerenderForTest(FiberUpdatePriority.Transition);
             fiber.FlushStateWithTinyBudgetForTest();
-            Assume.That(fiber.HasPendingReconcileWorkForTest(), Is.True, "Precondition: the commit paused mid-flight");
+            var pausedMidFlight = fiber.HasPendingReconcileWorkForTest();
 
             // Act
             fiber.DrainTimeSlicedReconcileForTest();
 
             // Assert — the ref rides the LAST leaf (created only after the resume), yet the effect sees it attached
-            Assert.That((s_refOrderingEffectRan, s_refOrderingRefWasNullAtEffect), Is.EqualTo((true, false)),
-                "After the commit completes the deferred layout effect runs once and observes its ref'd element attached");
+            Assert.That((pausedMidFlight, s_refOrderingEffectRan, s_refOrderingRefWasNullAtEffect),
+                Is.EqualTo((true, true, false)),
+                "After the paused commit completes the deferred layout effect runs once and observes its ref'd element attached");
         }
 
         #endregion
@@ -308,7 +310,7 @@ namespace Velvet.Tests
             s_siblingBCount = 30;
             s_siblingBFiber.ScheduleRerenderForTest(FiberUpdatePriority.Transition);
             s_siblingBFiber.FlushStateWithTinyBudgetForTest();
-            Assume.That(s_siblingBFiber.HasPendingReconcileWorkForTest(), Is.True, "Precondition: B parks at A's slot count");
+            var bParkedAtASlotCount = s_siblingBFiber.HasPendingReconcileWorkForTest();
 
             // Act — A grows by 2 synchronously (Normal lane), which must re-base parked B's captured slotStart
             s_siblingACount = 5;
@@ -317,8 +319,8 @@ namespace Velvet.Tests
             s_siblingBFiber.DrainTimeSlicedReconcileForTest();
 
             // Assert
-            Assert.That(SiblingLayout(host, aCount: 5, bCount: 30), Is.True,
-                "B's resumed body lands after A's grown prefix, in order, without corrupting either slot");
+            Assert.That((bParkedAtASlotCount, SiblingLayout(host, aCount: 5, bCount: 30)), Is.EqualTo((true, true)),
+                "B parks, and its resumed body lands after A's grown prefix, in order, without corrupting either slot");
         }
 
         [Test]
@@ -333,7 +335,7 @@ namespace Velvet.Tests
             s_siblingBCount = 30;
             s_siblingBFiber.ScheduleRerenderForTest(FiberUpdatePriority.Transition);
             s_siblingBFiber.FlushStateWithTinyBudgetForTest();
-            Assume.That(s_siblingBFiber.HasPendingReconcileWorkForTest(), Is.True, "Precondition: B parks at slotStart = 5");
+            var bParkedAtSlotStartFive = s_siblingBFiber.HasPendingReconcileWorkForTest();
 
             // Act — A shrinks 5 -> 2 synchronously, so B's parked slotStart must re-base by -3
             s_siblingACount = 2;
@@ -342,8 +344,8 @@ namespace Velvet.Tests
             s_siblingBFiber.DrainTimeSlicedReconcileForTest();
 
             // Assert
-            Assert.That(SiblingLayout(host, aCount: 2, bCount: 30), Is.True,
-                "B's resumed body lands after A's left-shifted prefix, in order");
+            Assert.That((bParkedAtSlotStartFive, SiblingLayout(host, aCount: 2, bCount: 30)), Is.EqualTo((true, true)),
+                "B parks, and its resumed body lands after A's left-shifted prefix, in order");
         }
 
         [Test]
@@ -360,11 +362,11 @@ namespace Velvet.Tests
             s_siblingBReversed = true;
             s_siblingBFiber.ScheduleRerenderForTest(FiberUpdatePriority.Transition);
             s_siblingBFiber.FlushStateWithTinyBudgetForTest();
-            Assume.That(s_siblingBFiber.HasPendingReconcileWorkForTest(), Is.True, "Precondition: B parks");
+            var bParked = s_siblingBFiber.HasPendingReconcileWorkForTest();
             s_siblingCReversed = true;
             s_siblingCFiber.ScheduleRerenderForTest(FiberUpdatePriority.Transition);
             s_siblingCFiber.FlushStateWithTinyBudgetForTest();
-            Assume.That(s_siblingCFiber.HasPendingReconcileWorkForTest(), Is.True, "Precondition: C parks");
+            var cParked = s_siblingCFiber.HasPendingReconcileWorkForTest();
 
             // Act — A grows 2 -> 4 synchronously while both B and C are parked
             s_siblingACount = 4;
@@ -374,8 +376,9 @@ namespace Velvet.Tests
             s_siblingCFiber.DrainTimeSlicedReconcileForTest();
 
             // Assert — the shift loop walks every following sibling, so A's single delta re-bases both B and C
-            Assert.That(ThreeSiblingReversedLayout(host, aCount: 4, bCount: 20, cCount: 20), Is.True,
-                "A's single delta re-bases both parked B and C; each resumes its reversed order at its rebased slot");
+            Assert.That((bParked, cParked, ThreeSiblingReversedLayout(host, aCount: 4, bCount: 20, cCount: 20)),
+                Is.EqualTo((true, true, true)),
+                "Both B and C park, and A's single delta re-bases both; each resumes its reversed order at its rebased slot");
         }
 
         [Test]
@@ -394,7 +397,7 @@ namespace Velvet.Tests
             s_siblingBCount = 30;
             s_siblingBFiber.ScheduleRerenderForTest(FiberUpdatePriority.Transition);
             s_siblingBFiber.FlushStateWithTinyBudgetForTest();
-            Assume.That(s_siblingBFiber.HasPendingReconcileWorkForTest(), Is.True, "Precondition: B parks mid-commit");
+            var bParkedMidCommit = s_siblingBFiber.HasPendingReconcileWorkForTest();
 
             // Act — A grows 2 -> 5 synchronously; B's parked SlotLimit (= C's MountSlotStart) must re-base by +3
             // too, or the resumed Common-phase seam check rejects B's own trailing rows as out-of-range and
@@ -405,8 +408,9 @@ namespace Velvet.Tests
             s_siblingBFiber.DrainTimeSlicedReconcileForTest();
 
             // Assert
-            Assert.That(ThreeSiblingAscendingLayout(host, aCount: 5, bCount: 30, cCount: 20), Is.True,
-                "B resumes within its rebased SlotLimit, patching its trailing rows in place instead of mis-creating them at the C seam");
+            Assert.That((bParkedMidCommit, ThreeSiblingAscendingLayout(host, aCount: 5, bCount: 30, cCount: 20)),
+                Is.EqualTo((true, true)),
+                "B parks and resumes within its rebased SlotLimit, patching its trailing rows in place instead of mis-creating them at the C seam");
         }
 
         [Test]
@@ -423,20 +427,21 @@ namespace Velvet.Tests
             s_siblingBCount = 30;
             s_siblingBFiber.ScheduleRerenderForTest(FiberUpdatePriority.Transition);
             s_siblingBFiber.FlushStateWithTinyBudgetForTest();
-            Assume.That(s_siblingBFiber.HasPendingReconcileWorkForTest(), Is.True, "Precondition: B parks at A's original slot count");
+            var bParkedAtAOriginalSlotCount = s_siblingBFiber.HasPendingReconcileWorkForTest();
 
             // Act — A grows 2 -> 25 on the Transition lane so A itself parks and commits its +23 delta across
             // several slices; driving A to completion exercises both the partial and incremental propagation paths
             s_siblingACount = 25;
             s_siblingAFiber.ScheduleRerenderForTest(FiberUpdatePriority.Transition);
             s_siblingAFiber.FlushStateWithTinyBudgetForTest();
-            Assume.That(s_siblingAFiber.HasPendingReconcileWorkForTest(), Is.True, "Precondition: A itself parks");
+            var aParked = s_siblingAFiber.HasPendingReconcileWorkForTest();
             s_siblingAFiber.DrainTimeSlicedReconcileForTest();
             s_siblingBFiber.DrainTimeSlicedReconcileForTest();
 
             // Assert
-            Assert.That(SiblingLayout(host, aCount: 25, bCount: 30), Is.True,
-                "B's resumed body lands after A's incrementally-grown prefix, in order");
+            Assert.That((bParkedAtAOriginalSlotCount, aParked, SiblingLayout(host, aCount: 25, bCount: 30)),
+                Is.EqualTo((true, true, true)),
+                "Both siblings park, and B's resumed body lands after A's incrementally-grown prefix, in order");
         }
 
         [Test]
@@ -452,7 +457,7 @@ namespace Velvet.Tests
             s_siblingACount = 20;
             s_siblingAFiber.ScheduleRerenderForTest(FiberUpdatePriority.Transition);
             s_siblingAFiber.FlushStateWithTinyBudgetForTest();
-            Assume.That(s_siblingAFiber.HasPendingReconcileWorkForTest(), Is.True, "Precondition: A parked mid-grow");
+            var aParkedMidGrow = s_siblingAFiber.HasPendingReconcileWorkForTest();
 
             // Act — A re-renders AGAIN (Normal lane) while still parked. RenderAndReconcile force-drains the parked
             // grow before the new render; the drain's child-count delta must propagate to B (else B's MountSlotStart
@@ -463,8 +468,8 @@ namespace Velvet.Tests
             s_siblingAFiber.DrainTimeSlicedReconcileForTest();
 
             // Assert
-            Assert.That(SiblingLayout(host, aCount: 25, bCount: 3), Is.True,
-                "The force-drained grow's delta propagated to B, so B's rows stay aligned after A's grown prefix");
+            Assert.That((aParkedMidGrow, SiblingLayout(host, aCount: 25, bCount: 3)), Is.EqualTo((true, true)),
+                "A parks mid-grow and the force-drained grow's delta propagates to B, so B's rows stay aligned after A's grown prefix");
         }
 
         [Test]
@@ -484,7 +489,7 @@ namespace Velvet.Tests
             s_siblingBCount = 30;
             s_siblingBFiber.ScheduleRerenderForTest(FiberUpdatePriority.Transition);
             s_siblingBFiber.FlushStateWithTinyBudgetForTest();
-            Assume.That(s_siblingBFiber.HasPendingReconcileWorkForTest(), Is.True, "Precondition: B parks at slotStart = 1");
+            var bParkedAtSlotStartOne = s_siblingBFiber.HasPendingReconcileWorkForTest();
 
             // Act — the inner grows synchronously; the host-level child count (the div itself) is unchanged
             s_nestedInnerCount = 6;
@@ -493,8 +498,9 @@ namespace Velvet.Tests
             s_siblingBFiber.DrainTimeSlicedReconcileForTest();
 
             // Assert — the wrapper absorbs the delta, so B's slot does not move
-            Assert.That(NestedLayout(host, innerDiv, innerCount: 6, bCount: 30), Is.True,
-                "The nested growth stays inside the wrapper; B's body still lands after the single Outer div");
+            Assert.That((bParkedAtSlotStartOne, NestedLayout(host, innerDiv, innerCount: 6, bCount: 30)),
+                Is.EqualTo((true, true)),
+                "B parks, the nested growth stays inside the wrapper, and B's body still lands after the single Outer div");
         }
 
         #endregion
@@ -523,11 +529,12 @@ namespace Velvet.Tests
             s_rotationSorted = true;
             fiber.ScheduleRerenderForTest(FiberUpdatePriority.Transition);
             fiber.FlushStateWithTinyBudgetForTest();
+            var parkedMidPass = fiber.HasPendingReconcileWorkForTest();
             fiber.DrainTimeSlicedReconcileForTest();
 
             // Assert — every leaf sits at its sorted slot; the time-sliced reorder must not transpose any pair.
-            Assert.That(RotationSortedLayout(_root, 24), Is.True,
-                "After the time-sliced reorder the keyed list is fully sorted r-0..r-23 with no transposed pair");
+            Assert.That((parkedMidPass, RotationSortedLayout(_root, 24)), Is.EqualTo((true, true)),
+                "The keyed reorder parks mid-pass and, after resuming, the list is fully sorted r-0..r-23 with no transposed pair");
         }
 
         #endregion

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/TimeSlicedReconcilerTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/TimeSlicedReconcilerTests.cs
@@ -165,13 +165,14 @@ namespace Velvet.Tests
             // Arrange
             var newChildren = BuildLabelArray(10);
             _reconciler.Reconcile(_root, Array.Empty<VNode>(), newChildren, frameBudgetMs: 0.001);
-            Assume.That(_reconciler.HasPendingWork, Is.True, "Precondition: the tiny budget parked the diff");
+            var parkedUnderTinyBudget = _reconciler.HasPendingWork;
 
             // Act
             _reconciler.ContinueReconcile(frameBudgetMs: 10000);
 
             // Assert
-            Assert.That(_reconciler.HasPendingWork, Is.False, "A single sufficient-budget resume completes the diff");
+            Assert.That((parkedUnderTinyBudget, _reconciler.HasPendingWork), Is.EqualTo((true, false)),
+                "The tiny budget parks the diff and a single sufficient-budget resume completes it");
         }
 
         #endregion
@@ -463,14 +464,15 @@ namespace Velvet.Tests
             var newChildren = ReversedKeyedLabelArray(100, "k");
             _reconciler.Reconcile(_root, Array.Empty<VNode>(), oldChildren);
             _reconciler.Reconcile(_root, oldChildren, newChildren, frameBudgetMs: 0.001);
-            Assume.That(_reconciler.HasPendingWork, Is.True, "Precondition: the reversed list parked");
+            var parkedUnderTinyBudget = _reconciler.HasPendingWork;
 
             // Act
             _reconciler.ContinueReconcile(frameBudgetMs: 10000);
 
             // Assert
-            Assert.That((_reconciler.HasPendingWork, _root.childCount), Is.EqualTo((false, 100)),
-                "A sufficient-budget resume completes the parked keyed reorder in one step");
+            Assert.That((parkedUnderTinyBudget, _reconciler.HasPendingWork, _root.childCount),
+                Is.EqualTo((true, false, 100)),
+                "The reversed list parks and a sufficient-budget resume completes the keyed reorder in one step");
         }
 
         [Test]
@@ -613,10 +615,21 @@ namespace Velvet.Tests
             var newChildren = ReversedKeyedLabelArray(100, "a");
             _reconciler.Reconcile(_root, Array.Empty<VNode>(), oldChildren);
             _reconciler.Reconcile(_root, oldChildren, newChildren, frameBudgetMs: 0.001);
-            Assume.That(_reconciler.HasPendingWork, Is.True, "Precondition: a yield must have occurred");
+            var parkedBeforeDispose = _reconciler.HasPendingWork;
 
-            // Act + Assert — Dispose returns the pending-state buffers without throwing
-            Assert.DoesNotThrow(() => _reconciler.Dispose());
+            // Act — capturing the throw rather than using DoesNotThrow keeps the park in the same comparison
+            Exception disposeError = null;
+            try
+            {
+                _reconciler.Dispose();
+            }
+            catch (Exception error)
+            {
+                disposeError = error;
+            }
+
+            // Assert — Dispose returns the pending-state buffers without throwing
+            Assert.That((parkedBeforeDispose, disposeError), Is.EqualTo((true, (Exception)null)));
         }
 
         [Test]
@@ -627,13 +640,14 @@ namespace Velvet.Tests
             var newChildren = ReversedKeyedLabelArray(100, "a");
             _reconciler.Reconcile(_root, Array.Empty<VNode>(), oldChildren);
             _reconciler.Reconcile(_root, oldChildren, newChildren, frameBudgetMs: 0.001);
-            Assume.That(_reconciler.HasPendingWork, Is.True, "Precondition: a yield must have occurred");
+            var parkedBeforeDispose = _reconciler.HasPendingWork;
 
             // Act
             _reconciler.Dispose();
 
             // Assert
-            Assert.That(_reconciler.HasPendingWork, Is.False, "Dispose clears the parked diff's pending work");
+            Assert.That((parkedBeforeDispose, _reconciler.HasPendingWork), Is.EqualTo((true, false)),
+                "Dispose clears the parked diff's pending work");
         }
 
         [Test]
@@ -644,7 +658,7 @@ namespace Velvet.Tests
             var newChildren = ReversedKeyedLabelArray(100, "a");
             _reconciler.Reconcile(_root, Array.Empty<VNode>(), oldChildren);
             _reconciler.Reconcile(_root, oldChildren, newChildren, frameBudgetMs: 0.001);
-            Assume.That(_reconciler.HasPendingWork, Is.True, "Precondition: a yield must have occurred");
+            var parkedBeforeDispose = _reconciler.HasPendingWork;
             _reconciler.Dispose();
 
             // Act
@@ -653,7 +667,7 @@ namespace Velvet.Tests
             _reconciler.Reconcile(freshRoot, Array.Empty<VNode>(), BuildKeyedLabelArray(3, "x"));
 
             // Assert
-            Assert.That(freshRoot.childCount, Is.EqualTo(3),
+            Assert.That((parkedBeforeDispose, freshRoot.childCount), Is.EqualTo((true, 3)),
                 "A fresh reconciler works after a parked one is disposed (pool state has no destructive side effects)");
         }
 
@@ -808,13 +822,15 @@ namespace Velvet.Tests
             s_indexedTotalCount = 41;
             fiber.ScheduleRerenderForTest(FiberUpdatePriority.Transition);
             fiber.FlushStateWithTinyBudgetForTest();
+            var parkedThroughThePortalDrain = fiber.HasPendingReconcileWorkForTest();
             fiber.DrainTimeSlicedReconcileForTest();
 
             // Assert — RED without the fix: the same-pass drain's nested Reconcile call wipes PendingIndexedState
             // the instant it is set, so HasPendingWork already reads false when FlushState returns; the drain
             // above is then a no-op and the list stays truncated at 1 (only the Portal placeholder) forever.
-            Assert.That((_root.childCount, target.childCount), Is.EqualTo((41, 1)),
-                "The parked pass resumes through the same-pass Portal drain and commits every trailing row, with the Portal's content mounted exactly once");
+            Assert.That((parkedThroughThePortalDrain, _root.childCount, target.childCount),
+                Is.EqualTo((true, 41, 1)),
+                "The parked pass survives the same-pass Portal drain, then resumes and commits every trailing row, with the Portal's content mounted exactly once");
         }
 
         [Test]
@@ -832,13 +848,15 @@ namespace Velvet.Tests
             s_keyedTotalCount = 41;
             fiber.ScheduleRerenderForTest(FiberUpdatePriority.Transition);
             fiber.FlushStateWithTinyBudgetForTest();
+            var parkedThroughThePortalDrain = fiber.HasPendingReconcileWorkForTest();
             fiber.DrainTimeSlicedReconcileForTest();
 
             // Assert — RED without the fix: DiscardPendingKeyedState (invoked by the same entry-clear) also
             // returns PendingKeyedState's pooled buffers to the shared pool, so the wipe is destructive twice
             // over here; the list stays truncated at 1 (only the Portal placeholder) forever.
-            Assert.That((_root.childCount, target.childCount), Is.EqualTo((41, 1)),
-                "The parked keyed pass resumes through the same-pass Portal drain and commits every trailing row, with the Portal's content mounted exactly once");
+            Assert.That((parkedThroughThePortalDrain, _root.childCount, target.childCount),
+                Is.EqualTo((true, 41, 1)),
+                "The parked keyed pass survives the same-pass Portal drain, then resumes and commits every trailing row, with the Portal's content mounted exactly once");
         }
 
         #region Indexed list component (unkeyed; Portal occupies index 0 once the count is nonzero)

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ZIndexStackingTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ZIndexStackingTests.cs
@@ -742,15 +742,15 @@ namespace Velvet.Tests
             s_zParkZManaged = true;
             s_zParkFiber.ScheduleRerenderForTest(FiberUpdatePriority.Transition);
             s_zParkFiber.FlushStateWithTinyBudgetForTest();
-            Assume.That(s_zParkFiber.HasPendingReconcileWorkForTest(), Is.True,
-                "Precondition: the tiny budget parked the pass right after item0's own iteration");
+            var parkedAfterItem0 = s_zParkFiber.HasPendingReconcileWorkForTest();
             s_zParkFiber.DrainTimeSlicedReconcileForTest();
 
             // Assert — every trailing item resumed and patched at its correct (post-shift) physical index.
             // RED without the fix: the resumed slice keeps reading one slot short of where the container's
             // insertion actually left each row, so each iteration patches (and renames, via PatchCommon) the
             // WRONG physical element — a cascading off-by-one that leaves a stale/duplicated name in this join.
-            Assert.That(TrailingItemOrder(root), Is.EqualTo(ExpectedTrailingItemOrder));
+            Assert.That((parkedAfterItem0, TrailingItemOrder(root)),
+                Is.EqualTo((true, ExpectedTrailingItemOrder)));
         }
 
         [Test]
@@ -772,13 +772,13 @@ namespace Velvet.Tests
             s_zParkZManaged = false;
             s_zParkFiber.ScheduleRerenderForTest(FiberUpdatePriority.Transition);
             s_zParkFiber.FlushStateWithTinyBudgetForTest();
-            Assume.That(s_zParkFiber.HasPendingReconcileWorkForTest(), Is.True,
-                "Precondition: the tiny budget parked the pass right after item0's own iteration");
+            var parkedAfterItem0 = s_zParkFiber.HasPendingReconcileWorkForTest();
             s_zParkFiber.DrainTimeSlicedReconcileForTest();
 
             // Assert — mirrors the creation-direction test above, in the opposite (-1) direction: every trailing
             // item resumed at its correct (post-shift) physical index instead of one slot past it.
-            Assert.That(TrailingItemOrder(root), Is.EqualTo(ExpectedTrailingItemOrder));
+            Assert.That((parkedAfterItem0, TrailingItemOrder(root)),
+                Is.EqualTo((true, ExpectedTrailingItemOrder)));
         }
 
         #endregion
@@ -975,10 +975,8 @@ namespace Velvet.Tests
             s_crossParkACount = 60;
             s_crossParkAFiber.ScheduleRerenderForTest(FiberUpdatePriority.Transition);
             s_crossParkAFiber.FlushStateWithTinyBudgetForTest();
-            Assume.That(s_crossParkAFiber.HasPendingReconcileWorkForTest(), Is.True,
-                "Precondition: A's own tiny-budget pass parked mid-commit");
-            Assume.That(ctx.ParkedBaselineFibers.Contains(s_crossParkAFiber), Is.True,
-                "Precondition: A is registered as a cross-fiber parked baseline while still parked");
+            var aParked = s_crossParkAFiber.HasPendingReconcileWorkForTest();
+            var aRegisteredAsParkedBaseline = ctx.ParkedBaselineFibers.Contains(s_crossParkAFiber);
 
             // Act — B re-renders synchronously (Normal lane), turning its own first item z-managed: the
             // shared host's FIRST negative-z child ever, so B's own top-level drain creates the back
@@ -1003,7 +1001,8 @@ namespace Velvet.Tests
             // propagation.
             var expected = new List<string>();
             for (var i = 0; i < 60; i++) { expected.Add("cpa" + i); }
-            Assert.That(CrossParkAOrder(host), Is.EqualTo(string.Join(",", expected)));
+            Assert.That((aParked, aRegisteredAsParkedBaseline, CrossParkAOrder(host)),
+                Is.EqualTo((true, true, string.Join(",", expected))));
         }
 
         [Test]
@@ -1027,10 +1026,8 @@ namespace Velvet.Tests
             s_crossParkACount = 60;
             s_crossParkAFiber.ScheduleRerenderForTest(FiberUpdatePriority.Transition);
             s_crossParkAFiber.FlushStateWithTinyBudgetForTest();
-            Assume.That(s_crossParkAFiber.HasPendingReconcileWorkForTest(), Is.True,
-                "Precondition: A's own tiny-budget pass parked mid-commit");
-            Assume.That(ctx.ParkedBaselineFibers.Contains(s_crossParkAFiber), Is.True,
-                "Precondition: A is registered as a cross-fiber parked baseline while still parked");
+            var aParked = s_crossParkAFiber.HasPendingReconcileWorkForTest();
+            var aRegisteredAsParkedBaseline = ctx.ParkedBaselineFibers.Contains(s_crossParkAFiber);
 
             // Act — B re-renders synchronously (Normal lane), flipping its own first item back to
             // ordinary: the shared host's ONLY back-container member leaves, so B's own top-level drain
@@ -1049,7 +1046,8 @@ namespace Velvet.Tests
             // order — the -1 teardown direction stays consistent with the +1 creation direction above.
             var expected = new List<string>();
             for (var i = 0; i < 60; i++) { expected.Add("cpa" + i); }
-            Assert.That(CrossParkAOrder(host), Is.EqualTo(string.Join(",", expected)));
+            Assert.That((aParked, aRegisteredAsParkedBaseline, CrossParkAOrder(host)),
+                Is.EqualTo((true, true, string.Join(",", expected))));
         }
 
         // Keyed mirror of CrossParkARender/CrossParkSiblingHost: every one of A's own children carries an
@@ -1122,10 +1120,8 @@ namespace Velvet.Tests
             s_crossParkKeyedACount = 60;
             s_crossParkKeyedAFiber.ScheduleRerenderForTest(FiberUpdatePriority.Transition);
             s_crossParkKeyedAFiber.FlushStateWithTinyBudgetForTest();
-            Assume.That(s_crossParkKeyedAFiber.HasPendingReconcileWorkForTest(), Is.True,
-                "Precondition: A's own tiny-budget pass parked mid-commit");
-            Assume.That(ctx.ParkedBaselineFibers.Contains(s_crossParkKeyedAFiber), Is.True,
-                "Precondition: A is registered as a cross-fiber parked baseline while still parked");
+            var aParked = s_crossParkKeyedAFiber.HasPendingReconcileWorkForTest();
+            var aRegisteredAsParkedBaseline = ctx.ParkedBaselineFibers.Contains(s_crossParkKeyedAFiber);
 
             // Act — B re-renders synchronously (Normal lane), turning its own first item z-managed: the
             // shared host's FIRST negative-z child ever, so B's own top-level drain creates the back
@@ -1144,7 +1140,8 @@ namespace Velvet.Tests
             // resume writes one slot short of where the container's insertion actually left each row.
             var expected = new List<string>();
             for (var i = 0; i < 60; i++) { expected.Add("cpka" + i); }
-            Assert.That(CrossParkKeyedAOrder(host), Is.EqualTo(string.Join(",", expected)));
+            Assert.That((aParked, aRegisteredAsParkedBaseline, CrossParkKeyedAOrder(host)),
+                Is.EqualTo((true, true, string.Join(",", expected))));
         }
 
         [Test]
@@ -1167,10 +1164,8 @@ namespace Velvet.Tests
             s_crossParkKeyedACount = 60;
             s_crossParkKeyedAFiber.ScheduleRerenderForTest(FiberUpdatePriority.Transition);
             s_crossParkKeyedAFiber.FlushStateWithTinyBudgetForTest();
-            Assume.That(s_crossParkKeyedAFiber.HasPendingReconcileWorkForTest(), Is.True,
-                "Precondition: A's own tiny-budget pass parked mid-commit");
-            Assume.That(ctx.ParkedBaselineFibers.Contains(s_crossParkKeyedAFiber), Is.True,
-                "Precondition: A is registered as a cross-fiber parked baseline while still parked");
+            var aParked = s_crossParkKeyedAFiber.HasPendingReconcileWorkForTest();
+            var aRegisteredAsParkedBaseline = ctx.ParkedBaselineFibers.Contains(s_crossParkKeyedAFiber);
 
             // Act — B re-renders synchronously (Normal lane), flipping its own first item back to
             // ordinary: the shared host's ONLY back-container member leaves, so B's own top-level drain
@@ -1188,7 +1183,8 @@ namespace Velvet.Tests
             // keyed branch too: every one of A's 60 items landed at its correct (post-shift-back) slot.
             var expected = new List<string>();
             for (var i = 0; i < 60; i++) { expected.Add("cpka" + i); }
-            Assert.That(CrossParkKeyedAOrder(host), Is.EqualTo(string.Join(",", expected)));
+            Assert.That((aParked, aRegisteredAsParkedBaseline, CrossParkKeyedAOrder(host)),
+                Is.EqualTo((true, true, string.Join(",", expected))));
         }
 
         #endregion
@@ -1229,15 +1225,16 @@ namespace Velvet.Tests
             s_drainZManaged = true;
             s_drainFiber.ScheduleRerenderForTest(FiberUpdatePriority.Transition);
             s_drainFiber.FlushStateWithTinyBudgetForTest();
-            Assume.That(s_drainFiber.HasPendingReconcileWorkForTest(), Is.True,
-                "Precondition: the tiny budget parked the pass right after item0's own iteration");
+            var parkedBeforeItem1 = s_drainFiber.HasPendingReconcileWorkForTest();
             s_drainFiber.DrainTimeSlicedReconcileForTest();
 
             // Assert — RED without draining at a resumed slice's own completion: nothing ever creates the
             // back container (creation itself lives behind the drain) and item1's real content stays
             // orphaned (parent null), so BOTH sides must be pinned non-null — a bare reference comparison
             // would let null == null pass for exactly the broken state.
-            Assert.That(item1.parent, Is.Not.Null.And.SameAs(FindLayerContainer(root, front: false)));
+            var backContainer = FindLayerContainer(root, front: false);
+            Assert.That((parkedBeforeItem1, backContainer != null, ReferenceEquals(item1.parent, backContainer)),
+                Is.EqualTo((true, true, true)));
         }
 
         #endregion
@@ -1261,10 +1258,8 @@ namespace Velvet.Tests
             s_drainZManaged = true;
             s_drainFiber.ScheduleRerenderForTest(FiberUpdatePriority.Transition);
             s_drainFiber.FlushStateWithTinyBudgetForTest();
-            Assume.That(s_drainFiber.HasPendingReconcileWorkForTest(), Is.True,
-                "Precondition: the tiny budget parked the pass right after item0's own iteration");
-            Assume.That(ctx.ParkedBaselineFibers.Contains(s_drainFiber), Is.True,
-                "Precondition: the fiber is registered as a parked baseline before its own container-creating tick");
+            var parkedAfterItem0 = s_drainFiber.HasPendingReconcileWorkForTest();
+            var registeredAsParkedBaseline = ctx.ParkedBaselineFibers.Contains(s_drainFiber);
 
             // Act — tick 2 (a single manual resume, which continues at the tiny budget tick 1 captured on the
             // fiber): processes item1, creating the shared parent's first back container INSIDE this tick's drain,
@@ -1274,8 +1269,7 @@ namespace Velvet.Tests
             FiberWorkLoop.ContinueReconcile(s_drainFiber);
             Assume.That(FindLayerContainer(root, front: false), Is.Not.Null,
                 "Precondition: this single resume tick actually created the shared parent's first back container");
-            Assume.That(s_drainFiber.HasPendingReconcileWorkForTest(), Is.True,
-                "Precondition: the same tick re-parked (item2..item9 still pending) while still registered");
+            var reParkedWhileStillRegistered = s_drainFiber.HasPendingReconcileWorkForTest();
 
             // Act — drain the remainder; the double-rebase this test targets is already fully determined by
             // tick 2 above.
@@ -1286,7 +1280,9 @@ namespace Velvet.Tests
             // again in the ParkedBaselineFibers loop, since nothing yet removed it from that registry), so
             // every trailing item resumes two physical slots ahead of where the container's single
             // insertion actually left it.
-            Assert.That(TrailingItemOrder(root), Is.EqualTo("item2,item3,item4,item5,item6,item7,item8,item9"));
+            Assert.That(
+                (parkedAfterItem0, registeredAsParkedBaseline, reParkedWhileStillRegistered, TrailingItemOrder(root)),
+                Is.EqualTo((true, true, true, "item2,item3,item4,item5,item6,item7,item8,item9")));
         }
 
         #endregion


### PR DESCRIPTION
## What

Tests across five fixtures put the behaviour they exist to pin inside an `Assume`. When time-slicing regressed so nothing parked, they reported **Inconclusive** rather than Failed — and Unity's XML does not count that as a failure.

Deleting the `Assume` would not have fixed it. In 22 of 23 cases the assertion alone still passes on the broken behaviour, because a flush that never parked commits everything synchronously and the layout assertion holds anyway. So deleting converts an inconclusive into a silent pass. They are folded into the single assertion instead.

## The population, established before changing anything

The issue's total of 20 was right; its split was not.

| fixture | `Assume` before → after | park gates folded |
|---|---|---|
| `TimeSlicedFiberTests` | 25 → 13 | 12 |
| `ZIndexStackingTests` | 49 → 35 | 14 |
| `ContinueReconcileAbortLeakTests` | 6 → 4 | 2 |
| `TimeSlicedPortalDrainParkTests` | 2 → 2 | **0** |
| `TimeSlicedReconcilerTests` — **not in the issue** | 6 → 1 | 5 |

Two corrections matter. `TimeSlicedPortalDrainParkTests` held none of the twenty: **neither of its tests ever assumed or asserted its park, so both passed silently on the regression** rather than reporting inconclusive — strictly worse than the defect the issue describes. A third test elsewhere had the same shape. All three now assert the park.

And a fifth fixture had five more of the identical defect, invisible to the original measurement because it drives the reconciler directly instead of routing through a lane.

## Verification

Two neuters, because one does not reach everything:

| neuter | inconclusive | failed |
|---|---|---|
| every lane takes the frame budget — before | **20** | 4 |
| — after | **0** | 27 |
| the child reconciler forces a zero budget — before | 5 | 24 |
| — after | **0** | 29 |

Sample: `Expected: (True, False, 40) But was: (False, False, 40)` — the park term is the one that moved, and the subject terms match, which is precisely why deletion would have been silent.

**One case was different**, and it is the distinction worth recording: one test's subject term was *also* wrong, so deletion alone would have failed it. It was folded anyway, because the subject assertion cannot distinguish "deferred" from "never ran" — the fold guards a second regression rather than being ceremony.

55 `Assume`s were kept. Each states a fact about a different, already-tested component, or a genuine environment precondition, and each message names which.

EditMode 3469 passed / 0 failed / **0 inconclusive** / 3 pre-existing skips — identical to the baseline. PlayMode 121/121.

## Left alone, with the reason

Roughly 29 `Assume`s in the z-layer fixture gate the *stimulus* rather than the park, and would leave their assertions passing vacuously if false. They are not folded because **no neuter run makes them inconclusive**, so folding them would have been asserted rather than evidenced — and a regression in that area is already reported as a Failure by that fixture's own dedicated container tests, which is the condition the convention permits. Settling it needs a z-layer neuter, which is its own piece of work.

One in-code claim went stale and was rewritten: a comment stating that the dependent fixtures report inconclusive on their park precondition, which this change makes false.

Closes #193