### PR TITLE
test(velvet): let an analyzer case reach the two hooks the derivation named stable

### DIFF
--- a/Packages/com.velvet.core/Generators~/tests/Velvet.SourceGenerators.Tests/GeneratorTestHelper.cs
+++ b/Packages/com.velvet.core/Generators~/tests/Velvet.SourceGenerators.Tests/GeneratorTestHelper.cs
@@ -139,6 +139,14 @@ namespace Velvet
         public static T UseContext<T>(global::Velvet.ComponentContext<T> context) => default;
         public static (bool isPending, global::Velvet.TransitionStarter startTransition) UseTransition() =>
             (false, default);
+        public static (global::Velvet.ISearchParams searchParams, global::Velvet.SearchParamsSetter setSearchParams) UseSearchParams() =>
+            (null, null);
+        public static global::Velvet.MutationResult<TVariables, TData> UseMutation<TVariables, TData>(
+            global::Velvet.MutationOptions<TVariables, TData> options) => null;
+        public static global::Velvet.MutationResult<TVariables, global::Velvet.Unit> UseMutation<TVariables>(
+            global::Velvet.MutationOptions<TVariables> options) => null;
+        public static global::Velvet.MutationResult<global::Velvet.Unit, global::Velvet.Unit> UseMutation(
+            global::Velvet.MutationOptions options) => null;
         public static global::Velvet.Ref<T> UseRef<T>() where T : class => null;
         public static global::Velvet.Ref<T> UseRef<T>(global::System.Func<T> initialFactory) where T : class => null;
         public static global::Velvet.MutableRef<T> UseMutableRef<T>(T initial) =>
@@ -150,12 +158,40 @@ namespace Velvet
         public static void UseImperativeHandle<THandle>(
             global::Velvet.Ref<THandle> handleRef, global::System.Func<THandle> factory, params object[] deps) where THandle : class { }
     }
+
+    public interface ISearchParams : global::System.Collections.Generic.IEnumerable<string> { }
+    public sealed class SearchParamsSetter { }
+    public readonly struct Unit : global::System.IEquatable<global::Velvet.Unit>
+    {
+        public bool Equals(global::Velvet.Unit other) => true;
+        public override bool Equals(object obj) => true;
+        public override int GetHashCode() => 0;
+    }
+    public sealed class MutationResult<TVariables, TData> { }
+    public sealed record MutationOptions<TVariables, TData>(
+        global::System.Func<TVariables, global::System.Threading.CancellationToken,
+            global::Cysharp.Threading.Tasks.UniTask<TData>> MutationFn,
+        global::System.Action<TData, TVariables>? OnSuccess = null,
+        global::System.Action<global::System.Exception, TVariables>? OnError = null);
+    public sealed record MutationOptions<TVariables>(
+        global::System.Func<TVariables, global::System.Threading.CancellationToken,
+            global::Cysharp.Threading.Tasks.UniTask> MutationFn,
+        global::System.Action<TVariables>? OnSuccess = null,
+        global::System.Action<global::System.Exception, TVariables>? OnError = null);
+    public sealed record MutationOptions(
+        global::System.Func<global::System.Threading.CancellationToken,
+            global::Cysharp.Threading.Tasks.UniTask> MutationFn,
+        global::System.Action? OnSuccess = null,
+        global::System.Action<global::System.Exception>? OnError = null);
 }
 
 namespace Cysharp.Threading.Tasks
 {
     // Stands in for the real UniTask<T> so UseBlocker's async overload keeps its true arity here.
     public struct UniTask<T> { }
+
+    // The void mutations' MutationFn returns the non-generic form.
+    public struct UniTask { }
 }
 ";
 

--- a/Packages/com.velvet.core/Generators~/tests/Velvet.SourceGenerators.Tests/UseEffectExhaustiveDepsAnalyzerTests.cs
+++ b/Packages/com.velvet.core/Generators~/tests/Velvet.SourceGenerators.Tests/UseEffectExhaustiveDepsAnalyzerTests.cs
@@ -897,6 +897,57 @@ namespace MyApp.Pages
         }
 
         [Fact]
+        public void Given_UseSearchParamsSetter_When_MissingFromDeps_Then_DoesNotReport()
+        {
+            // Arrange — the setter (tuple position 1) is a shared singleton, so React would not ask for it
+            // either. Membership of the stable set is derived from the runtime docs; this is the diagnostic
+            // behaviour that membership causes, which nothing could exercise while the stub omitted the hook.
+            const string source = @"
+namespace MyApp.Pages
+{
+    public static class HomePage
+    {
+        public static void Render()
+        {
+            var (searchParams, setSearchParams) = global::Velvet.Hooks.UseSearchParams();
+            global::Velvet.Hooks.UseEffect(() => () => System.Console.WriteLine(setSearchParams), new object[] { });
+        }
+    }
+}";
+
+            // Act
+            var diagnostics = GeneratorTestHelper.RunAnalyzer(source, new UseEffectExhaustiveDepsAnalyzer());
+
+            // Assert
+            Assert.Empty(diagnostics.Where(d => d.Id == "VEL100"));
+        }
+
+        [Fact]
+        public void Given_UseMutationResult_When_MissingFromDeps_Then_DoesNotReport()
+        {
+            // Arrange — the handle is created once per slot and returned unchanged thereafter.
+            const string source = @"
+namespace MyApp.Pages
+{
+    public static class HomePage
+    {
+        public static void Render()
+        {
+            var mutation = global::Velvet.Hooks.UseMutation(new global::Velvet.MutationOptions(
+                _ => default(global::Cysharp.Threading.Tasks.UniTask)));
+            global::Velvet.Hooks.UseEffect(() => () => System.Console.WriteLine(mutation), new object[] { });
+        }
+    }
+}";
+
+            // Act
+            var diagnostics = GeneratorTestHelper.RunAnalyzer(source, new UseEffectExhaustiveDepsAnalyzer());
+
+            // Assert
+            Assert.Empty(diagnostics.Where(d => d.Id == "VEL100"));
+        }
+
+        [Fact]
         public void Reports_When_UseReducer_State_Element_Is_Missing_From_Deps()
         {
             // The state element (tuple position 0) of UseReducer changes between renders and is not exempt; only


### PR DESCRIPTION
The stable-slot set is derived from the runtime docs, which correctly admits `UseSearchParams` and `UseMutation`. The stub declared neither, so **nothing could exercise what that membership causes** — only the derivation guard covered it, and a derivation is a claim about which names belong, not about what the analyzer then does with them.

The stub gains the four hooks and the seven types they name: `ISearchParams`, `SearchParamsSetter`, `Unit`, `MutationResult<,>`, the three `MutationOptions` records, and the non-generic `UniTask` the void mutations return.

**`StubSurfaceDriftTests` is what makes that safe rather than plausible**, and it was exact about it. Declaring `Unit.Equals` by name obliged the stub to model the runtime's `object` overload too — without it, a fixture's sample source resolves to a candidate that would lose, or be ambiguous, against the real surface. That is the guard doing precisely the job the issue says makes the stub trustworthy, and also what makes it expensive.

**Both new cases were checked for discrimination rather than assumed.** Removing each hook from the analyzer's stable set fails its own case and only its own:

    Given_UseMutationResult_When_MissingFromDeps_Then_DoesNotReport      [FAIL]
    Given_UseSearchParamsSetter_When_MissingFromDeps_Then_DoesNotReport  [FAIL]

The issue files this as out of proportion to the change that surfaced it. What made it proportionate is the drift guard: with it holding every stub declaration against the runtime, adding them is mechanical rather than a second surface to keep true by hand.

Verified: generators 422/422, EditMode 3734/3734.

Closes #518
