### PR TITLE
chore(velvet): refuse to stop on a green PR nobody has merged

### DIFF
--- a/.claude/hooks/block-stop-on-unsettled-pr.sh
+++ b/.claude/hooks/block-stop-on-unsettled-pr.sh
@@ -12,6 +12,12 @@
 # force-push leaves behind, and reading it as pending is how the 7h45m gap started. So a PR
 # with zero checks blocks too, with a different reason.
 #
+# A PR whose checks have all passed and that nobody has merged is the state this exists for as
+# much as a pending one. It reads as "settled", and settled is what an assistant stops on — eight
+# green PRs sat unmerged for nine hours behind a watcher that was alive, emitting nothing, because
+# it only reported checks CHANGING state and every check had finished changing. A live watcher with
+# nothing left to say is indistinguishable from progress.
+#
 # A pending check is forgiven while a watcher is demonstrably alive. The heartbeat is written by
 # the watching process itself on each poll, never by the assistant, so it cannot be satisfied by
 # intending to watch — if the watcher dies the file goes stale within one poll and this blocks
@@ -65,9 +71,24 @@ for pr in $prs; do
     continue
   fi
 
+  pending=$(echo "$checks" | jq '[.[] | select(.bucket == "pending")] | length' 2>/dev/null || echo 0)
+  if [ "$pending" = "0" ]; then
+    # Nothing is running, so a watcher has nothing to observe and its heartbeat vouches for nothing.
+    state=$(gh pr view "$pr" --json mergeStateStatus --jq '.mergeStateStatus' 2>/dev/null || echo "")
+    fails=$(echo "$checks" | jq '[.[] | select(.bucket == "fail")] | length' 2>/dev/null || echo 0)
+    if [ "$fails" != "0" ]; then
+      blocked="$blocked
+  PR #$pr — $fails check(s) failed. Read the run, fix or say why it is not yours to fix."
+    elif [ "$state" = "CLEAN" ]; then
+      blocked="$blocked
+  PR #$pr — every check passed and it is unmerged. Merge it, or say what it is waiting on and arm
+    something that brings you back when that arrives."
+    fi
+    continue
+  fi
+
   watcher_is_alive && continue
 
-  pending=$(echo "$checks" | jq '[.[] | select(.bucket == "pending")] | length' 2>/dev/null || echo 0)
   if [ "$pending" != "0" ]; then
     names=$(echo "$checks" | jq -r '[.[] | select(.bucket == "pending") | .name] | join(", ")' 2>/dev/null)
     blocked="$blocked


### PR DESCRIPTION
The Stop guard asked only about checks still running. A PR whose checks have all passed and that nobody has merged reads as *settled*, and settled is what an assistant stops on — eight of them sat unmerged for nine hours.

What made it invisible is the shape worth recording. A watcher was alive the whole time and emitting nothing, because it reported checks **changing state** and every check had finished changing. Its silence meant "everything is ready and waiting for you" and was indistinguishable from "still working". That is the same reading-absence-of-signal-as-progress failure this guard was built for, reintroduced by the heartbeat exemption that fixed a different one: the exemption was written for *a pending check somebody is watching*, and a fresh heartbeat also satisfies it when nothing is pending at all.

Now the heartbeat is consulted only where it means something. With nothing pending there is nothing for a watcher to observe, so a mergeable PR blocks regardless of it, and so does a failed check — which the previous version also let through, since a failed check is not a pending one.

Verified against the live PR list: with eight CLEAN unmerged PRs it exits 2 and names them; the message asks for a merge or for a stated dependency with something armed to return on.

No `Documentation~` impact — local loop tooling.