### PR TITLE
fix(velvet): keep an unfinished navigation out of the shared history

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -9,6 +9,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A navigation waiting on a Blocker no longer takes the history with it. `Router` moved the history index
+  before running the Guard and Blocker phases, so a Back parked on a confirm dialog left the router
+  pointing at the entry the user had not gone to yet: clicking a link before answering the dialog pushed
+  onto that position and deleted the page the dialog was covering. The destination is now resolved per
+  attempt and applied when it commits, so a second navigation started meanwhile reads the position the
+  user is actually on. `Router.CanGoBack` / `CanGoForward` describe that position during the wait too.
+
+- A Guard redirect abandoned before it arrives no longer leaves an entry for the path it started from.
+  The originating path was appended up front for the redirect target to overwrite, so a redirect that a
+  Blocker parked and a newer navigation superseded stranded that entry for the rest of the session, with
+  Back onto it re-running the guard and landing on the redirect target. The pair now records only the
+  target, with the originating navigation's own Push/Replace effect.
+
+- Going Back to a route whose `LoaderMode.Suspend` loader had not resolved runs its loaders again instead
+  of restoring an empty snapshot. The history entry recorded the loader data as it stood at commit time
+  with nothing marking it unfinished, so a route left before its loader resolved was cached in that state
+  and rendered empty on every later visit. Entries now record whether their loader round finished, and
+  only a finished one is served from the Back/Forward cache.
+
+- A `RouteDefinition.Guard` that throws, or a redirect target that declares both `RedirectTo` and `Guard`,
+  no longer leaves the router mid-navigation. The exception still reaches the caller, but `Router.Status`
+  now becomes `Error` instead of staying at `Matching` — which every `UseNavigation()` consumer rendered
+  as a pending navigation that would never finish — and the history is left as the throwing attempt found
+  it.
+
 - `Hooks.UseDeferredValue` now hands its new value over only on the render that drains the Transition
   lane. Previously any re-render still carrying the same input promoted it — a sibling `UseState` setter
   firing before that lane drained was enough — so the expensive subtree the deferral exists to keep off

--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -32,7 +32,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   no longer leaves the router mid-navigation. The exception still reaches the caller, but `Router.Status`
   now becomes `Error` instead of staying at `Matching` — which every `UseNavigation()` consumer rendered
   as a pending navigation that would never finish — and the history is left as the throwing attempt found
-  it.
+  it. This covers an exception from the commit itself, which previously escaped past the unwind and left
+  the status at `Loading`.
+
+- A `LoaderMode.Suspend` loader that answers immediately now delivers its result to the location it was
+  loaded for. Its value arrived while the navigation was still running and was then overwritten by the
+  loader results the commit takes, so `UseLoaderData` read null on the first render and every later visit
+  was served that empty snapshot from the history cache. The same early arrival was also written into the
+  entry the user was navigating away from, which then carried loader data for a location it never was.
+
+- `NavigateAsync` in `NavigationMode.Back` or `NavigationMode.Forward` with no entry to step onto now
+  returns `Cancelled`, as `GoBack` / `GoForward` already did for the same request. It previously ran the
+  navigation against a history slot that does not exist: with a Guard redirect on the route it appended an
+  entry while leaving the index on the previous one, so `CanGoForward` pointed at the page already on
+  screen, and without one it threw out of the commit.
 
 - `Hooks.UseDeferredValue` now hands its new value over only on the render that drains the Transition
   lane. Previously any re-render still carrying the same input promoted it — a sibling `UseState` setter
@@ -227,6 +240,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   that stronger part it ties rather than wins, and the tie is settled the way the same file's *Same
   family, different values* bullet already describes.
 
+### Changed
+
+- A Blocker registered during a Guard redirect is now told the attempt is a `Push` where it was told
+  `Replace`. The redirect target is committed with the originating navigation's history effect, so a
+  leave-confirmation asked about a pushed redirect now describes the step the history actually takes.
+
 ## [2.0.0] - 2026-08-02
 
 ### Highlights
@@ -335,6 +354,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   no width to move.
 
 ### Changed
+
 
 - The semantic colour tokens are two opaque theme sets instead of one translucent one, and a light theme
   now exists. `_tokens.uss` declared 27 of its 31 `--color-*` values with an alpha — twelve as white overlays, twelve

--- a/Packages/com.velvet.core/Runtime/Routing/RouteLoaderRunner.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/RouteLoaderRunner.cs
@@ -28,15 +28,25 @@ namespace Velvet
 
         private int _activeSuspendTaskCount;
 
-        // Suspend loaders launched by the current round that have not terminated yet. CancelPending resets
-        // it, and a task whose round has been superseded returns without decrementing, so a late task cannot
-        // count against the round that replaced it.
-        private int _pendingSuspendLoaders;
+        // One RunLoadersSync call's outstanding Suspend loaders. The count lives on the round rather than on
+        // the runner so that a round asked whether it finished answers for itself: a loader delegate is free
+        // to start a navigation, which begins another round from inside the one still launching, and a
+        // runner-wide count would be reset under it.
+        internal sealed class LoaderRound
+        {
+            internal int Pending;
 
-        // False while a Suspend loader of the current round is still outstanding. The router records this on
-        // the history entry it commits, which is what separates an unfinished round's data from the data a
-        // finished one produced.
-        internal bool CurrentRoundSettled => _pendingSuspendLoaders == 0;
+            // False while a Suspend loader of this round has not terminated. The router records it on the
+            // history entry it commits, which is what separates an unfinished round's data from the data a
+            // finished one produced.
+            internal bool Settled => Pending == 0;
+        }
+
+        private LoaderRound _currentRound = new();
+
+        // The round a Suspend completion belongs to: the events fire only after the supersession check, so a
+        // subscriber reading this from inside one of them is reading its own round.
+        internal LoaderRound CurrentRound => _currentRound;
 
         // Number of live Suspend loader tasks. Incremented at the start of RunSuspendLoader and
         // decremented in the finally block at completion (success / failure / cancel alike).
@@ -55,6 +65,8 @@ namespace Velvet
             CancelPending();
             _errors.Clear();
             _cts = CancellationTokenSource.CreateLinkedTokenSource(externalToken);
+            var round = new LoaderRound();
+            _currentRound = round;
 
             var results = new Dictionary<string?, object>();
             var awaitTasks = new List<(string? routeId, UniTask<object> task)>();
@@ -98,8 +110,8 @@ namespace Velvet
                 else
                 {
                     allCompleted = false;
-                    _pendingSuspendLoaders++;
-                    RunSuspendLoader(key, task, _cts).Forget();
+                    round.Pending++;
+                    RunSuspendLoader(key, task, _cts, round, results).Forget();
                 }
             }
 
@@ -130,29 +142,37 @@ namespace Velvet
             return (results, allCompleted);
         }
 
-        private async UniTask RunSuspendLoader(string? routeId, UniTask<object> task, CancellationTokenSource ownCts)
+        private async UniTask RunSuspendLoader(string? routeId, UniTask<object> task, CancellationTokenSource ownCts,
+            LoaderRound round, Dictionary<string?, object> results)
         {
             try
             {
                 _activeSuspendTaskCount++;
                 var result = await task;
+                // Counted off before the supersession check and before the event, not in the finally below: a
+                // superseded round is still owed this task's departure, and a subscriber reading the round
+                // from inside the callback — the router's history write-back does — must see it already gone.
+                round.Pending--;
+                // Written into the round's results and not only announced through the event: a loader may hand
+                // back a task that is already complete, and the caller assigns these results over whatever the
+                // event wrote.
+                results[routeId] = result;
                 // A loader that ignored its token can resolve after CancelPending replaced (or nulled) _cts.
                 // That makes this a superseded round; drop the stale result rather than firing into the live
                 // state of an unrelated current location.
                 if (ownCts != _cts) return;
-                // Decremented before the event and not in the finally below: a subscriber that reads
-                // CurrentRoundSettled from inside the callback — the router's history write-back does — must
-                // see this loader already accounted for.
-                _pendingSuspendLoaders--;
                 OnSuspendLoaderCompleted?.Invoke(routeId, result);
             }
-            catch (OperationCanceledException) { }
+            catch (OperationCanceledException)
+            {
+                round.Pending--;
+            }
             catch (Exception ex)
             {
+                round.Pending--;
                 // Same supersession guard as the success path: a stale round's failure must not record an
                 // error nor re-emit under the current location.
                 if (ownCts != _cts) return;
-                _pendingSuspendLoaders--;
                 _errors[routeId] = ex;
                 OnSuspendLoaderFailed?.Invoke(routeId, ex);
             }
@@ -165,9 +185,9 @@ namespace Velvet
         // This also runs automatically at the start of the next RunLoadersSync call.
         public void CancelPending()
         {
-            // A cancelled round has nothing left that will report, so it counts as settled. The tasks it
-            // leaves behind read _cts to find their round gone and return without decrementing this.
-            _pendingSuspendLoaders = 0;
+            // A fresh round rather than a reset of the outgoing one: whoever holds the outgoing round is
+            // asking whether it finished, and it did not.
+            _currentRound = new LoaderRound();
             if (_cts != null)
             {
                 // Cleared before the Cancel, not after: a loader continuation that resumes synchronously

--- a/Packages/com.velvet.core/Runtime/Routing/RouteLoaderRunner.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/RouteLoaderRunner.cs
@@ -28,6 +28,16 @@ namespace Velvet
 
         private int _activeSuspendTaskCount;
 
+        // Suspend loaders launched by the current round that have not terminated yet. CancelPending resets
+        // it, and a task whose round has been superseded returns without decrementing, so a late task cannot
+        // count against the round that replaced it.
+        private int _pendingSuspendLoaders;
+
+        // False while a Suspend loader of the current round is still outstanding. The router records this on
+        // the history entry it commits, which is what separates an unfinished round's data from the data a
+        // finished one produced.
+        internal bool CurrentRoundSettled => _pendingSuspendLoaders == 0;
+
         // Number of live Suspend loader tasks. Incremented at the start of RunSuspendLoader and
         // decremented in the finally block at completion (success / failure / cancel alike).
         // Internal accessor used for test verification.
@@ -88,6 +98,7 @@ namespace Velvet
                 else
                 {
                     allCompleted = false;
+                    _pendingSuspendLoaders++;
                     RunSuspendLoader(key, task, _cts).Forget();
                 }
             }
@@ -129,6 +140,10 @@ namespace Velvet
                 // That makes this a superseded round; drop the stale result rather than firing into the live
                 // state of an unrelated current location.
                 if (ownCts != _cts) return;
+                // Decremented before the event and not in the finally below: a subscriber that reads
+                // CurrentRoundSettled from inside the callback — the router's history write-back does — must
+                // see this loader already accounted for.
+                _pendingSuspendLoaders--;
                 OnSuspendLoaderCompleted?.Invoke(routeId, result);
             }
             catch (OperationCanceledException) { }
@@ -137,6 +152,7 @@ namespace Velvet
                 // Same supersession guard as the success path: a stale round's failure must not record an
                 // error nor re-emit under the current location.
                 if (ownCts != _cts) return;
+                _pendingSuspendLoaders--;
                 _errors[routeId] = ex;
                 OnSuspendLoaderFailed?.Invoke(routeId, ex);
             }
@@ -149,6 +165,9 @@ namespace Velvet
         // This also runs automatically at the start of the next RunLoadersSync call.
         public void CancelPending()
         {
+            // A cancelled round has nothing left that will report, so it counts as settled. The tasks it
+            // leaves behind read _cts to find their round gone and return without decrementing this.
+            _pendingSuspendLoaders = 0;
             if (_cts != null)
             {
                 // Cleared before the Cancel, not after: a loader continuation that resumes synchronously

--- a/Packages/com.velvet.core/Runtime/Routing/Router.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/Router.cs
@@ -31,6 +31,11 @@ namespace Velvet
         // after a newer navigation has established its own Status, and by then the value it would write
         // describes a router that no longer exists.
         private int _navigationSequence;
+        // The loader round whose data the current location was committed with. A round that has not reached
+        // its commit has no location to write under: the live loader state and _historyIndex still describe
+        // where the user is, so a loader that resolves before that commit would record its result against the
+        // entry being navigated away from. The commit takes such a result from the round's results instead.
+        private RouteLoaderRunner.LoaderRound? _committedRound;
 
         /// <summary>
         /// The currently active <see cref="Router"/> instance, or null when none is mounted. Set when a
@@ -91,6 +96,7 @@ namespace Velvet
             _loaderRunner.OnSuspendLoaderFailed += (routeId, ex) =>
             {
                 UnityEngine.Debug.LogException(ex);
+                if (!ResolvedIntoTheCommittedRound()) return;
                 // Suspend-mode loader failed: record the error keyed by RouteId and re-emit so the nearest
                 // ErrorElement renders, mirroring the synchronous Await-mode error commit.
                 _loaderErrors = new Dictionary<string?, Exception>(_loaderErrors) { [routeId] = ex };
@@ -99,6 +105,7 @@ namespace Velvet
             };
             _loaderRunner.OnSuspendLoaderCompleted += (routeId, result) =>
             {
+                if (!ResolvedIntoTheCommittedRound()) return;
                 // Suspend-mode loader completed: replace _loaderData with a new instance so a re-render
                 // re-reads the resolved data. The location content is unchanged, so RepublishCurrentLocation
                 // re-emits OnLocationChanged with a fresh identity to force that re-render.
@@ -119,8 +126,10 @@ namespace Velvet
 
         /// <summary>
         /// Navigates to the given path. Evaluation order is Guard -&gt; Blocker -&gt; Loader.
-        /// When a Guard returns a redirect, recursively navigates to the redirect target with
-        /// NavigationMode.Replace (the original path is not pushed onto the history). Up to 5 redirects.
+        /// When a Guard returns a redirect, recursively navigates to the redirect target and records only
+        /// that target, with this navigation's own history effect: a Push appends it where the originating
+        /// path would have gone, and a Replace or a Back/Forward step overwrites the entry at the slot this
+        /// navigation resolved. Up to 5 redirects.
         /// </summary>
         /// <param name="path">Target path to navigate to.</param>
         /// <param name="mode">How the destination is recorded in the history stack. Defaults to <see cref="NavigationMode.Push"/>.</param>
@@ -341,13 +350,35 @@ namespace Velvet
                 return NavigationResult.NotFound;
             }
 
-            // The claim is taken after the match and not when the navigation started: every return above this
-            // line leaves Status describing its own outcome, so a navigation that matches no route must not
-            // dispossess an attempt parked in a blocker — that attempt is then the only one able to put
-            // Status back. A redirect inherits its initiator's claim rather than taking one, so it does not
-            // dispossess the navigation it is part of, and it commits into the slot the initiator resolved.
-            var pending = initiator ?? new PendingNavigation(++_navigationSequence, CommitIndexFor(mode));
+            PendingNavigation pending;
+            if (initiator.HasValue)
+            {
+                // A redirect inherits its initiator's claim rather than taking one, so it does not dispossess
+                // the navigation it is part of, and it commits into the slot the initiator resolved.
+                pending = initiator.Value;
+            }
+            else
+            {
+                var commitIndex = CommitIndexFor(mode);
+                if ((mode == NavigationMode.Back || mode == NavigationMode.Forward)
+                    && (commitIndex < 0 || commitIndex >= _history.Count))
+                {
+                    // A step with no entry to land on. GoBack/GoForward refuse it before starting; a direct
+                    // NavigateAsync in Back or Forward mode reaches here, and committing would write into a
+                    // slot that does not exist — appending a second entry under an index still pointing at
+                    // the first, when a Guard redirect turns the step into a Replace.
+                    Status = RouterStatus.Idle;
+                    return NavigationResult.Cancelled;
+                }
+                // The claim is taken after the match and not when the navigation started: every return above
+                // this line leaves Status describing its own outcome, so a navigation that matches no route
+                // must not dispossess an attempt parked in a blocker — that attempt is then the only one able
+                // to put Status back.
+                pending = new PendingNavigation(++_navigationSequence, commitIndex);
+            }
 
+            RouterLocation location;
+            RouteLoaderRunner.LoaderRound round;
             try
             {
                 var guardResult = await RunGuardChecks(matches, mode, pending, cancellationToken, redirectCount);
@@ -362,11 +393,15 @@ namespace Velvet
                     return blockerResult.Value;
                 }
 
-                var loaderResult = await RunLoaderPhase(matches, mode, pending, cancellationToken);
+                var (loaderResult, loaderRound) = await RunLoaderPhase(matches, mode, pending, cancellationToken);
                 if (loaderResult.HasValue)
                 {
                     return loaderResult.Value;
                 }
+                round = loaderRound;
+                // Inside the try: the commit throws on a navigation mode outside the enum, and leaving that
+                // to escape past the handlers is what left Status mid-flight before.
+                location = CommitHistoryEntry(path, matches, mode, pending, round);
             }
             catch (OperationCanceledException)
             {
@@ -387,9 +422,10 @@ namespace Velvet
                 throw;
             }
 
-            var location = CommitHistoryEntry(path, matches, mode, pending);
-
             CurrentLocation = location;
+            // Only now may the round's late results reach the live state: the write-back they trigger reads
+            // CurrentLocation and _historyIndex, and both describe this round's location from here on.
+            _committedRound = round;
             Status = RouterStatus.Ready;
             OnLocationChanged?.Invoke(location);
 
@@ -422,6 +458,12 @@ namespace Velvet
             NavigationMode.Forward => _historyIndex + 1,
             _ => _historyIndex,
         };
+
+        // Whether the Suspend loader now reporting belongs to the round the current location was committed
+        // with. The runner fires its events only for the round it holds as current, so this compares that
+        // round against the committed one.
+        private bool ResolvedIntoTheCommittedRound() =>
+            ReferenceEquals(_loaderRunner.CurrentRound, _committedRound);
 
         private bool StillCurrent(PendingNavigation pending) =>
             pending.Sequence == _navigationSequence;
@@ -541,10 +583,10 @@ namespace Velvet
 
         #region Loading
 
-        // Returns null on a normal completion (cached or fresh), leaving _loaderData/_loaderErrors set
-        // for CommitHistoryEntry; returns Cancelled only when a fresh (non-cached) loader run observes
-        // cancellation.
-        private async UniTask<NavigationResult?> RunLoaderPhase(
+        // Returns a null outcome on a normal completion (cached or fresh), leaving _loaderData/_loaderErrors
+        // set for CommitHistoryEntry along with the round that produced them; returns Cancelled only when a
+        // fresh (non-cached) loader run observes cancellation.
+        private async UniTask<(NavigationResult? outcome, RouteLoaderRunner.LoaderRound round)> RunLoaderPhase(
             IReadOnlyList<RouteMatch> matches,
             NavigationMode mode,
             PendingNavigation pending,
@@ -569,29 +611,33 @@ namespace Velvet
                 // on its first load (UseRouteError / ErrorElement), symmetrically with the loader data.
                 _loaderErrors = new Dictionary<string?, Exception>(entry.LoaderErrors);
                 Status = RouterStatus.Loading; // for status-transition consistency
+                // A restored entry ran no loaders of its own, and Back/Forward rewrites no entry, so the round
+                // handed back is only the empty one CancelPending installed.
+                return (null, _loaderRunner.CurrentRound);
             }
-            else
+
+            Status = RouterStatus.Loading;
+            // allCompleted is unused (errors are detected via the runner's Errors map).
+            var (results, _) = _loaderRunner.RunLoadersSync(matches, cancellationToken);
+            // Captured here rather than read back at commit time: this is the round whose data the commit
+            // records, and a loader delegate that navigates starts another one.
+            var round = _loaderRunner.CurrentRound;
+
+            if (cancellationToken.IsCancellationRequested)
             {
-                Status = RouterStatus.Loading;
-                // allCompleted is unused (errors are detected via the runner's Errors map).
-                var (results, _) = _loaderRunner.RunLoadersSync(matches, cancellationToken);
-
-                if (cancellationToken.IsCancellationRequested)
-                {
-                    _loaderData = new Dictionary<string?, object>();
-                    _loaderErrors = new Dictionary<string?, Exception>();
-                    Status = RouterStatus.Idle;
-                    return NavigationResult.Cancelled;
-                }
-
-                _loaderData = results;
-
-                // A loader error does not abort navigation. The location commits and
-                // the nearest RouteDefinition.ErrorElement renders in place of the route's Element. Errors
-                // are surfaced through RouterContext.Errors (keyed by RouteId) for UseRouteError.
-                _loaderErrors = new Dictionary<string?, Exception>(_loaderRunner.Errors);
+                _loaderData = new Dictionary<string?, object>();
+                _loaderErrors = new Dictionary<string?, Exception>();
+                Status = RouterStatus.Idle;
+                return (NavigationResult.Cancelled, round);
             }
-            return null;
+
+            _loaderData = results;
+
+            // A loader error does not abort navigation. The location commits and
+            // the nearest RouteDefinition.ErrorElement renders in place of the route's Element. Errors
+            // are surfaced through RouterContext.Errors (keyed by RouteId) for UseRouteError.
+            _loaderErrors = new Dictionary<string?, Exception>(_loaderRunner.Errors);
+            return (null, round);
         }
 
         #endregion
@@ -621,14 +667,15 @@ namespace Velvet
             }
         }
 
-        private HistoryEntry NewEntry(string path, IReadOnlyList<RouteMatch> matches) =>
+        private HistoryEntry NewEntry(string path, IReadOnlyList<RouteMatch> matches,
+            RouteLoaderRunner.LoaderRound round) =>
             new(path, matches,
                 new Dictionary<string?, object>(_loaderData),
                 new Dictionary<string?, Exception>(_loaderErrors),
-                _loaderRunner.CurrentRoundSettled);
+                round.Settled);
 
         private RouterLocation CommitHistoryEntry(string path, IReadOnlyList<RouteMatch> matches, NavigationMode mode,
-            PendingNavigation pending)
+            PendingNavigation pending, RouteLoaderRunner.LoaderRound round)
         {
             var allParams = new Dictionary<string, string>();
             foreach (var match in matches)
@@ -649,17 +696,17 @@ namespace Velvet
             switch (mode)
             {
                 case NavigationMode.Push:
-                    PushHistoryEntry(NewEntry(path, matches));
+                    PushHistoryEntry(NewEntry(path, matches, round));
                     break;
                 case NavigationMode.Replace:
                     if (pending.CommitIndex >= 0)
                     {
-                        _history[pending.CommitIndex] = NewEntry(path, matches);
+                        _history[pending.CommitIndex] = NewEntry(path, matches, round);
                         _historyIndex = pending.CommitIndex;
                     }
                     else
                     {
-                        _history.Add(NewEntry(path, matches));
+                        _history.Add(NewEntry(path, matches, round));
                         _historyIndex = 0;
                     }
                     break;
@@ -727,8 +774,7 @@ namespace Velvet
         /// Writes the live loader data/errors back into the current history entry so a later
         /// Back/Forward cache hit restores the post-resolution state. Suspend-mode loaders resolve
         /// asynchronously after the navigation commit, while the history snapshot is frozen at commit
-        /// time; without this write-back the cache would replay the stale pre-resolution snapshot — and
-        /// would not replay it at all, since an entry whose round had not finished is not served.
+        /// time; without this write-back the entry would keep the pre-resolution snapshot.
         /// </summary>
         private void SyncCurrentHistorySnapshot()
         {
@@ -748,7 +794,7 @@ namespace Velvet
                 return;
             }
 
-            _history[_historyIndex] = NewEntry(entry.Path, entry.Matches);
+            _history[_historyIndex] = NewEntry(entry.Path, entry.Matches, _loaderRunner.CurrentRound);
         }
 
         private void PushHistoryEntry(HistoryEntry entry)

--- a/Packages/com.velvet.core/Runtime/Routing/Router.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/Router.cs
@@ -14,7 +14,7 @@ namespace Velvet
     {
         private readonly RouteTree _routeTree;
         private readonly RouteLoaderRunner _loaderRunner;
-        private readonly List<(string path, IReadOnlyList<RouteMatch> matches, Dictionary<string?, object>? loaderData, Dictionary<string?, Exception>? loaderErrors)> _history = new();
+        private readonly List<HistoryEntry> _history = new();
         private readonly RouteBlockerManager _blockerManager = new();
         private int _historyIndex = -1;
         private Dictionary<string?, object> _loaderData = new();
@@ -26,10 +26,10 @@ namespace Velvet
         // nav unwinds (NavigationResult.Cancelled) and the latest nav takes over, so concurrent
         // navigations during the blocker window resolve to the most recent one.
         private CancellationTokenSource? _activeNavigationCts;
-        // Identifies whoever currently owns _historyIndex. An attempt that has lost the claim must not put
-        // the index or Status back: cancelling its token does not force it to resume at that moment, so it
-        // can reach its rollback after a newer navigation has moved the index, and by then the value it
-        // saved describes a router that no longer exists.
+        // Identifies whoever currently owns Status. An attempt that has lost the claim must not put Status
+        // back: cancelling its token does not force it to resume at that moment, so it can reach its rollback
+        // after a newer navigation has established its own Status, and by then the value it would write
+        // describes a router that no longer exists.
         private int _navigationSequence;
 
         /// <summary>
@@ -137,7 +137,7 @@ namespace Velvet
             string path,
             NavigationMode mode = NavigationMode.Push,
             CancellationToken cancellationToken = default) =>
-            NavigateInternalAsync(ResolvePath(path), mode, cancellationToken, redirectCount: 0, initiatorSequence: 0);
+            NavigateInternalAsync(ResolvePath(path), mode, cancellationToken, redirectCount: 0, initiator: null);
 
         /// <summary>
         /// Navigates with relative resolution anchored to a specific matched-route level
@@ -152,7 +152,7 @@ namespace Velvet
             int baseRouteIndex,
             CancellationToken cancellationToken = default) =>
             NavigateInternalAsync(ResolvePath(path, baseRouteIndex), mode, cancellationToken, redirectCount: 0,
-                initiatorSequence: 0);
+                initiator: null);
 
         /// <summary>
         /// Resolves a relative navigation target (<c>.</c>, <c>..</c>, <c>../sibling</c>, or a bare
@@ -266,11 +266,11 @@ namespace Velvet
             NavigationMode mode,
             CancellationToken cancellationToken,
             int redirectCount,
-            int initiatorSequence)
+            PendingNavigation? initiator)
         {
             // Concurrent-navigation handling. Recursive redirect calls (redirectCount > 0) reuse the
             // outer navigation's CTS so a redirect doesn't cancel its own initiator, and inherit its
-            // history claim so a redirect's rollback is judged by whether the INITIATOR still holds it.
+            // claim so a redirect's rollback is judged by whether the INITIATOR still holds it.
             CancellationTokenSource? myCts = null;
             CancellationToken navToken = cancellationToken;
             if (redirectCount == 0)
@@ -287,7 +287,7 @@ namespace Velvet
 
             try
             {
-                return await NavigateCore(path, mode, navToken, redirectCount, initiatorSequence);
+                return await NavigateCore(path, mode, navToken, redirectCount, initiator);
             }
             catch (OperationCanceledException) when (myCts != null && myCts.IsCancellationRequested)
             {
@@ -315,7 +315,7 @@ namespace Velvet
             NavigationMode mode,
             CancellationToken cancellationToken,
             int redirectCount,
-            int initiatorSequence)
+            PendingNavigation? initiator)
         {
             if (redirectCount >= MaxRedirects)
             {
@@ -341,30 +341,28 @@ namespace Velvet
                 return NavigationResult.NotFound;
             }
 
-            var savedHistoryIndex = ApplyProvisionalHistoryIndex(mode);
-            // The claim is taken here, where the index is, and not when the navigation started: every return
-            // above this line leaves the index untouched, so a navigation that matches no route must not
-            // dispossess an attempt parked in a blocker — that attempt is then the only one able to put the
-            // index back. A redirect inherits its initiator's claim rather than taking one, so it does not
-            // dispossess the navigation it is part of.
-            var sequence = redirectCount == 0 ? ++_navigationSequence : initiatorSequence;
-            var provisional = new ProvisionalHistoryState(sequence, savedHistoryIndex);
+            // The claim is taken after the match and not when the navigation started: every return above this
+            // line leaves Status describing its own outcome, so a navigation that matches no route must not
+            // dispossess an attempt parked in a blocker — that attempt is then the only one able to put
+            // Status back. A redirect inherits its initiator's claim rather than taking one, so it does not
+            // dispossess the navigation it is part of, and it commits into the slot the initiator resolved.
+            var pending = initiator ?? new PendingNavigation(++_navigationSequence, CommitIndexFor(mode));
 
             try
             {
-                var guardResult = await RunGuardChecks(matches, path, mode, provisional, cancellationToken, redirectCount);
+                var guardResult = await RunGuardChecks(matches, mode, pending, cancellationToken, redirectCount);
                 if (guardResult.HasValue)
                 {
                     return guardResult.Value;
                 }
 
-                var blockerResult = await RunBlockerCheck(path, mode, provisional, cancellationToken);
+                var blockerResult = await RunBlockerCheck(path, mode, pending, cancellationToken);
                 if (blockerResult.HasValue)
                 {
                     return blockerResult.Value;
                 }
 
-                var loaderResult = await RunLoaderPhase(matches, mode, cancellationToken);
+                var loaderResult = await RunLoaderPhase(matches, mode, pending, cancellationToken);
                 if (loaderResult.HasValue)
                 {
                     return loaderResult.Value;
@@ -373,15 +371,23 @@ namespace Velvet
             catch (OperationCanceledException)
             {
                 // A Guard redirect or a Blocker that honors its token unwinds by exception, skipping the
-                // in-line rollbacks the returned-result paths use. The index moved before both of those
-                // awaits, and Status was set before them, so an aborted attempt would otherwise leave the
-                // history pointing somewhere the user never went and UseNavigation reporting a navigation
-                // that is no longer in flight.
-                RollBackProvisional(provisional);
+                // in-line rollback the blocked path uses. Status was set before both of those awaits, so an
+                // aborted attempt would otherwise leave UseNavigation reporting a navigation that is no
+                // longer in flight.
+                ReleaseClaim(pending, RouterStatus.Idle);
+                throw;
+            }
+            catch (Exception)
+            {
+                // A Guard delegate is application code invoked with nothing between it and the caller, and the
+                // guard phase's mutual-exclusion throw reaches here the same way. The exception is left to
+                // the caller, and the router records the failure rather than the phase it died in — Matching
+                // and Loading are what UseNavigation renders a pending branch for.
+                ReleaseClaim(pending, RouterStatus.Error);
                 throw;
             }
 
-            var location = CommitHistoryEntry(path, matches, mode);
+            var location = CommitHistoryEntry(path, matches, mode, pending);
 
             CurrentLocation = location;
             Status = RouterStatus.Ready;
@@ -390,50 +396,44 @@ namespace Velvet
             return NavigationResult.Success;
         }
 
-        #region Provisional history index for Back/Forward
+        #region Per-attempt navigation state
 
-        // What one navigation attempt provisionally changed and must put back if it unwinds, together with
-        // the sequence that decides whether it still may.
-        private readonly struct ProvisionalHistoryState
+        // Where one navigation attempt will land, and the sequence deciding whether it still owns Status.
+        // The destination stays here until the attempt commits, because the Guard and Blocker phases await
+        // application code and a navigation starting in that window resolves its own destination from the
+        // shared index: a parked Back that had already moved it puts a Push's forward truncation one entry
+        // too low, taking the entry the user is looking at with it.
+        private readonly struct PendingNavigation
         {
             internal readonly int Sequence;
-            internal readonly int SavedHistoryIndex;
+            // The history slot this attempt commits into. Unused by a Push, which appends.
+            internal readonly int CommitIndex;
 
-            internal ProvisionalHistoryState(int sequence, int savedHistoryIndex)
+            internal PendingNavigation(int sequence, int commitIndex)
             {
                 Sequence = sequence;
-                SavedHistoryIndex = savedHistoryIndex;
+                CommitIndex = commitIndex;
             }
         }
 
-        private bool StillCurrent(ProvisionalHistoryState provisional) =>
-            provisional.Sequence == _navigationSequence;
-
-        private void RollBackProvisional(ProvisionalHistoryState provisional)
+        private int CommitIndexFor(NavigationMode mode) => mode switch
         {
-            if (!StillCurrent(provisional))
+            NavigationMode.Back => _historyIndex - 1,
+            NavigationMode.Forward => _historyIndex + 1,
+            _ => _historyIndex,
+        };
+
+        private bool StillCurrent(PendingNavigation pending) =>
+            pending.Sequence == _navigationSequence;
+
+        private void ReleaseClaim(PendingNavigation pending, RouterStatus status)
+        {
+            if (!StillCurrent(pending))
             {
                 return;
             }
 
-            _historyIndex = provisional.SavedHistoryIndex;
-            Status = RouterStatus.Idle;
-        }
-
-        // The index must move before the Guard/Blocker checks so a Guard redirect (Replace)
-        // overwrites the correct entry; rolled back below if the Blocker check rejects the attempt.
-        private int ApplyProvisionalHistoryIndex(NavigationMode mode)
-        {
-            var savedHistoryIndex = _historyIndex;
-            if (mode == NavigationMode.Back)
-            {
-                _historyIndex--;
-            }
-            else if (mode == NavigationMode.Forward)
-            {
-                _historyIndex++;
-            }
-            return savedHistoryIndex;
+            Status = status;
         }
 
         #endregion
@@ -447,13 +447,11 @@ namespace Velvet
         // Returns null when no match redirected, so the caller falls through to the Blocker check.
         private async UniTask<NavigationResult?> RunGuardChecks(
             IReadOnlyList<RouteMatch> matches,
-            string path,
             NavigationMode mode,
-            ProvisionalHistoryState provisional,
+            PendingNavigation pending,
             CancellationToken cancellationToken,
             int redirectCount)
         {
-            var savedHistoryIndex = provisional.SavedHistoryIndex;
             foreach (var match in matches)
             {
                 if (match.Route == null) continue;
@@ -481,52 +479,19 @@ namespace Velvet
 
                 if (redirectTarget != null)
                 {
-                    // When a redirect happens during Push, provisionally append the Push entry first.
-                    // The redirect target's Replace overwrites this entry, preserving the previous
-                    // (originating) history.
-                    // Snapshot the FULL history (list + index) before any provisional mutation so a failed
-                    // redirect restores the prior state EXACTLY. A count-based rollback is insufficient: a Push
-                    // with forward history first TRUNCATES the forward entries (PushHistoryEntry → RemoveRange)
-                    // and then appends, so the net count can be ≤ the pre-push count and the truncated forward
-                    // entries would be lost. The snapshot captures them.
-                    var historySnapshot = _history.ToArray();
-                    if (mode == NavigationMode.Push)
-                    {
-                        PushHistoryEntry(path, matches);
-                    }
-                    NavigationResult redirectResult;
-                    try
-                    {
-                        redirectResult = await NavigateInternalAsync(
-                            redirectTarget, NavigationMode.Replace, cancellationToken, redirectCount + 1,
-                            provisional.Sequence);
-                    }
-                    catch (OperationCanceledException)
-                    {
-                        // NavigateCore's unwind handler restores the index and Status, but this snapshot is
-                        // local to the guard check that took it, so the provisional Push is undone here —
-                        // under the same ownership gate, since a snapshot taken before a newer navigation
-                        // pushed its own entries would delete them.
-                        if (StillCurrent(provisional))
-                        {
-                            _history.Clear();
-                            _history.AddRange(historySnapshot);
-                        }
-                        throw;
-                    }
-                    if (redirectResult != NavigationResult.Success && StillCurrent(provisional))
-                    {
-                        // On redirect failure, restore the snapshot: undoes the provisional Push (incl. its forward
-                        // truncation) and the provisional Back/Forward index move (savedHistoryIndex is the
-                        // pre-move value). Gated like the exceptional path above, and for the same reason: the
-                        // inner redirect can return Cancelled from its own blocker check rather than throwing,
-                        // long enough after the fact that this snapshot predates a newer navigation's entries.
-                        // Status is left as the failed redirect set it, so a NotFound target still reports so.
-                        _history.Clear();
-                        _history.AddRange(historySnapshot);
-                        _historyIndex = savedHistoryIndex;
-                    }
-                    return redirectResult;
+                    // The redirect target is the only entry the pair records, and it records it with the
+                    // originating navigation's own history effect: a Push appends the target where the
+                    // originating path would have gone, and a Back/Forward replaces the entry at the slot
+                    // that navigation resolved. The rejected alternative was to append the originating path
+                    // up front for the target's Replace to overwrite — a redirect abandoned in a Blocker
+                    // then leaves an entry for a path the user never reached, and it cannot be taken back
+                    // once a newer navigation has built on the stack that entry sits in.
+                    return await NavigateInternalAsync(
+                        redirectTarget,
+                        mode == NavigationMode.Push ? NavigationMode.Push : NavigationMode.Replace,
+                        cancellationToken,
+                        redirectCount + 1,
+                        pending);
                 }
             }
             return null;
@@ -541,7 +506,7 @@ namespace Velvet
         private async UniTask<NavigationResult?> RunBlockerCheck(
             string path,
             NavigationMode mode,
-            ProvisionalHistoryState provisional,
+            PendingNavigation pending,
             CancellationToken cancellationToken)
         {
             var currentPath = CurrentLocation?.Path ?? "";
@@ -554,19 +519,19 @@ namespace Velvet
             // A superseded navigation (a newer attempt cancelled our linked token) must unwind at the blocker
             // boundary. CheckAsync forwards the token to each blocker but cannot force one to honor it — a
             // blocker that returns false (or a synchronous blocker) leaves the loop returning false, which
-            // would otherwise fall through and run the loader phase or commit a cached Back/Forward entry
-            // (the cached branch below never reaches the loader-phase cancellation check). Roll back the
-            // provisional Back/Forward index like the Blocked path so the aborted attempt leaves no trace.
-            // Both rollbacks go through RollBackProvisional: a blocker that awaits without forwarding the
-            // token returns here rather than throwing, and can do so after a newer navigation has committed.
+            // would otherwise fall through and commit a location the router has already navigated past. The
+            // loader phase's own cancellation check cannot stand in for this one: a Back/Forward cache hit
+            // commits without ever reaching it. Both exits go through ReleaseClaim, since a blocker that
+            // awaits without forwarding the token returns here rather than throwing, and can do so after a
+            // newer navigation has established its Status.
             if (cancellationToken.IsCancellationRequested)
             {
-                RollBackProvisional(provisional);
+                ReleaseClaim(pending, RouterStatus.Idle);
                 return NavigationResult.Cancelled;
             }
             if (blocked)
             {
-                RollBackProvisional(provisional);
+                ReleaseClaim(pending, RouterStatus.Idle);
                 return NavigationResult.Blocked;
             }
             return null;
@@ -582,13 +547,15 @@ namespace Velvet
         private async UniTask<NavigationResult?> RunLoaderPhase(
             IReadOnlyList<RouteMatch> matches,
             NavigationMode mode,
+            PendingNavigation pending,
             CancellationToken cancellationToken)
         {
-            var cachedLoaderData = (mode == NavigationMode.Back || mode == NavigationMode.Forward)
-                ? _history[_historyIndex].loaderData
-                : null;
+            // Only a settled entry may be served; see HistoryEntry.LoadersSettled for what an unsettled one
+            // holds.
+            var restoring = (mode == NavigationMode.Back || mode == NavigationMode.Forward)
+                && _history[pending.CommitIndex].LoadersSettled;
 
-            if (cachedLoaderData != null)
+            if (restoring)
             {
                 // The else branch cancels the previous round by reaching RunLoadersSync; this one commits
                 // without ever reaching it. Leaving that round's CTS installed keeps it current for
@@ -596,13 +563,11 @@ namespace Velvet
                 // its late result into the entry restored here. Nothing downstream separates the two: RouteId
                 // is built from the route pattern, which both entries share whenever they match the same one.
                 _loaderRunner.CancelPending();
-                _loaderData = cachedLoaderData;
+                var entry = _history[pending.CommitIndex];
+                _loaderData = entry.LoaderData;
                 // Restore the cached errors too: a Back/Forward cache hit must re-present a route that errored
-                // on its first load (UseRouteError / ErrorElement), symmetrically with loaderData.
-                var cachedErrors = _history[_historyIndex].loaderErrors;
-                _loaderErrors = cachedErrors != null
-                    ? new Dictionary<string?, Exception>(cachedErrors)
-                    : new Dictionary<string?, Exception>();
+                // on its first load (UseRouteError / ErrorElement), symmetrically with the loader data.
+                _loaderErrors = new Dictionary<string?, Exception>(entry.LoaderErrors);
                 Status = RouterStatus.Loading; // for status-transition consistency
             }
             else
@@ -633,7 +598,37 @@ namespace Velvet
 
         #region History management
 
-        private RouterLocation CommitHistoryEntry(string path, IReadOnlyList<RouteMatch> matches, NavigationMode mode)
+        private readonly struct HistoryEntry
+        {
+            internal readonly string Path;
+            internal readonly IReadOnlyList<RouteMatch> Matches;
+            internal readonly Dictionary<string?, object> LoaderData;
+            internal readonly Dictionary<string?, Exception> LoaderErrors;
+            // An entry committed while a Suspend loader is still running holds whatever its loader round had
+            // produced by then, and nothing in the contents distinguishes that from what the route's loaders
+            // would finally have returned — so the Back/Forward cache reads this flag rather than the data.
+            internal readonly bool LoadersSettled;
+
+            internal HistoryEntry(string path, IReadOnlyList<RouteMatch> matches,
+                Dictionary<string?, object> loaderData, Dictionary<string?, Exception> loaderErrors,
+                bool loadersSettled)
+            {
+                Path = path;
+                Matches = matches;
+                LoaderData = loaderData;
+                LoaderErrors = loaderErrors;
+                LoadersSettled = loadersSettled;
+            }
+        }
+
+        private HistoryEntry NewEntry(string path, IReadOnlyList<RouteMatch> matches) =>
+            new(path, matches,
+                new Dictionary<string?, object>(_loaderData),
+                new Dictionary<string?, Exception>(_loaderErrors),
+                _loaderRunner.CurrentRoundSettled);
+
+        private RouterLocation CommitHistoryEntry(string path, IReadOnlyList<RouteMatch> matches, NavigationMode mode,
+            PendingNavigation pending)
         {
             var allParams = new Dictionary<string, string>();
             foreach (var match in matches)
@@ -654,28 +649,26 @@ namespace Velvet
             switch (mode)
             {
                 case NavigationMode.Push:
-                    PushHistoryEntry(path, matches, new Dictionary<string?, object>(_loaderData),
-                        new Dictionary<string?, Exception>(_loaderErrors));
+                    PushHistoryEntry(NewEntry(path, matches));
                     break;
                 case NavigationMode.Replace:
-                {
-                    var loaderDataSnapshot = new Dictionary<string?, object>(_loaderData);
-                    var loaderErrorsSnapshot = new Dictionary<string?, Exception>(_loaderErrors);
-                    if (_historyIndex >= 0)
+                    if (pending.CommitIndex >= 0)
                     {
-                        _history[_historyIndex] = (path, matches, loaderDataSnapshot, loaderErrorsSnapshot);
+                        _history[pending.CommitIndex] = NewEntry(path, matches);
+                        _historyIndex = pending.CommitIndex;
                     }
                     else
                     {
-                        _history.Add((path, matches, loaderDataSnapshot, loaderErrorsSnapshot));
+                        _history.Add(NewEntry(path, matches));
                         _historyIndex = 0;
                     }
                     break;
-                }
                 case NavigationMode.Back:
                 case NavigationMode.Forward:
-                    // The index was already provisionally applied before Guard/Blocker checks.
-                    // The loader data has already been restored from the cache.
+                    // The entry is not rewritten here even when its loaders ran again, because a round that
+                    // has not settled has nothing worth recording yet; the write-back that runs when it
+                    // settles is what makes the entry servable.
+                    _historyIndex = pending.CommitIndex;
                     break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(mode), mode, null);
@@ -734,7 +727,8 @@ namespace Velvet
         /// Writes the live loader data/errors back into the current history entry so a later
         /// Back/Forward cache hit restores the post-resolution state. Suspend-mode loaders resolve
         /// asynchronously after the navigation commit, while the history snapshot is frozen at commit
-        /// time; without this write-back the cache would replay the stale pre-resolution snapshot.
+        /// time; without this write-back the cache would replay the stale pre-resolution snapshot — and
+        /// would not replay it at all, since an entry whose round had not finished is not served.
         /// </summary>
         private void SyncCurrentHistorySnapshot()
         {
@@ -749,34 +743,22 @@ namespace Velvet
             // Only sync when the current entry is the location whose loaders just resolved. If the user
             // navigated away before the Suspend loader completed, _historyIndex points at a different
             // entry and the live state belongs to that other location, not this one.
-            if (entry.path != CurrentLocation.Path)
+            if (entry.Path != CurrentLocation.Path)
             {
                 return;
             }
 
-            // A provisional redirect entry (loaderData == null) is overwritten by the redirect target's
-            // Replace; do not seed it here before that commit lands.
-            if (entry.loaderData == null)
-            {
-                return;
-            }
-
-            _history[_historyIndex] = (
-                entry.path,
-                entry.matches,
-                new Dictionary<string?, object>(_loaderData),
-                new Dictionary<string?, Exception>(_loaderErrors));
+            _history[_historyIndex] = NewEntry(entry.Path, entry.Matches);
         }
 
-        private void PushHistoryEntry(string path, IReadOnlyList<RouteMatch> matches,
-            Dictionary<string?, object>? loaderData = null, Dictionary<string?, Exception>? loaderErrors = null)
+        private void PushHistoryEntry(HistoryEntry entry)
         {
             if (CanGoForward)
             {
                 _history.RemoveRange(_historyIndex + 1, _history.Count - (_historyIndex + 1));
             }
 
-            _history.Add((path, matches, loaderData, loaderErrors));
+            _history.Add(entry);
             _historyIndex = _history.Count - 1;
 
             // Evicting the head entry when the cap is exceeded shifts every remaining index down by
@@ -800,8 +782,7 @@ namespace Velvet
                 return UniTask.FromResult(NavigationResult.Cancelled);
             }
 
-            var (path, _, _, _) = _history[_historyIndex - 1];
-            return NavigateAsync(path, NavigationMode.Back, cancellationToken);
+            return NavigateAsync(_history[_historyIndex - 1].Path, NavigationMode.Back, cancellationToken);
         }
 
         /// <summary>
@@ -816,8 +797,7 @@ namespace Velvet
                 return UniTask.FromResult(NavigationResult.Cancelled);
             }
 
-            var (path, _, _, _) = _history[_historyIndex + 1];
-            return NavigateAsync(path, NavigationMode.Forward, cancellationToken);
+            return NavigateAsync(_history[_historyIndex + 1].Path, NavigationMode.Forward, cancellationToken);
         }
 
         /// <summary>

--- a/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/BlockerTests.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/BlockerTests.cs
@@ -21,8 +21,8 @@ namespace Velvet.Tests
     /// <item><c>ResetAllBlocked</c> returns every Blocked state to Idle.</item>
     /// <item><c>CheckAsync</c> evaluates every registered blocker (sync and async entries alike).</item>
     /// <item>A blocking blocker on a router navigation yields <see cref="NavigationResult.Blocked"/> and keeps
-    /// the current location, and on a Back/Forward step the provisional history index is rolled back; an
-    /// allowing blocker yields <see cref="NavigationResult.Success"/>.</item>
+    /// the current location — and, on a Back/Forward step, the history index describing it; an allowing
+    /// blocker yields <see cref="NavigationResult.Success"/>.</item>
     /// <item>A re-attempt after being blocked resets the prior block and navigates.</item>
     /// <item><c>UseBlocker</c> registers the committed predicate at settle and survives a render-phase re-run
     /// without registering a discarded attempt's transient predicate.</item>
@@ -378,9 +378,9 @@ namespace Velvet.Tests
         }
 
         [Test]
-        public void Given_BlockerRegisteredAfterArriving_When_GoBackBlocked_Then_HistoryIndexIsRolledBack()
+        public void Given_BlockerRegisteredAfterArriving_When_GoBackBlocked_Then_HistoryIndexIsUnchanged()
         {
-            // The provisional Back index decrement is undone when the blocker rejects the step.
+            // A blocked step never commits, so the history keeps describing the entry the user is on.
             // Arrange
             var router = BuildRouter("/home", Route("home"), Route("other"));
             router.NavigateSync("/other");

--- a/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RedirectTests.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RedirectTests.cs
@@ -1,5 +1,6 @@
 using NUnit.Framework;
 using Velvet;
+using Velvet.TestUtilities;
 using static Velvet.Tests.RouteTestStubs;
 
 namespace Velvet.Tests
@@ -7,15 +8,17 @@ namespace Velvet.Tests
     /// <summary>
     /// Specifies how <see cref="Router"/> resolves declarative redirects and route Guards.
     /// <list type="bullet">
-    /// <item>A route's <c>RedirectTo</c> sends navigation to the target in Replace mode, following a chain of
-    /// redirects to its final target; a redirect cycle yields <see cref="NavigationResult.Error"/>.</item>
+    /// <item>A route's <c>RedirectTo</c> sends navigation on to the target, following a chain of redirects
+    /// to its final target and recording only where that chain arrived; a cycle yields
+    /// <see cref="NavigationResult.Error"/>.</item>
     /// <item>A Guard returning null lets navigation pass; returning a path redirects there; the Guard receives
     /// the matched route's params.</item>
     /// <item>A Guard redirect during Back replaces the previous history entry (the index lands on it and
-    /// forward navigation remains available), while a failed Guard redirect rolls the history index back.</item>
+    /// forward navigation remains available), while a failed Guard redirect leaves the history index alone.</item>
     /// <item>A Guard redirect during Forward redirects to the Guard target.</item>
     /// <item>A redirect route reached by Forward replaces its history entry, so the forward target becomes the
     /// redirect destination.</item>
+    /// <item>A pushed redirect records a step even when its target is the path the user is already on.</item>
     /// </list>
     /// </summary>
     [TestFixture]
@@ -169,8 +172,9 @@ namespace Velvet.Tests
         [Test]
         public void Given_GuardRedirectDuringBack_When_LandedOnTarget_Then_ReplacesPreviousEntry()
         {
-            // The Guard redirect runs in Replace mode and overwrites history[0] with /login, so the index lands
-            // on it with no further back step but a forward step still available to the untouched /other entry.
+            // A Back step's redirect overwrites the entry that step resolved to, so /login takes history[0]
+            // and the index lands on it with no further back step but a forward step still available to the
+            // untouched /other entry.
             // Arrange
             var router = new Router(new[]
             {
@@ -283,7 +287,7 @@ namespace Velvet.Tests
 
         #endregion
 
-        #region Push with failed redirect (history rollback)
+        #region Push with failed redirect
 
         [Test]
         public void Given_PushRedirectFailsWithForwardHistory_When_RolledBack_Then_ForwardEntryIsPreserved()
@@ -313,7 +317,54 @@ namespace Velvet.Tests
             // Assert — forward navigation reaches the preserved /page, not the rolled-back ghost /admin.
             router.GoForwardSync();
             Assert.That(router.CurrentLocation.Path, Is.EqualTo("/page"),
-                "A failed push-redirect with forward history must restore the truncated forward entry");
+                "A push that never arrives must not truncate the forward entry it would have replaced");
+        }
+
+        #endregion
+
+        #region Push whose redirect resolves to the current path
+
+        [Test]
+        public void Given_AGuardRedirectingToTheCurrentPath_When_Pushed_Then_TheTargetIsAppendedAsItsOwnEntry()
+        {
+            // A pushed redirect commits its target the way the Push would have committed the originating
+            // path, so a guard that normalises a path to the one the user is already on still records a step
+            // and Back returns to that path — rather than the push resolving to nothing at all.
+            // Arrange
+            var router = BuildRouter("/target", Route("guarded", guard: _ => "/target"), Route("target"));
+            Assume.That(router.CanGoBack, Is.False, "Precondition: the start entry is the only one on the stack");
+
+            // Act
+            router.NavigateSync("/guarded");
+
+            // Assert
+            Assert.That($"{RouterHistoryProbe.PathsOf(router)} idx={router.HistoryIndex}",
+                Is.EqualTo("/target,/target idx=1"));
+        }
+
+        [Test]
+        public void Given_APushedGuardRedirect_When_TheBlockerIsAsked_Then_ItIsToldTheStepIsAPush()
+        {
+            // The Blocker check runs inside the redirect target's own navigation, and what it reports is what
+            // a leave-confirmation tells the user about the step: this one appends an entry, so Push is what
+            // describes it.
+            // Arrange
+            var router = BuildRouter("/home",
+                Route("home"), Route("guarded", guard: _ => "/target"), Route("target"));
+            var seen = (NavigationMode?)null;
+            using var registration = router.RouteBlockerManager.Register(
+                attempt =>
+                {
+                    seen ??= attempt.NavigationMode;
+                    return false;
+                },
+                new RouteBlockerState());
+
+            // Act
+            router.NavigateSync("/guarded");
+
+            // Assert
+            Assert.That($"{seen} to {router.CurrentLocation.Path}", Is.EqualTo("Push to /target"));
         }
 
         #endregion

--- a/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RedirectTests.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RedirectTests.cs
@@ -212,10 +212,9 @@ namespace Velvet.Tests
         }
 
         [Test]
-        public void Given_FailedGuardRedirectDuringBack_When_Rejected_Then_HistoryIndexIsRolledBack()
+        public void Given_FailedGuardRedirectDuringBack_When_Rejected_Then_HistoryIndexIsUnchanged()
         {
-            // The provisional Back index decrement is undone when the guard redirect fails, leaving the router
-            // on /a at index 1.
+            // The Back step commits nothing once its guard redirect fails, leaving the router on /a at index 1.
             // Arrange
             var router = new Router(new[]
             {
@@ -289,10 +288,9 @@ namespace Velvet.Tests
         [Test]
         public void Given_PushRedirectFailsWithForwardHistory_When_RolledBack_Then_ForwardEntryIsPreserved()
         {
-            // history = [/home, /page]; GoBack to /home leaves /page available forward. Pushing /admin truncates
-            // the forward /page (Push semantics) and provisionally appends /admin; the guard then redirects to a
-            // missing route and FAILS. The rollback must restore the prior history EXACTLY — including the
-            // truncated forward /page — not leave the ghost /admin in the forward slot.
+            // history = [/home, /page]; GoBack to /home leaves /page available forward. Pushing /admin would
+            // truncate the forward /page (Push semantics), but its guard redirects to a missing route and the
+            // push FAILS. Nothing may be truncated for an entry that never arrives, so /page stays reachable.
             // Arrange
             var router = new Router(new[]
             {
@@ -325,8 +323,8 @@ namespace Velvet.Tests
         [Test]
         public void Given_ForwardEntryIsRedirectRoute_When_GoForward_Then_LandsOnRedirectTarget()
         {
-            // Navigating to /old pushes it provisionally, then the redirect's Replace overwrites it with /new,
-            // so a later GoForward from /home resolves to /new.
+            // Navigating to /old records only where the redirect arrived, so the pushed entry is /new and a
+            // later GoForward from /home resolves to it.
             // Arrange
             var router = new Router(new[]
             {

--- a/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouteLoaderRunnerTests.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouteLoaderRunnerTests.cs
@@ -23,6 +23,8 @@ namespace Velvet.Tests
     /// <item>The loader receives a cancelable token that <c>CancelPending</c> cancels, and a loader that
     /// answers that token by succeeding rather than throwing is still treated as a torn-down round.</item>
     /// <item>An Await loader that throws records the error in <c>Errors</c> and reports <c>allCompleted</c> false.</item>
+    /// <item>Each round tracks its own outstanding Suspend loaders, so a round asked after a later one has
+    /// started still answers for itself.</item>
     /// </list>
     /// </summary>
     [TestFixture]
@@ -344,6 +346,34 @@ namespace Velvet.Tests
 
             // Assert
             Assert.That(runner.Errors["fail"].Message, Does.Contain("loader failed"));
+        }
+
+        #endregion
+
+        #region Round settlement
+
+        [Test]
+        public void Given_ARoundWithAnUnfinishedSuspendLoader_When_ALaterRoundHasNone_Then_EachRoundReportsItsOwn()
+        {
+            // The router asks a round whether it finished at the moment it commits the entry that round's
+            // data went into, which can be after another round has started — a loader delegate that
+            // navigates starts one before the round it belongs to has even finished launching. A round that
+            // answered for whichever round is current would report an unfinished one as finished.
+            // Arrange
+            var runner = new RouteLoaderRunner();
+            var unresolved = new UniTaskCompletionSource<object>();
+            runner.RunLoadersSync(
+                MakeMatch("slow", loader: (ctx, ct) => unresolved.Task, loaderMode: LoaderMode.Suspend),
+                CancellationToken.None);
+            var firstRound = runner.CurrentRound;
+
+            // Act
+            runner.RunLoadersSync(MakeMatch("plain"), CancellationToken.None);
+
+            // Assert
+            Assert.That($"first={firstRound.Settled} second={runner.CurrentRound.Settled}",
+                Is.EqualTo("first=False second=True"),
+                "A round reports its own outstanding loaders, not those of whichever round is current");
         }
 
         #endregion

--- a/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouterCancellationUnwindTests.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouterCancellationUnwindTests.cs
@@ -1,27 +1,25 @@
 using System.Collections;
-using System.Reflection;
 using System.Threading;
 using Cysharp.Threading.Tasks;
 using NUnit.Framework;
 using UnityEngine.TestTools;
 using Velvet;
+using Velvet.TestUtilities;
 using static Velvet.Tests.RouteTestStubs;
 
 namespace Velvet.Tests
 {
     /// <summary>
-    /// Specifies what an abandoned navigation leaves behind. Its provisional history mutations happen before
-    /// the Guard and Blocker awaits, so an attempt that abandons them has to undo those mutations whether it
-    /// leaves by exception (a blocker honoring its token) or by return value (one awaiting without
-    /// forwarding it).
+    /// Specifies what an abandoned navigation leaves behind. It sets <see cref="RouterStatus"/> before the
+    /// Guard and Blocker awaits, so an attempt that abandons them has to put it back whether it leaves by
+    /// exception (a blocker honoring its token) or by return value (one awaiting without forwarding it).
     /// <list type="bullet">
-    /// <item>The provisional Back/Forward index is restored, so the history keeps describing the entry the
-    /// user is still on.</item>
-    /// <item>The provisional Push entry a Guard redirect appended is removed again.</item>
+    /// <item>The history keeps describing the entry the user is still on, and holds no entry for a path an
+    /// abandoned Guard redirect started from.</item>
     /// <item><see cref="RouterStatus"/> returns to Idle, so <c>UseNavigation</c> stops reporting a pending
     /// navigation that no longer exists.</item>
-    /// <item>None of those restores happens once a newer navigation has taken over, since the state they
-    /// would put back describes a router that navigation has already replaced.</item>
+    /// <item>That restore does not happen once a newer navigation has taken over, since the status it would
+    /// put back describes a router that navigation has already replaced.</item>
     /// </list>
     /// </summary>
     [TestFixture]
@@ -50,7 +48,7 @@ namespace Velvet.Tests
         }
 
         [UnityTest]
-        public IEnumerator Given_BlockerHonorsToken_When_CancelledDuringBackAwait_Then_HistoryIndexIsRestored()
+        public IEnumerator Given_BlockerHonorsToken_When_CancelledDuringBackAwait_Then_HistoryIndexIsUnchanged()
             => UniTask.ToCoroutine(async () =>
         {
             // Arrange
@@ -75,12 +73,12 @@ namespace Velvet.Tests
         });
 
         [UnityTest]
-        public IEnumerator Given_GuardRedirect_When_CancelledDuringRedirectBlockerAwait_Then_ProvisionalPushIsUndone()
+        public IEnumerator Given_GuardRedirect_When_CancelledDuringRedirectBlockerAwait_Then_NothingIsRecorded()
             => UniTask.ToCoroutine(async () =>
         {
             // The redirect target's own navigation is what parks on the blocker, so the cancellation surfaces
-            // inside the await that RunGuardChecks wraps around it — past the point where the originating Push
-            // entry was appended for the redirect to overwrite.
+            // inside the await that RunGuardChecks wraps around it, with the whole redirect pair still
+            // uncommitted.
             // Arrange
             var router = BuildRouter("/home",
                 Route("/", children: new[]
@@ -100,8 +98,8 @@ namespace Velvet.Tests
             await nav;
 
             // Assert
-            Assert.That($"{HistoryCountOf(router)}/{router.HistoryIndex}", Is.EqualTo("1/0"),
-                "A cancelled redirect restores the history list and the index together; restoring either alone "
+            Assert.That($"{RouterHistoryProbe.CountOf(router)}/{router.HistoryIndex}", Is.EqualTo("1/0"),
+                "A cancelled redirect leaves neither an entry nor an index move behind; either one alone "
                 + "still leaves the stack describing a navigation that never happened");
         });
 
@@ -132,15 +130,12 @@ namespace Velvet.Tests
         });
 
         [UnityTest]
-        public IEnumerator Given_SupersededBackUnwindsLate_When_NewerBackHasCommitted_Then_IndexMatchesTheCommittedLocation()
+        public IEnumerator Given_SupersededBackUnwindsLate_When_NewerBackHasCommitted_Then_TheCommittedStateSurvives()
             => UniTask.ToCoroutine(async () =>
         {
-            // The superseded attempt saved an index describing a router that the newer navigation has since
-            // replaced, so putting that index back desyncs it from the location actually on screen.
-            // The asserted location records today's behaviour, not the intended one: both Backs land on
-            // /home because the parked attempt already moved the shared index and nothing resets it while it
-            // waits, so the second Back reads its target from the moved index and /about is skipped. That is
-            // a separate open defect; this case discriminates only the index/location desync.
+            // The superseded attempt was parked while the newer Back committed, so the Idle status it would
+            // put back describes a router that no longer exists — one with nothing in flight, where the newer
+            // navigation has just finished one.
             // Arrange
             var router = BuildRouter("/home",
                 Route("/", children: new[] { Route("home"), Route("about"), Route("contact") }));
@@ -151,7 +146,7 @@ namespace Velvet.Tests
             var superseded = router.GoBack();
             await entered.Task;
             await router.GoBack();
-            Assume.That(router.CurrentLocation?.Path, Is.EqualTo("/home"),
+            Assume.That(router.CurrentLocation?.Path, Is.EqualTo("/about"),
                 "Precondition: the newer Back committed while the superseded one was still parked");
 
             // Act
@@ -159,21 +154,17 @@ namespace Velvet.Tests
             await superseded;
 
             // Assert
-            Assert.That($"idx={router.HistoryIndex} at={router.CurrentLocation?.Path}",
-                Is.EqualTo("idx=0 at=/home"),
-                "A late unwind must not move the index away from the entry the newer navigation committed");
+            Assert.That($"idx={router.HistoryIndex} at={router.CurrentLocation?.Path} status={router.Status}",
+                Is.EqualTo("idx=1 at=/about status=Ready"),
+                "A late unwind must leave the newer navigation's own position and status standing");
         });
 
         [UnityTest]
         public IEnumerator Given_SupersededRedirectUnwindsLate_When_NewerNavigationHasPushed_Then_ItsHistorySurvives()
             => UniTask.ToCoroutine(async () =>
         {
-            // The guard snapshot was taken before the newer navigation pushed, so replaying it would delete
-            // entries that belong to the location now on screen.
-            // The asserted count records today's behaviour, not the intended one: the count is 3 because the
-            // middle entry is the provisional /guarded push, a path the user never arrived at, stranded
-            // precisely because the skipped restore is the correct choice here — a Back from /x re-runs its
-            // guard and lands on /target. Reclaiming just that entry is a separate open defect.
+            // The abandoned redirect wrote nothing, so the stack holds exactly what the newer navigation put
+            // there: /home and the /x it pushed onto it.
             // Arrange
             var router = BuildRouter("/home",
                 Route("/", children: new[]
@@ -196,8 +187,10 @@ namespace Velvet.Tests
             await superseded;
 
             // Assert
-            Assert.That($"count={HistoryCountOf(router)} idx={router.HistoryIndex}", Is.EqualTo("count=3 idx=2"),
-                "A late unwind must not replay a snapshot that predates the newer navigation's own entries");
+            Assert.That(
+                $"count={RouterHistoryProbe.CountOf(router)} idx={router.HistoryIndex} status={router.Status}",
+                Is.EqualTo("count=2 idx=1 status=Ready"),
+                "A late unwind must leave the newer navigation's own entries and status exactly as it left them");
         });
 
         [UnityTest]
@@ -206,9 +199,7 @@ namespace Velvet.Tests
         {
             // A blocker that awaits without forwarding the token returns "not blocked" instead of throwing,
             // so the abandoned attempt reaches the blocker check's own rollback rather than the exception
-            // handlers — a separate pair of writes that needs the same ownership test.
-            // The asserted location records today's behaviour on the same open defect as the case above:
-            // both Backs land on /home because the parked attempt already moved the shared index.
+            // handlers — a separate write that needs the same ownership test.
             // Arrange
             var router = BuildRouter("/home",
                 Route("/", children: new[] { Route("home"), Route("about"), Route("settings") }));
@@ -219,7 +210,7 @@ namespace Velvet.Tests
             var superseded = router.GoBack();
             await entered.Task;
             await router.GoBack();
-            Assume.That(router.CurrentLocation?.Path, Is.EqualTo("/home"),
+            Assume.That(router.CurrentLocation?.Path, Is.EqualTo("/about"),
                 "Precondition: the newer Back committed while the superseded one was still parked");
 
             // Act
@@ -227,18 +218,18 @@ namespace Velvet.Tests
             await superseded;
 
             // Assert
-            Assert.That($"idx={router.HistoryIndex} status={router.Status}", Is.EqualTo("idx=0 status=Ready"),
+            Assert.That($"idx={router.HistoryIndex} status={router.Status}", Is.EqualTo("idx=1 status=Ready"),
                 "A blocker returning after it was superseded must roll back neither the index nor the Status "
                 + "the newer navigation established");
         });
 
         [UnityTest]
-        public IEnumerator Given_SupersededByAnUnmatchedPath_When_ItResumes_Then_TheIndexIsStillRestored()
+        public IEnumerator Given_SupersededByAnUnmatchedPath_When_ItResumes_Then_TheStatusIsStillRestored()
             => UniTask.ToCoroutine(async () =>
         {
-            // A navigation that matches no route returns before the index is ever touched, so it takes no
-            // claim on it. The parked attempt is then still the only holder and must put the index back —
-            // leaving it moved would strand it away from the location the user never left.
+            // A navigation that matches no route returns before the claim is taken, so the parked attempt is
+            // still the only holder and must put the status back — leaving it as the unmatched attempt did
+            // would report a navigation nobody is waiting on.
             // Arrange
             var router = BuildRouter("/home",
                 Route("/", children: new[] { Route("home"), Route("about"), Route("contact") }));
@@ -250,26 +241,24 @@ namespace Velvet.Tests
             await entered.Task;
             var unmatched = await router.NavigateAsync("/no-such-route");
             Assume.That(unmatched, Is.EqualTo(NavigationResult.NotFound),
-                "Precondition: the superseding navigation returned without reaching the history index");
+                "Precondition: the superseding navigation returned without reaching the claim");
 
             // Act
             resumeCancelled();
             await superseded;
 
             // Assert
-            Assert.That($"idx={router.HistoryIndex} at={router.CurrentLocation?.Path}",
-                Is.EqualTo("idx=2 at=/contact"),
-                "Only an attempt that took the index may stop the parked one from restoring it");
+            Assert.That(router.Status, Is.EqualTo(RouterStatus.Idle),
+                "Only an attempt that took the claim may stop the parked one from restoring the status");
         });
 
         [UnityTest]
         public IEnumerator Given_SupersededRedirectReturnsLate_When_NewerNavigationHasPushed_Then_ItsHistorySurvives()
             => UniTask.ToCoroutine(async () =>
         {
-            // The inner redirect returns Cancelled from its own blocker check instead of throwing, so the
-            // outer reaches the returned-result restore rather than the exception one. Same stale snapshot,
-            // a different line has to refuse to replay it.
-            // The asserted count records today's behaviour for the same reason as the case above.
+            // The inner redirect returns Cancelled from its own blocker check instead of throwing, so it
+            // reaches the returned-result exit rather than the exception one. That exit is the one that must
+            // also refuse to commit the redirect target onto the stack the newer navigation now owns.
             // Arrange
             var router = BuildRouter("/home",
                 Route("/", children: new[]
@@ -292,8 +281,8 @@ namespace Velvet.Tests
             await superseded;
 
             // Assert
-            Assert.That($"count={HistoryCountOf(router)} idx={router.HistoryIndex}", Is.EqualTo("count=3 idx=2"),
-                "A redirect that returns Cancelled after being superseded must not replay its stale snapshot");
+            Assert.That($"count={RouterHistoryProbe.CountOf(router)} idx={router.HistoryIndex}", Is.EqualTo("count=2 idx=1"),
+                "A redirect that returns Cancelled after being superseded must commit nothing of its own");
         });
 
         [UnityTest]
@@ -319,16 +308,8 @@ namespace Velvet.Tests
             await parked;
 
             // Assert
-            Assert.That($"statusEvents={statusEvents} idx={router.HistoryIndex}", Is.EqualTo("statusEvents=0 idx=0"),
-                "Teardown leaves nothing for a resuming blocker to restore, so it must write neither field");
+            Assert.That(statusEvents, Is.EqualTo(0),
+                "Teardown leaves nothing for a resuming blocker to restore, so it must raise no transition");
         });
-
-        // The history list has no accessor of its own, and adding one would put a test-only member on a
-        // production type.
-        private static int HistoryCountOf(Router router)
-        {
-            var field = typeof(Router).GetField("_history", BindingFlags.Instance | BindingFlags.NonPublic);
-            return ((ICollection)field.GetValue(router)).Count;
-        }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouterTests.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouterTests.cs
@@ -19,7 +19,8 @@ namespace Velvet.Tests
     /// <item>An Await loader's result is committed before navigation completes and is keyed by
     /// <see cref="RouteMatch.RouteId"/>.</item>
     /// <item>Each successful navigation pushes a history entry; GoBack/GoForward restore the previous/next
-    /// location, and stepping past either end returns <see cref="NavigationResult.Cancelled"/>.</item>
+    /// location, and stepping past either end returns <see cref="NavigationResult.Cancelled"/> — including a
+    /// Back or Forward asked for directly through <c>NavigateAsync</c>, which those two never reach.</item>
     /// <item>The history stack is FIFO-capped: pushing beyond the cap evicts the oldest entry while the
     /// Back/Forward index keeps pointing at the same locations.</item>
     /// <item>GoBack/GoForward serve loader data and loader errors from the history cache without re-running the
@@ -29,6 +30,9 @@ namespace Velvet.Tests
     /// fresh identity, but a resolution arriving after the user navigated away does not churn the current
     /// location — including when the exit was a Back/Forward served from the cache, which commits without
     /// running the loaders.</item>
+    /// <item>A Suspend loader whose task is already complete resolves before its own navigation commits: its
+    /// result still reaches that navigation's loader data, and it is not recorded against the location being
+    /// navigated away from.</item>
     /// <item><c>OnLocationChanged</c> fires once per navigation with the committed location.</item>
     /// <item>An optional <see cref="IRouteScopeFactory"/> is exposed through <c>ScopeFactory</c> and is null
     /// when not supplied.</item>
@@ -257,6 +261,44 @@ namespace Velvet.Tests
 
             // Assert
             Assert.That(result, Is.EqualTo(NavigationResult.Cancelled));
+        }
+
+        [Test]
+        public void Given_ABackModeNavigationAtTheFirstEntry_When_Requested_Then_ItIsRefusedWithoutTouchingHistory()
+        {
+            // GoBack refuses this before starting, so only a direct NavigateAsync reaches the step itself. The
+            // route redirects because that is what turns an out-of-range step from a throw into silent
+            // corruption: the redirect's Replace finds no slot to overwrite and appends instead, leaving the
+            // index pointing at an entry that is no longer the last one.
+            // Arrange
+            var router = BuildRouter("/home",
+                Route("home"), Route("guarded", guard: _ => "/target"), Route("target"));
+            Assume.That(router.CanGoBack, Is.False, "Precondition: the start entry is the only one on the stack");
+
+            // Act
+            var result = router.NavigateAsync("/guarded", NavigationMode.Back).GetAwaiter().GetResult();
+
+            // Assert
+            Assert.That($"result={result} paths={RouterHistoryProbe.PathsOf(router)}",
+                Is.EqualTo("result=Cancelled paths=/home"));
+        }
+
+        [Test]
+        public void Given_AForwardModeNavigationAtTheLastEntry_When_Requested_Then_TheRouterIsNotLeftInFlight()
+        {
+            // The mirror of the Back case, and the one that used to throw from the commit rather than corrupt:
+            // the commit sits after the phases, so an exception raised there escaped the unwind handlers and
+            // left the status reporting a navigation that had already failed.
+            // Arrange
+            var router = BuildRouter("/home",
+                Route("home"), Route("guarded", guard: _ => "/target"), Route("target"));
+            Assume.That(router.CanGoForward, Is.False, "Precondition: the start entry is the last on the stack");
+
+            // Act
+            var result = router.NavigateAsync("/guarded", NavigationMode.Forward).GetAwaiter().GetResult();
+
+            // Assert
+            Assert.That($"result={result} status={router.Status}", Is.EqualTo("result=Cancelled status=Idle"));
         }
 
         #endregion
@@ -876,6 +918,55 @@ namespace Velvet.Tests
             Assert.That(string.Join(",", router.CurrentLoaderData.Values), Is.EqualTo("user-1"),
                 "A Back that hits the cache supersedes the round it left, so that round's late result is dropped");
         });
+
+        [Test]
+        public void Given_ASuspendLoaderHandedACompletedTask_When_ItResolvesBeforeTheCommit_Then_ItsResultIsStillCommitted()
+        {
+            // A loader is free to answer immediately, and one that does resolves while its own round is still
+            // running rather than after the navigation that started it.
+            // Arrange
+            var router = new Router(new[]
+            {
+                Route("/", children: new[]
+                {
+                    Route("ready", loaderMode: LoaderMode.Suspend,
+                        loader: (ctx, ct) => UniTask.FromResult((object)"ready-data")),
+                }),
+            });
+
+            // Act
+            router.NavigateSync("/ready");
+
+            // Assert
+            Assert.That(router.GetLoaderData("/ready"), Is.EqualTo("ready-data"),
+                "A result produced before the commit belongs to the location that commit establishes");
+        }
+
+        [Test]
+        public void Given_ASuspendLoaderHandedACompletedTask_When_ItResolvesBeforeTheCommit_Then_ThePreviousEntryIsUntouched()
+        {
+            // The write-back that a resolving Suspend loader triggers reads the live location, which until the
+            // commit is still the one being navigated away from — so the entry it would reach is that one.
+            // Arrange
+            var router = new Router(new[]
+            {
+                Route("/", children: new[]
+                {
+                    Route("first", loader: (ctx, ct) => UniTask.FromResult((object)"first-data")),
+                    Route("ready", loaderMode: LoaderMode.Suspend,
+                        loader: (ctx, ct) => UniTask.FromResult((object)"ready-data")),
+                }),
+            });
+            router.NavigateSync("/first");
+            router.NavigateSync("/ready");
+
+            // Act
+            router.GoBackSync();
+
+            // Assert
+            Assert.That(string.Join(",", router.CurrentLoaderData.Keys), Is.EqualTo("/first"),
+                "Nothing from the round that had not committed may be cached under the entry it left");
+        }
 
         #endregion
 

--- a/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouterUnfinishedNavigationTests.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouterUnfinishedNavigationTests.cs
@@ -18,7 +18,8 @@ namespace Velvet.Tests
     /// attempt's destination.</item>
     /// <item>A Guard redirect appends nothing before its target commits, so an attempt that never gets there
     /// leaves no entry for a path the user did not arrive at.</item>
-    /// <item>A navigation that dies on an exception leaves no in-flight <see cref="RouterStatus"/> behind.</item>
+    /// <item>A navigation that dies on an exception leaves no in-flight <see cref="RouterStatus"/> behind,
+    /// whether it died in a phase or in the commit that follows them.</item>
     /// <item>A history entry committed while a Suspend loader is still running is not served from the
     /// Back/Forward cache, since the snapshot it holds is not the data the route asked for.</item>
     /// </list>
@@ -150,6 +151,32 @@ namespace Velvet.Tests
             // Assert
             Assert.That(RouterHistoryProbe.PathsOf(router), Is.EqualTo("/home"),
                 "A navigation that threw before committing leaves the history as it found it");
+        });
+
+        [UnityTest]
+        public IEnumerator Given_ACommitThatThrows_When_TheExceptionReachesTheCaller_Then_TheRouterIsNoLongerInFlight()
+            => UniTask.ToCoroutine(async () =>
+        {
+            // The commit is the last thing a navigation does and the only step after the phases, so an
+            // exception raised there is the one an unwind handler placed around the phases alone would miss.
+            // A mode outside the enum is what reaches it: every defined mode has a commit branch.
+            // Arrange
+            var router = BuildRouter("/home", Route("home"), Route("other"));
+            Exception caught = null;
+
+            // Act
+            try
+            {
+                await router.NavigateAsync("/other", (NavigationMode)int.MaxValue);
+            }
+            catch (ArgumentOutOfRangeException ex)
+            {
+                caught = ex;
+            }
+
+            // Assert
+            Assert.That($"threw={caught != null} status={router.Status}", Is.EqualTo("threw=True status=Error"),
+                "A navigation that died in its commit stops reporting itself as in flight, like one that died earlier");
         });
 
         [UnityTest]

--- a/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouterUnfinishedNavigationTests.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouterUnfinishedNavigationTests.cs
@@ -1,0 +1,189 @@
+using System;
+using System.Collections;
+using System.Threading;
+using Cysharp.Threading.Tasks;
+using NUnit.Framework;
+using UnityEngine.TestTools;
+using Velvet.TestUtilities;
+using static Velvet.Tests.RouteTestStubs;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Specifies what a navigation that has not finished may leave in the router's shared state — the history
+    /// list, the history index, and <see cref="RouterStatus"/> — while a second navigation reads it.
+    /// <list type="bullet">
+    /// <item>An attempt parked in a Blocker leaves the index and the history list describing the entry the
+    /// user is still on, so a navigation started meanwhile builds on that entry rather than on the parked
+    /// attempt's destination.</item>
+    /// <item>A Guard redirect appends nothing before its target commits, so an attempt that never gets there
+    /// leaves no entry for a path the user did not arrive at.</item>
+    /// <item>A navigation that dies on an exception leaves no in-flight <see cref="RouterStatus"/> behind.</item>
+    /// <item>A history entry committed while a Suspend loader is still running is not served from the
+    /// Back/Forward cache, since the snapshot it holds is not the data the route asked for.</item>
+    /// </list>
+    /// </summary>
+    [TestFixture]
+    internal sealed class RouterUnfinishedNavigationTests
+    {
+        // Same isolation rule as RouterTests: Router.Current is a global that each new Router() overwrites.
+        [TearDown]
+        public void TearDown()
+        {
+            Router.Current?.Dispose();
+        }
+
+        [UnityTest]
+        public IEnumerator Given_ABackParkedInABlocker_When_APushCommitsMeanwhile_Then_TheEntryTheUserIsOnSurvives()
+            => UniTask.ToCoroutine(async () =>
+        {
+            // The parked Back is the one navigation that could have removed /settings: a Push truncates the
+            // forward entries above the index it reads, and the entry the user is on sits above the parked
+            // Back's destination.
+            // Arrange
+            var router = BuildRouter("/home",
+                Route("/", children: new[]
+                {
+                    Route("home"), Route("about"), Route("settings"), Route("contact"),
+                }));
+            await router.NavigateAsync("/about");
+            await router.NavigateAsync("/settings");
+            var (check, entered, _, _) = MakeDeferredBlocker();
+            using var registration = router.RouteBlockerManager.Register(check, new RouteBlockerState());
+            var parked = router.GoBack();
+            await entered.Task;
+            Assume.That(router.CurrentLocation?.Path, Is.EqualTo("/settings"),
+                "Precondition: the Back is still parked in the blocker and has committed nothing");
+
+            // Act
+            await router.NavigateAsync("/contact");
+
+            // Assert
+            Assert.That(RouterHistoryProbe.PathsOf(router), Is.EqualTo("/home,/about,/settings,/contact"),
+                "A navigation that has not committed must not move the position a later Push builds on");
+        });
+
+        [UnityTest]
+        public IEnumerator Given_ARedirectParkedInABlocker_When_ANewerNavigationCommits_Then_NoEntryForTheRedirectingPathRemains()
+            => UniTask.ToCoroutine(async () =>
+        {
+            // The redirect's own target parks, so the originating path is as far as the attempt ever got. An
+            // entry for it would sit in the stack for the rest of the session, and a Back onto it would re-run
+            // the guard and land on the redirect target instead.
+            // Arrange
+            var router = BuildRouter("/home",
+                Route("/", children: new[]
+                {
+                    Route("home"),
+                    Route("guarded", guard: _ => "/target"),
+                    Route("target"),
+                    Route("x"),
+                }));
+            var (check, entered, _, _) = MakeDeferredBlocker();
+            using var registration = router.RouteBlockerManager.Register(check, new RouteBlockerState());
+            var parked = router.NavigateAsync("/guarded");
+            await entered.Task;
+
+            // Act
+            await router.NavigateAsync("/x");
+
+            // Assert
+            Assert.That(RouterHistoryProbe.PathsOf(router), Is.EqualTo("/home,/x"),
+                "A redirect that never reached its target must leave no entry for the path it started from");
+        });
+
+        [UnityTest]
+        public IEnumerator Given_AGuardThatThrows_When_TheExceptionReachesTheCaller_Then_TheRouterIsNoLongerInFlight()
+            => UniTask.ToCoroutine(async () =>
+        {
+            // A Guard is an application delegate invoked with nothing between it and the caller. Leaving the
+            // in-flight Status behind would make every UseNavigation consumer render its pending branch for
+            // the rest of the session, including components mounted after the throw.
+            // Arrange
+            var router = BuildRouter("/home",
+                Route("/", children: new[]
+                {
+                    Route("home"),
+                    Route("boom", guard: _ => throw new InvalidOperationException("guard-boom")),
+                }));
+            Exception caught = null;
+
+            // Act
+            try
+            {
+                await router.NavigateAsync("/boom");
+            }
+            catch (InvalidOperationException ex)
+            {
+                caught = ex;
+            }
+
+            // Assert
+            Assert.That($"threw={caught != null} status={router.Status}", Is.EqualTo("threw=True status=Error"),
+                "A navigation that died on an exception reports the failure and stops reporting itself as in flight");
+        });
+
+        [UnityTest]
+        public IEnumerator Given_ARedirectTargetDeclaringBothRedirectToAndGuard_When_ItThrows_Then_TheOriginatingPathIsNotRecorded()
+            => UniTask.ToCoroutine(async () =>
+        {
+            // The mutual-exclusion throw comes from inside the redirect target's own navigation, so the
+            // originating path is the one an aborted attempt could leave on the stack.
+            // Arrange
+            var router = BuildRouter("/home",
+                Route("/", children: new[]
+                {
+                    Route("home"),
+                    Route("start", guard: _ => "/broken"),
+                    Route("broken", redirectTo: "/home", guard: _ => null),
+                }));
+
+            // Act
+            try
+            {
+                await router.NavigateAsync("/start");
+            }
+            catch (InvalidOperationException)
+            {
+            }
+
+            // Assert
+            Assert.That(RouterHistoryProbe.PathsOf(router), Is.EqualTo("/home"),
+                "A navigation that threw before committing leaves the history as it found it");
+        });
+
+        [UnityTest]
+        public IEnumerator Given_AnEntryCommittedWhileItsSuspendLoaderRuns_When_GoingBackToIt_Then_TheLoaderRunsAgain()
+            => UniTask.ToCoroutine(async () =>
+        {
+            // The entry's snapshot is empty because the loader never resolved, which is indistinguishable by
+            // content from a route whose loaders legitimately produced nothing.
+            // Arrange
+            var unresolved = new UniTaskCompletionSource<object>();
+            var loaderCalls = 0;
+            var router = new Router(new[]
+            {
+                Route("/", children: new[]
+                {
+                    Route("users/:id", loaderMode: LoaderMode.Suspend,
+                        loader: (ctx, ct) =>
+                        {
+                            Interlocked.Increment(ref loaderCalls);
+                            return unresolved.Task;
+                        }),
+                    Route("other"),
+                }),
+            });
+            await router.NavigateAsync("/users/1");
+            await router.NavigateAsync("/other");
+            Assume.That(loaderCalls, Is.EqualTo(1), "Precondition: the loader ran once and never resolved");
+
+            // Act
+            await router.GoBack();
+
+            // Assert
+            Assert.That(loaderCalls, Is.EqualTo(2),
+                "A snapshot taken before the loaders finished is not the data the route asked for, so it is not cached");
+        });
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouterUnfinishedNavigationTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouterUnfinishedNavigationTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 141f6ebbfd08446af84ae8cfe9fced93

--- a/Packages/com.velvet.core/TestUtilities/RouterHistoryProbe.cs
+++ b/Packages/com.velvet.core/TestUtilities/RouterHistoryProbe.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace Velvet.TestUtilities
+{
+    /// <summary>
+    /// Reads the <see cref="Router"/>'s history stack. Reached by reflection because production types carry
+    /// no test-only members, and the stack has no public accessor: <c>CurrentLocation</c> plus
+    /// <c>CanGoBack</c>/<c>CanGoForward</c> describe where the user is, not what entries stand behind them.
+    /// </summary>
+    public static class RouterHistoryProbe
+    {
+        private const string HistoryFieldName = "_history";
+
+        /// <summary>
+        /// The path of every history entry, oldest first, joined with commas.
+        /// </summary>
+        /// <exception cref="MissingFieldException">
+        /// The history field was renamed or removed. Throwing is the point: a probe that quietly reached
+        /// nothing would report an empty stack, which several callers assert is not what they left behind.
+        /// </exception>
+        public static string PathsOf(Router router) => string.Join(",", EntryPaths(router));
+
+        /// <summary>
+        /// The number of entries on the history stack.
+        /// </summary>
+        public static int CountOf(Router router) => ((ICollection)HistoryOf(router)).Count;
+
+        private const string PathFieldName = "Path";
+
+        private static IEnumerable<string> EntryPaths(Router router)
+        {
+            foreach (var entry in HistoryOf(router))
+            {
+                var field = entry.GetType().GetField(PathFieldName, BindingFlags.Instance | BindingFlags.NonPublic);
+                if (field == null)
+                {
+                    throw new MissingFieldException(entry.GetType().FullName, PathFieldName);
+                }
+                yield return (string)field.GetValue(entry)!;
+            }
+        }
+
+        private static IEnumerable HistoryOf(Router router)
+        {
+            var field = typeof(Router).GetField(HistoryFieldName, BindingFlags.Instance | BindingFlags.NonPublic);
+            if (field == null)
+            {
+                throw new MissingFieldException(typeof(Router).FullName, HistoryFieldName);
+            }
+            return (IEnumerable)field.GetValue(router)!;
+        }
+    }
+}

--- a/Packages/com.velvet.core/TestUtilities/RouterHistoryProbe.cs.meta
+++ b/Packages/com.velvet.core/TestUtilities/RouterHistoryProbe.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 03978dbe7b81b4ad59b8519628e5c555


### PR DESCRIPTION
Four defects, one root: an attempt wrote shared state — the history index, the history list, `Status` — before the Guard and Blocker awaits, and a navigation starting inside that window read it.

- Pressing Back with a confirm-dialog blocker open, then clicking a link, ran the Push against the parked Back's decremented index and removed the page the user was on from history.
- A guard redirect superseded by a newer navigation left the provisional entry it had pushed for the redirect target to overwrite. Back onto it re-ran the guard.
- A guard delegate that threw, or a redirect target declaring both `RedirectTo` and `Guard`, left the index moved and `Status` at `Matching` — which renders as `Loading`, so every `UseNavigation` showed its pending branch forever.
- A route committed while its `Suspend` loader was still in flight cached an empty-but-non-null snapshot, and the cache hit on non-null meant Back never re-ran the loader.

The first three are fixed by not writing early. A `PendingNavigation` resolves where an attempt will land when it starts, and the index is written only at commit — `ApplyProvisionalHistoryIndex` and `RollBackProvisional` are deleted, because with nothing moved there is nothing to roll back. The redirect's provisional Push goes the same way: the target commits with the originating navigation's own history effect, so a Push stays a Push and an abandoned redirect leaves nothing, by construction rather than by restore. That removes the snapshot-and-restore block and its two ownership gates. The sequence claim survives, now guarding only `Status`, the one shared write that still precedes the awaits.

An exception now leaves `RouterStatus.Error`. `ReadNavigationState` maps it to `NavigationLifecycle.Idle`, so `UseNavigation` matches React Router in never being mid-flight after a throw, while `Router.Status` still records that the last navigation failed rather than claiming it was cancelled. The commit moved inside the try, and a direct `Back`/`Forward` with no slot is bounds-checked — without it, `Back` at index 0 onto a redirecting route committed a second entry with the index still on the first, so `CurrentLocation` and the stack disagreed with no exception and no log.

The cache defect needed its own machinery. A `LoaderRound` carries its own outstanding count and its own results, `CancelPending` installs a fresh round rather than zeroing the outgoing one, and the entry records whether the round that produced its snapshot settled. A Suspend loader that hands back an already-complete task now writes into that round's results, where before the commit's assignment erased it — so the flag means the loaders finished *and* their results are in the entry, rather than only the first.

One behaviour change worth stating: a blocker predicate now sees `NavigationMode.Push` for a pushed guard redirect, where it saw `Replace`. The history genuinely grows by one, so the old value described a step the router did not take.

Three defects in the same area are filed rather than fixed: the cancellation branch of the loader phase wipes loader data ungated (#492), a superseded round's later loaders register under a nested round's token (bounded here, not fixed), and `NavigateAsync` with `Back` at index 0 has no result to return where every other unavailable navigation does (#493).

No routing guide exists in `Documentation~` — `react-migration.md` says routing is not yet documented separately, which stays true.

Closes #437
Closes #438
Closes #439
Closes #440
