### PR TITLE
fix(velvet): let the branch guard read the spellings it was passing

### DIFF
--- a/.claude/hooks/refuse-branch-from-unmerged.py
+++ b/.claude/hooks/refuse-branch-from-unmerged.py
@@ -6,35 +6,51 @@ after that pull request was squash-merged, rebasing the new branch replayed cont
 main and conflicted, and the pull request had to be abandoned and reopened at a new number.
 Branching from a stale main produces a branch the merge guard refuses later, when the fix is a
 rebase rather than a different starting point.
+
+The command is split into segments and tokenised rather than matched as text. A regex over the
+masked command missed eleven spellings of a creation, quoting the branch name among them, and
+each miss is silent: exit 0 and no output is what a guard with nothing to say looks like.
+`BranchGuardParsingTests` holds the table of what is and is not a creation.
 """
 
 import json
 import os
 import re
+import shlex
 import subprocess
 import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib"))
 from velvet_hooks import BRANCH_BASES
 
-# Anchored at a command position — start of input, or after a separator or newline. Quoted
-# arguments and heredoc bodies are masked before matching; a newline inside them is not a command
-# boundary. The blind-add sibling records the first version refused the change that would have
-# fixed it.
-_GIT = r"git\s+(?:-C\s+\S+\s+)?"
-_END = r"(?:\s*$|\s*[;&|])"
-ANCHOR = r"(?:^|[;&|]|\n)\s*"
-# Trailing flags only — a non-flag token is a start point, which is what the guard is about.
-_TRAILING_FLAGS = r"(?:\s+-\S+)*"
-CHECKOUT_B = re.compile(
-    ANCHOR + _GIT + r"checkout(?:\s+(?!-b\b)\S+)*\s+-b\s+([^-\s]\S+)" + _TRAILING_FLAGS + _END
-)
-SWITCH_CREATE = re.compile(
-    ANCHOR + _GIT
-    + r"switch(?:\s+(?!(?:-c|--create)\b)\S+)*\s+(?:-c|--create)\s+([^-\s]\S+)"
-    + _TRAILING_FLAGS + _END
-)
-BRANCH = re.compile(ANCHOR + _GIT + r"branch\s+([^-\s]\S*)" + _END)
+SEPARATORS = set(";&|\n")
+
+# Words that may precede the command without changing which command it is. `then`/`do`/`else`
+# because a creation inside a conditional or a loop is still a creation.
+LEADING_WORDS = {"then", "do", "else", "elif", "!", "time", "command", "nohup", "exec"}
+ENV_ASSIGNMENT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+REDIRECTION = re.compile(r"^\d*(?:>>|>&|<&|>|<)")
+
+# git's own options, before the subcommand. Only -C is read: it names the repository the command
+# acts on, and evaluating the cwd instead answers about a different tree.
+GLOBAL_VALUE_FLAGS = {"-C", "-c", "--git-dir", "--work-tree", "--namespace", "--config-env"}
+
+CHECKOUT_CREATE = ("-b", "-B")
+SWITCH_CREATE = ("-c", "-C", "--create", "--force-create")
+
+# `git branch` creates only when it is not doing one of these instead. Copy and move are excluded
+# because both name their source, which is the explicit-start-point case.
+BRANCH_NOT_CREATING = {
+    "-d", "-D", "--delete", "-m", "-M", "--move", "-c", "-C", "--copy",
+    "-l", "--list", "-a", "--all", "-r", "--remotes", "-v", "-vv", "--verbose",
+    "--show-current", "--merged", "--no-merged", "--contains", "--points-at",
+    "-u", "--set-upstream-to", "--unset-upstream", "--edit-description", "--format",
+    "--sort", "-h", "--help",
+}
+BRANCH_VALUE_FLAGS = {
+    "--contains", "--no-contains", "--points-at", "--merged", "--no-merged",
+    "--set-upstream-to", "-u", "--format", "--sort",
+}
 
 
 def mask_shell_literals(command):
@@ -116,20 +132,146 @@ def mask_shell_literals(command):
     return "".join(out)
 
 
+def command_segments(command):
+    """The command's segments, split at separators that are not inside a literal.
+
+    The mask preserves length, so a separator's index in it is its index in the original — which
+    is what lets the split find boundaries on masked text and take the tokens from unmasked text.
+    """
+    masked = mask_shell_literals(command)
+    segments = []
+    start = 0
+    for index, char in enumerate(masked):
+        if char in SEPARATORS:
+            segments.append(command[start:index])
+            start = index + 1
+    segments.append(command[start:])
+    return [segment for segment in (s.strip().strip("(){} ") for s in segments) if segment]
+
+
+def tokens_of(segment):
+    try:
+        return shlex.split(segment, comments=False, posix=True)
+    except ValueError:
+        return []
+
+
+def without_redirections(tokens):
+    kept = []
+    skip_next = False
+    for token in tokens:
+        if skip_next:
+            skip_next = False
+            continue
+        match = REDIRECTION.match(token)
+        if match:
+            skip_next = match.end() == len(token)
+            continue
+        kept.append(token)
+    return kept
+
+
+def git_invocation(tokens):
+    """(-C directory, subcommand, operands) when the segment runs git, else None."""
+    index = 0
+    while index < len(tokens) and (
+        ENV_ASSIGNMENT.match(tokens[index]) or tokens[index] in LEADING_WORDS
+    ):
+        index += 1
+    if index >= len(tokens) or os.path.basename(tokens[index]) != "git":
+        return None
+
+    index += 1
+    directory = None
+    while index < len(tokens) and tokens[index].startswith("-"):
+        flag, _, attached = tokens[index].partition("=")
+        if flag in GLOBAL_VALUE_FLAGS:
+            if attached:
+                value = attached
+                index += 1
+            else:
+                value = tokens[index + 1] if index + 1 < len(tokens) else None
+                index += 2
+            if flag == "-C":
+                directory = value
+            continue
+        index += 1
+
+    if index >= len(tokens):
+        return None
+    return directory, tokens[index], tokens[index + 1:]
+
+
+def flag_value(token, following, flags):
+    """The branch name a creation flag carries, in any of its three spellings."""
+    for flag in flags:
+        if token == flag:
+            return following, 2
+        if token.startswith(flag + "="):
+            return token[len(flag) + 1:], 1
+        if len(flag) == 2 and len(token) > 2 and token.startswith(flag):
+            return token[2:], 1
+    return None, 0
+
+
+def created_by_flag(operands, flags):
+    index = 0
+    while index < len(operands):
+        following = operands[index + 1] if index + 1 < len(operands) else None
+        name, consumed = flag_value(operands[index], following, flags)
+        if name:
+            rest = operands[index + consumed:]
+            start_point = next((t for t in rest if not t.startswith("-")), None)
+            return name, start_point
+        index += 1
+    return None
+
+
+def created_by_branch(operands):
+    index = 0
+    while index < len(operands):
+        token = operands[index]
+        if token.startswith("-"):
+            flag = token.partition("=")[0]
+            if flag in BRANCH_NOT_CREATING:
+                return None
+            if flag in BRANCH_VALUE_FLAGS and "=" not in token:
+                index += 2
+                continue
+            index += 1
+            continue
+        following = operands[index + 1] if index + 1 < len(operands) else None
+        start_point = following if following and not following.startswith("-") else None
+        return token, start_point
+    return None
+
+
+def creations(command):
+    """Every branch this command would create, as (name, start point, -C directory)."""
+    found = []
+    for segment in command_segments(command):
+        invocation = git_invocation(without_redirections(tokens_of(segment)))
+        if not invocation:
+            continue
+        directory, subcommand, operands = invocation
+        if subcommand == "checkout":
+            made = created_by_flag(operands, CHECKOUT_CREATE)
+        elif subcommand == "switch":
+            made = created_by_flag(operands, SWITCH_CREATE)
+        elif subcommand == "branch":
+            made = created_by_branch(operands)
+        else:
+            made = None
+        if made:
+            found.append((made[0], made[1], directory))
+    return found
+
+
 def git(cwd, *args):
     return subprocess.run(
         ["git", "-C", cwd, *args],
         capture_output=True, text=True, timeout=30,
     )
-
-
-def branch_name(command):
-    masked = mask_shell_literals(command)
-    for pattern in (CHECKOUT_B, SWITCH_CREATE, BRANCH):
-        match = pattern.search(masked)
-        if match:
-            return match.group(1)
-    return None
 
 
 def deferred(key):
@@ -166,54 +308,35 @@ def record_branch_base(name, sha):
         return False
 
 
-def main():
-    try:
-        event = json.load(sys.stdin)
-    except Exception:
-        return 0
-    if event.get("tool_name") != "Bash":
-        return 0
-    command = event.get("tool_input", {}).get("command", "")
-    name = branch_name(command)
-    if not name:
-        return 0
-
-    cwd = event.get("cwd") or "."
-
-    if deferred(name):
-        # Parent tip at branch creation is gone after squash-merge; rebase --onto needs it recorded now.
-        head_sha = git(cwd, "rev-parse", "HEAD").stdout.strip()
-        record_branch_base(name, head_sha)
-        sys.stderr.write(
-            f"Recorded base {head_sha} for `{name}`. "
-            f"After parent merges (assumes origin/main is current — fetch first if unsure):\n"
-            f"git fetch origin main\n"
-            f"git rebase --onto origin/main {head_sha}\n"
-        )
-        return 0
-
+def refusal(cwd, name, start_point):
+    """The refusal text for one creation, or None when it is allowed."""
+    # A start point named on purpose is the sanctioned way to stack, and origin/main is current by
+    # definition. `main` is the exception: it is what the refusal below recommends, and it is stale
+    # exactly when the guard's second arm exists to say so.
+    explicit_elsewhere = start_point is not None and start_point != "main"
+    if explicit_elsewhere:
+        return None
 
     head_not_main = False
-    head_ref = git(cwd, "rev-parse", "--abbrev-ref", "HEAD").stdout.strip()
-    if head_ref != "main":
-        on_main = git(cwd, "merge-base", "--is-ancestor", "HEAD", "main")
-        if on_main.returncode != 0:
-            head_not_main = True
+    if start_point is None:
+        head_ref = git(cwd, "rev-parse", "--abbrev-ref", "HEAD").stdout.strip()
+        if head_ref != "main":
+            on_main = git(cwd, "merge-base", "--is-ancestor", "HEAD", "main")
+            if on_main.returncode != 0:
+                head_not_main = True
 
-    main_behind = False
     behind_count = None
     origin_main = git(cwd, "rev-parse", "--verify", "origin/main")
-    if origin_main.returncode != 0:
-        origin_missing = True
-    else:
-        origin_missing = False
+    origin_missing = origin_main.returncode != 0
+    main_behind = False
+    if not origin_missing:
         count = git(cwd, "rev-list", "--count", "main..origin/main")
         behind_count = count.stdout.strip()
         if behind_count and behind_count != "0":
             main_behind = True
 
     if not head_not_main and not main_behind:
-        return 0
+        return None
 
     head = head_description(cwd)
     lines = []
@@ -228,11 +351,9 @@ def main():
             "produced a rebase against squash-merged content already on main, conflicts, and a pull "
             "request that had to be abandoned and reopened.",
             "",
-            f"git checkout main",
-            f"git pull",
+            "git checkout main",
+            "git pull",
             f"git checkout -b {name}",
-            "",
-            f"Or branch from main in one step: git checkout -b {name} main",
             "",
             f"To stack on unmerged work on purpose, record intent and retry:",
             f'  echo "{name} <why> $(date +%s)" >> ~/.velvet-pr-deferrals',
@@ -260,7 +381,45 @@ def main():
             "origin/main is not present locally; staleness against it was not checked.",
         ]
 
-    sys.stderr.write("\n".join(lines) + "\n")
+    return "\n".join(lines)
+
+
+def main():
+    try:
+        event = json.load(sys.stdin)
+    except Exception:
+        return 0
+    if event.get("tool_name") != "Bash":
+        return 0
+
+    made = creations(event.get("tool_input", {}).get("command", ""))
+    if not made:
+        return 0
+
+    cwd = event.get("cwd") or "."
+    refusals = []
+    # Every creation in the command is evaluated. Consulting only the first let an undeferred
+    # creation chained after a deferred one through on the deferral meant for the other name.
+    for name, start_point, directory in made:
+        target = directory or cwd
+        if deferred(name):
+            # Parent tip at branch creation is gone after squash-merge; rebase --onto needs it now.
+            head_sha = git(target, "rev-parse", "HEAD").stdout.strip()
+            record_branch_base(name, head_sha)
+            sys.stderr.write(
+                f"Recorded base {head_sha} for `{name}`. "
+                f"After parent merges (assumes origin/main is current — fetch first if unsure):\n"
+                f"git fetch origin main\n"
+                f"git rebase --onto origin/main {head_sha}\n"
+            )
+            continue
+        text = refusal(target, name, start_point)
+        if text:
+            refusals.append(text)
+
+    if not refusals:
+        return 0
+    sys.stderr.write("\n\n".join(refusals) + "\n")
     return 2
 
 

--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,7 @@ docs/guides/
 # command line rather than reading this, so tracking it would only make every checkout dirty after
 # its first run.
 ProjectSettings/Packages/
+
+# Python bytecode, written beside a hook by anything that imports it.
+__pycache__/
+*.pyc

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/BranchGuardParsingTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/BranchGuardParsingTests.cs
@@ -103,6 +103,9 @@ namespace Velvet.Tests
                 UseShellExecute = false,
                 CreateNoWindow = true,
             };
+            // -B: importing the guard would otherwise leave a __pycache__ beside it, which the
+            // wiring guard reads as a script nothing runs.
+            start.ArgumentList.Add("-B");
             start.ArgumentList.Add("-c");
             start.ArgumentList.Add(Driver);
             start.ArgumentList.Add(hook);

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/BranchGuardParsingTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/BranchGuardParsingTests.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using NUnit.Framework;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins which commands <c>.claude/hooks/refuse-branch-from-unmerged.py</c> reads as creating a
+    /// branch. The guard's only failure mode is silence — a spelling it does not recognise exits 0 with
+    /// no output, which is what a guard with nothing to say also does — so the coverage is asserted
+    /// rather than assumed. Eleven of the fifteen spellings below were missed at once, quoting the
+    /// branch name among them.
+    /// </summary>
+    [TestFixture]
+    internal sealed class BranchGuardParsingTests
+    {
+        private const string HookPath = ".claude/hooks/refuse-branch-from-unmerged.py";
+
+        // Expected value is the comma-joined names the guard should extract, empty for no creation.
+        private static readonly (string Command, string Expected)[] Table =
+        {
+            ("git checkout -b topic", "topic"),
+            ("git checkout -b \"topic\"", "topic"),
+            ("git checkout -b 'topic'", "topic"),
+            ("git switch -c \"topic\"", "topic"),
+            ("git branch \"topic\"", "topic"),
+            ("git checkout -B topic", "topic"),
+            ("git switch -C topic", "topic"),
+            ("git switch --force-create topic", "topic"),
+            ("git checkout -btopic", "topic"),
+            ("git switch --create=topic", "topic"),
+            ("git checkout -b topic 2>&1", "topic"),
+            ("git checkout -b topic > /dev/null", "topic"),
+            ("git branch topic >> /tmp/log", "topic"),
+            ("git checkout -q -b topic", "topic"),
+            ("FOO=1 git checkout -b topic", "topic"),
+            ("/usr/bin/git checkout -b topic", "topic"),
+            ("if true; then git checkout -b topic; fi", "topic"),
+            ("(git checkout -b topic)", "topic"),
+            ("cd /x && git checkout -b topic", "topic"),
+            ("git checkout -b first && git checkout -b second", "first,second"),
+            ("git -C /elsewhere checkout -b topic", "topic"),
+
+            ("git branch", ""),
+            ("git branch && git status", ""),
+            ("git branch &", ""),
+            ("git branch -a", ""),
+            ("git branch -d old", ""),
+            ("git branch --list", ""),
+            ("git branch 2>&1", ""),
+            ("git status", ""),
+            ("git checkout main", ""),
+            ("git switch main", ""),
+            ("git commit -m \"git checkout -b nope\"", ""),
+            ("gh pr create --body \"run git checkout -b nope\"", ""),
+        };
+
+        // One process for the whole table: the guard is imported once and asked about each command,
+        // which keeps the fixture at a single spawn rather than one per row.
+        private const string Driver =
+            "import importlib.util,sys\n" +
+            "spec=importlib.util.spec_from_file_location('guard', sys.argv[1])\n" +
+            "guard=importlib.util.module_from_spec(spec)\n" +
+            "spec.loader.exec_module(guard)\n" +
+            "for line in sys.stdin.read().split('\\0'):\n" +
+            "    if not line: continue\n" +
+            "    print(','.join(made[0] for made in guard.creations(line)))\n";
+
+        [Test]
+        public void Given_TheCommandTable_When_TheBranchGuardParsesEach_Then_ItNamesExactlyTheBranchesCreated()
+        {
+            // Arrange
+            var hook = Path.GetFullPath(HookPath);
+            Assume.That(File.Exists(hook), Is.True, $"Precondition: {HookPath} exists");
+
+            // Act
+            var parsed = RunDriver(hook, Table.Select(row => row.Command));
+            Assume.That(parsed, Is.Not.Null, "Precondition: python3 ran the guard");
+            Assume.That(parsed.Count, Is.EqualTo(Table.Length), "Precondition: one answer per command");
+
+            var disagreements = Table
+                .Select((row, index) => (row, actual: parsed[index]))
+                .Where(pair => pair.actual != pair.row.Expected)
+                .Select(pair =>
+                    $"{pair.row.Command}\n    expected [{pair.row.Expected}] got [{pair.actual}]")
+                .ToList();
+
+            // Assert
+            Assert.That(string.Join("\n", disagreements), Is.Empty,
+                "a spelling the guard does not read as a creation is refused by nothing and says so to nobody");
+        }
+
+        private static List<string> RunDriver(string hook, IEnumerable<string> commands)
+        {
+            var start = new ProcessStartInfo("python3")
+            {
+                RedirectStandardInput = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            };
+            start.ArgumentList.Add("-c");
+            start.ArgumentList.Add(Driver);
+            start.ArgumentList.Add(hook);
+
+            try
+            {
+                using var process = Process.Start(start);
+                if (process == null)
+                {
+                    return null;
+                }
+
+                process.StandardInput.Write(string.Join("\0", commands));
+                process.StandardInput.Close();
+                var output = process.StandardOutput.ReadToEnd();
+                process.StandardError.ReadToEnd();
+                if (!process.WaitForExit(30000) || process.ExitCode != 0)
+                {
+                    return null;
+                }
+
+                var lines = output.Replace("\r\n", "\n").Split('\n').ToList();
+                if (lines.Count > 0 && lines[^1].Length == 0)
+                {
+                    lines.RemoveAt(lines.Count - 1);
+                }
+
+                return lines;
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/BranchGuardParsingTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/BranchGuardParsingTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4960a1236b34b45268caefc87b42966e

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/HookWiringCoverageTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/HookWiringCoverageTests.cs
@@ -62,9 +62,13 @@ namespace Velvet.Tests
         {
             // Arrange
             var wired = new HashSet<string>(ReadWiring().Select(reference => reference.Name), StringComparer.Ordinal);
+            // __pycache__ is written beside a hook by anything that imports it, so its contents are
+            // output rather than scripts. Counting them made this fixture fail for the presence of a
+            // sibling fixture's bytecode, which says nothing about whether a guard is wired.
             var scripts = Directory
                 .GetFiles(Path.GetFullPath(HookDirectory), "*", SearchOption.AllDirectories)
                 .Select(RelativeToHookDirectory)
+                .Where(script => !script.Contains("__pycache__", StringComparison.Ordinal))
                 .ToList();
             Assume.That(scripts, Is.Not.Empty, "the hook directory is empty");
 


### PR DESCRIPTION
The guard that exists to refuse a branch cut from an unmerged tip was passing eleven of fifteen spellings of a creation, and every miss is silent — exit 0 with no output is what a guard with nothing to say also looks like.

## What was getting through

Asked of `branch_name()` directly, on the version this replaces:

| command | recognised |
| --- | --- |
| `git checkout -b topic` | yes |
| `git checkout -b "topic"` | **no** |
| `git checkout -b 'topic'` | **no** |
| `git switch -c "topic"` | **no** |
| `git branch "topic"` | **no** |
| `git checkout -B topic` | **no** |
| `git switch -C topic` | **no** |
| `git switch --force-create topic` | **no** |
| `git checkout -btopic` | **no** |
| `git switch --create=topic` | **no** |
| `git checkout -b topic 2>&1` | **no** |
| `git checkout -b topic > /dev/null` | **no** |

Quoting is the widest of these and the most ordinary to type. `mask_shell_literals` blanks a quoted argument before matching — correct for finding where a command starts, and wrong as the source of a capture, because the name it should capture has been replaced by spaces. The capture groups require a non-space first character, so the match simply fails.

`git branch && git status` went the other way: `&` was captured as a branch name and the read-only listing was refused.

## What replaces it

The command is split into segments at separators the mask locates, and each segment is tokenised with `shlex`, which knows what a quote is. Tokens then answer the questions the regex was approximating: is this git, which subcommand, which flag carries the name, is there an explicit start point.

That also closes four things the regex was not shaped to reach:

- `git -C <dir>` now decides which repository is evaluated. It named one tree and the guard measured another.
- Every creation in a chain is evaluated. Consulting only the first let `git checkout -b deferred && git checkout -b other` through on the deferral meant for the other name.
- A leading environment assignment, an absolute path to git, and a creation inside `then`/`do` or a subshell are recognised.
- A trailing redirection no longer ends the match.

The explicit-start-point pass-through stays: naming a start point is the sanctioned way to stack, and `~/.velvet-pr-deferrals` remains the way to say so for `HEAD`. The one start point still checked is `main`, because that is what the refusal itself recommends and it is stale exactly when the second arm exists to say so.

## Verification

`BranchGuardParsingTests` pins the table above in both directions — 21 spellings that must be read as creations, 12 that must not, with the extracted names compared rather than a boolean, since the name is what gets recorded as a branch base.

Against the version on main the table disagrees on **20 of 33 rows**; against this one, on none.

Whole EditMode suite on this branch: **3587 passed, 0 failed, 0 inconclusive**, no compile errors.

## Documentation

No `Documentation~` impact: the guard is harness tooling, and `CONTRIBUTING.md` does not describe its command surface.
