### PR TITLE
Collect the coverage report this project already pays for

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,6 +96,7 @@ jobs:
             Library-${{ matrix.testMode }}-
 
       - name: Run ${{ matrix.testMode }} tests
+        id: unity-tests
         uses: game-ci/unity-test-runner@0ff419b913a3630032cbe0de48a0099b5a9f0ed9 # v4
         env:
           UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
@@ -116,6 +117,13 @@ jobs:
           projectPath: .
           artifactsPath: ${{ matrix.testMode }}-results
           githubToken: ${{ secrets.GITHUB_TOKEN }}
+          # Without assemblyFilters the default covers Assets/ only, and the package lives under
+          # Packages/com.velvet.core: measured, the default reports 236 coverable lines of sample
+          # code where the filter below reports 27255 of the package's own.
+          # Unity.Velvet.CodeGen is left out because the compilation pipeline loads it rather than
+          # the test domain, so a figure for it would read zero for code every compile exercises.
+          coverageOptions: >-
+            generateAdditionalMetrics;generateHtmlReport;generateBadgeReport;dontClear;assemblyFilters:+Velvet,+Velvet.Editor
 
       # Unity exits 0 on an inconclusive case and game-ci's reporter reads only
       # passed/failed/skipped off <test-run>, so a test whose Assume stopped holding
@@ -130,6 +138,15 @@ jobs:
         with:
           name: Test results (${{ matrix.testMode }})
           path: ${{ matrix.testMode }}-results
+
+      # game-ci passes -enableCodeCoverage on every run whatever this workflow asks for, so the
+      # recorder's cost is paid either way; what the manifest's com.unity.testtools.codecoverage
+      # adds is the directory this output names.
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: Code coverage (${{ matrix.testMode }})
+          path: ${{ steps.unity-tests.outputs.coveragePath }}
 
   # ---------------------------------------------------------------------------
   # The one check branch protection requires from this workflow. Naming a real

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -5,6 +5,7 @@
     "com.unity.nuget.mono-cecil": "1.11.5",
     "com.unity.render-pipelines.universal": "17.3.0",
     "com.unity.test-framework": "1.6.0",
+    "com.unity.testtools.codecoverage": "1.3.0",
     "com.unity.test-framework.performance": "3.0.3",
     "com.unity.ui.test-framework": "6.3.0",
     "com.unity.ide.visualstudio": "2.0.23",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -139,6 +139,13 @@
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
+    "com.unity.settings-manager": {
+      "version": "2.1.1",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
     "com.unity.shadergraph": {
       "version": "17.3.0",
       "depth": 1,
@@ -165,6 +172,16 @@
       "dependencies": {
         "com.unity.test-framework": "1.1.31",
         "com.unity.modules.jsonserialize": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.testtools.codecoverage": {
+      "version": "1.3.0",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.test-framework": "1.4.5",
+        "com.unity.settings-manager": "2.0.0"
       },
       "url": "https://packages.unity.com"
     },


### PR DESCRIPTION
Part of #318 — the reachability item.

The pinned game-ci action invokes the editor with `-enableCodeCoverage` and `-debugCodeOptimization` as bare arguments with no conditional and no input that suppresses them, so the recorder runs on every job. It also passes `-coverageResultsPath` and exposes that path as an output. What was missing is the package that turns any of it into a report: the action installs `com.unity.testtools.codecoverage` only on the branch that wraps a package under test in a temporary project, and this workflow passes `projectPath: .` instead. The action's own last line says so — it prints that the results directory does not exist and to make sure the package is installed.

So the cost was paid in full and nothing was collected. The crash that flag combination caused on 6000.3.11f1 is why `unityVersion` here sits above this project's floor.

## The filter is the part that matters

Measured locally with the recorder's own flags, on the EditMode suite:

| | default `coverageOptions` | with `assemblyFilters:+Velvet,+Velvet.Editor` |
| --- | --- | --- |
| line coverage | 11% | **85.4%** |
| coverable lines | 236 | **27,255** |
| covered lines | 26 | **23,293** |
| assemblies | 4 | 2 |
| classes | 9 | **403** |

Unity's default filter covers user assemblies under `Assets/` and not embedded packages, and this package is embedded at `Packages/com.velvet.core`. The default report's per-assembly pages are `Assembly-CSharp-Editor`, `Velvet.Samples.StarterApp` and two sample test assemblies — **the runtime assembly is not in it at all**. Uploading that would ship a report about the sample app.

Specifying `coverageOptions` replaces the action's default, so the value carries the four report flags it would otherwise use alongside the filter.

`Unity.Velvet.CodeGen` is deliberately excluded: the compilation pipeline loads it rather than the test domain, so a figure for it would report zero for code that every compile runs. Test assemblies and `Velvet.TestUtilities` are excluded because measuring the tests' own coverage says nothing.

## Verification

- The report is produced: 63 files under the results path, including OpenCover XML per test mode and a `Report/` tree with `index.html`, `Summary.json`, and line and branch badges.
- With the filter, the report's assemblies are exactly `Velvet` and `Velvet.Editor`.
- EditMode suite with the coverage flags: 3586 cases, 3583 passed, 0 failed, 0 inconclusive.
- EditMode suite without them, which is what a contributor runs: 3586 cases, 3583 passed, 0 failed, 0 inconclusive.

No threshold and no gate is added. Collecting the report is the change; deciding what to require of it is not.

No `Documentation~` impact: this collects an artifact rather than changing package behaviour.
