### PR TITLE
fix(velvet): make three documents say what the code does

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -86,6 +86,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   React does — the success state is dispatched after the handler runs, so a handler that throws never
   reaches it.
 
+- `TransitionType.Spring` and `TransitionType.Bezier` no longer tell you in IntelliSense that colours
+  and lengths are out of scope. Both have been driven channels since 2.0.0 and the tooltip's exclusion
+  list was left behind — a consumer who read it hand-rolled a separate tween for a background colour or
+  a width that the spring config was already animating. Both members now point at
+  `Documentation~/motion.md`'s "Driven channels", which owns the list; the guide gains the two
+  exclusions it was missing (percentage-based translate and per-axis `scale-x-` / `scale-y-`), and both
+  are now pinned by tests.
+
+  Two guide corrections ride along. `Documentation~/react-migration.md`'s Store example did not
+  compile: it passed `onChange:` to `V.Slider`, whose handler parameter is `onValueChanged`, and its
+  `Store<T>` subclass left `ResetCore` unimplemented. `Documentation~/styling-variants.md` claimed a
+  stacked variant sits above either of its parts alone; it layers at the higher of the two, so against
+  that stronger part it ties rather than wins, and the tie is settled the way the same file's *Same
+  family, different values* bullet already describes.
+
 ## [2.0.0] - 2026-08-02
 
 ### Highlights

--- a/Packages/com.velvet.core/Documentation~/motion.md
+++ b/Packages/com.velvet.core/Documentation~/motion.md
@@ -226,6 +226,10 @@ the plan are built in one synchronous call, off-panel, before any style resoluti
   modes, not magnitudes; `rounded-full` is a saturating pill sentinel; `shadow-*`, `skew-*` and
   gradients are baked silhouette paints; `filter-*` is driven by its own opt-in
   `transition-filter`; `z-*` is a physical reparent.
+- **Percentage-based translate** (`translate-x-1/2`, `translate-x-full`) **and per-axis `scale-x-` /
+  `scale-y-` are not channels either,** for all that the quartet above names `translate` and `scale`.
+  Both families resolve as ordinary utilities; they just apply as plain classes, so the swap lands
+  them instantly.
 - **A play suspends the element's own USS transitions when they cover what it drives.** A driver
   writes the exact value the curve or the physics calls for on that frame, so a transition utility
   naming that same property restarts a native transition on every one of those writes and leaves

--- a/Packages/com.velvet.core/Documentation~/react-migration.md
+++ b/Packages/com.velvet.core/Documentation~/react-migration.md
@@ -339,6 +339,10 @@ public sealed class SettingsStore : Store<SettingsState>
 
     public void SetVolume(float v)
         => SetState(s => s with { Volume = v });
+
+    // Store<T> declares this abstract: what Reset() puts the state back to.
+    protected override void ResetCore()
+        => SetState(_ => new SettingsState(1.0f, false));
 }
 
 // Component (Presentation layer)
@@ -350,7 +354,7 @@ private static VNode VolumeSliderRender()
     var store = Hooks.UseContext(SettingsStoreContext);
     // Re-render only when Volume changes
     var volume = Hooks.UseStore(store, s => s.Volume);
-    return V.Slider(value: volume, onChange: store.SetVolume);
+    return V.Slider(value: volume, onValueChanged: store.SetVolume);
 }
 
 // Provider site (once at the page root, etc.)

--- a/Packages/com.velvet.core/Documentation~/styling-variants.md
+++ b/Packages/com.velvet.core/Documentation~/styling-variants.md
@@ -158,8 +158,9 @@ not, each still occupies a layer of its own, so turning one off never disturbs a
 | 8 | Element state — `checked:` < `hover:` < `focus:` < `focus-visible:` < `active:` |
 | 9 | The important band — rows 1–8 again, one level each, for anything carrying `!` |
 
-A **stacked** variant (`dark:hover:bg-red`) layers at the higher of its two parts, so it sits above
-either one alone.
+A **stacked** variant (`dark:hover:bg-red`) layers at the higher of its two parts — row 8's `hover:`
+layer here, not a layer of its own above it. So it outranks the weaker part alone and only **ties**
+with the stronger one; *Same family, different values* above settles such a tie.
 
 ### The important modifier
 

--- a/Packages/com.velvet.core/Runtime/Styling/StyleTransitionConfig.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleTransitionConfig.cs
@@ -336,11 +336,8 @@ namespace Velvet
         /// Only <see cref="Velvet.MotionNode"/>'s variant enter/exit (<c>variants</c> + <c>initial</c>/<c>animate</c>/
         /// <c>exit</c>) plays a spring — the classic preset transitions (<see cref="StyleTransition"/>) are always
         /// tweens, since their enter/exit classes are internal to the package.
-        /// Only OPACITY and the transform trio — translate x/y (pixels only; percentage-based translate such as
-        /// <c>translate-x-1/2</c> or <c>translate-x-full</c> is out of scope), uniform scale, and rotate (degrees)
-        /// — are spring-animated; colors, arbitrary lengths (width/height/margin/…), and per-axis
-        /// <c>scale-x-</c>/<c>scale-y-</c> are out of scope and are NOT animated by a spring (they still apply as
-        /// plain classes, just without a tween/spring transition on them).
+        /// Which class pairs the tick interpolates, and which fall through to a plain class swap with no
+        /// animation on them, is owned by <c>Documentation~/motion.md</c>'s "Driven channels".
         /// </summary>
         Spring,
 
@@ -350,10 +347,9 @@ namespace Velvet
         /// <see cref="StyleTransitionConfig.BezierX2"/>, <see cref="StyleTransitionConfig.BezierY2"/><c>)</c> curve
         /// instead of one of UI Toolkit's five <c>EasingMode</c> keywords (which cannot express an arbitrary
         /// cubic-bezier). Like <see cref="Spring"/>, this cannot be expressed by CSS/USS transitions, so it is
-        /// driven by a per-frame tick that writes inline styles directly — and so shares the spring's channel
-        /// scope EXACTLY: only OPACITY and the transform trio (translate x/y in pixels, uniform scale, rotate
-        /// degrees) are animated; everything else applies as a plain class with no tween. One curve drives BOTH
-        /// enter and exit (there is no separate exit curve, mirroring the spring's single stiffness/damping/mass),
+        /// driven by a per-frame tick that writes inline styles directly — off the same resolved channel plan,
+        /// so its channel scope is <see cref="Spring"/>'s exactly. One curve drives BOTH enter and exit
+        /// (there is no separate exit curve, mirroring the spring's single stiffness/damping/mass),
         /// and <see cref="StyleTransitionConfig.PropertyOverrides"/> is not read (no per-property curve). A zero
         /// <see cref="StyleTransitionConfig.DurationSec"/> completes immediately with no animation, exactly like a
         /// zero-duration <see cref="Tween"/>.

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/MotionSpringDriverTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/MotionSpringDriverTests.cs
@@ -12,7 +12,9 @@ namespace Velvet.Tests
     /// needs), the per-frame physics tick (<see cref="MotionSpringDriver.Step"/>) moves the inline style toward
     /// the target and reports settled once it arrives, an exit-cancel retarget
     /// (<see cref="MotionSpringDriver.Retarget"/>) redirects a channel toward its resting value without resetting
-    /// its integrator; the underlying pure physics of <see cref="SpringIntegrator"/> — it converges to its target
+    /// its integrator; the axis-scope holes <c>Documentation~/motion.md</c>'s "Driven channels" documents
+    /// (percentage-based translate, per-axis <c>scale-x-</c>/<c>scale-y-</c>), which resolve as utilities but
+    /// plan no channel; the underlying pure physics of <see cref="SpringIntegrator"/> — it converges to its target
     /// given enough time, an underdamped configuration overshoots before settling (Framer Motion's spring is
     /// underdamped by default), and retargeting an in-flight spring carries its CURRENT value/velocity forward
     /// instead of resetting them (the continuity an interrupted AnimatePresence exit/enter needs); validation of
@@ -191,6 +193,38 @@ namespace Velvet.Tests
             // Assert — a pair that resolved no rotate channel reads as null here and fails the same
             // comparison a wrong magnitude would.
             Assert.That(plan.Rotate, Is.EqualTo(((float, float)?)(45f, -45f)));
+        }
+
+        [Test]
+        public void Given_APercentTranslateClassPair_When_Resolved_Then_NoTranslateChannelIsPlanned()
+        {
+            // Arrange — the gate carries the fact that these two spellings ARE real translate utilities,
+            // resolving onto TranslateX in percent. Without it the case would pass just as well on a class
+            // nothing recognizes, pinning the scope hole in name only.
+            var resolvesAsPercentTranslate =
+                StyleArbitraryValueResolver.TryParse("translate-x-1/2", out var half)
+                && half.Property == ArbitraryProperty.TranslateX && half.Unit == LengthUnit.Percent;
+
+            // Act
+            var plan = MotionSpringClassParser.Resolve(new[] { "translate-x-1/2" }, new[] { "translate-x-full" });
+
+            // Assert
+            Assert.That((resolvesAsPercentTranslate, plan.TranslateX.HasValue), Is.EqualTo((true, false)));
+        }
+
+        [Test]
+        public void Given_APerAxisScaleClassPair_When_Resolved_Then_NoScaleChannelIsPlanned()
+        {
+            // Arrange — same gate shape as the percent-translate case above.
+            var resolvesAsPerAxisScale =
+                StyleArbitraryValueResolver.TryParse("scale-x-50", out var half)
+                && half.Property == ArbitraryProperty.ScaleX;
+
+            // Act
+            var plan = MotionSpringClassParser.Resolve(new[] { "scale-x-50" }, new[] { "scale-x-110" });
+
+            // Assert
+            Assert.That((resolvesAsPerAxisScale, plan.Scale.HasValue), Is.EqualTo((true, false)));
         }
 
         [Test]


### PR DESCRIPTION
Three documents told a reader something the code does not do.

**The canonical Zustand-migration sample did not compile.** `react-migration.md` §5-2 passed `onChange:` to `V.Slider`, where the parameter is `onValueChanged`, and its `Store<TState>` subclass had no `ResetCore()` override — `Store<TState>` declares it abstract, so the sample failed CS0534 as well as CS1739. It is among the first Velvet code a React developer writes. Both were found by extracting the fenced block and compiling it against the built `Velvet.dll`; the corrected block now compiles with no diagnostics.

**`styling-variants.md` contradicted itself on stacked-variant precedence.** The precedence section said a stack "sits above either of its parts", so a reader would expect `dark:hover:bg-red-500` to beat a plain `hover:bg-blue-500` in dark mode. `GateStackedVariant` computes a plain max of the two priorities with no additive term, and `Dark = 20` while `Hover = 40`, so `dark:hover:` lands at 40 — exactly where `hover:` alone lands. The projection suppresses only strictly-lower entries and deliberately leaves ties alone, so the stack outranks the weaker part and ties with the stronger one, leaving the outcome to declaration order in the bundled sheets. The paragraph now says that and defers to the guide's existing tie-break rule rather than restating it.

**`TransitionType.Spring` / `.Bezier`'s XmlDoc told consumers colours and arbitrary lengths are not spring-animated.** Both drivers write interpolated colours and lengths inline every tick, ungated, and have since 2.0.0 — so a reader hand-rolled a tween for something a spring config already drove, or misread an animated width as a bug. The enumeration is gone from the XmlDoc, which now points at `motion.md`'s "Driven channels" as the owning document.

Two exclusions only the XmlDoc carried — percentage `translate` and per-axis `scale-x`/`scale-y` are genuinely not planned as channels — moved into that guide, and each is now pinned by a test rather than living in prose alone. Each folds its recogniser gate into the assertion, so a rename that made the arranged class unrecognised fails the case instead of passing it vacuously.

Four things found in passing are filed rather than fixed: the same false precedence sentence survives in two code comments (#477); nothing compiles the guide samples and the drift guard strips them by design (#478); `motion.md`'s not-driven list omits `aspect-[…]` (#479); and three ignored tests justify themselves by coverage elsewhere that nothing verifies (#480).

Closes #395
Closes #396
Closes #397
