### PR TITLE
perf(velvet): drain each frame of the capture wait

### DIFF
--- a/Packages/com.velvet.core/Runtime/Preview/Tests/PlayMode/StoryCaptureTests.cs
+++ b/Packages/com.velvet.core/Runtime/Preview/Tests/PlayMode/StoryCaptureTests.cs
@@ -177,7 +177,7 @@ namespace Velvet.Tests
             probe.AddToClassList("bg-slate-700");
             host.Root.Add(probe);
 
-            yield return WaitFrames(8);
+            yield return WaitFramesDraining(8, host.TargetTexture);
 
             result.Problem = probe.resolvedStyle.backgroundColor == default
                 ? "the bundled stylesheet resolves none of its plain classes"
@@ -206,13 +206,14 @@ namespace Velvet.Tests
             using var previewHost = new VelvetPreviewHost(host.Root);
             previewHost.Mount(story);
 
-            // Frames rather than seconds. What a capture needs is that the panel has been drawn, and
-            // a realtime wait spins as many frames as it can — on a runner whose rasterisation is
-            // queued rather than executed that is hundreds, each queueing a full render that the
-            // readback below then pays for. Eight covers the first-run text shaping and glyph-atlas
-            // warm-up the half second was absorbing; too few would surface as the uniform-frame
-            // failure the assertion already makes.
-            yield return WaitFrames(8);
+            // Frames rather than seconds, and drained rather than queued. What a capture needs is
+            // that the panel has been drawn; a realtime wait spins as many frames as it can, and on
+            // a runner whose rasterisation is queued rather than executed that is hundreds. Eight
+            // covers the first-run text shaping and glyph-atlas warm-up the half second was
+            // absorbing — too few would surface as the uniform-frame failure the assertion already
+            // makes — and draining each of them is what stops the readback below paying for all
+            // eight at once.
+            yield return WaitFramesDraining(8, host.TargetTexture);
 
             Debug.Log($"[StoryCapture] {story.Id}: texture {width}x{height}, root layout {host.Root.layout}");
 

--- a/Packages/com.velvet.core/TestUtilities/TargetFrameRateScope.cs
+++ b/Packages/com.velvet.core/TestUtilities/TargetFrameRateScope.cs
@@ -52,6 +52,23 @@ namespace Velvet.TestUtilities
         }
 
         /// <summary>
+        /// Yields for a fixed number of frames, draining the render queue on each one.
+        /// </summary>
+        /// <remarks>
+        /// Eight frames of one story cost 96.8 s queued and 13.4 s drained on a runner that
+        /// rasterises on the CPU, for the same eight frames and a byte-identical capture. Paying per
+        /// frame is not merely a redistribution of when the cost lands.
+        /// </remarks>
+        public static IEnumerator WaitFramesDraining(int frames, RenderTexture texture)
+        {
+            for (var frame = 0; frame < frames; frame++)
+            {
+                yield return null;
+                RenderTexturePixelReader.ReadPixels(texture, new RectInt(0, 0, 1, 1));
+            }
+        }
+
+        /// <summary>
         /// Yields for the given realtime, draining the render queue on every frame.
         /// </summary>
         /// <remarks>


### PR DESCRIPTION
Closes #348.

The capture became the largest single item once #363 stopped the particle waits leaving a backlog for it to share — 96.8 s, up from 59.9 s at baseline, for eight frames per story that it now pays for itself.

## Queued and drained are not the same price

Timing each of those eight frames on the runner, with a one-pixel readback after each:

| story | per frame (ms) |
| --- | --- |
| Examples/Card | 743, 102, 103, 95, 96, 102, 96, 92 |
| Examples/Responsive | 152, 166, 162, 147, 177, 173, 174, 175 |
| Examples/Tall List | 1338, 1349, 1345, 1416, 1308, 1310, 1322, 1345 |

That is **13.4 s** for the three stories. The same eight frames queued and flushed once cost **96.8 s**.

So draining is not merely a redistribution of when the cost lands, which is what the particle result could have been read as. The queued path is seven times dearer for the identical work — eight frames either way, and a byte-identical PNG either way.

## Result

| | |
| --- | --- |
| capture case | 96.8 s → **13.7 s** |
| whole PlayMode run | 274.2 s → **187.5 s** |

Across today: the job was **1027.4 s** before #360.

## Verification

Whole PlayMode suite on this branch, locally: **161 passed, 0 failed, 0 inconclusive**.

The three PNGs are byte-identical to the ones the original half-second realtime wait produced — the same comparison #360 made, re-run against this change.

## Documentation

No `Documentation~` impact. `CONTRIBUTING.md` documents how to run the capture and to look at the images, neither of which changes.
