### PR TITLE
test(velvet): mutate a clause away, and require every job the aggregate forgot

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -165,6 +165,19 @@ jobs:
       - run: python3 scripts/release/test_release_notes.py
 
   # ---------------------------------------------------------------------------
+  # mutation_check.py needs a licence to kill a mutant, but not to build one, and the building is
+  # the half everything else rests on: an operator that emits uncompilable C# reports that mutant as
+  # noise rather than as a survivor, so a real hole hides behind it. That half runs here.
+  # ---------------------------------------------------------------------------
+  test-quality:
+    name: Test quality
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - run: python3 scripts/test_quality/test_mutation_check.py
+
+  # ---------------------------------------------------------------------------
   # The one check branch protection requires from this workflow. Naming a real
   # job instead would tie branch protection to that job's name and to its
   # continuing to run at all; this reports for every pull request whatever the
@@ -178,11 +191,11 @@ jobs:
   required-checks:
     name: Required checks (Unity)
     if: always()
-    needs: [license-check, unity-tests, release-notes]
+    needs: [license-check, unity-tests, release-notes, test-quality]
     runs-on: ubuntu-latest
     steps:
       - env:
-          RESULTS: ${{ needs.license-check.result }} ${{ needs.unity-tests.result }} ${{ needs.release-notes.result }}
+          RESULTS: ${{ needs.license-check.result }} ${{ needs.unity-tests.result }} ${{ needs.release-notes.result }} ${{ needs.test-quality.result }}
         run: |
           failed=0
           for result in $RESULTS; do

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/RequiredCheckAggregationTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/RequiredCheckAggregationTests.cs
@@ -1,0 +1,155 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using NUnit.Framework;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Holds every job in a required workflow against the aggregate job branch protection actually names.
+    /// A job left out of that aggregate still runs and still goes red, and nothing is blocked by it — the
+    /// same absence of a red required check as a repository with no such job at all. So a check added and
+    /// left unwired reports for as long as anyone reads the run page and never once stops a merge.
+    /// <para>
+    /// Both halves are read out of the workflow rather than listed here, so a job added tomorrow is in
+    /// scope for having been added. <c>WorkflowTriggerCoverageTests</c> owns which events start these
+    /// workflows and which paths they filter on; this one owns what their results are wired into.
+    /// </para>
+    /// </summary>
+    [TestFixture]
+    internal sealed class RequiredCheckAggregationTests
+    {
+        // The aggregate is found by the name branch protection requires rather than by position, because a
+        // workflow may hold several jobs that depend on others and only this one stands for all of them.
+        private static readonly (string Workflow, string Aggregate)[] RequiredWorkflows =
+        {
+            (".github/workflows/test.yml", "required-checks"),
+            (".github/workflows/generators.yml", "required-checks"),
+        };
+
+        private static readonly Regex JobKeyPattern =
+            new(@"^  ([A-Za-z_][A-Za-z0-9_-]*):\s*$", RegexOptions.Compiled);
+
+        private static readonly Regex NeedsListPattern =
+            new(@"^\s*needs:\s*\[(?<jobs>[^\]]*)\]", RegexOptions.Compiled | RegexOptions.Multiline);
+
+        private static readonly Regex ResultReferencePattern =
+            new(@"needs\.(?<job>[A-Za-z_][A-Za-z0-9_-]*)\.result", RegexOptions.Compiled);
+
+        private static string RepositoryRoot()
+        {
+            var directory = new DirectoryInfo(Directory.GetCurrentDirectory());
+            while (directory != null && !Directory.Exists(Path.Combine(directory.FullName, ".github")))
+            {
+                directory = directory.Parent;
+            }
+
+            return directory?.FullName ?? Directory.GetCurrentDirectory();
+        }
+
+        private static string ReadWorkflow(string relativePath) =>
+            File.ReadAllText(Path.Combine(RepositoryRoot(), relativePath));
+
+        private static IReadOnlyList<string> JobNames(string workflow)
+        {
+            var names = new List<string>();
+            var inJobs = false;
+            foreach (var line in workflow.Split('\n'))
+            {
+                if (line.StartsWith("jobs:", StringComparison.Ordinal))
+                {
+                    inJobs = true;
+                    continue;
+                }
+
+                // A key back at column zero ends the jobs block; nothing else in the file is indented as a job.
+                if (inJobs && line.Length > 0 && !char.IsWhiteSpace(line[0]) && !line.StartsWith("#", StringComparison.Ordinal))
+                {
+                    inJobs = false;
+                }
+
+                if (!inJobs)
+                {
+                    continue;
+                }
+
+                var match = JobKeyPattern.Match(line.TrimEnd('\r'));
+                if (match.Success)
+                {
+                    names.Add(match.Groups[1].Value);
+                }
+            }
+
+            return names;
+        }
+
+        private static string AggregateBlock(string workflow, string aggregate)
+        {
+            var lines = workflow.Split('\n');
+            var start = Array.FindIndex(lines, line => line.TrimEnd('\r') == "  " + aggregate + ":");
+            if (start < 0)
+            {
+                return string.Empty;
+            }
+
+            var end = Array.FindIndex(lines, start + 1, line => JobKeyPattern.IsMatch(line.TrimEnd('\r')));
+            return string.Join("\n", lines.Skip(start).Take((end < 0 ? lines.Length : end) - start));
+        }
+
+        private static IEnumerable<string> Unwired(string relativePath, string aggregate, Func<string, IEnumerable<string>> read)
+        {
+            var workflow = ReadWorkflow(relativePath);
+            var block = AggregateBlock(workflow, aggregate);
+            var wired = read(block).ToHashSet(StringComparer.Ordinal);
+            return JobNames(workflow)
+                .Where(job => job != aggregate && !wired.Contains(job))
+                .Select(job => relativePath + ":" + job);
+        }
+
+        [Test]
+        public void Given_EveryJobInARequiredWorkflow_When_TheAggregateIsRead_Then_ItDependsOnThatJob()
+        {
+            // Arrange
+            var aggregates = RequiredWorkflows;
+
+            // Act
+            var unwired = aggregates
+                .SelectMany(entry => Unwired(entry.Workflow, entry.Aggregate, block => NeedsListPattern
+                    .Match(block).Groups["jobs"].Value
+                    .Split(',')
+                    .Select(job => job.Trim())
+                    .Where(job => job.Length > 0)))
+                .ToList();
+
+            // Assume — an aggregate whose block or needs list went unread would report nothing missing.
+            Assume.That(aggregates.Select(entry => JobNames(ReadWorkflow(entry.Workflow)).Count),
+                Is.All.GreaterThan(1));
+
+            // Assert
+            Assert.That(string.Join("\n", unwired), Is.Empty);
+        }
+
+        [Test]
+        public void Given_EveryJobARequiredAggregateDependsOn_When_ItsStepIsRead_Then_ThatResultIsInspected()
+        {
+            // Arrange — depending on a job without reading its result makes the aggregate wait and pass anyway.
+            var aggregates = RequiredWorkflows;
+
+            // Act
+            var uninspected = aggregates
+                .SelectMany(entry => Unwired(entry.Workflow, entry.Aggregate, block => ResultReferencePattern
+                    .Matches(block)
+                    .Select(match => match.Groups["job"].Value)))
+                .ToList();
+
+            // Assume
+            Assume.That(aggregates.Select(entry => JobNames(ReadWorkflow(entry.Workflow)).Count),
+                Is.All.GreaterThan(1));
+
+            // Assert
+            Assert.That(string.Join("\n", uninspected), Is.Empty);
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/RequiredCheckAggregationTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/RequiredCheckAggregationTests.cs
@@ -21,13 +21,15 @@ namespace Velvet.Tests
     [TestFixture]
     internal sealed class RequiredCheckAggregationTests
     {
-        // The aggregate is found by the name branch protection requires rather than by position, because a
-        // workflow may hold several jobs that depend on others and only this one stands for all of them.
-        private static readonly (string Workflow, string Aggregate)[] RequiredWorkflows =
-        {
-            (".github/workflows/test.yml", "required-checks"),
-            (".github/workflows/generators.yml", "required-checks"),
-        };
+        // Which workflows these are is read out of the workflows, not listed: a workflow is required when
+        // it carries a job whose display name is a required status check, and the repository-settings job
+        // in generators.yml asserts against GitHub's own ruleset that the required contexts are exactly the
+        // names matched here. Listing the pair instead would leave a third one outside every case below
+        // for as long as nobody remembered the list — which is the failure this fixture is about, one
+        // level up.
+        private static readonly Regex RequiredContextPattern =
+            new(@"^\s*name:\s*(?<context>Required checks \([^)]+\))\s*$",
+                RegexOptions.Compiled | RegexOptions.Multiline);
 
         private static readonly Regex JobKeyPattern =
             new(@"^  ([A-Za-z_][A-Za-z0-9_-]*):\s*$", RegexOptions.Compiled);
@@ -51,6 +53,26 @@ namespace Velvet.Tests
 
         private static string ReadWorkflow(string relativePath) =>
             File.ReadAllText(Path.Combine(RepositoryRoot(), relativePath));
+
+        /// <summary>Each workflow holding a required-status-check aggregate, paired with that job's key.</summary>
+        private static IReadOnlyList<(string Workflow, string Aggregate)> RequiredWorkflows()
+        {
+            var found = new List<(string, string)>();
+            var directory = Path.Combine(RepositoryRoot(), ".github", "workflows");
+            foreach (var path in Directory.EnumerateFiles(directory, "*.yml").OrderBy(path => path, StringComparer.Ordinal))
+            {
+                var workflow = File.ReadAllText(path);
+                foreach (var job in JobNames(workflow))
+                {
+                    if (RequiredContextPattern.IsMatch(AggregateBlock(workflow, job)))
+                    {
+                        found.Add((".github/workflows/" + Path.GetFileName(path), job));
+                    }
+                }
+            }
+
+            return found;
+        }
 
         private static IReadOnlyList<string> JobNames(string workflow)
         {
@@ -112,7 +134,7 @@ namespace Velvet.Tests
         public void Given_EveryJobInARequiredWorkflow_When_TheAggregateIsRead_Then_ItDependsOnThatJob()
         {
             // Arrange
-            var aggregates = RequiredWorkflows;
+            var aggregates = RequiredWorkflows();
 
             // Act
             var unwired = aggregates
@@ -123,19 +145,20 @@ namespace Velvet.Tests
                     .Where(job => job.Length > 0)))
                 .ToList();
 
-            // Assume — an aggregate whose block or needs list went unread would report nothing missing.
-            Assume.That(aggregates.Select(entry => JobNames(ReadWorkflow(entry.Workflow)).Count),
-                Is.All.GreaterThan(1));
-
-            // Assert
-            Assert.That(string.Join("\n", unwired), Is.Empty);
+            // Assert — the two counts ride along because no aggregate found, or an aggregate whose block
+            // went unread, reports nothing missing and would pass for having measured nothing. They are
+            // floors rather than exact numbers: an exact one is a hand-maintained mirror, and this fixture
+            // exists because those go stale.
+            var scanned = aggregates.Sum(entry => JobNames(ReadWorkflow(entry.Workflow)).Count);
+            Assert.That((aggregates.Count >= 2, scanned > aggregates.Count, string.Join("\n", unwired)),
+                Is.EqualTo((true, true, string.Empty)));
         }
 
         [Test]
         public void Given_EveryJobARequiredAggregateDependsOn_When_ItsStepIsRead_Then_ThatResultIsInspected()
         {
             // Arrange — depending on a job without reading its result makes the aggregate wait and pass anyway.
-            var aggregates = RequiredWorkflows;
+            var aggregates = RequiredWorkflows();
 
             // Act
             var uninspected = aggregates
@@ -144,12 +167,10 @@ namespace Velvet.Tests
                     .Select(match => match.Groups["job"].Value)))
                 .ToList();
 
-            // Assume
-            Assume.That(aggregates.Select(entry => JobNames(ReadWorkflow(entry.Workflow)).Count),
-                Is.All.GreaterThan(1));
-
-            // Assert
-            Assert.That(string.Join("\n", uninspected), Is.Empty);
+            // Assert — same floors as above, for the same reason.
+            var scanned = aggregates.Sum(entry => JobNames(ReadWorkflow(entry.Workflow)).Count);
+            Assert.That((aggregates.Count >= 2, scanned > aggregates.Count, string.Join("\n", uninspected)),
+                Is.EqualTo((true, true, string.Empty)));
         }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/RequiredCheckAggregationTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/RequiredCheckAggregationTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f0a66a3d067a44aafbd22e24bcc947b4

--- a/scripts/test_quality/mutation_check.py
+++ b/scripts/test_quality/mutation_check.py
@@ -131,6 +131,88 @@ WORD_OPERATORS = [("true", "false", "literal"), ("false", "true", "literal")]
 # exactly one behaviour and leaves the rest of the method intact.
 VOID_CALL = re.compile(r"^[A-Za-z_][A-Za-z0-9_.]*(\.[A-Za-z_][A-Za-z0-9_]*)*\s*\([^;]*\)\s*;$")
 
+# Every operator above keeps the clause it lands in participating in the condition, so a clause no test
+# reaches survives all of them: swapping its comparison or its join still leaves some test's own clause
+# deciding the outcome. Removing the clause is the only mutation that asks whether anything depends on
+# that condition existing, and the same holds one level out for a guard statement, whose condition the
+# operators above mutate while none of them deletes the guard.
+LOGIC_JOINS = (" && ", " || ")
+GUARD_STATEMENT = re.compile(r"^if \(.+\)\s*(?:return[^;]*|continue|break);$")
+
+
+def encloses_its_own_groups(line, start, mask, limit):
+    """Whether every parenthesis the line opens it also closes, and it closes none it did not open."""
+    depth = 0
+    for index in range(limit):
+        if not mask[start + index]:
+            continue
+        if line[index] == "(":
+            depth += 1
+        elif line[index] == ")":
+            depth -= 1
+            if depth < 0:
+                return False
+    return depth == 0
+
+
+def clause_cuts(line, start, mask, limit):
+    """Removable (column, text) spans over one line, each a join plus the clause it introduces.
+
+    A span ends at the next join of its own depth or at the close of the group holding it, so what comes
+    out is parenthesis-balanced and the remainder still parses. A chain's first clause has no preceding
+    join to carry away with it, and where its expression begins cannot be read off the line, so it is
+    left alone: under-reporting one clause beats emitting mutants that only ever come back uncompilable.
+
+    A condition spread over several lines is skipped whole, for the same reason. Its group closes on a
+    later line, so a cut runs to the end of this one and takes an unmatched parenthesis with it — which
+    is what the generation-health guard in test_mutation_check.py caught when this returned cuts for any
+    line at all.
+    """
+    if not encloses_its_own_groups(line, start, mask, limit):
+        return []
+
+    joins = []
+    depth = 0
+    index = 0
+    while index < limit:
+        if not mask[start + index]:
+            index += 1
+            continue
+        character = line[index]
+        if character == "(":
+            depth += 1
+        elif character == ")":
+            depth -= 1
+        else:
+            join = next((candidate for candidate in LOGIC_JOINS
+                         if line.startswith(candidate, index)), None)
+            if join is not None:
+                joins.append((index, depth, join))
+                index += len(join)
+                continue
+        index += 1
+
+    cuts = []
+    for column, depth, join in joins:
+        probe = column + len(join)
+        level = depth
+        while probe < limit:
+            if mask[start + probe]:
+                character = line[probe]
+                if character == "(":
+                    level += 1
+                elif character == ")":
+                    if level == depth:
+                        break
+                    level -= 1
+                elif level == depth and any(line.startswith(c, probe) for c in LOGIC_JOINS):
+                    break
+            probe += 1
+        text = line[column:probe]
+        if text.strip() != join.strip():
+            cuts.append((column, text))
+    return cuts
+
 
 def line_spans(text):
     spans = []
@@ -163,6 +245,11 @@ def mutations_for(path, text, target_lines):
         stripped = line.strip()
         if VOID_CALL.match(stripped) and not stripped.startswith(("return", "throw", "yield")):
             found.append(Mutant(path, number, 0, stripped, ";", "void call removed"))
+        limit = len(line.rstrip())
+        for column, text in clause_cuts(line, start, mask, limit):
+            found.append(Mutant(path, number, column, text, "", "clause removed"))
+        if GUARD_STATEMENT.match(stripped) and all(mask[start:start + limit]):
+            found.append(Mutant(path, number, line.index(stripped), stripped, "", "guard removed"))
     return found
 
 
@@ -170,7 +257,9 @@ def apply_mutation(text, mutant):
     spans = line_spans(text)
     start, end = spans[mutant.line - 1]
     line = text[start:end]
-    if mutant.operator == "void call removed":
+    if mutant.operator in ("clause removed", "guard removed"):
+        mutated = line[:mutant.column] + line[mutant.column + len(mutant.before):]
+    elif mutant.operator == "void call removed":
         mutated = line.replace(mutant.before, ";", 1)
     elif mutant.operator == "literal":
         mutated = (

--- a/scripts/test_quality/test_mutation_check.py
+++ b/scripts/test_quality/test_mutation_check.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Unit tests for mutation_check.py's mutant generation, plus guards over this repository's sources.
+
+Generation is separable from the Unity runs that kill or spare a mutant, so it is tested here and runs
+without a licence. What a run then reports rests entirely on this half being right: a mutant that comes
+back uncompilable is indistinguishable from one nothing tested, so an operator that emits broken C# does
+not report a false survivor — it hides a real one behind noise.
+
+Run: python3 scripts/test_quality/test_mutation_check.py
+"""
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RUNTIME = REPO_ROOT / "Packages/com.velvet.core/Runtime"
+
+
+def load_module():
+    """Imports mutation_check by path, since scripts/test_quality is not a package."""
+    spec = importlib.util.spec_from_file_location(
+        "mutation_check", Path(__file__).with_name("mutation_check.py")
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+mutation_check = load_module()
+
+
+def mutants_of(text, operator=None):
+    lines = set(range(1, len(text.splitlines()) + 1))
+    found = mutation_check.mutations_for(Path("probe.cs"), text, lines)
+    return [mutant for mutant in found if operator is None or mutant.operator == operator]
+
+
+def applied(text, mutant):
+    return mutation_check.apply_mutation(text, mutant).splitlines()[mutant.line - 1].strip()
+
+
+class ClauseRemovalTests(unittest.TestCase):
+    def test_Given_AThreeClauseCondition_When_MutantsAreGenerated_Then_EachTrailingClauseIsRemovable(self):
+        # Arrange
+        text = "if (a == null || b <= 0 || b > c.Count)\n"
+
+        # Act
+        cuts = sorted(applied(text, mutant) for mutant in mutants_of(text, "clause removed"))
+
+        # Assert
+        self.assertEqual(cuts, ["if (a == null || b <= 0)", "if (a == null || b > c.Count)"])
+
+    def test_Given_AClauseHoldingItsOwnParentheses_When_ItIsRemoved_Then_TheLineStaysBalanced(self):
+        # Arrange
+        text = "if (a || Ready(x, y) && Live(z))\n"
+
+        # Act
+        balances = {applied(text, m).count("(") - applied(text, m).count(")")
+                    for m in mutants_of(text, "clause removed")}
+
+        # Assert
+        self.assertEqual(balances, {0})
+
+    def test_Given_AJoinInsideANestedGroup_When_ItIsRemoved_Then_TheOuterGroupIsUntouched(self):
+        # Arrange
+        text = "if (a && (b || c))\n"
+
+        # Act
+        cuts = sorted(applied(text, mutant) for mutant in mutants_of(text, "clause removed"))
+
+        # Assert
+        self.assertEqual(cuts, ["if (a && (b))", "if (a)"])
+
+    def test_Given_AJoinInsideAStringLiteral_When_MutantsAreGenerated_Then_ItIsNotACut(self):
+        # Arrange
+        text = 'var message = "a && b";\n'
+
+        # Act
+        cuts = mutants_of(text, "clause removed")
+
+        # Assert
+        self.assertEqual(cuts, [])
+
+    def test_Given_AChainsFirstClause_When_MutantsAreGenerated_Then_ItIsNotOffered(self):
+        # Arrange — where the first clause begins cannot be read off the line, so it is left alone.
+        text = "if (a == null || b <= 0)\n"
+
+        # Act
+        cuts = [applied(text, mutant) for mutant in mutants_of(text, "clause removed")]
+
+        # Assert
+        self.assertEqual(cuts, ["if (a == null)"])
+
+
+class GuardRemovalTests(unittest.TestCase):
+    def test_Given_ASingleLineReturnGuard_When_ItIsRemoved_Then_OnlyTheGuardGoes(self):
+        # Arrange
+        text = "        if (ownCts != _cts) return;\n"
+
+        # Act
+        results = [applied(text, mutant) for mutant in mutants_of(text, "guard removed")]
+
+        # Assert
+        self.assertEqual(results, [""])
+
+    def test_Given_AGuardWhoseBodyIsABlock_When_MutantsAreGenerated_Then_ItIsNotOffered(self):
+        # Arrange — deleting the condition of a multi-line guard would leave its block dangling.
+        text = "if (ownCts != _cts)\n{\n    return;\n}\n"
+
+        # Act
+        guards = mutants_of(text, "guard removed")
+
+        # Assert
+        self.assertEqual(guards, [])
+
+    def test_Given_AnAssignmentThatMerelyMentionsReturn_When_MutantsAreGenerated_Then_ItIsNotAGuard(self):
+        # Arrange
+        text = "var returned = Compute(a);\n"
+
+        # Act
+        guards = mutants_of(text, "guard removed")
+
+        # Assert
+        self.assertEqual(guards, [])
+
+
+class RepositoryReachTests(unittest.TestCase):
+    """The operators exist because two real defects survived every other one. Pin that they reach them."""
+
+    def test_Given_TheNestedOutletGuard_When_MutantsAreGenerated_Then_ItsDepthClauseIsRemovable(self):
+        # Arrange — a route depth past the matched chain must return null rather than index past its end.
+        source = (RUNTIME / "Hooks/Hooks.cs").read_text()
+        line = next(number for number, text in enumerate(source.splitlines(), 1)
+                    if "depth > location.Matches.Count" in text)
+
+        # Act
+        cuts = [mutant.before.strip() for mutant
+                in mutation_check.mutations_for(Path("Hooks.cs"), source, {line})
+                if mutant.operator == "clause removed"]
+
+        # Assert
+        self.assertIn("|| depth > location.Matches.Count", cuts)
+
+    def test_Given_TheSupersessionChecks_When_MutantsAreGenerated_Then_EachIsRemovable(self):
+        # Arrange — a superseded loader round must not report into the live one.
+        source = (RUNTIME / "Routing/RouteLoaderRunner.cs").read_text()
+
+        # Act
+        guards = {mutant.before for mutant in mutants_of(source, "guard removed")}
+
+        # Assert
+        self.assertEqual(guards, {"if (ownCts != _cts) return;"})
+
+
+class GenerationHealthTests(unittest.TestCase):
+    def test_Given_EveryRuntimeSource_When_MutantsAreGenerated_Then_NoCutSpansAnUnbalancedParenthesis(self):
+        # Arrange — an unbalanced cut compiles nowhere, and uncompilable noise hides real survivors.
+        sources = [path for path in RUNTIME.rglob("*.cs") if "/Tests/" not in path.as_posix()]
+
+        # Act
+        unbalanced = []
+        for path in sources:
+            text = path.read_text()
+            for mutant in mutants_of(text, "clause removed"):
+                if mutant.before.count("(") != mutant.before.count(")"):
+                    unbalanced.append(f"{path.name}:{mutant.line} {mutant.before.strip()}")
+
+        # Assert — the source count rides along because an empty scan satisfies "none unbalanced".
+        self.assertEqual((len(sources) > 200, unbalanced), (True, []))
+
+    def test_Given_EveryRuntimeSource_When_MutantsAreGenerated_Then_NoRemovalLeavesADanglingJoin(self):
+        # Arrange
+        sources = [path for path in RUNTIME.rglob("*.cs") if "/Tests/" not in path.as_posix()]
+
+        # Act
+        dangling = []
+        for path in sources:
+            text = path.read_text()
+            for mutant in mutants_of(text, "clause removed"):
+                remainder = applied(text, mutant)
+                if remainder.endswith(("&&", "||")) or "&&)" in remainder or "||)" in remainder:
+                    dangling.append(f"{path.name}:{mutant.line} {remainder}")
+
+        # Assert
+        self.assertEqual((len(sources) > 200, dangling), (True, []))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Two guards that could not have caught the defects found by hand this week, and one that was never wired to anything.

**Every mutation operator the harness had leaves the clause it lands in participating in the condition.** Swapping a comparison inside a clause, or swapping the join beside it, still leaves some other clause deciding the outcome — so a clause no test reaches survives all of them. Removing the clause is the only mutation that asks whether anything depends on that condition existing, and the same holds one level out for a single-line guard, whose condition the operators mutate while none of them deletes the guard.

Both shapes were reached for by hand this week and neither had an operator. The nested-outlet depth clause in `Hooks.CurrentRouteId` is green across the repository with its last clause deleted, and `RouteLoaderRunner`'s two supersession checks are green deleted outright. Each is now a mutant the harness builds — 187 clause removals and 75 guard removals over the runtime, against roughly 1,600 mutants the operator table produced before.

A condition spread over several lines is skipped whole. Its group closes on a later line, so a cut runs to the end of this one and carries an unmatched parenthesis with it — which is what the generation-health case caught when this cut on any line at all. An uncompilable mutant is not a false survivor; it is a real one hidden behind noise, so under-reporting a clause is the cheaper side of that trade.

**Generation needs no licence, and everything a mutation run reports rests on it,** so it is tested here and given a job of its own. That job is what surfaced the second half.

**Nothing held the aggregate branch protection requires against the jobs beside it.** A job left out of `required-checks` still runs and still goes red, and blocks nothing — the same absence of a red required check as a repository with no such job at all. Adding the new job walked straight into it, and the guard set had no case that would have said so.

Both halves are now read out of the workflow, so a job added tomorrow is in scope for having been added, and the two cases separate a job never declared from one declared and never inspected. Which workflows are required is derived rather than listed: a workflow is required when it holds a job whose display name is a required status check, and `generators.yml`'s `repository-settings` job asserts against GitHub's own ruleset that the required contexts are exactly those names. The counts that ride along with each assertion are floors rather than exact numbers — an exact one fails when a workflow is added, which makes it a number somebody maintains, and this fixture exists because those go stale.

No package behaviour changes, so no CHANGELOG entry.
