### PR TITLE
Restore what a cut stopped a fixture from cleaning up

### DIFF
--- a/scripts/neuter-check.py
+++ b/scripts/neuter-check.py
@@ -108,6 +108,74 @@ def locate(project, edit):
     return brace, None
 
 
+def git_porcelain(project):
+    result = subprocess.run(["git", "-C", str(project), "status", "--porcelain"],
+                            capture_output=True, text=True)
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or "git status failed")
+    entries = {}
+    for line in result.stdout.splitlines():
+        if not line.strip():
+            continue
+        status = line[:2]
+        path = line[3:]
+        if " -> " in path:
+            path = path.split(" -> ", 1)[1]
+        entries[path] = status
+    return entries
+
+
+def path_in_harness_output(project, path, output_dir):
+    try:
+        output_dir.resolve().relative_to(project.resolve())
+    except ValueError:
+        return False
+    resolved = (project / path).resolve()
+    output_resolved = output_dir.resolve()
+    try:
+        resolved.relative_to(output_resolved)
+        return True
+    except ValueError:
+        pass
+    try:
+        output_resolved.relative_to(resolved)
+        return True
+    except ValueError:
+        return False
+
+
+def restore_foreign_dirty(project, cut, before_dirty, output_dir):
+    """A cut's revert() only puts back files listed in the cut map.
+
+    The cut runs first, so the fixture exercises disabled code and its teardown cannot undo what that
+    run wrote. Cutting the revert of BundledShaderBuildInclusion and BundledStyleSheetBuildInclusion left
+    ProjectSettings/GraphicsSettings.asset and ProjectSettings/ProjectSettings.asset modified after the
+    sweep finished.
+    """
+    try:
+        after_dirty = git_porcelain(project)
+    except RuntimeError as exc:
+        print(f"    failed to read git status: {exc}", flush=True)
+        return
+    cut_files = {edit["file"] for edit in cut["edits"]}
+    foreign = sorted(
+        path for path in set(after_dirty) - set(before_dirty) - cut_files
+        if not path_in_harness_output(project, path, output_dir)
+    )
+    for path in foreign:
+        if after_dirty[path] == "??":
+            command = ["git", "-C", str(project), "clean", "-fd", "--", path]
+        else:
+            command = ["git", "-C", str(project), "restore", "--source=HEAD",
+                         "--staged", "--worktree", "--", path]
+        result = subprocess.run(command, capture_output=True, text=True)
+        if result.returncode != 0:
+            detail = (result.stderr or result.stdout).strip()
+            print(f"    failed to restore {path}: {detail}", flush=True)
+        else:
+            print(f"    restored {path}", flush=True)
+
+
 def dirty_cut_files(project, cuts):
     """Cut files git already reports as modified.
 
@@ -296,6 +364,7 @@ def main():
             if not wait_for_quiet(args.busy_timeout):
                 print("error: the machine did not go quiet", file=sys.stderr)
                 return 1
+            before_dirty = git_porcelain(project)
             originals = apply_cut(project, cut)
             try:
                 elapsed, killed, peak = run_suite(
@@ -303,6 +372,7 @@ def main():
                     out / f"{short}-{name}.xml", out / f"{short}-{name}.log", args.timeout)
             finally:
                 revert(originals)
+                restore_foreign_dirty(project, cut, before_dirty, out)
             holes = report_pair(entry, name, cut, baseline,
                                 None if killed else outcomes(out / f"{short}-{name}.xml"),
                                 elapsed, peak)


### PR DESCRIPTION
Closes #324.

A cut disables a named method and the fixture then runs against it, so a cut on a cleanup path leaves whatever that path would have undone sitting in the tree. `neuter-check.py` restores the source it edited and had no view of anything else, and the residue was in tracked files: cutting the two build-inclusion reverts left `ProjectSettings/GraphicsSettings.asset` and `ProjectSettings/ProjectSettings.asset` modified after the sweep finished.

## It was not only untidiness — it moved the measurement

State surviving one cut is arranged state for the next. Sweeping `BundledShaderInclusionTests` before and after this change, on the same code:

| cut | holes before | holes after |
| --- | --- | --- |
| `shader-inject` | 4 | 5 |
| `shader-revert` | 1 | 2 |
| `shader-repair` | 2 | 6 |

The earlier numbers were lower because the leftover entries were still in Always Included Shaders when the next cut ran, so cases asserting an absence failed and were scored as having noticed the cut. They had noticed the previous cut`s residue. The figures quoted in #327 were taken on that instrument and are corrected here.

## The fix

Each cut brackets its run with the repository`s dirty set and puts back anything newly dirty that is not a file it edited itself — `git restore` for a tracked modification, `git clean` for an untracked path. A path already dirty before the sweep is left alone, so work in progress survives. A failure to read status or to restore is reported and returns rather than raising, since the restore runs in the `finally` that exists to follow a failure in the run.

The harness`s own output directory is excluded in **both** containment directions. Measured: with `NeuterProbe/inner/x.xml` present and `NeuterProbe` otherwise untracked, `git status --porcelain` reports exactly `?? NeuterProbe/` — the shallowest untracked directory, not the nested path. A one-directional test therefore misses the case it exists for and the sweep deletes the XML it is about to read, which `report_pair` then reports as `NO RESULTS ... the cut may not compile`.

## Verification

- The exclusion helper exercised directly over five shapes: nested output reported as a shallow directory, direct-child output, real residue under the default output, real residue with the output outside the repository, and an unrelated untracked file. All five correct.
- A live sweep of `BundledShaderInclusionTests` prints `restored ProjectSettings/GraphicsSettings.asset` and ends with a clean tree.

No `Documentation~` impact: `CONTRIBUTING.md` owns what the harness is, and this changes what it cleans up rather than how a cut is written or scoped.