### PR TITLE
docs(velvet): drop two comments claiming a stacked variant outranks both its parts

### DIFF
--- a/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
@@ -446,10 +446,9 @@ namespace Velvet
         public Dictionary<(VisualElement target, object owner, int outerPriority, StyleVariantKind inner, string innerName, string? leaf), StyleStackedVariantManipulator> StackedVariantManipulators { get; } = new();
 
         // Looks up/creates the stacked manipulator for this outer owner + inner variant + leaf and toggles its
-        // outer gate. Called by StyleVariantPayload.Apply when a payload is itself a variant. A composed
-        // arbitrary leaf layers at max(outer, inner) priority so it sits above either variant alone. A named
-        // inner relational (group-hover/sidebar:) threads its name through so the nested manipulator resolves
-        // the named source, not the unnamed group/peer.
+        // outer gate. Called by StyleVariantPayload.Apply when a payload is itself a variant. A named inner
+        // relational (group-hover/sidebar:) threads its name through so the nested manipulator resolves the
+        // named source, not the unnamed group/peer.
         internal void GateStackedVariant(VisualElement target, object owner, string variantPayload,
             bool outerOn, int outerPriority, int declaration)
         {

--- a/Packages/com.velvet.core/Runtime/Styling/StyleArbitraryModel.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleArbitraryModel.cs
@@ -98,8 +98,6 @@ namespace Velvet
         public static int ImportantOf(int priority) => Important + priority;
         #endregion
 
-        // The layer priority a stacked variant's inner kind contributes; a composed arbitrary leaf
-        // (dark:hover:w-[200px]) layers at max(outer, inner) so it sits above either variant alone.
         internal static int ForVariant(StyleVariantKind kind) => kind switch
         {
             StyleVariantKind.Sm => ResponsiveSm,


### PR DESCRIPTION
Two comments claimed a stacked variant "sits above either variant alone". It does not — it outranks the weaker part and ties with the stronger one.

`GateStackedVariant` takes a plain max of the outer and inner priorities with no additive term, and `Dark = 20` while `Hover = 40`, so `dark:hover:` lands at 40 — exactly where a plain `hover:` payload lands. Two paths then decide the tie, and neither favours the stack:

- On the class path, `TryNextBand` cuts on `entry.Priority < cutoff`, strictly, so equal priorities form one band; `Recompute` judges a band before claiming it, so no member can kill a peer.
- On the arbitrary-value path — which is what these comments were actually about, since they sat over `w-[200px]`-style leaves — `StyleArbitraryValueResolver.Apply` writes `layers[priority] = style` into a `SortedList<int, ArbitraryStyle>`. One slot per priority, so a plain `hover:` applied afterwards silently replaces the stack.

The first clause of each comment was true (it does layer at max) and the conclusion drawn from it was false, which is the shape CLAUDE.md names with the observation right and the mechanism assumed.

Both are deleted rather than rewritten. `StyleStackedVariantManipulator` already states the accurate version, and at the `GateStackedVariant` site the next line constructs that type by name, so a "see also" would be dead text by the deletion test. Nothing replaces them with a reason for taking the max: that rationale is not derivable from the code, and inventing one is the failure this change exists to undo.

The codebase already contradicted these two sentences in two places — `ReconcilerContext.cs:189` says the same promotion lands a payload on the hover band *beside* the child's own, and `styling-variants.md` states the outcome correctly with a worked example.

A sweep of every comment in `Runtime/Styling` and `Runtime/Reconciler` pairing *above / outrank / wins / beats* with layer or priority language found no further instance. Two nearby claims were checked and hold: the important band really is `100 + priority` with a floor above Active, and relational variants really do share one `(property, priority)` slot where the last to apply wins.

Comment-only, so there is no behaviour change and no regression test: nothing asserts on this text, and `DocumentationDriftTests` strips C# comments before building its corpus, so the identifiers inside the deleted lines never resolved anything. The suites were run to show nothing else moved, not to establish the claim — that was established by reading the sources.

No CHANGELOG entry: `[Unreleased]` describes behaviour a consumer can observe, and nothing an installed package does changed. The user-visible half of this fact is the guide sentence, corrected separately in #481.

Closes #477
