### PR TITLE
fix(velvet): enrol a mount-time shadow paint in the covering fade

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -133,6 +133,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A `shadow-*` / `drop-shadow-*` paint now tracks an enter or exit animation covering it in the two
+  mount-time cases that previously escaped. An element mounted with the utility already in its class
+  list, under a play that was already running, joined that play's fade nowhere and stayed at resting
+  strength for the rest of it; and a `V.Motion` playing its own mount enter re-sampled a shadow the
+  play had already picked up, at a moment when the caster's from-class has not resolved yet, so the
+  shadow snapped back to resting strength over an `opacity-0` card until the next animation frame —
+  for a staggered `AnimatePresence` list, for the whole stagger delay. A shadow that arrived through
+  a later class change was already handled.
 - **BREAKING:** A utility whose property set contains another's is now declared before the narrower
   one in the bundled stylesheets, so the narrower utility wins the properties they share. Bundled
   utilities are single-class selectors, so two on one element tie on specificity and the later

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberDropShadowApplier.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberDropShadowApplier.cs
@@ -9,17 +9,22 @@ namespace Velvet
     internal sealed class FiberDropShadowApplier
     {
         private readonly ReconcilerContext _ctx;
+        // One delegate for the whole reconciler: the caster is read back off the event, so deferring an
+        // enrolment allocates no per-element closure on the create path.
+        private readonly EventCallback<AttachToPanelEvent> _onAttachedToPanel;
 
         public FiberDropShadowApplier(ReconcilerContext ctx)
         {
             _ctx = ctx;
+            _onAttachedToPanel = EnrollOnAttach;
         }
 
         // Create-time entry point: when classNames carries a shadow-* utility, attaches the drop-shadow
         // paint onto the element (no structural wrapper — the baked shadow texture is the element's own
         // generateVisualContent, drawn behind its content and bleeding outside the box). Composes like skew
         // and gradient: a paint, not a wrapper, so it works alongside a clip / ring wrapper and a user
-        // wrapElement. The element is NOT yet in the hierarchy here, which the paint does not need.
+        // wrapElement. The element is NOT yet in the hierarchy here, which the paint itself does not need but
+        // the co-fade enrolment does — hence EnrollForCoFade's deferral.
         internal void ApplyShadowOnCreate(VisualElement element, string[] classNames)
         {
             if (!StyleShadowClass.HasShadowClass(classNames) || !StyleShadowClass.TryExtract(classNames, out var spec))
@@ -48,6 +53,40 @@ namespace Velvet
             var shadowBinding = DropShadowSilhouette.Attach(element, spec, classNames, skewXDeg, casterSkewed);
             _ctx.ShadowBindings[element] = shadowBinding;
             DropShadowSilhouette.SetWantSpacer(element, shadowBinding, WrapperInfrastructure.CarriesFilter(classNames), classNames);
+            EnrollForCoFade(element, shadowBinding);
+        }
+
+        // Enrols a freshly attached paint in every in-flight enter / exit covering its caster. The scheduler
+        // answers "which plays cover this element" by walking the element's ANCESTORS, so an element the
+        // factory has not parented yet matches nothing and enrols nowhere.
+        // The deferral waits for the PANEL rather than merely for a parent, even though the ancestor walk
+        // alone would be satisfied earlier: the enrolment samples the caster's live resolvedStyle.opacity,
+        // which resolves to a default off-panel.
+        // One-shot: a play that begins while the caster is in the tree walks it and finds the binding itself
+        // (CollectShadowsForCoFade), so the detach/attach of a keyed reorder has nothing left to enrol and
+        // would only re-scan every in-flight play. Enrolling twice is harmless — AdoptShadow is idempotent per
+        // play — so this is about not repeating the work, not about correctness.
+        private void EnrollForCoFade(VisualElement element, DropShadowBinding binding)
+        {
+            if (element.panel != null)
+            {
+                _ctx.StyleAnimationScheduler.AdoptShadowForCoFade(element, binding);
+                return;
+            }
+            binding.OnAttachedToPanel = _onAttachedToPanel;
+            element.RegisterCallback(_onAttachedToPanel);
+        }
+
+        private void EnrollOnAttach(AttachToPanelEvent evt)
+        {
+            var element = (VisualElement)evt.currentTarget;
+            element.UnregisterCallback(_onAttachedToPanel);
+            if (!_ctx.ShadowBindings.TryGetValue(element, out var binding))
+            {
+                return;
+            }
+            binding.OnAttachedToPanel = null;
+            _ctx.StyleAnimationScheduler.AdoptShadowForCoFade(element, binding);
         }
 
         // Patch-time reconciliation of an element's shadow state against its new class list. Mirrors the
@@ -89,9 +128,8 @@ namespace Velvet
                 DropShadowSilhouette.SetWantSpacer(element, fresh, WrapperInfrastructure.CarriesFilter(classNames), classNames);
                 // A paint that appears while an enter / exit covering this element is already running has to
                 // join that fade: the play snapshotted the subtree's shadows when it began, and this one was
-                // not there, so nothing else would ever scale its alpha and it would paint at full strength
-                // through an already-translucent caster.
-                _ctx.StyleAnimationScheduler.AdoptShadowForCoFade(element, fresh);
+                // not there, so nothing else would ever scale its alpha.
+                EnrollForCoFade(element, fresh);
             }
             else if (bound)
             {

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodeFactory.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodeFactory.cs
@@ -265,20 +265,19 @@ namespace Velvet
                     // transition-filter on a Motion host: a Motion can carry filter utilities + that class
                     // just like a plain element, so register the tween binding here too.
                     _patcher.Appliers.ApplyFilterTransitionOnCreate(element, motionPaintClasses);
-                    // Motion does NOT paint a drop shadow: the animation scheduler hides a subtree's shadow
-                    // paints for the lifetime of an enter / exit (the opacity-blind shadow would otherwise
-                    // show through the fading caster as a dark box), and a shadow ON the animating Motion
-                    // itself would be the very paint that must stay hidden — so the shadow belongs on a Div the
-                    // Motion wraps (the Div carries the shadow, the Motion carries the transition). Warn and
-                    // skip the paint. Warn only for an ACTIVE shadow (shadow-none deliberately cancelling the
-                    // cascade is not "ignored" — nothing would render anywhere).
+                    // Motion does NOT paint a drop shadow: the three silhouette paints stand down on a Motion
+                    // on BOTH halves — here, and on the patch path through ApplyResolvedClassPasses' paintTail
+                    // gate — so attaching one here would leave a binding the Motion's own patch never syncs
+                    // against a class change and never detaches. The shadow belongs on a Div the Motion wraps
+                    // (the Div carries the shadow, the Motion carries the transition). Warn and skip the paint.
+                    // Warn only for an ACTIVE shadow (shadow-none deliberately cancelling the cascade is not
+                    // "ignored" — nothing would render anywhere).
                     if (StyleShadowClass.HasShadowClass(appliedClasses)
                         && StyleShadowClass.TryExtract(appliedClasses, out _))
                     {
                         FiberLogger.LogWarning("Motion",
-                            "A shadow-* utility on a Motion is ignored: the enter/exit fade hides shadow paints, "
-                            + "so a shadow on the animating element itself cannot show. "
-                            + "Wrap the Motion around a shadowed Div instead.");
+                            "A shadow-* utility on a Motion is ignored: a Motion carries the transition, not "
+                            + "the paint layers. Wrap the Motion around a shadowed Div instead.");
                     }
                     // clip-path-* is a structural wrapper, which would become the AnimatePresence anchor while
                     // the enter/exit transition stays on the inner Motion: ignored on a Motion, never wrapped.

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/MountTimeShadowCoFadeTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/MountTimeShadowCoFadeTests.cs
@@ -1,0 +1,179 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.UIElements;
+using UnityEngine.UIElements.TestFramework;
+using UnityEditor.UIElements.TestFramework;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Every drop-shadow paint under an in-flight enter/exit is enrolled as that play's co-fade subject
+    /// exactly once. The scheduler decides which plays cover a shadow by walking the caster's ANCESTORS, so
+    /// the question is unanswerable while the caster is unparented — which is the state the factory attaches
+    /// the paint in. Two ways that goes wrong meet here: a caster mounted under a play that started before it
+    /// existed is enrolled by nobody, and a caster whose play started while the whole subtree was still
+    /// detached is enrolled by both that play's own snapshot and the deferred attach-time pass.
+    /// </summary>
+    /// <remarks>
+    /// A simulated panel rather than the panel-free setup: the enrolment samples the caster's live
+    /// <c>resolvedStyle.opacity</c>, which resolves to a default off-panel — which is exactly why the missing
+    /// mount-time wire was invisible without a panel.
+    /// </remarks>
+    [TestFixture]
+    internal sealed class MountTimeShadowCoFadeTests
+    {
+        private readonly record struct ShowState(bool Shown);
+
+        private sealed class ShowStore : Store<ShowState>
+        {
+            public ShowStore() : base(new ShowState(false)) { }
+            public void Show() => SetState(_ => new ShowState(true));
+            protected override void ResetCore() => SetState(_ => new ShowState(false));
+        }
+
+        private static readonly StyleTransitionConfig SpringEnter = new()
+        {
+            Type = TransitionType.Spring,
+            Stiffness = 200f,
+            Damping = 26f,
+            EnterFromClass = "opacity-0",
+            EnterToClass = "opacity-100",
+        };
+
+        private static readonly Dictionary<string, string> Fade = new()
+        {
+            ["hidden"] = "opacity-0",
+            ["visible"] = "opacity-100",
+        };
+
+        private static ShowStore s_store;
+
+        private EditorPanelSimulator _sim;
+
+        [SetUp]
+        public void SetUp()
+        {
+            PanelSimulator.ResetCurrentTime();
+            _sim = new EditorPanelSimulator { panelSize = new Vector2(800, 600) };
+            _sim.ResetTimePerSimulatedFrameToDefault();
+            s_store = null;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _sim?.Dispose();
+            _sim = null;
+        }
+
+        private VisualElement Root => _sim.rootVisualElement;
+
+        private void Tick() => _sim.FrameUpdateMs(16);
+
+        // The shadowed child appears only once the store flips, so its class list carries shadow-lg from the
+        // very first render of that element — the create path, not a class patch.
+        [Component]
+        private static VNode CasterWithLateChild()
+        {
+            var shown = Hooks.UseStore(s_store, s => s.Shown);
+            return V.Div(name: "caster", className: "w-[80px] h-[80px]", children: shown
+                ? new VNode[] { V.Div(name: "late", className: "shadow-lg w-[40px] h-[40px]") }
+                : System.Array.Empty<VNode>());
+        }
+
+        // A Motion's standalone mount enter starts inside CreateElement, after the Motion's children exist and
+        // while the whole subtree is still detached — so the play's own snapshot reaches the shadow before
+        // anything parents it. A TWEEN enter, not a spring: a spring writes its from-value as an inline style
+        // synchronously, so the caster reports opacity 0 the moment it attaches and a re-seed would land the
+        // same 0 the snapshot already set. A tween's from-value is a CLASS, which the panel has not resolved
+        // when the attach event fires, so only this shape separates one enrolment from two.
+        [Component]
+        private static VNode MotionWithShadowedChild()
+        {
+            return V.Motion(name: "m", variants: Fade, initial: "hidden", animate: "visible",
+                transition: new StyleTransitionConfig { DurationSec = 0.5f },
+                children: new VNode[] { V.Div(name: "late", className: "shadow-lg w-[40px] h-[40px]") });
+        }
+
+        // The co-fade subjects the scheduler holds for the enter running on `animating`. Private state, so
+        // reflection: the list is the play's own bookkeeping and has no production reader.
+        private static List<(VisualElement element, DropShadowBinding binding)> EnterCoFadeSubjects(
+            StyleAnimationScheduler scheduler, VisualElement animating)
+        {
+            var map = (System.Collections.IDictionary)typeof(StyleAnimationScheduler)
+                .GetField("_pendingEnters", BindingFlags.NonPublic | BindingFlags.Instance)
+                .GetValue(scheduler);
+            var pending = map[animating];
+            return (List<(VisualElement element, DropShadowBinding binding)>)pending.GetType()
+                .GetField("Shadows", BindingFlags.Public | BindingFlags.Instance)
+                .GetValue(pending);
+        }
+
+        private static int SubjectCount(StyleAnimationScheduler scheduler, VisualElement animating,
+            DropShadowBinding binding)
+        {
+            var subjects = EnterCoFadeSubjects(scheduler, animating);
+            return subjects == null ? 0 : subjects.Count(s => ReferenceEquals(s.binding, binding));
+        }
+
+        [Test]
+        public void Given_AnEnterInFlight_When_AnElementWhoseInitialClassListCarriesAShadowMounts_Then_ItsShadowCoFades()
+        {
+            // Arrange — a caster mid-climb through a spring enter, with no shadow anywhere in its subtree yet,
+            // so the play's own snapshot cannot be what enrols the shadow that follows.
+            using var store = new ShowStore();
+            s_store = store;
+            using var mounted = V.Mount(Root, V.Component(CasterWithLateChild, key: "root"));
+            var caster = Root.Q<VisualElement>("caster");
+            var scheduler = mounted.Root.Reconciler.Context.StyleAnimationScheduler;
+            scheduler.PlayEnter(caster, SpringEnter);
+            Tick();
+            Tick();
+            Tick();
+
+            // Act — a re-render mounts a shadowed child under the still-animating caster.
+            store.Show();
+            mounted.Root.Reconciler.Context.BatchScheduler.DrainImmediateForTest();
+
+            // Assert — the paint exists AND is below full strength: enrolled at the caster's sampled opacity.
+            // Unenrolled it would sit at its resting 1 and paint a hard box through the translucent caster.
+            var binding = DropShadowSilhouette.TryGet(Root.Q<VisualElement>("late"));
+            Assert.That((Painted: binding != null, CoFading: binding != null && binding.ShadowOpacity < 1f),
+                Is.EqualTo((true, true)));
+        }
+
+        [Test]
+        public void Given_AMotionEnrollingItsChildShadowWhileDetached_When_TheSubtreeEntersThePanel_Then_TheShadowHoldsTheEnterFromValue()
+        {
+            // Arrange / Act — mounting the Motion runs its standalone enter during creation: the play seeds
+            // the child shadow at the enter from-value (0) so nothing flashes on the first frame, and the
+            // subtree is inserted only afterwards.
+            using var mounted = V.Mount(Root, V.Component(MotionWithShadowedChild, key: "root"));
+
+            // Assert — entering the panel must not re-seed a shadow this play already drives. Re-seeding
+            // samples the caster's opacity before its from-class has resolved, reading 1 and putting the
+            // shadow back to full strength over an opacity-0 card until the next driver frame corrects it.
+            var binding = DropShadowSilhouette.TryGet(Root.Q<VisualElement>("late"));
+            Assert.That((Painted: binding != null, AtFromValue: binding != null && binding.ShadowOpacity <= 1e-4f),
+                Is.EqualTo((true, true)));
+        }
+
+        [Test]
+        public void Given_AMotionThatSnapshottedItsChildShadowWhileDetached_When_TheSubtreeAttaches_Then_TheShadowIsEnrolledOnce()
+        {
+            // Arrange / Act — the play's detached snapshot and the deferred attach-time enrolment both reach
+            // the same binding, so this is the interleaving where one play can collect a shadow twice.
+            using var mounted = V.Mount(Root, V.Component(MotionWithShadowedChild, key: "root"));
+
+            // Assert — the play holds it once. A second copy is written by every co-fade tick and unwound by
+            // an EndCoFade that only removes a driver once, so the list would stop matching what it releases.
+            var m = Root.Q<VisualElement>("m");
+            var binding = DropShadowSilhouette.TryGet(Root.Q<VisualElement>("late"));
+            Assert.That(SubjectCount(mounted.Root.Reconciler.Context.StyleAnimationScheduler, m, binding),
+                Is.EqualTo(1));
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/MountTimeShadowCoFadeTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/MountTimeShadowCoFadeTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d1f603e79b5f241dda591652b589b7f5

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/PaintBindingPatchTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/PaintBindingPatchTests.cs
@@ -92,8 +92,9 @@ namespace Velvet.Tests
         [Test]
         public void Given_ShadowOnMotion_When_Reconciled_Then_NoPaintBindingIsCreated()
         {
-            // Arrange — a Motion carrying a shadow-* utility. A shadow on the animating element itself cannot
-            // show: the enter/exit fade hides shadow paints, so the shadow belongs on a wrapped Div.
+            // Arrange — a Motion carrying a shadow-* utility. The silhouette paints stand down on a Motion, so
+            // one attached here would be a binding its own patch path never reconciles; the shadow belongs on
+            // a wrapped Div.
             using var scope = new ReconcilerScope();
             LogAssert.Expect(LogType.Warning, new Regex(@"shadow-\* utility on a Motion is ignored"));
 

--- a/Packages/com.velvet.core/Runtime/Styling/DropShadowSilhouette.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/DropShadowSilhouette.cs
@@ -46,15 +46,24 @@ namespace Velvet
         public Action<MeshGenerationContext>? OnGenerate;
         public EventCallback<GeometryChangedEvent>? OnGeometryChanged;
         public EventCallback<CustomStyleResolvedEvent>? OnStyleResolved;
+        // Set while a co-fade enrolment is still waiting for the caster to enter the tree; see
+        // FiberDropShadowApplier's deferral. Held here so Detach can unregister it with the rest.
+        public EventCallback<AttachToPanelEvent>? OnAttachedToPanel;
 
         // The native-face stash + sentinel suppression (UPRIGHT casters only). Shared with the skew layer; a
         // skewed caster leaves this untouched (HasStash false) because its SkewSilhouette owns the face.
         public readonly SilhouetteFaceStash Face = new();
 
-        // Multiplier applied to the shadow's alpha at paint time (Draw). The baked quad does NOT honor UI
-        // Toolkit opacity, so an enter / exit fade drives this from the caster's animated opacity (see
-        // SetCoFade / EndCoFade) and the shadow fades together with its element, like a CSS box-shadow, instead
-        // of showing through the still-translucent caster as a flat box. 1 = fully shown (at rest).
+        // Multiplier applied to the shadow's alpha at paint time (Draw), driven by each enter / exit fade
+        // covering the caster (see SetCoFade / EndCoFade). 1 = fully shown (at rest).
+        //
+        // Measured on 6000.3.11f1 by reading back a render-texture panel: UI Toolkit scales a textured
+        // mgc.Allocate quad by the element's own opacity AND by an animating ancestor's, byte-for-byte the same
+        // as it scales painter2D output (white-on-black at opacity 0.5 reads 128 for both, at opacity 1 reads
+        // 255 for both). So this multiplier is a SECOND application of an opacity the renderer has already
+        // applied, and a fading shadow lands at opacity squared rather than at the caster's opacity. Whether
+        // the correction should exist at all is unresolved; do not restore the claim that the baked quad is
+        // opacity-blind without re-measuring, because that claim is what this note replaces.
         public float ShadowOpacity = 1f;
 
         // Co-fade drivers: each in-flight enter / exit covering this shadow contributes a [0,1] factor, and
@@ -243,6 +252,11 @@ namespace Velvet
             {
                 element.UnregisterCallback(binding.OnStyleResolved);
             }
+            if (binding.OnAttachedToPanel != null)
+            {
+                element.UnregisterCallback(binding.OnAttachedToPanel);
+                binding.OnAttachedToPanel = null;
+            }
             if (binding.Face.SuppressionApplied)
             {
                 binding.Face.Release(element);
@@ -340,12 +354,12 @@ namespace Velvet
         public static DropShadowBinding? TryGet(VisualElement element)
             => s_byElement.TryGetValue(element, out var binding) ? binding : null;
 
-        // Registers / updates an enter or exit animation's co-fade factor on this shadow and repaints. The
-        // baked-quad paint does not inherit UITK opacity, so the scheduler samples the caster's animated
-        // opacity each frame and pushes it here; Draw multiplies the shadow alpha by the resulting ShadowOpacity
-        // so the shadow fades together with its element. factor 0 = fully faded, 1 = at rest. OVERLAPPING
-        // drivers compose multiplicatively (see DropShadowBinding), so the shadow can never out-shine the
-        // most-faded fade covering it.
+        // Registers / updates an enter or exit animation's co-fade factor on this shadow and repaints: the
+        // scheduler samples the caster's animated opacity each frame and pushes it here, and Draw multiplies
+        // the shadow alpha by the resulting ShadowOpacity (whose own note carries what the renderer already
+        // does with that opacity). factor 0 = fully faded, 1 = at rest. OVERLAPPING drivers compose
+        // multiplicatively (see DropShadowBinding), so the shadow can never out-shine the most-faded fade
+        // covering it.
         public static void SetCoFade(DropShadowBinding binding, VisualElement element, object driver, float factor)
         {
             binding.SetCoFadeFactor(driver, factor);
@@ -388,9 +402,9 @@ namespace Velvet
         // interior and its offset-up overlap, leaving only the outer halo. A SKEWED caster skips (2)/(3): its
         // SkewSilhouette repaints the sheared fill/border just after this paint. Skipped before layout gives a
         // real size. During an enter / exit only the shadow QUAD's alpha is scaled by the co-fade ShadowOpacity
-        // (DrawShadowQuad) so it fades with its element; the repainted upright fill/border are left at full
-        // alpha because UI Toolkit already scales them by the caster's own animated opacity (only the
-        // opacity-blind baked quad needs the correction).
+        // (DrawShadowQuad); the repainted upright fill/border are left at full alpha because UI Toolkit already
+        // scales them by the caster's own animated opacity — which, as measured, it also does to the quad (see
+        // DropShadowBinding.ShadowOpacity), so the asymmetry between the two is not the engine's.
         private static void Draw(MeshGenerationContext mgc, VisualElement ve, DropShadowBinding binding)
         {
             var w = ve.layout.width;
@@ -419,8 +433,8 @@ namespace Velvet
             float w, float h)
         {
             var spec = binding.Spec;
-            // Scale the shadow alpha by the co-fade multiplier so the opacity-blind baked quad fades with its
-            // element during an enter / exit (1 at rest). Bail before baking when effectively invisible.
+            // Scale the shadow alpha by the co-fade multiplier (1 at rest). Bail before baking when
+            // effectively invisible.
             var alpha = spec.Color.a * binding.ShadowOpacity;
             if (alpha <= 0.004f)
             {

--- a/Packages/com.velvet.core/Runtime/Styling/StyleAnimationScheduler.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleAnimationScheduler.cs
@@ -1479,6 +1479,18 @@ namespace Velvet
             internal static void AdoptShadow(StyleAnimationScheduler.PendingAnimation pending,
                 VisualElement animating, VisualElement element, DropShadowBinding binding)
             {
+                // A play that began while its subtree was still detached (a Motion's mount enter, a presence
+                // enter dispatched before the entering element is placed) has already walked that subtree and
+                // seeded this binding at its from-value. Re-seeding it here would sample an opacity the panel
+                // has not resolved yet — AttachToPanelEvent is dispatched BEFORE the style invalidation the
+                // play's own class swap triggers, so an element carrying `opacity-0` still reports
+                // resolvedStyle.opacity 1 at that moment — and would replace a correct 0 with 1 until the next
+                // driver frame. Idempotence per play is also what keeps the subject list one-for-one with the
+                // EndCoFade that unwinds it.
+                if (pending.Shadows != null && AlreadyDriving(pending.Shadows, binding))
+                {
+                    return;
+                }
                 var raw = animating.resolvedStyle.opacity;
                 DropShadowSilhouette.SetCoFade(binding, element, pending,
                     float.IsNaN(raw) ? 1f : UnityEngine.Mathf.Clamp01(raw));
@@ -1489,6 +1501,19 @@ namespace Velvet
                 {
                     StartShadowCoFadeTick(pending);
                 }
+            }
+
+            private static bool AlreadyDriving(
+                List<(VisualElement element, DropShadowBinding binding)> shadows, DropShadowBinding binding)
+            {
+                for (var i = 0; i < shadows.Count; i++)
+                {
+                    if (ReferenceEquals(shadows[i].binding, binding))
+                    {
+                        return true;
+                    }
+                }
+                return false;
             }
 
             // Starts the recurring co-fade tick: every frame, sample the animating element's current (transition-

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/VariantGatedPaintPassTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/VariantGatedPaintPassTests.cs
@@ -264,8 +264,8 @@ namespace Velvet.Tests
         [Test]
         public void Given_ADarkGatedShadowOnAMotion_When_TheThemeTurnsDark_Then_NoShadowPaintIsAttached()
         {
-            // Arrange — a Motion never paints a drop shadow (an enter/exit fade hides shadow paints, so one
-            // on the animating element itself could never show), and a variant must not be a way in.
+            // Arrange — a Motion never paints a drop shadow (the silhouette paints stand down on a Motion, so
+            // nothing would reconcile one afterwards), and a variant must not be a way in.
             using var scope = new ReconcilerScope();
             scope.Reconciler.Reconcile(scope.Root, System.Array.Empty<VNode>(),
                 new VNode[] { V.Motion(className: "bg-[#FFFFFF] dark:shadow-lg", name: "mover") });


### PR DESCRIPTION
The scheduler decides which enter/exit plays co-fade a drop shadow by walking the caster's ancestors, so the question can only be answered once the caster is in the tree. The create path attaches the paint before anything parents the element, so an element whose initial class list carried `shadow-*` enrolled nowhere and kept painting at full strength through an already-translucent caster for the rest of the play. Only a shadow arriving through a later class change was handled.

Enrolment now defers to the caster's first panel attach, and both the create and patch paths go through that one seam. The panel — not merely a parent — is the right gate: the enrolment samples `resolvedStyle.opacity`, which resolves to its default off-panel.

Adoption is idempotent per play. That is load-bearing rather than an optimisation: a presence enter and a standalone Motion enter both start **while the subtree is still detached**, so the play's own snapshot can seed a binding at factor 0 before the deferral fires. Without the guard the deferral then re-sampled `resolvedStyle.opacity` at attach — which still reads 1, because `HasChangedPanel` dispatches the attach event *before* it invalidates style — and overwrote the seeded 0. The result was the symptom this change exists to remove, still present for a shadow inside a Motion.

Disarming from the collection side instead would be wrong: a Motion whose own play collected the shadow can still be inserted under a different, outer play that never saw it.

## A measurement that overturns a claim this code carried

The old rationale was that a textured `mgc.Allocate` quad does not honour UI Toolkit opacity while `painter2D` output does. Measured by render-texture readback, sampling both drawn in the same `generateVisualContent`:

| | textured quad | painter2D |
|---|---|---|
| self-opacity 1 | 255 | 255 |
| self-opacity 0.5 | 128 | 128 |
| animating ancestor at 0.5 | 128 | 128 |

They are scaled identically. Decompiling `UIR.EntryProcessor` agrees structurally: opacity is resolved once per element and stamped onto every mesh entry, with no texture-conditional branch.

So `SkewSilhouette.DrawGradientQuad` and `ParticlesDriver` are **not** holes of the same class, and the sentences claiming otherwise are corrected to carry the measurement. What the measurement implies about the co-fade multiplier itself — that it re-applies an opacity the renderer already applied — is left open here; deciding it means deciding whether the mechanism should exist, which is a separate change.

Four further sentences described the Motion shadow restriction with a reason that was false on its own terms (the scheduler does not hide shadow paints for the lifetime of a play, and a shadow on the Motion itself would enrol). One of them shipped to users as a runtime warning. They now state the real reason — the silhouette paints stand down on a Motion on both the create and patch halves, so a shadow attached there would be a binding the Motion's own patch never syncs or detaches. The restriction itself is unchanged.

## Verification

- EditMode 3495 passed / 0 failed / 0 inconclusive; PlayMode 123 passed / 0 failed / 0 inconclusive; 0 compile errors; `assert-no-inconclusive.py` clean on both.
- RED for the mount-time case, and separately for the Motion enrolment order with the idempotence guard removed (`Expected: (True, True) / But was: (True, False)`, and a subject count of 2 where 1 is required).
- The Motion test uses a **tween** enter deliberately: a spring writes its from-value as an inline style synchronously, so the caster really does report opacity 0 at attach and the case cannot discriminate. A tween's from-value is a class, which is what exposes the ordering.

## Documentation

No `Documentation~` guide describes co-fade, so none changed. CHANGELOG entry added under Fixed.
