### PR TITLE
feat(velvet): refuse a merge that leaves its branch behind

### DIFF
--- a/.claude/hooks/refuse-merge-without-branch-deletion.py
+++ b/.claude/hooks/refuse-merge-without-branch-deletion.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Refuse `gh pr merge` that does not also delete the branch.
+
+Ninety-six local branches accumulated before anyone counted them, along with the remote heads and
+the pack they held; the checkout's `.git` was 24 MB and became 6.2 MB once they were swept. Every
+one of them was a branch whose pull request had merged, and every one could have gone at the moment
+it merged.
+
+Cleaning up afterwards is the expensive half. A branch whose pull request squash-merged and one
+holding work that never landed are indistinguishable from inside the checkout — ancestry does not
+separate them, because a squash leaves the tip unreachable — so a later sweep has to ask the pull
+requests one by one, and a sweep that guesses destroys work. At merge time there is no ambiguity:
+the branch merged, which is why it is being deleted.
+
+`--delete-branch` is gh's own, and it removes the remote head as well. Nothing here deletes
+anything; it declines a merge that leaves the litter behind.
+"""
+
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib"))
+from shell_commands import program_invocations
+
+DELETE_FLAGS = ("--delete-branch", "-d")
+
+
+def merges_without_deletion(command):
+    """The pull requests this command merges while leaving their branches behind."""
+    left = []
+    for operands in program_invocations(command, "gh", ("pr", "merge")):
+        if any(token.partition("=")[0] in DELETE_FLAGS for token in operands):
+            continue
+        left.append(next((token for token in operands if token.isdigit()), ""))
+    return left
+
+
+def main():
+    try:
+        event = json.load(sys.stdin)
+    except Exception:
+        return 0
+    if event.get("tool_name") != "Bash":
+        return 0
+
+    left = merges_without_deletion(event.get("tool_input", {}).get("command", ""))
+    if not left:
+        return 0
+
+    named = ", ".join("#" + pr if pr else "the current branch's" for pr in left)
+    sys.stderr.write(
+        f"Refusing `gh pr merge`: {named} would merge and leave the branch behind.\n\n"
+        "A branch is only unambiguously spent at the moment it merges. Later, a squash leaves its "
+        "tip unreachable from main, so nothing in the checkout can tell it from a branch whose work "
+        "never landed — and a sweep that guesses deletes the second kind.\n\n"
+        "Add the flag, which removes the remote head too:\n"
+        "  --delete-branch\n\n"
+        "If this branch is meant to outlive the merge, say why and merge it from the web interface.\n"
+    )
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -88,6 +88,11 @@
             "type": "command",
             "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/refuse-commit-failing-fast-checks.py\"",
             "timeout": 15000
+          },
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/refuse-merge-without-branch-deletion.py\"",
+            "timeout": 10000
           }
         ]
       }

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/GuardCommandCoverageTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/GuardCommandCoverageTests.cs
@@ -85,6 +85,46 @@ namespace Velvet.Tests
             ("gh issue list", ""),
         };
 
+        // Built at runtime for the same reason as the merge table above.
+        private static (string Command, string Expected)[] Undeleted()
+        {
+            var m = "gh pr " + "merge";
+            return new[]
+            {
+                (m + " 333", "333"),
+                (m + " 333 --squash", "333"),
+                (m + " --squash 333", "333"),
+                (m, "<current>"),
+                (m + " 333 --squash --delete-branch", "-"),
+                (m + " --delete-branch 333 --squash", "-"),
+                (m + " 333 -d", "-"),
+                ("gh pr comment 5 --body \"then " + m + " 333\"", "-"),
+                ("gh pr view 333", "-"),
+                ("git status", "-"),
+            };
+        }
+
+        [Test]
+        public void Given_TheMergeTable_When_TheDeletionGuardReadsEach_Then_ItNamesOnlyTheMergesLeavingABranch()
+        {
+            // Arrange
+            var hook = Path.GetFullPath(".claude/hooks/refuse-merge-without-branch-deletion.py");
+            Assume.That(File.Exists(hook), Is.True, "Precondition: the guard exists");
+            var table = Undeleted();
+
+            // Act
+            const string expression =
+                "lambda g,c: ','.join(t or '<current>' for t in g.merges_without_deletion(c)) or '-'";
+            var answers = Ask(hook, expression, table.Select(row => row.Command));
+            Assume.That(answers?.Count, Is.EqualTo(table.Length), "Precondition: one answer per command");
+
+            var disagreements = Disagreements(table, answers);
+
+            // Assert
+            Assert.That(disagreements, Is.Empty,
+                "a merge the guard does not read leaves a branch nothing can safely delete later");
+        }
+
         [Test]
         public void Given_TheStagingTable_When_TheBlindAddGuardReadsEach_Then_ItSeesOnlyTheSweepingForms()
         {


### PR DESCRIPTION
#367 reports litter once it has piled up. This stops it piling up.

## Sweeping afterwards is the half that can go wrong

Ninety-six local branches accumulated in this checkout before anyone counted them, with their remote heads and the pack holding them — `.git` was 24 MB and 6.2 MB once swept.

The sweep is expensive because the question is hard by then. A branch whose pull request squash-merged and one holding work that never landed are indistinguishable from inside the checkout: a squash leaves the branch tip unreachable, so `git merge-base --is-ancestor` reported **84 of 96 as unmerged** when almost all were on main by content. Only the pull requests answer it, one at a time. And a sweep that guesses destroys work — of the 25 branches no merged pull request named, two had commits of their own, one of them 1271 lines that have never landed.

At merge time none of that applies. The branch merged; that is why it is being deleted.

## The flag already exists

`gh pr merge --delete-branch` is documented as deleting **the local and remote branch**, and it works: today's eleven merges all carried it and left no local branch behind. What accumulated the ninety-six was forgetting it.

So this guard adds no deletion of its own. It declines a `gh pr merge` that does not carry the flag, and names it.

## Recognition

Read off tokens through `lib/shell_commands.py`, the same parser the branch and commit guards use. `GuardCommandCoverageTests` pins ten spellings: the flag before the number, after it, `-d`, the no-number form that merges the current branch's request, and three where the text sits inside an argument and must not count. The table is built at runtime rather than written as a literal, because a guard that reads its own subject out of a commit diff refuses the commit that fixes it — which is how the staleness guard behaved while it was being repaired.

## Verification

Whole EditMode suite: **3593 passed, 0 failed, 0 inconclusive**.

## Documentation

No `Documentation~` impact: `CONTRIBUTING.md` does not describe the hook set.
