### PR TITLE
Register the build and balance mechanisms as neuter cuts, and close what the sweep found

### DIFF
--- a/Packages/com.velvet.core/Editor/PlayerBuild/Tests/Editor/BundledShaderInclusionTests.cs
+++ b/Packages/com.velvet.core/Editor/PlayerBuild/Tests/Editor/BundledShaderInclusionTests.cs
@@ -269,11 +269,14 @@ namespace Velvet.Tests
 
             // Assert — the record survives carrying exactly what could not be removed, so a later pass can
             // finish. Both terms in one comparison: a revert that deleted the file and one that left it
-            // holding the whole original list are different failures.
+            // holding the whole original list are different failures. The count of shaders no longer in the
+            // list rides along because a surviving record is also what a revert that never ran at all
+            // leaves, and the first two terms alone cannot tell those apart.
             var kept = File.Exists(RecordFilePath()) ? File.ReadAllLines(RecordFilePath()) : null;
             Assert.That(
-                (kept != null, string.Join(", ", kept ?? System.Array.Empty<string>())),
-                Is.EqualTo((true, "Velvet/NoSuchShader")));
+                (kept != null, string.Join(", ", kept ?? System.Array.Empty<string>()),
+                    BundledShaderBuildInclusion.Unreached().Length),
+                Is.EqualTo((true, "Velvet/NoSuchShader", VelvetShaders.Names.Length)));
         }
 
         private static string RecordFilePath()

--- a/Packages/com.velvet.core/Editor/PlayerBuild/Tests/Editor/BundledStyleSheetInclusionTests.cs
+++ b/Packages/com.velvet.core/Editor/PlayerBuild/Tests/Editor/BundledStyleSheetInclusionTests.cs
@@ -209,10 +209,13 @@ namespace Velvet.Tests
             // Assert — the record survives carrying exactly what could not be removed, so a later pass can
             // finish. The lines are read before the comparison so that a revert which deleted the file
             // reports as a missing record rather than throwing out of the tuple's second element.
+            // The removal rides along because a surviving record is also what a revert that never ran at all
+            // leaves, and the first two terms alone cannot tell those apart.
             var kept = File.Exists(RecordFilePath()) ? File.ReadAllLines(RecordFilePath()) : null;
             Assert.That(
-                (kept != null, string.Join(", ", kept ?? System.Array.Empty<string>())),
-                Is.EqualTo((true, "Packages/com.velvet.core/Runtime/Assets/NoSuchHolder.asset")));
+                (kept != null, string.Join(", ", kept ?? System.Array.Empty<string>()),
+                    BundledStyleSheetBuildInclusion.Unreached()),
+                Is.EqualTo((true, "Packages/com.velvet.core/Runtime/Assets/NoSuchHolder.asset", true)));
         }
 
         [Test]

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/NeuterCutAnchorTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/NeuterCutAnchorTests.cs
@@ -88,7 +88,7 @@ namespace Velvet.Tests
             // Assert — the edit count is folded in because a map that parsed to nothing satisfies
             // "no anchor is wrong" exactly, and a renamed JSON key is what produces that.
             Assert.That((map.cuts.Sum(cut => cut.edits.Length), string.Join("\n", wrong)),
-                Is.EqualTo((8, string.Empty)));
+                Is.EqualTo((19, string.Empty)));
         }
 
         [Test]
@@ -108,7 +108,7 @@ namespace Velvet.Tests
 
             // Assert — the edit count rides along for the same reason it does above.
             Assert.That((map.cuts.Sum(cut => cut.edits.Length), string.Join("\n", wrong)),
-                Is.EqualTo((8, string.Empty)));
+                Is.EqualTo((19, string.Empty)));
         }
 
         [Test]
@@ -125,7 +125,7 @@ namespace Velvet.Tests
                             select $"{entry.fixture} names '{name}'").ToList();
 
             // Assert
-            Assert.That((map.fixtures.Length, string.Join("\n", dangling)), Is.EqualTo((2, string.Empty)));
+            Assert.That((map.fixtures.Length, string.Join("\n", dangling)), Is.EqualTo((6, string.Empty)));
         }
 
         [Test]
@@ -144,7 +144,7 @@ namespace Velvet.Tests
                 .ToList();
 
             // Assert — the fixture count is folded in because an empty map has no missing fixture either.
-            Assert.That((map.fixtures.Length, string.Join("\n", missing)), Is.EqualTo((2, string.Empty)));
+            Assert.That((map.fixtures.Length, string.Join("\n", missing)), Is.EqualTo((6, string.Empty)));
         }
 
         [Test]
@@ -168,7 +168,7 @@ namespace Velvet.Tests
             // single-mechanism satisfies this by never classifying anything.
             Assert.That(
                 (map.fixtures.Count(entry => Mechanisms(map, entry).Count > 1), string.Join("\n", wrong)),
-                Is.EqualTo((1, string.Empty)));
+                Is.EqualTo((3, string.Empty)));
         }
 
         [Test]
@@ -186,7 +186,7 @@ namespace Velvet.Tests
                 .ToList();
 
             // Assert
-            Assert.That((map.fixtures.Length, string.Join("\n", declaring)), Is.EqualTo((2, string.Empty)));
+            Assert.That((map.fixtures.Length, string.Join("\n", declaring)), Is.EqualTo((6, string.Empty)));
         }
 
         [Test]
@@ -207,7 +207,7 @@ namespace Velvet.Tests
             // Assert
             Assert.That(
                 (map.fixtures.Count(entry => Mechanisms(map, entry).Count > 1), string.Join("\n", unscoped)),
-                Is.EqualTo((1, string.Empty)));
+                Is.EqualTo((3, string.Empty)));
         }
 
         private static string DeclaringSource(string fixture)

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/TextBalanceParityTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/TextBalanceParityTests.cs
@@ -68,15 +68,15 @@ namespace Velvet.Tests
             using var scope = new ReconcilerScope();
             var tree1 = new VNode[] { V.Label(className: "text-balance", text: "hello") };
             scope.Reconciler.Reconcile(scope.Root, System.Array.Empty<VNode>(), tree1);
-            Assume.That(GetManipulatorCount(scope.Reconciler), Is.EqualTo(1),
-                "Precondition: the text-balance class registered a manipulator");
+            var attached = GetManipulatorCount(scope.Reconciler);
 
             // Act — patch the same label without the text-balance class.
             var tree2 = new VNode[] { V.Label(text: "hello") };
             scope.Reconciler.Reconcile(scope.Root, tree1, tree2);
 
-            // Assert
-            Assert.That(GetManipulatorCount(scope.Reconciler), Is.EqualTo(0));
+            // Assert — the registration is folded in rather than assumed: a reconciler that registered
+            // nothing in the first place also holds none here, and detaching is the claim.
+            Assert.That((attached, GetManipulatorCount(scope.Reconciler)), Is.EqualTo((1, 0)));
         }
 
         [Test]
@@ -186,6 +186,7 @@ namespace Velvet.Tests
             Assume.That(label, Is.Not.Null, "Precondition: the label mounted");
             Assume.That(label.style.width.value.value, Is.EqualTo(50f),
                 "Precondition: the co-present w-[50px] utility resolved its own value at mount");
+            var attached = GetManipulatorCount(scope.Reconciler);
 
             // Act — patch away JUST the text-balance token; the w-[50px] utility stays in the class list.
             var tree2 = new VNode[] { V.Label(className: "w-[50px]", text: "hello") };
@@ -193,8 +194,10 @@ namespace Velvet.Tests
 
             // Assert — the utility's own value survives text-balance's teardown instead of being left
             // cleared by it (StyleTextBalanceManipulator.Clear unconditionally nulls the width first; the
-            // reconciler must restore the co-present utility's value right after).
-            Assert.That(label.style.width.value.value, Is.EqualTo(50f));
+            // reconciler must restore the co-present utility's value right after). The attachment rides
+            // along because a reconciler that never attached anything clears no width either, and the
+            // surviving value alone cannot tell that apart from a restore.
+            Assert.That((attached, label.style.width.value.value), Is.EqualTo((1, 50f)));
         }
 
         [Test]
@@ -208,13 +211,15 @@ namespace Velvet.Tests
             var label = scope.Root.Q<Label>();
             Assume.That(label.style.width.value.value, Is.EqualTo(40f),
                 "Precondition: the co-present size-[40px] utility resolved its own width at mount");
+            var attached = GetManipulatorCount(scope.Reconciler);
 
             // Act
             var tree2 = new VNode[] { V.Label(className: "size-[40px]", text: "hello") };
             scope.Reconciler.Reconcile(scope.Root, tree1, tree2);
 
-            // Assert
-            Assert.That(label.style.width.value.value, Is.EqualTo(40f));
+            // Assert — the attachment rides along because a reconciler that never attached anything clears
+            // no width either, and the surviving value alone cannot tell that apart from a restore.
+            Assert.That((attached, label.style.width.value.value), Is.EqualTo((1, 40f)));
         }
 
         private static int GetManipulatorCount(Reconciler reconciler)

--- a/scripts/neuter-cuts.json
+++ b/scripts/neuter-cuts.json
@@ -67,6 +67,138 @@
           "neuter": "return;"
         }
       ]
+    },
+    {
+      "name": "balance-attach",
+      "mechanism": "balance",
+      "summary": "the balance manipulator subscribes to nothing on its target",
+      "edits": [
+        {
+          "file": "Packages/com.velvet.core/Runtime/Styling/StyleTextBalanceManipulator.cs",
+          "anchor": "protected override void RegisterCallbacksOnTarget()",
+          "neuter": "return;"
+        }
+      ]
+    },
+    {
+      "name": "balance-apply",
+      "mechanism": "balance",
+      "summary": "the balance manipulator narrows nothing it observes",
+      "edits": [
+        {
+          "file": "Packages/com.velvet.core/Runtime/Styling/StyleTextBalanceManipulator.cs",
+          "anchor": "private void Apply()",
+          "neuter": "return;"
+        }
+      ]
+    },
+    {
+      "name": "stylesheet-inject",
+      "mechanism": "stylesheet-build",
+      "summary": "no build preloads the bundled stylesheet's holder",
+      "edits": [
+        {
+          "file": "Packages/com.velvet.core/Editor/PlayerBuild/BundledStyleSheetBuildInclusion.cs",
+          "anchor": "internal static void Inject()",
+          "neuter": "return;"
+        }
+      ]
+    },
+    {
+      "name": "stylesheet-revert",
+      "mechanism": "stylesheet-build",
+      "summary": "a finished build takes the stylesheet's holder back out of nothing",
+      "edits": [
+        {
+          "file": "Packages/com.velvet.core/Editor/PlayerBuild/BundledStyleSheetBuildInclusion.cs",
+          "anchor": "internal static void Revert()",
+          "neuter": "return;"
+        }
+      ]
+    },
+    {
+      "name": "shader-inject",
+      "mechanism": "shader-build",
+      "summary": "no build adds the bundled shaders to the always-included list",
+      "edits": [
+        {
+          "file": "Packages/com.velvet.core/Editor/PlayerBuild/BundledShaderBuildInclusion.cs",
+          "anchor": "internal static void Inject()",
+          "neuter": "return;"
+        }
+      ]
+    },
+    {
+      "name": "shader-revert",
+      "mechanism": "shader-build",
+      "summary": "a finished build takes the bundled shaders back out of nothing",
+      "edits": [
+        {
+          "file": "Packages/com.velvet.core/Editor/PlayerBuild/BundledShaderBuildInclusion.cs",
+          "anchor": "internal static void Revert()",
+          "neuter": "return;"
+        }
+      ]
+    },
+    {
+      "name": "balance-register",
+      "mechanism": "balance-wiring",
+      "summary": "the reconciler attaches and detaches no balance manipulator",
+      "edits": [
+        {
+          "file": "Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs",
+          "anchor": "private void ApplyTextBalanceManipulator(VisualElement element, string[] classNames)",
+          "neuter": "return;"
+        }
+      ]
+    },
+    {
+      "name": "stylesheet-repair",
+      "mechanism": "stylesheet-build",
+      "summary": "a domain reload repairs nothing an ended build left in the stylesheet settings",
+      "edits": [
+        {
+          "file": "Packages/com.velvet.core/Editor/PlayerBuild/BundledStyleSheetBuildInclusion.cs",
+          "anchor": "internal static void RevertWhatAnEndedSessionLeft()",
+          "neuter": "return;"
+        }
+      ]
+    },
+    {
+      "name": "stylesheet-gate",
+      "mechanism": "stylesheet-gate",
+      "summary": "the stylesheet build step never refuses an unwritable settings file",
+      "edits": [
+        {
+          "file": "Packages/com.velvet.core/Editor/PlayerBuild/BundledStyleSheetBuildInclusion.cs",
+          "anchor": "private static void RequireWritableSettings()",
+          "neuter": "return;"
+        }
+      ]
+    },
+    {
+      "name": "shader-repair",
+      "mechanism": "shader-build",
+      "summary": "a domain reload repairs nothing an ended build left in the shader settings",
+      "edits": [
+        {
+          "file": "Packages/com.velvet.core/Editor/PlayerBuild/BundledShaderBuildInclusion.cs",
+          "anchor": "internal static void RevertWhatAnEndedSessionLeft()",
+          "neuter": "return;"
+        }
+      ]
+    },
+    {
+      "name": "shader-gate",
+      "mechanism": "shader-gate",
+      "summary": "the shader build step never refuses an unwritable settings file",
+      "edits": [
+        {
+          "file": "Packages/com.velvet.core/Editor/PlayerBuild/BundledShaderBuildInclusion.cs",
+          "anchor": "private static void RequireWritableSettings()",
+          "neuter": "return;"
+        }
+      ]
     }
   ],
   "fixtures": [
@@ -95,6 +227,59 @@
         "ring-parser"
       ],
       "caseScopes": []
+    },
+    {
+      "fixture": "Velvet.Tests.TextBalanceParityTests",
+      "cuts": [
+        "balance-register"
+      ],
+      "caseScopes": []
+    },
+    {
+      "fixture": "Velvet.Tests.TextBalancePlaybackTests",
+      "cuts": [
+        "balance-attach",
+        "balance-apply"
+      ],
+      "caseScopes": []
+    },
+    {
+      "fixture": "Velvet.Tests.BundledStyleSheetInclusionTests",
+      "cuts": [
+        "stylesheet-inject",
+        "stylesheet-revert",
+        "stylesheet-repair",
+        "stylesheet-gate"
+      ],
+      "caseScopes": [
+        {
+          "mechanism": "stylesheet-build",
+          "pattern": "PreprocessInjects|InjectsAndReverts|InjectedAndReverted|RevertRuns|RepairRuns|Repairs|LoadsAgain|Record"
+        },
+        {
+          "mechanism": "stylesheet-gate",
+          "pattern": "WouldInject"
+        }
+      ]
+    },
+    {
+      "fixture": "Velvet.Tests.BundledShaderInclusionTests",
+      "cuts": [
+        "shader-inject",
+        "shader-revert",
+        "shader-repair",
+        "shader-gate"
+      ],
+      "caseScopes": [
+        {
+          "mechanism": "shader-build",
+          "pattern": "PreprocessInjects|InjectsAndReverts|InjectedAndReverted|RevertRuns|RepairRuns|Repairs|LoadsAgain|Record"
+        },
+        {
+          "mechanism": "shader-gate",
+          "pattern": "WouldInject"
+        }
+      ]
     }
   ]
 }

--- a/scripts/neuter-cuts.json
+++ b/scripts/neuter-cuts.json
@@ -254,7 +254,7 @@
       "caseScopes": [
         {
           "mechanism": "stylesheet-build",
-          "pattern": "PreprocessInjects|InjectsAndReverts|InjectedAndReverted|RevertRuns|RepairRuns|Repairs|LoadsAgain|Record"
+          "pattern": "PreprocessInjects|InjectsAndReverts|InjectedAndReverted|RevertRuns|RepairRuns|Repairs|LoadsAgain|Record|IsRead|AreRead"
         },
         {
           "mechanism": "stylesheet-gate",
@@ -273,7 +273,7 @@
       "caseScopes": [
         {
           "mechanism": "shader-build",
-          "pattern": "PreprocessInjects|InjectsAndReverts|InjectedAndReverted|RevertRuns|RepairRuns|Repairs|LoadsAgain|Record"
+          "pattern": "PreprocessInjects|InjectsAndReverts|InjectedAndReverted|RevertRuns|RepairRuns|Repairs|LoadsAgain|Record|IsRead|AreRead"
         },
         {
           "mechanism": "shader-gate",


### PR DESCRIPTION
Four cuts were registered in `scripts/neuter-cuts.json`, all for clip-path and ring. The build-inclusion steps and the text-balance frame had none, so `neuter-check.py` — which asks whether a fixture notices the mechanism it is named for dying — had never been pointed at either.

## What was registered

Eleven cuts across five layers: injection, revert and the domain-reload repair for each build-inclusion twin, the writability gate they share, the reconciler`s attach-and-detach of the balance manipulator, and the manipulator`s own subscription and apply.

The layers are what the first pass got wrong, for the third time on this instrument. Mapping the EditMode balance fixture to the manipulator`s internals reported all nine of its cases as holes — true and about nothing, because that fixture pins attach and detach and the reconciler is what does those. The unwritable-settings case is the same story one layer up: the gate refuses before injection runs, so it takes a cut of its own and a case scope that keeps it out of the other three.

## What the sweep found

Five cases were green with the code they are named for disabled.

Both twins carry a case asserting that a record naming something unresolvable survives the revert. A revert that never ran leaves the same survival, so neither case could tell the fix from the mechanism being dead — and both were written to pin exactly that fix. Each now folds in the removal the same revert did make.

The three balance cases have the same shape one layer over: a co-present width utility survives text-balance`s teardown, and a reconciler that attached no manipulator has no teardown to survive. Each folds in the attachment, which is this repository`s own rule for a precondition that gates the behaviour under test.

Holes under the mechanisms these fixtures name:

| fixture | before | after |
| --- | --- | --- |
| `TextBalanceParityTests` | 9 | 2 |
| `BundledStyleSheetInclusionTests` | 7 | 3 |
| `BundledShaderInclusionTests` | 6 | 1 |

What remains is what a cut cannot reach: negative assertions no cut can falsify, a case whose subject is the pool reset, and cases that are statements about a sibling cut`s layer.

## Verification

Every number above is a `neuter-check.py` run, not a hand-broken line. Each fixture`s baseline was green before each cut, and the cases named as fixed moved from the hole list to the failing list under the cut that names their mechanism.

Two things the sweep surfaced are filed rather than fixed here: #324, a sweep leaving project settings a neutered revert never took back out, and the remaining negative-assertion cases, which need a different instrument than a cut.

No `Documentation~` impact: `CONTRIBUTING.md` already owns what the harness is and how a cut is scoped, and this adds cuts rather than behaviour.

## Anchor guard

The first push failed `NeuterCutAnchorTests` and this branch fixes it. A fixture whose cuts span two mechanisms must classify every one of its cases, so none is silently asked nothing. Two cases were left unclaimed — the one reading the holder's sheet and the one reading the shader names — because neither has a cut: `Holder()` is expression-bodied and `VelvetShaders.Names` is a field, and the harness anchors on a body brace. Dropping them from scope is exactly what that guard refuses, so both are claimed by the build mechanism and report as holes under every build cut, which is true and now visible.

The guard's folded counts move with the map: eight anchors to nineteen, two fixtures to six, one mixed fixture to three.

Verified with the whole EditMode suite rather than the touched fixtures alone: 3583 cases, 3580 passed, 0 failed, 0 inconclusive.