### PR TITLE
Let the branch guard see the forms it was passing

### DIFF
--- a/.claude/hooks/refuse-branch-from-unmerged.py
+++ b/.claude/hooks/refuse-branch-from-unmerged.py
@@ -17,15 +17,103 @@ import sys
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib"))
 from velvet_hooks import BRANCH_BASES
 
-# Anchored at a command position — start of input, or after a separator or newline — so the same
-# text quoted inside an argument does not trip it. The blind-add sibling records the first version
-# refused the change that would have fixed it.
+# Anchored at a command position — start of input, or after a separator or newline. Quoted
+# arguments and heredoc bodies are masked before matching; a newline inside them is not a command
+# boundary. The blind-add sibling records the first version refused the change that would have
+# fixed it.
 _GIT = r"git\s+(?:-C\s+\S+\s+)?"
 _END = r"(?:\s*$|\s*[;&|])"
 ANCHOR = r"(?:^|[;&|]|\n)\s*"
-CHECKOUT_B = re.compile(ANCHOR + _GIT + r"checkout\s+-b\s+(\S+)" + _END)
-SWITCH_CREATE = re.compile(ANCHOR + _GIT + r"switch\s+(?:-c|--create)\s+(\S+)" + _END)
+# Trailing flags only — a non-flag token is a start point, which is what the guard is about.
+_TRAILING_FLAGS = r"(?:\s+-\S+)*"
+CHECKOUT_B = re.compile(
+    ANCHOR + _GIT + r"checkout(?:\s+(?!-b\b)\S+)*\s+-b\s+([^-\s]\S+)" + _TRAILING_FLAGS + _END
+)
+SWITCH_CREATE = re.compile(
+    ANCHOR + _GIT
+    + r"switch(?:\s+(?!(?:-c|--create)\b)\S+)*\s+(?:-c|--create)\s+([^-\s]\S+)"
+    + _TRAILING_FLAGS + _END
+)
 BRANCH = re.compile(ANCHOR + _GIT + r"branch\s+([^-\s]\S*)" + _END)
+
+
+def mask_shell_literals(command):
+    out = list(command)
+    i = 0
+    n = len(command)
+    while i < n:
+        ch = command[i]
+        if ch in "'\"":
+            quote = ch
+            out[i] = " "
+            i += 1
+            while i < n:
+                if quote == '"' and command[i] == "\\" and i + 1 < n:
+                    out[i] = out[i + 1] = " "
+                    i += 2
+                    continue
+                if command[i] == quote:
+                    out[i] = " "
+                    i += 1
+                    break
+                out[i] = " "
+                i += 1
+        elif ch == "\\" and i + 1 < n:
+            out[i] = out[i + 1] = " "
+            i += 2
+        elif command.startswith("<<", i):
+            j = i + 2
+            strip_tabs = j < n and command[j] == "-"
+            if strip_tabs:
+                j += 1
+            if j < n and command[j] in "'\"":
+                quote = command[j]
+                j += 1
+                start = j
+                while j < n and command[j] != quote:
+                    j += 1
+                delimiter = command[start:j]
+                if j < n:
+                    j += 1
+            else:
+                start = j
+                while j < n and not command[j].isspace():
+                    j += 1
+                delimiter = command[start:j]
+            while i < j:
+                out[i] = " "
+                i += 1
+            while i < n and command[i] != "\n":
+                out[i] = " "
+                i += 1
+            if i < n:
+                out[i] = "\n"
+                i += 1
+            while i < n:
+                line_start = i
+                line_end = command.find("\n", i)
+                if line_end == -1:
+                    line_end = n
+                line = command[line_start:line_end]
+                body = line.lstrip("\t") if strip_tabs else line
+                if body == delimiter:
+                    for k in range(line_start, line_end):
+                        out[k] = " "
+                    if line_end < n:
+                        i = line_end + 1
+                    else:
+                        i = line_end
+                    break
+                for k in range(line_start, line_end):
+                    out[k] = " "
+                if line_end < n:
+                    out[line_end] = " "
+                    i = line_end + 1
+                else:
+                    i = line_end
+        else:
+            i += 1
+    return "".join(out)
 
 
 def git(cwd, *args):
@@ -36,8 +124,9 @@ def git(cwd, *args):
 
 
 def branch_name(command):
+    masked = mask_shell_literals(command)
     for pattern in (CHECKOUT_B, SWITCH_CREATE, BRANCH):
-        match = pattern.search(command)
+        match = pattern.search(masked)
         if match:
             return match.group(1)
     return None


### PR DESCRIPTION
`refuse-branch-from-unmerged.py` was passing the commands it exists to refuse, and refusing commands that only mentioned them.

## It missed every flagged form

The patterns required the create flag to sit directly after the subcommand and the branch name to end the command. Measured against a HEAD that is not a commit `main` contains, where every one of these must be refused:

| command | before |
| --- | --- |
| `git checkout -b docs/x` | 2 — refused |
| `git checkout -q -b docs/x` | 0 — passed |
| `git checkout -b docs/x -q` | 0 — passed |
| `git switch -q -c docs/x` | 0 — passed |

Options are now accepted around the create flag.

A trailing token is read by what it is. A flag is noise and the refusal stands — the branch is still cut from wherever HEAD happens to be. Anything else is a start point, and the caller has said where to branch from, which is the thing the guard is about; that is the rule the bare `git branch <name> <start-point>` form already followed. Widening without that distinction made the hook refuse `git checkout -b <name> main`, which is the command its own refusal message advises.

## It refused text inside a quoted argument

`ANCHOR` accepts a newline as a command position, and a newline inside a quoted argument satisfies it. Any command carrying a commit message, a pull request body or a heredoc that names a branch-creating command was refused. Quoted strings and heredoc bodies are masked before matching, so a real command following a newline still refuses while the same text inside them does not.

The sibling `refuse-blind-git-add.py` records that its first version had this shape and was anchored to fix it. Anchoring on a newline does not fix it, because a quoted argument contains newlines too.

## Verification

Every case run against a HEAD not contained in `main`:

Refused — plain `checkout -b`; `-q` before the create flag; `-q` after the name; `--quiet`; `switch -c`; `switch -q -c`; bare `git branch <name>`; and a `checkout -b` that genuinely follows a newline as the next command.

Allowed — `checkout -b <name> main`; `checkout -b <name> origin/main`; the same with a trailing `-q`; `switch -c <name> origin/main`; `git branch <name> origin/main`; `git checkout main`; `git status --short`; the same text inside double quotes, inside single quotes, and inside a heredoc body; and a branch covered by a live deferral.

The captured branch name in a refused case is the branch, not a flag.

Whole EditMode suite: 3586 cases, 3583 passed, 0 failed, 0 inconclusive.

No `Documentation~` impact: the hooks are loop machinery rather than package behaviour.
