### PR TITLE
test(velvet): say at each test helper which production path it does not take

### DIFF
--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/TestUtilityBypassTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/TestUtilityBypassTests.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using NUnit.Framework;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Requires every <c>TestUtilities</c> helper named for tests to say which production path it does not
+    /// take, so the bypass is visible where the helper is read rather than only where it is written.
+    /// <para>
+    /// EditMode drives neither the scheduler, the layout pass nor animations, so bypassing is a necessity
+    /// rather than a shortcut. The hazard is that the bypass is invisible at the call site:
+    /// <c>FlushEffectsForTest</c> says it flushes effects and does not say it skips the registration that
+    /// hosts the drain — which is the question a tree-wide effect stall turned on, and the reason no
+    /// existing fixture could ask it.
+    /// </para>
+    /// <para>
+    /// Each declaration is a claim about this repository's own code, read off the production call site, so
+    /// it is a decision the repo owns rather than an engine fact. What this holds is only that one exists:
+    /// whether it is true stays with whoever writes it, and a helper added without one fails here rather
+    /// than joining the set in silence.
+    /// </para>
+    /// </summary>
+    [TestFixture]
+    internal sealed class TestUtilityBypassTests
+    {
+        private const string UtilitiesDirectory = "Packages/com.velvet.core/TestUtilities";
+
+        // A member is in scope for its name: the convention that marks a helper as test-only is the same one
+        // TestOnlyMemberConventionTests reads, so the two cannot disagree about which members these are.
+        private static readonly Regex DeclarationPattern =
+            new(@"^\s*(?:public|internal)\s[^;{]*\b(?<name>\w+ForTest)\b", RegexOptions.Compiled);
+
+        private static readonly Regex BypassPattern =
+            new(@"^\s*//\s*Bypasses:\s*(?<what>\S.*)$", RegexOptions.Compiled);
+
+        [Test]
+        public void Given_EveryTestOnlyHelper_When_ItsSourceIsRead_Then_ItSaysWhichPathItDoesNotTake()
+        {
+            // Arrange
+            var sources = Directory.GetFiles(Path.GetFullPath(UtilitiesDirectory), "*.cs")
+                .OrderBy(path => path, StringComparer.Ordinal)
+                .ToList();
+
+            // Act
+            var found = new List<string>();
+            var silent = new List<string>();
+            foreach (var path in sources)
+            {
+                var lines = File.ReadAllLines(path);
+                for (var index = 0; index < lines.Length; index++)
+                {
+                    var declaration = DeclarationPattern.Match(lines[index]);
+                    if (!declaration.Success)
+                    {
+                        continue;
+                    }
+
+                    var name = declaration.Groups["name"].Value;
+                    found.Add(name);
+                    // The line above it, which is where the writer of the declaration is looking.
+                    if (index == 0 || !BypassPattern.IsMatch(lines[index - 1]))
+                    {
+                        silent.Add($"{Path.GetFileName(path)}: {name}");
+                    }
+                }
+            }
+
+            // Assert — the count rides along because an empty scan reports nothing silent either, and this
+            // fixture's whole subject is a check that does not run looking like one that found nothing.
+            Assert.That((found.Count > 10, string.Join("\n", silent)), Is.EqualTo((true, string.Empty)),
+                "a helper reaches its behaviour by a different route than production, and the call site "
+                + "cannot see that; say which path it does not take, or say it takes them all");
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/TestUtilityBypassTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/TestUtilityBypassTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 39bf2f456496c4b0a905ff6877303640

--- a/Packages/com.velvet.core/TestUtilities/ClassNameCacheTestAccess.cs
+++ b/Packages/com.velvet.core/TestUtilities/ClassNameCacheTestAccess.cs
@@ -20,6 +20,7 @@ namespace Velvet.TestUtilities
         /// entries below the cache's size bound, or to push content-identical trees off the reference-identity
         /// fast path, and a clear that quietly reached nothing would leave both asserting on the wrong state.
         /// </exception>
+        // Bypasses: nothing — it resets a static cache, which no production path does.
         public static void ClearForTest()
         {
             var field = typeof(V).GetField(CacheFieldName, BindingFlags.Static | BindingFlags.NonPublic);

--- a/Packages/com.velvet.core/TestUtilities/FiberBatchSchedulerTestExtensions.cs
+++ b/Packages/com.velvet.core/TestUtilities/FiberBatchSchedulerTestExtensions.cs
@@ -24,10 +24,12 @@ namespace Velvet.TestUtilities
         private const string DrainDelayedMethodName = "DrainDelayed";
 
         /// <summary>Drains the Normal / Urgent tier.</summary>
+        // Bypasses: the panel scheduler callback: production registers DrainImmediate with _anchor.schedule.Execute and never calls it.
         internal static void DrainImmediateForTest(this FiberBatchScheduler scheduler)
             => Drain(scheduler, DrainImmediateMethodName);
 
         /// <summary>Drains the Deferred / Transition tier.</summary>
+        // Bypasses: the panel scheduler callback and its delay: production registers DrainDelayed with schedule.Execute(...).ExecuteLater(delayMs).
         internal static void DrainDelayedForTest(this FiberBatchScheduler scheduler)
             => Drain(scheduler, DrainDelayedMethodName);
 

--- a/Packages/com.velvet.core/TestUtilities/MountedTreeTestExtensions.cs
+++ b/Packages/com.velvet.core/TestUtilities/MountedTreeTestExtensions.cs
@@ -10,6 +10,7 @@ namespace Velvet.TestUtilities
         /// drains a tier (DrainImmediateForTest/DrainDelayedForTest) or inspects pending counts needs this same
         /// accessor path. Test-only.
         /// </summary>
+        // Bypasses: nothing — it reaches internal state a test cannot name, and production reaches the same scheduler the same way.
         internal static FiberBatchScheduler GetSchedulerForTest(this MountedTree mounted)
             => mounted.Root.Reconciler.Context.BatchScheduler;
 
@@ -19,6 +20,7 @@ namespace Velvet.TestUtilities
         /// FiberWorkLoop.FlushState on each fiber.
         /// Test-only. Must not be used from production code.
         /// </summary>
+        // Bypasses: the batch scheduler's tier and drain buffer: production calls FiberWorkLoop.FlushState from inside DrainImmediate, over the buffer that pass built.
         public static void FlushStateForTest(this MountedTree mounted)
         {
             FiberTreeTraversal.Visit(mounted.Root, FiberWorkLoop.FlushState);
@@ -31,6 +33,7 @@ namespace Velvet.TestUtilities
         /// same ordering production observes on the post-paint scheduler tick.
         /// Test-only. Must not be used from production code.
         /// </summary>
+        // Bypasses: the drain's registration and its anchor: production reaches the passive flush through FiberBatchScheduler.FlushPendingPassiveEffects, set by Reconciler as SetPassiveEffectFlush and fired from schedule.Execute.
         public static void FlushEffectsForTest(this MountedTree mounted)
         {
             FiberEffects.FlushPendingPassiveEffects(mounted.Root);
@@ -45,6 +48,7 @@ namespace Velvet.TestUtilities
         /// drain entry point.
         /// Test-only. Must not be used from production code.
         /// </summary>
+        // Bypasses: lane selection: production picks the lane from the surrounding scheduling context rather than being handed one.
         public static void ScheduleRerenderForTest(this ComponentFiber fiber, FiberUpdatePriority priority)
         {
             FiberWorkLoop.ScheduleRerender(fiber, priority);
@@ -63,6 +67,7 @@ namespace Velvet.TestUtilities
         /// tiny budget) and is invisible to every other fiber's flush.
         /// Test-only. Must not be used from production code.
         /// </summary>
+        // Bypasses: the real time-slice budget, which no production caller passes.
         public static void FlushStateWithTinyBudgetForTest(this ComponentFiber fiber)
         {
             FiberWorkLoop.FlushState(fiber, TinyTimeSlicedBudgetMs);
@@ -72,6 +77,7 @@ namespace Velvet.TestUtilities
         /// True while a time-sliced reconcile started by <paramref name="fiber"/> is paused with work still
         /// pending (the fast-path diff exceeded its frame budget and parked). Test-only.
         /// </summary>
+        // Bypasses: nothing — it reads Reconciler.HasPendingWork, which production reads too.
         public static bool HasPendingReconcileWorkForTest(this ComponentFiber fiber)
             => fiber.Reconciler?.HasPendingWork == true;
 
@@ -81,6 +87,7 @@ namespace Velvet.TestUtilities
         /// EditMode). Each call resumes one frame's worth of work at the budget the starting lane chose.
         /// Test-only. Must not be used from production code.
         /// </summary>
+        // Bypasses: the frame boundary: production resumes a parked reconcile from the UIToolkit scheduler, one frame at a time.
         public static void DrainTimeSlicedReconcileForTest(this ComponentFiber fiber, int maxIterations = 1000)
         {
             var iterations = 0;

--- a/Packages/com.velvet.core/TestUtilities/VNodePoolTestAccess.cs
+++ b/Packages/com.velvet.core/TestUtilities/VNodePoolTestAccess.cs
@@ -24,18 +24,25 @@ namespace Velvet.TestUtilities
         private const string ClearMethodName = "Clear";
         private const string CountPropertyName = "Count";
 
+        // Bypasses: nothing — it resets a static pool, which no production path does.
         public static void ClearLabelPoolForTest() => Clear(LabelPoolFieldName);
 
+        // Bypasses: nothing — it resets a static pool, which no production path does.
         public static void ClearButtonPoolForTest() => Clear(ButtonPoolFieldName);
 
+        // Bypasses: nothing — it resets a static pool, which no production path does.
         public static void ClearTogglePoolForTest() => Clear(TogglePoolFieldName);
 
+        // Bypasses: nothing — it resets a static pool, which no production path does.
         public static void ClearSliderPoolForTest() => Clear(SliderPoolFieldName);
 
+        // Bypasses: nothing — it resets a static pool, which no production path does.
         public static void ClearTextFieldPoolForTest() => Clear(TextFieldPoolFieldName);
 
+        // Bypasses: nothing — it reads a static pool's depth.
         public static int LabelPoolCountForTest => Count(LabelPoolFieldName);
 
+        // Bypasses: nothing — it reads a static pool's depth.
         public static int ButtonPoolCountForTest => Count(ButtonPoolFieldName);
 
         private static void Clear(string fieldName)


### PR DESCRIPTION
EditMode drives neither the scheduler, the layout pass nor animations, so a helper that reaches a behaviour by a different route is a necessity rather than a shortcut. The hazard is that the bypass is invisible where the helper is *read*: `FlushEffectsForTest` says it flushes effects and does not say it skips the registration that hosts the drain — which is the question a tree-wide effect stall turned on, and the reason no existing fixture could ask it.

**Each declaration was read off the production call site**, not written from the method's name.

| helper | what it does not take |
|---|---|
| `FlushEffectsForTest` | the registration and the anchor — production reaches the passive flush through `FiberBatchScheduler`, set by `Reconciler` as `SetPassiveEffectFlush` and fired from `schedule.Execute` |
| `DrainImmediateForTest` / `DrainDelayedForTest` | the panel scheduler callback, which is the only thing production ever registers them with |
| `FlushStateForTest` | the tier and the drain buffer — production calls `FlushState` from inside a drain, over the buffer that pass built |
| `ScheduleRerenderForTest` | lane selection |
| `FlushStateWithTinyBudgetForTest` | the real time-slice budget |
| `DrainTimeSlicedReconcileForTest` | the frame boundary |

**Nine of the seventeen bypass something.** The issue counts all seventeen; the other eight — the pool clears, their counts, and the class-name cache reset — read or reset static state and take no production path at all. They say that, rather than owing a pairing they cannot have.

The guard holds only that a declaration exists. Whether it is true stays with whoever writes it, the same as any comment: each is a claim about this repository's own code rather than about the engine, which is the kind that belongs in one. A helper added without one fails rather than joining the set in silence.

What is not here is the pairing table — a fixture per bypass that takes the real path. `PassiveEffectDrainHostTests` is the only one that exists, so requiring the rest now would mean either eight red cases or eight allowlist entries whose stated reason would not be true. That belongs in its own change, recorded the way `neuter_coverage.txt` records what the neuter harness cannot reach.

Closes #445
