### PR TITLE
fix(velvet): let a child-combinator font payload reach the child

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A `font-*` utility a container imposes on its children with `[&>*]:` now reaches them. The font layer
+  was re-derived only when a child's own class list changed content, and a `[&>*]:` payload lands on the
+  child's live list without touching that array — so `[&>*]:font-mono` over a child that declares no
+  variant of its own and whose own classes never change was lost for that element's whole life, while
+  `[&>*]:uppercase` in the same markup appeared on the next render. Both now land from the child's next
+  render. Neither lands at mount for such a child, which is unchanged.
+
 - A `UseTransition` slot's `isPending` now reports its own transition rather than whatever holds the
   Transition lane. Two cases showed a spinner after the work it described was over: a `startTransition`
   whose callback scheduled no update stayed pending for as long as anything else on the component was

--- a/Packages/com.velvet.core/Documentation~/styling-variants.md
+++ b/Packages/com.velvet.core/Documentation~/styling-variants.md
@@ -353,9 +353,10 @@ would resolve *something*. The only array a container-driven child has of its ow
 list, and a `font-[…]` or `leading-[…]` the child declared is deliberately kept off it — the resolver
 owns those — while the class channels above put utilities on it the child never declared. So both
 stand down there rather than replace what the child's own render got right with nothing left to put
-it back: `[&>*]:uppercase` over a `leading-[24px]` label leaves the label alone. What a later render
-of the child then delivers is not the same for the two, so lean on neither and put these on the
-child.
+it back: `[&>*]:uppercase` over a `leading-[24px]` label leaves the label alone. From that child's
+next render on the two agree and both land — `[&>*]:font-mono` and `[&>*]:uppercase` alike. Mount is
+what neither reaches there, so a child that must carry the family or the transform on its first frame
+declares it itself, or declares a variant of its own — the same escape the paints take.
 
 ## Container queries — `@container`
 

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
@@ -261,7 +261,7 @@ namespace Velvet
         // so the full set of class-driven mechanisms lives in one place and the two paths cannot drift.
         // Gap is intentionally excluded: it is re-applied separately by the per-node patch methods
         // (PatchElement / PatchMotion) AFTER children reconcile, so it sees the
-        // final child list. The variant/font work is gated on DiffClassList's own verdict of whether the
+        // final child list. The variant work is gated on DiffClassList's own verdict of whether the
         // class list actually changed CONTENT (not merely array identity) — every variant manipulator this
         // derives from (ApplyVariantManipulators and its callees) reads ONLY the classNames array, so a
         // freshly-allocated array with the same tokens carries no new information and re-deriving from it
@@ -274,11 +274,26 @@ namespace Velvet
             if (changed)
             {
                 ApplyVariantManipulators(element, newClasses);
+            }
+            // The font layer reads the COMPOSED source, so the class diff answers only half of whether its
+            // input moved: applying a variant's payload moves the token set without moving either class
+            // array, and a [&>*]: one moves nothing on the child at all. Lit tokens are the other half.
+            // Its place here, ahead of ApplyPostChildrenClassPasses, is the order the variant re-sync
+            // mirrors.
+            if (changed || HasLitVariantGateTokens(element))
+            {
                 // Font family / weight / italic are resolved together (so font-bold + italic compose)
                 // and written as inline style that overrides the USS fallback classes.
                 ApplyFontLayer(element, oldClasses, newClasses);
             }
         }
+
+        // The condition under which ResolveGateClasses hands back something other than the reconciled
+        // array, which is what the class diff cannot answer for.
+        private bool HasLitVariantGateTokens(VisualElement element)
+            => _ctx.VariantGateClasses.Count != 0
+                && _ctx.VariantGateClasses.TryGetValue(element, out var state)
+                && state.Tokens.Count != 0;
 
         private void PatchElement(VisualElement element, ElementNode oldNode, ElementNode newNode)
         {

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/VariantGatedTypographyPassTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/VariantGatedTypographyPassTests.cs
@@ -236,6 +236,40 @@ namespace Velvet.Tests
         }
 
         [Test]
+        public void Given_AChildCombinatorFontOverAChildDeclaringNoPayload_When_ItRerenders_Then_TheFamilyResolves()
+        {
+            // Arrange — the child declares no gate payload, so it has no recorded array and the re-sync the
+            // landing payload raises stands the font layer down. Its class content never changes afterwards
+            // either, which is the other half: a font layer re-derived only from a class-array diff has
+            // nothing left to run it, and the family the container asked for is lost for the child's life.
+            using var scope = new ReconcilerScope();
+            var first = new VNode[]
+            {
+                V.Div(className: "[&>*]:font-mono", children: new VNode[]
+                {
+                    V.Label(className: "text-sm", text: "1", name: "card"),
+                }),
+            };
+            scope.Reconciler.Reconcile(scope.Root, Array.Empty<VNode>(), first);
+            var card = scope.Root.Q<VisualElement>("card");
+            var second = new VNode[]
+            {
+                V.Div(className: "[&>*]:font-mono", children: new VNode[]
+                {
+                    V.Label(className: "text-sm", text: "2", name: "card"),
+                }),
+            };
+
+            // Act
+            scope.Reconciler.Reconcile(scope.Root, first, second);
+
+            // Assert — the payload reaching the child rides along, so a walk that never applied it fails
+            // here rather than reading as a font the resolver declined to write.
+            Assert.That((card.ClassListContains("font-mono"), ResolvesToMono(card)),
+                Is.EqualTo((true, true)));
+        }
+
+        [Test]
         public void Given_AChildCombinatorPayloadOverABracketLeading_When_ItLands_Then_TheChildKeepsItsTag()
         {
             // Arrange — the same incomplete source on the text side, and it needs no second token: the live


### PR DESCRIPTION
A child reached only by a parent's `[&>*]:` rule declares no gate payload of its own, so it correctly stands down at mount. What it did not do is recover the same way for both axes.

The string axes — `uppercase`, `underline`, `line-through`, `whitespace-pre-line`, `leading-*` — resolve on the child's next render, because their pass runs unconditionally. The font layer sits behind `if (changed)`, and the diff compares the VNode class arrays, which a `[&>*]:` payload never touches: it lands on the child's live list. So `V.Div(className: "[&>*]:font-mono", children: new[]{ V.Label(className: "text-sm", …) })` never got its font, while the same markup with `uppercase` got it on the second render.

The two axes now recover alike.

**Mount still misses both, and that is stated rather than implied.** The opportunity exists in time — a child's create pass finishes before the container's rules run — but the knowledge does not: in that frame the element is still unparented, so it cannot know a container rule will drive it, and the record it would need is only opened for an element that declares a payload itself. Every substitute source is wrong rather than merely narrower; capturing the child's live class list at the moment the payload lands loses a declared `font-[…]`, which is the trap the re-sync already documents and an existing case already pins. Closing it needs a reconcile-scoped parent-to-child signal consulted before children reconcile, and would also flip the documented `[&>*]:` paint inconsistency — a wider change than this.

Two things measured while establishing that, neither of which was written down anywhere:

- The issue's "never resolves, for the element's whole life" holds only while the child's own class content is constant. Patch the child's classes and the font resolves even unfixed, because the diff then reports a change and the pass already reads the composed source.
- **The child's record self-heals at its first patch.** The entry is created when the payload lands, and every later patch writes its reconciled array — so from that render on it behaves exactly like a child that declared a payload. That is why the off-edge already worked, and it is why this fix cannot leave a stale font behind.

`styling-variants.md` had become false: it said what a later render delivers "is not the same for the two, so lean on neither". It is the same now.

Closes #454
