### PR TITLE
Register the build and balance mechanisms as neuter cuts, and close what the sweep found

### DIFF
--- a/.claude/hooks/block-stop-on-open-backlog.sh
+++ b/.claude/hooks/block-stop-on-open-backlog.sh
@@ -2,17 +2,16 @@
 # Blocks Stop while assigned work is open and nothing is in flight to carry it.
 #
 # block-stop-on-unsettled-pr.sh returns 0 before looking at anything when the open-pull-request
-# list is empty. That is the state this fires in, and it is the state the failure happened in:
-# six issues open, a next action named in the closing paragraph, and the turn ended without it.
-# Naming the next action is what the stall looks like from inside — it reads as a plan rather
-# than as stopping — so the guard cannot key on intent. It keys on the backlog being non-empty
-# with nothing carrying it.
+# list is empty. That is the state this fires in, and it is the state the failure happened in: a
+# backlog of assigned issues, the next action named in a closing paragraph, and the turn ending
+# without it. Naming the next action is what the stall looks like from inside — it reads as a plan
+# rather than as stopping — so the guard cannot key on intent. It keys on the backlog being
+# non-empty with nothing carrying it.
 #
-# An open pull request means the other guard owns the decision; reporting the same stall from two
-# hooks would double every message and let a fix in one be undone by silence in the other.
+# An open pull request hands the decision to the other guard, so one stall is never reported twice.
 #
-# Only issues assigned to the authenticated user count. A contributor with nothing assigned is
-# not held by this repository's backlog.
+# Only issues assigned to the authenticated user count, so a contributor is not held by somebody
+# else's backlog.
 #
 # `blocked` is the exclusion, and it is a label rather than a deferral because the two say
 # different things: a deferral is a claim that work will resume, and it expires so the claim gets
@@ -27,26 +26,8 @@ set -uo pipefail
 command -v gh >/dev/null 2>&1 || exit 0
 command -v jq >/dev/null 2>&1 || exit 0
 
-# Shared with the pull-request guard so a held item is re-read in one place, under the same
-# expiry. `backlog` holds every issue at once, for a pause that is not about any one of them.
-DEFERRALS="$HOME/.velvet-pr-deferrals"
-DEFER_TTL=2700
-
-deferred() {
-  DEFER_REASON=""
-  DEFER_AGE=""
-  [ -f "$DEFERRALS" ] || return 1
-  local line stamp
-  line=$(grep "^$1 " "$DEFERRALS" 2>/dev/null | tail -1) || return 1
-  [ -n "$line" ] || return 1
-  stamp=${line##* }
-  case "$stamp" in ''|*[!0-9]*) return 1 ;; esac
-  [ $(( $(date +%s) - stamp )) -lt "$DEFER_TTL" ] || return 1
-  DEFER_REASON=${line#"$1 "}
-  DEFER_REASON=${DEFER_REASON% *}
-  DEFER_AGE=$(( ($(date +%s) - stamp) / 60 ))
-  return 0
-}
+# shellcheck source=lib/deferrals.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib/deferrals.sh"
 
 deferred backlog && exit 0
 

--- a/.claude/hooks/block-stop-on-open-backlog.sh
+++ b/.claude/hooks/block-stop-on-open-backlog.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Blocks Stop while assigned work is open and nothing is in flight to carry it.
+#
+# block-stop-on-unsettled-pr.sh returns 0 before looking at anything when the open-pull-request
+# list is empty. That is the state this fires in, and it is the state the failure happened in:
+# six issues open, a next action named in the closing paragraph, and the turn ended without it.
+# Naming the next action is what the stall looks like from inside — it reads as a plan rather
+# than as stopping — so the guard cannot key on intent. It keys on the backlog being non-empty
+# with nothing carrying it.
+#
+# An open pull request means the other guard owns the decision; reporting the same stall from two
+# hooks would double every message and let a fix in one be undone by silence in the other.
+#
+# Only issues assigned to the authenticated user count. A contributor with nothing assigned is
+# not held by this repository's backlog.
+#
+# `blocked` is the exclusion, and it is a label rather than a deferral because the two say
+# different things: a deferral is a claim that work will resume, and it expires so the claim gets
+# re-read; a `blocked` label says the work cannot proceed for a reason outside this repository,
+# which no amount of re-reading changes. Labelling it also puts that state in the issue list,
+# where the next reader sees it without running anything.
+#
+# Exit 2 with output on stderr is what Stop reads as "do not stop, here is why".
+
+set -uo pipefail
+
+command -v gh >/dev/null 2>&1 || exit 0
+command -v jq >/dev/null 2>&1 || exit 0
+
+# Shared with the pull-request guard so a held item is re-read in one place, under the same
+# expiry. `backlog` holds every issue at once, for a pause that is not about any one of them.
+DEFERRALS="$HOME/.velvet-pr-deferrals"
+DEFER_TTL=2700
+
+deferred() {
+  DEFER_REASON=""
+  DEFER_AGE=""
+  [ -f "$DEFERRALS" ] || return 1
+  local line stamp
+  line=$(grep "^$1 " "$DEFERRALS" 2>/dev/null | tail -1) || return 1
+  [ -n "$line" ] || return 1
+  stamp=${line##* }
+  case "$stamp" in ''|*[!0-9]*) return 1 ;; esac
+  [ $(( $(date +%s) - stamp )) -lt "$DEFER_TTL" ] || return 1
+  DEFER_REASON=${line#"$1 "}
+  DEFER_REASON=${DEFER_REASON% *}
+  DEFER_AGE=$(( ($(date +%s) - stamp) / 60 ))
+  return 0
+}
+
+deferred backlog && exit 0
+
+prs=$(gh pr list --state open --json number --jq '.[].number' 2>/dev/null) || exit 0
+[ -n "$prs" ] && exit 0
+
+me=$(gh api user --jq .login 2>/dev/null) || exit 0
+[ -n "$me" ] || exit 0
+
+issues=$(gh issue list --state open --assignee "$me" --json number,title,labels 2>/dev/null) || exit 0
+
+open_work=""
+held=""
+while IFS=$'\t' read -r number title; do
+  [ -n "$number" ] || continue
+  if deferred "$number"; then
+    held="$held
+  #$number — held ${DEFER_AGE}m ago because: $DEFER_REASON"
+    continue
+  fi
+  open_work="$open_work
+  #$number $title"
+done < <(echo "$issues" | jq -r '.[] | select([.labels[].name] | index("blocked") | not)
+  | [.number, .title] | @tsv' 2>/dev/null)
+
+if [ -z "$open_work" ]; then
+  if [ -n "$held" ]; then
+    cat >&2 <<EOF
+Held, not settled — check each reason is still true:
+$held
+EOF
+  fi
+  exit 0
+fi
+
+cat >&2 <<EOF
+Do not stop: assigned work is open and no pull request is carrying any of it.
+$open_work
+${held:+
+Held on purpose, and worth re-reading:}$held
+
+Pick one and start it. If the next action is already named above this message, that naming is
+what the stall looks like from inside — do the thing instead of announcing it again.
+
+If the user asked something and is waiting on the answer, or the pause is deliberate, say so and
+arm the deferral. It expires after 45 minutes so the reason gets re-examined rather than forgotten:
+
+  echo "backlog <what clears it> \$(date +%s)" >> $HOME/.velvet-pr-deferrals
+
+A single issue is deferred the same way, by its number in place of \`backlog\`.
+
+Work that cannot proceed for a reason outside this repository is labelled \`blocked\` instead, which
+stops it counting here and says so in the issue list:
+
+  gh issue edit <n> --add-label blocked
+EOF
+exit 2

--- a/.claude/hooks/block-stop-on-unsettled-pr.sh
+++ b/.claude/hooks/block-stop-on-unsettled-pr.sh
@@ -36,37 +36,8 @@ HEARTBEAT="$HOME/.velvet-pr-watch.heartbeat"
 # Three polls of the 60s cycle, so one slow `gh` call does not read as a dead watcher.
 STALE_AFTER=180
 
-# A merge held on purpose — a review in flight, a dependency on another PR — is not the failure this
-# guards, but "I am waiting" is exactly what the nine-hour stall said too. So a deferral is accepted
-# and EXPIRES: it names the PR, states what clears it, and stops counting after DEFER_TTL. That cannot
-# decay into permanent silence the way an unqualified exemption did, and re-stating it is the moment
-# the reason gets re-examined, which is the only part that ever mattered.
-#
-#   echo "236 waiting on round-4 review $(date +%s)" >> ~/.velvet-pr-deferrals
-DEFERRALS="$HOME/.velvet-pr-deferrals"
-DEFER_TTL=2700
-
-# Sets DEFER_REASON and DEFER_AGE when a live deferral covers this PR. The reason is free text
-# nothing can check, so a stale one silences the guard exactly as well as a true one — which is what
-# happened: a PR was held as "fix agent working" after the agent had finished and its work sat
-# unpushed in a worktree. Suppression is therefore never silent; the PR is still printed, with what
-# was claimed and how long ago, so a reason that has stopped being true is in front of the reader
-# instead of behind them.
-deferred() {
-  DEFER_REASON=""
-  DEFER_AGE=""
-  [ -f "$DEFERRALS" ] || return 1
-  local line stamp
-  line=$(grep "^$1 " "$DEFERRALS" 2>/dev/null | tail -1) || return 1
-  [ -n "$line" ] || return 1
-  stamp=${line##* }
-  case "$stamp" in ''|*[!0-9]*) return 1 ;; esac
-  [ $(( $(date +%s) - stamp )) -lt "$DEFER_TTL" ] || return 1
-  DEFER_REASON=${line#"$1 "}
-  DEFER_REASON=${DEFER_REASON% *}
-  DEFER_AGE=$(( ($(date +%s) - stamp) / 60 ))
-  return 0
-}
+# shellcheck source=lib/deferrals.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib/deferrals.sh"
 
 watcher_is_alive() {
   [ -f "$HEARTBEAT" ] || return 1

--- a/.claude/hooks/lib/deferrals.sh
+++ b/.claude/hooks/lib/deferrals.sh
@@ -1,0 +1,36 @@
+# A merge or a pause held on purpose — a review in flight, a dependency on another change, a user
+# waiting on an answer — is not the failure the Stop guards exist for, but "I am waiting" is exactly
+# what a nine-hour stall said too. So a deferral is accepted and EXPIRES: it names what is held,
+# states what clears it, and stops counting after DEFER_TTL. That cannot decay into permanent silence
+# the way an unqualified exemption did, and re-stating it is the moment the reason gets re-examined,
+# which is the only part that ever mattered.
+#
+#   echo "236 waiting on round-4 review $(date +%s)" >> ~/.velvet-pr-deferrals
+#
+# Both Stop guards read this one file under one expiry, so a held item is re-read in one place and a
+# change to the format cannot land in one guard and not the other.
+
+DEFERRALS="$HOME/.velvet-pr-deferrals"
+DEFER_TTL=2700
+
+# Sets DEFER_REASON and DEFER_AGE when a live deferral covers the given key. The reason is free text
+# nothing can check, so a stale one silences a guard exactly as well as a true one — which is what
+# happened: a pull request was held as "fix agent working" after the agent had finished and its work
+# sat unpushed in a worktree. Suppression is therefore never silent; a caller still prints what was
+# claimed and how long ago, so a reason that has stopped being true is in front of the reader instead
+# of behind them.
+deferred() {
+  DEFER_REASON=""
+  DEFER_AGE=""
+  [ -f "$DEFERRALS" ] || return 1
+  local line stamp
+  line=$(grep "^$1 " "$DEFERRALS" 2>/dev/null | tail -1) || return 1
+  [ -n "$line" ] || return 1
+  stamp=${line##* }
+  case "$stamp" in ''|*[!0-9]*) return 1 ;; esac
+  [ $(( $(date +%s) - stamp )) -lt "$DEFER_TTL" ] || return 1
+  DEFER_REASON=${line#"$1 "}
+  DEFER_REASON=${DEFER_REASON% *}
+  DEFER_AGE=$(( ($(date +%s) - stamp) / 60 ))
+  return 0
+}

--- a/.claude/hooks/lib/deferrals.sh
+++ b/.claude/hooks/lib/deferrals.sh
@@ -1,3 +1,6 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2034  # DEFER_REASON and DEFER_AGE are read by the guard that calls this.
+#
 # A merge or a pause held on purpose — a review in flight, a dependency on another change, a user
 # waiting on an answer — is not the failure the Stop guards exist for, but "I am waiting" is exactly
 # what a nine-hour stall said too. So a deferral is accepted and EXPIRES: it names what is held,

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -30,6 +30,11 @@
             "type": "command",
             "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/block-stop-on-unsettled-pr.sh",
             "timeout": 20000
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/block-stop-on-open-backlog.sh",
+            "timeout": 20000
           }
         ]
       }

--- a/Packages/com.velvet.core/Editor/PlayerBuild/Tests/Editor/BundledShaderInclusionTests.cs
+++ b/Packages/com.velvet.core/Editor/PlayerBuild/Tests/Editor/BundledShaderInclusionTests.cs
@@ -269,11 +269,14 @@ namespace Velvet.Tests
 
             // Assert — the record survives carrying exactly what could not be removed, so a later pass can
             // finish. Both terms in one comparison: a revert that deleted the file and one that left it
-            // holding the whole original list are different failures.
+            // holding the whole original list are different failures. The count of shaders no longer in the
+            // list rides along because a surviving record is also what a revert that never ran at all
+            // leaves, and the first two terms alone cannot tell those apart.
             var kept = File.Exists(RecordFilePath()) ? File.ReadAllLines(RecordFilePath()) : null;
             Assert.That(
-                (kept != null, string.Join(", ", kept ?? System.Array.Empty<string>())),
-                Is.EqualTo((true, "Velvet/NoSuchShader")));
+                (kept != null, string.Join(", ", kept ?? System.Array.Empty<string>()),
+                    BundledShaderBuildInclusion.Unreached().Length),
+                Is.EqualTo((true, "Velvet/NoSuchShader", VelvetShaders.Names.Length)));
         }
 
         private static string RecordFilePath()

--- a/Packages/com.velvet.core/Editor/PlayerBuild/Tests/Editor/BundledStyleSheetInclusionTests.cs
+++ b/Packages/com.velvet.core/Editor/PlayerBuild/Tests/Editor/BundledStyleSheetInclusionTests.cs
@@ -209,10 +209,13 @@ namespace Velvet.Tests
             // Assert — the record survives carrying exactly what could not be removed, so a later pass can
             // finish. The lines are read before the comparison so that a revert which deleted the file
             // reports as a missing record rather than throwing out of the tuple's second element.
+            // The removal rides along because a surviving record is also what a revert that never ran at all
+            // leaves, and the first two terms alone cannot tell those apart.
             var kept = File.Exists(RecordFilePath()) ? File.ReadAllLines(RecordFilePath()) : null;
             Assert.That(
-                (kept != null, string.Join(", ", kept ?? System.Array.Empty<string>())),
-                Is.EqualTo((true, "Packages/com.velvet.core/Runtime/Assets/NoSuchHolder.asset")));
+                (kept != null, string.Join(", ", kept ?? System.Array.Empty<string>()),
+                    BundledStyleSheetBuildInclusion.Unreached()),
+                Is.EqualTo((true, "Packages/com.velvet.core/Runtime/Assets/NoSuchHolder.asset", true)));
         }
 
         [Test]

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/HookWiringCoverageTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/HookWiringCoverageTests.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using NUnit.Framework;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pairs the hook scripts in <c>.claude/hooks</c> with the two files that run them — the project
+    /// settings and the agent definitions — in both directions. A hook is wired by path, so a rename
+    /// leaves the wiring naming nothing and a hook leaves the tree referenced by nothing, and neither
+    /// shows up as a failure: a guard that stops being invoked reports exactly what a guard that passes
+    /// reports.
+    /// </summary>
+    [TestFixture]
+    internal sealed class HookWiringCoverageTests
+    {
+        private const string HookDirectory = ".claude/hooks";
+
+        // Settings and agent frontmatter are where a hook is given an event to fire on. A skill or a guide
+        // may name one in prose, and naming it there does not run it, so those are not read here — counting
+        // a prose mention as wiring is how an unwired hook would pass.
+        private static IEnumerable<string> WiringFiles()
+        {
+            yield return ".claude/settings.json";
+            var agents = Path.GetFullPath(".claude/agents");
+            if (Directory.Exists(agents))
+            {
+                foreach (var file in Directory.GetFiles(agents, "*.md"))
+                {
+                    yield return file;
+                }
+            }
+        }
+
+        private static readonly Regex HookReferencePattern =
+            new(@"\.claude/hooks/([A-Za-z0-9_./-]+)", RegexOptions.Compiled);
+
+        [Test]
+        public void Given_TheHookWiring_When_EachReferencedPathIsResolved_Then_EveryOneNamesAFileThatExists()
+        {
+            // Arrange
+            var wiring = ReadWiring();
+            Assume.That(wiring, Is.Not.Empty, "no hook reference was found to check");
+
+            // Act
+            var missing = wiring
+                .Where(reference => !File.Exists(Path.GetFullPath(HookDirectory + "/" + reference.Name)))
+                .Select(reference => $"{reference.Source} names {HookDirectory}/{reference.Name}")
+                .Distinct()
+                .ToList();
+
+            // Assert
+            Assert.That(missing, Is.Empty,
+                "a hook is wired by path, so one that names nothing never fires:\n" + string.Join("\n", missing));
+        }
+
+        [Test]
+        public void Given_TheHookDirectory_When_EachScriptIsTracedBack_Then_EveryOneIsWiredOrSourced()
+        {
+            // Arrange
+            var wired = new HashSet<string>(ReadWiring().Select(reference => reference.Name), StringComparer.Ordinal);
+            var scripts = Directory
+                .GetFiles(Path.GetFullPath(HookDirectory), "*", SearchOption.AllDirectories)
+                .Select(RelativeToHookDirectory)
+                .ToList();
+            Assume.That(scripts, Is.Not.Empty, "the hook directory is empty");
+
+            // A file a wired hook sources is reached the same way a wired one is, so it is not an orphan.
+            // Read out of the hooks rather than exempted by directory: a shared file that stops being
+            // sourced is the same dead script as one that stops being wired.
+            var sourced = string.Concat(scripts
+                .Where(script => wired.Contains(script))
+                .Select(script => File.ReadAllText(Path.GetFullPath(HookDirectory + "/" + script))));
+
+            // Act
+            var orphans = scripts
+                .Where(script => !wired.Contains(script))
+                .Where(script => !sourced.Contains(Path.GetFileName(script), StringComparison.Ordinal))
+                .ToList();
+
+            // Assert
+            Assert.That(orphans, Is.Empty,
+                $"nothing runs these, so whatever they guard is unguarded:\n{string.Join("\n", orphans)}");
+        }
+
+        private static List<(string Name, string Source)> ReadWiring() =>
+            (from file in WiringFiles()
+             let path = Path.GetFullPath(file)
+             where File.Exists(path)
+             from Match match in HookReferencePattern.Matches(File.ReadAllText(path))
+             select (match.Groups[1].Value, RepoRelative(path))).ToList();
+
+        private static string RelativeToHookDirectory(string path) =>
+            Path.GetRelativePath(Path.GetFullPath(HookDirectory), path).Replace('\\', '/');
+
+        private static string RepoRelative(string path) =>
+            Path.GetRelativePath(Path.GetFullPath("."), path).Replace('\\', '/');
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/HookWiringCoverageTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/HookWiringCoverageTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 708b2f199d61d4b8593ab073487da515

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/TextBalanceParityTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/TextBalanceParityTests.cs
@@ -68,15 +68,15 @@ namespace Velvet.Tests
             using var scope = new ReconcilerScope();
             var tree1 = new VNode[] { V.Label(className: "text-balance", text: "hello") };
             scope.Reconciler.Reconcile(scope.Root, System.Array.Empty<VNode>(), tree1);
-            Assume.That(GetManipulatorCount(scope.Reconciler), Is.EqualTo(1),
-                "Precondition: the text-balance class registered a manipulator");
+            var attached = GetManipulatorCount(scope.Reconciler);
 
             // Act — patch the same label without the text-balance class.
             var tree2 = new VNode[] { V.Label(text: "hello") };
             scope.Reconciler.Reconcile(scope.Root, tree1, tree2);
 
-            // Assert
-            Assert.That(GetManipulatorCount(scope.Reconciler), Is.EqualTo(0));
+            // Assert — the registration is folded in rather than assumed: a reconciler that registered
+            // nothing in the first place also holds none here, and detaching is the claim.
+            Assert.That((attached, GetManipulatorCount(scope.Reconciler)), Is.EqualTo((1, 0)));
         }
 
         [Test]
@@ -186,6 +186,7 @@ namespace Velvet.Tests
             Assume.That(label, Is.Not.Null, "Precondition: the label mounted");
             Assume.That(label.style.width.value.value, Is.EqualTo(50f),
                 "Precondition: the co-present w-[50px] utility resolved its own value at mount");
+            var attached = GetManipulatorCount(scope.Reconciler);
 
             // Act — patch away JUST the text-balance token; the w-[50px] utility stays in the class list.
             var tree2 = new VNode[] { V.Label(className: "w-[50px]", text: "hello") };
@@ -193,8 +194,10 @@ namespace Velvet.Tests
 
             // Assert — the utility's own value survives text-balance's teardown instead of being left
             // cleared by it (StyleTextBalanceManipulator.Clear unconditionally nulls the width first; the
-            // reconciler must restore the co-present utility's value right after).
-            Assert.That(label.style.width.value.value, Is.EqualTo(50f));
+            // reconciler must restore the co-present utility's value right after). The attachment rides
+            // along because a reconciler that never attached anything clears no width either, and the
+            // surviving value alone cannot tell that apart from a restore.
+            Assert.That((attached, label.style.width.value.value), Is.EqualTo((1, 50f)));
         }
 
         [Test]
@@ -208,13 +211,15 @@ namespace Velvet.Tests
             var label = scope.Root.Q<Label>();
             Assume.That(label.style.width.value.value, Is.EqualTo(40f),
                 "Precondition: the co-present size-[40px] utility resolved its own width at mount");
+            var attached = GetManipulatorCount(scope.Reconciler);
 
             // Act
             var tree2 = new VNode[] { V.Label(className: "size-[40px]", text: "hello") };
             scope.Reconciler.Reconcile(scope.Root, tree1, tree2);
 
-            // Assert
-            Assert.That(label.style.width.value.value, Is.EqualTo(40f));
+            // Assert — the attachment rides along because a reconciler that never attached anything clears
+            // no width either, and the surviving value alone cannot tell that apart from a restore.
+            Assert.That((attached, label.style.width.value.value), Is.EqualTo((1, 40f)));
         }
 
         private static int GetManipulatorCount(Reconciler reconciler)

--- a/scripts/neuter-cuts.json
+++ b/scripts/neuter-cuts.json
@@ -67,6 +67,138 @@
           "neuter": "return;"
         }
       ]
+    },
+    {
+      "name": "balance-attach",
+      "mechanism": "balance",
+      "summary": "the balance manipulator subscribes to nothing on its target",
+      "edits": [
+        {
+          "file": "Packages/com.velvet.core/Runtime/Styling/StyleTextBalanceManipulator.cs",
+          "anchor": "protected override void RegisterCallbacksOnTarget()",
+          "neuter": "return;"
+        }
+      ]
+    },
+    {
+      "name": "balance-apply",
+      "mechanism": "balance",
+      "summary": "the balance manipulator narrows nothing it observes",
+      "edits": [
+        {
+          "file": "Packages/com.velvet.core/Runtime/Styling/StyleTextBalanceManipulator.cs",
+          "anchor": "private void Apply()",
+          "neuter": "return;"
+        }
+      ]
+    },
+    {
+      "name": "stylesheet-inject",
+      "mechanism": "stylesheet-build",
+      "summary": "no build preloads the bundled stylesheet's holder",
+      "edits": [
+        {
+          "file": "Packages/com.velvet.core/Editor/PlayerBuild/BundledStyleSheetBuildInclusion.cs",
+          "anchor": "internal static void Inject()",
+          "neuter": "return;"
+        }
+      ]
+    },
+    {
+      "name": "stylesheet-revert",
+      "mechanism": "stylesheet-build",
+      "summary": "a finished build takes the stylesheet's holder back out of nothing",
+      "edits": [
+        {
+          "file": "Packages/com.velvet.core/Editor/PlayerBuild/BundledStyleSheetBuildInclusion.cs",
+          "anchor": "internal static void Revert()",
+          "neuter": "return;"
+        }
+      ]
+    },
+    {
+      "name": "shader-inject",
+      "mechanism": "shader-build",
+      "summary": "no build adds the bundled shaders to the always-included list",
+      "edits": [
+        {
+          "file": "Packages/com.velvet.core/Editor/PlayerBuild/BundledShaderBuildInclusion.cs",
+          "anchor": "internal static void Inject()",
+          "neuter": "return;"
+        }
+      ]
+    },
+    {
+      "name": "shader-revert",
+      "mechanism": "shader-build",
+      "summary": "a finished build takes the bundled shaders back out of nothing",
+      "edits": [
+        {
+          "file": "Packages/com.velvet.core/Editor/PlayerBuild/BundledShaderBuildInclusion.cs",
+          "anchor": "internal static void Revert()",
+          "neuter": "return;"
+        }
+      ]
+    },
+    {
+      "name": "balance-register",
+      "mechanism": "balance-wiring",
+      "summary": "the reconciler attaches and detaches no balance manipulator",
+      "edits": [
+        {
+          "file": "Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs",
+          "anchor": "private void ApplyTextBalanceManipulator(VisualElement element, string[] classNames)",
+          "neuter": "return;"
+        }
+      ]
+    },
+    {
+      "name": "stylesheet-repair",
+      "mechanism": "stylesheet-build",
+      "summary": "a domain reload repairs nothing an ended build left in the stylesheet settings",
+      "edits": [
+        {
+          "file": "Packages/com.velvet.core/Editor/PlayerBuild/BundledStyleSheetBuildInclusion.cs",
+          "anchor": "internal static void RevertWhatAnEndedSessionLeft()",
+          "neuter": "return;"
+        }
+      ]
+    },
+    {
+      "name": "stylesheet-gate",
+      "mechanism": "stylesheet-gate",
+      "summary": "the stylesheet build step never refuses an unwritable settings file",
+      "edits": [
+        {
+          "file": "Packages/com.velvet.core/Editor/PlayerBuild/BundledStyleSheetBuildInclusion.cs",
+          "anchor": "private static void RequireWritableSettings()",
+          "neuter": "return;"
+        }
+      ]
+    },
+    {
+      "name": "shader-repair",
+      "mechanism": "shader-build",
+      "summary": "a domain reload repairs nothing an ended build left in the shader settings",
+      "edits": [
+        {
+          "file": "Packages/com.velvet.core/Editor/PlayerBuild/BundledShaderBuildInclusion.cs",
+          "anchor": "internal static void RevertWhatAnEndedSessionLeft()",
+          "neuter": "return;"
+        }
+      ]
+    },
+    {
+      "name": "shader-gate",
+      "mechanism": "shader-gate",
+      "summary": "the shader build step never refuses an unwritable settings file",
+      "edits": [
+        {
+          "file": "Packages/com.velvet.core/Editor/PlayerBuild/BundledShaderBuildInclusion.cs",
+          "anchor": "private static void RequireWritableSettings()",
+          "neuter": "return;"
+        }
+      ]
     }
   ],
   "fixtures": [
@@ -95,6 +227,59 @@
         "ring-parser"
       ],
       "caseScopes": []
+    },
+    {
+      "fixture": "Velvet.Tests.TextBalanceParityTests",
+      "cuts": [
+        "balance-register"
+      ],
+      "caseScopes": []
+    },
+    {
+      "fixture": "Velvet.Tests.TextBalancePlaybackTests",
+      "cuts": [
+        "balance-attach",
+        "balance-apply"
+      ],
+      "caseScopes": []
+    },
+    {
+      "fixture": "Velvet.Tests.BundledStyleSheetInclusionTests",
+      "cuts": [
+        "stylesheet-inject",
+        "stylesheet-revert",
+        "stylesheet-repair",
+        "stylesheet-gate"
+      ],
+      "caseScopes": [
+        {
+          "mechanism": "stylesheet-build",
+          "pattern": "PreprocessInjects|InjectsAndReverts|InjectedAndReverted|RevertRuns|RepairRuns|Repairs|LoadsAgain|Record"
+        },
+        {
+          "mechanism": "stylesheet-gate",
+          "pattern": "WouldInject"
+        }
+      ]
+    },
+    {
+      "fixture": "Velvet.Tests.BundledShaderInclusionTests",
+      "cuts": [
+        "shader-inject",
+        "shader-revert",
+        "shader-repair",
+        "shader-gate"
+      ],
+      "caseScopes": [
+        {
+          "mechanism": "shader-build",
+          "pattern": "PreprocessInjects|InjectsAndReverts|InjectedAndReverted|RevertRuns|RepairRuns|Repairs|LoadsAgain|Record"
+        },
+        {
+          "mechanism": "shader-gate",
+          "pattern": "WouldInject"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Four cuts were registered in `scripts/neuter-cuts.json`, all for clip-path and ring. The build-inclusion steps and the text-balance frame had none, so `neuter-check.py` — which asks whether a fixture notices the mechanism it is named for dying — had never been pointed at either.

## What was registered

Eleven cuts across five layers: injection, revert and the domain-reload repair for each build-inclusion twin, the writability gate they share, the reconciler`s attach-and-detach of the balance manipulator, and the manipulator`s own subscription and apply.

The layers are what the first pass got wrong, for the third time on this instrument. Mapping the EditMode balance fixture to the manipulator`s internals reported all nine of its cases as holes — true and about nothing, because that fixture pins attach and detach and the reconciler is what does those. The unwritable-settings case is the same story one layer up: the gate refuses before injection runs, so it takes a cut of its own and a case scope that keeps it out of the other three.

## What the sweep found

Five cases were green with the code they are named for disabled.

Both twins carry a case asserting that a record naming something unresolvable survives the revert. A revert that never ran leaves the same survival, so neither case could tell the fix from the mechanism being dead — and both were written to pin exactly that fix. Each now folds in the removal the same revert did make.

The three balance cases have the same shape one layer over: a co-present width utility survives text-balance`s teardown, and a reconciler that attached no manipulator has no teardown to survive. Each folds in the attachment, which is this repository`s own rule for a precondition that gates the behaviour under test.

Holes under the mechanisms these fixtures name:

| fixture | before | after |
| --- | --- | --- |
| `TextBalanceParityTests` | 9 | 2 |
| `BundledStyleSheetInclusionTests` | 7 | 3 |
| `BundledShaderInclusionTests` | 6 | 1 |

What remains is what a cut cannot reach: negative assertions no cut can falsify, a case whose subject is the pool reset, and cases that are statements about a sibling cut`s layer.

## Verification

Every number above is a `neuter-check.py` run, not a hand-broken line. Each fixture`s baseline was green before each cut, and the cases named as fixed moved from the hole list to the failing list under the cut that names their mechanism.

Two things the sweep surfaced are filed rather than fixed here: #324, a sweep leaving project settings a neutered revert never took back out, and the remaining negative-assertion cases, which need a different instrument than a cut.

No `Documentation~` impact: `CONTRIBUTING.md` already owns what the harness is and how a cut is scoped, and this adds cuts rather than behaviour.