### PR TITLE
test: throwaway probe, do not merge (markdown-only trigger)

### DIFF
--- a/Packages/com.velvet.core/Documentation~/focus.md
+++ b/Packages/com.velvet.core/Documentation~/focus.md
@@ -55,7 +55,7 @@ The `focus-visible:` class variant covers keyboard/gamepad-only focus styling: i
 focus NOT caused by a pointer press on the element (keyboard, gamepad navigation, or
 programmatic focus) and stays dark for click-to-focus, mirroring CSS `:focus-visible`.
 
-`Hooks.UseFocusRing` is the render-state channel for the same distinction — React Aria's
+`Hooks.UseFocusRingState` is the render-state channel for the same distinction — React Aria's
 `useFocusRing` parity: it returns the element's `IsFocused` / `IsFocusVisible` as re-rendering
 component state plus a `Ref` to pass as the element's `refCallback:`. Reach for it when the
 component must render differently (say, a "press A to select" hint), not just restyle; it rides

--- a/Packages/com.velvet.core/Documentation~/focus.md
+++ b/Packages/com.velvet.core/Documentation~/focus.md
@@ -88,3 +88,4 @@ blurred synchronously and the target focused on its own panel's next tick.
 - No cross-panel containment — `contain` is per panel. A globally exclusive modal is the Topmost
   layer plus a full-screen scrim, which makes outside input land in the modal's own panel
   physically.
+


### PR DESCRIPTION
One guide, one renamed hook reference. Nothing else in the diff — the point is what CI does for a markdown-only pull request. Do not merge; close when it has been read.