### PR TITLE
fix(velvet): let a child-combinator font or text-effect payload reach a V.Text child

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- A `[&>*]:` font or text-effect payload now reaches a `V.Text` child. The payload already landed on that
+  child's class list — a plain `[&>*]:bg-red-500` styled it — but the two resolvers stood down for it at
+  every render, so `[&>*]:uppercase` over mixed children transformed the element children and left the text
+  one alone. The paint families (`shadow-*`, `ring-*`, `skew-*`, the gradients, `animate-*`,
+  `border-dashed`) still do not reach such a child at all: they run behind a paint verdict only an
+  element's own class pass records.
+
 ### Added
 
 - `grow-[N]` and `shrink-[N]` arbitrary values for `flex-grow` / `flex-shrink`. The utility vocabulary

--- a/Packages/com.velvet.core/Documentation~/styling-variants.md
+++ b/Packages/com.velvet.core/Documentation~/styling-variants.md
@@ -357,10 +357,12 @@ on it the child never declared. So both stand down there rather than replace wha
 render got right with nothing left to put it back: `[&>*]:uppercase` over a `leading-[24px]` label
 leaves the label alone. From that child's next render on the two agree and both land —
 `[&>*]:font-mono` and `[&>*]:uppercase` alike — for a child rendered as an element. A `V.Text`
-child is the exception: the payload reaches its class list and neither resolver ever reads it, at
-any render, so put the utility on a `V.Label` there. Mount is what neither reaches for a child
-that declares none, so a child that must carry the family or the transform on its first frame
-declares it itself, or declares a variant of its own — the same escape the paints take.
+child takes them at mount instead: it declares no class of its own at any render, so there is
+nothing of its own for the payload to resolve over and nothing to wait for. For a child rendered as
+an element that declares none, mount is what neither reaches — one that must carry the family or the
+transform on its first frame declares it itself, or declares a variant of its own, the same escape
+the paints take. The paints reach a `V.Text` child at no render at all: they run behind a verdict
+only an element's own class pass records.
 
 ## Container queries — `@container`
 

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
@@ -2760,18 +2760,24 @@ namespace Velvet
             // one: the trigger was a width payload, which gates nothing and so never earns an entry, or the
             // payload came from a [&>*]: rule on the PARENT, whose children are fully created before it runs.
             // The second case is temporary for a child rendered as an element — its own next patch runs the
-            // class passes and records the array — and permanent for a V.Text child, whose patch runs none.
-            // The live list stands in for the layout gates in both cases, while the paint sequence stands
-            // down, since PaintTail is unknown and a Motion must not be given a silhouette.
+            // class passes and records the array. A V.Text child's patch runs none, ever, which is why the
+            // empty array below is its reconciled array rather than a stand-in; the live list stands in for
+            // the layout gates in the element case only. The paint sequence stands down for both, since
+            // PaintTail is unknown and a Motion must not be given a silhouette.
             // That makes a [&>*]: paint land inconsistently, which is the cost of not guessing: a child that
             // declares ANY gated payload of its own was recorded at create, so the parent's payload finds
             // PaintTail set and paints at mount, while a child that declares none paints only from its next
             // patch. Recording how a child is driven before its parent's rules run would close it.
-            var reconciled = state?.Reconciled;
+            // A TextNode's element applies no class of its own at any render, so an empty array is not a
+            // stand-in for its reconciled one — it IS its reconciled one. Without this the two resolvers
+            // below stand down for such a child forever, and a container's [&>*]:font-mono or
+            // [&>*]:uppercase lands on its class list and changes nothing, at mount and at every patch.
+            var reconciled = state?.Reconciled
+                ?? (_ctx.TextNodeElements.ContainsKey(element) ? System.Array.Empty<string>() : null);
             var previous = state?.Resolved;
-            var resolved = reconciled == null
-                ? LiveClasses(element)
-                : ComposeVariantClasses(reconciled, state!.Tokens, state.Resolved);
+            var resolved = reconciled == null ? LiveClasses(element)
+                : state == null ? reconciled
+                : ComposeVariantClasses(reconciled, state.Tokens, state.Resolved);
             var classesChanged = !ReferenceEquals(previous, resolved);
             if (state != null)
             {

--- a/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
@@ -392,10 +392,20 @@ namespace Velvet
         public Dictionary<VisualElement, string> TextRawText { get; } = new();
         public Dictionary<VisualElement, bool> TextWhitespaceOwned { get; } = new();
 
-        // A FOURTH table for the same subsystem, backing the Decoration axis's Overline value specifically:
+        // A FOURTH pure table, set-shaped like TextWhitespaceOwned: presence means the reconciler made this
+        // element for a TextNode, so its own reconcile applies no class of its own — ever, not merely not
+        // yet. That is what lets the variant re-sync resolve a parent's [&>*]: payload for it from the
+        // payload alone: for every other element an absent reconciled array means "its own pass has not run
+        // yet", and resolving without it would overwrite the font or leading that element declares. Written
+        // at the TextNode text-set seam (StyleTextEffectResolver.OnTextSet), which the Text-prop seam
+        // (CaptureRaw) deliberately does not share.
+        public Dictionary<VisualElement, bool> TextNodeElements { get; } = new();
+
+        // The one table for this subsystem that is NOT pure, backing the Decoration axis's Overline value
+        // specifically:
         // UI Toolkit rich text has no overline tag (unlike Underline/LineThrough, which rewrite the string
         // with <u>/<s>), so Overline is realised as a generateVisualContent PAINT binding on the leaf
-        // TextElement instead — see TextOverlineBinding / TextOverlineSilhouette. Unlike the three pure
+        // TextElement instead — see TextOverlineBinding / TextOverlineSilhouette. Unlike the pure
         // tables above, an entry here owns a live delegate subscription (like ShadowBindings / SkewBindings
         // / BorderStyleBindings below), so it is deliberately NOT enrolled in _pureElementSideTables —
         // FiberElementCleaner detaches the callback explicitly before an element is torn down or returned to
@@ -1235,6 +1245,7 @@ namespace Velvet
                 TextEffects,
                 TextRawText,
                 TextWhitespaceOwned,
+                TextNodeElements,
                 VariantGateClasses,
                 ZLayerHosts,
                 ZLayerMembers,

--- a/Packages/com.velvet.core/Runtime/Styling/StyleTextEffectResolver.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleTextEffectResolver.cs
@@ -16,7 +16,7 @@ namespace Velvet
     // every axis cascades by walking ancestors (StyleTextEffectClass holds the pure parse + string ops; this
     // owns the reconciler-side cascade and the per-element side-tables).
     //
-    // Three per-element side-tables are pure (on ReconcilerContext): TextEffects = an element's OWN parsed
+    // Four per-element side-tables are pure (on ReconcilerContext): TextEffects = an element's OWN parsed
     // effect (each axis nullable so an explicit reset — normal-case / no-underline / an explicit
     // whitespace-* class — is distinct from "inherit"; Leading has no reset form, see LeadingUnit, but is
     // still nullable the same way for "inherit" vs. "this element sets a real value"); TextRawText = the
@@ -100,6 +100,11 @@ namespace Velvet
         // inherited effect, rather than waiting for the ancestor's next pass. Idempotent (resolves from the raw).
         public static void OnTextSet(ReconcilerContext ctx, VisualElement element, string raw)
         {
+            // The mark belongs here rather than in CaptureRaw below: an element's Text prop calls CaptureRaw
+            // DIRECTLY and never routes through this method, while a TextNode reaches it only through here.
+            // Moving the mark down one call would mark every text-bearing element — see
+            // ReconcilerContext.TextNodeElements.
+            ctx.TextNodeElements[element] = true;
             CaptureRaw(ctx, element, raw);
             ApplyToElement(ctx, element);
         }

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/VariantGatedTypographyPassTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/VariantGatedTypographyPassTests.cs
@@ -236,6 +236,36 @@ namespace Velvet.Tests
         }
 
         [Test]
+        public void Given_AChildCombinatorTextEffectOverATextChild_When_Mounted_Then_TheTransformReachesIt()
+        {
+            // Arrange — a V.Text child gets the payload on its class list like any other child, and its own
+            // reconcile applies no class at any render, so a re-sync that waits for a recorded array waits
+            // forever. An element child in the same markup is the control: it resolves from its first patch.
+            using var scope = new ReconcilerScope();
+            VNode[] Tree(string label) => new VNode[]
+            {
+                V.Div(className: "[&>*]:uppercase", children: new VNode?[]
+                {
+                    V.Label(className: "text-sm", text: label, name: "elem"),
+                    V.Text("text-child"),
+                }),
+            };
+            var first = Tree("label-child");
+
+            // Act — read the text child after ONE render as well, because it is reached at mount and the
+            // element child is not: a fix that only worked from the second render would otherwise pass.
+            scope.Reconciler.Reconcile(scope.Root, Array.Empty<VNode>(), first);
+            var text = scope.Root[0].Children().OfType<Label>().Last();
+            var textAtMount = text.text;
+            scope.Reconciler.Reconcile(scope.Root, first, Tree("label-child"));
+
+            // Assert — the element child rides along, so a walk that reached neither fails here rather than
+            // reading as a transform the resolver declined to write.
+            Assert.That((textAtMount, scope.Root.Q<Label>("elem").text, text.text),
+                Is.EqualTo(("TEXT-CHILD", "LABEL-CHILD", "TEXT-CHILD")));
+        }
+
+        [Test]
         public void Given_AChildCombinatorFontOverAChildDeclaringNoPayload_When_ItRerenders_Then_TheFamilyResolves()
         {
             // Arrange — the child declares no gate payload, so it has no recorded array and the re-sync the


### PR DESCRIPTION
A `[&>*]:` payload lands on a `V.Text` child's class list like any other child's — a plain `[&>*]:bg-red-500` styles it — but the font and text-effect resolvers stood down for it at every render. `[&>*]:uppercase` over mixed children transformed the element children and left the text one alone, with no diagnostic.

Both resolvers run only from a RECORDED class array, and the reason is real: for an element child the only other array available is its live class list, which deliberately does not hold a `font-[…]` or `leading-[…]` that child declared, so resolving from it would overwrite what the child's own render got right. A `V.Text` child declares nothing at any render, so that reason does not reach it — but nothing at the re-sync could tell the two apart, since an absent record means "no pass has run **yet**" for one and "no pass ever runs" for the other.

The discriminator is a seam that already exists. `StyleTextEffectResolver.OnTextSet` runs for a `TextNode` and only for one; an element's `Text` prop calls `CaptureRaw` directly and never routes through it. Marking there gives an exact record of "the reconciler made this element for a `TextNode`", in a fourth pure side table that rides the existing `ClearElementSideTables` sweep — so pool return and unmount need no new handling. For a marked element the empty array is not a stand-in for its reconciled array; it **is** its reconciled array.

**Parity, measured rather than assumed.** In CSS `> *` matches element children only and would not select a text node at all. Velvet has no text node — `V.Text` produces a real `Label`, and the selector already reaches it for every USS-backed utility. So the choice was between making the C#-realised families agree with that, or excluding `V.Text` labels from the walk to match the DOM literally. The second reverts shipped behaviour, needs the same side table this adds to recognise the label, and turns `[&>*]:` from "every direct child" into "every direct child except one node kind". Consistency inside Velvet's own element model is the better deviation, and the deviation itself is forced by UI Toolkit rather than chosen.

What this does **not** close, and the CHANGELOG and the guide now say so: the paint families (`shadow-*`, `ring-*`, `skew-*`, the gradients, `animate-*`, `border-dashed`) reach such a child at no render at all, because they run behind a paint verdict only an element's own class pass records. Once `V.Text` is a `> *` member, they owe it the same reach — that is a separate change.

The case reads the text child after ONE render as well as after two: it is reached at mount and the element child is not, so a fix that only worked from the second render would otherwise pass. Red without it:

    Expected: (TEXT-CHILD, LABEL-CHILD, TEXT-CHILD)  But was: (text-child, LABEL-CHILD, text-child)

One adjacent hazard the work surfaced is filed separately as #564: the child-variant manipulator holds raw element references, so a pooled child re-rented under another container can have its payload turned off by its former owner — which this change widens from a class to the text transform.

Verified: EditMode 3747/3747, PlayMode 161/161.

Closes #531