### PR TITLE
fix(velvet): let a variant reach the font and text-effect resolvers

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `font-<family>` and the text-transform / text-decoration / `whitespace-pre-line` / `leading-*`
+  utilities now take effect behind a variant. `dark:font-mono`, `md:font-display`,
+  `hover:uppercase`, `md:dark:hover:underline` and `md:leading-loose` all changed nothing before:
+  both families are realised from the class array Velvet last reconciled, and a variant writes its
+  payload onto the element's live class list instead, so the resolver never saw it — and neither
+  family has a USS rule the bare class could fall back on, which made the failure silent. Both are
+  now re-derived on a variant toggle exactly as the layout and paint utilities already were, at
+  mount and in both directions. For a child that a `[&>*]:` container rule reaches, both stand down
+  at mount instead: the only class array available there is the child's live list, which cannot see
+  that child's own `font-[…]` / `leading-[…]`, and both resolvers rewrite unconditionally — so such a
+  rule leaves the child's own font and line height alone rather than resolving over them.
+
+  `font-<weight>` and `italic` behind a variant were only partly working, through the coarse
+  `-unity-font-style` fallback in the bundled stylesheet; they now go through the resolver and get
+  the full weight scale and a weight-specific Font Asset.
+
+  An arbitrary `font-[…]` or `leading-[…]` payload behind a variant also no longer leaves its raw
+  bracket token sitting on the USS class list while the variant is lit — the reconciled path already
+  kept those two families off it.
+
 - A Back or Forward navigation served from the history's loader cache now cancels the loaders still in
   flight from the round it left. That branch commits without running `RunLoadersSync`, which is where a
   previous round is superseded, so a `LoaderMode.Suspend` loader belonging to the page the user navigated

--- a/Packages/com.velvet.core/Documentation~/styling-variants.md
+++ b/Packages/com.velvet.core/Documentation~/styling-variants.md
@@ -13,9 +13,9 @@ list; the reconciler routes each one to a **manipulator** that toggles the paylo
 as the matching signal changes.
 
 A payload may also be one of the utilities Velvet realises itself rather than through a USS rule.
-Those need re-deriving when the variant toggles, and nearly all of them get it — see
-[Payloads Velvet realises itself](#payloads-velvet-realises-itself) for the one family that does not
-and for the class channels that are not variants at all.
+Those need re-deriving when the variant toggles — see
+[Payloads Velvet realises itself](#payloads-velvet-realises-itself) for the ones that get it and for
+the class channels that are not variants at all.
 
 A payload occupies one slot per `(priority, token)` pair. Declaring the same token literally and
 behind a variant is therefore safe — in `gap-4 md:gap-4` the `md:` payload turning off leaves the
@@ -234,13 +234,18 @@ payload, since `md:shadow-lg` is a variant token and `shadow-lg` is what it reso
 utilities have to be re-derived when the variant toggles.
 
 **Re-derived, so the variant behaves exactly like a literal class.** The manipulator-backed layout
-utilities — `gap-*` / `space-*`, `grid` / `grid-cols-*`, `divide-*`, `text-balance` — and the
+utilities — `gap-*` / `space-*`, `grid` / `grid-cols-*`, `divide-*`, `text-balance`; the
 wrapper-less paints — `skew-*`, `shadow-*` / `drop-shadow-*`, gradients (`bg-gradient-*` and its
 `from-` / `via-` / `to-` stops), `animate-*`, `border-dashed` / `border-dotted`, and `ring-*` /
-`outline-*`. Each resolves at mount and on every toggle in both directions, and the order they compose
-in is preserved on a toggle just as on a render — so `className="gap-4 md:grid md:grid-cols-3"` is a
+`outline-*`; the inline font layer — `font-<family>`, `font-<weight>`, `italic` / `not-italic` and the
+`font-[…]` forms; and the axes Velvet writes into the displayed string — `uppercase` / `lowercase` /
+`capitalize` / `normal-case`, `underline` / `line-through` / `overline` / `no-underline`,
+`whitespace-pre-line`, `leading-*`. Each resolves at mount and on every toggle in both directions, and
+the order they compose in is preserved on a toggle just as on a render — so
+`className="gap-4 md:grid md:grid-cols-3"` is a
 gapped flex row below `md` and a three-column grid (spaced by the grid, which owns its gap) from `md`
-up, `className="bg-white shadow-sm md:shadow-lg"` deepens its shadow from `md` up, and
+up, `className="bg-white shadow-sm md:shadow-lg"` deepens its shadow from `md` up,
+`className="font-sans dark:font-mono"` swaps the family with the theme, and
 `className="focus:ring-2"` shows a ring while focused and none otherwise.
 
 **Where `ring-*` deviates from CSS.** UI Toolkit has neither `box-shadow` nor `outline`, so Velvet
@@ -340,6 +345,16 @@ declares a variant-gated payload **of its own** — any one, `hover:gap-4` is en
 recorded at create and `[&>*]:shadow-lg` paints at mount; if it declares none, the same class paints
 only from that child's next render. Do not lean on either outcome. Put the utility on the child, or
 behind a variant the child declares itself.
+
+The font layer and the string axes fail it differently again. A paint that cannot resolve does not
+paint; these two resolve a whole family out of a class array and rewrite the element from it, so they
+would resolve *something*. The only array a container-driven child has of its own is its live class
+list, and a `font-[…]` or `leading-[…]` the child declared is deliberately kept off it — the resolver
+owns those — while the class channels above put utilities on it the child never declared. So both
+stand down there rather than replace what the child's own render got right with nothing left to put
+it back: `[&>*]:uppercase` over a `leading-[24px]` label leaves the label alone. What a later render
+of the child then delivers is not the same for the two, so lean on neither and put these on the
+child.
 
 ## Container queries — `@container`
 

--- a/Packages/com.velvet.core/PublicAPI.txt
+++ b/Packages/com.velvet.core/PublicAPI.txt
@@ -381,6 +381,7 @@ method Velvet.StyleClassNames.Class(System.String[]): System.String
 method Velvet.StyleClassNames.When(System.Boolean, System.String): System.String
 method Velvet.StyleFontClass.HasFontClass(System.String[]): System.Boolean
 method Velvet.StyleFontClass.IsArbitraryFontClass(System.String): System.Boolean
+method Velvet.StyleFontClass.IsFontToken(System.String): System.Boolean
 method Velvet.StyleFontClass.TryExtract(System.String[], Velvet.FontIntent&): System.Boolean
 method Velvet.StyleFontResolver.Apply(UnityEngine.UIElements.VisualElement, System.String[]): System.Void
 method Velvet.StyleFontResolver.ApplyIfPresent(UnityEngine.UIElements.VisualElement, System.String[]): System.Void

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodeFactory.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodeFactory.cs
@@ -127,7 +127,7 @@ namespace Velvet
             // attribute store from the props and evaluate, so a data-[..]/aria-[..] variant lights from
             // the element's carried attribute values at mount.
             _patcher.ApplyAttributes(element, elementNode.Props);
-            StyleFontResolver.ApplyIfPresent(element, elementNode.ClassNames);
+            _patcher.ApplyFontLayerOnCreate(element, elementNode.ClassNames);
             // After ReconcileChildren so the gap / divide manipulators see the final child list.
             // [&>*]: runs before gap / divide / grid so those win a shared child edge (see
             // ApplyPostChildrenClassPasses for the same ordering on the patch path).
@@ -142,7 +142,7 @@ namespace Velvet
             _patcher.ApplyHasVariantManipulators(element);
             // text-transform / -decoration cascade: after children are placed so it can reach descendant
             // text leaves, and after the element's own text is set so it transforms the final value.
-            StyleTextEffectResolver.Apply(_ctx, element, elementNode.ClassNames);
+            _patcher.ApplyTextEffects(element, elementNode.ClassNames);
 
             // The paint layers read a class source that also carries what the passes above have already
             // written onto the live class list, so a payload ALREADY LIT at this point paints from the
@@ -285,7 +285,7 @@ namespace Velvet
             _patcher.ApplyVariantManipulators(element, appliedClasses);
             _patcher.ApplyAttributes(element, motionNode.Props);
             ApplyOptionalCreateBindings(element, motionNode.Props, appliedClasses);
-            StyleFontResolver.ApplyIfPresent(element, appliedClasses);
+            _patcher.ApplyFontLayerOnCreate(element, appliedClasses);
             _patcher.ApplyChildVariantManipulator(element, appliedClasses);
             _patcher.ApplyLayoutManipulators(element, appliedClasses);
             _patcher.ApplyStructuralVariants(element);
@@ -487,7 +487,7 @@ namespace Velvet
             // ScrollView's direct children are the height spacer + absolutely-positioned visible
             // container, not the list items, so gap-* would have nothing meaningful to space.
             _patcher.ApplyVariantManipulators(scrollView, virtualListNode.ClassNames);
-            StyleFontResolver.ApplyIfPresent(scrollView, virtualListNode.ClassNames);
+            _patcher.ApplyFontLayerOnCreate(scrollView, virtualListNode.ClassNames);
             return scrollView;
         }
 

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
@@ -276,7 +276,7 @@ namespace Velvet
                 ApplyVariantManipulators(element, newClasses);
                 // Font family / weight / italic are resolved together (so font-bold + italic compose)
                 // and written as inline style that overrides the USS fallback classes.
-                StyleFontResolver.ApplyOnClassChange(element, oldClasses, newClasses);
+                ApplyFontLayer(element, oldClasses, newClasses);
             }
         }
 
@@ -389,7 +389,7 @@ namespace Velvet
             ApplyStructuralVariants(element);
             ApplyHasClassVariants(element);
             ApplyHasVariantManipulators(element);
-            StyleTextEffectResolver.Apply(_ctx, element, newClassNames);
+            ApplyTextEffects(element, newClassNames);
             var resolved = ResolveVariantClasses(element, oldClassNames, newClassNames, paintTail,
                 out var classesChanged);
             // canReleaseFace: a reconcile pass may let the silhouette stashes release, because this same
@@ -2695,7 +2695,21 @@ namespace Velvet
         // Resolves its own class source rather than taking the one the paint passes use: those resolve after
         // the structural / has- passes (see ApplyPostChildrenClassPasses), and gap has to run before them.
         internal void ApplyLayoutManipulators(VisualElement element, string[] classNames)
-            => ApplyResolvedLayoutManipulators(element, ResolveLayoutClasses(element, classNames));
+            => ApplyResolvedLayoutManipulators(element, ResolveGateClasses(element, classNames));
+
+        // The composed source (see ResolveGateClasses) rather than the reconciled array: the bare class
+        // `dark:font-mono` puts on the live list carries no rule of its own, so nothing but this resolver
+        // realises the payload. TypographyHasNoStylesheetRuleTests fails if a sheet ever declares one.
+        internal void ApplyFontLayer(VisualElement element, string[] oldClassNames, string[] newClassNames)
+            => StyleFontResolver.ApplyOnClassChange(element, oldClassNames,
+                ResolveGateClasses(element, newClassNames));
+
+        internal void ApplyFontLayerOnCreate(VisualElement element, string[] classNames)
+            => StyleFontResolver.ApplyIfPresent(element, ResolveGateClasses(element, classNames));
+
+        // Same rule as ApplyFontLayer, over the same guard's other half.
+        internal void ApplyTextEffects(VisualElement element, string[] classNames)
+            => StyleTextEffectResolver.Apply(_ctx, element, ResolveGateClasses(element, classNames));
 
         // Re-runs every class-driven pass a variant payload can change, for an element a variant just
         // toggled a gate token on (wired to ReconcilerContext.VariantGatedReSync). Runs the same bodies the
@@ -2708,23 +2722,41 @@ namespace Velvet
             // The array the element's own reconcile pass last applied, or none when no pass ever recorded
             // one: the trigger was a width payload, which gates nothing and so never earns an entry, or the
             // payload came from a [&>*]: rule on the PARENT, whose children are fully created before it runs.
-            // The live list stands in for the layout gates in both cases — every token those four families
-            // parse is a plain USS class — while the paint sequence stands down, since PaintTail is unknown
-            // and a Motion must not be given a silhouette.
+            // The live list stands in for the layout gates in both cases, while the paint sequence stands
+            // down, since PaintTail is unknown and a Motion must not be given a silhouette.
             // That makes a [&>*]: paint land inconsistently, which is the cost of not guessing: a child that
             // declares ANY gated payload of its own was recorded at create, so the parent's payload finds
             // PaintTail set and paints at mount, while a child that declares none paints only from its next
             // patch. Recording how a child is driven before its parent's rules run would close it.
             var reconciled = state?.Reconciled;
+            var previous = state?.Resolved;
             var resolved = reconciled == null
                 ? LiveClasses(element)
                 : ComposeVariantClasses(reconciled, state!.Tokens, state.Resolved);
-            var classesChanged = !ReferenceEquals(state?.Resolved, resolved);
+            var classesChanged = !ReferenceEquals(previous, resolved);
             if (state != null)
             {
                 state.Resolved = resolved;
             }
+            // Font and text effects run only from a RECORDED array, never from the live-list stand-in the
+            // layout gates accept above. Both resolvers rewrite unconditionally, and the live list is not a
+            // narrower version of their source but a different one: the reconciler keeps a DECLARED font-[…]
+            // / leading-[…] off it, since those two are resolver-owned, and the channels that raise no
+            // signal (whileHoverClass and its siblings) put utilities on it that no reconcile ever saw.
+            // Handing it over would not lose the payload, it would resolve some other answer over the
+            // element's correct one with nothing left to put it back.
+            // Their order is the reconcile path's own (SyncClassDrivenStyling ahead of
+            // ApplyPostChildrenClassPasses), so a re-sync cannot resolve a pass against a different
+            // predecessor than a patch would.
+            if (reconciled != null)
+            {
+                StyleFontResolver.ApplyOnClassChange(element, previous ?? resolved, resolved);
+            }
             ApplyResolvedLayoutManipulators(element, resolved);
+            if (reconciled != null)
+            {
+                StyleTextEffectResolver.Apply(_ctx, element, resolved);
+            }
             var paintTail = state?.PaintTail;
             if (paintTail == null)
             {
@@ -2851,11 +2883,12 @@ namespace Velvet
         internal string[] ResolveVariantClassesOnCreate(VisualElement element, string[] classNames, bool paintTail)
             => ResolveVariantClasses(element, classNames, classNames, paintTail, out _);
 
-        // The same source for the four layout gates, which resolve at their own point in the sequence (see
-        // ApplyLayoutManipulators). It reads the cached array but does not REPLACE it: the paint resolve a few
+        // The same source for the gates that resolve at their own point in the sequence — the four layout
+        // manipulators (ApplyLayoutManipulators), the font layer (ApplyFontLayer) and the text-effect cascade
+        // (ApplyTextEffects). It reads the cached array but does not REPLACE it: the paint resolve a few
         // passes later answers "did the classes change" by comparing against that same record, and advancing it
         // here would swallow a payload one of the has- / attribute passes in between had just toggled.
-        private string[] ResolveLayoutClasses(VisualElement element, string[] classNames)
+        private string[] ResolveGateClasses(VisualElement element, string[] classNames)
             => _ctx.VariantGateClasses.Count == 0
                 || !_ctx.VariantGateClasses.TryGetValue(element, out var state)
                 || state.Tokens.Count == 0

--- a/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
@@ -502,9 +502,8 @@ namespace Velvet
         public Dictionary<VisualElement, StyleTextBalanceManipulator> TextBalanceManipulators { get; } = new();
 
         // Elements a VARIANT currently has a gate token toggled onto, keyed by that element. A gate token is
-        // one whose mere presence in a class array decides what a class-driven pass builds — the four layout
-        // manipulators (gap-* / space-* / grid / grid-cols-* / divide-* / text-balance) and the five paint
-        // layers (skew-*, shadow-*, bg-gradient-* and its stops, animate-*, border-dashed / -dotted). Those
+        // one whose mere presence in a class array decides what a class-driven pass builds; the families are
+        // enumerated once, in StyleVariantPayload.IsVariantGateToken. Those
         // passes are configured from the RECONCILED class array, which never carries such a token: `md:grid`
         // is a variant token, and the bare `grid` it resolves to is written straight onto the live class list
         // by the conditional manipulator without passing back through the reconciler. An entry here marks the

--- a/Packages/com.velvet.core/Runtime/Styling/StyleFontClass.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleFontClass.cs
@@ -80,7 +80,7 @@ namespace Velvet
 
             foreach (var cls in classNames)
             {
-                if (IsFontClass(cls))
+                if (IsFontToken(cls))
                 {
                     return true;
                 }
@@ -89,7 +89,16 @@ namespace Velvet
             return false;
         }
 
-        private static bool IsFontClass(string cls)
+        /// <summary>
+        /// Whether <paramref name="cls"/> can change what <see cref="TryExtract"/> builds. Both readers ask
+        /// it as a cheap over-approximation and pay only a wasted resolve for a false positive — the
+        /// presence gate below decides whether to run the resolver at all, and
+        /// <c>StyleVariantPayload.IsVariantGateToken</c> decides whether to track a payload for it. Reading
+        /// the <c>font-</c> prefix rather than the parse is what keeps it on the cheap side of that trade:
+        /// a suffix <see cref="TryExtract"/> goes on to reject still enters, where a spelling this failed to
+        /// recognise would cost the payload its effect.
+        /// </summary>
+        public static bool IsFontToken(string cls)
         {
             if (string.IsNullOrEmpty(cls))
             {

--- a/Packages/com.velvet.core/Runtime/Styling/StyleTextEffectClass.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleTextEffectClass.cs
@@ -157,49 +157,19 @@ namespace Velvet
         // Overline.
         public static TextEffect Parse(string[] classNames)
         {
-            TextTransformKind? transform = null;
-            TextDecorationKind? decoration = null;
-            WhitespaceCollapseKind? whitespace = null;
-            LeadingValue? leading = null;
             if (classNames == null)
             {
                 return default;
             }
-            var sawExplicitWhitespaceClass = false;
+            var facets = default(TextEffectFacets);
             foreach (var cls in classNames)
             {
-                switch (cls)
-                {
-                    case "uppercase": transform = TextTransformKind.Upper; break;
-                    case "lowercase": transform = TextTransformKind.Lower; break;
-                    case "capitalize": transform = TextTransformKind.Capitalize; break;
-                    case "normal-case": transform = TextTransformKind.None; break;
-                    case "underline": decoration = TextDecorationKind.Underline; break;
-                    case "line-through": decoration = TextDecorationKind.LineThrough; break;
-                    case "overline": decoration = TextDecorationKind.Overline; break;
-                    case "no-underline": decoration = TextDecorationKind.None; break;
-                    case "whitespace-pre-line": whitespace = WhitespaceCollapseKind.PreLine; break;
-                    case "whitespace-normal":
-                    case "whitespace-nowrap":
-                    case "whitespace-pre":
-                    case "whitespace-pre-wrap":
-                        sawExplicitWhitespaceClass = true;
-                        break;
-                    default:
-                        if (s_leadingPresets.TryGetValue(cls, out var em))
-                        {
-                            leading = new LeadingValue(LeadingUnit.Em, em);
-                        }
-                        else if (TryParseLeadingBracket(cls, out var px))
-                        {
-                            leading = new LeadingValue(LeadingUnit.Pixel, px);
-                        }
-                        break;
-                }
+                ParseToken(cls, ref facets);
             }
+            var whitespace = facets.Whitespace;
             // An explicit whitespace-{normal,nowrap,pre,pre-wrap} class on the SAME element always wins over
             // that element's own whitespace-pre-line token, regardless of which appears earlier/later in the
-            // class list — order-dependent "last wins" (the rule every other case above uses) is not a
+            // class list — order-dependent "last wins" (the rule every other case in ParseToken uses) is not a
             // meaningful concept across two independently-authored utility families, so the choice is made
             // unconditionally instead. This is the least-surprising option: pre-line mutates the displayed
             // string, so a reader who also reached for a direct, single-purpose whitespace-* class most
@@ -208,11 +178,67 @@ namespace Velvet
             // pre-line request from a FARTHER ancestor from still reaching this element through the normal
             // cascade — the same explicit-reset semantics normal-case / no-underline already give
             // Transform/Decoration.
-            if (sawExplicitWhitespaceClass)
+            if (facets.SawExplicitWhitespaceClass)
             {
                 whitespace = WhitespaceCollapseKind.None;
             }
-            return new TextEffect(transform, decoration, whitespace, leading);
+            return new TextEffect(facets.Transform, facets.Decoration, whitespace, facets.Leading);
+        }
+
+        // The four axes plus the cross-family marker Parse folds a class array into, bundled so the
+        // per-token step can be shared with IsTextEffectToken. Mirrors StyleFontClass.FontFacets.
+        private struct TextEffectFacets
+        {
+            public TextTransformKind? Transform;
+            public TextDecorationKind? Decoration;
+            public WhitespaceCollapseKind? Whitespace;
+            public LeadingValue? Leading;
+            public bool SawExplicitWhitespaceClass;
+        }
+
+        // Returns true when cls was recognised as a text-effect utility (and folded into facets).
+        private static bool ParseToken(string cls, ref TextEffectFacets facets)
+        {
+            switch (cls)
+            {
+                case null:
+                case "": return false;
+                case "uppercase": facets.Transform = TextTransformKind.Upper; return true;
+                case "lowercase": facets.Transform = TextTransformKind.Lower; return true;
+                case "capitalize": facets.Transform = TextTransformKind.Capitalize; return true;
+                case "normal-case": facets.Transform = TextTransformKind.None; return true;
+                case "underline": facets.Decoration = TextDecorationKind.Underline; return true;
+                case "line-through": facets.Decoration = TextDecorationKind.LineThrough; return true;
+                case "overline": facets.Decoration = TextDecorationKind.Overline; return true;
+                case "no-underline": facets.Decoration = TextDecorationKind.None; return true;
+                case "whitespace-pre-line": facets.Whitespace = WhitespaceCollapseKind.PreLine; return true;
+                case "whitespace-normal":
+                case "whitespace-nowrap":
+                case "whitespace-pre":
+                case "whitespace-pre-wrap":
+                    facets.SawExplicitWhitespaceClass = true;
+                    return true;
+            }
+            if (s_leadingPresets.TryGetValue(cls, out var em))
+            {
+                facets.Leading = new LeadingValue(LeadingUnit.Em, em);
+                return true;
+            }
+            if (TryParseLeadingBracket(cls, out var px))
+            {
+                facets.Leading = new LeadingValue(LeadingUnit.Pixel, px);
+                return true;
+            }
+            return false;
+        }
+
+        // Whether a variant payload spelling cls can change what Parse builds, which is what puts the token
+        // in the class source this family resolves from (StyleVariantPayload.IsVariantGateToken). Shares
+        // ParseToken with Parse itself so the two cannot answer differently about one token.
+        public static bool IsTextEffectToken(string cls)
+        {
+            var facets = default(TextEffectFacets);
+            return ParseToken(cls, ref facets);
         }
 
         // True when cls is the leading-[...] arbitrary bracket form, regardless of whether its value parses.

--- a/Packages/com.velvet.core/Runtime/Styling/StyleVariantPayload.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleVariantPayload.cs
@@ -134,6 +134,16 @@ namespace Velvet
                 return (false, false);
             }
 
+            // font-[…] / leading-[…]: no arbitrary property claims either prefix, so both fall past the
+            // branch above, and their own resolvers read them back out of the composed class source instead.
+            // Tracked but never projected, so the variant path leaves no bracket token on the USS class list
+            // — the same exclusion the reconciled path applies at FiberNodePatcher.IsManipulatorOwnedClass.
+            if (StyleFontClass.IsArbitraryFontClass(core)
+                || StyleTextEffectClass.IsArbitraryLeadingClass(core))
+            {
+                return (TrackVariantGate(ctx, target, core, effectivePriority, declaration, on), false);
+            }
+
             // The off-toggle of a filter-[name:args] payload whose name was unregistered while the layer was
             // active — the shared clear resolves the name syntactically and removes the mirrored class (see
             // TryClearUnregisteredFilterToken).
@@ -199,9 +209,11 @@ namespace Velvet
                 && ctx.TrackVariantGateClass(target, core, priority, declaration, on);
 
         // The utility tokens whose mere PRESENCE in a class array decides what a class-driven pass builds:
-        // the four layout manipulators (FiberNodePatcher.ApplyLayoutManipulators) and the six wrapper-less
-        // paint layers (FiberNodePatcher.ApplyResolvedClassPasses). Each family answers for its own prefix
-        // set so this gate cannot drift from the array scans those passes run.
+        // the four layout manipulators (FiberNodePatcher.ApplyLayoutManipulators), the six wrapper-less
+        // paint layers (FiberNodePatcher.ApplyResolvedClassPasses), the inline font layer
+        // (FiberNodePatcher.ApplyFontLayer) and the text-effect cascade (FiberNodePatcher.ApplyTextEffects).
+        // Each family answers for its own prefix set so this gate cannot drift from the array scans those
+        // passes run.
         //
         // Deliberately NOT the same set as the re-sync trigger: entering this one also routes the element
         // to the composed class source on every later patch, which costs an array per patch, and that is
@@ -217,6 +229,8 @@ namespace Velvet
                 || StyleGradientClass.IsGradientClass(core)
                 || StyleAnimateClass.IsAnimateClass(core)
                 || StyleBorderStyleClass.IsBorderStyleClass(core)
-                || StyleRingClass.IsRingClass(core);
+                || StyleRingClass.IsRingClass(core)
+                || StyleFontClass.IsFontToken(core)
+                || StyleTextEffectClass.IsTextEffectToken(core);
     }
 }

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/VariantGatedTypographyPassTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/VariantGatedTypographyPassTests.cs
@@ -1,0 +1,386 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TextCore.Text;
+using UnityEngine.UIElements;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Behavioural regression coverage for the two families Velvet realises from a class ARRAY rather than
+    /// from USS — the inline font layer (<see cref="StyleFontResolver"/>) and the text-transform /
+    /// -decoration / whitespace-pre-line / leading cascade (<c>StyleTextEffectResolver</c>) — when the class
+    /// that drives one arrives through a <b>variant</b>. A payload is written onto the element's live class
+    /// list by its manipulator; neither <c>font-&lt;family&gt;</c> nor any text-effect class has a USS rule
+    /// behind it, so a resolver reading only the reconciled array leaves <c>dark:font-mono</c> and
+    /// <c>dark:underline</c> as silent no-ops.
+    /// </summary>
+    /// <remarks>
+    /// Each case asserts the write the resolver actually makes — the resolved Font Asset, the rich-text tag
+    /// wrapped around the displayed string — rather than class membership, which is true whether or not the
+    /// resolver ever ran. <c>dark:</c> needs no panel: the conditional manipulator subscribes to
+    /// <see cref="VelvetTheme"/>'s theme signal when it attaches and evaluates it off-panel. Both edges go
+    /// into one comparison wherever an element that never resolved at all would satisfy the post-toggle half
+    /// on its own. GWT, one assert per case.
+    /// </remarks>
+    [TestFixture]
+    internal sealed class VariantGatedTypographyThemeTests
+    {
+        private FontAsset _mono;
+        private FontAsset _sans;
+
+        [SetUp]
+        public void SetUp()
+        {
+            VelvetFonts.Clear();
+            _mono = ScriptableObject.CreateInstance<FontAsset>();
+            _sans = ScriptableObject.CreateInstance<FontAsset>();
+            VelvetFonts.Register(new VelvetFontFamily("mono",
+                new VelvetFontWeightEntry { weight = VelvetFontWeight.Normal, upright = _mono }));
+            VelvetFonts.Register(new VelvetFontFamily("sans",
+                new VelvetFontWeightEntry { weight = VelvetFontWeight.Normal, upright = _sans }));
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            VelvetTheme.IsDark = false;
+            VelvetFonts.Clear();
+            UnityEngine.Object.DestroyImmediate(_mono);
+            UnityEngine.Object.DestroyImmediate(_sans);
+        }
+
+        private static VisualElement Mount(ReconcilerScope scope, VNode node)
+        {
+            scope.Reconciler.Reconcile(scope.Root, Array.Empty<VNode>(), new[] { node });
+            return scope.Root.Q<VisualElement>("card");
+        }
+
+        private bool ResolvesToMono(VisualElement element) =>
+            ReferenceEquals(element.style.unityFontDefinition.value.fontAsset, _mono);
+
+        [Test]
+        public void Given_ADarkGatedFontFamily_When_TheThemeTurnsDark_Then_TheRegisteredAssetIsApplied()
+        {
+            // Arrange — the family axis is written only as inline style, so the bare `font-mono` the variant
+            // puts on the class list resolves nothing on its own.
+            using var scope = new ReconcilerScope();
+            var card = Mount(scope, V.Label(className: "dark:font-mono", text: "Docs", name: "card"));
+            var appliedWhileLight = ResolvesToMono(card);
+
+            // Act
+            VelvetTheme.IsDark = true;
+
+            // Assert
+            Assert.That((appliedWhileLight, ResolvesToMono(card)), Is.EqualTo((false, true)));
+        }
+
+        [Test]
+        public void Given_ADarkGatedFontFamilyApplied_When_TheThemeTurnsLight_Then_TheAssetIsCleared()
+        {
+            // Arrange
+            using var scope = new ReconcilerScope();
+            var card = Mount(scope, V.Label(className: "dark:font-mono", text: "Docs", name: "card"));
+            VelvetTheme.IsDark = true;
+            var appliedWhileDark = ResolvesToMono(card);
+
+            // Act
+            VelvetTheme.IsDark = false;
+
+            // Assert — an element whose font never resolved at all would satisfy the light half alone.
+            Assert.That((appliedWhileDark, ResolvesToMono(card)), Is.EqualTo((true, false)));
+        }
+
+        [Test]
+        public void Given_ALitDarkGatedFontFamily_When_AnUnrelatedClassPatches_Then_TheAssetSurvives()
+        {
+            // Arrange — a re-render brings the reconciled array back, and that array spells the payload only
+            // as `dark:font-mono`. The literal `font-sans` alongside it is what makes the difference visible:
+            // it opens the resolver's own gate, so a patch resolving from the reconciled array alone answers
+            // `sans` and reverts the element while the theme is still dark.
+            using var scope = new ReconcilerScope();
+            var first = new VNode[]
+                { V.Label(className: "font-sans dark:font-mono p-2", text: "Docs", name: "card") };
+            scope.Reconciler.Reconcile(scope.Root, Array.Empty<VNode>(), first);
+            var card = scope.Root.Q<VisualElement>("card");
+            VelvetTheme.IsDark = true;
+            var appliedBeforePatch = ResolvesToMono(card);
+            var second = new VNode[]
+                { V.Label(className: "font-sans dark:font-mono p-4", text: "Docs", name: "card") };
+
+            // Act
+            scope.Reconciler.Reconcile(scope.Root, first, second);
+
+            // Assert — an element whose font never resolved would satisfy neither half, so both are read.
+            Assert.That((appliedBeforePatch, ResolvesToMono(card)), Is.EqualTo((true, true)));
+        }
+
+        [Test]
+        public void Given_ADarkGatedArbitraryFontFamily_When_TheThemeTurnsDark_Then_NoBracketTokenIsLeftOnTheClassList()
+        {
+            // Arrange — the reconciled path keeps a font-[…] token off the USS class list because the
+            // resolver owns it; the variant path has to reach the same two outcomes from its own toggle.
+            using var scope = new ReconcilerScope();
+            var card = Mount(scope, V.Label(className: "dark:font-[mono]", text: "Docs", name: "card"));
+
+            // Act
+            VelvetTheme.IsDark = true;
+
+            // Assert — the payload resolved AND left no dead class behind; a token that merely landed on the
+            // class list would fail the first half, and one that vanished entirely would fail the second.
+            Assert.That((card.ClassListContains("font-[mono]"), ResolvesToMono(card)),
+                Is.EqualTo((false, true)));
+        }
+
+        [Test]
+        public void Given_ADarkGatedUnderline_When_TheThemeTurnsDark_Then_TheTextIsWrappedInTheUnderlineTag()
+        {
+            // Arrange — no bundled stylesheet carries an `underline` rule, so the displayed string is the
+            // only place the decoration can show up.
+            using var scope = new ReconcilerScope();
+            var card = (Label)Mount(scope, V.Label(className: "dark:underline", text: "Docs", name: "card"));
+            var textWhileLight = card.text;
+
+            // Act
+            VelvetTheme.IsDark = true;
+
+            // Assert
+            Assert.That((textWhileLight, card.text), Is.EqualTo(("Docs", "<u>Docs</u>")));
+        }
+
+        [Test]
+        public void Given_ADarkGatedUnderlineApplied_When_TheThemeTurnsLight_Then_TheTagIsRemoved()
+        {
+            // Arrange
+            using var scope = new ReconcilerScope();
+            var card = (Label)Mount(scope, V.Label(className: "dark:underline", text: "Docs", name: "card"));
+            VelvetTheme.IsDark = true;
+            var textWhileDark = card.text;
+
+            // Act
+            VelvetTheme.IsDark = false;
+
+            // Assert — a label that never got the tag would satisfy the light half alone.
+            Assert.That((textWhileDark, card.text), Is.EqualTo(("<u>Docs</u>", "Docs")));
+        }
+
+        [Test]
+        public void Given_ALitDarkGatedUppercase_When_AnUnrelatedClassPatches_Then_TheTransformSurvives()
+        {
+            // Arrange — the patch re-parses the element's own effect; from the reconciled array alone that
+            // parse comes back empty and the pass then re-walks the leaf to undo the transform.
+            using var scope = new ReconcilerScope();
+            var first = new VNode[] { V.Label(className: "dark:uppercase p-2", text: "Docs", name: "card") };
+            scope.Reconciler.Reconcile(scope.Root, Array.Empty<VNode>(), first);
+            var card = scope.Root.Q<Label>("card");
+            VelvetTheme.IsDark = true;
+            var textBeforePatch = card.text;
+            var second = new VNode[] { V.Label(className: "dark:uppercase p-4", text: "Docs", name: "card") };
+
+            // Act
+            scope.Reconciler.Reconcile(scope.Root, first, second);
+
+            // Assert
+            Assert.That((textBeforePatch, card.text), Is.EqualTo(("DOCS", "DOCS")));
+        }
+
+        [Test]
+        public void Given_AHasClassGatedUppercase_When_TheElementMounts_Then_TheDescendantTextIsTransformed()
+        {
+            // Arrange — the matching descendant is present from the first render, so the has- pass lights the
+            // payload while the element is still being created. Nothing re-runs the cascade afterwards, so a
+            // create pass reading the reconciled array alone would leave the leaf untransformed for good.
+            using var scope = new ReconcilerScope();
+
+            // Act
+            scope.Reconciler.Reconcile(scope.Root, Array.Empty<VNode>(),
+                new VNode[]
+                {
+                    V.Div(className: "has-[.flag]:uppercase", name: "card",
+                        children: new VNode[] { V.Div("flag"), V.Text("Docs") })
+                });
+
+            // Assert
+            Assert.That(scope.Root.Q<VisualElement>("card").Q<Label>().text, Is.EqualTo("DOCS"));
+        }
+
+        [Test]
+        public void Given_AChildCombinatorPayloadOverABracketFont_When_ItLands_Then_TheChildKeepsItsFamily()
+        {
+            // Arrange — a [&>*]: payload lands on a child the container's own pass has already finished
+            // building, so the re-sync it raises has no reconciled array for that child and would have to
+            // stand the live class list in. That list cannot hold `font-[mono]` (the resolver owns the
+            // bracket forms), so resolving the font from it answers "no family" and overwrites one the
+            // child's own create pass got right, with no later pass to put it back.
+            using var scope = new ReconcilerScope();
+
+            // Act
+            scope.Reconciler.Reconcile(scope.Root, Array.Empty<VNode>(),
+                new VNode[]
+                {
+                    V.Div(className: "[&>*]:uppercase", children: new VNode[]
+                    {
+                        V.Label(className: "font-[mono] font-bold", text: "Docs", name: "card"),
+                    }),
+                });
+
+            // Assert — the payload reaching the child at all is what makes this an arrangement rather than
+            // a decoration, so it rides along.
+            var card = scope.Root.Q<VisualElement>("card");
+            Assert.That((card.ClassListContains("uppercase"), ResolvesToMono(card)),
+                Is.EqualTo((true, true)));
+        }
+
+        [Test]
+        public void Given_AChildCombinatorPayloadOverABracketLeading_When_ItLands_Then_TheChildKeepsItsTag()
+        {
+            // Arrange — the same incomplete source on the text side, and it needs no second token: the live
+            // class list holds neither `leading-[24px]` nor anything else this family parses, so a resolve
+            // from it drops the element's own effect and re-walks the leaf to strip the tag.
+            using var scope = new ReconcilerScope();
+
+            // Act
+            scope.Reconciler.Reconcile(scope.Root, Array.Empty<VNode>(),
+                new VNode[]
+                {
+                    V.Div(className: "[&>*]:gap-2", children: new VNode[]
+                    {
+                        V.Label(className: "leading-[24px]", text: "Docs", name: "card"),
+                    }),
+                });
+
+            // Assert
+            var card = scope.Root.Q<Label>("card");
+            Assert.That((card.ClassListContains("gap-2"), card.text),
+                Is.EqualTo((true, "<line-height=24px>Docs</line-height>")));
+        }
+
+        [Test]
+        public void Given_AHoverChannelClassOnTheLiveList_When_AWidthPayloadReSyncs_Then_TheTextIsUntouched()
+        {
+            // Arrange — whileHoverClass writes straight onto the live class list and raises no signal, so
+            // nothing would ever undo an effect derived from it. A width payload re-syncs an element that
+            // declares no gate payload at all, which is the same no-recorded-array path a [&>*]: rule takes
+            // — and here the live list is not merely missing tokens but carrying one the element never
+            // declared.
+            using var scope = new ReconcilerScope();
+            var card = (Label)Mount(scope,
+                V.Label(className: "dark:w-64", whileHoverClass: "uppercase", text: "Docs", name: "card"));
+            using (var over = PointerOverEvent.GetPooled())
+            {
+                card.SimulateEvent(over);
+            }
+
+            // Act
+            VelvetTheme.IsDark = true;
+
+            // Assert — the channel's class being live is what the case is about, so it rides along; a
+            // transform taken from it would be baked into the string for the element's remaining life.
+            Assert.That((card.ClassListContains("uppercase"), card.text), Is.EqualTo((true, "Docs")));
+        }
+    }
+
+    /// <summary>
+    /// The same contract driven by a real breakpoint crossing rather than a theme flip. A responsive payload
+    /// is applied by the conditional manipulator when the resolved scope width crosses the breakpoint, which
+    /// only a real panel can produce — so this runs inside a live <see cref="UnityEditor.EditorWindow"/>
+    /// panel (via <see cref="PanelTestBase"/>), forces the layout pass so <c>resolvedStyle.width</c>
+    /// resolves, then delivers a <see cref="GeometryChangedEvent"/> so the manipulator re-evaluates.
+    /// </summary>
+    [TestFixture]
+    internal sealed class VariantGatedTypographyPanelTests : PanelTestBase
+    {
+        private const float MdBreakpoint = 768f;
+        private const float WidePanel = 1000f;
+
+        [Test]
+        public void Given_AResponsiveUnderline_When_TheRootIsWiderThanMd_Then_TheTextIsWrappedInTheUnderlineTag()
+        {
+            // Arrange
+            _window.position = new Rect(0, 0, WidePanel, 600);
+            _mounted = V.Mount(_window.rootVisualElement,
+                V.Label(className: "md:underline", text: "Docs", name: "card"));
+            var card = _window.rootVisualElement.Q<Label>("card");
+
+            // Act — resolve the breakpoint against the panel and let the manipulator re-read the width.
+            ForcePanelUpdate(card.panel);
+            using (var evt = EventBase<GeometryChangedEvent>.GetPooled())
+            {
+                card.panel.visualTree.SimulateEvent(evt);
+            }
+
+            // Assert — the resolved width rides along, so a panel that never reached the breakpoint fails
+            // here rather than reporting inconclusive.
+            Assert.That(
+                (card.panel.visualTree.resolvedStyle.width >= MdBreakpoint, card.text),
+                Is.EqualTo((true, "<u>Docs</u>")));
+        }
+    }
+
+    /// <summary>
+    /// Pins the stylesheet absence the two resolvers above are built on: a variant realises its payload by
+    /// putting the bare utility on the live class list, and for these families that class has no rule behind
+    /// it, which is why the reconciler routes the payload back to a resolver instead. A sheet that started
+    /// declaring one of them would make the bare class meaningful and change that reasoning, silently —
+    /// so it is read out of the derived table rather than asserted in a comment.
+    /// </summary>
+    /// <remarks>
+    /// <c>StyleUtilityProperties</c> is generated from <c>Runtime/Styles/*.uss</c> and pinned against them
+    /// by the generator suite's own census, so a claim about the table is a claim about the sheets.
+    /// </remarks>
+    [TestFixture]
+    internal sealed class TypographyHasNoStylesheetRuleTests
+    {
+        // The weight scale and the italic alias are the only font- rules _typography.uss carries; a family
+        // needs a real Font Asset, so it can only be an inline write.
+        private static readonly string[] DeclaredFontClasses =
+        {
+            "font-thin", "font-extralight", "font-light", "font-normal", "font-medium",
+            "font-semibold", "font-bold", "font-extrabold", "font-black", "font-italic",
+        };
+
+        // Every class StyleTextEffectClass.Parse folds into a non-whitespace axis, plus the one whitespace
+        // value it realises itself. The other four whitespace classes ARE USS rules and are left out.
+        private static readonly string[] StringAxisClasses =
+        {
+            "uppercase", "lowercase", "capitalize", "normal-case",
+            "underline", "line-through", "overline", "no-underline",
+            "whitespace-pre-line",
+            "leading-none", "leading-tight", "leading-snug", "leading-normal", "leading-relaxed",
+            "leading-loose",
+        };
+
+        [Test]
+        public void Given_TheDerivedUtilityTable_When_ItsFontRulesAreListed_Then_NoFamilyIsAmongThem()
+        {
+            // Arrange
+            var byClassName = (Dictionary<string, int>)typeof(StyleUtilityProperties)
+                .GetField("ByClassName", BindingFlags.NonPublic | BindingFlags.Static)!
+                .GetValue(null)!;
+
+            // Act — anything font-prefixed that is not the weight scale or the italic alias is a family.
+            var families = byClassName.Keys
+                .Where(name => name.StartsWith("font-", StringComparison.Ordinal))
+                .Where(name => Array.IndexOf(DeclaredFontClasses, name) < 0)
+                .OrderBy(name => name, StringComparer.Ordinal);
+
+            // Assert — joined rather than compared as a collection, so a mismatch names the offender.
+            Assert.That(string.Join(" ", families), Is.Empty);
+        }
+
+        [Test]
+        public void Given_TheDerivedUtilityTable_When_TheStringAxisClassesAreLookedUp_Then_NoneIsDeclared()
+        {
+            // Arrange / Act
+            var declared = StringAxisClasses
+                .Where(name => StyleUtilityProperties.TryGet(name, out _));
+
+            // Assert
+            Assert.That(string.Join(" ", declared), Is.Empty);
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/VariantGatedTypographyPassTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/VariantGatedTypographyPassTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: dba993d7b78c4448081b153a69159b5a


### PR DESCRIPTION
Two style families are realised from C# rather than from a stylesheet, and both resolved from the **reconciled** class array while a variant writes its payload onto the **live** class list. So the payload never reached the resolver, and the class the variant did write was inert, because neither family has a USS rule to fall back on.

`V.Label(className: "md:dark:hover:underline", text: "Docs")` — the literal example in `styling-variants.md` — rendered plain text under every combination of theme, width and hover. So did `hover:uppercase`, `dark:line-through`, `md:leading-loose`, `focus:overline`. `dark:font-mono`, `md:font-display` and `hover:font-[addr:JP]` changed nothing. No warning, no diagnostic.

`font-<weight>` behind a variant survived by accident, because `_typography.uss` carries a coarse `-unity-font-style` rule for the weight scale and none for any family — which made the family case failing while the weight case appeared to work read as arbitrary rather than as a bug.

Both families now join the mechanism the ten existing gate-token families already use, rather than gaining a parallel path: `IsVariantGateToken` recognises them, so a toggled payload is tracked, enters the composed class source, and raises a re-sync. `StyleTextEffectClass.Parse`'s per-token switch is extracted so the recogniser and the parser share one body and cannot drift apart.

Two details the mechanism needed:

- A `font-[…]` or `leading-[…]` payload is tracked without being projected onto the live class list, matching how the reconciled path already treats a declared one. That covers `leading-[…]` as well as fonts.
- The re-sync resolves these two families only when a reconciled array was recorded. Both resolvers rewrite unconditionally, so the live-class-list stand-in the layout gates use would not make them skip a payload it cannot carry — it would make them resolve a different answer over a correct one. The layout gates keep that stand-in, because every token they parse does reach the live list.

Three gaps in the same area are left open and filed separately: `V.Motion` applies no text-effect cascade at create (#453), so a literal `uppercase` on a Motion waits for a first patch that may never come; a child reached only by a parent's `[&>*]:` rule stands down at mount, and what a later render delivers differs between the font layer and the string axes (#454); and the analyzer's stable-slot list is unguarded (#452), unrelated but adjacent.

`styling-variants.md` gains the font layer and the four text axes, and loses a stale hedge that was written about `ring-*` before ring was fixed and never named these families. `fonts.md` is deliberately unchanged: it lists `font-<family>` as shipped and makes no claim about variants, and variant behaviour is owned by the other guide.

Closes #392
Closes #394
