### PR TITLE
fix(velvet): stop the Stop guards failing in silence

### DIFF
--- a/.claude/hooks/block-stop-on-open-backlog.sh
+++ b/.claude/hooks/block-stop-on-open-backlog.sh
@@ -37,15 +37,43 @@ command -v jq >/dev/null 2>&1 || exit 0
 # shellcheck source=lib/deferrals.sh
 . "$(dirname "${BASH_SOURCE[0]}")/lib/deferrals.sh"
 
-deferred backlog && exit 0
+# Printed rather than exited on quietly: this is the one key that suppresses the whole guard, and
+# lib/deferrals.sh states the invariant that suppression names what was claimed and how long ago.
+if deferred backlog; then
+  cat >&2 <<EOF
+The whole backlog is held — check the reason is still true:
+  held ${DEFER_AGE}m ago because: $DEFER_REASON
+EOF
+  exit 0
+fi
 
-prs=$(gh pr list --state open --json number --jq '.[].number' 2>/dev/null) || exit 0
+# A gh that cannot answer is not an empty answer. Every one of these used to take `|| exit 0` with
+# stderr discarded, so an unauthenticated, offline or rate-limited run reported exactly what a
+# cleared backlog reports. Refusing instead is what puts the difference in front of the reader; the
+# deferral below is the way past it when the network is the thing that is wrong.
+unreachable() {
+  cat >&2 <<EOF
+Do not stop: the backlog could not be read, so nothing here says it is clear.
+
+  gh $1 exited $2
+$3
+
+If gh is unauthenticated or the network is down, say so and arm the deferral rather than treating
+an unanswered question as a settled one:
+
+  echo "backlog <what clears it> \$(date +%s)" >> $HOME/.velvet-pr-deferrals
+EOF
+  exit 2
+}
+
+prs=$(gh pr list --state open --json number --jq '.[].number' 2>&1) || unreachable "pr list" "$?" "$prs"
 [ -n "$prs" ] && exit 0
 
-me=$(gh api user --jq .login 2>/dev/null) || exit 0
-[ -n "$me" ] || exit 0
+me=$(gh api user --jq .login 2>&1) || unreachable "api user" "$?" "$me"
+[ -n "$me" ] || unreachable "api user" "0" "  it named no login"
 
-issues=$(gh issue list --state open --assignee "$me" --json number,title,labels 2>/dev/null) || exit 0
+issues=$(gh issue list --state open --assignee "$me" --json number,title,labels 2>&1) \
+  || unreachable "issue list" "$?" "$issues"
 
 open_work=""
 held=""

--- a/.claude/hooks/block-stop-on-unsettled-pr.sh
+++ b/.claude/hooks/block-stop-on-unsettled-pr.sh
@@ -41,13 +41,32 @@ STALE_AFTER=180
 
 watcher_is_alive() {
   [ -f "$HEARTBEAT" ] || return 1
-  local beat
+  local beat age
   beat=$(cat "$HEARTBEAT" 2>/dev/null) || return 1
   case "$beat" in ''|*[!0-9]*) return 1 ;; esac
-  [ $(( $(date +%s) - beat )) -lt "$STALE_AFTER" ]
+  # Same two bounds as lib/deferrals.sh, and for the same reason: a leading zero reads as octal and
+  # aborts the comparison, and a stamp in the future vouches for a watcher permanently.
+  age=$(( $(date +%s) - 10#$beat )) || return 1
+  [ "$age" -ge 0 ] || return 1
+  [ "$age" -lt "$STALE_AFTER" ]
 }
 
-prs=$(gh pr list --state open --json number --jq '.[].number' 2>/dev/null) || exit 0
+# A gh that cannot answer is not an answer of "nothing open". Taking `|| exit 0` here reported
+# exactly what a settled repository reports.
+prs=$(gh pr list --state open --json number --jq '.[].number' 2>&1) || {
+  cat >&2 <<EOF
+Do not stop: the open pull requests could not be read, so nothing here says they are settled.
+
+  gh pr list exited $?
+$prs
+
+If gh is unauthenticated or the network is down, say so and arm the deferral rather than treating
+an unanswered question as a settled one:
+
+  echo "backlog <what clears it> \$(date +%s)" >> $HOME/.velvet-pr-deferrals
+EOF
+  exit 2
+}
 [ -z "$prs" ] && exit 0
 
 blocked=""
@@ -93,14 +112,23 @@ for pr in $prs; do
   if [ "$pending" = "0" ]; then
     # Nothing is running, so a watcher has nothing to observe and its heartbeat vouches for nothing.
     state=$(gh pr view "$pr" --json mergeStateStatus --jq '.mergeStateStatus' 2>/dev/null || echo "")
-    fails=$(echo "$checks" | jq '[.[] | select(.bucket == "fail")] | length' 2>/dev/null || echo 0)
+    # A cancelled check is counted here rather than nowhere. In gh's buckets it is neither `pass`
+    # nor `fail`, so a run that was cancelled outright used to read as every check having passed.
+    fails=$(echo "$checks" | jq '[.[] | select(.bucket == "fail" or .bucket == "cancel")] | length' 2>/dev/null || echo 0)
     if [ "$fails" != "0" ]; then
       blocked="$blocked
-  PR #$pr — $fails check(s) failed. Read the run, fix or say why it is not yours to fix."
+  PR #$pr — $fails check(s) failed or were cancelled. Read the run, fix or say why it is not yours
+    to fix. A cancelled run does not restart on its own."
     elif [ "$state" = "CLEAN" ]; then
       blocked="$blocked
   PR #$pr — every check passed and it is unmerged. Merge it, or say what it is waiting on and arm
     something that brings you back when that arrives."
+    else
+      # Every other merge state, rather than the ones seen so far. Listing them made an unlisted
+      # state mean "settled", which is how a green DIRTY or DRAFT pull request passed both guards.
+      blocked="$blocked
+  PR #$pr — checks are settled but the merge state is ${state:-unknown}, so it cannot go green on
+    its own. Rebase it, take it out of draft, or say what it is waiting on."
     fi
     continue
   fi

--- a/.claude/hooks/lib/deferrals.sh
+++ b/.claude/hooks/lib/deferrals.sh
@@ -31,9 +31,16 @@ deferred() {
   [ -n "$line" ] || return 1
   stamp=${line##* }
   case "$stamp" in ''|*[!0-9]*) return 1 ;; esac
-  [ $(( $(date +%s) - stamp )) -lt "$DEFER_TTL" ] || return 1
+  # 10# because bash reads a leading zero as octal, and a stamp like 0900 then aborts arithmetic
+  # evaluation — which discarded the whole backlog rather than one deferral.
+  local age
+  age=$(( $(date +%s) - 10#$stamp )) || return 1
+  # Bounded below as well as above. A stamp in the future — a millisecond epoch, a typo, a backward
+  # clock step — was live indefinitely, which is the permanent silence the expiry exists to prevent.
+  [ "$age" -ge 0 ] || return 1
+  [ "$age" -lt "$DEFER_TTL" ] || return 1
   DEFER_REASON=${line#"$1 "}
   DEFER_REASON=${DEFER_REASON% *}
-  DEFER_AGE=$(( ($(date +%s) - stamp) / 60 ))
+  DEFER_AGE=$(( age / 60 ))
   return 0
 }


### PR DESCRIPTION
Closes #355.

Every way these guards could fail returned 0 with nothing on stderr — the same thing they return when they have looked and found nothing to say.

## Measured, driving both versions with a shimmed `gh`

| pull request state | main | this |
| --- | --- | --- |
| every check green, merge state CLEAN | exit 2 | exit 2 |
| every check green, merge state DIRTY | **exit 0** | **exit 2** |
| every check green, merge state DRAFT | **exit 0** | **exit 2** |
| every check cancelled, merge state BLOCKED | **exit 0** | **exit 2** |
| every check cancelled, merge state CLEAN | exit 2, "every check passed" | exit 2, "2 check(s) failed or were cancelled" |

The last row is the one that lied rather than stayed quiet: no check passed, both were cancelled.

Merge states were a list — `UNSTABLE|BEHIND|BLOCKED|""` continue, `CLEAN` blocks — so an unlisted state meant "settled". Since the backlog guard also returns 0 as soon as any pull request is open, both guards passed together on an unmergeable one with the whole assigned backlog unworked. It is now exhaustive: anything that is neither CLEAN nor a failure is reported with its state named.

`cancel` is one of gh's buckets and was counted as neither `pass` nor `fail`. It is counted with the failures, because a cancelled run does not restart on its own.

## The deferral arithmetic

```
0900          -> bash: value too great for base (error token is "0900")
99999999999   -> live, age -1636905657m
```

A last field with a leading zero reads as octal, and one containing an 8 or 9 aborts the comparison — which discarded the entire backlog rather than the one deferral, including issues that carried none. A stamp in the future was live indefinitely, which is exactly the permanent silence the 45-minute expiry exists to prevent.

Both are now bounded: base 10 forced, and the age has a floor as well as a ceiling. Verified across six stamps — `0900`, `0700`, a future one, now, 100 s ago, and 5000 s ago — each landing on the right side.

`watcher_is_alive()` compared its heartbeat the same unbounded way and gets the same two bounds.

## A gh that cannot answer

Unauthenticated, offline and rate-limited all took `|| exit 0` with `2>/dev/null` swallowing what gh said. Under a shim returning exit 4, the guard now refuses and names the call and its output, with the deferral as the way past it when the network is what is wrong. Reporting on stderr while exiting 0 was not an option here: the message would not reach a reader.

## Verification

Whole EditMode suite on this branch: **3589 passed, 0 failed, 0 inconclusive**, no compile errors.

## Documentation

No `Documentation~` impact: the Stop guards are harness tooling and `CONTRIBUTING.md` does not describe them.
