### PR TITLE
feat(velvet): report unreapable processes once they cost enough to act on

### DIFF
--- a/.claude/hooks/report-wedged-processes.sh
+++ b/.claude/hooks/report-wedged-processes.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Reports unreapable processes once they hold enough memory for a reboot to be worth it.
+#
+# Gated on resident memory rather than on the count, and silent below the gate. No signal
+# recovers one of these, so the only response is a reboot, and a report that cannot be acted
+# on except by rebooting has to stay quiet until rebooting is the right call. The count goes
+# in the report because it is what a reader sees in `ps`, but it is not what decides.
+#
+# Darwin only: the state letters this reads are that platform's.
+#
+# Exit 0 always.
+
+set -uo pipefail
+
+[ "$(uname -s 2>/dev/null)" = "Darwin" ] || exit 0
+command -v ps >/dev/null 2>&1 || exit 0
+
+THRESHOLD_MB="${VELVET_WEDGE_REPORT_MB:-500}"
+case "$THRESHOLD_MB" in
+  ''|*[!0-9]*) THRESHOLD_MB=500 ;;
+esac
+
+report=$(ps ax -o stat=,rss=,comm= 2>/dev/null | awk -v limit="$THRESHOLD_MB" '
+  $1 ~ /^UE/ {
+    kb += $2
+    n += 1
+    name = $3
+    for (i = 4; i <= NF; i++) { name = name " " $i }
+    sub(/.*\//, "", name)
+    held[name] += 1
+  }
+  END {
+    mb = kb / 1024
+    if (n == 0 || mb < limit) { exit 1 }
+    printf "%d processes cannot be reaped, holding %.0f MB. Only a reboot clears them.\n\n", n, mb
+    sorter = "sort -rn"
+    fflush()
+    for (name in held) { printf "  %4d  %s\n", held[name], name | sorter }
+    close(sorter)
+    printf "\nEach is in state UE, where no signal reaches it. A run that is only slow is a\n"
+    printf "different thing; CONTRIBUTING.md separates the two.\n"
+  }
+')
+
+[ -n "$report" ] || exit 0
+printf '%s\n' "$report"
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,6 +7,11 @@
             "type": "command",
             "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/report-stale-main.sh",
             "timeout": 15000
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/report-wedged-processes.sh",
+            "timeout": 10000
           }
         ]
       }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,24 +40,29 @@ story capture near-blank, and a panel whose height was its content's rather than
 green under every check and visible immediately in the PNG. Interactively the same stories are live
 in **Window ▸ Velvet ▸ Preview**.
 
-### A batchmode run that finishes but stays in the process list
+### A run that stays in the process list
 
-A Unity process can finish its work and then fail to exit. It shows in `ps` with state `UE` —
-uninterruptible wait while exiting — and `kill -9` does not remove it: measured on the editor
-process, still `UE` two seconds after the signal.
-
-The run's result is not affected. Check the log before treating one as a failure:
+A process can enter macOS state `UE` — uninterruptible wait while exiting — where no signal
+reaches it, `kill -9` included, and only a reboot clears it. Two different situations end there,
+and they want opposite responses, so read the log before deciding which one is in front of you:
 
 ```bash
-ps -eo pid,stat,etime,time,comm | grep -i unity
-grep -c "Exiting batchmode successfully now!" <logfile>
+ps -eo pid,stat,etime,time,comm | awk '$2 ~ /^UE/'
+tail -3 <logfile>
 ```
 
-A log carrying that line has done its work, and its results stand even while the process is still
-listed. Every such log observed here ends inside the shutdown sequence and none inside a build.
+**The log ends after `Exiting batchmode successfully now!`** — the run did its work and then could
+not exit. Its results stand while the process is still listed. Ten of these were resident while
+twenty-five editor invocations ran on the same machine, eight player builds and fifteen EditMode
+suites, and all twenty-five completed. Nothing needs doing.
 
-Ten of these were resident while twenty-five editor invocations ran on the same machine — eight
-player builds and fifteen EditMode suites — and all twenty-five completed.
+**The log stops mid-compile and stays that size** — the run stalled, and the `netcorerun` it
+launched wedges while the editor is still alive, before anything is killed. `SIGTERM` on the editor
+reaps the editor; the wedged child does not follow it out, and no signal recovers it.
+
+Not every unreapable process here comes from Unity, and none of them blocks a later run. They
+accumulate, so `.claude/hooks/report-wedged-processes.sh` reports the set at session start once it
+holds enough memory for a reboot to be worth the interruption, and says nothing below that.
 
 ### Checking that the tests can fail
 


### PR DESCRIPTION
Closes #295 — the part of it this repository can act on.

## What was measured

A compilation stall leaves a wedged process **on its own**. A clone carrying an asmdef reference cycle stalls compilation, and the `netcorerun` it launched enters macOS state `UE` while its parent editor is still alive and before any signal is sent. A matched clone without the cycle, sampled every 20 s across its run, added none and completed the whole EditMode suite with its editor exiting on its own.

That corrects the previous reading of the issue, which attributed this shape to the kill that followed the stall.

Two further measurements shape what this adds:

- `SIGTERM` reaps a stalled editor — gone within 20 s, with the count of `UE` processes unchanged at 14 across the signal. What no signal does is recover a process already in `UE`.
- Two of the fourteen resident wedges are a .NET 10 console application from a directory with no Unity in it. Avoiding a particular Unity operation is not a way around this.

Why the exit does not complete is not known, and nothing here claims it.

## What this adds

Since nothing here can reap them, the addition observes.

`report-wedged-processes.sh` runs at session start and sums the resident memory of processes in `UE`. Below the gate it prints nothing; above it, the count, the memory and a breakdown by binary. Gated on **memory** rather than on the count because a reboot is the only response, and a count alone does not say whether rebooting is worth the interruption. The default gate is 500 MB, overridable by `VELVET_WEDGE_REPORT_MB`.

The resident set on the machine this was written on is 14 processes holding 96 MB, accumulated over 31 hours, so the hook is silent — the intended behaviour when there is nothing to do.

Verified in both directions: silent at the default gate, reporting at a gate below the current set, and the breakdown ordered identically across repeated runs. Silent on any platform that is not Darwin, since the state letters it reads are that platform's.

## The CONTRIBUTING note

The existing note covers only a run that finished and then could not exit, and tells the reader to check the log for the successful-exit line and trust the result. That says nothing to someone looking at a stalled compile — the shape this experiment produced deliberately. The section now separates the two by what the log shows, and gives each its own response.

## Verification

Whole EditMode suite on this branch: **3586 passed, 0 failed, 0 inconclusive**, no compile errors. `HookWiringCoverageTests`, `DocumentationDriftTests` and `CorrectedSentenceTests` all pass.

The first was also run against the hook left unwired, which is the state it exists to catch:

```
nothing runs these, so whatever they guard is unguarded:
report-wedged-processes.sh
  Expected: <empty>
  But was:  < "report-wedged-processes.sh" >
```

## Documentation

`CONTRIBUTING.md` owns the harness and is updated here. No `Documentation~` guide covers process handling, so there is no index entry to add.
