### PR TITLE
Say what a batchmode run still in the process list means

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,25 @@ story capture near-blank, and a panel whose height was its content's rather than
 green under every check and visible immediately in the PNG. Interactively the same stories are live
 in **Window ▸ Velvet ▸ Preview**.
 
+### A batchmode run that finishes but stays in the process list
+
+A Unity process can finish its work and then fail to exit. It shows in `ps` with state `UE` —
+uninterruptible wait while exiting — and `kill -9` does not remove it: measured on the editor
+process, still `UE` two seconds after the signal.
+
+The run's result is not affected. Check the log before treating one as a failure:
+
+```bash
+ps -eo pid,stat,etime,time,comm | grep -i unity
+grep -c "Exiting batchmode successfully now!" <logfile>
+```
+
+A log carrying that line has done its work, and its results stand even while the process is still
+listed. Every such log observed here ends inside the shutdown sequence and none inside a build.
+
+Ten of these were resident while twenty-five editor invocations ran on the same machine — eight
+player builds and fifteen EditMode suites — and all twenty-five completed.
+
 ### Checking that the tests can fail
 
 A green suite says nothing about whether the tests would have noticed the change. `scripts/mutation-check.py`


### PR DESCRIPTION
Closes #295.

A Unity process can finish its work and then fail to exit. Without a note saying so, a run whose process is still listed reads as a hang and gets debugged as a build failure.

The note states only what was measured:

- the process shows in `ps` with state `UE` — uninterruptible wait while exiting;
- `kill -9` does not remove it, measured on the editor process, still `UE` two seconds after the signal;
- a log carrying `Exiting batchmode successfully now!` has done its work and its results stand while the process is still listed;
- every such log observed ends inside the shutdown sequence and none inside a build;
- ten were resident while twenty-five editor invocations ran on the same machine — eight player builds and fifteen EditMode suites — and all twenty-five completed.

Why the exit stalls is not known and is not written. Nothing reproduced it across those twenty-five invocations under any combination of cold or warm `Library`, the Velvet IL post-processor present or absent, a build that stops before packaging or one that produces a player, and sequential or concurrent runs.

`CONTRIBUTING.md` is not in the documentation-guard corpus, so nothing machine-checks the names this note carries. It names one log line and two shell commands and no repository symbol.

Whole EditMode suite: 3586 cases, 3583 passed, 0 failed, 0 inconclusive.
