### PR TITLE
docs(velvet): record the mutation callback change in the changelog

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this package are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- An exception thrown by a mutation's `onError` handler no longer changes what the mutation reports.
+  Through `MutateAsync` it used to replace the mutation's own exception, so the caller awaited a
+  failure and received the handler's error instead of the one the mutation function raised, and
+  nothing was logged; through `Mutate` the same exception was already logged and the outcome was
+  already unaffected. The handler's exception now goes to the unobserved-exception channel in both
+  cases, and `MutateAsync` rethrows the mutation's own exception.
+
+  A throwing `onSuccess` handler is unchanged and still makes the mutation an error, which is what
+  React does — the success state is dispatched after the handler runs, so a handler that throws never
+  reaches it.
+
 ## [2.0.0] - 2026-08-02
 
 ### Highlights


### PR DESCRIPTION
The `onError` routing fix landed without a changelog entry, and it is observable by a consumer: a
caller awaiting `MutateAsync` used to receive the handler's exception in place of the one the
mutation function raised, and now receives the mutation's own. Releasing that unrecorded would leave
anyone reading the notes unable to explain a behaviour change they can see in their own code.

The entry also states what did *not* change, because that half was a deliberate decision rather than
an oversight: a throwing `onSuccess` still turns the mutation into an error, which is what React
does — the success state is dispatched after the handler runs, so a handler that throws never reaches
it. Recording it here keeps the next reader from filing it as a bug.

`[Unreleased]` did not exist on `main` at all, so this creates it.