### PR TITLE
fix(velvet): host the passive-effect drain on the tree-stable anchor

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -42,6 +42,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   pushed. Disposing the router retires the claim the same way, so a blocker resuming after teardown no
   longer writes to it.
 
+- `UseEffect` no longer stops running across the whole tree after a subtree is removed. One scheduled
+  callback drains every pending passive effect in a mounted tree, and it used to be registered on the
+  mount point of whichever fiber staged an effect first — routinely a container inside a subtree that
+  a route change, an error-boundary fallback or a conditional render then removed before the next
+  frame. Removing that container took the callback out of the panel's scheduler, and the flag marking it
+  as already registered was never cleared, so nothing registered a replacement. From then on the frame
+  tick ran no passive effect anywhere in the tree — subscriptions did not attach, fetches did not fire
+  and cleanups did not run — until something else forced them: a click or another discrete event, which
+  flushes pending passive effects synchronously, or the removed container being rented back out of the
+  element pool and re-attached, which resumed the callback at an arbitrary later moment. The drain is now
+  registered on the root mount element, the same tree-stable host the batch scheduler already uses for
+  its own drains and for the same reason.
+
 - An exception thrown by a mutation's `onError` handler no longer changes what the mutation reports.
   Through `MutateAsync` it used to replace the mutation's own exception, so the caller awaited a
   failure and received the handler's error instead of the one the mutation function raised, and

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberBatchScheduler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberBatchScheduler.cs
@@ -104,6 +104,10 @@ namespace Velvet
         // root fiber that owns this context mounts.
         internal void SetAnchor(VisualElement anchor) => _anchor = anchor;
 
+        // Also hosts the passive-effect drain (FiberEffects.ScheduleRunEffects): that callback serves the
+        // whole context too, so it needs the same tree stability the tier drains do.
+        internal VisualElement? Anchor => _anchor;
+
         // Registers a probe reporting whether a reconcile pass is currently on the stack. Called once by the
         // owning Reconciler so FlushImmediate can block a synchronous discrete-event flush during
         // a time-sliced resume, which runs outside the batch Drain (so _draining is false)

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberEffects.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberEffects.cs
@@ -260,11 +260,19 @@ namespace Velvet
             {
                 context.PendingPassiveEffectFibers.Add(fiber);
             }
-            if (!context.PassiveEffectDrainScheduled)
-            {
-                context.PassiveEffectDrainScheduled = true;
-                fiber.MountPoint.schedule.Execute(() => DrainPassiveEffects(context));
-            }
+            if (context.PassiveEffectDrainScheduled) return;
+            // One drain serves the whole context and only that drain clears the latch below, so the
+            // registration has to sit on a host outliving any single subtree: the batch scheduler's
+            // tree-stable anchor, the same hazard SetAnchor exists for, one level out. Whichever fiber
+            // stages first is the one that registers, and that is routinely a descendant.
+            // PassiveEffectDrainHostTests fails if this moves back onto the staging fiber's MountPoint.
+            var anchor = context.BatchScheduler.Anchor;
+            // Armed only for a registration that actually happened: a context whose scheduler has no anchor
+            // must not latch a drain nothing will run. That the production mount path sets the anchor before
+            // any fiber stages — so this return is never on it — is held by PassiveEffectDrainArmingTests.
+            if (anchor == null) return;
+            context.PassiveEffectDrainScheduled = true;
+            anchor.schedule.Execute(() => DrainPassiveEffects(context));
         }
 
         // Tree-ordered, 2-phase passive (UseEffect) commit across every fiber staged in the current

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/PassiveEffectDrainArmingTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/PassiveEffectDrainArmingTests.cs
@@ -1,0 +1,48 @@
+using NUnit.Framework;
+using UnityEngine.UIElements;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins that a mount arms the context-wide passive-effect drain. The registration is declined when the
+    /// batch scheduler has no anchor yet, which keeps an anchorless context from latching a drain nothing
+    /// would run — and makes the mount path's ordering load-bearing: the anchor is set during SetupMount,
+    /// several lines before the render whose commit stages the first effect. Move that write after the
+    /// render, or drop it from the root path, and every mount-time UseEffect goes unregistered with nothing
+    /// else in the tree reporting it, so this case asserts the arming itself rather than where it landed.
+    /// </summary>
+    internal sealed class PassiveEffectDrainArmingTests
+    {
+        private VisualElement _root;
+        private MountedTree _mounted;
+
+        [SetUp]
+        public void SetUp() => _root = new VisualElement();
+
+        [TearDown]
+        public void TearDown()
+        {
+            _mounted?.Dispose();
+            _mounted = null;
+        }
+
+        [Component]
+        private static VNode EffectHost()
+        {
+            Hooks.UseEffect(() => () => { }, new object[] { "host" });
+            return V.Label(name: "host-label");
+        }
+
+        [Test]
+        public void Given_AComponentWithAPassiveEffect_When_ItMountsThroughVMount_Then_TheContextWideDrainIsAlreadyRegistered()
+        {
+            // Arrange — nothing beyond the mount target; the mount itself is the act.
+
+            // Act
+            _mounted = V.Mount(_root, V.Component(EffectHost, key: "host"));
+
+            // Assert — no flush in between, so this reads the state the mount left behind.
+            Assert.That(_mounted.Root.Reconciler.Context.PassiveEffectDrainScheduled, Is.True);
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/PassiveEffectDrainArmingTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/PassiveEffectDrainArmingTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7c534349174e445a78a48ffe4b8ababc

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/PassiveEffectDrainHostTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/PassiveEffectDrainHostTests.cs
@@ -1,0 +1,104 @@
+using NUnit.Framework;
+using UnityEngine.UIElements;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins which element hosts the context-wide passive-effect drain. One scheduled callback serves the
+    /// whole context, and the fiber that stages first is the one that registers it — routinely a descendant,
+    /// since an outer component without UseEffect stages after the nested one that has it. Hosted on that
+    /// fiber's own mount point, the callback stops being delivered as soon as its subtree leaves the panel,
+    /// while the context latch stays set and blocks any replacement, so the scheduler stops running passive
+    /// effects for the whole context rather than only for the removed subtree. Driven through the real panel
+    /// scheduler: FlushEffectsForTest calls the drain directly and so cannot observe where it was registered.
+    /// </summary>
+    internal sealed class PassiveEffectDrainHostTests
+    {
+        private HeadlessEditorPanelHost _host;
+        private MountedTree _mounted;
+
+        private static StateUpdater<bool> s_setShowTransient;
+        private static bool s_survivorEffectRan;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _host = new HeadlessEditorPanelHost();
+            s_setShowTransient = default;
+            s_survivorEffectRan = false;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _mounted?.Dispose();
+            _mounted = null;
+            _host?.Dispose();
+            _host = null;
+        }
+
+        // Rendered ahead of the surviving branch so this fiber stages the mount's first passive effect and
+        // is therefore the one that registers the drain; its mount point is the wrapper removed with it.
+        [Component]
+        private static VNode Transient()
+        {
+            Hooks.UseEffect(() => () => { }, new object[] { "transient" });
+            return V.Label(name: "transient-label");
+        }
+
+        [Component]
+        private static VNode Survivor()
+        {
+            Hooks.UseEffect(() =>
+            {
+                s_survivorEffectRan = true;
+                return () => { };
+            }, new object[] { "survivor" });
+            return V.Label(name: "survivor-label");
+        }
+
+        // Both branches carry a key so dropping the transient one detaches the wrapper this case holds a
+        // reference to; the positional path would instead patch that wrapper into the surviving branch and
+        // detach the trailing element, leaving the reference on-panel and the case asserting nothing.
+        [Component]
+        private static VNode Host()
+        {
+            var (showTransient, setShowTransient) = Hooks.UseState(true);
+            s_setShowTransient = setShowTransient;
+            return V.Div(name: "host", children: new VNode?[]
+            {
+                showTransient
+                    ? V.Div(
+                        key: "transient",
+                        name: "transient-wrapper",
+                        children: new VNode?[] { V.Component(Transient, key: "t") })
+                    : null,
+                V.Div(
+                    key: "survivor",
+                    name: "survivor-wrapper",
+                    children: new VNode?[] { V.Component(Survivor, key: "s") }),
+            });
+        }
+
+        [Test]
+        public void Given_TheFirstStagingFibersSubtreeDetachesBeforeTheTick_When_ThePanelSchedulerTicks_Then_ASurvivingFibersPassiveEffectRuns()
+        {
+            // Arrange — mount on a real panel, then drop the transient branch synchronously, before any
+            // tick has had the chance to run a passive effect.
+            _mounted = V.Mount(_host.Root, V.Component(Host, key: "host"));
+            var transientWrapper = _host.Root.Q<VisualElement>("transient-wrapper");
+            s_setShowTransient.Invoke(false);
+            _mounted.GetSchedulerForTest().DrainImmediateForTest();
+
+            // Act
+            EditorPanelTestHelpers.DriveSchedulerOnce(_host.Panel);
+
+            // Assert — the detach is asserted with the effect rather than assumed: a reconcile that left the
+            // wrapper attached would not have exercised the detach, and the effect would run either way.
+            Assert.That(
+                (transientWrapperAttached: transientWrapper.panel != null, survivorEffectRan: s_survivorEffectRan),
+                Is.EqualTo((transientWrapperAttached: false, survivorEffectRan: true)));
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/PassiveEffectDrainHostTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/PassiveEffectDrainHostTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: da9407d7d3a7e46ce8dd5a6473e5a704


### PR DESCRIPTION
One drain serves a whole reconciler context, and it was registered on whichever fiber happened to stage passive effects first in a batch — routinely a container inside a freshly mounted subtree, since an inline-mounted descendant stages before the root fiber does.

When that subtree went away before the scheduler tick — a route swap, a closed panel, a mount-then-remove within one frame, an error-boundary or Suspense fallback — the callback stopped being delivered, and `PassiveEffectDrainScheduled` was never cleared, because its only reset is the first line of `DrainPassiveEffects`. Every later `ScheduleRunEffects` in that context then queued its fiber and took the early skip, so nothing re-registered. No `UseEffect` anywhere in the tree ran again: subscriptions never attached, fetches never fired, cleanups never ran. A discrete event — a click, a value change — flushed them synchronously and cleared the latch, so the stall lasted until the user happened to touch a control. It could also end by luck: the removed container is pooled, and renting it back out re-attached it and resumed the callback, committing the whole context's queued effects at an arbitrary later moment.

The drain now registers on `FiberBatchScheduler`'s tree-stable anchor — the element `SetAnchor` already exists to provide, and which `FiberRenderer` and `UseFrameDispatcher` use against this same hazard. `FiberEffects` was the one drain registration still hosted on a per-fiber element.

Two tests hold it. `PassiveEffectDrainHostTests` drives the real panel scheduler and fails if the registration moves back onto the staging fiber's mount point; the existing passive-effect fixtures could not see this, because they reach the drain through `FlushPendingPassiveEffects` and never involve `schedule.Execute` at all. `PassiveEffectDrainArmingTests` pins that the drain is armed at all by the time `V.Mount` returns, which fails if `SetAnchor` stops running before the first render.

No API change and no `Documentation~` guide change: the public contract for `UseEffect` is what this restores rather than something it alters, and no guide describes where the drain is hosted.

Closes #387
