### PR TITLE
fix(velvet): give each loader round its own state and let UseContext admit null

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -237,11 +237,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `Router.CurrentLocation` before the first navigation. The sibling router hooks `UseMatch`,
   `UseOutletContext`, `UseLoaderData` and `UseRouteError` were already annotated nullable.
 
-  The read path underneath is unchanged and still hands a null past a non-null declaration:
-  `Hooks.UseContext<T>` returns `T` while `ComponentContext<T>.DefaultValue` is `T?`, so
-  `Hooks.UseContext(RouterContext.Location).Path` still compiles clean and throws with no router
-  above it.
-
 - `ISearchParams.Get` is declared `string?`, matching the null it documents for an absent key and the
   `SearchParams` implementation that returns it. `Hooks.UseSearchParams()` hands back the interface,
   so the interface declaration is the one a consumer reads: `searchParams.Get("id").Length` compiled
@@ -261,6 +256,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   stacked variant sits above either of its parts alone; it layers at the higher of the two, so against
   that stronger part it ties rather than wins, and the tie is settled the way the same file's *Same
   family, different values* bullet already describes.
+
+- `Hooks.UseContext<T>` is declared `T?`. It hands back `ComponentContext<T>.DefaultValue` when no
+  Provider is above the caller, and that property is `T?` — `ComponentContext<T>.Create` takes a null
+  default, which is how `RouterContext.Location` and `RouterContext.OutletContext` are both built — so
+  `Hooks.UseContext(RouterContext.Location).Path` compiled without a warning in a nullable-enabled
+  assembly and threw `NullReferenceException` with no router above it. This is the read path underneath
+  `Hooks.UseLocation()`, which was annotated in isolation. Throwing when no Provider is found was
+  rejected for the reason `UseLocation` was not made to throw: a Velvet context is seeded with a
+  default rather than being absent, so a context legitimately created with a null default and a
+  missing Provider are the same read, and `UseOutletContext` documents the first of those as normal.
+  Nothing changes at runtime, and a context of a value type is unaffected either way, since `T?` on an
+  unconstrained type parameter is an annotation rather than `Nullable<T>`.
+
+- Stepping onto a history entry whose `LoaderMode.Suspend` loaders all answer immediately now leaves that
+  entry servable. Such an entry is recorded unfinished and re-runs its loaders when stepped onto, which is
+  correct — but a loader handed an already-complete task resolves inside the run that launched it, before
+  the step has a location to record its result under, so the write-back that marks an entry finished never
+  arrived. The entry stayed unfinished, and a route whose loaders all answer that way could therefore never
+  be served from the Back/Forward cache: its loaders ran again on every step onto it. A Back or Forward
+  whose loader round finished before the step committed now records the entry from that commit.
 
 ### Changed
 

--- a/Packages/com.velvet.core/PublicAPI.txt
+++ b/Packages/com.velvet.core/PublicAPI.txt
@@ -296,7 +296,7 @@
 [Velvet] method Velvet.Hooks.UseBlocker(System.Func`3[Velvet.NavigationAttempt, System.Threading.CancellationToken, Cysharp.Threading.Tasks.UniTask`1[System.Boolean]], System.Object?[]?): Velvet.RouteBlockerState
 [Velvet] method Velvet.Hooks.UseCallback`1(T): T
 [Velvet] method Velvet.Hooks.UseCallback`1(T, System.Object?[]): T
-[Velvet] method Velvet.Hooks.UseContext`1(Velvet.ComponentContext`1[T]): T
+[Velvet] method Velvet.Hooks.UseContext`1(Velvet.ComponentContext`1[T]): T?
 [Velvet] method Velvet.Hooks.UseDeferredValue`1(T): T
 [Velvet] method Velvet.Hooks.UseDeferredValue`1(T, T): T
 [Velvet] method Velvet.Hooks.UseEffect(System.Func`1[System.Action?]?, System.Object?[]?): System.Void

--- a/Packages/com.velvet.core/Runtime/Component/ComponentContextStack.cs
+++ b/Packages/com.velvet.core/Runtime/Component/ComponentContextStack.cs
@@ -17,7 +17,7 @@ namespace Velvet
 
         public void Pop<T>(ComponentContext<T> context) => PopRaw(context);
 
-        public T Get<T>(ComponentContext<T> context)
+        public T? Get<T>(ComponentContext<T> context)
         {
             object key = context;
             if (_stacks.TryGetValue(key, out var stack) && stack.Count > 0)
@@ -25,7 +25,7 @@ namespace Velvet
                 return (T)stack.Peek();
             }
 
-            return context.DefaultValue!;
+            return context.DefaultValue;
         }
 
         // Captures the current top value of every active context as an untyped snapshot. Used to carry the

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/ContextApiTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/ContextApiTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using NUnit.Framework;
 using UnityEngine.UIElements;
 using Velvet.TestUtilities;
@@ -25,6 +26,8 @@ namespace Velvet.Tests
     /// (<c>0</c> for int, <c>null</c> for string), exposed as <see cref="ComponentContext{T}.DefaultValue"/>.</item>
     /// <item>A wrapper-emitting node (such as Suspense) between a Provider and a consumer does not break
     /// propagation: the consumer still observes the Provider value.</item>
+    /// <item><see cref="Hooks.UseContext"/> is declared nullable, because the default it falls back to is one
+    /// <see cref="ComponentContext{T}.Create"/> accepts as null.</item>
     /// </list>
     /// </summary>
     /// <remarks>
@@ -230,6 +233,35 @@ namespace Velvet.Tests
             Assert.That(s_themeDisplayLastRendered, Is.EqualTo("forest"),
                 "A wrapper-emitting Suspense node between the Provider and consumer does not break propagation");
         }
+
+        #region Declared nullability
+
+        [Test]
+        public void Given_UseContextAndUseDeferredValue_When_ReturnAnnotationsRead_Then_OnlyUseContextAdmitsNull()
+        {
+            // Arrange
+            var useContext = typeof(Hooks).GetMethod(nameof(Hooks.UseContext));
+            var useDeferredValue = typeof(Hooks).GetMethods().Single(
+                method => method.Name == nameof(Hooks.UseDeferredValue)
+                    && method.GetParameters().Length == 1);
+
+            // Act
+            var annotations = (
+                context: NullableAnnotationProbe.ReturnAnnotation(useContext),
+                deferred: NullableAnnotationProbe.ReturnAnnotation(useDeferredValue));
+
+            // Assert
+            Assert.That(
+                annotations,
+                Is.EqualTo((
+                    NullableAnnotationProbe.Annotation.Nullable,
+                    NullableAnnotationProbe.Annotation.NotNullable)),
+                "UseContext hands back a default a context is free to have created as null, so its "
+                + "declaration must admit null; UseDeferredValue returns the value it was given and is the "
+                + "control showing the probe separates the two states on an unconstrained type parameter");
+        }
+
+        #endregion
 
         #region Consumer components (leaf that calls UseContext)
 

--- a/Packages/com.velvet.core/Runtime/Hooks/Hooks.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Hooks.cs
@@ -238,14 +238,17 @@ namespace Velvet
         /// </remarks>
         /// <typeparam name="T">Context value type.</typeparam>
         /// <param name="context">Context object to read. Must not be null.</param>
-        /// <returns>Provided value when an ancestor Provider is present, otherwise <c>context.DefaultValue</c>.</returns>
-        public static T UseContext<T>(ComponentContext<T> context)
+        /// <returns>
+        /// Provided value when an ancestor Provider is present, otherwise <c>context.DefaultValue</c>, which
+        /// is null for a context created with a null default.
+        /// </returns>
+        public static T? UseContext<T>(ComponentContext<T> context)
         {
             if (context == null) throw new ArgumentNullException(nameof(context));
             var fiber = Resolve("UseContext");
             fiber.RegisterContextDependency(context);
             var stack = fiber.Reconciler?.Context.ComponentContextStack;
-            return stack != null ? stack.Get(context) : context.DefaultValue!;
+            return stack != null ? stack.Get(context) : context.DefaultValue;
         }
 
         #endregion

--- a/Packages/com.velvet.core/Runtime/Routing/RouteLoaderRunner.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/RouteLoaderRunner.cs
@@ -11,30 +11,34 @@ namespace Velvet
     {
         private CancellationTokenSource? _cts;
 
-        // Per-route errors (keyed by RouteId) raised by the most recent RunLoadersSync call.
-        public IReadOnlyDictionary<string?, Exception> Errors => _errors;
-        private readonly Dictionary<string?, Exception> _errors = new();
-
         // Notification event fired with (routeId, result) when a Suspend loader of the CURRENT round
         // succeeds. A loader that ignores the CancellationToken and resolves after a newer RunLoadersSync
-        // (or after disposal) belongs to a superseded round; its result is stale and is dropped without
-        // firing this event or touching Errors, so a navigated-away route cannot pollute the live state.
+        // (or after disposal) belongs to a superseded round; its result is dropped without firing this event,
+        // so a navigated-away route cannot pollute the live state.
         public event Action<string?, object>? OnSuspendLoaderCompleted;
 
         // Notification event fired with (routeId, exception) when a Suspend loader of the current round
-        // fails. The failure is also recorded in Errors. A superseded round's late failure is dropped
-        // (no event, no Errors write) for the same reason as OnSuspendLoaderCompleted.
+        // fails. The failure is also recorded in the round's Errors. A superseded round's late failure is
+        // dropped (no event, no Errors write) for the same reason as OnSuspendLoaderCompleted.
         public event Action<string?, Exception>? OnSuspendLoaderFailed;
 
         private int _activeSuspendTaskCount;
 
-        // One RunLoadersSync call's outstanding Suspend loaders. The count lives on the round rather than on
-        // the runner so that a round asked whether it finished answers for itself: a loader delegate is free
-        // to start a navigation, which begins another round from inside the one still launching, and a
-        // runner-wide count would be reset under it.
+        // One RunLoadersSync call's results, errors, outstanding-loader count and completion flag. They live
+        // on the round rather than on the runner so that a round asked anything answers for itself: a loader
+        // delegate is free to start a navigation, which begins another round from inside the one still
+        // launching, and runner-wide state would be cleared and then written under it.
         internal sealed class LoaderRound
         {
+            // Loader results and errors are keyed by RouteId (stable per-route identity) so sibling index
+            // routes, whose MatchedPath is the empty string, do not collide.
+            internal readonly Dictionary<string?, object> Results = new();
+
+            internal readonly Dictionary<string?, Exception> Errors = new();
+
             internal int Pending;
+
+            internal bool AllCompleted = true;
 
             // False while a Suspend loader of this round has not terminated. The router records it on the
             // history entry it commits, which is what separates an unfinished round's data from the data a
@@ -56,14 +60,13 @@ namespace Velvet
         // This counter therefore tracks "all live tasks across rounds", not "tasks of the current round".
         internal int ActiveSuspendTaskCount => _activeSuspendTaskCount;
 
-        // Per-route errors are recorded in Errors rather than the return value; the caller is expected
-        // to inspect Errors after this returns.
-        public (Dictionary<string?, object> results, bool allCompleted) RunLoadersSync(
+        // The round is handed back rather than read off CurrentRound afterwards, because a loader that
+        // navigates has by then made a nested round current.
+        public LoaderRound RunLoadersSync(
             IReadOnlyList<RouteMatch> matches,
             CancellationToken externalToken)
         {
             CancelPending();
-            _errors.Clear();
             var cts = CancellationTokenSource.CreateLinkedTokenSource(externalToken);
             _cts = cts;
             // A loader delegate is free to navigate, which reaches this method again and replaces _cts. The
@@ -74,9 +77,7 @@ namespace Velvet
             var round = new LoaderRound();
             _currentRound = round;
 
-            var results = new Dictionary<string?, object>();
             var awaitTasks = new List<(string? routeId, UniTask<object> task)>();
-            var allCompleted = true;
 
             foreach (var match in matches)
             {
@@ -93,8 +94,6 @@ namespace Velvet
                     Path = match.MatchedPath,
                 };
 
-                // Loader results / errors are keyed by RouteId (stable per-route identity) so sibling index
-                // routes (whose MatchedPath is the empty string) do not collide.
                 var key = match.RouteId;
 
                 UniTask<object> task;
@@ -104,8 +103,8 @@ namespace Velvet
                 }
                 catch (Exception ex)
                 {
-                    _errors[key] = ex;
-                    allCompleted = false;
+                    round.Errors[key] = ex;
+                    round.AllCompleted = false;
                     continue;
                 }
 
@@ -115,9 +114,9 @@ namespace Velvet
                 }
                 else
                 {
-                    allCompleted = false;
+                    round.AllCompleted = false;
                     round.Pending++;
-                    RunSuspendLoader(key, task, cts, round, results).Forget();
+                    RunSuspendLoader(key, task, cts, round).Forget();
                 }
             }
 
@@ -132,24 +131,24 @@ namespace Velvet
                             "Use LoaderMode.Suspend for async loaders.");
                     }
                     var result = task.GetAwaiter().GetResult();
-                    results[routeId] = result;
+                    round.Results[routeId] = result;
                 }
                 catch (OperationCanceledException)
                 {
-                    allCompleted = false;
+                    round.AllCompleted = false;
                 }
                 catch (Exception ex)
                 {
-                    _errors[routeId] = ex;
-                    allCompleted = false;
+                    round.Errors[routeId] = ex;
+                    round.AllCompleted = false;
                 }
             }
 
-            return (results, allCompleted);
+            return round;
         }
 
         private async UniTask RunSuspendLoader(string? routeId, UniTask<object> task, CancellationTokenSource ownCts,
-            LoaderRound round, Dictionary<string?, object> results)
+            LoaderRound round)
         {
             try
             {
@@ -162,7 +161,7 @@ namespace Velvet
                 // Written into the round's results and not only announced through the event: a loader may hand
                 // back a task that is already complete, and the caller assigns these results over whatever the
                 // event wrote.
-                results[routeId] = result;
+                round.Results[routeId] = result;
                 // A loader that ignored its token can resolve after CancelPending replaced (or nulled) _cts.
                 // That makes this a superseded round; drop the stale result rather than firing into the live
                 // state of an unrelated current location.
@@ -179,7 +178,7 @@ namespace Velvet
                 // Same supersession guard as the success path: a stale round's failure must not record an
                 // error nor re-emit under the current location.
                 if (ownCts != _cts) return;
-                _errors[routeId] = ex;
+                round.Errors[routeId] = ex;
                 OnSuspendLoaderFailed?.Invoke(routeId, ex);
             }
             finally

--- a/Packages/com.velvet.core/Runtime/Routing/Router.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/Router.cs
@@ -625,9 +625,7 @@ namespace Velvet
             }
 
             Status = RouterStatus.Loading;
-            // allCompleted is unused (errors are detected via the runner's Errors map).
-            var (results, _) = _loaderRunner.RunLoadersSync(matches, cancellationToken);
-            var round = _loaderRunner.CurrentRound;
+            var round = _loaderRunner.RunLoadersSync(matches, cancellationToken);
 
             if (cancellationToken.IsCancellationRequested)
             {
@@ -638,12 +636,12 @@ namespace Velvet
                 return (NavigationResult.Cancelled, round);
             }
 
-            _loaderData = results;
+            _loaderData = round.Results;
 
             // A loader error does not abort navigation. The location commits and
             // the nearest RouteDefinition.ErrorElement renders in place of the route's Element. Errors
             // are surfaced through RouterContext.Errors (keyed by RouteId) for UseRouteError.
-            _loaderErrors = new Dictionary<string?, Exception>(_loaderRunner.Errors);
+            _loaderErrors = new Dictionary<string?, Exception>(round.Errors);
             return (null, round);
         }
 
@@ -719,10 +717,16 @@ namespace Velvet
                     break;
                 case NavigationMode.Back:
                 case NavigationMode.Forward:
-                    // The entry is not rewritten here even when its loaders ran again, because a round that
-                    // has not settled has nothing worth recording yet; the write-back that runs when it
-                    // settles is what makes the entry servable.
                     _historyIndex = pending.CommitIndex;
+                    // A round still running has nothing worth recording, and the write-back it triggers on
+                    // settling is what makes the entry servable. A round already settled by here has no such
+                    // write-back coming: it settled before this navigation had a location for its results to
+                    // be written under, which is where _committedRound refused them. Without this the entry
+                    // would stay unservable and re-run its loaders on every step onto it.
+                    if (round.Settled)
+                    {
+                        _history[_historyIndex] = NewEntry(path, matches, round);
+                    }
                     break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(mode), mode, null);

--- a/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouteLoaderRunnerTests.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouteLoaderRunnerTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using Cysharp.Threading.Tasks;
 using NUnit.Framework;
@@ -18,7 +19,7 @@ namespace Velvet.Tests
     /// <see cref="RouteMatch.RouteId"/>, and <c>allCompleted</c> is true.</item>
     /// <item>A Suspend loader returns immediately with <c>allCompleted</c> false and runs in the background,
     /// firing <c>OnSuspendLoaderCompleted</c> on success or <c>OnSuspendLoaderFailed</c> on failure; a failure
-    /// is also recorded per-path in <c>Errors</c> symmetrically with the Await path.</item>
+    /// is also recorded per-path in the round's errors, symmetrically with the Await path.</item>
     /// <item><see cref="RouteLoaderRunner.ActiveSuspendTaskCount"/> is incremented while a Suspend task is live
     /// and returned to zero in the finally block on success, failure, and honored cancellation alike.</item>
     /// <item>The loader receives a cancelable token that <c>CancelPending</c> cancels, and a loader that
@@ -28,6 +29,8 @@ namespace Velvet.Tests
     /// started still answers for itself.</item>
     /// <item>A round's loaders all launch under that round's own token, so a loader that starts another round
     /// mid-run does not lend the next round's currency to the leftovers of the one it superseded.</item>
+    /// <item>A round's errors are its own, so a nested round neither wipes the errors already recorded by the
+    /// round it started from nor collects the ones that round records afterwards.</item>
     /// </list>
     /// </summary>
     [TestFixture]
@@ -42,7 +45,7 @@ namespace Velvet.Tests
             var runner = new RouteLoaderRunner();
 
             // Act
-            var (_, allCompleted) = runner.RunLoadersSync(MakeMatch("/"), CancellationToken.None);
+            var allCompleted = runner.RunLoadersSync(MakeMatch("/"), CancellationToken.None).AllCompleted;
 
             // Assert
             Assert.That(allCompleted, Is.True);
@@ -55,7 +58,7 @@ namespace Velvet.Tests
             var runner = new RouteLoaderRunner();
 
             // Act
-            var (results, _) = runner.RunLoadersSync(MakeMatch("/"), CancellationToken.None);
+            var results = runner.RunLoadersSync(MakeMatch("/"), CancellationToken.None).Results;
 
             // Assert
             Assert.That(results, Is.Empty);
@@ -73,7 +76,7 @@ namespace Velvet.Tests
             var matches = MakeMatch("test", loader: (ctx, ct) => UniTask.FromResult<object>("loaded-data"));
 
             // Act
-            var (_, allCompleted) = runner.RunLoadersSync(matches, CancellationToken.None);
+            var allCompleted = runner.RunLoadersSync(matches, CancellationToken.None).AllCompleted;
 
             // Assert
             Assert.That(allCompleted, Is.True);
@@ -87,7 +90,7 @@ namespace Velvet.Tests
             var matches = MakeMatch("test", loader: (ctx, ct) => UniTask.FromResult<object>("loaded-data"));
 
             // Act
-            var (results, _) = runner.RunLoadersSync(matches, CancellationToken.None);
+            var results = runner.RunLoadersSync(matches, CancellationToken.None).Results;
 
             // Assert
             Assert.That(results["test"], Is.EqualTo("loaded-data"));
@@ -106,7 +109,7 @@ namespace Velvet.Tests
             var matches = MakeMatch("test", loader: (ctx, ct) => tcs.Task, loaderMode: LoaderMode.Suspend);
 
             // Act
-            var (_, allCompleted) = runner.RunLoadersSync(matches, CancellationToken.None);
+            var allCompleted = runner.RunLoadersSync(matches, CancellationToken.None).AllCompleted;
 
             // Assert
             Assert.That(allCompleted, Is.False);
@@ -190,14 +193,14 @@ namespace Velvet.Tests
             var runner = new RouteLoaderRunner();
             var tcs = new UniTaskCompletionSource<object>();
             var matches = MakeMatch("fail", loader: (ctx, ct) => tcs.Task, loaderMode: LoaderMode.Suspend);
-            runner.RunLoadersSync(matches, CancellationToken.None);
+            var round = runner.RunLoadersSync(matches, CancellationToken.None);
 
             // Act
             tcs.TrySetException(new InvalidOperationException("deferred-failure"));
             await UniTask.Yield();
 
             // Assert
-            Assert.That(runner.Errors["fail"].Message, Does.Contain("deferred-failure"));
+            Assert.That(round.Errors["fail"].Message, Does.Contain("deferred-failure"));
         });
 
         [UnityTest]
@@ -331,7 +334,7 @@ namespace Velvet.Tests
             var matches = MakeMatch("fail", loader: (ctx, ct) => throw new InvalidOperationException("loader failed"));
 
             // Act
-            var (_, allCompleted) = runner.RunLoadersSync(matches, CancellationToken.None);
+            var allCompleted = runner.RunLoadersSync(matches, CancellationToken.None).AllCompleted;
 
             // Assert
             Assert.That(allCompleted, Is.False);
@@ -345,10 +348,10 @@ namespace Velvet.Tests
             var matches = MakeMatch("fail", loader: (ctx, ct) => throw new InvalidOperationException("loader failed"));
 
             // Act
-            runner.RunLoadersSync(matches, CancellationToken.None);
+            var round = runner.RunLoadersSync(matches, CancellationToken.None);
 
             // Assert
-            Assert.That(runner.Errors["fail"].Message, Does.Contain("loader failed"));
+            Assert.That(round.Errors["fail"].Message, Does.Contain("loader failed"));
         }
 
         #endregion
@@ -406,6 +409,32 @@ namespace Velvet.Tests
             // Assert
             Assert.That(nextLoaderSawCancellation, Is.True,
                 "A round's later loaders must launch under the token of the round they belong to");
+        }
+
+        [Test]
+        public void Given_ALoaderThatStartsAnotherRound_When_TheOuterRoundFailsOnBothSidesOfIt_Then_BothErrorsAreTheOuterRounds()
+        {
+            // The nested round starts from inside the loop that is still launching the outer round's loaders,
+            // so an error map belonging to the runner rather than to the round is cleared between the two
+            // failures and then written by the second one.
+            // Arrange
+            var runner = new RouteLoaderRunner();
+            var matches = new List<RouteMatch>();
+            matches.AddRange(MakeMatch("early", loader: (ctx, ct) => throw new InvalidOperationException("early")));
+            matches.AddRange(MakeMatch("nesting", loader: (ctx, ct) =>
+            {
+                runner.RunLoadersSync(MakeMatch("nested"), CancellationToken.None);
+                return UniTask.FromResult<object>("nesting-data");
+            }));
+            matches.AddRange(MakeMatch("late", loader: (ctx, ct) => throw new InvalidOperationException("late")));
+
+            // Act
+            var round = runner.RunLoadersSync(matches, CancellationToken.None);
+
+            // Assert
+            Assert.That(string.Join(",", round.Errors.Keys.OrderBy(key => key, StringComparer.Ordinal)),
+                Is.EqualTo("early,late"),
+                "A round keeps every error its own loaders raised, on both sides of a nested round");
         }
 
         #endregion

--- a/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouterUnfinishedNavigationTests.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouterUnfinishedNavigationTests.cs
@@ -21,7 +21,9 @@ namespace Velvet.Tests
     /// <item>A navigation that dies on an exception leaves no in-flight <see cref="RouterStatus"/> behind,
     /// whether it died in a phase or in the commit that follows them.</item>
     /// <item>A history entry committed while a Suspend loader is still running is not served from the
-    /// Back/Forward cache, since the snapshot it holds is not the data the route asked for.</item>
+    /// Back/Forward cache, since the snapshot it holds is not the data the route asked for. Stepping onto it
+    /// runs the loaders again, and once a round of them finishes the entry is servable, including when they
+    /// all finished before that step committed.</item>
     /// <item>An attempt cancelled by a loader that navigated leaves the loader data and the status of the
     /// location that navigation committed, rather than clearing state it never owned.</item>
     /// </list>
@@ -213,6 +215,43 @@ namespace Velvet.Tests
             // Assert
             Assert.That(loaderCalls, Is.EqualTo(2),
                 "A snapshot taken before the loaders finished is not the data the route asked for, so it is not cached");
+        });
+
+        [UnityTest]
+        public IEnumerator Given_AStepOntoAnUnsettledEntryWhoseSuspendLoaderAnswersImmediately_When_TheEntryIsSteppedOntoAgain_Then_ItIsServedFromTheCache()
+            => UniTask.ToCoroutine(async () =>
+        {
+            // A loader handed an already-complete task resolves inside the run that launched it, so its
+            // completion reaches the router before this step has a location to write it under and is refused.
+            // The commit is then the only thing left that can mark the entry finished.
+            // Arrange
+            var unresolved = new UniTaskCompletionSource<object>();
+            var loaderCalls = 0;
+            var router = new Router(new[]
+            {
+                Route("/", children: new[]
+                {
+                    Route("users/:id", loaderMode: LoaderMode.Suspend,
+                        loader: (ctx, ct) => Interlocked.Increment(ref loaderCalls) == 1
+                            ? unresolved.Task
+                            : UniTask.FromResult((object)"user-data")),
+                    Route("other"),
+                }),
+            });
+            await router.NavigateAsync("/users/1");
+            await router.NavigateAsync("/other");
+            await router.GoBack();
+
+            // Act
+            await router.NavigateAsync("/other");
+            await router.GoBack();
+
+            // Assert
+            Assert.That(
+                $"calls={loaderCalls} data={string.Join(",", router.CurrentLoaderData.Values)}",
+                Is.EqualTo("calls=2 data=user-data"),
+                "A round that finished before its step committed leaves the entry servable, so the next step "
+                + "onto it reads the cache rather than running the loader again");
         });
 
         [Test]


### PR DESCRIPTION
Three defects, two of them the last shared-state holes in the loader runner.

**`Hooks.UseContext<T>` promised non-null while returning a null default.** It was declared to return `T` and ended in `context.DefaultValue!`, while `ComponentContext<T>.DefaultValue` is `T?` and the router contexts are created with null — so `Hooks.UseContext(RouterContext.Location).Path` compiled clean and threw with no router above it. That `!` is the mechanism that made the `UseLocation` annotation defect possible, and fixing the hook did not reach the read path underneath. It returns `T?` now, and the same operator is gone from `ComponentContextStack.Get<T>`, which was the second launderer one level down.

Throwing was rejected for the reason `UseLocation` was not made to throw. React Router's invariant tests whether the context *object* is present; Velvet's contexts are static singletons seeded with a default, so "no Provider above me" and "Provider present, default is null" are literally the same read. `UseOutletContext<T>` already documents the first as a normal state, and `RouteNavLink` renders inactive off a null location — throwing would turn both into crashes. Returning `T?` does push a check onto consumers whose context has a genuinely non-null default; that is the honest price, since `DefaultValue` is `T?` and `Create` accepts null, so the type system cannot separate the two cases either.

**A loader round's errors were shared across rounds** where its results and pending count were not. A loader that navigates during its own run made the nested round's clear wipe the outer round's errors, and the outer round's remaining loaders then wrote theirs into the nested round's map. It cannot reach live state today, because the Router copies the errors at commit before any leftover lands — so this makes a bound structural rather than changing behaviour, and gets no CHANGELOG entry.

**An entry whose Suspend loaders all answer immediately never became servable.** Two of the three symptoms originally filed here were already fixed by the round-identity work and are pinned by existing cases — the result is no longer discarded, and the previous entry is no longer rewritten, because the completion is refused when its round is not the committed one. What remained is the consequence of that refusal: the refused callback owns the history write-back, and a `Back`/`Forward` commit deliberately records no entry of its own, so the loaders re-ran on every step onto that entry, forever. The commit now records the entry when the round settled.

The issue's suggested shape — defer the completion out of `RunLoadersSync` — was rejected: deferring to the end of that method leaves the round still uncommitted, and deferring past the commit needs a callback queue the Router drives, then double-writes data the commit already captured.

A paragraph already sitting in `[Unreleased]` is deleted rather than left: the `UseLocation` entry ended by stating that the read path underneath still hands a null past a non-null declaration. That was true when written and is false now, and would have shipped in the release notes.

Two things are filed rather than fixed: `RunSuspendLoader` writes results before its supersession check and errors after, which now only leaves a superseded round's errors incomplete relative to its results (#509); and `Router._loaderData` aliases the round's results until the first late completion replaces it, which is pre-existing and costs an allocation per navigation to close (#510).

`PublicAPI.txt` moves by one line, `UseContext`'s return going from `T` to `T?`. That it moves at all is new: the surface renderer began carrying nullability a few hours before this landed, and this is the first change to exercise it. `ComponentContextStack` is internal, so the second operator removed here has no surface line to move.

No routing guide exists in `Documentation~`. `react-migration.md` documents `UseContext`'s live-propagation semantics, which are unchanged and state nothing about return nullability; the owning source for that is the XML doc, which is updated.

Closes #461
Closes #491
Closes #500
