### PR TITLE
fix(velvet): restore the default a dropped prop and a cancelled loader owe

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -9,6 +9,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A `Focusable` prop that a later render stops declaring now hands the element back the focusability it
+  was constructed with, instead of making it focusable. Dropping the prop compares unequal to the
+  declared value, and the absent case coalesced to `true`: a `V.Div` that carried `Focusable = true` for
+  one render stayed a Tab stop and a 2D navigation target until some later render declared the prop
+  again, and one that carried `Focusable = false` was *granted* focusability by the render that removed
+  the prop — on a runtime panel, an invisible container catching gamepad navigation. Mounting already left
+  an absent `Focusable` alone, so the two paths disagreed about what "not declared" means. The value the
+  element carries before Velvet writes the flag at all is now recorded and restored — including before a
+  drag session's transient keyboard-focus anchor writes it, which would otherwise be handed back as the
+  element's own — and that answers for a `V.Custom<T>` type whose default no table could know. `TabIndex` and `DelegatesFocus` are
+  unchanged and still coalesce to `0` / `false` when dropped.
+
+- A Suspense primary that suspends after creating a `V.Custom<T>` element now disposes the component
+  fibers mounted inside that element, whatever `T` is. The rollback's fiber sweep skipped any element
+  matching `Label`, `Toggle`, `Slider` or `TextField` as a childless primitive, which `V.Custom<T>`
+  reaches with both a subclass of one of them and one of them itself — and `V.Custom<T>` declares
+  children for any `T`. A `V.Component` declared in such an element's `children` therefore kept its
+  `ComponentRegistry` entry pointing into a subtree dropped for GC, ran its layout effect against that
+  dead element while the boundary was showing its fallback, and left a `UseStore` subscription taken
+  during the speculative render live. The sweep no longer tests the element's type at all: what decides
+  whether an orphan can hold a fiber is whether its node declared children, which the element cannot say.
+
+- A `Hooks.Use` loader cancelled through a token the caller owns now surfaces the cancellation to the
+  nearest error boundary, instead of leaving its Suspense boundary in fallback with no way out. A
+  cancellation that reached the awaiting frame was swallowed without recording an outcome, which is
+  correct only for Velvet's own cancellation; a logout CTS, a linked token in a data layer or a
+  superseded request left the resource `Pending`, and nothing restarts a resource in that state while
+  its key is unchanged. Only a cancellation Velvet itself requested is silent now.
+
 - `font-<family>` and the text-transform / text-decoration / `whitespace-pre-line` / `leading-*`
   utilities now take effect behind a variant. `dark:font-mono`, `md:font-display`,
   `hover:uppercase`, `md:dark:hover:underline` and `md:leading-loose` all changed nothing before:

--- a/Packages/com.velvet.core/Documentation~/focus.md
+++ b/Packages/com.velvet.core/Documentation~/focus.md
@@ -49,6 +49,12 @@ Three focus-related element props ride `FiberElementProps` alongside the existin
 `DelegatesFocus` (focusing the element forwards to its first focusable child), and `FocusScope`
 (the settings record behind the scope knobs above).
 
+`Focusable` is restored rather than coalesced when a later render stops declaring it: dropping the
+prop hands the element back the focusability it was constructed with, so a `V.Div` that carried
+`Focusable = true` for one render stops being a Tab stop again, and a control that is focusable by
+construction keeps its own default. `TabIndex` and `DelegatesFocus` behave differently: dropping either
+coalesces to `0` / `false`.
+
 ## Focus-visible styling and state
 
 The `focus-visible:` class variant covers keyboard/gamepad-only focus styling: it lights for

--- a/Packages/com.velvet.core/Documentation~/react-migration.md
+++ b/Packages/com.velvet.core/Documentation~/react-migration.md
@@ -208,7 +208,7 @@ Since C# has no JSX syntax, Velvet builds the VNode tree through `V.*` method ca
 | React | Velvet | Notes |
 |-------|--------|------|
 | `<Suspense fallback={<Spinner/>}>` | `V.Suspense(fallback, children)` | Equivalent |
-| `use(promise)` | `Hooks.Use(() => someUniTask, resourceKey)` | Reads an async resource declaratively; while pending it throws to the nearest `V.Suspense` boundary, just like React's `use()` with a Promise |
+| `use(promise)` | `Hooks.Use(() => someUniTask, resourceKey)` | Reads an async resource declaratively; while pending it throws to the nearest `V.Suspense` boundary, just like React's `use()` with a Promise. A loader cancelled through a token the caller owns (a logout CTS, a superseded request) surfaces the `OperationCanceledException` to the nearest error boundary, as React does for an aborted promise. Velvet's own cancellation of the token it hands the loader — on supersede or unmount, as the `Use` API doc describes — records nothing instead |
 | Class Component + `getDerivedStateFromError` | The `V.ErrorBoundary(fallback, children)` helper, or `[Component(IsErrorBoundary = true)]` + `Hooks.UseFallback(fn)` | Explicit opt-in. The helper suits a use directly under Mount; the functional pattern suits cases where you want fallback/children values to update dynamically on parent re-render |
 | Class Component + `componentDidCatch` | `Hooks.UseEffect` + try-catch, or logging via an error-notification Store | When you want to log side effects from a functional component, do it inside an effect |
 

--- a/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseAsyncTests.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseAsyncTests.cs
@@ -20,7 +20,8 @@ namespace Velvet.Tests
     /// completed task or <c>Error</c> for a faulted one, and stays <c>Pending</c> while the task is in flight.</item>
     /// <item>The completion callback fires when an in-flight task settles (success or failure) but is suppressed for
     /// a synchronously completed task, whose value is returned to the caller directly.</item>
-    /// <item>Cancelling or disposing a pending resource cancels the factory's token.</item>
+    /// <item>Cancelling or disposing a pending resource cancels the factory's token and records no outcome; a
+    /// cancellation raised by a token the consumer owns settles the resource into <c>Error</c> instead.</item>
     /// <item>A synchronously completed factory returns its value on the first render; a faulted factory surfaces its
     /// exception; a pending factory without a Suspense boundary suspends, warns, and leaves the value unset until
     /// the task completes and re-renders with the value.</item>
@@ -243,6 +244,57 @@ namespace Velvet.Tests
 
             // Assert
             Assert.That(fired, Is.True, "The completion callback fires when an in-flight task fails");
+        }
+
+        [Test]
+        public void Given_PendingResource_When_ConsumerOwnedTokenCancels_Then_EntersErrorState()
+        {
+            // Arrange — the loader honours the resource's token and also a token the consumer owns (a logout, a
+            // superseded request). A cancellation from the consumer's side is an outcome the consumer must see,
+            // so it has to reach a terminal state; staying Pending would suspend the boundary with no restart.
+            var resource = new FiberAsyncResource<int>(Array.Empty<object>());
+            using var consumerCts = new CancellationTokenSource();
+            var source = new UniTaskCompletionSource<int>();
+            resource.Start(_ => source.Task.AttachExternalCancellation(consumerCts.Token));
+            Assume.That(resource.Status, Is.EqualTo(FiberAsyncResourceStatus.Pending),
+                "Precondition: the loader is still in flight before the consumer cancels");
+
+            // Act
+            consumerCts.Cancel();
+
+            // Assert
+            Assert.That(resource.Status, Is.EqualTo(FiberAsyncResourceStatus.Error),
+                "A cancellation the resource did not request settles it into a terminal state");
+        }
+
+        [Test]
+        public void Given_PendingResource_When_DisposedWhileInFlight_Then_NoOutcomeIsRecorded()
+        {
+            // Arrange — guards the over-correction of recording an Error for any cancellation, which would make
+            // Velvet's own teardown surface an exception the consumer never asked about. The loader reports
+            // whether the cancellation reached it, because Pending is also the state before anything happens.
+            var resource = new FiberAsyncResource<int>(Array.Empty<object>());
+            var source = new UniTaskCompletionSource<int>();
+            var reachedLoader = false;
+            resource.Start(async ct =>
+            {
+                try
+                {
+                    return await source.Task.AttachExternalCancellation(ct);
+                }
+                catch (OperationCanceledException)
+                {
+                    reachedLoader = true;
+                    throw;
+                }
+            });
+
+            // Act
+            resource.Dispose();
+
+            // Assert
+            Assert.That((reachedLoader, resource.Status), Is.EqualTo((true, FiberAsyncResourceStatus.Pending)),
+                "The resource's own cancellation reaches the loader and still records no outcome");
         }
 
         #endregion

--- a/Packages/com.velvet.core/Runtime/Reconciler/DndActiveDrag.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/DndActiveDrag.cs
@@ -380,6 +380,10 @@ namespace Velvet
             {
                 if (!_source.focusable)
                 {
+                    // Ordering: seed before the write, per FiberPropApplier.RecordFocusableDefault. A Focusable
+                    // prop first declared while this anchor stands would otherwise take the anchor's value as
+                    // the source's own, and dropping that prop later would hand it back.
+                    FiberPropApplier.RecordFocusableDefault(_source);
                     _source.focusable = true;
                     _madeSourceFocusable = true;
                 }

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberAsyncResource.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberAsyncResource.cs
@@ -28,6 +28,10 @@ namespace Velvet
     // (the entire slot is discarded and recreated).
     // Cancel / Dispose cancels the token, but if the loader does not honor ct the task may keep running internally.
     // Even in that case, the OnCompleted callback satisfies the contract of "reflecting the Status at completion".
+    // Only this resource's own cancellation leaves the machine non-terminal. A cancellation raised by a token
+    // the consumer owns becomes Error instead: a resource left Pending holds its Suspense boundary in its
+    // fallback, and Hooks.UseCore starts a resource only on the render that allocates its slot, so a slot whose
+    // key is unchanged never gets another attempt.
     internal sealed class FiberAsyncResource<T> : IFiberAsyncResource
     {
         private readonly CancellationTokenSource _cts = new();
@@ -98,7 +102,10 @@ namespace Velvet
                 Result = result;
                 Status = FiberAsyncResourceStatus.Success;
             }
-            catch (OperationCanceledException)
+            // The gate asks who requested the cancellation, not which token carried it out to the awaiting frame,
+            // so a loader that awaits on some token of its own is still judged by whether this resource asked.
+            // Everything else falls through to the generic catch and lands in Error (see the class note above).
+            catch (OperationCanceledException) when (_disposed || _cts.IsCancellationRequested)
             {
                 return;
             }

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberPropApplier.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberPropApplier.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using UnityEngine.UIElements;
 
 namespace Velvet
@@ -48,8 +49,50 @@ namespace Velvet
 
         private static readonly int s_hiddenPriority = StyleLayerPriority.ImportantOf(StyleLayerPriority.Base);
 
+        // Unlike ApplyEnabled / ApplyTabIndex / ApplyDelegatesFocus, a dropped Focusable cannot coalesce to a
+        // constant: what an absent prop has to restore is the element's own constructed value, which differs by
+        // type — FiberElementPoolReset.ResetCommonState writes one answer and every widget helper but the Label
+        // one overwrites it — and which no table can answer for a V.Custom<T> type. The element is asked instead
+        // of a table: the create path never writes an absent Focusable (FiberElementFactory.ApplyProps guards on
+        // HasValue), so the value standing here before the first declared write is that default. Recording it at
+        // the first declared write is what makes that ordering hold; recording later would capture a declared
+        // value as the default. Any other writer of a mounted element's focusable owes RecordFocusableDefault
+        // first, for the same reason.
         public static void ApplyFocusable(VisualElement element, bool? focusable)
-            => element.focusable = focusable ?? true;
+        {
+            if (focusable.HasValue)
+            {
+                RecordFocusableDefault(element);
+                element.focusable = focusable.Value;
+                return;
+            }
+
+            // No record means no declared value was ever written, so the element still carries its own default.
+            if (s_focusableDefaults.TryGetValue(element, out var recorded))
+            {
+                element.focusable = recorded.Value;
+            }
+        }
+
+        // Callers writing focusable outside the prop path must run this before their write, or the value they
+        // are about to install becomes what a Focusable prop first declared afterwards records as the
+        // element's own. Idempotent: the first record for an element is the one that stands.
+        internal static void RecordFocusableDefault(VisualElement element)
+        {
+            if (!s_focusableDefaults.TryGetValue(element, out _))
+            {
+                s_focusableDefaults.Add(element, new FocusableDefault(element.focusable));
+            }
+        }
+
+        private sealed class FocusableDefault
+        {
+            public readonly bool Value;
+
+            public FocusableDefault(bool value) => Value = value;
+        }
+
+        private static readonly ConditionalWeakTable<VisualElement, FocusableDefault> s_focusableDefaults = new();
 
         public static void ApplyTabIndex(VisualElement element, int? tabIndex)
             => element.tabIndex = tabIndex ?? 0;

--- a/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
@@ -326,6 +326,13 @@ namespace Velvet
         // an INNER ReconcileChildren call and therefore are NOT in the rolling-back scope's `newFibers` set.
         // The caller disposes every inline fiber whose MountPoint sits inside the returned range so its
         // effect cleanup runs and the deferred layout-effect drain short-circuits via IsDisposed.
+        // Every created orphan enters the set, with no attempt to exclude the ones that cannot hold a fiber.
+        // Excluding by element type was wrong twice over — a subclass and the type itself both reach here via
+        // V.Custom<T>, which declares children for any T — and the question is unanswerable from the element
+        // in any case, since what decides it is whether the NODE declared children. The set is a containment
+        // filter, so a surplus member costs a hash entry and changes nothing: a leaf holding no fiber
+        // contributes no fiber to dispose. The exact-type dispatch in FiberElementCleaner.ReturnToPool asks a
+        // different question — may this element enter the shared pool — and stays a type test.
         private static HashSet<VisualElement>? CollectOrphanContainers(GeneralCommitState commit, int preCount)
         {
             HashSet<VisualElement>? orphanContainers = null;
@@ -333,11 +340,6 @@ namespace Velvet
             {
                 var (element, isExisting) = commit.NewElements[i];
                 if (isExisting || element == null) continue;
-                if (element is Label or Toggle or Slider or TextField)
-                {
-                    // Poolable leaves cannot host inline-mounted descendant fibers; skip.
-                    continue;
-                }
                 (orphanContainers ??= new HashSet<VisualElement>()).Add(element);
             }
             return orphanContainers;

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/DndInteractionTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/DndInteractionTests.cs
@@ -31,6 +31,7 @@ namespace Velvet.Tests
         private static int s_cancelCount;
         private static StateUpdater<bool> s_setShowSource;
         private static StateUpdater<bool> s_setAltDraggingClass;
+        private static StateUpdater<bool> s_setDeclaringFocusable;
 
         [SetUp]
         public void SetUp()
@@ -42,6 +43,7 @@ namespace Velvet.Tests
             s_cancelCount = 0;
             s_setShowSource = default;
             s_setAltDraggingClass = default;
+            s_setDeclaringFocusable = default;
         }
 
         [TearDown]
@@ -425,6 +427,46 @@ namespace Velvet.Tests
             Assert.That(
                 (ReferenceEquals(_host.Panel.focusController.focusedElement, item), item.focusable),
                 Is.EqualTo((false, false)));
+        }
+
+        [Component]
+        private static VNode DeclaredFocusableMidDragScene()
+        {
+            var (declaring, setDeclaring) = Hooks.UseState(false);
+            s_setDeclaringFocusable = setDeclaring;
+            return V.DndContext(
+                className: "w-[300px] h-[300px]",
+                children: new VNode[]
+                {
+                    V.Draggable("item", key: "item", name: "item",
+                        props: declaring ? new FiberElementProps { Focusable = true } : null,
+                        className: "absolute left-[0px] top-[0px] w-[50px] h-[50px]"),
+                });
+        }
+
+        [Test]
+        public void Given_AFocusablePropFirstDeclaredWhileTheAnchorHoldsIt_When_ThePropIsDropped_Then_TheSourceIsNotLeftFocusable()
+        {
+            // Arrange — with nothing focused, activation makes the source focusable transiently so the Escape
+            // KeyDownEvent is deliverable. That write is the session's, not the element's own value, and a
+            // Focusable prop declared for the first time while it stands must not be able to capture it: a
+            // later render dropping the prop restores what the element carried before Velvet touched the flag.
+            Mount(DeclaredFocusableMidDragScene);
+            var item = Q("item");
+            SendPointerDown(item, new Vector2(10, 10));
+            SendPointerMove(item, new Vector2(30, 10));
+            var whileAnchored = item.focusable;
+
+            // Act — declare the prop under the anchor, end the drag, then stop declaring it.
+            s_setDeclaringFocusable.Invoke(true);
+            _mounted.FlushStateForTest();
+            SendPointerUp(item, new Vector2(30, 10));
+            s_setDeclaringFocusable.Invoke(false);
+            _mounted.FlushStateForTest();
+
+            // Assert — the first term keeps the anchor load-bearing: without its transient write the
+            // declaration would have nothing to capture and the case would pin nothing.
+            Assert.That((whileAnchored, item.focusable), Is.EqualTo((true, false)));
         }
 
         [Test]

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/PropsDiffTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/PropsDiffTests.cs
@@ -14,6 +14,8 @@ namespace Velvet.Tests
     /// written to the element on patch; a value set to null clears the corresponding property.</item>
     /// <item>A changed choices collection (dropdown, radio group) replaces the element's choices.</item>
     /// <item>A <c>Visible = false</c> prop adds the reserved hidden class to the element.</item>
+    /// <item>A <c>Focusable</c> prop that a later render drops restores the value the element was constructed
+    /// with, from either declared value, rather than coalescing to a constant.</item>
     /// <item>The class list is reconciled by diffing old against new: only the symmetric difference is
     /// applied, removed classes leave and added classes enter while unchanged ones stay. The diff uses
     /// a linear comparison when both sides hold at most eight classes and a HashSet beyond that, with
@@ -181,6 +183,46 @@ namespace Velvet.Tests
 
             // Assert
             Assert.That(Root.ElementAt(0).tooltip, Is.EqualTo(string.Empty));
+        }
+
+        [Test]
+        public void Given_FocusableTrue_When_PatchedToUnset_Then_ElementConstructedValueRestored()
+        {
+            // Arrange — the mount render declares the Div focusable; the next render drops the prop entirely,
+            // which must hand the element back to the value it was constructed with rather than strand the
+            // declared one (a Div a later render never asks for stays a Tab stop otherwise).
+            var oldTree = new VNode[] { V.Div(props: new FiberElementProps { Focusable = true }) };
+            var newTree = new VNode[] { V.Div() };
+            Reconciler.Reconcile(Root, Array.Empty<VNode>(), oldTree);
+            var element = Root.ElementAt(0);
+            var whileDeclared = element.focusable;
+
+            // Act
+            Reconciler.Reconcile(Root, oldTree, newTree);
+
+            // Assert — the first term keeps the declaration load-bearing: a mount that never applied it would
+            // leave the drop with nothing to undo.
+            Assert.That((whileDeclared, element.focusable), Is.EqualTo((true, false)),
+                "Dropping Focusable restores the element's constructed value, which a Div does not have set");
+        }
+
+        [Test]
+        public void Given_FocusableFalse_When_PatchedToUnset_Then_ElementNotMadeFocusable()
+        {
+            // Arrange — no render in this sequence ever asks for a focusable Div, so the drop must not be the
+            // render that grants it.
+            var oldTree = new VNode[] { V.Div(props: new FiberElementProps { Focusable = false }) };
+            var newTree = new VNode[] { V.Div() };
+            Reconciler.Reconcile(Root, Array.Empty<VNode>(), oldTree);
+            var element = Root.ElementAt(0);
+
+            // Act
+            Reconciler.Reconcile(Root, oldTree, newTree);
+
+            // Assert — the first term keeps the patch load-bearing: a drop served by replacing the element
+            // instead of patching it would leave a fresh Div here, which is non-focusable for another reason.
+            Assert.That((ReferenceEquals(Root.ElementAt(0), element), element.focusable), Is.EqualTo((true, false)),
+                "Dropping Focusable never adds focusability the declarations did not ask for");
         }
 
         [Test]

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/SuspenseBoundaryTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/SuspenseBoundaryTests.cs
@@ -39,7 +39,8 @@ namespace Velvet.Tests
     /// <item>A primary that suspends rolls back cleanly: a childless poolable leaf it created is reclaimed into the
     /// pool, a child-bearing container orphan is left for GC (not pooled), and a container orphan's deferred child
     /// layout effect never runs against the dead orphan; on resume the primary subtree is rebuilt and its effect
-    /// runs exactly once.</item>
+    /// runs exactly once. A <c>V.Custom&lt;T&gt;</c> orphan is a container for this purpose whatever <c>T</c> is,
+    /// so its child fiber is disposed too.</item>
     /// </list>
     /// </summary>
     /// <remarks>
@@ -578,6 +579,24 @@ namespace Velvet.Tests
         }
 
         [Test]
+        public void Given_SuspendedPrimaryWithCustomLeafSubclassFiber_When_RolledBack_Then_DeferredChildEffectDoesNotRun()
+        {
+            // Arrange — V.Custom<T> declares children for any T, so a subclass of a poolable primitive holds an
+            // inline-expanded child fiber exactly as a Div does, and the rollback owes it the same disposal.
+            s_customLeafOrphanEffectMountCount = 0;
+            s_customLeafOrphanEffectCleanupCount = 0;
+            var source = new UniTaskCompletionSource<string>();
+            s_asyncChildFactory = _ => source.Task;
+
+            // Act
+            using var mounted = V.Mount(_root, V.Component(CustomLeafOrphanFiberSuspenseHostRender, key: "host"));
+
+            // Assert
+            Assert.That((s_customLeafOrphanEffectMountCount, s_customLeafOrphanEffectCleanupCount), Is.EqualTo((0, 0)),
+                "A suspended primary's custom-leaf-orphan child layout effect never runs, so no cleanup pairs against it");
+        }
+
+        [Test]
         public void Given_SuspendedPrimaryWithContainerFiber_When_Resolved_Then_FreshChildEffectRunsOnce()
         {
             // Arrange
@@ -672,6 +691,37 @@ namespace Velvet.Tests
                     V.Div(children: new VNode[]
                     {
                         V.Component(LeadingEffectChildRender, key: "leading"),
+                    }),
+                    V.Component(SuspenseAsyncChildRender, key: "child"),
+                });
+
+        private sealed class ProbeLabel : Label
+        {
+        }
+
+        private static int s_customLeafOrphanEffectMountCount;
+        private static int s_customLeafOrphanEffectCleanupCount;
+
+        [Component]
+        private static VNode CustomLeafOrphanEffectChildRender()
+        {
+            Hooks.UseLayoutEffect(() =>
+            {
+                s_customLeafOrphanEffectMountCount++;
+                return () => s_customLeafOrphanEffectCleanupCount++;
+            }, Array.Empty<object>());
+            return V.Label(text: "custom-leaf-effect");
+        }
+
+        [Component]
+        private static VNode CustomLeafOrphanFiberSuspenseHostRender()
+            => V.Suspense(
+                fallback: V.Label(text: "loading"),
+                children: new VNode[]
+                {
+                    V.Custom<ProbeLabel>(children: new VNode[]
+                    {
+                        V.Component(CustomLeafOrphanEffectChildRender, key: "leading"),
                     }),
                     V.Component(SuspenseAsyncChildRender, key: "child"),
                 });


### PR DESCRIPTION
Three unrelated defects sharing a shape: a default or a terminal state the code got wrong, with nothing detecting it.

**Dropping the `Focusable` prop made the element focusable.** The create path guards on `props.Focusable.HasValue`, so a node without the prop never writes it at mount. The patch path did not: a `true -> null` or `false -> null` transition compared unequal, called the applier with null, and `focusable ?? true` left the element a Tab stop and a 2D navigation target for the rest of its life, with no way back. On a runtime panel this is an invisible container stealing focus during gamepad navigation.

The sibling appliers coalesce to a universal default and that is right for them; `focusable`'s default is type-dependent. Rather than mirror the engine's constructors in a table — which could not answer for a `V.Custom<T>` user type, and would un-focus one on drop, the same defect with the sign flipped — the element is asked: the value standing on it before Velvet's first declared write is recorded and restored. The drag layer's focus anchor writes `focusable` outside the applier, so it seeds that record before its own transient write; without that, a prop first declared mid-drag would record the anchor's value as the element's default.

**A rollback left fibers alive under a custom leaf.** `CollectOrphanContainers` skipped any element matching `is Label or Toggle or Slider or TextField`, on the grounds that poolable leaves cannot host inline-mounted descendants. That holds for the exact types, but `V.Custom<T>` accepts children for any `T`, so a `V.Custom<MyLabel>(children: …)` orphan was skipped and the fibers mounted inside it were never disposed — effect cleanups never ran, store subscriptions stayed live, and they lingered in the registry pointing into a subtree dropped for GC, which is what the method's own comment says it exists to prevent.

The skip is now gone rather than corrected. Whether an orphan can hold a fiber is decided by whether its *node* declared children, and the element cannot answer that for any type; the sweep is a containment filter, so a surplus member costs one hash entry and can contribute no fiber. The reclaim path keeps its exact-type test, which asks a different question — whether the element may enter the shared pool — that genuinely is about the type.

**A cancelled loader stranded its Suspense boundary forever.** `catch (OperationCanceledException) { return; }` was unconditional, so a loader awaiting a token the *consumer* owns — a scene-teardown CTS, a linked token in a data layer — left the resource `Pending` with no terminal state. `Hooks.UseCore` turns any non-terminal status into a suspend, so the boundary showed its fallback permanently, nothing reached an error boundary, and nothing could restart it. A cancellation now becomes `Error` unless this resource requested it, matching what React does with an aborted promise handed to `use()`. Velvet's own teardown is still silent, because nothing reads the status after it.

`focus.md` gains the rule for dropping the prop; `react-migration.md`'s `Hooks.Use` row gains the cancellation semantics. Two defects found in passing are filed rather than fixed: the `Label` pool helper does not clear children, so a `V.Custom<Label>` subtree can travel into the pool (#475), and the drag session is told a `Focusable` prop was declared on the render that removes it (#474).

Closes #383
Closes #384
Closes #388
