### PR TITLE
fix(velvet): pin delete_branch_on_merge and bypass_actors when readable

### DIFF
--- a/.github/workflows/generators.yml
+++ b/.github/workflows/generators.yml
@@ -83,11 +83,12 @@ jobs:
     if: github.repository == 's4k10503/velvet'
     runs-on: ubuntu-latest
     steps:
-      - name: Assert protect-main ruleset
+      - name: Assert repository settings
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           failed=0
+          unverifiable=0
 
           rulesets=$(gh api "repos/${GITHUB_REPOSITORY}/rulesets")
           protect_count=$(jq '[.[] | select(.name == "protect-main")] | length' <<<"$rulesets")
@@ -138,6 +139,34 @@ jobs:
               echo "::error::protect-main required_status_checks must list exactly Required checks (Unity) and Required checks (generators), got ${contexts} (${context_count} entries): those names are the required-checks aggregates in test.yml and this workflow, and branch protection must require both."
               failed=1
             fi
+          fi
+
+          repo=$(gh api "repos/${GITHUB_REPOSITORY}")
+          if jq -e 'has("delete_branch_on_merge")' <<<"$repo" >/dev/null; then
+            delete_on_merge=$(jq -r '.delete_branch_on_merge' <<<"$repo")
+            if [ "$delete_on_merge" != "true" ]; then
+              echo "::error::delete_branch_on_merge is '${delete_on_merge}', expected true: merged pull request branches accumulate on the remote when this is off — fifty-four of sixty-six remote branches were from merged pull requests before anyone noticed."
+              failed=1
+            fi
+          else
+            echo "::warning::delete_branch_on_merge is absent from the repository API response for GITHUB_TOKEN: merged pull request branches accumulate on the remote when this is off — fifty-four of sixty-six remote branches were from merged pull requests before anyone noticed — and this check cannot verify the setting until the response exposes the field."
+            unverifiable=1
+          fi
+
+          if jq -e 'has("bypass_actors")' <<<"$ruleset" >/dev/null; then
+            bypass_count=$(jq '[.bypass_actors[]?] | length' <<<"$ruleset")
+            if [ "$bypass_count" -ne 0 ]; then
+              bypass=$(jq -c '.bypass_actors' <<<"$ruleset")
+              echo "::error::protect-main bypass_actors must be empty, got ${bypass} (${bypass_count} entries): a non-empty bypass list would let named actors merge without Required checks (Unity) and Required checks (generators)."
+              failed=1
+            fi
+          else
+            echo "::warning::protect-main bypass_actors is absent from the ruleset API response for GITHUB_TOKEN: a non-empty bypass list would let named actors merge without Required checks (Unity) and Required checks (generators) — and this check cannot verify the list is empty until the response exposes the field."
+            unverifiable=1
+          fi
+
+          if [ "$unverifiable" -gt 0 ]; then
+            echo "::warning::${unverifiable} repository setting(s) could not be verified — GITHUB_TOKEN's API response omitted the field; see messages above."
           fi
 
           exit "$failed"

--- a/.github/workflows/generators.yml
+++ b/.github/workflows/generators.yml
@@ -150,7 +150,7 @@ jobs:
             fi
           else
             echo "::warning::delete_branch_on_merge is absent from the repository API response for GITHUB_TOKEN: merged pull request branches accumulate on the remote when this is off — fifty-four of sixty-six remote branches were from merged pull requests before anyone noticed — and this check cannot verify the setting until the response exposes the field."
-            unverifiable=1
+            unverifiable=$((unverifiable + 1))
           fi
 
           if jq -e 'has("bypass_actors")' <<<"$ruleset" >/dev/null; then
@@ -162,7 +162,7 @@ jobs:
             fi
           else
             echo "::warning::protect-main bypass_actors is absent from the ruleset API response for GITHUB_TOKEN: a non-empty bypass list would let named actors merge without Required checks (Unity) and Required checks (generators) — and this check cannot verify the list is empty until the response exposes the field."
-            unverifiable=1
+            unverifiable=$((unverifiable + 1))
           fi
 
           if [ "$unverifiable" -gt 0 ]; then


### PR DESCRIPTION
The `repository-settings` job already pins most of what branch protection decides: the `protect-main`
ruleset exists and is unique, enforcement is active, it targets exactly `refs/heads/main`, it carries
one `required_status_checks` rule, `strict_required_status_checks_policy` is false, and both
aggregate contexts are named.

Two decided settings were left unpinned, and they are the two that were reported unreadable from
`GITHUB_TOKEN`: `delete_branch_on_merge`, whose drift is what prompted the issue — fifty-four of
sixty-six remote branches belonged to merged pull requests before a person noticed — and
`bypass_actors` being empty, which is what makes the required checks unbypassable.

A local user token reads both today. An installation token may not, and that difference is only
observable in a run. So the job now reads each one and distinguishes three outcomes rather than two:

- present and correct — passes, and the setting is pinned from here on;
- present and wrong — fails, with a message naming the decision behind the setting;
- absent from the response — warns, names the setting, and counts it in a summary line.

Absent does not fail. Failing would put `Required checks (generators)` red until someone adds an
`administration:read` PAT as a repository secret, which is a decision nobody has made. Warning keeps
the outcome legible in the log, which is what the issue asks for: the failure mode here has been
drift going unnoticed.

`jq -e 'has(...)'` is what separates absent from null; conflating them is how a check ends up
asserting against nothing.

This run answers the question the issue could not: whether the two fields reach an installation
token. If they do, both settings are pinned. If they do not, the log says which ones and why, and
adding the PAT becomes a decision with a visible cost rather than an invisible one.
