### PR TITLE
Ignore the settings file a package writes on first load

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,9 @@ docs/guides/
 # The hand-authored DocFX and source-generator projects need no re-include: the *.csproj / *.sln rules
 # above are anchored to the root, so no rule ever matched them. Four negations sat here saying otherwise
 # and reached nothing.
+
+# Written by com.unity.settings-manager the first time a package that uses it loads. The one the
+# Code Coverage package leaves holds an empty dictionary, and CI passes its coverage options on the
+# command line rather than reading this, so tracking it would only make every checkout dirty after
+# its first run.
+ProjectSettings/Packages/


### PR DESCRIPTION
Follow-up to #339.

Adding `com.unity.testtools.codecoverage` brought `com.unity.settings-manager` with it, and that writes `ProjectSettings/Packages/com.unity.testtools.codecoverage/Settings.json` the first time the package loads. Every checkout therefore goes dirty the first time the suite runs, which is the state `refuse-blind-git-add.py` exists to keep readable.

The file holds an empty dictionary:

```json
{
    "m_Dictionary": {
        "m_DictionaryValues": []
    }
}
```

and CI passes its coverage options on the game-ci step`s `coverageOptions` input rather than reading it, so there is nothing in it to keep.

Nothing is tracked under `ProjectSettings/Packages/` today — `git ls-files` returns zero entries there — so the rule hides no decision. The other 24 files under `ProjectSettings/` are untouched.

No `Documentation~` impact: this ignores a generated file rather than changing behaviour.