### PR TITLE
fix(velvet): route a throwing mutation onError to the unobserved-exception channel

### DIFF
--- a/Packages/com.velvet.core/Documentation~/react-migration.md
+++ b/Packages/com.velvet.core/Documentation~/react-migration.md
@@ -89,6 +89,21 @@ public static VNode UserCard()
   (separation of responsibilities)
 - `UseService<T>()` cannot be called **from within a Store's async lifecycle methods** (hook discipline). A Store obtains its UseCase via constructor injection
 
+### 1-2a. Async mutations — `Hooks.UseMutation`
+
+TanStack Query's `useMutation` equivalent. Returns a handle with `Mutate` (fire-and-forget) and `MutateAsync` (awaitable), plus `Status` / `Data` / `Error` / `Variables` snapshots and `Reset`.
+
+| React Query | Velvet |
+|-------------|--------|
+| `useMutation({ mutationFn, onSuccess, onError })` | `Hooks.UseMutation(new MutationOptions<TVariables, TData>(MutationFn: ..., OnSuccess: ..., OnError: ...))` |
+| `mutate(variables)` | `mutation.Mutate(variables)` |
+| `mutateAsync(variables)` | `await mutation.MutateAsync(variables)` |
+
+**Callback error semantics** (TanStack Query v5 parity):
+
+- A throwing **`onSuccess`** handler makes the mutation an **error**: `Status` becomes `Error`, `Error` holds the handler's exception, `onError` runs with that exception, and `MutateAsync` rethrows it to the caller. This matches React Query — the success state is not committed when the handler throws.
+- A throwing **`onError`** handler does **not** change the mutation outcome already written to the slot (`Status` / `Error` stay the mutation's). The handler exception is routed to the same unobserved-exception channel as `.Forget()` (logged via `Debug.LogException` when no custom handler is registered). `MutateAsync` still rethrows the **mutation** exception, not the handler's.
+
 ### 1-3. State Management (React + Zustand)
 
 Velvet state is organized into two layers — **"component-local state" and "shared Store"** — each modeled on React and Zustand respectively.

--- a/Packages/com.velvet.core/Runtime/Hooks/Hooks.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Hooks.cs
@@ -1794,7 +1794,14 @@ namespace Velvet
                 }
                 slot.Result.Error = ex;
                 slot.Result.Status = MutationStatus.Error;
-                slot.OnError?.Invoke(ex, variables);
+                try
+                {
+                    slot.OnError?.Invoke(ex, variables);
+                }
+                catch (Exception handlerEx)
+                {
+                    UniTask.FromException(handlerEx).Forget();
+                }
                 RequestRender(fiber);
                 if (rethrowOnFailure) throw;
                 return default!;

--- a/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseMutationHookTests.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseMutationHookTests.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Collections;
+using System.Text.RegularExpressions;
 using System.Threading;
 using Cysharp.Threading.Tasks;
 using NUnit.Framework;
+using UnityEngine;
 using UnityEngine.TestTools;
 using UnityEngine.UIElements;
 using Velvet.TestUtilities;
@@ -48,6 +50,8 @@ namespace Velvet.Tests
             s_onErrorCount = 0;
             s_voidCaptured = null;
             s_noInputCaptured = null;
+            s_onSuccessThrowException = null;
+            s_onErrorThrowException = null;
         }
 
         [Test]
@@ -296,6 +300,155 @@ namespace Velvet.Tests
         });
 
         [UnityTest]
+        public IEnumerator Given_SucceededMutation_When_OnSuccessThrows_Then_StatusIsError() => UniTask.ToCoroutine(async () =>
+        {
+            // Arrange
+            s_onSuccessThrowException = new InvalidOperationException("onSuccess");
+            using var mounted = V.Mount(_root, V.Component(CaptureMutationWithThrowingOnSuccessRender, key: "onsuccess-status"));
+
+            // Act
+            try { await s_captured!.MutateAsync(21); } catch (InvalidOperationException) { }
+            mounted.FlushStateForTest();
+
+            // Assert
+            Assert.That(s_captured!.Status, Is.EqualTo(MutationStatus.Error),
+                "A throwing onSuccess handler transitions the slot to Error");
+        });
+
+        [UnityTest]
+        public IEnumerator Given_SucceededMutation_When_OnSuccessThrows_Then_ResultErrorIsHandlerException() => UniTask.ToCoroutine(async () =>
+        {
+            // Arrange
+            s_onSuccessThrowException = new InvalidOperationException("onSuccess");
+            using var mounted = V.Mount(_root, V.Component(CaptureMutationWithThrowingOnSuccessRender, key: "onsuccess-error"));
+            Exception? rethrown = null;
+
+            // Act
+            try { await s_captured!.MutateAsync(21); } catch (InvalidOperationException caught) { rethrown = caught; }
+            mounted.FlushStateForTest();
+            Assume.That(rethrown, Is.SameAs(s_onSuccessThrowException),
+                "Precondition: MutateAsync rethrew the onSuccess exception");
+
+            // Assert
+            Assert.That(s_captured!.Error, Is.SameAs(s_onSuccessThrowException),
+                "The handle retains the onSuccess exception as Error");
+        });
+
+        [UnityTest]
+        public IEnumerator Given_SucceededMutation_When_OnSuccessThrows_Then_OnErrorRuns() => UniTask.ToCoroutine(async () =>
+        {
+            // Arrange
+            s_onSuccessThrowException = new InvalidOperationException("onSuccess");
+            s_onErrorCount = 0;
+            using var mounted = V.Mount(_root, V.Component(CaptureMutationWithThrowingOnSuccessRender, key: "onsuccess-onerror"));
+
+            // Act
+            try { await s_captured!.MutateAsync(21); } catch (InvalidOperationException) { }
+            mounted.FlushStateForTest();
+
+            // Assert
+            Assert.That(s_onErrorCount, Is.EqualTo(1),
+                "A throwing onSuccess handler routes the exception through onError");
+        });
+
+        [UnityTest]
+        public IEnumerator Given_SucceededMutation_When_OnSuccessThrows_Then_MutateAsyncRethrowsHandlerException() => UniTask.ToCoroutine(async () =>
+        {
+            // Arrange
+            s_onSuccessThrowException = new InvalidOperationException("onSuccess");
+            using var mounted = V.Mount(_root, V.Component(CaptureMutationWithThrowingOnSuccessRender, key: "onsuccess-rethrow"));
+            Exception? rethrown = null;
+
+            // Act
+            try { await s_captured!.MutateAsync(21); } catch (InvalidOperationException caught) { rethrown = caught; }
+            mounted.FlushStateForTest();
+
+            // Assert
+            Assert.That(rethrown, Is.SameAs(s_onSuccessThrowException),
+                "MutateAsync rethrows the onSuccess exception instead of returning the mutation data");
+        });
+
+        [UnityTest]
+        public IEnumerator Given_SucceededMutation_When_OnSuccessThrowsOnFireAndForgetMutate_Then_OnErrorRunsWithoutUnobservedException() => UniTask.ToCoroutine(async () =>
+        {
+            // Arrange
+            s_onSuccessThrowException = new InvalidOperationException("onSuccess");
+            s_onErrorCount = 0;
+            using var mounted = V.Mount(_root, V.Component(CaptureMutationWithThrowingOnSuccessRender, key: "onsuccess-forget"));
+
+            // Act
+            s_captured!.Mutate(21);
+            await UniTask.Yield();
+            await UniTask.Yield();
+            mounted.FlushStateForTest();
+
+            // Assert
+            Assert.That((s_captured!.Status, s_onErrorCount), Is.EqualTo((MutationStatus.Error, 1)),
+                "Fire-and-forget Mutate routes a throwing onSuccess through onError without an unobserved rethrow");
+        });
+
+        [UnityTest]
+        public IEnumerator Given_FailingMutation_When_OnErrorThrows_Then_StatusRemainsErrorWithMutationException() => UniTask.ToCoroutine(async () =>
+        {
+            // Arrange
+            var failingException = new InvalidOperationException("mutation");
+            s_onErrorThrowException = new InvalidOperationException("onError");
+            s_mutationFn = (_, _) => throw failingException;
+            using var mounted = V.Mount(_root, V.Component(CaptureMutationWithThrowingOnErrorRender, key: "onerror-status"));
+            LogAssert.Expect(LogType.Exception, new Regex("InvalidOperationException: onError"));
+
+            // Act
+            try { await s_captured!.MutateAsync(1); } catch (InvalidOperationException) { }
+            mounted.FlushStateForTest();
+
+            // Assert
+            Assert.That(s_captured!.Error, Is.SameAs(failingException),
+                "A throwing onError handler does not replace the mutation error stored on the slot");
+        });
+
+        [UnityTest]
+        public IEnumerator Given_FailingMutation_When_OnErrorThrowsOnFireAndForgetMutate_Then_LogsWithoutDisturbingOutcome() => UniTask.ToCoroutine(async () =>
+        {
+            // Arrange
+            var failingException = new InvalidOperationException("mutation");
+            s_onErrorThrowException = new InvalidOperationException("onError");
+            s_mutationFn = (_, _) => throw failingException;
+            using var mounted = V.Mount(_root, V.Component(CaptureMutationWithThrowingOnErrorRender, key: "onerror-forget"));
+            LogAssert.Expect(LogType.Exception, new Regex("InvalidOperationException: onError"));
+
+            // Act
+            s_captured!.Mutate(1);
+            await UniTask.Yield();
+            await UniTask.Yield();
+            mounted.FlushStateForTest();
+
+            // Assert
+            Assert.That((s_captured!.Status, ReferenceEquals(s_captured.Error, failingException)),
+                Is.EqualTo((MutationStatus.Error, true)),
+                "A throwing onError handler is logged and does not replace the mutation outcome on the slot");
+        });
+
+        [UnityTest]
+        public IEnumerator Given_FailingMutation_When_OnErrorThrows_Then_MutateAsyncRethrowsMutationException() => UniTask.ToCoroutine(async () =>
+        {
+            // Arrange
+            var failingException = new InvalidOperationException("mutation");
+            s_onErrorThrowException = new InvalidOperationException("onError");
+            s_mutationFn = (_, _) => throw failingException;
+            using var mounted = V.Mount(_root, V.Component(CaptureMutationWithThrowingOnErrorRender, key: "onerror-rethrow"));
+            LogAssert.Expect(LogType.Exception, new Regex("InvalidOperationException: onError"));
+            Exception? rethrown = null;
+
+            // Act
+            try { await s_captured!.MutateAsync(1); } catch (InvalidOperationException caught) { rethrown = caught; }
+            mounted.FlushStateForTest();
+
+            // Assert
+            Assert.That(rethrown, Is.SameAs(failingException),
+                "MutateAsync rethrows the mutation exception even when onError throws");
+        });
+
+        [UnityTest]
         public IEnumerator Given_InFlightMutation_When_ComponentUnmounted_Then_DisposedFiberNotSetToSuccess() => UniTask.ToCoroutine(async () =>
         {
             // Arrange
@@ -332,6 +485,29 @@ namespace Velvet.Tests
         }
 
         [Component]
+        public static VNode CaptureMutationWithThrowingOnSuccessRender()
+        {
+            s_captured = Hooks.UseMutation(new MutationOptions<int, int>(
+                MutationFn: s_mutationFn,
+                OnSuccess: (_, _) => throw s_onSuccessThrowException!,
+                OnError: (_, _) => s_onErrorCount++));
+            return V.Label(text: "ok");
+        }
+
+        [Component]
+        public static VNode CaptureMutationWithThrowingOnErrorRender()
+        {
+            s_captured = Hooks.UseMutation(new MutationOptions<int, int>(
+                MutationFn: s_mutationFn,
+                OnError: (ex, _) =>
+                {
+                    s_onErrorCount++;
+                    throw s_onErrorThrowException!;
+                }));
+            return V.Label(text: "ok");
+        }
+
+        [Component]
         public static VNode CaptureUnitMutationRender()
         {
             _ = Hooks.UseMutation(new MutationOptions<Unit, Unit>(
@@ -342,5 +518,7 @@ namespace Velvet.Tests
         private static int s_onErrorCount;
         private static MutationResult<int, Unit>? s_voidCaptured;
         private static MutationResult<Unit, Unit>? s_noInputCaptured;
+        private static Exception? s_onSuccessThrowException;
+        private static Exception? s_onErrorThrowException;
     }
 }


### PR DESCRIPTION
A mutation's `onError` handler could throw, and where that exception went depended on how the
mutation had been started. Observed before this change:

- through `MutateAsync`, the handler's exception **replaced** the mutation's own — the caller awaited
  a failure and received the wrong one, while the slot still held the right one, and nothing was
  logged;
- through `Mutate`, the same exception reached the unobserved-exception channel and was logged, and
  the outcome was unaffected.

Two entry points, two behaviours, neither of them written down.

The reference implementation settles which one is right. TanStack Query wraps every callback in its
catch individually and routes what they throw out of the mutation flow
(`try { await this.options.onError?.(...) } catch (e) { void Promise.reject(e) }`), so a failing
handler never changes what the mutation reports. `onError` is now wrapped the same way, and the
handler's exception goes to the channel `.Forget()` already uses. `MutateAsync` rethrows the
mutation's exception, as it did for every other path.

## The success path is parity, and is now pinned

The issue also asked whether a throwing `onSuccess` should turn a successful mutation into an error.
It should, because that is what React does: `onSuccess` is awaited inside the try, and the success
dispatch sits after it, so a throwing success handler skips the success state, runs `onError` with
its own exception, and propagates. Velvet already matched that.

Since that is now a decision rather than an accident, it is pinned by tests — status, `Result.Error`,
whether `onError` ran, and what `mutateAsync` did — so it does not get "fixed" into a deviation later.

`Documentation~/react-migration.md` states both halves.

Closes #376
