### PR TITLE
Report a checkout that has drifted behind origin/main

### DIFF
--- a/.claude/hooks/report-stale-main.sh
+++ b/.claude/hooks/report-stale-main.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Reports when local main or the checked-out branch lags origin/main.
+#
+# Verification here reads the working copy. A checkout ten commits behind origin/main
+# answered a guard question with the file absent — the guard had merged — and the
+# near-miss was caught only because the same tree disagreed with a second fact
+# already known to be true. Pull requests merge through the API, origin/main advances,
+# and nothing pulls afterwards.
+#
+# Exit 0 always.
+
+set -uo pipefail
+
+command -v git >/dev/null 2>&1 || exit 0
+
+tree="${CLAUDE_PROJECT_DIR:-}"
+if [ -z "$tree" ]; then
+  tree=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+fi
+cd "$tree" 2>/dev/null || exit 0
+git rev-parse --git-dir >/dev/null 2>&1 || exit 0
+git remote get-url origin >/dev/null 2>&1 || exit 0
+
+FETCH_TIMEOUT=15
+
+fetch_origin_main() {
+  git fetch -q origin main &
+  local pid=$!
+  local waited=0
+  while kill -0 "$pid" 2>/dev/null; do
+    if [ "$waited" -ge "$FETCH_TIMEOUT" ]; then
+      kill "$pid" 2>/dev/null
+      wait "$pid" 2>/dev/null
+      return 1
+    fi
+    sleep 1
+    waited=$((waited + 1))
+  done
+  wait "$pid"
+}
+
+fetch_origin_main || exit 0
+git rev-parse --verify refs/remotes/origin/main >/dev/null 2>&1 || exit 0
+
+main_report=""
+branch_report=""
+branch=$(git symbolic-ref --quiet --short HEAD 2>/dev/null || true)
+
+if git rev-parse --verify refs/heads/main >/dev/null 2>&1; then
+  main_behind=$(git rev-list --count main..origin/main 2>/dev/null || echo 0)
+  if [ "${main_behind:-0}" -gt 0 ]; then
+    commit_word=commits
+    [ "$main_behind" -eq 1 ] && commit_word=commit
+    main_report="Local main is $main_behind $commit_word behind origin/main.
+
+git fetch origin main
+git checkout main
+git merge --ff-only origin/main"
+  fi
+fi
+
+if [ -n "$branch" ] && [ "$branch" != "main" ]; then
+  if ! git merge-base --is-ancestor origin/main HEAD 2>/dev/null; then
+    branch_behind=$(git rev-list --count HEAD..origin/main 2>/dev/null || echo 0)
+    if [ "${branch_behind:-0}" -gt 0 ]; then
+      commit_word=commits
+      [ "$branch_behind" -eq 1 ] && commit_word=commit
+      branch_report="Branch $branch is $branch_behind $commit_word behind origin/main.
+
+git fetch origin
+git rebase origin/main
+git push origin $branch --force-with-lease"
+    fi
+  fi
+fi
+
+[ -z "$main_report" ] && [ -z "$branch_report" ] && exit 0
+
+if [ -n "$main_report" ] && [ -n "$branch_report" ]; then
+  printf '%s\n\n%s\n' \
+    "This checkout may not match origin/main.
+
+$main_report" \
+    "$branch_report"
+else
+  report="${main_report:-$branch_report}"
+  printf 'This checkout may not match origin/main.
+
+%s\n' "$report"
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,16 @@
 {
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/report-stale-main.sh",
+            "timeout": 15000
+          }
+        ]
+      }
+    ],
     "SubagentStop": [
       {
         "hooks": [


### PR DESCRIPTION
Closes #322.

Verification here reads the working copy. A checkout some number of merges old answers questions about a tree that no longer exists, and the failure is silent and symmetric: a mechanism that exists reads as absent, and one that was deleted reads as present.

It happened. Checking whether a guard was present, the file did not contain it — the guard had landed, been reviewed and been merged, and the local checkout was ten commits behind `origin/main`. That was about to be reported as a fact about the repository. Nothing caught it; what stopped it was the same tree also disagreeing with a second thing already known to be true.

Pull requests merge through the API, which advances `origin/main` and leaves the local ref where it was. Nothing pulls afterwards, so the gap grows by one per merge.

`report-stale-main.sh` runs at `SessionStart`, fetches `origin/main` only, and reports the count with the commands that fix it. It **reports rather than refuses** — a session may legitimately begin on an old checkout, and a `SessionStart` hook that refused would make the repository unusable. It says nothing when there is nothing to say, because a hook that speaks every session is a hook that gets ignored. The fetch is bounded, so an offline machine costs a session nothing rather than fifteen seconds of hanging.

The worktree half of #322 is already done: sixty worktrees under `.claude/worktrees`, 81 GB, removed.

## What review caught

The branch block printed `git merge --ff-only origin/main` as its fix. Measured against a clone with a branch two commits behind `origin/main` and one commit of its own, git refuses it: diverging branches cannot be fast-forwarded.

A branch that is behind and has any commit of its own has diverged, and that is the only case the branch block fires in — so the command was wrong for every case that reached it. It now prints the rebase-and-force-push form this repository actually uses, with the branch name substituted. The `--ff-only` form stays in the main block, where a fast-forward is what happens.

A comment asserting what Claude Code does with a `SessionStart` hook's stdout was also removed: unverified, and about a program outside this repository.

## Verification

| checkout | exit | output |
| --- | --- | --- |
| this repository, main current | 0 | none |
| clone with main moved back ten | 0 | the count and the ff-only fix |
| clone on a branch two behind with one of its own | 0 | the count and the rebase form, naming the branch |

Separately measured, because the hook depends on it: `git fetch -q origin main` does move `refs/remotes/origin/main` — a clone whose ref was moved back five commits came back to the real tip.

`HookWiringCoverageTests` covers the wiring. Whole EditMode suite: 3585 cases, 3582 passed, 0 failed, 0 inconclusive.

No `Documentation~` impact: the hooks are loop machinery rather than package behaviour.
