### PR TITLE
perf(velvet): drain the render queue on every frame of a particle wait

### DIFF
--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/ParticlesPlaybackTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/ParticlesPlaybackTests.cs
@@ -97,7 +97,7 @@ namespace Velvet.Tests
 
             // Act
             MountPanel(effect, PlayTrigger.Mount);
-            yield return WaitRealtime(0.8);
+            yield return WaitRealtimeDraining(0.8, _host.TargetTexture);
 
             // Assert — the element's center carries particle-colored pixels.
             Assert.That(CountParticlePixels(), Is.GreaterThan(20));
@@ -109,12 +109,12 @@ namespace Velvet.Tests
             // Arrange
             var effect = CreateEmitter();
             MountPanel(effect, PlayTrigger.Mount);
-            yield return WaitRealtime(0.6);
+            yield return WaitRealtimeDraining(0.6, _host.TargetTexture);
             var first = Snapshot();
             Assume.That(CountParticlePixels(), Is.GreaterThan(20), "Precondition: particles are visible");
 
             // Act — no Velvet re-render: the simulation alone must change the drawn output.
-            yield return WaitRealtime(0.4);
+            yield return WaitRealtimeDraining(0.4, _host.TargetTexture);
 
             // Assert
             var second = Snapshot();
@@ -182,7 +182,7 @@ namespace Velvet.Tests
 
             // Act — Manual instantiates the host stopped; nothing should emit or draw.
             MountPanel(effect, PlayTrigger.Manual);
-            yield return WaitRealtime(0.6);
+            yield return WaitRealtimeDraining(0.6, _host.TargetTexture);
 
             // Assert
             Assert.That(CountParticlePixels(), Is.EqualTo(0));
@@ -194,14 +194,14 @@ namespace Velvet.Tests
             // Arrange — Manual's other half: the element exposes the imperative trigger.
             var effect = CreateEmitter();
             MountPanel(effect, PlayTrigger.Manual);
-            yield return WaitRealtime(0.3);
+            yield return WaitRealtimeDraining(0.3, _host.TargetTexture);
             Assume.That(CountParticlePixels(), Is.EqualTo(0), "Precondition: nothing draws before Play");
             var element = _host.Root.Q<ParticlesElement>();
             Assume.That(element, Is.Not.Null, "Precondition: the particles element mounted");
 
             // Act
             element.Play();
-            yield return WaitRealtime(0.8);
+            yield return WaitRealtimeDraining(0.8, _host.TargetTexture);
 
             // Assert
             Assert.That(CountParticlePixels(), Is.GreaterThan(20));
@@ -216,12 +216,12 @@ namespace Velvet.Tests
             s_effect = effect;
             _host = new RenderTexturePanelHost("ParticlesPanel", 300, 300);
             _mounted = V.Mount(_host.Root, V.Component(TriggerFlipHost, key: "root"));
-            yield return WaitRealtime(0.3);
+            yield return WaitRealtimeDraining(0.3, _host.TargetTexture);
             Assume.That(CountParticlePixels(), Is.EqualTo(0), "Precondition: Manual draws nothing");
 
             // Act
             s_setFlag.Invoke(true);
-            yield return WaitRealtime(0.8);
+            yield return WaitRealtimeDraining(0.8, _host.TargetTexture);
 
             // Assert
             Assert.That(CountParticlePixels(), Is.GreaterThan(20));
@@ -238,14 +238,14 @@ namespace Velvet.Tests
             s_effect = effect;
             _host = new RenderTexturePanelHost("ParticlesPanel", 300, 300);
             _mounted = V.Mount(_host.Root, V.Component(ReorderHost, key: "root"));
-            yield return WaitRealtime(0.5);
+            yield return WaitRealtimeDraining(0.5, _host.TargetTexture);
             Assume.That(CountParticlePixels(), Is.GreaterThan(20), "Precondition: particles are visible");
 
             // Act — swap the keyed siblings, then let the simulation advance.
             s_setFlag.Invoke(true);
-            yield return WaitRealtime(0.3);
+            yield return WaitRealtimeDraining(0.3, _host.TargetTexture);
             var first = Snapshot();
-            yield return WaitRealtime(0.4);
+            yield return WaitRealtimeDraining(0.4, _host.TargetTexture);
 
             // Assert — the drawn output still changes after the move (the tick survived the reorder).
             var second = Snapshot();

--- a/Packages/com.velvet.core/TestUtilities/TargetFrameRateScope.cs
+++ b/Packages/com.velvet.core/TestUtilities/TargetFrameRateScope.cs
@@ -51,6 +51,26 @@ namespace Velvet.TestUtilities
             }
         }
 
+        /// <summary>
+        /// Yields for the given realtime, draining the render queue on every frame.
+        /// </summary>
+        /// <remarks>
+        /// For a fixture that needs real time to pass AND draws every frame. Where rasterisation is
+        /// queued rather than executed, a plain realtime wait spins as many frames as the CPU allows
+        /// and each one queues a full render that the next readback pays for; draining each frame
+        /// makes the frame cost what it costs, so the number of frames falls to what the wall clock
+        /// affords and the total is bounded by the wait rather than by the spin rate.
+        /// </remarks>
+        public static IEnumerator WaitRealtimeDraining(double seconds, RenderTexture texture)
+        {
+            var deadline = Time.realtimeSinceStartupAsDouble + seconds;
+            while (Time.realtimeSinceStartupAsDouble < deadline)
+            {
+                yield return null;
+                RenderTexturePixelReader.ReadPixels(texture, new RectInt(0, 0, 1, 1));
+            }
+        }
+
         /// <summary>Yields until at least <paramref name="seconds"/> of realtime have elapsed.</summary>
         public static IEnumerator WaitRealtime(double seconds)
         {


### PR DESCRIPTION
The rest of #348. `ParticlesPlaybackTests` held 388.8 s of a 597.7 s PlayMode job.

## Why frames could not simply be counted

#360 replaced the story capture's realtime wait with a frame count, because a capture needs the panel drawn rather than time elapsed. These two cases are the other shape: they assert that the drawn output **changed** between two readbacks, which needs the simulation to advance in real time. A fixed frame count would make the assertion about frames rather than about time, which is the thing under test.

What they do not need is a full panel render queued on every frame. Where rasterisation is queued rather than executed a frame returns almost immediately, so a realtime wait spins hundreds of them, and the first readback afterwards executes every one.

Draining on each frame makes a frame cost what it costs. The count then falls to what the wall clock affords, and the total is bounded by the wait the test declared.

## Measured on the runner

Frames spun per wait, with draining:

```
keyed reorder:   warm=2  settle=3  advance=2
live simulation: warm=11           advance=3
```

| case | before | after |
| --- | --- | --- |
| `Given_AKeyedReorder_When_TheElementMoves_Then_TheDrawnParticlesKeepMoving` | 276.7 s | **2.5 s** |
| `Given_ALiveSimulation_When_FramesAdvance_Then_TheDrawnParticlesMove` | 112.1 s | **1.1 s** |
| whole PlayMode run | 597.7 s | **274.2 s** |

No failures. Two to eleven frames still satisfy both assertions — the particles are visible, and the drawn output differs across the wait.

## Every wait, not only the slow two

Draining only the two slowest took them to 3.5 s and moved **94 s onto a sibling that still spun freely**: `Given_AManualPlayTrigger_When_PlayIsCalledOnTheElement_Then_ParticlesRender` went from 1.5 s to 95.7 s without being touched. Draining the whole fixture put it back to 1.2 s and took the job from 346.5 s to 274.2 s.

That is what establishes the cost belongs to un-drained frames rather than to any particular case, and it is why the change is not scoped to the two cases the issue named.

## What is left on #348

The story capture is now the largest single item at 96.8 s, up from 59.9 s at baseline — it is bounded at eight frames per story and pays for them itself now that nothing else leaves a backlog for it to share. Whether eight is more than a capture needs is a separate question and a separate measurement.

## Verification

Whole PlayMode suite on this branch, locally: **161 passed, 0 failed, 0 inconclusive**.

## Documentation

No `Documentation~` impact: these are tests, and the guide describes what the fixtures assert rather than how they wait.
