### PR TITLE
chore(velvet): refuse to stop while an open PR has an unsettled check

### DIFF
--- a/.claude/hooks/block-stop-on-unsettled-pr.sh
+++ b/.claude/hooks/block-stop-on-unsettled-pr.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Blocks Stop while an open PR still has a check that has not reached a terminal state.
+#
+# A run that is already green is not the failure this guards. The failure is the assistant
+# reading a check list once, seeing "pending", turning to something else, and never looking
+# again — twice in one session, for 7h45m and for 33m, the second time after writing the rule
+# that was supposed to prevent it. An intention to re-check is not a mechanism; a Stop that
+# refuses to return is.
+#
+# The judgement is two-stage on purpose. An empty check list is NOT "still running": it means
+# no workflow was ever triggered for that SHA, which is what a cancelled run followed by a
+# force-push leaves behind, and reading it as pending is how the 7h45m gap started. So a PR
+# with zero checks blocks too, with a different reason.
+#
+# Exit 2 with output on stderr is what Stop reads as "do not stop, here is why".
+
+set -uo pipefail
+
+command -v gh >/dev/null 2>&1 || exit 0
+command -v jq >/dev/null 2>&1 || exit 0
+
+prs=$(gh pr list --state open --json number --jq '.[].number' 2>/dev/null) || exit 0
+[ -z "$prs" ] && exit 0
+
+blocked=""
+for pr in $prs; do
+  checks=$(gh pr checks "$pr" --json name,bucket 2>/dev/null || echo "[]")
+
+  count=$(echo "$checks" | jq 'length' 2>/dev/null || echo 0)
+  if [ "$count" = "0" ]; then
+    blocked="$blocked
+  PR #$pr — no checks reported. A workflow was never triggered for this head, or the run was
+    cancelled and nothing re-queued. This is not 'still running'. Check the head SHA against
+    'gh run list --branch <b> --json headSha', and check 'gh pr view $pr --json mergeable' —
+    a conflicting PR reports UNKNOWN or DIRTY and never starts CI at all."
+    continue
+  fi
+
+  pending=$(echo "$checks" | jq '[.[] | select(.bucket == "pending")] | length' 2>/dev/null || echo 0)
+  if [ "$pending" != "0" ]; then
+    names=$(echo "$checks" | jq -r '[.[] | select(.bucket == "pending") | .name] | join(", ")' 2>/dev/null)
+    blocked="$blocked
+  PR #$pr — $pending check(s) still pending: $names"
+  fi
+done
+
+[ -z "$blocked" ] && exit 0
+
+cat >&2 <<EOF
+Do not stop: an open PR has not settled.
+$blocked
+
+Either wait for it with a Monitor that emits on both pass and fail, or keep working on
+something that is itself on the critical path. Work that is off the critical path satisfies
+"do not idle" while the thing you are actually waiting on goes unwatched.
+EOF
+exit 2

--- a/.claude/hooks/block-stop-on-unsettled-pr.sh
+++ b/.claude/hooks/block-stop-on-unsettled-pr.sh
@@ -28,11 +28,21 @@ for pr in $prs; do
 
   count=$(echo "$checks" | jq 'length' 2>/dev/null || echo 0)
   if [ "$count" = "0" ]; then
+    # Zero checks is legitimate when nothing the PR touches matches a workflow's path filter —
+    # a docs-only or .claude/-only change reports none and is ready to merge. It is a problem
+    # when the head never got a run it should have, and the tell is the merge state: a
+    # conflicting PR reports DIRTY (or UNKNOWN while GitHub is still computing) and never
+    # starts CI at all, which is the shape that went unwatched for seven hours.
+    state=$(gh pr view "$pr" --json mergeStateStatus --jq '.mergeStateStatus' 2>/dev/null || echo "")
+    case "$state" in
+      CLEAN|UNSTABLE|BEHIND|BLOCKED|"")
+        continue
+        ;;
+    esac
     blocked="$blocked
-  PR #$pr — no checks reported. A workflow was never triggered for this head, or the run was
-    cancelled and nothing re-queued. This is not 'still running'. Check the head SHA against
-    'gh run list --branch <b> --json headSha', and check 'gh pr view $pr --json mergeable' —
-    a conflicting PR reports UNKNOWN or DIRTY and never starts CI at all."
+  PR #$pr — no checks reported and merge state is $state. A conflicting PR never starts CI, so
+    this is not 'still running'. Rebase it, or check the head SHA against
+    'gh run list --branch <b> --json headSha' if you expected a run."
     continue
   fi
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -22,6 +22,17 @@
           }
         ]
       }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/block-stop-on-unsettled-pr.sh",
+            "timeout": 20000
+          }
+        ]
+      }
     ]
   }
 }

--- a/.claude/skills/unity-tests/SKILL.md
+++ b/.claude/skills/unity-tests/SKILL.md
@@ -33,6 +33,17 @@ Concurrent Unity instances make unrelated tests fail. A failure measured while a
 
 **`inconclusive` is not counted as a failure by the runner.** A non-zero count means a test skipped rather than reported — usually an `Assume` gating the behaviour under test. Treat it as a failure and find the test.
 
+## A pixel fixture on `RenderTexturePanelHost` mounts without the bundled stylesheet
+
+Every plain USS class silently does nothing there, while arbitrary-value utilities keep working, because Velvet resolves those to inline style. So a fixture written from `w-[60px] bg-[#0000ff] flex flex-row` looks correctly constructed and is not: the sizes and colours land, the `flex-row` does not, and the container stays UI Toolkit's default `column`.
+
+This has produced a wrong conclusion (a paint was reported as surviving `overflow-hidden` when the clip had never applied) and, separately, two reds that looked like evidence about paint order and were actually a fixture measuring non-overlapping elements. It costs more than either trap above.
+
+- **Attach the sheet** (`LoadBundledStyleUtilitiesForTest`) or use inline style deliberately — not a mix you have not checked.
+- **Assert the measured geometry before reading a pixel**, and derive every sample coordinate from the measured `layout`/`resolvedStyle` values rather than from expected ones. If the layout assertion fails, that is the finding.
+- **Put a control in the frame.** "The paint was clipped" and "the clip never applied" are indistinguishable without one — an overflowing child on the opposite side answers it in the same capture.
+- Log more than one axis. An x-only diagnostic read a 20px difference that was really a column layout with a 60px y-shift.
+
 ## Reading a result you intend to report
 
 - EditMode batchmode does not run layout. A test that reads `resolvedStyle` must force it through the panel's `ApplyStyles`/`UpdateForRepaint`, or it silently measures nothing. Assertions on measured values belong in PlayMode.

--- a/.claude/skills/unity-tests/SKILL.md
+++ b/.claude/skills/unity-tests/SKILL.md
@@ -33,6 +33,21 @@ Concurrent Unity instances make unrelated tests fail. A failure measured while a
 
 **`inconclusive` is not counted as a failure by the runner.** A non-zero count means a test skipped rather than reported — usually an `Assume` gating the behaviour under test. Treat it as a failure and find the test.
 
+## Eight ways a test here has passed while checking nothing
+
+Every one was found by mutating the implementation and confirming a test died — none by reading the test, because each reads as reasonable. The common shape is that **the input's form never reaches the code under test**.
+
+- **Siblings do not nest.** Five `from` clauses, or five `using var` declarations, are siblings at depth 1. A test for "does this construct open a nesting level" must put it *inside* several levels.
+- **The depth is the same either way.** A `try` at depth 4 reports nothing whether or not `try` opens a level, so `Assert.Empty` passes on both.
+- **The attribute never bound.** A `namespace` written above `[assembly: …]` is invalid C#; the attribute does not bind, so a gate keyed on it returns false regardless of what the gate does.
+- **N configurations, one test.** A guard evaluating both `UNITY_EDITOR` and no-symbols needs a case per configuration: each conditional spelling is visible to exactly one, so one case leaves the other deletable with nothing going red.
+- **A static field collapses the covering set.** A fixture caching generated output in `static readonly` gets the whole class attributed to whichever test touched it first, so mutation testing runs one test per mutant and whole regions go unasserted.
+- **An `Assume` gates the behaviour under test.** The regression reports Inconclusive, which the runner does not count. Fold it into the assertion as one tuple comparison.
+- **An arbitrary value skips the path.** `rounded-tl-[12px]` is not in the scale, so a fallback under test never fires; `rounded-tl-lg` reaches it.
+- **The class under test was inert.** See the stylesheet trap below — the rest of the fixture works, so it looks built.
+
+Two traps in the folding itself, both of which pass a count check: **`Is.EqualTo(tuple)` matches a nested collection by reference** (join to strings instead; `.Within()` does propagate correctly), and **the logically sharpest gate is not always the discriminating one** — a `ReferenceEquals` precondition on a LIFO pool holds even when the mechanism is neutered, and a count term next to it is what goes red.
+
 ## A pixel fixture on `RenderTexturePanelHost` mounts without the bundled stylesheet
 
 Every plain USS class silently does nothing there, while arbitrary-value utilities keep working, because Velvet resolves those to inline style. So a fixture written from `w-[60px] bg-[#0000ff] flex flex-row` looks correctly constructed and is not: the sizes and colours land, the `flex-row` does not, and the container stays UI Toolkit's default `column`.


### PR DESCRIPTION
Twice in one session a PR sat unwatched after its check list was read once and found pending — for seven hours and forty-five minutes, and then for another thirty-three after the rule against it had been written down. The second time is what settles it: a rule I wrote and then broke within the same session is not a mechanism.

`gh pr checks` returns an empty list when no workflow was ever triggered for a head, which is what a cancelled run followed by a force-push leaves behind, and also what a conflicting PR looks like — it never starts CI at all. Reading that as "still running" is how the first gap started, so the hook treats zero checks as its own case with its own reason, pointing at the head SHA and the mergeable state rather than at the check list.

The `unity-tests` skill gains the trap that cost the most: a pixel fixture on `RenderTexturePanelHost` mounts without the bundled stylesheet, so plain USS classes silently do nothing while arbitrary-value utilities keep working, since those resolve to inline style. A fixture written from `w-[60px] bg-[#0000ff] flex flex-row` looks correctly constructed and is not. It produced a wrong conclusion about a paint surviving `overflow-hidden`, and separately two reds that read as evidence about paint order while measuring elements that were never overlapping. Alongside it: assert the measured geometry before reading a pixel, put a control in the frame, and log more than one axis.