### PR TITLE
probe: demonstrate that a skipped dependency still satisfies the aggregate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,8 +50,9 @@ jobs:
       - id: check
         env:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+          FORCE_NO_LICENSE: "1"
         run: |
-          if [ -n "$UNITY_LICENSE" ]; then
+          if [ -n "$UNITY_LICENSE" ] && [ "$FORCE_NO_LICENSE" != "1" ]; then
             echo "has_license=true" >> "$GITHUB_OUTPUT"
           else
             echo "has_license=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Throwaway. Forces the licence check to report false so unity-tests is skipped, which is the state a fork with no secret is in. Shows Required checks (Unity) passing anyway. Deleted once recorded.