### PR TITLE
test(velvet): fold the preconditions that gate what their own test pins

### DIFF
--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/AnimatePresencePopLayoutTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/AnimatePresencePopLayoutTests.cs
@@ -210,8 +210,7 @@ namespace Velvet.Tests
             store.Set("ac");
             scheduler.DrainImmediateForTest();
             var pinnedBeforeCancel = _window.rootVisualElement.Q<VisualElement>("item-b");
-            Assume.That(pinnedBeforeCancel.style.position.value, Is.EqualTo(Position.Absolute),
-                "Precondition: the exiting real element is pinned out of flow");
+            var positionWhilePinned = pinnedBeforeCancel.style.position.value;
 
             // Act — re-add the key before the exit finishes, cancelling it.
             store.Set("abc");
@@ -222,10 +221,12 @@ namespace Velvet.Tests
             // class: RestorePopLayoutChildToFlow reapplies the ANCHOR's own declared classes (item-b's
             // "absolute z-10", neither an arbitrary-value token), not the differently-classed Motion nested
             // inside it — a stray reapply from the wrong element's class list would otherwise leave a
-            // concrete (non-Null) width behind.
+            // concrete (non-Null) width behind. The pin itself is asserted first: an element that was never
+            // pinned reads Null on both counts without the cancel clearing anything.
             var restored = _window.rootVisualElement.Q<VisualElement>("item-b");
-            Assert.That((restored.style.position.keyword, restored.style.width.keyword),
-                Is.EqualTo((StyleKeyword.Null, StyleKeyword.Null)));
+            Assert.That(
+                (positionWhilePinned, restored.style.position.keyword, restored.style.width.keyword),
+                Is.EqualTo((Position.Absolute, StyleKeyword.Null, StyleKeyword.Null)));
         }
 
         [Test]
@@ -289,16 +290,18 @@ namespace Velvet.Tests
             store.Set("ac");
             scheduler.DrainImmediateForTest();
             var pinnedBeforeCancel = _window.rootVisualElement.Q<VisualElement>("item-b");
-            Assume.That(pinnedBeforeCancel.style.position.value, Is.EqualTo(Position.Absolute),
-                "Precondition: the exiting ghost is pinned out of flow");
+            var positionWhilePinned = pinnedBeforeCancel.style.position.value;
 
             // Act — re-add the key before the exit finishes, cancelling it.
             store.Set("abc");
             scheduler.DrainImmediateForTest();
 
-            // Assert — the cancel clears the inline position back to Null, rejoining normal flow.
-            Assert.That(_window.rootVisualElement.Q<VisualElement>("item-b").style.position.keyword,
-                Is.EqualTo(StyleKeyword.Null));
+            // Assert — the cancel clears the inline position back to Null, rejoining normal flow. A ghost that
+            // was never pinned reads Null already, so the pin is asserted with the clear.
+            Assert.That(
+                (positionWhilePinned,
+                    _window.rootVisualElement.Q<VisualElement>("item-b").style.position.keyword),
+                Is.EqualTo((Position.Absolute, StyleKeyword.Null)));
         }
 
         [Test]

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ButtonChildPoolReuseTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ButtonChildPoolReuseTests.cs
@@ -116,14 +116,16 @@ namespace Velvet.Tests
             var scheduler = mounted.GetSchedulerForTest();
             store.Set(false);
             scheduler.DrainImmediateForTest();
-            Assume.That(ChildCountOf(_root, "item-a"), Is.EqualTo(-1), "Precondition: the footer buttons are gone while hidden");
+            var childCountWhileHidden = ChildCountOf(_root, "item-a");
 
             // Act — the footer is shown again, recreating each button by renting it back from the pool.
             store.Set(true);
             scheduler.DrainImmediateForTest();
 
-            // Assert — the recreated button holds exactly its one declared child (not the leftover plus the new one).
-            Assert.AreEqual(1, ChildCountOf(_root, "item-a"));
+            // Assert — the recreated button holds exactly its one declared child (not the leftover plus the
+            // new one). The hidden count is asserted with it because a footer that never went away still
+            // holds its single original child, which the recreated count alone cannot tell apart.
+            Assert.That((childCountWhileHidden, ChildCountOf(_root, "item-a")), Is.EqualTo((-1, 1)));
         }
 
         [Test]

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/CommitPhaseEdgeCaseTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/CommitPhaseEdgeCaseTests.cs
@@ -340,7 +340,7 @@ namespace Velvet.Tests
             // Establish a pin: an immediate drain renders the reader, which pins the now-current snapshot (v1).
             store.Set("v1");
             scheduler.DrainImmediateForTest();
-            Assume.That(s_lastRendered, Is.EqualTo("v1"), "Precondition: the immediate wave pinned and rendered v1");
+            var renderedByImmediateWave = s_lastRendered;
 
             // The reader is inside a transition (the async-transition await window): a store mutation now routes
             // its re-render to the delayed (Transition) tier, so the next drain is a SOLO delayed drain with no
@@ -350,8 +350,10 @@ namespace Velvet.Tests
             scheduler.DrainDelayedForTest();
 
             // Assert — the solo delayed drain must open a fresh wave: the reader reads the current snapshot (v2),
-            // NOT the stale pin (v1) left over from the prior immediate drain's wave.
-            Assert.That(s_lastRendered, Is.EqualTo("v2"),
+            // NOT the stale pin (v1) left over from the prior immediate drain's wave. What the immediate wave
+            // rendered is asserted with it: without a v1 pin in place there is no stale pin to reuse, and the
+            // delayed drain reads v2 for reasons this test does not pin.
+            Assert.That((renderedByImmediateWave, s_lastRendered), Is.EqualTo(("v1", "v2")),
                 "A solo delayed drain must not reuse a stale store snapshot pin from a previous wave");
         }
     }

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/EffectOrderTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/EffectOrderTests.cs
@@ -601,10 +601,12 @@ namespace Velvet.Tests
             scheduler.DrainImmediateForTest();
 
             // Assert — A's layout effect runs AFTER B has rendered (all mutations precede any layout effect).
-            // Per-fiber commit would run A-layout before B-render.
-            Assume.That(s_log, Does.Contain("A-layout").And.Contain("B-render"),
-                "Precondition: both the layout effect and the sibling render ran in this drain");
-            Assert.That(s_log.IndexOf("A-layout"), Is.GreaterThan(s_log.IndexOf("B-render")),
+            // Per-fiber commit would run A-layout before B-render. Both entries are asserted present in the
+            // same comparison: a missing B-render reads as index -1, which the ordering term alone accepts.
+            Assert.That(
+                (s_log.Contains("A-layout") && s_log.Contains("B-render"),
+                    s_log.IndexOf("A-layout") > s_log.IndexOf("B-render")),
+                Is.EqualTo((true, true)),
                 "All renders in a batch must complete before any layout effect runs (React commit-phase order)");
         }
     }

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/FilterSpacerTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/FilterSpacerTests.cs
@@ -209,10 +209,12 @@ namespace Velvet.Tests
         {
             Mount();
             SetClass(SkewNoFilter);
-            Assume.That(SpacerCount(), Is.EqualTo(0), "Precondition: no spacer without a filter");
+            var countWithoutFilter = SpacerCount();
             SetClass(SkewFilter);
 
-            Assert.That(SpacerCount(), Is.EqualTo(1));
+            // The unfiltered count is asserted with the filtered one: the spacer mounted with the container,
+            // so a patch that added nothing would still show one here.
+            Assert.That((countWithoutFilter, SpacerCount()), Is.EqualTo((0, 1)));
         }
 
         [Test]
@@ -291,10 +293,11 @@ namespace Velvet.Tests
         {
             MountShadowCard();
             SetClass(ShadowNoFilter);
-            Assume.That(ShadowSpacerCount(), Is.EqualTo(0), "Precondition: no spacer without a filter");
+            var countWithoutFilter = ShadowSpacerCount();
             SetClass(ShadowFilter);
 
-            Assert.That(ShadowSpacerCount(), Is.EqualTo(1));
+            // Same pairing as the skew-layer sibling above.
+            Assert.That((countWithoutFilter, ShadowSpacerCount()), Is.EqualTo((0, 1)));
         }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/MotionRuntimeSwapTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/MotionRuntimeSwapTests.cs
@@ -328,8 +328,7 @@ namespace Velvet.Tests
             Tick();
             labels.Set("visible");
             scheduler.DrainImmediateForTest();
-            Assume.That(InlineDurationIsSet(Root.Q<VisualElement>("item-x")), Is.True,
-                "Precondition: the child's runtime-swap play started, claimed behind its 500ms stagger slot");
+            var swapClaimedBeforeExit = InlineDurationIsSet(Root.Q<VisualElement>("item-x"));
 
             // Act — remove the key inside the parked window; the exit (its own 0.3s duration, no delay of
             // its own) must cancel the parked swap and start immediately.
@@ -339,8 +338,10 @@ namespace Velvet.Tests
             scheduler.DrainImmediateForTest();
 
             // Assert — the ghost is already gone well before the original 500ms claim would have elapsed:
-            // the exit ran on its own schedule instead of being postponed by the cancelled swap.
-            Assert.That(Root.Q<VisualElement>("item-x"), Is.Null);
+            // the exit ran on its own schedule instead of being postponed by the cancelled swap. The claim is
+            // asserted with it, because an exit that never had a claim to cancel finishes on time anyway.
+            Assert.That((swapClaimedBeforeExit, Root.Q<VisualElement>("item-x") == null),
+                Is.EqualTo((true, true)));
         }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/PooledElementStyleGhostTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/PooledElementStyleGhostTests.cs
@@ -403,8 +403,11 @@ namespace Velvet.Tests
             return V.Div(name: "host", children: new VNode[] { s_render(mode) });
         }
 
-        // Drives a configured → removed → plain recycle and returns the recycled element by name.
-        private T Recycle<T>(Func<int, VNode> render, string name) where T : VisualElement
+        // Drives a configured → removed → plain recycle. Whether the configured widget actually went away is
+        // handed back rather than assumed: each caller's assertion reads default state, which a widget that
+        // was never removed and never reset can also carry, so the two only pin the reset together.
+        private (bool RemovedWhileHidden, T Recycled) Recycle<T>(Func<int, VNode> render, string name)
+            where T : VisualElement
         {
             s_render = render;
             using var store = new ModeStore();
@@ -413,12 +416,10 @@ namespace Velvet.Tests
             var scheduler = mounted.Root.Reconciler.Context.BatchScheduler;
             store.Set(1);
             scheduler.DrainImmediateForTest();
-            Assume.That(_root.Q<T>(name), Is.Null, "Precondition: the configured widget is removed while hidden");
+            var removedWhileHidden = _root.Q<T>(name) == null;
             store.Set(2);
             scheduler.DrainImmediateForTest();
-            var recycled = _root.Q<T>(name);
-            Assume.That(recycled, Is.Not.Null, "Precondition: a plain widget was recreated from the pool");
-            return recycled;
+            return (removedWhileHidden, _root.Q<T>(name));
         }
 
         [Test]
@@ -444,28 +445,28 @@ namespace Velvet.Tests
         public void Given_ACheckedToggleWasRemoved_When_APlainToggleIsRecreatedFromThePool_Then_ItIsUnchecked()
         {
             // Arrange/Act — a checked toggle is pooled and a plain toggle (no value) is rented back.
-            var toggle = Recycle<Toggle>(
+            var (removedWhileHidden, toggle) = Recycle<Toggle>(
                 mode => mode == 0 ? V.Toggle(name: "t", value: true)
                       : mode == 2 ? V.Toggle(name: "t")
                       : V.Fragment(Array.Empty<VNode>()),
                 "t");
 
             // Assert — the recycled toggle does not ghost the prior checked state.
-            Assert.IsFalse(toggle.value);
+            Assert.That((removedWhileHidden, toggle.value), Is.EqualTo((true, false)));
         }
 
         [Test]
         public void Given_ALabelledToggleWasRemoved_When_APlainToggleIsRecreatedFromThePool_Then_ItHasNoLabel()
         {
             // Arrange/Act — a labelled toggle is pooled and a plain toggle (no label) is rented back.
-            var toggle = Recycle<Toggle>(
+            var (removedWhileHidden, toggle) = Recycle<Toggle>(
                 mode => mode == 0 ? V.Toggle(name: "t", label: "Stale")
                       : mode == 2 ? V.Toggle(name: "t")
                       : V.Fragment(Array.Empty<VNode>()),
                 "t");
 
             // Assert — the recycled toggle carries no leftover label.
-            Assert.AreEqual(string.Empty, toggle.label);
+            Assert.That((removedWhileHidden, toggle.label), Is.EqualTo((true, string.Empty)));
         }
 
         // TextField (security-critical)
@@ -474,42 +475,42 @@ namespace Velvet.Tests
         public void Given_ATextFieldHeldPii_When_APlainTextFieldIsRecreatedFromThePool_Then_ItHasNoStaleValue()
         {
             // Arrange/Act — a field holding PII is pooled and a plain field (no value) is rented back.
-            var field = Recycle<TextField>(
+            var (removedWhileHidden, field) = Recycle<TextField>(
                 mode => mode == 0 ? V.TextField(name: "tf", value: "secret@example.com")
                       : mode == 2 ? V.TextField(name: "tf")
                       : V.Fragment(Array.Empty<VNode>()),
                 "tf");
 
             // Assert — the recycled field surfaces no prior value (PII must not ghost across pool reuse).
-            Assert.AreEqual(string.Empty, field.value);
+            Assert.That((removedWhileHidden, field.value), Is.EqualTo((true, string.Empty)));
         }
 
         [Test]
         public void Given_APasswordTextFieldWasRemoved_When_APlainTextFieldIsRecreatedFromThePool_Then_ItIsNotMasked()
         {
             // Arrange/Act — a password (masked) field is pooled and a plain field is rented back.
-            var field = Recycle<TextField>(
+            var (removedWhileHidden, field) = Recycle<TextField>(
                 mode => mode == 0 ? V.TextField(name: "tf", value: "pw", isPasswordField: true)
                       : mode == 2 ? V.TextField(name: "tf")
                       : V.Fragment(Array.Empty<VNode>()),
                 "tf");
 
             // Assert — the recycled field is not still masking input from the previous consumer.
-            Assert.IsFalse(field.textEdition.isPassword);
+            Assert.That((removedWhileHidden, field.textEdition.isPassword), Is.EqualTo((true, false)));
         }
 
         [Test]
         public void Given_ALabelledTextFieldWasRemoved_When_APlainTextFieldIsRecreatedFromThePool_Then_ItHasNoLabel()
         {
             // Arrange/Act — a labelled field is pooled and a plain field (no label) is rented back.
-            var field = Recycle<TextField>(
+            var (removedWhileHidden, field) = Recycle<TextField>(
                 mode => mode == 0 ? V.TextField(name: "tf", label: "Email")
                       : mode == 2 ? V.TextField(name: "tf")
                       : V.Fragment(Array.Empty<VNode>()),
                 "tf");
 
             // Assert — the recycled field carries no leftover label.
-            Assert.AreEqual(string.Empty, field.label);
+            Assert.That((removedWhileHidden, field.label), Is.EqualTo((true, string.Empty)));
         }
 
         // Slider
@@ -518,28 +519,28 @@ namespace Velvet.Tests
         public void Given_ASliderWithCustomRangeWasRemoved_When_APlainSliderIsRecreatedFromThePool_Then_ItHasTheDefaultHighValue()
         {
             // Arrange/Act — a slider with a widened range is pooled and a plain slider (default range) is rented back.
-            var slider = Recycle<Slider>(
+            var (removedWhileHidden, slider) = Recycle<Slider>(
                 mode => mode == 0 ? V.Slider(name: "s", value: 80f, lowValue: 0f, highValue: 100f)
                       : mode == 2 ? V.Slider(name: "s")
                       : V.Fragment(Array.Empty<VNode>()),
                 "s");
 
             // Assert — the recycled slider is restored to Unity's default highValue (10), not the prior 100.
-            Assert.AreEqual(10f, slider.highValue);
+            Assert.That((removedWhileHidden, slider.highValue), Is.EqualTo((true, 10f)));
         }
 
         [Test]
         public void Given_ASliderWithAValueWasRemoved_When_APlainSliderIsRecreatedFromThePool_Then_ItHasNoStaleValue()
         {
             // Arrange/Act — a slider carrying a value is pooled and a plain slider (no value) is rented back.
-            var slider = Recycle<Slider>(
+            var (removedWhileHidden, slider) = Recycle<Slider>(
                 mode => mode == 0 ? V.Slider(name: "s", value: 7f, lowValue: 0f, highValue: 10f)
                       : mode == 2 ? V.Slider(name: "s")
                       : V.Fragment(Array.Empty<VNode>()),
                 "s");
 
             // Assert — the recycled slider does not ghost the prior value.
-            Assert.AreEqual(0f, slider.value);
+            Assert.That((removedWhileHidden, slider.value), Is.EqualTo((true, 0f)));
         }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ReconcilerFragmentTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ReconcilerFragmentTests.cs
@@ -393,14 +393,19 @@ namespace Velvet.Tests
             {
                 store.Set(1);
                 scheduler.DrainImmediateForTest();
-                Assume.That(HostChildNames(_root), Is.EqualTo(new[] { "live" }), "Precondition: collapsed to the live sibling");
+                // Joined rather than compared as arrays: NUnit's tuple comparison matches a nested array by
+                // reference, so a tuple of string[] passes only when both sides are the same instance.
+                var collapsedOrder = string.Join(",", HostChildNames(_root));
 
                 // Act — the fragment re-expands, renting its labels back from the pool.
                 store.Set(0);
                 scheduler.DrainImmediateForTest();
 
-                // Assert — the children are restored in order ahead of the live sibling, with no leftover duplicates.
-                Assert.AreEqual(new[] { "fa", "fb", "live" }, HostChildNames(_root));
+                // Assert — the children are restored in order ahead of the live sibling, with no leftover
+                // duplicates. The collapsed shape is asserted with the restored one: a fragment that never
+                // collapsed already reads the restored order, and pins neither the collapse nor the re-expand.
+                Assert.That((collapsedOrder, string.Join(",", HostChildNames(_root))),
+                    Is.EqualTo(("live", "fa,fb,live")));
             }
         }
 

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ReconcilerRefTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ReconcilerRefTests.cs
@@ -449,16 +449,18 @@ namespace Velvet.Tests
             var scheduler = mounted.Root.Reconciler.Context.BatchScheduler;
             store.Increment();
             scheduler.DrainImmediateForTest();
-            Assume.That((s_setupCount, s_cleanupCount), Is.EqualTo((1, 1)),
-                "Precondition: the first tenancy ran one setup and one cleanup");
+            var setupsAfterFirstTenancy = s_setupCount;
+            var cleanupsAfterFirstTenancy = s_cleanupCount;
 
             // Act — show the tenant again: the recreated button (likely the pooled instance) mounts
             // under the same callback identity and the same context.
             store.Increment();
             scheduler.DrainImmediateForTest();
 
-            // Assert — the new tenancy's setup ran.
-            Assert.That(s_setupCount, Is.EqualTo(2),
+            // Assert — the new tenancy's setup ran. The first tenancy's counts are asserted with it: a
+            // second setup that ran during the first tenancy instead reaches the same total.
+            Assert.That((setupsAfterFirstTenancy, cleanupsAfterFirstTenancy, s_setupCount),
+                Is.EqualTo((1, 1, 2)),
                 "A re-rented element under the same ref identity must run its setup again");
         }
     }

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/SkewChildTranslateManipulatorTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/SkewChildTranslateManipulatorTests.cs
@@ -193,16 +193,17 @@ namespace Velvet.Tests
             // reconciler's steady-state SyncChildTranslate re-run as the ONLY thing that can seat the new row.
             ForcePanelUpdate(col.panel);
             var added = _window.rootVisualElement.Q<VisualElement>("c");
-            Assume.That(added != null && !float.IsNaN(added.layout.height)
-                && added.style.translate.keyword == StyleKeyword.Null, Is.True,
-                "Precondition: the added row is laid out but NOT yet seated, so only SyncChildTranslate can seat it");
+            var laidOutButUnseated = added != null && !float.IsNaN(added.layout.height)
+                && added.style.translate.keyword == StyleKeyword.Null;
 
             // Act — a steady-state patch (skew tokens unchanged) after layout.
             s_setItems.Invoke(new[] { "a", "b", "c" });
             Drain();
 
-            // Assert
-            Assert.That(added.style.translate.keyword, Is.Not.EqualTo(StyleKeyword.Null));
+            // Assert — the pre-act unseated state is asserted alongside the seat, because a row seated before
+            // the patch would satisfy the seat on its own and attribute nothing to SyncChildTranslate.
+            Assert.That((laidOutButUnseated, added?.style.translate.keyword != StyleKeyword.Null),
+                Is.EqualTo((true, true)));
         }
 
         [Test]
@@ -271,14 +272,16 @@ namespace Velvet.Tests
             SeatViaGeometry(col);
             s_setChildClass.Invoke("absolute translate-x-1 h-[24px]");
             Drain();
-            Assume.That(child.resolvedStyle.position == Position.Absolute
-                && Mathf.Approximately(child.style.translate.value.x.value, 4f), Is.True,
-                "Precondition: the out-of-flow child carries its OWN 4px translate before the caster is unskewed");
+            var ownTranslateBeforeUnskew = child.resolvedStyle.position == Position.Absolute
+                && Mathf.Approximately(child.style.translate.value.x.value, 4f);
             s_setCasterClass.Invoke("w-[120px] h-[200px]");
             Drain();
 
-            // Assert — unskew released the out-of-flow child untouched instead of restoring the stale Null capture.
-            Assert.That(child.style.translate.value.x.value, Is.EqualTo(4f).Within(0.01f));
+            // Assert — unskew released the out-of-flow child untouched instead of restoring the stale Null
+            // capture. The pre-unskew state joins the assertion because a child that never reached out-of-flow
+            // carrying its own 4px would read 4px afterwards for reasons the release path had no part in.
+            Assert.That((ownTranslateBeforeUnskew, child.style.translate.value.x.value),
+                Is.EqualTo((true, 4f)).Within(0.01f));
         }
 
         [Test]
@@ -324,15 +327,17 @@ namespace Velvet.Tests
             s_setChildClass.Invoke("absolute h-[24px]");
             Drain();
             ForcePanelUpdate(col.panel);
-            Assume.That(child.resolvedStyle.position == Position.Absolute
-                && child.style.translate.keyword != StyleKeyword.Null, Is.True,
-                "Precondition: the child is out-of-flow but the un-reseated manipulator still holds its shear write");
+            var outOfFlowStillCarryingShear = child.resolvedStyle.position == Position.Absolute
+                && child.style.translate.keyword != StyleKeyword.Null;
             s_setCasterClass.Invoke("w-[120px] h-[200px]");
             Drain();
 
             // Assert — teardown restored the still-shear-carrying out-of-flow child to its captured pre-shear
-            // translate (Null here), so the stale shear does not leak on a seatless element the manipulator let go.
-            Assert.That(child.style.translate.keyword, Is.EqualTo(StyleKeyword.Null));
+            // translate (Null here), so the stale shear does not leak on a seatless element the manipulator let
+            // go. A child that reached teardown carrying no shear would read Null without teardown doing
+            // anything, so the pre-teardown state is asserted with it.
+            Assert.That((outOfFlowStillCarryingShear, child.style.translate.keyword),
+                Is.EqualTo((true, StyleKeyword.Null)));
         }
 
         [Test]
@@ -354,13 +359,13 @@ namespace Velvet.Tests
             s_setChildClass.Invoke("absolute translate-x-1 h-[24px]");
             Drain();
             SeatViaGeometry(col);
-            Assume.That(child.resolvedStyle.position, Is.EqualTo(Position.Absolute),
-                "Precondition: the child transitioned out of flow, so the relinquish path ran for it");
 
             // Assert — the relinquish cleared the shear only if the child still carried it; here the child had
             // replaced it with its own 4px, so that authored translate survives instead of being clobbered back
-            // to the stale Null capture.
-            Assert.That(child.style.translate.value.x.value, Is.EqualTo(4f).Within(0.01f));
+            // to the stale Null capture. The out-of-flow transition is asserted with it: a child still in flow
+            // never reaches the relinquish path at all, and would carry its own 4px regardless.
+            Assert.That((child.resolvedStyle.position, child.style.translate.value.x.value),
+                Is.EqualTo((Position.Absolute, 4f)).Within(0.01f));
         }
 
         [Test]

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/StyleTextEffectPanelTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/StyleTextEffectPanelTests.cs
@@ -381,7 +381,7 @@ namespace Velvet.Tests
                 "Precondition: the first label carries the inline pre-wrap write");
             s_setPoolReuseState.Invoke("hidden");
             scheduler.DrainImmediateForTest();
-            Assume.That(_window.rootVisualElement.Q<Label>("leaf"), Is.Null, "Precondition: the label is pooled while hidden");
+            var pooledWhileHidden = _window.rootVisualElement.Q<Label>("leaf") == null;
 
             // Act — an unrelated plain label rents the pooled instance back.
             s_setPoolReuseState.Invoke("plain");
@@ -389,9 +389,12 @@ namespace Velvet.Tests
 
             // Assert — the recycled instance carries no leftover inline pre-wrap AND no leftover collapsed
             // text from the previous consumer's side-table entry (a ghosted TextEffects/TextRawText row would
-            // still show "c d" here, not the fixture's raw, uncollapsed "c   d").
+            // still show "c d" here, not the fixture's raw, uncollapsed "c   d"). The pool round-trip is
+            // asserted alongside them: a label patched in place instead of pooled clears both anyway, so the
+            // remaining terms alone would hold on a reconciler that never pooled it.
             var recycled = _window.rootVisualElement.Q<Label>("leaf");
-            Assert.That((recycled.style.whiteSpace.keyword, recycled.text), Is.EqualTo((StyleKeyword.Null, "c   d")));
+            Assert.That((pooledWhileHidden, recycled.style.whiteSpace.keyword, recycled.text),
+                Is.EqualTo((true, StyleKeyword.Null, "c   d")));
         }
 
         [Test]
@@ -478,7 +481,7 @@ namespace Velvet.Tests
                 "Precondition: the first label carries the line-height tag");
             s_setLeadingPoolReuseState.Invoke("hidden");
             scheduler.DrainImmediateForTest();
-            Assume.That(_window.rootVisualElement.Q<Label>("leaf"), Is.Null, "Precondition: the label is pooled while hidden");
+            var pooledWhileHidden = _window.rootVisualElement.Q<Label>("leaf") == null;
 
             // Act — an unrelated plain label rents the pooled instance back.
             s_setLeadingPoolReuseState.Invoke("plain");
@@ -486,8 +489,10 @@ namespace Velvet.Tests
 
             // Assert — the recycled instance carries no leftover line-height tag from the previous
             // consumer's side-table entry (a ghosted TextEffects/TextRawText row would still show a
-            // wrapped tag here, not the fixture's raw "there").
-            Assert.That(_window.rootVisualElement.Q<Label>("leaf").text, Is.EqualTo("there"));
+            // wrapped tag here, not the fixture's raw "there"). The pool round-trip is asserted alongside
+            // it for the same reason as the PreLine sibling above.
+            Assert.That((pooledWhileHidden, _window.rootVisualElement.Q<Label>("leaf").text),
+                Is.EqualTo((true, "there")));
         }
 
         [Test]
@@ -569,18 +574,19 @@ namespace Velvet.Tests
                 "Precondition: the first label carries an overline binding");
             s_setOverlinePoolReuseState.Invoke("hidden");
             scheduler.DrainImmediateForTest();
-            Assume.That(_window.rootVisualElement.Q<Label>("leaf"), Is.Null, "Precondition: the label is pooled while hidden");
+            var pooledWhileHidden = _window.rootVisualElement.Q<Label>("leaf") == null;
 
             // Act — an unrelated plain label rents the pooled instance back.
             s_setOverlinePoolReuseState.Invoke("plain");
             scheduler.DrainImmediateForTest();
 
-            // Assert — genuinely the SAME recycled instance (not a coincidentally-unbound new one), carrying
-            // no leftover binding from the previous consumer.
+            // Assert — the label really left the tree and the SAME instance came back (not a coincidentally
+            // unbound new one), carrying no leftover binding from the previous consumer.
             var recycled = _window.rootVisualElement.Q<Label>("leaf");
             Assert.That(
-                (ReferenceEquals(recycled, firstLabel), ctx.TextOverlineBindings.ContainsKey(recycled)),
-                Is.EqualTo((true, false)));
+                (pooledWhileHidden, ReferenceEquals(recycled, firstLabel),
+                    ctx.TextOverlineBindings.ContainsKey(recycled)),
+                Is.EqualTo((true, true, false)));
         }
 
         private void Mount(VNode tree)

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/TextBalanceParityTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/TextBalanceParityTests.cs
@@ -122,16 +122,17 @@ namespace Velvet.Tests
             // Act — remove (returns the label to the pool with the stale width still on it), then
             // recreate a text-balance label at the same position, renting the SAME pooled instance back.
             scope.Reconciler.Reconcile(scope.Root, tree1, System.Array.Empty<VNode>());
-            Assume.That(VNodePoolTestAccess.LabelPoolCountForTest, Is.EqualTo(1),
-                "Precondition: the label was returned to the pool");
+            var pooledCount = VNodePoolTestAccess.LabelPoolCountForTest;
             var tree3 = new VNode[] { V.Label(className: "text-balance", text: "world") };
             scope.Reconciler.Reconcile(scope.Root, System.Array.Empty<VNode>(), tree3);
             var recreated = scope.Root.Q<Label>();
-            Assume.That(ReferenceEquals(original, recreated), Is.True,
-                "Precondition: the same pooled Label instance was rented back");
 
-            // Assert
-            Assert.That(recreated.style.width.keyword, Is.EqualTo(StyleKeyword.Null));
+            // Assert — the pool round-trip is asserted alongside the width because a fresh Label carries no
+            // width either: with the round-trip merely assumed, a reconciler that stopped pooling the label
+            // would satisfy the width on its own.
+            Assert.That(
+                (pooledCount, ReferenceEquals(original, recreated), recreated.style.width.keyword),
+                Is.EqualTo((1, true, StyleKeyword.Null)));
         }
 
         [Test]


### PR DESCRIPTION
When `TestUtilities`' reflection helpers were made to throw rather than degrade, their author measured the degradation both ways and found that running them as silent no-ops turned **25 tests Inconclusive rather than Failed**. An `Assume` that gates the behaviour a test exists to pin converts a regression into a result the NUnit runner does not count as a failure — only `scripts/assert-no-inconclusive.py` surfaces it at all.

21 `Assume` statements across 12 fixtures are folded into their assertions, and 1 is deleted. Each fold is a single tuple comparison, so one assert per test still holds.

The silent-no-op helper is the neuter, and there are two of them reaching disjoint sets, so both were measured separately:

| neuter | | inconclusive | failed |
|---|---|---|---|
| scheduler drain | before | **24** | 100 |
| | after | **0** | 124 |
| pool access | before | **1** | 2 |
| | after | **0** | 3 |

All 25 were verified Inconclusive → Failed individually rather than by count. Green both before and after with the neuters removed: EditMode 3508 passed / 0 failed / 0 inconclusive, PlayMode 123 / 0 / 0.

## Two things the measurement contradicted

**The precondition that reads as the sharpest is not sufficient on its own.** `TextBalanceParityTests` gates on `ReferenceEquals(original, recreated)`, and if a different Label came back the stale-width assertion would pass trivially — but folding only that term leaves the test green under its neuter, because the Label pool is LIFO and the same instance returns even with the drain neutered. The pool-count term is what makes it red. Both had to be folded.

**A fold introduced a defect that the count would not have caught.** Comparing two string arrays inside a tuple looked correct and was not: `Is.EqualTo(tuple)` matches a nested array **by reference**, so that test failed under the neuter that cannot even reach it. It surfaced only from the per-fixture breakdown; a check that 24 results moved from Inconclusive to Failed would have passed it through. (`.Within()` does propagate into tuples correctly.)

## Holes named rather than closed

Eight tests still pass under the scheduler neuter even though their Act runs entirely through it — the "assertion satisfied by the untouched state" shape. A pure negative is the clearest: `Given_ASyncModeChild_When_ItIsExiting_Then_ItsInlinePositionStaysNull` is satisfied by an exit that never starts, exactly as by a correct one. Closing it needs a positive term the fixture has no cheap probe for. The others are listed in the commit message.

A further class of identically-shaped `Assume` statements sits in `FilterSpacerTests` and `StyleTextEffectPanelTests` where neither neuter reaches them — mirrors of ones folded here, unfixed because they cannot be shown red. Closing that class wants a neuter aimed at the feature rather than at a test helper.

Two structural holes, distinct from the `Assume` question: the pooled-widget ghosting helper never checks that the *same* instance came back, so a reconciler that discarded the widget and built a fresh one would satisfy every assertion — which is precisely what those tests claim to prove about the reset. And three fixtures built on `EditorPanelSimulator` drive the panel scheduler through `Tick()`, which drains on its own, so their explicit drains are redundant and the scheduler neuter under-reports coverage there.

No CHANGELOG entry and no `Documentation~` change: test-only, no API surface, and nothing outside the fixtures references what was renamed.
