### PR TITLE
probe: demonstrate that a red required check blocks merging

### DIFF
--- a/Packages/com.velvet.core/Generators~/tests/Velvet.SourceGenerators.Tests/SolutionPaths.cs
+++ b/Packages/com.velvet.core/Generators~/tests/Velvet.SourceGenerators.Tests/SolutionPaths.cs
@@ -53,3 +53,13 @@ namespace Velvet.SourceGenerators.Tests
         }
     }
 }
+
+// throwaway: proves a red required check cannot be merged past
+namespace Velvet.SourceGenerators.Tests
+{
+    public sealed class DeliberateFailureProbe
+    {
+        [Xunit.Fact]
+        public void Fails() => Xunit.Assert.True(false, "deliberate, for the merge-gate demonstration");
+    }
+}


### PR DESCRIPTION
Throwaway. A deliberately failing generator test so that Required checks (generators) goes red, to show branch protection refusing the merge. Deleted once the refusal is recorded.