### PR TITLE
fix(velvet): attach the utilities through the resolver in three new fixtures

### DIFF
--- a/Packages/com.velvet.core/Runtime/Styling/Tests/PlayMode/PaintOpacityParityPlaybackTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/PlayMode/PaintOpacityParityPlaybackTests.cs
@@ -155,7 +155,7 @@ namespace Velvet.Tests
             _host?.Dispose();
             _host = new RenderTexturePanelHost(name, Size, Size);
             _host.Root.style.backgroundColor = Color.black;
-            _host.Root.LoadBundledStyleUtilitiesForTest();
+            VelvetStyleUtilities.AttachTo(_host.Root);
             _mounted = V.Mount(_host.Root, V.Div(name: "wrap", className: "w-[240px] h-[160px]",
                 children: new[] { V.Div(name: "probe", className: ProbeClasses + probeExtra) }));
             var wrap = _host.Root.Q<VisualElement>("wrap");

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/PlayMode/ShadowFadeOpacityPlaybackTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/PlayMode/ShadowFadeOpacityPlaybackTests.cs
@@ -92,7 +92,7 @@ namespace Velvet.Tests
             DisposePanel();
             _host = new RenderTexturePanelHost(name, Size, Size);
             _host.Root.style.backgroundColor = Color.black;
-            _host.Root.LoadBundledStyleUtilitiesForTest();
+            VelvetStyleUtilities.AttachTo(_host.Root);
             _mounted = V.Mount(_host.Root, V.Div(name: "caster", className: CasterClasses));
             _host.Root.Q<VisualElement>("caster").style.opacity = opacity;
             yield return WaitRealtime(0.9);

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/PlayMode/WrapperLessPaintOverflowClipPlaybackTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/PlayMode/WrapperLessPaintOverflowClipPlaybackTests.cs
@@ -70,7 +70,7 @@ namespace Velvet.Tests
             DisposePanel();
             _host = new RenderTexturePanelHost(name, Size, Size);
             _host.Root.style.backgroundColor = backdrop;
-            _host.Root.LoadBundledStyleUtilitiesForTest();
+            VelvetStyleUtilities.AttachTo(_host.Root);
         }
 
         private static bool IsRed(Color32 p) => p.r > 140 && p.g < 90 && p.b < 90;


### PR DESCRIPTION
**`main` does not compile.** Two PRs were CLEAN alone and broke together: #239 deleted the editor-only `LoadBundledStyleUtilitiesForTest` in favour of `VelvetStyleUtilities.AttachTo`, which works in a built player, and #236 added three PlayMode fixtures that call the deleted helper. Neither CI run could see the other's change, so merging them in either order leaves three `CS1061`s on `main`.

The three call sites now use the resolver.

Verified **after** the change and before pushing this time: PlayMode 149 passed, 0 failed, 0 inconclusive, no compile errors.

This exact break was predicted for #229 and handled there — the same check was not run for #236, which is the process failure worth naming. A branch that is green against a `main` it has not merged says nothing about the `main` it produces, and nothing in CI asks the second question.