### PR TITLE
docs(velvet): a case can arrange the thing it is named for and assert nothing about it

### DIFF
--- a/.claude/skills/unity-tests/SKILL.md
+++ b/.claude/skills/unity-tests/SKILL.md
@@ -33,7 +33,7 @@ Concurrent Unity instances make unrelated tests fail. A failure measured while a
 
 **`inconclusive` is not counted as a failure by the runner.** A non-zero count means a test skipped rather than reported — usually an `Assume` gating the behaviour under test. Treat it as a failure and find the test.
 
-## Eight ways a test here has passed while checking nothing
+## Nine ways a test here has passed while checking nothing
 
 Every one was found by mutating the implementation and confirming a test died — none by reading the test, because each reads as reasonable. The common shape is that **the input's form never reaches the code under test**.
 
@@ -45,12 +45,22 @@ Every one was found by mutating the implementation and confirming a test died �
 - **An `Assume` gates the behaviour under test.** The regression reports Inconclusive, which the runner does not count. Fold it into the assertion as one tuple comparison.
 - **An arbitrary value skips the path.** `rounded-tl-[12px]` is not in the scale, so a fallback under test never fires; `rounded-tl-lg` reaches it.
 - **The class under test was inert.** See the stylesheet trap below — the rest of the fixture works, so it looks built.
+- **The arranged condition has no term depending on it.** A case named for a clipped opacity group, or for an inline filter, sets that condition up and then asserts only what is true without it — so it passes with the clip or the filter removed, and pins its context in name only. Found three times in one fixture family, each next door to the one just fixed.
 
 Three traps in the folding itself, each of which passes a count check:
 
 - **`Is.EqualTo(tuple)` matches a nested collection by reference.** Join to strings instead.
 - **`.Within()` does not reach the members of a tuple.** Unity's NUnit ships no `ValueTupleComparer`, so `NUnitEqualityComparer.AreEqual` falls through to `FirstImplementsIEquatableOfSecond`, which never sees the tolerance — `Assert.That((0.99999f, 0.00001f), Is.EqualTo((1f, 0f)).Within(1e-4f))` **fails**, while printing the tolerance it did not apply. A fold that moves a scalar comparison into a tuple silently converts it to bit-exact equality wearing a tolerance suffix. Round each term before comparing, or compare formatted strings.
 - **The logically sharpest gate is not always the discriminating one.** A `ReferenceEquals` precondition on a LIFO pool holds even when the mechanism is neutered, and a count term next to it is what goes red.
+
+## Sweep for the shape, not the instance
+
+Three consecutive review rounds on one branch each found one instance of the same defect, each fix was right, and the class never moved — because each round fixed what it was handed. Two sweeps end that, and both cost minutes:
+
+- **Every assertion**: remove the condition the case arranges and check that something goes red. If nothing does, the arrangement is decoration.
+- **Every sentence containing `every`, `no other`, `always` or `none`**: check it against the set it quantifies over. Universals written from memory have been false here more often than they have held, including inside the rule that forbids writing an unverified claim, and including in a comment written after that rule landed.
+
+Report what a sweep found, zero included. One nobody hears about is indistinguishable from one nobody ran.
 
 ## A pixel fixture on `RenderTexturePanelHost` mounts without the bundled stylesheet
 

--- a/.claude/skills/unity-tests/SKILL.md
+++ b/.claude/skills/unity-tests/SKILL.md
@@ -45,7 +45,7 @@ Every one was found by mutating the implementation and confirming a test died �
 - **An `Assume` gates the behaviour under test.** The regression reports Inconclusive, which the runner does not count. Fold it into the assertion as one tuple comparison.
 - **An arbitrary value skips the path.** `rounded-tl-[12px]` is not in the scale, so a fallback under test never fires; `rounded-tl-lg` reaches it.
 - **The class under test was inert.** See the stylesheet trap below — the rest of the fixture works, so it looks built.
-- **The arranged condition has no term depending on it.** A case named for a clipped opacity group, or for an inline filter, sets that condition up and then asserts only what is true without it — so it passes with the clip or the filter removed, and pins its context in name only. Found three times in one fixture family, each next door to the one just fixed.
+- **The arranged condition has no term depending on it.** A case named for a clipped opacity group, or for an inline filter, sets that condition up and then asserts only what is true without it — so it passes with the clip or the filter removed, and pins its context in name only. Two instances in one fixture, found in consecutive review rounds — the second was next door to the first and survived the round that fixed it.
 
 Three traps in the folding itself, each of which passes a count check:
 
@@ -55,7 +55,7 @@ Three traps in the folding itself, each of which passes a count check:
 
 ## Sweep for the shape, not the instance
 
-Three consecutive review rounds on one branch each found one instance of the same defect, each fix was right, and the class never moved — because each round fixed what it was handed. Two sweeps end that, and both cost minutes:
+Consecutive review rounds on one branch kept finding one more instance of a defect already fixed, each fix right, the class never moving — because each round fixed what it was handed. Two sweeps end that, and both cost minutes:
 
 - **Every assertion**: remove the condition the case arranges and check that something goes red. If nothing does, the arrangement is decoration.
 - **Every sentence containing `every`, `no other`, `always` or `none`**: check it against the set it quantifies over. Universals written from memory have been false here more often than they have held, including inside the rule that forbids writing an unverified claim, and including in a comment written after that rule landed.


### PR DESCRIPTION
A ninth entry for the list of ways a test here has passed while checking nothing, plus the sweep that would have found both at once.

**The shape**: a case arranges the condition it is named for — a clipped opacity group, an inline filter — and asserts only what is true without it. It passes with the clip or the filter removed, and pins its context in name only. It reads as coverage of that context, and the fixture's other cases really do cover theirs, which is what makes it invisible.

Two instances in one fixture, found in consecutive rounds — the second next door to the first, surviving the round that fixed it. Both fixes were correct; the class never moved, because each round fixed what it was handed.

So the entry comes with two sweeps, both minutes of work:

- for every assertion, delete the condition the case arranges and check that something goes red — if nothing does, the arrangement is decoration;
- for every sentence containing `every`, `no other`, `always` or `none`, check it against the set it quantifies over.

The second has failed here more often than it has held this session, including inside the convention that forbids writing an unverified claim, and including in a comment written after that convention landed.

And a sweep has to be reported, zero included: one nobody hears about is indistinguishable from one nobody ran.

Touches only the skill. No package surface changes.
