### PR TITLE
fix(velvet): drop the unread memo-cache surface and the unwritten loader-data stubs

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -14,7 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   child's live list without touching that array — so `[&>*]:font-mono` over a child that declares no
   variant of its own and whose own classes never change was lost for that element's whole life, while
   `[&>*]:uppercase` in the same markup appeared on the next render. Both now land from the child's next
-  render. Neither lands at mount for such a child, which is unchanged.
+  render, for a child rendered as an element; neither lands at mount for a child that declares no variant
+  of its own, which is unchanged. A `V.Text` child never gets either: the payload reaches its class list
+  and neither resolver ever reads it, at any render, so put the utility on a `V.Label` there.
 
 - A `UseTransition` slot's `isPending` now reports its own transition rather than whatever holds the
   Transition lane. Two cases showed a spinner after the work it described was over: a `startTransition`

--- a/Packages/com.velvet.core/Documentation~/styling-variants.md
+++ b/Packages/com.velvet.core/Documentation~/styling-variants.md
@@ -348,14 +348,18 @@ only from that child's next render. Do not lean on either outcome. Put the utili
 behind a variant the child declares itself.
 
 The font layer and the string axes fail it differently again. A paint that cannot resolve does not
-paint; these two resolve a whole family out of a class array and rewrite the element from it, so they
-would resolve *something*. The only array a container-driven child has of its own is its live class
-list, and a `font-[…]` or `leading-[…]` the child declared is deliberately kept off it — the resolver
-owns those — while the class channels above put utilities on it the child never declared. So both
-stand down there rather than replace what the child's own render got right with nothing left to put
-it back: `[&>*]:uppercase` over a `leading-[24px]` label leaves the label alone. From that child's
-next render on the two agree and both land — `[&>*]:font-mono` and `[&>*]:uppercase` alike. Mount is
-what neither reaches there, so a child that must carry the family or the transform on its first frame
+paint; these two resolve a whole family out of a class array and rewrite the element from it, so
+they would resolve *something*. Until that child's own next render there is no array of its own to
+resolve from: the payload's landing opens its record and that render fills it in. Before that the
+only array there is its live class list, and a `font-[…]` or `leading-[…]` the child declared is
+deliberately kept off it — the resolver owns those — while the class channels above put utilities
+on it the child never declared. So both stand down there rather than replace what the child's own
+render got right with nothing left to put it back: `[&>*]:uppercase` over a `leading-[24px]` label
+leaves the label alone. From that child's next render on the two agree and both land —
+`[&>*]:font-mono` and `[&>*]:uppercase` alike — for a child rendered as an element. A `V.Text`
+child is the exception: the payload reaches its class list and neither resolver ever reads it, at
+any render, so put the utility on a `V.Label` there. Mount is what neither reaches for a child
+that declares none, so a child that must carry the family or the transform on its first frame
 declares it itself, or declares a variant of its own — the same escape the paints take.
 
 ## Container queries — `@container`

--- a/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/RouterHooksTests.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/RouterHooksTests.cs
@@ -11,8 +11,9 @@ using Velvet.TestUtilities;
 namespace Velvet.Tests
 {
     /// <summary>
-    /// Specifies the contract of the router context hooks (<see cref="Hooks.UseParams"/> and
-    /// <see cref="Hooks.UseLocation"/>) reading from <see cref="RouterContext.Location"/>.
+    /// Specifies the contract of the router context hooks (<see cref="Hooks.UseParams"/>,
+    /// <see cref="Hooks.UseLocation"/> and <c>UseLoaderData</c>) reading from
+    /// <see cref="RouterContext.Location"/> and <see cref="RouterContext.LoaderData"/>.
     /// <list type="bullet">
     /// <item>Reading the router location without any <see cref="RouterContext.Location"/> Provider yields the
     /// context default: a null location, and therefore an empty parameter dictionary.</item>
@@ -20,6 +21,10 @@ namespace Velvet.Tests
     /// observes that exact location and its route parameters.</item>
     /// <item><see cref="Hooks.UseLocation"/> declares that null return, while <see cref="Hooks.UseParams"/>
     /// declares the empty dictionary it substitutes instead.</item>
+    /// <item>Loader data is read for the route matched at the reader's own Outlet depth: at a depth the
+    /// match list does not reach the default comes back even while the map holds entries, and at a nested
+    /// depth the answer is that depth's route rather than the outermost or the innermost. Reading it
+    /// through a real <c>Router</c> and a real Outlet is specified by <c>RoutingHooksTests</c>.</item>
     /// </list>
     /// </summary>
     /// <remarks>
@@ -41,6 +46,7 @@ namespace Velvet.Tests
             _reconciler = new Reconciler();
             ParamsCapture.Reset();
             LocationCapture.Reset();
+            LoaderDataCapture.Reset();
         }
 
         [TearDown]
@@ -157,21 +163,78 @@ namespace Velvet.Tests
 
         #endregion
 
-        #region UseLoaderData (suspense-based; covered by Suspense integration)
+        #region UseLoaderData
 
-        // UseLoaderData<T> either returns T directly or throws FiberSuspendSignal, so its behavior is verified by
-        // Suspense integration tests. These ignored stubs keep the contract trackable in the Test Runner UI.
+        [Test]
+        public void Given_ADepthPastTheMatchedRoutes_When_Rendered_Then_LoaderDataIsDefault()
+        {
+            // Arrange — read at depth 1 from a location that matched nothing, with loader data present so
+            // an entry is there to be wrongly returned. The depth has to be supplied: the hook answers a
+            // depth of 0 before it ever looks at the match list, so a reader outside an Outlet would take
+            // that arm instead of this one whatever the list held.
+            var loaderData = new Dictionary<string, object> { { "route", "loaded" } };
 
-        [Test, Ignore("UseLoaderData uses a FiberSuspendSignal design verified by Suspense integration tests.")]
-        public void Given_LoaderDataAndMatch_When_Rendered_Then_ReturnsData() { }
+            // Act
+            using var mounted = V.Mount(_root, RouterProviders(
+                LocationMatching(),
+                loaderData,
+                depth: 1,
+                V.Component(LoaderDataCapture.Render)));
 
-        [Test, Ignore("UseLoaderData uses a FiberSuspendSignal design verified by Suspense integration tests.")]
-        public void Given_NoMatch_When_Rendered_Then_ReturnsDefault() { }
+            // Assert
+            Assert.That(LoaderDataCapture.LastData, Is.Null,
+                "No route matched at the reader's depth, so there is no key to read loader data by and the "
+                + "default is returned rather than an entry the map happens to hold");
+        }
 
-        [Test, Ignore("UseLoaderData uses a FiberSuspendSignal design verified by Suspense integration tests.")]
-        public void Given_NoProvider_When_Rendered_Then_ReturnsDefault() { }
+        [Test]
+        public void Given_LoaderDataForEveryMatch_When_ReadAtANestedDepth_Then_ReturnsThatDepthsRoute()
+        {
+            // Arrange — three matched routes, each with its own loader entry, read at depth 2. The three
+            // values differ so the answer separates this depth's route from the outermost and the innermost.
+            var loaderData = new Dictionary<string, object>
+            {
+                { "root", "root-data" },
+                { "middle", "middle-data" },
+                { "leaf", "leaf-data" },
+            };
+
+            // Act
+            using var mounted = V.Mount(_root, RouterProviders(
+                LocationMatching("root", "middle", "leaf"),
+                loaderData,
+                depth: 2,
+                V.Component(LoaderDataCapture.Render)));
+
+            // Assert
+            Assert.That(LoaderDataCapture.LastData, Is.EqualTo("middle-data"),
+                "Loader data is read for the route matched at the reader's own Outlet depth, not for the "
+                + "outermost or the innermost match");
+        }
 
         #endregion
+
+        // A location whose match list carries one entry per routeId, parent first.
+        private static RouterLocation LocationMatching(params string[] routeIds)
+            => new()
+            {
+                Path = "/" + string.Join("/", routeIds),
+                Params = new Dictionary<string, string>(),
+                Matches = Array.ConvertAll(routeIds, id => new RouteMatch { RouteId = id }),
+            };
+
+        // The three contexts an Outlet-rendered route reads loader data through. Depth is supplied
+        // directly because V.Outlet is what writes it, and an Outlet renders the route it matched — so a
+        // depth the match list does not reach cannot be arranged by mounting one.
+        private static VNode RouterProviders(
+            RouterLocation location, IReadOnlyDictionary<string, object> loaderData, int depth, VNode child)
+            => V.Provider(RouterContext.Location, location, new VNode[]
+            {
+                V.Provider(RouterContext.LoaderData, loaderData, new VNode[]
+                {
+                    V.Provider(RouterContext.Depth, depth, new[] { child }),
+                }),
+            });
 
         #region Capture components
 
@@ -187,6 +250,24 @@ namespace Velvet.Tests
                 var location = Hooks.UseContext(RouterContext.Location);
                 LastParams = location?.Params ?? new Dictionary<string, string>();
                 return V.Label(text: "params");
+            }
+        }
+
+        private static class LoaderDataCapture
+        {
+            // A non-null starting value, so a mount that never reached the component cannot satisfy an
+            // assertion that the hook returned the default.
+            public static string? LastData = Unrendered;
+
+            private const string Unrendered = "unrendered";
+
+            public static void Reset() => LastData = Unrendered;
+
+            [Component]
+            public static VNode Render()
+            {
+                LastData = Hooks.UseLoaderData<string>();
+                return V.Label(text: "loader-data");
             }
         }
 

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberMemoCache.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberMemoCache.cs
@@ -10,10 +10,7 @@ namespace Velvet
     {
         private readonly Dictionary<string, (object?[]? deps, MemoNode node, VNode cached)> _cache = new();
 
-        // Convenience overload for callers that don't need the cache-hit flags.
-        public VNode GetOrCompute(string cacheKey, MemoNode memo) => GetOrComputeWithHitInfo(cacheKey, memo).result;
-
-        public (VNode result, bool wasHit, VNode? previousCached) GetOrComputeWithHitInfo(string cacheKey, MemoNode memo)
+        public (VNode result, VNode? previousCached) GetOrCompute(string cacheKey, MemoNode memo)
         {
             VNode? previousCached = null;
             if (_cache.TryGetValue(cacheKey, out var entry))
@@ -28,7 +25,7 @@ namespace Velvet
                 if (ReferenceEquals(entry.node, memo)
                     || (memo.Dependencies != null && ObjectIs.AreEqualDeps(entry.deps, memo.Dependencies)))
                 {
-                    return (entry.cached, true, null);
+                    return (entry.cached, null);
                 }
                 previousCached = entry.cached;
             }
@@ -39,7 +36,7 @@ namespace Velvet
                 throw new InvalidOperationException("MemoNode.Factory returned null.");
             }
             _cache[cacheKey] = (memo.Dependencies, memo, result);
-            return (result, false, previousCached);
+            return (result, previousCached);
         }
 
         // Returns the currently cached inner VNode for cacheKey without invoking the

--- a/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
@@ -861,7 +861,7 @@ namespace Velvet
         {
             var innerPosition = FiberKeying.MemoInner(position, nodeIndex);
             var cacheKey = FiberKeying.MemoCacheKey(memo.Key, innerPosition.Scope!);
-            var (inner, _, previousCached) = _ctx.FiberMemoCache.GetOrComputeWithHitInfo(cacheKey, memo);
+            var (inner, previousCached) = _ctx.FiberMemoCache.GetOrCompute(cacheKey, memo);
             if (previousCached != null)
             {
                 // A deps change just replaced the cached inner tree. The memo wrapper is opaque to the


### PR DESCRIPTION
Three things in the tree described a state of affairs that was not the case.

**`FiberMemoCache` offered a `GetOrCompute` overload nothing called**, beside a `wasHit` element its one caller discarded. It now has a single method whose whole tuple is read by `GeneralPathReconciler.ExpandMemoInline`. `wasHit` was not derivable-and-discarded: a hit and a first miss both hand back a null previous entry, so nothing wanted the distinction and the tuple shrank rather than gaining a consumer.

**`RouterHooksTests` carried three empty cases ignored with a reason that named coverage which does not exist.** The reason said `UseLoaderData` is verified by the Suspense integration tests. `UseLoaderData` throws no `FiberSuspendSignal` — `Hooks.Use<T>` is the one hook that does — and no Suspense fixture reaches the hook at all; what a matched route delivers is pinned by `RoutingHooksTests`.

Of the three shapes, one had real content and it replaces them: loader data present, no matched route, the default returned rather than an entry the map happens to hold. The other two were dropped rather than written, and the reasons are worth stating. A matched route is already covered by that routing test, so writing it duplicates. The no-provider shape has no discriminating mutation — with no provider the context default is null too, so the guard's removal short-circuits and such a test would pin only "does not throw".

The replacement was cut twice. Deleting the null-route guard makes it fail on the sentinel the capture starts at; deleting the guard *and* returning the map's first entry — a hook that ignores which route matched — makes it fail on the value. Under that second cut the whole of `RoutingHooksTests` stayed green, so the existing routing coverage does not discriminate that defect.

These were the only `[Ignore]` in the package, so an EditMode run now reports no skips.

**A guide sentence and a CHANGELOG entry claimed a universal that a probe falsified.** Both said a `[&>*]:` font or text-effect payload lands from the child's next render. Measured on one container carrying `[&>*]:font-mono [&>*]:uppercase` over two children: the element child resolves both from its first patch, while a `V.Text` child carries the two classes on its live list and resolves neither — at mount, at its first patch, or at its second. Both now say which child they hold for and what to write instead. The CHANGELOG entry is lifted verbatim into a release note, so a universal that is false there is published.

That `V.Text` case is a silent no-op rather than a documented boundary — `[&>*]:bg-red-500` lands on the same child because it is a plain USS class — and is filed separately.

Closes #480
Closes #516
Closes #517
