### PR TITLE
docs(velvet): state the reason a ring on a Motion is actually refused

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -72,9 +72,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   after all of them, so it paints in that element's own position: overlapping `-space-x-*` avatars
   carrying `ring-2 ring-white` occlude the previous one's band as they do on the web, and two
   `focus:ring-2` siblings render the same whichever was focused first. The deviations from CSS this
-  hosting still carries — `ring-inset` painting over an opaque full-bleed child, and a ring on a
-  `V.Motion` being ignored with a warning — are documented in `Documentation~/styling-variants.md`. A
-  ring on an ordinary element inside a `V.AnimatePresence` fades with its element's enter and exit.
+  hosting still carries — `ring-inset` painting over an opaque full-bleed child, a transform on the
+  ringed element moving the element and not the band, and a ring on a `V.Motion` being ignored with a
+  warning — are documented in `Documentation~/styling-variants.md`. A ring on an ordinary element
+  inside a `V.AnimatePresence` fades with its element's enter and exit.
 - A variant payload spelled as a **USS class** (`dark:bg-neutral-900`, `md:flex-col`) now overrides a
   base utility writing the same properties regardless of the order the bundled stylesheets declare
   them in. Previously the payload was added to the live class list as a bare utility, where it tied

--- a/Packages/com.velvet.core/Documentation~/styling-variants.md
+++ b/Packages/com.velvet.core/Documentation~/styling-variants.md
@@ -222,12 +222,17 @@ band takes that element's own paint position, so overlapping `-space-x-*` avatar
 `ring-2 ring-white` occlude the previous one's band as they do on the web, and the order among several
 bands on one parent is their elements' order rather than the order the bands happened to be attached —
 two `focus:ring-2` siblings render the same whichever was focused first. The hosting stays visible in
-two places:
+three places:
 
 - `ring-inset` paints **over** an opaque full-bleed child rather than under it. This matches the
   order CSS gives an inset box-shadow, not an inset outline.
-- A ring on a `V.Motion` is ignored, with a warning. The band is outside the Motion's own opacity, so
-  it could not fade with an enter or exit. Put the ring on a `Div` the Motion wraps.
+- A transform on the ringed element itself — `translate-*`, `scale-*`, `rotate-*`, or an animation
+  driving those — moves the element and leaves the band on the laid-out box, because a transform
+  composites over the transformed element's own subtree and the band is not in it. A transform on an
+  **ancestor** carries element and band together. CSS moves an outline with its element.
+- A ring on a `V.Motion` is ignored, with a warning: it is the transform case above, and animating a
+  transform is what a `V.Motion` is for. Put the ring on a `Div` the Motion wraps — there the band is
+  inside the Motion's subtree, so it rides both the transform and the opacity.
 
 A ring on an ordinary element inside a `V.AnimatePresence` **does** fade with that element's enter and
 exit: the band is driven from the same per-frame opacity sample that fades a drop shadow.

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodeFactory.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodeFactory.cs
@@ -374,16 +374,23 @@ namespace Velvet
                     "A shadow-* utility on a Motion is ignored: a Motion carries the transition, not "
                     + "the paint layers. Wrap the Motion around a shadowed Div instead.");
             }
-            // ring-* / outline-* is ignored for the same reason as shadow-*, by a different route: the band
-            // is hosted as a SIBLING of the ringed element, so it is outside the Motion's own opacity and
-            // would stay at full strength through an enter / exit fade. Same active-only gate.
+            // ring-* / outline-* is ignored on a Motion because the band is a SIBLING placed from the
+            // element's LAYOUT box, and UI Toolkit composites a transform onto the transformed element's own
+            // subtree only — so a Motion animating translate / scale / rotate slides out from under its own
+            // band and leaves it behind for the whole play. Both halves of that are pinned by
+            // RingOverlayTests' transform pair. On a Div the Motion wraps, the band is IN the Motion's
+            // subtree and rides its transform, which is what the advice below buys.
+            // Rejected: warning only for a Motion whose transition declares a transform channel. layoutId, the
+            // gesture class channels and a later Transition swap each introduce one without recreating the
+            // element, and this gate runs once, at create.
+            // Same active-only gate as the shadow above.
             if (StyleRingClass.HasRingClass(appliedClasses)
                 && StyleRingClass.TryExtract(appliedClasses, out _))
             {
                 FiberLogger.LogWarning("Motion",
-                    "A ring-* / outline-* utility on a Motion is ignored: the band is drawn beside the "
-                    + "element, so it cannot fade with an enter/exit. "
-                    + "Wrap the Motion around a ringed Div instead.");
+                    "A ring-* / outline-* utility on a Motion is ignored: the band is placed from the "
+                    + "element's laid-out box, which a Motion's transform does not move, so a slide / scale / "
+                    + "layoutId play would leave it behind. Wrap the Motion around a ringed Div instead.");
             }
             // clip-path-* is a structural wrapper, which would become the AnimatePresence anchor while
             // the enter/exit transition stays on the inner Motion: ignored on a Motion, never wrapped.

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
@@ -426,9 +426,11 @@ namespace Velvet
         //   one that touches the element's PARENT rather than the element.
         // The particles spacer is here, not in the Particles-settings diff, because it follows the CLASS list
         // (a filter comes and goes via a class swap or a variant).
-        // paintTail is the one per-path knob, and it is the same distinction the gradient's skewable flag
-        // draws: an ElementNode may render a sheared silhouette, a Motion never does, so a Motion's gradient
-        // stays on the straight background-image path and the three silhouette layers stand down entirely.
+        // paintTail is the one per-path knob, and for the three silhouette layers it is the same distinction
+        // the gradient's skewable flag draws: an ElementNode may render a sheared silhouette, a Motion never
+        // does, so a Motion's gradient stays on the straight background-image path and those three stand down
+        // entirely. The ring rides the same knob on a reason of its own, stated where the Motion path warns
+        // about it (FiberNodeFactory.WarnIgnoredMotionUtilities).
         private void ApplyResolvedClassPasses(VisualElement element, string[] classNames, bool classesChanged,
             bool paintTail, bool clipActive, bool canReleaseFace)
         {

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ClipPathWrapTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ClipPathWrapTests.cs
@@ -498,9 +498,9 @@ namespace Velvet.Tests
         [Test]
         public void Given_RingOnMotion_When_Reconciled_Then_NoRingBindingIsCreated()
         {
-            // A Motion stands down: the band is hosted beside the element, outside the Motion's own opacity,
-            // so it could not fade with an enter / exit. Warned about rather than silently dropped, like the
-            // shadow-* / clip-path-* / z-* gates on a Motion.
+            // A Motion stands down: the band is placed from the element's laid-out box, which the Motion's
+            // own transform does not move (see FiberNodeFactory.WarnIgnoredMotionUtilities). Warned about
+            // rather than silently dropped, like the shadow-* / clip-path-* / z-* gates on a Motion.
             using var scope = new ReconcilerScope();
             LogAssert.Expect(LogType.Warning, new Regex(@"ring-\*.*on a Motion is ignored"));
 

--- a/Packages/com.velvet.core/Runtime/Styling/RingOverlay.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/RingOverlay.cs
@@ -49,8 +49,11 @@ namespace Velvet
     /// Toolkit paints an absolutely-positioned sibling in child order against an in-flow one rather than
     /// lifting positioned elements above the in-flow ones as CSS does; that engine fact is measured by
     /// pixel readback in <c>RingSiblingPaintOrderPlaybackTests</c>, and the whole placement rests on it.
-    /// The deviation it does carry: <c>ring-inset</c> paints over an opaque full-bleed child rather than
-    /// under it.
+    /// The two deviations it does carry: <c>ring-inset</c> paints over an opaque full-bleed child rather than
+    /// under it, and a transform on the ringed element moves the element out from under the band, since the
+    /// placement below is built from the laid-out box and a transform composites over the transformed
+    /// element's own subtree only. That second one is why a <c>ring-*</c> on a <c>V.Motion</c> is refused
+    /// outright (<see cref="FiberNodeFactory"/>).
     /// </para>
     /// </remarks>
     internal static class RingOverlay

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/RingOverlayTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/RingOverlayTests.cs
@@ -1,4 +1,5 @@
 using NUnit.Framework;
+using UnityEngine;
 using UnityEngine.UIElements;
 using Velvet.TestUtilities;
 
@@ -42,10 +43,11 @@ namespace Velvet.Tests
                 : null;
         }
 
-        // How far along x a band paints from the element it rings, in panel space. worldBound (not layout)
-        // because it is the only reading that carries the transforms of every ancestor between the two: an
-        // offset built from each element's own box would read the same whether or not the band shares its
-        // element's transformed frame, which is precisely what these two cases pull apart.
+        // How far along x a band paints from the element it rings. worldBound and not layout because layout
+        // is the pre-transform box: read from layout, both cases below measure the same -4 and neither says
+        // anything. An ancestor's transform is not the reason — band and element are siblings, so any
+        // transform above them cancels in the difference — it is the element's OWN transform, which
+        // worldBound carries and layout does not, that these cases exist to pull apart.
         private static float BandOffsetX(VisualElement element)
             => BandFor(element).worldBound.x - element.worldBound.x;
 
@@ -166,13 +168,16 @@ namespace Velvet.Tests
             // Act
             ForcePanelUpdate(still.panel);
 
-            // Assert — the untransformed card is the control: -4 is the band sitting exactly ring-4 outside
-            // its element, so a fixture where the bundled sheet never attached (translate-x-8 inert) reports
-            // -4 twice and fails here rather than reading as evidence. The transformed card measures the
-            // whole of its own 32px translate further out, because the band is placed from the laid-out box
-            // and is not in the subtree the transform composites over.
-            Assert.That((BandOffsetX(still), BandOffsetX(moved)),
-                Is.EqualTo((-4f, -36f)).Within(0.01f));
+            // Assert — the untransformed card is the control: -4 is a band sitting exactly ring-4 outside
+            // its element, so any state in which the translate did not take effect reports -4 twice and
+            // fails here rather than reading as evidence of a band that followed. The transformed card
+            // measures the whole of its own 32px translate further out, because the band is placed from the
+            // laid-out box and is not in the subtree the transform composites over.
+            //
+            // Rounded because .Within() does not reach the members of a ValueTuple under Unity's NUnit —
+            // the comparison is exact, and both quantities are whole pixels by construction.
+            Assert.That((Mathf.Round(BandOffsetX(still)), Mathf.Round(BandOffsetX(moved))),
+                Is.EqualTo((-4f, -36f)));
         }
 
         [Test]
@@ -193,8 +198,8 @@ namespace Velvet.Tests
             // Assert — the ancestor's transform term is real (32), and the band still paints exactly ring-4
             // outside its element in panel space, so the transform carried the two together. Both in one
             // comparison: the offset alone reads the same on a host whose transform never resolved.
-            Assert.That((card.parent.resolvedStyle.translate.x, BandOffsetX(card)),
-                Is.EqualTo((32f, -4f)).Within(0.01f));
+            Assert.That((Mathf.Round(card.parent.resolvedStyle.translate.x), Mathf.Round(BandOffsetX(card))),
+                Is.EqualTo((32f, -4f)));
         }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/RingOverlayTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/RingOverlayTests.cs
@@ -44,10 +44,12 @@ namespace Velvet.Tests
         }
 
         // How far along x a band paints from the element it rings. worldBound and not layout because layout
-        // is the pre-transform box: read from layout, both cases below measure the same -4 and neither says
-        // anything. An ancestor's transform is not the reason — band and element are siblings, so any
-        // transform above them cancels in the difference — it is the element's OWN transform, which
-        // worldBound carries and layout does not, that these cases exist to pull apart.
+        // is the pre-transform box, and the element's OWN transform is the thing this reading exists to
+        // catch: read from layout, a translated element and a still one both measure -4.
+        // Scope, and the reason the ancestor case below measures absolute positions rather than calling
+        // this: the band and its element are SIBLINGS, so an ancestor's TRANSLATION cancels out of the
+        // difference exactly and this helper cannot see one at all. An ancestor SCALE does not cancel — it
+        // multiplies the difference, so scale-150 over a ring-4 band reads -6 and not -4.
         private static float BandOffsetX(VisualElement element)
             => BandFor(element).worldBound.x - element.worldBound.x;
 
@@ -183,23 +185,36 @@ namespace Velvet.Tests
         [Test]
         public void Given_ARingedElement_When_AnAncestorCarriesTheTransform_Then_TheBandMovesWithIt()
         {
-            // Arrange — the transform is on the host this time, so the band is inside the subtree it
-            // composites over. This is why putting the ring on a Div a V.Motion wraps works.
+            // Arrange — two identically laid-out hosts, one translated, each holding one ringed card. Two
+            // hosts and not one, because band and card are siblings: their DIFFERENCE cancels an ancestor's
+            // translation exactly, so the only reading that can see one is an absolute position compared
+            // across a transformed and an untransformed copy of the same arrangement.
             _mounted = V.Mount(_window.rootVisualElement,
-                V.Div(name: "wrap", className: "w-[300px] h-[200px] translate-x-8", children: new VNode[]
+                V.Div(name: "wrap", className: "w-[300px] h-[200px]", children: new VNode[]
                 {
-                    V.Div(name: "card", className: "w-[100px] h-[40px] ring-4"),
+                    V.Div(name: "stillHost", className: "w-[300px] h-[60px]", children: new VNode[]
+                    {
+                        V.Div(name: "stillCard", className: "w-[100px] h-[40px] ring-4"),
+                    }),
+                    V.Div(name: "movedHost", className: "w-[300px] h-[60px] translate-x-8", children: new VNode[]
+                    {
+                        V.Div(name: "movedCard", className: "w-[100px] h-[40px] ring-4"),
+                    }),
                 }));
-            var card = _window.rootVisualElement.Q<VisualElement>("card");
+            var stillCard = _window.rootVisualElement.Q<VisualElement>("stillCard");
+            var movedCard = _window.rootVisualElement.Q<VisualElement>("movedCard");
 
             // Act
-            ForcePanelUpdate(card.panel);
+            ForcePanelUpdate(stillCard.panel);
 
-            // Assert — the ancestor's transform term is real (32), and the band still paints exactly ring-4
-            // outside its element in panel space, so the transform carried the two together. Both in one
-            // comparison: the offset alone reads the same on a host whose transform never resolved.
-            Assert.That((Mathf.Round(card.parent.resolvedStyle.translate.x), Mathf.Round(BandOffsetX(card))),
-                Is.EqualTo((32f, -4f)));
+            // Assert — the card's own 32px shift is the control: it is the ancestor transform actually
+            // resolving and moving the subtree, so a state in which the translate never took effect reports
+            // 0 here and fails rather than reading as evidence. The band shifts by the same 32px, which is
+            // the claim — it sits inside the host and is carried by the transform, unlike the element's own
+            // transform in the case above. This is what makes wrapping a V.Motion around a ringed Div work.
+            var cardShift = Mathf.Round(movedCard.worldBound.x - stillCard.worldBound.x);
+            var bandShift = Mathf.Round(BandFor(movedCard).worldBound.x - BandFor(stillCard).worldBound.x);
+            Assert.That((cardShift, bandShift), Is.EqualTo((32f, 32f)));
         }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/RingOverlayTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/RingOverlayTests.cs
@@ -9,8 +9,8 @@ namespace Velvet.Tests
     /// reconciler-invisible sibling overlay rather than on a structural wrapper around the ringed element.
     /// Two things the wrapper could not do are pinned here: a ring behind a VARIANT renders (attaching an
     /// overlay is not parent surgery on the element's own slot, so the variant re-sync may do it), and the
-    /// band's per-corner radii follow the element's own. The band's size and position against the USS-scale
-    /// radius are covered by RingGeometryPanelTests.
+    /// band's per-corner radii follow the element's own. The geometry section also pins which transforms the
+    /// band follows, which is what the <c>V.Motion</c> exclusion in <see cref="FiberNodeFactory"/> rests on.
     /// </summary>
     internal sealed class RingOverlayTests : PanelTestBase
     {
@@ -30,6 +30,24 @@ namespace Velvet.Tests
             }
             return null;
         }
+
+        // The band belonging to one particular element, rather than the first in the parent: the transform
+        // cases put two ringed elements under one host.
+        private static VisualElement BandFor(VisualElement element)
+        {
+            var host = element.parent;
+            var next = host.IndexOf(element) + 1;
+            return next < host.childCount && host[next].ClassListContains(RingOverlay.MarkerClass)
+                ? host[next]
+                : null;
+        }
+
+        // How far along x a band paints from the element it rings, in panel space. worldBound (not layout)
+        // because it is the only reading that carries the transforms of every ancestor between the two: an
+        // offset built from each element's own box would read the same whether or not the band shares its
+        // element's transformed frame, which is precisely what these two cases pull apart.
+        private static float BandOffsetX(VisualElement element)
+            => BandFor(element).worldBound.x - element.worldBound.x;
 
         private VisualElement MountRinged(string className)
         {
@@ -126,6 +144,57 @@ namespace Velvet.Tests
             // rounded-lg is 8px.
             Assert.That((overlay?.resolvedStyle.borderTopLeftRadius, overlay?.resolvedStyle.borderTopRightRadius),
                 Is.EqualTo(((float?)12f, (float?)4f)));
+        }
+
+        // Which transforms the band follows. These two are what the V.Motion ring exclusion rests on, so a
+        // change that made the band track its own element's transform should turn the first of them red and
+        // be taken as licence to lift that exclusion.
+
+        [Test]
+        public void Given_ARingedElement_When_ATransformMovesIt_Then_TheBandStaysOnTheUntransformedBox()
+        {
+            // Arrange — two ringed cards under one host, identical but for the transform on the second.
+            _mounted = V.Mount(_window.rootVisualElement,
+                V.Div(name: "wrap", className: "w-[300px] h-[200px]", children: new VNode[]
+                {
+                    V.Div(name: "still", className: "w-[100px] h-[40px] ring-4"),
+                    V.Div(name: "moved", className: "w-[100px] h-[40px] ring-4 translate-x-8"),
+                }));
+            var still = _window.rootVisualElement.Q<VisualElement>("still");
+            var moved = _window.rootVisualElement.Q<VisualElement>("moved");
+
+            // Act
+            ForcePanelUpdate(still.panel);
+
+            // Assert — the untransformed card is the control: -4 is the band sitting exactly ring-4 outside
+            // its element, so a fixture where the bundled sheet never attached (translate-x-8 inert) reports
+            // -4 twice and fails here rather than reading as evidence. The transformed card measures the
+            // whole of its own 32px translate further out, because the band is placed from the laid-out box
+            // and is not in the subtree the transform composites over.
+            Assert.That((BandOffsetX(still), BandOffsetX(moved)),
+                Is.EqualTo((-4f, -36f)).Within(0.01f));
+        }
+
+        [Test]
+        public void Given_ARingedElement_When_AnAncestorCarriesTheTransform_Then_TheBandMovesWithIt()
+        {
+            // Arrange — the transform is on the host this time, so the band is inside the subtree it
+            // composites over. This is why putting the ring on a Div a V.Motion wraps works.
+            _mounted = V.Mount(_window.rootVisualElement,
+                V.Div(name: "wrap", className: "w-[300px] h-[200px] translate-x-8", children: new VNode[]
+                {
+                    V.Div(name: "card", className: "w-[100px] h-[40px] ring-4"),
+                }));
+            var card = _window.rootVisualElement.Q<VisualElement>("card");
+
+            // Act
+            ForcePanelUpdate(card.panel);
+
+            // Assert — the ancestor's transform term is real (32), and the band still paints exactly ring-4
+            // outside its element in panel space, so the transform carried the two together. Both in one
+            // comparison: the offset alone reads the same on a host whose transform never resolved.
+            Assert.That((card.parent.resolvedStyle.translate.x, BandOffsetX(card)),
+                Is.EqualTo((32f, -4f)).Within(0.01f));
         }
     }
 }


### PR DESCRIPTION
The restriction stays. Both reasons given for it were wrong, and the code, the guide, the CHANGELOG and the warning text all repeated one of them.

**The opacity reason is false, measured.** Mid-exit the ringed element read `0.4624` and its band `0.5377778` — different samples of the same fade, not a band frozen at full strength. The band does fade with an enter and an exit, which the guide already said for an ordinary element inside a `V.AnimatePresence` while the Motion warning said the opposite three paragraphs away.

**The real reason is the transform.** The band is a sibling placed from the element's laid-out box, and UI Toolkit composites a transform over the transformed element's own subtree only. A Motion animating `translate` / `scale` / `rotate` therefore slides out from under its own band and leaves it behind for the whole play — measured at `translate=(0, 31.02, 0)` on the element against `(0, 0, 0)` on the band. Animating a transform is what a `V.Motion` is for, so the exclusion is right; only its stated reason was not.

That deviation from CSS — which moves an outline with its element — was undocumented, so `Documentation~/styling-variants.md` now lists three hosting consequences rather than two, and says that a transform on an *ancestor* carries element and band together, which is what makes the "wrap the Motion around a ringed Div" advice work.

**Two tests pin it**, and they are what a future change should be read against: if the band is ever made to track its own element's transform, the first goes red and that is licence to lift the exclusion. Each folds its control into the assertion: an untransformed sibling measured in the same frame, so any state in which the translate did not take effect reports the same offset twice and fails rather than reading as evidence of a band that followed.

The `FiberNodeFactory` comment records the alternative that was rejected: warning only for a Motion whose transition declares a transform channel. `layoutId`, the gesture class channels and a later `Transition` swap each introduce one without recreating the element, and that gate runs once, at create.

Verified on `11ecf66`: EditMode **3540 passed, 0 failed, 0 inconclusive**; PlayMode **128 passed, 0 failed, 0 inconclusive**. The PlayMode run overlapped one other Unity instance, which produces spurious failures rather than spurious passes.

Closes #224.
