### PR TITLE
test(velvet): fail a runtime member no shipped assembly calls

### DIFF
--- a/Packages/com.velvet.core/Runtime/Component/ComponentRegistry.cs
+++ b/Packages/com.velvet.core/Runtime/Component/ComponentRegistry.cs
@@ -352,11 +352,6 @@ namespace Velvet
             DisposeFiberInternal(fiber);
         }
 
-        // Returns the fiber bound to the given wrapper in O(1). Returns null if the wrapper
-        // is not registered (e.g. the parent VE of inline-mounted fibers).
-        internal ComponentFiber? TryGetFiberForWrapper(VisualElement wrapper)
-            => _wrapperIndex.TryGetValue(wrapper, out var fiber) ? fiber : null;
-
         // Inline-mounted lookup by tree-position key (parent fiber, position key, identity). Used by
         // the old-side walk in GeneralPathReconciler to read the previously rendered
         // ComponentFiber.PreviousTree without triggering a re-render.

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/ComponentStateReparityTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/ComponentStateReparityTests.cs
@@ -320,7 +320,7 @@ namespace Velvet.Tests
             }
             finally
             {
-                FiberPortalRegistry.Clear();
+                RuntimeStateProbe.ClearPortalRegistry();
             }
         }
 

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/PortalContextInheritanceTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/PortalContextInheritanceTests.cs
@@ -32,13 +32,13 @@ namespace Velvet.Tests
         {
             _root = new VisualElement();
             _portalTarget = new VisualElement();
-            FiberPortalRegistry.Clear();
+            RuntimeStateProbe.ClearPortalRegistry();
             FiberPortalRegistry.Register("ctx-portal-target", _portalTarget);
             s_lastSeen = null;
         }
 
         [TearDown]
-        public void TearDown() => FiberPortalRegistry.Clear();
+        public void TearDown() => RuntimeStateProbe.ClearPortalRegistry();
 
         private static string s_lastSeen;
         private static StateUpdater<int> s_setCount;

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/TestOnlyMemberConventionTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/TestOnlyMemberConventionTests.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
@@ -6,10 +8,18 @@ using NUnit.Framework;
 namespace Velvet.Tests
 {
     /// <summary>
-    /// Fails when a type or member whose name marks it as test-only reappears in the runtime assembly. Three
-    /// such batches have been removed: each was a drain or a probe only a test called, and leaving one in
-    /// place gives production code a seam to start leaning on, at which point removing it stops being a
-    /// refactor. The replacement is a reflection helper under <c>TestUtilities/</c>.
+    /// Fails when a type or member declares itself test-only in the runtime assembly — by its name, or by
+    /// saying so in its own comment. Three such batches have been removed: each was a drain or a probe only
+    /// a test called, and leaving one in place gives production code a seam to start leaning on, at which
+    /// point removing it stops being a refactor. The replacement is a reflection helper under
+    /// <c>TestUtilities/</c>.
+    /// <para>
+    /// Neither axis reaches a member that is test-only and says nothing about it. What would is the
+    /// property that actually matters — a member under <c>Runtime/</c> with no production caller — and the
+    /// call graph for it is reachable, since <c>Mono.Cecil</c> is a reference of this assembly. What that
+    /// needs first is a rule for the members reflection and domain-reload attributes reach, which have no
+    /// call site to find and are the bulk of what a first pass reports.
+    /// </para>
     /// </summary>
     [TestFixture]
     internal sealed class TestOnlyMemberConventionTests
@@ -44,6 +54,53 @@ namespace Velvet.Tests
             Assert.That(offenders, Is.Empty,
                 "Runtime declares test-only names; move each to a TestUtilities reflection helper:\n"
                 + string.Join("\n", offenders));
+        }
+
+        // "test-only" and "test only", in a comment of any kind, on the line above a declaration or on it.
+        // Wider than the two that were removed, because the phrase is what an author reaches for and the
+        // punctuation between the words is not.
+        private static readonly Regex TestOnlyProse =
+            new(@"(?i)\btest[- ]only\b", RegexOptions.Compiled);
+
+        private static readonly Regex Declaration =
+            new(@"^\s*(?:\[.*\]\s*)?(?:public|internal|private|protected)\s", RegexOptions.Compiled);
+
+        [Test]
+        public void Given_TheRuntimeSources_When_ScannedForTestOnlyProse_Then_NoDeclarationClaimsIt()
+        {
+            // Arrange — the compiled assembly cannot answer this: a comment is not in it.
+            var runtime = Path.GetFullPath("Packages/com.velvet.core/Runtime");
+            var sources = Directory.GetFiles(runtime, "*.cs", SearchOption.AllDirectories)
+                .Where(path => !path.Replace('\\', '/').Contains("/Tests/"))
+                .ToList();
+
+            // Act — a comment claims the declaration it precedes, so the match is reported with the line
+            // below it rather than on its own; a trailing comment claims its own line.
+            var offenders = new List<string>();
+            foreach (var path in sources)
+            {
+                var lines = File.ReadAllLines(path);
+                for (var index = 0; index < lines.Length; index++)
+                {
+                    if (!TestOnlyProse.IsMatch(lines[index]))
+                    {
+                        continue;
+                    }
+
+                    var declares = Declaration.IsMatch(lines[index])
+                        || lines.Skip(index + 1).Take(6).Any(line => Declaration.IsMatch(line));
+                    if (declares)
+                    {
+                        offenders.Add($"{Path.GetRelativePath(runtime, path).Replace('\\', '/')}:{index + 1}");
+                    }
+                }
+            }
+
+            // Assert — the source count rides along because an empty scan reports no offender either, and
+            // the offenders are joined rather than compared as lists, which NUnit would settle by reference.
+            Assert.That((sources.Count > 100, string.Join("\n", offenders)), Is.EqualTo((true, string.Empty)),
+                "a member that says it is test-only is one production can start leaning on; move it to a "
+                + "TestUtilities reflection helper");
         }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/UncalledRuntimeMemberTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/UncalledRuntimeMemberTests.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using NUnit.Framework;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Fails when an assembly-visible runtime method has no caller in the shipped assemblies, because the
+    /// only thing left that can reach it is a test — which is the seam CLAUDE.md forbids under
+    /// <c>Runtime/</c>, whatever the member is called and whether or not it admits to it.
+    /// <para>
+    /// This is the property <c>TestOnlyMemberConventionTests</c> approximates from two directions. Its name
+    /// axis catches a member called <c>*ForTest</c> and its prose axis one whose comment says so, and a
+    /// member that is neither walks past both. Nothing here reads a name or a comment.
+    /// </para>
+    /// <para>
+    /// Every exemption below is derived from the code rather than listed. A hand-kept list of "reached some
+    /// other way" would be the same mirror this fixture exists to replace, and would go stale in the
+    /// direction that passes.
+    /// </para>
+    /// </summary>
+    [TestFixture]
+    internal sealed class UncalledRuntimeMemberTests
+    {
+        // The engine calls these itself, so no call site exists to find. Matched on the attribute type's
+        // name so a Unity namespace move does not silently drop an exemption and fail an innocent member.
+        private static readonly string[] EngineInvokedAttributes =
+        {
+            "RuntimeInitializeOnLoadMethodAttribute",
+            "InitializeOnLoadMethodAttribute",
+            "InitializeOnEnterPlayModeAttribute",
+            "DidReloadScriptsAttribute",
+            "MenuItemAttribute",
+            "PreserveAttribute",
+        };
+
+        private static string ShippedAssembly(string name)
+        {
+            var directory = Path.GetDirectoryName(typeof(V).Assembly.Location)!;
+            return Path.Combine(directory, name + ".dll");
+        }
+
+        /// <summary>Every method any instruction in the shipped assemblies names, by its own definition.</summary>
+        /// <remarks>
+        /// Resolved to the element method because a generic call site carries its instantiation in
+        /// <c>FullName</c> and would never match the declaration — which is most of what a first pass
+        /// reports. A reference into another assembly resolves to null and is simply not ours.
+        /// </remarks>
+        private static HashSet<string> CalledMethods(IEnumerable<ModuleDefinition> modules)
+        {
+            var called = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var module in modules)
+            {
+                foreach (var method in module.GetTypes().SelectMany(type => type.Methods))
+                {
+                    if (!method.HasBody)
+                    {
+                        continue;
+                    }
+                    foreach (var instruction in method.Body.Instructions)
+                    {
+                        if (instruction.Operand is not MethodReference reference)
+                        {
+                            continue;
+                        }
+                        var definition = SafeResolve(reference);
+                        called.Add((definition ?? reference.GetElementMethod()).FullName);
+                    }
+                }
+            }
+            return called;
+        }
+
+        private static MethodDefinition? SafeResolve(MethodReference reference)
+        {
+            try
+            {
+                return reference.Resolve();
+            }
+            catch (AssemblyResolutionException)
+            {
+                return null;
+            }
+        }
+
+        /// <summary>Every string literal in the shipped assemblies, which is how a reflective call names its target.</summary>
+        private static HashSet<string> LiteralStrings(IEnumerable<ModuleDefinition> modules) =>
+            new(modules
+                    .SelectMany(module => module.GetTypes())
+                    .SelectMany(type => type.Methods)
+                    .Where(method => method.HasBody)
+                    .SelectMany(method => method.Body.Instructions)
+                    .Where(instruction => instruction.OpCode == OpCodes.Ldstr)
+                    .Select(instruction => (string)instruction.Operand),
+                StringComparer.Ordinal);
+
+        private static bool EngineInvoked(MethodDefinition method) =>
+            method.CustomAttributes.Any(attribute =>
+                EngineInvokedAttributes.Contains(attribute.AttributeType.Name, StringComparer.Ordinal));
+
+        private static bool Callable(MethodDefinition method) =>
+            // Public is library surface a consumer calls, and PublicApiSurfaceTests is what holds it honest.
+            // Private cannot be reached from a test assembly except by reflection, which is the sanctioned
+            // route. What is left is assembly-visible: reachable from a test because of InternalsVisibleTo,
+            // and from nothing else outside the package.
+            method.IsAssembly
+            && !method.IsConstructor
+            && !method.IsGetter && !method.IsSetter && !method.IsAddOn && !method.IsRemoveOn
+            // An override or an implementation is reached through the declaration it satisfies, and the
+            // call site names that one.
+            && !method.IsVirtual && !method.IsAbstract
+            && !method.HasOverrides;
+
+        [Test]
+        public void Given_TheShippedAssemblies_When_TheirCallGraphIsRead_Then_NoAssemblyVisibleMethodIsUnreachable()
+        {
+            // Arrange
+            using var runtime = ModuleDefinition.ReadModule(typeof(V).Assembly.Location);
+            using var editor = ModuleDefinition.ReadModule(ShippedAssembly("Velvet.Editor"));
+            var modules = new[] { runtime, editor };
+            var called = CalledMethods(modules);
+            var literals = LiteralStrings(modules);
+
+            // Act
+            var unreachable = runtime.GetTypes()
+                // A compiler-generated closure or state machine is named by its enclosing method's body and
+                // never declared by hand, so an unreachable one is a fact about the compiler.
+                .Where(type => !type.Name.Contains('<') && type.Namespace?.StartsWith("Velvet", StringComparison.Ordinal) == true)
+                .SelectMany(type => type.Methods)
+                .Where(Callable)
+                .Where(method => !called.Contains(method.FullName))
+                .Where(method => !EngineInvoked(method))
+                // A name spelled as a literal is how GetMethod finds its target; the call graph cannot see
+                // that edge, so the literal stands in for it.
+                .Where(method => !literals.Contains(method.Name))
+                .Select(method => $"{method.DeclaringType.FullName}.{method.Name}")
+                .Distinct()
+                .OrderBy(name => name, StringComparer.Ordinal)
+                .ToList();
+
+            // Assert — the call count rides along because an empty graph leaves everything unreachable and
+            // a graph that failed to load would report the opposite, and neither is this passing.
+            Assert.That((called.Count > 1000, string.Join("\n", unreachable)), Is.EqualTo((true, string.Empty)),
+                "nothing in the shipped assemblies calls these, so a test is the only thing that can; move "
+                + "each to a TestUtilities reflection helper");
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/UncalledRuntimeMemberTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/UncalledRuntimeMemberTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 125491d6405e64a519d1d644938c3578

--- a/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseAsyncTests.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseAsyncTests.cs
@@ -174,7 +174,7 @@ namespace Velvet.Tests
             resource.Start(ct => { capturedToken = ct; return source.Task; });
 
             // Act
-            resource.Cancel();
+            RuntimeStateProbe.CancelAsyncResource(resource);
 
             // Assert
             Assert.That(capturedToken.IsCancellationRequested, Is.True, "Cancel cancels the factory token");

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberAsyncResource.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberAsyncResource.cs
@@ -118,19 +118,6 @@ namespace Velvet
             OnCompleted?.Invoke();
         }
 
-        // Test-only API that cancels the CancellationToken. Production code should call only
-        // Dispose (Dispose performs cancel + token source release + OnCompleted clear).
-        // Intentionally excluded from the IFiberAsyncResource interface to prevent production flows
-        // (e.g. UseAsync) from accidentally calling Cancel alone and leaking the token source.
-        internal void Cancel()
-        {
-            if (_disposed) return;
-            if (!_cts.IsCancellationRequested)
-            {
-                _cts.Cancel();
-            }
-        }
-
         public void Dispose()
         {
             if (_disposed) return;

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodeFactory.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodeFactory.cs
@@ -768,30 +768,11 @@ namespace Velvet
                 }
             };
 
-        // Resolves the MotionNode that drives an AnimatePresence keyed entry's
-        // enter / exit lifecycle (Transition + OnEnterComplete). Walks transparent wrappers
-        // (ContextProviderNode, FragmentNode) via
-        // FindFirstMotionDescendant and emits a warning when no Motion is found so
-        // the keyed entry surfaces as a missing animation in logs. AnimatePresence mount and patch
-        // paths read both Transition and OnEnterComplete from the same resolved
-        // Motion, so this helper exists to fold the walk + warning into a single pass — callsites
-        // that read both fields would otherwise traverse the transparent-wrapper chain twice.
-        internal static MotionNode? ResolveAnimatePresenceMotion(VNode node)
-        {
-            var motion = FindFirstMotionDescendant(node);
-            if (motion == null && node != null && node is not TextNode)
-            {
-                FiberLogger.LogWarning("FiberNodeFactory",
-                    $"Non-MotionNode child ({node.GetType().Name}) has no transition. Use V.Motion() to wrap children for enter/exit animations.");
-            }
-            return motion;
-        }
-
         // Walks node and returns the first MotionNode descendant
         // reachable through transparent wrappers — ContextProviderNode, FragmentNode, and a z-managed
         // ElementNode. Returns the node itself when it is already a MotionNode, or
         // null when no MotionNode exists in this transparent-wrapper chain. Used by
-        // ResolveAnimatePresenceMotion and AnimatePresence's else-branch
+        // AnimatePresence's else-branch
         // (Initial=false) where no warning should be emitted — so a Provider-wrapped Motion
         // contributes its transition / OnEnterComplete to the keyed entry: AnimatePresence tracks
         // the outer wrapper element while transitions remain on the inner motion components.

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberPortalRegistry.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberPortalRegistry.cs
@@ -72,10 +72,5 @@ namespace Velvet
         /// <param name="id">Identifier to test. Null or empty values always return <c>false</c>.</param>
         /// <returns><c>true</c> when a target is currently registered for <paramref name="id"/>; otherwise <c>false</c>.</returns>
         public static bool IsRegistered(string id) => NameKeyedRegistry.IsRegistered(id, _targets);
-
-        /// <summary>
-        /// Test-only: clears all registrations.
-        /// </summary>
-        internal static void Clear() => _targets.Clear();
     }
 }

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/PortalTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/PortalTests.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 using UnityEngine.TestTools;
 using Velvet;
 using UnityEngine.UIElements;
+using Velvet.TestUtilities;
 
 namespace Velvet.Tests
 {
@@ -42,14 +43,14 @@ namespace Velvet.Tests
         {
             _reconciler = new Reconciler();
             _root = new VisualElement();
-            FiberPortalRegistry.Clear();
+            RuntimeStateProbe.ClearPortalRegistry();
         }
 
         [TearDown]
         public void TearDown()
         {
             _reconciler.Dispose();
-            FiberPortalRegistry.Clear();
+            RuntimeStateProbe.ClearPortalRegistry();
         }
 
         #region Rendering into the target

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ReconcilerAbortSafetyTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ReconcilerAbortSafetyTests.cs
@@ -215,7 +215,7 @@ namespace Velvet.Tests
         public void SetUp()
         {
             _root = new VisualElement();
-            FiberPortalRegistry.Clear();
+            RuntimeStateProbe.ClearPortalRegistry();
             s_fallbackShown = false;
             s_listCount = 3;
             s_portalAdded = false;
@@ -228,7 +228,7 @@ namespace Velvet.Tests
         [TearDown]
         public void TearDown()
         {
-            FiberPortalRegistry.Clear();
+            RuntimeStateProbe.ClearPortalRegistry();
         }
 
         [Test]

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/RenderedTreePropsRecycleTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/RenderedTreePropsRecycleTests.cs
@@ -61,7 +61,7 @@ namespace Velvet.Tests
         {
             _root = new VisualElement();
             _portalTarget = new VisualElement();
-            FiberPortalRegistry.Clear();
+            RuntimeStateProbe.ClearPortalRegistry();
             FiberPortalRegistry.Register("props-recycle-probe", _portalTarget);
             s_store = null;
             s_capturedMemoNode = null;
@@ -70,7 +70,7 @@ namespace Velvet.Tests
         [TearDown]
         public void TearDown()
         {
-            FiberPortalRegistry.Clear();
+            RuntimeStateProbe.ClearPortalRegistry();
         }
 
         #region depth: retired bags return from every nesting position

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/SamePanelPortalBubblingTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/SamePanelPortalBubblingTests.cs
@@ -53,7 +53,7 @@ namespace Velvet.Tests
         {
             base.SetUp();
             _reconciler = new Reconciler();
-            FiberPortalRegistry.Clear();
+            RuntimeStateProbe.ClearPortalRegistry();
 
             _root = new VisualElement();
             _window.rootVisualElement.Add(_root);
@@ -79,7 +79,7 @@ namespace Velvet.Tests
         public override void TearDown()
         {
             _reconciler.Dispose();
-            FiberPortalRegistry.Clear();
+            RuntimeStateProbe.ClearPortalRegistry();
             base.TearDown();
         }
 

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/TimeSlicedReconcilerTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/TimeSlicedReconcilerTests.cs
@@ -792,7 +792,7 @@ namespace Velvet.Tests
         {
             FiberWorkLoop.IsInDiscreteEvent = false;
             _root = new VisualElement();
-            FiberPortalRegistry.Clear();
+            RuntimeStateProbe.ClearPortalRegistry();
             ResetIndexedList();
             ResetKeyedList();
         }
@@ -801,7 +801,7 @@ namespace Velvet.Tests
         public void TearDown()
         {
             FiberWorkLoop.IsInDiscreteEvent = false;
-            FiberPortalRegistry.Clear();
+            RuntimeStateProbe.ClearPortalRegistry();
         }
 
         [Test]

--- a/Packages/com.velvet.core/Runtime/Styling/SkewSilhouette.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/SkewSilhouette.cs
@@ -95,11 +95,9 @@ namespace Velvet
     /// </remarks>
     internal static class SkewSilhouette
     {
-        // The suppression sentinel + bit-exact tests live in SilhouetteFace (shared with the drop-shadow layer);
-        // forwarded here so existing call-sites / tests keep reading them off SkewSilhouette.
+        // The suppression sentinel lives in SilhouetteFace, shared with the drop-shadow layer; forwarded
+        // here so a call site reads it off the layer it is working in.
         internal static Color SuppressedColor => SilhouetteFace.SuppressedColor;
-
-        internal static bool IsSentinel(Color c) => SilhouetteFace.IsSentinel(c);
 
         // Wires the paint + stash callbacks onto the element and returns the binding. The first stash
         // (capture the face colors, then suppress the native rect chrome) MUST land before the first paint:

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/SilhouetteBoundsSpacerTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/SilhouetteBoundsSpacerTests.cs
@@ -333,14 +333,14 @@ namespace Velvet.Tests
                 "Precondition: Unity's approximate == misreads this near color as the sentinel");
 
             // Act / Assert — the bit-exact test keeps it as a real color.
-            Assert.That(SkewSilhouette.IsSentinel(nearButReal), Is.False);
+            Assert.That(SilhouetteFace.IsSentinel(nearButReal), Is.False);
         }
 
         [Test]
         public void Given_TheExactSentinelColor_When_Tested_Then_ItIsTheSentinel()
         {
             // Arrange/Act/Assert — the real suppression write must still be recognized.
-            Assert.That(SkewSilhouette.IsSentinel(SkewSilhouette.SuppressedColor), Is.True);
+            Assert.That(SilhouetteFace.IsSentinel(SkewSilhouette.SuppressedColor), Is.True);
         }
     }
 }

--- a/Packages/com.velvet.core/TestUtilities/RuntimeStateProbe.cs
+++ b/Packages/com.velvet.core/TestUtilities/RuntimeStateProbe.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Reflection;
+
+namespace Velvet.TestUtilities
+{
+    /// <summary>
+    /// Reaches runtime state a test needs and production does not, so no seam for it is declared under
+    /// <c>Runtime/</c>. A member kept there for a test is one production code can start leaning on, at
+    /// which point removing it stops being a refactor — which is why
+    /// <c>TestOnlyMemberConventionTests</c> fails on one.
+    /// </summary>
+    public static class RuntimeStateProbe
+    {
+        private const BindingFlags AnyInstance =
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
+
+        private const BindingFlags AnyStatic =
+            BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic;
+
+        /// <summary>Cancels an async resource's token without releasing its source, as a consumer's own
+        /// cancellation does.</summary>
+        /// <remarks>
+        /// Production reaches this only through Dispose, which cancels, releases the source and clears the
+        /// completion callback together. Cancelling alone is the state a test needs to observe and the one
+        /// a production caller must not be able to reach, since it leaks the source.
+        /// </remarks>
+        public static void CancelAsyncResource(object resource)
+        {
+            if (resource == null) throw new ArgumentNullException(nameof(resource));
+            var field = Field(resource.GetType(), "_cts", AnyInstance);
+            var source = field.GetValue(resource);
+            var requested = (bool)Property(source.GetType(), "IsCancellationRequested").GetValue(source);
+            if (!requested)
+            {
+                Method(source.GetType(), "Cancel", Type.EmptyTypes).Invoke(source, null);
+            }
+        }
+
+        /// <summary>Empties the portal registry, which persists across mounts within a domain.</summary>
+        public static void ClearPortalRegistry()
+        {
+            var registry = typeof(V).Assembly.GetType("Velvet.FiberPortalRegistry", throwOnError: true);
+            var targets = Field(registry, "_targets", AnyStatic).GetValue(null);
+            Method(targets.GetType(), "Clear", Type.EmptyTypes).Invoke(targets, null);
+        }
+
+        // Each lookup reports the name it could not find rather than a NullReferenceException one frame
+        // later, because a rename here fails in a fixture's setup where the cause is least visible.
+        private static FieldInfo Field(Type type, string name, BindingFlags flags) =>
+            type.GetField(name, flags) ?? throw new MissingMemberException(type.FullName, name);
+
+        private static PropertyInfo Property(Type type, string name) =>
+            type.GetProperty(name, AnyInstance) ?? throw new MissingMemberException(type.FullName, name);
+
+        private static MethodInfo Method(Type type, string name, Type[] parameters) =>
+            type.GetMethod(name, AnyInstance | BindingFlags.Static, null, parameters, null)
+            ?? throw new MissingMemberException(type.FullName, name);
+    }
+}

--- a/Packages/com.velvet.core/TestUtilities/RuntimeStateProbe.cs.meta
+++ b/Packages/com.velvet.core/TestUtilities/RuntimeStateProbe.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 795e5ada0ea394089b6d8e9f0cdd7073


### PR DESCRIPTION
The existing guard reads names, so a member is caught when it is called `*ForTest` and walks past when it is called anything else. Widening it to the prose an author writes catches the honest case and leaves the same hole one word over: a member that is test-only and says nothing about it.

So the property itself is checked. `Mono.Cecil` is already a reference of this assembly, so the call graph of `Velvet` and `Velvet.Editor` is readable here — and an assembly-visible method nothing in either calls can be reached only from a test, which is the seam CLAUDE.md forbids under `Runtime/`.

**Every exemption is derived rather than listed**, because a list of "reached some other way" would be the same mirror this replaces, and would go stale in the direction that passes.

| exempt | derived from |
|---|---|
| the engine's own entry points | the attribute on the method |
| a reflective call | its target spelled as a string literal, standing in for the edge the graph cannot see |
| an override or implementation | reached through the declaration it satisfies, which is what the call site names |
| public API | library surface, held by `PublicApiSurfaceTests` |
| compiler-generated | the `<` in the type name |

A first pass reported 58, and both reasons it was wrong are in the code now. A generic call site carries its instantiation in `FullName` and never matches its declaration, so every generic method looked uncalled; and `Velvet.Editor` was not being read at all. Resolving each reference to its definition and scanning both leaves **three**.

All three were real.

- `ComponentRegistry.TryGetFiberForWrapper` and `FiberNodeFactory.ResolveAnimatePresenceMotion` have no caller anywhere — not in the package, not in its tests.
- `SkewSilhouette.IsSentinel` is called by one fixture and nothing else. Deleting it broke that fixture's build, which is the guard pointing at exactly what it exists for. The fixture now reads the sentinel off `SilhouetteFace`, which owns it and has production callers.

`FiberAsyncResource<T>.Cancel()` and `FiberPortalRegistry.Clear()` go the same way, into a `TestUtilities` probe. Both declared themselves test-only in their own comments and neither was caught by anything.

The name axis stays. It is cheaper than reading IL and it catches the intent before the member is written.

Closes #473
