### PR TITLE
fix(velvet): route every stacked inner kind, and let the compiler check the classification

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `checked:`, `peer-checked:`, `group-focus-within:` and `peer-focus-within:` now work as the *inner*
+  half of a stacked variant. `dark:checked:bg-primary` and `dark:group-focus-within:ring-2` applied
+  nothing, while the same pair written the other way round (`checked:dark:bg-primary`) applied — so the
+  documented rule that stacking order does not matter held for every family except these four. The
+  stacked manipulator classified its inner kind with a set of independent bool predicates, and a set of
+  bools has no way to report a kind matching none of them: all four fell past every branch into the
+  relational one, which mapped hover / focus / active only, so their gate had no signal that could open
+  it. A `checked:` inner now reads the target's own `ChangeEvent<bool>` and a `peer-checked:` inner the
+  resolved peer's, both seeded from an already-checked control when the gate is built, the same way the
+  top-level variants are.
+
 - A `Focusable` prop that a later render stops declaring now hands the element back the focusability it
   was constructed with, instead of making it focusable. Dropping the prop compares unequal to the
   declared value, and the absent case coalesced to `true`: a `V.Div` that carried `Focusable = true` for

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
@@ -2038,11 +2038,11 @@ namespace Velvet
             for (var i = 0; i < classNames.Length; i++)
             {
                 if (!StyleVariantClass.TryParse(classNames[i], out var kind, out var name, out var payload)
-                    || !StyleVariantClass.IsRelational(kind))
+                    || StyleVariantClass.RelationalOf(kind) is not { } relational)
                 {
                     continue;
                 }
-                var key = (StyleVariantClass.RelationalIsPeer(kind), name ?? string.Empty);
+                var key = (relational.IsPeer, name ?? string.Empty);
                 map ??= new Dictionary<(bool, string), List<string>[]>();
                 positions ??= new Dictionary<(bool, string), List<int>[]>();
                 if (!map.TryGetValue(key, out var states))
@@ -2051,7 +2051,7 @@ namespace Velvet
                     map[key] = states;
                     positions[key] = new List<int>[5];
                 }
-                var slot = (int)StyleVariantClass.RelationalStateOf(kind);
+                var slot = (int)relational.State;
                 (states[slot] ??= new List<string>()).Add(payload ?? string.Empty);
                 (positions![key][slot] ??= new List<int>()).Add(i);
             }

--- a/Packages/com.velvet.core/Runtime/Styling/StyleArbitraryModel.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleArbitraryModel.cs
@@ -100,8 +100,10 @@ namespace Velvet
 
         // The layer priority a stacked variant's inner kind contributes; a composed arbitrary leaf
         // (dark:hover:w-[200px]) layers at max(outer, inner) so it sits above either variant alone.
+#pragma warning disable CS8524 // no discard arm — see the remarks on StyleVariantKind
         internal static int ForVariant(StyleVariantKind kind) => kind switch
         {
+            StyleVariantKind.Hover => Hover,
             StyleVariantKind.Sm => ResponsiveSm,
             StyleVariantKind.Md => ResponsiveMd,
             StyleVariantKind.Lg => ResponsiveLg,
@@ -121,8 +123,8 @@ namespace Velvet
             StyleVariantKind.FocusVisible => FocusVisible,
             StyleVariantKind.Active => Active,
             StyleVariantKind.Checked => Checked,
-            _ => Hover,
         };
+#pragma warning restore CS8524
     }
     // The style property an arbitrary-value utility targets (e.g. w-[120px] → Width,
     // bg-[#fff] → background color, rotate-[45deg] → rotation). Shorthand members fan out to

--- a/Packages/com.velvet.core/Runtime/Styling/StyleStackedVariantManipulator.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleStackedVariantManipulator.cs
@@ -3,6 +3,15 @@ using UnityEngine.UIElements;
 
 namespace Velvet
 {
+    // Where an inner kind's signal comes from, and so which branch of the manipulator below owns it.
+    internal enum StackedInnerSource
+    {
+        ElementLocal,
+        Theme,
+        Responsive,
+        Relational,
+    }
+
     // Applies a stacked-variant leaf payload iff BOTH the outer gate (set by the owning manipulator when its
     // own condition holds) AND this inner variant's own signal are active, implementing variant
     // stacking (dark:hover:bg-red == apply bg-red iff dark AND hovered, order-independent). One instance per
@@ -15,6 +24,9 @@ namespace Velvet
     {
         private readonly ReconcilerContext _ctx;
         private readonly StyleVariantKind _innerKind;
+        private readonly StackedInnerSource _source;
+        // Non-null exactly for a relational inner: the source it resolves and the state it reacts to.
+        private readonly (bool IsPeer, StyleVariantClass.RelationalState State)? _relational;
         private readonly string _innerName; // relational name of a NAMED inner (group-hover/sidebar:), else ""
         private readonly string[] _leaf;
         private readonly int _priority;
@@ -37,6 +49,8 @@ namespace Velvet
             _declarations = new[] { declaration };
             _ctx = ctx;
             _innerKind = innerKind;
+            _source = SourceOf(innerKind);
+            _relational = StyleVariantClass.RelationalOf(innerKind);
             _innerName = innerName ?? string.Empty;
             _leaf = leaf != null
                 ? Array.ConvertAll(leaf, static x => x ?? string.Empty)
@@ -55,23 +69,35 @@ namespace Velvet
             Sync();
         }
 
-        // The newer variant kinds (checked:, group/peer-focus-within:, peer-checked:) are intentionally
-        // absent here: they are supported as TOP-LEVEL variants but not yet as the INNER of a stack
-        // (dark:checked:…). An unrecognized inner kind falls through to the relational branch and stays
-        // inert (no signal ever flips the inner gate) rather than crashing.
-        private bool IsElementLocal =>
-            _innerKind is StyleVariantKind.Hover or StyleVariantKind.Focus
-                or StyleVariantKind.FocusVisible or StyleVariantKind.Active;
-
-        private bool IsRelational =>
-            _innerKind is StyleVariantKind.GroupHover or StyleVariantKind.GroupFocus or StyleVariantKind.GroupActive
-                or StyleVariantKind.PeerHover or StyleVariantKind.PeerFocus or StyleVariantKind.PeerActive;
+#pragma warning disable CS8524 // no discard arm — see the remarks on StyleVariantKind
+        private static StackedInnerSource SourceOf(StyleVariantKind kind) => kind switch
+        {
+            StyleVariantKind.Hover or StyleVariantKind.Focus or StyleVariantKind.FocusVisible
+                or StyleVariantKind.Active or StyleVariantKind.Checked => StackedInnerSource.ElementLocal,
+            StyleVariantKind.Dark => StackedInnerSource.Theme,
+            StyleVariantKind.Sm or StyleVariantKind.Md or StyleVariantKind.Lg
+                or StyleVariantKind.Xl or StyleVariantKind.Xxl => StackedInnerSource.Responsive,
+            StyleVariantKind.GroupHover or StyleVariantKind.GroupFocus
+                or StyleVariantKind.GroupFocusWithin or StyleVariantKind.GroupActive
+                or StyleVariantKind.PeerHover or StyleVariantKind.PeerFocus
+                or StyleVariantKind.PeerFocusWithin or StyleVariantKind.PeerActive
+                or StyleVariantKind.PeerChecked => StackedInnerSource.Relational,
+        };
 
         // Edge-based inners survive an outer-gate close (see ReconcilerContext.GateStackedVariant):
-        // their pointer/focus signals fire only on state edges, so a re-created manipulator could
-        // not re-seed a continuously-held hover/focus. Level-based inners (dark, responsive)
-        // re-derive their truth on attach and are detached on close to release their subscriptions.
-        internal bool RetainsAcrossOuterClose => IsElementLocal || IsRelational;
+        // their signals fire only on state edges, so a re-created manipulator could not re-seed a
+        // continuously-held hover/focus. Level-based inners (dark, responsive) re-derive their truth
+        // on attach and are detached on close to release their subscriptions.
+        internal bool RetainsAcrossOuterClose => _source switch
+        {
+            StackedInnerSource.ElementLocal or StackedInnerSource.Relational => true,
+            StackedInnerSource.Theme or StackedInnerSource.Responsive => false,
+        };
+#pragma warning restore CS8524
+
+        private bool TracksChecked =>
+            _innerKind == StyleVariantKind.Checked
+            || _relational is { State: StyleVariantClass.RelationalState.Checked };
 
         // Forwards a drag session's synthetic release to the shared signal source (see
         // ElementLocalVariantSignals.SettleRelease); a non-element-local inner (dark:/sm:) has no press
@@ -83,13 +109,12 @@ namespace Velvet
 
         protected override void RegisterCallbacksOnTarget()
         {
-            if (IsElementLocal)
+            if (_source == StackedInnerSource.ElementLocal)
             {
                 _elementSignals ??= new ElementLocalVariantSignals(OnElementSignal);
-                // The stacked inner never tracks checked:, so the ChangeEvent path is skipped.
-                _elementSignals.Hook(target, seedChecked: false, registerChecked: false);
+                _elementSignals.Hook(target, seedChecked: TracksChecked, registerChecked: TracksChecked);
             }
-            else if (_innerKind == StyleVariantKind.Dark)
+            else if (_source == StackedInnerSource.Theme)
             {
                 VelvetTheme.DarkModeChanged += OnDarkChanged;
                 EvaluateDark();
@@ -100,7 +125,7 @@ namespace Velvet
                 target.RegisterCallback<DetachFromPanelEvent>(OnDetach);
                 if (target.panel != null)
                 {
-                    if (StyleVariantClass.IsResponsive(_innerKind))
+                    if (_source == StackedInnerSource.Responsive)
                     {
                         _widthSource ??= new ResponsiveWidthSource(EvaluateResponsive);
                         _widthSource.Hook(StyleResponsiveScope.ResolveWidthSource(target, target.panel.visualTree));
@@ -120,11 +145,11 @@ namespace Velvet
             _innerOn = false;
             _outerOn = false;
 
-            if (IsElementLocal)
+            if (_source == StackedInnerSource.ElementLocal)
             {
                 _elementSignals?.Unhook();
             }
-            else if (_innerKind == StyleVariantKind.Dark)
+            else if (_source == StackedInnerSource.Theme)
             {
                 VelvetTheme.DarkModeChanged -= OnDarkChanged;
             }
@@ -137,7 +162,7 @@ namespace Velvet
             }
         }
 
-        #region element-local signals (hover / focus / focus-visible / active; shared detection via ElementLocalVariantSignals)
+        #region element-local signals (hover / focus / focus-visible / active / checked; shared detection via ElementLocalVariantSignals)
 
         // Opens/closes the inner gate when the detected element-local signal matches this stack's inner kind.
         // SetInner dedups, so the focus-visible-drop-on-PointerDown (a no-op unless the ring is on) and any
@@ -145,14 +170,16 @@ namespace Velvet
         // bubbling, so this only routes the edge.
         private void OnElementSignal(VariantSignal signal, bool on)
         {
+#pragma warning disable CS8524 // no discard arm: a signal this stack cannot route has to warn
             var matches = signal switch
             {
                 VariantSignal.Hover => _innerKind == StyleVariantKind.Hover,
                 VariantSignal.Focus => _innerKind == StyleVariantKind.Focus,
                 VariantSignal.FocusVisible => _innerKind == StyleVariantKind.FocusVisible,
                 VariantSignal.Active => _innerKind == StyleVariantKind.Active,
-                _ => false,
+                VariantSignal.Checked => _innerKind == StyleVariantKind.Checked,
             };
+#pragma warning restore CS8524
             if (matches)
             {
                 SetInner(on);
@@ -170,7 +197,7 @@ namespace Velvet
 
         private void OnAttach(AttachToPanelEvent evt)
         {
-            if (StyleVariantClass.IsResponsive(_innerKind))
+            if (_source == StackedInnerSource.Responsive)
             {
                 _widthSource ??= new ResponsiveWidthSource(EvaluateResponsive);
                 _widthSource.Hook(StyleResponsiveScope.ResolveWidthSource(target, evt.destinationPanel?.visualTree));
@@ -201,27 +228,31 @@ namespace Velvet
 
         #region group / peer (shared detection via RelationalVariantSignals)
 
-        private bool RelIsHover => _innerKind is StyleVariantKind.GroupHover or StyleVariantKind.PeerHover;
-        private bool RelIsFocus => _innerKind is StyleVariantKind.GroupFocus or StyleVariantKind.PeerFocus;
-        private bool RelIsActive => _innerKind is StyleVariantKind.GroupActive or StyleVariantKind.PeerActive;
-
         private void ResolveRelational()
         {
             UnhookRelational();
-            var isGroup = _innerKind is StyleVariantKind.GroupHover or StyleVariantKind.GroupFocus
-                or StyleVariantKind.GroupActive;
+            if (_relational is not { } rel)
+            {
+                return;
+            }
+            // A checked inner's value is seeded at hook time rather than arriving as an edge, so a re-resolve
+            // has to drop what the previous source seeded before reading the new one — the same order
+            // StyleRelationalVariantManipulator's Binding.Resolve keeps.
+            if (TracksChecked)
+            {
+                SetInner(false);
+            }
             // A named inner (dark:group-hover/sidebar:) resolves the `group/sidebar` source, not the unnamed one.
-            var sourceClass = StyleRelationalVariantManipulator.SourceClassFor(!isGroup, _innerName);
-            var source = isGroup
-                ? StyleRelationalVariantManipulator.FindAncestorWithClass(target, sourceClass)
-                : StyleRelationalVariantManipulator.FindPrevSiblingWithClass(target, sourceClass, _ctx);
+            var sourceClass = StyleRelationalVariantManipulator.SourceClassFor(rel.IsPeer, _innerName);
+            var source = rel.IsPeer
+                ? StyleRelationalVariantManipulator.FindPrevSiblingWithClass(target, sourceClass, _ctx)
+                : StyleRelationalVariantManipulator.FindAncestorWithClass(target, sourceClass);
             if (source == null)
             {
                 return;
             }
-            // The stacked relational inner never tracks peer-checked, so the ChangeEvent path is skipped.
             _relSignals ??= new RelationalVariantSignals(OnRelSignal);
-            _relSignals.Hook(source, seedChecked: false, registerChecked: false);
+            _relSignals.Hook(source, seedChecked: TracksChecked, registerChecked: TracksChecked);
         }
 
         private void UnhookRelational()
@@ -229,22 +260,27 @@ namespace Velvet
             _relSignals?.Unhook();
         }
 
-        // Opens/closes the inner gate when the detected relational signal matches this stack's inner kind. The
-        // stacked relational inner supports hover/focus/active only — focus-within and peer-checked are ignored.
+        // Opens/closes the inner gate when the detected relational signal matches this stack's inner kind.
         private void OnRelSignal(RelationalVariantSignal signal, bool on)
         {
-            var matches = signal switch
-            {
-                RelationalVariantSignal.Hover => RelIsHover,
-                RelationalVariantSignal.Focus => RelIsFocus,
-                RelationalVariantSignal.Active => RelIsActive,
-                _ => false,
-            };
-            if (matches)
+            if (_relational is { } rel && StateOf(signal) == rel.State)
             {
                 SetInner(on);
             }
         }
+
+        // The two enumerations name the same five relational states; this pairing is what says so, rather
+        // than a cast that would silently survive either one being reordered.
+#pragma warning disable CS8524 // no discard arm: an unpaired signal has to warn
+        private static StyleVariantClass.RelationalState StateOf(RelationalVariantSignal signal) => signal switch
+        {
+            RelationalVariantSignal.Hover => StyleVariantClass.RelationalState.Hover,
+            RelationalVariantSignal.Focus => StyleVariantClass.RelationalState.Focus,
+            RelationalVariantSignal.FocusWithin => StyleVariantClass.RelationalState.FocusWithin,
+            RelationalVariantSignal.Active => StyleVariantClass.RelationalState.Active,
+            RelationalVariantSignal.Checked => StyleVariantClass.RelationalState.Checked,
+        };
+#pragma warning restore CS8524
         #endregion
 
         #region gating

--- a/Packages/com.velvet.core/Runtime/Styling/StyleVariantClass.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleVariantClass.cs
@@ -13,6 +13,13 @@ namespace Velvet
     /// (the curated <c>disabled-*</c> utilities). Responsive (<c>sm:</c>/<c>md:</c>), <c>dark:</c>, and
     /// <c>group</c>/<c>peer</c> are tracked separately (they need a breakpoint / theme / structural
     /// signal source).
+    /// <para/>
+    /// Every switch that CLASSIFIES these kinds — which signal source drives one, which layer it occupies —
+    /// is written without a discard arm, so adding a member here raises CS8509 at each site that has to learn
+    /// it. A set of independent <c>is X or Y</c> predicates cannot report a member matching none, and that is
+    /// what left <c>checked:</c>, the two focus-within relationals and <c>peer-checked:</c> unclassified and
+    /// inert as the inner of a stacked variant. Those sites suppress CS8524 instead: it asks for an arm
+    /// covering an out-of-range cast, which no named member can supply.
     /// </remarks>
     public enum StyleVariantKind
     {
@@ -176,39 +183,46 @@ namespace Velvet
         /// checked), shared by the group and peer families.</summary>
         internal enum RelationalState { Hover, Focus, FocusWithin, Active, Checked }
 
-        /// <summary>True for the relational variant kinds (group-* / peer-*), the only ones that accept a name.</summary>
-        internal static bool IsRelational(StyleVariantKind kind)
-            => kind is StyleVariantKind.GroupHover or StyleVariantKind.GroupFocus
-                or StyleVariantKind.GroupFocusWithin or StyleVariantKind.GroupActive
-                or StyleVariantKind.PeerHover or StyleVariantKind.PeerFocus
-                or StyleVariantKind.PeerFocusWithin or StyleVariantKind.PeerActive
-                or StyleVariantKind.PeerChecked;
-
-        /// <summary>True when a relational kind is a peer-* (previous-sibling source); false for group-*.</summary>
-        internal static bool RelationalIsPeer(StyleVariantKind kind)
-            => kind is StyleVariantKind.PeerHover or StyleVariantKind.PeerFocus
-                or StyleVariantKind.PeerFocusWithin or StyleVariantKind.PeerActive
-                or StyleVariantKind.PeerChecked;
-
-        /// <summary>Maps a relational kind to the source state it reacts to.</summary>
-        internal static RelationalState RelationalStateOf(StyleVariantKind kind) => kind switch
+        /// <summary>
+        /// Which source a relational kind reads (a preceding <c>peer</c> sibling when <c>IsPeer</c>, else the
+        /// nearest <c>group</c> ancestor) and which of that source's states it reacts to; null for every
+        /// non-relational kind. One switch answers all three questions so they cannot answer differently, and
+        /// it carries no discard arm — see the remarks on <see cref="StyleVariantKind"/>.
+        /// </summary>
+#pragma warning disable CS8524 // no discard arm — see the remarks on StyleVariantKind
+        internal static (bool IsPeer, RelationalState State)? RelationalOf(StyleVariantKind kind) => kind switch
         {
-            StyleVariantKind.GroupHover or StyleVariantKind.PeerHover => RelationalState.Hover,
-            StyleVariantKind.GroupFocus or StyleVariantKind.PeerFocus => RelationalState.Focus,
-            StyleVariantKind.GroupFocusWithin or StyleVariantKind.PeerFocusWithin => RelationalState.FocusWithin,
-            StyleVariantKind.GroupActive or StyleVariantKind.PeerActive => RelationalState.Active,
-            _ => RelationalState.Checked, // PeerChecked
+            StyleVariantKind.GroupHover => (false, RelationalState.Hover),
+            StyleVariantKind.GroupFocus => (false, RelationalState.Focus),
+            StyleVariantKind.GroupFocusWithin => (false, RelationalState.FocusWithin),
+            StyleVariantKind.GroupActive => (false, RelationalState.Active),
+            StyleVariantKind.PeerHover => (true, RelationalState.Hover),
+            StyleVariantKind.PeerFocus => (true, RelationalState.Focus),
+            StyleVariantKind.PeerFocusWithin => (true, RelationalState.FocusWithin),
+            StyleVariantKind.PeerActive => (true, RelationalState.Active),
+            StyleVariantKind.PeerChecked => (true, RelationalState.Checked),
+            StyleVariantKind.Hover or StyleVariantKind.Focus or StyleVariantKind.FocusVisible
+                or StyleVariantKind.Active or StyleVariantKind.Checked
+                or StyleVariantKind.Sm or StyleVariantKind.Md or StyleVariantKind.Lg
+                or StyleVariantKind.Xl or StyleVariantKind.Xxl
+                or StyleVariantKind.Dark => null,
         };
+#pragma warning restore CS8524
 
-        /// <summary>True for the responsive min-width variants (<c>sm:</c>…<c>2xl:</c>).</summary>
-        public static bool IsResponsive(StyleVariantKind kind)
-            => kind is StyleVariantKind.Sm or StyleVariantKind.Md or StyleVariantKind.Lg
-                or StyleVariantKind.Xl or StyleVariantKind.Xxl;
+        /// <summary>True for the relational variant kinds (group-* / peer-*), the only ones that accept a name.</summary>
+        internal static bool IsRelational(StyleVariantKind kind) => RelationalOf(kind).HasValue;
+
+        /// <summary>
+        /// True for the responsive min-width variants (<c>sm:</c>…<c>2xl:</c>) — read off
+        /// <see cref="BreakpointPx"/> rather than listing them again, so the two cannot disagree.
+        /// </summary>
+        public static bool IsResponsive(StyleVariantKind kind) => BreakpointPx(kind) > 0f;
 
         /// <summary>
         /// Min-width (px) at which a responsive variant activates. The default breakpoints:
         /// sm 640, md 768, lg 1024, xl 1280, 2xl 1536. Returns 0 for non-responsive kinds.
         /// </summary>
+#pragma warning disable CS8524 // no discard arm — see the remarks on StyleVariantKind
         public static float BreakpointPx(StyleVariantKind kind) => kind switch
         {
             StyleVariantKind.Sm => 640f,
@@ -216,7 +230,14 @@ namespace Velvet
             StyleVariantKind.Lg => 1024f,
             StyleVariantKind.Xl => 1280f,
             StyleVariantKind.Xxl => 1536f,
-            _ => 0f,
+            StyleVariantKind.Hover or StyleVariantKind.Focus or StyleVariantKind.FocusVisible
+                or StyleVariantKind.Active or StyleVariantKind.Checked or StyleVariantKind.Dark
+                or StyleVariantKind.GroupHover or StyleVariantKind.GroupFocus
+                or StyleVariantKind.GroupFocusWithin or StyleVariantKind.GroupActive
+                or StyleVariantKind.PeerHover or StyleVariantKind.PeerFocus
+                or StyleVariantKind.PeerFocusWithin or StyleVariantKind.PeerActive
+                or StyleVariantKind.PeerChecked => 0f,
         };
+#pragma warning restore CS8524
     }
 }

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/StackedVariantEdgeTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/StackedVariantEdgeTests.cs
@@ -11,8 +11,10 @@ namespace Velvet.Tests
     /// inner signal, e.g. <c>dark:active:</c> / <c>dark:hover:</c> / <c>dark:focus-visible:</c>) that the broader
     /// <see cref="StackedVariantBehaviorTests"/> does not exercise: the element-local press/release/cancel and the
     /// worldBound-gated pointer-out for an <c>active</c> inner, the bounds-kept hover for a <c>hover</c> inner, the
-    /// pointer-vs-keyboard split for a <c>focus-visible</c> inner, the inner kinds that are NOT supported as a
-    /// stack (<c>checked:</c> / <c>focus-within:</c> / <c>peer-checked:</c> stay inert rather than crashing), and
+    /// pointer-vs-keyboard split for a <c>focus-visible</c> inner, the four inner kinds driven by something
+    /// other than a pointer edge (<c>checked:</c> and <c>peer-checked:</c> by a change of checked state and
+    /// by the hook-time read of a control mounted already checked, <c>group-focus-within:</c> and
+    /// <c>peer-focus-within:</c> by the source's bubbling focus), and
     /// the detach teardown that clears the leaf and releases the inner subscription. These pin the current
     /// behavior so a refactor of the manipulator preserves it. Element-local / dark-only cases run off panel
     /// (the manipulator registers on the element itself); worldBound, responsive and relational cases mount in a
@@ -22,7 +24,7 @@ namespace Velvet.Tests
     [TestFixture]
     internal sealed class StackedVariantEdgeTests
     {
-        // --- off-panel: element-local inner (active / focus-visible) AND the dark outer gate ---
+        // --- off-panel: element-local inner (active / focus-visible / checked) AND the dark outer gate ---
 
         [TestFixture]
         internal sealed class ElementLocalInner
@@ -130,9 +132,41 @@ namespace Velvet.Tests
                 // Assert — both dark AND keyboard focus-visible hold, so the leaf applies.
                 Assert.IsTrue(leaf.ClassListContains("ring-kbd"));
             }
+
+            [Test]
+            public void Given_DarkCheckedToggleWithDarkOn_When_TheToggleIsChecked_Then_TheLeafIsApplied()
+            {
+                // Arrange — dark:checked:bg-on on an unchecked Toggle with dark on (outer gate open).
+                _mounted = V.Mount(_root, V.Toggle(name: "leaf", className: "dark:checked:bg-on"));
+                var leaf = _root.Q<Toggle>("leaf");
+                VelvetTheme.IsDark = true;
+                Assume.That(leaf.ClassListContains("bg-on"), Is.False, "Precondition: dark alone does not apply (unchecked)");
+
+                // Act — the toggle is checked (the checked inner gate opens).
+                leaf.SimulateChange(true);
+
+                // Assert — both dark AND checked hold, so the leaf applies.
+                Assert.IsTrue(leaf.ClassListContains("bg-on"));
+            }
+
+            [Test]
+            public void Given_DarkCheckedToggleMountedAlreadyChecked_When_TheDarkGateOpens_Then_TheLeafIsApplied()
+            {
+                // Arrange — dark:checked:bg-on on a Toggle mounted ALREADY checked, in the light theme. No
+                // ChangeEvent will ever fire, so the inner gate can only come from the hook-time read.
+                _mounted = V.Mount(_root, V.Toggle(name: "leaf", className: "dark:checked:bg-on", value: true));
+                var leaf = _root.Q<Toggle>("leaf");
+                Assume.That(leaf.ClassListContains("bg-on"), Is.False, "Precondition: checked alone does not apply (light)");
+
+                // Act — the outer (dark) gate opens, which is what builds and hooks the inner.
+                VelvetTheme.IsDark = true;
+
+                // Assert — the inner is seeded from the control's current value, so the leaf applies.
+                Assert.IsTrue(leaf.ClassListContains("bg-on"));
+            }
         }
 
-        // --- panel: worldBound-gated pointer-out, unsupported inners, and detach teardown ---
+        // --- panel: worldBound-gated pointer-out, relational inners, and detach teardown ---
 
         [TestFixture]
         internal sealed class Panel : PanelTestBase
@@ -218,26 +252,9 @@ namespace Velvet.Tests
             }
 
             [Test]
-            public void Given_DarkCheckedLeafWithDarkOn_When_NoPeerSourceExists_Then_TheLeafIsNotApplied()
+            public void Given_DarkPeerCheckedChildWithDarkOn_When_ThePeerSourceIsChecked_Then_TheLeafIsApplied()
             {
-                // Arrange — dark:checked:bg-on. `checked` is not supported as a stacked inner: it falls through to
-                // the relational branch, which seeks a preceding `peer` source and finds none, so it stays inert.
-                _mounted = V.Mount(_window.rootVisualElement, V.Div(name: "leaf", className: "dark:checked:bg-on"));
-                var leaf = _window.rootVisualElement.Q<VisualElement>("leaf");
-
-                // Act — the outer (dark) gate opens, which is the only signal a stacked dark:checked: can ever receive.
-                VelvetTheme.IsDark = true;
-
-                // Assert — the unsupported checked inner never lights the leaf (and does not crash).
-                Assert.IsFalse(leaf.ClassListContains("bg-on"));
-            }
-
-            [Test]
-            public void Given_DarkPeerCheckedChildWithDarkOn_When_ThePeerSourceIsChecked_Then_TheLeafIsNotApplied()
-            {
-                // Arrange — dark:peer-checked:bg-on preceded by a `peer` Toggle. peer-checked is not supported as a
-                // stacked inner: the relational branch resolves the source but never subscribes to its ChangeEvent
-                // nor seeds the initial checked state, so the inner gate can never open.
+                // Arrange — dark:peer-checked:bg-on preceded by an unchecked `peer` Toggle, dark on.
                 _mounted = V.Mount(_window.rootVisualElement, V.Div(
                     "container",
                     V.Toggle(name: "peer", className: "peer"),
@@ -247,29 +264,69 @@ namespace Velvet.Tests
                 VelvetTheme.IsDark = true;
                 Assume.That(child.ClassListContains("bg-on"), Is.False, "Precondition: payload off before any change");
 
-                // Act — the preceding peer toggle is checked.
+                // Act — the preceding peer toggle is checked (the peer-checked inner gate opens).
                 peer.SimulateChange(true);
 
-                // Assert — the unsupported peer-checked inner ignores the source's checked state, so the leaf stays off.
-                Assert.IsFalse(child.ClassListContains("bg-on"));
+                // Assert — both dark AND the peer's checked state hold, so the leaf applies.
+                Assert.IsTrue(child.ClassListContains("bg-on"));
             }
 
             [Test]
-            public void Given_DarkGroupFocusWithinChildUnderAGroup_When_TheOuterDarkGateOpens_Then_TheLeafIsNotApplied()
+            public void Given_DarkPeerCheckedChildWhosePeerIsAlreadyChecked_When_TheDarkGateOpens_Then_TheLeafIsApplied()
             {
-                // Arrange — dark:group-focus-within:bg-on under a `group` source. focus-within is not supported as a
-                // stacked inner: the relational branch does not treat group-focus-within as a group kind, so it
-                // seeks a `peer` sibling, finds none, and stays inert — no source signal can ever open the inner.
+                // Arrange — dark:peer-checked:bg-on preceded by a `peer` Toggle mounted ALREADY checked, light
+                // theme. No ChangeEvent will fire, so the inner gate can only come from the hook-time read.
+                _mounted = V.Mount(_window.rootVisualElement, V.Div(
+                    "container",
+                    V.Toggle(name: "peer", className: "peer", value: true),
+                    V.Label(name: "child", className: "dark:peer-checked:bg-on")));
+                var child = _window.rootVisualElement.Q<Label>("child");
+                Assume.That(child.ClassListContains("bg-on"), Is.False, "Precondition: the peer's state alone does not apply (light)");
+
+                // Act — the outer (dark) gate opens, which is what resolves and hooks the peer source.
+                VelvetTheme.IsDark = true;
+
+                // Assert — the inner is seeded from the resolved source's current value, so the leaf applies.
+                Assert.IsTrue(child.ClassListContains("bg-on"));
+            }
+
+            [Test]
+            public void Given_DarkGroupFocusWithinChildWithDarkOn_When_TheGroupSourceGainsFocus_Then_TheLeafIsApplied()
+            {
+                // Arrange — dark:group-focus-within:bg-on under a `group` ancestor, dark on.
                 _mounted = V.Mount(_window.rootVisualElement, V.Div(
                     "group",
                     V.Label(name: "child", className: "dark:group-focus-within:bg-on")));
+                var source = _window.rootVisualElement.Q<VisualElement>(className: "group");
                 var child = _window.rootVisualElement.Q<Label>("child");
-
-                // Act — the outer (dark) gate opens, which is the only signal a fully-inert stacked inner can receive.
                 VelvetTheme.IsDark = true;
+                Assume.That(child.ClassListContains("bg-on"), Is.False, "Precondition: dark alone does not apply (unfocused)");
 
-                // Assert — the unsupported focus-within inner never lights the leaf (and does not crash).
-                Assert.IsFalse(child.ClassListContains("bg-on"));
+                // Act — focus reaches the group source (its bubbling FocusIn is the focus-within signal).
+                Fire<FocusInEvent>(source);
+
+                // Assert — both dark AND focus-within hold, so the leaf applies.
+                Assert.IsTrue(child.ClassListContains("bg-on"));
+            }
+
+            [Test]
+            public void Given_DarkPeerFocusWithinChildWithDarkOn_When_ThePrecedingPeerGainsFocus_Then_TheLeafIsApplied()
+            {
+                // Arrange — dark:peer-focus-within:bg-on preceded by a `peer` sibling, dark on.
+                _mounted = V.Mount(_window.rootVisualElement, V.Div(
+                    "container",
+                    V.Label(name: "peer", className: "peer"),
+                    V.Label(name: "child", className: "dark:peer-focus-within:bg-on")));
+                var peer = _window.rootVisualElement.Q<Label>("peer");
+                var child = _window.rootVisualElement.Q<Label>("child");
+                VelvetTheme.IsDark = true;
+                Assume.That(child.ClassListContains("bg-on"), Is.False, "Precondition: dark alone does not apply (unfocused)");
+
+                // Act — focus reaches the preceding peer (its bubbling FocusIn is the focus-within signal).
+                Fire<FocusInEvent>(peer);
+
+                // Assert — both dark AND focus-within hold, so the leaf applies.
+                Assert.IsTrue(child.ClassListContains("bg-on"));
             }
 
             [Test]


### PR DESCRIPTION
`dark:checked:bg-primary` never applied, while `checked:dark:bg-primary` did — and the guide says the order does not matter. Same for `md:peer-checked:`, `dark:group-focus-within:` and `hover:peer-focus-within:`. Worse than inert: a `dark:checked:` stack fell into the relational branch and subscribed to whatever previous sibling carried the `peer` class, a live event subscription on an unrelated element that could never produce an effect.

Four inner kinds now route correctly. A `Checked` inner hooks the element-local signals with checked registration and seeding; the relational branch resolves its source from `RelationalOf`, so `group-focus-within` seeks an **ancestor** — the hand-written list it replaces looked for a sibling — and `peer-checked` registers and seeds the peer's `ChangeEvent<bool>`. `OnRelSignal` pairs all five relational signals instead of three.

The reason four kinds could go missing is the part worth fixing structurally. The classification was a set of independent `bool` members using `is X or Y or Z`, and a set of booleans has no notion of covering its enum, so a member matching none is invisible. Four classifications are now discard-free `switch` expressions, and the compiler reports a non-exhaustive one itself:

- the stacked inner source, replacing two bools and a call
- `RelationalOf`, which absorbs `RelationalIsPeer` and `RelationalStateOf` — three mirrors that could disagree, now one that cannot
- `BreakpointPx`, replacing a `_ => 0f`
- `ForVariant`, replacing a `_ => Hover` that would have silently layered any new kind onto hover

`IsRelational` and `IsResponsive` survive by name but derive from the classifications, so they can no longer drift from them. Two further switches over the signal enums replace an implicit ordinal correspondence.

Verified against this project's compiler rather than assumed: a switch covering every *named* member still warns CS8524 for the unnamed-value case, so each site carries a file-local pragma for that one — and a probe adding a 21st member confirmed CS8509 still fires at all four sites, in every assembly that compiles them. So the guard the conversion exists to create is live, and the warning it does not need is off. No backlog remains, so no `.globalconfig` was added; the diagnostic to silence is not the one to keep.

`styling-variants.md` needed no edit. Its claims that order does not matter and that stacking composes any of the listed families were the false statements; this makes them true. Both directions were checked — every kind now classifies to a driven source as an inner, and all four outer families route through `GateStackedVariant`.

Three tests that pinned the old inert behaviour are removed: they characterised a defect rather than a decision.

Closes #393
Closes #444
