### PR TITLE
fix(velvet): align three routing hook declarations with what they do

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -66,6 +66,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   React does — the success state is dispatched after the handler runs, so a handler that throws never
   reaches it.
 
+- `Hooks.UseBlocker` now has a single-argument overload, and calling it without a dependency array
+  re-registers the predicate on every render. Because deps were declared `params`, omitting them used
+  to bind an *empty* array rather than the null that means "re-register every render", and an empty
+  array compares equal to itself on every subsequent render. The blocker therefore kept the predicate
+  closure the mount render created, and answered forever with the state that render had captured: the
+  idiomatic `Hooks.UseBlocker(attempt => isDirty)` never fired an unsaved-changes prompt, or, if the
+  first render had `isDirty` true, blocked every departure permanently. Nothing reported it — the VEL100
+  exhaustive-deps analyzer skips a call with no deps argument, correctly for the sibling hooks whose
+  omitted form is already safe. `UseCallback`, `UseMemo` and `UseImperativeHandle` carry the same
+  deps-less overload for the same reason, and `UseEffect`, `UseLayoutEffect` and `UseInsertionEffect`
+  reach the same place through an optional `deps = null` parameter. The deps-taking overloads now also
+  accept a null array without a nullable warning; that is `UseMemo`'s annotation, not its behaviour —
+  `UseBlocker` guards on `deps != null` and re-registers, where `UseMemo` and `UseCallback` compare a
+  null against a null, find them equal and freeze.
+
+- `Hooks.UseLocation()` is declared `RouterLocation?`. Its documentation already said it returns null
+  with no router mounted, and Velvet's own `RouteNavLink` already reads it that way, but the
+  declaration promised non-null, so `Hooks.UseLocation().Path` compiled without a warning in a
+  nullable-enabled assembly and threw `NullReferenceException`. The documentation now also names a
+  second case it had left out: a mounted router returns null until it publishes its first location,
+  which is the state `Samples~/StarterApp` starts in, seeding the location context from
+  `Router.CurrentLocation` before the first navigation. The sibling router hooks `UseMatch`,
+  `UseOutletContext`, `UseLoaderData` and `UseRouteError` were already annotated nullable.
+
+  The read path underneath is unchanged and still hands a null past a non-null declaration:
+  `Hooks.UseContext<T>` returns `T` while `ComponentContext<T>.DefaultValue` is `T?`, so
+  `Hooks.UseContext(RouterContext.Location).Path` still compiles clean and throws with no router
+  above it.
+
+- `ISearchParams.Get` is declared `string?`, matching the null it documents for an absent key and the
+  `SearchParams` implementation that returns it. `Hooks.UseSearchParams()` hands back the interface,
+  so the interface declaration is the one a consumer reads: `searchParams.Get("id").Length` compiled
+  without a warning and threw for any query string lacking the key. The mismatch was also raising
+  CS8766 in the package's own build.
+
 ## [2.0.0] - 2026-08-02
 
 ### Highlights

--- a/Packages/com.velvet.core/Generators~/tests/Velvet.SourceGenerators.Tests/GeneratorTestHelper.cs
+++ b/Packages/com.velvet.core/Generators~/tests/Velvet.SourceGenerators.Tests/GeneratorTestHelper.cs
@@ -113,7 +113,12 @@ namespace Velvet
         public static T UseMemo<T>(global::System.Func<T> factory) => factory();
         public static T UseMemo<T>(global::System.Func<T> factory, params object[] deps) => factory();
         public static global::Velvet.RouteBlockerState UseBlocker(
+            global::System.Func<global::Velvet.NavigationAttempt, bool> shouldBlock) => null;
+        public static global::Velvet.RouteBlockerState UseBlocker(
             global::System.Func<global::Velvet.NavigationAttempt, bool> shouldBlock, params object[] deps) => null;
+        public static global::Velvet.RouteBlockerState UseBlocker(
+            global::System.Func<global::Velvet.NavigationAttempt, global::System.Threading.CancellationToken,
+                global::Cysharp.Threading.Tasks.UniTask<bool>> shouldBlock) => null;
         public static global::Velvet.RouteBlockerState UseBlocker(
             global::System.Func<global::Velvet.NavigationAttempt, global::System.Threading.CancellationToken,
                 global::Cysharp.Threading.Tasks.UniTask<bool>> shouldBlock, params object[] deps) => null;

--- a/Packages/com.velvet.core/PublicAPI.txt
+++ b/Packages/com.velvet.core/PublicAPI.txt
@@ -272,7 +272,9 @@ method Velvet.Hooks.ForwardedRef`1(): Velvet.Ref`1[T]
 method Velvet.Hooks.StoreMemoizedVNode(System.Int32, System.Object[], Velvet.VNode): System.Void
 method Velvet.Hooks.TryGetMemoizedVNode(System.Object[], System.Int32&, Velvet.VNode&): System.Boolean
 method Velvet.Hooks.UseAnimationSequence(System.Collections.Generic.IReadOnlyList`1[Velvet.AnimationSequenceStep], System.Boolean, System.Boolean, System.Object[]): System.ValueTuple`2[Velvet.AnimationSequenceState, Velvet.AnimationSequenceControls]
+method Velvet.Hooks.UseBlocker(System.Func`2[Velvet.NavigationAttempt, System.Boolean]): Velvet.RouteBlockerState
 method Velvet.Hooks.UseBlocker(System.Func`2[Velvet.NavigationAttempt, System.Boolean], System.Object[]): Velvet.RouteBlockerState
+method Velvet.Hooks.UseBlocker(System.Func`3[Velvet.NavigationAttempt, System.Threading.CancellationToken, Cysharp.Threading.Tasks.UniTask`1[System.Boolean]]): Velvet.RouteBlockerState
 method Velvet.Hooks.UseBlocker(System.Func`3[Velvet.NavigationAttempt, System.Threading.CancellationToken, Cysharp.Threading.Tasks.UniTask`1[System.Boolean]], System.Object[]): Velvet.RouteBlockerState
 method Velvet.Hooks.UseCallback`1(T): T
 method Velvet.Hooks.UseCallback`1(T, System.Object[]): T

--- a/Packages/com.velvet.core/Runtime/Hooks/Hooks.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Hooks.cs
@@ -451,13 +451,33 @@ namespace Velvet
         #region UseBlocker
 
         /// <summary>
-        /// Conditionally blocks navigation departures (synchronous variant).
+        /// Conditionally blocks navigation departures (synchronous variant), re-registering the predicate on
+        /// every render so it answers with the state the latest render captured.
+        /// Must be used inside Render() only.
+        /// </summary>
+        /// <remarks>
+        /// The single-argument overload exists so that omitting deps is unambiguous — see
+        /// <see cref="UseCallback{T}(T)"/> for the hazard it avoids.
+        /// </remarks>
+        /// <param name="shouldBlock">Predicate delegate; returning true blocks the departure.</param>
+        /// <returns>The shared <see cref="RouteBlockerState"/> handle for inspecting / resolving the pending departure.</returns>
+        public static RouteBlockerState UseBlocker(Func<NavigationAttempt, bool> shouldBlock)
+        {
+            if (shouldBlock == null) throw new ArgumentNullException(nameof(shouldBlock));
+            return UseBlockerCore(
+                (router, state) => router.RouteBlockerManager.Register(shouldBlock, state),
+                null);
+        }
+
+        /// <summary>
+        /// Conditionally blocks navigation departures (synchronous variant), re-registering the predicate
+        /// only when a dependency changes.
         /// Must be used inside Render() only.
         /// </summary>
         /// <param name="shouldBlock">Predicate delegate; returning true blocks the departure.</param>
         /// <param name="deps">Dependency array. When null, re-registers on every render.</param>
         /// <returns>The shared <see cref="RouteBlockerState"/> handle for inspecting / resolving the pending departure.</returns>
-        public static RouteBlockerState UseBlocker(Func<NavigationAttempt, bool> shouldBlock, params object?[] deps)
+        public static RouteBlockerState UseBlocker(Func<NavigationAttempt, bool> shouldBlock, params object?[]? deps)
         {
             if (shouldBlock == null) throw new ArgumentNullException(nameof(shouldBlock));
             return UseBlockerCore(
@@ -466,13 +486,33 @@ namespace Velvet
         }
 
         /// <summary>
-        /// Conditionally blocks navigation departures (asynchronous variant). Use when integrating with
+        /// Conditionally blocks navigation departures (asynchronous variant), re-registering the predicate on
+        /// every render so it answers with the state the latest render captured. Use when integrating with
         /// asynchronous UI such as confirmation dialogs.
+        /// </summary>
+        /// <remarks>
+        /// The single-argument overload exists so that omitting deps is unambiguous — see
+        /// <see cref="UseCallback{T}(T)"/> for the hazard it avoids.
+        /// </remarks>
+        /// <param name="shouldBlock">Async predicate; returning true blocks the departure. The CancellationToken is cancelled on unmount.</param>
+        /// <returns>The shared <see cref="RouteBlockerState"/> handle for inspecting / resolving the pending departure.</returns>
+        public static RouteBlockerState UseBlocker(Func<NavigationAttempt, CancellationToken, UniTask<bool>> shouldBlock)
+        {
+            if (shouldBlock == null) throw new ArgumentNullException(nameof(shouldBlock));
+            return UseBlockerCore(
+                (router, state) => router.RouteBlockerManager.Register(shouldBlock, state),
+                null);
+        }
+
+        /// <summary>
+        /// Conditionally blocks navigation departures (asynchronous variant), re-registering the predicate
+        /// only when a dependency changes. Use when integrating with asynchronous UI such as confirmation
+        /// dialogs.
         /// </summary>
         /// <param name="shouldBlock">Async predicate; returning true blocks the departure. The CancellationToken is cancelled on unmount.</param>
         /// <param name="deps">Dependency array. When null, re-registers on every render.</param>
         /// <returns>The shared <see cref="RouteBlockerState"/> handle for inspecting / resolving the pending departure.</returns>
-        public static RouteBlockerState UseBlocker(Func<NavigationAttempt, CancellationToken, UniTask<bool>> shouldBlock, params object?[] deps)
+        public static RouteBlockerState UseBlocker(Func<NavigationAttempt, CancellationToken, UniTask<bool>> shouldBlock, params object?[]? deps)
         {
             if (shouldBlock == null) throw new ArgumentNullException(nameof(shouldBlock));
             return UseBlockerCore(
@@ -480,7 +520,7 @@ namespace Velvet
                 deps);
         }
 
-        private static RouteBlockerState UseBlockerCore(Func<Router, RouteBlockerState, IDisposable> registerFn, object?[] deps)
+        private static RouteBlockerState UseBlockerCore(Func<Router, RouteBlockerState, IDisposable> registerFn, object?[]? deps)
         {
             var fiber = Resolve("UseBlocker");
 
@@ -530,9 +570,10 @@ namespace Velvet
 
         /// <summary>
         /// Returns the current router location.
-        /// Reads <see cref="RouterContext.Location"/>; returns null when no router is mounted.
+        /// Reads <see cref="RouterContext.Location"/>; returns null when no router is mounted, and until a
+        /// mounted router publishes its first location.
         /// </summary>
-        public static RouterLocation UseLocation()
+        public static RouterLocation? UseLocation()
         {
             _ = Resolve("UseLocation");
             return UseContext(RouterContext.Location);

--- a/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/RouterHooksTests.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/RouterHooksTests.cs
@@ -6,6 +6,7 @@ using NUnit.Framework;
 using UnityEngine.UIElements;
 
 using Velvet;
+using Velvet.TestUtilities;
 
 namespace Velvet.Tests
 {
@@ -17,6 +18,8 @@ namespace Velvet.Tests
     /// context default: a null location, and therefore an empty parameter dictionary.</item>
     /// <item>When a <see cref="RouterContext.Location"/> Provider supplies a location, a descendant component
     /// observes that exact location and its route parameters.</item>
+    /// <item><see cref="Hooks.UseLocation"/> declares that null return, while <see cref="Hooks.UseParams"/>
+    /// declares the empty dictionary it substitutes instead.</item>
     /// </list>
     /// </summary>
     /// <remarks>
@@ -123,6 +126,33 @@ namespace Velvet.Tests
 
             // Assert
             Assert.That(LocationCapture.LastLocation, Is.SameAs(location), "The descendant observes the exact provided location instance");
+        }
+
+        #endregion
+
+        #region Declared nullability
+
+        [Test]
+        public void Given_RouterContextHooks_When_ReturnAnnotationsRead_Then_UseLocationIsNullableAndUseParamsIsNot()
+        {
+            // Arrange
+            var useLocation = typeof(Hooks).GetMethod(nameof(Hooks.UseLocation), Type.EmptyTypes)!;
+            var useParams = typeof(Hooks).GetMethod(nameof(Hooks.UseParams), Type.EmptyTypes)!;
+
+            // Act
+            var annotations = (
+                location: NullableAnnotationProbe.ReturnAnnotation(useLocation),
+                parameters: NullableAnnotationProbe.ReturnAnnotation(useParams));
+
+            // Assert
+            Assert.That(
+                annotations,
+                Is.EqualTo((
+                    NullableAnnotationProbe.Annotation.Nullable,
+                    NullableAnnotationProbe.Annotation.NotNullable)),
+                "UseLocation hands back the context default with no Provider above the caller, so its "
+                + "declaration must admit null; UseParams substitutes an empty dictionary and is the control "
+                + "showing the probe separates the two states");
         }
 
         #endregion

--- a/Packages/com.velvet.core/Runtime/Routing/SearchParams.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/SearchParams.cs
@@ -63,7 +63,7 @@ namespace Velvet
         bool Has(string key);
 
         /// <summary>Returns the first value for a key, or <c>null</c> when the key is absent.</summary>
-        string Get(string key);
+        string? Get(string key);
 
         /// <summary>Returns every value for a key in insertion order, or an empty list when absent.</summary>
         IReadOnlyList<string> GetAll(string key);

--- a/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/BlockerTests.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/BlockerTests.cs
@@ -26,6 +26,9 @@ namespace Velvet.Tests
     /// <item>A re-attempt after being blocked resets the prior block and navigates.</item>
     /// <item><c>UseBlocker</c> registers the committed predicate at settle and survives a render-phase re-run
     /// without registering a discarded attempt's transient predicate.</item>
+    /// <item><c>UseBlocker</c> called without a deps argument re-registers every render, so the predicate
+    /// answers with the state it captured on the render that registered it — on both the synchronous and
+    /// the asynchronous overload.</item>
     /// <item>A blocker's Block() side effect lands only for live registrations on a live attempt: an entry
     /// disposed mid-pass (by its own check, or by an earlier blocker's decision) stays Idle, and a pass whose
     /// attempt token is already cancelled flips no state at all.</item>
@@ -545,6 +548,77 @@ namespace Velvet.Tests
 
             // Assert
             Assert.That(s_blockerObservedDep, Is.EqualTo("settled"));
+        }
+
+        #endregion
+
+        #region UseBlocker with deps omitted
+
+        private static StateUpdater<bool> s_omittedDepsSetDirty;
+
+        [Component]
+        private static VNode OmittedDepsBlockerRender()
+        {
+            var (isDirty, setDirty) = Hooks.UseState(false);
+            s_omittedDepsSetDirty = setDirty;
+            Hooks.UseBlocker(_ => isDirty);
+            return V.Label(text: isDirty ? "dirty" : "clean");
+        }
+
+        [Test]
+        public void Given_UseBlockerWithDepsOmitted_When_TheCapturedStateChanges_Then_TheNewAnswerBlocks()
+        {
+            // Arrange
+            var router = BuildRouter("/home", Route("home"), Route("other"));
+            s_omittedDepsSetDirty = default;
+            using var mounted = V.Mount(new VisualElement(), V.Component(OmittedDepsBlockerRender, key: "blk"));
+
+            // Act — the first departure reads the mount render's false, the second the re-render's true.
+            var beforeChange = router.NavigateSync("/other");
+            s_omittedDepsSetDirty.Invoke(true);
+            mounted.FlushStateForTest();
+            var afterChange = router.NavigateSync("/home");
+
+            // Assert
+            Assert.That(
+                (beforeChange, afterChange),
+                Is.EqualTo((NavigationResult.Success, NavigationResult.Blocked)),
+                "Omitting deps re-registers the predicate every render, so the blocker answers with the "
+                + "state of the render that registered it rather than the mount render's");
+        }
+
+        private static StateUpdater<bool> s_omittedDepsAsyncSetDirty;
+
+        [Component]
+        private static VNode OmittedDepsAsyncBlockerRender()
+        {
+            var (isDirty, setDirty) = Hooks.UseState(false);
+            s_omittedDepsAsyncSetDirty = setDirty;
+            Hooks.UseBlocker((_, _) => UniTask.FromResult(isDirty));
+            return V.Label(text: isDirty ? "dirty" : "clean");
+        }
+
+        [Test]
+        public void Given_AsyncUseBlockerWithDepsOmitted_When_TheCapturedStateChanges_Then_TheNewAnswerBlocks()
+        {
+            // Arrange
+            var router = BuildRouter("/home", Route("home"), Route("other"));
+            s_omittedDepsAsyncSetDirty = default;
+            using var mounted = V.Mount(
+                new VisualElement(), V.Component(OmittedDepsAsyncBlockerRender, key: "blk-async"));
+
+            // Act — the first departure reads the mount render's false, the second the re-render's true.
+            var beforeChange = router.NavigateSync("/other");
+            s_omittedDepsAsyncSetDirty.Invoke(true);
+            mounted.FlushStateForTest();
+            var afterChange = router.NavigateSync("/home");
+
+            // Assert
+            Assert.That(
+                (beforeChange, afterChange),
+                Is.EqualTo((NavigationResult.Success, NavigationResult.Blocked)),
+                "The async overload stages the same null deps as the synchronous one, so the two must not "
+                + "drift apart under an edit to either");
         }
 
         #endregion

--- a/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouteTreeTests.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouteTreeTests.cs
@@ -1,6 +1,7 @@
 using System;
 using NUnit.Framework;
 using Velvet;
+using Velvet.TestUtilities;
 using static Velvet.Tests.RouteTestStubs;
 
 namespace Velvet.Tests
@@ -12,7 +13,8 @@ namespace Velvet.Tests
     /// <item>A path matches the highest-specificity branch whose pattern consumes it fully; a leading slash on
     /// the queried path is optional and the root path <c>"/"</c> resolves to a declared <c>"/"</c> route.</item>
     /// <item>A null or empty queried path matches nothing.</item>
-    /// <item>A path that no branch consumes returns null.</item>
+    /// <item>A path that no branch consumes returns null, and <see cref="RouteTree.Match"/> declares that
+    /// null where <see cref="RouteMatch.Params"/> is declared non-null.</item>
     /// <item>A dynamic <c>:param</c> segment captures the corresponding path segment under the param name.</item>
     /// <item>Nested routes return the full parent-first chain, and every level shares the one cumulative
     /// parameter set captured across the whole branch.</item>
@@ -122,6 +124,30 @@ namespace Velvet.Tests
 
             // Assert
             Assert.That(result, Is.Null);
+        }
+
+        [Test]
+        public void Given_RouteTreeMatch_When_ReturnAnnotationsRead_Then_TheChainIsNullableAndItsParamsAreNot()
+        {
+            // Arrange
+            var match = typeof(RouteTree).GetMethod(nameof(RouteTree.Match))!;
+            var matchParams = typeof(RouteMatch).GetProperty(nameof(RouteMatch.Params))!.GetMethod!;
+
+            // Act
+            var annotations = (
+                chain: NullableAnnotationProbe.ReturnAnnotation(match),
+                parameters: NullableAnnotationProbe.ReturnAnnotation(matchParams));
+
+            // Assert
+            Assert.That(
+                annotations,
+                Is.EqualTo((
+                    NullableAnnotationProbe.Annotation.Nullable,
+                    NullableAnnotationProbe.Annotation.NotNullable)),
+                "Match declares the null it returns for a path no branch consumes, against a sibling "
+                + "declared non-null. Match's constructed nullable return type is what makes the compiler "
+                + "emit the annotation as a flag array, so this case also fixes which element of that "
+                + "array the probe reads");
         }
 
         #endregion

--- a/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RoutingHooksTests.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RoutingHooksTests.cs
@@ -217,6 +217,9 @@ namespace Velvet.Tests
     /// the current location, matching case-insensitively by default and independently of the route table, and
     /// returns null when the pattern does not match.</item>
     /// <item><c>UseSearchParams</c> parses the query string of the current location.</item>
+    /// <item><see cref="ISearchParams"/> — the type the hook hands back — declares the null
+    /// <see cref="ISearchParams.Get"/> returns for an absent key, while
+    /// <see cref="ISearchParams.GetAll"/> declares the empty list it substitutes instead.</item>
     /// </list>
     /// </summary>
     [TestFixture]
@@ -439,6 +442,29 @@ namespace Velvet.Tests
             Assert.That(Capture.SearchParams!.Has("q"), Is.True);
             Assert.That(Capture.SearchParams!.Has("missing"), Is.False);
             Assert.That(Capture.SearchParams!.Keys, Is.EqualTo(new[] { "q", "page" }));
+        }
+
+        [Test]
+        public void Given_SearchParamsInterface_When_ReturnAnnotationsRead_Then_GetIsNullableAndGetAllIsNot()
+        {
+            // Arrange
+            var get = typeof(ISearchParams).GetMethod(nameof(ISearchParams.Get))!;
+            var getAll = typeof(ISearchParams).GetMethod(nameof(ISearchParams.GetAll))!;
+
+            // Act
+            var annotations = (
+                get: NullableAnnotationProbe.ReturnAnnotation(get),
+                getAll: NullableAnnotationProbe.ReturnAnnotation(getAll));
+
+            // Assert
+            Assert.That(
+                annotations,
+                Is.EqualTo((
+                    NullableAnnotationProbe.Annotation.Nullable,
+                    NullableAnnotationProbe.Annotation.NotNullable)),
+                "The hook hands back the interface, so the interface is the declaration a consumer reads: "
+                + "Get answers an absent key with null, while GetAll substitutes an empty list and is the "
+                + "control showing the probe separates the two states");
         }
 
         [Test]

--- a/Packages/com.velvet.core/TestUtilities/NullableAnnotationProbe.cs
+++ b/Packages/com.velvet.core/TestUtilities/NullableAnnotationProbe.cs
@@ -1,0 +1,88 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Reflection;
+
+namespace Velvet.TestUtilities
+{
+    /// <summary>
+    /// Reads back the nullable reference annotation the compiler emitted for a method's return type, so a
+    /// fixture can pin a shipped signature's nullability the way <c>PublicAPI.txt</c> pins its shape.
+    /// </summary>
+    /// <remarks>
+    /// <c>PublicAPI.txt</c> renders a return type without its annotation, so nothing else in the repository
+    /// pins one. The compiler catches the disagreement when the member implements an interface (CS8766); it
+    /// reported nothing for <see cref="Hooks.UseLocation"/>, whose null arrived through a null-forgiving
+    /// operator one call away.
+    /// </remarks>
+    public static class NullableAnnotationProbe
+    {
+        /// <summary>Nullable reference states, valued as the compiler encodes them.</summary>
+        public enum Annotation
+        {
+            /// <summary>Declared outside a nullable context.</summary>
+            Oblivious = 0,
+
+            /// <summary>Declared non-nullable (<c>T</c>).</summary>
+            NotNullable = 1,
+
+            /// <summary>Declared nullable (<c>T?</c>).</summary>
+            Nullable = 2,
+        }
+
+        private const string NullableAttributeName = "System.Runtime.CompilerServices.NullableAttribute";
+
+        private const string NullableContextAttributeName =
+            "System.Runtime.CompilerServices.NullableContextAttribute";
+
+        /// <summary>
+        /// Returns the declared annotation of <paramref name="method"/>'s return type.
+        /// </summary>
+        /// <param name="method">Method whose return type is read. Must not be null.</param>
+        public static Annotation ReturnAnnotation(MethodInfo method)
+        {
+            if (method == null) throw new ArgumentNullException(nameof(method));
+
+            // A member agreeing with the enclosing NullableContext carries no attribute of its own, so an
+            // absent attribute is a reading to be resolved outward rather than a missing one.
+            var declared = ReadFlag(method.ReturnParameter.GetCustomAttributesData(), NullableAttributeName);
+            if (declared.HasValue) return (Annotation)declared.Value;
+
+            var onMethod = ReadFlag(method.GetCustomAttributesData(), NullableContextAttributeName);
+            if (onMethod.HasValue) return (Annotation)onMethod.Value;
+
+            for (var type = method.DeclaringType; type != null; type = type.DeclaringType)
+            {
+                var onType = ReadFlag(type.GetCustomAttributesData(), NullableContextAttributeName);
+                if (onType.HasValue) return (Annotation)onType.Value;
+            }
+
+            var onModule = ReadFlag(method.Module.GetCustomAttributesData(), NullableContextAttributeName);
+            return onModule.HasValue ? (Annotation)onModule.Value : Annotation.Oblivious;
+        }
+
+        private static byte? ReadFlag(IList<CustomAttributeData> attributes, string attributeFullName)
+        {
+            foreach (var attribute in attributes)
+            {
+                if (attribute.AttributeType.FullName != attributeFullName) continue;
+                if (attribute.ConstructorArguments.Count != 1) continue;
+
+                var argument = attribute.ConstructorArguments[0];
+                if (argument.Value is byte flag) return flag;
+
+                // Which element of a constructed return type's flag array belongs to the returned reference
+                // itself is pinned by the Match return-annotation case in RouteTreeTests.
+                if (argument.Value is ReadOnlyCollection<CustomAttributeTypedArgument> flags
+                    && flags.Count > 0
+                    && flags[0].Value is byte outermost)
+                {
+                    return outermost;
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/Packages/com.velvet.core/TestUtilities/NullableAnnotationProbe.cs.meta
+++ b/Packages/com.velvet.core/TestUtilities/NullableAnnotationProbe.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: bc988a02c66704eb1a2b2a19cecb1bff


### PR DESCRIPTION
Three routing hooks declared one thing and did another.

**`UseBlocker` had no deps-less overload.** Because the deps list is `params`, omitting it does not mean "no dependencies" — the compiler passes the shared empty array, and `ObjectIs.AreEqualDeps` short-circuits on `ReferenceEquals` before comparing anything, so the comparison sees the same instance every render and can never be perturbed. The predicate froze at the mount closure. A blocker guarding an unsaved-changes form therefore kept answering from the state the form had when it mounted: never blocking, or — if the mount value happened to be true — blocking permanently. Both silently.

`UseBlocker` now has deps-less overloads for the sync and async forms, meaning "re-register every render" as `UseCallback` and `UseMemo` already do. The deps-taking overloads widen to `params object?[]? deps`, which is `UseMemo`'s annotation; note that only the annotation matches, since `UseBlocker` guards on `deps != null` and re-registers where `UseMemo` compares a null against a null and freezes.

**`UseLocation()` was annotated non-nullable and returns null.** The annotation was the side that was wrong. React Router's `useLocation` throws and is typed non-null because of that invariant, but its invariant tests the router *context object*, and once a Router is mounted its location is always real. Velvet has no built-in Router component: the location context *is* the location, seeded with a null default, so "no router above me" and "router mounted, first location not yet published" are the same observation — both reachable, the second in the starter sample. Throwing would turn a legitimate pre-navigation render into a crash. Every sibling hook is already annotated nullable.

**`ISearchParams.Get` was annotated non-nullable** while its only implementation returns null and documents null. This one was raising CS8766 in the package's own build.

Nullability produces no diff in `PublicAPI.txt`, which renders return types without their annotations — that is why all three could ship, and it is filed separately (#457). Two probe tests pin these members by reading the emitted metadata; they are regression pins for what shipped wrong, not a pattern to propagate, since each one covers only a member someone already suspected.

Four defects found while establishing the above are filed rather than fixed here: `Hooks.UseContext<T>` still promises non-null while returning a null default, so reading a router context off it throws with no warning (#461); an explicit `null` deps list freezes `UseCallback` and `UseMemo` but re-runs `UseBlocker` and `UseEffect` (#462); `V.Memoized` with deps omitted caches its subtree permanently, and the remedy used here does not transfer to it (#458); and `RouteNavLink` with `To = "/"` renders active when there is no location (#459).

No `Documentation~` impact: there is no routing guide, and no guide, index entry or migration section mentions `UseBlocker`, `UseLocation`, `RouterLocation` or `SearchParams`.

Closes #398
Closes #399
Closes #400
