### PR TITLE
chore(velvet): refuse to merge a branch that does not contain main

### DIFF
--- a/.claude/hooks/refuse-stale-merge.py
+++ b/.claude/hooks/refuse-stale-merge.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Refuse `gh pr merge` for a branch that does not contain the current main.
+
+Two branches green against a main neither contained broke this repository once: one deleted a
+helper, the other added callers of it, and merging them in either order left main not compiling.
+CI does ask the right question — it tests the merge result — but the answer expires when main moves
+and nothing looks again.
+
+The staleness is computed here rather than read from mergeStateStatus. GitHub reports BEHIND only
+when the base branch requires the head to be up to date, and this repository sets no required
+status checks, so that field answers CLEAN for a branch eight commits behind. A guard keyed on it
+would never fire.
+"""
+import json
+import re
+import subprocess
+import sys
+
+
+def git(*args):
+    return subprocess.run(
+        ["git", *args], stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, timeout=30
+    )
+
+
+def main():
+    try:
+        payload = json.load(sys.stdin)
+    except ValueError:
+        return 0
+
+    command = (payload.get("tool_input") or {}).get("command") or ""
+    match = re.search(r"gh\s+pr\s+merge\s+(\d+)", command)
+    if not match:
+        return 0
+    pr = match.group(1)
+
+    try:
+        head = subprocess.run(
+            ["gh", "pr", "view", pr, "--json", "headRefName", "--jq", ".headRefName"],
+            stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, timeout=20,
+        ).stdout.decode().strip()
+    except Exception:
+        return 0
+    if not head:
+        return 0
+
+    git("fetch", "-q", "origin", "main", head)
+    if git("merge-base", "--is-ancestor", "origin/main", "origin/" + head).returncode == 0:
+        return 0
+
+    behind = git("rev-list", "--count", "origin/{}..origin/main".format(head)).stdout.decode().strip()
+    sys.stderr.write(
+        "PR #{} does not contain the current main — it is {} commit(s) behind.\n\n"
+        "Its checks passed against a main this merge does not produce. That is how main was broken "
+        "here: two branches, each green, neither containing the other's change.\n\n"
+        "Merge origin/main into {}, let the checks re-run, then merge.\n\n"
+        "Note mergeStateStatus says CLEAN for this PR. GitHub only reports BEHIND when the base "
+        "requires the head to be up to date, which protect-main does not — so that field cannot be "
+        "the thing you check.\n".format(pr, behind or "?", head)
+    )
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -33,6 +33,18 @@
           }
         ]
       }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/refuse-stale-merge.py\"",
+            "timeout": 25000
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
`main` was broken by two pull requests that were each green and could not see each other — one deleted a helper, the other added three fixtures calling it. CI already asks the right question, because it tests the PR merged **into** `main`; what is missing is that the answer expires when `main` moves and nothing looks again.

A `PreToolUse` hook on `gh pr merge` now refuses when the head does not contain the current `main`.

**It computes that itself rather than reading `mergeStateStatus`.** GitHub reports `BEHIND` only when the base branch requires the head to be up to date, and `protect-main` sets no required status checks — so that field answers `CLEAN` for a branch eight commits behind. The first version of this guard keyed on it and could not fire in any state. I found that by opening a throwaway PR built to be behind and watching the guard pass it, which is the check the guard's own subject says to make.

It caught a real one immediately: `chore/generators-code-shape`, the branch this session was about to merge as soon as its checks went green, is two commits behind.

Weaker than the server-side rule in one way worth stating: it binds this machine only, so a merge from the GitHub UI or another clone is unaffected. #250 covers the ruleset, where requiring status checks is ordinary practice and the only real question is what `strict` costs — measured today at 21–25 minutes per Unity CI run, so at eight open PRs a serial queue of about three hours.