### PR TITLE
test(velvet): reach the markdown and the Python the corpus was missing

### DIFF
--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/DocumentationCorpus.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/DocumentationCorpus.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace Velvet.Tests
 {
@@ -31,6 +32,55 @@ namespace Velvet.Tests
         // full checkout of this repository and would report its own copy of every path.
         internal static IReadOnlyList<string> RepoEntries(bool includeClaude) =>
             (includeClaude ? ClaudeAwareWalk : DocumentationWalk).Value;
+
+        /// <summary>Top-level directories holding markdown that the walk does not reach.</summary>
+        /// <remarks>
+        /// The walk is rooted, so a document under a directory nobody added to the roots is scanned by
+        /// nothing and no drift guard sees it. Asking the question over every top-level directory cannot be
+        /// done: a developer machine carries untracked ones a runner does not, so such a check would be red
+        /// here and green in CI — which is the asymmetry the rooting exists to avoid, one level up.
+        /// <para>
+        /// The population is therefore the directories that hold markdown, minus what .gitignore already
+        /// excludes. Both halves are read off the repository: the ignore file is where a machine-local
+        /// directory is already declared, so one appearing tomorrow excuses itself, and a root holding a
+        /// document does not.
+        /// </para>
+        /// </remarks>
+        internal static IReadOnlyList<string> UnwalkedMarkdownRoots()
+        {
+            var ignored = IgnoredRoots();
+            var walked = new HashSet<string>(BaseWalkedRoots.Append(".claude"), StringComparer.Ordinal);
+            var found = new List<string>();
+            foreach (var directory in Directory.EnumerateDirectories(Path.GetFullPath(".")))
+            {
+                var name = Path.GetFileName(directory);
+                if (walked.Contains(name) || BaseUnwalkedDirectories.Contains(name) || ignored.Contains(name))
+                {
+                    continue;
+                }
+                if (Directory.EnumerateFiles(directory, "*.md", SearchOption.AllDirectories).Any())
+                {
+                    found.Add(name);
+                }
+            }
+
+            found.Sort(StringComparer.Ordinal);
+            return found;
+        }
+
+        // Unity's own template writes /[Ll]ibrary/, so a root is a character class rather than a name;
+        // one alternative compared case-insensitively covers both spellings.
+        private static readonly Regex CharacterClassPattern = new(@"\[(\w)\w*\]", RegexOptions.Compiled);
+
+        private static HashSet<string> IgnoredRoots() =>
+            File.ReadAllLines(Path.GetFullPath(".gitignore"))
+                .Select(line => line.Trim())
+                .Where(line => line.Length > 0 && !line.StartsWith("#", StringComparison.Ordinal)
+                               && !line.StartsWith("!", StringComparison.Ordinal))
+                .Select(line => line.Trim('/').Split('/')[0])
+                .Where(root => root.Length > 0 && !root.Contains('*'))
+                .Select(root => CharacterClassPattern.Replace(root, match => match.Groups[1].Value))
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
         private static readonly string[] BaseWalkedRoots =
             { "Packages", "Assets", ".github", "scripts", "ProjectSettings", "docs" };

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/DocumentationDriftTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/DocumentationDriftTests.cs
@@ -44,9 +44,9 @@ namespace Velvet.Tests
         // One entry sits outside even that: "VEL" is the ID space written as a shape (VEL###) rather than an
         // ID, which that guard's VEL\d{3} pattern is right not to match.
         //
-        // The sixth group is code this repository owns in a format the corpus does not read. HOOK_SCOPE is
-        // declared by a Python hook, and HookWiringCoverageTests fails when no hook declares it.
-        // VELVET_STORY_CAPTURE_DIR is an environment variable, which C# can hold only as a string literal.
+        // The sixth group is code this repository owns in a format the corpus cannot resolve it from.
+        // VELVET_STORY_CAPTURE_DIR is an environment variable, which C# can hold only as a string literal,
+        // and the corpus strips a string for the reason StripProse gives.
         //
         // The seventh is the CHANGELOG's own headings and entry labels — Unreleased, Highlights, Added,
         // Changed, Breaking — and the date placeholder in its version heading. A document naming one is
@@ -67,7 +67,7 @@ namespace Velvet.Tests
             "NullReferenceException", "BringToFront", "SendToBack", "SetCursor", "AllocatingGCMemory",
             "UpdateForRepaint", "Alloc", "StandaloneOSX", "MacOS", "InitTestScene", "Unity_lic", "UE",
             "SIGTERM",
-            "HOOK_SCOPE", "VELVET_STORY_CAPTURE_DIR",
+            "VELVET_STORY_CAPTURE_DIR",
             "Unreleased", "Highlights", "Added", "Changed", "Breaking", "YYYY", "MM", "DD"
         };
 
@@ -75,7 +75,7 @@ namespace Velvet.Tests
         // git-ignored directory.
         private static readonly HashSet<string> PathAllowlist = new() { "Logs/story-captures/" };
 
-        private static readonly string[] SourceExtensions = { ".cs", ".uss", ".yml", ".json", ".asmdef" };
+        private static readonly string[] SourceExtensions = { ".cs", ".uss", ".yml", ".json", ".asmdef", ".py" };
 
         // Non-greedy, so the match closes on the first terminator rather than the last: a greedy one takes
         // every declaration between a file's first and last comment with it.
@@ -175,6 +175,19 @@ namespace Velvet.Tests
             CommentOrStringAlternation + "|" + RegionLabelAlternation,
             RegexOptions.Compiled | RegexOptions.Singleline | RegexOptions.Multiline);
 
+        // Python, ordered the same way and for the same reason: a delimiter inside the other form has to be
+        // inert. Triple quotes lead, since a docstring opens with the run an ordinary string would match and
+        // holds the longest prose in these files; a prefix run covers r, b, f and their combinations, so an
+        // f-string'"'"'s message does not survive as identifiers. Strings go with the comments here rather than
+        // staying like YAML'"'"'s, because a hook'"'"'s refusal text is a paragraph of ordinary English — pouring it
+        // in would let a document name almost anything and find it defined.
+        private static readonly Regex PythonCommentOrStringPattern = new(
+            "[rRbBfFuU]{0,2}(\"\"\"|''')(?:[\\s\\S])*?\\1"
+            + "|[rRbBfFuU]{0,2}\"(?:\\\\.|[^\"\\\\\n])*\""
+            + "|[rRbBfFuU]{0,2}'(?:\\\\.|[^'\\\\\n])*'"
+            + "|#[^\n]*",
+            RegexOptions.Compiled | RegexOptions.Singleline);
+
         [Test]
         public void Given_TheRepoSources_When_TheIdentifierCorpusIsBuilt_Then_EachFormatsCommentsAreTaken()
         {
@@ -186,6 +199,9 @@ namespace Velvet.Tests
             {
                 (Extension: ".uss", Comment: UssCommentPattern),
                 (Extension: ".yml", Comment: YamlCommentPattern),
+                // Python's strip takes strings as well, so the "came out of no comment" arm below reads
+                // the same alternation the strip uses rather than a comment-only one.
+                (Extension: ".py", Comment: PythonCommentOrStringPattern),
             };
 
             // Act — per format, so one arm going missing cannot hide behind the other.
@@ -520,6 +536,10 @@ namespace Velvet.Tests
             if (entry.EndsWith(".yml", StringComparison.Ordinal))
             {
                 return YamlCommentPattern.Replace(text, " ");
+            }
+            if (entry.EndsWith(".py", StringComparison.Ordinal))
+            {
+                return PythonCommentOrStringPattern.Replace(text, " ");
             }
             return text;
         }

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/DocumentationDriftTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/DocumentationDriftTests.cs
@@ -577,5 +577,22 @@ namespace Velvet.Tests
             }
             return unresolved.Distinct().ToList();
         }
+
+        [Test]
+        public void Given_EveryTopLevelDirectoryHoldingMarkdown_When_TheWalkIsRead_Then_TheWalkReachesIt()
+        {
+            // Arrange — the walk is rooted, so a document under a root nobody added is scanned by nothing
+            // and every drift guard reading this corpus passes over it in silence.
+            var scanned = DocumentationCorpus.Files().ToList();
+
+            // Act
+            var unwalked = DocumentationCorpus.UnwalkedMarkdownRoots();
+
+            // Assert — the scanned count rides along because a walk that collapsed to nothing would leave
+            // this reporting no unwalked root either.
+            Assert.That((scanned.Count > 20, string.Join(", ", unwalked)), Is.EqualTo((true, string.Empty)),
+                "markdown under a root the walk does not reach is checked by nothing; add the root to the "
+                + "walk, or to .gitignore if it is machine-local");
+        }
     }
 }


### PR DESCRIPTION
The walk is rooted, so a document under a directory nobody added to the roots is scanned by nothing and every drift guard reading the corpus passes over it in silence.

**Asking the question over every top-level directory is what the issue says cannot be written.** A developer machine carries untracked ones a runner does not — `merged/`, `.idea/`, `Recordings/` — so the check would be red here and green in CI, which is the same asymmetry the rooting exists to avoid, one level up.

Deriving the exclusions from `.gitignore` settles it. The population to exclude is exactly the one git already excludes, so a machine-local directory excuses itself by being declared where it is already declared, and a root holding a document does not. Unity's own template writes those roots as character classes (`/[Ll]ibrary/`), which the reader reduces.

The population is narrowed to roots that *hold markdown*, which is the issue's second suggested direction. An empty leftover directory is then not a failure — there is no document under it for anything to miss. One such leftover (`screenshots-tmp`, empty and untracked) turned up while measuring and is swept.

Verified both ways, which is the pair that matters here:

| | |
|---|---|
| `tools/GUIDE.md`, a root the walk does not reach | fails, naming `tools` |
| `Recordings/NOTE.md`, a root `.gitignore` names | reports nothing |

## Python enters the identifier corpus

`.py` contributed nothing, so `HOOK_SCOPE` — declared by a hook and read by `HookWiringCoverageTests` — resolved against nothing and needed an allowlist entry. That entry leaned on the wiring guard failing when no hook declares the marker, which is weaker than the corpus resolving the name where it is written.

Adding the extension alone would have been worse than the gap. A hook's refusal text is a paragraph of ordinary English held in a string, and with no strip those words become definitions — a document could then name almost anything and find it defined in a refusal message. Measured across the twenty-two hook scripts, the strip takes **1383 of 1831 words** and leaves `HOOK_SCOPE` standing.

Strings go with the comments here rather than staying as they do for YAML, where the string *is* the content. Triple quotes lead the alternation because a docstring opens with the run an ordinary string would match, and a prefix run covers `r`, `b`, `f` and their combinations so an f-string's message does not survive.

The case that pins each format's stripping gains Python as another arm, so the strip going missing fails rather than quietly widening the corpus.

Closes #497
Closes #498
