### PR TITLE
tooling(velvet): refuse a pull-request body that says nothing about where the change came from

### DIFF
--- a/.claude/hooks/lib/shell_commands.py
+++ b/.claude/hooks/lib/shell_commands.py
@@ -15,8 +15,10 @@ import shlex
 SEPARATORS = set(";&|\n")
 
 # Words that may precede the command without changing which command it is. `then`/`do`/`else`
-# because a command inside a conditional or a loop is still that command.
-LEADING_WORDS = {"then", "do", "else", "elif", "!", "time", "command", "nohup", "exec"}
+# because a command inside a conditional or a loop is still that command; `builtin` alongside
+# `command` because a guard reading the word after it saw `builtin cd` as neither a move nor a
+# command word, and answered about a file in the directory the move had left.
+LEADING_WORDS = {"then", "do", "else", "elif", "!", "time", "command", "builtin", "nohup", "exec"}
 ENV_ASSIGNMENT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
 REDIRECTION = re.compile(r"^\d*(?:>>|>&|<&|>|<)")
 

--- a/.claude/hooks/lib/shell_commands.py
+++ b/.claude/hooks/lib/shell_commands.py
@@ -194,28 +194,11 @@ def leading_program(tokens):
     return index
 
 
-# gh's own options, before the subcommand. Only the value-taking ones need naming: a boolean flag is
-# one token and is stepped over either way. `gh -R owner/repo pr create` is the spelling that made
-# this necessary — every guard reading a gh subcommand walked straight past it.
-GH_GLOBAL_VALUE_FLAGS = {"-R", "--repo"}
-
-
-def past_global_flags(tokens, index, value_flags):
-    """The index of the subcommand, stepping over a program's own options and their values."""
-    while index < len(tokens) and tokens[index].startswith("-"):
-        flag, sep, _ = tokens[index].partition("=")
-        index += 1 if sep or flag not in value_flags else 2
-    return index
-
-
 def program_invocations(command, program, words):
     """Operands after `program` followed by `words`, once per segment that runs it.
 
     For programs whose subcommand is a fixed word sequence — `gh issue create`, `gh pr merge`.
     A pattern over the whole command answered yes to the words appearing inside an argument.
-
-    A program's own options come before the subcommand and are stepped over. Matching from the token
-    straight after the program name is what let `gh -R owner/repo pr create` past every guard here.
     """
     found = []
     for segment in command_segments(command):
@@ -223,7 +206,7 @@ def program_invocations(command, program, words):
         index = leading_program(tokens)
         if index >= len(tokens) or os.path.basename(tokens[index]) != program:
             continue
-        index = past_global_flags(tokens, index + 1, GH_GLOBAL_VALUE_FLAGS)
+        index += 1
         if tokens[index:index + len(words)] != list(words):
             continue
         found.append(tokens[index + len(words):])

--- a/.claude/hooks/lib/shell_commands.py
+++ b/.claude/hooks/lib/shell_commands.py
@@ -194,11 +194,28 @@ def leading_program(tokens):
     return index
 
 
+# gh's own options, before the subcommand. Only the value-taking ones need naming: a boolean flag is
+# one token and is stepped over either way. `gh -R owner/repo pr create` is the spelling that made
+# this necessary — every guard reading a gh subcommand walked straight past it.
+GH_GLOBAL_VALUE_FLAGS = {"-R", "--repo"}
+
+
+def past_global_flags(tokens, index, value_flags):
+    """The index of the subcommand, stepping over a program's own options and their values."""
+    while index < len(tokens) and tokens[index].startswith("-"):
+        flag, sep, _ = tokens[index].partition("=")
+        index += 1 if sep or flag not in value_flags else 2
+    return index
+
+
 def program_invocations(command, program, words):
     """Operands after `program` followed by `words`, once per segment that runs it.
 
     For programs whose subcommand is a fixed word sequence — `gh issue create`, `gh pr merge`.
     A pattern over the whole command answered yes to the words appearing inside an argument.
+
+    A program's own options come before the subcommand and are stepped over. Matching from the token
+    straight after the program name is what let `gh -R owner/repo pr create` past every guard here.
     """
     found = []
     for segment in command_segments(command):
@@ -206,7 +223,7 @@ def program_invocations(command, program, words):
         index = leading_program(tokens)
         if index >= len(tokens) or os.path.basename(tokens[index]) != program:
             continue
-        index += 1
+        index = past_global_flags(tokens, index + 1, GH_GLOBAL_VALUE_FLAGS)
         if tokens[index:index + len(words)] != list(words):
             continue
         found.append(tokens[index + len(words):])

--- a/.claude/hooks/refuse/metadata_less_create.py
+++ b/.claude/hooks/refuse/metadata_less_create.py
@@ -13,7 +13,8 @@ asks; this refuses.
 Assignee is required on an issue and not on a pull request: a pull request already records its
 author, so a self-assignment adds nothing.
 
-`--web` hands the fields to the browser form, where they can be set, so it is left alone.
+`--web` hands the fields to the browser form, where they can be set, so it is left alone, and so is
+`--help`, which opens nothing.
 """
 
 import json
@@ -29,6 +30,17 @@ import repository
 # refusal by naming the command it refuses, which is exactly the text that would.
 LABEL_FLAGS = ("--label", "-l")
 ASSIGNEE_FLAGS = ("--assignee", "-a")
+
+
+# --web hands the fields to the browser form, where they can be set; --help opens nothing. Named
+# once so GuardCommandCoverageTests asks the guard rather than restating the rule — the copy in that
+# table listed only --web, and a row added for --help disagreed with the guard that had exempted it.
+EXEMPT_FLAGS = ("--web", "--help", "-h")
+
+
+def exempt(operands):
+    """Whether this invocation creates nothing a label could go on."""
+    return any(token in EXEMPT_FLAGS for token in operands)
 
 
 def carries(operands, flags):
@@ -74,7 +86,7 @@ def main():
     missing = []
     kind = ""
     for kind, operands in creations(command):
-        if "--web" in operands:
+        if exempt(operands):
             continue
         missing = []
         if not carries(operands, LABEL_FLAGS):

--- a/.claude/hooks/refuse/metadata_less_create.py
+++ b/.claude/hooks/refuse/metadata_less_create.py
@@ -13,8 +13,8 @@ asks; this refuses.
 Assignee is required on an issue and not on a pull request: a pull request already records its
 author, so a self-assignment adds nothing.
 
-`--web` hands the fields to the browser form, where they can be set, so it is left alone, and so is
-`--help`, which opens nothing.
+`--web` hands the fields to the browser form, where they can be set, so it is left alone, and so are
+`--help` and its short `-h`, which open nothing.
 """
 
 import json

--- a/.claude/hooks/refuse/pr_body_of_another_branch.py
+++ b/.claude/hooks/refuse/pr_body_of_another_branch.py
@@ -62,9 +62,8 @@ from shell_commands import command_segments, leading_program, program_invocation
 # reads this declaration to check that the registration is still there.
 HOOK_SCOPE = "session"
 
-# The tools this acts on, gated on below rather than restated there: the same fixture compares this
-# set against the matcher that routes tools to it, and a gate spelling the name a second time would
-# drift against both.
+# The tools this acts on, gated on below rather than spelled a second time there: two statements of
+# the same set drift.
 HOOK_TOOLS = {"Bash"}
 
 # The body file is opened, so a path the shell has not expanded leaves nothing to open. An inline

--- a/.claude/hooks/refuse/pr_body_of_another_branch.py
+++ b/.claude/hooks/refuse/pr_body_of_another_branch.py
@@ -74,15 +74,25 @@ DRAFTING_WINDOW = 900
 
 
 def valued(operands, flags):
-    """The value given to one of `flags`, or None. Handles both `--flag v` and `--flag=v`."""
+    """The value given to one of `flags`, or None.
+
+    Three spellings, because gh takes all three: `--flag v`, `--flag=v`, and `-Fv` — a short flag
+    carrying its value attached. The last was missed, so `-F/tmp/pr-body.md` reached none of the
+    checks below: the invocation was claimed, no body was found, and it took the exemption meant for
+    a body this cannot read. That is the accident this guard exists for, one character apart.
+    """
+    short = tuple(flag for flag in flags if len(flag) == 2 and flag.startswith("-") and flag[1] != "-")
     for index, token in enumerate(operands):
         name, sep, inline = token.partition("=")
-        if name not in flags:
-            continue
-        if sep:
-            return inline
-        if index + 1 < len(operands):
-            return operands[index + 1]
+        if name in flags:
+            if sep:
+                return inline
+            if index + 1 < len(operands):
+                return operands[index + 1]
+            return None
+        for flag in short:
+            if len(token) > 2 and token.startswith(flag):
+                return token[2:]
     return None
 
 

--- a/.claude/hooks/refuse/pr_body_of_another_branch.py
+++ b/.claude/hooks/refuse/pr_body_of_another_branch.py
@@ -1,24 +1,32 @@
 #!/usr/bin/env python3
 """Refuse a pull-request body that was not written for this branch.
 
-A pull request was opened whose whole description belonged to a different one, and it stayed that
-way until a person read it. The body file was named `pr-body.md`, a previous pull request had left
-a file of that name in the same scratch directory, and the write that was meant to replace it never
-ran: it sat in the same `&&` chain as a `gh pr create` that a hook refused, and a refusal stops the
-whole chain. Nothing about the second attempt looked wrong — the path existed, `gh` read it, the
-pull request opened green.
+A pull request was opened here whose whole description belonged to a different one, and it stayed
+that way until a person read it. The body file was named `pr-body.md`, a previous pull request had
+left a file of that name in the same scratch directory, and the write meant to replace it never ran:
+it sat in the same `&&` chain as a `gh pr create` that a hook refused, and a refusal stops the whole
+chain. Nothing about the retry looked wrong — the path existed, `gh` read it, the pull request opened
+and went green.
 
-Two checks, because "is this body about this branch" has two answers a machine can give:
+The body is the one artefact nothing else here checks. CI reads the diff and so does review; the
+description is whatever the file held.
 
-- **The file is older than the branch.** A body written before the branch's first commit cannot
-  describe what that branch does. This is what catches the stale file, whatever left it there, and
-  it needs no idea of what the body says.
-- **It names no issue.** Every pull request here that closes one says so on its first line, and the
-  one that forgot it also had the wrong body — the same omission twice over. A pull request that
-  genuinely closes nothing says so in a line of its own, which is a decision rather than a silence.
+Two questions, because "is this body about this branch" has exactly two a machine can answer:
 
-Not a check on what the body says: nothing can read prose and tell whose branch it is. These two
-are what remains once that is given up, and both would have fired here.
+- **The file predates the branch.** A body last written before the branch's first commit cannot
+  describe what that branch does, whatever left it there. A missing file is the same failure one
+  step earlier, which is the shape the incident took.
+- **It names no issue.** A pull request that closes one says so and the issue closes itself on merge;
+  one that closes nothing says `No issue: <where this came from>`, which is a decision rather than a
+  silence. CONTRIBUTING.md owns that rule — this refuses, it does not define.
+
+It does not read the prose: nothing can look at a description and tell whose branch it is.
+
+**Both halves fail closed.** The first version resolved the branch from the session's directory,
+which is the primary checkout while the branch under review sits in a worktree — the configuration
+this is used from. `origin/main..HEAD` was then empty, the start came back unknown, and the check
+that could not be made was skipped rather than refused. What a guard cannot determine is what it must
+refuse; the alternative is silence exactly where the input is unusual.
 """
 
 import json
@@ -26,34 +34,38 @@ import os
 import re
 import subprocess
 import sys
-import time
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lib"))
 from shell_commands import program_invocations, unexpanded
+from velvet_hooks import BRANCH_BASES
 
 # Registered on the event in .claude/settings.json rather than narrowed to the agents expected to
 # open pull requests, which would leave every other session unguarded. `HookWiringCoverageTests`
 # reads this declaration to check that the registration is still there.
 HOOK_SCOPE = "session"
 
-# An operand the shell rewrites is a path this cannot stat and a body it cannot read, so the
-# question goes unanswered. A guard that reads "I cannot tell" as "nothing to report" goes quiet
-# exactly when its subject is unusual, which is the shape the stale body already exploited.
+# Only the body operand is resolved, so only that one going unexpanded leaves the question
+# unanswered. A rewritten --title or --label costs nothing here, and refusing over one is how the
+# first version blocked bodies it could read perfectly well.
 UNEXPANDED_POLICY = "refuse"
 UNEXPANDED_PROBE = 'gh pr create --title t --body-file $BODY --label bug'
 
 BODY_FILE_FLAGS = ("--body-file", "-F")
 BODY_FLAGS = ("--body", "-b")
+HEAD_FLAGS = ("--head", "-H")
+BASE_FLAGS = ("--base", "-B")
+WEB_FLAGS = {"--web", "-w"}
 
 ISSUE_REFERENCE = re.compile(r"#\d+")
-# Written as a line rather than a flag so it lands in the published body, where a reader who
-# wonders which issue a change came from finds the answer instead of nothing.
-NO_ISSUE_LINE = re.compile(r"^\s*No issue[:.]", re.MULTILINE)
+# A line rather than a flag, so the answer lands in the published body where a reader looking for
+# where a change came from finds it. It has to carry a reason: the bare token would be a way of
+# saying nothing in a form that satisfies the check, which is the silence this asks about.
+NO_ISSUE_LINE = re.compile(r"^[^\S\n]*No issue[:.][^\S\n]*\S", re.MULTILINE | re.IGNORECASE)
 
-# Long enough that a body drafted alongside the first commit is not caught by clock skew between
-# the file system and the commit stamp, short enough that a body from a previous branch is.
-DRIFT = 300
+# A body is often written before the commit it describes. This is how much of that ordering is
+# allowed — our decision, not a measurement of anything.
+DRAFTING_WINDOW = 900
 
 
 def valued(operands, flags):
@@ -69,43 +81,120 @@ def valued(operands, flags):
     return None
 
 
-def branch_start(cwd):
-    """When the oldest commit this branch does not share with its base was authored, or None."""
+def git(cwd, *args):
+    """stdout of a git command, or None when it cannot be run or fails."""
     try:
-        base = subprocess.run(
-            ["git", "merge-base", "origin/main", "HEAD"],
-            cwd=cwd, capture_output=True, text=True, timeout=5)
-        if base.returncode != 0:
-            return None
-        stamps = subprocess.run(
-            ["git", "log", "--format=%ct", f"{base.stdout.strip()}..HEAD"],
-            cwd=cwd, capture_output=True, text=True, timeout=5)
-        if stamps.returncode != 0:
-            return None
-        lines = [line for line in stamps.stdout.split() if line.isdigit()]
-        return int(lines[-1]) if lines else None
-    except (OSError, subprocess.SubprocessError, ValueError):
+        done = subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True, timeout=5)
+    except (OSError, subprocess.SubprocessError):
         return None
+    return done.stdout.strip() if done.returncode == 0 else None
 
 
-def body_of(operands, cwd):
-    """(text, path, problem) for the body this invocation carries."""
-    path = valued(operands, BODY_FILE_FLAGS)
-    if path is None:
-        return valued(operands, BODY_FLAGS), None, None
-    resolved = Path(path) if os.path.isabs(path) else Path(cwd) / path
-    if not resolved.exists():
-        return None, resolved, f"{path} does not exist"
-    started = branch_start(cwd)
-    if started is not None and resolved.stat().st_mtime < started - DRIFT:
-        age = int((started - resolved.stat().st_mtime) // 60)
-        return None, resolved, (
-            f"{path} was last written {age} minutes before this branch's first commit, "
-            "so it was written for something else")
+def recorded_base(name):
+    """The start point `branch_from_unmerged.py` recorded for this branch, or None."""
     try:
-        return resolved.read_text(encoding="utf-8", errors="replace"), resolved, None
+        with open(BRANCH_BASES, encoding="utf-8") as bases:
+            matches = [line for line in bases if line.startswith(f"{name} ")]
     except OSError:
-        return None, resolved, f"{path} cannot be read"
+        return None
+    if not matches:
+        return None
+    parts = matches[-1].split(None, 1)
+    return parts[1].strip() if len(parts) == 2 else None
+
+
+def branch_start(cwd, head, base):
+    """When the branch's own first commit was authored, or None when that cannot be determined.
+
+    Author date, not committer date: a rebase — which the sibling guards here prescribe by name —
+    rewrites the committer date to now and would turn every correct body into a refusal.
+
+    The head is taken from the command when it names one, because the directory the command runs in
+    is routinely not the branch's: a session coordinating worktrees runs from the primary checkout.
+    """
+    ref = head or "HEAD"
+    start = recorded_base(head) if head else None
+    if start is None:
+        start = git(cwd, "merge-base", base, ref)
+    if start is None:
+        return None
+    stamps = git(cwd, "log", "--format=%at", f"{start}..{ref}")
+    if stamps is None:
+        return None
+    authored = [line for line in stamps.split() if line.isdigit()]
+    return int(authored[-1]) if authored else None
+
+
+def refuse(message):
+    print(message, file=sys.stderr)
+    return 2
+
+
+def check(operands, cwd):
+    """0, or 2 with the reason written to stderr."""
+    if WEB_FLAGS & set(operands):
+        return 0
+
+    path = valued(operands, BODY_FILE_FLAGS)
+    text = valued(operands, BODY_FLAGS)
+    if path is None and text is None:
+        # --fill, --fill-first, --template: the body comes from commits or a template, which are not
+        # a file this can date, and which the author did not write here to be checked.
+        return 0
+    if any(unexpanded(operand) for operand in (path, text) if operand is not None):
+        return refuse(
+            "Refusing `gh pr create`: the body operand is still unexpanded, so neither the file's\n"
+            "provenance nor the issue it names can be read.\n\n"
+            "Run it with the body spelled out.")
+
+    if path == "-":
+        return refuse(
+            "Refusing `gh pr create`: the body comes from stdin, which this cannot read.\n\n"
+            "Write it to a file and pass that, so the question of whose branch it describes has\n"
+            "an answer.")
+    if path is not None:
+        resolved = Path(path) if os.path.isabs(path) else Path(cwd) / path
+        if not resolved.exists():
+            return refuse(
+                f"Refusing `gh pr create`: {path} does not exist.\n\n"
+                "A body file that is not there is usually one whose write did not run — a refused\n"
+                "hook stops the whole `&&` chain it was in, including the write.")
+
+        head = valued(operands, HEAD_FLAGS)
+        base = valued(operands, BASE_FLAGS) or "origin/main"
+        started = branch_start(cwd, head, base)
+        if started is None:
+            return refuse(
+                "Refusing `gh pr create`: this cannot tell when the branch started, so it cannot\n"
+                f"tell whether {path} was written for it.\n\n"
+                f"Run it from the branch's own directory, or pass `--head <branch>`.")
+        try:
+            written = resolved.stat().st_mtime
+        except OSError:
+            return refuse(f"Refusing `gh pr create`: {path} cannot be read.")
+        if written < started - DRAFTING_WINDOW:
+            older = int((started - written) // 60)
+            return refuse(
+                f"Refusing `gh pr create`: {path} was last written {older} minutes before this\n"
+                "branch's first commit, so it was written for something else.\n\n"
+                "A pull request opened this way carries whatever that path held. On the occasion\n"
+                "this guard was written for, that was another branch's description, from creation\n"
+                "until a person read it.")
+        try:
+            text = resolved.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            return refuse(f"Refusing `gh pr create`: {path} cannot be read.")
+
+    if text is not None and not ISSUE_REFERENCE.search(text) and not NO_ISSUE_LINE.search(text):
+        return refuse(
+            "Refusing `gh pr create`: the body names no issue.\n\n"
+            "CONTRIBUTING.md asks every pull request to say where it came from. If it closes an\n"
+            "issue, the first line closes it on merge:\n\n"
+            "  Closes #<n>.\n\n"
+            "If it closes nothing — a tooling change, a release — say that instead, so a reader\n"
+            "who wonders where it came from finds an answer rather than a silence:\n\n"
+            "  No issue: <where this came from>")
+    return 0
 
 
 def main():
@@ -113,42 +202,24 @@ def main():
         event = json.load(sys.stdin)
     except Exception:
         return 0
-    if event.get("tool_name") != "Bash":
+    try:
+        if not isinstance(event, dict) or event.get("tool_name") != "Bash":
+            return 0
+        command = event.get("tool_input", {}).get("command") or ""
+        cwd = event.get("cwd") or "."
+        if not isinstance(command, str):
+            return 0
+        for operands in program_invocations(command, "gh", ("pr", "create")):
+            verdict = check(operands, cwd)
+            if verdict:
+                return verdict
         return 0
-    command = event.get("tool_input", {}).get("command", "")
-    cwd = event.get("cwd") or "."
-
-    for operands in program_invocations(command, "gh", ("pr", "create")):
-        if "--web" in operands:
-            continue
-        if any(unexpanded(token) for token in operands):
-            print(
-                "Refusing `gh pr create`: an operand is still unexpanded, so neither the body's\n"
-                "provenance nor the issue it closes can be read here.\n\n"
-                "Run it with the operands spelled out.", file=sys.stderr)
-            return 2
-
-        text, _, problem = body_of(operands, cwd)
-        if problem:
-            print(
-                f"Refusing `gh pr create`: {problem}.\n\n"
-                "A pull request opened this way carries whatever that path held — on the occasion\n"
-                "this guard was written for, another branch's description, from creation until a\n"
-                "person read it.\n\n"
-                "Write the body for this branch and pass that file.", file=sys.stderr)
-            return 2
-
-        if text is not None and not ISSUE_REFERENCE.search(text) and not NO_ISSUE_LINE.search(text):
-            print(
-                "Refusing `gh pr create`: the body names no issue.\n\n"
-                "A pull request that closes one says so on its first line, and the issue then closes\n"
-                "itself on merge. Add:\n\n"
-                "  Closes #<n>.\n\n"
-                "If it closes nothing, say that instead — a line of its own, so a reader who wonders\n"
-                "where the change came from finds an answer rather than a silence:\n\n"
-                "  No issue: <where this came from>", file=sys.stderr)
-            return 2
-    return 0
+    except Exception as err:
+        # Exit 1 is not a refusal — PreToolUse runs the tool anyway — so an unforeseen shape here
+        # would let through exactly what this exists to stop.
+        print(f"Refusing `gh pr create`: this guard failed to reach a verdict ({err!r}).",
+              file=sys.stderr)
+        return 2
 
 
 if __name__ == "__main__":

--- a/.claude/hooks/refuse/pr_body_of_another_branch.py
+++ b/.claude/hooks/refuse/pr_body_of_another_branch.py
@@ -23,6 +23,13 @@ Two questions, because "is this body about this branch" has exactly two a machin
 
 It does not judge what the body is about: nothing can read a description and tell whose branch it is.
 
+Nor does it see a `gh pr create` the shared parser does not claim — behind `sudo`, inside `bash -c`,
+or with gh's own options before the subcommand. Four attempts at that reached in both wrong
+directions: enumerating wrapper names refused `sudo gh auth status` and a `timeout gh run watch` CI
+wait, matching the phrase refused prose including the message of the commit that added it, and
+teaching the shared parser gh's options made every value-taking option it did not name walk off the
+subcommand and match nothing — in six guards, not one. What is left is what has never been in doubt.
+
 **What it can answer, it fails closed on.** The first version resolved the branch from the session's directory,
 which is the primary checkout while the branch under review sits in a worktree — the configuration
 this is used from. `origin/main..HEAD` was then empty, the start came back unknown, and the check
@@ -124,41 +131,6 @@ def branch_start(cwd, head, base):
 
 
 MOVERS = {"cd", "pushd", "popd"}
-# Programs whose whole purpose is to run another one in the caller's place. timeout and xargs were
-# here and are not: they are ordinarily given some other program, and `timeout 5 echo gh pr create`
-# is then indistinguishable from the call itself at token level.
-WRAPPERS = {"env", "sudo", "doas", "bash", "sh", "zsh", "eval", "nice", "stdbuf", "script", "flock"}
-
-
-def unclaimed_creation(segment, depth=0):
-    """Whether this segment runs `gh pr create` where program_invocations cannot claim it.
-
-    gh itself is no longer such a shape: the shared parser steps over gh's own options, so
-    `gh -R owner/repo pr create` is checked like any other spelling rather than refused.
-
-    What is left is a wrapper taking the command word. Two forms, and they need different questions.
-    Unquoted — `sudo gh pr create` — the call is in this segment's own tokens. Quoted — `bash -c "gh
-    pr create …"` — shlex hands the payload back as ONE token whose text is a whole command, so
-    asking the same question of each argument reaches it. Nothing is masked; an earlier version said
-    so and scanned the raw text instead, which refused prose twice.
-
-    Recursion does not remove the wrapper list, which is what it looked like it would do: `echo gh pr
-    create` and `sudo gh pr create` are the same tokens, so only a name separates a wrapper from a
-    program being handed words. The list is what decides whose arguments are worth recursing into.
-    """
-    if depth > 2:
-        return False
-    tokens = tokens_of(segment)
-    index = leading_program(tokens)
-    if index >= len(tokens) or os.path.basename(tokens[index]) not in WRAPPERS:
-        return False
-    rest = tokens[index + 1:]
-    if any(first == "pr" and second == "create" for first, second in zip(rest, rest[1:])):
-        return True
-    return any(
-        program_invocations(argument, "gh", ("pr", "create")) or unclaimed_creation(argument, depth + 1)
-        for argument in rest
-    )
 
 
 def moves_directory(segment):
@@ -267,13 +239,7 @@ def main():
             return 0
         moved = False
         for segment in command_segments(command):
-            claimed = program_invocations(segment, "gh", ("pr", "create"))
-            if not claimed and unclaimed_creation(segment):
-                return refuse(
-                    "Refusing `gh pr create`: it is wrapped in something this cannot read past, so\n"
-                    "neither the body's provenance nor the directory it resolves in can be told.\n\n"
-                    "Run gh directly.")
-            for operands in claimed:
+            for operands in program_invocations(segment, "gh", ("pr", "create")):
                 verdict = check(operands, cwd, moved)
                 if verdict:
                     return verdict

--- a/.claude/hooks/refuse/pr_body_of_another_branch.py
+++ b/.claude/hooks/refuse/pr_body_of_another_branch.py
@@ -127,44 +127,38 @@ MOVERS = {"cd", "pushd", "popd"}
 # Programs whose whole purpose is to run another one in the caller's place. timeout and xargs were
 # here and are not: they are ordinarily given some other program, and `timeout 5 echo gh pr create`
 # is then indistinguishable from the call itself at token level.
-WRAPPERS = {"env", "sudo", "doas", "bash", "sh", "zsh", "eval", "nice", "stdbuf"}
+WRAPPERS = {"env", "sudo", "doas", "bash", "sh", "zsh", "eval", "nice", "stdbuf", "script", "flock"}
 
 
-def unclaimed_creation(segment):
-    """Whether this segment runs `gh pr create` in a shape program_invocations does not claim.
+def unclaimed_creation(segment, depth=0):
+    """Whether this segment runs `gh pr create` where program_invocations cannot claim it.
 
-    Two shapes reach it. A wrapper takes the command word, so the invocation is invisible — `env -C`
-    is the one that also moves the directory, and `bash -c` hides the whole thing. And gh's own
-    global flags sit before the subcommand, so `gh -R owner/repo pr create` is plain gh that the
-    parser's fixed-word match walks past.
+    gh itself is no longer such a shape: the shared parser steps over gh's own options, so
+    `gh -R owner/repo pr create` is checked like any other spelling rather than refused.
 
-    Both read the command word and then adjacent tokens. Two weaker rules were tried and refused
-    ordinary commands: matching the phrase anywhere in the text blocked writing this branch's own
-    pull-request body, and asking whether `pr` and `create` merely appear blocked `gh pr list
-    --search create` and `gh issue create --label pr`.
+    What is left is a wrapper taking the command word. Two forms, and they need different questions.
+    Unquoted — `sudo gh pr create` — the call is in this segment's own tokens. Quoted — `bash -c "gh
+    pr create …"` — shlex hands the payload back as ONE token whose text is a whole command, so
+    asking the same question of each argument reaches it. Nothing is masked; an earlier version said
+    so and scanned the raw text instead, which refused prose twice.
 
-    Not seen, and left that way: a payload the tokeniser masks, as in `bash -c "gh pr create …"`.
-    Reading the raw text to reach it is the rule that refused prose, and a spelling nobody here uses
-    is worth less than not blocking the ones they do.
+    Recursion does not remove the wrapper list, which is what it looked like it would do: `echo gh pr
+    create` and `sudo gh pr create` are the same tokens, so only a name separates a wrapper from a
+    program being handed words. The list is what decides whose arguments are worth recursing into.
     """
+    if depth > 2:
+        return False
     tokens = tokens_of(segment)
     index = leading_program(tokens)
-    if index >= len(tokens):
+    if index >= len(tokens) or os.path.basename(tokens[index]) not in WRAPPERS:
         return False
-    word = os.path.basename(tokens[index])
     rest = tokens[index + 1:]
-    if word in WRAPPERS:
-        return any(os.path.basename(token) == "gh" for token in rest) and creation_in(rest)
-    return word == "gh" and creation_in(rest)
-
-
-def creation_in(tokens):
-    """Whether `pr create` appears as two adjacent tokens.
-
-    Adjacency, not membership: asking whether both merely appear refused `gh pr list --search
-    create` and `gh issue create --label pr`.
-    """
-    return any(first == "pr" and second == "create" for first, second in zip(tokens, tokens[1:]))
+    if any(first == "pr" and second == "create" for first, second in zip(rest, rest[1:])):
+        return True
+    return any(
+        program_invocations(argument, "gh", ("pr", "create")) or unclaimed_creation(argument, depth + 1)
+        for argument in rest
+    )
 
 
 def moves_directory(segment):

--- a/.claude/hooks/refuse/pr_body_of_another_branch.py
+++ b/.claude/hooks/refuse/pr_body_of_another_branch.py
@@ -14,13 +14,14 @@ description is whatever the file held.
 Two questions, because "is this body about this branch" has exactly two a machine can answer:
 
 - **The file predates the branch.** A body last written before the branch's first commit cannot
-  describe what that branch does, whatever left it there. A missing file is the same failure one
-  step earlier, which is the shape the incident took.
+  describe what that branch does, whatever left it there. A missing file is refused too: that is the
+  same accident before the leftover is found, and it is what the chain above would have produced in
+  a directory the previous pull request had not written to.
 - **It names no issue.** A pull request that closes one says so and the issue closes itself on merge;
   one that closes nothing says `No issue: <where this came from>`, which is a decision rather than a
   silence. CONTRIBUTING.md owns that rule — this refuses, it does not define.
 
-It does not read the prose: nothing can look at a description and tell whose branch it is.
+It does not judge what the body is about: nothing can read a description and tell whose branch it is.
 
 **Both halves fail closed.** The first version resolved the branch from the session's directory,
 which is the primary checkout while the branch under review sits in a worktree — the configuration
@@ -37,17 +38,16 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lib"))
-from shell_commands import program_invocations, unexpanded
-from velvet_hooks import BRANCH_BASES
+from shell_commands import command_segments, program_invocations, tokens_of, unexpanded
 
 # Registered on the event in .claude/settings.json rather than narrowed to the agents expected to
 # open pull requests, which would leave every other session unguarded. `HookWiringCoverageTests`
 # reads this declaration to check that the registration is still there.
 HOOK_SCOPE = "session"
 
-# Only the body operand is resolved, so only that one going unexpanded leaves the question
-# unanswered. A rewritten --title or --label costs nothing here, and refusing over one is how the
-# first version blocked bodies it could read perfectly well.
+# The operands this resolves — the body, and the refs it dates the body against. A rewritten --title
+# or --label is not read here and costs nothing, and refusing over one is how the first version
+# blocked bodies it could read perfectly well.
 UNEXPANDED_POLICY = "refuse"
 UNEXPANDED_PROBE = 'gh pr create --title t --body-file $BODY --label bug'
 
@@ -55,8 +55,6 @@ BODY_FILE_FLAGS = ("--body-file", "-F")
 BODY_FLAGS = ("--body", "-b")
 HEAD_FLAGS = ("--head", "-H")
 BASE_FLAGS = ("--base", "-B")
-WEB_FLAGS = {"--web", "-w"}
-
 ISSUE_REFERENCE = re.compile(r"#\d+")
 # A line rather than a flag, so the answer lands in the published body where a reader looking for
 # where a change came from finds it. It has to carry a reason: the bare token would be a way of
@@ -90,32 +88,23 @@ def git(cwd, *args):
     return done.stdout.strip() if done.returncode == 0 else None
 
 
-def recorded_base(name):
-    """The start point `branch_from_unmerged.py` recorded for this branch, or None."""
-    try:
-        with open(BRANCH_BASES, encoding="utf-8") as bases:
-            matches = [line for line in bases if line.startswith(f"{name} ")]
-    except OSError:
-        return None
-    if not matches:
-        return None
-    parts = matches[-1].split(None, 1)
-    return parts[1].strip() if len(parts) == 2 else None
-
-
 def branch_start(cwd, head, base):
     """When the branch's own first commit was authored, or None when that cannot be determined.
 
-    Author date, not committer date: a rebase — which the sibling guards here prescribe by name —
-    rewrites the committer date to now and would turn every correct body into a refusal.
+    Author date, not committer date: a rebase — which two sibling guards prescribe by name — rewrites
+    the committer date to now, which would refuse any body written before that rebase ran.
 
     The head is taken from the command when it names one, because the directory the command runs in
     is routinely not the branch's: a session coordinating worktrees runs from the primary checkout.
+
+    The base a sibling guard records in ~/.velvet-branch-bases was consulted here and is not any more.
+    It is one file for every repository on the machine, never pruned, and a stacked branch's entry
+    stops being an ancestor the moment the rebase that same guard prescribes runs — after which the
+    window widens by however long the parent sat unmerged. merge-base answered correctly in every
+    case that was built to separate them.
     """
     ref = head or "HEAD"
-    start = recorded_base(head) if head else None
-    if start is None:
-        start = git(cwd, "merge-base", base, ref)
+    start = git(cwd, "merge-base", base, ref)
     if start is None:
         return None
     stamps = git(cwd, "log", "--format=%at", f"{start}..{ref}")
@@ -125,27 +114,37 @@ def branch_start(cwd, head, base):
     return int(authored[-1]) if authored else None
 
 
+def moves_directory(command):
+    """Whether any segment of the command is a `cd`, which this cannot follow."""
+    for segment in command_segments(command):
+        tokens = tokens_of(segment)
+        if tokens and os.path.basename(tokens[0]) in ("cd", "pushd"):
+            return True
+    return False
+
+
 def refuse(message):
     print(message, file=sys.stderr)
     return 2
 
 
-def check(operands, cwd):
+def check(operands, cwd, moves_directory):
     """0, or 2 with the reason written to stderr."""
-    if WEB_FLAGS & set(operands):
-        return 0
-
     path = valued(operands, BODY_FILE_FLAGS)
     text = valued(operands, BODY_FLAGS)
     if path is None and text is None:
-        # --fill, --fill-first, --template: the body comes from commits or a template, which are not
-        # a file this can date, and which the author did not write here to be checked.
+        # --fill, --fill-first, --template: the body comes from commits or a template. Neither is a
+        # file this can date, and neither is text it holds, so both questions go unasked — including
+        # the issue one, which CONTRIBUTING states without that exception.
         return 0
-    if any(unexpanded(operand) for operand in (path, text) if operand is not None):
+    head = valued(operands, HEAD_FLAGS)
+    base = valued(operands, BASE_FLAGS) or "origin/main"
+    resolved_operands = [operand for operand in (path, text, head, base) if operand is not None]
+    if any(unexpanded(operand) for operand in resolved_operands):
         return refuse(
-            "Refusing `gh pr create`: the body operand is still unexpanded, so neither the file's\n"
-            "provenance nor the issue it names can be read.\n\n"
-            "Run it with the body spelled out.")
+            "Refusing `gh pr create`: an operand this reads is still unexpanded — the body, or the\n"
+            "branch it dates the body against.\n\n"
+            "Run it with those spelled out.")
 
     if path == "-":
         return refuse(
@@ -153,6 +152,11 @@ def check(operands, cwd):
             "Write it to a file and pass that, so the question of whose branch it describes has\n"
             "an answer.")
     if path is not None:
+        if moves_directory and not os.path.isabs(path):
+            return refuse(
+                "Refusing `gh pr create`: the command changes directory, so a relative body path\n"
+                "names one file here and another one to `gh`.\n\n"
+                "Give the body an absolute path.")
         resolved = Path(path) if os.path.isabs(path) else Path(cwd) / path
         if not resolved.exists():
             return refuse(
@@ -160,8 +164,6 @@ def check(operands, cwd):
                 "A body file that is not there is usually one whose write did not run — a refused\n"
                 "hook stops the whole `&&` chain it was in, including the write.")
 
-        head = valued(operands, HEAD_FLAGS)
-        base = valued(operands, BASE_FLAGS) or "origin/main"
         started = branch_start(cwd, head, base)
         if started is None:
             return refuse(
@@ -209,8 +211,9 @@ def main():
         cwd = event.get("cwd") or "."
         if not isinstance(command, str):
             return 0
+        moved = moves_directory(command)
         for operands in program_invocations(command, "gh", ("pr", "create")):
-            verdict = check(operands, cwd)
+            verdict = check(operands, cwd, moved)
             if verdict:
                 return verdict
         return 0

--- a/.claude/hooks/refuse/pr_body_of_another_branch.py
+++ b/.claude/hooks/refuse/pr_body_of_another_branch.py
@@ -124,20 +124,34 @@ def branch_start(cwd, head, base):
 
 
 MOVERS = {"cd", "pushd", "popd"}
+# Programs that take the command word and run something else with it.
+WRAPPERS = {"env", "sudo", "xargs", "bash", "sh", "zsh", "eval", "doas", "timeout"}
 
 
 def unclaimed_creation(segment):
-    """Whether a segment runs `gh pr create` in a shape program_invocations does not claim.
+    """Whether this segment runs `gh pr create` in a shape program_invocations does not claim.
 
-    `env -C dir gh pr create` is the reachable one: env is the command word, so the invocation is
-    invisible, and the -C is a directory change on top. Anything wrapping gh this way is a call this
-    cannot read, and a call it cannot read is one it must not pass.
+    Two shapes reach it. A wrapper takes the command word, so the invocation is invisible — `env -C`
+    is the one that also moves the directory, and `bash -c` hides the whole thing. And gh's own
+    global flags sit before the subcommand, so `gh -R owner/repo pr create` is plain gh that the
+    parser's fixed-word match walks past.
+
+    Matched off the command word: a segment merely containing the phrase is prose, and refusing that
+    blocked writing this branch's own pull-request body. Inside a wrapper the text is read as well,
+    because a wrapper's payload is a quoted argument the tokeniser has already masked.
     """
     tokens = tokens_of(segment)
-    for index, token in enumerate(tokens[:-2]):
-        if os.path.basename(token) == "gh" and tokens[index + 1] == "pr" and tokens[index + 2] == "create":
-            return True
-    return False
+    index = leading_program(tokens)
+    if index >= len(tokens):
+        return False
+    word = os.path.basename(tokens[index])
+    rest = tokens[index + 1:]
+    if word in WRAPPERS:
+        # A wrapper's payload is usually one quoted argument, which the tokeniser masks away, so the
+        # raw text is what is left to read. Confined to a wrapper: matching the phrase anywhere is
+        # what refused prose when it was the whole rule.
+        return any(os.path.basename(token) == "gh" for token in rest) or "gh pr create" in segment
+    return word == "gh" and "pr" in rest and "create" in rest
 
 
 def moves_directory(segment):

--- a/.claude/hooks/refuse/pr_body_of_another_branch.py
+++ b/.claude/hooks/refuse/pr_body_of_another_branch.py
@@ -124,8 +124,10 @@ def branch_start(cwd, head, base):
 
 
 MOVERS = {"cd", "pushd", "popd"}
-# Programs that take the command word and run something else with it.
-WRAPPERS = {"env", "sudo", "xargs", "bash", "sh", "zsh", "eval", "doas", "timeout"}
+# Programs whose whole purpose is to run another one in the caller's place. timeout and xargs were
+# here and are not: they are ordinarily given some other program, and `timeout 5 echo gh pr create`
+# is then indistinguishable from the call itself at token level.
+WRAPPERS = {"env", "sudo", "doas", "bash", "sh", "zsh", "eval", "nice", "stdbuf"}
 
 
 def unclaimed_creation(segment):
@@ -136,9 +138,14 @@ def unclaimed_creation(segment):
     global flags sit before the subcommand, so `gh -R owner/repo pr create` is plain gh that the
     parser's fixed-word match walks past.
 
-    Matched off the command word: a segment merely containing the phrase is prose, and refusing that
-    blocked writing this branch's own pull-request body. Inside a wrapper the text is read as well,
-    because a wrapper's payload is a quoted argument the tokeniser has already masked.
+    Both read the command word and then adjacent tokens. Two weaker rules were tried and refused
+    ordinary commands: matching the phrase anywhere in the text blocked writing this branch's own
+    pull-request body, and asking whether `pr` and `create` merely appear blocked `gh pr list
+    --search create` and `gh issue create --label pr`.
+
+    Not seen, and left that way: a payload the tokeniser masks, as in `bash -c "gh pr create …"`.
+    Reading the raw text to reach it is the rule that refused prose, and a spelling nobody here uses
+    is worth less than not blocking the ones they do.
     """
     tokens = tokens_of(segment)
     index = leading_program(tokens)
@@ -147,11 +154,17 @@ def unclaimed_creation(segment):
     word = os.path.basename(tokens[index])
     rest = tokens[index + 1:]
     if word in WRAPPERS:
-        # A wrapper's payload is usually one quoted argument, which the tokeniser masks away, so the
-        # raw text is what is left to read. Confined to a wrapper: matching the phrase anywhere is
-        # what refused prose when it was the whole rule.
-        return any(os.path.basename(token) == "gh" for token in rest) or "gh pr create" in segment
-    return word == "gh" and "pr" in rest and "create" in rest
+        return any(os.path.basename(token) == "gh" for token in rest) and creation_in(rest)
+    return word == "gh" and creation_in(rest)
+
+
+def creation_in(tokens):
+    """Whether `pr create` appears as two adjacent tokens.
+
+    Adjacency, not membership: asking whether both merely appear refused `gh pr list --search
+    create` and `gh issue create --label pr`.
+    """
+    return any(first == "pr" and second == "create" for first, second in zip(tokens, tokens[1:]))
 
 
 def moves_directory(segment):

--- a/.claude/hooks/refuse/pr_body_of_another_branch.py
+++ b/.claude/hooks/refuse/pr_body_of_another_branch.py
@@ -39,7 +39,6 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lib"))
 from shell_commands import command_segments, leading_program, program_invocations, tokens_of, unexpanded
-from velvet_hooks import BRANCH_BASES
 
 # Registered on the event in .claude/settings.json rather than narrowed to the agents expected to
 # open pull requests, which would leave every other session unguarded. `HookWiringCoverageTests`
@@ -89,21 +88,6 @@ def git(cwd, *args):
     return done.stdout.strip() if done.returncode == 0 else None
 
 
-def recorded_base(name):
-    """The start point `branch_from_unmerged.py` recorded for this branch, or None."""
-    if not name:
-        return None
-    try:
-        with open(BRANCH_BASES, encoding="utf-8") as bases:
-            matches = [line for line in bases if line.startswith(f"{name} ")]
-    except OSError:
-        return None
-    if not matches:
-        return None
-    parts = matches[-1].split(None, 1)
-    return parts[1].strip() if len(parts) == 2 else None
-
-
 def first_commit_after(cwd, start, ref):
     """When the oldest commit in start..ref was authored, or None when that cannot be read.
 
@@ -120,21 +104,23 @@ def first_commit_after(cwd, start, ref):
 def branch_start(cwd, head, base):
     """When the branch's own first commit was authored, or None when that cannot be determined.
 
-    Two sources, and the LATEST answer wins, because each is wrong in the same direction and only
-    one of them at a time. For a stacked branch before the rebase a sibling prescribes, merge-base
-    against the target reaches back past the parent and returns the PARENT's first commit; after that
-    rebase, the base that sibling recorded is no longer an ancestor and the walk widens the same way.
-    Both errors make the branch look older than it is, which widens the window a stale body has to
-    beat — so the younger of the two is the one that cannot be fooled by either.
+    One source, and a stated limit. The base a sibling records in ~/.velvet-branch-bases was tried
+    here twice and answers wrongly in both directions: after the rebase that sibling prescribes its
+    sha is no longer an ancestor and the walk widens, and an entry pointing part-way along a branch
+    — the file is machine-global, append-only and never pruned — makes the branch look YOUNGER than
+    it is and refuses a correct body. Both were built and run.
+
+    What is left over: a stacked branch that targets main and has not been rebased yet gets the
+    window measured from its PARENT's first commit rather than its own, because that is where
+    merge-base against main lands. Passing --base <parent> measures it correctly. A body older than
+    the parent is still caught; one written between the two is not.
 
     The head is taken from the command when it names one, because the directory the command runs in
     is routinely not the branch's: a session coordinating worktrees runs from the primary checkout.
     """
     ref = head or "HEAD"
-    starts = [recorded_base(head), git(cwd, "merge-base", base, ref)]
-    authored = [first_commit_after(cwd, start, ref) for start in starts if start]
-    answers = [when for when in authored if when is not None]
-    return max(answers) if answers else None
+    start = git(cwd, "merge-base", base, ref)
+    return first_commit_after(cwd, start, ref) if start else None
 
 
 MOVERS = {"cd", "pushd", "popd"}

--- a/.claude/hooks/refuse/pr_body_of_another_branch.py
+++ b/.claude/hooks/refuse/pr_body_of_another_branch.py
@@ -1,27 +1,44 @@
 #!/usr/bin/env python3
-"""Refuse a pull-request body that was not written for this branch.
+"""Refuse a pull-request body that names neither an issue nor a reason for having none.
 
-A pull request was opened here whose whole description belonged to a different one, and it stayed
-that way until a person read it. The body file was named `pr-body.md`, a previous pull request had
-left a file of that name in the same scratch directory, and the write meant to replace it never ran:
-it sat in the same `&&` chain as a `gh pr create` that a hook refused, and a refusal stops the whole
-chain. Nothing about the retry looked wrong — the path existed, `gh` read it, the pull request opened
-and went green.
+A change that came straight out of an issue was merged without linking it, so the issue stayed open
+with its work already shipped. The body is the one artefact nothing else here checks: CI reads the
+diff and so does review, and the description is whatever the file held.
 
-The body is the one artefact nothing else here checks. CI reads the diff and so does review; the
-description is whatever the file held.
+CONTRIBUTING.md owns the rule; this refuses, it does not define. An answer is a closing or referring
+keyword against a number, or a full issue URL, or a `No issue: <where this came from>` line — a
+decision rather than a silence. A bare `#` and digits is not one: a six-digit colour satisfies it,
+and a number mentioned in prose closes nothing on merge, which is the half of the accident that hurt.
 
-Two questions, because "is this body about this branch" has exactly two a machine can answer:
+## The staleness check is gone, and nothing replaced it
 
-- **The file predates the branch.** A body last written before the branch's first commit cannot
-  describe what that branch does, whatever left it there. A missing file is refused too: that is the
-  same accident before the leftover is found, and it is what the chain above would have produced in
-  a directory the previous pull request had not written to.
-- **It names no issue.** A pull request that closes one says so and the issue closes itself on merge;
-  one that closes nothing says `No issue: <where this came from>`, which is a decision rather than a
-  silence. CONTRIBUTING.md owns that rule — this refuses, it does not define.
+Earlier rounds of this also dated the body file against the branch's first commit, to catch the
+leftover of a previous pull request being reused by the next. It was posed the case it exists for,
+built from two pull requests opened one after another here: a body file stamped at the moment the
+first was opened, against the branch of the second, whose first commit lands sixteen seconds later.
+The check allowed fifteen minutes, and allowed it. The comparison was one-sided besides, so a
+leftover stamped after the branch's first commit was allowed with no bound at all.
 
-It does not judge what the body is about: nothing can read a description and tell whose branch it is.
+No window fixes that, wider or narrower, because of when a PreToolUse hook runs. Where the body is
+written by the very command that posts it — a heredoc into the path, then `gh pr create` reading it
+— this runs before the write. The mtime it reads then belongs to whatever was already at that path,
+which is the leftover itself, and the file it would date is the one the command is about to
+overwrite. A narrower window refuses correct bodies; a wider one admits more leftovers; neither is
+reading the description that will be posted.
+
+So it does not judge what the body is about at all — only whether it says where the change came from.
+
+## What it reads, and what it refuses for being unreadable
+
+It reads the description that will be posted, so the body has to be there before the command runs.
+What it cannot read it refuses rather than skips, because a guard that skips reports what a guard
+that passed reports: an absent file, a path the shell has yet to expand, a body on stdin, a relative
+path in a command that also changes directory, a file the filesystem will not hand over. Each
+refusal carries its own remedy.
+
+An inline `--body` is the description rather than a name for it, so it is searched as it stands and
+its backticks and `$` cost nothing. Only when the search finds no answer does an expansion in it
+matter, and then it is the same refusal for the same reason: the text posted is not the text here.
 
 Nor does it see a `gh pr create` the shared parser does not claim — behind `sudo`, inside `bash -c`,
 or with gh's own options before the subcommand. Four attempts at that reached in both wrong
@@ -29,18 +46,11 @@ directions: enumerating wrapper names refused `sudo gh auth status` and a `timeo
 wait, matching the phrase refused prose including the message of the commit that added it, and
 teaching the shared parser gh's options made every value-taking option it did not name walk off the
 subcommand and match nothing — in six guards, not one. What is left is what has never been in doubt.
-
-**What it can answer, it fails closed on.** The first version resolved the branch from the session's directory,
-which is the primary checkout while the branch under review sits in a worktree — the configuration
-this is used from. `origin/main..HEAD` was then empty, the start came back unknown, and the check
-that could not be made was skipped rather than refused. What a guard cannot determine is what it must
-refuse; the alternative is silence exactly where the input is unusual.
 """
 
 import json
 import os
 import re
-import subprocess
 import sys
 from pathlib import Path
 
@@ -52,25 +62,36 @@ from shell_commands import command_segments, leading_program, program_invocation
 # reads this declaration to check that the registration is still there.
 HOOK_SCOPE = "session"
 
-# The operands this resolves — the body, and the refs it dates the body against. A rewritten --title
-# or --label is not read here and costs nothing, and refusing over one is how the first version
-# blocked bodies it could read perfectly well.
+# The body file is opened, so a path the shell has not expanded leaves nothing to open. An inline
+# body is searched rather than resolved, and is refused only where the search comes back empty.
 UNEXPANDED_POLICY = "refuse"
-UNEXPANDED_PROBE = 'gh pr create --title t --body-file $BODY --label bug'
+UNEXPANDED_PROBE = 'gh pr create --title t --body-file $BODY'
 
 BODY_FILE_FLAGS = ("--body-file", "-F")
 BODY_FLAGS = ("--body", "-b")
-HEAD_FLAGS = ("--head", "-H")
-BASE_FLAGS = ("--base", "-B")
-ISSUE_REFERENCE = re.compile(r"#\d+")
+# Neither opens a pull request, so neither posts a description.
+EXEMPT_FLAGS = ("--dry-run", "--help", "-h")
+
+# A keyword against a number, or the issue's own URL. The keyword is what distinguishes a statement
+# of origin from a number that happens to appear: the bare form was satisfied by a six-digit colour,
+# and it counted a cross-reference in prose, which leaves the issue open exactly as before.
+ISSUE_REFERENCE = re.compile(
+    r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?|refs?)\b[^\S\n]*:?[^\S\n]*#\d+"
+    r"|github\.com/[\w.-]+/[\w.-]+/issues/\d+",
+    re.IGNORECASE)
 # A line rather than a flag, so the answer lands in the published body where a reader looking for
 # where a change came from finds it. It has to carry a reason: the bare token would be a way of
 # saying nothing in a form that satisfies the check, which is the silence this asks about.
 NO_ISSUE_LINE = re.compile(r"^[^\S\n]*No issue[:.][^\S\n]*\S", re.MULTILINE | re.IGNORECASE)
 
-# A body is often written before the commit it describes. This is how much of that ordering is
-# allowed — our decision, not a measurement of anything.
-DRAFTING_WINDOW = 900
+NO_ANSWER = (
+    "Refusing `gh pr create`: the body names no issue.\n\n"
+    "CONTRIBUTING.md asks every pull request to say where it came from. If it closes an\n"
+    "issue, the first line closes it on merge:\n\n"
+    "  Closes #<n>.\n\n"
+    "If it closes nothing — a tooling change, a release — say that instead, so a reader\n"
+    "who wonders where it came from finds an answer rather than a silence:\n\n"
+    "  No issue: <where this came from>")
 
 
 def valued(operands, flags):
@@ -80,6 +101,10 @@ def valued(operands, flags):
     carrying its value attached. The last was missed, so `-F/tmp/pr-body.md` reached none of the
     checks below: the invocation was claimed, no body was found, and it took the exemption meant for
     a body this cannot read. That is the accident this guard exists for, one character apart.
+
+    A name is read off any token, including one that is another option's value, so `-t -Fx` gives a
+    body file of `x` and the file asked about is not the one gh will post. Separating the two needs a
+    mirror of which of gh's options take a value, and an unpinned mirror drifts.
     """
     short = tuple(flag for flag in flags if len(flag) == 2 and flag.startswith("-") and flag[1] != "-")
     for index, token in enumerate(operands):
@@ -96,59 +121,15 @@ def valued(operands, flags):
     return None
 
 
-def git(cwd, *args):
-    """stdout of a git command, or None when it cannot be run or fails."""
-    try:
-        done = subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True, timeout=5)
-    except (OSError, subprocess.SubprocessError):
-        return None
-    return done.stdout.strip() if done.returncode == 0 else None
-
-
-def first_commit_after(cwd, start, ref):
-    """When the oldest commit in start..ref was authored, or None when that cannot be read.
-
-    Author date, not committer date: a rebase — which two sibling guards prescribe by name —
-    rewrites the committer date to now, which would refuse a body written before that rebase.
-    """
-    stamps = git(cwd, "log", "--format=%at", f"{start}..{ref}")
-    if stamps is None:
-        return None
-    authored = [line for line in stamps.split() if line.isdigit()]
-    return int(authored[-1]) if authored else None
-
-
-def branch_start(cwd, head, base):
-    """When the branch's own first commit was authored, or None when that cannot be determined.
-
-    One source, and a stated limit. The base a sibling records in ~/.velvet-branch-bases was tried
-    here twice and answers wrongly in both directions: after the rebase that sibling prescribes its
-    sha is no longer an ancestor and the walk widens, and an entry pointing part-way along a branch
-    — the file is machine-global, append-only and never pruned — makes the branch look YOUNGER than
-    it is and refuses a correct body. Both were built and run.
-
-    What is left over: a stacked branch that targets main and has not been rebased yet gets the
-    window measured from its PARENT's first commit rather than its own, because that is where
-    merge-base against main lands. Passing --base <parent> measures it correctly. A body older than
-    the parent is still caught; one written between the two is not.
-
-    The head is taken from the command when it names one, because the directory the command runs in
-    is routinely not the branch's: a session coordinating worktrees runs from the primary checkout.
-    """
-    ref = head or "HEAD"
-    start = git(cwd, "merge-base", base, ref)
-    return first_commit_after(cwd, start, ref) if start else None
-
-
 MOVERS = {"cd", "pushd", "popd"}
 
 
 def moves_directory(segment):
     """Whether this segment changes the directory a later segment runs in.
 
-    The command word is read the way shell_commands reads one, past `then`/`do` and an environment
-    assignment: reading tokens[0] instead missed `if true; then cd /tmp; fi`, which is the lib's own
-    documented reason for having leading_program at all.
+    The command word is read the way shell_commands reads one, past `then`/`do`, `builtin` and an
+    environment assignment: reading tokens[0] instead missed `if true; then cd /tmp; fi`, which is
+    the lib's own documented reason for having leading_program at all.
     """
     tokens = tokens_of(segment)
     index = leading_program(tokens)
@@ -163,75 +144,75 @@ def refuse(message):
     return 2
 
 
-def check(operands, cwd, after_a_move):
-    """0, or 2 with the reason written to stderr."""
-    path = valued(operands, BODY_FILE_FLAGS)
-    text = valued(operands, BODY_FLAGS)
-    if path is None and text is None:
-        # --fill, --fill-first, --template: the body is commits, or a file committed to be reused by
-        # every branch. Dating either against this branch answers nothing, and neither is text held
-        # here to search — so the issue question goes unasked too, which CONTRIBUTING states without
-        # this exception.
-        return 0
-    head = valued(operands, HEAD_FLAGS)
-    base = valued(operands, BASE_FLAGS) or "origin/main"
-    resolved_operands = [operand for operand in (path, text, head, base) if operand is not None]
-    if any(unexpanded(operand) for operand in resolved_operands):
-        return refuse(
-            "Refusing `gh pr create`: an operand this reads is still unexpanded — the body, or the\n"
-            "branch it dates the body against.\n\n"
-            "Run it with those spelled out.")
+def answered(text):
+    """Whether the body says where the change came from, either way round."""
+    return bool(ISSUE_REFERENCE.search(text) or NO_ISSUE_LINE.search(text))
 
+
+def judge_inline(text):
+    """0, or 2 with the reason written to stderr."""
+    if answered(text):
+        return 0
+    if unexpanded(text):
+        return refuse(
+            "Refusing `gh pr create`: the body is assembled by the shell, so the description this\n"
+            "can read is not the one that will be posted.\n\n"
+            "Write it to a file in a step of its own and pass `--body-file <path>`.")
+    return refuse(NO_ANSWER)
+
+
+def judge_file(path, cwd, after_a_move):
+    """0, or 2 with the reason written to stderr."""
+    if unexpanded(path):
+        return refuse(
+            "Refusing `gh pr create`: the body file's path is still unexpanded, so this cannot open\n"
+            "the description that will be posted.\n\n"
+            "Run it with the path spelled out.")
     if path == "-":
         return refuse(
             "Refusing `gh pr create`: the body comes from stdin, which this cannot read.\n\n"
-            "Write it to a file and pass that, so the question of whose branch it describes has\n"
-            "an answer.")
-    if path is not None:
-        if after_a_move and not os.path.isabs(path):
-            return refuse(
-                "Refusing `gh pr create`: the command changes directory, so a relative body path\n"
-                "names one file here and another one to `gh`.\n\n"
-                "Give the body an absolute path.")
-        resolved = Path(path) if os.path.isabs(path) else Path(cwd) / path
-        if not resolved.exists():
-            return refuse(
-                f"Refusing `gh pr create`: {path} does not exist.\n\n"
-                "A body file that is not there is usually one whose write did not run — a refused\n"
-                "hook stops the whole `&&` chain it was in, including the write.")
-
-        started = branch_start(cwd, head, base)
-        if started is None:
-            return refuse(
-                "Refusing `gh pr create`: this cannot tell when the branch started, so it cannot\n"
-                f"tell whether {path} was written for it.\n\n"
-                f"Run it from the branch's own directory, or pass `--head <branch>`.")
-        try:
-            written = resolved.stat().st_mtime
-        except OSError:
-            return refuse(f"Refusing `gh pr create`: {path} cannot be read.")
-        if written < started - DRAFTING_WINDOW:
-            older = int((started - written) // 60)
-            return refuse(
-                f"Refusing `gh pr create`: {path} was last written {older} minutes before this\n"
-                "branch's first commit, so it was written for something else.\n\n"
-                "A pull request opened this way carries whatever that path held. On the occasion\n"
-                "this guard was written for, that was another branch's description, from creation\n"
-                "until a person read it.")
-        try:
-            text = resolved.read_text(encoding="utf-8", errors="replace")
-        except OSError:
-            return refuse(f"Refusing `gh pr create`: {path} cannot be read.")
-
-    if text is not None and not ISSUE_REFERENCE.search(text) and not NO_ISSUE_LINE.search(text):
+            "Write it to a file and pass that, so the description that will be posted is one this\n"
+            "can read too.")
+    if after_a_move and not os.path.isabs(path):
         return refuse(
-            "Refusing `gh pr create`: the body names no issue.\n\n"
-            "CONTRIBUTING.md asks every pull request to say where it came from. If it closes an\n"
-            "issue, the first line closes it on merge:\n\n"
-            "  Closes #<n>.\n\n"
-            "If it closes nothing — a tooling change, a release — say that instead, so a reader\n"
-            "who wonders where it came from finds an answer rather than a silence:\n\n"
-            "  No issue: <where this came from>")
+            "Refusing `gh pr create`: the command changes directory, so a relative body path\n"
+            "names one file here and another one to `gh`.\n\n"
+            "Give the body an absolute path.")
+    resolved = Path(path) if os.path.isabs(path) else Path(cwd) / path
+    if not resolved.exists():
+        return refuse(
+            f"Refusing `gh pr create`: {path} does not exist.\n\n"
+            "The body has to be there before this command runs, so a body written by this same\n"
+            "command is too late — write it in a step of its own and create the pull request in\n"
+            "the next. A path that is missing for any other reason is usually one whose write did\n"
+            "not run: a refused hook stops the whole `&&` chain it was in, including the write.")
+    try:
+        text = resolved.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return refuse(f"Refusing `gh pr create`: {path} cannot be read.")
+    return 0 if answered(text) else refuse(NO_ANSWER)
+
+
+def check(operands, cwd, after_a_move):
+    """0, or 2 with the reason written to stderr."""
+    if any(token in EXEMPT_FLAGS for token in operands):
+        return 0
+    path = valued(operands, BODY_FILE_FLAGS)
+    text = valued(operands, BODY_FLAGS)
+    if path is None and text is None:
+        # No body operand at all: --fill and its relatives, --template, --recover, --editor, and the
+        # interactive form. The description comes from commits, from a file every branch reuses, or
+        # from a prompt after this has run, and none of those is text held here to search — so the
+        # question goes unasked, which CONTRIBUTING states without this exception.
+        return 0
+    # Both are judged when both are given: which one gh posts is not something this holds, so an
+    # answer carried only by the one it does not post would be an answer nobody reads.
+    if text is not None:
+        verdict = judge_inline(text)
+        if verdict:
+            return verdict
+    if path is not None:
+        return judge_file(path, cwd, after_a_move)
     return 0
 
 

--- a/.claude/hooks/refuse/pr_body_of_another_branch.py
+++ b/.claude/hooks/refuse/pr_body_of_another_branch.py
@@ -62,6 +62,11 @@ from shell_commands import command_segments, leading_program, program_invocation
 # reads this declaration to check that the registration is still there.
 HOOK_SCOPE = "session"
 
+# The tools this acts on, gated on below rather than restated there: the same fixture compares this
+# set against the matcher that routes tools to it, and a gate spelling the name a second time would
+# drift against both.
+HOOK_TOOLS = {"Bash"}
+
 # The body file is opened, so a path the shell has not expanded leaves nothing to open. An inline
 # body is searched rather than resolved, and is refused only where the search comes back empty.
 UNEXPANDED_POLICY = "refuse"
@@ -222,7 +227,7 @@ def main():
     except Exception:
         return 0
     try:
-        if not isinstance(event, dict) or event.get("tool_name") != "Bash":
+        if not isinstance(event, dict) or event.get("tool_name") not in HOOK_TOOLS:
             return 0
         command = event.get("tool_input", {}).get("command") or ""
         cwd = event.get("cwd") or "."

--- a/.claude/hooks/refuse/pr_body_of_another_branch.py
+++ b/.claude/hooks/refuse/pr_body_of_another_branch.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Refuse a pull-request body that was not written for this branch.
+
+A pull request was opened whose whole description belonged to a different one, and it stayed that
+way until a person read it. The body file was named `pr-body.md`, a previous pull request had left
+a file of that name in the same scratch directory, and the write that was meant to replace it never
+ran: it sat in the same `&&` chain as a `gh pr create` that a hook refused, and a refusal stops the
+whole chain. Nothing about the second attempt looked wrong — the path existed, `gh` read it, the
+pull request opened green.
+
+Two checks, because "is this body about this branch" has two answers a machine can give:
+
+- **The file is older than the branch.** A body written before the branch's first commit cannot
+  describe what that branch does. This is what catches the stale file, whatever left it there, and
+  it needs no idea of what the body says.
+- **It names no issue.** Every pull request here that closes one says so on its first line, and the
+  one that forgot it also had the wrong body — the same omission twice over. A pull request that
+  genuinely closes nothing says so in a line of its own, which is a decision rather than a silence.
+
+Not a check on what the body says: nothing can read prose and tell whose branch it is. These two
+are what remains once that is given up, and both would have fired here.
+"""
+
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lib"))
+from shell_commands import program_invocations, unexpanded
+
+# Registered on the event in .claude/settings.json rather than narrowed to the agents expected to
+# open pull requests, which would leave every other session unguarded. `HookWiringCoverageTests`
+# reads this declaration to check that the registration is still there.
+HOOK_SCOPE = "session"
+
+# An operand the shell rewrites is a path this cannot stat and a body it cannot read, so the
+# question goes unanswered. A guard that reads "I cannot tell" as "nothing to report" goes quiet
+# exactly when its subject is unusual, which is the shape the stale body already exploited.
+UNEXPANDED_POLICY = "refuse"
+UNEXPANDED_PROBE = 'gh pr create --title t --body-file $BODY --label bug'
+
+BODY_FILE_FLAGS = ("--body-file", "-F")
+BODY_FLAGS = ("--body", "-b")
+
+ISSUE_REFERENCE = re.compile(r"#\d+")
+# Written as a line rather than a flag so it lands in the published body, where a reader who
+# wonders which issue a change came from finds the answer instead of nothing.
+NO_ISSUE_LINE = re.compile(r"^\s*No issue[:.]", re.MULTILINE)
+
+# Long enough that a body drafted alongside the first commit is not caught by clock skew between
+# the file system and the commit stamp, short enough that a body from a previous branch is.
+DRIFT = 300
+
+
+def valued(operands, flags):
+    """The value given to one of `flags`, or None. Handles both `--flag v` and `--flag=v`."""
+    for index, token in enumerate(operands):
+        name, sep, inline = token.partition("=")
+        if name not in flags:
+            continue
+        if sep:
+            return inline
+        if index + 1 < len(operands):
+            return operands[index + 1]
+    return None
+
+
+def branch_start(cwd):
+    """When the oldest commit this branch does not share with its base was authored, or None."""
+    try:
+        base = subprocess.run(
+            ["git", "merge-base", "origin/main", "HEAD"],
+            cwd=cwd, capture_output=True, text=True, timeout=5)
+        if base.returncode != 0:
+            return None
+        stamps = subprocess.run(
+            ["git", "log", "--format=%ct", f"{base.stdout.strip()}..HEAD"],
+            cwd=cwd, capture_output=True, text=True, timeout=5)
+        if stamps.returncode != 0:
+            return None
+        lines = [line for line in stamps.stdout.split() if line.isdigit()]
+        return int(lines[-1]) if lines else None
+    except (OSError, subprocess.SubprocessError, ValueError):
+        return None
+
+
+def body_of(operands, cwd):
+    """(text, path, problem) for the body this invocation carries."""
+    path = valued(operands, BODY_FILE_FLAGS)
+    if path is None:
+        return valued(operands, BODY_FLAGS), None, None
+    resolved = Path(path) if os.path.isabs(path) else Path(cwd) / path
+    if not resolved.exists():
+        return None, resolved, f"{path} does not exist"
+    started = branch_start(cwd)
+    if started is not None and resolved.stat().st_mtime < started - DRIFT:
+        age = int((started - resolved.stat().st_mtime) // 60)
+        return None, resolved, (
+            f"{path} was last written {age} minutes before this branch's first commit, "
+            "so it was written for something else")
+    try:
+        return resolved.read_text(encoding="utf-8", errors="replace"), resolved, None
+    except OSError:
+        return None, resolved, f"{path} cannot be read"
+
+
+def main():
+    try:
+        event = json.load(sys.stdin)
+    except Exception:
+        return 0
+    if event.get("tool_name") != "Bash":
+        return 0
+    command = event.get("tool_input", {}).get("command", "")
+    cwd = event.get("cwd") or "."
+
+    for operands in program_invocations(command, "gh", ("pr", "create")):
+        if "--web" in operands:
+            continue
+        if any(unexpanded(token) for token in operands):
+            print(
+                "Refusing `gh pr create`: an operand is still unexpanded, so neither the body's\n"
+                "provenance nor the issue it closes can be read here.\n\n"
+                "Run it with the operands spelled out.", file=sys.stderr)
+            return 2
+
+        text, _, problem = body_of(operands, cwd)
+        if problem:
+            print(
+                f"Refusing `gh pr create`: {problem}.\n\n"
+                "A pull request opened this way carries whatever that path held — on the occasion\n"
+                "this guard was written for, another branch's description, from creation until a\n"
+                "person read it.\n\n"
+                "Write the body for this branch and pass that file.", file=sys.stderr)
+            return 2
+
+        if text is not None and not ISSUE_REFERENCE.search(text) and not NO_ISSUE_LINE.search(text):
+            print(
+                "Refusing `gh pr create`: the body names no issue.\n\n"
+                "A pull request that closes one says so on its first line, and the issue then closes\n"
+                "itself on merge. Add:\n\n"
+                "  Closes #<n>.\n\n"
+                "If it closes nothing, say that instead — a line of its own, so a reader who wonders\n"
+                "where the change came from finds an answer rather than a silence:\n\n"
+                "  No issue: <where this came from>", file=sys.stderr)
+            return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/hooks/refuse/pr_body_of_another_branch.py
+++ b/.claude/hooks/refuse/pr_body_of_another_branch.py
@@ -23,7 +23,7 @@ Two questions, because "is this body about this branch" has exactly two a machin
 
 It does not judge what the body is about: nothing can read a description and tell whose branch it is.
 
-**Both halves fail closed.** The first version resolved the branch from the session's directory,
+**What it can answer, it fails closed on.** The first version resolved the branch from the session's directory,
 which is the primary checkout while the branch under review sits in a worktree — the configuration
 this is used from. `origin/main..HEAD` was then empty, the start came back unknown, and the check
 that could not be made was skipped rather than refused. What a guard cannot determine is what it must
@@ -38,7 +38,8 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lib"))
-from shell_commands import command_segments, program_invocations, tokens_of, unexpanded
+from shell_commands import command_segments, leading_program, program_invocations, tokens_of, unexpanded
+from velvet_hooks import BRANCH_BASES
 
 # Registered on the event in .claude/settings.json rather than narrowed to the agents expected to
 # open pull requests, which would leave every other session unguarded. `HookWiringCoverageTests`
@@ -88,25 +89,27 @@ def git(cwd, *args):
     return done.stdout.strip() if done.returncode == 0 else None
 
 
-def branch_start(cwd, head, base):
-    """When the branch's own first commit was authored, or None when that cannot be determined.
-
-    Author date, not committer date: a rebase — which two sibling guards prescribe by name — rewrites
-    the committer date to now, which would refuse any body written before that rebase ran.
-
-    The head is taken from the command when it names one, because the directory the command runs in
-    is routinely not the branch's: a session coordinating worktrees runs from the primary checkout.
-
-    The base a sibling guard records in ~/.velvet-branch-bases was consulted here and is not any more.
-    It is one file for every repository on the machine, never pruned, and a stacked branch's entry
-    stops being an ancestor the moment the rebase that same guard prescribes runs — after which the
-    window widens by however long the parent sat unmerged. merge-base answered correctly in every
-    case that was built to separate them.
-    """
-    ref = head or "HEAD"
-    start = git(cwd, "merge-base", base, ref)
-    if start is None:
+def recorded_base(name):
+    """The start point `branch_from_unmerged.py` recorded for this branch, or None."""
+    if not name:
         return None
+    try:
+        with open(BRANCH_BASES, encoding="utf-8") as bases:
+            matches = [line for line in bases if line.startswith(f"{name} ")]
+    except OSError:
+        return None
+    if not matches:
+        return None
+    parts = matches[-1].split(None, 1)
+    return parts[1].strip() if len(parts) == 2 else None
+
+
+def first_commit_after(cwd, start, ref):
+    """When the oldest commit in start..ref was authored, or None when that cannot be read.
+
+    Author date, not committer date: a rebase — which two sibling guards prescribe by name —
+    rewrites the committer date to now, which would refuse a body written before that rebase.
+    """
     stamps = git(cwd, "log", "--format=%at", f"{start}..{ref}")
     if stamps is None:
         return None
@@ -114,13 +117,56 @@ def branch_start(cwd, head, base):
     return int(authored[-1]) if authored else None
 
 
-def moves_directory(command):
-    """Whether any segment of the command is a `cd`, which this cannot follow."""
-    for segment in command_segments(command):
-        tokens = tokens_of(segment)
-        if tokens and os.path.basename(tokens[0]) in ("cd", "pushd"):
+def branch_start(cwd, head, base):
+    """When the branch's own first commit was authored, or None when that cannot be determined.
+
+    Two sources, and the LATEST answer wins, because each is wrong in the same direction and only
+    one of them at a time. For a stacked branch before the rebase a sibling prescribes, merge-base
+    against the target reaches back past the parent and returns the PARENT's first commit; after that
+    rebase, the base that sibling recorded is no longer an ancestor and the walk widens the same way.
+    Both errors make the branch look older than it is, which widens the window a stale body has to
+    beat — so the younger of the two is the one that cannot be fooled by either.
+
+    The head is taken from the command when it names one, because the directory the command runs in
+    is routinely not the branch's: a session coordinating worktrees runs from the primary checkout.
+    """
+    ref = head or "HEAD"
+    starts = [recorded_base(head), git(cwd, "merge-base", base, ref)]
+    authored = [first_commit_after(cwd, start, ref) for start in starts if start]
+    answers = [when for when in authored if when is not None]
+    return max(answers) if answers else None
+
+
+MOVERS = {"cd", "pushd", "popd"}
+
+
+def unclaimed_creation(segment):
+    """Whether a segment runs `gh pr create` in a shape program_invocations does not claim.
+
+    `env -C dir gh pr create` is the reachable one: env is the command word, so the invocation is
+    invisible, and the -C is a directory change on top. Anything wrapping gh this way is a call this
+    cannot read, and a call it cannot read is one it must not pass.
+    """
+    tokens = tokens_of(segment)
+    for index, token in enumerate(tokens[:-2]):
+        if os.path.basename(token) == "gh" and tokens[index + 1] == "pr" and tokens[index + 2] == "create":
             return True
     return False
+
+
+def moves_directory(segment):
+    """Whether this segment changes the directory a later segment runs in.
+
+    The command word is read the way shell_commands reads one, past `then`/`do` and an environment
+    assignment: reading tokens[0] instead missed `if true; then cd /tmp; fi`, which is the lib's own
+    documented reason for having leading_program at all.
+    """
+    tokens = tokens_of(segment)
+    index = leading_program(tokens)
+    if index >= len(tokens):
+        return False
+    word = os.path.basename(tokens[index])
+    return word in MOVERS
 
 
 def refuse(message):
@@ -128,14 +174,15 @@ def refuse(message):
     return 2
 
 
-def check(operands, cwd, moves_directory):
+def check(operands, cwd, after_a_move):
     """0, or 2 with the reason written to stderr."""
     path = valued(operands, BODY_FILE_FLAGS)
     text = valued(operands, BODY_FLAGS)
     if path is None and text is None:
-        # --fill, --fill-first, --template: the body comes from commits or a template. Neither is a
-        # file this can date, and neither is text it holds, so both questions go unasked — including
-        # the issue one, which CONTRIBUTING states without that exception.
+        # --fill, --fill-first, --template: the body is commits, or a file committed to be reused by
+        # every branch. Dating either against this branch answers nothing, and neither is text held
+        # here to search — so the issue question goes unasked too, which CONTRIBUTING states without
+        # this exception.
         return 0
     head = valued(operands, HEAD_FLAGS)
     base = valued(operands, BASE_FLAGS) or "origin/main"
@@ -152,7 +199,7 @@ def check(operands, cwd, moves_directory):
             "Write it to a file and pass that, so the question of whose branch it describes has\n"
             "an answer.")
     if path is not None:
-        if moves_directory and not os.path.isabs(path):
+        if after_a_move and not os.path.isabs(path):
             return refuse(
                 "Refusing `gh pr create`: the command changes directory, so a relative body path\n"
                 "names one file here and another one to `gh`.\n\n"
@@ -211,11 +258,19 @@ def main():
         cwd = event.get("cwd") or "."
         if not isinstance(command, str):
             return 0
-        moved = moves_directory(command)
-        for operands in program_invocations(command, "gh", ("pr", "create")):
-            verdict = check(operands, cwd, moved)
-            if verdict:
-                return verdict
+        moved = False
+        for segment in command_segments(command):
+            claimed = program_invocations(segment, "gh", ("pr", "create"))
+            if not claimed and unclaimed_creation(segment):
+                return refuse(
+                    "Refusing `gh pr create`: it is wrapped in something this cannot read past, so\n"
+                    "neither the body's provenance nor the directory it resolves in can be told.\n\n"
+                    "Run gh directly.")
+            for operands in claimed:
+                verdict = check(operands, cwd, moved)
+                if verdict:
+                    return verdict
+            moved = moved or moves_directory(segment)
         return 0
     except Exception as err:
         # Exit 1 is not a refusal — PreToolUse runs the tool anyway — so an unforeseen shape here

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -113,6 +113,11 @@
             "type": "command",
             "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/refuse/merge_onto_unpublished_release.py\"",
             "timeout": 25000
+          },
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/refuse/pr_body_of_another_branch.py\"",
+            "timeout": 15000
           }
         ]
       },

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -37,7 +37,8 @@ python3 scripts/release/test_release_notes.py && python3 scripts/release/release
 ## 2. Land it on main
 
 Branch, pull request, squash merge — `main` and `upm` both refuse a direct push, whatever the change
-is. Merging to `main` re-runs the split into the `upm` branch on its own; never edit `upm` by hand,
+is. A release closes no issue, so its body opens with the line that says so — `No issue: the 2.1.0
+release.` — which is what CONTRIBUTING asks of every pull request that names none. Merging to `main` re-runs the split into the `upm` branch on its own; never edit `upm` by hand,
 it is a generated mirror.
 
 From this merge until step 3 runs, `settle.py merge` and `gh pr merge` refuse, and a pull request

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -42,7 +42,9 @@ request that names one nowhere:
 
 ```
 No issue: the X.Y.Z release.
-``` Merging to `main` re-runs the split into the `upm` branch on its own; never edit `upm` by hand,
+```
+
+Merging to `main` re-runs the split into the `upm` branch on its own; never edit `upm` by hand,
 it is a generated mirror.
 
 From this merge until step 3 runs, `settle.py merge` and `gh pr merge` refuse, and a pull request

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -37,8 +37,12 @@ python3 scripts/release/test_release_notes.py && python3 scripts/release/release
 ## 2. Land it on main
 
 Branch, pull request, squash merge — `main` and `upm` both refuse a direct push, whatever the change
-is. A release closes no issue, so its body opens with the line that says so — `No issue: the 2.1.0
-release.` — which is what CONTRIBUTING asks of every pull request that names none. Merging to `main` re-runs the split into the `upm` branch on its own; never edit `upm` by hand,
+is. A release closes no issue, so its body opens with the line CONTRIBUTING asks of every pull
+request that names one nowhere:
+
+```
+No issue: the X.Y.Z release.
+``` Merging to `main` re-runs the split into the `upm` branch on its own; never edit `upm` by hand,
 it is a generated mirror.
 
 From this merge until step 3 runs, `settle.py merge` and `gh pr merge` refuse, and a pull request

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,30 @@ they may be slow or sparse, and not every change can be merged.
 If you need Velvet to move on your own timeline, **forking is encouraged**. The MIT license
 lets you build on it and maintain your own line freely — no need to wait on upstream.
 
+### What a pull request says it came from
+
+A pull request opens by naming its origin. If it closes an issue, the first line closes it on merge:
+
+```
+Closes #123.
+```
+
+If it closes nothing — a tooling change, a release, something noticed while reading — say so with a
+reason, on a line of its own:
+
+```
+No issue: found while reading the pool reset helpers.
+```
+
+Either answer is fine; the silence is not, and it is the one that happened: a change that came
+straight out of an issue was merged without linking it, so the issue stayed open with its work
+already shipped. `refuse/pr_body_of_another_branch.py` declines a `gh pr create` whose body carries
+neither.
+
+The same guard declines a body file older than the branch's first commit, or one that is not there.
+Both are the same accident from opposite ends: the description belonged to a different pull request,
+and nothing about it looked wrong — the path existed and `gh` read it.
+
 ## Local development
 
 1. Install **Unity 6000.3.11f1** (see `ProjectSettings/ProjectVersion.txt`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,9 +27,9 @@ No issue: found while reading the pool reset helpers.
 Either answer is fine; the silence is not, and it is the one that happened: a change that came
 straight out of an issue was merged without linking it, so the issue stayed open with its work
 already shipped. `refuse/pr_body_of_another_branch.py` declines a `gh pr create` whose body carries
-neither. An answer is a closing or referring keyword — Closes, Fixes, Refs — against a number, or the
-issue's own URL. A number on its own is not one: a colour is six digits behind a `#`, and a number
-mentioned in passing closes nothing on merge.
+neither. An answer is a closing or referring keyword — Closes, Fixes, Resolves, Refs — against the
+number right after it, or the issue's own URL. A number on its own is not one: a colour is six digits
+behind a `#`, and a number mentioned in passing closes nothing on merge.
 
 The guard reads the description that will be posted, so the body has to exist before the command
 runs. What it cannot read it declines rather than skips, and that is the part you are most likely to
@@ -42,8 +42,9 @@ meet:
   than this one reads — give the body an absolute path.
 
 A command carrying no body operand at all — `--fill` and its relatives, `--template`, `--editor`, the
-interactive form — holds no text here, so the question goes unasked, and `--dry-run` opens nothing to
-ask about.
+interactive form — holds no text here, so the question goes unasked, and `--dry-run` or `--help`
+opens nothing to ask about. Only `gh pr create` is asked: `gh pr edit --body-file` is how an answer
+gets added after the fact.
 
 It does not judge what the body is about, and no longer tries to. An earlier version dated the body
 file against the branch's first commit. Posed the leftover it existed for — a body stamped when one

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,8 @@ It also declines what it cannot answer, which is the part you are most likely to
 - the command changes directory and the body path is relative, so `gh` would open a different file
   than this one stats — give the body an absolute path;
 - the body, `--head` or `--base` is still unexpanded, or the body comes from stdin;
-- `gh` runs behind a wrapper, or behind its own global flags, where the call cannot be read.
+- gh runs behind a wrapper — sudo, env, bash -c — where what it is given cannot be read. gh's own
+  options before the subcommand are read rather than refused; the shared parser steps over them.
 
 ## Local development
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,19 +27,30 @@ No issue: found while reading the pool reset helpers.
 Either answer is fine; the silence is not, and it is the one that happened: a change that came
 straight out of an issue was merged without linking it, so the issue stayed open with its work
 already shipped. `refuse/pr_body_of_another_branch.py` declines a `gh pr create` whose body carries
-neither — except with `--fill` or `--template`, where the body is not text it holds and both of its
-questions go unasked.
+neither. An answer is a closing or referring keyword — Closes, Fixes, Refs — against a number, or the
+issue's own URL. A number on its own is not one: a colour is six digits behind a `#`, and a number
+mentioned in passing closes nothing on merge.
 
-The same guard declines a body file older than the branch's first commit, and one that is not there:
-the description belonged to a different pull request, and nothing about it looked wrong — the path
-existed and `gh` read it.
+The guard reads the description that will be posted, so the body has to exist before the command
+runs. What it cannot read it declines rather than skips, and that is the part you are most likely to
+meet:
 
-It also declines what it cannot answer, which is the part you are most likely to meet:
-
-- it cannot tell when the branch started — run it from the branch's own directory, or pass `--head`;
+- the file is not there — write the body in a step of its own and open the pull request in the next,
+  because a heredoc in the same command has not run yet when the guard looks;
+- the path is still unexpanded, or the body comes from stdin;
 - the command changes directory and the body path is relative, so `gh` would open a different file
-  than this one stats — give the body an absolute path;
-- the body, `--head` or `--base` is still unexpanded, or the body comes from stdin.
+  than this one reads — give the body an absolute path.
+
+A command carrying no body operand at all — `--fill` and its relatives, `--template`, `--editor`, the
+interactive form — holds no text here, so the question goes unasked, and `--dry-run` opens nothing to
+ask about.
+
+It does not judge what the body is about, and no longer tries to. An earlier version dated the body
+file against the branch's first commit. Posed the leftover it existed for — a body stamped when one
+pull request here was opened, against the branch of the next, whose first commit lands sixteen
+seconds later — it allowed it, the window being fifteen minutes wide. Widening or narrowing that
+window does not help: a `PreToolUse` hook runs first, so the file it would date is whatever was
+already at the path rather than the description that will be posted.
 
 A gh that the parser does not recognise — behind sudo or bash -c, or with gh's own options before the
 subcommand — is not seen at all rather than refused. Four attempts to reach it each refused ordinary

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,8 @@ It also declines what it cannot answer, which is the part you are most likely to
 - it cannot tell when the branch started — run it from the branch's own directory, or pass `--head`;
 - the command changes directory and the body path is relative, so `gh` would open a different file
   than this one stats — give the body an absolute path;
-- the body, `--head` or `--base` is still unexpanded, or the body comes from stdin.
+- the body, `--head` or `--base` is still unexpanded, or the body comes from stdin;
+- `gh` runs behind a wrapper, or behind its own global flags, where the call cannot be read.
 
 ## Local development
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,8 @@ No issue: found while reading the pool reset helpers.
 Either answer is fine; the silence is not, and it is the one that happened: a change that came
 straight out of an issue was merged without linking it, so the issue stayed open with its work
 already shipped. `refuse/pr_body_of_another_branch.py` declines a `gh pr create` whose body carries
-neither.
+neither — except with `--fill` or `--template`, where the body is not text it holds and both of its
+questions go unasked.
 
 The same guard declines a body file older than the branch's first commit, and one that is not there:
 the description belonged to a different pull request, and nothing about it looked wrong — the path
@@ -38,7 +39,8 @@ It also declines what it cannot answer, which is the part you are most likely to
 - it cannot tell when the branch started — run it from the branch's own directory, or pass `--head`;
 - the command changes directory and the body path is relative, so `gh` would open a different file
   than this one stats — give the body an absolute path;
-- the body, `--head` or `--base` is still unexpanded, or the body comes from stdin;
+- the body, `--head` or `--base` is still unexpanded, or the body comes from stdin.
+
 A gh that the parser does not recognise — behind sudo or bash -c, or with gh's own options before the
 subcommand — is not seen at all rather than refused. Four attempts to reach it each refused ordinary
 commands or broke a sibling guard, so the guard stops where it can answer.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,9 +29,16 @@ straight out of an issue was merged without linking it, so the issue stayed open
 already shipped. `refuse/pr_body_of_another_branch.py` declines a `gh pr create` whose body carries
 neither.
 
-The same guard declines a body file older than the branch's first commit, or one that is not there.
-Both are the same accident from opposite ends: the description belonged to a different pull request,
-and nothing about it looked wrong — the path existed and `gh` read it.
+The same guard declines a body file older than the branch's first commit, and one that is not there:
+the description belonged to a different pull request, and nothing about it looked wrong — the path
+existed and `gh` read it.
+
+It also declines what it cannot answer, which is the part you are most likely to meet:
+
+- it cannot tell when the branch started — run it from the branch's own directory, or pass `--head`;
+- the command changes directory and the body path is relative, so `gh` would open a different file
+  than this one stats — give the body an absolute path;
+- the body, `--head` or `--base` is still unexpanded, or the body comes from stdin.
 
 ## Local development
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,8 +39,9 @@ It also declines what it cannot answer, which is the part you are most likely to
 - the command changes directory and the body path is relative, so `gh` would open a different file
   than this one stats — give the body an absolute path;
 - the body, `--head` or `--base` is still unexpanded, or the body comes from stdin;
-- gh runs behind a wrapper — sudo, env, bash -c — where what it is given cannot be read. gh's own
-  options before the subcommand are read rather than refused; the shared parser steps over them.
+A gh that the parser does not recognise — behind sudo or bash -c, or with gh's own options before the
+subcommand — is not seen at all rather than refused. Four attempts to reach it each refused ordinary
+commands or broke a sibling guard, so the guard stops where it can answer.
 
 ## Local development
 

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/DocumentationCorpus.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/DocumentationCorpus.cs
@@ -88,8 +88,16 @@ namespace Velvet.Tests
         // Build output and generated documentation: nothing a document names lives there, DocFX's api/ and
         // _site/ carry a stale copy of every runtime type name until docs/build.py is re-run, and Library
         // alone would make the walk the slowest thing in this fixture.
+        // StrykerOutput is here for a different reason, and it is the reason to be strict about the rest:
+        // a mutation report is a couple of megabytes of source excerpts, it is gitignored, and it survives
+        // the run that made it. One left over from three days earlier put the word this fixture was asked
+        // about into the corpus, so the check passed on the machine that had it and failed on CI.
         private static readonly HashSet<string> BaseUnwalkedDirectories =
-            new() { ".git", "Library", "Temp", "Logs", "Build", "UserSettings", "obj", "bin", "api", "_site" };
+            new()
+            {
+                ".git", "Library", "Temp", "Logs", "Build", "UserSettings",
+                "obj", "bin", "api", "_site", "StrykerOutput",
+            };
 
         private static readonly Lazy<List<string>> DocumentationWalk = new(() => Walk(includeClaude: false));
         private static readonly Lazy<List<string>> ClaudeAwareWalk = new(() => Walk(includeClaude: true));

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/GuardCommandCoverageTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/GuardCommandCoverageTests.cs
@@ -142,32 +142,30 @@ namespace Velvet.Tests
             ("echo 'git checkout main'", "-"),
         };
 
-        // file|inline|head|base|moved. Kept apart because the guard treats each differently — it dates
-        // the file, and only the file, against the head and the base; it reads either body for an
-        // issue; and it recognises a directory move, which decides elsewhere whether a relative path
-        // names the file gh opens. Recognition is all these columns hold — the lambda re-derives the
-        // ordering rather than calling the guard, so where a move sits relative to the call is not
-        // pinned here. A merged column agreed with a version that had the file and inline families
-        // swapped, and with one whose head, base and move recognition were each broken.
+        // file|inline|moved. Kept apart because the guard treats each differently — it opens the file
+        // and searches its text, it searches an inline body as it stands, and it recognises a
+        // directory move, which decides elsewhere whether a relative path names the file gh opens.
+        // Recognition is all these columns hold — the lambda re-derives the ordering rather than
+        // calling the guard, so where a move sits relative to the call is not pinned here. A merged
+        // column agreed with a version that had the file and inline families swapped, and with one
+        // whose move recognition was broken.
         private static readonly (string Command, string Expected)[] Bodies =
         {
-            ("gh pr create --title x --body-file b.md", "b.md||||no"),
+            ("gh pr create --title x --body-file b.md", "b.md||no"),
             ("gh pr list --search create", ""),
             ("gh issue create --label pr --title x", ""),
-            ("gh pr create --title x -F b.md", "b.md||||no"),
-            ("gh pr create --title x -Fb.md", "b.md||||no"),
-            ("gh pr create --title x -bhello", "|hello|||no"),
-            ("gh pr create --title x --body-file=b.md", "b.md||||no"),
-            ("gh pr create --title x --body text", "|text|||no"),
-            ("gh pr create --title x --body-file b.md --head feat/x", "b.md||feat/x||no"),
-            ("gh pr create --title x --body-file b.md -H feat/x", "b.md||feat/x||no"),
-            ("gh pr create --title x --body-file b.md --head=feat/x", "b.md||feat/x||no"),
-            ("gh pr create --title x --body-file b.md --base main", "b.md|||main|no"),
-            ("gh pr create --title x --body-file b.md -B main", "b.md|||main|no"),
-            ("cd d && gh pr create --title x --body-file b.md", "b.md||||yes"),
-            ("if true; then cd d; fi && gh pr create --title x --body-file b.md", "b.md||||yes"),
-            ("gh pr create --title x --body-file b.md && cd d", "b.md||||no"),
-            ("gh pr create --fill", "||||no"),
+            ("gh pr create --title x -F b.md", "b.md||no"),
+            ("gh pr create --title x -Fb.md", "b.md||no"),
+            ("gh pr create --title x -bhello", "|hello|no"),
+            ("gh pr create --title x --body-file=b.md", "b.md||no"),
+            ("gh pr create --title x --body text", "|text|no"),
+            // A head naming a fork is not read at all, so it neither answers nor disturbs the body.
+            ("gh pr create --title x --body-file b.md --head someone:feat/x", "b.md||no"),
+            ("cd d && gh pr create --title x --body-file b.md", "b.md||yes"),
+            ("builtin cd d && gh pr create --title x --body-file b.md", "b.md||yes"),
+            ("if true; then cd d; fi && gh pr create --title x --body-file b.md", "b.md||yes"),
+            ("gh pr create --title x --body-file b.md && cd d", "b.md||no"),
+            ("gh pr create --fill", "||no"),
             ("gh pr comment 5 --body \"run gh pr create --body-file b.md\"", ""),
             ("gh pr list", ""),
         };
@@ -278,7 +276,7 @@ namespace Velvet.Tests
                 "lambda g,c: ','.join([r for s in g.command_segments(c) "
                 + "for o in g.program_invocations(s, 'gh', ('pr', 'create')) "
                 + "for r in ['|'.join([str(g.valued(o, f) or '') "
-                + "for f in (g.BODY_FILE_FLAGS, g.BODY_FLAGS, g.HEAD_FLAGS, g.BASE_FLAGS)]) "
+                + "for f in (g.BODY_FILE_FLAGS, g.BODY_FLAGS)]) "
                 + "+ ('|yes' if any(g.moves_directory(p) for p in g.command_segments(c[:c.index(s)])) "
                 + "else '|no')]])";
             var answers = Ask(hook, expression, Bodies.Select(row => row.Command));

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/GuardCommandCoverageTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/GuardCommandCoverageTests.cs
@@ -142,16 +142,19 @@ namespace Velvet.Tests
             ("echo 'git checkout main'", "-"),
         };
 
-        // Which body operand the provenance guard resolves. Recognition is the half that goes silent:
-        // a guard that stops finding the operand reports what a guard with nothing to say reports.
+        // file|inline|head, kept apart because the guard treats them differently and a single column
+        // hid that: it stats the file, reads either for an issue, and dates both against the head. A
+        // version with the file and inline families swapped agreed with a merged column on every row.
         private static readonly (string Command, string Expected)[] Bodies =
         {
-            ("gh pr create --title x --body-file b.md", "b.md"),
-            ("gh pr create --title x -F b.md", "b.md"),
-            ("gh pr create --title x --body-file=b.md", "b.md"),
-            ("gh pr create --title x --body text", "text"),
-            ("gh pr create --title x --body-file b.md --head feat/x", "b.md"),
-            ("gh pr create --fill", ""),
+            ("gh pr create --title x --body-file b.md", "b.md||"),
+            ("gh pr create --title x -F b.md", "b.md||"),
+            ("gh pr create --title x --body-file=b.md", "b.md||"),
+            ("gh pr create --title x --body text", "|text|"),
+            ("gh pr create --title x --body-file b.md --head feat/x", "b.md||feat/x"),
+            ("gh pr create --title x --body-file b.md -H feat/x", "b.md||feat/x"),
+            ("gh pr create --title x --body-file b.md --head=feat/x", "b.md||feat/x"),
+            ("gh pr create --fill", "||"),
             ("gh pr comment 5 --body \"run gh pr create --body-file b.md\"", ""),
             ("gh pr list", ""),
         };
@@ -257,8 +260,8 @@ namespace Velvet.Tests
 
             // Act
             const string expression =
-                "lambda g,c: ','.join([str(g.valued(o, g.BODY_FILE_FLAGS) "
-                + "or g.valued(o, g.BODY_FLAGS) or '') "
+                "lambda g,c: ','.join(['|'.join([str(g.valued(o, f) or '') "
+                + "for f in (g.BODY_FILE_FLAGS, g.BODY_FLAGS, g.HEAD_FLAGS)]) "
                 + "for o in g.program_invocations(c, 'gh', ('pr', 'create'))])";
             var answers = Ask(hook, expression, Bodies.Select(row => row.Command));
             Assume.That(answers?.Count, Is.EqualTo(Bodies.Length), "Precondition: one answer per command");

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/GuardCommandCoverageTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/GuardCommandCoverageTests.cs
@@ -191,6 +191,8 @@ namespace Velvet.Tests
             ("gh pr create --title x --label ci", ""),
             ("gh pr comment 5 --body \"run gh issue create --title x\"", ""),
             ("gh issue list", ""),
+            ("gh pr create --help", ""),
+            ("gh issue create -h", ""),
         };
 
         // Built at runtime for the same reason as the merge table above.
@@ -306,7 +308,7 @@ namespace Velvet.Tests
 
             // Act
             const string expression =
-                "lambda g,c: ','.join([f for k,o in g.creations(c) if '--web' not in o "
+                "lambda g,c: ','.join([f for k,o in g.creations(c) if not g.exempt(o) "
                 + "for f in ((['--label'] if not g.carries(o, g.LABEL_FLAGS) else []) "
                 + "+ (['--assignee'] if k=='issue' and not g.carries(o, g.ASSIGNEE_FLAGS) else []))])";
             var answers = Ask(hook, expression, Creations.Select(row => row.Command));

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/GuardCommandCoverageTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/GuardCommandCoverageTests.cs
@@ -142,16 +142,28 @@ namespace Velvet.Tests
             ("echo 'git checkout main'", "-"),
         };
 
-        // file|inline|head|base|moved. Kept apart because the guard treats each differently — it dates
+        // file|inline|head|base|moved|hidden. Kept apart because the guard treats each differently — it dates
         // the file, and only the file, against the head and the base; it reads either body for an
         // issue; and it recognises a directory move, which decides elsewhere whether a relative path
         // names the file gh opens. Recognition is all these columns hold — the lambda re-derives the
         // ordering rather than calling the guard, so where a move sits relative to the call is not
         // pinned here. A merged column agreed with a version that had the file and inline families
-        // swapped, and with one whose head, base and move recognition were each broken.
+        // swapped, and with one whose head, base and move recognition were each broken. The hidden
+        // column is what four fix layers went without: nothing reached the wrapper check at all, so
+        // every version of it — including one that refused any command mentioning the phrase —
+        // shipped green.
         private static readonly (string Command, string Expected)[] Bodies =
         {
             ("gh pr create --title x --body-file b.md", "b.md||||no"),
+            ("gh -R owner/repo pr create --body-file b.md", "b.md||||no"),
+            ("gh --repo=owner/repo pr create --body-file b.md", "b.md||||no"),
+            ("sudo gh pr create --body-file b.md", "hidden"),
+            ("bash -c \"gh pr create --body-file b.md\"", "hidden"),
+            ("bash -c \"echo run gh pr create next\"", ""),
+            ("sudo gh auth status", ""),
+            ("timeout 5 echo gh pr create", ""),
+            ("gh pr list --search create", ""),
+            ("gh issue create --label pr --title x", ""),
             ("gh pr create --title x -F b.md", "b.md||||no"),
             ("gh pr create --title x --body-file=b.md", "b.md||||no"),
             ("gh pr create --title x --body text", "|text|||no"),
@@ -269,12 +281,13 @@ namespace Velvet.Tests
 
             // Act
             const string expression =
-                "lambda g,c: ','.join([r for s in g.command_segments(c) "
-                + "for o in g.program_invocations(s, 'gh', ('pr', 'create')) "
-                + "for r in ['|'.join([str(g.valued(o, f) or '') "
+                "lambda g,c: ','.join([r for s in g.command_segments(c) for r in "
+                + "(['hidden'] if g.unclaimed_creation(s) else "
+                + "['|'.join([str(g.valued(o, f) or '') "
                 + "for f in (g.BODY_FILE_FLAGS, g.BODY_FLAGS, g.HEAD_FLAGS, g.BASE_FLAGS)]) "
                 + "+ ('|yes' if any(g.moves_directory(p) for p in g.command_segments(c[:c.index(s)])) "
-                + "else '|no')]])";
+                + "else '|no') "
+                + "for o in g.program_invocations(s, 'gh', ('pr', 'create'))])])";
             var answers = Ask(hook, expression, Bodies.Select(row => row.Command));
             Assume.That(answers?.Count, Is.EqualTo(Bodies.Length), "Precondition: one answer per command");
 

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/GuardCommandCoverageTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/GuardCommandCoverageTests.cs
@@ -144,8 +144,10 @@ namespace Velvet.Tests
 
         // file|inline|head|base|moved. Kept apart because the guard treats each differently — it dates
         // the file, and only the file, against the head and the base; it reads either body for an
-        // issue; and a directory move before the call decides whether a relative path names the file
-        // gh opens. A merged column agreed with a version that had the file and inline families
+        // issue; and it recognises a directory move, which decides elsewhere whether a relative path
+        // names the file gh opens. Recognition is all these columns hold — the lambda re-derives the
+        // ordering rather than calling the guard, so where a move sits relative to the call is not
+        // pinned here. A merged column agreed with a version that had the file and inline families
         // swapped, and with one whose head, base and move recognition were each broken.
         private static readonly (string Command, string Expected)[] Bodies =
         {

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/GuardCommandCoverageTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/GuardCommandCoverageTests.cs
@@ -142,6 +142,20 @@ namespace Velvet.Tests
             ("echo 'git checkout main'", "-"),
         };
 
+        // Which body operand the provenance guard resolves. Recognition is the half that goes silent:
+        // a guard that stops finding the operand reports what a guard with nothing to say reports.
+        private static readonly (string Command, string Expected)[] Bodies =
+        {
+            ("gh pr create --title x --body-file b.md", "b.md"),
+            ("gh pr create --title x -F b.md", "b.md"),
+            ("gh pr create --title x --body-file=b.md", "b.md"),
+            ("gh pr create --title x --body text", "text"),
+            ("gh pr create --title x --body-file b.md --head feat/x", "b.md"),
+            ("gh pr create --fill", ""),
+            ("gh pr comment 5 --body \"run gh pr create --body-file b.md\"", ""),
+            ("gh pr list", ""),
+        };
+
         private static readonly (string Command, string Expected)[] Creations =
         {
             ("gh issue create --title x --body y", "--label,--assignee"),
@@ -229,6 +243,27 @@ namespace Velvet.Tests
             Assume.That(answers?.Count, Is.EqualTo(table.Length), "Precondition: one answer per command");
 
             var disagreements = Disagreements(table, answers);
+
+            // Assert
+            Assert.That(disagreements, Is.Empty);
+        }
+
+        [Test]
+        public void Given_TheBodyTable_When_TheProvenanceGuardReadsEach_Then_ItResolvesOnlyTheBodyItWouldCheck()
+        {
+            // Arrange
+            var hook = Path.GetFullPath(".claude/hooks/refuse/pr_body_of_another_branch.py");
+            Assume.That(File.Exists(hook), Is.True, "Precondition: the guard exists");
+
+            // Act
+            const string expression =
+                "lambda g,c: ','.join([str(g.valued(o, g.BODY_FILE_FLAGS) "
+                + "or g.valued(o, g.BODY_FLAGS) or '') "
+                + "for o in g.program_invocations(c, 'gh', ('pr', 'create'))])";
+            var answers = Ask(hook, expression, Bodies.Select(row => row.Command));
+            Assume.That(answers?.Count, Is.EqualTo(Bodies.Length), "Precondition: one answer per command");
+
+            var disagreements = Disagreements(Bodies, answers);
 
             // Assert
             Assert.That(disagreements, Is.Empty);

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/GuardCommandCoverageTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/GuardCommandCoverageTests.cs
@@ -142,26 +142,16 @@ namespace Velvet.Tests
             ("echo 'git checkout main'", "-"),
         };
 
-        // file|inline|head|base|moved|hidden. Kept apart because the guard treats each differently — it dates
+        // file|inline|head|base|moved. Kept apart because the guard treats each differently — it dates
         // the file, and only the file, against the head and the base; it reads either body for an
         // issue; and it recognises a directory move, which decides elsewhere whether a relative path
         // names the file gh opens. Recognition is all these columns hold — the lambda re-derives the
         // ordering rather than calling the guard, so where a move sits relative to the call is not
         // pinned here. A merged column agreed with a version that had the file and inline families
-        // swapped, and with one whose head, base and move recognition were each broken. The hidden
-        // column is what four fix layers went without: nothing reached the wrapper check at all, so
-        // every version of it — including one that refused any command mentioning the phrase —
-        // shipped green.
+        // swapped, and with one whose head, base and move recognition were each broken.
         private static readonly (string Command, string Expected)[] Bodies =
         {
             ("gh pr create --title x --body-file b.md", "b.md||||no"),
-            ("gh -R owner/repo pr create --body-file b.md", "b.md||||no"),
-            ("gh --repo=owner/repo pr create --body-file b.md", "b.md||||no"),
-            ("sudo gh pr create --body-file b.md", "hidden"),
-            ("bash -c \"gh pr create --body-file b.md\"", "hidden"),
-            ("bash -c \"echo run gh pr create next\"", ""),
-            ("sudo gh auth status", ""),
-            ("timeout 5 echo gh pr create", ""),
             ("gh pr list --search create", ""),
             ("gh issue create --label pr --title x", ""),
             ("gh pr create --title x -F b.md", "b.md||||no"),
@@ -283,13 +273,12 @@ namespace Velvet.Tests
 
             // Act
             const string expression =
-                "lambda g,c: ','.join([r for s in g.command_segments(c) for r in "
-                + "(['hidden'] if g.unclaimed_creation(s) else "
-                + "['|'.join([str(g.valued(o, f) or '') "
+                "lambda g,c: ','.join([r for s in g.command_segments(c) "
+                + "for o in g.program_invocations(s, 'gh', ('pr', 'create')) "
+                + "for r in ['|'.join([str(g.valued(o, f) or '') "
                 + "for f in (g.BODY_FILE_FLAGS, g.BODY_FLAGS, g.HEAD_FLAGS, g.BASE_FLAGS)]) "
                 + "+ ('|yes' if any(g.moves_directory(p) for p in g.command_segments(c[:c.index(s)])) "
-                + "else '|no') "
-                + "for o in g.program_invocations(s, 'gh', ('pr', 'create'))])])";
+                + "else '|no')]])";
             var answers = Ask(hook, expression, Bodies.Select(row => row.Command));
             Assume.That(answers?.Count, Is.EqualTo(Bodies.Length), "Precondition: one answer per command");
 

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/GuardCommandCoverageTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/GuardCommandCoverageTests.cs
@@ -142,19 +142,26 @@ namespace Velvet.Tests
             ("echo 'git checkout main'", "-"),
         };
 
-        // file|inline|head, kept apart because the guard treats them differently and a single column
-        // hid that: it stats the file, reads either for an issue, and dates both against the head. A
-        // version with the file and inline families swapped agreed with a merged column on every row.
+        // file|inline|head|base|moved. Kept apart because the guard treats each differently — it dates
+        // the file, and only the file, against the head and the base; it reads either body for an
+        // issue; and a directory move before the call decides whether a relative path names the file
+        // gh opens. A merged column agreed with a version that had the file and inline families
+        // swapped, and with one whose head, base and move recognition were each broken.
         private static readonly (string Command, string Expected)[] Bodies =
         {
-            ("gh pr create --title x --body-file b.md", "b.md||"),
-            ("gh pr create --title x -F b.md", "b.md||"),
-            ("gh pr create --title x --body-file=b.md", "b.md||"),
-            ("gh pr create --title x --body text", "|text|"),
-            ("gh pr create --title x --body-file b.md --head feat/x", "b.md||feat/x"),
-            ("gh pr create --title x --body-file b.md -H feat/x", "b.md||feat/x"),
-            ("gh pr create --title x --body-file b.md --head=feat/x", "b.md||feat/x"),
-            ("gh pr create --fill", "||"),
+            ("gh pr create --title x --body-file b.md", "b.md||||no"),
+            ("gh pr create --title x -F b.md", "b.md||||no"),
+            ("gh pr create --title x --body-file=b.md", "b.md||||no"),
+            ("gh pr create --title x --body text", "|text|||no"),
+            ("gh pr create --title x --body-file b.md --head feat/x", "b.md||feat/x||no"),
+            ("gh pr create --title x --body-file b.md -H feat/x", "b.md||feat/x||no"),
+            ("gh pr create --title x --body-file b.md --head=feat/x", "b.md||feat/x||no"),
+            ("gh pr create --title x --body-file b.md --base main", "b.md|||main|no"),
+            ("gh pr create --title x --body-file b.md -B main", "b.md|||main|no"),
+            ("cd d && gh pr create --title x --body-file b.md", "b.md||||yes"),
+            ("if true; then cd d; fi && gh pr create --title x --body-file b.md", "b.md||||yes"),
+            ("gh pr create --title x --body-file b.md && cd d", "b.md||||no"),
+            ("gh pr create --fill", "||||no"),
             ("gh pr comment 5 --body \"run gh pr create --body-file b.md\"", ""),
             ("gh pr list", ""),
         };
@@ -252,7 +259,7 @@ namespace Velvet.Tests
         }
 
         [Test]
-        public void Given_TheBodyTable_When_TheProvenanceGuardReadsEach_Then_ItResolvesOnlyTheBodyItWouldCheck()
+        public void Given_TheBodyTable_When_TheProvenanceGuardReadsEach_Then_ItResolvesOnlyWhatItWouldAct()
         {
             // Arrange
             var hook = Path.GetFullPath(".claude/hooks/refuse/pr_body_of_another_branch.py");
@@ -260,9 +267,12 @@ namespace Velvet.Tests
 
             // Act
             const string expression =
-                "lambda g,c: ','.join(['|'.join([str(g.valued(o, f) or '') "
-                + "for f in (g.BODY_FILE_FLAGS, g.BODY_FLAGS, g.HEAD_FLAGS)]) "
-                + "for o in g.program_invocations(c, 'gh', ('pr', 'create'))])";
+                "lambda g,c: ','.join([r for s in g.command_segments(c) "
+                + "for o in g.program_invocations(s, 'gh', ('pr', 'create')) "
+                + "for r in ['|'.join([str(g.valued(o, f) or '') "
+                + "for f in (g.BODY_FILE_FLAGS, g.BODY_FLAGS, g.HEAD_FLAGS, g.BASE_FLAGS)]) "
+                + "+ ('|yes' if any(g.moves_directory(p) for p in g.command_segments(c[:c.index(s)])) "
+                + "else '|no')]])";
             var answers = Ask(hook, expression, Bodies.Select(row => row.Command));
             Assume.That(answers?.Count, Is.EqualTo(Bodies.Length), "Precondition: one answer per command");
 

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/GuardCommandCoverageTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/GuardCommandCoverageTests.cs
@@ -216,7 +216,6 @@ namespace Velvet.Tests
             const string expression =
                 "lambda g,c: ','.join(t or '<current>' for t in g.merges_without_deletion(c)) or '-'";
             var answers = Ask(hook, expression, table.Select(row => row.Command));
-            Assume.That(answers?.Count, Is.EqualTo(table.Length), "Precondition: one answer per command");
 
             var disagreements = Disagreements(table, answers);
 
@@ -234,7 +233,6 @@ namespace Velvet.Tests
 
             // Act
             var answers = Ask(hook, "lambda g,c: str(g.sweeps(c))", Sweeping.Select(row => row.Command));
-            Assume.That(answers?.Count, Is.EqualTo(Sweeping.Length), "Precondition: one answer per command");
 
             var disagreements = Disagreements(Sweeping, answers);
 
@@ -256,7 +254,6 @@ namespace Velvet.Tests
             const string expression =
                 "lambda g,c: ','.join(t or '<current>' for t in g.merge_targets(c)) or '-'";
             var answers = Ask(hook, expression, table.Select(row => row.Command));
-            Assume.That(answers?.Count, Is.EqualTo(table.Length), "Precondition: one answer per command");
 
             var disagreements = Disagreements(table, answers);
 
@@ -280,7 +277,6 @@ namespace Velvet.Tests
                 + "+ ('|yes' if any(g.moves_directory(p) for p in g.command_segments(c[:c.index(s)])) "
                 + "else '|no')]])";
             var answers = Ask(hook, expression, Bodies.Select(row => row.Command));
-            Assume.That(answers?.Count, Is.EqualTo(Bodies.Length), "Precondition: one answer per command");
 
             var disagreements = Disagreements(Bodies, answers);
 
@@ -301,7 +297,6 @@ namespace Velvet.Tests
                 + "for f in ((['--label'] if not g.carries(o, g.LABEL_FLAGS) else []) "
                 + "+ (['--assignee'] if k=='issue' and not g.carries(o, g.ASSIGNEE_FLAGS) else []))])";
             var answers = Ask(hook, expression, Creations.Select(row => row.Command));
-            Assume.That(answers?.Count, Is.EqualTo(Creations.Length), "Precondition: one answer per command");
 
             var disagreements = Disagreements(Creations, answers);
 
@@ -325,7 +320,6 @@ namespace Velvet.Tests
                 // Act
                 var expression = "lambda g,c: ','.join(g.refusals(c, r'" + root + "')) or '-'";
                 var answers = Ask(hook, expression, SharedState.Select(row => row.Command));
-                Assume.That(answers?.Count, Is.EqualTo(SharedState.Length), "Precondition: one answer per command");
 
                 disagreements = Disagreements(SharedState, answers);
             }
@@ -496,11 +490,16 @@ namespace Velvet.Tests
             }
         }
 
+        // How many answers came back is folded in here rather than left to an `Assume` beside each
+        // call: a guard that raises on one command answers none of them, and an `Assume` would report
+        // the run that proves it broken as inconclusive, which the runner does not count as a failure.
         private static string Disagreements((string Command, string Expected)[] table, List<string> answers) =>
-            string.Join("\n", table
-                .Select((row, index) => (row, actual: answers[index]))
-                .Where(pair => pair.actual != pair.row.Expected)
-                .Select(pair => $"{pair.row.Command}\n    expected [{pair.row.Expected}] got [{pair.actual}]"));
+            answers?.Count == table.Length
+                ? string.Join("\n", table
+                    .Select((row, index) => (row, actual: answers[index]))
+                    .Where(pair => pair.actual != pair.row.Expected)
+                    .Select(pair => $"{pair.row.Command}\n    expected [{pair.row.Expected}] got [{pair.actual}]"))
+                : $"the guard answered {answers?.Count.ToString() ?? "nothing"} of {table.Length} commands";
 
         private static List<string> Ask(string hook, string expression, IEnumerable<string> commands)
         {

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/GuardCommandCoverageTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/GuardCommandCoverageTests.cs
@@ -155,6 +155,8 @@ namespace Velvet.Tests
             ("gh pr list --search create", ""),
             ("gh issue create --label pr --title x", ""),
             ("gh pr create --title x -F b.md", "b.md||||no"),
+            ("gh pr create --title x -Fb.md", "b.md||||no"),
+            ("gh pr create --title x -bhello", "|hello|||no"),
             ("gh pr create --title x --body-file=b.md", "b.md||||no"),
             ("gh pr create --title x --body text", "|text|||no"),
             ("gh pr create --title x --body-file b.md --head feat/x", "b.md||feat/x||no"),

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/PrBodyProvenanceGuardTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/PrBodyProvenanceGuardTests.cs
@@ -42,10 +42,20 @@ namespace Velvet.Tests
         // and nothing else, so no case here needs one.
         private static readonly (string Command, string Expected)[] Accepted =
         {
+            // Every spelling of every keyword, because narrowing one of the four to the single form
+            // CONTRIBUTING advertises leaves a table posing only that form green, and each of the
+            // other spellings flips from allow to refuse.
             ("gh pr create --title x --body-file {DIR}/closes.md", "allow"),
+            ("gh pr create --title x --body-file {DIR}/close.md", "allow"),
+            ("gh pr create --title x --body-file {DIR}/closed.md", "allow"),
             ("gh pr create --title x --body-file {DIR}/fixes.md", "allow"),
+            ("gh pr create --title x --body-file {DIR}/fix.md", "allow"),
+            ("gh pr create --title x --body-file {DIR}/fixed.md", "allow"),
             ("gh pr create --title x --body-file {DIR}/resolves.md", "allow"),
+            ("gh pr create --title x --body-file {DIR}/resolve.md", "allow"),
+            ("gh pr create --title x --body-file {DIR}/resolved.md", "allow"),
             ("gh pr create --title x --body-file {DIR}/refs.md", "allow"),
+            ("gh pr create --title x --body-file {DIR}/ref.md", "allow"),
             ("gh pr create --title x --body-file {DIR}/url.md", "allow"),
             ("gh pr create --title x --body-file {DIR}/no-issue.md", "allow"),
             ("gh pr create --title x --body-file {DIR}/no-issue-indented.md", "allow"),
@@ -59,7 +69,9 @@ namespace Velvet.Tests
             // A body flag given last has no value to read, which is a different way through the
             // reader than a command with no body flag at all.
             ("gh pr create --title x --body-file", "allow"),
-            ("gh pr create --title x --template {DIR}/closes.md", "allow"),
+            // A body naming nothing behind the flag, so the row answers whether `--template` is read
+            // as a body at all rather than passing on the strength of what the file says.
+            ("gh pr create --title x --template {DIR}/silent.md", "allow"),
             ("gh pr create --title x --editor", "allow"),
             ("gh pr create --title x --dry-run --body-file {DIR}/absent.md", "allow"),
             ("gh pr create --title x -h --body-file {DIR}/silent.md", "allow"),
@@ -101,6 +113,11 @@ namespace Velvet.Tests
             ("gh pr create --title x --body-file silent.md", "no-origin"),
             // A segment carrying only an environment assignment has no command word, and is not a move.
             ("BODY=x && gh pr create --title x --body-file silent.md", "no-origin"),
+            // The other side of the move set, which the rows below pin in one direction only: they
+            // fail when a mover is dropped and pass when one is added, and the repository's own way
+            // of opening a pull request runs `git push` in the segment before the create.
+            ("git push -u origin HEAD && gh pr create --title x --body-file silent.md", "no-origin"),
+            ("echo x && gh pr create --title x --body-file silent.md", "no-origin"),
             ("gh pr create --title x --body-file {DIR}/absent.md", "missing"),
             // A directory exists and does not read, which is the one way to reach that branch without
             // a permission bit — and a run as root would read a file this fixture had made unreadable.
@@ -115,7 +132,6 @@ namespace Velvet.Tests
             // A command word spelled by path is read by its basename, the way the shared parser reads
             // one.
             ("/bin/cd {DIR}/sub && gh pr create --title x --body-file relative.md", "moved"),
-            // A move holds for the rest of the command, not for the segment after it.
             ("cd {DIR}/sub && echo x && gh pr create --title x --body-file relative.md", "moved"),
         };
 
@@ -224,10 +240,20 @@ namespace Velvet.Tests
         private static void WriteBodies(string root)
         {
             Directory.CreateDirectory(Path.Combine(root, "sub"));
+            // The four keywords CONTRIBUTING advertises, and the spellings of each that answer as
+            // well. Only the advertised one used to be written for two of the four, so the form a
+            // reader is told to use was posed by nothing.
             Write(root, "closes.md", "Closes #123.\n\nWhat this changes and why.\n");
+            Write(root, "close.md", "Close #123, the half the pool reset left.\n");
+            Write(root, "closed.md", "Closed #123 with the pooled reset helper.\n");
             Write(root, "fixes.md", "Fixes #12 — the half that was left.\n");
-            Write(root, "resolves.md", "Resolved #12, measured against the pooled reset helper.\n");
+            Write(root, "fix.md", "Fix #12, measured against the pooled reset helper.\n");
+            Write(root, "fixed.md", "Fixed #12 in the pooled reset helper.\n");
+            Write(root, "resolves.md", "Resolves #12, measured against the pooled reset helper.\n");
+            Write(root, "resolve.md", "Resolve #12 in the same pass as the reset helper.\n");
+            Write(root, "resolved.md", "Resolved #12, measured against the pooled reset helper.\n");
             Write(root, "refs.md", "Refs #12 — the other half of that one.\n");
+            Write(root, "ref.md", "Ref #12 — the other half of that one.\n");
             Write(root, "url.md", "From https://github.com/s4k10503/velvet/issues/44, the second half.\n");
             Write(root, "no-issue.md", "No issue: found while reading the pool reset helpers.\n");
             // Four spellings of the same line, each free of the last: indented, ended with a full

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/PrBodyProvenanceGuardTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/PrBodyProvenanceGuardTests.cs
@@ -9,10 +9,11 @@ namespace Velvet.Tests
 {
     /// <summary>
     /// Poses <c>.claude/hooks/refuse/pr_body_of_another_branch.py</c> a body of each shape it decides
-    /// about, and reads the verdict it returns. <see cref="GuardCommandCoverageTests"/> asks what that
-    /// guard recognises in a command and <see cref="PreExpansionPolicyTests"/> asks the single verdict
-    /// its own probe poses; what it decides about a body was asked by neither. Of ten one-line changes
-    /// to it, nine left both of those green — including one that accepted every body.
+    /// about and an event varying what those commands hold fixed, and reads the verdict it returns.
+    /// <see cref="GuardCommandCoverageTests"/> asks what that guard recognises in a command
+    /// and <see cref="PreExpansionPolicyTests"/> asks the single verdict its own probe poses; what it
+    /// decides about a body was asked by neither. Of ten one-line changes to it, nine left both of
+    /// those green — including one that accepted every body.
     /// </summary>
     /// <remarks>
     /// A refusal is matched on a phrase only its own message carries, not on the exit code alone: a
@@ -42,17 +43,30 @@ namespace Velvet.Tests
         private static readonly (string Command, string Expected)[] Accepted =
         {
             ("gh pr create --title x --body-file {DIR}/closes.md", "allow"),
+            ("gh pr create --title x --body-file {DIR}/fixes.md", "allow"),
+            ("gh pr create --title x --body-file {DIR}/resolves.md", "allow"),
             ("gh pr create --title x --body-file {DIR}/refs.md", "allow"),
             ("gh pr create --title x --body-file {DIR}/url.md", "allow"),
             ("gh pr create --title x --body-file {DIR}/no-issue.md", "allow"),
+            ("gh pr create --title x --body-file {DIR}/no-issue-indented.md", "allow"),
+            ("gh pr create --title x --body-file {DIR}/no-issue-stop.md", "allow"),
+            ("gh pr create --title x --body-file {DIR}/no-issue-later.md", "allow"),
+            ("gh pr create --title x --body-file {DIR}/no-issue-lower.md", "allow"),
             ("gh pr create --title x -F{DIR}/closes.md", "allow"),
             // Backticks and a `$` in an inline body are the description rather than a name for it.
             ("gh pr create --title x --body 'Closes #7. `Foo.Bar` now reads $HOME.'", "allow"),
             ("gh pr create --fill", "allow"),
+            // A body flag given last has no value to read, which is a different way through the
+            // reader than a command with no body flag at all.
+            ("gh pr create --title x --body-file", "allow"),
             ("gh pr create --title x --template {DIR}/closes.md", "allow"),
             ("gh pr create --title x --editor", "allow"),
             ("gh pr create --title x --dry-run --body-file {DIR}/absent.md", "allow"),
             ("gh pr create --title x -h --body-file {DIR}/silent.md", "allow"),
+            ("gh pr create --title x --help --body-file {DIR}/silent.md", "allow"),
+            // Only `create` posts a new description. Editing one is how a body gets its answer added
+            // after the fact, so a guard that claimed it would refuse the remedy it hands out.
+            ("gh pr edit 1 --body-file {DIR}/silent.md", "allow"),
             // A head is not read at all now. One naming a fork used to be refused, with the remedy
             // being to pass the head the command had already passed.
             ("gh pr create --title x --body-file {DIR}/closes.md --head someone:feat/x", "allow"),
@@ -62,16 +76,31 @@ namespace Velvet.Tests
         };
 
         // {DIR}/relative.md is absent and {DIR}/sub/relative.md is not, so a move the guard fails to
-        // see answers "missing" instead, which is what keeps the last two rows from passing on the
+        // see answers "missing" instead, which is what keeps the move rows from passing on the
         // strength of the file being in the other directory.
         private static readonly (string Command, string Expected)[] Refused =
         {
             ("gh pr create --title x --body-file {DIR}/silent.md", "no-origin"),
             ("gh pr create --title x --body-file {DIR}/colour.md", "no-origin"),
             ("gh pr create --title x --body-file {DIR}/mention.md", "no-origin"),
+            ("gh pr create --title x --body-file {DIR}/distant.md", "no-origin"),
+            ("gh pr create --title x --body-file {DIR}/bare-no-issue.md", "no-origin"),
+            ("gh pr create --title x --body-file {DIR}/mid-line.md", "no-origin"),
             ("gh pr create --title x --body 'A change to the pooled reset helper.'", "no-origin"),
+            ("gh pr create --title x -b 'A change to the pooled reset helper.'", "no-origin"),
             ("gh pr create --title x --web --body-file {DIR}/silent.md", "no-origin"),
             ("gh pr create --title x --body 'Closes #7.' --body-file {DIR}/silent.md", "no-origin"),
+            // Each spelling of a value gh takes, on the side where missing one lets the body through
+            // unread: the accepted rows above pass whether or not the value was found. `-Fs` is the
+            // shortest token that carries one attached.
+            ("gh pr create --title x -F{DIR}/silent.md", "no-origin"),
+            ("gh pr create --title x --body-file={DIR}/silent.md", "no-origin"),
+            ("gh pr create --title x -Fs", "no-origin"),
+            // A relative path with nothing having moved is opened against the directory the command
+            // runs in, not the one this guard runs in.
+            ("gh pr create --title x --body-file silent.md", "no-origin"),
+            // A segment carrying only an environment assignment has no command word, and is not a move.
+            ("BODY=x && gh pr create --title x --body-file silent.md", "no-origin"),
             ("gh pr create --title x --body-file {DIR}/absent.md", "missing"),
             // A directory exists and does not read, which is the one way to reach that branch without
             // a permission bit — and a run as root would read a file this fixture had made unreadable.
@@ -81,6 +110,13 @@ namespace Velvet.Tests
             ("gh pr create --title x --body \"$(cat {DIR}/closes.md)\"", "assembled"),
             ("cd {DIR}/sub && gh pr create --title x --body-file relative.md", "moved"),
             ("builtin cd {DIR}/sub && gh pr create --title x --body-file relative.md", "moved"),
+            ("pushd {DIR}/sub && gh pr create --title x --body-file relative.md", "moved"),
+            ("popd && gh pr create --title x --body-file relative.md", "moved"),
+            // A command word spelled by path is read by its basename, the way the shared parser reads
+            // one.
+            ("/bin/cd {DIR}/sub && gh pr create --title x --body-file relative.md", "moved"),
+            // A move holds for the rest of the command, not for the segment after it.
+            ("cd {DIR}/sub && echo x && gh pr create --title x --body-file relative.md", "moved"),
         };
 
         [Test]
@@ -131,29 +167,87 @@ namespace Velvet.Tests
                 "a refusal that fires for another reason gives another remedy, and exits 2 either way");
         }
 
-        [Test]
-        public void Given_AnEventTheGuardCannotRead_When_ItAnswers_Then_ItRefusesRatherThanFallingThrough()
+        // Posed as whole events rather than as commands, because each row varies something the tables
+        // above hold fixed: the tool, the working directory, the type of the command, or the payload
+        // being no event at all. What the guard cannot read it refuses; what is no `gh pr create` of
+        // its it allows.
+        private static readonly (string Payload, string Expected)[] Events =
         {
-            // Arrange — a working directory that is not a string, which no check below is written for
-            const string payload =
-                "{\"tool_name\":\"Bash\",\"cwd\":12345,"
-                + "\"tool_input\":{\"command\":\"gh pr create --title x --body-file b.md\"}}";
+            // A working directory that is not a string reaches the code that opens the body.
+            ("{\"tool_name\":\"Bash\",\"cwd\":12345,"
+             + "\"tool_input\":{\"command\":\"gh pr create --title x --body-file b.md\"}}", "crashed"),
+            // Stdin that is no event at all: refusing here would refuse every tool call in the session.
+            ("this is not an event", "allow"),
+            // JSON that parses but is no object, which reads nothing back and answers nothing either.
+            ("[1, 2]", "allow"),
+            // A command that is not text is no `gh pr create`, and Bash will reject it on its own.
+            ("{\"tool_name\":\"Bash\",\"cwd\":\".\",\"tool_input\":{\"command\":12345}}", "allow"),
+            // A tool outside the declared set, carrying a command that would be refused under Bash, so
+            // the tool name is the only thing between this row and a refusal.
+            ("{\"tool_name\":\"Edit\",\"cwd\":\".\",\"tool_input\":"
+             + "{\"command\":\"gh pr create --title x --body-file velvet-no-such-body.md\"}}", "allow"),
+            // No working directory at all: a relative body path is opened against the one this runs in,
+            // which is what keeps the missing key from reaching the opener as a null.
+            ("{\"tool_name\":\"Bash\",\"tool_input\":"
+             + "{\"command\":\"gh pr create --title x --body-file velvet-no-such-body.md\"}}", "missing"),
+        };
+
+        [Test]
+        public void Given_AnEventRatherThanACommand_When_TheGuardAnswers_Then_ItRefusesOnlyWhatItCannotRead()
+        {
+            // Arrange
+            var hook = Path.GetFullPath(HookPath);
+            var answered = new List<string>();
+            var disagreements = new List<string>();
 
             // Act
-            var answer = Ask(Path.GetFullPath(HookPath), payload);
+            foreach (var (payload, expected) in Events)
+            {
+                var answer = Ask(hook, payload);
+                if (answer == null)
+                {
+                    continue;
+                }
 
-            // Assert — exit 1 is not a refusal, so an unforeseen shape here runs the command anyway
-            Assert.That(answer, Is.EqualTo("crashed"));
+                answered.Add(answer);
+                if (answer != expected)
+                {
+                    disagreements.Add($"{payload}\n    expected [{expected}] got [{answer}]");
+                }
+            }
+
+            // Assert — exit 1 is not a refusal, so a shape that falls through runs the command anyway
+            Assert.That((answered.Count, string.Join("\n", disagreements)),
+                Is.EqualTo((Events.Length, string.Empty)));
         }
 
         private static void WriteBodies(string root)
         {
             Directory.CreateDirectory(Path.Combine(root, "sub"));
             Write(root, "closes.md", "Closes #123.\n\nWhat this changes and why.\n");
+            Write(root, "fixes.md", "Fixes #12 — the half that was left.\n");
+            Write(root, "resolves.md", "Resolved #12, measured against the pooled reset helper.\n");
             Write(root, "refs.md", "Refs #12 — the other half of that one.\n");
             Write(root, "url.md", "From https://github.com/s4k10503/velvet/issues/44, the second half.\n");
             Write(root, "no-issue.md", "No issue: found while reading the pool reset helpers.\n");
+            // Four spellings of the same line, each free of the last: indented, ended with a full
+            // stop, below the first line, and lower-case.
+            Write(root, "no-issue-indented.md", "  No issue: contributor tooling only.\n");
+            Write(root, "no-issue-stop.md", "No issue. Contributor tooling only.\n");
+            Write(root, "no-issue-later.md", "A change to the release script.\n\nNo issue: it closes nothing.\n");
+            Write(root, "no-issue-lower.md", "no issue: contributor tooling only.\n");
+            // The phrase without a reason after it is the silence this asks about, in a form that
+            // would satisfy a check that only looked for the phrase.
+            Write(root, "bare-no-issue.md", "No issue:\n\nWhat this changes and why.\n");
+            // The phrase inside a sentence says the opposite of the line, and reads the same to a
+            // pattern that is not anchored at a line.
+            Write(root, "mid-line.md", "There is no issue: this came out of a review round.\n");
+            // A keyword and a number that are not one statement: nothing here closes #123 on merge.
+            Write(root, "distant.md", "Closes the gap the pooled reset left; see #123 for the measurements.\n");
             Write(root, "silent.md", "A description that says nothing about where it came from.\n");
+            // A one-character name, because an attached short value is read off the token being
+            // longer than the flag and `-Fs` is the shortest token that carries one.
+            Write(root, "s", "A description that says nothing about where it came from.\n");
             // Six digits behind a `#` is a colour here, and the rule that read one as an issue would
             // have taken this body as an answer.
             Write(root, "colour.md", "The swatch this restores is #123456, measured off the panel.\n");
@@ -231,11 +325,19 @@ namespace Velvet.Tests
                     return "allow";
                 }
 
+                // Only exit 2 stops the command — PreToolUse runs the tool on every other non-zero
+                // code — so the reason is read off the message only once the code says it refused.
+                // Reading the message alone called a guard that exits 1 a refusal.
+                if (process.ExitCode != 2)
+                {
+                    return $"exit {process.ExitCode}";
+                }
+
                 var matched = Reasons
                     .Where(reason => stderr.Contains(reason.Phrase, StringComparison.Ordinal))
                     .Select(reason => reason.Tag)
                     .ToList();
-                return matched.Count == 1 ? matched[0] : $"exit {process.ExitCode}: {string.Join("+", matched)}";
+                return matched.Count == 1 ? matched[0] : $"exit 2: {string.Join("+", matched)}";
             }
             catch (Exception)
             {

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/PrBodyProvenanceGuardTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/PrBodyProvenanceGuardTests.cs
@@ -1,0 +1,259 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using NUnit.Framework;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Poses <c>.claude/hooks/refuse/pr_body_of_another_branch.py</c> a body of each shape it decides
+    /// about, and reads the verdict it returns. <see cref="GuardCommandCoverageTests"/> asks what that
+    /// guard recognises in a command and <see cref="PreExpansionPolicyTests"/> asks the single verdict
+    /// its own probe poses; what it decides about a body was asked by neither. Of ten one-line changes
+    /// to it, nine left both of those green — including one that accepted every body.
+    /// </summary>
+    /// <remarks>
+    /// A refusal is matched on a phrase only its own message carries, not on the exit code alone: a
+    /// check that stops firing and a check that fires for another reason both exit 2, which is how
+    /// four of those ten read from outside — one of them landing on the tag for a file that will not
+    /// read, which an unlabelled exit 2 would have hidden.
+    /// </remarks>
+    [TestFixture]
+    internal sealed class PrBodyProvenanceGuardTests
+    {
+        private const string HookPath = ".claude/hooks/refuse/pr_body_of_another_branch.py";
+
+        private static readonly (string Tag, string Phrase)[] Reasons =
+        {
+            ("missing", "does not exist"),
+            ("stdin", "comes from stdin"),
+            ("unexpanded-path", "still unexpanded"),
+            ("moved", "changes directory"),
+            ("assembled", "assembled by the shell"),
+            ("no-origin", "names no issue"),
+            ("unreadable", "cannot be read"),
+            ("crashed", "failed to reach a verdict"),
+        };
+
+        // {DIR} is the fixture's own directory, which is not a git repository: the guard reads the body
+        // and nothing else, so no case here needs one.
+        private static readonly (string Command, string Expected)[] Accepted =
+        {
+            ("gh pr create --title x --body-file {DIR}/closes.md", "allow"),
+            ("gh pr create --title x --body-file {DIR}/refs.md", "allow"),
+            ("gh pr create --title x --body-file {DIR}/url.md", "allow"),
+            ("gh pr create --title x --body-file {DIR}/no-issue.md", "allow"),
+            ("gh pr create --title x -F{DIR}/closes.md", "allow"),
+            // Backticks and a `$` in an inline body are the description rather than a name for it.
+            ("gh pr create --title x --body 'Closes #7. `Foo.Bar` now reads $HOME.'", "allow"),
+            ("gh pr create --fill", "allow"),
+            ("gh pr create --title x --template {DIR}/closes.md", "allow"),
+            ("gh pr create --title x --editor", "allow"),
+            ("gh pr create --title x --dry-run --body-file {DIR}/absent.md", "allow"),
+            ("gh pr create --title x -h --body-file {DIR}/silent.md", "allow"),
+            // A head is not read at all now. One naming a fork used to be refused, with the remedy
+            // being to pass the head the command had already passed.
+            ("gh pr create --title x --body-file {DIR}/closes.md --head someone:feat/x", "allow"),
+            ("cd {DIR}/sub && gh pr create --title x --body-file {DIR}/closes.md", "allow"),
+            ("gh pr list", "allow"),
+            ("echo \"gh pr create --body-file {DIR}/silent.md\"", "allow"),
+        };
+
+        // {DIR}/relative.md is absent and {DIR}/sub/relative.md is not, so a move the guard fails to
+        // see answers "missing" instead, which is what keeps the last two rows from passing on the
+        // strength of the file being in the other directory.
+        private static readonly (string Command, string Expected)[] Refused =
+        {
+            ("gh pr create --title x --body-file {DIR}/silent.md", "no-origin"),
+            ("gh pr create --title x --body-file {DIR}/colour.md", "no-origin"),
+            ("gh pr create --title x --body-file {DIR}/mention.md", "no-origin"),
+            ("gh pr create --title x --body 'A change to the pooled reset helper.'", "no-origin"),
+            ("gh pr create --title x --web --body-file {DIR}/silent.md", "no-origin"),
+            ("gh pr create --title x --body 'Closes #7.' --body-file {DIR}/silent.md", "no-origin"),
+            ("gh pr create --title x --body-file {DIR}/absent.md", "missing"),
+            // A directory exists and does not read, which is the one way to reach that branch without
+            // a permission bit — and a run as root would read a file this fixture had made unreadable.
+            ("gh pr create --title x --body-file {DIR}/sub", "unreadable"),
+            ("gh pr create --title x --body-file -", "stdin"),
+            ("gh pr create --title x --body-file $BODY", "unexpanded-path"),
+            ("gh pr create --title x --body \"$(cat {DIR}/closes.md)\"", "assembled"),
+            ("cd {DIR}/sub && gh pr create --title x --body-file relative.md", "moved"),
+            ("builtin cd {DIR}/sub && gh pr create --title x --body-file relative.md", "moved"),
+        };
+
+        [Test]
+        public void Given_ABodyNamingWhereItCameFrom_When_TheGuardAnswers_Then_EveryFormIsAllowed()
+        {
+            // Arrange
+            var root = NewDirectory();
+            (int Count, string Disagreements) observed;
+
+            try
+            {
+                WriteBodies(root);
+
+                // Act
+                observed = Answers(root, Accepted);
+            }
+            finally
+            {
+                Delete(root);
+            }
+
+            // Assert — the count rides along because a driver that ran nothing disagrees with nothing.
+            Assert.That(observed, Is.EqualTo((Accepted.Length, string.Empty)),
+                "a guard that refuses a body naming its origin is one every pull request has to work around");
+        }
+
+        [Test]
+        public void Given_ABodyThatNamesNoOriginOrCannotBeRead_When_TheGuardAnswers_Then_EachRefusalIsItsOwn()
+        {
+            // Arrange
+            var root = NewDirectory();
+            (int Count, string Disagreements) observed;
+
+            try
+            {
+                WriteBodies(root);
+
+                // Act
+                observed = Answers(root, Refused);
+            }
+            finally
+            {
+                Delete(root);
+            }
+
+            // Assert
+            Assert.That(observed, Is.EqualTo((Refused.Length, string.Empty)),
+                "a refusal that fires for another reason gives another remedy, and exits 2 either way");
+        }
+
+        [Test]
+        public void Given_AnEventTheGuardCannotRead_When_ItAnswers_Then_ItRefusesRatherThanFallingThrough()
+        {
+            // Arrange — a working directory that is not a string, which no check below is written for
+            const string payload =
+                "{\"tool_name\":\"Bash\",\"cwd\":12345,"
+                + "\"tool_input\":{\"command\":\"gh pr create --title x --body-file b.md\"}}";
+
+            // Act
+            var answer = Ask(Path.GetFullPath(HookPath), payload);
+
+            // Assert — exit 1 is not a refusal, so an unforeseen shape here runs the command anyway
+            Assert.That(answer, Is.EqualTo("crashed"));
+        }
+
+        private static void WriteBodies(string root)
+        {
+            Directory.CreateDirectory(Path.Combine(root, "sub"));
+            Write(root, "closes.md", "Closes #123.\n\nWhat this changes and why.\n");
+            Write(root, "refs.md", "Refs #12 — the other half of that one.\n");
+            Write(root, "url.md", "From https://github.com/s4k10503/velvet/issues/44, the second half.\n");
+            Write(root, "no-issue.md", "No issue: found while reading the pool reset helpers.\n");
+            Write(root, "silent.md", "A description that says nothing about where it came from.\n");
+            // Six digits behind a `#` is a colour here, and the rule that read one as an issue would
+            // have taken this body as an answer.
+            Write(root, "colour.md", "The swatch this restores is #123456, measured off the panel.\n");
+            // A number mentioned in prose closes nothing on merge, which is the half that hurt.
+            Write(root, "mention.md", "This supersedes #448's other half, which is still open.\n");
+            Write(root, Path.Combine("sub", "relative.md"), "Closes #1.\n");
+        }
+
+        private static void Write(string root, string name, string text) =>
+            File.WriteAllText(Path.Combine(root, name), text);
+
+        private static (int Count, string Disagreements) Answers(
+            string root, (string Command, string Expected)[] table)
+        {
+            var hook = Path.GetFullPath(HookPath);
+            var answered = new List<string>();
+            var disagreements = new List<string>();
+            foreach (var (command, expected) in table)
+            {
+                var posed = command.Replace("{DIR}", root);
+                var answer = Answer(hook, root, posed);
+                if (answer == null)
+                {
+                    continue;
+                }
+
+                answered.Add(answer);
+                if (answer != expected)
+                {
+                    disagreements.Add($"{posed}\n    expected [{expected}] got [{answer}]");
+                }
+            }
+
+            return (answered.Count, string.Join("\n", disagreements));
+        }
+
+        private static string Answer(string hook, string cwd, string command) =>
+            Ask(hook, "{\"tool_name\":\"Bash\",\"cwd\":\"" + Escape(cwd)
+                + "\",\"tool_input\":{\"command\":\"" + Escape(command) + "\"}}");
+
+        /// <summary>"allow", the tag of the refusal the guard gave, or null when it could not be run.</summary>
+        private static string Ask(string hook, string payload)
+        {
+            var start = new ProcessStartInfo("python3")
+            {
+                RedirectStandardInput = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            };
+            start.ArgumentList.Add("-B");
+            start.ArgumentList.Add(hook);
+
+            try
+            {
+                using var process = Process.Start(start);
+                if (process == null)
+                {
+                    return null;
+                }
+
+                process.StandardInput.Write(payload);
+                process.StandardInput.Close();
+                process.StandardOutput.ReadToEnd();
+                var stderr = process.StandardError.ReadToEnd();
+                if (!process.WaitForExit(30000))
+                {
+                    process.Kill();
+                    return null;
+                }
+
+                if (process.ExitCode == 0)
+                {
+                    return "allow";
+                }
+
+                var matched = Reasons
+                    .Where(reason => stderr.Contains(reason.Phrase, StringComparison.Ordinal))
+                    .Select(reason => reason.Tag)
+                    .ToList();
+                return matched.Count == 1 ? matched[0] : $"exit {process.ExitCode}: {string.Join("+", matched)}";
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+        }
+
+        private static string Escape(string text) => text.Replace("\\", "\\\\").Replace("\"", "\\\"");
+
+        private static string NewDirectory() =>
+            Path.Combine(Path.GetTempPath(), "velvet-pr-body-" + Guid.NewGuid().ToString("N"));
+
+        private static void Delete(string root)
+        {
+            if (Directory.Exists(root))
+            {
+                Directory.Delete(root, true);
+            }
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/PrBodyProvenanceGuardTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/PrBodyProvenanceGuardTests.cs
@@ -114,10 +114,15 @@ namespace Velvet.Tests
             // A segment carrying only an environment assignment has no command word, and is not a move.
             ("BODY=x && gh pr create --title x --body-file silent.md", "no-origin"),
             // The other side of the move set, which the rows below pin in one direction only: they
-            // fail when a mover is dropped and pass when one is added, and the repository's own way
-            // of opening a pull request runs `git push` in the segment before the create.
+            // fail when a mover is dropped and pass when one is added.
             ("git push -u origin HEAD && gh pr create --title x --body-file silent.md", "no-origin"),
             ("echo x && gh pr create --title x --body-file silent.md", "no-origin"),
+            // Sharing a prefix with a mover is not being one, either way round: `cdk` starts with
+            // `cd`, and `pushd` starts with `push`. No other command word posed in this fixture does
+            // either, so a comparison loosened to a prefix match answers every other row the way the
+            // equality does, and only these two flip — to "moved", for a body it should have opened.
+            ("cdk deploy && gh pr create --title x --body-file silent.md", "no-origin"),
+            ("push && gh pr create --title x --body-file silent.md", "no-origin"),
             ("gh pr create --title x --body-file {DIR}/absent.md", "missing"),
             // A directory exists and does not read, which is the one way to reach that branch without
             // a permission bit — and a run as root would read a file this fixture had made unreadable.

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/PrBodyProvenanceGuardTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/PrBodyProvenanceGuardTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7a4717b565044a9b9432b9578ecd6500


### PR DESCRIPTION
No issue: the guard this branch adds was measured against the pull requests this repository actually
opens, and half of it did not hold.

## What the guard is now

`.claude/hooks/refuse/pr_body_of_another_branch.py` refuses a `gh pr create` whose body says nothing
about where the change came from. An answer is a closing or referring keyword — Closes, Fixes,
Resolves, Refs and their inflections — against the number right after it, or the issue's own URL, or
a `No issue: <reason>` line.

It reads the description that will be posted, so a body file it cannot read is refused rather than
skipped: an absent one, an unexpanded path, stdin, a relative path in a command that also changes
directory, and one the filesystem will not hand over. An inline `--body` is the description rather
than a name for it, so it is searched as it stands — its backticks and `$` cost nothing — and an
expansion in it is refused only where the search came back empty.

Only `gh pr create` is asked. `gh pr edit --body-file` is how an answer gets added after the fact, so
a guard that claimed it would refuse the remedy it hands out.

CONTRIBUTING.md owns the rule and now states it in these terms.

## What it deliberately does not do

**It does not date the body file against the branch.** That half is deleted, not narrowed.

Posed the case it existed for — a body file stamped at the moment one pull request here was opened,
against the branch of the next one opened, whose first commit lands sixteen seconds later — it
allowed it. The window was fifteen minutes wide and the comparison one-sided, so a leftover stamped
after the branch's first commit was allowed with no bound at all. It would not have caught the
occasion it was written for.

No width of window fixes that. A `PreToolUse` hook runs before the command, so where the body is
written by the same command that posts it — a heredoc into the path, then `gh pr create` reading it —
the mtime the guard reads belongs to whatever was already at that path. That is the leftover itself,
and the file it would date is the one the command is about to overwrite. A narrower window refuses
correct bodies; a wider one admits more leftovers; neither is reading the description that will be
posted. A guard that cannot catch its founding incident reads as coverage, which is worse than none.

**It does not require an issue.** A tooling or release change legitimately closes nothing, and the
`No issue:` line answers for it in one line. Measured over the last sixty merged pull requests here:
fifty carry a keyword against a number, one carries a `No issue:` line, two carry only a number
mentioned in passing, and seven carry nothing. So the rule leaves fifty of sixty untouched and asks
one line of the rest — including the two that mention a number in prose, which closes nothing on
merge and is the half of the accident that hurt.

**It does not separate a flag from another option's value.** `-t -Fx` reads a body file of `x`.
Separating them needs a mirror of which of gh's options take a value, and an unpinned mirror drifts.

## Collateral refusals removed

Each was measured against the guard as it stood on this branch, then against the reworked one:

- an inline `--body` containing a backtick was refused as unexpanded, with a remedy that could not be
  followed — the body is the description rather than a name for one, so it is now searched as it
  stands and only an unanswered body that carries an expansion is refused;
- `--dry-run` was refused, and it opens nothing;
- `--head` naming a fork was refused, with the remedy being to pass the head already passed — no head
  is read at all now;
- `--editor`, `--recover`, `--fill-verbose` and the interactive form were passing through an
  exception the guard documented as `--fill`/`--template`; the condition is stated instead of the
  list, since the list was short of what reaches it;
- `builtin cd` was not read as a directory move, so the guard answered about a file in the directory
  the move had left. `builtin` joins `command` in the shared parser's leading words.

## Tests, and how far they reach

`PrBodyProvenanceGuardTests` poses the guard fifty commands and six events, and reads the verdict
each time. A refusal is matched on a phrase only its own message carries **and** on exit 2: a check
that stops firing and a check that fires for another reason both exit 2, and `PreToolUse` runs the
command anyway on every other code, so reading the message alone called a guard that exits 1 a
refusal.

The earlier round claimed every verdict was posed and that was not true. Traced through the guard,
the tables reached **23 of its 29 `return` statements**; they reach all 29 now. The six they missed
were a value attached with `=`, a body flag given as the last token, a segment with no command word,
and the three early returns in `main()` — stdin that is not JSON, an event that is not an object or
not for this tool, and a command that is not text.

**Mutation campaign.** Seventy-five one-line changes to the guard, covering every verdict, every
early return, each accepted spelling, each member of the literal sets and each alternative in the two
patterns. Each is posed the fixture's own tables.

| | caught | survived |
|---|---|---|
| the fixture as this branch last pushed it | 46 | **29** |
| the fixture now | **74** | 1 |

The one survivor is equivalent: `return None` replaced by `break` in `valued()` breaks the only loop
it sits in and reaches the same `return None` two lines below, so no input can tell the two apart.

The campaign is scoped to this fixture alone, which can only make a mutation look more survivable
than it is — `GuardCommandCoverageTests` pins the same guard's recognition of `-Fb.md`,
`--body-file=b.md` and `-bhello`, and would independently have killed several of the twenty-nine.

What the twenty-nine were, and what now kills each:

- **four `NO_ISSUE_LINE` spellings and two widenings.** The line was posed once, unindented,
  lower-case-free, colon-ended and on the first line, so dropping the indent tolerance, the full-stop
  ending, the case-insensitivity or the multi-line anchoring changed nothing — and neither did
  accepting the bare phrase with no reason after it, nor matching it in the middle of a sentence.
  Four bodies now pose the spellings and two pose the widenings, `No issue:` alone and
  "There is no issue: …";
- **`Fixes` and `Resolves`.** Only `Closes` and `Refs` were posed, so half the keyword set was
  deletable. Both are posed now, and so is the adjacency — "Closes the gap … see #123" is a keyword
  and a number that are not one statement, and is refused;
- **the spellings of a body value — eight of the twenty-nine, and the equivalent one is among them.**
  `-F<path>`, `--body-file=<path>` and `-b <text>` appeared only on the accepting side, where losing
  the value reads as "no body" and allows either way. Each now has a refusing row, `-Fs` among them,
  which is the shortest token that carries an attached value and pins the boundary the founding
  accident sat one character from;
- **`--help`, and `gh pr edit`.** Neither was posed; widening the claim from `gh pr create` to
  `gh pr` refused nothing any row asked about;
- **`pushd`/`popd`, a path-spelled command word, an environment-assignment segment, and a move
  carrying past the next segment.** `cd` was the only mover posed, and both relative body paths in
  the table were refused for the move before they were opened, so nothing observed which directory a
  relative path resolves against;
- **four event shapes.** Stdin that is not JSON, JSON that is not an object, a command that is not
  text, and an event carrying no working directory each land in an early return the tables never
  reached. They are a table of their own now, beside the malformed event that was already there and
  a tool outside the declared set;
- **a refusal that exits 1.** The fixture read the reason off the message and returned it whatever
  the exit code was, so a guard that stopped blocking anything still answered "no-origin". Exit 2 is
  now required before the message is read, which is the one of the twenty-nine that made the fixture
  itself wrong rather than incomplete.

`GuardCommandCoverageTests` gained one thing beyond its new body table. Its six per-test
preconditions on how many answers came back are folded into `Disagreements`: a guard that raises on
one command answers none of them, and an `Assume` reported the run that proves it broken as
inconclusive, which the runner does not count as a failure.

## Which of this and #588 merges first

#588 adds a required `HOOK_TOOLS` declaration to every `PreToolUse` hook and a fixture that fails on
a registration without one. This branch registers a new `PreToolUse` hook, so whichever of the two
merged second would have broken the other's fixture on `main`. The hook here therefore declares
`HOOK_TOOLS = {"Bash"}` and gates on it, which makes either order safe.

**Recommend #588 first.** Its fixture then already guards this registration when it lands, and
CONTRIBUTING.md's statement of what `HOOK_TOOLS` is arrives with the check rather than after a hook
that already uses it. Nothing breaks the other way round; it just leaves a declaration undocumented
for as long as the gap lasts.

## Documentation and CHANGELOG

CONTRIBUTING.md owns the rule and is updated here: `Resolves` joins the keyword list, `--help` joins
`--dry-run` as opening nothing, and the section now says that only `gh pr create` is asked. No
`Documentation~` guide describes this — the guard is contributor tooling, not package behaviour, so
`Packages/com.velvet.core/CHANGELOG.md` gets no entry.

## Suites

EditMode 3781/3781 and PlayMode 161/161, 0 failed and 0 inconclusive in both,
`assert_no_inconclusive.py` clean on each.
