### PR TITLE
Hold the region strip's width against the tree's own preprocessor conditions

### DIFF
--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/DocumentationDriftTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/DocumentationDriftTests.cs
@@ -235,11 +235,44 @@ namespace Velvet.Tests
 
             // Assert — a strip that is not running removes nothing, so an empty first term is the shape
             // that catches it. The second catches a strip widened by any route other than the spelling both
-            // sides read; widening that spelling to every directive is caught instead by the identifier
-            // case, and only for as long as a guide keeps citing UNITY_EDITOR — Generators~/README.md is
-            // the one that does.
+            // sides read; widening that spelling to every directive is caught by the case below.
             Assert.That(
                 (removed.Count > 0, string.Join(", ", notFromALabel)),
+                Is.EqualTo((true, string.Empty)));
+        }
+
+        [Test]
+        public void Given_TheRepoSources_When_TheIdentifierCorpusIsBuilt_Then_ItKeepsEveryDirectiveCondition()
+        {
+            // Arrange — the conditions are read from the raw text while the corpus is built from the
+            // stripped text, so a strip that widens from the two region labels to every directive takes
+            // them out of one side and not the other. Deriving them rather than listing them is what keeps
+            // this from being a second copy of the strip: nothing here has to be updated when a condition
+            // is added or dropped.
+            var directive = new Regex(@"^[^\S\n]*#[^\S\n]*(?:if|elif)\b([^\n]*)$", RegexOptions.Multiline);
+            var word = new Regex(@"[A-Za-z_][A-Za-z0-9_]*", RegexOptions.Compiled);
+            var conditions = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var entry in DocumentationCorpus.RepoEntries(includeClaude: false).Where(
+                         e => e.EndsWith(".cs", StringComparison.Ordinal) && File.Exists(e)))
+            {
+                foreach (Match line in directive.Matches(File.ReadAllText(entry)))
+                {
+                    foreach (Match token in word.Matches(line.Groups[1].Value))
+                    {
+                        conditions.Add(token.Value);
+                    }
+                }
+            }
+
+            // Act
+            var absent = conditions
+                .Where(name => !SourceIdentifiers.Value.Contains(name))
+                .OrderBy(name => name, StringComparer.Ordinal);
+
+            // Assert — the count of conditions found rides along, because a walk that read no directive at
+            // all would satisfy an emptiness check on its own.
+            Assert.That(
+                (conditions.Count > 0, string.Join(", ", absent)),
                 Is.EqualTo((true, string.Empty)));
         }
 


### PR DESCRIPTION
Closes #310.

`DocumentationDriftTests` strips `#region` and `#endregion` labels from the identifier corpus. Only one direction of that strip is held: `Given_TheRepoSources_When_TheIdentifierCorpusIsBuilt_Then_TheRegionStripTakesOnlyLabelWords` fails when it stops running.

The other direction — widening it to every preprocessor directive — was caught only as a side effect. Widening drops the tree`s condition tokens out of the corpus, and `Generators~/README.md` happens to cite `UNITY_EDITOR` in a backtick span, so the identifier check reports it. A rewrite of that one bullet would retire the guard with nothing saying so, and this repository has already removed a load-bearing backtick span to make a check pass.

The new case reads `#if` and `#elif` conditions out of the raw sources and asserts the corpus keeps every one. Measured in the tree today: `UNITY_EDITOR` in 60 conditions, `ENABLE_IL2CPP` in 5, `NET5_0_OR_GREATER` in 1. It derives them rather than listing them, so a condition added or dropped needs no edit here.

The conditions are read from raw text while the corpus is built from stripped text, which is what makes the two sides disagree under a widened strip rather than widen together. The count of conditions found is folded into the assertion, so a walk that read no directive at all cannot satisfy it.

## Verification

- Green: the fixture`s 8 cases pass unmodified.
- Red: widening `RegionLabelAlternation` to `^[^\S\n]*#[^\n]*$` fails the new case. The incidental identifier check fails alongside it, which is the dependency this replaces rather than removes.

The comment on the region case no longer claims the widening is caught by the identifier check, since it now names the case that holds it.

No `Documentation~` impact: this adds a guard over the guides rather than changing anything they describe.