### PR TITLE
chore(velvet): ask the file which tree owns it

### DIFF
--- a/.claude/hooks/report-gitignored-write.py
+++ b/.claude/hooks/report-gitignored-write.py
@@ -30,11 +30,15 @@ def main():
     if not path or not path.endswith(TRACKABLE_SUFFIXES):
         return 0
 
-    # The session's own cwd first. An agent working in a git worktree writes paths under
-    # .claude/worktrees/, and the MAIN checkout excludes that directory — so asking the main checkout
-    # about a worktree path matches that rule and reports every file the agent writes as untracked
-    # when its own repository tracks them normally. Same misdirection the SubagentStop hook carried.
-    root = payload.get("cwd") or os.environ.get("CLAUDE_PROJECT_DIR") or "."
+    # Ask the tree that owns the FILE, not the session's cwd and not CLAUDE_PROJECT_DIR. An agent is
+    # given the main checkout as its cwd and writes into a worktree under .claude/worktrees/, which the
+    # main checkout excludes — so consulting either one reports every file the agent creates as
+    # unreachable by CI while its own repository stages it normally. Fixing this by preferring cwd
+    # addressed the wrong half and left the common case reporting a false positive on every write.
+    root = subprocess.run(
+        ["git", "-C", os.path.dirname(path) or ".", "rev-parse", "--show-toplevel"],
+        stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, timeout=10,
+    ).stdout.decode().strip() or payload.get("cwd") or os.environ.get("CLAUDE_PROJECT_DIR") or "."
     try:
         check = subprocess.run(
             ["git", "-C", root, "check-ignore", "-v", "--", path],


### PR DESCRIPTION
Every file an agent creates in a worktree was reported as excluded from CI. Three agents hit it; one listed all three of its new test files as unreachable while `git check-ignore` exits 1 on them from inside the worktree and they stage normally.

**A previous fix for this changed the wrong half.** It made the hook prefer the session's cwd over `CLAUDE_PROJECT_DIR`, which is correct when the cwd is the worktree — and that is not what happens. Agents are handed the main checkout as their cwd and write into `.claude/worktrees/`, which the main checkout excludes, so the false positive survived the fix aimed at it and fired on every write.

The file knows which tree it belongs to. `git -C <dirname> rev-parse --show-toplevel` answers it, and the hook asks that instead.

Verified with the cwd agents actually run with — the main checkout, writing into a worktree: silent where it previously reported a match, while `Logs/x.md` still reports its rule and line.

Worth noting what the false positive cost beyond noise: a warning that fires on every write stops being read, which is the state it was in when it was finally reported as a finding rather than acted on.