### PR TITLE
chore(velvet): a PR no workflow applies to is still a PR nobody merged

### DIFF
--- a/.claude/hooks/block-stop-on-unsettled-pr.sh
+++ b/.claude/hooks/block-stop-on-unsettled-pr.sh
@@ -59,8 +59,17 @@ for pr in $prs; do
     # conflicting PR reports DIRTY (or UNKNOWN while GitHub is still computing) and never
     # starts CI at all, which is the shape that went unwatched for seven hours.
     state=$(gh pr view "$pr" --json mergeStateStatus --jq '.mergeStateStatus' 2>/dev/null || echo "")
+    if [ "$state" = "CLEAN" ]; then
+      # Ready, and ready is the state that reads as finished. A docs-only or .claude/-only change
+      # reports no checks at all and so never reached the merge reminder below, which is the same
+      # hole one level down from the one that left eight green PRs sitting.
+      blocked="$blocked
+  PR #$pr — no checks apply to it and it is unmerged. Merge it, or say what it is waiting on and arm
+    something that brings you back when that arrives."
+      continue
+    fi
     case "$state" in
-      CLEAN|UNSTABLE|BEHIND|BLOCKED|"")
+      UNSTABLE|BEHIND|BLOCKED|"")
         continue
         ;;
     esac


### PR DESCRIPTION
The merge reminder added in #248 is reached only by a PR that **has** checks and passed them all. A docs-only or `.claude/`-only change matches no workflow path filter, reports zero checks, and took the earlier branch that treats `CLEAN` as nothing to say — so it sat ready and invisible, which is exactly the hole #248 closed, one level further down.

Found by the guard itself rather than by reading it: on its first run it named seven green PRs and omitted the eighth, whose only difference was having nothing to run.

Verified: the guard now names all eight, including the checkless one. A zero-check PR whose merge state is `DIRTY` or `UNKNOWN` still blocks for the original reason — a conflicting PR never starts CI, so an empty check list there is not "nothing applies".

No `Documentation~` impact — local loop tooling.