### PR TITLE
Fail when a cref names something that no longer exists

### DIFF
--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/CrefTargetTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/CrefTargetTests.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using NUnit.Framework;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins every XML-doc <c>cref</c> in the package against the stripped identifier corpus
+    /// <see cref="DocumentationDriftTests"/> already builds, because a broken cref is CS1574 and nothing
+    /// in the Unity compile or the pull-request path raises it: <c>csc.rsp</c> does not emit documentation,
+    /// <c>docs/Velvet.Docs.csproj</c> excludes test assemblies, and the docs workflow runs on push to main
+    /// only.
+    /// </summary>
+    [TestFixture]
+    internal sealed class CrefTargetTests
+    {
+        private const string PackagePrefix = "Packages/com.velvet.core/";
+
+        // Names that resolve nowhere in this repo's identifier corpus for a reason: external API the package
+        // documents but never spells as code — BCL (<c>NullReferenceException</c>), UI Toolkit
+        // (<c>enabledInHierarchy</c>), and Roslyn (<c>IncrementalValuesProvider</c>).
+        private static readonly HashSet<string> CrefAllowlist = new()
+        {
+            "NullReferenceException",
+            "enabledInHierarchy",
+            "IncrementalValuesProvider",
+        };
+
+        private static readonly Regex CrefPattern = new(
+            @"<see(?:also)?\s+cref\s*=\s*""([^""]+)""",
+            RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+        [Test]
+        public void Given_PackageSources_When_XmlDocCrefsAreScanned_Then_EveryTargetAppearsInTheIdentifierCorpus()
+        {
+            // Arrange
+            var corpus = DocumentationDriftTests.SourceIdentifiers.Value;
+
+            // Act
+            var crefCount = 0;
+            var unresolved = new List<string>();
+            foreach (var entry in DocumentationCorpus.RepoEntries(includeClaude: false).Where(e =>
+                         e.StartsWith(PackagePrefix, StringComparison.Ordinal)
+                         && e.EndsWith(".cs", StringComparison.Ordinal)
+                         && File.Exists(e)))
+            {
+                foreach (Match match in CrefPattern.Matches(File.ReadAllText(entry)))
+                {
+                    crefCount++;
+                    var target = match.Groups[1].Value;
+                    var name = ReduceCrefTarget(target);
+                    if (!corpus.Contains(name) && !CrefAllowlist.Contains(name))
+                    {
+                        unresolved.Add($"{entry}: {name} (in cref=\"{target}\")");
+                    }
+                }
+            }
+
+            // Assert — that any cref was read rides along, because a walk that found none satisfies an
+            // emptiness check on its own. The count itself is not pinned: adding one is ordinary.
+            Assert.That(
+                (crefCount > 0, string.Join(", ", unresolved.Distinct().OrderBy(s => s, StringComparer.Ordinal))),
+                Is.EqualTo((true, string.Empty)));
+        }
+
+        private static string ReduceCrefTarget(string target)
+        {
+            var reduced = target.Trim();
+            var paren = reduced.IndexOf('(');
+            if (paren >= 0)
+            {
+                reduced = reduced[..paren];
+            }
+
+            if (reduced.StartsWith("T:", StringComparison.Ordinal)
+                || reduced.StartsWith("M:", StringComparison.Ordinal)
+                || reduced.StartsWith("P:", StringComparison.Ordinal)
+                || reduced.StartsWith("F:", StringComparison.Ordinal)
+                || reduced.StartsWith("E:", StringComparison.Ordinal)
+                || reduced.StartsWith("N:", StringComparison.Ordinal))
+            {
+                reduced = reduced[2..];
+            }
+
+            var lastDot = reduced.LastIndexOf('.');
+            reduced = lastDot < 0 ? reduced : reduced[(lastDot + 1)..];
+
+            var generic = reduced.IndexOfAny(new[] { '{', '`' });
+            if (generic >= 0)
+            {
+                reduced = reduced[..generic];
+            }
+
+            return reduced.Trim();
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/CrefTargetTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/CrefTargetTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d461a991b9ad4c14bcc81cce2d5f48c3

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/DocumentationDriftTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/DocumentationDriftTests.cs
@@ -412,7 +412,7 @@ namespace Velvet.Tests
         // real declarations would need every one of those toolchains loaded into the test. What it does care
         // about is that the word is code — see the stripping patterns for why prose cannot be trusted here.
         // What is stripped per format is StripProse's to say.
-        private static readonly Lazy<HashSet<string>> SourceIdentifiers = new(() =>
+        internal static readonly Lazy<HashSet<string>> SourceIdentifiers = new(() =>
         {
             var words = new Regex(@"[A-Za-z_][A-Za-z0-9_]*", RegexOptions.Compiled);
             var identifiers = new HashSet<string>(StringComparer.Ordinal);


### PR DESCRIPTION
Part of #317 — the half of class C that can be checked.

The package carries 1433 `<see cref>` references. A cref naming something that no longer exists is CS1574, and measured, that diagnostic is emitted almost nowhere here:

- Unity's compile does not generate documentation. `Packages/com.velvet.core/Runtime/csc.rsp` asks only for `-langversion:preview` and `-nullable:enable`, so no build or test run raises it — a full EditMode log contains no XML-doc diagnostic of any kind.
- `docs/Velvet.Docs.csproj` does generate documentation and does not suppress CS1574, but compiles `Runtime/**` excluding Tests, so `Editor/`, `CodeGen/`, `TestUtilities/` and every test assembly are outside it.
- `.github/workflows/docs.yml`, which runs that compile, triggers on push to `main` only and carries a path filter limited to `Runtime/**/*.cs`, `Documentation~/**`, `docs/**` and itself. It does not run on a pull request.

So a cref that stops resolving was caught for `Runtime/` sources only, only after the change had landed, and never for `Editor/` — which is where this repository's one cross-file delegation sits: `BundledStyleSheetBuildInclusion` says `<see cref="BundledShaderBuildInclusion"/>` owns the explanation of why the record lives on disk.

## The check

Every `<see cref>` and `<seealso cref>` in the package is reduced to a name and resolved against the identifier corpus `DocumentationDriftTests` already builds from the sources. That corpus is now `internal` rather than `private`; the alternative was a second copy of its construction, which is the duplication this repository keeps removing.

Three targets are allowlisted — `NullReferenceException`, `enabledInHierarchy`, `IncrementalValuesProvider` — external API from the BCL, UI Toolkit and Roslyn that the package documents and never spells as code. That is the same category `DocumentationDriftTests` already justifies its own allowlist entries with.

## Verification

The extraction and resolution were run over the real sources before the fixture was written, and the numbers it must reproduce:

| | |
| --- | --- |
| crefs found | 1433 |
| unresolved against a comment-stripped corpus | 3 |
| the three | `NullReferenceException`, `enabledInHierarchy`, `IncrementalValuesProvider` |
| unresolved with those allowed | **0** |
| injecting a cref naming a renamed type | 1 unresolved |
| injecting a cref naming a removed member | 1 unresolved |

The assertion folds in that any cref was read, so a walk that found none cannot satisfy the emptiness check on its own. The count itself is not pinned — adding a cref is ordinary.

The suite has not been run locally for this branch: the editor is occupied by a timing measurement for #330 and a second one would contend for a single-seat licence and corrupt it. CI runs the real fixture.

## What this does not do

It checks that a delegate still exists. It does not check that the delegate still explains what the delegation says it explains. Nothing proposed closes that half, and #317 stays open for it.

No `Documentation~` impact: this adds a guard over doc comments rather than changing what they describe.
