### PR TITLE
Refuse a stop that leaves assigned work with nothing carrying it, and pin the wiring that runs the guards

### DIFF
--- a/.claude/hooks/block-stop-on-open-backlog.sh
+++ b/.claude/hooks/block-stop-on-open-backlog.sh
@@ -2,17 +2,16 @@
 # Blocks Stop while assigned work is open and nothing is in flight to carry it.
 #
 # block-stop-on-unsettled-pr.sh returns 0 before looking at anything when the open-pull-request
-# list is empty. That is the state this fires in, and it is the state the failure happened in:
-# six issues open, a next action named in the closing paragraph, and the turn ended without it.
-# Naming the next action is what the stall looks like from inside — it reads as a plan rather
-# than as stopping — so the guard cannot key on intent. It keys on the backlog being non-empty
-# with nothing carrying it.
+# list is empty. That is the state this fires in, and it is the state the failure happened in: a
+# backlog of assigned issues, the next action named in a closing paragraph, and the turn ending
+# without it. Naming the next action is what the stall looks like from inside — it reads as a plan
+# rather than as stopping — so the guard cannot key on intent. It keys on the backlog being
+# non-empty with nothing carrying it.
 #
-# An open pull request means the other guard owns the decision; reporting the same stall from two
-# hooks would double every message and let a fix in one be undone by silence in the other.
+# An open pull request hands the decision to the other guard, so one stall is never reported twice.
 #
-# Only issues assigned to the authenticated user count. A contributor with nothing assigned is
-# not held by this repository's backlog.
+# Only issues assigned to the authenticated user count, so a contributor is not held by somebody
+# else's backlog.
 #
 # `blocked` is the exclusion, and it is a label rather than a deferral because the two say
 # different things: a deferral is a claim that work will resume, and it expires so the claim gets
@@ -27,26 +26,8 @@ set -uo pipefail
 command -v gh >/dev/null 2>&1 || exit 0
 command -v jq >/dev/null 2>&1 || exit 0
 
-# Shared with the pull-request guard so a held item is re-read in one place, under the same
-# expiry. `backlog` holds every issue at once, for a pause that is not about any one of them.
-DEFERRALS="$HOME/.velvet-pr-deferrals"
-DEFER_TTL=2700
-
-deferred() {
-  DEFER_REASON=""
-  DEFER_AGE=""
-  [ -f "$DEFERRALS" ] || return 1
-  local line stamp
-  line=$(grep "^$1 " "$DEFERRALS" 2>/dev/null | tail -1) || return 1
-  [ -n "$line" ] || return 1
-  stamp=${line##* }
-  case "$stamp" in ''|*[!0-9]*) return 1 ;; esac
-  [ $(( $(date +%s) - stamp )) -lt "$DEFER_TTL" ] || return 1
-  DEFER_REASON=${line#"$1 "}
-  DEFER_REASON=${DEFER_REASON% *}
-  DEFER_AGE=$(( ($(date +%s) - stamp) / 60 ))
-  return 0
-}
+# shellcheck source=lib/deferrals.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib/deferrals.sh"
 
 deferred backlog && exit 0
 

--- a/.claude/hooks/block-stop-on-open-backlog.sh
+++ b/.claude/hooks/block-stop-on-open-backlog.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Blocks Stop while assigned work is open and nothing is in flight to carry it.
+#
+# block-stop-on-unsettled-pr.sh returns 0 before looking at anything when the open-pull-request
+# list is empty. That is the state this fires in, and it is the state the failure happened in:
+# six issues open, a next action named in the closing paragraph, and the turn ended without it.
+# Naming the next action is what the stall looks like from inside — it reads as a plan rather
+# than as stopping — so the guard cannot key on intent. It keys on the backlog being non-empty
+# with nothing carrying it.
+#
+# An open pull request means the other guard owns the decision; reporting the same stall from two
+# hooks would double every message and let a fix in one be undone by silence in the other.
+#
+# Only issues assigned to the authenticated user count. A contributor with nothing assigned is
+# not held by this repository's backlog.
+#
+# `blocked` is the exclusion, and it is a label rather than a deferral because the two say
+# different things: a deferral is a claim that work will resume, and it expires so the claim gets
+# re-read; a `blocked` label says the work cannot proceed for a reason outside this repository,
+# which no amount of re-reading changes. Labelling it also puts that state in the issue list,
+# where the next reader sees it without running anything.
+#
+# Exit 2 with output on stderr is what Stop reads as "do not stop, here is why".
+
+set -uo pipefail
+
+command -v gh >/dev/null 2>&1 || exit 0
+command -v jq >/dev/null 2>&1 || exit 0
+
+# Shared with the pull-request guard so a held item is re-read in one place, under the same
+# expiry. `backlog` holds every issue at once, for a pause that is not about any one of them.
+DEFERRALS="$HOME/.velvet-pr-deferrals"
+DEFER_TTL=2700
+
+deferred() {
+  DEFER_REASON=""
+  DEFER_AGE=""
+  [ -f "$DEFERRALS" ] || return 1
+  local line stamp
+  line=$(grep "^$1 " "$DEFERRALS" 2>/dev/null | tail -1) || return 1
+  [ -n "$line" ] || return 1
+  stamp=${line##* }
+  case "$stamp" in ''|*[!0-9]*) return 1 ;; esac
+  [ $(( $(date +%s) - stamp )) -lt "$DEFER_TTL" ] || return 1
+  DEFER_REASON=${line#"$1 "}
+  DEFER_REASON=${DEFER_REASON% *}
+  DEFER_AGE=$(( ($(date +%s) - stamp) / 60 ))
+  return 0
+}
+
+deferred backlog && exit 0
+
+prs=$(gh pr list --state open --json number --jq '.[].number' 2>/dev/null) || exit 0
+[ -n "$prs" ] && exit 0
+
+me=$(gh api user --jq .login 2>/dev/null) || exit 0
+[ -n "$me" ] || exit 0
+
+issues=$(gh issue list --state open --assignee "$me" --json number,title,labels 2>/dev/null) || exit 0
+
+open_work=""
+held=""
+while IFS=$'\t' read -r number title; do
+  [ -n "$number" ] || continue
+  if deferred "$number"; then
+    held="$held
+  #$number — held ${DEFER_AGE}m ago because: $DEFER_REASON"
+    continue
+  fi
+  open_work="$open_work
+  #$number $title"
+done < <(echo "$issues" | jq -r '.[] | select([.labels[].name] | index("blocked") | not)
+  | [.number, .title] | @tsv' 2>/dev/null)
+
+if [ -z "$open_work" ]; then
+  if [ -n "$held" ]; then
+    cat >&2 <<EOF
+Held, not settled — check each reason is still true:
+$held
+EOF
+  fi
+  exit 0
+fi
+
+cat >&2 <<EOF
+Do not stop: assigned work is open and no pull request is carrying any of it.
+$open_work
+${held:+
+Held on purpose, and worth re-reading:}$held
+
+Pick one and start it. If the next action is already named above this message, that naming is
+what the stall looks like from inside — do the thing instead of announcing it again.
+
+If the user asked something and is waiting on the answer, or the pause is deliberate, say so and
+arm the deferral. It expires after 45 minutes so the reason gets re-examined rather than forgotten:
+
+  echo "backlog <what clears it> \$(date +%s)" >> $HOME/.velvet-pr-deferrals
+
+A single issue is deferred the same way, by its number in place of \`backlog\`.
+
+Work that cannot proceed for a reason outside this repository is labelled \`blocked\` instead, which
+stops it counting here and says so in the issue list:
+
+  gh issue edit <n> --add-label blocked
+EOF
+exit 2

--- a/.claude/hooks/block-stop-on-unsettled-pr.sh
+++ b/.claude/hooks/block-stop-on-unsettled-pr.sh
@@ -36,37 +36,8 @@ HEARTBEAT="$HOME/.velvet-pr-watch.heartbeat"
 # Three polls of the 60s cycle, so one slow `gh` call does not read as a dead watcher.
 STALE_AFTER=180
 
-# A merge held on purpose — a review in flight, a dependency on another PR — is not the failure this
-# guards, but "I am waiting" is exactly what the nine-hour stall said too. So a deferral is accepted
-# and EXPIRES: it names the PR, states what clears it, and stops counting after DEFER_TTL. That cannot
-# decay into permanent silence the way an unqualified exemption did, and re-stating it is the moment
-# the reason gets re-examined, which is the only part that ever mattered.
-#
-#   echo "236 waiting on round-4 review $(date +%s)" >> ~/.velvet-pr-deferrals
-DEFERRALS="$HOME/.velvet-pr-deferrals"
-DEFER_TTL=2700
-
-# Sets DEFER_REASON and DEFER_AGE when a live deferral covers this PR. The reason is free text
-# nothing can check, so a stale one silences the guard exactly as well as a true one — which is what
-# happened: a PR was held as "fix agent working" after the agent had finished and its work sat
-# unpushed in a worktree. Suppression is therefore never silent; the PR is still printed, with what
-# was claimed and how long ago, so a reason that has stopped being true is in front of the reader
-# instead of behind them.
-deferred() {
-  DEFER_REASON=""
-  DEFER_AGE=""
-  [ -f "$DEFERRALS" ] || return 1
-  local line stamp
-  line=$(grep "^$1 " "$DEFERRALS" 2>/dev/null | tail -1) || return 1
-  [ -n "$line" ] || return 1
-  stamp=${line##* }
-  case "$stamp" in ''|*[!0-9]*) return 1 ;; esac
-  [ $(( $(date +%s) - stamp )) -lt "$DEFER_TTL" ] || return 1
-  DEFER_REASON=${line#"$1 "}
-  DEFER_REASON=${DEFER_REASON% *}
-  DEFER_AGE=$(( ($(date +%s) - stamp) / 60 ))
-  return 0
-}
+# shellcheck source=lib/deferrals.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib/deferrals.sh"
 
 watcher_is_alive() {
   [ -f "$HEARTBEAT" ] || return 1

--- a/.claude/hooks/lib/deferrals.sh
+++ b/.claude/hooks/lib/deferrals.sh
@@ -1,0 +1,36 @@
+# A merge or a pause held on purpose — a review in flight, a dependency on another change, a user
+# waiting on an answer — is not the failure the Stop guards exist for, but "I am waiting" is exactly
+# what a nine-hour stall said too. So a deferral is accepted and EXPIRES: it names what is held,
+# states what clears it, and stops counting after DEFER_TTL. That cannot decay into permanent silence
+# the way an unqualified exemption did, and re-stating it is the moment the reason gets re-examined,
+# which is the only part that ever mattered.
+#
+#   echo "236 waiting on round-4 review $(date +%s)" >> ~/.velvet-pr-deferrals
+#
+# Both Stop guards read this one file under one expiry, so a held item is re-read in one place and a
+# change to the format cannot land in one guard and not the other.
+
+DEFERRALS="$HOME/.velvet-pr-deferrals"
+DEFER_TTL=2700
+
+# Sets DEFER_REASON and DEFER_AGE when a live deferral covers the given key. The reason is free text
+# nothing can check, so a stale one silences a guard exactly as well as a true one — which is what
+# happened: a pull request was held as "fix agent working" after the agent had finished and its work
+# sat unpushed in a worktree. Suppression is therefore never silent; a caller still prints what was
+# claimed and how long ago, so a reason that has stopped being true is in front of the reader instead
+# of behind them.
+deferred() {
+  DEFER_REASON=""
+  DEFER_AGE=""
+  [ -f "$DEFERRALS" ] || return 1
+  local line stamp
+  line=$(grep "^$1 " "$DEFERRALS" 2>/dev/null | tail -1) || return 1
+  [ -n "$line" ] || return 1
+  stamp=${line##* }
+  case "$stamp" in ''|*[!0-9]*) return 1 ;; esac
+  [ $(( $(date +%s) - stamp )) -lt "$DEFER_TTL" ] || return 1
+  DEFER_REASON=${line#"$1 "}
+  DEFER_REASON=${DEFER_REASON% *}
+  DEFER_AGE=$(( ($(date +%s) - stamp) / 60 ))
+  return 0
+}

--- a/.claude/hooks/lib/deferrals.sh
+++ b/.claude/hooks/lib/deferrals.sh
@@ -1,3 +1,6 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034  # DEFER_REASON and DEFER_AGE are read by the guard that calls this.
+#
 # A merge or a pause held on purpose — a review in flight, a dependency on another change, a user
 # waiting on an answer — is not the failure the Stop guards exist for, but "I am waiting" is exactly
 # what a nine-hour stall said too. So a deferral is accepted and EXPIRES: it names what is held,

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -30,6 +30,11 @@
             "type": "command",
             "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/block-stop-on-unsettled-pr.sh",
             "timeout": 20000
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/block-stop-on-open-backlog.sh",
+            "timeout": 20000
           }
         ]
       }

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/HookWiringCoverageTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/HookWiringCoverageTests.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using NUnit.Framework;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pairs the hook scripts in <c>.claude/hooks</c> with the two files that run them — the project
+    /// settings and the agent definitions — in both directions. A hook is wired by path, so a rename
+    /// leaves the wiring naming nothing and a hook leaves the tree referenced by nothing, and neither
+    /// shows up as a failure: a guard that stops being invoked reports exactly what a guard that passes
+    /// reports.
+    /// </summary>
+    [TestFixture]
+    internal sealed class HookWiringCoverageTests
+    {
+        private const string HookDirectory = ".claude/hooks";
+
+        // Settings and agent frontmatter are where a hook is given an event to fire on. A skill or a guide
+        // may name one in prose, and naming it there does not run it, so those are not read here — counting
+        // a prose mention as wiring is how an unwired hook would pass.
+        private static IEnumerable<string> WiringFiles()
+        {
+            yield return ".claude/settings.json";
+            var agents = Path.GetFullPath(".claude/agents");
+            if (Directory.Exists(agents))
+            {
+                foreach (var file in Directory.GetFiles(agents, "*.md"))
+                {
+                    yield return file;
+                }
+            }
+        }
+
+        private static readonly Regex HookReferencePattern =
+            new(@"\.claude/hooks/([A-Za-z0-9_./-]+)", RegexOptions.Compiled);
+
+        [Test]
+        public void Given_TheHookWiring_When_EachReferencedPathIsResolved_Then_EveryOneNamesAFileThatExists()
+        {
+            // Arrange
+            var wiring = ReadWiring();
+            Assume.That(wiring, Is.Not.Empty, "no hook reference was found to check");
+
+            // Act
+            var missing = wiring
+                .Where(reference => !File.Exists(Path.GetFullPath(HookDirectory + "/" + reference.Name)))
+                .Select(reference => $"{reference.Source} names {HookDirectory}/{reference.Name}")
+                .Distinct()
+                .ToList();
+
+            // Assert
+            Assert.That(missing, Is.Empty,
+                "a hook is wired by path, so one that names nothing never fires:\n" + string.Join("\n", missing));
+        }
+
+        [Test]
+        public void Given_TheHookDirectory_When_EachScriptIsTracedBack_Then_EveryOneIsWiredOrSourced()
+        {
+            // Arrange
+            var wired = new HashSet<string>(ReadWiring().Select(reference => reference.Name), StringComparer.Ordinal);
+            var scripts = Directory
+                .GetFiles(Path.GetFullPath(HookDirectory), "*", SearchOption.AllDirectories)
+                .Select(RelativeToHookDirectory)
+                .ToList();
+            Assume.That(scripts, Is.Not.Empty, "the hook directory is empty");
+
+            // A file a wired hook sources is reached the same way a wired one is, so it is not an orphan.
+            // Read out of the hooks rather than exempted by directory: a shared file that stops being
+            // sourced is the same dead script as one that stops being wired.
+            var sourced = string.Concat(scripts
+                .Where(script => wired.Contains(script))
+                .Select(script => File.ReadAllText(Path.GetFullPath(HookDirectory + "/" + script))));
+
+            // Act
+            var orphans = scripts
+                .Where(script => !wired.Contains(script))
+                .Where(script => !sourced.Contains(Path.GetFileName(script), StringComparison.Ordinal))
+                .ToList();
+
+            // Assert
+            Assert.That(orphans, Is.Empty,
+                $"nothing runs these, so whatever they guard is unguarded:\n{string.Join("\n", orphans)}");
+        }
+
+        private static List<(string Name, string Source)> ReadWiring() =>
+            (from file in WiringFiles()
+             let path = Path.GetFullPath(file)
+             where File.Exists(path)
+             from Match match in HookReferencePattern.Matches(File.ReadAllText(path))
+             select (match.Groups[1].Value, RepoRelative(path))).ToList();
+
+        private static string RelativeToHookDirectory(string path) =>
+            Path.GetRelativePath(Path.GetFullPath(HookDirectory), path).Replace('\\', '/');
+
+        private static string RepoRelative(string path) =>
+            Path.GetRelativePath(Path.GetFullPath("."), path).Replace('\\', '/');
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/HookWiringCoverageTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/HookWiringCoverageTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 708b2f199d61d4b8593ab073487da515


### PR DESCRIPTION
The `Stop` guard on this repository blocks while an open pull request has an unsettled check. It returns before looking at anything when no pull request is open — `[ -z "$prs" ] && exit 0` — and that is the state the stall actually happens in: the backlog is non-empty, nothing is in flight, the next action gets named in a closing paragraph, and the turn ends without it. Naming the next action is what the stall looks like from inside, so a guard cannot key on intent.

Three changes.

## `block-stop-on-open-backlog.sh`

Keys on the backlog instead. Blocks `Stop` when issues assigned to the authenticated user are open and no pull request is carrying any of them. Four exits, each exercised against the live repository:

- backlog non-empty and no open pull request — blocks, listing each issue;
- an issue labelled `blocked` — excluded from the count;
- a per-issue deferral — moves that issue to a held list that is printed rather than silently skipped;
- a `backlog` deferral — returns 0.

The fifth is this pull request: while it is open the hook stands down and the pull-request guard owns the decision, so one stall is never reported by both.

`blocked` is a label rather than a deferral because the two say different things. A deferral claims work will resume and expires so the claim gets re-read; `blocked` says the work cannot proceed for a reason outside this repository, which re-reading does not change. It also puts that state in the issue list, where the next reader sees it without running anything. #298 carries it — GitHub does not offer the merge-queue rule for this ruleset.

## `lib/deferrals.sh`

The new guard arrived carrying a byte-identical copy of the older one`s `deferred`, its file path and its 45-minute expiry. Two copies of an expiry is the drift this repository has been bitten by elsewhere — a change to one guard`s window would leave the other silently holding the old one. Both now source one file that owns the format, the path and the window.

## `HookWiringCoverageTests`

Nothing paired the hook scripts with the files that run them. A hook is wired by path, from `.claude/settings.json` or from an agent definition`s frontmatter, so a rename on either side leaves a guard that never fires — and a guard that never fires reports exactly what a guard that passes reports.

Both directions are read out of the repository: every wired path names a file that exists, and every file under the hook directory is either wired or sourced by one that is. The sourced half is read out of the wired scripts rather than exempted by directory, so a shared file that stops being sourced fails the same way a script that stops being wired does. Verified red on both — a script nothing wires, and wiring that names a script that is not there — and green with neither break present.

The direction that pairs a script back to its wiring found `block-shared-git-state.sh` reachable only from the two agent definitions, which is why frontmatter is read alongside the settings.

No `Documentation~` impact: the hooks are loop machinery rather than package behaviour, and none of them is described in a guide.