### PR TITLE
fix(velvet): balance the lines inside the box the padding leaves

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -203,6 +203,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `text-balance` on an element with horizontal padding or a border no longer wraps the text one line
+  further than an unbalanced one. The search measures text, which is laid out inside the content box,
+  while the value it writes is a `width`, which in UI Toolkit covers the padding and the border; the two
+  were the same number, so the text was handed less room than the search had assumed. Measured on a
+  themeless panel, a balanced label with three pixels of horizontal padding came out one line taller than
+  its unbalanced sibling at four of five wrapper widths, and the width written was identical to the
+  unpadded case. Unity's default runtime theme puts padding on every `Label`, so this reached any project
+  that did not build its own theme.
+
 - The four shaders behind drop shadows, the gradient silhouette a `bg-gradient-*` gets on a `skew-*`
   element, and the `brightness-*` / `saturate-*` filters are now put in front of every player build.
   They are reached by name from C# alone and none is in a scene, so a build had nothing keeping them:

--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -209,8 +209,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   were the same number, so the text was handed less room than the search had assumed. Measured on a
   themeless panel, a balanced label with three pixels of horizontal padding came out one line taller than
   its unbalanced sibling at four of five wrapper widths, and the width written was identical to the
-  unpadded case. Velvet's own utility model makes a padded text element ordinary — any `px-*` or `p-*` on a
-  balanced label reached this.
+  unpadded case. Velvet's own utility model makes a padded text element ordinary — any non-zero `px-*` or
+  `p-*` on a balanced label reached this.
 
 - The four shaders behind drop shadows, the gradient silhouette a `bg-gradient-*` gets on a `skew-*`
   element, and the `brightness-*` / `saturate-*` filters are now put in front of every player build.

--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -209,8 +209,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   were the same number, so the text was handed less room than the search had assumed. Measured on a
   themeless panel, a balanced label with three pixels of horizontal padding came out one line taller than
   its unbalanced sibling at four of five wrapper widths, and the width written was identical to the
-  unpadded case. Unity's default runtime theme puts padding on every `Label`, so this reached any project
-  that did not build its own theme.
+  unpadded case. Velvet's own utility model makes a padded text element ordinary — any `px-*` or `p-*` on a
+  balanced label reached this.
 
 - The four shaders behind drop shadows, the gradient silhouette a `bg-gradient-*` gets on a `skew-*`
   element, and the `brightness-*` / `saturate-*` filters are now put in front of every player build.

--- a/Packages/com.velvet.core/Documentation~/fonts.md
+++ b/Packages/com.velvet.core/Documentation~/fonts.md
@@ -230,7 +230,8 @@ no-op** on a default `Label` — pair it with `text-wrap` / `whitespace-normal` 
 white-space) for it to have any effect.
 
 **Single-line gate:** CSS balance is a no-op on one line, and this approximation shrinks the box,
-so a width is written only when the text wraps at the ceiling-clamped available width. Otherwise —
+so a width is written only when the text wraps at the width the text actually gets — the
+ceiling-clamped available width less the element's own horizontal padding and border. Otherwise —
 empty text included — the slot goes back to the element's own cascade, dropping a previously
 balanced width and restoring a co-present `w-*` value. A `white-space: nowrap` element reaches the
 same verdict through the same comparison, which is why the prerequisite above is silent rather than

--- a/Packages/com.velvet.core/Documentation~/fonts.md
+++ b/Packages/com.velvet.core/Documentation~/fonts.md
@@ -186,9 +186,11 @@ multiplier of 1 included — is already a real value, so there is nothing to res
 **`text-balance`** approximates CSS `text-wrap: balance` even though UI Toolkit's text engine
 exposes no line-break hook. `StyleTextBalanceManipulator` narrows the box instead: it
 binary-searches `TextElement.MeasureTextSize` — the same method the engine's own autosize pass
-calls — for the narrowest inline **`width`** that still measures the height a normal, unbalanced
-layout would take at the available width. Comparing heights stands in for comparing line counts,
-since font metrics are constant across candidates.
+calls — for the narrowest width that still measures the height a normal, unbalanced layout would
+take at the available width. Comparing heights stands in for comparing line counts, since font
+metrics are constant across candidates. The search runs over the width the text gets, and the
+element's own horizontal padding and border are added back to the inline **`width`** it writes,
+since a `width` in UI Toolkit covers them.
 
 **What it honours.** `text-balance` writes the element's inline `width` and never its `max-width`:
 

--- a/Packages/com.velvet.core/Runtime/Styles/_typography.uss
+++ b/Packages/com.velvet.core/Runtime/Styles/_typography.uss
@@ -84,7 +84,7 @@
    line-breaking HEURISTICS (best-fit paragraph shaping), not a white-space value, so there is no rule
    for either here. text-pretty has no UI Toolkit hook and is intentionally omitted. text-balance DOES
    have a class-facing effect, but not through USS: StyleTextBalanceManipulator approximates it in C# by
-   binary-searching TextElement.MeasureTextSize for the narrowest inline maxWidth that keeps the same
+   binary-searching TextElement.MeasureTextSize for the narrowest inline width that keeps the same
    line count — see StyleTextBalanceManipulator.cs and Documentation~/fonts.md. */
 .text-wrap { white-space: normal; }
 .text-nowrap { white-space: nowrap; }

--- a/Packages/com.velvet.core/Runtime/Styling/StyleTextBalanceManipulator.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleTextBalanceManipulator.cs
@@ -39,8 +39,8 @@ namespace Velvet
     // the class again.
     //
     // Single-line gate: CSS balance is a no-op on one line, and narrowing a single-line box would shrink it
-    // for no parity benefit. Measured at the ceiling-clamped width, so text that fits the parent but wraps
-    // inside the ceiling still balances. A nowrap element reaches the same verdict through the same
+    // for no parity benefit. Measured at the width the text actually gets — ceiling-clamped, less the
+    // element's own frame — so text that fits the parent but wraps inside either still balances. A nowrap element reaches the same verdict through the same
     // comparison, since MeasureTextSize honors the element's own resolved white-space.
     //
     // Prerequisite: Velvet's Label ships no base white-space rule, so its engine default is nowrap and
@@ -68,8 +68,9 @@ namespace Velvet
         // mirroring StyleGridManipulator's WrapSafetyPx.
         private const float HeightEpsilonPx = 0.5f;
 
-        // A ceiling at or below this leaves nothing to redistribute, and keeps the search from being
-        // entered with a floor above its own upper bound.
+        // Content room at or below this leaves nothing to redistribute, and keeps the search from being
+        // entered with a floor above its own upper bound. A frame wider than the ceiling reaches it too,
+        // which is why the released box can be far wider than this value.
         private const float MinBalanceableWidthPx = 1f;
 
         // Answers whether the target's parent is a grid container, whose manipulator writes the same slot.
@@ -225,7 +226,7 @@ namespace Velvet
 
             if (content < MinBalanceableWidthPx)
             {
-                // The engine applies a ceiling this narrow to the released box on its own.
+                // Nothing to search over. Whatever the cascade then gives the box is the right answer here.
                 ReleaseWidth(textElement);
                 _lastSignature = signature;
                 _hasSignature = true;

--- a/Packages/com.velvet.core/Runtime/Styling/StyleTextBalanceManipulator.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleTextBalanceManipulator.cs
@@ -49,8 +49,8 @@ namespace Velvet
     // Re-derives on attach, on its own and its PARENT's GeometryChangedEvent, and on ChangeEvent<string>
     // (a text swap that keeps the same box size raises no geometry event). The parent subscription is what
     // catches an ancestor WIDENING: the written width pins the target's own rect, so nothing fires on the
-    // target. A signature over the clamped available width, the text and the font size absorbs the
-    // GeometryChangedEvent this manipulator's own write provokes.
+    // target. A signature over the clamped content width, the frame around it, the text and the font size
+    // absorbs the GeometryChangedEvent this manipulator's own write provokes.
     //
     // Lifecycle mirrors StyleGapManipulator / StyleGridManipulator: the reconciler attaches one per
     // element, tracks it in ReconcilerContext.TextBalanceManipulators, and removes it on cleanup. Detach
@@ -176,9 +176,19 @@ namespace Velvet
                 available = Mathf.Min(available, ceiling);
             }
 
+            // The search measures text, which is laid out inside the element's content box, while the value
+            // it writes is a `width` — and a width in UI Toolkit covers the padding and the border. So the
+            // two are separated here: everything below searches over content widths, and the frame is added
+            // back at the write. Measuring at the outer width instead hands the text less room than the
+            // measurement assumed and it wraps one line further than the search settled on.
+            var frame = textElement.resolvedStyle.paddingLeft + textElement.resolvedStyle.paddingRight
+                        + textElement.resolvedStyle.borderLeftWidth
+                        + textElement.resolvedStyle.borderRightWidth;
+            var content = available - frame;
+
             var text = textElement.text ?? string.Empty;
             var fontSize = textElement.resolvedStyle.fontSize;
-            var signature = ComputeSignature(available, text, fontSize);
+            var signature = ComputeSignature(content, frame, text, fontSize);
             if (_hasSignature && signature == _lastSignature)
             {
                 return;
@@ -213,7 +223,7 @@ namespace Velvet
                 return;
             }
 
-            if (available < MinBalanceableWidthPx)
+            if (content < MinBalanceableWidthPx)
             {
                 // The engine applies a ceiling this narrow to the released box on its own.
                 ReleaseWidth(textElement);
@@ -227,7 +237,7 @@ namespace Velvet
                 text, float.NaN, VisualElement.MeasureMode.Undefined,
                 float.NaN, VisualElement.MeasureMode.Undefined).y;
             var naturalHeight = textElement.MeasureTextSize(
-                text, available, VisualElement.MeasureMode.Exactly,
+                text, content, VisualElement.MeasureMode.Exactly,
                 float.NaN, VisualElement.MeasureMode.Undefined).y;
 
             if (naturalHeight <= 0f || float.IsNaN(naturalHeight))
@@ -246,9 +256,9 @@ namespace Velvet
                 return;
             }
 
-            var minWidth = Mathf.Max(1f, available * MinWidthFraction);
-            var narrowest = FindNarrowestWidth(textElement, text, minWidth, available, naturalHeight);
-            textElement.style.width = new StyleLength(narrowest);
+            var minWidth = Mathf.Max(1f, content * MinWidthFraction);
+            var narrowest = FindNarrowestWidth(textElement, text, minWidth, content, naturalHeight);
+            textElement.style.width = new StyleLength(narrowest + frame);
 
             _lastSignature = signature;
             _hasSignature = true;
@@ -341,12 +351,15 @@ namespace Velvet
 
         // The available width is already ceiling-clamped, so a ceiling change that can alter the outcome
         // changes the signature. The full text rather than its length, which would miss a same-length swap.
-        private static int ComputeSignature(float available, string text, float fontSize)
+        // The frame is its own term rather than folded into the content width: a padding change that a
+        // container width change cancels out leaves the same content width and a different value to write.
+        private static int ComputeSignature(float content, float frame, string text, float fontSize)
         {
             unchecked
             {
                 var hash = 17;
-                hash = hash * 31 + Mathf.RoundToInt(available);
+                hash = hash * 31 + Mathf.RoundToInt(content);
+                hash = hash * 31 + Mathf.RoundToInt(frame);
                 hash = hash * 31 + text.GetHashCode();
                 hash = hash * 31 + fontSize.GetHashCode();
                 return hash;

--- a/Packages/com.velvet.core/Runtime/Styling/StyleTextBalanceManipulator.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleTextBalanceManipulator.cs
@@ -68,9 +68,9 @@ namespace Velvet
         // mirroring StyleGridManipulator's WrapSafetyPx.
         private const float HeightEpsilonPx = 0.5f;
 
-        // Content room at or below this leaves nothing to redistribute, and keeps the search from being
-        // entered with a floor above its own upper bound. A frame wider than the ceiling reaches it too,
-        // which is why the released box can be far wider than this value.
+        // Content room below this leaves nothing to redistribute, and keeps the search from being entered
+        // with a floor above its own upper bound. A frame wider than the room around it reaches this too,
+        // so the released box can be far wider than the value itself.
         private const float MinBalanceableWidthPx = 1f;
 
         // Answers whether the target's parent is a grid container, whose manipulator writes the same slot.

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/PlayMode/TextBalancePlaybackTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/PlayMode/TextBalancePlaybackTests.cs
@@ -41,6 +41,22 @@ namespace Velvet.Tests
             return null;
         };
 
+        // The same font and wrap as its sibling above plus horizontal padding, which is what separates the
+        // width the search measures text at from the width it writes.
+        private static readonly Func<VisualElement, Action> s_wrapWithFontAndPaddingRef = element =>
+        {
+            element.style.whiteSpace = WhiteSpace.Normal;
+            element.style.paddingLeft = PaddingPx;
+            element.style.paddingRight = PaddingPx;
+            element.style.unityFontDefinition = new StyleFontDefinition(
+                FontDefinition.FromFont(UnityEngine.Resources.GetBuiltinResource<UnityEngine.Font>("LegacyRuntime.ttf")));
+            return null;
+        };
+
+        // Wide enough that the frame it adds moves the wrap point, narrow enough to stay inside the
+        // wrapper widths below.
+        private const float PaddingPx = 3f;
+
         // The wrapper's direction, supplied inline for the same reason the font is: no stylesheet is
         // loaded, so `flex-row` would be an inert class name and the engine's own default is a column.
         private static readonly Func<VisualElement, Action> s_rowRef = element =>
@@ -137,6 +153,47 @@ namespace Velvet.Tests
             });
             _mounted = V.Mount(_host.Root, tree);
             yield return WaitRealtime(0.5);
+        }
+
+        // The same pair as MountPair with horizontal padding on both labels, which is the case where the
+        // width the manipulator writes and the width the text is measured at come apart.
+        private IEnumerator MountPaddedPair(string text, int wrapperWidthPx)
+        {
+            _host = new RenderTexturePanelHost("TextBalancePaddedPanel", 400, 400);
+            var tree = V.Div(children: new VNode[]
+            {
+                V.Div(className: $"w-[{wrapperWidthPx}px]", children: new VNode[]
+                {
+                    V.Label(name: "unbalanced", text: text, refCallback: s_wrapWithFontAndPaddingRef),
+                }),
+                V.Div(className: $"w-[{wrapperWidthPx}px]", children: new VNode[]
+                {
+                    V.Label(name: "balanced", text: text, className: "text-balance",
+                        refCallback: s_wrapWithFontAndPaddingRef),
+                }),
+            });
+            _mounted = V.Mount(_host.Root, tree);
+            yield return WaitRealtime(0.5);
+        }
+
+        [UnityTest]
+        public IEnumerator Given_APaddedWrappedLabel_When_Balanced_Then_ItIsNarrowerThanItsUnbalancedSiblingAtTheSameHeight()
+        {
+            // Arrange / Act — the same claim the unpadded pair makes, on a box whose padding separates the
+            // width the search measures text at from the width it writes into.
+            yield return MountPaddedPair(LongWrapText, 320);
+            var unbalanced = _host.Root.Q<Label>("unbalanced");
+            var balanced = _host.Root.Q<Label>("balanced");
+            Assume.That(unbalanced.resolvedStyle.height, Is.GreaterThan(unbalanced.resolvedStyle.fontSize * 1.5f),
+                "Precondition: the long text actually wrapped onto multiple lines in the unbalanced sibling");
+
+            // Assert — a narrower box at the same line count. A search that measured at the outer width
+            // hands the text less room than it assumed and takes an extra line to fit, so the height half
+            // is what this case is for and the width half is what keeps it honest.
+            Assert.That(
+                (balanced.resolvedStyle.width < unbalanced.resolvedStyle.width,
+                 Mathf.Abs(balanced.resolvedStyle.height - unbalanced.resolvedStyle.height) < 0.5f),
+                Is.EqualTo((true, true)));
         }
 
         [UnityTest]

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/PlayMode/TextBalancePlaybackTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/PlayMode/TextBalancePlaybackTests.cs
@@ -53,8 +53,6 @@ namespace Velvet.Tests
             return null;
         };
 
-        // Wide enough that the frame it adds moves the wrap point, narrow enough to stay inside the
-        // wrapper widths below.
         private const float PaddingPx = 3f;
 
         // The wrapper's direction, supplied inline for the same reason the font is: no stylesheet is
@@ -174,6 +172,41 @@ namespace Velvet.Tests
             });
             _mounted = V.Mount(_host.Root, tree);
             yield return WaitRealtime(0.5);
+        }
+
+        [UnityTest]
+        public IEnumerator Given_APaddedBalancedLabel_When_ItsBoxIsCompared_Then_ItIsNotTheOneAnUnpaddedLabelGets()
+        {
+            // Arrange / Act — two balanced labels, same text, same wrapper width, differing only in
+            // padding. This is the shape of the defect stated without reference to where a wrap threshold
+            // falls: the search answered the same number for both, because it never read the padding.
+            _host = new RenderTexturePanelHost("TextBalancePaddingResponsePanel", 400, 400);
+            var tree = V.Div(children: new VNode[]
+            {
+                V.Div(className: $"w-[{WrapperWidthPx}px]", children: new VNode[]
+                {
+                    V.Label(name: "unpadded", text: LongWrapText, className: "text-balance",
+                        refCallback: s_wrapWithFontRef),
+                }),
+                V.Div(className: $"w-[{WrapperWidthPx}px]", children: new VNode[]
+                {
+                    V.Label(name: "padded", text: LongWrapText, className: "text-balance",
+                        refCallback: s_wrapWithFontAndPaddingRef),
+                }),
+            });
+            _mounted = V.Mount(_host.Root, tree);
+            yield return WaitRealtime(0.5);
+            var unpadded = _host.Root.Q<Label>("unpadded");
+            var padded = _host.Root.Q<Label>("padded");
+            Assume.That(padded.resolvedStyle.height, Is.GreaterThan(padded.resolvedStyle.fontSize * 1.5f),
+                "Precondition: the text wrapped, so balance wrote a real width rather than releasing");
+
+            // Assert — the two boxes differ. Before the fix they were bit-identical whatever the text did,
+            // so the floating-point margin separates the right outcome from the wrong one without a
+            // hand-picked pixel budget.
+            Assert.That(
+                Mathf.Abs(padded.resolvedStyle.width - unpadded.resolvedStyle.width),
+                Is.GreaterThan(0.5f));
         }
 
         [UnityTest]

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/PlayMode/TextBalancePlaybackTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/PlayMode/TextBalancePlaybackTests.cs
@@ -48,6 +48,8 @@ namespace Velvet.Tests
             element.style.whiteSpace = WhiteSpace.Normal;
             element.style.paddingLeft = PaddingPx;
             element.style.paddingRight = PaddingPx;
+            element.style.borderLeftWidth = PaddingPx;
+            element.style.borderRightWidth = PaddingPx;
             element.style.unityFontDefinition = new StyleFontDefinition(
                 FontDefinition.FromFont(UnityEngine.Resources.GetBuiltinResource<UnityEngine.Font>("LegacyRuntime.ttf")));
             return null;
@@ -281,7 +283,7 @@ namespace Velvet.Tests
             Assume.That(probe.resolvedStyle.height, Is.LessThan(probe.resolvedStyle.fontSize * 1.8f),
                 "Precondition: the text fits one line at the wrapper's own width, so only the ceiling makes it wrap");
 
-            // Assert — the single-line gate measures at the ceiling-clamped width, so this text counts as
+            // Assert — the single-line gate measures at the width the text gets, so this text counts as
             // wrapping and gets balanced. Measuring at the parent's width instead would dismiss it as
             // single-line and leave the box sitting at EXACTLY the ceiling, so the bound only has to clear
             // that value: how far under it a balanced width lands is font metrics, which differ per


### PR DESCRIPTION
Closes #302.

`StyleTextBalanceManipulator` binary-searches for the narrowest width whose measured height still matches an unbalanced layout's, then writes that into the element's inline `width`. It measures **text**, which is laid out inside the content box, and writes a **`width`**, which in UI Toolkit covers the padding and the border. Those were the same number, so on a padded element the text got `width - padding` and wrapped one line further than the search had settled on — the balanced label ends up **taller** than an unbalanced one.

## Measured

Two labels with identical text and font in equal wrappers, one carrying `text-balance`, on a panel with no theme. The only variable is inline horizontal padding.

| padding | wrapper | unbalanced h | balanced h | width written |
|---|---|---|---|---|
| 0 | 100 / 140 / 200 / 260 / 320 | 200 / 145 / 97 / 81 / 64 | same | 93.3 / 138.0 / 193.7 / 234.4 / 284.0 |
| 3 (before) | 100 / 140 / 200 / 260 / 320 | 180 / 161 / 97 / 81 / 64 | 220 / 161 / 113 / 97 / 81 | 93.3 / 138.0 / 193.7 / 234.4 / 284.0 |

The written width is identical across both rows at every wrapper width — the search's answer did not depend on the padding it had to live inside. After the fix, heights match at every width for padding 0, 3 and 8, and the balanced box is still narrower than its sibling in all fifteen combinations.

## What changed

The search runs over content widths — the available width less the element's own horizontal padding and border — and the frame is added back to the value written. The re-derive signature carries the frame as a separate term, so a padding change that a container-width change cancels out still re-derives: the content width is unchanged and the value to write is not.

## Verification

- New case `Given_APaddedWrappedLabel_When_Balanced_Then_ItIsNarrowerThanItsUnbalancedSiblingAtTheSameHeight`, verified red against the unfixed manipulator and green with it.
- EditMode 3565 total, 0 failed; PlayMode 160 total, 0 failed.

## Documentation

[fonts.md](Packages/com.velvet.core/Documentation~/fonts.md) described the search as finding a `width`; it now says the search runs over the width the text gets and that the frame is added back, since that is the distinction the defect turned on. CHANGELOG entry added under Fixed.