### PR TITLE
fix(velvet): apply the text cascade at Motion create, clear pooled Label children

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A `V.Motion` now applies the text-effect cascade when it mounts, not only when it next patches.
+  `uppercase` / `lowercase` / `capitalize`, `underline` / `line-through` / `overline`,
+  `whitespace-pre-line` and `leading-*` as a plain class on a Motion left its own text and its descendant
+  text leaves untransformed until some later render happened to patch it, so a Motion nothing re-renders
+  showed the wrong text for the element's whole life.
+
+- A `Label` given children through `V.Custom<Label>` no longer carries them into the element pool. The
+  Label reset cleared the text but not the child list, so the next `V.Label` mount rented an element that
+  still showed the previous subtree's content on top of its own. Both the ordinary unmount and the
+  Suspense rollback reclaim now treat a child-bearing Label exactly as they already treat a child-bearing
+  `Button`.
+
 - A navigation waiting on a Blocker no longer takes the history with it. `Router` moved the history index
   before running the Guard and Blocker phases, so a Back parked on a confirm dialog left the router
   pointing at the entry the user had not gone to yet: clicking a link before answering the dialog pushed

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberElementCleaner.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberElementCleaner.cs
@@ -78,13 +78,15 @@ namespace Velvet
         // side-tables (variant manipulators, the structural/has/data/aria/supports rules,
         // arbitrary-value layers, shadow/clip/gradient bindings) would retain the discarded element
         // for the context's whole lifetime. A genuine poolable leaf is also reclaimed to the pool:
-        // Label / Toggle / Slider / TextField never carry inline-mounted Velvet descendants (their
-        // DSL hardcodes empty children), and a Button is reclaimed only when childless. A container
-        // orphan — including a Button declared with children, whose children CreateElement
-        // inline-expands into the element itself — has its subtree's resources released recursively
-        // via CleanupElementCore, which deliberately does NOT dispose the subtree's fibers / Outlet
-        // scopes (that is CleanupElement's job): those anchor on the fiber tree and may be re-paired
-        // when the suspended primary later resolves. The element was never in the hierarchy, so there
+        // a Button or a Label only when childless, since either can be given children — V.Button's own DSL,
+        // or V.Custom<T> for both — which CreateElement inline-expands into the element itself, while this
+        // branch releases resources for the orphan alone. Toggle / Slider / TextField are reclaimed
+        // unconditionally: each already holds its own constructed sub-element, so a count cannot separate
+        // that from a V.Custom child, and the same gap reaches them through ordinary unmount besides. A
+        // container orphan — including a Button or a Label declared with children — has its subtree's
+        // resources released recursively via CleanupElementCore, which deliberately does NOT dispose the
+        // subtree's fibers / Outlet scopes (that is CleanupElement's job): those anchor on the fiber tree
+        // and may be re-paired when the suspended primary later resolves. The element was never in the hierarchy, so there
         // is no DOM detach.
         public void ReturnRolledBackOrphan(VisualElement? element)
         {
@@ -102,16 +104,15 @@ namespace Velvet
             }
 
             var exactType = element.GetType();
-            if (exactType == typeof(Label) || exactType == typeof(Toggle)
-                || exactType == typeof(Slider) || exactType == typeof(TextField)
-                || (exactType == typeof(Button) && ((Button)element).childCount == 0))
+            if (exactType == typeof(Toggle) || exactType == typeof(Slider) || exactType == typeof(TextField)
+                || ((exactType == typeof(Button) || exactType == typeof(Label)) && element.childCount == 0))
             {
                 CleanupElementResources(element);
                 ReturnToPool(element);
             }
             else
             {
-                // A plain container orphan (Div), a Button declared with children, or a user
+                // A plain container orphan (Div), a Button or Label declared with children, or a user
                 // subclass of a poolable primitive (never pooled — see ReturnToPool). Release the
                 // orphan subtree's element-keyed resources without disposing its fibers and
                 // without pooling the non-poolable container.

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodeFactory.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodeFactory.cs
@@ -102,12 +102,7 @@ namespace Velvet
             // walks it to climb ComponentFiber.Parent from wherever a pointer/focus event
             // physically landed. Null at the true tree root (nothing on FiberStack yet).
             element.userData = _ctx.FiberStack.Current;
-            // Capture an element's own Text prop (Label / Button) before the text-effect pass below
-            // transforms it, so a re-apply works from the raw value.
-            if (element is TextElement && elementNode.Props != null && elementNode.Props.Text != null)
-            {
-                StyleTextEffectResolver.CaptureRaw(_ctx, element, elementNode.Props.Text);
-            }
+            CaptureOwnRawText(element, elementNode.Props);
             if (elementNode.Children != null)
             {
                 var childContainer = FiberNodePatcher.GetChildContainer(element);
@@ -219,6 +214,17 @@ namespace Velvet
             return outer;
         }
 
+        // Runs before either create path's text-effect pass: that pass rewrites the element's displayed text
+        // from the raw value tracked here, and the element factory has just written the Text prop straight
+        // onto the element. FiberNodePatcher.PatchBaseElement is the same seam on the patch side.
+        private void CaptureOwnRawText(VisualElement element, FiberElementProps? props)
+        {
+            if (element is TextElement && props?.Text != null)
+            {
+                StyleTextEffectResolver.CaptureRaw(_ctx, element, props.Text);
+            }
+        }
+
         private VisualElement CreateForMotionNode(MotionNode motionNode)
         {
             // Resolve the applied classes against the effective label (own Animate, else the nearest
@@ -257,6 +263,7 @@ namespace Velvet
             {
                 _ctx.MotionChildLabel[element] = childLabel;
             }
+            CaptureOwnRawText(element, motionNode.Props);
             if (motionNode.Children != null)
             {
                 var childContainer = FiberNodePatcher.GetChildContainer(element);
@@ -291,6 +298,7 @@ namespace Velvet
             _patcher.ApplyStructuralVariants(element);
             _patcher.ApplyHasClassVariants(element);
             _patcher.ApplyHasVariantManipulators(element);
+            _patcher.ApplyTextEffects(element, appliedClasses);
             // Same composed source as the element path, recorded as a NON-paint-tail element so a
             // later variant re-sync never attaches to a Motion the three silhouette paints its own
             // patch would refuse.

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
@@ -2047,9 +2047,9 @@ namespace Velvet
                 positions ??= new Dictionary<(bool, string), List<int>[]>();
                 if (!map.TryGetValue(key, out var states))
                 {
-                    states = new List<string>[5];
+                    states = new List<string>[StyleVariantClass.RelationalStateCount];
                     map[key] = states;
-                    positions[key] = new List<int>[5];
+                    positions[key] = new List<int>[StyleVariantClass.RelationalStateCount];
                 }
                 var slot = (int)relational.State;
                 (states[slot] ??= new List<string>()).Add(payload ?? string.Empty);

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberPrimitiveElementPool.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberPrimitiveElementPool.cs
@@ -16,8 +16,6 @@ namespace Velvet
         {
             if (button == null) return;
 
-            // Button is the ONLY poolable primitive whose DSL allows children (icon + label, e.g.
-            // V.Button(children: ...)). Label / Toggle / Slider / TextField hardcode empty children.
             // CleanupDescendants resource-cleans a removed button's children but, by design, does NOT
             // pool-return or detach them (descendants ride along on the bulk parent.RemoveAt). For a
             // childless container that subtree is just GC'd; but a poolable Button carries its children
@@ -26,6 +24,13 @@ namespace Velvet
             // children on top — the button's contents visibly duplicate on reuse. Detach them here so a
             // recycled button is empty, matching a freshly constructed instance (and the childless-only
             // invariant already enforced on the rollback path in FiberElementCleaner.ReturnRolledBackOrphan).
+            //
+            // Only Button and Label may do this, and the split is not about which DSL factory takes a
+            // `children:` argument — V.Custom<T> takes one for any T. It is about what the child container
+            // already holds: Toggle, Slider and TextField each construct a sub-element into the very
+            // container FiberNodePatcher.GetChildContainer hands children to, so Clear() there would delete
+            // the control's own structure rather than a previous tenant's content.
+            // PoolableWidgetChildBaselineTests pins which types those are.
             if (button.childCount > 0) button.Clear();
 
             FiberElementPoolReset.ResetClassListAndCommon(button, TextElement.ussClassName, Button.ussClassName);
@@ -48,6 +53,11 @@ namespace Velvet
         public static void ResetLabelForReuse(Label label)
         {
             if (label == null) return;
+
+            // Same detach rule, and the same duplicate-on-reuse failure, as FiberButtonPoolHelper. A Label
+            // reaches it through V.Custom<Label>(children: ...), which mounts an exact pooled Label and
+            // expands the children into it.
+            if (label.childCount > 0) label.Clear();
 
             FiberElementPoolReset.ResetClassListAndCommon(label, TextElement.ussClassName, Label.ussClassName);
             label.text = string.Empty;

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/LabelChildPoolReuseTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/LabelChildPoolReuseTests.cs
@@ -1,0 +1,146 @@
+using System;
+using NUnit.Framework;
+using UnityEngine.UIElements;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Regression coverage for the same state-ghosting class <see cref="ButtonChildPoolReuseTests"/> pins, on
+    /// the Label pool. <c>V.Label</c> declares no children, but <c>V.Custom&lt;Label&gt;</c> does: it mounts an
+    /// exact pooled <see cref="Label"/> and expands its children into the element itself, so a released Label
+    /// carried them into the pool and the next <c>V.Label</c> rent handed them back on top of the fresh
+    /// content. The pool is process-wide, so driving the unfixed path leaves a children-bearing Label behind
+    /// for whatever runs next — hence the clear on both sides of every case here.
+    /// <para>
+    /// The rented instance is asserted alongside the child count: a rent that returned a DIFFERENT Label is
+    /// childless for a reason that has nothing to do with the reset, so the count alone would pass on a
+    /// mechanism that never ran.
+    /// </para>
+    /// GWT, one assert per case.
+    /// </summary>
+    [TestFixture]
+    internal sealed class LabelChildPoolReuseTests
+    {
+        [SetUp]
+        public void SetUp() => VNodePoolTestAccess.ClearLabelPoolForTest();
+
+        [TearDown]
+        public void TearDown() => VNodePoolTestAccess.ClearLabelPoolForTest();
+
+        [Test]
+        public void Given_ALabelCarryingAChild_When_ResetForReuse_Then_ItHasNoChildren()
+        {
+            // Arrange — a label that still holds a child, as a removed V.Custom<Label> subtree does on its
+            // way to the pool (its descendants are resource-cleaned but not detached).
+            var label = new Label("host");
+            label.Add(new Label("stale"));
+            Assume.That(label.childCount, Is.EqualTo(1), "Precondition: the label starts with one child");
+
+            // Act — it is reset for reuse.
+            FiberLabelPoolHelper.ResetLabelForReuse(label);
+
+            // Assert — the child is gone, so the recycled label matches a freshly constructed one.
+            Assert.That(label.childCount, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void Given_ALabelWithAChildWasReturnedToThePool_When_RentedAgain_Then_TheSameInstanceComesBackChildless()
+        {
+            // Arrange — a label that still holds a child is returned to the emptied pool.
+            var returned = new Label("host");
+            returned.Add(new Label("stale"));
+            VNodePool.ReturnLabel(returned);
+
+            // Act — a label is rented back.
+            var rented = VNodePool.RentLabel("fresh");
+
+            // Assert — it is the very instance that went in, and it is childless, so a fresh child reconcile
+            // cannot append onto leftover content.
+            Assert.That((ReferenceEquals(rented, returned), rented.childCount), Is.EqualTo((true, 0)));
+        }
+
+        // Integration: a V.Custom<Label> subtree unmounts, then a plain V.Label rents its element back.
+
+        private readonly record struct PhaseState(int Phase);
+
+        private sealed class PhaseStore : Store<PhaseState>
+        {
+            public PhaseStore() : base(new PhaseState(0)) { }
+            public void Set(int phase) => SetState(_ => new PhaseState(phase));
+            protected override void ResetCore() => SetState(_ => new PhaseState(0));
+        }
+
+        private static PhaseStore s_store;
+
+        // Phase 0 mounts a Label carrying a child; phase 1 unmounts it (its pooling opportunity); phase 2
+        // mounts a plain V.Label, which rents from the pool.
+        [Component]
+        private static VNode Screen()
+        {
+            var phase = Hooks.UseStore(s_store, s => s.Phase);
+            return V.Div(name: "screen", children: phase switch
+            {
+                0 => new VNode[]
+                {
+                    V.Custom<Label>(name: "host", children: new VNode[] { V.Label(name: "stale", text: "stale") }),
+                },
+                1 => Array.Empty<VNode>(),
+                _ => new VNode[] { V.Label(name: "plain", text: "plain") },
+            });
+        }
+
+        [Test]
+        public void Given_AChildBearingLabelWasUnmounted_When_APlainLabelMounts_Then_TheRecycledElementCarriesNoLeftoverChild()
+        {
+            // Arrange — mount the child-bearing Label, then unmount it so it hits the pool-return path.
+            using var store = new PhaseStore();
+            s_store = store;
+            var root = new VisualElement();
+            using var mounted = V.Mount(root, V.Component(Screen, key: "screen"));
+            var scheduler = mounted.GetSchedulerForTest();
+            var host = root.Q<Label>("host");
+            Assume.That(host?.childCount, Is.EqualTo(1), "Precondition: the custom Label mounts with its child");
+            store.Set(1);
+            scheduler.DrainImmediateForTest();
+
+            // Act — a plain label mounts, renting from the pool.
+            store.Set(2);
+            scheduler.DrainImmediateForTest();
+
+            // Assert — the plain label is the recycled instance and shows nothing but its own text. The
+            // identity term is asserted with the count because a rent that missed the pool is childless
+            // whether or not the reset detaches anything.
+            var plain = root.Q<Label>("plain");
+            Assert.That((ReferenceEquals(plain, host), plain.childCount), Is.EqualTo((true, 0)));
+        }
+    }
+
+    /// <summary>
+    /// Pins which poolable primitives may have their child container emptied on pool return. Button and Label
+    /// construct nothing into it, so <c>Clear()</c> there can only remove a previous tenant's content; Toggle,
+    /// Slider and TextField each build a sub-element into that same container (their <c>contentContainer</c>
+    /// is the element itself), so the same call would delete the control's own structure. This fails if a
+    /// UI Toolkit version changes those baselines, which is what makes it safe for
+    /// <c>FiberPrimitiveElementPool</c> to treat the five differently.
+    /// </summary>
+    [TestFixture]
+    internal sealed class PoolableWidgetChildBaselineTests
+    {
+        [Test]
+        public void Given_FreshlyConstructedPoolablePrimitives_When_TheirChildContainersAreCounted_Then_OnlyTheCompositesArrivePopulated()
+        {
+            // Arrange — one freshly constructed instance of each poolable primitive.
+            var widgets = new VisualElement[]
+            {
+                new Button(), new Label(), new Toggle(), new Slider(), new TextField(),
+            };
+
+            // Act — count what each one already holds in the container children are placed into.
+            var counts = Array.ConvertAll(widgets, w => FiberNodePatcher.GetChildContainer(w).childCount);
+
+            // Assert — the two clearable types start empty; the three composites do not.
+            Assert.That(counts, Is.EqualTo(new[] { 0, 0, 1, 1, 1 }));
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/LabelChildPoolReuseTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/LabelChildPoolReuseTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 344af839c157843619418458c6bcc8b3

--- a/Packages/com.velvet.core/Runtime/Styling/StyleRelationalVariantManipulator.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleRelationalVariantManipulator.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using UnityEngine.UIElements;
 
@@ -199,35 +200,51 @@ namespace Velvet
             private readonly StyleRelationalVariantManipulator _owner;
             private readonly bool _isPeer;
             private readonly string _name; // "" = unnamed
-            private readonly string[] _hover;
-            private readonly string[] _focus;
-            private readonly string[] _focusWithin;
-            private readonly string[] _active;
-            private readonly string[] _checked;
-            private readonly VariantDeclarations _declarations;
+            // Payloads, their className positions and their applied flags, one slot per
+            // StyleVariantClass.RelationalState (see RelationalStateCount) — so every state this binding can
+            // hook for is reached by iterating rather than by naming each one at each of the sites below.
+            private readonly string[][] _payloads;
+            private readonly int[][] _declarations;
+            private readonly bool[] _applied;
 
             private RelationalVariantSignals _signals = null!;
-            private bool _aHover, _aFocus, _aFocusWithin, _aActive, _aChecked;
 
             public Binding(StyleRelationalVariantManipulator owner, RelationalBindingConfig config)
             {
                 _owner = owner;
                 _isPeer = config.IsPeer;
                 _name = config.Name ?? string.Empty;
-                _hover = config.Payloads.Hover;
-                _focus = config.Payloads.Focus;
-                _focusWithin = config.Payloads.FocusVisible;
-                _active = config.Payloads.Active;
-                _checked = config.Payloads.Checked;
-                _declarations = config.Declarations;
+                var count = StyleVariantClass.RelationalStateCount;
+                _payloads = new string[count][];
+                _declarations = new int[count][];
+                _applied = new bool[count];
+                for (var slot = 0; slot < count; slot++)
+                {
+                    var state = (StyleVariantClass.RelationalState)slot;
+                    _payloads[slot] = PayloadFor(config.Payloads, state);
+                    _declarations[slot] = DeclarationFor(config.Declarations, state);
+                }
             }
 
             // The class that marks this binding's source (see SourceClassFor).
             private string SourceClass => SourceClassFor(_isPeer, _name);
 
             private bool HasAnyState()
-                => HasAny(_hover) || HasAny(_focus) || HasAny(_focusWithin) || HasAny(_active)
-                    || (_isPeer && HasAny(_checked));
+            {
+                for (var slot = 0; slot < _payloads.Length; slot++)
+                {
+                    if (_payloads[slot].Length > 0 && DrivesState((StyleVariantClass.RelationalState)slot))
+                    {
+                        return true;
+                    }
+                }
+                return false;
+            }
+
+            // Checked is the one state with no group spelling (StyleVariantClass lists peer-checked and no
+            // group-checked), so a group binding hooks no source for it even when handed a checked payload.
+            private bool DrivesState(StyleVariantClass.RelationalState state)
+                => _isPeer || state != StyleVariantClass.RelationalState.Checked;
 
             public void Resolve(VisualElement target)
             {
@@ -236,7 +253,8 @@ namespace Velvet
                 // peer-checked is the one state seeded by Resolve itself (the initial-checked read below), not
                 // purely by events. Clear any prior application up front so each Resolve re-derives it from
                 // scratch against the (possibly changed) source.
-                if (_aChecked) { _aChecked = false; Apply(_checked, false, StyleLayerPriority.PeerChecked); }
+                var checkedSlot = (int)StyleVariantClass.RelationalState.Checked;
+                if (_applied[checkedSlot]) { _applied[checkedSlot] = false; Apply(checkedSlot, false); }
 
                 var source = _isPeer
                     ? FindPrevSiblingWithClass(target, SourceClass, _owner._ctx)
@@ -248,8 +266,8 @@ namespace Velvet
 
                 _signals ??= new RelationalVariantSignals(OnSignal);
                 // registerChecked only for peer (group has no checked state). seedChecked reflects an
-                // already-checked peer Toggle immediately (_aChecked was cleared above, so no double-apply).
-                _signals.Hook(source, seedChecked: HasAny(_checked), registerChecked: _isPeer);
+                // already-checked peer Toggle immediately (the slot was cleared above, so no double-apply).
+                _signals.Hook(source, seedChecked: _payloads[checkedSlot].Length > 0, registerChecked: _isPeer);
             }
 
             public void Unhook()
@@ -259,11 +277,10 @@ namespace Velvet
 
             public void ResetApplied()
             {
-                if (_aHover) { _aHover = false; Apply(_hover, false, HoverPriority); }
-                if (_aFocus) { _aFocus = false; Apply(_focus, false, FocusPriority); }
-                if (_aFocusWithin) { _aFocusWithin = false; Apply(_focusWithin, false, FocusWithinPriority); }
-                if (_aActive) { _aActive = false; Apply(_active, false, ActivePriority); }
-                if (_aChecked) { _aChecked = false; Apply(_checked, false, StyleLayerPriority.PeerChecked); }
+                for (var slot = 0; slot < _applied.Length; slot++)
+                {
+                    if (_applied[slot]) { _applied[slot] = false; Apply(slot, false); }
+                }
             }
 
             // Maps a detected relational signal edge to its payload at the per-state priority, deduping on the
@@ -271,38 +288,44 @@ namespace Velvet
             // change) does not churn the payload.
             private void OnSignal(RelationalVariantSignal signal, bool on)
             {
-                switch (signal)
+                var slot = (int)StyleVariantClass.StateOf(signal);
+                if (on == _applied[slot])
                 {
-                    case RelationalVariantSignal.Hover:
-                        if (on != _aHover) { _aHover = on; Apply(_hover, on, HoverPriority); }
-                        break;
-                    case RelationalVariantSignal.Focus:
-                        if (on != _aFocus) { _aFocus = on; Apply(_focus, on, FocusPriority); }
-                        break;
-                    case RelationalVariantSignal.FocusWithin:
-                        if (on != _aFocusWithin) { _aFocusWithin = on; Apply(_focusWithin, on, FocusWithinPriority); }
-                        break;
-                    case RelationalVariantSignal.Active:
-                        if (on != _aActive) { _aActive = on; Apply(_active, on, ActivePriority); }
-                        break;
-                    case RelationalVariantSignal.Checked:
-                        if (on != _aChecked) { _aChecked = on; Apply(_checked, on, StyleLayerPriority.PeerChecked); }
-                        break;
+                    return;
                 }
+                _applied[slot] = on;
+                Apply(slot, on);
             }
 
             // Pass THIS binding as the stacked-gate owner so distinct named bindings never share a gate key.
-            private void Apply(string[] payloads, bool on, int priority)
-                => _owner.ApplyPayloads(this, payloads, DeclarationsFor(payloads), on, priority);
+            private void Apply(int slot, bool on)
+                => _owner.ApplyPayloads(this, _payloads[slot], _declarations[slot], on,
+                    PriorityFor((StyleVariantClass.RelationalState)slot));
 
-            // The className positions belonging to the payload array passed, paired by reference the same way
-            // the caller pairs the layer.
-            private int[] DeclarationsFor(string[] payloads) =>
-                ReferenceEquals(payloads, _checked) ? _declarations.Checked
-                : ReferenceEquals(payloads, _active) ? _declarations.Active
-                : ReferenceEquals(payloads, _focusWithin) ? _declarations.FocusVisible
-                : ReferenceEquals(payloads, _focus) ? _declarations.Focus
-                : _declarations.Hover;
+            // Where a relational state's payloads and their className positions sit in the pair, which is
+            // shared with the state-variant manipulator: that manipulator's third slot is focus-VISIBLE, a
+            // state no relational source has, so relational focus-within rides it. These two switches and
+            // PriorityFor below carry no discard arm — see the remarks on StyleVariantKind.
+#pragma warning disable CS8524 // no discard arm — see the remarks on StyleVariantKind
+            private static string[] PayloadFor(VariantPayloads payloads, StyleVariantClass.RelationalState state)
+                => (state switch
+                {
+                    StyleVariantClass.RelationalState.Hover => payloads.Hover,
+                    StyleVariantClass.RelationalState.Focus => payloads.Focus,
+                    StyleVariantClass.RelationalState.FocusWithin => payloads.FocusVisible,
+                    StyleVariantClass.RelationalState.Active => payloads.Active,
+                    StyleVariantClass.RelationalState.Checked => payloads.Checked,
+                }) ?? Array.Empty<string>();
+
+            private static int[] DeclarationFor(VariantDeclarations declarations, StyleVariantClass.RelationalState state)
+                => (state switch
+                {
+                    StyleVariantClass.RelationalState.Hover => declarations.Hover,
+                    StyleVariantClass.RelationalState.Focus => declarations.Focus,
+                    StyleVariantClass.RelationalState.FocusWithin => declarations.FocusVisible,
+                    StyleVariantClass.RelationalState.Active => declarations.Active,
+                    StyleVariantClass.RelationalState.Checked => declarations.Checked,
+                }) ?? Array.Empty<int>();
 
             // Each sub-state gets its OWN priority so two active on the same property layer independently and
             // clearing one falls back to the other. Group and peer have distinct priority sets; the priority is
@@ -313,12 +336,19 @@ namespace Velvet
             // plain USS class collide likewise (USS class toggling is not ref-counted) — the same pre-existing
             // behavior any two variants sharing a class already have (hover:bg-on focus:bg-on). Give distinct
             // names distinct payloads to avoid it. The stacked-inner case is kept independent via per-binding owners.
-            private int HoverPriority => _isPeer ? StyleLayerPriority.PeerHover : StyleLayerPriority.GroupHover;
-            private int FocusPriority => _isPeer ? StyleLayerPriority.PeerFocus : StyleLayerPriority.GroupFocus;
-            private int FocusWithinPriority => _isPeer ? StyleLayerPriority.PeerFocusWithin : StyleLayerPriority.GroupFocusWithin;
-            private int ActivePriority => _isPeer ? StyleLayerPriority.PeerActive : StyleLayerPriority.GroupActive;
-
-            private static bool HasAny(string[] arr) => arr != null && arr.Length > 0;
+            private int PriorityFor(StyleVariantClass.RelationalState state) => state switch
+            {
+                StyleVariantClass.RelationalState.Hover
+                    => _isPeer ? StyleLayerPriority.PeerHover : StyleLayerPriority.GroupHover,
+                StyleVariantClass.RelationalState.Focus
+                    => _isPeer ? StyleLayerPriority.PeerFocus : StyleLayerPriority.GroupFocus,
+                StyleVariantClass.RelationalState.FocusWithin
+                    => _isPeer ? StyleLayerPriority.PeerFocusWithin : StyleLayerPriority.GroupFocusWithin,
+                StyleVariantClass.RelationalState.Active
+                    => _isPeer ? StyleLayerPriority.PeerActive : StyleLayerPriority.GroupActive,
+                StyleVariantClass.RelationalState.Checked => StyleLayerPriority.PeerChecked,
+            };
+#pragma warning restore CS8524
         }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Styling/StyleStackedVariantManipulator.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleStackedVariantManipulator.cs
@@ -263,24 +263,11 @@ namespace Velvet
         // Opens/closes the inner gate when the detected relational signal matches this stack's inner kind.
         private void OnRelSignal(RelationalVariantSignal signal, bool on)
         {
-            if (_relational is { } rel && StateOf(signal) == rel.State)
+            if (_relational is { } rel && StyleVariantClass.StateOf(signal) == rel.State)
             {
                 SetInner(on);
             }
         }
-
-        // The two enumerations name the same five relational states; this pairing is what says so, rather
-        // than a cast that would silently survive either one being reordered.
-#pragma warning disable CS8524 // no discard arm: an unpaired signal has to warn
-        private static StyleVariantClass.RelationalState StateOf(RelationalVariantSignal signal) => signal switch
-        {
-            RelationalVariantSignal.Hover => StyleVariantClass.RelationalState.Hover,
-            RelationalVariantSignal.Focus => StyleVariantClass.RelationalState.Focus,
-            RelationalVariantSignal.FocusWithin => StyleVariantClass.RelationalState.FocusWithin,
-            RelationalVariantSignal.Active => StyleVariantClass.RelationalState.Active,
-            RelationalVariantSignal.Checked => StyleVariantClass.RelationalState.Checked,
-        };
-#pragma warning restore CS8524
         #endregion
 
         #region gating

--- a/Packages/com.velvet.core/Runtime/Styling/StyleVariantClass.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleVariantClass.cs
@@ -184,6 +184,30 @@ namespace Velvet
         internal enum RelationalState { Hover, Focus, FocusWithin, Active, Checked }
 
         /// <summary>
+        /// The length a per-state array is allocated at. Derived from the enum rather than written down:
+        /// a discard-less switch raises CS8509 for a member added here, but nothing about a switch can size
+        /// an array, and a literal length instead overflows in silence. Callers index such an array with
+        /// <c>(int)</c> of a <see cref="RelationalState"/>, so the length and the index cannot disagree.
+        /// </summary>
+        internal static readonly int RelationalStateCount = System.Enum.GetValues(typeof(RelationalState)).Length;
+
+        /// <summary>
+        /// The state a detected source signal belongs to. The two enumerations name the same relational
+        /// states; this pairing is what says so, rather than a cast that would silently survive either one
+        /// being reordered. No discard arm — see the remarks on <see cref="StyleVariantKind"/>.
+        /// </summary>
+#pragma warning disable CS8524 // no discard arm: an unpaired signal has to warn
+        internal static RelationalState StateOf(RelationalVariantSignal signal) => signal switch
+        {
+            RelationalVariantSignal.Hover => RelationalState.Hover,
+            RelationalVariantSignal.Focus => RelationalState.Focus,
+            RelationalVariantSignal.FocusWithin => RelationalState.FocusWithin,
+            RelationalVariantSignal.Active => RelationalState.Active,
+            RelationalVariantSignal.Checked => RelationalState.Checked,
+        };
+#pragma warning restore CS8524
+
+        /// <summary>
         /// Which source a relational kind reads (a preceding <c>peer</c> sibling when <c>IsPeer</c>, else the
         /// nearest <c>group</c> ancestor) and which of that source's states it reacts to; null for every
         /// non-relational kind. One switch answers all three questions so they cannot answer differently, and

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/MotionTextEffectCreateTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/MotionTextEffectCreateTests.cs
@@ -1,0 +1,53 @@
+using NUnit.Framework;
+using UnityEngine.UIElements;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Regression coverage for the text-effect cascade on a <c>V.Motion</c>'s CREATE path. That path ran no
+    /// cascade where the patch path did, so a plain <c>uppercase</c> (or <c>underline</c>,
+    /// <c>line-through</c>, <c>whitespace-pre-line</c>, <c>leading-*</c>) on a Motion rendered untransformed
+    /// text from mount — for the element's whole life when nothing ever re-rendered it. Two halves have to
+    /// be present for the cascade to land on a Motion: the pass itself, which reaches the descendant text
+    /// leaves, and the raw-text capture the pass rewrites the element's OWN text from. A test per half, so neither can
+    /// be dropped without one going red.
+    /// GWT, one assert per case.
+    /// </summary>
+    [TestFixture]
+    internal sealed class MotionTextEffectCreateTests
+    {
+        private VisualElement _root;
+
+        [SetUp]
+        public void SetUp() => _root = new VisualElement();
+
+        [Test]
+        public void Given_AMotionCarryingUppercase_When_ItMountsWithoutEverPatching_Then_ItsTextLeafIsUppercased()
+        {
+            // Arrange — a Motion whose only text is a descendant leaf, which carries no class of its own and
+            // so can only be transformed by the Motion's own cascade pass.
+            var tree = V.Motion(className: "uppercase", children: new VNode[] { V.Text("shout") });
+
+            // Act — mount it once and never patch.
+            using var mounted = V.Mount(_root, tree);
+
+            // Assert — the leaf shows the transformed string from the first frame.
+            Assert.That(_root.Q<Label>().text, Is.EqualTo("SHOUT"));
+        }
+
+        [Test]
+        public void Given_AMotionHostingALabelWithItsOwnText_When_ItMountsWithoutEverPatching_Then_ThatTextIsUppercased()
+        {
+            // Arrange — a Motion that IS the text-bearing element: the Text prop is applied by the element
+            // factory, so the cascade has nothing to rewrite from unless the raw value was captured.
+            var tree = V.Motion(className: "uppercase", elementType: typeof(Label),
+                props: new FiberElementProps { Text = "shout" });
+
+            // Act — mount it once and never patch.
+            using var mounted = V.Mount(_root, tree);
+
+            // Assert — the Motion's own text shows the transformed string.
+            Assert.That(_root.Q<Label>().text, Is.EqualTo("SHOUT"));
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/MotionTextEffectCreateTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/MotionTextEffectCreateTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d512637fcce3346e2a2e67be18ed8441

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/RelationalStateSlotTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/RelationalStateSlotTests.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Reflection;
+using NUnit.Framework;
+using UnityEngine.UIElements;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins that a relational (<c>group-*</c> / <c>peer-*</c>) binding keeps one payload slot per
+    /// <c>StyleVariantClass.RelationalState</c>, filled by the reconciler's own token grouping. Two sites used
+    /// to decide that set where the compiler could not check it — the binding enumerated the states by hand
+    /// when deciding whether to hook its source, and the grouping allocated its buckets at a literal five — so
+    /// a state added to the enum would land nowhere in the first and overflow the second. An exhaustive switch
+    /// cannot size an array; deriving the length from the enum can, and this fails when the binding stops
+    /// holding one slot per state or the grouping stops filling them all.
+    /// <para>
+    /// The class list carries a distinct payload per state so a slot filled from the wrong bucket is visible,
+    /// and the peer relation is used because <c>checked</c> has no group spelling.
+    /// </para>
+    /// GWT, one assert.
+    /// </summary>
+    [TestFixture]
+    internal sealed class RelationalStateSlotTests
+    {
+        private const string ClassName =
+            "peer-hover:h-on peer-focus:f-on peer-focus-within:w-on peer-active:a-on peer-checked:c-on";
+
+        // The binding is a private nested type of the manipulator, and its payload store is a private field:
+        // production types carry no test-only members, so both are reached by reflection. A missing member
+        // yields an empty result rather than an exception, so the failure reads as a mismatch against the
+        // expected slots.
+        private static string[] PayloadsPerState(StyleRelationalVariantManipulator manipulator)
+        {
+            var bindings = (System.Collections.IList)typeof(StyleRelationalVariantManipulator)
+                .GetField("_bindings", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .GetValue(manipulator)!;
+            var binding = bindings[0]!;
+            var slots = binding.GetType()
+                .GetField("_payloads", BindingFlags.Instance | BindingFlags.NonPublic)
+                ?.GetValue(binding) as string[][];
+            if (slots == null)
+            {
+                return Array.Empty<string>();
+            }
+            var states = Enum.GetValues(typeof(StyleVariantClass.RelationalState));
+            var perState = new string[states.Length];
+            for (var i = 0; i < states.Length; i++)
+            {
+                perState[i] = i < slots.Length ? string.Join("+", slots[i]) : "<no slot>";
+            }
+            return perState;
+        }
+
+        [Test]
+        public void Given_OneRelationalTokenPerState_When_TheBindingIsBuilt_Then_EveryStateHasItsOwnPayloadSlot()
+        {
+            // Arrange — a peer consumer declaring exactly one payload for each relational state, mounted so
+            // the reconciler groups the tokens and configures the manipulator.
+            var root = new VisualElement();
+            using var mounted = V.Mount(root,
+                V.Div("flex", V.Div("peer"), V.Label(name: "consumer", className: ClassName)));
+            var consumer = root.Q<Label>("consumer");
+            var manipulator = mounted.Root.Reconciler.Context.RelationalVariantManipulators[consumer];
+
+            // Act — read what the binding stored, slot by slot, over the whole state enum.
+            var perState = PayloadsPerState(manipulator);
+
+            // Assert — one slot per state, each holding the payload declared for it.
+            Assert.That(perState, Is.EqualTo(new[] { "h-on", "f-on", "w-on", "a-on", "c-on" }));
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/RelationalStateSlotTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/RelationalStateSlotTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b3626230e93c046bb8e31cf0718a40ab


### PR DESCRIPTION
Three defects, two of them user-visible.

**A `V.Motion` never applied the text cascade at create,** so `V.Motion(className: "uppercase")` — or `underline`, `line-through`, `whitespace-pre-line`, `leading-*` — rendered untransformed from mount until its first patch. A Motion that animates on mount and is then left alone never patches, so the text stayed wrong for the element's life.

It needed two halves rather than a missing call. `StyleTextEffectResolver.Apply` rewrites displayed text **from a tracked raw value**, and the Motion create path writes `props.Text` straight onto the element with nothing tracked — which is what the `CaptureRaw` seam on the element path exists for. Both halves are load-bearing, measured separately: with the resolver call added but the capture left out, a Motion carrying its own class passes and a Motion hosting a label with its own text still fails.

**A pooled `Label` carried its children into the pool.** `V.Custom<T>` accepts children for any `T`, `T` may be `Label`, and `CreateByType` maps `typeof(Label)` to the pooled rent — so a `V.Custom<Label>(children: …)` subtree travelled into the pool and the next `V.Label` showed it. The reset now detaches children, and the rollback reclaim pools a `Label` only when childless, which is the pair `Button` already had.

The rollback gate is required rather than symmetric: that path calls `CleanupElementResources` for the orphan alone, so clearing children there would drop a subtree with its context side-table entries still live. Ordinary unmount recurses through `CleanupDescendants`, so the reset's clear is safe there.

Whether all four leaf helpers should agree was settled by measuring what each child container already holds, not by reading which factory takes a `children:` argument:

    Button    content=0   Label     content=0
    Toggle    content=1   Slider    content=1   TextField content=1

Button and Label construct nothing into it, so clearing can only remove a previous tenant. The three composites build their own sub-element into that same container, so clearing deletes the control's own structure. That engine fact is now pinned by a baseline test rather than restated in a comment.

**Two sites hard-coded five relational states,** so a sixth would land nowhere in one and overflow the other. The count now derives from the enum and owns the length; the index is the state's own value, so length and index cannot disagree; and the two projections that *can* be switches — state to payload slot, state to priority — are discard-less, so a new member names its sites at compile time. Sizing alone would not have been enough: it stops the overflow and leaves a sixth state's payloads in a bucket nothing reads, which is worse than a crash.

That last one changes no behaviour and gets no CHANGELOG entry. Its guard is structural too — no behavioural test can go red without adding an enum member — so it drives real tokens through the builder and asserts every state has its own slot.

Three things surfaced and are filed rather than fixed. `Toggle`, `Slider` and `TextField` have the same ghosting hole and a plain clear cannot close it, since it would delete their own structure (#513). Two comments were false and one was load-bearing — the claim that the poolable primitives "hardcode empty children" is what justified the missing Label gate; both are corrected here, and the wider question of what else rested on them is filed (#514). And the relational binding paired payloads to declarations by reference identity down a five-way chain, so two states sharing an empty array resolved to whichever arm matched first — harmless today, removed by the index rewrite, noted because it was not what the issue asked about.

`styling-variants.md` says the string axes resolve at mount and on every toggle. That was false for a Motion carrying a plain string-axis class and is true now — the fix repairs the claim rather than invalidating it, so no guide edit.

Closes #453
Closes #475
Closes #485
