### PR TITLE
test: throwaway probe, do not merge

### DIFF
--- a/Assets/Editor/URPSetup.cs
+++ b/Assets/Editor/URPSetup.cs
@@ -67,3 +67,4 @@ namespace Velvet.EditorTools
     }
 }
 #endif
+

--- a/Packages/com.velvet.core/Documentation~/focus.md
+++ b/Packages/com.velvet.core/Documentation~/focus.md
@@ -55,7 +55,7 @@ The `focus-visible:` class variant covers keyboard/gamepad-only focus styling: i
 focus NOT caused by a pointer press on the element (keyboard, gamepad navigation, or
 programmatic focus) and stays dark for click-to-focus, mirroring CSS `:focus-visible`.
 
-`Hooks.UseFocusRing` is the render-state channel for the same distinction — React Aria's
+`Hooks.UseFocusRingState` is the render-state channel for the same distinction — React Aria's
 `useFocusRing` parity: it returns the element's `IsFocused` / `IsFocusVisible` as re-rendering
 component state plus a `Ref` to pass as the element's `refCallback:`. Reach for it when the
 component must render differently (say, a "press A to select" hint), not just restyle; it rides

--- a/Packages/com.velvet.core/Documentation~/focus.md
+++ b/Packages/com.velvet.core/Documentation~/focus.md
@@ -55,7 +55,7 @@ The `focus-visible:` class variant covers keyboard/gamepad-only focus styling: i
 focus NOT caused by a pointer press on the element (keyboard, gamepad navigation, or
 programmatic focus) and stays dark for click-to-focus, mirroring CSS `:focus-visible`.
 
-`Hooks.UseFocusRingState` is the render-state channel for the same distinction — React Aria's
+`Hooks.UseFocusRing` is the render-state channel for the same distinction — React Aria's
 `useFocusRing` parity: it returns the element's `IsFocused` / `IsFocusVisible` as re-rendering
 component state plus a `Ref` to pass as the element's `refCallback:`. Reach for it when the
 component must render differently (say, a "press A to select" hint), not just restyle; it rides


### PR DESCRIPTION
Deliberate break: one guide, one renamed hook reference, nothing else in the diff. Open only to record what CI does for it. Close without merging.