### PR TITLE
Refuse a commit whose staged content carries a sweep's neuter

### DIFF
--- a/.claude/hooks/refuse-commit-failing-fast-checks.py
+++ b/.claude/hooks/refuse-commit-failing-fast-checks.py
@@ -269,6 +269,46 @@ def run_checks(cwd):
     return 0
 
 
+def staged_neuters(repo_root):
+    """Cuts present in the staged content of the files the cut map names.
+
+    A sweep holds a neuter in a production source until its `finally` restores it, and while it is
+    there the cut reads as an ordinary modification — `git status` shows the file changed and the
+    diff shows a plausible early return. Committing then captures a method that silently does
+    nothing, for a reason the author cannot see in their own diff.
+
+    Asked of the staged content rather than of the process list. A pattern over `ps` matches any
+    command line that merely names the script, including the one carrying this check's own text,
+    and it says nothing about a sweep that died leaving a neuter behind — the state
+    `neuter-check.py`'s own `dirty_cut_files` refuses to start on top of.
+    """
+    cuts = os.path.join(repo_root, NEUTER_CUTS)
+    if not os.path.exists(cuts):
+        return []
+    try:
+        with open(cuts, encoding="utf-8") as handle:
+            edits = [edit for cut in json.load(handle)["cuts"] for edit in cut["edits"]]
+    except Exception:
+        return []
+
+    found = []
+    for edit in edits:
+        blob = subprocess.run(["git", "-C", repo_root, "show", ":" + edit["file"]],
+                              capture_output=True, text=True)
+        if blob.returncode != 0:
+            continue
+        lines = blob.stdout.splitlines()
+        for index, line in enumerate(lines):
+            if line.strip() != edit["anchor"]:
+                continue
+            body = next((i for i in range(index + 1, len(lines)) if lines[i].strip()), None)
+            after = next((lines[i].strip() for i in range(body + 1, len(lines))
+                          if lines[i].strip()), "") if body is not None else ""
+            if after == edit["neuter"]:
+                found.append(f"{edit['file']}: {edit['anchor']}")
+    return found
+
+
 def is_commit(command):
     return COMMIT.search(mask_shell_literals(command)) is not None
 
@@ -285,6 +325,21 @@ def main():
         return 0
 
     cwd = event.get("cwd") or "."
+    root = subprocess.run(["git", "-C", cwd, "rev-parse", "--show-toplevel"],
+                          capture_output=True, text=True)
+    if root.returncode == 0:
+        neutered = staged_neuters(root.stdout.strip())
+        if neutered:
+            sys.stderr.write(
+                "Refusing `git commit`: the staged content carries a neuter from a sweep.\n\n"
+                + "\n".join("  " + entry for entry in neutered)
+                + "\n\nEach names a method whose body would begin with the cut's early return — it "
+                  "compiles, it reads as an ordinary change, and it does nothing. Wait for a running "
+                  "sweep to restore it, or restore it yourself:\n"
+                  "  git checkout -- <file>\n"
+            )
+            return 2
+
     return run_checks(cwd)
 
 


### PR DESCRIPTION
Closes #346.

While `neuter-check.py` runs it inserts a neuter into a production source and restores it in a `finally`. During that window the cut reads as an ordinary modification — `git status` shows the file changed and the diff shows a plausible early return — so a commit staging it captures a method that silently does nothing, for a reason the author cannot see in their own diff.

Observed with a sweep in flight:

```
 M Packages/com.velvet.core/Runtime/Reconciler/FiberClipPathApplier.cs
```

which is the cut, not an edit.

## What did not catch it

`refuse-blind-git-add.py` refuses the sweeping forms only; a targeted `git add <path>` passes, which is what that same hook tells the reader to do instead. The fast checks added in #344 run `py_compile`, `bash -n`, JSON and YAML parsing and the cut map's anchor validation — a neutered C# file is none of those and parses fine. `neuter-check.py`'s own `dirty_cut_files` guards the opposite direction: it refuses to *start* a sweep on a cut file already modified.

## The check, and the one it replaces

The first attempt asked whether a sweep was running, with `pgrep -f neuter-check.py`. Measured, that refused a commit when no sweep was running at all: `pgrep -f` matches any command line containing the pattern, including the shell command that carries this check's own text. Tightening the pattern does not fix it — the matching text is in the command being run.

So the question changed from "is the script running" to "is a cut applied", which is the hazard itself. The cut map carries each cut's anchor and its neuter string; the check reads the staged blob with `git show :path`, finds the anchor, and compares the first line of the body. That:

- depends on no command-line text, so it cannot match its own mention;
- catches a neuter a **dead** sweep left behind, the state `dirty_cut_files` exists to refuse starting on top of;
- reads the index rather than the tree, so an unrelated file can still be committed while a sweep is in flight — it blocks the dangerous act, not the work.

## Verification

| case | exit |
| --- | --- |
| commit whose message names `neuter-check.py`, nothing staged | 0 |
| a real neuter staged into `StyleClipPathClass.cs` | 2 |
| commit of an unrelated file | 0 |

The refusal names the file and the anchor and says to wait for the sweep or run `git checkout --`:

```
Refusing `git commit`: the staged content carries a neuter from a sweep.

  Packages/com.velvet.core/Runtime/Styling/StyleClipPathClass.cs: public static bool TryExtract(…)

Each names a method whose body would begin with the cut's early return — it compiles, it reads as
an ordinary change, and it does nothing.
```

No `Documentation~` impact: the hooks are loop machinery rather than package behaviour.
