### PR TITLE
fix(velvet): rank variant gate tokens by declared priority and position

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -141,6 +141,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   shadow snapped back to resting strength over an `opacity-0` card until the next animation frame —
   for a staggered `AnimatePresence` list, for the whole stagger delay. A shadow that arrived through
   a later class change was already handled.
+- Two variants naming one of the utilities Velvet realises itself — `gap-*` / `space-*`, `grid` /
+  `grid-cols-*`, `divide-*`, `text-balance`, `skew-*`, `shadow-*`, the gradients, `animate-*`,
+  `border-dashed` / `border-dotted` — now rank against each other by the precedence table, and within
+  one precedence layer by their order in the className, instead of by the order their signals happened
+  to fire. Two variants supplying the SAME utility with no literal base (`"dark:gap-4 md:gap-4"`) kept
+  the class on the element but stopped driving it as soon as either turned off, dropping the spacing;
+  two payloads of one family (`"bg-white md:shadow-sm dark:shadow-lg"`) resolved to whichever lit
+  last, so one end state rendered two ways depending on the path the user took to reach it; and that
+  second shape held equally for two payloads the precedence table cannot separate, such as two
+  `data-[…]:` rules or two `has-[.class]:` rules on one element. A literal base re-asserted by the
+  stronger of two variants (`"shadow-lg dark:shadow-sm hover:shadow-lg"`) was likewise outranked by
+  the weaker payload. Only a rule that actually applies takes part in a tie, so adding one that cannot
+  — a `lg:` rule below the breakpoint, a `peer-` rule with no peer, a `[&>*]:` rule that lands on the
+  children — never moves what the element paints. A stacked variant is ranked by the position of the
+  stacked class itself, so `"dark:hover:shadow-lg hover:shadow-sm"` resolves to the later-written
+  payload rather than to whichever manipulator attached first.
+  See `Documentation~/styling-variants.md`.
 - **BREAKING:** A utility whose property set contains another's is now declared before the narrower
   one in the bundled stylesheets, so the narrower utility wins the properties they share. Bundled
   utilities are single-class selectors, so two on one element tie on specificity and the later

--- a/Packages/com.velvet.core/Documentation~/styling-variants.md
+++ b/Packages/com.velvet.core/Documentation~/styling-variants.md
@@ -24,24 +24,25 @@ literal `gap-4` alone — and so is declaring it behind two variants of differen
 precedence. Declaring the base value once and letting
 the variant override it (`gap-4 md:gap-8`) remains the idiomatic form.
 
-> **Two shapes to watch for, both when several variants name the same utility from
-> [Payloads Velvet realises itself](#payloads-velvet-realises-itself).** Ordinary USS utilities are
-> unaffected by either, since the ranking above governs them.
->
-> *Same token, no literal base* — `"dark:gap-4 md:gap-4"`, `"dark:shadow-lg has-[.sel]:shadow-lg"`.
-> When the first of the two turns off, the class stays on the element exactly as described above, but
-> stops being *driven*: the spacing disappears and the shadow stops painting while `gap-4` /
-> `shadow-lg` is still sitting in the class list. A literal base is immune — `"gap-4 md:gap-4"` keeps
-> its gap.
->
-> *Same family, different values* — `"bg-white md:shadow-sm dark:shadow-lg"`. Which one wins is decided
-> by the order the two signals happened to fire, not by the precedence table: go dark and then widen
-> past `md` and you get `shadow-sm`; widen first and then go dark and you get `shadow-lg`. The end
-> state is identical either way, so the same window can render differently depending on how the user
-> got there.
->
-> Both come from the same gap — these utilities have no USS property set for the ranking to work from —
-> and the idiomatic `"gap-4 md:gap-8"` shape, one base plus one variant per element, avoids both.
+The utilities from [Payloads Velvet realises itself](#payloads-velvet-realises-itself) are ranked by
+that same `(priority, token)` model directly rather than through the class list, since the class list
+records only *whether* a class is present and these are read out of it as a family. Two consequences
+worth knowing, both when several variants name one such utility:
+
+- *Same token, no literal base* — `"dark:gap-4 md:gap-4"`, `"dark:shadow-lg has-[.sel]:shadow-lg"`.
+  One of the two turning off leaves the other driving, so the spacing and the shadow stay. Two
+  payloads of the **same** precedence still share one slot, per the paragraph above, so there the
+  first to turn off takes the utility with it.
+- *Same family, different values* — `"bg-white md:shadow-sm dark:shadow-lg"` resolves by the
+  precedence table, not by the order the two signals fired. `dark:` outranks `md:`, so both lit paint
+  `shadow-lg` whichever way the window got there. Where the precedence table cannot separate them —
+  two `data-[…]:` rules, two `has-[.class]:` rules — the one written later in the className wins, the
+  way source order settles a tie between equal-specificity CSS rules. Only rules that actually apply
+  take part: a `lg:` rule below the breakpoint, a `peer-` rule with no peer, and a `[&>*]:` rule (which
+  lands on the children) rank nothing on this element, so adding one never moves what it paints.
+  A stacked variant is ranked by its own position too: `dark:hover:` layers at the stronger of its two
+  parts, which is the plain `hover:` layer, so `"dark:hover:shadow-lg hover:shadow-sm"` resolves to the
+  later-written `shadow-sm` while both are active.
 
 ## The variant set
 

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
@@ -1745,24 +1745,28 @@ namespace Velvet
             private readonly string[] _active;
             private readonly string[] _checked;
 
+            private readonly VariantDeclarations _declarations;
+
             internal VariantOp(string[] hover, string[] focus, string[] focusVisible, string[] active,
-                string[] @checked)
+                string[] @checked, VariantDeclarations declarations)
             {
                 _hover = hover;
                 _focus = focus;
                 _focusVisible = focusVisible;
                 _active = active;
                 _checked = @checked;
+                _declarations = declarations;
             }
 
             public Dictionary<VisualElement, StyleVariantManipulator> Table(ReconcilerContext ctx)
                 => ctx.VariantManipulators;
 
             public StyleVariantManipulator Create(ReconcilerContext ctx)
-                => new StyleVariantManipulator(ctx, _hover, _focus, _focusVisible, _active, _checked);
+                => new StyleVariantManipulator(ctx, _hover, _focus, _focusVisible, _active, _checked,
+                    _declarations);
 
             public void Update(StyleVariantManipulator manipulator)
-                => manipulator.UpdatePayloads(_hover, _focus, _focusVisible, _active, _checked);
+                => manipulator.UpdatePayloads(_hover, _focus, _focusVisible, _active, _checked, _declarations);
         }
 
         private readonly struct ConditionalVariantOp : IManipulatorOp<StyleConditionalVariantManipulator>
@@ -1770,20 +1774,27 @@ namespace Velvet
             private readonly string[][] _responsive;
             private readonly string[] _dark;
 
-            internal ConditionalVariantOp(string[][] responsive, string[] dark)
+            private readonly int[][] _responsiveDeclarations;
+            private readonly int[] _darkDeclarations;
+
+            internal ConditionalVariantOp(string[][] responsive, string[] dark,
+                int[][] responsiveDeclarations, int[] darkDeclarations)
             {
                 _responsive = responsive;
                 _dark = dark;
+                _responsiveDeclarations = responsiveDeclarations;
+                _darkDeclarations = darkDeclarations;
             }
 
             public Dictionary<VisualElement, StyleConditionalVariantManipulator> Table(ReconcilerContext ctx)
                 => ctx.ConditionalVariantManipulators;
 
             public StyleConditionalVariantManipulator Create(ReconcilerContext ctx)
-                => new StyleConditionalVariantManipulator(ctx, _responsive, _dark);
+                => new StyleConditionalVariantManipulator(ctx, _responsive, _dark,
+                    _responsiveDeclarations, _darkDeclarations);
 
             public void Update(StyleConditionalVariantManipulator manipulator)
-                => manipulator.UpdatePayloads(_responsive, _dark);
+                => manipulator.UpdatePayloads(_responsive, _dark, _responsiveDeclarations, _darkDeclarations);
         }
 
         private readonly struct RelationalVariantOp : IManipulatorOp<StyleRelationalVariantManipulator>
@@ -1809,21 +1820,27 @@ namespace Velvet
         {
             private readonly string[] _checked;
             private readonly string[] _focus;
+            private readonly int[] _checkedDeclarations;
+            private readonly int[] _focusDeclarations;
 
-            internal HasVariantOp(string[] @checked, string[] focus)
+            internal HasVariantOp(string[] @checked, string[] focus,
+                int[] checkedDeclarations, int[] focusDeclarations)
             {
                 _checked = @checked;
                 _focus = focus;
+                _checkedDeclarations = checkedDeclarations;
+                _focusDeclarations = focusDeclarations;
             }
 
             public Dictionary<VisualElement, StyleHasVariantManipulator> Table(ReconcilerContext ctx)
                 => ctx.HasVariantManipulators;
 
             public StyleHasVariantManipulator Create(ReconcilerContext ctx)
-                => new StyleHasVariantManipulator(ctx, _checked, _focus);
+                => new StyleHasVariantManipulator(ctx, _checked, _focus,
+                    _checkedDeclarations, _focusDeclarations);
 
             public void Update(StyleHasVariantManipulator manipulator)
-                => manipulator.UpdatePayloads(_checked, _focus);
+                => manipulator.UpdatePayloads(_checked, _focus, _checkedDeclarations, _focusDeclarations);
         }
 
         private readonly struct ChildVariantOp : IManipulatorOp<StyleChildVariantManipulator>
@@ -1916,34 +1933,39 @@ namespace Velvet
         // from the state-variant tokens (hover:/focus:/active:) found in classNames.
         internal void ApplyVariantManipulator(VisualElement element, string[] classNames)
         {
-            var hover = ExtractVariant(classNames, StyleVariantKind.Hover);
-            var focus = ExtractVariant(classNames, StyleVariantKind.Focus);
-            var focusVisible = ExtractVariant(classNames, StyleVariantKind.FocusVisible);
-            var active = ExtractVariant(classNames, StyleVariantKind.Active);
-            var @checked = ExtractVariant(classNames, StyleVariantKind.Checked);
+            var hover = ExtractVariant(classNames, StyleVariantKind.Hover, out var hoverDecl);
+            var focus = ExtractVariant(classNames, StyleVariantKind.Focus, out var focusDecl);
+            var focusVisible = ExtractVariant(classNames, StyleVariantKind.FocusVisible, out var focusVisibleDecl);
+            var active = ExtractVariant(classNames, StyleVariantKind.Active, out var activeDecl);
+            var @checked = ExtractVariant(classNames, StyleVariantKind.Checked, out var checkedDecl);
             var hasAny = hover.Length > 0 || focus.Length > 0 || focusVisible.Length > 0
                 || active.Length > 0 || @checked.Length > 0;
 
             Configure<VariantOp, StyleVariantManipulator>(element, hasAny,
-                new VariantOp(hover, focus, focusVisible, active, @checked));
+                new VariantOp(hover, focus, focusVisible, active, @checked,
+                    new VariantDeclarations(hoverDecl, focusDecl, focusVisibleDecl, activeDecl, checkedDecl)));
         }
 
-        private static string[] ExtractVariant(string[] classNames, StyleVariantKind kind)
+        private static string[] ExtractVariant(string[] classNames, StyleVariantKind kind, out int[] declarations)
         {
+            declarations = Array.Empty<int>();
             if (classNames == null || classNames.Length == 0)
             {
                 return Array.Empty<string>();
             }
 
             List<string>? payloads = null;
-            foreach (var cls in classNames)
+            List<int>? positions = null;
+            for (var i = 0; i < classNames.Length; i++)
             {
-                if (StyleVariantClass.TryParse(cls, out var k, out var payload) && k == kind)
+                if (StyleVariantClass.TryParse(classNames[i], out var k, out var payload) && k == kind)
                 {
                     (payloads ??= new List<string>()).Add(payload ?? string.Empty);
+                    (positions ??= new List<int>()).Add(i);
                 }
             }
 
+            declarations = positions?.ToArray() ?? Array.Empty<int>();
             return payloads?.ToArray() ?? Array.Empty<string>();
         }
 
@@ -1951,15 +1973,19 @@ namespace Velvet
         // (sm:/md:/lg:/xl:/2xl:) and dark: tokens in classNames.
         internal void ApplyConditionalVariantManipulator(VisualElement element, string[] classNames)
         {
-            var responsive = new[]
+            var responsiveKinds = new[]
             {
-                ExtractVariant(classNames, StyleVariantKind.Sm),
-                ExtractVariant(classNames, StyleVariantKind.Md),
-                ExtractVariant(classNames, StyleVariantKind.Lg),
-                ExtractVariant(classNames, StyleVariantKind.Xl),
-                ExtractVariant(classNames, StyleVariantKind.Xxl),
+                StyleVariantKind.Sm, StyleVariantKind.Md, StyleVariantKind.Lg,
+                StyleVariantKind.Xl, StyleVariantKind.Xxl,
             };
-            var dark = ExtractVariant(classNames, StyleVariantKind.Dark);
+            var responsive = new string[responsiveKinds.Length][];
+            var responsiveDeclarations = new int[responsiveKinds.Length][];
+            for (var i = 0; i < responsiveKinds.Length; i++)
+            {
+                responsive[i] = ExtractVariant(classNames, responsiveKinds[i], out var breakpointDecl);
+                responsiveDeclarations[i] = breakpointDecl;
+            }
+            var dark = ExtractVariant(classNames, StyleVariantKind.Dark, out var darkDecl);
 
             var hasAny = dark.Length > 0;
             for (var i = 0; i < responsive.Length && !hasAny; i++)
@@ -1968,7 +1994,7 @@ namespace Velvet
             }
 
             Configure<ConditionalVariantOp, StyleConditionalVariantManipulator>(element, hasAny,
-                new ConditionalVariantOp(responsive, dark));
+                new ConditionalVariantOp(responsive, dark, responsiveDeclarations, darkDecl));
         }
 
         // Configures the element's StyleRelationalVariantManipulator from the group-*/peer- tokens (incl. the
@@ -1993,24 +2019,29 @@ namespace Velvet
                 return null;
             }
 
-            // (isPeer, name) -> per-state payload lists, indexed by (int)RelationalState.
+            // (isPeer, name) -> per-state payload lists, indexed by (int)RelationalState, and the className
+            // position of each of those payloads in the parallel list beside it.
             Dictionary<(bool IsPeer, string Name), List<string>[]>? map = null;
-            foreach (var cls in classNames)
+            Dictionary<(bool IsPeer, string Name), List<int>[]>? positions = null;
+            for (var i = 0; i < classNames.Length; i++)
             {
-                if (!StyleVariantClass.TryParse(cls, out var kind, out var name, out var payload)
+                if (!StyleVariantClass.TryParse(classNames[i], out var kind, out var name, out var payload)
                     || !StyleVariantClass.IsRelational(kind))
                 {
                     continue;
                 }
                 var key = (StyleVariantClass.RelationalIsPeer(kind), name ?? string.Empty);
                 map ??= new Dictionary<(bool, string), List<string>[]>();
+                positions ??= new Dictionary<(bool, string), List<int>[]>();
                 if (!map.TryGetValue(key, out var states))
                 {
                     states = new List<string>[5];
                     map[key] = states;
+                    positions[key] = new List<int>[5];
                 }
                 var slot = (int)StyleVariantClass.RelationalStateOf(kind);
                 (states[slot] ??= new List<string>()).Add(payload ?? string.Empty);
+                (positions![key][slot] ??= new List<int>()).Add(i);
             }
 
             if (map == null)
@@ -2022,16 +2053,26 @@ namespace Velvet
             foreach (var kv in map)
             {
                 var s = kv.Value;
+                var d = positions![kv.Key];
                 configs.Add(new RelationalBindingConfig(
                     kv.Key.IsPeer, kv.Key.Name,
                     ToPayloadArray(s[(int)StyleVariantClass.RelationalState.Hover]),
                     ToPayloadArray(s[(int)StyleVariantClass.RelationalState.Focus]),
                     ToPayloadArray(s[(int)StyleVariantClass.RelationalState.FocusWithin]),
                     ToPayloadArray(s[(int)StyleVariantClass.RelationalState.Active]),
-                    ToPayloadArray(s[(int)StyleVariantClass.RelationalState.Checked])));
+                    ToPayloadArray(s[(int)StyleVariantClass.RelationalState.Checked]),
+                    new VariantDeclarations(
+                        ToPositionArray(d[(int)StyleVariantClass.RelationalState.Hover]),
+                        ToPositionArray(d[(int)StyleVariantClass.RelationalState.Focus]),
+                        ToPositionArray(d[(int)StyleVariantClass.RelationalState.FocusWithin]),
+                        ToPositionArray(d[(int)StyleVariantClass.RelationalState.Active]),
+                        ToPositionArray(d[(int)StyleVariantClass.RelationalState.Checked]))));
             }
             return configs;
         }
+
+        private static int[] ToPositionArray(List<int>? positions)
+            => positions?.ToArray() ?? Array.Empty<int>();
 
         private static string[] ToPayloadArray(List<string> payloads)
             => payloads?.ToArray() ?? Array.Empty<string>();
@@ -2058,27 +2099,30 @@ namespace Velvet
         // manipulator).
         internal void ApplyHasVariantManipulator(VisualElement element, string[] classNames)
         {
-            var @checked = ExtractHas(classNames, StyleHasKind.Checked);
-            var focus = ExtractHas(classNames, StyleHasKind.Focus);
+            var @checked = ExtractHas(classNames, StyleHasKind.Checked, out var checkedDeclarations);
+            var focus = ExtractHas(classNames, StyleHasKind.Focus, out var focusDeclarations);
             var hasAny = @checked.Length > 0 || focus.Length > 0;
 
             Configure<HasVariantOp, StyleHasVariantManipulator>(element, hasAny,
-                new HasVariantOp(@checked, focus));
+                new HasVariantOp(@checked, focus, checkedDeclarations, focusDeclarations));
         }
 
         // Collects the payloads of every has-[:checked]: / has-[:focus]: token of the given kind. A payload
         // that is itself a structural / has variant is skipped (it would have no gating owner on this path),
         // mirroring the structural-config skip.
-        private static string[] ExtractHas(string[] classNames, StyleHasKind kind)
+        private static string[] ExtractHas(string[] classNames, StyleHasKind kind, out int[] declarations)
         {
+            declarations = Array.Empty<int>();
             if (classNames == null || classNames.Length == 0)
             {
                 return Array.Empty<string>();
             }
 
             List<string>? payloads = null;
-            foreach (var cls in classNames)
+            List<int>? positions = null;
+            for (var i = 0; i < classNames.Length; i++)
             {
+                var cls = classNames[i];
                 if (StyleHasVariantClass.TryParse(cls, out var k, out _, out var payload)
                     && k == kind
                     && !StyleStructuralVariantClass.IsStructural(payload)
@@ -2087,9 +2131,11 @@ namespace Velvet
                     && !StyleSupportsVariantClass.IsSupports(payload))
                 {
                     (payloads ??= new List<string>()).Add(payload ?? string.Empty);
+                    (positions ??= new List<int>()).Add(i);
                 }
             }
 
+            declarations = positions?.ToArray() ?? Array.Empty<int>();
             return payloads?.ToArray() ?? Array.Empty<string>();
         }
 
@@ -2104,16 +2150,18 @@ namespace Velvet
             {
                 foreach (var rule in oldRules)
                 {
-                    StyleVariantPayload.Apply(element, rule.Payloads, false, StyleLayerPriority.Has, _ctx);
+                    StyleVariantPayload.Apply(element, rule.Payloads, false, StyleLayerPriority.Has, _ctx,
+                        declarations: rule.Declarations);
                 }
                 _ctx.HasClassVariants.Remove(element);
             }
 
-            List<(string? ClassName, string?[] Payloads)>? rules = null;
+            List<(string? ClassName, string?[] Payloads, int[] Declarations)>? rules = null;
             if (classNames != null)
             {
-                foreach (var cls in classNames)
+                for (var i = 0; i < classNames.Length; i++)
                 {
+                    var cls = classNames[i];
                     if (StyleHasVariantClass.TryParse(cls, out var kind, out var className, out var payload)
                         && kind == StyleHasKind.Class
                         // A has-[.foo]: payload has no gating owner on this side-table path, so a nested
@@ -2125,8 +2173,8 @@ namespace Velvet
                         && !StyleAttributeVariantClass.IsAttribute(payload)
                         && !StyleSupportsVariantClass.IsSupports(payload))
                     {
-                        (rules ??= new List<(string? ClassName, string?[] Payloads)>())
-                            .Add((className, new[] { payload }));
+                        (rules ??= new List<(string? ClassName, string?[] Payloads, int[] Declarations)>())
+                            .Add((className, new[] { payload }, new[] { i }));
                     }
                 }
             }
@@ -2153,7 +2201,7 @@ namespace Velvet
         // is root-inclusive, so querying the element itself would self-match — :has() is descendant-only, and
         // a self-match would also latch when the payload class equals the queried class).
         private static void EvaluateHasClass(ReconcilerContext ctx, VisualElement element,
-            List<(string? ClassName, string?[] Payloads)> rules)
+            List<(string? ClassName, string?[] Payloads, int[] Declarations)> rules)
         {
             foreach (var rule in rules)
             {
@@ -2166,7 +2214,8 @@ namespace Velvet
                         break;
                     }
                 }
-                StyleVariantPayload.Apply(element, rule.Payloads, on, StyleLayerPriority.Has, ctx);
+                StyleVariantPayload.Apply(element, rule.Payloads, on, StyleLayerPriority.Has, ctx,
+                    declarations: rule.Declarations);
             }
         }
 
@@ -2320,16 +2369,19 @@ namespace Velvet
             {
                 foreach (var rule in oldRules)
                 {
-                    StyleVariantPayload.Apply(element, rule.Payloads, false, StyleLayerPriority.Attribute, _ctx);
+                    StyleVariantPayload.Apply(element, rule.Payloads, false, StyleLayerPriority.Attribute, _ctx,
+                        declarations: rule.Declarations);
                 }
                 _ctx.AttributeVariants.Remove(element);
             }
 
-            List<(StyleAttributeNamespace Ns, string Key, string? ExpectedValue, string[] Payloads)>? rules = null;
+            List<(StyleAttributeNamespace Ns, string Key, string? ExpectedValue, string[] Payloads,
+                int[] Declarations)>? rules = null;
             if (classNames != null)
             {
-                foreach (var cls in classNames)
+                for (var i = 0; i < classNames.Length; i++)
                 {
+                    var cls = classNames[i];
                     if (StyleAttributeVariantClass.TryParse(cls, out var ns, out var key, out var value, out var payload)
                         // An attribute payload has no gating owner on this side-table path (the side-table is
                         // re-evaluated as a whole, not by a per-payload manipulator), so a nested state /
@@ -2342,8 +2394,8 @@ namespace Velvet
                         && !StyleSupportsVariantClass.IsSupports(payload))
                     {
                         if (payload == null) continue;
-                        (rules ??= new List<(StyleAttributeNamespace, string, string?, string[])>())
-                            .Add((ns, key ?? string.Empty, value, new[] { payload }));
+                        (rules ??= new List<(StyleAttributeNamespace, string, string?, string[], int[])>())
+                            .Add((ns, key ?? string.Empty, value, new[] { payload }, new[] { i }));
                     }
                 }
             }
@@ -2416,7 +2468,8 @@ namespace Velvet
         // and idempotent (StyleVariantPayload.Apply is a no-op when the layer is already in the target state).
         private static void EvaluateAttributes(
             ReconcilerContext ctx, VisualElement element, Dictionary<string, string>? store,
-            List<(StyleAttributeNamespace Ns, string Key, string? ExpectedValue, string[] Payloads)> rules)
+            List<(StyleAttributeNamespace Ns, string Key, string? ExpectedValue, string[] Payloads,
+                int[] Declarations)> rules)
         {
             foreach (var rule in rules)
             {
@@ -2427,7 +2480,8 @@ namespace Velvet
                     present = store.TryGetValue(StorePrefix(rule.Ns) + rule.Key, out actual);
                 }
                 var on = StyleAttributeVariantClass.Matches(rule.ExpectedValue, present, actual);
-                StyleVariantPayload.Apply(element, rule.Payloads, on, StyleLayerPriority.Attribute, ctx);
+                StyleVariantPayload.Apply(element, rule.Payloads, on, StyleLayerPriority.Attribute, ctx,
+                    declarations: rule.Declarations);
             }
         }
 
@@ -2443,18 +2497,20 @@ namespace Velvet
         {
             if (_ctx.SupportsVariants.TryGetValue(element, out var oldRules))
             {
-                foreach (var payloads in oldRules)
+                foreach (var rule in oldRules)
                 {
-                    StyleVariantPayload.Apply(element, payloads, false, StyleLayerPriority.Supports, _ctx);
+                    StyleVariantPayload.Apply(element, rule.Payloads, false, StyleLayerPriority.Supports, _ctx,
+                        declarations: rule.Declarations);
                 }
                 _ctx.SupportsVariants.Remove(element);
             }
 
-            List<string[]>? rules = null;
+            List<(string[] Payloads, int[] Declarations)>? rules = null;
             if (classNames != null)
             {
-                foreach (var cls in classNames)
+                for (var i = 0; i < classNames.Length; i++)
                 {
+                    var cls = classNames[i];
                     if (StyleSupportsVariantClass.TryParse(cls, out _, out _, out var payload)
                         // A supports- payload has no gating owner on this side-table path (the layer is
                         // applied unconditionally, not driven by a per-payload manipulator), so a nested
@@ -2466,7 +2522,8 @@ namespace Velvet
                         && !StyleAttributeVariantClass.IsAttribute(payload)
                         && !StyleSupportsVariantClass.IsSupports(payload))
                     {
-                        (rules ??= new List<string[]>()).Add(new string[] { payload ?? string.Empty });
+                        (rules ??= new List<(string[], int[])>())
+                            .Add((new string[] { payload ?? string.Empty }, new[] { i }));
                     }
                 }
             }
@@ -2478,9 +2535,10 @@ namespace Velvet
             _ctx.SupportsVariants[element] = rules;
 
             // Always-applied: the property is, by construction, one the author is using on a fixed engine.
-            foreach (var payloads in rules)
+            foreach (var rule in rules)
             {
-                StyleVariantPayload.Apply(element, payloads, true, StyleLayerPriority.Supports, _ctx);
+                StyleVariantPayload.Apply(element, rule.Payloads, true, StyleLayerPriority.Supports, _ctx,
+                    declarations: rule.Declarations);
             }
         }
 
@@ -2495,16 +2553,18 @@ namespace Velvet
             {
                 foreach (var rule in oldRules)
                 {
-                    StyleVariantPayload.Apply(element, rule.Payloads, false, StyleLayerPriority.Structural, _ctx);
+                    StyleVariantPayload.Apply(element, rule.Payloads, false, StyleLayerPriority.Structural, _ctx,
+                        declarations: rule.Declarations);
                 }
                 _ctx.StructuralVariants.Remove(element);
             }
 
-            List<(StyleStructuralKind Kind, int N, string[] Payloads)>? rules = null;
+            List<(StyleStructuralKind Kind, int N, string[] Payloads, int[] Declarations)>? rules = null;
             if (classNames != null)
             {
-                foreach (var cls in classNames)
+                for (var i = 0; i < classNames.Length; i++)
                 {
+                    var cls = classNames[i];
                     if (StyleStructuralVariantClass.TryParse(cls, out var kind, out var n, out var payload)
                         // Structural variants do not compose with a nested variant (first:hover:…), a has-
                         // variant (first:has-[:checked]:…), an attribute variant (first:data-[x]:…), or a
@@ -2516,8 +2576,9 @@ namespace Velvet
                         && !StyleAttributeVariantClass.IsAttribute(payload)
                         && !StyleSupportsVariantClass.IsSupports(payload))
                     {
-                        (rules ??= new List<(StyleStructuralKind Kind, int N, string[] Payloads)>())
-                            .Add((kind, n, new string[] { payload ?? string.Empty }));
+                        (rules ??= new List<(StyleStructuralKind Kind, int N, string[] Payloads,
+                                int[] Declarations)>())
+                            .Add((kind, n, new string[] { payload ?? string.Empty }, new[] { i }));
                     }
                 }
             }
@@ -2552,12 +2613,13 @@ namespace Velvet
         // Applies / clears each structural rule's payload for an element at the given sibling position.
         private static void EvaluateStructural(
             ReconcilerContext ctx, VisualElement element, int index, int count,
-            List<(StyleStructuralKind Kind, int N, string[] Payloads)> rules)
+            List<(StyleStructuralKind Kind, int N, string[] Payloads, int[] Declarations)> rules)
         {
             foreach (var rule in rules)
             {
                 var on = StyleStructuralVariantClass.Matches(rule.Kind, rule.N, index, count);
-                StyleVariantPayload.Apply(element, rule.Payloads, on, StyleLayerPriority.Structural, ctx);
+                StyleVariantPayload.Apply(element, rule.Payloads, on, StyleLayerPriority.Structural, ctx,
+                    declarations: rule.Declarations);
             }
         }
 
@@ -2720,7 +2782,7 @@ namespace Velvet
         }
 
         // The class source every gate-driven pass reads: the reconciled array, followed by each gate token a
-        // variant currently has applied that the reconciled array does not already name.
+        // variant currently has applied, weakest payload first.
         //
         // A variant payload is realized by writing its bare utility onto the live class list, and the bare
         // form is the only one the gates recognize — `md:shadow-lg` is not a shadow token, `shadow-lg` is —
@@ -2735,9 +2797,9 @@ namespace Velvet
         // Appending the payloads LAST is what ranks them above the base utilities: each of these families
         // resolves last-token-wins, and a payload outranks the base it overrides. Composing them that way
         // makes it structural rather than a property of the live list's own append order, which the class
-        // diff can invert by re-adding a base token after a payload that is already lit.
-        // It ranks payloads against BASES only. Two payloads of one family rank against each other by arrival
-        // instead of by priority — see ReconcilerContext.TrackVariantGateClass for that known limitation.
+        // diff can invert by re-adding a base token after a payload that is already lit. Two payloads of one
+        // family rank against each other by the priority each was applied at, which VariantGateState keeps
+        // the token order in.
         //
         // changed reports whether the result differs from what this element was last resolved to, which is
         // what the skew and border-style stashes need: a release-and-re-stash on a pass that changed nothing
@@ -2791,65 +2853,64 @@ namespace Velvet
                     ? classNames
                     : ComposeVariantClasses(classNames, state.Tokens, state.Resolved);
 
-        // Builds classNames plus every variant-applied gate token it does not already name, handing back
-        // reuse unchanged when the result would match it token for token, and classNames itself when the
-        // tokens add nothing.
+        // Builds classNames plus every variant-applied gate token, handing back reuse unchanged when the
+        // result would match it token for token, and classNames itself when no payload is lit.
         //
         // The tracked tokens rather than the element's live class list: they are the same set for every
-        // family these passes read, they are already ordered by when each payload arrived, and reading them
-        // costs no enumerator — where walking the live list costs one per element per patch, plus a
-        // membership test per class on it. The narrowing that buys is real and deliberate: a bare utility
+        // family these passes read, they are already ranked by the priority each payload was applied at, and
+        // reading them costs no enumerator — where walking the live list costs one per element per patch,
+        // plus a membership test per class on it. The narrowing that buys is real and deliberate: a bare utility
         // written by a subsystem that raises no signal (whileHoverClass / whileTapClass / whileFocusClass,
         // the animation scheduler, the drag layer) is on the live list but never in this source, so it drives
         // no gate. Only a signalling writer can, and a writer with no signal could not keep a pass correct
         // across the toggle back off anyway.
         //
-        // Two passes so the steady state allocates NOTHING: the first counts the additions and checks them
-        // against reuse as it goes, and only a genuine change reaches the second, which materializes the
-        // array. This runs on every patch of every element a variant has a gate token applied to.
+        // A token the reconciled array ALREADY names is appended again rather than left where it sits.
+        // Declaring one literally and behind a variant is legal (gap-4 md:gap-4), and the duplicate is inert
+        // to every last-token-wins reader here — but leaving the literal occurrence to stand for the payload
+        // ranks it below every appended token, so `shadow-lg dark:shadow-sm hover:shadow-lg` would paint the
+        // dark preset even though the hover layer outranks it.
+        //
+        // The reuse compare runs before anything is built, so the steady state allocates NOTHING. This runs
+        // on every patch of every element a variant has a gate token applied to.
         private static string[] ComposeVariantClasses(string[] classNames, List<string> tokens, string[]? reuse)
         {
-            var extra = 0;
-            var reusable = reuse != null && reuse.Length >= classNames.Length;
-            foreach (var token in tokens)
-            {
-                // Declaring a token literally AND behind a variant is legal (gap-4 md:gap-4), and every
-                // family read from this source resolves last-token-wins, so appending a duplicate of one the
-                // reconciled array already names would change nothing but the allocation.
-                if (Array.IndexOf(classNames, token) >= 0)
-                {
-                    continue;
-                }
-                var slot = classNames.Length + extra;
-                reusable = reusable && slot < reuse!.Length && reuse[slot] == token;
-                extra++;
-            }
-
-            if (extra == 0)
+            if (tokens.Count == 0)
             {
                 return classNames;
             }
-            if (reusable && reuse!.Length == classNames.Length + extra && HeadEquals(reuse, classNames))
+            var total = classNames.Length + tokens.Count;
+            if (reuse != null && reuse.Length == total && TailEquals(reuse, classNames.Length, tokens)
+                && HeadEquals(reuse, classNames))
             {
                 return reuse;
             }
 
-            var composed = new string[classNames.Length + extra];
+            var composed = new string[total];
             Array.Copy(classNames, composed, classNames.Length);
-            var next = classNames.Length;
-            foreach (var token in tokens)
+            for (var i = 0; i < tokens.Count; i++)
             {
-                if (Array.IndexOf(classNames, token) < 0)
-                {
-                    composed[next++] = token;
-                }
+                composed[classNames.Length + i] = tokens[i];
             }
             return composed;
         }
 
+        // Whether array carries exactly tokens from start on.
+        private static bool TailEquals(string[] array, int start, List<string> tokens)
+        {
+            for (var i = 0; i < tokens.Count; i++)
+            {
+                if (array[start + i] != tokens[i])
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
         // Whether array opens with exactly head's tokens. The reconciled array can be a fresh instance
         // carrying the same tokens on every render, so the cached composition is still reusable then — but
-        // only once its head is confirmed, since that is the half the token walk above never inspects.
+        // only once its head is confirmed.
         private static bool HeadEquals(string[] array, string[] head)
         {
             for (var i = 0; i < head.Length; i++)

--- a/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
@@ -113,17 +113,188 @@ namespace Velvet
     // NEXT toggle will need and no reconcile need ever run again to re-record it.
     internal sealed class VariantGateState
     {
-        // The gate tokens a variant currently has applied, in the order they arrived. Empty means the element
-        // declares one but has none lit, which is what puts it back on the cheap reconciled-array path.
-        // A list, not a set: these are appended to the reconciled array to form the class source the passes
-        // read, every family there resolves last-token-wins, and a set would leave two payloads of the same
-        // family ranked by hash order. Membership is checked linearly, which is what a handful of tokens
-        // wants anyway.
-        public readonly List<string> Tokens = new();
+        // One slot per (token, priority) pair a variant currently has applied — the same slot model
+        // StyleClassProjection keeps for the live class list, so the two agree on when a token is still
+        // wanted. The projection decides which CLASSES may sit on the element; it cannot decide which of two
+        // same-family tokens a class-driven pass reads, because that is settled by the order of the composed
+        // array. This list carries that ranking.
+        // Declaration is where the applying rule sits in the className, kept per slot so a tie inside one
+        // priority resolves by source order. Two rules of one family asserting the same token share the slot
+        // and it holds the LAST of them, which is the one source order would let win.
+        private readonly List<(string Token, int Priority, int Declaration)> _entries = new();
+
+        private readonly List<(string Token, int Priority, int Declaration)> _ranked = new();
+        private List<string> _tokens = new();
+        private List<string> _pending = new();
+
+        // Each applied gate token once, weakest first. Empty means the element declares one but has none lit,
+        // which is what puts it back on the cheap reconciled-array path.
+        // These are appended to the reconciled array to form the class source the passes read, and every
+        // family there resolves last-token-wins — so ascending is what makes the strongest payload win.
+        public List<string> Tokens => _tokens;
+
+        // Records / drops one applied payload, reporting whether Tokens changed as a sequence — which is
+        // what decides whether the caller re-derives the gated passes. A token another live layer still
+        // asserts at a DIFFERENT priority survives the drop and reports no change; two layers at one
+        // priority share a slot, exactly as they do in the projection, so the second one to leave is what
+        // drops it there and here alike.
+        public bool Track(string cls, int priority, int declaration, bool on)
+        {
+            var index = IndexOf(cls, priority);
+            if (on)
+            {
+                if (index >= 0)
+                {
+                    // A second rule of the same family claiming a token the slot already holds: source order
+                    // gives the tie to the later of the two, so the slot takes the later position and the
+                    // idempotent re-apply of the earlier one leaves it alone.
+                    if (declaration <= _entries[index].Declaration)
+                    {
+                        return false;
+                    }
+                    _entries[index] = (cls, priority, declaration);
+                }
+                else
+                {
+                    _entries.Add((cls, priority, declaration));
+                }
+            }
+            else
+            {
+                // declaration is not consulted here: the slot is keyed by (token, priority), so an off-toggle
+                // drops whichever rule holds it regardless of where that rule sits. Callers pass it anyway,
+                // to keep their clear and evaluate loops the same call.
+                if (index < 0)
+                {
+                    return false;
+                }
+                _entries.RemoveAt(index);
+            }
+            return Reorder();
+        }
+
+        // Ranks each distinct token by its HIGHEST asserted priority, so a token two layers assert sits where
+        // the stronger one puts it, and breaks a tie within a band by that layer's declaration position.
+        // A stable insertion sort, so a token neither key separates keeps arrival order.
+        //
+        // What was verified, enumerated over StyleLayerPriority rather than summarised: Structural, Supports
+        // and Attribute have one side-table supplier each; the responsive band and Dark have the conditional
+        // manipulator; the group/peer bands have the relational one; the element-state bands have the state
+        // manipulator; Has has BOTH the has-[.class]: side table and the event-driven manipulator; and
+        // ChildVariant has the child-combinator manipulator alone. All of those declare a position except
+        // the last. The important band is those priorities plus a constant, so it partitions identically.
+        //
+        // A band's supplier list is NOT the whole question, because a payload can be promoted OUT of the
+        // band its owner applies at: a state-variant payload gated by any of these owners layers at
+        // max(outer, inner) (see GateStackedVariant), which lands a [&>*]:hover: payload on the hover band
+        // beside the child's own. What makes that safe is not the enumeration but NoDeclaration being the
+        // weakest rank, so a payload with no position comparable to this element's className loses every tie
+        // it enters rather than winning it.
+        // Quadratic on a handful of tokens, and only on a toggle; the per-patch composition just reads it.
+        private bool Reorder()
+        {
+            BuildRanked();
+            for (var i = 1; i < _ranked.Count; i++)
+            {
+                var item = _ranked[i];
+                var at = i;
+                while (at > 0 && Outranks(_ranked[at - 1], item))
+                {
+                    _ranked[at] = _ranked[at - 1];
+                    at--;
+                }
+                _ranked[at] = item;
+            }
+
+            _pending.Clear();
+            foreach (var ranked in _ranked)
+            {
+                _pending.Add(ranked.Token);
+            }
+            if (SameSequence(_pending, _tokens))
+            {
+                return false;
+            }
+            (_tokens, _pending) = (_pending, _tokens);
+            return true;
+        }
+
+        private static bool Outranks((string Token, int Priority, int Declaration) a,
+            (string Token, int Priority, int Declaration) b)
+            => a.Priority > b.Priority || (a.Priority == b.Priority && a.Declaration > b.Declaration);
+
+        // Each distinct token at the strongest priority any layer asserts it at, carrying that same layer's
+        // declaration — the tie-break has to come from the rule that WINS the token, not from a weaker one
+        // that also names it.
+        private void BuildRanked()
+        {
+            _ranked.Clear();
+            foreach (var entry in _entries)
+            {
+                if (RankOf(entry.Token) < 0)
+                {
+                    _ranked.Add(StrongestOf(entry.Token));
+                }
+            }
+        }
+
+        private (string Token, int Priority, int Declaration) StrongestOf(string cls)
+        {
+            var strongest = (Token: cls, Priority: int.MinValue, Declaration: StyleVariantPayload.NoDeclaration);
+            foreach (var entry in _entries)
+            {
+                if (entry.Token == cls && entry.Priority > strongest.Priority)
+                {
+                    strongest = entry;
+                }
+            }
+            return strongest;
+        }
+
+        private int RankOf(string cls)
+        {
+            for (var i = 0; i < _ranked.Count; i++)
+            {
+                if (_ranked[i].Token == cls)
+                {
+                    return i;
+                }
+            }
+            return -1;
+        }
+
+        private int IndexOf(string cls, int priority)
+        {
+            for (var i = 0; i < _entries.Count; i++)
+            {
+                if (_entries[i].Priority == priority && _entries[i].Token == cls)
+                {
+                    return i;
+                }
+            }
+            return -1;
+        }
+
+        private static bool SameSequence(List<string> a, List<string> b)
+        {
+            if (a.Count != b.Count)
+            {
+                return false;
+            }
+            for (var i = 0; i < a.Count; i++)
+            {
+                if (a[i] != b[i])
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
 
         // The class array this element's last reconcile pass was given — the only source carrying the tokens
         // no class list can hold (variant tokens, and the bracket / static-scale values that resolve to
         // inline style), which is why the resolved array is built ON it rather than from the live list alone.
+        //
         public string[]? Reconciled;
 
         // The array the passes were last given. Returned again, by reference, whenever the freshly composed
@@ -166,7 +337,8 @@ namespace Velvet
         // evaluated against its position among siblings. Each such child registers its parsed rules here at
         // config time; the container's post-children pass (ApplyStructuralVariants) re-derives every rule's
         // match from the live sibling order. Cleared on element cleanup / reconciler dispose.
-        public Dictionary<VisualElement, List<(StyleStructuralKind Kind, int N, string[] Payloads)>> StructuralVariants { get; } = new();
+        public Dictionary<VisualElement, List<(StyleStructuralKind Kind, int N, string[] Payloads,
+            int[] Declarations)>> StructuralVariants { get; } = new();
 
         // has-[:checked]: / has-[:focus]: — an element styled by an event-driven descendant condition. The
         // manipulator lives on the element and listens to bubbling descendant events (ChangeEvent<bool> for
@@ -180,7 +352,8 @@ namespace Velvet
         // (ApplyHasClassVariants, the same hook ApplyStructuralVariants uses but with the element as subject)
         // re-derives every rule from a fresh descendant query, so a child added / removed re-derives it.
         // Cleared on element cleanup / reconciler dispose.
-        public Dictionary<VisualElement, List<(string? ClassName, string?[] Payloads)>> HasClassVariants { get; } = new();
+        public Dictionary<VisualElement, List<(string? ClassName, string?[] Payloads, int[] Declarations)>>
+            HasClassVariants { get; } = new();
 
         // data-[key=value]: / data-[key]: / aria-[...]: — an element styled by its OWN carried attribute
         // values (UI Toolkit has no HTML attributes, so the element supplies them via the Data / Aria props).
@@ -194,7 +367,8 @@ namespace Velvet
         //     event), so the props path drives the re-evaluation, mirroring the has-[.class]: side-table.
         // Both cleared on element cleanup / reconciler dispose.
         public Dictionary<VisualElement, Dictionary<string, string>> DataAttributes { get; } = new();
-        public Dictionary<VisualElement, List<(StyleAttributeNamespace Ns, string Key, string? ExpectedValue, string[] Payloads)>> AttributeVariants { get; } = new();
+        public Dictionary<VisualElement, List<(StyleAttributeNamespace Ns, string Key, string? ExpectedValue,
+            string[] Payloads, int[] Declarations)>> AttributeVariants { get; } = new();
 
         // supports-[prop:value]: — an element styled by a CSS feature query. UI Toolkit targets one fixed
         // engine, so a feature query is STATIC: a well-formed token is always-applied (see
@@ -202,7 +376,7 @@ namespace Velvet
         // exists only to remember the applied payloads: it is written once at config time (payload applied
         // immediately, always-on) and read solely so a later class-list change can clear the prior payload
         // before re-deriving. Cleared on element cleanup / reconciler dispose.
-        public Dictionary<VisualElement, List<string[]>> SupportsVariants { get; } = new();
+        public Dictionary<VisualElement, List<(string[] Payloads, int[] Declarations)>> SupportsVariants { get; } = new();
 
         // text-transform / text-decoration / whitespace-pre-line / leading-* (uppercase / underline / … / the
         // pre-line collapse / line-height). UI Toolkit has no property for any of them, so they are realised
@@ -276,7 +450,8 @@ namespace Velvet
         // arbitrary leaf layers at max(outer, inner) priority so it sits above either variant alone. A named
         // inner relational (group-hover/sidebar:) threads its name through so the nested manipulator resolves
         // the named source, not the unnamed group/peer.
-        internal void GateStackedVariant(VisualElement target, object owner, string variantPayload, bool outerOn, int outerPriority)
+        internal void GateStackedVariant(VisualElement target, object owner, string variantPayload,
+            bool outerOn, int outerPriority, int declaration)
         {
             if (!StyleVariantClass.TryParse(variantPayload, out var innerKind, out var innerName, out var leafPayload))
             {
@@ -292,7 +467,8 @@ namespace Velvet
                 {
                     var innerPriority = StyleLayerPriority.ForVariant(innerKind);
                     var priority = outerPriority > innerPriority ? outerPriority : innerPriority;
-                    m = new StyleStackedVariantManipulator(this, innerKind, innerName, new string?[] { leafPayload }, priority);
+                    m = new StyleStackedVariantManipulator(this, innerKind, innerName,
+                        new string?[] { leafPayload }, priority, declaration);
                     StackedVariantManipulators[key] = m;
                     target.AddManipulator(m);
                 }
@@ -348,24 +524,15 @@ namespace Velvet
         // change), so nothing else would re-run those passes. Null until the patcher wires it.
         public System.Action<VisualElement> VariantGatedReSync { get; set; } = null!;
 
-        // Records / drops one variant-applied gate token for target, returning true when the tracked
-        // set actually changed — so the caller signals a re-derive exactly once per real change. Set
-        // semantics rather than a counter: a manipulator may re-assert an already-applied payload, and an
-        // off-toggle for a payload that was never on is a no-op, either of which would drift a count.
-        // KNOWN LIMITATION, two faces of one cause: the tokens carry no priority, while StyleClassProjection —
-        // which owns the class list — ranks by it. None of these utilities has a USS property set, so the
-        // projection cannot rank them and this table is the only thing ordering them.
-        // - Two variants supplying the SAME token with no literal base (dark:gap-4 beside md:gap-4) diverge
-        //   when the first turns off: the projection keeps the class, because the other layer still wants it,
-        //   while the token leaves here and the gate the class drives turns off with it. A literal base is
-        //   unaffected — the composed source is built ON the reconciled array, which carries it.
-        // - Two payloads of one FAMILY (md:shadow-sm beside dark:shadow-lg) resolve by arrival rather than by
-        //   priority, because every family reads last-token-wins off the composed array. Lighting dark first
-        //   and then crossing md leaves shadow-sm winning, though the precedence table ranks dark: above md:;
-        //   the opposite order gives shadow-lg. Same end state, two renderings, decided by signal history.
-        // Both need the same fix: key the tokens by the priority the payload was applied at, the way the
-        // projection does, and order the composition by it instead of by arrival.
-        internal bool TrackVariantGateClass(VisualElement target, string cls, bool on)
+        // Records / drops one variant-applied gate token for target at the priority its payload was applied
+        // at — the same one StyleClassProjection layers the class itself at, so the token set and the class
+        // list rank and expire together — plus, for the rules that carry one, the className position that
+        // settles a tie inside that priority. Returns true when the composed order actually changed, so the
+        // caller signals a re-derive exactly once per real change: a manipulator may re-assert an
+        // already-applied payload, and an off-toggle for a payload that was never on is a no-op, either of
+        // which would drift a count.
+        internal bool TrackVariantGateClass(VisualElement target, string cls, int priority, int declaration,
+            bool on)
         {
             if (on)
             {
@@ -374,19 +541,15 @@ namespace Velvet
                     state = new VariantGateState();
                     VariantGateClasses[target] = state;
                 }
-                if (state.Tokens.Contains(cls))
-                {
-                    return false;
-                }
-                state.Tokens.Add(cls);
-                return true;
+                return state.Track(cls, priority, declaration, on: true);
             }
 
             // The entry stays behind once its last token leaves: an empty token set is already what puts the
             // element back on the cheap reconciled-array path, and the recorded array is what the NEXT toggle
             // composes from — dropping it would leave a payload that turns on again with nothing to build on,
             // since no reconcile need ever run in between to re-record it.
-            return VariantGateClasses.TryGetValue(target, out var current) && current.Tokens.Remove(cls);
+            return VariantGateClasses.TryGetValue(target, out var current)
+                && current.Track(cls, priority, declaration, on: false);
         }
 
         // Per-divided-child dashed / dotted divider paint (divide-dashed / divide-dotted), keyed by the CHILD

--- a/Packages/com.velvet.core/Runtime/Styling/StyleChildVariantManipulator.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleChildVariantManipulator.cs
@@ -179,6 +179,17 @@ namespace Velvet
         // Applies (on) or clears (off) the payload set on one child. owner == this is threaded through so a
         // state-variant payload defers to a per-child stacked manipulator gated by this walk, exactly as the
         // has- manipulator threads itself through for its own composed payloads.
+        //
+        // Deliberately passes NO className positions, unlike every other supplier: these payloads are written
+        // on the PARENT, so a position would index a different class list from the one every payload the
+        // CHILD declares is indexed in, and the two would be compared as if they were the same.
+        //
+        // What makes that safe is the rank they fall back to being the WEAKEST (see
+        // StyleVariantPayload.NoDeclaration), not the layer they are applied at: a state-variant payload
+        // here is promoted onto the inner variant's own layer, where the child's own payloads sit, so
+        // ranking these strongest would let the container's blanket rule beat the child's own. Among
+        // themselves they tie and fall back to arrival, which for one swept array is the parent's className
+        // order — their source order.
         private void ApplyPayloads(VisualElement child, bool on)
             => StyleVariantPayload.Apply(child, _payloads, on, StyleLayerPriority.ChildVariant, _ctx, this);
 

--- a/Packages/com.velvet.core/Runtime/Styling/StyleConditionalVariantManipulator.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleConditionalVariantManipulator.cs
@@ -21,6 +21,11 @@ namespace Velvet
         // Payload arrays aligned to Breakpoints (length 5) plus the dark payloads.
         private string[][] _responsive;
         private string[] _dark;
+        // Each payload's position in the className, aligned to the arrays above. Carried so a payload can be
+        // ranked against one another owner applied at the same layer — a dark:hover: leaf is gated from here
+        // but lands on the hover layer, where a plain hover: payload also sits.
+        private int[][] _responsiveDeclarations;
+        private int[] _darkDeclarations;
 
         private readonly bool[] _bpOn = new bool[Breakpoints.Length];
         private bool _darkOn;
@@ -28,19 +33,25 @@ namespace Velvet
 
         private readonly ReconcilerContext _ctx;
 
-        public StyleConditionalVariantManipulator(ReconcilerContext ctx, string[][] responsive, string[] dark)
+        public StyleConditionalVariantManipulator(ReconcilerContext ctx, string[][] responsive, string[] dark,
+            int[][] responsiveDeclarations, int[] darkDeclarations)
         {
             _ctx = ctx;
             _responsive = responsive ?? new string[Breakpoints.Length][];
             _dark = dark ?? Array.Empty<string>();
+            _responsiveDeclarations = responsiveDeclarations ?? new int[Breakpoints.Length][];
+            _darkDeclarations = darkDeclarations ?? Array.Empty<int>();
             _widthSource = new ResponsiveWidthSource(EvaluateResponsive);
         }
 
-        public void UpdatePayloads(string[][] responsive, string[] dark)
+        public void UpdatePayloads(string[][] responsive, string[] dark,
+            int[][] responsiveDeclarations, int[] darkDeclarations)
         {
             ResetApplied();
             _responsive = responsive ?? new string[Breakpoints.Length][];
             _dark = dark ?? Array.Empty<string>();
+            _responsiveDeclarations = responsiveDeclarations ?? new int[Breakpoints.Length][];
+            _darkDeclarations = darkDeclarations ?? Array.Empty<int>();
             Evaluate();
         }
 
@@ -144,7 +155,23 @@ namespace Velvet
         }
 
         private void ApplyPayloads(string[] payloads, bool on)
-            => StyleVariantPayload.Apply(target, payloads, on, PriorityFor(payloads), _ctx, this);
+            => StyleVariantPayload.Apply(target, payloads, on, PriorityFor(payloads), _ctx, this,
+                DeclarationsFor(payloads));
+
+        // The className positions belonging to the payload array passed, paired the same way PriorityFor
+        // pairs the layer.
+        private int[] DeclarationsFor(string[] payloads)
+        {
+            if (ReferenceEquals(payloads, _dark)) return _darkDeclarations;
+            for (var i = 0; i < _responsive.Length; i++)
+            {
+                if (ReferenceEquals(payloads, _responsive[i]))
+                {
+                    return i < _responsiveDeclarations.Length ? _responsiveDeclarations[i] : Array.Empty<int>();
+                }
+            }
+            return Array.Empty<int>();
+        }
 
         // Arbitrary-value layering priority: dark, or a responsive breakpoint (a larger min-width wins). Keyed
         // by reference to the payload array passed, so a higher breakpoint's arbitrary value layers over a lower

--- a/Packages/com.velvet.core/Runtime/Styling/StyleHasVariantManipulator.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleHasVariantManipulator.cs
@@ -25,16 +25,23 @@ namespace Velvet
     {
         private string[] _checked;
         private string[] _focus;
+        // Each payload's position in the className, so a tie against the has-[.class]: side table — the other
+        // supplier at this layer — resolves by source order rather than by which signal fired first.
+        private int[] _checkedDeclarations;
+        private int[] _focusDeclarations;
         private bool _isChecked;
         private bool _isFocused;
 
         private readonly ReconcilerContext _ctx;
 
-        public StyleHasVariantManipulator(ReconcilerContext ctx, string[] @checked, string[] focus)
+        public StyleHasVariantManipulator(ReconcilerContext ctx, string[] @checked, string[] focus,
+            int[] checkedDeclarations, int[] focusDeclarations)
         {
             _ctx = ctx;
             _checked = @checked ?? Array.Empty<string>();
             _focus = focus ?? Array.Empty<string>();
+            _checkedDeclarations = checkedDeclarations ?? Array.Empty<int>();
+            _focusDeclarations = focusDeclarations ?? Array.Empty<int>();
         }
 
         // Re-derives the checked / focus signals from a fresh subtree probe, syncing each payload to the
@@ -62,7 +69,8 @@ namespace Velvet
         // leaves a stale latched bit. The checked signal is re-derived from a fresh subtree probe; the focus
         // signal is event-driven and a re-render fires no focus event, so the live focus-within state still
         // holds and is merely re-applied under the new payload (cleared only when its set empties).
-        public void UpdatePayloads(string[] @checked, string[] focus)
+        public void UpdatePayloads(string[] @checked, string[] focus,
+            int[] checkedDeclarations, int[] focusDeclarations)
         {
             if (target != null)
             {
@@ -72,6 +80,8 @@ namespace Velvet
 
             _checked = @checked ?? Array.Empty<string>();
             _focus = focus ?? Array.Empty<string>();
+            _checkedDeclarations = checkedDeclarations ?? Array.Empty<int>();
+            _focusDeclarations = focusDeclarations ?? Array.Empty<int>();
 
             _isChecked = false;
             if (_focus.Length == 0)
@@ -229,6 +239,7 @@ namespace Velvet
         // applied as an inline style; otherwise it is toggled as a USS class. owner is passed so a payload
         // that is itself a (stacked) variant defers to a nested manipulator, matching the other manipulators.
         private void ApplyPayloads(string[] payloads, bool on)
-            => StyleVariantPayload.Apply(target, payloads, on, StyleLayerPriority.Has, _ctx, this);
+            => StyleVariantPayload.Apply(target, payloads, on, StyleLayerPriority.Has, _ctx, this,
+                ReferenceEquals(payloads, _checked) ? _checkedDeclarations : _focusDeclarations);
     }
 }

--- a/Packages/com.velvet.core/Runtime/Styling/StyleRelationalVariantManipulator.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleRelationalVariantManipulator.cs
@@ -17,10 +17,14 @@ namespace Velvet
         public readonly string[] FocusWithin;
         public readonly string[] Active;
         public readonly string[] Checked;
+        // Each payload's position in the className, aligned to the arrays above — see VariantDeclarations for
+        // why a payload has to carry one.
+        public readonly VariantDeclarations Declarations;
 
         public RelationalBindingConfig(
             bool isPeer, string name,
-            string[] hover, string[] focus, string[] focusWithin, string[] active, string[] checkedPayloads)
+            string[] hover, string[] focus, string[] focusWithin, string[] active, string[] checkedPayloads,
+            VariantDeclarations declarations)
         {
             IsPeer = isPeer;
             Name = name ?? string.Empty;
@@ -29,6 +33,7 @@ namespace Velvet
             FocusWithin = focusWithin ?? Array.Empty<string>();
             Active = active ?? Array.Empty<string>();
             Checked = checkedPayloads ?? Array.Empty<string>();
+            Declarations = declarations;
         }
     }
 
@@ -154,8 +159,8 @@ namespace Velvet
         // the owner, and the per-state priority is shared across names — so two named bindings of the same
         // state + same inner leaf must use DISTINCT owners or one's exit would tear down the gate the other
         // still needs. Per-binding owners keep their nested manipulators independent.
-        private void ApplyPayloads(object owner, string[] payloads, bool on, int priority)
-            => StyleVariantPayload.Apply(target, payloads, on, priority, _ctx, owner);
+        private void ApplyPayloads(object owner, string[] payloads, int[] declarations, bool on, int priority)
+            => StyleVariantPayload.Apply(target, payloads, on, priority, _ctx, owner, declarations);
 
         internal static VisualElement? FindAncestorWithClass(VisualElement element, string cls)
         {
@@ -210,6 +215,7 @@ namespace Velvet
             private readonly string[] _focusWithin;
             private readonly string[] _active;
             private readonly string[] _checked;
+            private readonly VariantDeclarations _declarations;
 
             private RelationalVariantSignals _signals = null!;
             private bool _aHover, _aFocus, _aFocusWithin, _aActive, _aChecked;
@@ -224,6 +230,7 @@ namespace Velvet
                 _focusWithin = config.FocusWithin;
                 _active = config.Active;
                 _checked = config.Checked;
+                _declarations = config.Declarations;
             }
 
             // The class that marks this binding's source (see SourceClassFor).
@@ -296,7 +303,17 @@ namespace Velvet
             }
 
             // Pass THIS binding as the stacked-gate owner so distinct named bindings never share a gate key.
-            private void Apply(string[] payloads, bool on, int priority) => _owner.ApplyPayloads(this, payloads, on, priority);
+            private void Apply(string[] payloads, bool on, int priority)
+                => _owner.ApplyPayloads(this, payloads, DeclarationsFor(payloads), on, priority);
+
+            // The className positions belonging to the payload array passed, paired by reference the same way
+            // the caller pairs the layer.
+            private int[] DeclarationsFor(string[] payloads) =>
+                ReferenceEquals(payloads, _checked) ? _declarations.Checked
+                : ReferenceEquals(payloads, _active) ? _declarations.Active
+                : ReferenceEquals(payloads, _focusWithin) ? _declarations.FocusVisible
+                : ReferenceEquals(payloads, _focus) ? _declarations.Focus
+                : _declarations.Hover;
 
             // Each sub-state gets its OWN priority so two active on the same property layer independently and
             // clearing one falls back to the other. Group and peer have distinct priority sets; the priority is

--- a/Packages/com.velvet.core/Runtime/Styling/StyleStackedVariantManipulator.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleStackedVariantManipulator.cs
@@ -18,6 +18,10 @@ namespace Velvet
         private readonly string _innerName; // relational name of a NAMED inner (group-hover/sidebar:), else ""
         private readonly string[] _leaf;
         private readonly int _priority;
+        // The position of the WHOLE stacked class (dark:hover:shadow-lg) in the className, not of the leaf it
+        // peels to — one written token is one declaration site, and that is the position a reader would point
+        // at when this leaf ties with a plain hover: payload on the shared layer.
+        private readonly int[] _declarations;
 
         private bool _outerOn;
         private bool _innerOn;
@@ -27,8 +31,10 @@ namespace Velvet
         private RelationalVariantSignals _relSignals = null!;
 
         public StyleStackedVariantManipulator(
-            ReconcilerContext ctx, StyleVariantKind innerKind, string? innerName, string?[] leaf, int priority)
+            ReconcilerContext ctx, StyleVariantKind innerKind, string? innerName, string?[] leaf, int priority,
+            int declaration)
         {
+            _declarations = new[] { declaration };
             _ctx = ctx;
             _innerKind = innerKind;
             _innerName = innerName ?? string.Empty;
@@ -263,7 +269,7 @@ namespace Velvet
                 return;
             }
             _applied = want;
-            StyleVariantPayload.Apply(target, _leaf, want, _priority, _ctx, this);
+            StyleVariantPayload.Apply(target, _leaf, want, _priority, _ctx, this, _declarations);
         }
 
         private void ClearApplied()
@@ -273,7 +279,7 @@ namespace Velvet
                 return;
             }
             _applied = false;
-            StyleVariantPayload.Apply(target, _leaf, false, _priority, _ctx, this);
+            StyleVariantPayload.Apply(target, _leaf, false, _priority, _ctx, this, _declarations);
         }
         #endregion
     }

--- a/Packages/com.velvet.core/Runtime/Styling/StyleVariantManipulator.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleVariantManipulator.cs
@@ -24,6 +24,33 @@ namespace Velvet
     // CSS :hover ancestor chain. On PointerOut the hover is cleared only
     // once the pointer has actually left this element's bounds; while it merely crosses between descendants the
     // payload is kept, avoiding a per-crossing remove/re-add that restarts any transition.
+    // The className position of every state payload, grouped so the five arrays travel together rather than
+    // as five more parameters on each of the two entry points that carry them.
+    internal readonly struct VariantDeclarations
+    {
+        public static readonly VariantDeclarations None = new(
+            Array.Empty<int>(), Array.Empty<int>(), Array.Empty<int>(), Array.Empty<int>(), Array.Empty<int>());
+
+        public VariantDeclarations(int[] hover, int[] focus, int[] focusVisible, int[] active, int[] @checked)
+        {
+            Hover = hover ?? Array.Empty<int>();
+            Focus = focus ?? Array.Empty<int>();
+            FocusVisible = focusVisible ?? Array.Empty<int>();
+            Active = active ?? Array.Empty<int>();
+            Checked = @checked ?? Array.Empty<int>();
+        }
+
+        public int[] Hover { get; }
+
+        public int[] Focus { get; }
+
+        public int[] FocusVisible { get; }
+
+        public int[] Active { get; }
+
+        public int[] Checked { get; }
+    }
+
     internal sealed class StyleVariantManipulator : Manipulator, IVariantSettleTarget
     {
         private string[] _hover;
@@ -31,6 +58,14 @@ namespace Velvet
         private string[] _focusVisible;
         private string[] _active;
         private string[] _checked;
+        // Each payload's position in the className, kept per state alongside the payloads themselves so a
+        // payload can be ranked against one a DIFFERENT owner applied at the same layer — a stacked
+        // dark:hover: shares this manipulator's hover layer. Identified by reference, like PriorityFor.
+        private int[] _hoverDeclarations;
+        private int[] _focusDeclarations;
+        private int[] _focusVisibleDeclarations;
+        private int[] _activeDeclarations;
+        private int[] _checkedDeclarations;
         private bool _isHovered;
         private bool _isFocused;
         private bool _isFocusVisible;
@@ -43,7 +78,8 @@ namespace Velvet
 
         private readonly ReconcilerContext _ctx;
 
-        public StyleVariantManipulator(ReconcilerContext ctx, string[] hover, string[] focus, string[] focusVisible, string[] active, string[] @checked)
+        public StyleVariantManipulator(ReconcilerContext ctx, string[] hover, string[] focus,
+            string[] focusVisible, string[] active, string[] @checked, VariantDeclarations declarations)
         {
             _ctx = ctx;
             _hover = hover ?? Array.Empty<string>();
@@ -51,6 +87,11 @@ namespace Velvet
             _focusVisible = focusVisible ?? Array.Empty<string>();
             _active = active ?? Array.Empty<string>();
             _checked = @checked ?? Array.Empty<string>();
+            _hoverDeclarations = declarations.Hover;
+            _focusDeclarations = declarations.Focus;
+            _focusVisibleDeclarations = declarations.FocusVisible;
+            _activeDeclarations = declarations.Active;
+            _checkedDeclarations = declarations.Checked;
         }
 
         // Applies (on) or clears (off) the payloads for every state currently flagged active, under the
@@ -66,7 +107,8 @@ namespace Velvet
         }
 
         // Swaps the payload sets, re-applying any currently-active state under the new sets.
-        public void UpdatePayloads(string[] hover, string[] focus, string[] focusVisible, string[] active, string[] @checked)
+        public void UpdatePayloads(string[] hover, string[] focus, string[] focusVisible, string[] active,
+            string[] @checked, VariantDeclarations declarations)
         {
             if (target != null) ReapplyActiveStates(false);
 
@@ -75,6 +117,11 @@ namespace Velvet
             _focusVisible = focusVisible ?? Array.Empty<string>();
             _active = active ?? Array.Empty<string>();
             _checked = @checked ?? Array.Empty<string>();
+            _hoverDeclarations = declarations.Hover;
+            _focusDeclarations = declarations.Focus;
+            _focusVisibleDeclarations = declarations.FocusVisible;
+            _activeDeclarations = declarations.Active;
+            _checkedDeclarations = declarations.Checked;
 
             if (target != null) ReapplyActiveStates(true);
         }
@@ -133,7 +180,17 @@ namespace Velvet
         // Applies (or clears) each payload. A payload containing [ that parses as an arbitrary
         // value is applied as an inline style; otherwise it is toggled as a USS class.
         private void ApplyPayloads(string[] payloads, bool on)
-            => StyleVariantPayload.Apply(target, payloads, on, PriorityFor(payloads), _ctx, this);
+            => StyleVariantPayload.Apply(target, payloads, on, PriorityFor(payloads), _ctx, this,
+                DeclarationsFor(payloads));
+
+        // The className positions belonging to the state whose payload array this is, paired the same way
+        // PriorityFor pairs the layer.
+        private int[] DeclarationsFor(string[] payloads) =>
+            ReferenceEquals(payloads, _checked) ? _checkedDeclarations
+            : ReferenceEquals(payloads, _active) ? _activeDeclarations
+            : ReferenceEquals(payloads, _focusVisible) ? _focusVisibleDeclarations
+            : ReferenceEquals(payloads, _focus) ? _focusDeclarations
+            : _hoverDeclarations;
 
         // Arbitrary-value layering priority for the state whose payload array this is (identified by reference),
         // so e.g. an active arbitrary value layers over a hover one, and clearing active falls back to hover.

--- a/Packages/com.velvet.core/Runtime/Styling/StyleVariantPayload.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleVariantPayload.cs
@@ -10,14 +10,36 @@ namespace Velvet
     // list, or an arbitrary value (w-[200px]) applied as an inline style.
     internal static class StyleVariantPayload
     {
+        // The rank a payload carries when no position in THIS element's className applies to it: a caller
+        // that supplies none, and the child-combinator manipulator, whose payloads are positioned in the
+        // PARENT's class list and so cannot be compared with the child's own.
+        //
+        // Deliberately the WEAKEST value rather than the strongest, so an unrankable payload loses a tie
+        // instead of winning it. A [&>*]:hover: payload is promoted out of the child-variant layer onto the
+        // hover layer (see ReconcilerContext.GateStackedVariant), where the child's own hover: payload sits;
+        // ranking it strongest would let a container's blanket rule beat a rule the child declares for
+        // itself, which is the opposite of what the child-variant layer exists to encode. Two unrankable
+        // payloads tie and fall back to arrival, which within one swept array is that array's own order.
+        public const int NoDeclaration = int.MinValue;
+
         // Applies (when on is true) or clears each payload on target.
         // A payload containing [ that parses as an arbitrary value is applied as an inline style at
         // priority; otherwise it is projected onto the class list at that same priority. Either way the
         // payload layers over the base and the lower-priority variants rather than tying with them, and
         // turning it off falls back to whatever is still active.
+        //
+        // declarations gives each payload, by position, where its rule sits in the element's className, which
+        // settles a tie between two gate payloads that layer at ONE priority the way source order settles a
+        // tie between two equal-specificity CSS rules (see ReconcilerContext.TrackVariantGateClass). It rides
+        // in from the caller rather than being read back out of the class array, because the array cannot say
+        // whether a rule is LIT: a `lg:shadow-lg` below the breakpoint, a `peer-checked:` with no peer, a
+        // `[&>*]:shadow-lg` that lands on the children, and a `first:hover:shadow-lg` the structural config
+        // refuses to register all spell a payload that never applies here, and a scan would rank the element
+        // by them anyway. A caller that supplies none leaves its payloads ranked behind every declared one in
+        // their band, tied among themselves and so ordered by arrival.
         public static void Apply(VisualElement target, string?[] payloads, bool on,
             int priority = StyleLayerPriority.Base,
-            ReconcilerContext? ctx = null, object? owner = null)
+            ReconcilerContext? ctx = null, object? owner = null, int[]? declarations = null)
         {
             if (target == null || payloads == null)
             {
@@ -36,12 +58,16 @@ namespace Velvet
             // spellings need nothing here — the manipulator's own layer probe sees both of their edges.
             var reSyncOnly = false;
 
-            foreach (var payload in payloads)
+            for (var index = 0; index < payloads.Length; index++)
             {
+                var payload = payloads[index];
                 if (string.IsNullOrEmpty(payload))
                 {
                     continue;
                 }
+                var declaration = declarations != null && index < declarations.Length
+                    ? declarations[index]
+                    : NoDeclaration;
 
                 // Stacked variant (e.g. the `hover:bg-red` remainder of `dark:hover:bg-red`): the outer
                 // manipulator's gate has flipped; defer to a nested manipulator that ANDs the inner variant's
@@ -49,7 +75,7 @@ namespace Velvet
                 // available (the parameterless callers and the leaf-path unit tests).
                 if (ctx != null && owner != null && StyleVariantClass.IsVariant(payload))
                 {
-                    ctx.GateStackedVariant(target, owner, payload, on, priority);
+                    ctx.GateStackedVariant(target, owner, payload, on, priority, declaration);
                     continue;
                 }
 
@@ -83,13 +109,13 @@ namespace Velvet
                 else if (on)
                 {
                     StyleClassProjection.Add(target, core, effectivePriority);
-                    gateChanged |= TrackVariantGate(ctx, target, core, true);
+                    gateChanged |= TrackVariantGate(ctx, target, core, effectivePriority, declaration, true);
                     reSyncOnly |= StyleTextBalanceClass.IsWidthDeclaringToken(core);
                 }
                 else
                 {
                     StyleClassProjection.Remove(target, core, effectivePriority);
-                    gateChanged |= TrackVariantGate(ctx, target, core, false);
+                    gateChanged |= TrackVariantGate(ctx, target, core, effectivePriority, declaration, false);
                     reSyncOnly |= StyleTextBalanceClass.IsWidthDeclaringToken(core);
                 }
 
@@ -151,8 +177,10 @@ namespace Velvet
         // Records a toggled payload that is one of the gate tokens, returning true when the tracked set
         // changed. Returns false without touching anything for the parameterless callers (no context to
         // record into) and for the overwhelmingly common non-gate payload.
-        private static bool TrackVariantGate(ReconcilerContext? ctx, VisualElement target, string core, bool on)
-            => ctx != null && IsVariantGateToken(core) && ctx.TrackVariantGateClass(target, core, on);
+        private static bool TrackVariantGate(ReconcilerContext? ctx, VisualElement target, string core,
+            int priority, int declaration, bool on)
+            => ctx != null && IsVariantGateToken(core)
+                && ctx.TrackVariantGateClass(target, core, priority, declaration, on);
 
         // The utility tokens whose mere PRESENCE in a class array decides what a class-driven pass builds:
         // the four layout manipulators (FiberNodePatcher.ApplyLayoutManipulators) and the five wrapper-less

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/VariantElementLocalEdgeTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/VariantElementLocalEdgeTests.cs
@@ -183,7 +183,8 @@ namespace Velvet.Tests
                 Assume.That(leaf.ClassListContains("bg-hot"), Is.True, "Precondition: old hover payload on while hovered");
 
                 // Act — the className changes so the hover payload becomes bg-cold (re-applied under the new set).
-                ManipulatorOf(leaf).UpdatePayloads(new[] { "bg-cold" }, null, null, null, null);
+                ManipulatorOf(leaf).UpdatePayloads(new[] { "bg-cold" }, null, null, null, null,
+                    VariantDeclarations.None);
 
                 // Assert — the previously-applied old payload class is cleared.
                 Assert.IsFalse(leaf.ClassListContains("bg-hot"));
@@ -198,7 +199,8 @@ namespace Velvet.Tests
                 Assume.That(leaf.ClassListContains("bg-cold"), Is.False, "Precondition: new payload not yet present");
 
                 // Act — the className changes so the hover payload becomes bg-cold.
-                ManipulatorOf(leaf).UpdatePayloads(new[] { "bg-cold" }, null, null, null, null);
+                ManipulatorOf(leaf).UpdatePayloads(new[] { "bg-cold" }, null, null, null, null,
+                    VariantDeclarations.None);
 
                 // Assert — the new payload class is applied under the still-hovered state.
                 Assert.IsTrue(leaf.ClassListContains("bg-cold"));

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/VariantGateTokenPriorityTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/VariantGateTokenPriorityTests.cs
@@ -1,0 +1,335 @@
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine.UIElements;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Several variants naming one utility, for the families Velvet realises in C# rather than in USS
+    /// (gap / divide / grid / text-balance and the wrapper-less paint layers). <see cref="StyleClassProjection"/>
+    /// decides which CLASSES may sit on the element and cannot decide which of two same-family tokens a
+    /// class-driven pass reads, because that is settled by the order of the composed array: the tracked
+    /// gate-token list is what orders it. It must rank by the priority each payload was applied at, and
+    /// within one priority by where the className declares the rule — never by the order the signals fired.
+    /// </summary>
+    /// <remarks>
+    /// Every signal here is driven off panel: <c>dark:</c> through <see cref="VelvetTheme"/>'s theme signal,
+    /// which the conditional manipulator subscribes to on attach, <c>hover:</c> through the element's own
+    /// callback registry, and <c>data-[…]:</c> through a props patch. <c>hover:</c> ranks above <c>dark:</c>
+    /// in the precedence table and every <c>data-[…]:</c> rule shares one layer, so which payload each case
+    /// owes its win to is a declared fact rather than a coincidence of the fixture. GWT, one assert per case.
+    /// </remarks>
+    [TestFixture]
+    internal sealed class VariantGateTokenPriorityTests
+    {
+        // --space-4 == 16px, --space-8 == 32px (see _tokens.uss).
+        private const float Space4 = 16f;
+        private const float Space8 = 32f;
+
+        // The blur reported for an element carrying no shadow at all, kept apart from every preset's blur so
+        // a case where nothing painted cannot pass as a case where the right preset did.
+        private const float NoShadow = -1f;
+
+        [TearDown]
+        public void TearDown() => VelvetTheme.IsDark = false;
+
+        private static VisualElement Mount(ReconcilerScope scope, string className, int childCount = 0)
+        {
+            var children = new VNode[childCount];
+            for (var i = 0; i < childCount; i++)
+            {
+                children[i] = V.Div(className: "child");
+            }
+            scope.Reconciler.Reconcile(scope.Root, Array.Empty<VNode>(),
+                new VNode[] { V.Div(className: className, name: "card", children: children) });
+            return scope.Root.Q<VisualElement>("card");
+        }
+
+        private static void Hover(VisualElement element)
+        {
+            using var evt = PointerOverEvent.GetPooled();
+            element.SimulateEvent(evt);
+        }
+
+        private static float BlurOf(ReconcilerScope scope, VisualElement element)
+            => scope.Reconciler.Context.ShadowBindings.TryGetValue(element, out var binding)
+                ? binding.Spec.Blur
+                : NoShadow;
+
+        // Lights both layers of "bg-[#FFFFFF] dark:shadow-lg hover:shadow-sm" in the given order and reports
+        // the blur the shadow paint settled on. Each order gets its own reconciler and its own element, since
+        // the theme signal is process-wide.
+        private static float BlurAfterBothLit(bool hoverFirst)
+        {
+            VelvetTheme.IsDark = false;
+            using var scope = new ReconcilerScope();
+            var card = Mount(scope, "bg-[#FFFFFF] dark:shadow-lg hover:shadow-sm");
+            if (hoverFirst)
+            {
+                Hover(card);
+                VelvetTheme.IsDark = true;
+            }
+            else
+            {
+                VelvetTheme.IsDark = true;
+                Hover(card);
+            }
+            return BlurOf(scope, card);
+        }
+
+        // Sets both attributes of "data-[state=open]:shadow-lg data-[busy=true]:shadow-sm" one at a time, in
+        // the given order, and reports the blur the shadow paint settled on. A data- rule re-evaluates on a
+        // props patch, so each step is its own render.
+        private static float BlurAfterBothAttributesSet(bool stateFirst)
+        {
+            using var scope = new ReconcilerScope();
+            var none = AttributeCard(new Dictionary<string, string>());
+            var one = AttributeCard(stateFirst
+                ? new Dictionary<string, string> { ["state"] = "open" }
+                : new Dictionary<string, string> { ["busy"] = "true" });
+            var both = AttributeCard(new Dictionary<string, string>
+            {
+                ["state"] = "open",
+                ["busy"] = "true",
+            });
+            scope.Reconciler.Reconcile(scope.Root, Array.Empty<VNode>(), none);
+            scope.Reconciler.Reconcile(scope.Root, none, one);
+            scope.Reconciler.Reconcile(scope.Root, one, both);
+            return BlurOf(scope, scope.Root.Q<VisualElement>("card"));
+        }
+
+        private static VNode[] AttributeCard(Dictionary<string, string> data)
+            => new VNode[]
+            {
+                V.Div(className: "bg-[#FFFFFF] data-[state=open]:shadow-lg data-[busy=true]:shadow-sm",
+                    name: "card", data: data),
+            };
+
+        [Test]
+        public void Given_TwoVariantsAssertingOneGapTokenWithNoLiteralBase_When_OneTurnsOff_Then_TheGapKeepsDriving()
+        {
+            // Arrange — nothing declares gap-4 literally, so the token exists only while a variant asserts it.
+            // Both do; the explicit flex-row fixes the axis the gap writes its margin on.
+            using var scope = new ReconcilerScope();
+            var card = Mount(scope, "flex flex-row dark:gap-4 hover:gap-4", childCount: 2);
+            VelvetTheme.IsDark = true;
+            Hover(card);
+            var spacedWhileBothLit = card[1].style.marginLeft.value.value;
+
+            // Act — only the dark layer turns off. The hover layer still asserts gap-4, and the projection
+            // duly leaves the class on the element.
+            VelvetTheme.IsDark = false;
+
+            // Assert — both edges, since a container that never got its gap would satisfy the second half on
+            // its own. A token dropped with the layer that left stops driving the manipulator, and the
+            // spacing disappears while the class sits there.
+            Assert.That((spacedWhileBothLit, card[1].style.marginLeft.value.value),
+                Is.EqualTo((Space4, Space4)));
+        }
+
+        [Test]
+        public void Given_TwoPrioritiesOfTheShadowFamily_When_TheSameStateIsReachedByEitherSignalOrder_Then_TheSameShadowPaints()
+        {
+            // Arrange — the oracle is the payload the precedence table elects, painted from a literal token:
+            // hover: outranks dark:, so shadow-sm is what both orders owe.
+            using var oracleScope = new ReconcilerScope();
+            var expected = BlurOf(oracleScope, Mount(oracleScope, "bg-[#FFFFFF] shadow-sm"));
+
+            // Act — the same two signals, in both orders.
+            var hoverThenDark = BlurAfterBothLit(hoverFirst: true);
+            var darkThenHover = BlurAfterBothLit(hoverFirst: false);
+
+            // Assert — one rendering, whichever path the window took to reach the state. Comparing the two
+            // against the elected preset rather than only against each other is what keeps a pair that
+            // agreed on the WRONG shadow (or on none) from passing.
+            Assert.That((hoverThenDark, darkThenHover), Is.EqualTo((expected, expected)));
+        }
+
+        [Test]
+        public void Given_TwoAttributeRulesOfTheShadowFamily_When_TheSameStateIsReachedByEitherRuleOrder_Then_TheSameShadowPaints()
+        {
+            // Arrange — both rules layer at the SAME priority (every data-/aria- rule does), so the
+            // precedence table cannot separate them and the className's own declaration order is what
+            // decides, exactly as source order decides a tie between two equal-specificity CSS rules. The
+            // later-declared shadow-sm is what both orders owe.
+            using var oracleScope = new ReconcilerScope();
+            var expected = BlurOf(oracleScope, Mount(oracleScope, "bg-[#FFFFFF] shadow-sm"));
+
+            // Act — the two attributes set one at a time, in both orders.
+            var stateThenBusy = BlurAfterBothAttributesSet(stateFirst: true);
+            var busyThenState = BlurAfterBothAttributesSet(stateFirst: false);
+
+            // Assert
+            Assert.That((stateThenBusy, busyThenState), Is.EqualTo((expected, expected)));
+        }
+
+        [Test]
+        public void Given_OneValueClaimedByTwoAttributeRules_When_TheLastOfThemIsWrittenLast_Then_ThatValuePaints()
+        {
+            // Arrange — three rules of one family at one priority. shadow-lg is claimed twice, and the LAST
+            // rule in the className is one of its two, so source order owes it the win; ranking the token at
+            // its opening rule instead would hand the element to the shadow-sm written between them.
+            using var oracleScope = new ReconcilerScope();
+            var expected = BlurOf(oracleScope, Mount(oracleScope, "bg-[#FFFFFF] shadow-lg"));
+            using var scope = new ReconcilerScope();
+            var lit = new Dictionary<string, string> { ["x"] = "1", ["a"] = "1", ["b"] = "1" };
+            var tree = new VNode[]
+            {
+                V.Div(className: "bg-[#FFFFFF] data-[x=1]:shadow-lg data-[a=1]:shadow-sm data-[b=1]:shadow-lg",
+                    name: "card", data: lit),
+            };
+
+            // Act
+            scope.Reconciler.Reconcile(scope.Root, Array.Empty<VNode>(), tree);
+
+            // Assert
+            Assert.That(BlurOf(scope, scope.Root.Q<VisualElement>("card")), Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void Given_AContainerBlanketHoverRule_When_TheChildDeclaresItsOwnHoverRule_Then_TheChildsRuleWins()
+        {
+            // Arrange — a [&>*]: payload that is itself a state variant is promoted out of the child-variant
+            // layer onto the hover layer, where the child's OWN hover: payload also sits. The promoted one is
+            // positioned in the PARENT's className, which cannot be compared with the child's, so it has to
+            // lose the tie: the child-variant layer exists to rank a container's blanket rule BELOW a rule
+            // the child declares for itself.
+            using var oracleScope = new ReconcilerScope();
+            var expected = BlurOf(oracleScope, Mount(oracleScope, "bg-[#FFFFFF] shadow-sm"));
+            using var scope = new ReconcilerScope();
+            scope.Reconciler.Reconcile(scope.Root, Array.Empty<VNode>(), new VNode[]
+            {
+                V.Div(className: "[&>*]:hover:shadow-lg", children: new VNode[]
+                {
+                    V.Div(className: "bg-[#FFFFFF] hover:shadow-sm", name: "child"),
+                }),
+            });
+            var child = scope.Root.Q<VisualElement>("child");
+
+            // Act
+            Hover(child);
+
+            // Assert
+            Assert.That(BlurOf(scope, child), Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void Given_AStackedVariantBesideThePlainOneItWraps_When_BothAreLit_Then_TheLaterWrittenOneWins()
+        {
+            // Arrange — dark:hover: layers at the stronger of its two parts, which is the plain hover: layer,
+            // so the two payloads share a layer while dark and hover are both on. They arrive from different
+            // manipulators, whose order is when each was attached; only the className can rank them, and
+            // shadow-sm is written later.
+            using var oracleScope = new ReconcilerScope();
+            var expected = BlurOf(oracleScope, Mount(oracleScope, "bg-[#FFFFFF] shadow-sm"));
+            using var scope = new ReconcilerScope();
+            var card = Mount(scope, "bg-[#FFFFFF] dark:hover:shadow-lg hover:shadow-sm");
+
+            // Act
+            VelvetTheme.IsDark = true;
+            Hover(card);
+
+            // Assert
+            Assert.That(BlurOf(scope, card), Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void Given_AnEventDrivenHasRuleBesideAClassHasRule_When_BothAreLit_Then_TheLaterWrittenOneWins()
+        {
+            // Arrange — the has- layer is reached by two different suppliers: has-[:checked]: rides the
+            // event-driven manipulator, has-[.class]: is a side table. Both land at the same priority, so
+            // only the className can separate them, and gap-8 is written later. A checked Toggle and an
+            // .error child light both at once.
+            using var scope = new ReconcilerScope();
+            scope.Reconciler.Reconcile(scope.Root, Array.Empty<VNode>(), new VNode[]
+            {
+                V.Div(className: "flex flex-row has-[:checked]:gap-4 has-[.error]:gap-8", name: "row",
+                    children: new VNode[]
+                    {
+                        V.Toggle(value: true),
+                        V.Div(className: "error"),
+                    }),
+            });
+            var row = scope.Root.Q<VisualElement>("row");
+
+            // Act — the container's post-children pass has already derived both; re-derive so the checked
+            // scan runs against the placed subtree.
+            scope.Reconciler.Context.HasVariantManipulators[row].Rescan();
+
+            // Assert — --space-8 == 32px, so the later-written gap-8 is what spaces the row.
+            Assert.That(row[1].style.marginLeft.value.value, Is.EqualTo(Space8));
+        }
+
+        [Test]
+        public void Given_ATiedPairBesideARuleThatNeverApplies_When_BothOfThePairAreLit_Then_TheDeadRuleDoesNotRank()
+        {
+            // Arrange — first:hover: is on the structural config's own skip list, so it registers nothing and
+            // can never apply a payload to anything. It still spells shadow-lg after a colon, which is all a
+            // scan of the className would see, and it is written last. Only the two data- rules are real, and
+            // between them source order gives shadow-sm the win.
+            using var oracleScope = new ReconcilerScope();
+            var expected = BlurOf(oracleScope, Mount(oracleScope, "bg-[#FFFFFF] shadow-sm"));
+            using var scope = new ReconcilerScope();
+            var lit = new Dictionary<string, string> { ["b"] = "1", ["a"] = "1" };
+            var tree = new VNode[]
+            {
+                V.Div(className: "bg-[#FFFFFF] data-[b=1]:shadow-lg data-[a=1]:shadow-sm first:hover:shadow-lg",
+                    name: "card", data: lit),
+            };
+
+            // Act
+            scope.Reconciler.Reconcile(scope.Root, Array.Empty<VNode>(), tree);
+
+            // Assert
+            Assert.That(BlurOf(scope, scope.Root.Q<VisualElement>("card")), Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void Given_TwoTiedRulesResolved_When_TheClassNameSwapsTheirOrder_Then_TheOtherValuePaints()
+        {
+            // Arrange — both rules lit and tied at the attribute layer, so the later-written shadow-lg paints.
+            using var oracleScope = new ReconcilerScope();
+            var expected = BlurOf(oracleScope, Mount(oracleScope, "bg-[#FFFFFF] shadow-sm"));
+            using var scope = new ReconcilerScope();
+            var lit = new Dictionary<string, string> { ["a"] = "1", ["b"] = "1" };
+            var first = new VNode[]
+            {
+                V.Div(className: "bg-[#FFFFFF] data-[a=1]:shadow-sm data-[b=1]:shadow-lg", name: "card", data: lit),
+            };
+            scope.Reconciler.Reconcile(scope.Root, Array.Empty<VNode>(), first);
+
+            // Act — only the writing order changes; both rules stay lit and neither payload moves layer.
+            // What carries the new order is the attribute config pass clearing and re-applying both payloads
+            // on a class change, each with its fresh position. A family that stopped cycling would keep the
+            // old ranking with nothing else to catch it, which is the invariant this case pins.
+            var second = new VNode[]
+            {
+                V.Div(className: "bg-[#FFFFFF] data-[b=1]:shadow-lg data-[a=1]:shadow-sm", name: "card", data: lit),
+            };
+            scope.Reconciler.Reconcile(scope.Root, first, second);
+
+            // Assert — the tie follows the new source order, so shadow-sm now wins.
+            Assert.That(BlurOf(scope, scope.Root.Q<VisualElement>("card")), Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void Given_ALiteralBaseTokenReassertedByTheStrongerVariant_When_AWeakerVariantNamesTheSameFamily_Then_TheStrongerPayloadPaints()
+        {
+            // Arrange — shadow-lg is declared literally AND behind hover:, with dark: naming a different
+            // preset of the same family below it.
+            using var oracleScope = new ReconcilerScope();
+            var expected = BlurOf(oracleScope, Mount(oracleScope, "bg-[#FFFFFF] shadow-lg"));
+            using var scope = new ReconcilerScope();
+            var card = Mount(scope, "bg-[#FFFFFF] shadow-lg dark:shadow-sm hover:shadow-lg");
+
+            // Act
+            VelvetTheme.IsDark = true;
+            Hover(card);
+
+            // Assert
+            Assert.That(BlurOf(scope, card), Is.EqualTo(expected));
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/VariantGateTokenPriorityTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/VariantGateTokenPriorityTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f42e5770c5a2a4c6884f2c4fdc45a23b


### PR DESCRIPTION
`VariantGateState` kept the tokens a gate contributed in arrival order, which produced two defects with one cause. A token co-referenced by two variants with no literal base died when either gate turned off, because the projection kept the class while the token left. And two payloads of one family settled in the order their signals happened to arrive, so the same end state rendered differently depending on the path taken to reach it — lighting `dark:` then crossing `md:` left `shadow-sm` winning where the reverse order gave `shadow-lg`.

Tokens are now keyed by `(token, priority)`, the model `StyleClassProjection` already keeps for the live class list, and ranked by `(max priority, declaration position)`.

## The position had to ride in on the rule, not be scanned for

The first attempt derived the position by scanning the className backwards for the token. That is wrong in a way worth recording, because it looks right: the scan cannot ask whether the rule it lands on is *lit*. A rule that never fires — an unmatched breakpoint, a `peer-` with no peer, a `[&>*]:` that targets children, or one the reconciler explicitly refuses to register — still moved the ranking. Deleting a redundant `lg:shadow-lg`, which reads like a no-op, would flip the render back.

So the declaring index is captured where the rule is built and threaded through `Apply`. An unlit or dead rule never calls `Apply`, so it cannot contribute a position. That made the residual disappear rather than become a documented limitation.

## Every supplier carries a position, and the sentinel loses

Threading covers the four side tables plus `StyleVariantManipulator`, `StyleConditionalVariantManipulator`, `StyleRelationalVariantManipulator`, `GateStackedVariant` and `StyleStackedVariantManipulator`. Two layers turned out to have two suppliers each — `Has`, reached by both the `has-[.class]:` side table and the event-driven `has-[:checked]:` manipulator, and the five state layers, reached by both the state manipulator and stacked variants.

`StyleChildVariantManipulator` deliberately carries none: its payloads are written on the *parent*, so a position would index a different className than every payload the child declares. The unrankable sentinel is `int.MinValue`, so such a payload **loses** every tie rather than winning it. That matters beyond tidiness — a container's `[&>*]:hover:shadow-lg` was beating the child's own `hover:shadow-sm`, inverting the principle the child-variant layer exists to encode. It is also fail-safe: a future supplier added without a position now loses its band instead of silently winning it, which is the shape that let two of these holes survive review rounds.

## Verification

Ten tests, each demonstrated RED for its own stated reason: the co-referenced token, the same end state by two signal orders, a value claimed by two rules, a dead rule that cannot fire, the `Has` band's two suppliers, a stacked variant beside the plain one it wraps, the container blanket rule versus the child's own, and a className reorder.

EditMode 3508 passed / 0 failed / 0 inconclusive; PlayMode 123 / 0 / 0; Generators 293 / 0; `assert-no-inconclusive.py` clean on both. All measured on the rebased tree with no concurrent Unity instances.

One thing removed along the way: a `Record` hook added to re-rank on a className write turned out to be dead code. Every side-table pass clears and re-derives after the record, so the re-rank could never be what fixed an order. It was neutered, the test stayed green, and it is gone — the className-reorder test remains, pinning the clear-and-re-derive discipline that makes it unnecessary.

## Documentation

`Documentation~/styling-variants.md` states the rule that now holds: only rules that actually apply take part in a tie, and a stacked variant is ranked by its own position. The limitation block written for the earlier approximation is deleted, along with a restated stylesheet fact (`grid` does have a USS property set) that the guide and a comment both carried.
