### PR TITLE
perf(velvet): drain the remaining realtime waits

### DIFF
--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/PortalLayersPlaybackTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/PortalLayersPlaybackTests.cs
@@ -123,7 +123,7 @@ namespace Velvet.Tests
                     V.Div(name: "fill", className: "w-[400px] h-[400px] bg-[#ef4444]"),
                 }),
             }));
-            yield return WaitRealtime(0.6);
+            yield return WaitRealtimeDraining(0.6, _cameraRt);
 
             // Assert — the camera's output carries the panel's red pixels.
             var pixels = RenderTexturePixelReader.ReadPixels(_cameraRt, new RectInt(0, 0, 200, 200));

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/SceneViewPlaybackTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/SceneViewPlaybackTests.cs
@@ -73,7 +73,7 @@ namespace Velvet.Tests
 
             // Act
             MountPanelWithSceneView(cam);
-            yield return WaitRealtime(0.5);
+            yield return WaitRealtimeDraining(0.5, _host.TargetTexture);
 
             // Assert — the element's pixels carry the camera's clear color (loose bounds absorb the
             // sRGB/linear round-trip; a missing wire-up leaves the panel's default background instead).
@@ -88,13 +88,13 @@ namespace Velvet.Tests
             // Arrange
             var cam = CreateSolidColorCamera(Color.red);
             MountPanelWithSceneView(cam);
-            yield return WaitRealtime(0.5);
+            yield return WaitRealtimeDraining(0.5, _host.TargetTexture);
             var before = SamplePanelCenterOfElement();
             Assume.That(before.r > 180, Is.True, "Precondition: the initial camera color rendered");
 
             // Act — no Velvet re-render: the element must sample the live texture.
             cam.backgroundColor = Color.blue;
-            yield return WaitRealtime(0.5);
+            yield return WaitRealtimeDraining(0.5, _host.TargetTexture);
 
             // Assert
             var c = SamplePanelCenterOfElement();

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/PlayMode/BuiltInFilterShaderPlaybackTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/PlayMode/BuiltInFilterShaderPlaybackTests.cs
@@ -53,7 +53,7 @@ namespace Velvet.Tests
         {
             _host = new RenderTexturePanelHost("FilterPanel", 100, 100);
             _mounted = V.Mount(_host.Root, V.Div(className: $"w-[100px] h-[100px] bg-[{fillColor}] {filterToken}"));
-            yield return WaitRealtime(0.4);
+            yield return WaitRealtimeDraining(0.4, _host.TargetTexture);
         }
 
         // The gap between a pixel's widest and narrowest colour channel — how far its colour sits from gray.
@@ -103,7 +103,7 @@ namespace Velvet.Tests
             // luminance gray. A deterministic endpoint that sanity-checks the shader's luma lerp.
             _host = new RenderTexturePanelHost("FilterPanel", 100, 100);
             _mounted = V.Mount(_host.Root, V.Div(className: "w-[100px] h-[100px] bg-[#c02020] saturate-[0]"));
-            yield return WaitRealtime(0.4);
+            yield return WaitRealtimeDraining(0.4, _host.TargetTexture);
             var c = SampleCenterAverage(20);
             Assume.That((int)c.r + c.g + c.b, Is.GreaterThan(0), "Precondition: the fill rendered a non-black pixel");
 

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/PlayMode/BundledStyleUtilitiesRuntimeTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/PlayMode/BundledStyleUtilitiesRuntimeTests.cs
@@ -47,7 +47,7 @@ namespace Velvet.Tests
             }
 
             _mounted = V.Mount(_host.Root, V.Div(name: "probe", className: "flex-row"));
-            return WaitRealtime(0.5);
+            return WaitRealtimeDraining(0.5, _host.TargetTexture);
         }
 
         private FlexDirection ProbeDirection() => _host.Root.Q<VisualElement>("probe").resolvedStyle.flexDirection;
@@ -88,7 +88,7 @@ namespace Velvet.Tests
             }));
 
             // Act
-            yield return WaitRealtime(0.5);
+            yield return WaitRealtimeDraining(0.5, _host.TargetTexture);
 
             // Assert — 4 units on the shared spacing scale, 4px each, on the leading edge of the column the
             // container resolves to without a direction class.

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/PlayMode/PaintOpacityParityPlaybackTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/PlayMode/PaintOpacityParityPlaybackTests.cs
@@ -166,7 +166,7 @@ namespace Velvet.Tests
             AddOverflowControl(wrap);
             PaintQuadAndFill(probe, tint);
             probe.MarkDirtyRepaint();
-            yield return WaitRealtime(0.9);
+            yield return WaitRealtimeDraining(0.9, _host.TargetTexture);
         }
 
         [UnityTest]

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/PlayMode/RingOverflowClipPlaybackTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/PlayMode/RingOverflowClipPlaybackTests.cs
@@ -116,7 +116,7 @@ namespace Velvet.Tests
             {
                 box.style.overflow = Overflow.Hidden;
             }
-            return WaitRealtime(0.8);
+            return WaitRealtimeDraining(0.8, _host.TargetTexture);
         }
 
         [UnityTest]
@@ -127,7 +127,7 @@ namespace Velvet.Tests
             PaintOutsideOwnBox(open);
             AddControlChild(open);
             open.MarkDirtyRepaint();
-            yield return WaitRealtime(0.8);
+            yield return WaitRealtimeDraining(0.8, _host.TargetTexture);
             var openPaint = RedPixels();
 
             // Act
@@ -135,7 +135,7 @@ namespace Velvet.Tests
             PaintOutsideOwnBox(clipped);
             AddControlChild(clipped);
             clipped.MarkDirtyRepaint();
-            yield return WaitRealtime(0.8);
+            yield return WaitRealtimeDraining(0.8, _host.TargetTexture);
             var clippedControl = GreenPixels();
             var clippedPaint = RedPixels();
 
@@ -159,7 +159,7 @@ namespace Velvet.Tests
             AddControlChild(avatar);
 
             // Act
-            yield return WaitRealtime(0.8);
+            yield return WaitRealtimeDraining(0.8, _host.TargetTexture);
             var control = GreenPixels();
             var band = RedPixels();
 

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/PlayMode/RingSiblingPaintOrderPlaybackTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/PlayMode/RingSiblingPaintOrderPlaybackTests.cs
@@ -118,7 +118,7 @@ namespace Velvet.Tests
             _host.Root.Q<VisualElement>("b").style.marginLeft = -20f;
 
             // Act
-            yield return WaitRealtime(0.8);
+            yield return WaitRealtimeDraining(0.8, _host.TargetTexture);
             var a = _host.Root.Q<VisualElement>("a").worldBound;
             var b = _host.Root.Q<VisualElement>("b").worldBound;
             var covered = BandStrip(a, right: true);
@@ -165,7 +165,7 @@ namespace Velvet.Tests
                 }));
             _host.Root.Q<VisualElement>("row").style.flexDirection = FlexDirection.Row;
             _host.Root.Q<VisualElement>("b").style.marginLeft = -40f;
-            yield return WaitRealtime(0.8);
+            yield return WaitRealtimeDraining(0.8, _host.TargetTexture);
 
             var elementA = _host.Root.Q<VisualElement>("a");
             var a = elementA.worldBound;
@@ -178,7 +178,7 @@ namespace Velvet.Tests
             // therefore the last band touch in this frame.
             var binding = _mounted.Root.Reconciler.Context.RingBindings[elementA];
             RingOverlay.Sync(elementA, binding, binding.Spec, binding.ClassNames);
-            yield return WaitRealtime(0.8);
+            yield return WaitRealtimeDraining(0.8, _host.TargetTexture);
             var greenAfterReSync = CountInPanelRect(shared, IsGreen);
             var redAfterReSync = CountInPanelRect(shared, IsRed);
 
@@ -211,7 +211,7 @@ namespace Velvet.Tests
                 }));
 
             // Act
-            yield return WaitRealtime(0.8);
+            yield return WaitRealtimeDraining(0.8, _host.TargetTexture);
             var a = _host.Root.Q<VisualElement>("a").worldBound;
             var b = _host.Root.Q<VisualElement>("b").worldBound;
 

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/PlayMode/SemanticTokenIdempotencePlaybackTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/PlayMode/SemanticTokenIdempotencePlaybackTests.cs
@@ -101,7 +101,7 @@ namespace Velvet.Tests
                     {
                         V.Div(name: "inner", className: "bg-surface w-[40px] h-[60px]"),
                     }));
-            yield return WaitRealtime(0.5);
+            yield return WaitRealtimeDraining(0.5, _host.TargetTexture);
         }
 
         private Reading Read()

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/PlayMode/ShaderBackedPaintRuntimeTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/PlayMode/ShaderBackedPaintRuntimeTests.cs
@@ -56,7 +56,7 @@ namespace Velvet.Tests
             _mounted = V.Mount(_host.Root, V.Div(
                 className: $"w-[{PanelSize}px] h-[{PanelSize}px] bg-[#0000ff] p-[30px]",
                 children: new[] { child }));
-            return WaitRealtime(0.6);
+            return WaitRealtimeDraining(0.6, _host.TargetTexture);
         }
 
         private int CountPixels(Func<Color32, bool> predicate)

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/PlayMode/ShadowFadeOpacityPlaybackTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/PlayMode/ShadowFadeOpacityPlaybackTests.cs
@@ -95,7 +95,7 @@ namespace Velvet.Tests
             VelvetStyleUtilities.AttachTo(_host.Root);
             _mounted = V.Mount(_host.Root, V.Div(name: "caster", className: CasterClasses));
             _host.Root.Q<VisualElement>("caster").style.opacity = opacity;
-            yield return WaitRealtime(0.9);
+            yield return WaitRealtimeDraining(0.9, _host.TargetTexture);
         }
 
         private const string EnterToClass = "opacity-100";
@@ -119,7 +119,7 @@ namespace Velvet.Tests
             yield return MountCaster("ShadowFading", 0.5f);
             var caster = _host.Root.Q<VisualElement>("caster");
             _mounted.Root.Reconciler.Context.StyleAnimationScheduler.PlayEnter(caster, LongEnter);
-            yield return WaitRealtime(1.2);
+            yield return WaitRealtimeDraining(1.2, _host.TargetTexture);
             var stillPlaying = caster.ClassListContains(EnterToClass);
             var casterOpacityPercent = Mathf.RoundToInt(caster.resolvedStyle.opacity * 100f);
             var fading = HaloRed(caster);

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/PlayMode/TextBalancePlaybackTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/PlayMode/TextBalancePlaybackTests.cs
@@ -131,7 +131,7 @@ namespace Velvet.Tests
                 }),
             });
             _mounted = V.Mount(_host.Root, tree);
-            yield return WaitRealtime(0.5);
+            yield return WaitRealtimeDraining(0.5, _host.TargetTexture);
         }
 
         // Mounts one balanced label carrying an extra sizing utility — a ceiling or a declared width —
@@ -162,7 +162,7 @@ namespace Velvet.Tests
                 };
             var tree = V.Div(className: $"w-[{WrapperWidthPx}px]", children: children);
             _mounted = V.Mount(_host.Root, tree);
-            yield return WaitRealtime(0.5);
+            yield return WaitRealtimeDraining(0.5, _host.TargetTexture);
         }
 
         // The same pair as MountPair with horizontal padding on both labels, which is the case where the
@@ -183,7 +183,7 @@ namespace Velvet.Tests
                 }),
             });
             _mounted = V.Mount(_host.Root, tree);
-            yield return WaitRealtime(0.5);
+            yield return WaitRealtimeDraining(0.5, _host.TargetTexture);
         }
 
         [UnityTest]
@@ -207,7 +207,7 @@ namespace Velvet.Tests
                 }),
             });
             _mounted = V.Mount(_host.Root, tree);
-            yield return WaitRealtime(0.5);
+            yield return WaitRealtimeDraining(0.5, _host.TargetTexture);
             var unpadded = _host.Root.Q<Label>("unpadded");
             var padded = _host.Root.Q<Label>("padded");
             Assume.That(padded.resolvedStyle.height, Is.GreaterThan(padded.resolvedStyle.fontSize * 1.5f),
@@ -287,7 +287,7 @@ namespace Velvet.Tests
                     className: $"text-balance {CoPresentMaxWidthClass}", refCallback: s_wrapWithFontRef),
             });
             _mounted = V.Mount(_host.Root, tree);
-            yield return WaitRealtime(0.5);
+            yield return WaitRealtimeDraining(0.5, _host.TargetTexture);
             var probe = _host.Root.Q<Label>("probe");
             var balanced = _host.Root.Q<Label>("balanced");
             Assume.That(probe.resolvedStyle.height, Is.LessThan(probe.resolvedStyle.fontSize * 1.8f),
@@ -368,7 +368,7 @@ namespace Velvet.Tests
             // Arrange
             _host = new RenderTexturePanelHost("TextBalanceWidenPanel", 400, 400);
             _mounted = V.Mount(_host.Root, V.Component(WidenHost, key: "root"));
-            yield return WaitRealtime(0.5);
+            yield return WaitRealtimeDraining(0.5, _host.TargetTexture);
             var balanced = _host.Root.Q<Label>("balanced");
             Assume.That(balanced, Is.Not.Null, "Precondition: the label mounted");
             var narrowWidth = balanced.resolvedStyle.width;
@@ -377,7 +377,7 @@ namespace Velvet.Tests
 
             // Act — widen the wrapper, an ANCESTOR of the label, not the label itself.
             s_setWrapperWide.Invoke(true);
-            yield return WaitRealtime(0.6);
+            yield return WaitRealtimeDraining(0.6, _host.TargetTexture);
 
             Assume.That(balanced.resolvedStyle.height, Is.GreaterThan(balanced.resolvedStyle.fontSize * 1.5f),
                 "Precondition: the text still wraps multi-line at the wider wrapper, so this is a real re-balance and not the single-line clear path");
@@ -410,7 +410,7 @@ namespace Velvet.Tests
             // unconstrained: no inline width exists yet, giving the swap below a clean edge to observe.
             _host = new RenderTexturePanelHost("TextBalanceTextSwapPanel", 400, 400);
             _mounted = V.Mount(_host.Root, V.Component(TextSwapHost, key: "root"));
-            yield return WaitRealtime(0.5);
+            yield return WaitRealtimeDraining(0.5, _host.TargetTexture);
             var balanced = _host.Root.Q<Label>("balanced");
             Assume.That(balanced, Is.Not.Null, "Precondition: the label mounted");
             Assume.That(balanced.resolvedStyle.height, Is.LessThan(balanced.resolvedStyle.fontSize * 1.8f),
@@ -420,7 +420,7 @@ namespace Velvet.Tests
 
             // Act — swap in text long enough to wrap at the SAME (unchanged) wrapper width.
             s_setSwapText.Invoke(LongWrapText);
-            yield return WaitRealtime(0.6);
+            yield return WaitRealtimeDraining(0.6, _host.TargetTexture);
 
             Assume.That(balanced.resolvedStyle.height, Is.GreaterThan(balanced.resolvedStyle.fontSize * 1.5f),
                 "Precondition: the new text actually wrapped onto multiple lines");
@@ -459,14 +459,14 @@ namespace Velvet.Tests
             _host = new RenderTexturePanelHost("TextBalanceLateCeilingPanel", 400, 400);
             VelvetStyleUtilities.AttachTo(_host.Root);
             _mounted = V.Mount(_host.Root, V.Component(LateCeilingHost, key: "root"));
-            yield return WaitRealtime(0.5);
+            yield return WaitRealtimeDraining(0.5, _host.TargetTexture);
             var balanced = _host.Root.Q<Label>("balanced");
             Assume.That(balanced.resolvedStyle.width, Is.GreaterThan(ScaleMaxWidthPx),
                 "Precondition: balance is holding a width wider than the ceiling that is about to arrive");
 
             // Act — the ceiling class enters the class list while that width is held.
             s_setAddCeiling.Invoke(true);
-            yield return WaitRealtime(0.6);
+            yield return WaitRealtimeDraining(0.6, _host.TargetTexture);
 
             // Assert — a ceiling is read fresh on every pass, so one that appears mid-life binds like one
             // present at mount. Reading it once and caching cannot see this, since a label whose text
@@ -489,14 +489,14 @@ namespace Velvet.Tests
                     className: $"text-balance {ScaleMaxWidthClass} dark:max-w-[80px]", refCallback: s_wrapWithFontRef),
             });
             _mounted = V.Mount(_host.Root, tree);
-            yield return WaitRealtime(0.5);
+            yield return WaitRealtimeDraining(0.5, _host.TargetTexture);
             var balanced = _host.Root.Q<Label>("balanced");
             Assume.That(balanced.resolvedStyle.width, Is.GreaterThan(80.5f),
                 "Precondition: the base ceiling is the one binding, so balance holds a width above the narrower one");
 
             // Act
             VelvetTheme.IsDark = true;
-            yield return WaitRealtime(0.6);
+            yield return WaitRealtimeDraining(0.6, _host.TargetTexture);
 
             // Assert
             Assert.That(balanced.resolvedStyle.width, Is.LessThanOrEqualTo(80.5f));
@@ -517,14 +517,14 @@ namespace Velvet.Tests
                     className: $"text-balance {ScaleMaxWidthClass} dark:max-w-[80px]", refCallback: s_wrapWithFontRef),
             });
             _mounted = V.Mount(_host.Root, tree);
-            yield return WaitRealtime(0.5);
+            yield return WaitRealtimeDraining(0.5, _host.TargetTexture);
             var balanced = _host.Root.Q<Label>("balanced");
             Assume.That(balanced.resolvedStyle.width, Is.LessThanOrEqualTo(80.5f),
                 "Precondition: the dark layer's narrower ceiling is the one binding to begin with");
 
             // Act
             VelvetTheme.IsDark = false;
-            yield return WaitRealtime(0.6);
+            yield return WaitRealtimeDraining(0.6, _host.TargetTexture);
 
             // Assert
             Assert.That(balanced.resolvedStyle.width, Is.LessThanOrEqualTo(ScaleMaxWidthPx + 0.5f));
@@ -537,17 +537,17 @@ namespace Velvet.Tests
             // stops needing a balanced value must hand that slot back or stay pinned at it forever.
             _host = new RenderTexturePanelHost("TextBalanceReleaseWidthPanel", 400, 400);
             _mounted = V.Mount(_host.Root, V.Component(TextSwapHost, key: "root"));
-            yield return WaitRealtime(0.5);
+            yield return WaitRealtimeDraining(0.5, _host.TargetTexture);
             var balanced = _host.Root.Q<Label>("balanced");
             s_setSwapText.Invoke(LongWrapText);
-            yield return WaitRealtime(0.6);
+            yield return WaitRealtimeDraining(0.6, _host.TargetTexture);
             var releasedWidth = _host.Root.Q<Label>("probe").resolvedStyle.width;
             Assume.That(balanced.resolvedStyle.width, Is.LessThan(releasedWidth - 0.5f),
                 "Precondition: balance is holding a width narrower than an unbalanced sibling");
 
             // Act — back to text that fits one line, which is a gate balance declines to act on.
             s_setSwapText.Invoke("Hi");
-            yield return WaitRealtime(0.6);
+            yield return WaitRealtimeDraining(0.6, _host.TargetTexture);
 
             // Assert — the box returns to what the cascade gives it, rather than staying at the width
             // balance wrote while it still had a reason to.
@@ -565,7 +565,7 @@ namespace Velvet.Tests
                 V.Label(name: "balanced", text: "Hi", className: "text-balance", refCallback: s_wrapWithFontRef),
             });
             _mounted = V.Mount(_host.Root, tree);
-            yield return WaitRealtime(0.5);
+            yield return WaitRealtimeDraining(0.5, _host.TargetTexture);
         }
 
         [UnityTest]
@@ -582,7 +582,7 @@ namespace Velvet.Tests
             // reaching the grid: TextElement raises ChangeEvent<string> synchronously, while the grid's own
             // re-derive is gated on a container width that a child re-wrapping never moves.
             balanced.text = LongWrapText;
-            yield return WaitRealtime(0.6);
+            yield return WaitRealtimeDraining(0.6, _host.TargetTexture);
 
             // Assert — the grid owns this slot, so balance stands down instead of taking the column.
             Assert.That(balanced.resolvedStyle.width, Is.EqualTo(plain.resolvedStyle.width).Within(0.5f));
@@ -599,7 +599,7 @@ namespace Velvet.Tests
                 V.Label(name: "balanced", text: LongWrapText, className: "text-balance", refCallback: s_wrapWithFontRef),
             });
             _mounted = V.Mount(_host.Root, tree);
-            yield return WaitRealtime(0.5);
+            yield return WaitRealtimeDraining(0.5, _host.TargetTexture);
             var balanced = _host.Root.Q<Label>("balanced");
             Assume.That(balanced.resolvedStyle.height, Is.GreaterThan(balanced.resolvedStyle.fontSize * 1.5f),
                 "Precondition: the text wrapped inside the widget's inner box");
@@ -622,7 +622,7 @@ namespace Velvet.Tests
                 V.Label(name: "balanced", text: "Hi", className: "text-balance", refCallback: s_wrapWithFontRef),
             });
             _mounted = V.Mount(_host.Root, tree);
-            yield return WaitRealtime(0.5);
+            yield return WaitRealtimeDraining(0.5, _host.TargetTexture);
             var plain = _host.Root.Q<Label>("plain");
             var balanced = _host.Root.Q<Label>("balanced");
             Assume.That(plain.resolvedStyle.width, Is.LessThan(plain.parent.resolvedStyle.width),
@@ -630,7 +630,7 @@ namespace Velvet.Tests
 
             // Act
             balanced.text = LongWrapText;
-            yield return WaitRealtime(0.6);
+            yield return WaitRealtimeDraining(0.6, _host.TargetTexture);
 
             // Assert
             Assert.That(balanced.resolvedStyle.width, Is.EqualTo(plain.resolvedStyle.width).Within(0.5f));
@@ -642,17 +642,17 @@ namespace Velvet.Tests
             // Arrange — the empty-text gate has its own release branch, reached before any measurement.
             _host = new RenderTexturePanelHost("TextBalanceReleaseEmptyPanel", 400, 400);
             _mounted = V.Mount(_host.Root, V.Component(TextSwapHost, key: "root"));
-            yield return WaitRealtime(0.5);
+            yield return WaitRealtimeDraining(0.5, _host.TargetTexture);
             var balanced = _host.Root.Q<Label>("balanced");
             s_setSwapText.Invoke(LongWrapText);
-            yield return WaitRealtime(0.6);
+            yield return WaitRealtimeDraining(0.6, _host.TargetTexture);
             var releasedWidth = _host.Root.Q<Label>("probe").resolvedStyle.width;
             Assume.That(balanced.resolvedStyle.width, Is.LessThan(releasedWidth - 0.5f),
                 "Precondition: balance is holding a width narrower than an unbalanced sibling");
 
             // Act
             s_setSwapText.Invoke(string.Empty);
-            yield return WaitRealtime(0.6);
+            yield return WaitRealtimeDraining(0.6, _host.TargetTexture);
 
             // Assert
             Assert.That(balanced.resolvedStyle.width, Is.EqualTo(releasedWidth).Within(0.5f));
@@ -671,7 +671,7 @@ namespace Velvet.Tests
 
             // Act
             VelvetTheme.IsDark = true;
-            yield return WaitRealtime(0.6);
+            yield return WaitRealtimeDraining(0.6, _host.TargetTexture);
 
             // Assert — `.w-40 { width: var(--space-40); }` with `--space-40: 160px`.
             Assert.That(balanced.resolvedStyle.width, Is.EqualTo(160f).Within(0.5f));
@@ -687,13 +687,13 @@ namespace Velvet.Tests
             var balanced = _host.Root.Q<Label>("balanced");
             var probe = _host.Root.Q<Label>("probe");
             VelvetTheme.IsDark = true;
-            yield return WaitRealtime(0.6);
+            yield return WaitRealtimeDraining(0.6, _host.TargetTexture);
             Assume.That(balanced.resolvedStyle.width, Is.EqualTo(200f).Within(0.5f),
                 "Precondition: the variant's width took the box over while it was active");
 
             // Act — the OFF edge removes the layer, which nothing else reports.
             VelvetTheme.IsDark = false;
-            yield return WaitRealtime(0.6);
+            yield return WaitRealtimeDraining(0.6, _host.TargetTexture);
 
             // Assert — back to a balanced box rather than the width the plain sibling stretches to.
             Assert.That(balanced.resolvedStyle.width, Is.LessThan(probe.resolvedStyle.width - 0.5f));
@@ -775,7 +775,7 @@ namespace Velvet.Tests
                 V.Div(name: "sibling", className: "w-[200px] h-[10px]"),
             });
             _mounted = V.Mount(_host.Root, tree);
-            yield return WaitRealtime(0.5);
+            yield return WaitRealtimeDraining(0.5, _host.TargetTexture);
             var balanced = _host.Root.Q<Label>("balanced");
             var sibling = _host.Root.Q<VisualElement>("sibling");
             Assume.That(balanced.resolvedStyle.height, Is.GreaterThan(balanced.resolvedStyle.fontSize * 1.5f),

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/PlayMode/TextOverlinePlaybackTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/PlayMode/TextOverlinePlaybackTests.cs
@@ -79,7 +79,7 @@ namespace Velvet.Tests
             var classNames = overline ? "overline " + LabelClasses : LabelClasses;
             _mounted = V.Mount(_host.Root, V.Label(
                 name: "lbl", className: classNames, text: GlyphOnlyText, refCallback: s_enableTextMeasurement));
-            yield return WaitRealtime(0.5);
+            yield return WaitRealtimeDraining(0.5, _host.TargetTexture);
         }
 
         // Counts red pixels in the TOP band (the top 20% of the label's own resolved height) of the ONLY

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/PlayMode/WrapperLessPaintOverflowClipPlaybackTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/PlayMode/WrapperLessPaintOverflowClipPlaybackTests.cs
@@ -146,7 +146,7 @@ namespace Velvet.Tests
             var box = _host.Root.Q<VisualElement>("box");
             if (clip) box.style.overflow = Overflow.Hidden;
             AddControlChild(box);
-            yield return WaitRealtime(0.9);
+            yield return WaitRealtimeDraining(0.9, _host.TargetTexture);
         }
 
         [UnityTest]
@@ -174,7 +174,7 @@ namespace Velvet.Tests
             box.MarkDirtyRepaint();
 
             // Act
-            yield return WaitRealtime(0.9);
+            yield return WaitRealtimeDraining(0.9, _host.TargetTexture);
             var bounds = box.worldBound;
             var border = box.resolvedStyle.borderLeftWidth;
             var leftmost = LeftmostMatch(IsRed);
@@ -250,7 +250,7 @@ namespace Velvet.Tests
             _mounted = V.Mount(_host.Root, V.Div(name: "card", className: BorderedCard + extra));
             var card = _host.Root.Q<VisualElement>("card");
             if (clip) card.style.overflow = Overflow.Hidden;
-            yield return WaitRealtime(0.9);
+            yield return WaitRealtimeDraining(0.9, _host.TargetTexture);
         }
 
         private (int Border, int Backdrop) SampleBorderStrip()
@@ -393,7 +393,7 @@ namespace Velvet.Tests
 
             NewPanel("DivideOpen");
             _mounted = V.Mount(_host.Root, V.Div(name: "list", className: list, children: children()));
-            yield return WaitRealtime(0.9);
+            yield return WaitRealtimeDraining(0.9, _host.TargetTexture);
             var openDivider = CountAll(IsRed);
 
             // Act
@@ -401,7 +401,7 @@ namespace Velvet.Tests
             _mounted = V.Mount(_host.Root, V.Div(name: "list", className: list, children: children()));
             var second = _host.Root.Q<VisualElement>("second");
             second.style.overflow = Overflow.Hidden;
-            yield return WaitRealtime(0.9);
+            yield return WaitRealtimeDraining(0.9, _host.TargetTexture);
             var clippedDivider = CountAll(IsRed);
 
             // Assert — the dashed divider sits in the child's own border band, so the same padding-box clip
@@ -433,7 +433,7 @@ namespace Velvet.Tests
                 className: "overline text-[48px] text-[#ff0000] mt-[60px] ml-[40px] w-[100px]",
                 text: "moonmoon", refCallback: s_measureWithoutWrapping));
             if (clip) _host.Root.Q<Label>("lbl").style.overflow = Overflow.Hidden;
-            yield return WaitRealtime(0.9);
+            yield return WaitRealtimeDraining(0.9, _host.TargetTexture);
         }
 
         // The ink that spills past the label's right edge — present unclipped, gone clipped. Vertically it is
@@ -515,14 +515,14 @@ namespace Velvet.Tests
                     backgroundColor = new Color(0f, 1f, 0f, 1f),
                 },
             });
-            yield return WaitRealtime(0.9);
+            yield return WaitRealtimeDraining(0.9, _host.TargetTexture);
             var ownAtRest = LeftmostMatch(IsRed);
             var siblingAtRest = LeftmostMatch(IsGreen);
 
             // Act
             box.style.scale = new StyleScale(new Scale(new Vector3(2f, 2f, 1f)));
             box.MarkDirtyRepaint();
-            yield return WaitRealtime(0.9);
+            yield return WaitRealtimeDraining(0.9, _host.TargetTexture);
             var ownScaled = LeftmostMatch(IsRed);
             var siblingScaled = LeftmostMatch(IsGreen);
 


### PR DESCRIPTION
Closes #365.

A wait left undrained is somewhere for the cost to collect. After #363 and #364 stopped the particle and capture fixtures queueing renders, `PaintOpacityParityPlaybackTests` went from **2.8 s to 28.2 s** without being touched and became the largest single case in the job — the same movement seen inside the particle fixture when only two of its cases were drained, one level out.

## What changed

Thirteen fixtures that mount onto a `RenderTexturePanelHost` now use `WaitRealtimeDraining` in place of `WaitRealtime`:

| fixture | waits |
| --- | --- |
| `TextBalancePlaybackTests` | 30 |
| `WrapperLessPaintOverflowClipPlaybackTests` | 8 |
| `RingOverflowClipPlaybackTests` | 4 |
| `RingSiblingPaintOrderPlaybackTests` | 4 |
| `SceneViewPlaybackTests` | 3 |
| `BuiltInFilterShaderPlaybackTests`, `BundledStyleUtilitiesRuntimeTests`, `ShadowFadeOpacityPlaybackTests` | 2 each |
| `PaintOpacityParityPlaybackTests`, `PortalLayersPlaybackTests`, `SemanticTokenIdempotencePlaybackTests`, `ShaderBackedPaintRuntimeTests`, `TextOverlinePlaybackTests` | 1 each |

`PortalLayersPlaybackTests` drains its camera's own `RenderTexture` rather than a panel host, which is what it reads back.

`UseFramePlaybackTests` keeps its ten plain waits: it paints nothing, so a readback there would add a texture allocation per frame and buy nothing.

## Verification

Whole PlayMode suite on this branch, locally: **161 passed, 0 failed, 0 inconclusive**, no compile errors.

The CI figure is what this is for, and it lands with the run on this pull request.

## Documentation

No `Documentation~` impact: these are tests, and no guide describes how they wait.
