### PR TITLE
docs(velvet): finish three statements that stopped being the whole truth

### DIFF
--- a/Packages/com.velvet.core/Documentation~/motion.md
+++ b/Packages/com.velvet.core/Documentation~/motion.md
@@ -225,7 +225,8 @@ the plan are built in one synchronous call, off-panel, before any style resoluti
   (`tracking-wide`) names likewise, per the bullet above; keyword lengths (`w-auto`, `w-full`) are
   modes, not magnitudes; `rounded-full` is a saturating pill sentinel; `shadow-*`, `skew-*` and
   gradients are baked silhouette paints; `filter-*` is driven by its own opt-in
-  `transition-filter`; `z-*` is a physical reparent.
+  `transition-filter`; `z-*` is a physical reparent; `aspect-[…]` is claimed by neither motion
+  parser, so a ratio change snaps.
 - **Percentage-based translate** (`translate-x-1/2`, `translate-x-full`) **and per-axis `scale-x-` /
   `scale-y-` are not channels either,** for all that the quartet above names `translate` and `scale`.
   Both families resolve as ordinary utilities; they just apply as plain classes, so the swap lands

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
@@ -2759,6 +2759,8 @@ namespace Velvet
             // The array the element's own reconcile pass last applied, or none when no pass ever recorded
             // one: the trigger was a width payload, which gates nothing and so never earns an entry, or the
             // payload came from a [&>*]: rule on the PARENT, whose children are fully created before it runs.
+            // The second case is temporary for a child rendered as an element — its own next patch runs the
+            // class passes and records the array — and permanent for a V.Text child, whose patch runs none.
             // The live list stands in for the layout gates in both cases, while the paint sequence stands
             // down, since PaintTail is unknown and a Motion must not be given a silhouette.
             // That makes a [&>*]: paint land inconsistently, which is the cost of not guessing: a child that

--- a/Packages/com.velvet.core/TestUtilities/NullableAnnotationProbe.cs
+++ b/Packages/com.velvet.core/TestUtilities/NullableAnnotationProbe.cs
@@ -12,8 +12,16 @@ namespace Velvet.TestUtilities
     /// <remarks>
     /// The compiler catches a disagreement between a member and the interface it implements (CS8766); it
     /// reported nothing for <see cref="Hooks.UseLocation"/>, whose null arrived through a null-forgiving
-    /// operator one call away. <c>PublicAPI.txt</c> is what pins every shipped member's annotations; this
-    /// reads one member's for a fixture that wants to assert it directly, and renders the surface file.
+    /// operator one call away.
+    /// <para>
+    /// Two guards read this, and they are not the same guard, which is worth saying because a reader
+    /// meeting both will otherwise see duplication and remove one. <c>PublicAPI.txt</c> covers every
+    /// shipped member without anyone writing a case, and catches DRIFT — the file changed, so something
+    /// moved. It cannot catch a regression: the file is maintained by regenerating it, so an annotation
+    /// going back to <c>T</c> is recorded as the new expected value the next time somebody does. A probe
+    /// test asserts what one member's annotation OUGHT to be and carries the reason, so it fails on that
+    /// regression rather than absorbing it. The broad one has no opinion; the narrow one does.
+    /// </para>
     /// </remarks>
     public static class NullableAnnotationProbe
     {


### PR DESCRIPTION
Three statements that were true when written and stopped being the whole truth.

**`motion.md`'s exclusion list omitted `aspect-[…]`**, so a ratio change snapped and a reader consulting the list to find out why found the word nowhere in the guide.

Derived rather than guessed. Thirteen `ArbitraryProperty` members are claimed by neither `MotionPropertyClassParser`'s slot table nor `MotionSpringClassParser`'s axis switch, and the list already accounts for twelve of them — per-axis scale and the nine filters. The one it missed is the one filed.

**The nullable probe's rationale** no longer claims nothing else pins an annotation, but it also did not say why two guards read it, and a reader meeting both sees duplication and removes one. What separates them: `PublicAPI.txt` catches *drift* and cannot catch a *regression*, because the file is maintained by regenerating it — an annotation going back to `T` is recorded as the new expected value the next time somebody does. A probe test asserts what the annotation ought to be and carries the reason, so it fails on that regression instead of absorbing it. The broad guard has no opinion; the narrow one does.

**`ReSyncVariantGatedPasses`** said a container-driven child has no recorded array and stopped there. Measured: a child rendered as an element gains one at its own next patch, because `ResolveVariantClasses` writes it on every post-children pass — and a `V.Text` child never does, because its patch runs no class pass at all. The second half is what a reader acts on and what the sentence was missing.

**The derived guard #479 asks for is not here**, and the reason is worth recording. The complement is clean — thirteen members, computed from the two parsers — but turning a member into the token a reader would write (`AspectRatio` → `aspect-`) has no source to derive from. Building the mapping by hand would produce exactly the drifting list the guard was meant to replace.

Closes #479
Closes #512
Closes #529
