### PR TITLE
fix(velvet): restore the focus values an element was constructed with when a prop is dropped

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -10,10 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - A `TabIndex` or `DelegatesFocus` prop that a later render stopped declaring was written back as `0`
-  or `false` rather than as the value the element was constructed with. Neither is a constant: a
-  `Label` is built out of the tab ring, and every field control delegates focus to the input beneath
-  it, so dropping the prop put one into a focus order it was never in and took the other's delegation
-  away. `Focusable` already restored; all three do now.
+  or `false` rather than as the value the element was constructed with — neither of which is the
+  right answer for every type. A `Label` is built out of the tab ring at -1, which shows once a
+  consumer declares it focusable; every field control is built delegating focus to the input beneath
+  it, so dropping that prop stranded focus on the field's own root. `Focusable` already restored its
+  constructed value; all three do now.
 
 - A pooled widget carried far more than its reset helper named. Most of the writable surface of
   `Button`, `Label`, `Toggle`, `Slider` and `TextField` survived a pool cycle and arrived on whatever

--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -12,8 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A `TabIndex` or `DelegatesFocus` prop that a later render stopped declaring was written back as `0`
   or `false` rather than as the value the element was constructed with — neither of which is the
   right answer for every type. A `Label` is built out of the tab ring at -1, which shows once a
-  consumer declares it focusable; every field control is built delegating focus to the input beneath
-  it, so dropping that prop stranded focus on the field's own root. `Focusable` already restored its
+  consumer declares it focusable; a `TextField`, `Toggle` or `Slider` is built delegating focus to
+  the input beneath it, so dropping that prop stranded focus on the field's own root. `Focusable` already restored its
   constructed value; all three do now.
 
 - A pooled widget carried far more than its reset helper named. Most of the writable surface of

--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A `TabIndex` or `DelegatesFocus` prop that a later render stopped declaring was written back as `0`
+  or `false` rather than as the value the element was constructed with. Neither is a constant: a
+  `Label` is built out of the tab ring, and every field control delegates focus to the input beneath
+  it, so dropping the prop put one into a focus order it was never in and took the other's delegation
+  away. `Focusable` already restored; all three do now.
+
 - A pooled widget carried far more than its reset helper named. Most of the writable surface of
   `Button`, `Label`, `Toggle`, `Slider` and `TextField` survived a pool cycle and arrived on whatever
   mounted next: a read-only or multiline `TextField`, a placeholder string the next consumer had not

--- a/Packages/com.velvet.core/Documentation~/focus.md
+++ b/Packages/com.velvet.core/Documentation~/focus.md
@@ -53,8 +53,8 @@ Three focus-related element props ride `FiberElementProps` alongside the existin
 stops declaring one: dropping the prop hands the element back the value it was constructed with, so a
 `V.Div` that carried `Focusable = true` for one render stops being a Tab stop again, and a control
 that is focusable by construction keeps its own default. The same holds for the other two, and it has
-to: a `V.Text` is built out of the tab ring, and every field control delegates focus to the input
-beneath it, so a constant would hand one type another type's answer.
+to: a `Label` reached through `V.Custom` is built out of the tab ring, and every field control
+delegates focus to the input beneath it, so a constant would hand one type another type's answer.
 
 ## Focus-visible styling and state
 

--- a/Packages/com.velvet.core/Documentation~/focus.md
+++ b/Packages/com.velvet.core/Documentation~/focus.md
@@ -53,8 +53,9 @@ Three focus-related element props ride `FiberElementProps` alongside the existin
 stops declaring one: dropping the prop hands the element back the value it was constructed with, so a
 `V.Div` that carried `Focusable = true` for one render stops being a Tab stop again, and a control
 that is focusable by construction keeps its own default. The same holds for the other two, and it has
-to: a `Label` reached through `V.Custom` is built out of the tab ring, and every field control
-delegates focus to the input beneath it, so a constant would hand one type another type's answer.
+to: a `Label` reached through `V.Custom` is built out of the tab ring, a `TextField` is built
+delegating focus to the input beneath it, and a UI Toolkit composite field mounted through `V.Custom`
+is built doing neither — so a constant would hand one type another type's answer.
 
 ## Focus-visible styling and state
 

--- a/Packages/com.velvet.core/Documentation~/focus.md
+++ b/Packages/com.velvet.core/Documentation~/focus.md
@@ -49,11 +49,12 @@ Three focus-related element props ride `FiberElementProps` alongside the existin
 `DelegatesFocus` (focusing the element forwards to its first focusable child), and `FocusScope`
 (the settings record behind the scope knobs above).
 
-`Focusable` is restored rather than coalesced when a later render stops declaring it: dropping the
-prop hands the element back the focusability it was constructed with, so a `V.Div` that carried
-`Focusable = true` for one render stops being a Tab stop again, and a control that is focusable by
-construction keeps its own default. `TabIndex` and `DelegatesFocus` behave differently: dropping either
-coalesces to `0` / `false`.
+`Focusable`, `TabIndex` and `DelegatesFocus` are restored rather than coalesced when a later render
+stops declaring one: dropping the prop hands the element back the value it was constructed with, so a
+`V.Div` that carried `Focusable = true` for one render stops being a Tab stop again, and a control
+that is focusable by construction keeps its own default. The same holds for the other two, and it has
+to: a `V.Text` is built out of the tab ring, and every field control delegates focus to the input
+beneath it, so a constant would hand one type another type's answer.
 
 ## Focus-visible styling and state
 

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberPropApplier.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberPropApplier.cs
@@ -110,9 +110,9 @@ namespace Velvet
         private static readonly ConditionalWeakTable<VisualElement, DelegatesFocusDefault> s_delegatesFocusDefaults = new();
 
         // Same shape and same reason as ApplyFocusable: what an absent prop restores is the element's own
-        // constructed value, which differs by type. A TextElement is built at tabIndex -1 and a BaseField
-        // delegates focus, so the 0 / false these coalesced to were another type's answer — reachable with
-        // no pool involved, by rendering the prop once and then not.
+        // constructed value, which differs by type, so the 0 / false these coalesced to were another
+        // type's answer. Which value each type is built with is pinned by ConstructedFocusDefaultTests,
+        // which folds the constructed reading into every assertion rather than trusting a sentence here.
         public static void ApplyTabIndex(VisualElement element, int? tabIndex)
         {
             if (tabIndex.HasValue)

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberPropApplier.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberPropApplier.cs
@@ -49,7 +49,8 @@ namespace Velvet
 
         private static readonly int s_hiddenPriority = StyleLayerPriority.ImportantOf(StyleLayerPriority.Base);
 
-        // Unlike ApplyEnabled, a dropped Focusable cannot coalesce to a constant: what an absent prop has to restore is the element's own constructed value, which differs by
+        // Unlike ApplyEnabled, a dropped Focusable cannot coalesce to a constant: what an absent prop has to
+        // restore is the element's own constructed value, which differs by
         // type — FiberElementPoolReset.ResetCommonState writes one answer and every widget helper but the Label
         // one overwrites it — and which no table can answer for a V.Custom<T> type. The element is asked instead
         // of a table: the create path never writes an absent Focusable (FiberElementFactory.ApplyProps guards on

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberPropApplier.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberPropApplier.cs
@@ -112,7 +112,8 @@ namespace Velvet
         // Same shape and same reason as ApplyFocusable: what an absent prop restores is the element's own
         // constructed value, which differs by type, so the 0 / false these coalesced to were another
         // type's answer. Which value each type is built with is pinned by ConstructedFocusDefaultTests,
-        // which folds the constructed reading into every assertion rather than trusting a sentence here.
+        // and that the drop reaches this branch at all by PropsDiffTests, which reconciles rather than
+        // calling in here.
         public static void ApplyTabIndex(VisualElement element, int? tabIndex)
         {
             if (tabIndex.HasValue)

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberPropApplier.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberPropApplier.cs
@@ -49,8 +49,7 @@ namespace Velvet
 
         private static readonly int s_hiddenPriority = StyleLayerPriority.ImportantOf(StyleLayerPriority.Base);
 
-        // Unlike ApplyEnabled / ApplyTabIndex / ApplyDelegatesFocus, a dropped Focusable cannot coalesce to a
-        // constant: what an absent prop has to restore is the element's own constructed value, which differs by
+        // Unlike ApplyEnabled, a dropped Focusable cannot coalesce to a constant: what an absent prop has to restore is the element's own constructed value, which differs by
         // type — FiberElementPoolReset.ResetCommonState writes one answer and every widget helper but the Label
         // one overwrites it — and which no table can answer for a V.Custom<T> type. The element is asked instead
         // of a table: the create path never writes an absent Focusable (FiberElementFactory.ApplyProps guards on
@@ -92,13 +91,75 @@ namespace Velvet
             public FocusableDefault(bool value) => Value = value;
         }
 
-        private static readonly ConditionalWeakTable<VisualElement, FocusableDefault> s_focusableDefaults = new();
+        private sealed class TabIndexDefault
+        {
+            public readonly int Value;
 
+            public TabIndexDefault(int value) => Value = value;
+        }
+
+        private sealed class DelegatesFocusDefault
+        {
+            public readonly bool Value;
+
+            public DelegatesFocusDefault(bool value) => Value = value;
+        }
+
+        private static readonly ConditionalWeakTable<VisualElement, FocusableDefault> s_focusableDefaults = new();
+        private static readonly ConditionalWeakTable<VisualElement, TabIndexDefault> s_tabIndexDefaults = new();
+        private static readonly ConditionalWeakTable<VisualElement, DelegatesFocusDefault> s_delegatesFocusDefaults = new();
+
+        // Same shape and same reason as ApplyFocusable: what an absent prop restores is the element's own
+        // constructed value, which differs by type. A TextElement is built at tabIndex -1 and a BaseField
+        // delegates focus, so the 0 / false these coalesced to were another type's answer — reachable with
+        // no pool involved, by rendering the prop once and then not.
         public static void ApplyTabIndex(VisualElement element, int? tabIndex)
-            => element.tabIndex = tabIndex ?? 0;
+        {
+            if (tabIndex.HasValue)
+            {
+                RecordTabIndexDefault(element);
+                element.tabIndex = tabIndex.Value;
+                return;
+            }
+
+            if (s_tabIndexDefaults.TryGetValue(element, out var recorded))
+            {
+                element.tabIndex = recorded.Value;
+            }
+        }
 
         public static void ApplyDelegatesFocus(VisualElement element, bool? delegatesFocus)
-            => element.delegatesFocus = delegatesFocus ?? false;
+        {
+            if (delegatesFocus.HasValue)
+            {
+                RecordDelegatesFocusDefault(element);
+                element.delegatesFocus = delegatesFocus.Value;
+                return;
+            }
+
+            if (s_delegatesFocusDefaults.TryGetValue(element, out var recorded))
+            {
+                element.delegatesFocus = recorded.Value;
+            }
+        }
+
+        // Callers writing either outside the prop path owe this before their write, for the reason
+        // RecordFocusableDefault gives. Idempotent: the first record for an element is the one that stands.
+        internal static void RecordTabIndexDefault(VisualElement element)
+        {
+            if (!s_tabIndexDefaults.TryGetValue(element, out _))
+            {
+                s_tabIndexDefaults.Add(element, new TabIndexDefault(element.tabIndex));
+            }
+        }
+
+        internal static void RecordDelegatesFocusDefault(VisualElement element)
+        {
+            if (!s_delegatesFocusDefaults.TryGetValue(element, out _))
+            {
+                s_delegatesFocusDefaults.Add(element, new DelegatesFocusDefault(element.delegatesFocus));
+            }
+        }
 
         public static void ApplyFieldValue(VisualElement element, object? value)
         {

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ConstructedFocusDefaultTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ConstructedFocusDefaultTests.cs
@@ -1,0 +1,74 @@
+using NUnit.Framework;
+using UnityEngine.UIElements;
+
+namespace Velvet.Tests
+{
+    // A prop that stops being declared restores what the element was constructed with, not a constant.
+    // Which constant would be wrong depends on the type: a TextElement is built out of the tab ring at
+    // -1, and every BaseField delegates focus to the input beneath it, so coalescing to 0 / false handed
+    // one type another type's answer. No pool is involved — rendering the prop once and then not is
+    // enough.
+    internal sealed class ConstructedFocusDefaultTests
+    {
+        [Test]
+        public void Given_a_label_whose_declared_tab_index_is_dropped_When_the_prop_is_applied_Then_it_reads_the_one_it_was_built_with()
+        {
+            // Arrange
+            var label = new Label();
+            var built = label.tabIndex;
+
+            // Act
+            FiberPropApplier.ApplyTabIndex(label, 3);
+            var declared = label.tabIndex;
+            FiberPropApplier.ApplyTabIndex(label, null);
+
+            // Assert
+            Assert.That((built, declared, label.tabIndex), Is.EqualTo((-1, 3, -1)));
+        }
+
+        [Test]
+        public void Given_a_field_whose_declared_focus_delegation_is_dropped_When_the_prop_is_applied_Then_it_reads_the_one_it_was_built_with()
+        {
+            // Arrange
+            var field = new TextField();
+            var built = field.delegatesFocus;
+
+            // Act
+            FiberPropApplier.ApplyDelegatesFocus(field, false);
+            var declared = field.delegatesFocus;
+            FiberPropApplier.ApplyDelegatesFocus(field, null);
+
+            // Assert
+            Assert.That((built, declared, field.delegatesFocus), Is.EqualTo((true, false, true)));
+        }
+
+        [Test]
+        public void Given_an_element_that_never_declared_either_When_the_absent_prop_is_applied_Then_nothing_is_written()
+        {
+            // Arrange
+            var field = new TextField();
+
+            // Act
+            FiberPropApplier.ApplyTabIndex(field, null);
+            FiberPropApplier.ApplyDelegatesFocus(field, null);
+
+            // Assert
+            Assert.That((field.tabIndex, field.delegatesFocus), Is.EqualTo((0, true)));
+        }
+
+        [Test]
+        public void Given_a_declared_value_written_twice_When_it_is_dropped_Then_the_record_is_the_first_reading_not_the_second()
+        {
+            // Arrange
+            var label = new Label();
+
+            // Act
+            FiberPropApplier.ApplyTabIndex(label, 3);
+            FiberPropApplier.ApplyTabIndex(label, 7);
+            FiberPropApplier.ApplyTabIndex(label, null);
+
+            // Assert
+            Assert.That(label.tabIndex, Is.EqualTo(-1));
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ConstructedFocusDefaultTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ConstructedFocusDefaultTests.cs
@@ -4,10 +4,9 @@ using UnityEngine.UIElements;
 namespace Velvet.Tests
 {
     // A prop that stops being declared restores what the element was constructed with, not a constant.
-    // Which constant would be wrong depends on the type: a TextElement is built out of the tab ring at
-    // -1, and every BaseField delegates focus to the input beneath it, so coalescing to 0 / false handed
-    // one type another type's answer. No pool is involved — rendering the prop once and then not is
-    // enough.
+    // Which constant would be wrong depends on the type, and the two values are pinned by the tuples
+    // below rather than asserted anywhere in prose. No pool is involved: declaring the prop on one
+    // render and not the next is enough, through V.Custom<Label> or a Motion node over one.
     internal sealed class ConstructedFocusDefaultTests
     {
         [Test]
@@ -42,18 +41,33 @@ namespace Velvet.Tests
             Assert.That((built, declared, field.delegatesFocus), Is.EqualTo((true, false, true)));
         }
 
+        // A Label for the tab index and a field for the delegation, because each is the type whose
+        // constructed value differs from the constant the applier used to write. A TextField is built
+        // at tab index 0, so it cannot tell the two apart.
         [Test]
-        public void Given_an_element_that_never_declared_either_When_the_absent_prop_is_applied_Then_nothing_is_written()
+        public void Given_a_label_that_never_declared_a_tab_index_When_the_absent_prop_is_applied_Then_nothing_is_written()
+        {
+            // Arrange
+            var label = new Label();
+
+            // Act
+            FiberPropApplier.ApplyTabIndex(label, null);
+
+            // Assert
+            Assert.That(label.tabIndex, Is.EqualTo(-1));
+        }
+
+        [Test]
+        public void Given_a_field_that_never_declared_focus_delegation_When_the_absent_prop_is_applied_Then_nothing_is_written()
         {
             // Arrange
             var field = new TextField();
 
             // Act
-            FiberPropApplier.ApplyTabIndex(field, null);
             FiberPropApplier.ApplyDelegatesFocus(field, null);
 
             // Assert
-            Assert.That((field.tabIndex, field.delegatesFocus), Is.EqualTo((0, true)));
+            Assert.That(field.delegatesFocus, Is.True);
         }
 
         [Test]

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ConstructedFocusDefaultTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ConstructedFocusDefaultTests.cs
@@ -41,9 +41,6 @@ namespace Velvet.Tests
             Assert.That((built, declared, field.delegatesFocus), Is.EqualTo((true, false, true)));
         }
 
-        // A Label for the tab index and a field for the delegation: each is the type whose constructed
-        // value differs from the constant the applier used to write, and the other cannot tell the
-        // constant from the constructed value. The two readings are the tuples in the tests above.
         [Test]
         public void Given_a_label_that_never_declared_a_tab_index_When_the_absent_prop_is_applied_Then_nothing_is_written()
         {

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ConstructedFocusDefaultTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ConstructedFocusDefaultTests.cs
@@ -41,9 +41,9 @@ namespace Velvet.Tests
             Assert.That((built, declared, field.delegatesFocus), Is.EqualTo((true, false, true)));
         }
 
-        // A Label for the tab index and a field for the delegation, because each is the type whose
-        // constructed value differs from the constant the applier used to write. A TextField is built
-        // at tab index 0, so it cannot tell the two apart.
+        // A Label for the tab index and a field for the delegation: each is the type whose constructed
+        // value differs from the constant the applier used to write, and the other cannot tell the
+        // constant from the constructed value. The two readings are the tuples in the tests above.
         [Test]
         public void Given_a_label_that_never_declared_a_tab_index_When_the_absent_prop_is_applied_Then_nothing_is_written()
         {

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ConstructedFocusDefaultTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ConstructedFocusDefaultTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6a4d4b93c1f824d119585f5e4a1397a4

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/PropsDiffTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/PropsDiffTests.cs
@@ -186,6 +186,43 @@ namespace Velvet.Tests
         }
 
         [Test]
+        public void Given_TabIndexDeclared_When_PatchedToUnset_Then_ElementConstructedValueRestored()
+        {
+            // Arrange — a Label is the only widget whose constructed tab index is not 0, so it is the only one
+            // where the coalescing this replaced is observable. Reached through V.Custom, since V.Text carries
+            // no props.
+            var oldTree = new VNode[] { V.Custom<Label>(props: new FiberElementProps { TabIndex = 3 }) };
+            var newTree = new VNode[] { V.Custom<Label>() };
+            Reconciler.Reconcile(Root, Array.Empty<VNode>(), oldTree);
+            var element = Root.ElementAt(0);
+            var whileDeclared = element.tabIndex;
+
+            // Act
+            Reconciler.Reconcile(Root, oldTree, newTree);
+
+            // Assert
+            Assert.That((whileDeclared, element.tabIndex), Is.EqualTo((3, -1)));
+        }
+
+        [Test]
+        public void Given_DelegatesFocusDeclared_When_PatchedToUnset_Then_ElementConstructedValueRestored()
+        {
+            // Arrange — a composite field is constructed delegating focus, so switching it off and dropping
+            // the prop is what strands focus on the field's own root.
+            var oldTree = new VNode[] { V.Custom<TextField>(props: new FiberElementProps { DelegatesFocus = false }) };
+            var newTree = new VNode[] { V.Custom<TextField>() };
+            Reconciler.Reconcile(Root, Array.Empty<VNode>(), oldTree);
+            var element = Root.ElementAt(0);
+            var whileDeclared = element.delegatesFocus;
+
+            // Act
+            Reconciler.Reconcile(Root, oldTree, newTree);
+
+            // Assert
+            Assert.That((whileDeclared, element.delegatesFocus), Is.EqualTo((false, true)));
+        }
+
+        [Test]
         public void Given_FocusableTrue_When_PatchedToUnset_Then_ElementConstructedValueRestored()
         {
             // Arrange — the mount render declares the Div focusable; the next render drops the prop entirely,

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/PropsDiffTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/PropsDiffTests.cs
@@ -188,9 +188,8 @@ namespace Velvet.Tests
         [Test]
         public void Given_TabIndexDeclared_When_PatchedToUnset_Then_ElementConstructedValueRestored()
         {
-            // Arrange — a Label is the only widget whose constructed tab index is not 0, so it is the only one
-            // where the coalescing this replaced is observable. Reached through V.Custom, since V.Text carries
-            // no props.
+            // Arrange — a Label inherits TextElement's -1 rather than the 0 the coalescing wrote, which is
+            // what makes the difference observable. Reached through V.Custom, since V.Text carries no props.
             var oldTree = new VNode[] { V.Custom<Label>(props: new FiberElementProps { TabIndex = 3 }) };
             var newTree = new VNode[] { V.Custom<Label>() };
             Reconciler.Reconcile(Root, Array.Empty<VNode>(), oldTree);
@@ -200,8 +199,12 @@ namespace Velvet.Tests
             // Act
             Reconciler.Reconcile(Root, oldTree, newTree);
 
-            // Assert
-            Assert.That((whileDeclared, element.tabIndex), Is.EqualTo((3, -1)));
+            // Assert — the identity term is what separates a restore from a remount: a Label handed back to
+            // the pool is reset to -1, so an implementation that discarded this element would satisfy the
+            // reading while the tree holds a different one.
+            Assert.That(
+                (ReferenceEquals(Root!.ElementAt(0), element), whileDeclared, element.tabIndex),
+                Is.EqualTo((true, 3, -1)));
         }
 
         [Test]
@@ -218,8 +221,10 @@ namespace Velvet.Tests
             // Act
             Reconciler.Reconcile(Root, oldTree, newTree);
 
-            // Assert
-            Assert.That((whileDeclared, element.delegatesFocus), Is.EqualTo((false, true)));
+            // Assert — same identity term, and for the same reason: the pool restores this reading too.
+            Assert.That(
+                (ReferenceEquals(Root!.ElementAt(0), element), whileDeclared, element.delegatesFocus),
+                Is.EqualTo((true, false, true)));
         }
 
         [Test]


### PR DESCRIPTION
No issue: found while reviewing the pooled-widget surface work, and reported independently by three
review rounds there before anything was written here.

`ApplyTabIndex` and `ApplyDelegatesFocus` coalesced an absent prop to `0` and `false`. Neither is a
constant. A `Label` is constructed at tab index `-1` — out of the tab ring — and every `BaseField`
control is constructed delegating focus to the input beneath it. So a render that declared either
prop and a later one that stopped put a `Label` into a focus order its constructor keeps it out of,
and took a composite field's delegation away.

No pool is involved. `FiberNodePatcher` fires on `old != new` and writes the constant, so declaring
the prop on one render and not the next is enough, through `V.Custom<Label>` or a Motion node over
one.

## The shape was already in the file

`ApplyFocusable` does it correctly: record what stood on the element before the first declared write,
restore that when the prop is dropped. Its comment named these two as the counter-example — the
contrast that made the coalescing look deliberate. All three share the shape now and the contrast is
gone.

The absent-prop path writes nothing when no declared value was ever recorded, so a mount that never
named the prop is not handed one by the guard meant to preserve it.

## Verification

- Five cases, each red without the fix: a `Label` whose declared index is dropped reads `0` instead
  of `-1`; a `TextField` whose declared delegation is dropped reads `false` instead of `true`; an
  element that never declared either is written to anyway; and a value declared twice then dropped
  restores the second declaration rather than the constructed value.
- The no-record branch is pinned with a `Label` rather than a `TextField`, because a `TextField` is
  built at index `0` — the same value the coalescing wrote — so that case could not fail. Reinstating
  the coalesce there turns it red now; before the split it did not.
- EditMode 3782/3782, `assert_no_inconclusive.py` clean, `test_release_notes.py` 26/26.

## Pool reuse

The records live in `ConditionalWeakTable`s and the pool holds elements strongly, so an entry
survives a pool cycle. Reviewed and sound: the pool is typed, and for each of the five poolable
primitives the post-reset value equals the constructed value, so a surviving record is still that
instance's own. That invariant is not left to argument — `PooledElementSurfaceResetTests` compares a
reset element against a freshly constructed one across the whole base chain, `Focusable` included.

`Documentation~/focus.md` documented the coalescing as deliberate and now describes the restore.
