### PR TITLE
test(velvet): compile the documentation samples that opt in

### DIFF
--- a/Packages/com.velvet.core/Documentation~/preview-tooling.md
+++ b/Packages/com.velvet.core/Documentation~/preview-tooling.md
@@ -17,9 +17,7 @@ Open the window via **Window ▸ Velvet ▸ Preview**.
 Annotate a `static` method that takes no parameters (or a single args object — see
 [Controls](#controls--args)) and returns a `VNode`:
 
-```csharp
-using Velvet;
-
+```csharp compile
 internal static class MyPreviews
 {
     [VelvetPreview(Name = "Primary button", Group = "Buttons", Width = 240, Height = 80)]

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/DocumentationSampleCompileTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/DocumentationSampleCompileTests.cs
@@ -1,0 +1,179 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using NUnit.Framework;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Compiles every documentation sample that opts in, against the assembly a consumer actually binds to.
+    /// <para>
+    /// Nothing compiled them before, and <c>DocumentationDriftTests</c> strips fenced blocks by design — so
+    /// a sample could name a parameter that does not exist or omit a required override and no guard
+    /// anywhere noticed. The canonical store sample carried two such errors at once, and they were found by
+    /// extracting the block and running a compiler by hand.
+    /// </para>
+    /// <para>
+    /// Opt-in rather than universal, because the samples are fragments: loose members, a bare statement at a
+    /// provider site, host-DI attributes that are not Velvet APIs. A harness that guesses scaffolding fails
+    /// about its own scaffolding, which is the fixture-repairs-the-defect shape. Marking a block declares
+    /// that it compiles as written under the preamble below, and makes that claim the author's rather than
+    /// the harness's.
+    /// </para>
+    /// </summary>
+    [TestFixture]
+    internal sealed class DocumentationSampleCompileTests
+    {
+        // The fence's info string. A block opts in by carrying it; every other block is prose as far as
+        // this fixture is concerned.
+        private static readonly Regex CompilableBlockPattern = new(
+            @"^```csharp\s+compile\s*$(?<body>.*?)^```\s*$",
+            RegexOptions.Compiled | RegexOptions.Multiline | RegexOptions.Singleline);
+
+        // Everything a marked block may assume, and nothing else. A sample needing more says so in itself.
+        private const string Preamble =
+            "using System;\nusing System.Collections.Generic;\nusing UnityEngine;\n"
+            + "using UnityEngine.UIElements;\nusing Velvet;\n";
+
+        /// <summary>The editor's own compiler host, so nothing here depends on what is on PATH.</summary>
+        /// <remarks>
+        /// A test run has an editor by construction, and the editor ships both the host and the compiler it
+        /// uses for the project itself. Reaching for <c>dotnet</c> instead would add an environment
+        /// dependency to a job that has none, and one that is unverified on the CI container.
+        /// </remarks>
+        private static string EditorRoot =>
+            Path.GetFullPath(Path.Combine(
+                Path.GetDirectoryName(UnityEditor.EditorApplication.applicationPath)!,
+                "Unity.app/Contents/Resources/Scripting"));
+
+        private static IEnumerable<(string Path, string Body)> MarkedSamples()
+        {
+            foreach (var document in DocumentationCorpus.Files())
+            {
+                var text = File.ReadAllText(document);
+                foreach (Match block in CompilableBlockPattern.Matches(text))
+                {
+                    yield return (document, block.Groups["body"].Value);
+                }
+            }
+        }
+
+        [Test]
+        public void Given_EveryMarkedDocumentationSample_When_CompiledAgainstTheShippedAssembly_Then_ItCompiles()
+        {
+            // Arrange
+            var samples = MarkedSamples().ToList();
+            var references = References();
+
+            // Act
+            var failures = new List<string>();
+            foreach (var (document, body) in samples)
+            {
+                var diagnostics = Compile(Preamble + body, references);
+                if (diagnostics.Length > 0)
+                {
+                    failures.Add($"{document}:\n{diagnostics}");
+                }
+            }
+
+            // Assert — the sample count rides along because an unmarked corpus compiles nothing and reports
+            // no failure, which is this guard not running rather than this guard passing.
+            Assert.That((samples.Count > 0, string.Join("\n\n", failures)), Is.EqualTo((true, string.Empty)),
+                "a documentation sample marked compilable does not compile against the assembly a reader "
+                + "would bind to");
+        }
+
+        private static IReadOnlyList<string> References()
+        {
+            var managed = Path.Combine(EditorRoot, "Managed/UnityEngine");
+            var found = new List<string>
+            {
+                Path.Combine(EditorRoot, "NetStandard/ref/2.1.0/netstandard.dll"),
+                Path.Combine(managed, "UnityEngine.CoreModule.dll"),
+                Path.Combine(managed, "UnityEngine.UIElementsModule.dll"),
+                Path.GetFullPath("Library/ScriptAssemblies/Velvet.dll"),
+            };
+            // UniTask is a declared dependency of the package, so a sample awaiting one is not reaching
+            // outside what a consumer has.
+            var uniTask = Directory.EnumerateFiles(Path.GetFullPath("Library/ScriptAssemblies"), "UniTask.dll")
+                .FirstOrDefault();
+            if (uniTask != null)
+            {
+                found.Add(uniTask);
+            }
+            return found;
+        }
+
+        /// <summary>Compiler output for one source, or empty when it compiled.</summary>
+        private static string Compile(string source, IReadOnlyList<string> references)
+        {
+            var directory = Path.Combine(Path.GetTempPath(), "velvet-doc-sample-" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(directory);
+            var sourcePath = Path.Combine(directory, "Sample.cs");
+            File.WriteAllText(sourcePath, source);
+
+            var start = new ProcessStartInfo(Path.Combine(EditorRoot, "netcorerun/netcorerun"))
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            };
+            start.ArgumentList.Add(Path.Combine(EditorRoot, "DotNetSdkRoslyn/csc.dll"));
+            start.ArgumentList.Add("-nologo");
+            start.ArgumentList.Add("-nostdlib");
+            start.ArgumentList.Add("-target:library");
+            start.ArgumentList.Add("-nullable:enable");
+            start.ArgumentList.Add("-out:" + Path.Combine(directory, "Sample.dll"));
+            foreach (var reference in references.Where(File.Exists))
+            {
+                start.ArgumentList.Add("-r:" + reference);
+            }
+            start.ArgumentList.Add(sourcePath);
+
+            try
+            {
+                using var process = Process.Start(start);
+                if (process == null)
+                {
+                    return "the compiler did not start";
+                }
+
+                var output = process.StandardOutput.ReadToEnd() + process.StandardError.ReadToEnd();
+                if (!process.WaitForExit(120000))
+                {
+                    process.Kill();
+                    return "the compiler timed out";
+                }
+
+                // csc reports warnings on stdout too, so the exit code decides and the text explains.
+                return process.ExitCode == 0 ? string.Empty : Trim(output, sourcePath);
+            }
+            finally
+            {
+                try
+                {
+                    Directory.Delete(directory, recursive: true);
+                }
+                catch (IOException)
+                {
+                    // A temp directory the OS still holds is not this fixture's problem to report.
+                }
+            }
+        }
+
+        private static string Trim(string output, string sourcePath)
+        {
+            var builder = new StringBuilder();
+            foreach (var line in output.Split('\n').Where(line => line.Contains("error", StringComparison.Ordinal)))
+            {
+                builder.AppendLine("  " + line.Replace(sourcePath, "sample").Trim());
+            }
+            return builder.ToString();
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/DocumentationSampleCompileTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/DocumentationSampleCompileTests.cs
@@ -43,12 +43,30 @@ namespace Velvet.Tests
         /// <remarks>
         /// A test run has an editor by construction, and the editor ships both the host and the compiler it
         /// uses for the project itself. Reaching for <c>dotnet</c> instead would add an environment
-        /// dependency to a job that has none, and one that is unverified on the CI container.
+        /// dependency to a job that has none.
+        /// <para>
+        /// Both are searched for under <c>applicationContentsPath</c> rather than composed from it. A
+        /// composed path was macOS's bundle layout and did not exist on the Linux runner, and replacing one
+        /// composition with another only moves the guess: the subtree under the contents directory differs
+        /// per platform too. Searching asks the installation what it has.
+        /// </para>
         /// </remarks>
-        private static string EditorRoot =>
-            Path.GetFullPath(Path.Combine(
-                Path.GetDirectoryName(UnityEditor.EditorApplication.applicationPath)!,
-                "Unity.app/Contents/Resources/Scripting"));
+        private static string Locate(string leaf, string requiredSegment = "")
+        {
+            var contents = UnityEditor.EditorApplication.applicationContentsPath;
+            // A leaf name is not always unique under the installation — netstandard.dll sits in five places
+            // and only the reference assembly under ref/ is the one to compile against. The caller says
+            // which by naming a path segment, so the choice is stated rather than left to enumeration order.
+            var found = Directory.EnumerateFiles(contents, leaf, SearchOption.AllDirectories)
+                .Where(path => requiredSegment.Length == 0
+                               || path.Replace('\\', '/').Contains("/" + requiredSegment + "/", StringComparison.Ordinal))
+                .OrderBy(path => path, StringComparer.Ordinal)
+                .FirstOrDefault();
+            // Loud rather than silent: a fixture that quietly skips because it could not find its compiler
+            // reports exactly what one that ran and found nothing reports.
+            Assert.That(found, Is.Not.Null, $"the editor at {contents} does not carry {leaf}");
+            return found!;
+        }
 
         private static IEnumerable<(string Path, string Body)> MarkedSamples()
         {
@@ -89,12 +107,11 @@ namespace Velvet.Tests
 
         private static IReadOnlyList<string> References()
         {
-            var managed = Path.Combine(EditorRoot, "Managed/UnityEngine");
             var found = new List<string>
             {
-                Path.Combine(EditorRoot, "NetStandard/ref/2.1.0/netstandard.dll"),
-                Path.Combine(managed, "UnityEngine.CoreModule.dll"),
-                Path.Combine(managed, "UnityEngine.UIElementsModule.dll"),
+                Locate("netstandard.dll", "ref"),
+                Locate("UnityEngine.CoreModule.dll", "UnityEngine"),
+                Locate("UnityEngine.UIElementsModule.dll", "UnityEngine"),
                 Path.GetFullPath("Library/ScriptAssemblies/Velvet.dll"),
             };
             // UniTask is a declared dependency of the package, so a sample awaiting one is not reaching
@@ -116,14 +133,14 @@ namespace Velvet.Tests
             var sourcePath = Path.Combine(directory, "Sample.cs");
             File.WriteAllText(sourcePath, source);
 
-            var start = new ProcessStartInfo(Path.Combine(EditorRoot, "netcorerun/netcorerun"))
+            var start = new ProcessStartInfo(Locate("netcorerun"))
             {
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
                 UseShellExecute = false,
                 CreateNoWindow = true,
             };
-            start.ArgumentList.Add(Path.Combine(EditorRoot, "DotNetSdkRoslyn/csc.dll"));
+            start.ArgumentList.Add(Locate("csc.dll"));
             start.ArgumentList.Add("-nologo");
             start.ArgumentList.Add("-nostdlib");
             start.ArgumentList.Add("-target:library");

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/DocumentationSampleCompileTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/DocumentationSampleCompileTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 18efcce58197e43ca9a953431947f5be


### PR DESCRIPTION
Nothing compiled the documentation samples, and `DocumentationDriftTests` strips fenced blocks by design — so a sample could name a parameter that does not exist or omit a required override and no guard anywhere noticed. Two such errors shipped in one block, and were found only by extracting it and running a compiler by hand.

**Opt-in rather than universal.** The samples are fragments: loose members, a bare statement at a provider site, host-DI attributes that are not Velvet APIs. A harness that guesses their scaffolding fails *about its own scaffolding*, which is the shape where a fixture repairs the defect it was meant to catch. A fence marked ```` ```csharp compile ```` declares that the block compiles as written under one fixed preamble — which makes the claim the author's rather than the harness's.

**No new environment dependency.** The compiler is the editor's own, reached through its `netcorerun` host, so nothing here cares what is on `PATH`. A test run has an editor by construction. This was measured before the guard was written, not after — the previous attempt at a CI guard in this session shipped on an environment I had not checked and failed on the runner.

**Against the real assembly.** References are the editor's `netstandard` and UnityEngine assemblies plus `Library/ScriptAssemblies/Velvet.dll`, which is what the issue asks for: a stub would pin the stub instead of the API.

Red on a broken sample, with the error the issue's own defect had:

    sample(11,18): error CS1739  — no argument by that name on 'Button'

That is the same class as the `onChange:` / `onValueChanged` error the store sample carried. Had that block been marked, it would have been caught.

The marked block is the preview-attribute sample, already self-contained. **The store sample is not marked**, and that is deliberate: making it compile would mean dropping its `[Inject]` and its provider-site statement, and those are what the sample is showing. Marking it wants the harness to grow, not the documentation to shrink.

A block count rides along in the assertion, because an unmarked corpus compiles nothing and reports nothing — the guard not running would otherwise read exactly like the guard passing.

Verified: EditMode 3735/3735, PlayMode 161/161.

Closes #478
