### PR TITLE
fix(velvet): leave no router state behind when a navigation is abandoned

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -10,18 +10,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - A Back or Forward navigation served from the history's loader cache now cancels the loaders still in
-  flight from the round it left. That branch commits without ever reaching the loader runner, so a
-  `LoaderMode.Suspend` loader belonging to the page the user navigated away from still counted as the
-  current round: its result landed in the live loader data of the entry the user had gone *back* to,
-  re-rendered that page showing the other page's data, and was written into the history entry so the
-  wrong data persisted. Two entries matching the same route pattern share a route id, so neither the
-  re-publish check nor the history write-back could separate them — `/users/1` re-rendered with user 2's
-  record and kept it.
+  flight from the round it left. That branch commits without running `RunLoadersSync`, which is where a
+  previous round is superseded, so a `LoaderMode.Suspend` loader belonging to the page the user navigated
+  away from still counted as the current round: its result landed in the live loader data of the entry
+  the user had gone *back* to, re-rendered that page showing the other page's data, and was written into
+  the history entry so the wrong data persisted. Two entries matching the same route pattern share a
+  route id, so neither the re-publish check nor the history write-back could separate them — `/users/1`
+  re-rendered with user 2's record and kept it.
 
-- A navigation cancelled through its `CancellationToken` while a Blocker or a Guard redirect was still
-  awaiting now leaves the router as it found it. A blocker that honors the token raises
-  `OperationCanceledException` out of the await, which jumped over the rollbacks that the blocked and
-  superseded paths run:
+  This narrows a second, still-open defect rather than fixing it: a history entry left before its Suspend
+  loader resolved is cached as an empty-but-complete snapshot, and Back or Forward serves that snapshot
+  without re-running the loader, so the page shows no data. Previously the departing round sometimes
+  resolved into the cache by luck; now it is reliably cancelled, so that entry keeps its pre-resolution
+  snapshot every time. Wrong data is traded for absent data.
+
+- A navigation abandoned while a Blocker or a Guard redirect was still awaiting now leaves the router as
+  it found it. A blocker that honors its token raises `OperationCanceledException` out of the await,
+  which jumped over the rollbacks that the blocked and superseded paths run:
 
   - `GoBack` / `GoForward` left the history index on the entry they had provisionally moved to, so
     `CanGoBack` described a location the user was not on and the next `Push` truncated the entry they
@@ -32,9 +37,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `Status` stayed at `Matching`, so every component calling `UseNavigation` rendered its pending
     branch indefinitely with no navigation in flight.
 
-  This is reachable from application code that passes its own token to `Router.NavigateAsync`,
-  `Router.GoBack` or `Router.GoForward`. `UseNavigate` supplies no token, and a cancellation caused by a
-  newer navigation taking over is followed by that navigation driving the state on.
+  Each of those rollbacks now runs only while the attempt is still the current navigation. Cancelling a
+  token does not oblige a blocker to resume at that moment, so an abandoned attempt can reach its rollback
+  after the navigation that superseded it has committed; it would then put back an index, a `Status` and a
+  history snapshot describing a router that no longer exists, destroying entries the newer navigation had
+  pushed. Disposing the router retires the claim the same way, so a blocker resuming after teardown no
+  longer writes to it.
 
 - An exception thrown by a mutation's `onError` handler no longer changes what the mutation reports.
   Through `MutateAsync` it used to replace the mutation's own exception, so the caller awaited a

--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -18,11 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   route id, so neither the re-publish check nor the history write-back could separate them — `/users/1`
   re-rendered with user 2's record and kept it.
 
-  This narrows a second, still-open defect rather than fixing it: a history entry left before its Suspend
-  loader resolved is cached as an empty-but-complete snapshot, and Back or Forward serves that snapshot
-  without re-running the loader, so the page shows no data. Previously the departing round sometimes
-  resolved into the cache by luck; now it is reliably cancelled, so that entry keeps its pre-resolution
-  snapshot every time. Wrong data is traded for absent data.
+  A separate defect in the same area remains open: a history entry left before its Suspend loader resolved
+  is cached as an empty-but-complete snapshot, and Back or Forward serves that snapshot without re-running
+  the loader, so the page shows no data.
 
 - A navigation abandoned while a Blocker or a Guard redirect was still awaiting now leaves the router as
   it found it. A blocker that honors its token raises `OperationCanceledException` out of the await,

--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -9,6 +9,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A Back or Forward navigation served from the history's loader cache now cancels the loaders still in
+  flight from the round it left. That branch commits without ever reaching the loader runner, so a
+  `LoaderMode.Suspend` loader belonging to the page the user navigated away from still counted as the
+  current round: its result landed in the live loader data of the entry the user had gone *back* to,
+  re-rendered that page showing the other page's data, and was written into the history entry so the
+  wrong data persisted. Two entries matching the same route pattern share a route id, so neither the
+  re-publish check nor the history write-back could separate them — `/users/1` re-rendered with user 2's
+  record and kept it.
+
+- A navigation cancelled through its `CancellationToken` while a Blocker or a Guard redirect was still
+  awaiting now leaves the router as it found it. A blocker that honors the token raises
+  `OperationCanceledException` out of the await, which jumped over the rollbacks that the blocked and
+  superseded paths run:
+
+  - `GoBack` / `GoForward` left the history index on the entry they had provisionally moved to, so
+    `CanGoBack` described a location the user was not on and the next `Push` truncated the entry they
+    were still looking at. From `/about`, a cancelled `GoBack` followed by `Push("/contact")` and
+    `GoBack()` landed on `/home` rather than `/about`.
+  - A cancelled Guard redirect left on the stack the provisional Push entry it had appended for the
+    redirect target to overwrite.
+  - `Status` stayed at `Matching`, so every component calling `UseNavigation` rendered its pending
+    branch indefinitely with no navigation in flight.
+
+  This is reachable from application code that passes its own token to `Router.NavigateAsync`,
+  `Router.GoBack` or `Router.GoForward`. `UseNavigate` supplies no token, and a cancellation caused by a
+  newer navigation taking over is followed by that navigation driving the state on.
+
 - An exception thrown by a mutation's `onError` handler no longer changes what the mutation reports.
   Through `MutateAsync` it used to replace the mutation's own exception, so the caller awaited a
   failure and received the handler's error instead of the one the mutation function raised, and

--- a/Packages/com.velvet.core/Runtime/Routing/RouteLoaderRunner.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/RouteLoaderRunner.cs
@@ -151,9 +151,13 @@ namespace Velvet
         {
             if (_cts != null)
             {
-                _cts.Cancel();
-                _cts.Dispose();
+                // Cleared before the Cancel, not after: a loader continuation that resumes synchronously
+                // inside Cancel() and completes successfully would otherwise still read _cts as its own
+                // and fire its completion event for a round that is being torn down.
+                var cancelling = _cts;
                 _cts = null;
+                cancelling.Cancel();
+                cancelling.Dispose();
             }
 
             // _activeSuspendTaskCount is decremented in the finally block of RunSuspendLoader.

--- a/Packages/com.velvet.core/Runtime/Routing/Router.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/Router.cs
@@ -334,22 +334,37 @@ namespace Velvet
 
             var savedHistoryIndex = ApplyProvisionalHistoryIndex(mode);
 
-            var guardResult = await RunGuardChecks(matches, path, mode, savedHistoryIndex, cancellationToken, redirectCount);
-            if (guardResult.HasValue)
+            try
             {
-                return guardResult.Value;
-            }
+                var guardResult = await RunGuardChecks(matches, path, mode, savedHistoryIndex, cancellationToken, redirectCount);
+                if (guardResult.HasValue)
+                {
+                    return guardResult.Value;
+                }
 
-            var blockerResult = await RunBlockerCheck(path, mode, savedHistoryIndex, cancellationToken);
-            if (blockerResult.HasValue)
-            {
-                return blockerResult.Value;
-            }
+                var blockerResult = await RunBlockerCheck(path, mode, savedHistoryIndex, cancellationToken);
+                if (blockerResult.HasValue)
+                {
+                    return blockerResult.Value;
+                }
 
-            var loaderResult = await RunLoaderPhase(matches, mode, cancellationToken);
-            if (loaderResult.HasValue)
+                var loaderResult = await RunLoaderPhase(matches, mode, cancellationToken);
+                if (loaderResult.HasValue)
+                {
+                    return loaderResult.Value;
+                }
+            }
+            catch (OperationCanceledException)
             {
-                return loaderResult.Value;
+                // A Guard redirect or a Blocker that honors its token unwinds by exception, skipping the
+                // in-line rollbacks the returned-result paths use. The index moved before both of those
+                // awaits, and Status was set before them, so an aborted attempt would otherwise leave the
+                // history pointing somewhere the user never went and UseNavigation reporting a navigation
+                // that is no longer in flight. The provisional Push entry a redirect appended is undone in
+                // RunGuardChecks, which owns the snapshot it needs.
+                _historyIndex = savedHistoryIndex;
+                Status = RouterStatus.Idle;
+                throw;
             }
 
             var location = CommitHistoryEntry(path, matches, mode);
@@ -436,8 +451,20 @@ namespace Velvet
                     {
                         PushHistoryEntry(path, matches);
                     }
-                    var redirectResult = await NavigateInternalAsync(
-                        redirectTarget, NavigationMode.Replace, cancellationToken, redirectCount + 1);
+                    NavigationResult redirectResult;
+                    try
+                    {
+                        redirectResult = await NavigateInternalAsync(
+                            redirectTarget, NavigationMode.Replace, cancellationToken, redirectCount + 1);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        // NavigateCore's unwind handler restores the index and Status, but this snapshot is
+                        // local to the guard check that took it, so the provisional Push is undone here.
+                        _history.Clear();
+                        _history.AddRange(historySnapshot);
+                        throw;
+                    }
                     if (redirectResult != NavigationResult.Success)
                     {
                         // On redirect failure, restore the snapshot: undoes the provisional Push (incl. its forward
@@ -511,6 +538,12 @@ namespace Velvet
 
             if (cachedLoaderData != null)
             {
+                // The else branch cancels the previous round by reaching RunLoadersSync; this one commits
+                // without ever reaching it. Leaving that round's CTS installed keeps it current for
+                // RouteLoaderRunner's supersession guard, so the round being navigated away from would write
+                // its late result into the entry restored here. Nothing downstream separates the two: RouteId
+                // is built from the route pattern, which both entries share whenever they match the same one.
+                _loaderRunner.CancelPending();
                 _loaderData = cachedLoaderData;
                 // Restore the cached errors too: a Back/Forward cache hit must re-present a route that errored
                 // on its first load (UseRouteError / ErrorElement), symmetrically with loaderData.

--- a/Packages/com.velvet.core/Runtime/Routing/Router.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/Router.cs
@@ -26,6 +26,11 @@ namespace Velvet
         // nav unwinds (NavigationResult.Cancelled) and the latest nav takes over, so concurrent
         // navigations during the blocker window resolve to the most recent one.
         private CancellationTokenSource? _activeNavigationCts;
+        // Claimed by each top-level navigation and inherited by the redirects it spawns. An attempt that has
+        // lost the claim must not put the router state back: cancelling its token does not force it to resume
+        // at that moment, so it can unwind after a newer navigation has already committed, and by then the
+        // state it saved describes a router that no longer exists.
+        private int _navigationSequence;
 
         /// <summary>
         /// The currently active <see cref="Router"/> instance, or null when none is mounted. Set when a
@@ -132,7 +137,7 @@ namespace Velvet
             string path,
             NavigationMode mode = NavigationMode.Push,
             CancellationToken cancellationToken = default) =>
-            NavigateInternalAsync(ResolvePath(path), mode, cancellationToken, redirectCount: 0);
+            NavigateInternalAsync(ResolvePath(path), mode, cancellationToken, redirectCount: 0, initiatorSequence: 0);
 
         /// <summary>
         /// Navigates with relative resolution anchored to a specific matched-route level
@@ -146,7 +151,8 @@ namespace Velvet
             NavigationMode mode,
             int baseRouteIndex,
             CancellationToken cancellationToken = default) =>
-            NavigateInternalAsync(ResolvePath(path, baseRouteIndex), mode, cancellationToken, redirectCount: 0);
+            NavigateInternalAsync(ResolvePath(path, baseRouteIndex), mode, cancellationToken, redirectCount: 0,
+                initiatorSequence: 0);
 
         /// <summary>
         /// Resolves a relative navigation target (<c>.</c>, <c>..</c>, <c>../sibling</c>, or a bare
@@ -259,12 +265,15 @@ namespace Velvet
             string? path,
             NavigationMode mode,
             CancellationToken cancellationToken,
-            int redirectCount)
+            int redirectCount,
+            int initiatorSequence)
         {
             // Concurrent-navigation handling. Recursive redirect calls (redirectCount > 0) reuse the
-            // outer navigation's CTS so a redirect doesn't cancel its own initiator.
+            // outer navigation's CTS so a redirect doesn't cancel its own initiator, and inherit its
+            // sequence so a redirect's rollback is judged by whether the INITIATOR is still current.
             CancellationTokenSource? myCts = null;
             CancellationToken navToken = cancellationToken;
+            var sequence = initiatorSequence;
             if (redirectCount == 0)
             {
                 // Cancel any in-flight navigation so it unwinds (Blocker.CheckAsync await observes
@@ -275,11 +284,14 @@ namespace Velvet
                 myCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
                 _activeNavigationCts = myCts;
                 navToken = myCts.Token;
+                // Claimed after that Cancel, so a prior navigation that does unwind synchronously inside it
+                // still sees itself as current and puts its own state back before this one reads the index.
+                sequence = ++_navigationSequence;
             }
 
             try
             {
-                return await NavigateCore(path, mode, navToken, redirectCount);
+                return await NavigateCore(path, mode, navToken, redirectCount, sequence);
             }
             catch (OperationCanceledException) when (myCts != null && myCts.IsCancellationRequested)
             {
@@ -306,7 +318,8 @@ namespace Velvet
             string? path,
             NavigationMode mode,
             CancellationToken cancellationToken,
-            int redirectCount)
+            int redirectCount,
+            int sequence)
         {
             if (redirectCount >= MaxRedirects)
             {
@@ -333,16 +346,17 @@ namespace Velvet
             }
 
             var savedHistoryIndex = ApplyProvisionalHistoryIndex(mode);
+            var provisional = new ProvisionalHistoryState(sequence, savedHistoryIndex);
 
             try
             {
-                var guardResult = await RunGuardChecks(matches, path, mode, savedHistoryIndex, cancellationToken, redirectCount);
+                var guardResult = await RunGuardChecks(matches, path, mode, provisional, cancellationToken, redirectCount);
                 if (guardResult.HasValue)
                 {
                     return guardResult.Value;
                 }
 
-                var blockerResult = await RunBlockerCheck(path, mode, savedHistoryIndex, cancellationToken);
+                var blockerResult = await RunBlockerCheck(path, mode, provisional, cancellationToken);
                 if (blockerResult.HasValue)
                 {
                     return blockerResult.Value;
@@ -360,10 +374,8 @@ namespace Velvet
                 // in-line rollbacks the returned-result paths use. The index moved before both of those
                 // awaits, and Status was set before them, so an aborted attempt would otherwise leave the
                 // history pointing somewhere the user never went and UseNavigation reporting a navigation
-                // that is no longer in flight. The provisional Push entry a redirect appended is undone in
-                // RunGuardChecks, which owns the snapshot it needs.
-                _historyIndex = savedHistoryIndex;
-                Status = RouterStatus.Idle;
+                // that is no longer in flight.
+                RollBackProvisional(provisional);
                 throw;
             }
 
@@ -377,6 +389,38 @@ namespace Velvet
         }
 
         #region Provisional history index for Back/Forward
+
+        // What one navigation attempt provisionally changed and must put back if it unwinds, together with
+        // the sequence that decides whether it still may.
+        private readonly struct ProvisionalHistoryState
+        {
+            internal readonly int Sequence;
+            internal readonly int SavedHistoryIndex;
+
+            internal ProvisionalHistoryState(int sequence, int savedHistoryIndex)
+            {
+                Sequence = sequence;
+                SavedHistoryIndex = savedHistoryIndex;
+            }
+        }
+
+        private bool StillCurrent(ProvisionalHistoryState provisional) =>
+            provisional.Sequence == _navigationSequence;
+
+        // Every index/Status rollback goes through here rather than writing the two fields directly, so no
+        // site can be added that forgets the ownership test: an attempt can resume long after a newer
+        // navigation committed — a blocker is only obliged to observe its token when it next resumes — and
+        // putting this attempt's saved index back then would describe a router that no longer exists.
+        private void RollBackProvisional(ProvisionalHistoryState provisional)
+        {
+            if (!StillCurrent(provisional))
+            {
+                return;
+            }
+
+            _historyIndex = provisional.SavedHistoryIndex;
+            Status = RouterStatus.Idle;
+        }
 
         // The index must move before the Guard/Blocker checks so a Guard redirect (Replace)
         // overwrites the correct entry; rolled back below if the Blocker check rejects the attempt.
@@ -407,10 +451,11 @@ namespace Velvet
             IReadOnlyList<RouteMatch> matches,
             string path,
             NavigationMode mode,
-            int savedHistoryIndex,
+            ProvisionalHistoryState provisional,
             CancellationToken cancellationToken,
             int redirectCount)
         {
+            var savedHistoryIndex = provisional.SavedHistoryIndex;
             foreach (var match in matches)
             {
                 if (match.Route == null) continue;
@@ -455,21 +500,30 @@ namespace Velvet
                     try
                     {
                         redirectResult = await NavigateInternalAsync(
-                            redirectTarget, NavigationMode.Replace, cancellationToken, redirectCount + 1);
+                            redirectTarget, NavigationMode.Replace, cancellationToken, redirectCount + 1,
+                            provisional.Sequence);
                     }
                     catch (OperationCanceledException)
                     {
                         // NavigateCore's unwind handler restores the index and Status, but this snapshot is
-                        // local to the guard check that took it, so the provisional Push is undone here.
-                        _history.Clear();
-                        _history.AddRange(historySnapshot);
+                        // local to the guard check that took it, so the provisional Push is undone here —
+                        // under the same ownership gate, since a snapshot taken before a newer navigation
+                        // pushed its own entries would delete them.
+                        if (StillCurrent(provisional))
+                        {
+                            _history.Clear();
+                            _history.AddRange(historySnapshot);
+                        }
                         throw;
                     }
-                    if (redirectResult != NavigationResult.Success)
+                    if (redirectResult != NavigationResult.Success && StillCurrent(provisional))
                     {
                         // On redirect failure, restore the snapshot: undoes the provisional Push (incl. its forward
                         // truncation) and the provisional Back/Forward index move (savedHistoryIndex is the
-                        // pre-move value).
+                        // pre-move value). Gated like the exceptional path above, and for the same reason: the
+                        // inner redirect can return Cancelled from its own blocker check rather than throwing,
+                        // long enough after the fact that this snapshot predates a newer navigation's entries.
+                        // Status is left as the failed redirect set it, so a NotFound target still reports so.
                         _history.Clear();
                         _history.AddRange(historySnapshot);
                         _historyIndex = savedHistoryIndex;
@@ -489,7 +543,7 @@ namespace Velvet
         private async UniTask<NavigationResult?> RunBlockerCheck(
             string path,
             NavigationMode mode,
-            int savedHistoryIndex,
+            ProvisionalHistoryState provisional,
             CancellationToken cancellationToken)
         {
             var currentPath = CurrentLocation?.Path ?? "";
@@ -505,16 +559,16 @@ namespace Velvet
             // would otherwise fall through and run the loader phase or commit a cached Back/Forward entry
             // (the cached branch below never reaches the loader-phase cancellation check). Roll back the
             // provisional Back/Forward index like the Blocked path so the aborted attempt leaves no trace.
+            // Both rollbacks go through RollBackProvisional: a blocker that awaits without forwarding the
+            // token returns here rather than throwing, and can do so after a newer navigation has committed.
             if (cancellationToken.IsCancellationRequested)
             {
-                _historyIndex = savedHistoryIndex;
-                Status = RouterStatus.Idle;
+                RollBackProvisional(provisional);
                 return NavigationResult.Cancelled;
             }
             if (blocked)
             {
-                _historyIndex = savedHistoryIndex;
-                Status = RouterStatus.Idle;
+                RollBackProvisional(provisional);
                 return NavigationResult.Blocked;
             }
             return null;
@@ -797,6 +851,10 @@ namespace Velvet
             _activeNavigationCts?.Cancel();
             _activeNavigationCts?.Dispose();
             _activeNavigationCts = null;
+            // Retire the outstanding claim after that Cancel, on the same reasoning as a newer navigation
+            // taking one: an await that resumes past this point must not write an index back or raise
+            // OnStatusChanged on a router that is gone.
+            _navigationSequence++;
             _loaderRunner.Dispose();
             if (Current == this)
             {

--- a/Packages/com.velvet.core/Runtime/Routing/Router.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/Router.cs
@@ -26,10 +26,10 @@ namespace Velvet
         // nav unwinds (NavigationResult.Cancelled) and the latest nav takes over, so concurrent
         // navigations during the blocker window resolve to the most recent one.
         private CancellationTokenSource? _activeNavigationCts;
-        // Claimed by each top-level navigation and inherited by the redirects it spawns. An attempt that has
-        // lost the claim must not put the router state back: cancelling its token does not force it to resume
-        // at that moment, so it can unwind after a newer navigation has already committed, and by then the
-        // state it saved describes a router that no longer exists.
+        // Identifies whoever currently owns _historyIndex. An attempt that has lost the claim must not put
+        // the index or Status back: cancelling its token does not force it to resume at that moment, so it
+        // can reach its rollback after a newer navigation has moved the index, and by then the value it
+        // saved describes a router that no longer exists.
         private int _navigationSequence;
 
         /// <summary>
@@ -270,10 +270,9 @@ namespace Velvet
         {
             // Concurrent-navigation handling. Recursive redirect calls (redirectCount > 0) reuse the
             // outer navigation's CTS so a redirect doesn't cancel its own initiator, and inherit its
-            // sequence so a redirect's rollback is judged by whether the INITIATOR is still current.
+            // history claim so a redirect's rollback is judged by whether the INITIATOR still holds it.
             CancellationTokenSource? myCts = null;
             CancellationToken navToken = cancellationToken;
-            var sequence = initiatorSequence;
             if (redirectCount == 0)
             {
                 // Cancel any in-flight navigation so it unwinds (Blocker.CheckAsync await observes
@@ -284,14 +283,11 @@ namespace Velvet
                 myCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
                 _activeNavigationCts = myCts;
                 navToken = myCts.Token;
-                // Claimed after that Cancel, so a prior navigation that does unwind synchronously inside it
-                // still sees itself as current and puts its own state back before this one reads the index.
-                sequence = ++_navigationSequence;
             }
 
             try
             {
-                return await NavigateCore(path, mode, navToken, redirectCount, sequence);
+                return await NavigateCore(path, mode, navToken, redirectCount, initiatorSequence);
             }
             catch (OperationCanceledException) when (myCts != null && myCts.IsCancellationRequested)
             {
@@ -319,7 +315,7 @@ namespace Velvet
             NavigationMode mode,
             CancellationToken cancellationToken,
             int redirectCount,
-            int sequence)
+            int initiatorSequence)
         {
             if (redirectCount >= MaxRedirects)
             {
@@ -346,6 +342,12 @@ namespace Velvet
             }
 
             var savedHistoryIndex = ApplyProvisionalHistoryIndex(mode);
+            // The claim is taken here, where the index is, and not when the navigation started: every return
+            // above this line leaves the index untouched, so a navigation that matches no route must not
+            // dispossess an attempt parked in a blocker — that attempt is then the only one able to put the
+            // index back. A redirect inherits its initiator's claim rather than taking one, so it does not
+            // dispossess the navigation it is part of.
+            var sequence = redirectCount == 0 ? ++_navigationSequence : initiatorSequence;
             var provisional = new ProvisionalHistoryState(sequence, savedHistoryIndex);
 
             try
@@ -407,10 +409,6 @@ namespace Velvet
         private bool StillCurrent(ProvisionalHistoryState provisional) =>
             provisional.Sequence == _navigationSequence;
 
-        // Every index/Status rollback goes through here rather than writing the two fields directly, so no
-        // site can be added that forgets the ownership test: an attempt can resume long after a newer
-        // navigation committed — a blocker is only obliged to observe its token when it next resumes — and
-        // putting this attempt's saved index back then would describe a router that no longer exists.
         private void RollBackProvisional(ProvisionalHistoryState provisional)
         {
             if (!StillCurrent(provisional))
@@ -846,15 +844,17 @@ namespace Velvet
 
         public void Dispose()
         {
+            // Retire the outstanding claim BEFORE the Cancel, which inverts the ordering a navigation uses.
+            // A navigation takes its claim afterwards so that a prior attempt unwinding synchronously inside
+            // the Cancel still restores its own state; here there is no such attempt worth restoring, and
+            // that same synchronous unwind would write an index back and raise OnStatusChanged on a router
+            // being torn down.
+            _navigationSequence++;
             // Cancel and dispose any in-flight navigation CTS so a pending Blocker await unwinds
             // cleanly during shutdown.
             _activeNavigationCts?.Cancel();
             _activeNavigationCts?.Dispose();
             _activeNavigationCts = null;
-            // Retire the outstanding claim after that Cancel, on the same reasoning as a newer navigation
-            // taking one: an await that resumes past this point must not write an index back or raise
-            // OnStatusChanged on a router that is gone.
-            _navigationSequence++;
             _loaderRunner.Dispose();
             if (Current == this)
             {

--- a/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouteLoaderRunnerTests.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouteLoaderRunnerTests.cs
@@ -20,7 +20,8 @@ namespace Velvet.Tests
     /// is also recorded per-path in <c>Errors</c> symmetrically with the Await path.</item>
     /// <item><see cref="RouteLoaderRunner.ActiveSuspendTaskCount"/> is incremented while a Suspend task is live
     /// and returned to zero in the finally block on success, failure, and honored cancellation alike.</item>
-    /// <item>The loader receives a cancelable token that <c>CancelPending</c> cancels.</item>
+    /// <item>The loader receives a cancelable token that <c>CancelPending</c> cancels, and a loader that
+    /// answers that token by succeeding rather than throwing is still treated as a torn-down round.</item>
     /// <item>An Await loader that throws records the error in <c>Errors</c> and reports <c>allCompleted</c> false.</item>
     /// </list>
     /// </summary>
@@ -235,6 +236,38 @@ namespace Velvet.Tests
 
             // Assert
             Assert.That(runner.ActiveSuspendTaskCount, Is.EqualTo(0), "A token-honoring loader unwinds and the counter returns to zero");
+        });
+
+        [UnityTest]
+        public IEnumerator Given_SuspendLoaderSucceedsOnCancellation_When_CancelPendingRuns_Then_NoCompletionIsFired()
+            => UniTask.ToCoroutine(async () =>
+        {
+            // A loader may answer its token by resolving a fallback rather than throwing, and that
+            // continuation runs inside CancelPending's own Cancel call. The live-task count is folded into
+            // the assertion because a zero firing count would otherwise also be satisfied by a loader that
+            // never ran at all.
+            // Arrange
+            var runner = new RouteLoaderRunner();
+            var tcs = new UniTaskCompletionSource<object>();
+            var fired = 0;
+            runner.OnSuspendLoaderCompleted += (_, __) => fired++;
+            var matches = MakeMatch("succeed-on-ct",
+                loader: (ctx, ct) =>
+                {
+                    ct.Register(() => tcs.TrySetResult("fallback"));
+                    return tcs.Task;
+                },
+                loaderMode: LoaderMode.Suspend);
+            runner.RunLoadersSync(matches, CancellationToken.None);
+            var liveBefore = runner.ActiveSuspendTaskCount;
+
+            // Act
+            runner.CancelPending();
+            await UniTask.Yield();
+
+            // Assert
+            Assert.That($"live={liveBefore} fired={fired}", Is.EqualTo("live=1 fired=0"),
+                "The round being torn down must not be read as the current one by its own late success");
         });
 
         #endregion

--- a/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouteTestStubs.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouteTestStubs.cs
@@ -96,6 +96,29 @@ namespace Velvet.Tests
         }
 
         /// <summary>
+        /// Creates an async Blocker whose FIRST invocation parks on <c>UniTask.Never(ct)</c> — raising
+        /// OperationCanceledException once the navigation's token is cancelled — and whose later
+        /// invocations pass through without blocking. Await the returned <c>Entered</c> to be sure the
+        /// navigation has reached the blocker await before cancelling it.
+        /// </summary>
+        public static (Func<NavigationAttempt, CancellationToken, UniTask<bool>> Check, UniTaskCompletionSource Entered) MakeOneShotBlocker()
+        {
+            var entered = new UniTaskCompletionSource();
+            int invocationCount = 0;
+            UniTask<bool> Check(NavigationAttempt _, CancellationToken ct)
+            {
+                var n = Interlocked.Increment(ref invocationCount);
+                if (n == 1)
+                {
+                    entered.TrySetResult();
+                    return UniTask.Never<bool>(ct);
+                }
+                return UniTask.FromResult(false);
+            }
+            return (Check, entered);
+        }
+
+        /// <summary>
         /// Builds a Router from <paramref name="routes"/> and synchronously navigates to
         /// <paramref name="startPath"/>. Use when a test starts from a known location; otherwise
         /// construct the Router directly.

--- a/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouteTestStubs.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouteTestStubs.cs
@@ -11,8 +11,9 @@ namespace Velvet.Tests
     /// (Blocker / Redirect / Loader / RouteTree / Router).
     /// Used to verify path matching / loader / blocker logic; not mounted into the Outlet.
     ///
-    /// Exposes factory helpers (Route / MakeMatch / Attempt / MakeToggleGuard / BuildRouter)
-    /// that eliminate boilerplate envelope construction in routing test files.
+    /// Exposes factory helpers (Route / MakeMatch / Attempt / MakeToggleGuard / MakeOneShotBlocker /
+    /// MakeDeferredBlocker / BuildRouter) that eliminate boilerplate envelope construction in
+    /// routing test files.
     /// </summary>
     internal static class RouteTestStubs
     {
@@ -116,6 +117,35 @@ namespace Velvet.Tests
                 return UniTask.FromResult(false);
             }
             return (Check, entered);
+        }
+
+        /// <summary>
+        /// Creates an async Blocker whose FIRST invocation parks on a task that ignores the navigation's
+        /// token: cancelling it does not resume the blocker, which resumes only when the caller invokes
+        /// <c>ResumeCancelled</c> (raising OperationCanceledException) or <c>ResumeUnblocked</c> (returning
+        /// "not blocked"). That separation is the point — it puts the resume after the superseding
+        /// navigation has committed, which <see cref="MakeOneShotBlocker"/> cannot do because its parked
+        /// task unwinds synchronously inside <c>Cancel()</c>, before the newer navigation proceeds.
+        /// The two resumes reach different rollbacks: throwing unwinds through the exception handlers,
+        /// while returning falls into the blocker check's own cancellation branch.
+        /// </summary>
+        public static (Func<NavigationAttempt, CancellationToken, UniTask<bool>> Check,
+            UniTaskCompletionSource Entered, Action ResumeCancelled, Action ResumeUnblocked) MakeDeferredBlocker()
+        {
+            var entered = new UniTaskCompletionSource();
+            var parked = new UniTaskCompletionSource<bool>();
+            int invocationCount = 0;
+            UniTask<bool> Check(NavigationAttempt _, CancellationToken ct)
+            {
+                var n = Interlocked.Increment(ref invocationCount);
+                if (n == 1)
+                {
+                    entered.TrySetResult();
+                    return parked.Task;
+                }
+                return UniTask.FromResult(false);
+            }
+            return (Check, entered, () => parked.TrySetCanceled(), () => parked.TrySetResult(false));
         }
 
         /// <summary>

--- a/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouterCancellationUnwindTests.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouterCancellationUnwindTests.cs
@@ -10,16 +10,17 @@ using static Velvet.Tests.RouteTestStubs;
 namespace Velvet.Tests
 {
     /// <summary>
-    /// Specifies what a cancelled navigation leaves behind when it unwinds by exception rather than by
-    /// return value. A Blocker or a Guard redirect that honors its cancellation token raises
-    /// OperationCanceledException out of an await that sits after the provisional history mutations, so
-    /// each of those mutations needs undoing on the exceptional path as well as the normal one.
+    /// Specifies what an abandoned navigation leaves behind. Its provisional history mutations happen before
+    /// the Guard and Blocker awaits, so every way of leaving those awaits has to undo them — by exception
+    /// when a blocker honors its token, and by return value when one awaits without forwarding it.
     /// <list type="bullet">
     /// <item>The provisional Back/Forward index is restored, so the history keeps describing the entry the
     /// user is still on.</item>
     /// <item>The provisional Push entry a Guard redirect appended is removed again.</item>
     /// <item><see cref="RouterStatus"/> returns to Idle, so <c>UseNavigation</c> stops reporting a pending
     /// navigation that no longer exists.</item>
+    /// <item>None of those restores happens once a newer navigation has taken over, since the state they
+    /// would put back describes a router that navigation has already replaced.</item>
     /// </list>
     /// </summary>
     [TestFixture]
@@ -127,6 +128,107 @@ namespace Velvet.Tests
             // Assert
             Assert.That(router.Status, Is.EqualTo(RouterStatus.Idle),
                 "With no navigation left in flight, UseNavigation must not keep reporting one");
+        });
+
+        [UnityTest]
+        public IEnumerator Given_SupersededBackUnwindsLate_When_NewerBackHasCommitted_Then_IndexMatchesTheCommittedLocation()
+            => UniTask.ToCoroutine(async () =>
+        {
+            // The superseded attempt saved an index describing a router that the newer navigation has since
+            // replaced, so putting that index back desyncs it from the location actually on screen.
+            // The asserted location records today's behaviour, not the intended one: both Backs land on
+            // /home because the parked attempt already moved the shared index and nothing resets it while it
+            // waits, so the second Back reads its target from the moved index and /about is skipped. That is
+            // a separate open defect; this case discriminates only the index/location desync.
+            // Arrange
+            var router = BuildRouter("/home",
+                Route("/", children: new[] { Route("home"), Route("about"), Route("contact") }));
+            await router.NavigateAsync("/about");
+            await router.NavigateAsync("/contact");
+            var (check, entered, resumeCancelled, _) = MakeDeferredBlocker();
+            using var registration = router.RouteBlockerManager.Register(check, new RouteBlockerState());
+            var superseded = router.GoBack();
+            await entered.Task;
+            await router.GoBack();
+            Assume.That(router.CurrentLocation?.Path, Is.EqualTo("/home"),
+                "Precondition: the newer Back committed while the superseded one was still parked");
+
+            // Act
+            resumeCancelled();
+            await superseded;
+
+            // Assert
+            Assert.That($"idx={router.HistoryIndex} at={router.CurrentLocation?.Path}",
+                Is.EqualTo("idx=0 at=/home"),
+                "A late unwind must not move the index away from the entry the newer navigation committed");
+        });
+
+        [UnityTest]
+        public IEnumerator Given_SupersededRedirectUnwindsLate_When_NewerNavigationHasPushed_Then_ItsHistorySurvives()
+            => UniTask.ToCoroutine(async () =>
+        {
+            // The guard snapshot was taken before the newer navigation pushed, so replaying it would delete
+            // entries that belong to the location now on screen.
+            // The asserted count records today's behaviour, not the intended one: the third entry is the
+            // provisional /guarded push, a path the user never arrived at, stranded precisely because the
+            // skipped restore is the correct choice here — a Back from /x re-runs its guard and lands on
+            // /target. Reclaiming just that entry is a separate open defect.
+            // Arrange
+            var router = BuildRouter("/home",
+                Route("/", children: new[]
+                {
+                    Route("home"),
+                    Route("guarded", guard: _ => "/target"),
+                    Route("target"),
+                    Route("x"),
+                }));
+            var (check, entered, resumeCancelled, _) = MakeDeferredBlocker();
+            using var registration = router.RouteBlockerManager.Register(check, new RouteBlockerState());
+            var superseded = router.NavigateAsync("/guarded");
+            await entered.Task;
+            await router.NavigateAsync("/x");
+            Assume.That(router.CurrentLocation?.Path, Is.EqualTo("/x"),
+                "Precondition: the newer navigation committed while the redirect was still parked");
+
+            // Act
+            resumeCancelled();
+            await superseded;
+
+            // Assert
+            Assert.That($"count={HistoryCountOf(router)} idx={router.HistoryIndex}", Is.EqualTo("count=3 idx=2"),
+                "A late unwind must not replay a snapshot that predates the newer navigation's own entries");
+        });
+
+        [UnityTest]
+        public IEnumerator Given_SupersededBlockerReturnsLate_When_NewerBackHasCommitted_Then_IndexAndStatusSurvive()
+            => UniTask.ToCoroutine(async () =>
+        {
+            // A blocker that awaits without forwarding the token returns "not blocked" instead of throwing,
+            // so the abandoned attempt reaches the blocker check's own rollback rather than the exception
+            // handlers — a separate pair of writes that needs the same ownership test.
+            // The asserted location records today's behaviour on the same open defect as the case above:
+            // both Backs land on /home because the parked attempt already moved the shared index.
+            // Arrange
+            var router = BuildRouter("/home",
+                Route("/", children: new[] { Route("home"), Route("about"), Route("settings") }));
+            await router.NavigateAsync("/about");
+            await router.NavigateAsync("/settings");
+            var (check, entered, _, resumeUnblocked) = MakeDeferredBlocker();
+            using var registration = router.RouteBlockerManager.Register(check, new RouteBlockerState());
+            var superseded = router.GoBack();
+            await entered.Task;
+            await router.GoBack();
+            Assume.That(router.CurrentLocation?.Path, Is.EqualTo("/home"),
+                "Precondition: the newer Back committed while the superseded one was still parked");
+
+            // Act
+            resumeUnblocked();
+            await superseded;
+
+            // Assert
+            Assert.That($"idx={router.HistoryIndex} status={router.Status}", Is.EqualTo("idx=0 status=Ready"),
+                "A blocker returning after it was superseded must roll back neither the index nor the Status "
+                + "the newer navigation established");
         });
 
         // The history list has no accessor of its own, and adding one would put a test-only member on a

--- a/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouterCancellationUnwindTests.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouterCancellationUnwindTests.cs
@@ -11,8 +11,9 @@ namespace Velvet.Tests
 {
     /// <summary>
     /// Specifies what an abandoned navigation leaves behind. Its provisional history mutations happen before
-    /// the Guard and Blocker awaits, so every way of leaving those awaits has to undo them — by exception
-    /// when a blocker honors its token, and by return value when one awaits without forwarding it.
+    /// the Guard and Blocker awaits, so an attempt that abandons them has to undo those mutations whether it
+    /// leaves by exception (a blocker honoring its token) or by return value (one awaiting without
+    /// forwarding it).
     /// <list type="bullet">
     /// <item>The provisional Back/Forward index is restored, so the history keeps describing the entry the
     /// user is still on.</item>
@@ -169,10 +170,10 @@ namespace Velvet.Tests
         {
             // The guard snapshot was taken before the newer navigation pushed, so replaying it would delete
             // entries that belong to the location now on screen.
-            // The asserted count records today's behaviour, not the intended one: the third entry is the
-            // provisional /guarded push, a path the user never arrived at, stranded precisely because the
-            // skipped restore is the correct choice here — a Back from /x re-runs its guard and lands on
-            // /target. Reclaiming just that entry is a separate open defect.
+            // The asserted count records today's behaviour, not the intended one: the count is 3 because the
+            // middle entry is the provisional /guarded push, a path the user never arrived at, stranded
+            // precisely because the skipped restore is the correct choice here — a Back from /x re-runs its
+            // guard and lands on /target. Reclaiming just that entry is a separate open defect.
             // Arrange
             var router = BuildRouter("/home",
                 Route("/", children: new[]
@@ -229,6 +230,97 @@ namespace Velvet.Tests
             Assert.That($"idx={router.HistoryIndex} status={router.Status}", Is.EqualTo("idx=0 status=Ready"),
                 "A blocker returning after it was superseded must roll back neither the index nor the Status "
                 + "the newer navigation established");
+        });
+
+        [UnityTest]
+        public IEnumerator Given_SupersededByAnUnmatchedPath_When_ItResumes_Then_TheIndexIsStillRestored()
+            => UniTask.ToCoroutine(async () =>
+        {
+            // A navigation that matches no route returns before the index is ever touched, so it takes no
+            // claim on it. The parked attempt is then still the only holder and must put the index back —
+            // leaving it moved would strand it away from the location the user never left.
+            // Arrange
+            var router = BuildRouter("/home",
+                Route("/", children: new[] { Route("home"), Route("about"), Route("contact") }));
+            await router.NavigateAsync("/about");
+            await router.NavigateAsync("/contact");
+            var (check, entered, resumeCancelled, _) = MakeDeferredBlocker();
+            using var registration = router.RouteBlockerManager.Register(check, new RouteBlockerState());
+            var superseded = router.GoBack();
+            await entered.Task;
+            var unmatched = await router.NavigateAsync("/no-such-route");
+            Assume.That(unmatched, Is.EqualTo(NavigationResult.NotFound),
+                "Precondition: the superseding navigation returned without reaching the history index");
+
+            // Act
+            resumeCancelled();
+            await superseded;
+
+            // Assert
+            Assert.That($"idx={router.HistoryIndex} at={router.CurrentLocation?.Path}",
+                Is.EqualTo("idx=2 at=/contact"),
+                "Only an attempt that took the index may stop the parked one from restoring it");
+        });
+
+        [UnityTest]
+        public IEnumerator Given_SupersededRedirectReturnsLate_When_NewerNavigationHasPushed_Then_ItsHistorySurvives()
+            => UniTask.ToCoroutine(async () =>
+        {
+            // The inner redirect returns Cancelled from its own blocker check instead of throwing, so the
+            // outer reaches the returned-result restore rather than the exception one. Same stale snapshot,
+            // a different line has to refuse to replay it.
+            // The asserted count records today's behaviour for the same reason as the case above.
+            // Arrange
+            var router = BuildRouter("/home",
+                Route("/", children: new[]
+                {
+                    Route("home"),
+                    Route("guarded", guard: _ => "/target"),
+                    Route("target"),
+                    Route("x"),
+                }));
+            var (check, entered, _, resumeUnblocked) = MakeDeferredBlocker();
+            using var registration = router.RouteBlockerManager.Register(check, new RouteBlockerState());
+            var superseded = router.NavigateAsync("/guarded");
+            await entered.Task;
+            await router.NavigateAsync("/x");
+            Assume.That(router.CurrentLocation?.Path, Is.EqualTo("/x"),
+                "Precondition: the newer navigation committed while the redirect was still parked");
+
+            // Act
+            resumeUnblocked();
+            await superseded;
+
+            // Assert
+            Assert.That($"count={HistoryCountOf(router)} idx={router.HistoryIndex}", Is.EqualTo("count=3 idx=2"),
+                "A redirect that returns Cancelled after being superseded must not replay its stale snapshot");
+        });
+
+        [UnityTest]
+        public IEnumerator Given_BlockerParkedAcrossDispose_When_DisposeCancelsIt_Then_TheDeadRouterIsNotWritten()
+            => UniTask.ToCoroutine(async () =>
+        {
+            // Dispose retires the claim before cancelling, the opposite order to a navigation taking one.
+            // A blocker of this shape unwinds synchronously inside that Cancel, so with the navigation
+            // ordering it would still hold the claim and write to a router that is being torn down.
+            // Arrange
+            var router = BuildRouter("/home",
+                Route("/", children: new[] { Route("home"), Route("about") }));
+            await router.NavigateAsync("/about");
+            var (check, entered) = MakeOneShotBlocker();
+            using var registration = router.RouteBlockerManager.Register(check, new RouteBlockerState());
+            var statusEvents = 0;
+            var parked = router.GoBack();
+            await entered.Task;
+            router.OnStatusChanged += _ => statusEvents++;
+
+            // Act
+            router.Dispose();
+            await parked;
+
+            // Assert
+            Assert.That($"statusEvents={statusEvents} idx={router.HistoryIndex}", Is.EqualTo("statusEvents=0 idx=0"),
+                "Teardown leaves nothing for a resuming blocker to restore, so it must write neither field");
         });
 
         // The history list has no accessor of its own, and adding one would put a test-only member on a

--- a/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouterCancellationUnwindTests.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouterCancellationUnwindTests.cs
@@ -1,0 +1,140 @@
+using System.Collections;
+using System.Reflection;
+using System.Threading;
+using Cysharp.Threading.Tasks;
+using NUnit.Framework;
+using UnityEngine.TestTools;
+using Velvet;
+using static Velvet.Tests.RouteTestStubs;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Specifies what a cancelled navigation leaves behind when it unwinds by exception rather than by
+    /// return value. A Blocker or a Guard redirect that honors its cancellation token raises
+    /// OperationCanceledException out of an await that sits after the provisional history mutations, so
+    /// each of those mutations needs undoing on the exceptional path as well as the normal one.
+    /// <list type="bullet">
+    /// <item>The provisional Back/Forward index is restored, so the history keeps describing the entry the
+    /// user is still on.</item>
+    /// <item>The provisional Push entry a Guard redirect appended is removed again.</item>
+    /// <item><see cref="RouterStatus"/> returns to Idle, so <c>UseNavigation</c> stops reporting a pending
+    /// navigation that no longer exists.</item>
+    /// </list>
+    /// </summary>
+    [TestFixture]
+    internal sealed class RouterCancellationUnwindTests
+    {
+        private RouteDefinition[] _routes;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _routes = new[]
+            {
+                Route("/", children: new[]
+                {
+                    Route("home"),
+                    Route("about"),
+                }),
+            };
+        }
+
+        // Same isolation rule as RouterTests: Router.Current is a global that each new Router() overwrites.
+        [TearDown]
+        public void TearDown()
+        {
+            Router.Current?.Dispose();
+        }
+
+        [UnityTest]
+        public IEnumerator Given_BlockerHonorsToken_When_CancelledDuringBackAwait_Then_HistoryIndexIsRestored()
+            => UniTask.ToCoroutine(async () =>
+        {
+            // Arrange
+            var router = new Router(_routes);
+            await router.NavigateAsync("/home");
+            await router.NavigateAsync("/about");
+            var (check, entered) = MakeOneShotBlocker();
+            using var registration = router.RouteBlockerManager.Register(check, new RouteBlockerState());
+            using var callerCts = new CancellationTokenSource();
+            var nav = router.GoBack(callerCts.Token);
+            await entered.Task;
+            Assume.That(router.CurrentLocation?.Path, Is.EqualTo("/about"),
+                "Precondition: the Back is still parked in the blocker and has committed nothing");
+
+            // Act
+            callerCts.Cancel();
+            await nav;
+
+            // Assert
+            Assert.That(router.HistoryIndex, Is.EqualTo(1),
+                "A cancelled Back leaves the history pointing at the entry the user never left");
+        });
+
+        [UnityTest]
+        public IEnumerator Given_GuardRedirect_When_CancelledDuringRedirectBlockerAwait_Then_ProvisionalPushIsUndone()
+            => UniTask.ToCoroutine(async () =>
+        {
+            // The redirect target's own navigation is what parks on the blocker, so the cancellation surfaces
+            // inside the await that RunGuardChecks wraps around it — past the point where the originating Push
+            // entry was appended for the redirect to overwrite.
+            // Arrange
+            var router = BuildRouter("/home",
+                Route("/", children: new[]
+                {
+                    Route("home"),
+                    Route("guarded", guard: _ => "/target"),
+                    Route("target"),
+                }));
+            var (check, entered) = MakeOneShotBlocker();
+            using var registration = router.RouteBlockerManager.Register(check, new RouteBlockerState());
+            using var callerCts = new CancellationTokenSource();
+            var nav = router.NavigateAsync("/guarded", NavigationMode.Push, callerCts.Token);
+            await entered.Task;
+
+            // Act
+            callerCts.Cancel();
+            await nav;
+
+            // Assert
+            Assert.That($"{HistoryCountOf(router)}/{router.HistoryIndex}", Is.EqualTo("1/0"),
+                "A cancelled redirect restores the history list and the index together; restoring either alone "
+                + "still leaves the stack describing a navigation that never happened");
+        });
+
+        [UnityTest]
+        public IEnumerator Given_BlockerHonorsToken_When_CancelledWithNoFollowUpNavigation_Then_StatusReturnsToIdle()
+            => UniTask.ToCoroutine(async () =>
+        {
+            // A caller-supplied token rather than a second navigation taking over: the newer navigation
+            // would commit and set Status itself, masking whether this one cleaned up after itself.
+            // Arrange
+            var router = new Router(_routes);
+            await router.NavigateAsync("/home");
+            var (check, entered) = MakeOneShotBlocker();
+            using var registration = router.RouteBlockerManager.Register(check, new RouteBlockerState());
+            using var callerCts = new CancellationTokenSource();
+            var nav = router.NavigateAsync("/about", NavigationMode.Push, callerCts.Token);
+            await entered.Task;
+            Assume.That(router.CurrentLocation?.Path, Is.EqualTo("/home"),
+                "Precondition: the cancelled navigation never commits a location");
+
+            // Act
+            callerCts.Cancel();
+            await nav;
+
+            // Assert
+            Assert.That(router.Status, Is.EqualTo(RouterStatus.Idle),
+                "With no navigation left in flight, UseNavigation must not keep reporting one");
+        });
+
+        // The history list has no accessor of its own, and adding one would put a test-only member on a
+        // production type.
+        private static int HistoryCountOf(Router router)
+        {
+            var field = typeof(Router).GetField("_history", BindingFlags.Instance | BindingFlags.NonPublic);
+            return ((ICollection)field.GetValue(router)).Count;
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouterCancellationUnwindTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouterCancellationUnwindTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 244a25e9b00294b41a5a2fa80984c94e

--- a/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouterTests.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouterTests.cs
@@ -27,7 +27,8 @@ namespace Velvet.Tests
     /// <item>A Suspend loader commits navigation immediately and resolves later; on resolution or failure the
     /// router writes the post-resolution value into the current history entry and re-emits the location with a
     /// fresh identity, but a resolution arriving after the user navigated away does not churn the current
-    /// location.</item>
+    /// location — including when the exit was a Back/Forward served from the cache, which commits without
+    /// reaching the loader runner.</item>
     /// <item><c>OnLocationChanged</c> fires once per navigation with the committed location.</item>
     /// <item>An optional <see cref="IRouteScopeFactory"/> is exposed through <c>ScopeFactory</c> and is null
     /// when not supplied.</item>
@@ -839,6 +840,43 @@ namespace Velvet.Tests
                 "A navigated-away Suspend loader's late failure does not record an error under the current location");
         });
 
+        [UnityTest]
+        public IEnumerator Given_InFlightSuspendLoader_When_BackHitsTheCache_Then_ItsLateResultIsDropped()
+            => UniTask.ToCoroutine(async () =>
+        {
+            // Leaving by Back/Forward is the one exit that can serve loader data from the history cache, and
+            // therefore the one that never reaches the loader runner. Both entries here match the same route
+            // pattern, so they share a RouteId and nothing downstream of the runner can tell the late result
+            // apart from the restored one.
+            // Arrange
+            var first = new UniTaskCompletionSource<object>();
+            var second = new UniTaskCompletionSource<object>();
+            var loaderCalls = 0;
+            var router = new Router(new[]
+            {
+                Route("/", children: new[]
+                {
+                    Route("users/:id", loaderMode: LoaderMode.Suspend,
+                        loader: (ctx, ct) => Interlocked.Increment(ref loaderCalls) == 1 ? first.Task : second.Task),
+                }),
+            });
+            router.NavigateSync("/users/1");
+            first.TrySetResult("user-1");
+            await UniTask.Yield();
+            router.NavigateSync("/users/2");
+            router.GoBackSync();
+            Assume.That(router.CurrentLocation?.Path, Is.EqualTo("/users/1"),
+                "Precondition: the Back committed the earlier entry");
+
+            // Act
+            second.TrySetResult("user-2");
+            await UniTask.Yield();
+
+            // Assert
+            Assert.That(string.Join(",", router.CurrentLoaderData.Values), Is.EqualTo("user-1"),
+                "A Back that hits the cache supersedes the round it left, so that round's late result is dropped");
+        });
+
         #endregion
 
         #region ScopeFactory
@@ -1002,26 +1040,6 @@ namespace Velvet.Tests
             Assert.That(router.CurrentLocation?.Path, Is.EqualTo("/about"),
                 "A cancelled cached Back does not commit the previous entry");
         });
-
-        // Blocker test infra: the first nav parks on UniTask.Never(ct) (raises OCE on cancellation);
-        // subsequent navs pass through without blocking. A per-invocation counter keeps the two navs from
-        // sharing TCS state.
-        private static (Func<NavigationAttempt, CancellationToken, UniTask<bool>> Check, UniTaskCompletionSource Entered) MakeOneShotBlocker()
-        {
-            var entered = new UniTaskCompletionSource();
-            int invocationCount = 0;
-            UniTask<bool> Check(NavigationAttempt _, CancellationToken ct)
-            {
-                var n = Interlocked.Increment(ref invocationCount);
-                if (n == 1)
-                {
-                    entered.TrySetResult();
-                    return UniTask.Never<bool>(ct);
-                }
-                return UniTask.FromResult(false);
-            }
-            return (Check, entered);
-        }
 
         #endregion
     }

--- a/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouterTests.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouterTests.cs
@@ -28,7 +28,7 @@ namespace Velvet.Tests
     /// router writes the post-resolution value into the current history entry and re-emits the location with a
     /// fresh identity, but a resolution arriving after the user navigated away does not churn the current
     /// location — including when the exit was a Back/Forward served from the cache, which commits without
-    /// reaching the loader runner.</item>
+    /// running the loaders.</item>
     /// <item><c>OnLocationChanged</c> fires once per navigation with the committed location.</item>
     /// <item>An optional <see cref="IRouteScopeFactory"/> is exposed through <c>ScopeFactory</c> and is null
     /// when not supplied.</item>
@@ -845,9 +845,9 @@ namespace Velvet.Tests
             => UniTask.ToCoroutine(async () =>
         {
             // Leaving by Back/Forward is the one exit that can serve loader data from the history cache, and
-            // therefore the one that never reaches the loader runner. Both entries here match the same route
-            // pattern, so they share a RouteId and nothing downstream of the runner can tell the late result
-            // apart from the restored one.
+            // therefore the one that never runs RunLoadersSync, where a previous round is superseded. Both
+            // entries here match the same route pattern, so they share a RouteId and nothing downstream of
+            // the runner can tell the late result apart from the restored one.
             // Arrange
             var first = new UniTaskCompletionSource<object>();
             var second = new UniTaskCompletionSource<object>();


### PR DESCRIPTION
Velvet's router left state behind whenever a navigation was abandoned mid-flight.

**A Back or Forward served from the loader cache never superseded the round it left.** That branch commits without running `RunLoadersSync`, which is where a previous round is superseded, so a `LoaderMode.Suspend` loader belonging to the page the user had left still counted as current and wrote its result into the entry they had gone *back* to. A route id is built from the route pattern, so nothing downstream could separate the two locations: `/users/1` re-rendered with user 2's record and cached it into history permanently.

**A Blocker or a Guard redirect that abandoned its attempt jumped over every rollback.** The blocked and superseded paths undo the provisional history move; an abandoned one did not. That left the index moved — so `CanGoBack` described a location the user was not on, and the next `Push` truncated the entry they were looking at — a provisional Push entry stranded on the stack, and `Status` pinned at `Matching`, so every component calling `UseNavigation` rendered its pending branch indefinitely with nothing in flight.

The cached branch now cancels the departing round, and each rollback runs only while the attempt still owns the history index. Ownership is claimed where the index is actually taken rather than when the navigation starts, so a navigation that matches no route cannot dispossess a blocker parked on a Back; it is inherited by redirects, so an inner attempt is judged by its initiator; and `Dispose` retires the claim before cancelling, so a blocker resuming during teardown writes nothing. `RouteLoaderRunner.CancelPending` also clears its token source before cancelling it, so a loader that answers cancellation by resolving a fallback is no longer read as the round still in force.

Three defects in the same area are deliberately left open, each filed separately:

- A history entry left before its Suspend loader resolved is cached as an empty-but-complete snapshot, and Back or Forward serves it without re-running the loader (#437).
- `ApplyProvisionalHistoryIndex` moves the shared index before the awaits, so a second navigation started while one is parked reads a polluted index (#439).
- A cancelled Guard redirect's provisional Push entry stays on the stack, because removing it is exactly what the ownership gate correctly declines to do once a newer navigation has pushed its own entries (#440).

A fourth, that a non-cancellation exception out of a guard escapes these handlers entirely, is filed as #438.

No `Documentation~` guide covers Blockers or navigation cancellation, so there is no doc impact.

Closes #389
Closes #390
Closes #391
