### PR TITLE
test: throwaway probe, do not merge (scripts-only trigger)

### DIFF
--- a/scripts/assert-no-inconclusive.py
+++ b/scripts/assert-no-inconclusive.py
@@ -87,3 +87,4 @@ def main(arguments):
 
 if __name__ == "__main__":
     sys.exit(main(sys.argv[1:]))
+

--- a/scripts/assert-no-inconclusive.py
+++ b/scripts/assert-no-inconclusive.py
@@ -11,6 +11,7 @@ import xml.etree.ElementTree as ET
 from pathlib import Path
 
 USAGE = "usage: assert-no-inconclusive.py RESULTS_XML_OR_DIRECTORY [...]"
+PROBE = True  # throwaway probe, do not merge
 
 
 def result_files(arguments):


### PR DESCRIPTION
One line added to the script both Unity jobs run as their last step. Nothing else in the diff. Do not merge; close when it has been read.