### PR TITLE
test(velvet): hold the analyzer solution to the rules it implements

### DIFF
--- a/Packages/com.velvet.core/Generators~/src/Velvet.SourceGenerators.CodeFixes/CodeShapeOptIn.cs
+++ b/Packages/com.velvet.core/Generators~/src/Velvet.SourceGenerators.CodeFixes/CodeShapeOptIn.cs
@@ -1,0 +1,5 @@
+// The rules this solution implements apply to it too. The wiring that makes that possible is
+// Velvet.SourceGenerators.Bootstrap, which every project here already references as an analyzer;
+// this marker is what turns the rules on, and it goes in last because they are error severity — an
+// assembly that opts in with a backlog cannot build.
+[assembly: System.Reflection.AssemblyMetadata("Velvet.CodeShape", "enforce")]

--- a/Packages/com.velvet.core/Generators~/src/Velvet.SourceGenerators/CodeShapeOptIn.cs
+++ b/Packages/com.velvet.core/Generators~/src/Velvet.SourceGenerators/CodeShapeOptIn.cs
@@ -1,0 +1,5 @@
+// The rules this solution implements apply to it too. The wiring that makes that possible is
+// Velvet.SourceGenerators.Bootstrap, which every project here already references as an analyzer;
+// this marker is what turns the rules on, and it goes in last because they are error severity — an
+// assembly that opts in with a backlog cannot build.
+[assembly: System.Reflection.AssemblyMetadata("Velvet.CodeShape", "enforce")]

--- a/Packages/com.velvet.core/Generators~/src/Velvet.StyleTable/CodeShapeOptIn.cs
+++ b/Packages/com.velvet.core/Generators~/src/Velvet.StyleTable/CodeShapeOptIn.cs
@@ -1,0 +1,5 @@
+// The rules this solution implements apply to it too. The wiring that makes that possible is
+// Velvet.SourceGenerators.Bootstrap, which every project here already references as an analyzer;
+// this marker is what turns the rules on, and it goes in last because they are error severity — an
+// assembly that opts in with a backlog cannot build.
+[assembly: System.Reflection.AssemblyMetadata("Velvet.CodeShape", "enforce")]


### PR DESCRIPTION
Closes #313.

VEL500 (nesting deeper than four), VEL501 (more than twenty branching decisions) and VEL502 (more than six parameters) are opt-in per assembly. The package's runtime and every one of its test assemblies opt in. The projects that *implement* those rules did not — the one place the argument for them is weakest.

## Why this is a marker and not a restructure

The self-application wiring already exists and is documented in its own project file. `Velvet.SourceGenerators.Bootstrap` recompiles the analyzer sources under a second assembly name precisely so the declaring project can load them, because a project referencing itself as an analyzer is rejected by MSBuild with MSB4006 before any compile starts. All three projects — `Velvet.SourceGenerators`, `Velvet.SourceGenerators.CodeFixes`, `Velvet.StyleTable` — already reference it as `OutputItemType="Analyzer"`.

Only the opt-in marker was missing.

## The backlog is empty

The rule for introducing these limits is that an assembly opts in at error severity, so the backlog reaches zero before the marker goes in. Two members were on record as over the branch limit; both have since been brought under it. With the marker in place the whole solution builds clean.

## That the analyzers run is measured, not inferred

A clean build proves nothing on its own — an incremental build skips the compile and the analyzers with it. A member making twenty-five branching decisions was added and reported:

```
error VEL501: Member 'Probe' makes 25 branching decisions; the limit is 20
```

then removed. The generator suite passes with the marker committed.