### PR TITLE
fix(velvet): decide what each guard does with an operand the shell has not expanded

### DIFF
--- a/.claude/hooks/lib/shell_commands.py
+++ b/.claude/hooks/lib/shell_commands.py
@@ -211,3 +211,16 @@ def program_invocations(command, program, words):
             continue
         found.append(tokens[index + len(words):])
     return found
+
+
+# A hook is handed the command before the shell expands it, so an operand spelled with a variable or
+# a substitution is not the text the program will receive. A guard that resolves such an operand
+# answers about the literal, and every resolution of a literal fails — which for most guards is the
+# pass, so the check silently does not happen. Each guard states which way it errs there; this only
+# recognises the case.
+UNEXPANDED = re.compile(r"[$`]")
+
+
+def unexpanded(token):
+    """Whether the shell will rewrite this operand before the program sees it."""
+    return bool(UNEXPANDED.search(token))

--- a/.claude/hooks/refuse/blind_git_add.py
+++ b/.claude/hooks/refuse/blind_git_add.py
@@ -28,6 +28,12 @@ from shell_commands import git_invocations
 # path to git all passed as well. Quoting inside an argument is handled by the tokeniser, which is
 # what the anchor was there for: the first version of this guard refused its own first use, on a
 # pull request body that named the command in prose.
+# The sweeping form is recognised from the operand's own text — `-A`, `.` — and an unexpanded one is
+# not that text and cannot become it, since the shell substitutes a value rather than a flag. Nothing
+# is resolved here, so nothing goes unchecked.
+UNEXPANDED_POLICY = "allow"
+UNEXPANDED_PROBE = 'git add $FILES'
+
 SWEEPING = {"-A", "--all", "--no-ignore-removal", ".", ":/", "*"}
 
 

--- a/.claude/hooks/refuse/branch_from_unmerged.py
+++ b/.claude/hooks/refuse/branch_from_unmerged.py
@@ -106,6 +106,13 @@ def creations(command):
     return found
 
 
+# Resolving an unexpanded operand fails, and this already refuses on that failure — the right
+# direction for a guard over branch creation. What it used to print was the failure itself, as a
+# detached HEAD at an empty SHA, so the refusal named a repository state that was never true.
+UNEXPANDED_POLICY = "refuse"
+UNEXPANDED_PROBE = 'git -C "$D" branch feat/x'
+
+
 def git(cwd, *args):
     return subprocess.run(
         ["git", "-C", cwd, *args],

--- a/.claude/hooks/refuse/commit_failing_fast_checks.py
+++ b/.claude/hooks/refuse/commit_failing_fast_checks.py
@@ -19,7 +19,7 @@ import tempfile
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lib"))
-from shell_commands import git_invocations
+from shell_commands import git_invocations, unexpanded
 
 NEUTER_CUTS = "scripts/test_quality/neuter_cuts.json"
 
@@ -30,6 +30,13 @@ COMMIT_VALUE_FLAGS = {
     "-S", "--gpg-sign", "--trailer", "--pathspec-from-file",
 }
 COMMIT_ALL_FLAGS = {"-a", "--all"}
+
+
+# A pathspec the shell has not expanded names no file, so every check runs over nothing and the
+# commit records content none of them saw — the check silently not happening. Refusing errs the cheap
+# way here: a commit is remade in a second, and the alternative is a blob nothing looked at.
+UNEXPANDED_POLICY = "refuse"
+UNEXPANDED_PROBE = 'git commit -m x $PATHS'
 
 
 def git(cwd, *args):
@@ -289,6 +296,17 @@ def main():
 
     cwd = event.get("cwd") or "."
     for directory, commits_all, pathspecs in commits:
+        unresolved = [token for token in list(pathspecs) + ([directory] if directory else [])
+                      if unexpanded(token)]
+        if unresolved:
+            sys.stderr.write(
+                "Refusing `git commit`: it is scoped by an operand the shell has not expanded yet.\n\n"
+                + "\n".join("  " + token for token in unresolved)
+                + "\n\nEvery check below reads the content the commit would record, and a pathspec that "
+                  "is still a variable names no file — so they would all run over nothing and pass, "
+                  "and the commit would record content none of them saw.\n\n"
+                  "Name the paths, or commit the index and let the checks read that.\n")
+            return 2
         code = audit(directory or cwd, commits_all, pathspecs)
         if code:
             return code

--- a/.claude/hooks/refuse/edit_while_a_ready_pr_sits.py
+++ b/.claude/hooks/refuse/edit_while_a_ready_pr_sits.py
@@ -27,6 +27,10 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lib"))
 from deferrals import DEFERRALS, deferred
 
+# Held on Edit and Write, which carry a file path rather than a shell command, so there is no operand
+# for the shell to expand and nothing here reads one.
+UNEXPANDED_POLICY = "n/a"
+
 READY_STATE = Path.home() / ".velvet-pr-ready"
 HEARTBEAT = Path.home() / ".velvet-pr-watch.heartbeat"
 

--- a/.claude/hooks/refuse/merge_branch_held_by_worktree.py
+++ b/.claude/hooks/refuse/merge_branch_held_by_worktree.py
@@ -61,10 +61,14 @@ def branch_of(cwd, operands):
 
 
 def blocked(command, cwd):
-    """(branch, worktree path) for each merge whose branch a worktree holds."""
-    held = held_branches(cwd)
-    if not held:
-        return []
+    """(branch, worktree path) for each merge whose branch this cannot clear.
+
+    The unexpanded operand is answered before the worktree list is consulted. Returning early on an
+    empty list put the refusal behind "some worktree exists", so the policy held on a checkout that
+    happened to have one and lapsed on a runner that did not — which is the guard being exercised
+    only in the states its environment happens to be in.
+    """
+    held = None
     found = []
     for operands in program_invocations(command, "gh", ("pr", "merge")):
         named = [token for token in operands if not token.startswith("-")]
@@ -72,6 +76,8 @@ def blocked(command, cwd):
             found.append(("the branch named by an unexpanded operand",
                           "unreadable — resolve it, or name the pull request"))
             continue
+        if held is None:
+            held = held_branches(cwd)
         branch = branch_of(cwd, operands)
         if branch and branch in held:
             found.append((branch, held[branch]))

--- a/.claude/hooks/refuse/merge_branch_held_by_worktree.py
+++ b/.claude/hooks/refuse/merge_branch_held_by_worktree.py
@@ -21,7 +21,13 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lib"))
-from shell_commands import program_invocations
+from shell_commands import program_invocations, unexpanded
+
+
+# An operand the shell has not expanded yet resolves to nothing readable, and a merge guard errs
+# toward refusing: allowing means --delete-branch half-fails after the merge has already landed.
+UNEXPANDED_POLICY = "refuse"
+UNEXPANDED_PROBE = 'gh pr merge $PR --squash --delete-branch'
 
 
 def held_branches(cwd):
@@ -61,6 +67,11 @@ def blocked(command, cwd):
         return []
     found = []
     for operands in program_invocations(command, "gh", ("pr", "merge")):
+        named = [token for token in operands if not token.startswith("-")]
+        if any(unexpanded(token) for token in named):
+            found.append(("the branch named by an unexpanded operand",
+                          "unreadable — resolve it, or name the pull request"))
+            continue
         branch = branch_of(cwd, operands)
         if branch and branch in held:
             found.append((branch, held[branch]))

--- a/.claude/hooks/refuse/merge_unproven_head.py
+++ b/.claude/hooks/refuse/merge_unproven_head.py
@@ -27,9 +27,14 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lib"))
-from shell_commands import program_invocations
+from shell_commands import program_invocations, unexpanded
 
 TERMINAL_PASS = frozenset({"pass", "skipping"})
+
+# An operand the shell has not expanded yet resolves to nothing readable, and a merge guard errs
+# toward refusing: allowing means the branch lands with this check never having run.
+UNEXPANDED_POLICY = "refuse"
+UNEXPANDED_PROBE = 'gh pr merge $PR --squash --delete-branch'
 
 
 def gh_json(cwd, args):
@@ -51,6 +56,11 @@ def unproven(command, cwd):
     """(pull request, reason) for each merge whose head is not covered by its own passing checks."""
     found = []
     for operands in program_invocations(command, "gh", ("pr", "merge")):
+        named = [token for token in operands if not token.startswith("-")]
+        if any(unexpanded(token) for token in named):
+            found.append(("the pull request named",
+                          "an operand the shell has not expanded, so its checks cannot be read"))
+            continue
         number = next((token for token in operands if token.isdigit()), None)
         label = "#" + number if number else "the current branch"
 

--- a/.claude/hooks/refuse/merge_without_branch_deletion.py
+++ b/.claude/hooks/refuse/merge_without_branch_deletion.py
@@ -23,6 +23,11 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lib"))
 from shell_commands import program_invocations
 
+# The verdict is whether the command carries the flag, which is its own text. An operand the shell has
+# not expanded cannot add or remove one, so nothing is resolved and nothing goes unchecked.
+UNEXPANDED_POLICY = "allow"
+UNEXPANDED_PROBE = 'gh pr merge $PR --squash --delete-branch'
+
 DELETE_FLAGS = ("--delete-branch", "-d")
 
 

--- a/.claude/hooks/refuse/metadata_less_create.py
+++ b/.claude/hooks/refuse/metadata_less_create.py
@@ -48,6 +48,13 @@ def creations(command):
     return found
 
 
+# The verdict is whether the command carries --label and --assignee, which is its own text. The
+# repository is read only to list the labels the refusal offers, so an unexpanded operand costs a
+# less helpful message and never a missed check.
+UNEXPANDED_POLICY = "allow"
+UNEXPANDED_PROBE = 'gh issue create --title $T --label bug --assignee @me'
+
+
 def labels(cwd):
     listing = subprocess.run(
         ["gh", "label", "list", "--json", "name", "--jq", ".[].name"],

--- a/.claude/hooks/refuse/shared_git_state.py
+++ b/.claude/hooks/refuse/shared_git_state.py
@@ -21,7 +21,7 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lib"))
-from shell_commands import git_invocations
+from shell_commands import git_invocations, unexpanded
 
 # Registered on the event in .claude/settings.json rather than narrowed to the agents expected to
 # run git, which would leave every other session unguarded. `HookWiringCoverageTests` reads this
@@ -44,10 +44,11 @@ RESTORE_FLAGS = {
     "--overlay", "--no-overlay",
 }
 
-# A hook is handed the command before the shell expands it, so an operand spelled with a variable or
-# a substitution is not the text git will run. Resolving it below would answer about the literal and
-# answer no, which is the pass — so it takes the refusal without being resolved at all.
-UNEXPANDED = re.compile(r"[$`]")
+# Resolving an operand the shell has not expanded would answer about the literal and answer no, which
+# is the pass — so it takes the refusal without being resolved at all. Recognising the case is shared
+# with every other guard that resolves an operand; which way to err is each guard's own.
+UNEXPANDED_POLICY = "refuse"
+UNEXPANDED_PROBE = 'git checkout $BRANCH'
 
 # A glob is the other operand the shell rewrites, and it cannot take the same refusal: `git checkout
 # '*.cs'` is an ordinary restore, and refusing it is the over-refusal this guard was rewritten to
@@ -120,7 +121,7 @@ def restores_paths(directory, operands, cwd):
     if "--" in operands:
         return True
     named = [token for token in operands if not token.startswith("-")]
-    if not named or any(UNEXPANDED.search(token) for token in named):
+    if not named or any(unexpanded(token) for token in named):
         return False
     root = directory or cwd
     if directory and not os.path.isabs(directory):

--- a/.claude/hooks/refuse/stale_merge.py
+++ b/.claude/hooks/refuse/stale_merge.py
@@ -17,8 +17,16 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lib"))
-from shell_commands import program_invocations
+from shell_commands import program_invocations, unexpanded
 from velvet_hooks import BRANCH_BASES
+
+
+# What an operand the shell has not expanded yet resolves to, which is nothing this can read. A merge
+# guard errs toward refusing: allowing means the branch is merged with the check it exists for never
+# having run, and the merge is what cannot be taken back.
+UNEXPANDED_POLICY = "refuse"
+UNEXPANDED_PROBE = 'gh pr merge $PR --squash --delete-branch'
+UNRESOLVED = object()
 
 
 def merge_targets(command):
@@ -30,10 +38,14 @@ def merge_targets(command):
     anchor, so naming the command inside an argument spent a `gh pr view` and a `git fetch` on a
     refusal; that happened while this fix was being tested.
     """
-    return [
-        next((token for token in operands if token.isdigit()), "")
-        for operands in program_invocations(command, "gh", ("pr", "merge"))
-    ]
+    targets = []
+    for operands in program_invocations(command, "gh", ("pr", "merge")):
+        named = [token for token in operands if not token.startswith("-")]
+        if any(unexpanded(token) for token in named):
+            targets.append(UNRESOLVED)
+            continue
+        targets.append(next((token for token in operands if token.isdigit()), ""))
+    return targets
 
 
 def git(*args):
@@ -64,6 +76,14 @@ def main():
     targets = merge_targets(command)
     if not targets:
         return 0
+    if UNRESOLVED in targets:
+        sys.stderr.write(
+            "Refusing `gh pr merge`: the pull request is named by an operand the shell has not "
+            "expanded yet, so whether its branch contains main cannot be read.\n\n"
+            "Resolving the literal would fail and read as a pass, which is the check silently not "
+            "happening. Name the pull request, or see every merge precondition at once:\n"
+            "  python3 scripts/pr/settle.py merge <pr> --dry-run\n")
+        return 2
     pr = targets[0]
 
     try:

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/PreExpansionPolicyTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/PreExpansionPolicyTests.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using NUnit.Framework;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Holds every refusing guard to what it says it does with an operand the shell has not expanded.
+    /// <para>
+    /// A <c>PreToolUse</c> hook is handed the command as typed, so <c>$BRANCH</c>, a backtick and
+    /// <c>$(…)</c> arrive as themselves. A guard that resolves such an operand asks about the literal,
+    /// and the resolution fails — which for most of them is the pass. The check does not happen, and a
+    /// guard that did not run reports exactly what one that ran and found nothing reports.
+    /// </para>
+    /// <para>
+    /// Which way to err is not uniform and cannot be decided once: a guard over merges must refuse,
+    /// because a merge is what cannot be taken back, while one whose verdict is its command's own text
+    /// resolves nothing and has nothing to miss. So each guard states its own answer, and states the
+    /// command that demonstrates it — a guard added without either fails here rather than joining the
+    /// set silently.
+    /// </para>
+    /// </summary>
+    [TestFixture]
+    internal sealed class PreExpansionPolicyTests
+    {
+        private const string RefuseDirectory = ".claude/hooks/refuse";
+
+        private static readonly Regex PolicyPattern =
+            new(@"^UNEXPANDED_POLICY = ""(?<policy>refuse|allow|n/a)""$",
+                RegexOptions.Compiled | RegexOptions.Multiline);
+
+        private static readonly Regex ProbePattern =
+            new(@"^UNEXPANDED_PROBE = (?<quote>['""])(?<probe>.*)\k<quote>$",
+                RegexOptions.Compiled | RegexOptions.Multiline);
+
+        private static IReadOnlyList<string> Guards() =>
+            Directory.GetFiles(Path.GetFullPath(RefuseDirectory), "*.py")
+                .OrderBy(path => path, StringComparer.Ordinal)
+                .ToList();
+
+        [Test]
+        public void Given_EveryRefusingGuard_When_ItsSourceIsRead_Then_ItStatesAPreExpansionPolicy()
+        {
+            // Arrange
+            var guards = Guards();
+
+            // Act
+            var silent = guards
+                .Where(path =>
+                {
+                    var source = File.ReadAllText(path);
+                    var policy = PolicyPattern.Match(source);
+                    // "n/a" is a guard that reads no shell operand at all, so it owes no probe.
+                    return !policy.Success
+                           || (policy.Groups["policy"].Value != "n/a" && !ProbePattern.IsMatch(source));
+                })
+                .Select(Path.GetFileName)
+                .ToList();
+
+            // Assert — the guard count rides along because an empty directory states nothing either.
+            Assert.That((guards.Count > 5, string.Join("\n", silent)), Is.EqualTo((true, string.Empty)),
+                "a guard that resolves an operand decides about the literal when the shell has not "
+                + "expanded it, and that decision is usually the pass; state which way this one errs");
+        }
+
+        [Test]
+        public void Given_EveryStatedPolicy_When_ItsOwnProbeIsPosed_Then_TheGuardAnswersWhatItStates()
+        {
+            // Arrange
+            var stated = Guards()
+                .Select(path => (Path: path, Source: File.ReadAllText(path)))
+                .Select(entry => (entry.Path,
+                    Policy: PolicyPattern.Match(entry.Source).Groups["policy"].Value,
+                    Probe: ProbePattern.Match(entry.Source).Groups["probe"].Value))
+                .Where(entry => entry.Policy is "refuse" or "allow")
+                .ToList();
+
+            // Act
+            var disagreements = stated
+                .Select(entry => (entry.Path, entry.Policy, Observed: Answer(entry.Path, entry.Probe)))
+                .Where(entry => entry.Observed != entry.Policy)
+                .Select(entry => $"{Path.GetFileName(entry.Path)} states {entry.Policy}, answers {entry.Observed}")
+                .ToList();
+
+            // Assert — the stated count rides along because a parse that matched nothing agrees with
+            // everything, which is the same silence this fixture is about.
+            Assert.That((stated.Count > 5, string.Join("\n", disagreements)), Is.EqualTo((true, string.Empty)));
+        }
+
+        /// <summary>What the guard does with the probe: "refuse", "allow", or how it failed.</summary>
+        private static string Answer(string hook, string probe)
+        {
+            var command = probe.Replace("\\", "\\\\").Replace("\"", "\\\"");
+            var cwd = Path.GetFullPath(".");
+            var payload = "{\"tool_name\":\"Bash\",\"cwd\":\"" + cwd.Replace("\\", "\\\\")
+                + "\",\"tool_input\":{\"command\":\"" + command + "\"}}";
+
+            var start = new ProcessStartInfo("python3")
+            {
+                RedirectStandardInput = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            };
+            // -B, as the sibling guard fixture does: a __pycache__ beside a hook reads to the wiring
+            // guard as a script nothing runs.
+            start.ArgumentList.Add("-B");
+            start.ArgumentList.Add(hook);
+
+            using var process = Process.Start(start);
+            if (process == null)
+            {
+                return "did not start";
+            }
+
+            process.StandardInput.Write(payload);
+            process.StandardInput.Close();
+            process.StandardOutput.ReadToEnd();
+            process.StandardError.ReadToEnd();
+            if (!process.WaitForExit(60000))
+            {
+                process.Kill();
+                return "timed out";
+            }
+
+            return process.ExitCode switch
+            {
+                0 => "allow",
+                2 => "refuse",
+                var code => $"exit {code}",
+            };
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/PreExpansionPolicyTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/PreExpansionPolicyTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6a9d06e14375d43e3bf936058d8dd06e


### PR DESCRIPTION
A `PreToolUse` hook is handed the command as typed, so `$BRANCH`, a backtick and `$(…)` arrive as themselves. A guard that resolves such an operand asks about the literal, the resolution fails, and for most of them that failure is the pass — so the check does not happen, and a guard that did not run reports exactly what one that ran and found nothing reports.

**Four were letting something through.**

| guard | with an unexpanded operand |
|---|---|
| `stale_merge` | merged without reading whether the branch contains main |
| `merge_unproven_head` | merged without reading the head's checks |
| `merge_branch_held_by_worktree` | merged, then `--delete-branch` half-fails |
| `commit_failing_fast_checks` | ran every check over a pathspec naming no file, and passed them all |

All four now refuse: a merge cannot be taken back, and a commit is remade in a second.

`branch_from_unmerged` already refused, which is the right direction, but printed the failed resolution as its reason — a detached HEAD at an empty SHA, a repository state that was never true.

**The direction is not uniform and cannot be settled once.** `blind_git_add` reads whether the operand is `-A` or a dot, `merge_without_branch_deletion` whether the flag is present, `metadata_less_create` whether `--label` and `--assignee` are. Each is the command's own text, which no expansion adds to or removes from, so they resolve nothing and have nothing to miss.

**So the answer is checked rather than documented.** The issue proposes each guard's docstring carry it; a docstring is prose nothing reads, and this is the class of defect where prose already stood in for a check. Each guard states its policy beside the command that demonstrates it, and the fixture poses each probe to its own guard and compares the verdict. A guard added without either fails rather than joining the set silently.

Red both ways: a guard stating `allow` while refusing reports `stale_merge.py states allow, answers refuse`, and one stating nothing reports its own name.

Writing it found the fifth. `commit_failing_fast_checks` had been marked `refuse` by hand and was still answering `allow` — which is the same gap one level up, and exactly what a stated-but-unchecked policy looks like.

Closes #505
