### PR TITLE
Pin the shipped public surface to a checked-in file

### DIFF
--- a/Packages/com.velvet.core/PublicAPI.txt
+++ b/Packages/com.velvet.core/PublicAPI.txt
@@ -1,0 +1,1039 @@
+ctor System.Runtime.CompilerServices.ModuleInitializerAttribute.ctor(): System.Void
+ctor Velvet.AnchoredSettings.ctor(UnityEngine.Transform, UnityEngine.Camera, UnityEngine.Vector2, System.Boolean, System.Boolean, System.Nullable`1[UnityEngine.LayerMask], System.Nullable`1[System.Single]): System.Void
+ctor Velvet.AnimatePresenceNode.ctor(): System.Void
+ctor Velvet.BlurBinding.ctor(): System.Void
+ctor Velvet.ChangeEventBinding`1.ctor(): System.Void
+ctor Velvet.ChoicesSettings.ctor(System.Collections.Generic.List`1[System.String]): System.Void
+ctor Velvet.ClickedBinding.ctor(): System.Void
+ctor Velvet.ComponentAttribute.ctor(): System.Void
+ctor Velvet.ComponentFiber.ctor(): System.Void
+ctor Velvet.ComponentNode.ctor(): System.Void
+ctor Velvet.ContextProviderNode`1.ctor(): System.Void
+ctor Velvet.DndCollisionDetection.ctor(System.Object, System.IntPtr): System.Void
+ctor Velvet.DndCollisionQuery.ctor(UnityEngine.Rect, UnityEngine.Vector2, System.Collections.Generic.IReadOnlyList`1[Velvet.DndDroppableRect]): System.Void
+ctor Velvet.DndContextSettings.ctor(System.Action`1[Velvet.DragStartArgs], System.Action`1[Velvet.DragOverArgs], System.Action`1[Velvet.DragEndArgs], System.Action`1[Velvet.DragCancelArgs], Velvet.DndCollisionDetection, Velvet.DragActivation): System.Void
+ctor Velvet.DndDroppableRect.ctor(System.String, UnityEngine.Rect, System.Object): System.Void
+ctor Velvet.DragActivation.ctor(System.Single, System.Single, System.Single): System.Void
+ctor Velvet.DragCancelArgs.ctor(Velvet.DraggableInfo): System.Void
+ctor Velvet.DragEndArgs.ctor(Velvet.DraggableInfo, Velvet.DroppableInfo, UnityEngine.Vector2, UnityEngine.Vector2): System.Void
+ctor Velvet.DragOverArgs.ctor(Velvet.DraggableInfo, Velvet.DroppableInfo, UnityEngine.Vector2): System.Void
+ctor Velvet.DragOverlaySettings.ctor(): System.Void
+ctor Velvet.DragStartArgs.ctor(Velvet.DraggableInfo, UnityEngine.Vector2): System.Void
+ctor Velvet.DraggableInfo.ctor(System.String, System.Object, UnityEngine.UIElements.VisualElement): System.Void
+ctor Velvet.DraggableSettings.ctor(System.String, System.Object, System.Boolean, Velvet.DragMovement, Velvet.DragActivation, System.String): System.Void
+ctor Velvet.DroppableInfo.ctor(System.String, System.Object, UnityEngine.UIElements.VisualElement): System.Void
+ctor Velvet.DroppableSettings.ctor(System.String, System.Object, System.Boolean, System.String, System.String): System.Void
+ctor Velvet.ElementNode.ctor(): System.Void
+ctor Velvet.ErrorInfo.ctor(System.String): System.Void
+ctor Velvet.Experimental.VButton.ctor(System.String): System.Void
+ctor Velvet.Experimental.VCustom`1.ctor(System.String): System.Void
+ctor Velvet.Experimental.VDiv.ctor(System.String): System.Void
+ctor Velvet.Experimental.VImage.ctor(System.String): System.Void
+ctor Velvet.Experimental.VLabel.ctor(System.String): System.Void
+ctor Velvet.Experimental.VScrollView.ctor(System.String): System.Void
+ctor Velvet.Experimental.VSlider.ctor(System.String): System.Void
+ctor Velvet.Experimental.VTextField.ctor(System.String): System.Void
+ctor Velvet.Experimental.VToggle.ctor(System.String): System.Void
+ctor Velvet.FiberElementProps.ctor(): System.Void
+ctor Velvet.FocusBinding.ctor(): System.Void
+ctor Velvet.FocusInBinding.ctor(): System.Void
+ctor Velvet.FocusOutBinding.ctor(): System.Void
+ctor Velvet.FocusScopeSettings.ctor(System.Boolean, System.Boolean, System.Boolean, System.Boolean): System.Void
+ctor Velvet.FontIntent.ctor(System.String, System.Boolean, Velvet.VelvetFontWeight, System.Boolean, System.Boolean, System.Boolean): System.Void
+ctor Velvet.FragmentNode.ctor(): System.Void
+ctor Velvet.GeometryChangedBinding.ctor(): System.Void
+ctor Velvet.KeyDownBinding.ctor(): System.Void
+ctor Velvet.KeyUpBinding.ctor(): System.Void
+ctor Velvet.MemoNode.ctor(): System.Void
+ctor Velvet.MemoizeMethodAttribute.ctor(): System.Void
+ctor Velvet.MotionNode.ctor(): System.Void
+ctor Velvet.MutableRef`1.ctor(T): System.Void
+ctor Velvet.MutationOptions.ctor(System.Func`2[System.Threading.CancellationToken, Cysharp.Threading.Tasks.UniTask], System.Action, System.Action`1[System.Exception]): System.Void
+ctor Velvet.MutationOptions`1.ctor(System.Func`3[TVariables, System.Threading.CancellationToken, Cysharp.Threading.Tasks.UniTask], System.Action`1[TVariables], System.Action`2[System.Exception, TVariables]): System.Void
+ctor Velvet.MutationOptions`2.ctor(System.Func`3[TVariables, System.Threading.CancellationToken, Cysharp.Threading.Tasks.UniTask`1[TData]], System.Action`2[TData, TVariables], System.Action`2[System.Exception, TVariables]): System.Void
+ctor Velvet.MutationResult`2.ctor(): System.Void
+ctor Velvet.Navigate+Props.ctor(System.String, System.Boolean): System.Void
+ctor Velvet.NavigationAttempt.ctor(): System.Void
+ctor Velvet.NullStoreLogger.ctor(): System.Void
+ctor Velvet.OutletNode.ctor(): System.Void
+ctor Velvet.ParticlesElement.ctor(): System.Void
+ctor Velvet.ParticlesSettings.ctor(UnityEngine.ParticleSystem, Velvet.PlayTrigger, System.Single): System.Void
+ctor Velvet.PointerDownBinding.ctor(): System.Void
+ctor Velvet.PointerEnterBinding.ctor(): System.Void
+ctor Velvet.PointerLeaveBinding.ctor(): System.Void
+ctor Velvet.PointerMoveBinding.ctor(): System.Void
+ctor Velvet.PointerUpBinding.ctor(): System.Void
+ctor Velvet.PortalNode.ctor(): System.Void
+ctor Velvet.PureAttribute.ctor(): System.Void
+ctor Velvet.Ref`1.ctor(): System.Void
+ctor Velvet.ResolvedFont.ctor(UnityEngine.TextCore.Text.FontAsset, System.Boolean, System.Boolean): System.Void
+ctor Velvet.RouteBlockerManager.ctor(): System.Void
+ctor Velvet.RouteBlockerState.ctor(): System.Void
+ctor Velvet.RouteDefinition.ctor(): System.Void
+ctor Velvet.RouteLink+Props.ctor(System.String, System.String, System.String, System.String, Velvet.VNode[], System.Boolean): System.Void
+ctor Velvet.RouteLoaderContext.ctor(): System.Void
+ctor Velvet.RouteMatch.ctor(): System.Void
+ctor Velvet.RouteNavLink+Props.ctor(): System.Void
+ctor Velvet.RouteTree.ctor(Velvet.RouteDefinition[]): System.Void
+ctor Velvet.Router.ctor(Velvet.RouteDefinition[], Velvet.IRouteScopeFactory): System.Void
+ctor Velvet.RouterLocation.ctor(): System.Void
+ctor Velvet.SceneViewElement.ctor(): System.Void
+ctor Velvet.SceneViewSettings.ctor(UnityEngine.Camera, System.Single): System.Void
+ctor Velvet.ScrollViewSettings.ctor(System.Nullable`1[UnityEngine.UIElements.ScrollerVisibility], System.Nullable`1[UnityEngine.UIElements.ScrollerVisibility], System.Nullable`1[UnityEngine.UIElements.ScrollView+TouchScrollBehavior]): System.Void
+ctor Velvet.SearchParams.ctor(): System.Void
+ctor Velvet.SliderSettings.ctor(System.Nullable`1[System.Single], System.Nullable`1[System.Single]): System.Void
+ctor Velvet.StoreLogger.ctor(): System.Void
+ctor Velvet.StyleOverrides.ctor(): System.Void
+ctor Velvet.StylePropertyTransition.ctor(System.String, System.Nullable`1[System.Single], System.Nullable`1[UnityEngine.UIElements.EasingMode], System.Nullable`1[System.Single]): System.Void
+ctor Velvet.StyleRecipe+CompoundVariant.ctor(System.Collections.Generic.Dictionary`2[System.String, System.String], System.String): System.Void
+ctor Velvet.StyleRecipe.ctor(System.String, System.Collections.Generic.Dictionary`2[System.String, System.Collections.Generic.Dictionary`2[System.String, System.String]], System.Collections.Generic.Dictionary`2[System.String, System.String], Velvet.StyleRecipe+CompoundVariant[]): System.Void
+ctor Velvet.StyleSlotClasses.ctor(System.Collections.Generic.Dictionary`2[System.String, System.String]): System.Void
+ctor Velvet.StyleSlotRecipe+SlotCompoundVariant.ctor(System.Collections.Generic.Dictionary`2[System.String, System.String], System.Collections.Generic.Dictionary`2[System.String, System.String]): System.Void
+ctor Velvet.StyleSlotRecipe.ctor(System.Collections.Generic.Dictionary`2[System.String, System.String]): System.Void
+ctor Velvet.StyleSlotRecipe.ctor(System.Collections.Generic.Dictionary`2[System.String, System.String], System.Collections.Generic.Dictionary`2[System.String, System.Collections.Generic.Dictionary`2[System.String, System.Collections.Generic.Dictionary`2[System.String, System.String]]], System.Collections.Generic.Dictionary`2[System.String, System.String], Velvet.StyleSlotRecipe+SlotCompoundVariant[]): System.Void
+ctor Velvet.StyleTransitionConfig.ctor(): System.Void
+ctor Velvet.SuspenseNode.ctor(): System.Void
+ctor Velvet.TextFieldSettings.ctor(System.Nullable`1[System.Boolean]): System.Void
+ctor Velvet.TextNode.ctor(): System.Void
+ctor Velvet.VelvetFontFamily.ctor(): System.Void
+ctor Velvet.VelvetFontFamily.ctor(System.String, Velvet.VelvetFontWeightEntry[]): System.Void
+ctor Velvet.VelvetFontWeightEntry.ctor(): System.Void
+ctor Velvet.VelvetPreviewAttribute.ctor(): System.Void
+ctor Velvet.VelvetPreviewHost.ctor(UnityEngine.UIElements.VisualElement): System.Void
+ctor Velvet.VelvetPreviewSetupAttribute.ctor(): System.Void
+ctor Velvet.VelvetRuntimeAssets.ctor(): System.Void
+ctor Velvet.VirtualListNode.ctor(System.Collections.Generic.IReadOnlyList`1[System.Object], System.Func`2[System.Object, System.String], System.Single, System.Func`2[System.Object, Velvet.VNode], System.Int32): System.Void
+ctor Velvet.WheelBinding.ctor(): System.Void
+ctor Velvet.WorldSpaceNode.ctor(): System.Void
+ctor protected Velvet.BaseElementNode.ctor(): System.Void
+ctor protected Velvet.ContextProviderNode.ctor(): System.Void
+ctor protected Velvet.Experimental.VBuilder.ctor(System.String): System.Void
+ctor protected Velvet.FiberEventBinding.ctor(): System.Void
+ctor protected Velvet.Store`1.ctor(TState): System.Void
+ctor protected Velvet.VNode.ctor(): System.Void
+event Velvet.DevTools.VelvetDevToolsRegistry.RegistryChanged: System.Action
+event Velvet.Router.OnLocationChanged: System.Action`1[Velvet.RouterLocation]
+event Velvet.Router.OnStatusChanged: System.Action`1[Velvet.RouterStatus]
+event Velvet.VelvetFonts.FontsChanged: System.Action
+event Velvet.VelvetTheme.DarkModeChanged: System.Action
+field Velvet.AnimatePresenceMode.PopLayout: Velvet.AnimatePresenceMode
+field Velvet.AnimatePresenceMode.Sync: Velvet.AnimatePresenceMode
+field Velvet.AnimatePresenceMode.Wait: Velvet.AnimatePresenceMode
+field Velvet.ComponentFiber.RenderCount: System.Int32
+field Velvet.ComponentFiber.RequestRenderForContextHandler: System.Action`1[Velvet.ComponentFiber]
+field Velvet.DndCollisions.ClosestCenter: Velvet.DndCollisionDetection
+field Velvet.DndCollisions.PointerWithin: Velvet.DndCollisionDetection
+field Velvet.DndCollisions.RectIntersection: Velvet.DndCollisionDetection
+field Velvet.DragActivation.Default: Velvet.DragActivation
+field Velvet.DragActivation.None: Velvet.DragActivation
+field Velvet.DragMovement.None: Velvet.DragMovement
+field Velvet.DragMovement.Translate: Velvet.DragMovement
+field Velvet.FiberElementProps.Empty: Velvet.FiberElementProps
+field Velvet.FiberUpdatePriority.Deferred: Velvet.FiberUpdatePriority
+field Velvet.FiberUpdatePriority.Normal: Velvet.FiberUpdatePriority
+field Velvet.FiberUpdatePriority.Transition: Velvet.FiberUpdatePriority
+field Velvet.FiberUpdatePriority.Urgent: Velvet.FiberUpdatePriority
+field Velvet.FontIntent.Family: System.String
+field Velvet.FontIntent.HasFamily: System.Boolean
+field Velvet.FontIntent.HasItalic: System.Boolean
+field Velvet.FontIntent.HasWeight: System.Boolean
+field Velvet.FontIntent.Italic: System.Boolean
+field Velvet.FontIntent.Weight: Velvet.VelvetFontWeight
+field Velvet.HookServiceContext.Ref: Velvet.ComponentContext`1[Velvet.IHookServiceResolver]
+field Velvet.LoaderMode.Await: Velvet.LoaderMode
+field Velvet.LoaderMode.Suspend: Velvet.LoaderMode
+field Velvet.MutationStatus.Error: Velvet.MutationStatus
+field Velvet.MutationStatus.Idle: Velvet.MutationStatus
+field Velvet.MutationStatus.Pending: Velvet.MutationStatus
+field Velvet.MutationStatus.Success: Velvet.MutationStatus
+field Velvet.NavigationLifecycle.Idle: Velvet.NavigationLifecycle
+field Velvet.NavigationLifecycle.Loading: Velvet.NavigationLifecycle
+field Velvet.NavigationMode.Back: Velvet.NavigationMode
+field Velvet.NavigationMode.Forward: Velvet.NavigationMode
+field Velvet.NavigationMode.Push: Velvet.NavigationMode
+field Velvet.NavigationMode.Replace: Velvet.NavigationMode
+field Velvet.NavigationResult.Blocked: Velvet.NavigationResult
+field Velvet.NavigationResult.Cancelled: Velvet.NavigationResult
+field Velvet.NavigationResult.Error: Velvet.NavigationResult
+field Velvet.NavigationResult.NotFound: Velvet.NavigationResult
+field Velvet.NavigationResult.Success: Velvet.NavigationResult
+field Velvet.PanelFocusOrder.Chained: Velvet.PanelFocusOrder
+field Velvet.PanelFocusOrder.Isolated: Velvet.PanelFocusOrder
+field Velvet.PlayTrigger.Manual: Velvet.PlayTrigger
+field Velvet.PlayTrigger.Mount: Velvet.PlayTrigger
+field Velvet.ResolvedFont.Asset: UnityEngine.TextCore.Text.FontAsset
+field Velvet.ResolvedFont.HasAsset: System.Boolean
+field Velvet.ResolvedFont.ResidualBold: System.Boolean
+field Velvet.ResolvedFont.ResidualItalic: System.Boolean
+field Velvet.RouteBlockerStatus.Blocked: Velvet.RouteBlockerStatus
+field Velvet.RouteBlockerStatus.Idle: Velvet.RouteBlockerStatus
+field Velvet.RouterContext.Depth: Velvet.ComponentContext`1[System.Int32]
+field Velvet.RouterContext.Errors: Velvet.ComponentContext`1[System.Collections.Generic.IReadOnlyDictionary`2[System.String, System.Exception]]
+field Velvet.RouterContext.LoaderData: Velvet.ComponentContext`1[System.Collections.Generic.IReadOnlyDictionary`2[System.String, System.Object]]
+field Velvet.RouterContext.Location: Velvet.ComponentContext`1[Velvet.RouterLocation]
+field Velvet.RouterContext.OutletContext: Velvet.ComponentContext`1[System.Object]
+field Velvet.RouterStatus.Error: Velvet.RouterStatus
+field Velvet.RouterStatus.Idle: Velvet.RouterStatus
+field Velvet.RouterStatus.Loading: Velvet.RouterStatus
+field Velvet.RouterStatus.Matching: Velvet.RouterStatus
+field Velvet.RouterStatus.NotFound: Velvet.RouterStatus
+field Velvet.RouterStatus.Ready: Velvet.RouterStatus
+field Velvet.SearchParams.Empty: Velvet.SearchParams
+field Velvet.StyleOverrides.Empty: Velvet.StyleOverrides
+field Velvet.StyleTransition.Fade: Velvet.StyleTransitionConfig
+field Velvet.StyleTransition.FadeSlideUp: Velvet.StyleTransitionConfig
+field Velvet.StyleTransition.ScaleIn: Velvet.StyleTransitionConfig
+field Velvet.StyleTransition.SlideDown: Velvet.StyleTransitionConfig
+field Velvet.StyleTransition.SlideLeft: Velvet.StyleTransitionConfig
+field Velvet.StyleTransition.SlideRight: Velvet.StyleTransitionConfig
+field Velvet.StyleTransition.SlideUp: Velvet.StyleTransitionConfig
+field Velvet.StyleTransitionConfig.None: Velvet.StyleTransitionConfig
+field Velvet.StyleVariantKind.Active: Velvet.StyleVariantKind
+field Velvet.StyleVariantKind.Checked: Velvet.StyleVariantKind
+field Velvet.StyleVariantKind.Dark: Velvet.StyleVariantKind
+field Velvet.StyleVariantKind.Focus: Velvet.StyleVariantKind
+field Velvet.StyleVariantKind.FocusVisible: Velvet.StyleVariantKind
+field Velvet.StyleVariantKind.GroupActive: Velvet.StyleVariantKind
+field Velvet.StyleVariantKind.GroupFocus: Velvet.StyleVariantKind
+field Velvet.StyleVariantKind.GroupFocusWithin: Velvet.StyleVariantKind
+field Velvet.StyleVariantKind.GroupHover: Velvet.StyleVariantKind
+field Velvet.StyleVariantKind.Hover: Velvet.StyleVariantKind
+field Velvet.StyleVariantKind.Lg: Velvet.StyleVariantKind
+field Velvet.StyleVariantKind.Md: Velvet.StyleVariantKind
+field Velvet.StyleVariantKind.PeerActive: Velvet.StyleVariantKind
+field Velvet.StyleVariantKind.PeerChecked: Velvet.StyleVariantKind
+field Velvet.StyleVariantKind.PeerFocus: Velvet.StyleVariantKind
+field Velvet.StyleVariantKind.PeerFocusWithin: Velvet.StyleVariantKind
+field Velvet.StyleVariantKind.PeerHover: Velvet.StyleVariantKind
+field Velvet.StyleVariantKind.Sm: Velvet.StyleVariantKind
+field Velvet.StyleVariantKind.Xl: Velvet.StyleVariantKind
+field Velvet.StyleVariantKind.Xxl: Velvet.StyleVariantKind
+field Velvet.TransitionType.Bezier: Velvet.TransitionType
+field Velvet.TransitionType.Spring: Velvet.TransitionType
+field Velvet.TransitionType.Tween: Velvet.TransitionType
+field Velvet.TransitionWhen.AfterChildren: Velvet.TransitionWhen
+field Velvet.TransitionWhen.BeforeChildren: Velvet.TransitionWhen
+field Velvet.TransitionWhen.Together: Velvet.TransitionWhen
+field Velvet.UILayer.Background: Velvet.UILayer
+field Velvet.UILayer.Overlay: Velvet.UILayer
+field Velvet.UILayer.Topmost: Velvet.UILayer
+field Velvet.Unit.Default: Velvet.Unit
+field Velvet.VelvetFontFamily.name: System.String
+field Velvet.VelvetFontFamily.weights: System.Collections.Generic.List`1[Velvet.VelvetFontWeightEntry]
+field Velvet.VelvetFontWeight.Black: Velvet.VelvetFontWeight
+field Velvet.VelvetFontWeight.Bold: Velvet.VelvetFontWeight
+field Velvet.VelvetFontWeight.ExtraBold: Velvet.VelvetFontWeight
+field Velvet.VelvetFontWeight.ExtraLight: Velvet.VelvetFontWeight
+field Velvet.VelvetFontWeight.Light: Velvet.VelvetFontWeight
+field Velvet.VelvetFontWeight.Medium: Velvet.VelvetFontWeight
+field Velvet.VelvetFontWeight.Normal: Velvet.VelvetFontWeight
+field Velvet.VelvetFontWeight.SemiBold: Velvet.VelvetFontWeight
+field Velvet.VelvetFontWeight.Thin: Velvet.VelvetFontWeight
+field Velvet.VelvetFontWeightEntry.italic: UnityEngine.TextCore.Text.FontAsset
+field Velvet.VelvetFontWeightEntry.italicAddress: System.String
+field Velvet.VelvetFontWeightEntry.upright: UnityEngine.TextCore.Text.FontAsset
+field Velvet.VelvetFontWeightEntry.uprightAddress: System.String
+field Velvet.VelvetFontWeightEntry.weight: Velvet.VelvetFontWeight
+field Velvet.VelvetResponsive.ContainerClass: System.String
+field Velvet.VelvetStyleUtilities.DarkThemeClass: System.String
+method Velvet.AnimatePresenceNode.StaggerDelaySec(System.Int32, System.Int32): System.Single
+method Velvet.AnimationSequenceStep.Call(System.Action): Velvet.AnimationSequenceStep
+method Velvet.AnimationSequenceStep.To(System.String, Velvet.StyleTransitionConfig, System.Nullable`1[System.Single]): Velvet.AnimationSequenceStep
+method Velvet.AnimationSequenceStep.Wait(System.Single): Velvet.AnimationSequenceStep
+method Velvet.ComponentContext`1.Create(T): Velvet.ComponentContext`1
+method Velvet.ComponentFiber.AppendChild(Velvet.ComponentFiber): System.Void
+method Velvet.ComponentFiber.Detach(): System.Void
+method Velvet.ComponentFiber.RemoveChild(Velvet.ComponentFiber): System.Void
+method Velvet.ComponentMethodRegistry.RegisterComponentDisplayName(System.String, System.String, System.String): System.Void
+method Velvet.ComponentMethodRegistry.RegisterErrorBoundary(System.String, System.String): System.Void
+method Velvet.ComponentMethodRegistry.RegisterMemoize(System.String, System.String): System.Void
+method Velvet.DevTools.VelvetDevToolsRegistry.Clear(): System.Void
+method Velvet.DevTools.VelvetDevToolsRegistry.Register(Velvet.ComponentFiber, System.String): System.Void
+method Velvet.DevTools.VelvetDevToolsRegistry.Unregister(Velvet.ComponentFiber): System.Void
+method Velvet.DndCollisionDetection.BeginInvoke(Velvet.DndCollisionQuery&, System.AsyncCallback, System.Object): System.IAsyncResult
+method Velvet.DndCollisionDetection.EndInvoke(Velvet.DndCollisionQuery&, System.IAsyncResult): System.String
+method Velvet.DndCollisionDetection.Invoke(Velvet.DndCollisionQuery&): System.String
+method Velvet.Experimental.VBuilder.Add(Velvet.VNode): System.Void
+method Velvet.Experimental.VBuilder.Build(): Velvet.VNode
+method Velvet.Experimental.VButton.Build(): Velvet.VNode
+method Velvet.Experimental.VCustom`1.Build(): Velvet.VNode
+method Velvet.Experimental.VDiv.Build(): Velvet.VNode
+method Velvet.Experimental.VImage.Build(): Velvet.VNode
+method Velvet.Experimental.VLabel.Build(): Velvet.VNode
+method Velvet.Experimental.VScrollView.Build(): Velvet.VNode
+method Velvet.Experimental.VSlider.Build(): Velvet.VNode
+method Velvet.Experimental.VTextField.Build(): Velvet.VNode
+method Velvet.Experimental.VToggle.Build(): Velvet.VNode
+method Velvet.FiberPortalRegistry.Get(System.String): UnityEngine.UIElements.VisualElement
+method Velvet.FiberPortalRegistry.IsRegistered(System.String): System.Boolean
+method Velvet.FiberPortalRegistry.Register(System.String, UnityEngine.UIElements.VisualElement): System.Void
+method Velvet.FiberPortalRegistry.Unregister(System.String): System.Void
+method Velvet.Hooks.ForwardedRef`1(): Velvet.Ref`1[T]
+method Velvet.Hooks.StoreMemoizedVNode(System.Int32, System.Object[], Velvet.VNode): System.Void
+method Velvet.Hooks.TryGetMemoizedVNode(System.Object[], System.Int32&, Velvet.VNode&): System.Boolean
+method Velvet.Hooks.UseAnimationSequence(System.Collections.Generic.IReadOnlyList`1[Velvet.AnimationSequenceStep], System.Boolean, System.Boolean, System.Object[]): System.ValueTuple`2[Velvet.AnimationSequenceState, Velvet.AnimationSequenceControls]
+method Velvet.Hooks.UseBlocker(System.Func`2[Velvet.NavigationAttempt, System.Boolean], System.Object[]): Velvet.RouteBlockerState
+method Velvet.Hooks.UseBlocker(System.Func`3[Velvet.NavigationAttempt, System.Threading.CancellationToken, Cysharp.Threading.Tasks.UniTask`1[System.Boolean]], System.Object[]): Velvet.RouteBlockerState
+method Velvet.Hooks.UseCallback`1(T): T
+method Velvet.Hooks.UseCallback`1(T, System.Object[]): T
+method Velvet.Hooks.UseContext`1(Velvet.ComponentContext`1[T]): T
+method Velvet.Hooks.UseDeferredValue`1(T): T
+method Velvet.Hooks.UseDeferredValue`1(T, T): T
+method Velvet.Hooks.UseEffect(System.Func`1[System.Action], System.Object[]): System.Void
+method Velvet.Hooks.UseEffect(System.Func`1[System.IDisposable], System.Object[]): System.Void
+method Velvet.Hooks.UseFallback(System.Func`2[System.Exception, Velvet.VNode]): System.Void
+method Velvet.Hooks.UseFallback(System.Func`3[System.Exception, Velvet.ErrorInfo, Velvet.VNode]): System.Void
+method Velvet.Hooks.UseFocusRing(): Velvet.FocusRing
+method Velvet.Hooks.UseFrame(System.Action`1[System.Single], System.Int32): System.Void
+method Velvet.Hooks.UseId(System.String): System.String
+method Velvet.Hooks.UseImperativeHandle`1(Velvet.Ref`1[THandle], System.Func`1[THandle]): System.Void
+method Velvet.Hooks.UseImperativeHandle`1(Velvet.Ref`1[THandle], System.Func`1[THandle], System.Object[]): System.Void
+method Velvet.Hooks.UseInsertionEffect(System.Func`1[System.Action], System.Object[]): System.Void
+method Velvet.Hooks.UseInsertionEffect(System.Func`1[System.IDisposable], System.Object[]): System.Void
+method Velvet.Hooks.UseLayoutEffect(System.Func`1[System.Action], System.Object[]): System.Void
+method Velvet.Hooks.UseLayoutEffect(System.Func`1[System.IDisposable], System.Object[]): System.Void
+method Velvet.Hooks.UseLoaderData`1(): T
+method Velvet.Hooks.UseLocation(): Velvet.RouterLocation
+method Velvet.Hooks.UseMatch(System.String): Velvet.RouteMatch
+method Velvet.Hooks.UseMemo`1(System.Func`1[T]): T
+method Velvet.Hooks.UseMemo`1(System.Func`1[T], System.Object[]): T
+method Velvet.Hooks.UseMutableRef`1(System.Func`1[T]): Velvet.MutableRef`1[T]
+method Velvet.Hooks.UseMutableRef`1(T): Velvet.MutableRef`1[T]
+method Velvet.Hooks.UseMutation(Velvet.MutationOptions): Velvet.MutationResult`2[Velvet.Unit, Velvet.Unit]
+method Velvet.Hooks.UseMutation`1(Velvet.MutationOptions`1[TVariables]): Velvet.MutationResult`2[TVariables, Velvet.Unit]
+method Velvet.Hooks.UseMutation`2(Velvet.MutationOptions`2[TVariables, TData]): Velvet.MutationResult`2[TVariables, TData]
+method Velvet.Hooks.UseNavigate(System.Boolean): System.Func`2[System.String, Cysharp.Threading.Tasks.UniTask`1[Velvet.NavigationResult]]
+method Velvet.Hooks.UseNavigation(): Velvet.NavigationState
+method Velvet.Hooks.UseOptimistic`2(TState, System.Func`3[TState, TAction, TState]): System.ValueTuple`2[TState, System.Action`1[TAction]]
+method Velvet.Hooks.UseOutletContext`1(): T
+method Velvet.Hooks.UseParams(): System.Collections.Generic.IReadOnlyDictionary`2[System.String, System.String]
+method Velvet.Hooks.UseReducer`2(System.Func`3[TState, TAction, TState], TState): System.ValueTuple`2[TState, System.Action`1[TAction]]
+method Velvet.Hooks.UseReducer`3(System.Func`3[TState, TAction, TState], TArg, System.Func`2[TArg, TState]): System.ValueTuple`2[TState, System.Action`1[TAction]]
+method Velvet.Hooks.UseRef`1(): Velvet.Ref`1[T]
+method Velvet.Hooks.UseRef`1(System.Func`1[T]): Velvet.Ref`1[T]
+method Velvet.Hooks.UseRouteError(): System.Exception
+method Velvet.Hooks.UseSearchParams(): System.ValueTuple`2[Velvet.ISearchParams, Velvet.SearchParamsSetter]
+method Velvet.Hooks.UseService`1(): T
+method Velvet.Hooks.UseState`1(System.Func`1[T]): System.ValueTuple`2[T, Velvet.StateUpdater`1[T]]
+method Velvet.Hooks.UseState`1(T): System.ValueTuple`2[T, Velvet.StateUpdater`1[T]]
+method Velvet.Hooks.UseStore`2(Velvet.Store`1[TStore], System.Func`2[TStore, TSel], System.Collections.Generic.IEqualityComparer`1[TSel]): TSel
+method Velvet.Hooks.UseTransition(): System.ValueTuple`2[System.Boolean, Velvet.TransitionStarter]
+method Velvet.Hooks.Use`1(System.Func`1[Cysharp.Threading.Tasks.UniTask`1[T]], System.Object): T
+method Velvet.Hooks.Use`1(System.Func`2[System.Threading.CancellationToken, Cysharp.Threading.Tasks.UniTask`1[T]], System.Object): T
+method Velvet.IHookServiceResolver.Resolve`1(): T
+method Velvet.IRouteScope.Resolve`1(): T
+method Velvet.IRouteScopeFactory.CreateScope(Velvet.RouteDefinition, Velvet.IRouteScope): Velvet.IRouteScope
+method Velvet.ISearchParams.Get(System.String): System.String
+method Velvet.ISearchParams.GetAll(System.String): System.Collections.Generic.IReadOnlyList`1[System.String]
+method Velvet.ISearchParams.Has(System.String): System.Boolean
+method Velvet.IStoreWriter`1.Mutate(System.Func`2[TState, TState]): System.Void
+method Velvet.IStoreWriter`1.SetState(System.Func`2[TState, TState]): System.Boolean
+method Velvet.MountedTree.Dispose(): System.Void
+method Velvet.MutationResultExtensions.MutateAsync`1(Velvet.MutationResult`2[Velvet.Unit, TData]): Cysharp.Threading.Tasks.UniTask`1[TData]
+method Velvet.MutationResultExtensions.Mutate`1(Velvet.MutationResult`2[Velvet.Unit, TData]): System.Void
+method Velvet.MutationResult`2.Mutate(TVariables): System.Void
+method Velvet.MutationResult`2.MutateAsync(TVariables): Cysharp.Threading.Tasks.UniTask`1[TData]
+method Velvet.MutationResult`2.Reset(): System.Void
+method Velvet.NullStoreLogger.Log(System.String): System.Void
+method Velvet.NullStoreLogger.LogError(System.String): System.Void
+method Velvet.NullStoreLogger.LogWarning(System.String): System.Void
+method Velvet.ParticlesElement.Play(): System.Void
+method Velvet.ParticlesElement.Stop(): System.Void
+method Velvet.Ref`1.Set(T): System.Void
+method Velvet.RouteBlockerManager.Register(System.Func`2[Velvet.NavigationAttempt, System.Boolean], Velvet.RouteBlockerState): System.IDisposable
+method Velvet.RouteBlockerManager.Register(System.Func`3[Velvet.NavigationAttempt, System.Threading.CancellationToken, Cysharp.Threading.Tasks.UniTask`1[System.Boolean]], Velvet.RouteBlockerState): System.IDisposable
+method Velvet.RouteBlockerManager.ResetAllBlocked(): System.Void
+method Velvet.RouteBlockerState.Proceed(): System.Void
+method Velvet.RouteBlockerState.Reset(): System.Void
+method Velvet.RouteTree.Match(System.String): System.Collections.Generic.IReadOnlyList`1[Velvet.RouteMatch]
+method Velvet.Router.Dispose(): System.Void
+method Velvet.Router.GetLoaderData(System.String): System.Object
+method Velvet.Router.GoBack(System.Threading.CancellationToken): Cysharp.Threading.Tasks.UniTask`1[Velvet.NavigationResult]
+method Velvet.Router.GoForward(System.Threading.CancellationToken): Cysharp.Threading.Tasks.UniTask`1[Velvet.NavigationResult]
+method Velvet.Router.NavigateAsync(System.String, Velvet.NavigationMode, System.Int32, System.Threading.CancellationToken): Cysharp.Threading.Tasks.UniTask`1[Velvet.NavigationResult]
+method Velvet.Router.NavigateAsync(System.String, Velvet.NavigationMode, System.Threading.CancellationToken): Cysharp.Threading.Tasks.UniTask`1[Velvet.NavigationResult]
+method Velvet.SearchParams.Append(System.String, System.String): System.Void
+method Velvet.SearchParams.Get(System.String): System.String
+method Velvet.SearchParams.GetAll(System.String): System.Collections.Generic.IReadOnlyList`1[System.String]
+method Velvet.SearchParams.GetEnumerator(): System.Collections.Generic.IEnumerator`1[System.String]
+method Velvet.SearchParams.Has(System.String): System.Boolean
+method Velvet.SearchParamsSetter.Invoke(System.Func`2[Velvet.ISearchParams, Velvet.ISearchParams], Velvet.NavigationMode): System.Void
+method Velvet.SearchParamsSetter.Invoke(Velvet.ISearchParams, Velvet.NavigationMode): System.Void
+method Velvet.StateUpdater`1.Equals(System.Object): System.Boolean
+method Velvet.StateUpdater`1.Equals(Velvet.StateUpdater`1): System.Boolean
+method Velvet.StateUpdater`1.GetHashCode(): System.Int32
+method Velvet.StateUpdater`1.Invoke(System.Func`2[T, T]): System.Void
+method Velvet.StateUpdater`1.Invoke(T): System.Void
+method Velvet.StoreLogger.Log(System.String): System.Void
+method Velvet.StoreLogger.LogError(System.String): System.Void
+method Velvet.StoreLogger.LogWarning(System.String): System.Void
+method Velvet.StoreShallowEqualityComparer.Sequence`1(): System.Collections.Generic.IEqualityComparer`1[System.Collections.Generic.IReadOnlyList`1[T]]
+method Velvet.Store`1.Dispose(): System.Void
+method Velvet.Store`1.Reset(): System.Void
+method Velvet.Store`1.Select`1(System.Func`2[TState, T], System.Action`2[T, T], System.Collections.Generic.IEqualityComparer`1[T], System.Boolean): System.IDisposable
+method Velvet.Store`1.Subscribe(System.Action`1[TState], System.Boolean): System.IDisposable
+method Velvet.Store`1.Subscribe(System.Action`2[TState, TState], System.Boolean): System.IDisposable
+method Velvet.StyleBackgroundImageResolver.Apply(UnityEngine.UIElements.VisualElement, UnityEngine.Texture2D): System.Void
+method Velvet.StyleBackgroundImageResolver.Clear(UnityEngine.UIElements.VisualElement): System.Void
+method Velvet.StyleBackgroundImageResolver.HasBackgroundImageClass(System.String[]): System.Boolean
+method Velvet.StyleBackgroundImageResolver.TryParse(System.String, UnityEngine.Texture2D&): System.Boolean
+method Velvet.StyleClassNames.Class(System.String[]): System.String
+method Velvet.StyleClassNames.When(System.Boolean, System.String): System.String
+method Velvet.StyleFontClass.HasFontClass(System.String[]): System.Boolean
+method Velvet.StyleFontClass.IsArbitraryFontClass(System.String): System.Boolean
+method Velvet.StyleFontClass.TryExtract(System.String[], Velvet.FontIntent&): System.Boolean
+method Velvet.StyleFontResolver.Apply(UnityEngine.UIElements.VisualElement, System.String[]): System.Void
+method Velvet.StyleFontResolver.ApplyIfPresent(UnityEngine.UIElements.VisualElement, System.String[]): System.Void
+method Velvet.StyleFontResolver.ApplyOnClassChange(UnityEngine.UIElements.VisualElement, System.String[], System.String[]): System.Void
+method Velvet.StyleFontResolver.Clear(UnityEngine.UIElements.VisualElement): System.Void
+method Velvet.StyleFontResolver.ComputeFontStyle(System.Boolean, System.Boolean): UnityEngine.FontStyle
+method Velvet.StyleRecipe+CompoundVariant.Matches(System.ValueTuple`2[System.String, System.String][], System.Int32): System.Boolean
+method Velvet.StyleRecipe.Apply(System.String, System.ValueTuple`2[System.String, System.String][]): System.String
+method Velvet.StyleRecipe.Apply(System.ValueTuple`2[System.String, System.String][]): System.String
+method Velvet.StyleSlotRecipe+SlotCompoundVariant.Matches(System.ValueTuple`2[System.String, System.String][], System.Int32): System.Boolean
+method Velvet.StyleSlotRecipe.Apply(): Velvet.StyleSlotClasses
+method Velvet.StyleSlotRecipe.Apply(System.ValueTuple`2[System.String, System.String][]): Velvet.StyleSlotClasses
+method Velvet.StyleTransitionConfig.With(System.Nullable`1[System.Single], System.Nullable`1[UnityEngine.UIElements.EasingMode], System.Nullable`1[UnityEngine.UIElements.EasingMode], System.Nullable`1[System.Single]): Velvet.StyleTransitionConfig
+method Velvet.StyleVariantClass.BreakpointPx(Velvet.StyleVariantKind): System.Single
+method Velvet.StyleVariantClass.IsResponsive(Velvet.StyleVariantKind): System.Boolean
+method Velvet.StyleVariantClass.IsVariant(System.String): System.Boolean
+method Velvet.StyleVariantClass.TryParse(System.String, Velvet.StyleVariantKind&, System.String&): System.Boolean
+method Velvet.TransitionStarter.Equals(System.Object): System.Boolean
+method Velvet.TransitionStarter.Equals(Velvet.TransitionStarter): System.Boolean
+method Velvet.TransitionStarter.GetHashCode(): System.Int32
+method Velvet.TransitionStarter.Invoke(System.Action): System.Void
+method Velvet.TransitionStarter.Invoke(System.Func`1[Cysharp.Threading.Tasks.UniTask]): System.Void
+method Velvet.Unit.Equals(System.Object): System.Boolean
+method Velvet.Unit.Equals(Velvet.Unit): System.Boolean
+method Velvet.Unit.GetHashCode(): System.Int32
+method Velvet.Unit.ToString(): System.String
+method Velvet.V.Anchored(UnityEngine.Transform, UnityEngine.Camera, System.Nullable`1[UnityEngine.Vector2], System.Boolean, System.Boolean, System.Nullable`1[UnityEngine.LayerMask], System.Nullable`1[System.Single], System.String, System.String, System.String, Velvet.FiberElementProps, Velvet.StyleOverrides, System.Func`2[UnityEngine.UIElements.VisualElement, System.Action], Velvet.VNode[], System.String, System.String, System.String, System.Collections.Generic.IReadOnlyDictionary`2[System.String, System.String], System.Collections.Generic.IReadOnlyDictionary`2[System.String, System.String]): Velvet.ElementNode
+method Velvet.V.AnimatePresence(Velvet.VNode[], System.String, System.Boolean, System.Single, System.Single, System.Int32, Velvet.AnimatePresenceMode, System.Action): Velvet.AnimatePresenceNode
+method Velvet.V.Button(System.String, System.String, System.Action, System.String, System.String, System.String, System.Nullable`1[System.Boolean], Velvet.StyleOverrides, System.Func`2[UnityEngine.UIElements.VisualElement, System.Action], System.Func`2[UnityEngine.UIElements.VisualElement, UnityEngine.UIElements.VisualElement], System.String, System.String, System.String, Velvet.VNode[], System.Collections.Generic.IReadOnlyDictionary`2[System.String, System.String], System.Collections.Generic.IReadOnlyDictionary`2[System.String, System.String]): Velvet.ElementNode
+method Velvet.V.Button(System.String, Velvet.VNode[]): Velvet.ElementNode
+method Velvet.V.Component(System.Func`1[Velvet.VNode], System.String): Velvet.ComponentNode
+method Velvet.V.Component`1(System.Func`1[Velvet.VNode], Velvet.Ref`1[TRef], System.String): Velvet.ComponentNode
+method Velvet.V.Component`1(System.Func`2[TProps, Velvet.VNode], TProps, System.String): Velvet.ComponentNode
+method Velvet.V.Custom`1(System.String, System.String, System.String, Velvet.FiberElementProps, System.Func`2[UnityEngine.UIElements.VisualElement, System.Action], Velvet.VNode[], System.String, System.String, System.String, System.Collections.Generic.IReadOnlyDictionary`2[System.String, System.String], System.Collections.Generic.IReadOnlyDictionary`2[System.String, System.String]): Velvet.ElementNode
+method Velvet.V.Custom`1(System.String, Velvet.VNode[]): Velvet.ElementNode
+method Velvet.V.Div(System.String, System.String, System.String, Velvet.FiberElementProps, Velvet.StyleOverrides, System.Func`2[UnityEngine.UIElements.VisualElement, System.Action], Velvet.VNode[], System.String, System.String, System.String, System.Collections.Generic.IReadOnlyDictionary`2[System.String, System.String], System.Collections.Generic.IReadOnlyDictionary`2[System.String, System.String]): Velvet.ElementNode
+method Velvet.V.Div(System.String, Velvet.VNode[]): Velvet.ElementNode
+method Velvet.V.DndContext(System.Action`1[Velvet.DragStartArgs], System.Action`1[Velvet.DragOverArgs], System.Action`1[Velvet.DragEndArgs], System.Action`1[Velvet.DragCancelArgs], Velvet.DndCollisionDetection, Velvet.DragActivation, System.String, System.String, System.String, Velvet.FiberElementProps, Velvet.StyleOverrides, System.Func`2[UnityEngine.UIElements.VisualElement, System.Action], Velvet.VNode[], System.String, System.String, System.String, System.Collections.Generic.IReadOnlyDictionary`2[System.String, System.String], System.Collections.Generic.IReadOnlyDictionary`2[System.String, System.String]): Velvet.ElementNode
+method Velvet.V.DragOverlay(Velvet.VNode[], System.String): Velvet.PortalNode
+method Velvet.V.Draggable(System.String, System.Object, System.Boolean, Velvet.DragMovement, Velvet.DragActivation, System.String, System.String, System.String, System.String, Velvet.FiberElementProps, Velvet.StyleOverrides, System.Func`2[UnityEngine.UIElements.VisualElement, System.Action], Velvet.VNode[], System.String, System.String, System.String, System.Collections.Generic.IReadOnlyDictionary`2[System.String, System.String], System.Collections.Generic.IReadOnlyDictionary`2[System.String, System.String]): Velvet.ElementNode
+method Velvet.V.DropdownField(System.String, System.String, System.Collections.Generic.List`1[System.String], System.Action`1[System.String], System.String, System.String, System.String, System.Nullable`1[System.Boolean], System.Func`2[UnityEngine.UIElements.VisualElement, System.Action], System.String, System.String, System.String, System.Collections.Generic.IReadOnlyDictionary`2[System.String, System.String], System.Collections.Generic.IReadOnlyDictionary`2[System.String, System.String]): Velvet.ElementNode
+method Velvet.V.Droppable(System.String, System.Object, System.Boolean, System.String, System.String, System.String, System.String, System.String, Velvet.FiberElementProps, Velvet.StyleOverrides, System.Func`2[UnityEngine.UIElements.VisualElement, System.Action], Velvet.VNode[], System.String, System.String, System.String, System.Collections.Generic.IReadOnlyDictionary`2[System.String, System.String], System.Collections.Generic.IReadOnlyDictionary`2[System.String, System.String]): Velvet.ElementNode
+method Velvet.V.ErrorBoundary(System.Func`2[System.Exception, Velvet.VNode], Velvet.VNode[], System.String): Velvet.ComponentNode
+method Velvet.V.FocusScope(System.String, System.String, System.String, System.Boolean, System.Boolean, System.Boolean, System.Boolean, Velvet.FiberElementProps, Velvet.StyleOverrides, System.Func`2[UnityEngine.UIElements.VisualElement, System.Action], Velvet.VNode[], System.String, System.String, System.String, System.Collections.Generic.IReadOnlyDictionary`2[System.String, System.String], System.Collections.Generic.IReadOnlyDictionary`2[System.String, System.String]): Velvet.ElementNode
+method Velvet.V.Fragment(Velvet.VNode[], System.String): Velvet.FragmentNode
+method Velvet.V.Image(System.String, System.String, System.String, Velvet.StyleOverrides, System.Func`2[UnityEngine.UIElements.VisualElement, System.Action], System.String, System.String, System.String, System.Collections.Generic.IReadOnlyDictionary`2[System.String, System.String], System.Collections.Generic.IReadOnlyDictionary`2[System.String, System.String]): Velvet.ElementNode
+method Velvet.V.IntegerField(System.String, System.Nullable`1[System.Int32], System.Action`1[System.Int32], System.String, System.String, System.String, System.Nullable`1[System.Boolean], System.Func`2[UnityEngine.UIElements.VisualElement, System.Action], System.String, System.String, System.String, System.Collections.Generic.IReadOnlyDictionary`2[System.String, System.String], System.Collections.Generic.IReadOnlyDictionary`2[System.String, System.String]): Velvet.ElementNode
+method Velvet.V.Label(System.String, System.String, System.String, System.String, System.Func`2[UnityEngine.UIElements.VisualElement, System.Action], System.String, System.String, System.String, System.Collections.Generic.IReadOnlyDictionary`2[System.String, System.String], System.Collections.Generic.IReadOnlyDictionary`2[System.String, System.String]): Velvet.ElementNode
+method Velvet.V.Link(System.String, System.String, System.String, System.String, Velvet.VNode[], System.Boolean, System.String): Velvet.ComponentNode
+method Velvet.V.ListFragment`1(System.Collections.Generic.IReadOnlyList`1[T], System.Func`2[T, System.String], System.Func`2[T, Velvet.VNode], System.String): Velvet.FragmentNode
+method Velvet.V.ListFragment`1(System.Collections.Generic.IReadOnlyList`1[T], System.Func`3[T, System.Int32, System.String], System.Func`3[T, System.Int32, Velvet.VNode], System.String): Velvet.FragmentNode
+method Velvet.V.ListView(System.String, System.String, System.String, System.Nullable`1[System.Boolean], Velvet.StyleOverrides, System.Func`2[UnityEngine.UIElements.VisualElement, System.Action], System.String, System.String, System.String, System.Collections.Generic.IReadOnlyDictionary`2[System.String, System.String], System.Collections.Generic.IReadOnlyDictionary`2[System.String, System.String]): Velvet.ElementNode
+method Velvet.V.List`1(System.Collections.Generic.IReadOnlyList`1[T], System.Func`2[T, System.String], System.Func`2[T, Velvet.VNode]): Velvet.VNode[]
+method Velvet.V.List`1(System.Collections.Generic.IReadOnlyList`1[T], System.Func`3[T, System.Int32, System.String], System.Func`3[T, System.Int32, Velvet.VNode]): Velvet.VNode[]
+method Velvet.V.Memo`1(System.Func`2[TProps, Velvet.VNode], TProps, System.Func`3[TProps, TProps, System.Boolean], System.String): Velvet.ComponentNode
+method Velvet.V.Memoized(System.Func`1[Velvet.VNode], System.Object[]): Velvet.MemoNode
+method Velvet.V.MemoizedWithKey(System.String, System.Func`1[Velvet.VNode], System.Object[]): Velvet.MemoNode
+method Velvet.V.MemoizedWithKey`1(System.String, System.Func`1[Velvet.VNode], T1): Velvet.MemoNode
+method Velvet.V.MemoizedWithKey`2(System.String, System.Func`1[Velvet.VNode], T1, T2): Velvet.MemoNode
+method Velvet.V.MemoizedWithKey`3(System.String, System.Func`1[Velvet.VNode], T1, T2, T3): Velvet.MemoNode
+method Velvet.V.MemoizedWithKey`4(System.String, System.Func`1[Velvet.VNode], T1, T2, T3, T4): Velvet.MemoNode
+method Velvet.V.MemoizedWithKey`5(System.String, System.Func`1[Velvet.VNode], T1, T2, T3, T4, T5): Velvet.MemoNode
+method Velvet.V.MemoizedWithKey`6(System.String, System.Func`1[Velvet.VNode], T1, T2, T3, T4, T5, T6): Velvet.MemoNode
+method Velvet.V.MemoizedWithKey`7(System.String, System.Func`1[Velvet.VNode], T1, T2, T3, T4, T5, T6, T7): Velvet.MemoNode
+method Velvet.V.MemoizedWithKey`8(System.String, System.Func`1[Velvet.VNode], T1, T2, T3, T4, T5, T6, T7, T8): Velvet.MemoNode
+method Velvet.V.Memoized`1(System.Func`1[Velvet.VNode], T1): Velvet.MemoNode
+method Velvet.V.Memoized`2(System.Func`1[Velvet.VNode], T1, T2): Velvet.MemoNode
+method Velvet.V.Memoized`3(System.Func`1[Velvet.VNode], T1, T2, T3): Velvet.MemoNode
+method Velvet.V.Memoized`4(System.Func`1[Velvet.VNode], T1, T2, T3, T4): Velvet.MemoNode
+method Velvet.V.Memoized`5(System.Func`1[Velvet.VNode], T1, T2, T3, T4, T5): Velvet.MemoNode
+method Velvet.V.Memoized`6(System.Func`1[Velvet.VNode], T1, T2, T3, T4, T5, T6): Velvet.MemoNode
+method Velvet.V.Memoized`7(System.Func`1[Velvet.VNode], T1, T2, T3, T4, T5, T6, T7): Velvet.MemoNode
+method Velvet.V.Memoized`8(System.Func`1[Velvet.VNode], T1, T2, T3, T4, T5, T6, T7, T8): Velvet.MemoNode
+method Velvet.V.Motion(System.String, System.String, System.String, Velvet.StyleTransitionConfig, System.Nullable`1[System.Single], System.Nullable`1[UnityEngine.UIElements.EasingMode], System.Nullable`1[System.Single], System.Action, Velvet.VNode[], Velvet.FiberElementProps, Velvet.FiberEventBinding[], System.Func`2[UnityEngine.UIElements.VisualElement, System.Action], System.String, System.String, System.String, System.Type, System.Collections.Generic.IReadOnlyDictionary`2[System.String, System.String], System.String, System.String, System.String, System.String): Velvet.MotionNode
+method Velvet.V.Mount(UnityEngine.UIElements.VisualElement, Velvet.VNode): Velvet.MountedTree
+method Velvet.V.NavLink(System.String, System.String, System.String, System.String, System.String, Velvet.VNode[], System.Boolean, System.Boolean, System.Boolean, System.String): Velvet.ComponentNode
+method Velvet.V.Navigate(System.String, System.Boolean, System.String): Velvet.ComponentNode
+method Velvet.V.Outlet(System.Object, System.String): Velvet.OutletNode
+method Velvet.V.Particles(UnityEngine.ParticleSystem, System.String, System.String, System.String, Velvet.PlayTrigger, System.Single, Velvet.StyleOverrides, System.Func`2[UnityEngine.UIElements.VisualElement, System.Action], System.String, System.String, System.String, System.Collections.Generic.IReadOnlyDictionary`2[System.String, System.String], System.Collections.Generic.IReadOnlyDictionary`2[System.String, System.String]): Velvet.ElementNode
+method Velvet.V.Portal(System.String, Velvet.VNode[], System.String): Velvet.PortalNode
+method Velvet.V.Portal(Velvet.UILayer, Velvet.VNode[], System.String, Velvet.PanelFocusOrder): Velvet.PortalNode
+method Velvet.V.Provider`1(Velvet.ComponentContext`1[T], T, Velvet.VNode[], System.String): Velvet.ContextProviderNode`1[T]
+method Velvet.V.RadioButton(System.String, System.Nullable`1[System.Boolean], System.Action`1[System.Boolean], System.String, System.String, System.String, System.Nullable`1[System.Boolean], System.Func`2[UnityEngine.UIElements.VisualElement, System.Action], System.String, System.String, System.String, System.Collections.Generic.IReadOnlyDictionary`2[System.String, System.String], System.Collections.Generic.IReadOnlyDictionary`2[System.String, System.String]): Velvet.ElementNode
+method Velvet.V.RadioButtonGroup(System.String, System.Nullable`1[System.Int32], System.Collections.Generic.List`1[System.String], System.Action`1[System.Int32], System.String, System.String, System.String, System.Nullable`1[System.Boolean], System.Func`2[UnityEngine.UIElements.VisualElement, System.Action], System.String, System.String, System.String, System.Collections.Generic.IReadOnlyDictionary`2[System.String, System.String], System.Collections.Generic.IReadOnlyDictionary`2[System.String, System.String]): Velvet.ElementNode
+method Velvet.V.Route(System.String, Velvet.ComponentNode, System.String, System.Func`3[Velvet.RouteLoaderContext, System.Threading.CancellationToken, Cysharp.Threading.Tasks.UniTask`1[System.Object]], Velvet.LoaderMode, Velvet.ComponentNode, Velvet.RouteDefinition[], System.String, System.Func`2[Velvet.RouteLoaderContext, System.String], System.Boolean): Velvet.RouteDefinition
+method Velvet.V.Routes(Velvet.RouteDefinition[]): Velvet.RouteDefinition[]
+method Velvet.V.SceneView(UnityEngine.Camera, System.String, System.String, System.String, System.Single, Velvet.StyleOverrides, System.Func`2[UnityEngine.UIElements.VisualElement, System.Action], System.String, System.String, System.String, System.Collections.Generic.IReadOnlyDictionary`2[System.String, System.String], System.Collections.Generic.IReadOnlyDictionary`2[System.String, System.String]): Velvet.ElementNode
+method Velvet.V.ScrollView(System.String, System.String, System.String, System.Nullable`1[UnityEngine.UIElements.ScrollerVisibility], System.Nullable`1[UnityEngine.UIElements.ScrollerVisibility], System.Nullable`1[UnityEngine.UIElements.ScrollView+TouchScrollBehavior], System.Action`1[UnityEngine.UIElements.VisualElement], System.Func`2[UnityEngine.UIElements.VisualElement, System.Action], Velvet.VNode[], System.String, System.String, System.String, System.Collections.Generic.IReadOnlyDictionary`2[System.String, System.String], System.Collections.Generic.IReadOnlyDictionary`2[System.String, System.String]): Velvet.ElementNode
+method Velvet.V.ScrollView(System.String, Velvet.VNode[]): Velvet.ElementNode
+method Velvet.V.Slider(System.String, System.Nullable`1[System.Single], System.Nullable`1[System.Single], System.Nullable`1[System.Single], System.Action`1[System.Single], System.String, System.String, System.Nullable`1[System.Boolean], System.Func`2[UnityEngine.UIElements.VisualElement, System.Action], System.Action`1[UnityEngine.UIElements.VisualElement], System.String, System.String, System.String, System.Collections.Generic.IReadOnlyDictionary`2[System.String, System.String], System.Collections.Generic.IReadOnlyDictionary`2[System.String, System.String]): Velvet.ElementNode
+method Velvet.V.Suspense(Velvet.VNode, Velvet.VNode[], System.String): Velvet.SuspenseNode
+method Velvet.V.Text(System.String): Velvet.TextNode
+method Velvet.V.TextField(System.String, System.String, System.Action`1[System.String], System.String, System.String, System.String, System.Nullable`1[System.Boolean], System.Nullable`1[System.Boolean], System.Func`2[UnityEngine.UIElements.VisualElement, System.Action], System.String, System.String, System.String, System.Collections.Generic.IReadOnlyDictionary`2[System.String, System.String], System.Collections.Generic.IReadOnlyDictionary`2[System.String, System.String]): Velvet.ElementNode
+method Velvet.V.Toggle(System.String, System.Nullable`1[System.Boolean], System.Action`1[System.Boolean], System.String, System.String, System.String, System.Nullable`1[System.Boolean], System.Func`2[UnityEngine.UIElements.VisualElement, System.Action], System.String, System.String, System.String, System.Collections.Generic.IReadOnlyDictionary`2[System.String, System.String], System.Collections.Generic.IReadOnlyDictionary`2[System.String, System.String]): Velvet.ElementNode
+method Velvet.V.VirtualList`1(System.Collections.Generic.IReadOnlyList`1[T], System.Func`2[T, System.String], System.Single, System.Func`2[T, Velvet.VNode], System.Int32, System.String, System.String, System.String): Velvet.VirtualListNode
+method Velvet.V.When(System.Boolean, System.Func`1[Velvet.VNode]): Velvet.VNode
+method Velvet.V.WorldSpace(UnityEngine.Vector3, System.Nullable`1[UnityEngine.Quaternion], System.Nullable`1[UnityEngine.Vector2], Velvet.VNode[], System.String, Velvet.PanelFocusOrder): Velvet.WorldSpaceNode
+method Velvet.VelvetFilters.Register(System.String, UnityEngine.UIElements.FilterFunctionDefinition): System.Void
+method Velvet.VelvetFilters.Unregister(System.String): System.Boolean
+method Velvet.VelvetFontFamily.FindClosestWeight(Velvet.VelvetFontWeight): Velvet.VelvetFontWeightEntry
+method Velvet.VelvetFonts.Clear(): System.Void
+method Velvet.VelvetFonts.IsRegistered(System.String): System.Boolean
+method Velvet.VelvetFonts.Register(System.Collections.Generic.IEnumerable`1[Velvet.VelvetFontFamily], System.String): System.Void
+method Velvet.VelvetFonts.Register(Velvet.VelvetFontFamily): System.Void
+method Velvet.VelvetFonts.Resolve(System.String, Velvet.VelvetFontWeight, System.Boolean): Velvet.ResolvedFont
+method Velvet.VelvetFonts.TryLoadAddressableFont(System.String, UnityEngine.TextCore.Text.FontAsset&): System.Boolean
+method Velvet.VelvetFonts.Unregister(System.String): System.Void
+method Velvet.VelvetPreviewHost.Dispose(): System.Void
+method Velvet.VelvetPreviewHost.Mount(Velvet.VelvetPreviewStory): System.Void
+method Velvet.VelvetPreviewHost.Mount(Velvet.VelvetPreviewStory, System.Object): System.Void
+method Velvet.VelvetPreviewHost.UpdateArgs(System.Object): System.Boolean
+method Velvet.VelvetPreviewRegistry.DiscoverStories(): System.Collections.Generic.List`1[Velvet.VelvetPreviewStory]
+method Velvet.VelvetPreviewRegistry.RunSetupFor(System.Reflection.Assembly): System.IDisposable
+method Velvet.VelvetPreviewStory.Build(): Velvet.VNode
+method Velvet.VelvetPreviewStory.Build(System.Object): Velvet.VNode
+method Velvet.VelvetPreviewStory.CreateDefaultArgs(): System.Object
+method Velvet.VelvetStyleUtilities.AttachTo(UnityEngine.UIElements.VisualElement): System.Void
+method Velvet.VelvetStyleUtilities.BindThemeTo(UnityEngine.UIElements.VisualElement): System.Void
+method protected Velvet.Experimental.VBuilder.BuildChildren(): Velvet.VNode[]
+method protected Velvet.Store`1.Mutate(System.Func`2[TState, TState]): System.Void
+method protected Velvet.Store`1.OnDispose(): System.Void
+method protected Velvet.Store`1.ResetCore(): System.Void
+method protected Velvet.Store`1.SetState(System.Func`2[TState, TState]): System.Boolean
+property Velvet.AnchoredSettings.Camera: UnityEngine.Camera
+property Velvet.AnchoredSettings.DistanceFactor: System.Nullable`1[System.Single]
+property Velvet.AnchoredSettings.HideWhenBehindCamera: System.Boolean
+property Velvet.AnchoredSettings.Occlude: System.Boolean
+property Velvet.AnchoredSettings.OccludeLayerMask: UnityEngine.LayerMask
+property Velvet.AnchoredSettings.Offset: UnityEngine.Vector2
+property Velvet.AnchoredSettings.Target: UnityEngine.Transform
+property Velvet.AnimatePresenceNode.Children: Velvet.VNode[]
+property Velvet.AnimatePresenceNode.DelayChildrenSec: System.Single
+property Velvet.AnimatePresenceNode.Initial: System.Boolean
+property Velvet.AnimatePresenceNode.Mode: Velvet.AnimatePresenceMode
+property Velvet.AnimatePresenceNode.OnExitComplete: System.Action
+property Velvet.AnimatePresenceNode.StaggerDirection: System.Int32
+property Velvet.AnimatePresenceNode.StaggerSec: System.Single
+property Velvet.AnimationSequenceControls.Pause: System.Action
+property Velvet.AnimationSequenceControls.Play: System.Action
+property Velvet.AnimationSequenceControls.Restart: System.Action
+property Velvet.AnimationSequenceState.CurrentLabel: System.String
+property Velvet.AnimationSequenceState.CurrentTransition: Velvet.StyleTransitionConfig
+property Velvet.AnimationSequenceState.IsComplete: System.Boolean
+property Velvet.AnimationSequenceState.StepIndex: System.Int32
+property Velvet.AnimationSequenceStep.Callback: System.Action
+property Velvet.AnimationSequenceStep.HoldSec: System.Nullable`1[System.Single]
+property Velvet.AnimationSequenceStep.Label: System.String
+property Velvet.AnimationSequenceStep.Transition: Velvet.StyleTransitionConfig
+property Velvet.BaseElementNode.Children: Velvet.VNode[]
+property Velvet.BaseElementNode.ClassNames: System.String[]
+property Velvet.BaseElementNode.ElementType: System.Type
+property Velvet.BaseElementNode.Events: Velvet.FiberEventBinding[]
+property Velvet.BaseElementNode.Name: System.String
+property Velvet.BaseElementNode.Props: Velvet.FiberElementProps
+property Velvet.BaseElementNode.RefCallback: System.Func`2[UnityEngine.UIElements.VisualElement, System.Action]
+property Velvet.BaseElementNode.WhileFocusClass: System.String
+property Velvet.BaseElementNode.WhileHoverClass: System.String
+property Velvet.BaseElementNode.WhileTapClass: System.String
+property Velvet.BlurBinding.EventId: System.String
+property Velvet.BlurBinding.Handler: UnityEngine.UIElements.EventCallback`1[UnityEngine.UIElements.BlurEvent]
+property Velvet.ChangeEventBinding`1.EventId: System.String
+property Velvet.ChangeEventBinding`1.Handler: System.Action`1[T]
+property Velvet.ChoicesSettings.Choices: System.Collections.Generic.List`1[System.String]
+property Velvet.ClickedBinding.EventId: System.String
+property Velvet.ClickedBinding.Handler: System.Action
+property Velvet.ComponentAttribute.Compiler: System.Boolean
+property Velvet.ComponentAttribute.DisplayName: System.String
+property Velvet.ComponentAttribute.IsErrorBoundary: System.Boolean
+property Velvet.ComponentAttribute.Memoize: System.Boolean
+property Velvet.ComponentContext`1.DefaultValue: T
+property Velvet.ComponentFiber.Child: Velvet.ComponentFiber
+property Velvet.ComponentFiber.IsDirty: System.Boolean
+property Velvet.ComponentFiber.IsDisposed: System.Boolean
+property Velvet.ComponentFiber.IsErrorBoundary: System.Boolean
+property Velvet.ComponentFiber.IsMounted: System.Boolean
+property Velvet.ComponentFiber.IsRendering: System.Boolean
+property Velvet.ComponentFiber.IsSuspenseBoundary: System.Boolean
+property Velvet.ComponentFiber.Parent: Velvet.ComponentFiber
+property Velvet.ComponentFiber.Ref: System.Object
+property Velvet.ComponentFiber.Sibling: Velvet.ComponentFiber
+property Velvet.ComponentNode.Body: System.Func`1[Velvet.VNode]
+property Velvet.ComponentNode.Identity: System.Object
+property Velvet.ComponentNode.IsErrorBoundary: System.Boolean
+property Velvet.ComponentNode.Props: System.Object
+property Velvet.ContextProviderNode.Children: Velvet.VNode[]
+property Velvet.ContextProviderNode`1.Context: Velvet.ComponentContext`1[T]
+property Velvet.ContextProviderNode`1.Value: T
+property Velvet.DevTools.VelvetDevToolsRegistry+ComponentEntry.Fiber: Velvet.ComponentFiber
+property Velvet.DevTools.VelvetDevToolsRegistry+ComponentEntry.Label: System.String
+property Velvet.DevTools.VelvetDevToolsRegistry+ComponentEntry.RegisteredAt: System.DateTime
+property Velvet.DevTools.VelvetDevToolsRegistry+ComponentEntry.TypeName: System.String
+property Velvet.DevTools.VelvetDevToolsRegistry.Entries: System.Collections.Generic.IReadOnlyList`1[Velvet.DevTools.VelvetDevToolsRegistry+ComponentEntry]
+property Velvet.DndCollisionQuery.ActiveRect: UnityEngine.Rect
+property Velvet.DndCollisionQuery.Droppables: System.Collections.Generic.IReadOnlyList`1[Velvet.DndDroppableRect]
+property Velvet.DndCollisionQuery.PointerPosition: UnityEngine.Vector2
+property Velvet.DndContextSettings.Activation: Velvet.DragActivation
+property Velvet.DndContextSettings.CollisionDetection: Velvet.DndCollisionDetection
+property Velvet.DndContextSettings.OnDragCancel: System.Action`1[Velvet.DragCancelArgs]
+property Velvet.DndContextSettings.OnDragEnd: System.Action`1[Velvet.DragEndArgs]
+property Velvet.DndContextSettings.OnDragOver: System.Action`1[Velvet.DragOverArgs]
+property Velvet.DndContextSettings.OnDragStart: System.Action`1[Velvet.DragStartArgs]
+property Velvet.DndDroppableRect.Data: System.Object
+property Velvet.DndDroppableRect.Id: System.String
+property Velvet.DndDroppableRect.Rect: UnityEngine.Rect
+property Velvet.DragActivation.DelaySec: System.Single
+property Velvet.DragActivation.Distance: System.Single
+property Velvet.DragActivation.Tolerance: System.Single
+property Velvet.DragCancelArgs.Active: Velvet.DraggableInfo
+property Velvet.DragEndArgs.Active: Velvet.DraggableInfo
+property Velvet.DragEndArgs.Delta: UnityEngine.Vector2
+property Velvet.DragEndArgs.Over: Velvet.DroppableInfo
+property Velvet.DragEndArgs.Position: UnityEngine.Vector2
+property Velvet.DragOverArgs.Active: Velvet.DraggableInfo
+property Velvet.DragOverArgs.Delta: UnityEngine.Vector2
+property Velvet.DragOverArgs.Over: Velvet.DroppableInfo
+property Velvet.DragStartArgs.Active: Velvet.DraggableInfo
+property Velvet.DragStartArgs.Origin: UnityEngine.Vector2
+property Velvet.DraggableInfo.Data: System.Object
+property Velvet.DraggableInfo.Element: UnityEngine.UIElements.VisualElement
+property Velvet.DraggableInfo.Id: System.String
+property Velvet.DraggableSettings.Activation: Velvet.DragActivation
+property Velvet.DraggableSettings.Data: System.Object
+property Velvet.DraggableSettings.Disabled: System.Boolean
+property Velvet.DraggableSettings.Id: System.String
+property Velvet.DraggableSettings.Movement: Velvet.DragMovement
+property Velvet.DraggableSettings.WhileDraggingClass: System.String
+property Velvet.DroppableInfo.Data: System.Object
+property Velvet.DroppableInfo.Element: UnityEngine.UIElements.VisualElement
+property Velvet.DroppableInfo.Id: System.String
+property Velvet.DroppableSettings.Data: System.Object
+property Velvet.DroppableSettings.Disabled: System.Boolean
+property Velvet.DroppableSettings.Id: System.String
+property Velvet.DroppableSettings.WhileDragActiveClass: System.String
+property Velvet.DroppableSettings.WhileOverClass: System.String
+property Velvet.ElementNode.OnCreated: System.Action`1[UnityEngine.UIElements.VisualElement]
+property Velvet.ElementNode.Styles: Velvet.StyleOverrides
+property Velvet.ElementNode.WrapElement: System.Func`2[UnityEngine.UIElements.VisualElement, UnityEngine.UIElements.VisualElement]
+property Velvet.ErrorInfo.ComponentStack: System.String
+property Velvet.Experimental.VBuilder.Class: System.String
+property Velvet.Experimental.VBuilder.Key: System.String
+property Velvet.Experimental.VBuilder.Name: System.String
+property Velvet.Experimental.VButton.Enabled: System.Nullable`1[System.Boolean]
+property Velvet.Experimental.VButton.OnClick: System.Action
+property Velvet.Experimental.VButton.Text: System.String
+property Velvet.Experimental.VImage.Styles: Velvet.StyleOverrides
+property Velvet.Experimental.VImage.WhileFocusClass: System.String
+property Velvet.Experimental.VImage.WhileHoverClass: System.String
+property Velvet.Experimental.VImage.WhileTapClass: System.String
+property Velvet.Experimental.VLabel.Text: System.String
+property Velvet.Experimental.VSlider.Enabled: System.Nullable`1[System.Boolean]
+property Velvet.Experimental.VSlider.HighValue: System.Nullable`1[System.Single]
+property Velvet.Experimental.VSlider.LowValue: System.Nullable`1[System.Single]
+property Velvet.Experimental.VSlider.OnChange: System.Action`1[System.Single]
+property Velvet.Experimental.VSlider.Value: System.Nullable`1[System.Single]
+property Velvet.Experimental.VTextField.Enabled: System.Nullable`1[System.Boolean]
+property Velvet.Experimental.VTextField.IsPasswordField: System.Nullable`1[System.Boolean]
+property Velvet.Experimental.VTextField.Label: System.String
+property Velvet.Experimental.VTextField.OnChange: System.Action`1[System.String]
+property Velvet.Experimental.VTextField.Value: System.String
+property Velvet.Experimental.VToggle.Enabled: System.Nullable`1[System.Boolean]
+property Velvet.Experimental.VToggle.Label: System.String
+property Velvet.Experimental.VToggle.OnChange: System.Action`1[System.Boolean]
+property Velvet.Experimental.VToggle.Value: System.Nullable`1[System.Boolean]
+property Velvet.FiberElementProps.Anchored: Velvet.AnchoredSettings
+property Velvet.FiberElementProps.Aria: System.Collections.Generic.IReadOnlyDictionary`2[System.String, System.String]
+property Velvet.FiberElementProps.Choices: Velvet.ChoicesSettings
+property Velvet.FiberElementProps.Data: System.Collections.Generic.IReadOnlyDictionary`2[System.String, System.String]
+property Velvet.FiberElementProps.DelegatesFocus: System.Nullable`1[System.Boolean]
+property Velvet.FiberElementProps.DndContext: Velvet.DndContextSettings
+property Velvet.FiberElementProps.DragOverlay: Velvet.DragOverlaySettings
+property Velvet.FiberElementProps.Draggable: Velvet.DraggableSettings
+property Velvet.FiberElementProps.Droppable: Velvet.DroppableSettings
+property Velvet.FiberElementProps.Enabled: System.Nullable`1[System.Boolean]
+property Velvet.FiberElementProps.FieldValue: System.Object
+property Velvet.FiberElementProps.FocusScope: Velvet.FocusScopeSettings
+property Velvet.FiberElementProps.Focusable: System.Nullable`1[System.Boolean]
+property Velvet.FiberElementProps.Particles: Velvet.ParticlesSettings
+property Velvet.FiberElementProps.SceneView: Velvet.SceneViewSettings
+property Velvet.FiberElementProps.ScrollView: Velvet.ScrollViewSettings
+property Velvet.FiberElementProps.Slider: Velvet.SliderSettings
+property Velvet.FiberElementProps.TabIndex: System.Nullable`1[System.Int32]
+property Velvet.FiberElementProps.Text: System.String
+property Velvet.FiberElementProps.TextField: Velvet.TextFieldSettings
+property Velvet.FiberElementProps.Tooltip: System.String
+property Velvet.FiberElementProps.Visible: System.Nullable`1[System.Boolean]
+property Velvet.FiberEventBinding.EventId: System.String
+property Velvet.FiberStrictMode.Enabled: System.Boolean
+property Velvet.FocusBinding.EventId: System.String
+property Velvet.FocusBinding.Handler: UnityEngine.UIElements.EventCallback`1[UnityEngine.UIElements.FocusEvent]
+property Velvet.FocusInBinding.EventId: System.String
+property Velvet.FocusInBinding.Handler: UnityEngine.UIElements.EventCallback`1[UnityEngine.UIElements.FocusInEvent]
+property Velvet.FocusOutBinding.EventId: System.String
+property Velvet.FocusOutBinding.Handler: UnityEngine.UIElements.EventCallback`1[UnityEngine.UIElements.FocusOutEvent]
+property Velvet.FocusRing.IsFocusVisible: System.Boolean
+property Velvet.FocusRing.IsFocused: System.Boolean
+property Velvet.FocusRing.Ref: System.Func`2[UnityEngine.UIElements.VisualElement, System.Action]
+property Velvet.FocusScopeSettings.AutoFocus: System.Boolean
+property Velvet.FocusScopeSettings.Contain: System.Boolean
+property Velvet.FocusScopeSettings.RestoreFocus: System.Boolean
+property Velvet.FocusScopeSettings.SingleTabStop: System.Boolean
+property Velvet.FragmentNode.Children: Velvet.VNode[]
+property Velvet.GeometryChangedBinding.EventId: System.String
+property Velvet.GeometryChangedBinding.Handler: UnityEngine.UIElements.EventCallback`1[UnityEngine.UIElements.GeometryChangedEvent]
+property Velvet.ISearchParams.Count: System.Int32
+property Velvet.ISearchParams.Keys: System.Collections.Generic.IReadOnlyList`1[System.String]
+property Velvet.IStoreWriter`1.Current: TState
+property Velvet.KeyDownBinding.EventId: System.String
+property Velvet.KeyDownBinding.Handler: UnityEngine.UIElements.EventCallback`1[UnityEngine.UIElements.KeyDownEvent]
+property Velvet.KeyUpBinding.EventId: System.String
+property Velvet.KeyUpBinding.Handler: UnityEngine.UIElements.EventCallback`1[UnityEngine.UIElements.KeyUpEvent]
+property Velvet.MemoNode.Dependencies: System.Object[]
+property Velvet.MemoNode.Factory: System.Func`1[Velvet.VNode]
+property Velvet.MotionNode.Animate: System.String
+property Velvet.MotionNode.Exit: System.String
+property Velvet.MotionNode.Initial: System.String
+property Velvet.MotionNode.LayoutId: System.String
+property Velvet.MotionNode.OnEnterComplete: System.Action
+property Velvet.MotionNode.Transition: Velvet.StyleTransitionConfig
+property Velvet.MotionNode.Variants: System.Collections.Generic.IReadOnlyDictionary`2[System.String, System.String]
+property Velvet.MutableRef`1.Current: T
+property Velvet.MutationOptions.MutationFn: System.Func`2[System.Threading.CancellationToken, Cysharp.Threading.Tasks.UniTask]
+property Velvet.MutationOptions.OnError: System.Action`1[System.Exception]
+property Velvet.MutationOptions.OnSuccess: System.Action
+property Velvet.MutationOptions`1.MutationFn: System.Func`3[TVariables, System.Threading.CancellationToken, Cysharp.Threading.Tasks.UniTask]
+property Velvet.MutationOptions`1.OnError: System.Action`2[System.Exception, TVariables]
+property Velvet.MutationOptions`1.OnSuccess: System.Action`1[TVariables]
+property Velvet.MutationOptions`2.MutationFn: System.Func`3[TVariables, System.Threading.CancellationToken, Cysharp.Threading.Tasks.UniTask`1[TData]]
+property Velvet.MutationOptions`2.OnError: System.Action`2[System.Exception, TVariables]
+property Velvet.MutationOptions`2.OnSuccess: System.Action`2[TData, TVariables]
+property Velvet.MutationResult`2.Data: TData
+property Velvet.MutationResult`2.Error: System.Exception
+property Velvet.MutationResult`2.IsError: System.Boolean
+property Velvet.MutationResult`2.IsIdle: System.Boolean
+property Velvet.MutationResult`2.IsPending: System.Boolean
+property Velvet.MutationResult`2.IsSuccess: System.Boolean
+property Velvet.MutationResult`2.Status: Velvet.MutationStatus
+property Velvet.MutationResult`2.Variables: TVariables
+property Velvet.Navigate+Props.Replace: System.Boolean
+property Velvet.Navigate+Props.To: System.String
+property Velvet.NavigationAttempt.CurrentPath: System.String
+property Velvet.NavigationAttempt.NavigationMode: Velvet.NavigationMode
+property Velvet.NavigationAttempt.NextPath: System.String
+property Velvet.NavigationState.Location: Velvet.RouterLocation
+property Velvet.NavigationState.State: Velvet.NavigationLifecycle
+property Velvet.ParticlesSettings.Effect: UnityEngine.ParticleSystem
+property Velvet.ParticlesSettings.PixelsPerUnit: System.Single
+property Velvet.ParticlesSettings.PlayOn: Velvet.PlayTrigger
+property Velvet.PointerDownBinding.EventId: System.String
+property Velvet.PointerDownBinding.Handler: UnityEngine.UIElements.EventCallback`1[UnityEngine.UIElements.PointerDownEvent]
+property Velvet.PointerEnterBinding.EventId: System.String
+property Velvet.PointerEnterBinding.Handler: UnityEngine.UIElements.EventCallback`1[UnityEngine.UIElements.PointerEnterEvent]
+property Velvet.PointerLeaveBinding.EventId: System.String
+property Velvet.PointerLeaveBinding.Handler: UnityEngine.UIElements.EventCallback`1[UnityEngine.UIElements.PointerLeaveEvent]
+property Velvet.PointerMoveBinding.EventId: System.String
+property Velvet.PointerMoveBinding.Handler: UnityEngine.UIElements.EventCallback`1[UnityEngine.UIElements.PointerMoveEvent]
+property Velvet.PointerUpBinding.EventId: System.String
+property Velvet.PointerUpBinding.Handler: UnityEngine.UIElements.EventCallback`1[UnityEngine.UIElements.PointerUpEvent]
+property Velvet.PortalNode.Children: Velvet.VNode[]
+property Velvet.PortalNode.FocusOrder: Velvet.PanelFocusOrder
+property Velvet.PortalNode.Layer: System.Nullable`1[Velvet.UILayer]
+property Velvet.PortalNode.TargetId: System.String
+property Velvet.Ref`1.Current: T
+property Velvet.Ref`1.SetElement: System.Func`2[UnityEngine.UIElements.VisualElement, System.Action]
+property Velvet.RouteBlockerState.Attempt: Velvet.NavigationAttempt
+property Velvet.RouteBlockerState.Status: Velvet.RouteBlockerStatus
+property Velvet.RouteDefinition.CaseSensitive: System.Boolean
+property Velvet.RouteDefinition.Children: Velvet.RouteDefinition[]
+property Velvet.RouteDefinition.Element: Velvet.ComponentNode
+property Velvet.RouteDefinition.ErrorElement: Velvet.ComponentNode
+property Velvet.RouteDefinition.Guard: System.Func`2[Velvet.RouteLoaderContext, System.String]
+property Velvet.RouteDefinition.Loader: System.Func`3[Velvet.RouteLoaderContext, System.Threading.CancellationToken, Cysharp.Threading.Tasks.UniTask`1[System.Object]]
+property Velvet.RouteDefinition.LoaderMode: Velvet.LoaderMode
+property Velvet.RouteDefinition.Path: System.String
+property Velvet.RouteDefinition.RedirectTo: System.String
+property Velvet.RouteDefinition.ScopeId: System.String
+property Velvet.RouteLink+Props.Children: Velvet.VNode[]
+property Velvet.RouteLink+Props.ClassName: System.String
+property Velvet.RouteLink+Props.Name: System.String
+property Velvet.RouteLink+Props.Replace: System.Boolean
+property Velvet.RouteLink+Props.Text: System.String
+property Velvet.RouteLink+Props.To: System.String
+property Velvet.RouteLoaderContext.Params: System.Collections.Generic.IReadOnlyDictionary`2[System.String, System.String]
+property Velvet.RouteLoaderContext.Path: System.String
+property Velvet.RouteMatch.MatchedPath: System.String
+property Velvet.RouteMatch.Params: System.Collections.Generic.IReadOnlyDictionary`2[System.String, System.String]
+property Velvet.RouteMatch.PathnameBase: System.String
+property Velvet.RouteMatch.Route: Velvet.RouteDefinition
+property Velvet.RouteMatch.RouteId: System.String
+property Velvet.RouteNavLink+Props.ActiveClass: System.String
+property Velvet.RouteNavLink+Props.CaseSensitive: System.Boolean
+property Velvet.RouteNavLink+Props.Children: Velvet.VNode[]
+property Velvet.RouteNavLink+Props.ClassName: System.String
+property Velvet.RouteNavLink+Props.End: System.Boolean
+property Velvet.RouteNavLink+Props.Name: System.String
+property Velvet.RouteNavLink+Props.Replace: System.Boolean
+property Velvet.RouteNavLink+Props.Text: System.String
+property Velvet.RouteNavLink+Props.To: System.String
+property Velvet.Router.CanGoBack: System.Boolean
+property Velvet.Router.CanGoForward: System.Boolean
+property Velvet.Router.Current: Velvet.Router
+property Velvet.Router.CurrentLoaderData: System.Collections.Generic.IReadOnlyDictionary`2[System.String, System.Object]
+property Velvet.Router.CurrentLoaderErrors: System.Collections.Generic.IReadOnlyDictionary`2[System.String, System.Exception]
+property Velvet.Router.CurrentLocation: Velvet.RouterLocation
+property Velvet.Router.RouteBlockerManager: Velvet.RouteBlockerManager
+property Velvet.Router.Status: Velvet.RouterStatus
+property Velvet.RouterLocation.Matches: System.Collections.Generic.IReadOnlyList`1[Velvet.RouteMatch]
+property Velvet.RouterLocation.Params: System.Collections.Generic.IReadOnlyDictionary`2[System.String, System.String]
+property Velvet.RouterLocation.Path: System.String
+property Velvet.SceneViewSettings.Camera: UnityEngine.Camera
+property Velvet.SceneViewSettings.ResolutionScale: System.Single
+property Velvet.ScrollViewSettings.HorizontalScrollerVisibility: System.Nullable`1[UnityEngine.UIElements.ScrollerVisibility]
+property Velvet.ScrollViewSettings.TouchScrollBehavior: System.Nullable`1[UnityEngine.UIElements.ScrollView+TouchScrollBehavior]
+property Velvet.ScrollViewSettings.VerticalScrollerVisibility: System.Nullable`1[UnityEngine.UIElements.ScrollerVisibility]
+property Velvet.SearchParams.Count: System.Int32
+property Velvet.SearchParams.Keys: System.Collections.Generic.IReadOnlyList`1[System.String]
+property Velvet.SliderSettings.HighValue: System.Nullable`1[System.Single]
+property Velvet.SliderSettings.LowValue: System.Nullable`1[System.Single]
+property Velvet.StoreLogger.Default: Velvet.StoreLogger
+property Velvet.Store`1.Current: TState
+property Velvet.Store`1.InitialState: TState
+property Velvet.StyleOverrides.BackgroundColor: System.Nullable`1[UnityEngine.UIElements.StyleColor]
+property Velvet.StyleOverrides.BackgroundImage: System.Nullable`1[UnityEngine.UIElements.StyleBackground]
+property Velvet.StyleOverrides.Color: System.Nullable`1[UnityEngine.UIElements.StyleColor]
+property Velvet.StylePropertyTransition.DelaySec: System.Nullable`1[System.Single]
+property Velvet.StylePropertyTransition.DurationSec: System.Nullable`1[System.Single]
+property Velvet.StylePropertyTransition.Easing: System.Nullable`1[UnityEngine.UIElements.EasingMode]
+property Velvet.StylePropertyTransition.Property: System.String
+property Velvet.StyleRecipe+CompoundVariant.ClassName: System.String
+property Velvet.StyleRecipe+CompoundVariant.Conditions: System.Collections.Generic.Dictionary`2[System.String, System.String]
+property Velvet.StyleSlotClasses.Item[System.String]: System.String
+property Velvet.StyleSlotRecipe+SlotCompoundVariant.Conditions: System.Collections.Generic.Dictionary`2[System.String, System.String]
+property Velvet.StyleSlotRecipe+SlotCompoundVariant.SlotClasses: System.Collections.Generic.Dictionary`2[System.String, System.String]
+property Velvet.StyleTransitionConfig.BezierX1: System.Single
+property Velvet.StyleTransitionConfig.BezierX2: System.Single
+property Velvet.StyleTransitionConfig.BezierY1: System.Single
+property Velvet.StyleTransitionConfig.BezierY2: System.Single
+property Velvet.StyleTransitionConfig.Damping: System.Single
+property Velvet.StyleTransitionConfig.DelayChildrenSec: System.Single
+property Velvet.StyleTransitionConfig.DelaySec: System.Single
+property Velvet.StyleTransitionConfig.DurationSec: System.Single
+property Velvet.StyleTransitionConfig.Easing: UnityEngine.UIElements.EasingMode
+property Velvet.StyleTransitionConfig.ExitEasing: System.Nullable`1[UnityEngine.UIElements.EasingMode]
+property Velvet.StyleTransitionConfig.Mass: System.Single
+property Velvet.StyleTransitionConfig.PropertyOverrides: System.Collections.Generic.IReadOnlyList`1[Velvet.StylePropertyTransition]
+property Velvet.StyleTransitionConfig.StaggerChildrenSec: System.Single
+property Velvet.StyleTransitionConfig.Stiffness: System.Single
+property Velvet.StyleTransitionConfig.Type: Velvet.TransitionType
+property Velvet.StyleTransitionConfig.When: Velvet.TransitionWhen
+property Velvet.SuspenseNode.Children: Velvet.VNode[]
+property Velvet.SuspenseNode.Fallback: Velvet.VNode
+property Velvet.TextFieldSettings.IsPassword: System.Nullable`1[System.Boolean]
+property Velvet.TextNode.Text: System.String
+property Velvet.VNode.Key: System.String
+property Velvet.VelvetFonts.DefaultFamily: System.String
+property Velvet.VelvetPreviewAttribute.Group: System.String
+property Velvet.VelvetPreviewAttribute.Height: System.Int32
+property Velvet.VelvetPreviewAttribute.Name: System.String
+property Velvet.VelvetPreviewAttribute.Width: System.Int32
+property Velvet.VelvetPreviewHost.MountError: System.Exception
+property Velvet.VelvetPreviewHost.Story: Velvet.VelvetPreviewStory
+property Velvet.VelvetPreviewStory.ArgsType: System.Type
+property Velvet.VelvetPreviewStory.Assembly: System.Reflection.Assembly
+property Velvet.VelvetPreviewStory.Group: System.String
+property Velvet.VelvetPreviewStory.Height: System.Int32
+property Velvet.VelvetPreviewStory.Id: System.String
+property Velvet.VelvetPreviewStory.Name: System.String
+property Velvet.VelvetPreviewStory.Width: System.Int32
+property Velvet.VelvetStyleHints.PreviewStyleSheet: UnityEngine.UIElements.StyleSheet
+property Velvet.VelvetStyleUtilities.Sheet: UnityEngine.UIElements.StyleSheet
+property Velvet.VelvetTheme.IsDark: System.Boolean
+property Velvet.VirtualListNode.ClassNames: System.String[]
+property Velvet.VirtualListNode.ItemHeight: System.Single
+property Velvet.VirtualListNode.Items: System.Collections.Generic.IReadOnlyList`1[System.Object]
+property Velvet.VirtualListNode.KeySelector: System.Func`2[System.Object, System.String]
+property Velvet.VirtualListNode.Name: System.String
+property Velvet.VirtualListNode.Overscan: System.Int32
+property Velvet.VirtualListNode.Renderer: System.Func`2[System.Object, Velvet.VNode]
+property Velvet.WheelBinding.EventId: System.String
+property Velvet.WheelBinding.Handler: UnityEngine.UIElements.EventCallback`1[UnityEngine.UIElements.WheelEvent]
+property Velvet.WorldSpaceNode.Children: Velvet.VNode[]
+property Velvet.WorldSpaceNode.FocusOrder: Velvet.PanelFocusOrder
+property Velvet.WorldSpaceNode.PanelSize: UnityEngine.Vector2
+property Velvet.WorldSpaceNode.Position: UnityEngine.Vector3
+property Velvet.WorldSpaceNode.Rotation: UnityEngine.Quaternion
+property protected Velvet.Store`1.CancellationToken: System.Threading.CancellationToken
+property protected Velvet.Store`1.Logger: Velvet.StoreLogger
+type System.Runtime.CompilerServices.ModuleInitializerAttribute
+type Velvet.AnchoredSettings
+type Velvet.AnimatePresenceMode
+type Velvet.AnimatePresenceNode
+type Velvet.AnimationSequenceControls
+type Velvet.AnimationSequenceState
+type Velvet.AnimationSequenceStep
+type Velvet.BaseElementNode
+type Velvet.BlurBinding
+type Velvet.ChangeEventBinding`1
+type Velvet.ChoicesSettings
+type Velvet.ClickedBinding
+type Velvet.ComponentAttribute
+type Velvet.ComponentContext`1
+type Velvet.ComponentFiber
+type Velvet.ComponentMethodRegistry
+type Velvet.ComponentNode
+type Velvet.ContextProviderNode
+type Velvet.ContextProviderNode`1
+type Velvet.DevTools.VelvetDevToolsRegistry
+type Velvet.DevTools.VelvetDevToolsRegistry+ComponentEntry
+type Velvet.DndCollisionDetection
+type Velvet.DndCollisionQuery
+type Velvet.DndCollisions
+type Velvet.DndContextSettings
+type Velvet.DndDroppableRect
+type Velvet.DragActivation
+type Velvet.DragCancelArgs
+type Velvet.DragEndArgs
+type Velvet.DragMovement
+type Velvet.DragOverArgs
+type Velvet.DragOverlaySettings
+type Velvet.DragStartArgs
+type Velvet.DraggableInfo
+type Velvet.DraggableSettings
+type Velvet.DroppableInfo
+type Velvet.DroppableSettings
+type Velvet.ElementNode
+type Velvet.ErrorInfo
+type Velvet.Experimental.VBuilder
+type Velvet.Experimental.VButton
+type Velvet.Experimental.VCustom`1
+type Velvet.Experimental.VDiv
+type Velvet.Experimental.VImage
+type Velvet.Experimental.VLabel
+type Velvet.Experimental.VScrollView
+type Velvet.Experimental.VSlider
+type Velvet.Experimental.VTextField
+type Velvet.Experimental.VToggle
+type Velvet.FiberElementProps
+type Velvet.FiberEventBinding
+type Velvet.FiberPortalRegistry
+type Velvet.FiberStrictMode
+type Velvet.FiberUpdatePriority
+type Velvet.FocusBinding
+type Velvet.FocusInBinding
+type Velvet.FocusOutBinding
+type Velvet.FocusRing
+type Velvet.FocusScopeSettings
+type Velvet.FontIntent
+type Velvet.FragmentNode
+type Velvet.GeometryChangedBinding
+type Velvet.HookServiceContext
+type Velvet.Hooks
+type Velvet.IHookServiceResolver
+type Velvet.IRouteScope
+type Velvet.IRouteScopeFactory
+type Velvet.ISearchParams
+type Velvet.IStoreWriter`1
+type Velvet.KeyDownBinding
+type Velvet.KeyUpBinding
+type Velvet.LoaderMode
+type Velvet.MemoNode
+type Velvet.MemoizeMethodAttribute
+type Velvet.MotionNode
+type Velvet.MountedTree
+type Velvet.MutableRef`1
+type Velvet.MutationOptions
+type Velvet.MutationOptions`1
+type Velvet.MutationOptions`2
+type Velvet.MutationResultExtensions
+type Velvet.MutationResult`2
+type Velvet.MutationStatus
+type Velvet.Navigate+Props
+type Velvet.NavigationAttempt
+type Velvet.NavigationLifecycle
+type Velvet.NavigationMode
+type Velvet.NavigationResult
+type Velvet.NavigationState
+type Velvet.NullStoreLogger
+type Velvet.OutletNode
+type Velvet.PanelFocusOrder
+type Velvet.ParticlesElement
+type Velvet.ParticlesSettings
+type Velvet.PlayTrigger
+type Velvet.PointerDownBinding
+type Velvet.PointerEnterBinding
+type Velvet.PointerLeaveBinding
+type Velvet.PointerMoveBinding
+type Velvet.PointerUpBinding
+type Velvet.PortalNode
+type Velvet.PureAttribute
+type Velvet.Ref`1
+type Velvet.ResolvedFont
+type Velvet.RouteBlockerManager
+type Velvet.RouteBlockerState
+type Velvet.RouteBlockerStatus
+type Velvet.RouteDefinition
+type Velvet.RouteLink+Props
+type Velvet.RouteLoaderContext
+type Velvet.RouteMatch
+type Velvet.RouteNavLink+Props
+type Velvet.RouteTree
+type Velvet.Router
+type Velvet.RouterContext
+type Velvet.RouterLocation
+type Velvet.RouterStatus
+type Velvet.SceneViewElement
+type Velvet.SceneViewSettings
+type Velvet.ScrollViewSettings
+type Velvet.SearchParams
+type Velvet.SearchParamsSetter
+type Velvet.SliderSettings
+type Velvet.StateUpdater`1
+type Velvet.StoreLogger
+type Velvet.StoreShallowEqualityComparer
+type Velvet.Store`1
+type Velvet.StyleBackgroundImageResolver
+type Velvet.StyleClassNames
+type Velvet.StyleFontClass
+type Velvet.StyleFontResolver
+type Velvet.StyleOverrides
+type Velvet.StylePropertyTransition
+type Velvet.StyleRecipe
+type Velvet.StyleRecipe+CompoundVariant
+type Velvet.StyleSlotClasses
+type Velvet.StyleSlotRecipe
+type Velvet.StyleSlotRecipe+SlotCompoundVariant
+type Velvet.StyleTransition
+type Velvet.StyleTransitionConfig
+type Velvet.StyleVariantClass
+type Velvet.StyleVariantKind
+type Velvet.SuspenseNode
+type Velvet.TextFieldSettings
+type Velvet.TextNode
+type Velvet.TransitionStarter
+type Velvet.TransitionType
+type Velvet.TransitionWhen
+type Velvet.UILayer
+type Velvet.Unit
+type Velvet.V
+type Velvet.VNode
+type Velvet.VelvetFilters
+type Velvet.VelvetFontFamily
+type Velvet.VelvetFontWeight
+type Velvet.VelvetFontWeightEntry
+type Velvet.VelvetFonts
+type Velvet.VelvetPreviewAttribute
+type Velvet.VelvetPreviewHost
+type Velvet.VelvetPreviewRegistry
+type Velvet.VelvetPreviewSetupAttribute
+type Velvet.VelvetPreviewStory
+type Velvet.VelvetResponsive
+type Velvet.VelvetRuntimeAssets
+type Velvet.VelvetStyleHints
+type Velvet.VelvetStyleUtilities
+type Velvet.VelvetTheme
+type Velvet.VirtualListNode
+type Velvet.WheelBinding
+type Velvet.WorldSpaceNode

--- a/Packages/com.velvet.core/PublicAPI.txt.meta
+++ b/Packages/com.velvet.core/PublicAPI.txt.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 988a8886105374941a8195bd893f4275
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/PublicApiSurfaceTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/PublicApiSurfaceTests.cs
@@ -1,0 +1,332 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using NUnit.Framework;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins the shipped runtime assembly's public and protected member surface to a checked-in file so every
+    /// addition and removal is a reviewable diff. The CHANGELOG's [Unreleased] breaking entries are written
+    /// down by hand; nothing else compares two commits.
+    /// </summary>
+    [TestFixture]
+    internal sealed class PublicApiSurfaceTests
+    {
+        // Regeneration is opt-in so a normal test run never rewrites the pin file.
+        private const string UpdateEnvironmentVariable = "VELVET_UPDATE_PUBLIC_API";
+
+        private static readonly string PublicApiPath =
+            Path.GetFullPath("Packages/com.velvet.core/PublicAPI.txt");
+
+        [Test]
+        public void Given_VelvetRuntimeAssembly_When_PublicApiSurfaceIsRendered_Then_ItMatchesPublicApiTxt()
+        {
+            // Arrange
+            var rendered = PublicApiSurface.Render(typeof(V).Assembly).ToArray();
+
+            // Act
+            if (string.Equals(
+                    Environment.GetEnvironmentVariable(UpdateEnvironmentVariable),
+                    "1",
+                    StringComparison.Ordinal))
+            {
+                File.WriteAllLines(PublicApiPath, rendered);
+            }
+
+            var onDisk = File.Exists(PublicApiPath)
+                ? File.ReadAllLines(PublicApiPath)
+                : Array.Empty<string>();
+            var added = rendered.Except(onDisk, StringComparer.Ordinal).OrderBy(line => line, StringComparer.Ordinal)
+                .ToArray();
+            var removed = onDisk.Except(rendered, StringComparer.Ordinal)
+                .OrderBy(line => line, StringComparer.Ordinal).ToArray();
+
+            // Assert
+            Assert.That(
+                (added.Length, removed.Length),
+                Is.EqualTo((0, 0)),
+                BuildDriftMessage(added, removed));
+        }
+
+        private static string BuildDriftMessage(IReadOnlyList<string> added, IReadOnlyList<string> removed)
+        {
+            var message = "Public API surface drifted from Packages/com.velvet.core/PublicAPI.txt.";
+            if (added.Count > 0)
+            {
+                message += "\n\nAdded:\n" + string.Join("\n", added);
+            }
+
+            if (removed.Count > 0)
+            {
+                message += "\n\nRemoved:\n" + string.Join("\n", removed);
+            }
+
+            message += "\n\nTo regenerate PublicAPI.txt, run:\n"
+                       + "VELVET_UPDATE_PUBLIC_API=1 \"$UNITY\" -runTests -batchmode -projectPath \"$PWD\" "
+                       + "-testPlatform EditMode -testFilter Velvet.Tests.PublicApiSurfaceTests";
+            return message;
+        }
+    }
+
+    internal static class PublicApiSurface
+    {
+        private const BindingFlags MemberFlags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance
+            | BindingFlags.Static | BindingFlags.DeclaredOnly;
+
+        public static IReadOnlyList<string> Render(Assembly assembly)
+        {
+            var lines = new List<string>();
+            foreach (var type in assembly.GetTypes()
+                         .Where(IsSurfaceType)
+                         .OrderBy(type => type.FullName, StringComparer.Ordinal))
+            {
+                lines.Add(RenderType(type));
+                lines.AddRange(RenderMembers(type));
+            }
+
+            lines.Sort(StringComparer.Ordinal);
+            return lines;
+        }
+
+        private static bool IsSurfaceType(Type type)
+        {
+            if (!type.IsPublic && !type.IsNestedPublic)
+            {
+                return false;
+            }
+
+            return !IsCompilerGenerated(type);
+        }
+
+        private static IEnumerable<string> RenderMembers(Type type)
+        {
+            foreach (var constructor in type.GetConstructors(MemberFlags))
+            {
+                var line = RenderConstructor(type, constructor);
+                if (line != null)
+                {
+                    yield return line;
+                }
+            }
+
+            foreach (var method in type.GetMethods(MemberFlags))
+            {
+                var line = RenderMethod(type, method);
+                if (line != null)
+                {
+                    yield return line;
+                }
+            }
+
+            foreach (var property in type.GetProperties(MemberFlags))
+            {
+                var line = RenderProperty(type, property);
+                if (line != null)
+                {
+                    yield return line;
+                }
+            }
+
+            foreach (var field in type.GetFields(MemberFlags))
+            {
+                var line = RenderField(type, field);
+                if (line != null)
+                {
+                    yield return line;
+                }
+            }
+
+            foreach (var eventInfo in type.GetEvents(MemberFlags))
+            {
+                var line = RenderEvent(type, eventInfo);
+                if (line != null)
+                {
+                    yield return line;
+                }
+            }
+        }
+
+        private static string RenderType(Type type) => "type " + FormatType(type);
+
+        private static string RenderConstructor(Type declaringType, ConstructorInfo constructor)
+        {
+            if (!IsVisibleMethod(constructor) || IsCompilerGenerated(constructor))
+            {
+                return null;
+            }
+
+            return Prefix("ctor", constructor)
+                   + FormatType(declaringType)
+                   + ".ctor("
+                   + FormatParameters(constructor.GetParameters())
+                   + "): System.Void";
+        }
+
+        private static string RenderMethod(Type declaringType, MethodInfo method)
+        {
+            if (method.IsSpecialName || !IsVisibleMethod(method) || IsCompilerGenerated(method))
+            {
+                return null;
+            }
+
+            var name = method.Name;
+            if (method.IsGenericMethodDefinition || method.IsGenericMethod)
+            {
+                name += "`" + method.GetGenericArguments().Length;
+            }
+
+            return Prefix("method", method)
+                   + FormatType(declaringType)
+                   + "."
+                   + name
+                   + "("
+                   + FormatParameters(method.GetParameters())
+                   + "): "
+                   + FormatType(method.ReturnType);
+        }
+
+        private static string RenderProperty(Type declaringType, PropertyInfo property)
+        {
+            if (IsCompilerGenerated(property) || !HasVisibleAccessor(property, out var accessor))
+            {
+                return null;
+            }
+
+            var indexer = property.GetIndexParameters();
+            var indexerSuffix = indexer.Length == 0
+                ? string.Empty
+                : "[" + FormatParameters(indexer) + "]";
+
+            return Prefix("property", accessor)
+                   + FormatType(declaringType)
+                   + "."
+                   + property.Name
+                   + indexerSuffix
+                   + ": "
+                   + FormatType(property.PropertyType);
+        }
+
+        private static string RenderField(Type declaringType, FieldInfo field)
+        {
+            if (field.IsSpecialName || !IsVisibleField(field) || IsCompilerGenerated(field))
+            {
+                return null;
+            }
+
+            return Prefix("field", field)
+                   + FormatType(declaringType)
+                   + "."
+                   + field.Name
+                   + ": "
+                   + FormatType(field.FieldType);
+        }
+
+        private static string RenderEvent(Type declaringType, EventInfo eventInfo)
+        {
+            if (IsCompilerGenerated(eventInfo) || !HasVisibleAccessor(eventInfo, out var accessor))
+            {
+                return null;
+            }
+
+            return Prefix("event", accessor)
+                   + FormatType(declaringType)
+                   + "."
+                   + eventInfo.Name
+                   + ": "
+                   + FormatType(eventInfo.EventHandlerType);
+        }
+
+        private static bool HasVisibleAccessor(PropertyInfo property, out MethodInfo accessor)
+        {
+            accessor = ChooseVisibleAccessor(property.GetMethod, property.SetMethod);
+            return accessor != null;
+        }
+
+        private static bool HasVisibleAccessor(EventInfo eventInfo, out MethodInfo accessor)
+        {
+            accessor = ChooseVisibleAccessor(eventInfo.AddMethod, eventInfo.RemoveMethod);
+            return accessor != null;
+        }
+
+        private static MethodInfo ChooseVisibleAccessor(MethodInfo first, MethodInfo second)
+        {
+            if (first != null && IsVisibleMethod(first))
+            {
+                return first;
+            }
+
+            if (second != null && IsVisibleMethod(second))
+            {
+                return second;
+            }
+
+            return null;
+        }
+
+        private static bool IsVisibleMethod(MethodBase method) =>
+            method != null && (method.IsPublic || method.IsFamily);
+
+        private static bool IsVisibleField(FieldInfo field) =>
+            field.IsPublic || field.IsFamily;
+
+        private static bool IsCompilerGenerated(MemberInfo member) =>
+            member.GetCustomAttribute<CompilerGeneratedAttribute>() != null;
+
+        private static string Prefix(string kind, MemberInfo member)
+        {
+            var visibility = member switch
+            {
+                MethodBase { IsFamily: true } => "protected ",
+                FieldInfo { IsFamily: true } => "protected ",
+                _ => string.Empty
+            };
+
+            return kind + " " + visibility;
+        }
+
+        private static string FormatParameters(IReadOnlyList<ParameterInfo> parameters) =>
+            string.Join(", ", parameters.Select(parameter => FormatType(parameter.ParameterType)));
+
+        private static string FormatType(Type type)
+        {
+            if (type.IsByRef)
+            {
+                return FormatType(type.GetElementType()!) + "&";
+            }
+
+            if (type.IsArray)
+            {
+                var rank = type.GetArrayRank();
+                var suffix = rank == 1 ? "[]" : "[" + new string(',', rank - 1) + "]";
+                return FormatType(type.GetElementType()!) + suffix;
+            }
+
+            if (type.IsGenericParameter)
+            {
+                return type.Name;
+            }
+
+            if (type.IsGenericType)
+            {
+                var definition = type.IsGenericTypeDefinition ? type : type.GetGenericTypeDefinition();
+                var definitionName = definition.FullName ?? definition.Name;
+                var tickIndex = definitionName.IndexOf('`', StringComparison.Ordinal);
+                var baseName = tickIndex >= 0 ? definitionName[..tickIndex] : definitionName;
+                var arity = definition.GetGenericArguments().Length;
+                if (type.IsGenericTypeDefinition)
+                {
+                    return baseName + "`" + arity;
+                }
+
+                var arguments = string.Join(", ", type.GetGenericArguments().Select(FormatType));
+                return baseName + "`" + arity + "[" + arguments + "]";
+            }
+
+            return type.FullName ?? type.Name;
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/PublicApiSurfaceTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/PublicApiSurfaceTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c066bd2a6c88844c39f3b8b262487836


### PR DESCRIPTION
Part of #318 — the second measure it names, brought forward because a release is due and four BREAKING entries are already in `[Unreleased]`.

Each of those four was noticed because its author wrote it down. Nothing compares the shipped surface between two commits, so a breaking change nobody labelled reaches a release unlabelled.

`PublicAPI.txt` is that comparison: 1039 lines rendered from the runtime assembly`s public and protected members, one per member, sorted ordinally and using full type names so the rendering is stable across runs and machines. An addition and a removal are both a diff a reviewer sees rather than something they have to notice. Regeneration is opt-in through an environment variable, and the failure message prints the exact command.

| kind | lines |
| --- | --- |
| property | 363 |
| method | 268 |
| type | 170 |
| field | 120 |
| ctor | 113 |
| event | 5 |

## What review caught

The first rendering was **726 lines and contained no property and no event at all** — 363 and 5 of them missing. Accessors were correctly filtered as special-name methods, but properties and events were never enumerated separately, so removing the accessors removed the only trace they had. A guard over half the surface, passing.

It also carried 43 members the compiler synthesises: 26 record `<Clone>$` methods and 17 enum `value__` fields. Those are now filtered by the attribute and flag that identify them rather than by spelling.

## Verification

- **Red, both directions.** Deleting `property Velvet.ComponentAttribute.Memoize` from the pin file fails with that line under `Added:` — the current surface carries what the pin does not. Adding a line the surface does not have fails with it under `Removed:`.
- **Green** with neither break present.
- **Stable**: two consecutive regenerations produce byte-identical files.
- Whole EditMode suite: 3585 cases, 3582 passed, 0 failed, 0 inconclusive, no compile errors.

The remaining measures #318 names — reachability and type-level shape — are not in this change.

No `Documentation~` impact: this adds a guard over the surface rather than changing it.