### PR TITLE
fix(velvet): keep the story-capture fixture out of a player build

### DIFF
--- a/Packages/com.velvet.core/Runtime/Preview/Tests/PlayMode/StoryCaptureTests.cs
+++ b/Packages/com.velvet.core/Runtime/Preview/Tests/PlayMode/StoryCaptureTests.cs
@@ -1,3 +1,9 @@
+// The preview registry, story and host are all #if UNITY_EDITOR — previewing is an editor activity and
+// none of it is compiled into a player. This fixture drives them, so it is editor-only too. Without the
+// guard the assembly still compiles in the editor and fails only when something builds a standalone
+// player, which is the one configuration that would have caught the shader stripping this repository
+// went on to find.
+#if UNITY_EDITOR
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
@@ -284,3 +290,4 @@ namespace Velvet.Tests
 
     }
 }
+#endif


### PR DESCRIPTION
`-testPlatform StandaloneOSX` does not compile on `main`. Everything under `Runtime/Preview` is `#if UNITY_EDITOR` — previewing is an editor activity and none of it reaches a player — while `StoryCaptureTests` drives that registry from an assembly built for every platform. `CS0246: VelvetPreviewStory could not be found`.

It compiled in the editor, which is where every suite in this repository runs, so nothing reported it.

**The consequence is larger than a broken configuration.** A standalone player build is the only setting in which a shader stripped out of the build shows itself, and this fixture made that build fail before it started. With the guard in place I built one and measured the defect directly:

```
Shader not found: Velvet/FilterBrightness
Shader not found: Velvet/FilterSaturate
```

`BuiltInFilterShaderPlaybackTests` — three cases, all failing in the player, all passing in the editor. That is #246, and until this change nobody could have run the check that shows it.

Editor PlayMode is unaffected: the fixture still compiles and runs there, because `UNITY_EDITOR` is defined.