### PR TITLE
chore(velvet): report the tree a subagent worked in, not the main checkout

### DIFF
--- a/.claude/hooks/report-untracked-scratch.sh
+++ b/.claude/hooks/report-untracked-scratch.sh
@@ -1,14 +1,29 @@
 #!/usr/bin/env bash
-# Reports what a subagent left in the working tree, into the parent's context.
+# Reports what a subagent left in the tree IT worked in, into the parent's context.
 #
 # Two failures this guards. A read-only agent creating a probe fixture and not
 # removing it — self-reported cleanup has been wrong before, and the leftover
 # reads as production code to the next session. And a source file .gitignore
 # excludes, which stays untracked while every local run passes because the file
 # is there.
+#
+# The tree comes from the session's own cwd, not from CLAUDE_PROJECT_DIR. An agent
+# running in a git worktree has its own checkout, and reporting the MAIN checkout's
+# untracked files to it produced a non-terminating loop: it was told about files it
+# had not created, could not clear them without destroying another agent's in-flight
+# work, and was told again on every stop because nothing it could do changed the
+# condition. Three agents hit it in one session, and one was instructed to delete the
+# three source files of an open PR. The wording below carries the same lesson: this
+# is a report, and whoever owns a tree decides what is left in it.
 set -uo pipefail
 
-cd "${CLAUDE_PROJECT_DIR:-.}" 2>/dev/null || exit 0
+payload=$(cat 2>/dev/null || echo '')
+tree=$(printf '%s' "$payload" | python3 -c 'import json,sys
+try: print(json.load(sys.stdin).get("cwd") or "")
+except Exception: print("")' 2>/dev/null)
+[ -n "$tree" ] || tree="${CLAUDE_PROJECT_DIR:-.}"
+
+cd "$tree" 2>/dev/null || exit 0
 command -v git >/dev/null 2>&1 || exit 0
 git rev-parse --git-dir >/dev/null 2>&1 || exit 0
 
@@ -26,18 +41,18 @@ ignored=$(git status --porcelain --ignored=matching --untracked-files=all 2>/dev
 
 [ -z "$untracked" ] && [ -z "$ignored" ] && exit 0
 
-python3 - "$untracked" "$ignored" <<'PY'
+python3 - "$untracked" "$ignored" "$tree" <<'PY'
 import json, sys
-untracked, ignored = sys.argv[1], sys.argv[2]
+untracked, ignored, tree = sys.argv[1], sys.argv[2], sys.argv[3]
 parts, headline = [], []
 if untracked:
     n = len(untracked.splitlines())
     headline.append("{} untracked".format(n))
     parts.append(
-        "Untracked files remain in the working tree. Read each before deciding "
-        "it is harmless — a probe fixture left behind reads as production code "
-        "to the next session, and an agent's own report that it cleaned up has "
-        "been wrong before:\n" + untracked
+        "Untracked files remain in {}. Read each before deciding it is harmless — a probe "
+        "fixture left behind reads as production code to the next session, and an agent's own "
+        "report that it cleaned up has been wrong before. What stays is for whoever owns this "
+        "tree to decide; nothing here asks for a deletion:\n{}".format(tree, untracked)
     )
 if ignored:
     n = len(ignored.splitlines())


### PR DESCRIPTION
The `SubagentStop` hook inspected `CLAUDE_PROJECT_DIR`. An agent running in its own git worktree was therefore told about untracked files in the **main checkout** — files it had never created, sitting in a tree it does not own.

That is a non-terminating loop, not just a wrong report. The agent cannot clear those files without destroying another agent's in-flight work, so nothing it can legitimately do changes the condition, and the same report returns on every stop. Three agents hit it in one session. One was instructed to delete the three source files of an open PR and correctly refused; two others ended their runs on it rather than on their work.

The session's own cwd arrives in the hook's stdin payload, which is what the tree is now taken from, falling back to `CLAUDE_PROJECT_DIR` only when it is absent — the single-checkout case, where the two agree. The message wording changes with it, since the old phrasing read as an instruction: a report of what is in a tree is not a request to empty it, and what stays belongs to whoever owns that tree.

Verified against three inputs: a clean worktree cwd produces no output at all, where before it reported the main checkout's seven untracked files; the main checkout's own cwd still reports those seven; and no stdin still falls back and reports them.

No `Documentation~` impact — local loop tooling.