### PR TITLE
perf(velvet): wait frames rather than seconds before capturing a story

### DIFF
--- a/Packages/com.velvet.core/Runtime/Preview/Tests/PlayMode/StoryCaptureTests.cs
+++ b/Packages/com.velvet.core/Runtime/Preview/Tests/PlayMode/StoryCaptureTests.cs
@@ -177,7 +177,7 @@ namespace Velvet.Tests
             probe.AddToClassList("bg-slate-700");
             host.Root.Add(probe);
 
-            yield return WaitRealtime(0.2);
+            yield return WaitFrames(8);
 
             result.Problem = probe.resolvedStyle.backgroundColor == default
                 ? "the bundled stylesheet resolves none of its plain classes"
@@ -206,9 +206,13 @@ namespace Velvet.Tests
             using var previewHost = new VelvetPreviewHost(host.Root);
             previewHost.Mount(story);
 
-            // Long enough to absorb a first-run text-shaping and glyph-atlas warm-up, the same posture the
-            // package's own playback specs take for their first draw.
-            yield return WaitRealtime(0.5);
+            // Frames rather than seconds. What a capture needs is that the panel has been drawn, and
+            // a realtime wait spins as many frames as it can — on a runner whose rasterisation is
+            // queued rather than executed that is hundreds, each queueing a full render that the
+            // readback below then pays for. Eight covers the first-run text shaping and glyph-atlas
+            // warm-up the half second was absorbing; too few would surface as the uniform-frame
+            // failure the assertion already makes.
+            yield return WaitFrames(8);
 
             Debug.Log($"[StoryCapture] {story.Id}: texture {width}x{height}, root layout {host.Root.layout}");
 

--- a/Packages/com.velvet.core/TestUtilities/TargetFrameRateScope.cs
+++ b/Packages/com.velvet.core/TestUtilities/TargetFrameRateScope.cs
@@ -35,6 +35,22 @@ namespace Velvet.TestUtilities
     /// </summary>
     public static class PlayModeRealtimeTestHelpers
     {
+        /// <summary>
+        /// Yields for a fixed number of frames.
+        /// </summary>
+        /// <remarks>
+        /// For a fixture that needs the panel drawn rather than time elapsed. A realtime wait spins as
+        /// many frames as it can, and where a frame's rasterisation is queued rather than executed it
+        /// can spin hundreds — each queueing a full panel render that the next readback pays for.
+        /// </remarks>
+        public static IEnumerator WaitFrames(int frames)
+        {
+            for (var frame = 0; frame < frames; frame++)
+            {
+                yield return null;
+            }
+        }
+
         /// <summary>Yields until at least <paramref name="seconds"/> of realtime have elapsed.</summary>
         public static IEnumerator WaitRealtime(double seconds)
         {


### PR DESCRIPTION
Part of #348. `StoryCaptureTests` was 462.8 s of a 1027 s PlayMode job and 1.8 s on a developer machine.

## Where the time was

Measured on the runner, one phase at a time.

**All of it is the readback**, and mount, layout, the wait and the PNG encode are within noise of a developer machine:

| story | pixels | setup | mount | wait | read |
| --- | --- | --- | --- | --- | --- |
| Card | 64,000 | 1 ms | 10 ms | 664 ms | 98 ms |
| Responsive | 153,600 | 0 ms | 4 ms | 506 ms | 86,533 ms |
| Tall List | 504,000 | 0 ms | 12 ms | 509 ms | 355,383 ms |

**None of it is the transfer.** A 16x16 read placed immediately before the full one carries the whole cost and the full read that follows is free:

| story | 16x16 read before | full read | 16x16 read after |
| --- | --- | --- | --- |
| Card | 102 ms | 0 ms | 1 ms |
| Responsive | 111,992 ms | 0 ms | 1 ms |
| Tall List | 321,406 ms | 1 ms | 0 ms |

256 pixels cost 321 seconds and 504,000 cost 1 ms, so what `Texture2D.ReadPixels` is paying for is the rasterisation queued behind the synchronisation, not the bytes moved.

**It accrues per frame.** Flushing after `Mount`, after one frame, and after the wait:

| story | after mount | after one frame | after the 0.5 s wait |
| --- | --- | --- | --- |
| Card | 2 ms | 108 ms | 71,021 ms |
| Responsive | 1 ms | 191 ms | 158,993 ms |
| Tall List | 2 ms | 1,474 ms | 431,387 ms |

Nothing is queued at mount. One frame of the tall story costs 1.47 s. The wait costs 293 of those, because a frame whose rasterisation is queued returns immediately, so `while (realtime < deadline) yield return null` spins hundreds of times in half a second and queues a full panel render on each. `Application.targetFrameRate = 120` does not pace it: what would make a frame take 8 ms is exactly the work not being done yet.

## It is not the framework

A panel with no Velvet on it — one solid `VisualElement` filling a 360x1400 render texture — costs 351 ms for one frame and 40,697 ms for twenty on the same runner. Every frame redraws a surface that never changed. That is what a render-texture panel costs where rasterisation is on the CPU, so the lever is how many frames are spun before anything reads, not what is mounted on it.

The runner's renderer, from the job's own log:

```
Renderer: llvmpipe (LLVM 15.0.7, 256 bits)
Vendor:   Mesa
```

## The change

A capture needs the panel drawn, not half a second elapsed, so it waits frames. Eight covers what the half second was absorbing — first-run text shaping and glyph-atlas warm-up — and too few would surface as the uniform-frame failure the assertion already makes rather than as a quiet difference.

`WaitFrames` sits beside `WaitRealtime` rather than replacing it: the particle fixtures assert on real elapsed time and still want the realtime form.

## Result

| | before | after |
| --- | --- | --- |
| capture case, on CI | 462.8 s | **59.4 s** |
| whole PlayMode run, on CI | 1027.4 s | **658.8 s** |

The three PNGs are **byte-identical** to the ones the realtime wait produced, checked locally against both.

Whole PlayMode suite on this branch, locally: **161 passed, 0 failed, 0 inconclusive**.

The two `ParticlesPlaybackTests` cases are now 450 s of the remaining 659 s. They advance real frames and assert on what was drawn, so the same substitution does not apply to them; that stays open on #348.

## Documentation

No `Documentation~` impact. `CONTRIBUTING.md` documents how to run the capture and to look at the images, neither of which changes.
