### PR TITLE
Fail when a sentence recorded as false reappears

### DIFF
--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/CorrectedSentenceTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/CorrectedSentenceTests.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using NUnit.Framework;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Fails when a sentence CLAUDE.md records as false reappears anywhere else in the tree. Each entry in
+    /// that list was copy-pasted into a comment, a skill, or prose, found wrong, and corrected — a
+    /// reintroduction is the same failure mode with nothing to catch it today.
+    /// </summary>
+    [TestFixture]
+    internal sealed class CorrectedSentenceTests
+    {
+        private const string ClaudePath = "CLAUDE.md";
+
+        // The list entries are the only lines in CLAUDE.md that open with a hyphen, a space, and a quote.
+        private static readonly Regex CorrectedSentenceEntryPattern =
+            new(@"^- ""([^""]+)""", RegexOptions.Compiled);
+
+        private static readonly string[] ScannedExtensions = { ".cs", ".md", ".py", ".sh" };
+
+        [Test]
+        public void Given_TheRepoSources_When_ScannedForCorrectedSentences_Then_NoneReappearOutsideTheList()
+        {
+            // Arrange — derived from CLAUDE.md so a sixth list entry needs no edit here.
+            var sentences = ExtractCorrectedSentences();
+
+            // Act
+            var findings = ScanForSentences(sentences);
+
+            // Assert — the count rides along so an extractor that found nothing cannot satisfy emptiness alone.
+            Assert.That(
+                (sentences.Count > 0, string.Join("\n", findings)),
+                Is.EqualTo((true, string.Empty)),
+                "A corrected sentence reappeared outside the CLAUDE.md list:\n" + string.Join("\n", findings));
+        }
+
+        private static List<string> ExtractCorrectedSentences()
+        {
+            var sentences = new List<string>();
+            foreach (var line in File.ReadAllLines(ClaudePath))
+            {
+                var match = CorrectedSentenceEntryPattern.Match(line);
+                if (match.Success)
+                {
+                    sentences.Add(match.Groups[1].Value);
+                }
+            }
+            return sentences;
+        }
+
+        private static List<string> ScanForSentences(IReadOnlyList<string> sentences)
+        {
+            var findings = new List<string>();
+            foreach (var entry in DocumentationCorpus.RepoEntries(includeClaude: true))
+            {
+                if (!ScannedExtensions.Any(extension => entry.EndsWith(extension, StringComparison.Ordinal))
+                    || !File.Exists(entry))
+                {
+                    continue;
+                }
+                var lines = File.ReadAllLines(entry);
+                for (var lineIndex = 0; lineIndex < lines.Length; lineIndex++)
+                {
+                    var line = lines[lineIndex];
+                    if (entry == ClaudePath && CorrectedSentenceEntryPattern.IsMatch(line))
+                    {
+                        continue;
+                    }
+                    foreach (var sentence in sentences)
+                    {
+                        if (line.Contains(sentence, StringComparison.Ordinal))
+                        {
+                            findings.Add($"{entry}:{lineIndex + 1}: {sentence}");
+                        }
+                    }
+                }
+            }
+            return findings;
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/CorrectedSentenceTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/CorrectedSentenceTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: bda0c2ec98b554b7aada81d8df9569ee

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/DocumentationCorpus.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/DocumentationCorpus.cs
@@ -1,12 +1,14 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 namespace Velvet.Tests
 {
     /// <summary>
-    /// The markdown files this suite machine-checks. One enumeration serves both the fixture that scans
-    /// them and the fixture that asks whether CI starts for a change to one, so neither can be widened
-    /// without the other following.
+    /// The markdown files and repository paths these fixtures machine-check. One enumeration serves the
+    /// fixtures that read from it, so neither the markdown set nor the walk can be widened without the
+    /// others that share it following.
     /// </summary>
     internal static class DocumentationCorpus
     {
@@ -29,6 +31,79 @@ namespace Velvet.Tests
             yield return (Path.GetFullPath("CLAUDE.md"), "CLAUDE.md");
             yield return (Path.GetFullPath("Packages/com.velvet.core/Generators~/README.md"),
                 "Generators~/README.md");
+        }
+
+        // Every entry under the walked roots, repo-relative and slash-separated. includeClaude adds
+        // .claude/skills and agent definitions to the tree; worktrees is skipped there because each is a
+        // full checkout of this repository and would report its own copy of every path.
+        internal static IReadOnlyList<string> RepoEntries(bool includeClaude) =>
+            (includeClaude ? ClaudeAwareWalk : DocumentationWalk).Value;
+
+        private static readonly string[] BaseWalkedRoots =
+            { "Packages", "Assets", ".github", "scripts", "ProjectSettings", "docs" };
+
+        // Build output and generated documentation: nothing a document names lives there, DocFX's api/ and
+        // _site/ carry a stale copy of every runtime type name until docs/build.sh is re-run, and Library
+        // alone would make the walk the slowest thing in this fixture.
+        private static readonly HashSet<string> BaseUnwalkedDirectories =
+            new() { ".git", "Library", "Temp", "Logs", "Build", "UserSettings", "obj", "bin", "api", "_site" };
+
+        private static readonly Lazy<List<string>> DocumentationWalk = new(() => Walk(includeClaude: false));
+        private static readonly Lazy<List<string>> ClaudeAwareWalk = new(() => Walk(includeClaude: true));
+
+        private static List<string> Walk(bool includeClaude)
+        {
+            // The walk is rooted rather than filtered because this repo's own workflow puts full checkouts of
+            // itself under .claude/worktrees/ while a suite runs: an exclusion list has to anticipate every such
+            // directory, and one it misses resolves every name the docs carry against a copy of the very sources
+            // the rename was supposed to remove them from — leaving the check structurally green on a developer
+            // machine and red only on CI.
+            var walkedRoots = includeClaude
+                ? BaseWalkedRoots.Append(".claude").ToArray()
+                : BaseWalkedRoots;
+            var unwalked = new HashSet<string>(BaseUnwalkedDirectories);
+            if (includeClaude)
+            {
+                unwalked.Add("worktrees");
+            }
+
+            var root = Path.GetFullPath(".");
+            var entries = new List<string>();
+            // Depth-bounded rather than visited-set guarded: a symlink cycle yields a FRESH path string every
+            // lap, so a set keyed on the path never closes it, and the link-resolving API that would is not in
+            // Unity's target framework. The deepest real directory here sits at 7, so a bound of 32 stops a
+            // cycle while leaving room the layout will not reach.
+            const int maxDepth = 32;
+            var pending = new Stack<(string Directory, int Depth)>(
+                walkedRoots.Select(Path.GetFullPath).Where(Directory.Exists).Select(walked => (walked, 1)));
+            entries.AddRange(walkedRoots.Where(walked => Directory.Exists(Path.GetFullPath(walked))));
+            entries.AddRange(Directory.EnumerateFiles(root).Select(file => Path.GetFileName(file)));
+            while (pending.Count > 0)
+            {
+                var (directory, depth) = pending.Pop();
+                string[] children;
+                try
+                {
+                    children = Directory.GetFileSystemEntries(directory);
+                }
+                catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
+                {
+                    continue;
+                }
+                foreach (var entry in children)
+                {
+                    if (unwalked.Contains(Path.GetFileName(entry)))
+                    {
+                        continue;
+                    }
+                    entries.Add(Path.GetRelativePath(root, entry).Replace('\\', '/'));
+                    if (Directory.Exists(entry) && depth < maxDepth)
+                    {
+                        pending.Push((entry, depth + 1));
+                    }
+                }
+            }
+            return entries;
         }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/DocumentationDriftTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/DocumentationDriftTests.cs
@@ -67,20 +67,6 @@ namespace Velvet.Tests
         private static readonly Regex YamlCommentPattern =
             new(@"(?<=^|\s)#[^\n]*", RegexOptions.Compiled | RegexOptions.Multiline);
 
-        // The walk is rooted rather than filtered because this repo's own workflow puts full checkouts of
-        // itself under .claude/worktrees/ while a suite runs: an exclusion list has to anticipate every such
-        // directory, and one it misses resolves every name the docs carry against a copy of the very sources
-        // the rename was supposed to remove them from — leaving the check structurally green on a developer
-        // machine and red only on CI.
-        private static readonly string[] WalkedRoots =
-            { "Packages", "Assets", ".github", "scripts", "ProjectSettings", "docs" };
-
-        // Build output and generated documentation: nothing a document names lives there, DocFX's api/ and
-        // _site/ carry a stale copy of every runtime type name until docs/build.sh is re-run, and Library
-        // alone would make the walk the slowest thing in this fixture.
-        private static readonly HashSet<string> UnwalkedDirectories =
-            new() { ".git", "Library", "Temp", "Logs", "Build", "UserSettings", "obj", "bin", "api", "_site" };
-
         private static readonly Regex VReferencePattern = new(@"\bV\.([A-Z][A-Za-z0-9_]*)", RegexOptions.Compiled);
         private static readonly Regex HookReferencePattern = new(@"\bUse[A-Z]\w*", RegexOptions.Compiled);
         private static readonly Regex DocLinkPattern = new(@"\]\(([A-Za-z0-9_.-]+\.md)\)", RegexOptions.Compiled);
@@ -176,7 +162,7 @@ namespace Velvet.Tests
             {
                 var whole = new HashSet<string>(StringComparer.Ordinal);
                 var inComments = new HashSet<string>(StringComparer.Ordinal);
-                foreach (var entry in RepoEntries.Value.Where(e =>
+                foreach (var entry in DocumentationCorpus.RepoEntries(includeClaude: false).Where(e =>
                              e.EndsWith(extension, StringComparison.Ordinal) && File.Exists(e)))
                 {
                     var text = File.ReadAllText(entry);
@@ -200,7 +186,7 @@ namespace Velvet.Tests
             // it by widening both sides. What a widened one cannot do is leave the sheets' own selectors in
             // the corpus: it takes everything between a file's first and last comment with it.
             var selector = new Regex(@"^[^\S\n]*\.([A-Za-z_][A-Za-z0-9_]*)", RegexOptions.Multiline);
-            foreach (var entry in RepoEntries.Value.Where(e =>
+            foreach (var entry in DocumentationCorpus.RepoEntries(includeClaude: false).Where(e =>
                          e.EndsWith(".uss", StringComparison.Ordinal) && File.Exists(e)))
             {
                 unheld.AddRange(selector.Matches(File.ReadAllText(entry))
@@ -227,7 +213,7 @@ namespace Velvet.Tests
             var labelPattern = new Regex(RegionLabelAlternation, RegexOptions.Multiline);
             var withRegions = new HashSet<string>(StringComparer.Ordinal);
             var labelWords = new HashSet<string>(StringComparer.Ordinal);
-            foreach (var entry in RepoEntries.Value.Where(
+            foreach (var entry in DocumentationCorpus.RepoEntries(includeClaude: false).Where(
                          e => e.EndsWith(".cs", StringComparison.Ordinal) && File.Exists(e)))
             {
                 var text = File.ReadAllText(entry);
@@ -387,52 +373,6 @@ namespace Velvet.Tests
             return unresolved.Distinct().ToList();
         }
 
-        // Every entry under the walked roots, repo-relative and slash-separated, so a path reference can be
-        // matched as a SUFFIX: the docs write `Component/V.cs` for a file under Packages/com.velvet.core/Runtime.
-        // A directory that vanishes mid-walk is skipped rather than thrown from — this repo creates and deletes
-        // worktrees while suites run, and Lazy caches a thrown exception for the rest of the domain, which would
-        // turn one transient miss into a permanently failing fixture.
-        private static readonly Lazy<List<string>> RepoEntries = new(() =>
-        {
-            var root = Path.GetFullPath(".");
-            var entries = new List<string>();
-            // Depth-bounded rather than visited-set guarded: a symlink cycle yields a FRESH path string every
-            // lap, so a set keyed on the path never closes it, and the link-resolving API that would is not in
-            // Unity's target framework. The deepest real directory here sits at 7, so a bound of 32 stops a
-            // cycle while leaving room the layout will not reach.
-            const int maxDepth = 32;
-            var pending = new Stack<(string Directory, int Depth)>(
-                WalkedRoots.Select(Path.GetFullPath).Where(Directory.Exists).Select(walked => (walked, 1)));
-            entries.AddRange(WalkedRoots.Where(walked => Directory.Exists(Path.GetFullPath(walked))));
-            entries.AddRange(Directory.EnumerateFiles(root).Select(file => Path.GetFileName(file)));
-            while (pending.Count > 0)
-            {
-                var (directory, depth) = pending.Pop();
-                string[] children;
-                try
-                {
-                    children = Directory.GetFileSystemEntries(directory);
-                }
-                catch (Exception exception) when (exception is IOException or UnauthorizedAccessException)
-                {
-                    continue;
-                }
-                foreach (var entry in children)
-                {
-                    if (UnwalkedDirectories.Contains(Path.GetFileName(entry)))
-                    {
-                        continue;
-                    }
-                    entries.Add(Path.GetRelativePath(root, entry).Replace('\\', '/'));
-                    if (Directory.Exists(entry) && depth < maxDepth)
-                    {
-                        pending.Push((entry, depth + 1));
-                    }
-                }
-            }
-            return entries;
-        });
-
         // Every identifier-shaped word in the repo's own CODE. A name surviving nowhere in it was renamed or
         // deleted, which is the drift this checks for. It deliberately does not care WHERE the word occurs:
         // resolving this mix of runtime types, Unity types, generator symbols and CI variables against their
@@ -443,7 +383,7 @@ namespace Velvet.Tests
         {
             var words = new Regex(@"[A-Za-z_][A-Za-z0-9_]*", RegexOptions.Compiled);
             var identifiers = new HashSet<string>(StringComparer.Ordinal);
-            foreach (var entry in RepoEntries.Value)
+            foreach (var entry in DocumentationCorpus.RepoEntries(includeClaude: false))
             {
                 if (!SourceExtensions.Any(extension => entry.EndsWith(extension, StringComparison.Ordinal))
                     || !File.Exists(entry))
@@ -498,11 +438,12 @@ namespace Velvet.Tests
             var leaf = trimmed[(separator + 1)..];
             if (!leaf.Contains('*'))
             {
-                return trimmed.Contains('*') || RepoEntries.Value.Any(entry => IsSuffixPath(entry, trimmed));
+                return trimmed.Contains('*') || DocumentationCorpus.RepoEntries(includeClaude: false)
+                    .Any(entry => IsSuffixPath(entry, trimmed));
             }
             var directory = separator < 0 ? string.Empty : trimmed[..separator];
             var extension = leaf.TrimStart('*');
-            return RepoEntries.Value.Any(entry =>
+            return DocumentationCorpus.RepoEntries(includeClaude: false).Any(entry =>
                 entry.EndsWith(extension, StringComparison.Ordinal)
                 && entry.LastIndexOf('/') >= 0
                 && IsSuffixPath(entry[..entry.LastIndexOf('/')], directory));


### PR DESCRIPTION
Part of #317, class B.

CLAUDE.md lists five sentences that were written into this repository, found false, and corrected. Nothing stopped one being pasted back, and that list is the only record they were ever wrong.

`CorrectedSentenceTests` derives the sentences from the list rather than repeating them — a sixth entry is picked up with no edit here — and reports the file and line of any exact reappearance outside the list itself. It scans `.claude` alongside the source roots, because one of the five lived in a skill, and skips `worktrees`, since each is a full checkout that would report its own copy.

## What it does and does not hold

It holds verbatim reuse, which is what copy-paste produces.

It does not hold a paraphrase. **And whether it would have caught the copies that prompted the list is not knowable**: those were corrected before the branches carrying them were squashed, so no wording survives to compare against. `git log -S` on the canonical wording finds only the two commits that added the list. The issue asserts this guard "would have caught five of this session`s copies" — that claim cannot be checked and is not repeated here.

## The walk moved

The first version of this fixture carried a verbatim duplicate of the repository walk in `DocumentationDriftTests` — same roots, same skip list, same depth bound. A fixture that guards against copy-paste, written by copy-paste. Both now call one walk in `DocumentationCorpus`, which already exists to be the single enumeration these fixtures read; the difference between the callers is a parameter, since only this one needs `.claude`. `DocumentationDriftTests` walks exactly the roots it walked before, because its identifier corpus is load-bearing for several other cases.

## Verification

- Red: a file under `scripts/` carrying one of the five fails the case, naming `scripts/_red_probe.py:2` and the sentence.
- Green: whole EditMode suite, 3584 cases, 3581 passed, 0 failed, 0 inconclusive.

No `Documentation~` impact: CLAUDE.md already owns the list and the rule; this adds a check over it.