### PR TITLE
Let the backlog guard see work that is not the assistant's to advance

### DIFF
--- a/.claude/hooks/block-stop-on-open-backlog.sh
+++ b/.claude/hooks/block-stop-on-open-backlog.sh
@@ -13,11 +13,19 @@
 # Only issues assigned to the authenticated user count, so a contributor is not held by somebody
 # else's backlog.
 #
-# `blocked` is the exclusion, and it is a label rather than a deferral because the two say
+# Two labels are the exclusion, and they are labels rather than deferrals because the two forms say
 # different things: a deferral is a claim that work will resume, and it expires so the claim gets
-# re-read; a `blocked` label says the work cannot proceed for a reason outside this repository,
-# which no amount of re-reading changes. Labelling it also puts that state in the issue list,
-# where the next reader sees it without running anything.
+# re-read; a label says the work is not the assistant's to advance, which no amount of re-reading
+# changes. Labelling also puts that state in the issue list, where the next reader sees it without
+# running anything.
+#
+# `blocked` — cannot proceed for a reason outside this repository.
+# `needs-decision` — measured to the point where what remains is a call only the owner can make.
+#
+# The second was added after an issue reached that state and this guard kept naming it, because the
+# only alternative was a deferral that expires every forty-five minutes on a reason that does not
+# change. Both labels are visible in the issue list, which is what stops either being a quiet way to
+# silence this: applying one is on the record.
 #
 # Exit 2 with output on stderr is what Stop reads as "do not stop, here is why".
 
@@ -50,7 +58,8 @@ while IFS=$'\t' read -r number title; do
   fi
   open_work="$open_work
   #$number $title"
-done < <(echo "$issues" | jq -r '.[] | select([.labels[].name] | index("blocked") | not)
+done < <(echo "$issues" | jq -r '.[]
+  | select([.labels[].name] | (index("blocked") // index("needs-decision")) | not)
   | [.number, .title] | @tsv' 2>/dev/null)
 
 if [ -z "$open_work" ]; then
@@ -79,9 +88,11 @@ arm the deferral. It expires after 45 minutes so the reason gets re-examined rat
 
 A single issue is deferred the same way, by its number in place of \`backlog\`.
 
-Work that cannot proceed for a reason outside this repository is labelled \`blocked\` instead, which
-stops it counting here and says so in the issue list:
+Work that is not yours to advance is labelled instead, which stops it counting here and says so in
+the issue list. \`blocked\` is for a reason outside this repository; \`needs-decision\` is for work
+measured to the point where what remains is a call only the owner can make:
 
   gh issue edit <n> --add-label blocked
+  gh issue edit <n> --add-label needs-decision
 EOF
 exit 2


### PR DESCRIPTION
`block-stop-on-open-backlog.sh` refuses `Stop` while issues assigned to the authenticated user are open and no pull request is carrying any of them. It excluded issues labelled `blocked` — work stopped for a reason outside this repository.

It had no way to express the other reason work stops. An issue can be measured to the point where what remains is a call only the repository owner can make: which of two designs to take, whether an option is worth its cost, whether to close something as declined. That is not blocked, and it is not the assistant's to advance either.

Three issues reached exactly that state, and the only thing available for them was a deferral — which expires every forty-five minutes so the reason gets re-examined. Re-examining "the owner has not decided yet" every forty-five minutes is the decay that expiry exists to prevent.

## The change

`needs-decision` now excludes alongside `blocked`. Both are labels rather than deferrals for the same reason the hook already gives for `blocked`: a deferral is a claim that work will resume and expires so the claim gets re-read, while a label says the work is not the assistant's to advance, which re-reading does not change.

Both are visible in the issue list. That is what stops either being a quiet way to silence the guard — applying one is on the record, where the next reader sees it without running anything.

## Verification

The label filter, against synthetic label sets, checking in particular that `index` returning `0` for a label in first position is not read as absent:

| labels | counted |
| --- | --- |
| `["blocked"]` | excluded |
| `["needs-decision"]` | excluded |
| `["tooling","blocked"]` | excluded |
| `["tooling","needs-decision"]` | excluded |
| `["tooling"]` | counted |
| `[]` | counted |

End to end against the live repository: the guard returns 0 with three `needs-decision` issues open, and still prints the one issue held by a live deferral so its reason is re-read rather than trusted.

Whole EditMode suite: 3587 cases, 3584 passed, 0 failed, 0 inconclusive.

No `Documentation~` impact: the hooks are loop machinery rather than package behaviour.
