### PR TITLE
chore(velvet): judge a gitignored write from the tree that wrote it

### DIFF
--- a/.claude/hooks/report-gitignored-write.py
+++ b/.claude/hooks/report-gitignored-write.py
@@ -30,7 +30,11 @@ def main():
     if not path or not path.endswith(TRACKABLE_SUFFIXES):
         return 0
 
-    root = os.environ.get("CLAUDE_PROJECT_DIR") or payload.get("cwd") or "."
+    # The session's own cwd first. An agent working in a git worktree writes paths under
+    # .claude/worktrees/, and the MAIN checkout excludes that directory — so asking the main checkout
+    # about a worktree path matches that rule and reports every file the agent writes as untracked
+    # when its own repository tracks them normally. Same misdirection the SubagentStop hook carried.
+    root = payload.get("cwd") or os.environ.get("CLAUDE_PROJECT_DIR") or "."
     try:
         check = subprocess.run(
             ["git", "-C", root, "check-ignore", "-v", "--", path],


### PR DESCRIPTION
The `PostToolUse:Write` hook preferred `CLAUDE_PROJECT_DIR` over the session's own cwd, so a file written inside a git worktree was checked against the **main** checkout — which excludes `.claude/worktrees/`, the directory every such path sits under. The rule always matched, so every write an agent made in its own worktree was reported as excluded from CI while that worktree tracked it normally.

Two agents reported it independently, and it fired directly on an `AssemblyInfo.cs` write whose file `git check-ignore -v` exits 1 on from the worktree.

This is the same misdirection the `SubagentStop` hook carried, fixed the same way and for the same reason: a hook that asks one tree about another tree's files answers a question nobody asked.

Verified both directions — a worktree path judged from its worktree is now silent where it previously reported a match, and a genuinely ignored file (`Logs/x.md`) is still reported with its rule.

No `Documentation~` impact — local loop tooling.