### PR TITLE
Refuse an issue or a pull request opened with no metadata

### DIFF
--- a/.claude/hooks/refuse-metadata-less-create.py
+++ b/.claude/hooks/refuse-metadata-less-create.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Refuse `gh issue create` / `gh pr create` that set no label, and an issue that sets no assignee.
+
+Every issue on this repository was opened with none of either. Nine of them, before a person
+noticed rather than a check. An unlabelled backlog cannot be filtered, so "what is broken" and
+"what is a tooling gap" and "what is blocked on a platform decision" read the same from the
+list, and the only way to tell is to open each one.
+
+A hook rather than `.github/ISSUE_TEMPLATE`, because a template sets defaults for the web form
+and does nothing for `gh issue create`, which is how every one of these was filed. A template
+asks; this refuses.
+
+Assignee is required on an issue and not on a pull request: a pull request already records its
+author, so a self-assignment adds nothing.
+
+`--web` hands the fields to the browser form, where they can be set, so it is left alone.
+"""
+
+import json
+import re
+import subprocess
+import sys
+
+# Anchored at a command position — start of input, or after a separator or newline — so the same
+# text quoted inside an argument or named in a body does not trip it. This file argues for a
+# refusal by naming the command it refuses, which is exactly the text that would.
+CREATE = re.compile(r"(?:^|[;&|]|\n)\s*gh\s+(issue|pr)\s+create\b")
+
+LABEL = re.compile(r"(?:^|\s)(?:--label(?:=|\s)|-l\s)")
+ASSIGNEE = re.compile(r"(?:^|\s)(?:--assignee(?:=|\s)|-a\s)")
+WEB = re.compile(r"(?:^|\s)--web(?:\s|$)")
+
+
+def labels(cwd):
+    listing = subprocess.run(
+        ["gh", "label", "list", "--json", "name", "--jq", ".[].name"],
+        capture_output=True, text=True, cwd=cwd)
+    return [name for name in listing.stdout.splitlines() if name.strip()]
+
+
+def main():
+    try:
+        event = json.load(sys.stdin)
+    except Exception:
+        return 0
+    if event.get("tool_name") != "Bash":
+        return 0
+    command = event.get("tool_input", {}).get("command", "")
+    match = CREATE.search(command)
+    if not match or WEB.search(command):
+        return 0
+
+    kind = match.group(1)
+    missing = []
+    if not LABEL.search(command):
+        missing.append("--label")
+    if kind == "issue" and not ASSIGNEE.search(command):
+        missing.append("--assignee")
+    if not missing:
+        return 0
+
+    cwd = event.get("cwd") or "."
+    reason = [
+        f"Refusing `gh {kind} create`: it sets no {' and no '.join(missing)}.",
+        "",
+        "An unlabelled backlog cannot be filtered, so every entry reads the same from the list and",
+        "the only way to know what one is, is to open it.",
+        "",
+        "Labels on this repository:",
+        "  " + (", ".join(labels(cwd)) or "(none yet — `gh label create` makes one)"),
+    ]
+    if "--assignee" in missing:
+        reason += ["", "`--assignee @me` is the usual answer."]
+    print("\n".join(reason), file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -52,6 +52,11 @@
             "type": "command",
             "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/refuse-blind-git-add.py\"",
             "timeout": 10000
+          },
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/refuse-metadata-less-create.py\"",
+            "timeout": 15000
           }
         ]
       }


### PR DESCRIPTION
Closes #319.

Every issue on this repository was opened with no label and no assignee. Nine of them, before a person noticed rather than a check. An unlabelled backlog cannot be filtered, so what is broken, what is a tooling gap and what is blocked on a platform decision all read the same from the list, and the only way to know is to open each one.

`refuse-metadata-less-create.py` is a `PreToolUse` refusal, the same shape as the two this repository already runs. A hook rather than `.github/ISSUE_TEMPLATE`, because a template sets defaults for the web form and does nothing for the command every one of these was filed with — a template asks, a hook refuses. The message names the labels the repository has, so the answer is to hand rather than something to go and look up.

An assignee is required on an issue and not on a pull request, whose author is already recorded, so a self-assignment adds nothing. `--web` hands the fields to the browser form where they can be set, so it is left alone.

Nine branches exercised against the hook before pushing:

| command | verdict |
| --- | --- |
| issue, no metadata | refused |
| issue, label only | refused |
| issue, label and assignee | allowed |
| issue, short flags `-l` / `-a` | allowed |
| pull request, no label | refused |
| pull request, label | allowed |
| issue with `--web` | allowed |
| `gh issue edit --add-label` | allowed |
| the command quoted inside an argument | allowed |

The last one is why the pattern is anchored at a command position: the first version of the blind-`git add` hook was not, and refused the pull request whose body named the command it refuses.

`HookWiringCoverageTests` covers the wiring, so a rename on either side fails rather than silently stopping the refusal.

Verified with the whole EditMode suite: 3583 cases, 3580 passed, 0 failed, 0 inconclusive.

The milestone question #319 raises is deliberately not settled here — it belongs with the release scope rather than before it.

No `Documentation~` impact: the hooks are loop machinery rather than package behaviour.