### PR TITLE
fix(velvet): ask git whether a checkout operand is a commit

### DIFF
--- a/.claude/hooks/refuse/shared_git_state.py
+++ b/.claude/hooks/refuse/shared_git_state.py
@@ -14,6 +14,8 @@ case the rule exists for — was invisible to it.
 
 import json
 import os
+import re
+import subprocess
 import sys
 from pathlib import Path
 
@@ -28,6 +30,24 @@ HOOK_SCOPE = "session"
 # `git stash list` and `git stash show` read; every other form moves the shared stash.
 STASH_READS = {"list", "show"}
 
+# Flags a path-restoring checkout may carry. Anything else — `-b`, `-B`, `--detach`, `--orphan`,
+# or a flag added to git after this line was written — takes the refusal, because the operand it
+# governs is then not a pathspec and the question below is being asked about the wrong thing.
+RESTORE_FLAGS = {
+    "--",
+    "-f", "--force",
+    "-q", "--quiet",
+    "-m", "--merge",
+    "-p", "--patch",
+    "--ours", "--theirs",
+    "--overlay", "--no-overlay",
+}
+
+# A hook is handed the command before the shell expands it, so an operand spelled with a variable or
+# a substitution is not the text git will run. Resolving it below would answer about the literal and
+# answer no, which is the pass — so it takes the refusal without being resolved at all.
+UNEXPANDED = re.compile(r"[$`]")
+
 SWITCH_REFUSAL = (
     "Refused: `git switch` and `git stash` move state other worktrees share. Work in the worktree "
     "you were given; if you need a different base, say so and stop.\n"
@@ -38,19 +58,65 @@ CHECKOUT_REFUSAL = (
 )
 
 
+def names_a_commit(root, token):
+    """Whether git resolves `token` to a commit, answering yes when git cannot be asked.
+
+    The alternative that spends no subprocess is `os.path.exists`, and it reads a path the working
+    tree no longer has — restoring a file you just deleted, the ordinary reason to run this command
+    — as a branch. Reading `.git/refs` and `packed-refs` from here would also answer without git,
+    and was rejected as a second implementation of ref resolution that drifts against the first.
+
+    Answering yes is the refusal, and a refusal leaves the caller `git checkout -- <path>`, which
+    this guard allows; the other direction retargets a branch another worktree is on.
+    `GuardCommandCoverageTests` poses a command for each of the three answers git gives.
+    """
+    try:
+        completed = subprocess.run(
+            ["git", "-C", root, "rev-parse", "--verify", "--quiet", "--end-of-options",
+             token + "^{commit}"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=10,
+        )
+    except Exception:
+        return True
+    return completed.returncode != 1
+
+
 def restores_paths(directory, operands, cwd):
     """Whether this checkout restores files rather than moving HEAD.
 
-    `--` says so outright. Otherwise every non-flag operand has to name something that exists,
-    which is the same question git resolves — and the only one answerable without moving anything.
+    `--` says so outright, and settles it before any operand is resolved, so the escape hatch the
+    refusal text offers stays open even where git is unreachable.
     """
+    if any(token.startswith("-") and token not in RESTORE_FLAGS for token in operands):
+        return False
     if "--" in operands:
         return True
-    root = directory or cwd
     named = [token for token in operands if not token.startswith("-")]
-    if not named:
+    if not named or any(UNEXPANDED.search(token) for token in named):
         return False
-    return all(os.path.exists(os.path.join(root, token)) for token in named)
+    root = directory or cwd
+    if directory and not os.path.isabs(directory):
+        root = os.path.join(cwd, directory)
+    return not any(names_a_commit(root, token) for token in named)
+
+
+def refusals(command, cwd):
+    """The subcommand of every invocation in `command` this guard refuses, in the order they run.
+
+    Split from `main` so a command table can pose one without a hook payload around it, and left
+    lazy so a caller wanting only the first refusal resolves no operand belonging to a later one.
+    """
+    for directory, subcommand, operands in git_invocations(command, {"switch", "stash", "checkout"}):
+        if subcommand == "stash":
+            first = next((token for token in operands if not token.startswith("-")), "")
+            if first not in STASH_READS:
+                yield subcommand
+        elif subcommand == "switch":
+            yield subcommand
+        elif not restores_paths(directory, operands, cwd):
+            yield subcommand
 
 
 def main():
@@ -63,21 +129,11 @@ def main():
         return 0
     cwd = event.get("cwd") or "."
 
-    for directory, subcommand, operands in git_invocations(command, {"switch", "stash", "checkout"}):
-        if subcommand == "stash":
-            first = next((token for token in operands if not token.startswith("-")), "")
-            if first in STASH_READS:
-                continue
-            sys.stderr.write(SWITCH_REFUSAL)
-            return 2
-        if subcommand == "switch":
-            sys.stderr.write(SWITCH_REFUSAL)
-            return 2
-        if not restores_paths(directory, operands, cwd):
-            sys.stderr.write(CHECKOUT_REFUSAL)
-            return 2
-
-    return 0
+    refused = next(refusals(command, cwd), None)
+    if refused is None:
+        return 0
+    sys.stderr.write(CHECKOUT_REFUSAL if refused == "checkout" else SWITCH_REFUSAL)
+    return 2
 
 
 if __name__ == "__main__":

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/GuardCommandCoverageTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/GuardCommandCoverageTests.cs
@@ -8,15 +8,15 @@ using NUnit.Framework;
 namespace Velvet.Tests
 {
     /// <summary>
-    /// Pins which commands the three smaller guards act on. Each of them accepted a spelling of the
+    /// Pins which commands each of the smaller guards acts on. Each of them accepted a spelling of the
     /// thing it exists to refuse, and a guard that does not recognise a command reports exactly what a
     /// guard with nothing to say reports — so the recognition is asserted rather than assumed.
     /// </summary>
     /// <remarks>
-    /// The fourth guard, <c>.claude/hooks/refuse/shared_git_state.py</c>, is absent from these tables
-    /// rather than covered elsewhere: its answer depends on whether an operand names a file that
-    /// exists, which is the question it replaced a slash-matching pattern with, and a table of
-    /// commands cannot pose it. Nothing poses it — that guard is unasserted.
+    /// <c>.claude/hooks/refuse/shared_git_state.py</c> answers about operands rather than about the
+    /// command alone, so its table is posed against a git repository this fixture builds in a
+    /// temporary directory and names as the working directory. It went uncovered while the other four
+    /// were covered, and it is the one that shipped a parsing defect.
     /// </remarks>
     [TestFixture]
     internal sealed class GuardCommandCoverageTests
@@ -72,6 +72,54 @@ namespace Velvet.Tests
                 ("git status", "-"),
             };
         }
+
+        // Read against the fixture's own repository: `main` and `feat/x` are branches in it, `kept.txt`
+        // and `sub` exist in it, and `gone.txt` names neither — the shape of a path git can restore
+        // that the working tree no longer holds.
+        private static readonly (string Command, string Expected)[] SharedState =
+        {
+            ("git checkout main", "checkout"),
+            ("git checkout feat/x", "checkout"),
+            ("git checkout \"feat/x\"", "checkout"),
+            ("git checkout HEAD", "checkout"),
+            ("git checkout -f main", "checkout"),
+            ("git checkout main kept.txt", "checkout"),
+            ("git checkout -b kept.txt", "checkout"),
+            ("git checkout -B main", "checkout"),
+            ("git checkout --detach HEAD", "checkout"),
+            ("git checkout -", "checkout"),
+            ("git checkout main; git status", "checkout"),
+            ("if true; then git checkout main; fi", "checkout"),
+            ("/usr/bin/git checkout main", "checkout"),
+            ("git -c core.pager=cat checkout main", "checkout"),
+            ("git -C sub checkout main", "checkout"),
+            // A repository git cannot open leaves the question unanswered, and an unanswered question
+            // takes the refusal rather than the pass. So does an operand the shell has yet to expand,
+            // whose literal text resolves to nothing and would otherwise read as a path.
+            ("git -C /velvet-no-such-tree checkout gone.txt", "checkout"),
+            ("git checkout $BRANCH", "checkout"),
+            ("git checkout \"$BRANCH\"", "checkout"),
+            ("git checkout $(cat branch.txt)", "checkout"),
+            ("git checkout `cat branch.txt`", "checkout"),
+
+            ("git checkout kept.txt", "-"),
+            ("git checkout gone.txt", "-"),
+            ("git checkout kept.txt gone.txt", "-"),
+            ("git checkout -- gone.txt", "-"),
+            ("git checkout --ours gone.txt", "-"),
+            ("git -C sub checkout gone.txt", "-"),
+
+            ("git switch main", "switch"),
+            ("git switch -c topic", "switch"),
+            ("git stash", "stash"),
+            ("git stash pop", "stash"),
+            ("git stash list", "-"),
+            ("git stash show", "-"),
+
+            ("git status", "-"),
+            ("git commit -m \"git checkout main\"", "-"),
+            ("echo 'git checkout main'", "-"),
+        };
 
         private static readonly (string Command, string Expected)[] Creations =
         {
@@ -184,6 +232,105 @@ namespace Velvet.Tests
 
             // Assert
             Assert.That(disagreements, Is.Empty);
+        }
+
+        [Test]
+        public void Given_TheCheckoutTable_When_TheSharedStateGuardReadsEach_Then_ItRefusesOnlyWhatCanMoveHead()
+        {
+            // Arrange
+            var hook = Path.GetFullPath(".claude/hooks/refuse/shared_git_state.py");
+            Assume.That(File.Exists(hook), Is.True, "Precondition: the guard exists");
+            var root = Path.Combine(Path.GetTempPath(), "velvet-guard-" + Guid.NewGuid().ToString("N"));
+            string disagreements;
+
+            try
+            {
+                Assume.That(BuildRepository(root), Is.True, "Precondition: git built the fixture repository");
+
+                // Act
+                var expression = "lambda g,c: ','.join(g.refusals(c, r'" + root + "')) or '-'";
+                var answers = Ask(hook, expression, SharedState.Select(row => row.Command));
+                Assume.That(answers?.Count, Is.EqualTo(SharedState.Length), "Precondition: one answer per command");
+
+                disagreements = Disagreements(SharedState, answers);
+            }
+            finally
+            {
+                if (Directory.Exists(root))
+                {
+                    Directory.Delete(root, true);
+                }
+            }
+
+            // Assert
+            Assert.That(disagreements, Is.Empty,
+                "a checkout read wrongly either retargets a branch another worktree is on or refuses a restore");
+        }
+
+        // Built rather than posed against this repository, whose branches and whose absent files a table
+        // cannot predict, and placed outside the working tree so nothing here can reach a repository
+        // another session holds.
+        private static bool BuildRepository(string root)
+        {
+            // --template=: a template directory on the machine running this would seed the fixture with
+            // hooks, and a hook that rejects the commit below would report as git being unavailable.
+            if (Git(null, "init", "-q", "--template=", "-b", "main", root) != 0)
+            {
+                return false;
+            }
+
+            if (Git(root, "-c", "user.email=fixture@example.invalid", "-c", "user.name=fixture",
+                    "-c", "commit.gpgsign=false", "commit", "-q", "--allow-empty", "-m", "root") != 0)
+            {
+                return false;
+            }
+
+            if (Git(root, "branch", "feat/x") != 0)
+            {
+                return false;
+            }
+
+            File.WriteAllText(Path.Combine(root, "kept.txt"), string.Empty);
+            Directory.CreateDirectory(Path.Combine(root, "sub"));
+            return true;
+        }
+
+        private static int Git(string directory, params string[] arguments)
+        {
+            var start = new ProcessStartInfo("git")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            };
+            if (directory != null)
+            {
+                start.ArgumentList.Add("-C");
+                start.ArgumentList.Add(directory);
+            }
+
+            foreach (var argument in arguments)
+            {
+                start.ArgumentList.Add(argument);
+            }
+
+            try
+            {
+                using var process = Process.Start(start);
+                if (process == null)
+                {
+                    return -1;
+                }
+
+                process.StandardOutput.ReadToEnd();
+                process.StandardError.ReadToEnd();
+                return process.WaitForExit(30000) ? process.ExitCode : -1;
+            }
+            catch (Exception)
+            {
+                return -1;
+            }
         }
 
         private static string Disagreements((string Command, string Expected)[] table, List<string> answers) =>


### PR DESCRIPTION
The shared-git-state guard decided whether a `git checkout` restored paths or moved branches by asking the filesystem whether the operand existed. That is wrong for the ordinary reason to run the command — restoring a file you just deleted was refused — and, in the other direction, `git checkout -b Packages` was **allowed**, because a path by that name existed, so creating and switching to a branch read as a restore. The first cost a confusing message on every session since the guard was wired globally; the second let through precisely what the guard exists to stop.

It now asks git: `git rev-parse --verify --quiet --end-of-options <token>^{commit}`. An operand is a branch move exactly when it resolves to a commit.

Every unanswerable case takes the refusal. `rev-parse` gives three answers and the guard reads three: exit 0 is a commit and refuses, exit 1 is not and allows, anything else means git could not answer and refuses. Measured on git 2.50.1 — 0 for `main`, `feat/…`, `HEAD`, `@`; 1 for `CLAUDE.md`, `a/b/c.cs`, `*.cs`, `..`, `file[1].cs`, `a b.cs`, `x^y`; 128 only for a `-C` directory that is not a repository. Refusing costs the caller the `git checkout -- <path>` form the refusal already names; allowing wrongly retargets a branch another worktree is sitting on.

Checkout flags outside a small restore allowlist now refuse outright, so `-b`, `-B`, `--detach`, `--orphan` and anything git adds later cannot slip through on a coincidental path name.

One regression was caught before it landed, by diffing old against new behaviour rather than by reading: a `PreToolUse` hook is handed the command **before** the shell expands it, so `rev-parse` correctly reports the literal `$BRANCH` as not-a-commit and the first version of this change allowed `git checkout $BRANCH` where the shipped guard refused it. That is the unsafe direction. An operand carrying `$` or a backtick now refuses without being resolved.

The cost concern turned out to be misplaced, and measuring it is what made this approach affordable: the hook runs on every `Bash` call but the subprocess runs only for a `git checkout` with no `--`. Mean of 20 invocations each — `ls -la` 38.5 ms, `git status` 38.1 ms, `git checkout -- CLAUDE.md` 38.2 ms, `git checkout CLAUDE.md` 54.9 ms, `git checkout main` 68.3 ms. Zero added on everything that is not an ambiguous checkout.

Reading `.git/refs` and `packed-refs` directly was rejected and is recorded as such: it costs no subprocess and is a second implementation of ref resolution — worktree commondirs, symrefs, packed refs, `HEAD~1`, `@{u}`, raw SHAs — that drifts against the first with nothing failing.

This guard was the one `refuse/` hook with no command table, and it is the one that broke. It has one now: 38 rows against a repository the fixture builds under the temp directory, so no row depends on the host repository's state, with `--template=` so a host template cannot seed it with hooks. Four deliberate breakages were each measured red — the shipped defect, the flag allowlist, reading `returncode == 0` so an unanswerable question passes, and the unexpanded-operand check.

Three things are filed rather than fixed. Glob operands are still allowed, deliberately: `$` and a backtick are never legal in a refname so refusing them costs nothing, while refusing `git checkout '*.cs'` would recreate the over-refusal this change removes (#505). Every guard under `refuse/` reads pre-expansion text and only this one now accounts for it — `branch_from_unmerged.py` demonstrated the same exposure during this work (#506). And the new fixture needs `git` on `PATH` inside the Unity test process; if it is absent the case reports Inconclusive, which the suite turns into a failure — loud, which is the right direction, but a new environmental dependency for that job (#507).

No CHANGELOG entry: `.claude/` is not in the published package, the only package file touched is a test fixture, and the commit that wired this guard set the same precedent.

Closes #488
