### PR TITLE
fix(velvet): keep a pooled composite's own structure, and let a controlled bool reach the variants

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -15,9 +15,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   control did not construct and leaves the control itself intact. Without that, the next `V.Toggle` mount
   rented an element still showing the previous subtree's content beside its own.
 
-- `checked:` now applies at mount to a control that reports a bool without being a `Toggle` — `RadioButton`
-  and `Foldout` among the built-in ones. Their change events already drove the variant, so such a control
-  mounted already checked styled correctly from the first interaction onward and only started wrong.
+- `checked:` and `peer-checked:` now apply at mount to a control that reports a bool without being a
+  `Toggle` — `RadioButton` and `Foldout` among the built-in ones. The change registration beside each seed
+  never restricted the type, so such a control styled correctly from the first interaction onward and only
+  started wrong. A `Foldout` reports itself checked from its own constructor, so `checked:` on one now
+  paints at mount without anyone having set a value.
+
+- A variant stacked three deep no longer throws out of the operation that settles its outer gate. Settling
+  a consumer applies its payload, and a payload that is itself a variant registers a further manipulator in
+  the registry the settle was walking, which ends the walk with an `InvalidOperationException`. All three
+  settles could reach it: `dark:active:sm:bg-on` on a drag source or any of its ancestors threw on the drag
+  release, `dark:focus:sm:bg-on` on the focus revert a containment snap-back performs, and
+  `dark:checked:hover:bg-on` on a value written through a controlled prop.
 
 - A `font-*` utility a container imposes on its children with `[&>*]:` now reaches them. The font layer
   was re-derived only when a child's own class list changed content, and a `[&>*]:` payload lands on the

--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A `Toggle`, `Slider` or `TextField` given children through `V.Custom<T>` no longer carries them into the
+  element pool. Each of the three builds its own input into the very container those children expand into,
+  so the reset could not simply empty it as the `Button` and `Label` resets do — it now detaches what the
+  control did not construct and leaves the control itself intact. Without that, the next `V.Toggle` mount
+  rented an element still showing the previous subtree's content beside its own.
+
+- `checked:` now applies at mount to a control that reports a bool without being a `Toggle` — `RadioButton`
+  and `Foldout` among the built-in ones. Their change events already drove the variant, so such a control
+  mounted already checked styled correctly from the first interaction onward and only started wrong.
+
 - A `font-*` utility a container imposes on its children with `[&>*]:` now reaches them. The font layer
   was re-derived only when a child's own class list changed content, and a `[&>*]:` payload lands on the
   child's live list without touching that array — so `[&>*]:font-mono` over a child that declares no
@@ -335,8 +345,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   written to the control without notification, so the `ChangeEvent<bool>` the variant listens for never
   fired and the payload stayed on whatever the last user interaction had left it at — in the shape a React
   developer reaches for first, a parent holding the state and passing it down. The stacked forms
-  (`dark:checked:` and the rest) get it too. `peer-checked:` is unchanged: it still tracks the change
-  event only, so a peer written through a controlled prop does not restyle its siblings.
+  (`dark:checked:` and the rest) get it too, and so does `peer-checked:` — a peer written through a
+  controlled prop restyles the siblings that consume it, in the plain and the stacked spelling alike.
 
 - A render that drops a `Focusable` prop from a drag source no longer leaves the source unfocusable for
   the rest of the drag. A session anchors keyboard focus on a source that carries no focusability of its

--- a/Packages/com.velvet.core/Documentation~/styling-variants.md
+++ b/Packages/com.velvet.core/Documentation~/styling-variants.md
@@ -52,7 +52,7 @@ worth knowing, both when several variants name one such utility:
 | **Theme** | `dark:` | `VelvetTheme.IsDark` |
 | **Responsive** | `sm:` · `md:` · `lg:` · `xl:` · `2xl:` | The resolved responsive-scope width (the panel root by default — see below) |
 | **Relational (group)** | `group-hover:` · `group-focus:` · `group-focus-within:` · `group-active:` | A marked ancestor's (`group`) state |
-| **Relational (peer)** | `peer-hover:` · `peer-focus:` · `peer-focus-within:` · `peer-active:` · `peer-checked:` | A marked previous-sibling's (`peer`) state |
+| **Relational (peer)** | `peer-hover:` · `peer-focus:` · `peer-focus-within:` · `peer-active:` · `peer-checked:` | A marked previous-sibling's (`peer`) state; `peer-checked:` reads its value on the same terms as `checked:` above |
 
 ```csharp
 // State: a hover background and an active scale, layered over the base utilities.

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberElementCleaner.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberElementCleaner.cs
@@ -82,7 +82,8 @@ namespace Velvet
         // or V.Custom<T> for both — which CreateElement inline-expands into the element itself, while this
         // branch releases resources for the orphan alone. Toggle / Slider / TextField are reclaimed
         // unconditionally: each already holds its own constructed sub-element, so a count cannot separate
-        // that from a V.Custom child, and the same gap reaches them through ordinary unmount besides. A
+        // that from a V.Custom child — their reset detaches one by exclusion instead
+        // (FiberElementPoolReset.DetachForeignChildren), on this path and on ordinary unmount alike. A
         // container orphan — including a Button or a Label declared with children — has its subtree's
         // resources released recursively via CleanupElementCore, which deliberately does NOT dispose the
         // subtree's fibers / Outlet scopes (that is CleanupElement's job): those anchor on the fiber tree

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberElementPoolReset.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberElementPoolReset.cs
@@ -63,6 +63,29 @@ namespace Velvet
             ResetCommonState(element);
         }
 
+        // A composite field builds its own input, and its label, into the very container children are expanded
+        // into, so its pool return cannot empty that container the way the childless primitives do —
+        // FiberButtonPoolHelper states that split. Nor can it count: CompositeFieldChildPoolReuseTests pins
+        // that an expanded child takes the container's FIRST slot, ahead of what the constructor left, so
+        // neither end of a count separates the two. What the control made is identified by the two classes
+        // passed here instead, which PoolableWidgetChildBaselineTests pins as accounting for all of it.
+        // field: Pooled composite to strip. Null is a no-op.
+        public static void DetachForeignChildren(VisualElement field, string inputUssClass, string labelUssClass)
+        {
+            if (field == null) return;
+
+            var container = FiberNodePatcher.GetChildContainer(field);
+            for (var i = container.childCount - 1; i >= 0; i--)
+            {
+                var child = container.ElementAt(i);
+                if (child.ClassListContains(inputUssClass) || child.ClassListContains(labelUssClass))
+                {
+                    continue;
+                }
+                container.RemoveAt(i);
+            }
+        }
+
         // Empties the class list and the per-element style model that decides what may be on it, in one step.
         // Dropping only the classes would leave the model holding a prior consumer's layers and its record of
         // which of them it had suppressed, so the next consumer's first recompute could take a class off the

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
@@ -1466,10 +1466,13 @@ namespace Velvet
         }
 
         // A controlled value reaches the control through SetValueWithoutNotify, so the ChangeEvent the
-        // checked: variant listens for never arrives — the same suppression RefreshHasVariants compensates
-        // for on the has- side. Reads the control back instead of re-deriving the value from the prop: a
-        // FieldValue cleared to null resets a bool control through ApplyFieldValue's own branch, and the
-        // control is where both branches land.
+        // checked: and peer-checked: variants listen for never arrives — the same suppression
+        // RefreshHasVariants compensates for on the has- side. Reads the control back instead of re-deriving
+        // the value from the prop: a FieldValue cleared to null resets a bool control through
+        // ApplyFieldValue's own branch, and the control is where both branches land.
+        // Two sweeps because the two families are keyed opposite ways (see IRelationalSettleTarget): the
+        // element-local one visits what is registered against this element, the relational one offers the
+        // edge to every consumer so each can recognise its own source.
         private void RaiseCheckedSignal(VisualElement element)
         {
             if (element is not INotifyValueChanged<bool> boolField)
@@ -1479,6 +1482,7 @@ namespace Velvet
 
             var value = boolField.value;
             VariantSettleSweep.ForEach(element, _ctx, consumer => consumer.SettleChecked(value));
+            VariantSettleSweep.SettleCheckedFromSource(element, _ctx, value);
         }
 
         // The props that wire a binding onto the element rather than writing a VisualElement property; the

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberPrimitiveElementPool.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberPrimitiveElementPool.cs
@@ -29,7 +29,8 @@ namespace Velvet
             // `children:` argument — V.Custom<T> takes one for any T. It is about what the child container
             // already holds: Toggle, Slider and TextField each construct a sub-element into the very
             // container FiberNodePatcher.GetChildContainer hands children to, so Clear() there would delete
-            // the control's own structure rather than a previous tenant's content.
+            // the control's own structure rather than a previous tenant's content. They reach the same
+            // outcome by exclusion instead (FiberElementPoolReset.DetachForeignChildren).
             // PoolableWidgetChildBaselineTests pins which types those are.
             if (button.childCount > 0) button.Clear();
 
@@ -87,6 +88,8 @@ namespace Velvet
         {
             if (slider == null) return;
 
+            FiberElementPoolReset.DetachForeignChildren(
+                slider, BaseField<float>.inputUssClassName, BaseField<float>.labelUssClassName);
             FiberElementPoolReset.ResetClassListAndCommon(
                 slider,
                 BaseField<float>.ussClassName,
@@ -143,6 +146,8 @@ namespace Velvet
         {
             if (textField == null) return;
 
+            FiberElementPoolReset.DetachForeignChildren(
+                textField, BaseField<string>.inputUssClassName, BaseField<string>.labelUssClassName);
             FiberElementPoolReset.ResetClassListAndCommon(
                 textField,
                 BaseField<string>.ussClassName,
@@ -180,6 +185,8 @@ namespace Velvet
         {
             if (toggle == null) return;
 
+            FiberElementPoolReset.DetachForeignChildren(
+                toggle, BaseField<bool>.inputUssClassName, BaseField<bool>.labelUssClassName);
             FiberElementPoolReset.ResetClassListAndCommon(toggle, BaseField<bool>.ussClassName, Toggle.ussClassName);
             toggle.SetValueWithoutNotify(false);
             toggle.label = string.Empty;

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/CompositeFieldChildPoolReuseTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/CompositeFieldChildPoolReuseTests.cs
@@ -1,0 +1,174 @@
+using System;
+using NUnit.Framework;
+using UnityEngine.UIElements;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Regression coverage for the state-ghosting class <see cref="ButtonChildPoolReuseTests"/> and
+    /// <see cref="LabelChildPoolReuseTests"/> pin, on the three poolable composites. <c>V.Custom&lt;Toggle&gt;</c>
+    /// (and the Slider / TextField spellings) expand their children into the very container the control built
+    /// its own input into, and the pool return detached nothing — so the next rent handed the leftover child
+    /// back on top of the fresh content. Emptying that container is not the fix, because it would take the
+    /// control's own structure with it.
+    /// <para>
+    /// Each case asserts the rented instance alongside what it holds: a rent that returned a DIFFERENT control
+    /// holds only its own input for a reason that has nothing to do with the reset, so the child term alone
+    /// would pass on a mechanism that never ran. The surviving child is compared by reference to the input the
+    /// constructor made, which is what separates the fix from a <c>Clear()</c> that deletes it.
+    /// </para>
+    /// <para>
+    /// The foreign child is inserted at the FRONT, which is where the reconciler was measured to place it: a
+    /// fresh control's own sub-element is the container's only child and the expansion writes into slot 0.
+    /// The pools are process-wide, so a children-bearing control left in one breaks whatever runs next — hence
+    /// the clear on both sides of every case here.
+    /// </para>
+    /// GWT, one assert per case.
+    /// </summary>
+    [TestFixture]
+    internal sealed class CompositeFieldChildPoolReuseTests
+    {
+        [SetUp]
+        public void SetUp() => ClearPools();
+
+        [TearDown]
+        public void TearDown() => ClearPools();
+
+        private static void ClearPools()
+        {
+            VNodePoolTestAccess.ClearTogglePoolForTest();
+            VNodePoolTestAccess.ClearSliderPoolForTest();
+            VNodePoolTestAccess.ClearTextFieldPoolForTest();
+            VNodePoolTestAccess.ClearLabelPoolForTest();
+        }
+
+        [Test]
+        public void Given_AToggleCarryingAForeignChild_When_ItIsRentedBackFromThePool_Then_ItHoldsOnlyItsOwnInput()
+        {
+            // Arrange — a Toggle that still holds a foreign child, as a removed V.Custom<Toggle> subtree does
+            // on its way to the pool (its descendants are resource-cleaned but not detached).
+            var returned = new Toggle();
+            var ownInput = returned.ElementAt(0);
+            returned.Insert(0, new Label("stale"));
+            VNodePool.ReturnToggle(returned);
+
+            // Act — a toggle is rented back.
+            var rented = VNodePool.RentToggle();
+
+            // Assert — it is the very instance that went in, and the one child it holds is the input its
+            // constructor made, so a fresh child reconcile appends onto nothing and the control survives.
+            Assert.That(
+                (ReferenceEquals(rented, returned), rented.childCount, ReferenceEquals(rented.ElementAt(0), ownInput)),
+                Is.EqualTo((true, 1, true)));
+        }
+
+        [Test]
+        public void Given_ASliderCarryingAForeignChild_When_ItIsRentedBackFromThePool_Then_ItHoldsOnlyItsOwnInput()
+        {
+            // Arrange — a Slider that still holds a foreign child.
+            var returned = new Slider();
+            var ownInput = returned.ElementAt(0);
+            returned.Insert(0, new Label("stale"));
+            VNodePool.ReturnSlider(returned);
+
+            // Act — a slider is rented back.
+            var rented = VNodePool.RentSlider();
+
+            // Assert — same instance, and only the dragger container its constructor made.
+            Assert.That(
+                (ReferenceEquals(rented, returned), rented.childCount, ReferenceEquals(rented.ElementAt(0), ownInput)),
+                Is.EqualTo((true, 1, true)));
+        }
+
+        [Test]
+        public void Given_ATextFieldCarryingAForeignChild_When_ItIsRentedBackFromThePool_Then_ItHoldsOnlyItsOwnInput()
+        {
+            // Arrange — a TextField that still holds a foreign child.
+            var returned = new TextField();
+            var ownInput = returned.ElementAt(0);
+            returned.Insert(0, new Label("stale"));
+            VNodePool.ReturnTextField(returned);
+
+            // Act — a text field is rented back.
+            var rented = VNodePool.RentTextField();
+
+            // Assert — same instance, and only the text input its constructor made.
+            Assert.That(
+                (ReferenceEquals(rented, returned), rented.childCount, ReferenceEquals(rented.ElementAt(0), ownInput)),
+                Is.EqualTo((true, 1, true)));
+        }
+
+        [Test]
+        public void Given_ACustomToggleDeclaringAChild_When_ItMounts_Then_TheChildTakesTheSlotAheadOfTheControlsOwnInput()
+        {
+            // Arrange / Act — a V.Custom<Toggle> declaring one child is mounted.
+            var root = new VisualElement();
+            using var mounted = V.Mount(root,
+                V.Custom<Toggle>(name: "host", children: new VNode[] { V.Label(name: "stale", text: "stale") }));
+            var host = root.Q<Toggle>("host");
+
+            // Assert — the expanded child takes slot 0, ahead of the input the constructor left there. This is
+            // why the reset identifies the control's own children instead of trimming a count from an end.
+            Assert.That(host.ElementAt(0).name, Is.EqualTo("stale"));
+        }
+
+        // Integration: a V.Custom<Toggle> subtree unmounts, then a plain V.Toggle rents its element back.
+
+        private readonly record struct PhaseState(int Phase);
+
+        private sealed class PhaseStore : Store<PhaseState>
+        {
+            public PhaseStore() : base(new PhaseState(0)) { }
+            public void Set(int phase) => SetState(_ => new PhaseState(phase));
+            protected override void ResetCore() => SetState(_ => new PhaseState(0));
+        }
+
+        private static PhaseStore s_store;
+
+        // Phase 0 mounts a Toggle carrying a child; phase 1 unmounts it (its pooling opportunity); phase 2
+        // mounts a plain V.Toggle, which rents from the pool.
+        [Component]
+        private static VNode Screen()
+        {
+            var phase = Hooks.UseStore(s_store, s => s.Phase);
+            return V.Div(name: "screen", children: phase switch
+            {
+                0 => new VNode[]
+                {
+                    V.Custom<Toggle>(name: "host", children: new VNode[] { V.Label(name: "stale", text: "stale") }),
+                },
+                1 => Array.Empty<VNode>(),
+                _ => new VNode[] { V.Toggle(name: "plain") },
+            });
+        }
+
+        [Test]
+        public void Given_AChildBearingToggleWasUnmounted_When_APlainToggleMounts_Then_TheRecycledElementCarriesNoLeftoverChild()
+        {
+            // Arrange — mount the child-bearing Toggle, then unmount it so it hits the pool-return path.
+            using var store = new PhaseStore();
+            s_store = store;
+            var root = new VisualElement();
+            using var mounted = V.Mount(root, V.Component(Screen, key: "screen"));
+            var scheduler = mounted.GetSchedulerForTest();
+            var host = root.Q<Toggle>("host");
+            var ownInput = host.Q<VisualElement>(className: BaseField<bool>.inputUssClassName);
+            Assume.That(host.childCount, Is.EqualTo(2), "Precondition: the custom Toggle mounts with its child beside its own input");
+            store.Set(1);
+            scheduler.DrainImmediateForTest();
+
+            // Act — a plain toggle mounts, renting from the pool.
+            store.Set(2);
+            scheduler.DrainImmediateForTest();
+
+            // Assert — the plain toggle is the recycled instance and shows nothing but its own input. The
+            // identity term is asserted with the rest because a rent that missed the pool holds only its own
+            // input whether or not the reset detaches anything.
+            var plain = root.Q<Toggle>("plain");
+            Assert.That(
+                (ReferenceEquals(plain, host), plain.childCount, ReferenceEquals(plain.ElementAt(0), ownInput)),
+                Is.EqualTo((true, 1, true)));
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/CompositeFieldChildPoolReuseTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/CompositeFieldChildPoolReuseTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4369ec9994d6f4c90b27fdb3939d87a2

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/LabelChildPoolReuseTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/LabelChildPoolReuseTests.cs
@@ -123,6 +123,12 @@ namespace Velvet.Tests
     /// is the element itself), so the same call would delete the control's own structure. This fails if a
     /// UI Toolkit version changes those baselines, which is what makes it safe for
     /// <c>FiberPrimitiveElementPool</c> to treat the five differently.
+    /// <para>
+    /// The second case pins the classification the three composites' reset depends on in place of a count:
+    /// the field's input and label USS classes identify what the constructor left, which is what lets the
+    /// reset keep it while detaching a <c>V.Custom&lt;T&gt;</c> child. Why a count will not do is pinned next
+    /// to the reset itself, in <see cref="CompositeFieldChildPoolReuseTests"/>.
+    /// </para>
     /// </summary>
     [TestFixture]
     internal sealed class PoolableWidgetChildBaselineTests
@@ -141,6 +147,36 @@ namespace Velvet.Tests
 
             // Assert — the two clearable types start empty; the three composites do not.
             Assert.That(counts, Is.EqualTo(new[] { 0, 0, 1, 1, 1 }));
+        }
+
+        [Test]
+        public void Given_LabelledComposites_When_TheirOwnChildrenAreClassified_Then_TheFieldInputAndLabelClassesIdentifyEveryOne()
+        {
+            // Arrange — each composite constructed WITH a label, the shape that holds both sub-elements, paired
+            // with the input / label class its own BaseField specialisation declares.
+            var widgets = new (VisualElement Widget, string Input, string Label)[]
+            {
+                (new Toggle("l"), BaseField<bool>.inputUssClassName, BaseField<bool>.labelUssClassName),
+                (new Slider("l", 0f, 10f), BaseField<float>.inputUssClassName, BaseField<float>.labelUssClassName),
+                (new TextField("l"), BaseField<string>.inputUssClassName, BaseField<string>.labelUssClassName),
+            };
+
+            // Act — count, per widget, how many of the children it holds carry one of those two classes.
+            var summary = Array.ConvertAll(widgets, w =>
+            {
+                var container = FiberNodePatcher.GetChildContainer(w.Widget);
+                var identified = 0;
+                for (var i = 0; i < container.childCount; i++)
+                {
+                    var child = container.ElementAt(i);
+                    if (child.ClassListContains(w.Input) || child.ClassListContains(w.Label)) identified++;
+                }
+                return $"{w.Widget.GetType().Name} {identified}/{container.childCount}";
+            });
+
+            // Assert — the two classes account for every child the constructors leave, which is what lets the
+            // pool reset detach a V.Custom child by exclusion instead of emptying the container.
+            Assert.That(string.Join(",", summary), Is.EqualTo("Toggle 2/2,Slider 2/2,TextField 2/2"));
         }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/LabelChildPoolReuseTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/LabelChildPoolReuseTests.cs
@@ -125,9 +125,10 @@ namespace Velvet.Tests
     /// <c>FiberPrimitiveElementPool</c> to treat the five differently.
     /// <para>
     /// The second case pins the classification the three composites' reset depends on in place of a count:
-    /// the field's input and label USS classes identify what the constructor left, which is what lets the
-    /// reset keep it while detaching a <c>V.Custom&lt;T&gt;</c> child. Why a count will not do is pinned next
-    /// to the reset itself, in <see cref="CompositeFieldChildPoolReuseTests"/>.
+    /// the field's input and label USS classes identify what the constructor left, in the unlabelled and the
+    /// labelled shape alike, which is what lets the reset keep it while detaching a
+    /// <c>V.Custom&lt;T&gt;</c> child. Why a count will not do is pinned next to the reset itself, in
+    /// <see cref="CompositeFieldChildPoolReuseTests"/>.
     /// </para>
     /// </summary>
     [TestFixture]
@@ -150,12 +151,16 @@ namespace Velvet.Tests
         }
 
         [Test]
-        public void Given_LabelledComposites_When_TheirOwnChildrenAreClassified_Then_TheFieldInputAndLabelClassesIdentifyEveryOne()
+        public void Given_Composites_When_TheirOwnChildrenAreClassified_Then_TheFieldInputAndLabelClassesIdentifyEveryOne()
         {
-            // Arrange — each composite constructed WITH a label, the shape that holds both sub-elements, paired
-            // with the input / label class its own BaseField specialisation declares.
+            // Arrange — each composite in both shapes the reset can meet, unlabelled and labelled, paired with
+            // the input / label class its own BaseField specialisation declares. A label is added and removed
+            // after construction, so both shapes have to classify.
             var widgets = new (VisualElement Widget, string Input, string Label)[]
             {
+                (new Toggle(), BaseField<bool>.inputUssClassName, BaseField<bool>.labelUssClassName),
+                (new Slider(), BaseField<float>.inputUssClassName, BaseField<float>.labelUssClassName),
+                (new TextField(), BaseField<string>.inputUssClassName, BaseField<string>.labelUssClassName),
                 (new Toggle("l"), BaseField<bool>.inputUssClassName, BaseField<bool>.labelUssClassName),
                 (new Slider("l", 0f, 10f), BaseField<float>.inputUssClassName, BaseField<float>.labelUssClassName),
                 (new TextField("l"), BaseField<string>.inputUssClassName, BaseField<string>.labelUssClassName),
@@ -174,9 +179,11 @@ namespace Velvet.Tests
                 return $"{w.Widget.GetType().Name} {identified}/{container.childCount}";
             });
 
-            // Assert — the two classes account for every child the constructors leave, which is what lets the
-            // pool reset detach a V.Custom child by exclusion instead of emptying the container.
-            Assert.That(string.Join(",", summary), Is.EqualTo("Toggle 2/2,Slider 2/2,TextField 2/2"));
+            // Assert — the two classes account for every child the constructors leave, in both shapes, which
+            // is what lets the pool reset detach a V.Custom child by exclusion instead of emptying the
+            // container.
+            Assert.That(string.Join(",", summary), Is.EqualTo(
+                "Toggle 1/1,Slider 1/1,TextField 1/1,Toggle 2/2,Slider 2/2,TextField 2/2"));
         }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Styling/StyleRelationalVariantManipulator.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleRelationalVariantManipulator.cs
@@ -276,7 +276,7 @@ namespace Velvet
 
                 _signals ??= new RelationalVariantSignals(OnSignal);
                 // registerChecked only for peer (group has no checked state). seedChecked reflects an
-                // already-checked peer Toggle immediately (the slot was cleared above, so no double-apply).
+                // already-checked peer immediately (the slot was cleared above, so no double-apply).
                 _signals.Hook(source, seedChecked: _payloads[checkedSlot].Length > 0, registerChecked: _isPeer);
             }
 

--- a/Packages/com.velvet.core/Runtime/Styling/StyleRelationalVariantManipulator.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleRelationalVariantManipulator.cs
@@ -39,7 +39,7 @@ namespace Velvet
     // (focus-within semantics) since group/peer sources are commonly containers or inputs. Sources are
     // resolved on AttachToPanelEvent. Lifecycle mirrors the other variant manipulators
     // (ReconcilerContext.RelationalVariantManipulators).
-    internal sealed class StyleRelationalVariantManipulator : Manipulator
+    internal sealed class StyleRelationalVariantManipulator : Manipulator, IRelationalSettleTarget
     {
         internal const string GroupClass = "group";
         internal const string PeerClass = "peer";
@@ -128,6 +128,16 @@ namespace Velvet
             foreach (var b in _bindings)
             {
                 b.Unhook();
+            }
+        }
+
+        // Forwards a controlled write's synthetic checked edge to each binding; a binding that hooked a
+        // different source, or none, drops it (RelationalVariantSignals.SettleChecked).
+        public void SettleCheckedFromSource(VisualElement source, bool value)
+        {
+            foreach (var b in _bindings)
+            {
+                b.SettleChecked(source, value);
             }
         }
 
@@ -273,6 +283,11 @@ namespace Velvet
             public void Unhook()
             {
                 _signals?.Unhook();
+            }
+
+            public void SettleChecked(VisualElement source, bool value)
+            {
+                _signals?.SettleChecked(source, value);
             }
 
             public void ResetApplied()

--- a/Packages/com.velvet.core/Runtime/Styling/StyleStackedVariantManipulator.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleStackedVariantManipulator.cs
@@ -20,7 +20,7 @@ namespace Velvet
     // top-level manipulator uses, but applies nothing until the outer gate opens. The leaf itself may STILL be
     // a variant (dark:hover:focus:...): StyleVariantPayload.Apply recurses, spawning a further stacked
     // manipulator gated by THIS one's combined state.
-    internal sealed class StyleStackedVariantManipulator : Manipulator, IVariantSettleTarget
+    internal sealed class StyleStackedVariantManipulator : Manipulator, IVariantSettleTarget, IRelationalSettleTarget
     {
         private readonly ReconcilerContext _ctx;
         private readonly StyleVariantKind _innerKind;
@@ -109,6 +109,12 @@ namespace Velvet
 
         // Forwards a controlled write's synthetic checked edge (see ElementLocalVariantSignals.SettleChecked).
         public void SettleChecked(bool value) => _elementSignals?.SettleChecked(value);
+
+        // The peer-checked inner's half of the same edge, arriving from the written SOURCE rather than from
+        // this manipulator's own target (see RelationalVariantSignals.SettleChecked). A non-relational inner
+        // has no signals instance, so the null-conditional is the whole guard.
+        public void SettleCheckedFromSource(VisualElement source, bool value)
+            => _relSignals?.SettleChecked(source, value);
 
         protected override void RegisterCallbacksOnTarget()
         {

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/PeerCheckedControlledValuePanelTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/PeerCheckedControlledValuePanelTests.cs
@@ -1,0 +1,137 @@
+using NUnit.Framework;
+using UnityEngine.UIElements;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Regression coverage for <c>peer-checked:</c> tracking a peer whose value arrives through a fully
+    /// controlled prop. <c>SetValueWithoutNotify</c> raises no <c>ChangeEvent</c>, which is what the relational
+    /// binding listens for, so the ordinary React shape — the owner holding the peer's state — left the
+    /// consuming child's payload behind. The element-local <c>checked:</c> half of the same suppression is
+    /// covered by <see cref="CheckedVariantBehaviorTests"/>; what the relational family adds is that the
+    /// consumer is a different element from the one written, so the edge has to travel from the source to
+    /// whoever resolved to it.
+    /// <para>
+    /// Both the plain binding and the stacked relational inner (<c>dark:peer-checked:</c>) are driven, because
+    /// they hold separate subscriptions to the same source. A real panel is required: a relational binding
+    /// resolves its source only once attached.
+    /// </para>
+    /// <para>
+    /// Each case asserts the payload beside the peer's own value and its state before the write: a controlled
+    /// write that never landed would make an absent payload correct, and a payload already applied would make
+    /// the final term true with the write under test doing nothing. GWT, one assert per case.
+    /// </para>
+    /// </summary>
+    [TestFixture]
+    internal sealed class PeerCheckedControlledValuePanelTests : PanelTestBase
+    {
+        private readonly record struct PeerState(bool Checked);
+
+        private sealed class PeerStore : Store<PeerState>
+        {
+            public PeerStore(bool initial) : base(new PeerState(initial)) { }
+            public void Set(bool value) => SetState(_ => new PeerState(value));
+            protected override void ResetCore() => SetState(_ => new PeerState(false));
+        }
+
+        private static PeerStore s_store;
+        private static string s_childClass;
+        private bool _darkBefore;
+
+        public override void SetUp()
+        {
+            base.SetUp();
+            _darkBefore = VelvetTheme.IsDark;
+            VelvetTheme.IsDark = false;
+        }
+
+        public override void TearDown()
+        {
+            VelvetTheme.IsDark = _darkBefore;
+            // After the base teardown: the store outlives the tree that subscribes to it, so it is released
+            // once the mount that reads it is gone.
+            base.TearDown();
+            s_store?.Dispose();
+            s_store = null;
+        }
+
+        // The peer's checked state is owned by the store, so a re-render writes it into the control through
+        // the controlled-value prop rather than through any interaction.
+        [Component]
+        private static VNode Screen()
+        {
+            var isChecked = Hooks.UseStore(s_store, s => s.Checked);
+            return V.Div(
+                "container",
+                V.Toggle(name: "peer", className: "peer", value: isChecked),
+                V.Label(name: "child", className: s_childClass));
+        }
+
+        private (Toggle Peer, Label Child) Mount(bool initial, string childClass)
+        {
+            s_store = new PeerStore(initial);
+            s_childClass = childClass;
+            _mounted = V.Mount(_window.rootVisualElement, V.Component(Screen, key: "screen"));
+            return (_window.rootVisualElement.Q<Toggle>("peer"), _window.rootVisualElement.Q<Label>("child"));
+        }
+
+        private void Rerender(bool value)
+        {
+            s_store.Set(value);
+            _mounted.GetSchedulerForTest().DrainImmediateForTest();
+        }
+
+        [Test]
+        public void Given_APeerCheckedChild_When_ThePeersValueArrivesThroughAControlledProp_Then_ThePayloadApplied()
+        {
+            // Arrange — a peer-checked child preceded by a controlled `peer` Toggle rendered unchecked.
+            var (peer, child) = Mount(initial: false, childClass: "peer-checked:bg-on");
+            var beforeTheControlledWrite = child.ClassListContains("bg-on");
+
+            // Act — the owner re-renders with the peer's value flipped; no interaction, so the control is
+            // written without notification.
+            Rerender(true);
+
+            // Assert — the peer took the value and the consuming child's payload followed it.
+            Assert.That(
+                (beforeTheControlledWrite, peer.value, child.ClassListContains("bg-on")),
+                Is.EqualTo((false, true, true)));
+        }
+
+        [Test]
+        public void Given_APeerCheckedPayloadApplied_When_AControlledPropUnchecksThePeer_Then_ThePayloadRemoved()
+        {
+            // Arrange — the same pair rendered checked, so the child's payload is seeded on at mount.
+            var (peer, child) = Mount(initial: true, childClass: "peer-checked:bg-on");
+            var beforeTheControlledWrite = child.ClassListContains("bg-on");
+
+            // Act — the owner re-renders with the peer's value flipped back.
+            Rerender(false);
+
+            // Assert — the payload clears with the value it tracks.
+            Assert.That(
+                (beforeTheControlledWrite, peer.value, child.ClassListContains("bg-on")),
+                Is.EqualTo((true, false, false)));
+        }
+
+        [Test]
+        public void Given_ADarkPeerCheckedChildWithDarkOn_When_ThePeersValueArrivesThroughAControlledProp_Then_TheLeafIsApplied()
+        {
+            // Arrange — dark:peer-checked:bg-on over a controlled `peer` Toggle rendered unchecked. Opening
+            // the dark gate is what builds the inner and resolves it against the peer.
+            var (peer, child) = Mount(initial: false, childClass: "dark:peer-checked:bg-on");
+            VelvetTheme.IsDark = true;
+            var beforeTheControlledWrite = child.ClassListContains("bg-on");
+
+            // Act — the owner re-renders with the peer's value flipped.
+            Rerender(true);
+
+            // Assert — the stacked inner holds its own subscription to the same source, and it tracks the
+            // controlled write too.
+            Assert.That(
+                (beforeTheControlledWrite, peer.value, child.ClassListContains("bg-on")),
+                Is.EqualTo((false, true, true)));
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/PeerCheckedControlledValuePanelTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/PeerCheckedControlledValuePanelTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1df01329f90594c32a72ea5cc651bd0b

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/RelationalVariantPanelTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/RelationalVariantPanelTests.cs
@@ -339,6 +339,25 @@ namespace Velvet.Tests
         }
 
         [Test]
+        public void Given_APeerCheckedChild_When_ThePrecedingPeerIsARadioButtonMountedAlreadyChecked_Then_ThePayloadIsSeededAtMount()
+        {
+            // Arrange/Act — the same mount-time read with a RadioButton as the peer, which reports a bool
+            // without being a Toggle. Its change path already drives peer-checked:, so only the read was
+            // narrower than the registration beside it.
+            _mounted = V.Mount(_window.rootVisualElement, V.Div(
+                "container",
+                V.Custom<RadioButton>(name: "peer", className: "peer",
+                    props: new FiberElementProps { FieldValue = true }),
+                V.Label(name: "child", className: "peer-checked:bg-on")));
+            var peer = _window.rootVisualElement.Q<RadioButton>("peer");
+            var child = _window.rootVisualElement.Q<Label>("child");
+
+            // Assert — folded rather than assumed: a controlled value that never reached the peer would make
+            // the absent payload correct, so the seed is read beside the value it seeds from.
+            Assert.That((peer.value, child.ClassListContains("bg-on")), Is.EqualTo((true, true)));
+        }
+
+        [Test]
         public void Given_AChildConsumingBothGroupFocusAndFocusWithin_When_TheSourceGainsFocus_Then_TheFocusPayloadIsApplied()
         {
             // Arrange — a child consuming BOTH group-focus and group-focus-within on the same `group` source, so a

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/StackedVariantEdgeTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/StackedVariantEdgeTests.cs
@@ -353,6 +353,29 @@ namespace Velvet.Tests
             }
 
             [Test]
+            public void Given_DarkPeerCheckedChildWhosePeerIsARadioButtonAlreadyChecked_When_TheDarkGateOpens_Then_TheLeafIsApplied()
+            {
+                // Arrange — the same hook-time read with a RadioButton as the peer, which reports a bool
+                // without being a Toggle. The stacked inner reaches the same read as the plain binding, so it
+                // was narrower than its own change registration in the same way.
+                _mounted = V.Mount(_window.rootVisualElement, V.Div(
+                    "container",
+                    V.Custom<RadioButton>(name: "peer", className: "peer",
+                        props: new FiberElementProps { FieldValue = true }),
+                    V.Label(name: "child", className: "dark:peer-checked:bg-on")));
+                var peer = _window.rootVisualElement.Q<RadioButton>("peer");
+                var child = _window.rootVisualElement.Q<Label>("child");
+                Assume.That(child.ClassListContains("bg-on"), Is.False, "Precondition: the peer's state alone does not apply (light)");
+
+                // Act — the outer (dark) gate opens, which is what resolves and hooks the peer source.
+                VelvetTheme.IsDark = true;
+
+                // Assert — folded rather than assumed: a controlled value that never reached the peer would
+                // make the absent leaf correct, so the seed is read beside the value it seeds from.
+                Assert.That((peer.value, child.ClassListContains("bg-on")), Is.EqualTo((true, true)));
+            }
+
+            [Test]
             public void Given_DarkGroupFocusWithinChildWithDarkOn_When_TheGroupSourceGainsFocus_Then_TheLeafIsApplied()
             {
                 // Arrange — dark:group-focus-within:bg-on under a `group` ancestor, dark on.

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/StackedVariantEdgeTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/StackedVariantEdgeTests.cs
@@ -14,7 +14,9 @@ namespace Velvet.Tests
     /// pointer-vs-keyboard split for a <c>focus-visible</c> inner, the four inner kinds driven by something
     /// other than a pointer edge (<c>checked:</c> and <c>peer-checked:</c> by a change of checked state and
     /// by the hook-time read of a control mounted already checked, <c>checked:</c> also by a value written
-    /// through a controlled prop, <c>group-focus-within:</c> and
+    /// through a controlled prop — including the three-deep spelling whose leaf peels to a further variant,
+    /// where opening the checked gate registers another manipulator while the settle is still walking the
+    /// registry — <c>group-focus-within:</c> and
     /// <c>peer-focus-within:</c> by the source's bubbling focus), and
     /// the detach teardown that clears the leaf and releases the inner subscription. These pin the current
     /// behavior so a refactor of the manipulator preserves it. Element-local / dark-only cases run off panel
@@ -174,6 +176,36 @@ namespace Velvet.Tests
 
                 // Assert — folded rather than assumed: dark alone applying the leaf would make the second
                 // term true without the write under test having done anything.
+                Assert.That(
+                    (beforeTheControlledWrite, leaf.ClassListContains("bg-on")),
+                    Is.EqualTo((false, true)));
+            }
+
+            [Test]
+            public void Given_DarkCheckedToggleWhoseLeafIsItselfAVariant_When_ItsValueArrivesThroughAControlledProp_Then_TheInnermostLeafStillApplies()
+            {
+                // Arrange — dark:checked:hover:bg-on, whose leaf peels to a further variant, on a controlled
+                // Toggle rendered unchecked with dark on.
+                using var scope = new ReconcilerScope();
+                var renderedUnchecked = new VNode[]
+                {
+                    V.Toggle(name: "leaf", className: "dark:checked:hover:bg-on", value: false),
+                };
+                scope.Reconciler.Reconcile(scope.Root, System.Array.Empty<VNode>(), renderedUnchecked);
+                var leaf = scope.Root.Q<Toggle>("leaf");
+                VelvetTheme.IsDark = true;
+                var beforeTheControlledWrite = leaf.ClassListContains("bg-on");
+
+                // Act — the controlled write settles the checked gate, which registers the hover manipulator
+                // its leaf needs while the settle is still walking the registry; then hover opens that one.
+                scope.Reconciler.Reconcile(scope.Root, renderedUnchecked, new VNode[]
+                {
+                    V.Toggle(name: "leaf", className: "dark:checked:hover:bg-on", value: true),
+                });
+                using (var evt = PointerOverEvent.GetPooled()) leaf.SimulateEvent(evt);
+
+                // Assert — folded rather than assumed: a payload already applied before the write would make
+                // the second term true with neither gate having moved.
                 Assert.That(
                     (beforeTheControlledWrite, leaf.ClassListContains("bg-on")),
                     Is.EqualTo((false, true)));

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/VariantBehaviorTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/VariantBehaviorTests.cs
@@ -314,5 +314,19 @@ namespace Velvet.Tests
             // Assert
             Assert.IsTrue(leaf.ClassListContains("bg-hot"));
         }
+
+        [Test]
+        public void Given_RadioButtonMountedAlreadyChecked_When_Mounted_Then_PayloadAppliedOnAttach()
+        {
+            // Arrange / Act — the same attach-time read on a RadioButton, which reports a bool without being
+            // a Toggle. Its change path already drives checked:, so only the mount read was left out.
+            _mounted = V.Mount(_root, V.Custom<RadioButton>(
+                name: "leaf", className: "checked:bg-hot", props: new FiberElementProps { FieldValue = true }));
+            var leaf = _root.Q<RadioButton>("leaf");
+
+            // Assert — folded rather than assumed: a controlled value that never reached the control would
+            // make the payload correctly absent, so the seed has to be read beside the value it seeds from.
+            Assert.That((leaf.value, leaf.ClassListContains("bg-hot")), Is.EqualTo((true, true)));
+        }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Styling/VariantSignalSource.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/VariantSignalSource.cs
@@ -26,6 +26,16 @@ namespace Velvet
         void SettleChecked(bool value);
     }
 
+    // The synthetic-settle surface a relational (group-/peer-) variant consumer implements. Kept apart from
+    // IVariantSettleTarget because the two are keyed opposite ways: an element-local consumer is registered
+    // against the element that was written, while a relational one is registered against the element that
+    // CONSUMES the payload and only knows its source from the inside. So the source travels as an argument
+    // and each consumer answers for itself.
+    internal interface IRelationalSettleTarget
+    {
+        void SettleCheckedFromSource(VisualElement source, bool value);
+    }
+
     // Enumerates every registered element-local variant consumer for one element through the shared
     // settle surface, so the reconciler-side sweeps cannot drift on WHICH registries participate.
     internal static class VariantSettleSweep
@@ -40,15 +50,47 @@ namespace Velvet
             {
                 action(variant);
             }
-            if (ctx.StackedVariantManipulators.Count > 0)
+            foreach (var m in SnapshotStacked(ctx))
             {
-                foreach (var kv in ctx.StackedVariantManipulators)
+                if (m.target == element)
                 {
-                    if (kv.Key.target == element)
-                    {
-                        action(kv.Value);
-                    }
+                    action(m);
                 }
+            }
+        }
+
+        // The stacked registry is copied before either sweep walks it, never enumerated live: settling a
+        // consumer applies its payload, and a payload that is itself a variant re-enters
+        // ReconcilerContext.GateStackedVariant, which adds to or removes from this very dictionary. Walking it
+        // live threw "Collection was modified" out of the reconcile; StackedVariantEdgeTests pins the case.
+        // Selecting by the manipulator's own target rather than by its key's is the same set — the gate adds
+        // each manipulator to the element its key names.
+        private static StyleStackedVariantManipulator[] SnapshotStacked(ReconcilerContext ctx)
+        {
+            var count = ctx.StackedVariantManipulators.Count;
+            if (count == 0)
+            {
+                return Array.Empty<StyleStackedVariantManipulator>();
+            }
+            var snapshot = new StyleStackedVariantManipulator[count];
+            ctx.StackedVariantManipulators.Values.CopyTo(snapshot, 0);
+            return snapshot;
+        }
+
+        // Offers a checked settle raised on source to every relational consumer in the context. Both registries
+        // are keyed by the consuming element, so there is nothing to look the source up in; each consumer
+        // compares it against the source it hooked, which costs one reference comparison per binding and walks
+        // no part of the tree. The caller gates this on a bool control whose controlled value actually changed,
+        // which is what keeps the scan off the ordinary render path.
+        public static void SettleCheckedFromSource(VisualElement source, ReconcilerContext ctx, bool value)
+        {
+            foreach (var kv in ctx.RelationalVariantManipulators)
+            {
+                kv.Value.SettleCheckedFromSource(source, value);
+            }
+            foreach (var m in SnapshotStacked(ctx))
+            {
+                m.SettleCheckedFromSource(source, value);
             }
         }
     }
@@ -78,9 +120,11 @@ namespace Velvet
 
         // Registers the detection callbacks on target. When registerChecked is false the ChangeEvent path is
         // skipped entirely (a consumer that does not support a checked signal — e.g. the stacked inner gate —
-        // keeps the original registration footprint). When seedChecked is true and the target is an
-        // already-checked Toggle, the initial Checked edge is emitted here (ChangeEvent fires only on change,
-        // so a mounted-true value must be read at hook time).
+        // keeps the original registration footprint). When seedChecked is true and the target reports itself
+        // already checked, the initial Checked edge is emitted here (ChangeEvent fires only on change, so a
+        // mounted-true value must be read at hook time). The read admits every control that reports a bool,
+        // not only Toggle: the registration above is untyped, so a narrower read would disagree with the
+        // change path about which controls drive checked: — CheckedVariantBehaviorTests pins the case.
         public void Hook(VisualElement target, bool seedChecked, bool registerChecked)
         {
             _target = target;
@@ -98,7 +142,7 @@ namespace Velvet
             if (registerChecked)
             {
                 target.RegisterCallback<ChangeEvent<bool>>(OnCheckedChange);
-                if (seedChecked && target is Toggle toggle && toggle.value)
+                if (seedChecked && target is INotifyValueChanged<bool> { value: true })
                 {
                     _emit(VariantSignal.Checked, true);
                 }
@@ -294,8 +338,9 @@ namespace Velvet
         public RelationalVariantSignals(Action<RelationalVariantSignal, bool> emit) => _emit = emit;
 
         // Registers the detection callbacks on the source. registerChecked enables the peer-checked path
-        // (ChangeEvent + the initial already-checked Toggle read via seedChecked, since ChangeEvent fires only
-        // on change); group bindings and the stacked relational inner pass false.
+        // (ChangeEvent + the initial already-checked read via seedChecked, since ChangeEvent fires only on
+        // change); group bindings pass false. The seed reads any control reporting a bool, for the reason
+        // ElementLocalVariantSignals.Hook gives.
         public void Hook(VisualElement source, bool seedChecked, bool registerChecked)
         {
             _source = source;
@@ -381,6 +426,20 @@ namespace Velvet
                 return;
             }
             _emit(RelationalVariantSignal.Checked, evt.newValue);
+        }
+
+        // Observes a synthetic checked change on a source, raised by the writer of a value the control takes
+        // without notification (the element-local counterpart is ElementLocalVariantSignals.SettleChecked).
+        // The settle is offered to every relational consumer rather than to the ones registered against the
+        // written element, because no source-to-consumer index exists — so the element it was raised on is
+        // passed in and compared against the one THIS binding hooked, which is the same own-source filter
+        // OnChange applies to a bubbling event.
+        public void SettleChecked(VisualElement source, bool value)
+        {
+            if (_registerChecked && ReferenceEquals(_source, source))
+            {
+                _emit(RelationalVariantSignal.Checked, value);
+            }
         }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Styling/VariantSignalSource.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/VariantSignalSource.cs
@@ -356,7 +356,7 @@ namespace Velvet
             if (registerChecked)
             {
                 source.RegisterCallback<ChangeEvent<bool>>(OnChange);
-                if (seedChecked && source is Toggle toggle && toggle.value)
+                if (seedChecked && source is INotifyValueChanged<bool> { value: true })
                 {
                     _emit(RelationalVariantSignal.Checked, true);
                 }


### PR DESCRIPTION
Three defects around a control's structure and its value being somewhere the code did not assume, plus a crash found while fixing the third.

**`Toggle`, `Slider` and `TextField` carried `V.Custom<T>` children into the element pool.** All three build their own input into the very container children are expanded into, so the reset could not empty it the way the `Button` and `Label` resets do — that would delete the control. It detaches by exclusion instead: what the constructor left is identified by the field's own input and label USS classes, and everything else goes.

A count would not have done the job. The reconciler places an expanded child in the container's *first* slot, ahead of what the constructor left, so trimming from the tail deletes the input and trimming from the head deletes the child's neighbour. That placement is pinned beside the reset, and the classification beside the existing baseline pin. Both are mirrors of an engine fact and are stated as such rather than restated in a comment.

**`peer-checked:` did not track a peer whose value arrives through a fully-controlled prop.** `SetValueWithoutNotify` raises no `ChangeEvent`, and the fix that closed the element-local half does not transfer: the relational manipulators are keyed by the consuming element, so there is nothing to look the written source up in.

Building a source-to-consumer index was weighed and not taken. Each consumer already records the source it hooked, so the settle is offered to every relational consumer and each compares that record — one reference comparison per binding, no walk of the tree, no new state to keep correct across reorders and unmounts. The scan it adds is bounded by the manipulators in the context and runs only when a bool control's controlled value actually changed.

**`checked:` never seeded on a control that reports a bool without being a `Toggle`.** Both seed sites gated on `Toggle`; the change registration beside them never did, so the two disagreed about which controls drive the variant. The widening was measured against every type it admits rather than assumed safe: on a panel, a `RadioButton` and a `Foldout` each dispatch their own `ChangeEvent<bool>` targeting themselves and already lit `checked:` through it, so this removes a disagreement rather than opening a surface. A `Foldout` reports itself checked from its own constructor, so `checked:` on one now paints at mount with nobody having set a value — the CHANGELOG says so.

**A variant stacked three deep threw out of the operation settling its outer gate.** Settling a consumer applies its payload, and a payload that is itself a variant registers a further manipulator in the registry the settle was walking, ending the walk with `InvalidOperationException`. All three settles could reach it, not only the controlled write this branch is about: `dark:active:sm:bg-on` on a drag source or any of its ancestors threw on the drag release, and `dark:focus:sm:bg-on` on the focus revert a containment snap-back performs. Both sweeps now walk a copy.

Review found the peer seed widened on one site and not the other, with the comment above the second describing the first. Both now read any control reporting a bool, both spellings are covered, and the sibling comment that stated the narrower rule agrees with them.

`styling-variants.md`'s peer row pointed at the State row rather than restating what `checked:` reads; that row already said the control's own value however it arrived. There is no pooling guide for the first fix to touch.

Closes #513
Closes #524
Closes #525
