### PR TITLE
fix(velvet): make the reporting hooks say what they already know

### DIFF
--- a/.claude/hooks/lib/wedged.awk
+++ b/.claude/hooks/lib/wedged.awk
@@ -1,0 +1,29 @@
+# Reports unreapable processes from `ps ax -o stat=,rss=,comm=`, above a memory gate in MB.
+#
+# Separated from its caller so the classification can be fed a process table rather than only the
+# machine's own. WedgedProcessFilterTests pins which STAT values count: E is looked for anywhere
+# among the flags, because anchoring it to the second character dropped every wedged process that
+# carried another flag first.
+#
+# Exits 1 when there is nothing to report, which is how the caller stays silent.
+
+$1 ~ /^U/ && $1 ~ /E/ {
+    kilobytes += $2
+    count += 1
+    name = $3
+    for (i = 4; i <= NF; i++) { name = name " " $i }
+    sub(/.*\//, "", name)
+    held[name] += 1
+}
+
+END {
+    megabytes = kilobytes / 1024
+    if (count == 0 || megabytes < limit) { exit 1 }
+    printf "%d processes cannot be reaped, holding %.0f MB. Only a reboot clears them.\n\n", count, megabytes
+    sorter = "sort -rn"
+    fflush()
+    for (name in held) { printf "  %4d  %s\n", held[name], name | sorter }
+    close(sorter)
+    printf "\nEach is in uninterruptible wait while exiting, where no signal reaches it. A run\n"
+    printf "that is only slow is a different thing; CONTRIBUTING.md separates the two.\n"
+}

--- a/.claude/hooks/report-stale-main.sh
+++ b/.claude/hooks/report-stale-main.sh
@@ -39,7 +39,11 @@ fetch_origin_main() {
   wait "$pid"
 }
 
-fetch_origin_main || exit 0
+# A failed fetch is not a reason to say nothing. main only ever advances here, so the ref already
+# on disk is a lower bound on how far behind the checkout is — the answer it gives is incomplete
+# in one direction only, and reporting it beats reporting silence over an unreachable remote.
+fetch_failed=""
+fetch_origin_main || fetch_failed="yes"
 git rev-parse --verify refs/remotes/origin/main >/dev/null 2>&1 || exit 0
 
 main_report=""
@@ -59,34 +63,52 @@ git merge --ff-only origin/main"
   fi
 fi
 
-if [ -n "$branch" ] && [ "$branch" != "main" ]; then
+# A detached HEAD has no branch name, and skipping it on that basis left the one checkout shape
+# whose staleness nothing else reports — local main can be current while HEAD is arbitrarily behind.
+if [ "$branch" != "main" ]; then
   if ! git merge-base --is-ancestor origin/main HEAD 2>/dev/null; then
     branch_behind=$(git rev-list --count HEAD..origin/main 2>/dev/null || echo 0)
     if [ "${branch_behind:-0}" -gt 0 ]; then
       commit_word=commits
       [ "$branch_behind" -eq 1 ] && commit_word=commit
-      branch_report="Branch $branch is $branch_behind $commit_word behind origin/main.
+      if [ -n "$branch" ]; then
+        branch_report="Branch $branch is $branch_behind $commit_word behind origin/main.
 
 git fetch origin
 git rebase origin/main
 git push origin $branch --force-with-lease"
+      else
+        branch_report="HEAD is detached at $(git rev-parse --short HEAD 2>/dev/null) and is \
+$branch_behind $commit_word behind origin/main.
+
+git fetch origin
+git checkout main
+git merge --ff-only origin/main"
+      fi
     fi
   fi
 fi
 
 [ -z "$main_report" ] && [ -z "$branch_report" ] && exit 0
 
+fetch_note=""
+if [ -n "$fetch_failed" ]; then
+  fetch_note="
+origin/main could not be fetched, so the counts above are against the ref already on disk and the
+real distance may be greater."
+fi
+
 if [ -n "$main_report" ] && [ -n "$branch_report" ]; then
-  printf '%s\n\n%s\n' \
+  printf '%s\n\n%s\n%s\n' \
     "This checkout may not match origin/main.
 
 $main_report" \
-    "$branch_report"
+    "$branch_report" "$fetch_note"
 else
   report="${main_report:-$branch_report}"
   printf 'This checkout may not match origin/main.
 
-%s\n' "$report"
+%s\n%s\n' "$report" "$fetch_note"
 fi
 
 exit 0

--- a/.claude/hooks/report-untracked-scratch.sh
+++ b/.claude/hooks/report-untracked-scratch.sh
@@ -27,40 +27,52 @@ cd "$tree" 2>/dev/null || exit 0
 command -v git >/dev/null 2>&1 || exit 0
 git rev-parse --git-dir >/dev/null 2>&1 || exit 0
 
-untracked=$(git status --porcelain --untracked-files=all 2>/dev/null \
+# Counted before the truncation, not after: the headline read "20 untracked" for a tree holding
+# thirty-seven, and a reader who clears the twenty believes they are done.
+untracked_all=$(git status --porcelain --untracked-files=all 2>/dev/null \
     | awk '/^\?\?/ { print substr($0, 4) }' \
-    | grep -v '^Library/' \
-    | head -20)
+    | grep -v '^Library/')
+untracked_total=$(printf '%s' "$untracked_all" | grep -c . || true)
+untracked=$(printf '%s' "$untracked_all" | head -20)
 
 # An ignored source file is the dangerous case; build output is ignored on purpose.
-ignored=$(git status --porcelain --ignored=matching --untracked-files=all 2>/dev/null \
+ignored_all=$(git status --porcelain --ignored=matching --untracked-files=all 2>/dev/null \
     | awk '/^!!/ { print substr($0, 4) }' \
     | grep -E '\.(cs|uss|uxml|asmdef|csproj|sln|md)$' \
-    | grep -vE '^(Library|Temp|obj|Logs)/' \
-    | head -20)
+    | grep -vE '^(Library|Temp|obj|Logs)/')
+ignored_total=$(printf '%s' "$ignored_all" | grep -c . || true)
+ignored=$(printf '%s' "$ignored_all" | head -20)
 
 [ -z "$untracked" ] && [ -z "$ignored" ] && exit 0
 
-python3 - "$untracked" "$ignored" "$tree" <<'PY'
+python3 - "$untracked" "$ignored" "$tree" "$untracked_total" "$ignored_total" <<'PY'
 import json, sys
 untracked, ignored, tree = sys.argv[1], sys.argv[2], sys.argv[3]
+untracked_total, ignored_total = int(sys.argv[4] or 0), int(sys.argv[5] or 0)
+
+
+def shown(listing, total):
+    listed = len(listing.splitlines())
+    return listing if total <= listed else listing + "\n... and {} more".format(total - listed)
+
+
 parts, headline = [], []
 if untracked:
-    n = len(untracked.splitlines())
+    n = untracked_total
     headline.append("{} untracked".format(n))
     parts.append(
         "Untracked files remain in {}. Read each before deciding it is harmless — a probe "
         "fixture left behind reads as production code to the next session, and an agent's own "
         "report that it cleaned up has been wrong before. What stays is for whoever owns this "
-        "tree to decide; nothing here asks for a deletion:\n{}".format(tree, untracked)
+        "tree to decide; nothing here asks for a deletion:\n{}".format(tree, shown(untracked, untracked_total))
     )
 if ignored:
-    n = len(ignored.splitlines())
+    n = ignored_total
     headline.append("{} gitignored source".format(n))
     parts.append(
         "Source files here are EXCLUDED by .gitignore, so they cannot reach CI "
         "while every local run stays green because the files are present "
-        "locally:\n" + ignored
+        "locally:\n" + shown(ignored, ignored_total)
     )
 # systemMessage is the transcript channel; additionalContext is the model's and does not display.
 print(json.dumps({

--- a/.claude/hooks/report-wedged-processes.sh
+++ b/.claude/hooks/report-wedged-processes.sh
@@ -20,27 +20,10 @@ case "$THRESHOLD_MB" in
   ''|*[!0-9]*) THRESHOLD_MB=500 ;;
 esac
 
-report=$(ps ax -o stat=,rss=,comm= 2>/dev/null | awk -v limit="$THRESHOLD_MB" '
-  $1 ~ /^UE/ {
-    kb += $2
-    n += 1
-    name = $3
-    for (i = 4; i <= NF; i++) { name = name " " $i }
-    sub(/.*\//, "", name)
-    held[name] += 1
-  }
-  END {
-    mb = kb / 1024
-    if (n == 0 || mb < limit) { exit 1 }
-    printf "%d processes cannot be reaped, holding %.0f MB. Only a reboot clears them.\n\n", n, mb
-    sorter = "sort -rn"
-    fflush()
-    for (name in held) { printf "  %4d  %s\n", held[name], name | sorter }
-    close(sorter)
-    printf "\nEach is in state UE, where no signal reaches it. A run that is only slow is a\n"
-    printf "different thing; CONTRIBUTING.md separates the two.\n"
-  }
-')
+filter="$(dirname "${BASH_SOURCE[0]}")/lib/wedged.awk"
+[ -f "$filter" ] || exit 0
+
+report=$(ps ax -o stat=,rss=,comm= 2>/dev/null | awk -v limit="$THRESHOLD_MB" -f "$filter")
 
 [ -n "$report" ] || exit 0
 printf '%s\n' "$report"

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/WedgedProcessFilterTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/WedgedProcessFilterTests.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using NUnit.Framework;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins which STAT values <c>.claude/hooks/lib/wedged.awk</c> counts as a process that cannot be
+    /// reaped. The report is gated on total memory, so a spelling the filter drops does not merely go
+    /// unlisted — it keeps the set under the threshold that would have reported the rest of it.
+    /// </summary>
+    /// <remarks>
+    /// `ps` composes STAT as a run-state letter followed by flags whose order the manual page does not
+    /// fix, which is why the filter looks for `E` among them rather than at a position, and why the
+    /// answer is asserted here against a supplied table rather than against whatever the machine
+    /// running the tests happens to hold.
+    /// </remarks>
+    [TestFixture]
+    internal sealed class WedgedProcessFilterTests
+    {
+        private const string FilterPath = ".claude/hooks/lib/wedged.awk";
+
+        private static readonly (string Stat, bool Counts)[] Table =
+        {
+            ("UE", true),
+            ("UNE", true),
+            ("U<E", true),
+            ("UWE", true),
+            ("UXE", true),
+            ("UEs", true),
+
+            ("U", false),
+            ("S", false),
+            ("SN", false),
+            ("Ss", false),
+            ("R", false),
+            ("Z", false),
+            ("IE", false),
+            ("TE", false),
+        };
+
+        [Test]
+        public void Given_TheStatTable_When_TheWedgeFilterReadsEach_Then_ItCountsExactlyTheExitingUninterruptibleOnes()
+        {
+            // Arrange
+            var filter = Path.GetFullPath(FilterPath);
+            Assume.That(File.Exists(filter), Is.True, $"Precondition: {FilterPath} exists");
+            Assume.That(Counted(filter, "UE"), Is.True, "Precondition: awk ran the filter");
+
+            // Act
+            var disagreements = Table
+                .Where(row => Counted(filter, row.Stat) != row.Counts)
+                .Select(row => $"{row.Stat} should {(row.Counts ? "count" : "not count")}")
+                .ToList();
+
+            // Assert
+            Assert.That(string.Join(", ", disagreements), Is.Empty,
+                "a spelling the filter drops keeps the set under the gate that would have reported it");
+        }
+
+        // One line, one megabyte, gate of zero: the row is reported if and only if it was counted.
+        private static bool Counted(string filter, string stat)
+        {
+            var start = new ProcessStartInfo("awk")
+            {
+                RedirectStandardInput = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            };
+            start.ArgumentList.Add("-v");
+            start.ArgumentList.Add("limit=0");
+            start.ArgumentList.Add("-f");
+            start.ArgumentList.Add(filter);
+
+            try
+            {
+                using var process = Process.Start(start);
+                if (process == null)
+                {
+                    return false;
+                }
+
+                process.StandardInput.Write($"{stat} 1024 /bin/probe\n");
+                process.StandardInput.Close();
+                var output = process.StandardOutput.ReadToEnd();
+                process.StandardError.ReadToEnd();
+                process.WaitForExit(15000);
+                return output.Contains("cannot be reaped", StringComparison.Ordinal);
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/WedgedProcessFilterTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/WedgedProcessFilterTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ff45e67cc09bf4f608a3cf2dd407289d


### PR DESCRIPTION
Closes #357.

## The wedge filter counted one spelling of a wedged process

`$1 ~ /^UE/` anchors `E` to the second character of STAT. `ps` composes STAT as a run-state letter followed by flags, and the manual page that lists those flags does not fix their order — this machine shows `SN` and `SNs`, with the nice flag sitting immediately after the state letter. So a niced, swapped or traced process in uninterruptible-exit contributed to neither the list nor the memory total.

The gate is what makes it more than a missing line: the report only fires above a memory threshold, so an undercounted set stays below the threshold that would have reported the rest of it.

The filter now asks the two questions separately — the run state is `U`, and `E` is among the flags. `E` is not a run-state letter, so looking for it anywhere cannot pick up a healthy process.

It moved to `.claude/hooks/lib/wedged.awk` so it can be handed a process table instead of only the machine's own. `WedgedProcessFilterTests` pins fourteen STAT values in both directions. Against the version on main, `UNE`, `U<E` and `UXE` are all missed; against this one, none are.

## `report-stale-main.sh` was silent twice

**A failed fetch abandoned the check.** Offline, a bad URL or an auth failure took `fetch_origin_main || exit 0` even though the `origin/main` already on disk still answered — measured at three commits behind with the hook reporting nothing. main only advances here, so the stored ref is a lower bound: incomplete in one direction, which beats silence. It now reports and says the fetch failed.

**A detached HEAD was never compared.** `git symbolic-ref` returns empty, so the branch arm was skipped entirely, and a checkout arbitrarily far behind produced an empty report whenever local `main` happened to be current. That is the shape the file's own header describes, and it was the one shape nothing covered.

## `report-untracked-scratch.sh` reported its own limit

`head -20` truncated before the count was taken, so a tree holding thirty-seven untracked files was headlined `20 untracked` with nothing marking it truncated — and a reader who clears the twenty believes they are done. Both lists are now counted whole, truncated for display, and the remainder is stated.

## Verification

Whole EditMode suite on this branch: **3587 passed, 0 failed, 0 inconclusive**, no compile errors.

## Documentation

No `Documentation~` impact: these are harness hooks, and `CONTRIBUTING.md` describes what the wedge report is for rather than which STAT values it reads.
