### PR TITLE
test(velvet): cover both preprocessor configurations of the code-shape opt-in guard

### DIFF
--- a/Packages/com.velvet.core/Generators~/tests/Velvet.SourceGenerators.Tests/CodeShapeOptInDriftTests.cs
+++ b/Packages/com.velvet.core/Generators~/tests/Velvet.SourceGenerators.Tests/CodeShapeOptInDriftTests.cs
@@ -28,6 +28,11 @@ namespace Velvet.SourceGenerators.Tests
         // Unity compiles the editor-platform assemblies with UNITY_EDITOR defined and player builds without
         // it. Requiring the marker under both is what stops a `#if`-guarded opt-in from enforcing the rule
         // in one configuration and silently skipping it in the other.
+        //
+        // Adding a third configuration means adding a third test. A conditional spelling is visible to
+        // exactly one configuration, so one case per configuration is the only coverage that holds: a single
+        // case reads as covering the feature while covering one configuration's worth of it, and the
+        // untested configuration can then be deleted with nothing going red.
         private static readonly string[][] PreprocessorConfigurations =
         {
             Array.Empty<string>(),
@@ -95,10 +100,28 @@ namespace Velvet.SourceGenerators.Tests
         }
 
         [Fact]
-        public void Given_AMarkerBehindAPreprocessorBranch_When_Checked_Then_ItDoesNotCount()
+        public void Given_AMarkerAbsentFromTheEditorBuild_When_Checked_Then_ItDoesNotCount()
         {
             // Arrange
             var source = "#if !UNITY_EDITOR\n"
+                + "[assembly: System.Reflection.AssemblyMetadata(\"Velvet.CodeShape\", \"enforce\")]\n"
+                + "#endif\n";
+
+            // Act
+            var declares = DeclaresMarkerInSources(new[] { source });
+
+            // Assert
+            Assert.False(declares);
+        }
+
+        [Fact]
+        public void Given_AMarkerAbsentFromThePlayerBuild_When_Checked_Then_ItDoesNotCount()
+        {
+            // The mirror of the case above. The two look mergeable and are not: this one fails only if the
+            // no-symbols configuration is consulted and the one above only if UNITY_EDITOR is, so collapsing
+            // them into a single case reopens the gap that motivated both.
+            // Arrange
+            var source = "#if UNITY_EDITOR\n"
                 + "[assembly: System.Reflection.AssemblyMetadata(\"Velvet.CodeShape\", \"enforce\")]\n"
                 + "#endif\n";
 


### PR DESCRIPTION
`CodeShapeOptInDriftTests` evaluates each assembly's marker under two preprocessor configurations — with `UNITY_EDITOR` defined and without — because Unity compiles the editor-platform assemblies with it and the player build without, and a marker visible to only one of those opts the assembly in for only one of them.

It had one test, using a marker inside `#if !UNITY_EDITOR`. That spelling is visible to the no-symbols configuration alone. Deleting the `UNITY_EDITOR` configuration outright left the suite green at 6/6, so half the guard was carrying no coverage: a package assembly could have wrapped its marker in `#if UNITY_EDITOR` and had the guard vouch for it while the analyzer never enforced in player builds.

The mirror case is added, and each configuration now dies to its own mutant:

```
drop the no-symbols configuration   -> Given_AMarkerAbsentFromThePlayerBuild_...
drop the UNITY_EDITOR configuration -> Given_AMarkerAbsentFromTheEditorBuild_...
All(...) -> Any(...)                -> both
```

The generalisation is recorded on the configuration list, since it is what the next person adding a third will need and will not derive: a conditional spelling is visible to exactly one configuration, so one case per configuration is the only coverage that holds — a single case reads as covering the feature while covering one configuration's worth of it, and the untested configuration can then be deleted with nothing going red. A second comment says the two cases are not mergeable despite looking it, because collapsing them reopens exactly the gap that motivated both.

## Verification

Generator suite 325 passed, 0 failed, run twice — before committing and on the committed tree.

No Unity run, and this is a judgement rather than a skipped step. The change is one file under `Generators~/`, which Unity ignores by the `~` convention. Verified rather than assumed: both Unity logs from the last full run contain zero `Generators~` references, and `git diff -- Runtime/Plugins` is empty, so Unity's compilation inputs are byte-identical to the run that produced EditMode 3498 / 0 failed / 0 inconclusive and PlayMode 123 / 0 / 0.

Follow-up to #212, which shipped the guard with this gap in it.
