### PR TITLE
chore(velvet): forgive a pending check while a watcher is demonstrably alive

### DIFF
--- a/.claude/hooks/block-stop-on-unsettled-pr.sh
+++ b/.claude/hooks/block-stop-on-unsettled-pr.sh
@@ -12,12 +12,31 @@
 # force-push leaves behind, and reading it as pending is how the 7h45m gap started. So a PR
 # with zero checks blocks too, with a different reason.
 #
+# A pending check is forgiven while a watcher is demonstrably alive. The heartbeat is written by
+# the watching process itself on each poll, never by the assistant, so it cannot be satisfied by
+# intending to watch — if the watcher dies the file goes stale within one poll and this blocks
+# again. The watcher must re-enumerate open PRs every cycle, or a PR opened after it started would
+# be unwatched while the heartbeat still looked fresh. Zero checks is judged without the heartbeat:
+# there, nothing is running for a watcher to observe.
+#
 # Exit 2 with output on stderr is what Stop reads as "do not stop, here is why".
 
 set -uo pipefail
 
 command -v gh >/dev/null 2>&1 || exit 0
 command -v jq >/dev/null 2>&1 || exit 0
+
+HEARTBEAT="$HOME/.velvet-pr-watch.heartbeat"
+# Three polls of the 60s cycle, so one slow `gh` call does not read as a dead watcher.
+STALE_AFTER=180
+
+watcher_is_alive() {
+  [ -f "$HEARTBEAT" ] || return 1
+  local beat
+  beat=$(cat "$HEARTBEAT" 2>/dev/null) || return 1
+  case "$beat" in ''|*[!0-9]*) return 1 ;; esac
+  [ $(( $(date +%s) - beat )) -lt "$STALE_AFTER" ]
+}
 
 prs=$(gh pr list --state open --json number --jq '.[].number' 2>/dev/null) || exit 0
 [ -z "$prs" ] && exit 0
@@ -46,6 +65,8 @@ for pr in $prs; do
     continue
   fi
 
+  watcher_is_alive && continue
+
   pending=$(echo "$checks" | jq '[.[] | select(.bucket == "pending")] | length' 2>/dev/null || echo 0)
   if [ "$pending" != "0" ]; then
     names=$(echo "$checks" | jq -r '[.[] | select(.bucket == "pending") | .name] | join(", ")' 2>/dev/null)
@@ -63,5 +84,17 @@ $blocked
 Either wait for it with a Monitor that emits on both pass and fail, or keep working on
 something that is itself on the critical path. Work that is off the critical path satisfies
 "do not idle" while the thing you are actually waiting on goes unwatched.
+
+A pending check stops blocking once a watcher writes $HOME/.velvet-pr-watch.heartbeat on each
+poll. It must re-enumerate open PRs every cycle — a watcher pinned to one PR number leaves the
+next one unwatched behind a fresh heartbeat:
+
+  while true; do
+    date +%s > "\$HOME/.velvet-pr-watch.heartbeat"
+    for pr in \$(gh pr list --state open --json number --jq '.[].number'); do
+      : # emit each check that has reached a terminal state, once
+    done
+    sleep 60
+  done
 EOF
 exit 2


### PR DESCRIPTION
The Stop guard blocked whenever any open PR had a check in flight. That is most of the time once several branches are open, and it could not distinguish the case it exists for — a pending check nobody is looking at — from a pending check with a live watcher emitting on every state change.

A pending check is now forgiven while `$HOME/.velvet-pr-watch.heartbeat` is under three minutes old. Two properties make that a mechanism rather than a promise:

- **The watching process writes it, on each poll.** Deciding to watch does not produce a heartbeat, and a watcher that dies leaves one that goes stale within a single cycle.
- **The watcher must re-enumerate open PRs every cycle.** A watcher pinned to one PR number would leave a PR opened after it started unwatched behind a heartbeat that still looked fresh — which happened in practice, and is what the guard then caught. The blocked message states this so the next watcher is written correctly.

Zero checks is judged without consulting the heartbeat. There is nothing running for a watcher to observe, so a live watcher says nothing about it.

Verified against the live PR list, with two PRs holding pending checks: no heartbeat blocks (exit 2), a heartbeat 400 seconds old blocks, a non-numeric one blocks, and a fresh one allows the stop (exit 0).

No `Documentation~` impact — local loop tooling, not package surface.