### PR TITLE
ci(velvet): stop running the suites on an editor that crashes when scripts reload

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,9 +96,10 @@ jobs:
         with:
           path: Library
           key: Library-${{ matrix.testMode }}-${{ hashFiles('Packages/**', 'ProjectSettings/**') }}
+          # No bare Library- fallback: it matches across test modes, and an EditMode job was measured
+          # restoring a cache whose key begins Library-PlayMode-.
           restore-keys: |
             Library-${{ matrix.testMode }}-
-            Library-
 
       - name: Run ${{ matrix.testMode }} tests
         uses: game-ci/unity-test-runner@0ff419b913a3630032cbe0de48a0099b5a9f0ed9 # v4
@@ -107,7 +108,16 @@ jobs:
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
         with:
-          unityVersion: 6000.3.11f1
+          # Deliberately ahead of ProjectVersion.txt's 6000.3.11f1. game-ci passes -enableCodeCoverage
+          # and -debugCodeOptimization unconditionally, and on 6000.3.11f1 that combination SIGSEGVs
+          # inside ScriptingCoverage::FilterRecordedMethods when a script reload happens during a run.
+          # Unity's 6000.3.14f1 release notes carry the fix as UUM-137724, "Added main-thread guard in
+          # ScriptingCoverage::FilterRecordedMethods for thread safety during script reload".
+          #
+          # What this costs: the floor version is no longer the one under test. It is bounded — the crash
+          # needs -enableCodeCoverage, which nothing but this workflow passes, so no consumer on the floor
+          # is exposed to it — but a Velvet defect that appears only on 6000.3.11f1 would now go unseen.
+          unityVersion: 6000.3.21f1
           testMode: ${{ matrix.testMode }}
           projectPath: .
           artifactsPath: ${{ matrix.testMode }}-results


### PR DESCRIPTION
PlayMode CI began dying before any test reported, on `main` twice at the same commit and on one pull request, with EditMode green in the same runs:

```
Caught fatal signal - signo:11 code:1 errno:0 addr:(nil)
Segmentation fault (core dumped)
Unexpected exit code 139
```

## The cause, from the crash's own stack

```
#14 ScriptingCoverage::FilterRecordedMethods(void*, MonoMethod*)
#13 GetCoreScriptingClassesPtr()
#12 InitializeCoreScriptingClasses()
#11 RequireType(char const*, char const*, char const*)
#10 DebugStringToFile(DebugStringToFileData const&)
...
#42 GC_inner_start_routine
```

Unity's own 6000.3.14f1 release notes carry the fix as **UUM-137724**: *"Added main-thread guard in ScriptingCoverage::FilterRecordedMethods for thread safety during script reload."* This project pins 6000.3.11f1, and the frames run off a GC thread, which is the race that note describes.

It is armed by the runner rather than by anything here. game-ci's `dist/platforms/ubuntu/run_tests.sh` passes `-enableCodeCoverage` and `-debugCodeOptimization` **unconditionally**, and the action exposes no input to turn them off. `Packages/manifest.json` does not carry the Code Coverage package — the flag arms the native path regardless, and the editor log says `Code Coverage is enabled`.

## What produces the reload, measured with the input held constant

The race needs a script reload during the run. Four PlayMode jobs restored the **identical** cache `Library-PlayMode-ddc1939b…`, written by a `main` job from a tree predating the starter sample:

| job | tree carries the sample | outcome |
|---|---|---|
| `fix/opaque-semantic-tokens` | no | pass |
| `test/pin-null-child-drop` @ `c4767c1` | no | pass |
| `fix/thread-scoped-alloc-probe` | no | pass |
| `main` @ `6d99ec2` | **yes** | **segfault** |

Same Library, tree varies, failure tracks whether the checkout holds assets the restored Library never imported. The failing job's log shows why: a full `Asset Pipeline Refresh` importing 233 items against a baseline of 217, then `Reloading assemblies after forced synchronous recompile`, then the signal. Deleting `main`'s caches and re-running cold passes, which is the same result from the other side.

EditMode is the control that narrows it to play-mode entry rather than the import: both EditMode jobs of the failing runs imported the sample from an equally stale Library and passed.

**It cannot self-heal.** A crashed PlayMode job never reaches its cache-save step, so `main` can never write a Library that knows about the sample, and every subsequent run repeats the crash. The only sample-warm PlayMode Library that was ever written belongs to a pull-request ref, and GitHub's cache scoping means `main` can never read it.

## Two changes

**The editor CI runs is bumped to 6000.3.21f1**, which carries the UUM-137724 guard. That removes the crash whatever produces the reload, where cache hygiene alone would only remove the triggers anyone has thought of.

**The bare `Library-` restore-key is dropped.** It matches across test modes, and it did so twice in this window in both directions — a PlayMode job restored `Library-EditMode-…`, and an EditMode job restored `Library-PlayMode-…`. That is wrong on its own terms and independent of this crash. The per-mode fallback stays: with the editor fixed, a Library that lags the tree is just a slower warm start, which is what restore-keys are for.

## What the bump costs

`ProjectSettings/ProjectVersion.txt` stays at 6000.3.11f1, so **the floor version is no longer the one CI tests.** The gap is bounded — the crash needs `-enableCodeCoverage`, which nothing but this workflow passes, so no consumer on the floor is exposed — but a Velvet defect appearing only on 6000.3.11f1 would now go unseen. The alternative considered and rejected was replacing `game-ci/unity-test-runner` with a hand-rolled editor invocation to control the arguments, which means reimplementing licence activation and return: a larger new failure surface than the one being closed.

`docs.yml` keeps 6000.3.11f1: it runs no tests and never passes the coverage flags.

## Two things found alongside, neither fixed here

`[Licensing::Module] Error: Access token is unavailable; failed to update` appears in **every** PlayMode job, including the ones that pass — twice per successful run. It is part of game-ci's licence-return sequence and is not a failure signature, though it sits close enough to the crash in the log to read as one. An earlier version of this description quoted it as part of the crash; that was wrong.

The repository's Actions cache is at its 10 GB limit while each job writes about 1.1 GB, so entries are evicted continuously and **no PlayMode job in the window ever got an exact key hit** — every one was a restore-keys fallback. That is why a mismatched Library is the normal case here rather than the exception, and it is worth its own change.

No `Documentation~` change: this alters no package behaviour.