### PR TITLE
refactor(velvet): address child slots logically and convert once at the DOM

### DIFF
--- a/Packages/com.velvet.core/Runtime/Reconciler/ChildElementPlacement.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ChildElementPlacement.cs
@@ -84,15 +84,28 @@ namespace Velvet
             var lisResult = pool.RentIntList();
             try
             {
-                // The retained range never exceeds max(oldLen, logicalNewLen) entries; clamp by
-                // childCount as a safety net while staying within this fiber's slot range.
-                var rangeEndExclusive = Math.Min(parent!.childCount,
-                    slotStart + Math.Max(range.OldLen, range.LogicalNewLen));
-                // Slot-local DOM positions in O(N). parent.IndexOf per element would be
-                // O(childCount) x newElements.Count = O(N^2).
-                for (var idx = range.ScanStart; idx < rangeEndExclusive; idx++)
+                // range.ScanStart / slotStart / both lengths are LOGICAL, so the scan bounds are converted
+                // before they can index the DOM (LogicalChildSlots). Physically walking from a logical
+                // slotStart used to be correct only because the entry gate had already folded a leading
+                // z-container's offset in; with an invisible child anywhere in the range it both under-covers
+                // the retained rows — the last one then maps to -1, reads as a created orphan, and is
+                // detached and re-attached on every re-render — and skews every recorded position.
+                var physicalScanStart = LogicalChildSlots.ToPhysical(parent!, range.ScanStart);
+                var physicalRangeEnd = Math.Min(parent!.childCount,
+                    LogicalChildSlots.ToPhysical(parent!, slotStart + Math.Max(range.OldLen, range.LogicalNewLen)));
+                // Slot-local positions in O(N). parent.IndexOf per element would be
+                // O(childCount) x newElements.Count = O(N^2). An invisible child in the range is simply not
+                // recorded, so it can never be picked as an anchor.
+                var logicalPos = range.ScanStart - slotStart;
+                for (var idx = physicalScanStart; idx < physicalRangeEnd; idx++)
                 {
-                    domPosMap[parent!.ElementAt(idx)] = idx - slotStart;
+                    var child = parent!.ElementAt(idx);
+                    if (SilhouetteBoundsSpacer.IsSpacer(child))
+                    {
+                        continue;
+                    }
+                    domPosMap[child] = logicalPos;
+                    logicalPos++;
                 }
 
                 // Current position of each committed element, in new order.
@@ -218,8 +231,15 @@ namespace Velvet
             {
                 if (element != null && element.parent == parent) liveCount++;
             }
-            var afterIndex = slotStart + liveCount;
-            var afterRangeAnchor = afterIndex < parent.childCount ? parent.ElementAt(afterIndex) : null;
+            // The first element PAST this range, by logical slot: the anchor everything in the range is
+            // inserted before. Converted, because a leading z-container or an invisible child inside the
+            // range shifts the physical position of that slot — reading it physically picked the range's own
+            // last element as its anchor and inserted the tail before it, inverting the declared order.
+            var afterLogical = slotStart + liveCount;
+            var afterIndex = LogicalChildSlots.ToPhysical(parent, afterLogical);
+            var afterRangeAnchor = afterLogical < LogicalChildSlots.Count(parent)
+                ? parent.ElementAt(afterIndex)
+                : null;
 
             // Search hints for IndexOfNear: the last insertion lands the right neighbour for the next move, and
             // consecutive removals cluster, so seeding each search from the previous result keeps it O(1) on the
@@ -267,9 +287,10 @@ namespace Velvet
                 }
                 else
                 {
-                    // Insert before any trailing filter bounds-spacer (not parent.Add, which appends past it)
-                    // so a skewed / shadowed + filtered container keeps its spacer last through the reorder.
-                    var end = SilhouetteBoundsSpacer.NonSpacerChildCount(parent);
+                    // The physical position just after the last rendered child, so a trailing invisible
+                    // child (a filter bounds spacer) stays last through the reorder — parent.Add would
+                    // append past it.
+                    var end = LogicalChildSlots.ToPhysical(parent, LogicalChildSlots.Count(parent));
                     parent.Insert(end, element);
                     insertHint = end;
                 }

--- a/Packages/com.velvet.core/Runtime/Reconciler/ChildReconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ChildReconciler.cs
@@ -74,10 +74,6 @@ namespace Velvet
         //     AnimatePresence overlap can leave the live range shorter than the baseline; the keyed
         //     prefix scan's slot always exists by construction (Pass 1 never changes childCount ahead
         //     of index i).
-        //   clampInsertIndex: the indexed diff inserts at an absolute position that must clamp to
-        //     parent.childCount on a desync-shortened range; the keyed scan's slotStart + i is always
-        //     in range on its own and must NOT be clamped (clamping would silently misplace an insert
-        //     once slotStart + i legitimately reaches parent.childCount, i.e. a tail slot).
         //   Removal deliberately stays BEFORE CreateElement (remove-then-create), not
         //     create-then-remove: an inline-mounted component fiber is keyed by
         //     (parentFiber, positionKey, identity) — NOT by which VisualElement currently hosts it
@@ -105,13 +101,16 @@ namespace Velvet
         // discarding anything: the boundary already resolved the failure, so any later slot's
         // patch/replace would be racing a reconcile the caller no longer owns end-to-end.
         private bool PatchOrReplaceAtSlot(
-            in ChildSlot slot, VNode? oldNode, VNode? newNode, bool slotExists, bool clampInsertIndex)
+            in ChildSlot slot, VNode? oldNode, VNode? newNode, bool slotExists)
         {
             var parent = slot.Parent;
-            var domIndex = slot.SlotStart + slot.Index;
+            // LOGICAL, converted per DOM touch. It is deliberately not pre-converted into a physical index:
+            // the removal below shifts every physical index after it, so a value captured before it would be
+            // stale by the insert.
+            var logicalIndex = slot.SlotStart + slot.Index;
             if (slotExists && ReconcileKeying.CanPatch(oldNode, newNode))
             {
-                var domElement = parent.ElementAt(domIndex);
+                var domElement = parent.ElementAt(LogicalChildSlots.ToPhysical(parent, logicalIndex));
                 var actualElement = _patcher.ResolveWrapped(domElement);
                 _patcher.PatchNode(actualElement, oldNode, newNode);
                 return false;
@@ -119,13 +118,12 @@ namespace Velvet
 
             if (slotExists)
             {
-                _cleaner.RemoveElement(parent, domIndex);
+                _cleaner.RemoveElement(parent, LogicalChildSlots.ToPhysical(parent, logicalIndex));
             }
             var newElement = _factory.CreateElement(newNode);
-            var insertIndex = clampInsertIndex
-                ? Math.Min(domIndex, SilhouetteBoundsSpacer.NonSpacerChildCount(parent))
-                : domIndex;
-            parent.Insert(insertIndex, newElement);
+            // ToPhysical clamps by construction — a slot past the last rendered child resolves to the
+            // position just after it — so the caller no longer chooses between two index formulas.
+            parent.Insert(LogicalChildSlots.ToPhysical(parent, logicalIndex), newElement);
             return _ctx.IsAborted;
         }
 
@@ -156,26 +154,15 @@ namespace Velvet
         {
             if (_ctx.IsAborted) return;
 
-            // A back z-layer container, when present, is parent's own leading child (physically preceding
-            // the ordinary children it must paint behind) — the one structural asymmetry against every other
-            // reconciler-invisible child (SilhouetteBoundsSpacer's own spacer, and the front z-layer
-            // container, are both trailing). Every caller's incoming slotStart/slotLimit is computed in
-            // purely logical terms (0 for a fresh range, or a sum of PRECEDING SIBLING FIBERS' own rendered
-            // counts for a shared-parent inline tenant) — entirely blind to this leading child — so folding
-            // the offset in ONCE here, at the single choke point every fresh (non-resumed) entry funnels
-            // through, corrects every downstream absolute-index computation without touching any of them
-            // individually (symmetrical to how NonSpacerChildCount centralizes the trailing side). A resumed
-            // time-sliced pass (ContinueIndexed/ContinueKeyed) never re-enters here — its saved slotStart
-            // already has this baked in from when it first ran — so this can never double-apply.
-            if (parent != null)
-            {
-                var leadingOffset = FiberZLayerCoordinator.LeadingOffset(parent);
-                if (leadingOffset != 0)
-                {
-                    slotStart += leadingOffset;
-                    if (slotLimit != int.MaxValue) slotLimit += leadingOffset;
-                }
-            }
+            // Slot indices are LOGICAL throughout: a slot counts rendered children only, and the
+            // reconciler-invisible ones (a z-index layer container, a filter bounds spacer, a ring band)
+            // are skipped by the one conversion applied where the DOM is actually touched — see
+            // LogicalChildSlots. This entry used to fold a back z-layer container's leading offset into
+            // slotStart instead, which worked only while every invisible child was pinned to one end of the
+            // list; a band that must sit beside its own element cannot be. Nothing is corrected here now,
+            // and the parked-slot rebasing that existed to keep those baked-in offsets true across a
+            // container appearing or disappearing is gone with it: a logical slot does not move when an
+            // invisible child does.
 
             // New entries discard any prior suspended state. ContinueXxx calls ReconcileXxxFrom
             // directly and bypasses this path, so discarding here does not break a Continue run.
@@ -300,7 +287,7 @@ namespace Velvet
                         // sign container creation can rebase a park THIS SAME instance's Reconcile() call just
                         // captured (see RebasePendingSlotStartIfTargeting) — invisible to any other lookup
                         // until this whole top-level call returns.
-                        FiberZLayerCoordinator.ResolveQueuedMount(_ctx, placeholder, zLayerMount, this);
+                        FiberZLayerCoordinator.ResolveQueuedMount(_ctx, placeholder, zLayerMount);
                         continue;
                     default:
                         // Only PortalNode / WorldSpaceNode enqueue deferred mounts; anything else is
@@ -311,21 +298,13 @@ namespace Velvet
                         continue;
                 }
                 var resolvedTarget = target!;
-                // Exclude a trailing filter bounds-spacer (a skewed / shadowed + filtered target carries one):
-                // portal children must land BEFORE it so it stays last and the recorded slot start does not
-                // drift when the spacer self-heals to the end. NonSpacerChildCount is a PHYSICAL count (it still
-                // counts a leading back z-layer container, if the target already carries one from an earlier
-                // relocation directly under it) — Reconcile's own entry point (this method's caller for an
-                // ordinary child list, and every subsequent patch of this same slot range) always re-adds
-                // LeadingOffset to convert a LOGICAL slotStart into a physical one, so passing the already-
-                // physical value here would fold the offset a second time and misplace every child after the
-                // first (a keyed insert can even index past childCount and throw). Subtracting it back out here,
-                // once, is the single point every consumer of the stored PortalState.SlotStart agrees on: a
-                // LOGICAL basis, re-derived fresh at each use (LeadingOffset reads the target's live physical
-                // structure, never a cached copy) so it stays correct even if the target's own leading container
-                // appears or disappears between this mount and a later patch.
-                var physicalSlotStart = SilhouetteBoundsSpacer.NonSpacerChildCount(resolvedTarget);
-                var slotStart = physicalSlotStart - FiberZLayerCoordinator.LeadingOffset(resolvedTarget);
+                // Append after the target's existing rendered children: LogicalChildSlots.Count is the
+                // logical slot the next child takes, and the conversion at each DOM touch is what keeps a
+                // trailing filter bounds-spacer last and skips a leading z-layer container. Stored logical,
+                // which is the basis every consumer of PortalState.SlotStart now shares — it no longer has to
+                // be re-derived against the target's live physical structure, so a container appearing or
+                // disappearing between this mount and a later patch cannot move it.
+                var slotStart = LogicalChildSlots.Count(resolvedTarget);
                 // Restore the context that enclosed the Portal's tree position (captured at enqueue) so the
                 // children mount under their enclosing Providers / MotionContext rather than an empty cursor.
                 // The children's own reconcile pushes/pops on top of these and balances out, so popping the
@@ -402,17 +381,14 @@ namespace Velvet
                         f.DetachedMountContext = detachedContext;
                     }
                 }
-                // The growth this mount contributed, in PHYSICAL terms (both operands share that basis, so the
-                // leading offset — constant across this call, since a nested z-layer mount targeting this same
-                // resolvedTarget only ever ENQUEUES here rather than resolving inline — cancels out of the
-                // difference either way); slotStart itself is stored LOGICAL, per the comment above.
-                var slotLength = SilhouetteBoundsSpacer.NonSpacerChildCount(resolvedTarget) - physicalSlotStart;
+                // The growth this mount contributed, in logical slots — the same basis as slotStart.
+                var slotLength = LogicalChildSlots.Count(resolvedTarget) - slotStart;
                 _ctx.PortalState[placeholder] = new PortalSlotInfo(resolvedTarget, slotStart, slotLength);
             }
             // Same safe (post-pass, no diff in flight) context as the drain above: a container that lost its
             // last member this pass tears down here, never synchronously mid-diff. `this` mirrors
             // ResolveQueuedMount's own reason above (a self-caused park from THIS instance's own pass).
-            FiberZLayerCoordinator.DrainTeardowns(_ctx, this);
+            FiberZLayerCoordinator.DrainTeardowns(_ctx);
         }
 
         private (VisualElement Target, VNode?[] Children) ResolveLayerPortalTarget(
@@ -531,34 +507,6 @@ namespace Velvet
         private static int ShiftSlotLimit(int slotLimit, int delta)
             => slotLimit == int.MaxValue ? slotLimit : slotLimit + delta;
 
-        // Rebases this instance's own parked state by delta, but only when its captured Parent is `parent` —
-        // called by FiberZLayerCoordinator when a back z-layer container is created or torn down (see
-        // FiberZLayerCoordinator.RebaseParkedSlotsForContainerChange). That mutation runs from
-        // DrainPendingPortalMounts, itself called from THIS instance's own top-level finally — Reconciler.
-        // Reconcile's on a fiber's first suspension, or Reconciler.ContinueReconcile's on a later resume tick
-        // that re-parks in the same tick it drains — so a park this SAME call just captured (its own
-        // placeholder insert queued the very mount this drain now resolves) is still sitting on this
-        // instance. On a first suspension that is also invisible to any cross-fiber sweep:
-        // ReconcilerContext.ParkedBaselineFibers only gains this fiber once Reconcile() itself has fully
-        // returned (FiberCommitWork.ReturnOldTreeAfterReconcile), strictly AFTER that drain finishes. On a
-        // later resume tick the fiber may ALREADY be registered there too (nothing removes it until
-        // HasPendingWork goes false) — RebaseParkedSlotsForContainerChange's own loop excludes this instance
-        // by identity so the two call sites never double-apply to the same captured state. Unlike
-        // RebasePendingSlotStart (which the caller already knows targets this instance's parked parent, from
-        // the inline-sibling walk), this call site has no such guarantee — a parked state here may belong to
-        // an unrelated parent entirely — so the Parent match is checked first.
-        internal void RebasePendingSlotStartIfTargeting(VisualElement parent, int delta)
-        {
-            if (delta == 0) return;
-            if (PendingIndexedState.HasValue && ReferenceEquals(PendingIndexedState.Value.Parent, parent))
-            {
-                RebasePendingSlotStart(delta);
-            }
-            else if (PendingKeyedState != null && ReferenceEquals(PendingKeyedState.Parent, parent))
-            {
-                RebasePendingSlotStart(delta);
-            }
-        }
 
         // Discards a suspended KeyedReconcile state and returns the held Pool buffers.
         // Invoked on a new Reconcile or during Dispose.
@@ -601,24 +549,27 @@ namespace Velvet
             VisualElement? parent, VNode?[]? oldNodes, VNode?[]? newNodes, int slotStart, int slotLimit)
         {
             if (parent == null || oldNodes == null || newNodes == null) return false;
-            // NonSpacerChildCount, not raw childCount: a trailing filter bounds-spacer on a skewed / shadowed +
+            // The LOGICAL count, not raw childCount: a filter bounds-spacer on a skewed / shadowed +
             // filtered parent is not a keyed row, so it must not pad `available` (masking a real desync) nor be
             // the first element the removal loop below tears out.
-            var rangeEnd = Math.Min(SilhouetteBoundsSpacer.NonSpacerChildCount(parent), slotLimit);
+            var rangeEnd = Math.Min(LogicalChildSlots.Count(parent), slotLimit);
             var available = rangeEnd - slotStart;
             if (available < 0) available = 0;
             if (oldNodes.Length <= available) return false;
 
+            // Logical slots, converted per step: the walk is downward so each removal only shifts slots
+            // after the one just removed, and an invisible child interleaved in the range is skipped rather
+            // than torn out with the rendered ones.
             for (var i = rangeEnd - 1; i >= slotStart; i--)
             {
-                _cleaner.RemoveElement(parent, i);
+                _cleaner.RemoveElement(parent, LogicalChildSlots.ToPhysical(parent, i));
                 if (_ctx.IsAborted) return true;
             }
             for (var i = 0; i < newNodes.Length; i++)
             {
                 var element = _factory.CreateElement(newNodes[i]);
                 if (_ctx.IsAborted) return true;
-                parent.Insert(Math.Min(slotStart + i, SilhouetteBoundsSpacer.NonSpacerChildCount(parent)), element);
+                parent.Insert(LogicalChildSlots.ToPhysical(parent, slotStart + i), element);
             }
             return true;
         }
@@ -767,10 +718,12 @@ namespace Velvet
                 // Bound by slotLimit (this fiber's range end), not just childCount: for a non-last inline
                 // tenant childCount includes the following sibling's rows, so an unbounded check would treat a
                 // sibling row as this fiber's and PATCH it. Out of range → create within this fiber's range.
-                var slotExists = slotStart + i < Math.Min(SilhouetteBoundsSpacer.NonSpacerChildCount(parent), slotLimit);
+                // One walk answers both "is the slot occupied" and "where is it", where a Count bound
+                // check would scan the whole child list per element on a phase that mutates nothing.
+                var slotExists = slotStart + i < slotLimit
+                    && LogicalChildSlots.TryGetPhysical(parent, slotStart + i, out _);
                 var slot = new ChildSlot { Parent = parent, SlotStart = slotStart, Index = i };
-                if (PatchOrReplaceAtSlot(in slot, oldNodes[i], newNodes[i],
-                        slotExists, clampInsertIndex: true))
+                if (PatchOrReplaceAtSlot(in slot, oldNodes[i], newNodes[i], slotExists))
                 {
                     return true;
                 }
@@ -802,12 +755,12 @@ namespace Velvet
 
                 // DOM-desync recovery (see the Common phase): when the live container is shorter than the
                 // baseline claims, the tail slot to remove may not exist — skip it instead of over-indexing.
-                // NonSpacerChildCount so a trailing filter bounds-spacer is never the slot removal targets.
-                if (slotStart + i >= SilhouetteBoundsSpacer.NonSpacerChildCount(parent))
+                // One walk resolves both the existence test and the physical index it removes at.
+                if (!LogicalChildSlots.TryGetPhysical(parent, slotStart + i, out var removeAt))
                 {
                     continue;
                 }
-                _cleaner.RemoveElement(parent, slotStart + i);
+                _cleaner.RemoveElement(parent, removeAt);
 
                 if (budgeted && _stopwatch!.Elapsed.TotalMilliseconds > frameBudgetMs)
                 {
@@ -849,7 +802,7 @@ namespace Velvet
                 // equivalent to Add (slotStart + i == parent.childCount at this point). Clamp to childCount so a
                 // DOM-desync resume directly into this phase (the live range shrank since the slice was parked)
                 // appends rather than over-indexing — symmetric with the Common-phase create-on-missing guard.
-                parent.Insert(Math.Min(slotStart + i, SilhouetteBoundsSpacer.NonSpacerChildCount(parent)), newElement);
+                parent.Insert(LogicalChildSlots.ToPhysical(parent, slotStart + i), newElement);
 
                 if (budgeted && _stopwatch!.Elapsed.TotalMilliseconds > frameBudgetMs)
                 {
@@ -956,7 +909,7 @@ namespace Velvet
 
                     var slot = new ChildSlot { Parent = parent, SlotStart = slotStart, Index = i };
                     if (PatchOrReplaceAtSlot(in slot, oldNodes[i], newNodes[i],
-                            slotExists: true, clampInsertIndex: false))
+                            slotExists: true))
                     {
                         return false;
                     }
@@ -972,7 +925,7 @@ namespace Velvet
             if (linearEnd == oldNodes.Length)
             {
                 for (var i = linearEnd; i < newNodes.Length; i++)
-                    parent.Insert(slotStart + i, _factory.CreateElement(newNodes[i]));
+                    parent.Insert(LogicalChildSlots.ToPhysical(parent, slotStart + i), _factory.CreateElement(newNodes[i]));
                 return false;
             }
 
@@ -980,7 +933,7 @@ namespace Velvet
             if (linearEnd == newNodes.Length)
             {
                 for (var i = oldNodes.Length - 1; i >= linearEnd; i--)
-                    _cleaner.RemoveElement(parent, slotStart + i);
+                    _cleaner.RemoveElement(parent, LogicalChildSlots.ToPhysical(parent, slotStart + i));
                 return false;
             }
 
@@ -1060,7 +1013,7 @@ namespace Velvet
                 var oi = oldMidEnd + k;
                 var ni = newMidEnd + k;
                 if (ReferenceEquals(oldNodes[oi], newNodes[ni])) continue;
-                var actualElement = _patcher.ResolveWrapped(parent.ElementAt(slotStart + oi));
+                var actualElement = _patcher.ResolveWrapped(parent.ElementAt(LogicalChildSlots.ToPhysical(parent, slotStart + oi)));
                 _patcher.PatchNode(actualElement, oldNodes[oi], newNodes[ni]);
                 if (_ctx.IsAborted) return;
             }
@@ -1070,7 +1023,7 @@ namespace Velvet
                 // Old middle empty → pure insert of new[linearEnd, newMidEnd) ahead of the suffix.
                 for (var i = linearEnd; i < newMidEnd; i++)
                 {
-                    parent.Insert(slotStart + i, _factory.CreateElement(newNodes[i]));
+                    parent.Insert(LogicalChildSlots.ToPhysical(parent, slotStart + i), _factory.CreateElement(newNodes[i]));
                     if (_ctx.IsAborted) return;
                 }
             }
@@ -1080,7 +1033,7 @@ namespace Velvet
                 // leaves the not-yet-removed indices intact.
                 for (var i = oldMidEnd - 1; i >= linearEnd; i--)
                 {
-                    _cleaner.RemoveElement(parent, slotStart + i);
+                    _cleaner.RemoveElement(parent, LogicalChildSlots.ToPhysical(parent, slotStart + i));
                     if (_ctx.IsAborted) return;
                 }
             }
@@ -1131,7 +1084,7 @@ namespace Velvet
                 {
                     if (ShouldRemoveOldKeyedEntry(oldNodes[i], i, usedKeys, replacedKeys, orphanedOldIndices))
                     {
-                        _cleaner.RemoveElement(parent, slotStart + i);
+                        _cleaner.RemoveElement(parent, LogicalChildSlots.ToPhysical(parent, slotStart + i));
                     }
                 }
 
@@ -1258,7 +1211,7 @@ namespace Velvet
 
                     var slot = new ChildSlot { Parent = parent, SlotStart = slotStart, Index = i };
                     if (PatchOrReplaceAtSlot(in slot, oldNodes[i], newNodes[i],
-                            slotExists: true, clampInsertIndex: false))
+                            slotExists: true))
                     {
                         state.Phase = KeyedReconcilePhase.Done;
                         return true;
@@ -1307,7 +1260,7 @@ namespace Velvet
 
                 var newElement = _factory.CreateElement(newNodes[i]);
                 if (AbortIfCanceled(state)) return true;
-                parent.Insert(slotStart + i, newElement);
+                parent.Insert(LogicalChildSlots.ToPhysical(parent, slotStart + i), newElement);
 
                 var next = i + 1;
                 if (next < newNodes.Length && TryYield(state, next, frameBudgetMs)) return false;
@@ -1325,7 +1278,7 @@ namespace Velvet
             {
                 if (AbortIfCanceled(state)) return true;
 
-                _cleaner.RemoveElement(parent, slotStart + i);
+                _cleaner.RemoveElement(parent, LogicalChildSlots.ToPhysical(parent, slotStart + i));
 
                 var next = i - 1;
                 if (next >= state.LinearEnd && TryYield(state, next, frameBudgetMs)) return false;
@@ -1418,7 +1371,7 @@ namespace Velvet
 
                 if (ShouldRemoveOldKeyedEntry(oldNodes[i], i, usedKeys, replacedKeys, orphanedOldIndices))
                 {
-                    _cleaner.RemoveElement(parent, slotStart + i);
+                    _cleaner.RemoveElement(parent, LogicalChildSlots.ToPhysical(parent, slotStart + i));
                 }
 
                 var next = i - 1;
@@ -1605,13 +1558,15 @@ namespace Velvet
         // stale element as the new type. Both the synchronous and time-sliced keyed paths gate on this.
         private static void AssertDomIndexInvariant(int slotStart, int oldIndex, VisualElement parent)
         {
-            // NonSpacerChildCount so a trailing filter bounds-spacer does not loosen the bound (masking a real
-            // Pass-1 ordering violation); keyed rows always precede the spacer, so the access itself is in range.
-            var rendered = SilhouetteBoundsSpacer.NonSpacerChildCount(parent);
+            // The logical count, not a physical one, so an invisible child cannot loosen the bound and mask a
+            // real Pass-1 ordering violation. Computed INSIDE the Debug.Assert arguments rather than into a
+            // local: Debug.Assert is [Conditional("UNITY_ASSERTIONS")], so the whole O(childCount) walk is
+            // compiled out of a player build along with the call. A local would have run in every build.
             UnityEngine.Debug.Assert(
-                slotStart + oldIndex < rendered,
-                $"[ChildReconciler] DOM index invariant violated: slotStart + old.index={slotStart + oldIndex} >= renderedChildCount={rendered}. " +
-                "Pass 1 may have modified parent's child order.");
+                slotStart + oldIndex < LogicalChildSlots.Count(parent),
+                $"[ChildReconciler] DOM index invariant violated: slotStart + old.index={slotStart + oldIndex} "
+                + $">= renderedChildCount={LogicalChildSlots.Count(parent)}. "
+                + "Pass 1 may have modified parent's child order.");
         }
 
         private static void FlattenAndFilterRecursive(VNode?[] nodes, System.Collections.Generic.List<VNode> result)
@@ -1675,7 +1630,7 @@ namespace Velvet
                     return false;
                 }
                 AssertDomIndexInvariant(slotStart, old.index, parent);
-                var existingDomElement = parent.ElementAt(slotStart + old.index);
+                var existingDomElement = parent.ElementAt(LogicalChildSlots.ToPhysical(parent, slotStart + old.index));
 
                 if (ReconcileKeying.CanPatch(old.node, newNode))
                 {
@@ -1688,7 +1643,7 @@ namespace Velvet
                         if (_ctx.IsAborted) return true;
                         // Re-fetch after PatchNode: a WrapElement wrapper swap may change the DOM element
                         // reference at this index.
-                        existingDomElement = parent.ElementAt(slotStart + old.index);
+                        existingDomElement = parent.ElementAt(LogicalChildSlots.ToPhysical(parent, slotStart + old.index));
                     }
                     newElements.Add((existingDomElement, true));
                 }

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberCommitWork.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberCommitWork.cs
@@ -38,22 +38,11 @@ namespace Velvet
             return limit;
         }
 
-        // The fiber's shared MountPoint child count, blind to a z-layer container's own physical presence.
-        // FiberZLayerCoordinator creates or removes a container on the SAME parent a caller measures
-        // before/after its own Reconcile / ContinueReconcile call (the container drain runs from inside
-        // that same call's safe post-pass point), so a raw childCount read attributes the container's
-        // leading/trailing +-1 to this fiber's own committed-row delta and leaks a physical offset into
-        // MountSlotCount / a following sibling's MountSlotStart — both already logical quantities the entry
-        // gate (ChildReconciler.Reconcile) re-adds LeadingOffset to on every fresh entry, so that offset
-        // would then apply twice. NonSpacerChildCount only trims the TRAILING spacer run (a front
-        // container, a bounds-spacer) — a leading back container stays counted by its contract — so the
-        // leading side must be subtracted separately for a container appearing or disappearing during the
-        // measured interval to cancel out of the delta symmetrically in either direction.
+        // The mount point's rendered child count, in LOGICAL slots — the basis every stored slotStart
+        // shares, so an invisible child appearing or disappearing anywhere in the list cancels out of a
+        // before/after delta instead of being read as a rendered child arriving or leaving.
         internal static int LogicalMountPointChildCount(VisualElement? mountPoint)
-            => mountPoint != null
-                ? SilhouetteBoundsSpacer.NonSpacerChildCount(mountPoint)
-                    - FiberZLayerCoordinator.LeadingOffset(mountPoint)
-                : 0;
+            => mountPoint != null ? LogicalChildSlots.Count(mountPoint) : 0;
 
         // Propagates an inline-mount fiber's committed child-count change to the siblings that share its
         // MountPoint. Updates the fiber's own slot count, then shifts every following sibling's

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberElementCleaner.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberElementCleaner.cs
@@ -518,18 +518,20 @@ namespace Velvet
                 return;
             }
 
-            // PortalState.SlotStart is stored LOGICAL (ChildReconciler.DrainPendingPortalMounts /
-            // FiberNodePatcher.PatchPortalChildren both keep it in that basis so Reconcile's own leading-offset
-            // entry gate folds it exactly once) — this walk indexes target's children PHYSICALLY and never goes
-            // through that entry gate, so it converts once here instead, re-deriving the live offset rather than
-            // trusting a stale copy (see FiberZLayerCoordinator.LeadingOffset's own doc on why it must always be
-            // read fresh).
-            var physicalSlotStart = portalInfo.SlotStart + FiberZLayerCoordinator.LeadingOffset(target);
-            var slotEnd = physicalSlotStart + portalInfo.SlotLength;
+            // Both ends of the range are LOGICAL, so BOTH are converted. Adding the logical length to the
+            // already-converted start mixes the two bases, and tears out one element too many the moment an
+            // invisible child sits anywhere inside the portal's range.
+            var physicalSlotStart = LogicalChildSlots.ToPhysical(target, portalInfo.SlotStart);
+            var slotEnd = LogicalChildSlots.ToPhysical(target, portalInfo.SlotStart + portalInfo.SlotLength);
             if (slotEnd > target.childCount) slotEnd = target.childCount;
             for (var i = slotEnd - 1; i >= physicalSlotStart; i--)
             {
                 var child = target.ElementAt(i);
+                // An invisible child inside the range belongs to whichever paint owns it, not to the portal.
+                if (SilhouetteBoundsSpacer.IsSpacer(child))
+                {
+                    continue;
+                }
                 var poolable = PoolableOccupantOf(child);
                 CleanupElement(child);
                 target.RemoveAt(i);

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
@@ -974,12 +974,16 @@ namespace Velvet
 
             var oldChildren = oldChildrenRaw ?? Array.Empty<VNode>();
             var newChildren = newChildrenRaw ?? Array.Empty<VNode>();
-            var beforeTailCount = target.childCount;
+            // LOGICAL counts on both sides of the reconcile, matching the basis SlotStart and SlotLength are
+            // stored in. Measuring this physically let an invisible child arriving on the target — a portal
+            // child gaining a filter, or a negative z — inflate the recorded length by one, which then
+            // shifted every downstream portal's SlotStart and made the cleanup walk over-remove.
+            var beforeTailCount = LogicalChildSlots.Count(target);
             _host.ReconcileChildren(target, oldChildren, newChildren, slotStart: prevState.SlotStart);
             // (beforeTailCount - prevState.SlotLength) is the count of target children that do NOT belong to
-            // this Portal's slot — unchanged by the reconcile above. Subtracting it from the new total childCount
+            // this Portal's slot — unchanged by the reconcile above. Subtracting it from the new total
             // isolates this Portal's new slot length without re-counting the foreign children.
-            var newSlotLength = target.childCount - (beforeTailCount - prevState.SlotLength);
+            var newSlotLength = LogicalChildSlots.Count(target) - (beforeTailCount - prevState.SlotLength);
             var delta = newSlotLength - prevState.SlotLength;
 
             // The RESOLVED target is written back: a portal that mounted before its id registered
@@ -2612,9 +2616,8 @@ namespace Velvet
             // Exclude the trailing filter bounds-spacer(s) AND a leading back z-layer container (either may
             // be present) from the sibling count: neither is part of the logical child list a
             // first:/last:/nth match sees.
-            var leadingOffset = FiberZLayerCoordinator.LeadingOffset(logicalParent!);
-            EvaluateStructural(_ctx, element, logicalIndex - leadingOffset,
-                SilhouetteBoundsSpacer.NonSpacerChildCount(logicalParent!) - leadingOffset, rules);
+            EvaluateStructural(_ctx, element, LogicalChildSlots.ToLogical(logicalParent!, logicalIndex),
+                LogicalChildSlots.Count(logicalParent!), rules);
         }
 
         // Applies / clears each structural rule's payload for an element at the given sibling position.
@@ -2641,17 +2644,14 @@ namespace Velvet
                 return;
             }
 
-            // The trailing filter bounds-spacer(s) are internal render-bounds children, not logical siblings:
-            // exclude them from the count and skip evaluating them so first:/last:/nth match the real children.
-            // A leading back z-layer container (FiberZLayerCoordinator), when present, is symmetrically
-            // excluded: NonSpacerChildCount only trims the trailing side, so the scan start and the count are
-            // both corrected by LeadingOffset here — otherwise every ordinary child's structural position
-            // computes one slot too high and the sibling count is inflated by one.
-            var leadingOffset = FiberZLayerCoordinator.LeadingOffset(container);
-            var count = SilhouetteBoundsSpacer.NonSpacerChildCount(container) - leadingOffset;
+            // The reconciler-invisible children — a filter bounds spacer, a z-index layer container, a ring
+            // band — are internal, not logical siblings, so first:/last:/nth must neither count them nor
+            // land on one. Walking logical slots and converting each to a physical index does both, wherever
+            // in the child list they happen to sit.
+            var count = LogicalChildSlots.Count(container);
             for (var i = 0; i < count; i++)
             {
-                var slotOccupant = container.ElementAt(i + leadingOffset);
+                var slotOccupant = container.ElementAt(LogicalChildSlots.ToPhysical(container, i));
                 // A z-managed child's slot holds its PLACEHOLDER, not the element the rules were registered
                 // against (ApplyStructuralVariantConfig keys by the real element / its own wrapper) — resolve
                 // through the z-registry first, then the ordinary wrapper unwrap (the slot may ALSO hold a

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberZLayerCoordinator.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberZLayerCoordinator.cs
@@ -57,6 +57,12 @@ namespace Velvet
         internal static bool IsLayerContainer(VisualElement child)
             => child.ClassListContains(FrontMarkerClass) || child.ClassListContains(BackMarkerClass);
 
+        // The BACK container is the only reconciler-invisible child that must stay a parent's FIRST physical
+        // child (it paints behind the ordinary children). Every other kind — the front container, a filter
+        // bounds spacer — must stay last. LogicalChildSlots needs the two apart to place an append.
+        internal static bool IsBackLayerContainer(VisualElement child)
+            => child != null && child.ClassListContains(BackMarkerClass);
+
         // The z-* scope gate: an element is z-managed only when it carries an explicit z-* utility class AND
         // is ALSO out-of-flow — either the "absolute" utility class (StyleOutOfFlowChild's off-panel/class-
         // based half: z-* on an in-flow element is a documented no-op, decided here before the element has
@@ -77,15 +83,6 @@ namespace Velvet
             }
             return StyleZIndexClass.TryExtract(classNames, out resolvedZ);
         }
-
-        // How many of `parent`'s LEADING children are its own back-layer container (0 or 1). Folded into
-        // wherever a fresh (non-resumed) slotStart originates — ChildReconciler.Reconcile's single entry
-        // point — so every downstream ordinary-child index computation is already correct without touching
-        // any of them individually. A resumed time-sliced pass never re-enters through that same point (its
-        // saved slotStart already has this baked in from when it first ran), so this must never be applied
-        // twice for the same logical pass.
-        internal static int LeadingOffset(VisualElement parent)
-            => parent.childCount > 0 && parent[0].ClassListContains(BackMarkerClass) ? 1 : 0;
 
         // A zero-footprint stand-in left at a z-managed element's logical slot while its real element
         // lives in a layer container. Carries focusable/tabIndex so it can act as a same-panel Tab proxy
@@ -138,11 +135,10 @@ namespace Velvet
         // Drain-time resolution of a queued mount (ChildReconciler.DrainPendingPortalMounts's new case arm).
         // By now placeholder.parent is set (the caller already inserted it at the ordinary slot like any
         // other created element), so the stacking parent — and therefore its container — is finally known.
-        // `current` is the ChildReconciler instance whose own top-level Reconcile() finally is running this
         // drain (see RebaseParkedSlotsForContainerChange) — threaded through only so GetOrCreateContainer can
         // rebase a same-pass self-park; it plays no other part in resolving this mount.
         internal static void ResolveQueuedMount(
-            ReconcilerContext ctx, VisualElement placeholder, ZLayerMountNode node, ChildReconciler current)
+            ReconcilerContext ctx, VisualElement placeholder, ZLayerMountNode node)
         {
             var stackingParent = placeholder.parent;
             if (stackingParent == null)
@@ -151,7 +147,7 @@ namespace Velvet
                 // this drained — mirrors DrainPendingPortalMounts' own placeholder.parent == null skip.
                 return;
             }
-            var container = GetOrCreateContainer(ctx, stackingParent, node.ResolvedZ, current);
+            var container = GetOrCreateContainer(ctx, stackingParent, node.ResolvedZ);
             Place(ctx, placeholder, container, stackingParent, node.Real, node.ResolvedZ, node.Order, node.RescueFocus);
         }
 
@@ -284,10 +280,8 @@ namespace Velvet
         }
 
         // Runs at the same post-pass safe point as DrainPendingPortalMounts: any container whose membership
-        // changed this pass and is now empty is removed from its stacking parent and forgotten. `current` is
-        // threaded through for the same reason as ResolveQueuedMount's own parameter — see
-        // RebaseParkedSlotsForContainerChange.
-        internal static void DrainTeardowns(ReconcilerContext ctx, ChildReconciler current)
+        // changed this pass and is now empty is removed from its stacking parent and forgotten.
+        internal static void DrainTeardowns(ReconcilerContext ctx)
         {
             if (ctx.PendingZLayerTeardownChecks.Count == 0)
             {
@@ -300,16 +294,7 @@ namespace Velvet
                     continue;
                 }
                 var stackingParent = container.parent;
-                // The marker class survives Remove (a detach, not a destroy), so reading it after is just as
-                // valid — checked here only because only a BACK container's removal is a LEADING-child change
-                // (LeadingOffset's whole reason to exist); a front container is trailing, so removing it never
-                // shifts any ordinary/placeholder index.
-                var wasBack = container.ClassListContains(BackMarkerClass);
                 stackingParent.Remove(container);
-                if (wasBack)
-                {
-                    RebaseParkedSlotsForContainerChange(ctx, stackingParent, -1, current);
-                }
                 if (!ctx.ZLayerHosts.TryGetValue(stackingParent, out var record))
                 {
                     continue;
@@ -381,11 +366,9 @@ namespace Velvet
         // The container for `resolvedZ`'s sign under `stackingParent`, creating (and physically attaching)
         // it on first use. Only ever called from a safe (post-pass) context — creating one changes
         // `stackingParent`'s own child list, which a live diff over that same parent may still be indexing
-        // by absolute position. `current` is the ChildReconciler instance running this drain — threaded
-        // through only for the back-container branch's rebase (see RebaseParkedSlotsForContainerChange); the
-        // front branch never needs it (trailing, no LeadingOffset impact).
+        // by absolute position.
         private static VisualElement GetOrCreateContainer(
-            ReconcilerContext ctx, VisualElement stackingParent, int resolvedZ, ChildReconciler current)
+            ReconcilerContext ctx, VisualElement stackingParent, int resolvedZ)
         {
             if (!ctx.ZLayerHosts.TryGetValue(stackingParent, out var record))
             {
@@ -398,15 +381,10 @@ namespace Velvet
                 {
                     record.Back = CreateContainer(BackMarkerClass);
                     // The back layer must physically PRECEDE the parent's ordinary children to paint behind
-                    // them — the one structural asymmetry against the front layer (SilhouetteBoundsSpacer's
-                    // own trailing-only spacer convention), which is what LeadingOffset exists to reconcile
-                    // against every ordinary-child index computation.
+                    // them. LogicalChildSlots is what keeps that invisible to every slot computation, and it
+                    // is the reason an append into a parent holding only this container must still resolve
+                    // AFTER it rather than to index 0.
                     stackingParent.Insert(0, record.Back);
-                    // A time-sliced pass — this same drain's own instance, mid-unwind through its own park, or
-                    // any other fiber already parked from an earlier pass — may have captured a slotStart/
-                    // slotLimit over this exact stackingParent before this LEADING insert existed. Every such
-                    // pass is now off by one in the corresponding direction.
-                    RebaseParkedSlotsForContainerChange(ctx, stackingParent, +1, current);
                 }
                 return record.Back;
             }
@@ -422,51 +400,6 @@ namespace Velvet
             return record.Front;
         }
 
-        // Rebases every time-sliced pass parked over `stackingParent` by delta, once a back container's
-        // creation or removal has just shifted every LEADING index there by that same amount. Two
-        // populations can be parked against the SAME stackingParent at this moment, and they are NOT always
-        // disjoint by fiber:
-        //   `current` — the ChildReconciler instance whose OWN top-level Reconcile()/ContinueReconcile() call
-        //     is unwinding through THIS SAME drain (both always run DrainPendingPortalMounts, hence
-        //     DrainTeardowns, from their own top-level finally before returning). A self-caused park — this
-        //     slice's own placeholder insert queued the very mount (or, for the negative direction, its own
-        //     patch synchronously emptied the container) this drain now resolves — is invisible to any
-        //     cross-fiber registry ONLY on a fiber's very FIRST suspension: FiberCommitWork adds a fiber to
-        //     ParkedBaselineFibers once its Reconcile() call has fully returned, strictly AFTER that first
-        //     drain finishes. But an INTERMEDIATE resume tick (FiberWorkLoop.ContinueReconcile driving an
-        //     already-parked fiber) runs with that SAME fiber already sitting in ParkedBaselineFibers from its
-        //     earlier suspension — nothing removes it until HasPendingWork finally goes false — so if that
-        //     tick both creates/removes a container under its OWN MountPoint and immediately re-parks, `current`
-        //     and the loop below would otherwise match the identical fiber twice. RebasePendingSlotStartIfTargeting
-        //     checks Parent match itself, since (unlike FiberCommitWork.PropagateInlineSlotShift's inline-sibling
-        //     walk) nothing here already guarantees `current` is even parked over THIS stackingParent.
-        //   ReconcilerContext.ParkedBaselineFibers — every fiber left parked by an earlier pass, MINUS
-        //     whichever one owns `current` (excluded below) — the same ctx-wide registry
-        //     FiberTreeReturn.MarkOwnerRoots already sweeps wholesale for its own cross-fiber mark. A fiber's
-        //     own Reconcile call always targets fiber.MountPoint as `parent`
-        //     (FiberCommitWork.ReconcileIntoSlotRange), so MountPoint identity is exactly the "this fiber's
-        //     parked state targets stackingParent" test — no separate per-parent index needs maintaining
-        //     alongside it.
-        private static void RebaseParkedSlotsForContainerChange(
-            ReconcilerContext ctx, VisualElement stackingParent, int delta, ChildReconciler current)
-        {
-            current.RebasePendingSlotStartIfTargeting(stackingParent, delta);
-            foreach (var fiber in ctx.ParkedBaselineFibers)
-            {
-                // `current`'s own owning fiber, when it is itself one of the parked entries this loop would
-                // otherwise reach (see this method's own doc), was already rebased by the direct call above —
-                // matching it again here would apply delta to the very same PendingIndexedState/
-                // PendingKeyedState instance a second time.
-                if (ReferenceEquals(fiber.Reconciler?.ChildReconciler, current))
-                {
-                    continue;
-                }
-                if (ReferenceEquals(fiber.MountPoint, stackingParent))
-                {
-                    fiber.Reconciler?.RebasePendingSlotStart(delta);
-                }
-            }
-        }
 
         private static VisualElement CreateContainer(string markerClass)
         {

--- a/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
@@ -202,7 +202,7 @@ namespace Velvet
             // IndexOutOfRange — the time-sliced keyed path asserts this invariant; the general path
             // can be re-entered mid-suspend so it guards defensively.
             var oldMatched = commit.OldKeyMap.TryGetValue(key, out var old)
-                && slotStart + old.index < SilhouetteBoundsSpacer.NonSpacerChildCount(parent);
+                && LogicalChildSlots.TryGetPhysical(parent, slotStart + old.index, out _);
             if (oldMatched && commit.UsedKeys.Contains(key))
             {
                 // A second new-side sibling resolved the same old entry its first occurrence already
@@ -216,14 +216,14 @@ namespace Velvet
             }
             if (oldMatched)
             {
-                var existingDom = parent.ElementAt(slotStart + old.index);
+                var existingDom = parent.ElementAt(LogicalChildSlots.ToPhysical(parent, slotStart + old.index));
                 if (ReconcileKeying.CanPatch(old.node, node))
                 {
                     var actual = _patcher.ResolveWrapped(existingDom);
                     _patcher.PatchNode(actual, old.node, node);
                     if (_ctx.IsAborted) return;
                     // Re-fetch: a WrapElement wrapper swap may change the element reference at this index.
-                    existingDom = parent.ElementAt(slotStart + old.index);
+                    existingDom = parent.ElementAt(LogicalChildSlots.ToPhysical(parent, slotStart + old.index));
                     commit.NewElements.Add((existingDom, true));
                     // Mark the old key consumed only AFTER the patch succeeds. PatchNode can re-enter a
                     // child reconcile that throws FiberSuspendSignal (a suspending descendant) or set
@@ -374,7 +374,7 @@ namespace Velvet
                     || !commit.UsedKeys.Contains(key)
                     || commit.ReplacedKeys.Contains(key))
                 {
-                    _cleaner.RemoveElement(parent, slotStart + i);
+                    _cleaner.RemoveElement(parent, LogicalChildSlots.ToPhysical(parent, slotStart + i));
                 }
             }
 

--- a/Packages/com.velvet.core/Runtime/Reconciler/LogicalChildSlots.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/LogicalChildSlots.cs
@@ -1,0 +1,153 @@
+using UnityEngine.UIElements;
+
+namespace Velvet
+{
+    /// <summary>
+    /// Translates between a container's LOGICAL child slots — the positions the reconciler addresses, one
+    /// per rendered VNode — and the PHYSICAL child indices those occupy, with reconciler-invisible children
+    /// (<see cref="SilhouetteBoundsSpacer.IsSpacer"/>) allowed to sit anywhere among them.
+    /// </summary>
+    /// <remarks>
+    /// The reconciler used to assume the invisible children were only ever a LEADING run (a z-index layer
+    /// container) or a TRAILING one (a filter bounds spacer), which let it treat
+    /// <c>physical = logical + LeadingOffset</c> as true across a whole child list: slot arithmetic was done
+    /// on physical indices and clamped against a count that trimmed only those two runs. That assumption is
+    /// what confined every invisible child to an end of the list, and a paint that must sit BESIDE the
+    /// element it decorates — a ring band, which has to occlude its own element but not its later siblings —
+    /// cannot honour it.
+    /// <para>
+    /// The replacement is a single rule: every slot index the reconciler computes or stores is LOGICAL, and
+    /// it is converted exactly once, at the point the DOM is touched. <see cref="ToPhysical"/> is that
+    /// conversion for a read, a removal or an insert; <see cref="Count"/> is the logical bound that replaces
+    /// the old physical one; <see cref="ToLogical"/> is the inverse, for the few places that start from a
+    /// physical index.
+    /// </para>
+    /// <para>
+    /// Cost, and where it is NOT paid. <see cref="ToPhysical"/> stops at the requested slot; <c>Count</c>
+    /// scans the whole child list, so it must not sit inside a per-child loop — the per-child sites ask
+    /// <see cref="TryGetPhysical"/> instead, which answers "is the slot occupied" and "where" in one walk,
+    /// and <c>AssertDomIndexInvariant</c> computes its count inside the <c>Debug.Assert</c> arguments so a
+    /// player build compiles it out with the call. What remains is one bounded walk per DOM touch on paths
+    /// that are already mutating the DOM. A container with no invisible child still pays it: the walk is
+    /// proportional to the slot index, not to the whole list, so a full pass stays quadratic in the child
+    /// count. If that shows up in a profile, the fix is a cursor advancing alongside the caller's own loop,
+    /// not a cached count (which every insert and remove would have to invalidate).
+    /// </para>
+    /// </remarks>
+    internal static class LogicalChildSlots
+    {
+        /// <summary>
+        /// The number of rendered children — the exclusive upper bound of the logical slot range. Replaces
+        /// the physical <c>NonSpacerChildCount</c> wherever that was being read as "how many slots are there".
+        /// </summary>
+        internal static int Count(VisualElement container)
+        {
+            if (container == null)
+            {
+                return 0;
+            }
+            var rendered = 0;
+            var physicalCount = container.childCount;
+            for (var i = 0; i < physicalCount; i++)
+            {
+                if (!SilhouetteBoundsSpacer.IsSpacer(container[i]))
+                {
+                    rendered++;
+                }
+            }
+            return rendered;
+        }
+
+        /// <summary>
+        /// Whether a rendered child currently occupies <paramref name="logical"/>, and where. One walk
+        /// instead of a <see cref="Count"/> bound check followed by a <see cref="ToPhysical"/> — the pair
+        /// the hot per-child loops used to do, where the bound check alone scanned the whole child list.
+        /// <paramref name="physical"/> is the append position when the slot is empty, so a caller that
+        /// inserts on the false branch needs no second call.
+        /// </summary>
+        internal static bool TryGetPhysical(VisualElement container, int logical, out int physical)
+        {
+            physical = ToPhysical(container, logical);
+            return logical >= 0 && physical < container.childCount
+                && !SilhouetteBoundsSpacer.IsSpacer(container[physical]);
+        }
+
+        /// <summary>
+        /// The physical index of the <paramref name="logical"/>-th rendered child.
+        /// </summary>
+        /// <remarks>
+        /// For <paramref name="logical"/> equal to (or past) <see cref="Count"/> this returns the position
+        /// just AFTER the last rendered child rather than the end of the child list, so an append lands
+        /// before a trailing invisible run instead of after it — the placement the filter bounds spacer
+        /// depends on. This is NOT always what the old <c>Insert(NonSpacerChildCount(parent), …)</c> idiom
+        /// answered: on a parent holding a back z-layer container and no rendered child that idiom said 0,
+        /// which would place the append ahead of a container that has to stay first.
+        /// Insert semantics follow from the same rule: inserting at a logical slot puts the new child
+        /// immediately before the child currently holding that slot, so an invisible child sitting between
+        /// two rendered ones stays attached to the rendered child it precedes.
+        /// </remarks>
+        internal static int ToPhysical(VisualElement container, int logical)
+        {
+            if (container == null)
+            {
+                return 0;
+            }
+            var physicalCount = container.childCount;
+            if (logical < 0)
+            {
+                logical = 0;
+            }
+            var rendered = 0;
+            // Where an append lands, decided by the invisible child's KIND rather than its position. The
+            // three kinds have opposite contracts: a z-index BACK container must stay the parent's first
+            // physical child, while a front container and a filter bounds spacer must stay last. So an
+            // append steps over a leading back container — slot 0 of a parent holding nothing else resolves
+            // AFTER it — and stops before everything else. Deciding this positionally instead ("anything
+            // invisible seen before the first rendered child is leading") sent an append past a bounds
+            // spacer on a parent whose rendered children had all been removed.
+            var appendAt = 0;
+            for (var i = 0; i < physicalCount; i++)
+            {
+                var child = container[i];
+                if (SilhouetteBoundsSpacer.IsSpacer(child))
+                {
+                    if (FiberZLayerCoordinator.IsBackLayerContainer(child))
+                    {
+                        appendAt = i + 1;
+                    }
+                    continue;
+                }
+                if (rendered == logical)
+                {
+                    return i;
+                }
+                rendered++;
+                appendAt = i + 1;
+            }
+            return appendAt;
+        }
+
+        /// <summary>
+        /// The logical slot a physical child index occupies — the number of rendered children before it.
+        /// For an invisible child this is the slot it sits in front of.
+        /// </summary>
+        internal static int ToLogical(VisualElement container, int physical)
+        {
+            if (container == null || physical <= 0)
+            {
+                return 0;
+            }
+            var limit = physical < container.childCount ? physical : container.childCount;
+            var rendered = 0;
+            for (var i = 0; i < limit; i++)
+            {
+                if (!SilhouetteBoundsSpacer.IsSpacer(container[i]))
+                {
+                    rendered++;
+                }
+            }
+            return rendered;
+        }
+
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/LogicalChildSlots.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/LogicalChildSlots.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 10ee4d59d86104eff9bf349486b5b07b

--- a/Packages/com.velvet.core/Runtime/Reconciler/Reconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Reconciler.cs
@@ -42,16 +42,6 @@ namespace Velvet
 
         internal ReconcilerContext Context => _ctx;
 
-        /// <summary>
-        /// This Reconciler's own <see cref="ChildReconciler"/> instance. Exposed so
-        /// <see cref="FiberZLayerCoordinator.RebaseParkedSlotsForContainerChange"/> can tell whether a fiber
-        /// found via <see cref="ReconcilerContext.ParkedBaselineFibers"/> is the SAME fiber already being
-        /// rebased directly (the caller's own <c>current</c> parameter), rather than a genuinely different,
-        /// unrelated parked fiber — the two are otherwise indistinguishable by fiber identity alone from
-        /// inside that method, which never sees a fiber, only a ChildReconciler.
-        /// </summary>
-        internal ChildReconciler ChildReconciler => _childReconciler;
-
         public Reconciler()
             : this(new ReconcilerContext(), ownsContext: true)
         {

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/LogicalChildSlotTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/LogicalChildSlotTests.cs
@@ -1,0 +1,276 @@
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine.UIElements;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Specifies that the reconciler addresses LOGICAL child slots — one per rendered VNode — and that a
+    /// reconciler-invisible child may sit ANYWHERE among them, not only in a leading or trailing run.
+    /// </summary>
+    /// <remarks>
+    /// The reconciler used to treat <c>physical = logical + LeadingOffset</c> as true across a whole child
+    /// list, which pinned every invisible child to one end. A paint that must sit BESIDE the element it
+    /// decorates cannot honour that, so <see cref="LogicalChildSlots"/> converts at each DOM touch instead.
+    /// The mid-list cases below are the ones that assumption made impossible; the leading (z-index back
+    /// container) and trailing (filter bounds spacer) cases are kept alongside them because both still have
+    /// to work, and they pull the append position in opposite directions.
+    /// </remarks>
+    [TestFixture]
+    internal sealed class LogicalChildSlotTests
+    {
+        // A stand-in for any reconciler-invisible child, marked the way the shared predicate recognizes one.
+        private static VisualElement Invisible()
+        {
+            var e = new VisualElement { name = "invisible" };
+            e.AddToClassList(SilhouetteBoundsSpacer.MarkerClass);
+            return e;
+        }
+
+        private static VisualElement Rendered(string name) => new() { name = name };
+
+        // The one invisible kind that must stay a parent's FIRST physical child, as against the trailing
+        // kinds Invisible() stands in for.
+        private static VisualElement BackLayerContainer()
+        {
+            var e = new VisualElement { name = "back" };
+            e.AddToClassList(FiberZLayerCoordinator.BackMarkerClass);
+            return e;
+        }
+
+        private static VisualElement Container(params VisualElement[] children)
+        {
+            var c = new VisualElement();
+            foreach (var child in children)
+            {
+                c.Add(child);
+            }
+            return c;
+        }
+
+        private static List<string> NamesOf(VisualElement container)
+        {
+            var names = new List<string>();
+            for (var i = 0; i < container.childCount; i++)
+            {
+                names.Add(container[i].name);
+            }
+            return names;
+        }
+
+        // Unit: the mapping itself
+
+        [Test]
+        public void Given_AnInvisibleChildBetweenTwoRendered_When_CountingSlots_Then_ItIsNotASlot()
+        {
+            // Arrange & Act
+            var container = Container(Rendered("a"), Invisible(), Rendered("b"));
+
+            // Assert
+            Assert.That(LogicalChildSlots.Count(container), Is.EqualTo(2));
+        }
+
+        [Test]
+        public void Given_AnInvisibleChildBetweenTwoRendered_When_ResolvingTheSecondSlot_Then_ItSkipsPastIt()
+        {
+            // Arrange & Act — logical slot 1 is "b", which sits at physical index 2.
+            var container = Container(Rendered("a"), Invisible(), Rendered("b"));
+
+            // Assert
+            Assert.That(LogicalChildSlots.ToPhysical(container, 1), Is.EqualTo(2));
+        }
+
+        [Test]
+        public void Given_AnInvisibleChildBetweenTwoRendered_When_ConvertingItsPhysicalIndex_Then_ItReportsTheSlotItPrecedes()
+        {
+            // Arrange & Act
+            var container = Container(Rendered("a"), Invisible(), Rendered("b"));
+
+            // Assert — one rendered child precedes it, so it sits in front of slot 1.
+            Assert.That(LogicalChildSlots.ToLogical(container, 1), Is.EqualTo(1));
+        }
+
+        [Test]
+        public void Given_OnlyABackLayerContainer_When_ResolvingTheAppendPosition_Then_ItLandsAfterIt()
+        {
+            // Arrange & Act — the back container must stay the parent's first physical child, so an append
+            // cannot resolve to 0. Its KIND is what decides this, not its position: see the trailing-kind
+            // twin below, which sits at the same index and must get the opposite answer.
+            var container = Container(BackLayerContainer());
+
+            // Assert
+            Assert.That(LogicalChildSlots.ToPhysical(container, 0), Is.EqualTo(1));
+        }
+
+        [Test]
+        public void Given_ATrailingInvisibleChild_When_ResolvingTheAppendPosition_Then_ItLandsBeforeIt()
+        {
+            // Arrange & Act — a filter bounds spacer must stay last, which pulls the append position the
+            // opposite way from the back container above.
+            var container = Container(Rendered("a"), Invisible());
+
+            // Assert
+            Assert.That(LogicalChildSlots.ToPhysical(container, 1), Is.EqualTo(1));
+        }
+
+        [Test]
+        public void Given_OnlyATrailingInvisibleChild_When_ResolvingTheAppendPosition_Then_ItStillLandsBeforeIt()
+        {
+            // Arrange & Act — the discriminating pair for the rule being kind-aware rather than positional:
+            // this spacer is the parent's ONLY child, exactly as the back container is above, and must get
+            // the opposite answer. Reachable — a filtered element whose rendered children have all been
+            // removed and which then gains one back.
+            var container = Container(Invisible());
+
+            // Assert
+            Assert.That(LogicalChildSlots.ToPhysical(container, 0), Is.EqualTo(0));
+        }
+
+        // End to end: the reconciler addressing slots across a mid-list invisible child
+
+        [Test]
+        public void Given_AMidListInvisibleChild_When_AChildIsPatchedInPlace_Then_TheCorrectSlotIsPatched()
+        {
+            // Arrange — mount two children, then splice an invisible child between them, exactly where the
+            // old trailing-only assumption said one could never be.
+            using var scope = new ReconcilerScope();
+            var before = new VNode[] { V.Div(name: "a", key: "a"), V.Div(name: "b", key: "b") };
+            scope.Reconciler.Reconcile(scope.Root, Array.Empty<VNode>(), before);
+            scope.Root.Insert(1, Invisible());
+
+            // Act — patch the second slot's identity.
+            scope.Reconciler.Reconcile(scope.Root, before,
+                new VNode[] { V.Div(name: "a", key: "a"), V.Div(name: "b2", key: "b") });
+
+            // Assert — the invisible child is untouched and "b" was the element renamed, not it.
+            Assert.That(NamesOf(scope.Root), Is.EqualTo(new[] { "a", "invisible", "b2" }));
+        }
+
+        [Test]
+        public void Given_AMidListInvisibleChild_When_AChildIsInserted_Then_ItLandsAtItsLogicalSlot()
+        {
+            // Arrange
+            using var scope = new ReconcilerScope();
+            var before = new VNode[] { V.Div(name: "a", key: "a"), V.Div(name: "b", key: "b") };
+            scope.Reconciler.Reconcile(scope.Root, Array.Empty<VNode>(), before);
+            scope.Root.Insert(1, Invisible());
+
+            // Act — a new child between the two existing ones.
+            scope.Reconciler.Reconcile(scope.Root, before, new VNode[]
+            {
+                V.Div(name: "a", key: "a"), V.Div(name: "mid", key: "mid"), V.Div(name: "b", key: "b"),
+            });
+
+            // Assert — inserting at logical slot 1 lands before "b" and after the invisible child, which
+            // stays attached to the rendered child it precedes.
+            Assert.That(NamesOf(scope.Root), Is.EqualTo(new[] { "a", "invisible", "mid", "b" }));
+        }
+
+        [Test]
+        public void Given_AMidListInvisibleChild_When_ARenderedChildIsRemoved_Then_OnlyThatChildLeaves()
+        {
+            // Arrange — this is the shape that exposed the old assumption: a keyed removal walks slots, and
+            // a miscounted invisible child made it tear out the wrong one.
+            using var scope = new ReconcilerScope();
+            var before = new VNode[]
+            {
+                V.Div(name: "a", key: "a"), V.Div(name: "b", key: "b"), V.Div(name: "c", key: "c"),
+            };
+            scope.Reconciler.Reconcile(scope.Root, Array.Empty<VNode>(), before);
+            scope.Root.Insert(1, Invisible());
+
+            // Act
+            scope.Reconciler.Reconcile(scope.Root, before,
+                new VNode[] { V.Div(name: "a", key: "a"), V.Div(name: "c", key: "c") });
+
+            // Assert
+            Assert.That(NamesOf(scope.Root), Is.EqualTo(new[] { "a", "invisible", "c" }));
+        }
+
+        [Test]
+        public void Given_AMidListInvisibleChild_When_TheLastKeyIsReplaced_Then_TheCreatedRowLandsLast()
+        {
+            // Reaches ChildElementPlacement, which four fast paths in ReconcileKeyedSync otherwise skip — a
+            // plain append exits at the pure-append path and never gets there. REPLACING the last key does:
+            // Pass 1 stops before the old list ends, and the trailing keys differ so the suffix trim yields
+            // nothing. The created row is the only new-side entry that maps to -1, which ComputeLisAnchors
+            // never makes an anchor, so it is the single entry that consults afterRangeAnchor — read
+            // physically that anchor is the range's OWN last element, and the new row lands before it.
+            using var scope = new ReconcilerScope();
+            var before = new VNode[]
+            {
+                V.Div(name: "a", key: "a"), V.Div(name: "b", key: "b"), V.Div(name: "c", key: "c"),
+            };
+            scope.Reconciler.Reconcile(scope.Root, Array.Empty<VNode>(), before);
+            scope.Root.Insert(1, Invisible());
+
+            // Act
+            scope.Reconciler.Reconcile(scope.Root, before, new VNode[]
+            {
+                V.Div(name: "a", key: "a"), V.Div(name: "b", key: "b"), V.Div(name: "x", key: "x"),
+            });
+
+            // Assert
+            Assert.That(NamesOf(scope.Root), Is.EqualTo(new[] { "a", "invisible", "b", "x" }));
+        }
+
+        [Test]
+        public void Given_AMidListInvisibleChild_When_AChildIsAppendedOnTheGeneralPath_Then_ItLandsLast()
+        {
+            // The general path has no fast paths at all — FinalizeGeneralCommit always ends in
+            // ComputeAnchorsAndReorder — so a plain append reaches the same anchor there. A single null child
+            // is enough to take that path, since RequiresInlineExpansion includes null.
+            using var scope = new ReconcilerScope();
+            var before = new VNode?[] { null, V.Div(name: "a", key: "a"), V.Div(name: "b", key: "b") };
+            scope.Reconciler.Reconcile(scope.Root, Array.Empty<VNode>(), before);
+            scope.Root.Insert(1, Invisible());
+
+            // Act
+            scope.Reconciler.Reconcile(scope.Root, before, new VNode?[]
+            {
+                null, V.Div(name: "a", key: "a"), V.Div(name: "b", key: "b"), V.Div(name: "c", key: "c"),
+            });
+
+            // Assert
+            Assert.That(NamesOf(scope.Root), Is.EqualTo(new[] { "a", "invisible", "b", "c" }));
+        }
+
+        [Test]
+        public void Given_AMidListInvisibleChild_When_StructuralVariantsAreDerived_Then_ItIsNotASibling()
+        {
+            // Arrange — last: must land on the final RENDERED child. With the invisible child mid-list, a
+            // physical walk would both inflate the sibling count and evaluate the wrong occupant.
+            using var scope = new ReconcilerScope();
+            var tree = new VNode[]
+            {
+                V.Div(name: "box", key: "box", children: new VNode[]
+                {
+                    V.Div(name: "a", key: "a", className: "last:underline"),
+                    V.Div(name: "b", key: "b", className: "last:underline"),
+                }),
+            };
+            scope.Reconciler.Reconcile(scope.Root, Array.Empty<VNode>(), tree);
+            var box = scope.Root.Q<VisualElement>("box");
+            box.Insert(1, Invisible());
+
+            // Act — FRESH VNode instances, not the same array: passing `tree` on both sides makes Pass 1's
+            // ReferenceEquals skip return before any PatchNode, so nothing would be re-derived and the case
+            // would only be re-reading its own mount-time result.
+            scope.Reconciler.Reconcile(scope.Root, tree, new VNode[]
+            {
+                V.Div(name: "box", key: "box", children: new VNode[]
+                {
+                    V.Div(name: "a", key: "a", className: "last:underline"),
+                    V.Div(name: "b", key: "b", className: "last:underline"),
+                }),
+            });
+
+            // Assert — "b" is the last rendered child and carries the payload; "a" does not.
+            Assert.That((box.Q<VisualElement>("a").ClassListContains("underline"),
+                    box.Q<VisualElement>("b").ClassListContains("underline")),
+                Is.EqualTo((false, true)));
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/LogicalChildSlotTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/LogicalChildSlotTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c33cffd58f26d4acf9fe1d2c82512c27

--- a/Packages/com.velvet.core/Runtime/Styling/SilhouetteBoundsSpacer.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/SilhouetteBoundsSpacer.cs
@@ -120,21 +120,12 @@ namespace Velvet
             return true;
         }
 
-        // The container's child count excluding the trailing bounds-spacer(s). The spacers are always kept
-        // last, so the real children occupy [0, this) — the range the child reconciler and structural
-        // variants must treat as the whole child list.
-        // Floored at the LEADING run of z-layer containers (FiberZLayerCoordinator's own back container is the
-        // one reconciler-invisible child ever placed leading, never trailing): IsSpacer also recognizes a layer
-        // container, so an unguarded trailing trim would eat it too whenever it is (even transiently, mid-diff)
-        // the parent's LAST child — e.g. the instant an interspersed ordinary sibling's own placeholder is
-        // removed and the back container is momentarily all that is left. Once eaten from the count, an
-        // ordinary insert clamped against that undercount lands BEFORE the back container instead of after it,
-        // permanently misplacing it (it stops being the parent's leading child, corrupting LeadingOffset for
-        // this parent from then on). Scanning the leading run first — not calling into the reconciler layer —
-        // keeps the Styling -> Reconciler dependency direction this file already has via IsLayerContainer, one
-        // level further. A front (trailing) container reached by this same leading scan only when it happens to
-        // be the parent's OWN sole child protects it identically; every other trailing case (the ordinary,
-        // overwhelming majority) is unaffected since the floor is 0 there.
+        // The container's child count with a TRAILING run of spacers trimmed and a LEADING run of z-layer
+        // containers counted — the physical bound the reconciler used before it addressed slots logically.
+        // Superseded by LogicalChildSlots.Count, which counts rendered children wherever they sit and so
+        // does NOT count that leading container; the two disagree by exactly that, which is why this is not
+        // a synonym. No production caller remains — it is kept only to avoid editing unrelated fixtures in
+        // the refactor that retired it, and reaching for it from reconciler code gives the wrong number.
         internal static int NonSpacerChildCount(VisualElement container)
         {
             var n = container.childCount;


### PR DESCRIPTION
The reconciler assumed invisible children are trailing: `NonSpacerChildCount` trimmed only a trailing run, and insert paths either clamped to that count or used `slotStart + i`. The z-layer container was the one exception — placed leading, special-cased, and compensated for by an entry-gate offset folded into `slotStart`.

That assumption was measured to be load-bearing. Placing a ring overlay at `parent.IndexOf(element) + 1` was implemented and run against the suite: the child reconciler mis-paired survivors and stranded a band, because an interleaved invisible child counts as rendered. Appending to the end was what the machinery required — and it makes paint order depend on when a variant fired rather than on declaration order.

The rule is now one line: **every slot index the reconciler computes or stores is logical, converted exactly once where the DOM is touched.** `LogicalChildSlots` is the whole API — `Count`, `ToPhysical`, `ToLogical`, `TryGetPhysical` — applied across roughly 25 sites in eight files.

## Two things fell out that are behaviour-shaped, though behaviour did not change

**Parked-slot rebasing became wrong, not merely unnecessary.** `FiberZLayerCoordinator` used to rebase every parked fiber's slot start by ±1 whenever a back container appeared or disappeared, because the entry gate had baked a physical offset into it. A logical slot does not move when an invisible child does, so leaving that machinery would have shifted correct slots. It is deleted; `RebasePendingSlotStart` stays, because `FiberCommitWork`'s inline-tenant use is a genuinely logical shift.

**The append position has two opposite ends, and telling them apart needs the child's kind, not its position.** The first implementation resolved "after the last rendered child", which is right for a trailing bounds spacer and wrong for a leading z-layer container. A second implementation decided "leading" by `rendered == 0`, which sent an append past a bounds spacer on a parent whose rendered children had all been removed. It now asks `IsBackLayerContainer`.

## Verification

`LogicalChildSlotTests`, 12 cases. With `ToPhysical` reverted to `physical == logical`, **5 of 9 mapping cases fail**, including all three mid-list reconcile cases. With the `ReorderToNewElementOrder` conversion reverted, the two placement cases fail, each landing the new row one slot early:

```
Given_AMidListInvisibleChild_When_TheLastKeyIsReplaced_Then_TheCreatedRowLandsLast
  Expected: "b"  But was: "x"
Given_AMidListInvisibleChild_When_AChildIsAppendedOnTheGeneralPath_Then_ItLandsLast
  Expected: "b"  But was: "c"
```

Reaching that branch is narrow and worth recording: the keyed diff has four exits before its LIS placement, so an append resolves on the tail-add path and never enters the placement code at all. Two conditions must hold together — the diff must reach Pass 2, and the last new-side entry must be a *created* element, since only a created element maps to `-1` and is therefore never an LIS anchor. Replacing the last key rather than appending it is the cheapest shape that does both. The general path has no fast paths, so a single `null` child reaches the same code by a different route.

EditMode **3520 passed / 0 failed / 0 inconclusive** — the pre-existing 3508 plus exactly the 12 new, with **zero edits to existing tests**, which is the no-behaviour-change constraint met literally rather than argued. PlayMode 123 / 0 / 0. `assert-no-inconclusive.py` clean on both. Neither code-shape analyzer fires.

## Stated gap: two of four placement sites are pinned by inspection, not by behaviour

The `ComputeLisAnchors` conversion is inert for ordering — shifting every recorded position by a constant leaves the LIS unchanged, and the under-covered tail element still lands correctly through the `nextSibling.parent != parent` fallback. Its only observable is the last retained element being detached and re-inserted on every render of a parent holding an invisible child, which shows up as a detach/attach event pair, needs a live panel, and is graphics-gated.

That is a real user-visible defect where it bites — focus loss and restarted transitions on every re-render — and it becomes common rather than rare once ring bands are hosted as invisible children. It is not fixed here and not pinned here.

## Also flagged rather than absorbed

`SilhouetteBoundsSpacer.NonSpacerChildCount` has no production callers and survives only through five test assertions. It is kept to avoid editing unrelated fixtures inside the refactor that retired it — migrating them is expectation-preserving, not behaviour-shaped, so a follow-up should delete the helper and fold its cases in. Its doc now warns that reaching for it from reconciler code gives a physical answer where the surrounding code is logical.

Not measured: each conversion walks to the requested slot, so a full pass remains quadratic in child count. `TryGetPhysical` answers occupancy and position in one walk and removed the whole-list scan from the hot guards, and `AssertDomIndexInvariant`'s walk now sits inside the `Debug.Assert` arguments so a player build compiles it out — but a large list still walks per touch, and the cursor is documented rather than applied.