### PR TITLE
Refuse a branch cut from something other than a current main, and keep a deliberate stack recoverable

### DIFF
--- a/.claude/hooks/lib/velvet_hooks.py
+++ b/.claude/hooks/lib/velvet_hooks.py
@@ -1,0 +1,4 @@
+import os
+
+# Written by refuse-branch-from-unmerged.py and read by refuse-stale-merge.py; one name, both sides.
+BRANCH_BASES = os.path.join(os.path.expanduser("~"), ".velvet-branch-bases")

--- a/.claude/hooks/refuse-branch-from-unmerged.py
+++ b/.claude/hooks/refuse-branch-from-unmerged.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Refuse creating a branch from HEAD when HEAD is not main and local main is not current.
+
+A branch cut from another change's tip carried three commits from an unmerged pull request;
+after that pull request was squash-merged, rebasing the new branch replayed content already on
+main and conflicted, and the pull request had to be abandoned and reopened at a new number.
+Branching from a stale main produces a branch the merge guard refuses later, when the fix is a
+rebase rather than a different starting point.
+"""
+
+import json
+import os
+import re
+import subprocess
+import sys
+
+# Anchored at a command position — start of input, or after a separator or newline — so the same
+# text quoted inside an argument does not trip it. The blind-add sibling records the first version
+# refused the change that would have fixed it.
+_GIT = r"git\s+(?:-C\s+\S+\s+)?"
+_END = r"(?:\s*$|\s*[;&|])"
+ANCHOR = r"(?:^|[;&|]|\n)\s*"
+CHECKOUT_B = re.compile(ANCHOR + _GIT + r"checkout\s+-b\s+(\S+)" + _END)
+SWITCH_CREATE = re.compile(ANCHOR + _GIT + r"switch\s+(?:-c|--create)\s+(\S+)" + _END)
+BRANCH = re.compile(ANCHOR + _GIT + r"branch\s+([^-\s]\S*)" + _END)
+
+
+def git(cwd, *args):
+    return subprocess.run(
+        ["git", "-C", cwd, *args],
+        capture_output=True, text=True, timeout=30,
+    )
+
+
+def branch_name(command):
+    for pattern in (CHECKOUT_B, SWITCH_CREATE, BRANCH):
+        match = pattern.search(command)
+        if match:
+            return match.group(1)
+    return None
+
+
+def deferred(key):
+    hook_dir = os.path.dirname(os.path.abspath(__file__))
+    deferrals = os.path.join(hook_dir, "lib", "deferrals.sh")
+    proc = subprocess.run(
+        ["bash", "-c",
+         f'. "{deferrals}" && deferred "$1" && printf "%s\\t%s" "$DEFER_REASON" "$DEFER_AGE"',
+         "deferred_check", key],
+        capture_output=True, text=True, timeout=5,
+    )
+    if proc.returncode != 0 or not proc.stdout.strip():
+        return None
+    reason, age = proc.stdout.strip().split("\t", 1)
+    return reason, int(age)
+
+
+def head_description(cwd):
+    ref = git(cwd, "rev-parse", "--abbrev-ref", "HEAD")
+    branch = ref.stdout.strip()
+    if branch and branch != "HEAD":
+        return branch
+    sha = git(cwd, "rev-parse", "--short", "HEAD")
+    return f"detached at {sha.stdout.strip()}"
+
+
+def main():
+    try:
+        event = json.load(sys.stdin)
+    except Exception:
+        return 0
+    if event.get("tool_name") != "Bash":
+        return 0
+    command = event.get("tool_input", {}).get("command", "")
+    name = branch_name(command)
+    if not name:
+        return 0
+
+    if deferred(name):
+        return 0
+
+    cwd = event.get("cwd") or "."
+
+    head_not_main = False
+    head_ref = git(cwd, "rev-parse", "--abbrev-ref", "HEAD").stdout.strip()
+    if head_ref != "main":
+        on_main = git(cwd, "merge-base", "--is-ancestor", "HEAD", "main")
+        if on_main.returncode != 0:
+            head_not_main = True
+
+    main_behind = False
+    behind_count = None
+    origin_main = git(cwd, "rev-parse", "--verify", "origin/main")
+    if origin_main.returncode != 0:
+        origin_missing = True
+    else:
+        origin_missing = False
+        count = git(cwd, "rev-list", "--count", "main..origin/main")
+        behind_count = count.stdout.strip()
+        if behind_count and behind_count != "0":
+            main_behind = True
+
+    if not head_not_main and not main_behind:
+        return 0
+
+    head = head_description(cwd)
+    lines = []
+
+    if head_not_main:
+        lines.append(
+            f"Refusing to create `{name}`: HEAD is {head}, not main and not a commit main contains."
+        )
+        lines += [
+            "",
+            "Branching from another change's tip carries its commits into the new branch. Here that "
+            "produced a rebase against squash-merged content already on main, conflicts, and a pull "
+            "request that had to be abandoned and reopened.",
+            "",
+            f"git checkout main",
+            f"git pull",
+            f"git checkout -b {name}",
+            "",
+            f"Or branch from main in one step: git checkout -b {name} main",
+            "",
+            f"To stack on unmerged work on purpose, record intent and retry:",
+            f'  echo "{name} <why> $(date +%s)" >> ~/.velvet-pr-deferrals',
+        ]
+
+    if main_behind:
+        if lines:
+            lines.append("")
+        lines.append(
+            f"Refusing to create `{name}`: local main is {behind_count} commit(s) behind origin/main."
+        )
+        lines += [
+            "",
+            "Branching from a stale main produces a branch the merge guard refuses later; the fix "
+            "then is a rebase rather than a different starting point.",
+            "",
+            "git checkout main",
+            "git pull",
+            f"git checkout -b {name}",
+        ]
+
+    if origin_missing and not main_behind:
+        lines += [
+            "",
+            "origin/main is not present locally; staleness against it was not checked.",
+        ]
+
+    sys.stderr.write("\n".join(lines) + "\n")
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/hooks/refuse-branch-from-unmerged.py
+++ b/.claude/hooks/refuse-branch-from-unmerged.py
@@ -14,6 +14,9 @@ import re
 import subprocess
 import sys
 
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib"))
+from velvet_hooks import BRANCH_BASES
+
 # Anchored at a command position — start of input, or after a separator or newline — so the same
 # text quoted inside an argument does not trip it. The blind-add sibling records the first version
 # refused the change that would have fixed it.
@@ -64,6 +67,16 @@ def head_description(cwd):
     return f"detached at {sha.stdout.strip()}"
 
 
+def record_branch_base(name, sha):
+    try:
+        with open(BRANCH_BASES, "a", encoding="utf-8") as bases:
+            bases.write(f"{name} {sha}\n")
+        return True
+    except OSError as err:
+        sys.stderr.write(f"Could not record branch base in {BRANCH_BASES}: {err}\n")
+        return False
+
+
 def main():
     try:
         event = json.load(sys.stdin)
@@ -76,10 +89,20 @@ def main():
     if not name:
         return 0
 
+    cwd = event.get("cwd") or "."
+
     if deferred(name):
+        # Parent tip at branch creation is gone after squash-merge; rebase --onto needs it recorded now.
+        head_sha = git(cwd, "rev-parse", "HEAD").stdout.strip()
+        record_branch_base(name, head_sha)
+        sys.stderr.write(
+            f"Recorded base {head_sha} for `{name}`. "
+            f"After parent merges (assumes origin/main is current — fetch first if unsure):\n"
+            f"git fetch origin main\n"
+            f"git rebase --onto origin/main {head_sha}\n"
+        )
         return 0
 
-    cwd = event.get("cwd") or "."
 
     head_not_main = False
     head_ref = git(cwd, "rev-parse", "--abbrev-ref", "HEAD").stdout.strip()

--- a/.claude/hooks/refuse-stale-merge.py
+++ b/.claude/hooks/refuse-stale-merge.py
@@ -12,15 +12,31 @@ status checks, so that field answers CLEAN for a branch eight commits behind. A 
 would never fire.
 """
 import json
+import os
 import re
 import subprocess
 import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib"))
+from velvet_hooks import BRANCH_BASES
 
 
 def git(*args):
     return subprocess.run(
         ["git", *args], stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, timeout=30
     )
+
+
+def branch_base(name):
+    try:
+        with open(BRANCH_BASES, encoding="utf-8") as bases:
+            matches = [line for line in bases if line.startswith(f"{name} ")]
+    except OSError:
+        return None
+    if not matches:
+        return None
+    parts = matches[-1].split(None, 1)
+    return parts[1].strip() if len(parts) == 2 else None
 
 
 def main():
@@ -50,15 +66,29 @@ def main():
         return 0
 
     behind = git("rev-list", "--count", "origin/{}..origin/main".format(head)).stdout.decode().strip()
-    sys.stderr.write(
-        "PR #{} does not contain the current main — it is {} commit(s) behind.\n\n"
-        "Its checks passed against a main this merge does not produce. That is how main was broken "
-        "here: two branches, each green, neither containing the other's change.\n\n"
-        "Merge origin/main into {}, let the checks re-run, then merge.\n\n"
-        "Note mergeStateStatus says CLEAN for this PR. GitHub only reports BEHIND when the base "
-        "requires the head to be up to date, which protect-main does not — so that field cannot be "
-        "the thing you check.\n".format(pr, behind or "?", head)
-    )
+    base = branch_base(head)
+    if base:
+        sys.stderr.write(
+            "PR #{} does not contain the current main — it is {} commit(s) behind.\n\n"
+            "Its checks passed against a main this merge does not produce. That is how main was broken "
+            "here: two branches, each green, neither containing the other's change.\n\n"
+            "This branch was created on top of unmerged work. After the parent merges, replay only "
+            "this branch's commits with:\n"
+            "git rebase --onto origin/main {}\n\n"
+            "Note mergeStateStatus says CLEAN for this PR. GitHub only reports BEHIND when the base "
+            "requires the head to be up to date, which protect-main does not — so that field cannot be "
+            "the thing you check.\n".format(pr, behind or "?", base)
+        )
+    else:
+        sys.stderr.write(
+            "PR #{} does not contain the current main — it is {} commit(s) behind.\n\n"
+            "Its checks passed against a main this merge does not produce. That is how main was broken "
+            "here: two branches, each green, neither containing the other's change.\n\n"
+            "Merge origin/main into {}, let the checks re-run, then merge.\n\n"
+            "Note mergeStateStatus says CLEAN for this PR. GitHub only reports BEHIND when the base "
+            "requires the head to be up to date, which protect-main does not — so that field cannot be "
+            "the thing you check.\n".format(pr, behind or "?", head)
+        )
     return 2
 
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -61,6 +61,11 @@
           },
           {
             "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/refuse-branch-from-unmerged.py\"",
+            "timeout": 15000
+          },
+          {
+            "type": "command",
             "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/refuse-blind-git-add.py\"",
             "timeout": 10000
           },

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/HookWiringCoverageTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/HookWiringCoverageTests.cs
@@ -75,10 +75,16 @@ namespace Velvet.Tests
                 .Where(script => wired.Contains(script))
                 .Select(script => File.ReadAllText(Path.GetFullPath(HookDirectory + "/" + script))));
 
-            // Act
+            // Python imports name the module, not the file; stem matching covers that route the
+            // same way lib/deferrals.sh is reached by its path. Stem matching is looser than the
+            // full name — a hook quoting a stem in prose would read as sourced when it is not —
+            // which is accepted because reporting a genuinely imported file as an orphan blocks
+            // sharing the way deferrals.sh was extracted to stop.
             var orphans = scripts
                 .Where(script => !wired.Contains(script))
-                .Where(script => !sourced.Contains(Path.GetFileName(script), StringComparison.Ordinal))
+                .Where(script =>
+                    !sourced.Contains(Path.GetFileName(script), StringComparison.Ordinal)
+                    && !sourced.Contains(Path.GetFileNameWithoutExtension(script), StringComparison.Ordinal))
                 .ToList();
 
             // Assert


### PR DESCRIPTION
Closes #328.

A branch created while the working copy stands on another change's branch carries that branch's commits, and nothing reports it. It stays invisible until the first branch merges: this repository squash-merges, so the second branch then holds commits whose content is on main under a different sha, and a plain rebase onto main replays them and conflicts.

`refuse-branch-from-unmerged.py` refuses at the moment the branch is created, on two independent conditions:

- HEAD is not a commit `main` contains — branching from another change's tip;
- local `main` is behind `origin/main` — branching from a stale main, which produces a branch `refuse-stale-merge.py` refuses later, when the fix is a rebase rather than a different starting point.

It reads the already-fetched `origin/main` rather than fetching, so a branch creation costs no network round trip, and says nothing on that ground when the ref is absent.

## Stacking stays possible, and now stays recoverable

Branching on top of unmerged work is legitimate, so the refusal clears through the expiring deferral the merge guard already uses, keyed on the branch being created.

Allowing it was the easy half. This repository squash-merges, so the parent's own commits never reach `main` and its branch is deleted on merge — the child is left holding commits whose content is on `main` under a different sha, and the base it needs to replay from is gone. Measured in a scratch repository, a parent of two commits squash-merged under a child of one:

| recovery | result |
| --- | --- |
| `git rebase main` | CONFLICT (add/add), exit 1 |
| `git merge main` | works, 4 commits vs main |
| `git rebase --onto main <parent-tip>` | works, 1 commit vs main — the child's own |

So the recovery needs the parent tip, and the branch guard holds exactly that at the moment it decides to allow the stack. It records the pair and prints the command; `refuse-stale-merge.py` reads the record back and prints it again at the moment it refuses, which is when the reader actually needs it. A branch with no record gets that hook's message unchanged.

Both name `origin/main` rather than `main`. The local ref is the one this repository cannot assume is current — `report-stale-main.sh` exists because of that — and the merge guard has already fetched by the time it prints.

The record's path lives in `lib/velvet_hooks.py` rather than being spelled in both hooks: a writer and a reader that disagree on a filename both keep working, and the recovery silently never appears.

## Exercised against the live repository

| case | exit |
| --- | --- |
| HEAD is a commit main does not contain, `git checkout -b` | 2 |
| same, `git switch -c` | 2 |
| local main one commit behind `origin/main`, HEAD equal to main | 2 |
| `git branch <name> <start-point>` | 0 |
| `git status` | 0 |
| the command text quoted inside an argument | 0 |
| a live deferral for the branch name | 0, base recorded, recovery printed |
| a deferral past its expiry | 2 |

The stale-main case was measured in a throwaway clone whose `main` was moved a commit behind its `origin/main`, so the two conditions could be separated — from the working copy, the first fires before the second can be reached. The deferral cases were run from a working directory outside the repository, so the shared-module import path is exercised rather than assumed.

## The wiring guard accepts a module name

`HookWiringCoverageTests` decided a file was reached by finding its name inside a wired hook, which a Python import never writes — an import names the module without its extension. It now accepts the stem as well, which covers both routes with one rule. The looser direction is stated in the comment — a stem appearing in prose would read as reached — and it is accepted because the opposite direction blocks a shared module from existing at all, which is the trade this repository already made when it extracted `lib/deferrals.sh`. Verified still live: a temporary unwired file in the hook directory fails the case.

Whole EditMode suite: 3585 cases, 3582 passed, 0 failed, 0 inconclusive.

No `Documentation~` impact: the hooks are loop machinery rather than package behaviour.

