### PR TITLE
fix(velvet): let a second Mutate call run without cancelling the first

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -13,7 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   its own `OnSuccess` / `OnError`, and `Status` / `Data` / `Variables` show the most recent — which is
   what TanStack Query does, and it hands `mutationFn` no signal at all. A double-tapped Buy used to
   abort a request the server may already have committed and then skip the `OnSuccess` that records
-  it. The token survives for unmount, where a request does want cancelling.
+  it. The token survives for unmount, where a request does want cancelling. A starting call also
+  clears `Data` along with `Error`, so a result belonging to the previous call is not read as this
+  one's while it is still pending.
 
 - A `TabIndex` or `DelegatesFocus` prop that a later render stopped declaring was written back as `0`
   or `false` rather than as the value the element was constructed with — neither of which is the

--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -10,8 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - A second `Mutate` call no longer cancels the first or drops its callbacks. Both run, each delivers
-  its own `OnSuccess` / `OnError`, and `Status` / `Data` / `Variables` show the most recent — which is
-  what TanStack Query does, and it hands `mutationFn` no signal at all. A double-tapped Buy used to
+  its own `OnSuccess` / `OnError`, and `Status` / `Data` / `Variables` show the most recent. Not
+  cancelling and showing the newest is what TanStack Query does, and it hands `mutationFn` no signal
+  at all; delivering the superseded call's callbacks is a deliberate deviation, since TanStack
+  detaches the observer and runs neither its handlers nor the hook's. A double-tapped Buy used to
   abort a request the server may already have committed and then skip the `OnSuccess` that records
   it. The token survives for unmount, where a request does want cancelling. A starting call also
   clears `Data` along with `Error`, so a result belonging to the previous call is not read as this

--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -10,10 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - A second `Mutate` call no longer cancels the first or drops its callbacks. Both run, each delivers
-  its own `OnSuccess` / `OnError`, and `Status` / `Data` / `Variables` show the most recent. Not
-  cancelling and showing the newest is what TanStack Query does, and it hands `mutationFn` no signal
-  at all; delivering the superseded call's callbacks is a deliberate deviation, since TanStack
-  detaches the observer and runs neither its handlers nor the hook's. A double-tapped Buy used to
+  its own `OnSuccess` / `OnError`, and `Status` / `Data` / `Variables` show the most recent — which
+  is what TanStack Query does, and it hands `mutationFn` no signal at all. A double-tapped Buy used to
   abort a request the server may already have committed and then skip the `OnSuccess` that records
   it. The token survives for unmount, where a request does want cancelling. A starting call also
   clears `Data` along with `Error`, so a result belonging to the previous call is not read as this

--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A second `Mutate` call no longer cancels the first or drops its callbacks. Both run, each delivers
+  its own `OnSuccess` / `OnError`, and `Status` / `Data` / `Variables` show the most recent — which is
+  what TanStack Query does, and it hands `mutationFn` no signal at all. A double-tapped Buy used to
+  abort a request the server may already have committed and then skip the `OnSuccess` that records
+  it. The token survives for unmount, where a request does want cancelling.
+
 - A `TabIndex` or `DelegatesFocus` prop that a later render stopped declaring was written back as `0`
   or `false` rather than as the value the element was constructed with — neither of which is the
   right answer for every type. A `Label` is built out of the tab ring at -1, which shows once a

--- a/Packages/com.velvet.core/Documentation~/react-migration.md
+++ b/Packages/com.velvet.core/Documentation~/react-migration.md
@@ -99,13 +99,13 @@ TanStack Query's `useMutation` equivalent. Returns a handle with `Mutate` (fire-
 | `mutate(variables)` | `mutation.Mutate(variables)` |
 | `mutateAsync(variables)` | `await mutation.MutateAsync(variables)` |
 
-**Concurrent calls** (TanStack Query v5 parity): calling `Mutate` twice starts two runs, neither
-cancels the other, each delivers its own `OnSuccess` / `OnError`, and `Status` / `Data` / `Error` /
-`Variables` are one snapshot following the newest — so a double-tapped button does not lose the
-first call's follow-up write. `Status` / `Data` / `Error` / `Variables` are one
-snapshot describing the most recent call, and starting a call resets all four to that call's own —
-`Data` included, so a pending call never shows the previous one's result. The `CancellationToken` handed to `MutationFn` is still cancelled when the
-component unmounts, which is what a Unity web request wants.
+**Concurrent calls** (TanStack Query v5 parity on cancellation and on the snapshot): calling
+`Mutate` twice starts two runs, neither cancels the other, each delivers its own `OnSuccess` /
+`OnError`, and `Status` / `Data` / `Error` / `Variables` are one snapshot following the newest — so
+a double-tapped button does not lose the first call's follow-up write. Starting a call resets all
+four to that call's own — `Data` included, so a pending call never shows the previous one's result.
+The `CancellationToken` handed to `MutationFn` is still cancelled when the component unmounts, which
+is what a Unity web request wants.
 
 **Callback error semantics** (TanStack Query v5 parity):
 

--- a/Packages/com.velvet.core/Documentation~/react-migration.md
+++ b/Packages/com.velvet.core/Documentation~/react-migration.md
@@ -99,9 +99,12 @@ TanStack Query's `useMutation` equivalent. Returns a handle with `Mutate` (fire-
 | `mutate(variables)` | `mutation.Mutate(variables)` |
 | `mutateAsync(variables)` | `await mutation.MutateAsync(variables)` |
 
-**Concurrent calls** (TanStack Query v5 parity): calling `Mutate` twice starts two runs. Neither
-cancels the other and each delivers its own `OnSuccess` / `OnError`, so a double-tapped button does
-not lose the first call's follow-up write. `Status` / `Data` / `Error` / `Variables` are one
+**Concurrent calls** (TanStack Query v5 parity, with one deliberate deviation): calling `Mutate`
+twice starts two runs, neither cancels the other, and the snapshot follows the newest — all as in
+v5. The deviation is that **each call still delivers its own `OnSuccess` / `OnError`**. v5 detaches
+the observer from the superseded mutation, so neither its handlers nor the hook's run; here a
+double-tapped button does not lose the first call's follow-up write, which is the failure this
+exists to prevent. `Status` / `Data` / `Error` / `Variables` are one
 snapshot describing the most recent call, and starting a call resets all four to that call's own —
 `Data` included, so a pending call never shows the previous one's result. The `CancellationToken` handed to `MutationFn` is still cancelled when the
 component unmounts, which is what a Unity web request wants.

--- a/Packages/com.velvet.core/Documentation~/react-migration.md
+++ b/Packages/com.velvet.core/Documentation~/react-migration.md
@@ -101,8 +101,9 @@ TanStack Query's `useMutation` equivalent. Returns a handle with `Mutate` (fire-
 
 **Concurrent calls** (TanStack Query v5 parity): calling `Mutate` twice starts two runs. Neither
 cancels the other and each delivers its own `OnSuccess` / `OnError`, so a double-tapped button does
-not lose the first call's follow-up write. `Status` / `Data` / `Variables` are one snapshot and show
-the most recent call. The `CancellationToken` handed to `MutationFn` is still cancelled when the
+not lose the first call's follow-up write. `Status` / `Data` / `Error` / `Variables` are one
+snapshot describing the most recent call, and starting a call resets all four to that call's own —
+`Data` included, so a pending call never shows the previous one's result. The `CancellationToken` handed to `MutationFn` is still cancelled when the
 component unmounts, which is what a Unity web request wants.
 
 **Callback error semantics** (TanStack Query v5 parity):

--- a/Packages/com.velvet.core/Documentation~/react-migration.md
+++ b/Packages/com.velvet.core/Documentation~/react-migration.md
@@ -100,12 +100,9 @@ TanStack Query's `useMutation` equivalent. Returns a handle with `Mutate` (fire-
 | `mutateAsync(variables)` | `await mutation.MutateAsync(variables)` |
 
 **Concurrent calls** (TanStack Query v5 parity): calling `Mutate` twice starts two runs, neither
-cancels the other, each delivers its own `OnSuccess` / `OnError`, and the snapshot follows the
-newest — so a double-tapped button does not lose the first call's follow-up write.
-
-One divergence, in which handler a superseded call runs: `UseMutation` rewrites the slot's handlers
-every render and the call reads them at completion, so a call that started before a re-render runs
-the **newest** `OnSuccess`. v5 keeps the options snapshot the mutation was built with. `Status` / `Data` / `Error` / `Variables` are one
+cancels the other, each delivers its own `OnSuccess` / `OnError`, and `Status` / `Data` / `Error` /
+`Variables` are one snapshot following the newest — so a double-tapped button does not lose the
+first call's follow-up write. `Status` / `Data` / `Error` / `Variables` are one
 snapshot describing the most recent call, and starting a call resets all four to that call's own —
 `Data` included, so a pending call never shows the previous one's result. The `CancellationToken` handed to `MutationFn` is still cancelled when the
 component unmounts, which is what a Unity web request wants.

--- a/Packages/com.velvet.core/Documentation~/react-migration.md
+++ b/Packages/com.velvet.core/Documentation~/react-migration.md
@@ -99,13 +99,16 @@ TanStack Query's `useMutation` equivalent. Returns a handle with `Mutate` (fire-
 | `mutate(variables)` | `mutation.Mutate(variables)` |
 | `mutateAsync(variables)` | `await mutation.MutateAsync(variables)` |
 
-**Concurrent calls** (TanStack Query v5 parity on cancellation and on the snapshot): calling
-`Mutate` twice starts two runs, neither cancels the other, each delivers its own `OnSuccess` /
-`OnError`, and `Status` / `Data` / `Error` / `Variables` are one snapshot following the newest — so
-a double-tapped button does not lose the first call's follow-up write. Starting a call resets all
-four to that call's own — `Data` included, so a pending call never shows the previous one's result.
-The `CancellationToken` handed to `MutationFn` is still cancelled when the component unmounts, which
-is what a Unity web request wants.
+**Concurrent calls.** Calling `Mutate` twice starts two runs, neither cancels the other, each
+delivers its own `OnSuccess` / `OnError`, and `Status` / `Data` / `Error` / `Variables` are one
+snapshot following the newest — so a double-tapped button does not lose the first call's follow-up
+write. Starting a call resets all four to that call's own — `Data` included, so a pending call never
+shows the previous one's result. Not cancelling on re-entry and following the newest are v5's
+behaviour.
+
+The `CancellationToken` handed to `MutationFn` has **no v5 counterpart** — a v5 `mutationFn` receives
+only its variables. It is cancelled when the component unmounts, which is what a Unity web request
+wants, and it is never cancelled by a later call.
 
 **Callback error semantics** (TanStack Query v5 parity):
 

--- a/Packages/com.velvet.core/Documentation~/react-migration.md
+++ b/Packages/com.velvet.core/Documentation~/react-migration.md
@@ -99,12 +99,13 @@ TanStack Query's `useMutation` equivalent. Returns a handle with `Mutate` (fire-
 | `mutate(variables)` | `mutation.Mutate(variables)` |
 | `mutateAsync(variables)` | `await mutation.MutateAsync(variables)` |
 
-**Concurrent calls** (TanStack Query v5 parity, with one deliberate deviation): calling `Mutate`
-twice starts two runs, neither cancels the other, and the snapshot follows the newest — all as in
-v5. The deviation is that **each call still delivers its own `OnSuccess` / `OnError`**. v5 detaches
-the observer from the superseded mutation, so neither its handlers nor the hook's run; here a
-double-tapped button does not lose the first call's follow-up write, which is the failure this
-exists to prevent. `Status` / `Data` / `Error` / `Variables` are one
+**Concurrent calls** (TanStack Query v5 parity): calling `Mutate` twice starts two runs, neither
+cancels the other, each delivers its own `OnSuccess` / `OnError`, and the snapshot follows the
+newest — so a double-tapped button does not lose the first call's follow-up write.
+
+One divergence, in which handler a superseded call runs: `UseMutation` rewrites the slot's handlers
+every render and the call reads them at completion, so a call that started before a re-render runs
+the **newest** `OnSuccess`. v5 keeps the options snapshot the mutation was built with. `Status` / `Data` / `Error` / `Variables` are one
 snapshot describing the most recent call, and starting a call resets all four to that call's own —
 `Data` included, so a pending call never shows the previous one's result. The `CancellationToken` handed to `MutationFn` is still cancelled when the
 component unmounts, which is what a Unity web request wants.

--- a/Packages/com.velvet.core/Documentation~/react-migration.md
+++ b/Packages/com.velvet.core/Documentation~/react-migration.md
@@ -99,6 +99,12 @@ TanStack Query's `useMutation` equivalent. Returns a handle with `Mutate` (fire-
 | `mutate(variables)` | `mutation.Mutate(variables)` |
 | `mutateAsync(variables)` | `await mutation.MutateAsync(variables)` |
 
+**Concurrent calls** (TanStack Query v5 parity): calling `Mutate` twice starts two runs. Neither
+cancels the other and each delivers its own `OnSuccess` / `OnError`, so a double-tapped button does
+not lose the first call's follow-up write. `Status` / `Data` / `Variables` are one snapshot and show
+the most recent call. The `CancellationToken` handed to `MutationFn` is still cancelled when the
+component unmounts, which is what a Unity web request wants.
+
 **Callback error semantics** (TanStack Query v5 parity):
 
 - A throwing **`onSuccess`** handler makes the mutation an **error**: `Status` becomes `Error`, `Error` holds the handler's exception, `onError` runs with that exception, and `MutateAsync` rethrows it to the caller. This matches React Query — the success state is not committed when the handler throws.

--- a/Packages/com.velvet.core/Runtime/Hooks/HookMutation.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/HookMutation.cs
@@ -66,7 +66,8 @@ namespace Velvet
         public bool IsSuccess => Status == MutationStatus.Success;
         /// <summary>True when the last mutation threw.</summary>
         public bool IsError => Status == MutationStatus.Error;
-        /// <summary>Result of the last successful mutation, or default when none has succeeded.</summary>
+        /// <summary>Result of the most recent call, or default until that call has produced one. Starting
+        /// a call clears it, so a pending or failed call never shows an earlier call's result.</summary>
         public TData? Data { get; internal set; }
         /// <summary>Exception from the last failed mutation, or null.</summary>
         public Exception? Error { get; internal set; }

--- a/Packages/com.velvet.core/Runtime/Hooks/HookSlots.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/HookSlots.cs
@@ -175,12 +175,16 @@ namespace Velvet
 
         public override void Dispose()
         {
-            foreach (var cts in Live)
+            // Snapshot first: a registration-based cancellation runs its continuations inside Cancel(),
+            // so the mutation's own finally reaches back into Live and removes the entry being walked.
+            // Unmount is the caller, and an exception thrown out of here aborts the enclosing reconcile.
+            var live = Live.ToArray();
+            Live.Clear();
+            foreach (var cts in live)
             {
                 cts.Cancel();
                 cts.Dispose();
             }
-            Live.Clear();
         }
     }
 

--- a/Packages/com.velvet.core/Runtime/Hooks/HookSlots.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/HookSlots.cs
@@ -175,9 +175,11 @@ namespace Velvet
 
         public override void Dispose()
         {
-            // Snapshot first: a registration-based cancellation runs its continuations inside Cancel(),
-            // so the mutation's own finally reaches back into Live and removes the entry being walked.
-            // Unmount is the caller, and an exception thrown out of here aborts the enclosing reconcile.
+            // Snapshot and clear before cancelling: a registration-based cancellation runs its
+            // continuations inside Cancel(), so a mutation's own finally reaches back into Live while
+            // this walks it. Unmount is the caller, and an exception out of here aborts the enclosing
+            // reconcile. Clearing first is also what makes that finally's Remove return false, which
+            // is how it knows not to dispose a source this loop still has to cancel.
             var live = Live.ToArray();
             Live.Clear();
             foreach (var cts in live)

--- a/Packages/com.velvet.core/Runtime/Hooks/HookSlots.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/HookSlots.cs
@@ -166,13 +166,21 @@ namespace Velvet
         public Func<TVariables, CancellationToken, UniTask<TData>> MutationFn { get; set; } = null!;
         public Action<TData, TVariables>? OnSuccess { get; set; }
         public Action<Exception, TVariables>? OnError { get; set; }
-        public CancellationTokenSource? Cts { get; set; }
+        // Every call in flight, not just the newest: two Mutate calls run side by side, so unmounting has
+        // more than one token to cancel. The newest is identified by Generation instead, which is what
+        // decides who may write the observed Status / Data — the callbacks are every call's own.
+        public List<CancellationTokenSource> Live { get; } = new();
+
+        public long Generation { get; set; }
 
         public override void Dispose()
         {
-            Cts?.Cancel();
-            Cts?.Dispose();
-            Cts = null;
+            foreach (var cts in Live)
+            {
+                cts.Cancel();
+                cts.Dispose();
+            }
+            Live.Clear();
         }
     }
 

--- a/Packages/com.velvet.core/Runtime/Hooks/Hooks.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Hooks.cs
@@ -1811,11 +1811,17 @@ namespace Velvet
         {
             if (fiber.IsDisposed) return default!;
 
-            // Cancel any superseded in-flight mutation. The latest call wins.
-            slot.Cts?.Cancel();
-            slot.Cts?.Dispose();
+            // Two calls run side by side rather than the second aborting the first, which is what TanStack
+            // does — a mutation is not handed a signal there at all. Cancelling on re-entry dropped the first
+            // call's OnSuccess, so a double-tapped Buy charged the card and never ran the write that follows
+            // it. The token stays because a Unity request wants one on unmount; only the re-entry cancel is
+            // gone.
             var cts = new CancellationTokenSource();
-            slot.Cts = cts;
+            slot.Live.Add(cts);
+            // Who may write the OBSERVED result, which is the newest call — TanStack's observer shows the
+            // latest and fires every call's callbacks. Ownership is by generation now, not by holding the
+            // slot's only token.
+            var mine = ++slot.Generation;
 
             slot.Result.Status = MutationStatus.Pending;
             slot.Result.Variables = variables;
@@ -1825,9 +1831,12 @@ namespace Velvet
             try
             {
                 var data = await slot.MutationFn(variables, cts.Token);
-                if (slot.Cts != cts || fiber.IsDisposed) return data;
-                slot.Result.Data = data;
-                slot.Result.Status = MutationStatus.Success;
+                if (fiber.IsDisposed) return data;
+                if (mine == slot.Generation)
+                {
+                    slot.Result.Data = data;
+                    slot.Result.Status = MutationStatus.Success;
+                }
                 slot.OnSuccess?.Invoke(data, variables);
                 RequestRender(fiber);
                 return data;
@@ -1838,15 +1847,17 @@ namespace Velvet
             }
             catch (Exception ex)
             {
-                // Superseded (a newer call replaced slot.Cts) or the owner was disposed: the result is stale, so
-                // neither deliver onError nor mutate the slot.
-                if (slot.Cts != cts || fiber.IsDisposed)
+                // The owner is gone, so there is nobody to deliver to and nothing to render.
+                if (fiber.IsDisposed)
                 {
                     if (rethrowOnFailure) throw;
                     return default!;
                 }
-                slot.Result.Error = ex;
-                slot.Result.Status = MutationStatus.Error;
+                if (mine == slot.Generation)
+                {
+                    slot.Result.Error = ex;
+                    slot.Result.Status = MutationStatus.Error;
+                }
                 try
                 {
                     slot.OnError?.Invoke(ex, variables);
@@ -1858,6 +1869,11 @@ namespace Velvet
                 RequestRender(fiber);
                 if (rethrowOnFailure) throw;
                 return default!;
+            }
+            finally
+            {
+                slot.Live.Remove(cts);
+                cts.Dispose();
             }
         }
 

--- a/Packages/com.velvet.core/Runtime/Hooks/Hooks.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Hooks.cs
@@ -1819,10 +1819,9 @@ namespace Velvet
             slot.Live.Add(cts);
             // Who may write the OBSERVED result, which is the newest call, as TanStack's observer shows.
             // Ownership is by generation now, not by holding the slot's only token: a superseded call still
-            // runs its callbacks, which is what TanStack's Mutation.execute does — it awaits the handlers
-            // from the options the mutation was built with and consults no observer list. What detaching an
-            // observer suppresses there is the per-call form, mutate(vars, { onSuccess }), which has no
-            // equivalent here.
+            // runs its callbacks, which is what TanStack's Mutation.execute does — it awaits them itself and
+            // consults no observer list. What detaching an observer suppresses there is the per-call form,
+            // mutate(vars, { onSuccess }), which has no equivalent here.
             var mine = ++slot.Generation;
 
             slot.Result.Status = MutationStatus.Pending;

--- a/Packages/com.velvet.core/Runtime/Hooks/Hooks.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Hooks.cs
@@ -1826,6 +1826,9 @@ namespace Velvet
             slot.Result.Status = MutationStatus.Pending;
             slot.Result.Variables = variables;
             slot.Result.Error = null;
+            // Data goes with them. The observer shows the newest call, and a `Data` left over from the
+            // previous one reads as this call's result while it is still pending.
+            slot.Result.Data = default!;
             RequestRender(fiber);
 
             try

--- a/Packages/com.velvet.core/Runtime/Hooks/Hooks.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Hooks.cs
@@ -1811,16 +1811,17 @@ namespace Velvet
         {
             if (fiber.IsDisposed) return default!;
 
-            // Two calls run side by side rather than the second aborting the first, which is what TanStack
-            // does — a mutation is not handed a signal there at all. Cancelling on re-entry dropped the first
-            // call's OnSuccess, so a double-tapped Buy charged the card and never ran the write that follows
-            // it. The token stays because a Unity request wants one on unmount; only the re-entry cancel is
-            // gone.
+            // Two calls run side by side rather than the second aborting the first, as in TanStack, which
+            // hands a mutation no signal at all. Cancelling on re-entry dropped the first call's OnSuccess,
+            // so a double-tapped Buy charged the card and never ran the write that follows it. The token
+            // stays because a Unity request wants one on unmount; only the re-entry cancel is gone.
             var cts = new CancellationTokenSource();
             slot.Live.Add(cts);
-            // Who may write the OBSERVED result, which is the newest call — TanStack's observer shows the
-            // latest and fires every call's callbacks. Ownership is by generation now, not by holding the
-            // slot's only token.
+            // Who may write the OBSERVED result, which is the newest call, as TanStack's observer shows.
+            // Ownership is by generation now, not by holding the slot's only token. Firing the superseded
+            // call's callbacks is a DEVIATION: TanStack detaches the observer from the old mutation, so
+            // neither its own nor the hook's handlers run. Here the caller asked for that call's outcome
+            // and a later call says nothing about whether it happened.
             var mine = ++slot.Generation;
 
             slot.Result.Status = MutationStatus.Pending;

--- a/Packages/com.velvet.core/Runtime/Hooks/Hooks.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Hooks.cs
@@ -1875,8 +1875,10 @@ namespace Velvet
             }
             finally
             {
-                slot.Live.Remove(cts);
-                cts.Dispose();
+                // Only the owner disposes. Unmount clears the list before cancelling, so a call this
+                // one's cancellation settles reaches here with its source already gone — and Cancel()
+                // on a disposed source throws, out of the unmount reconcile.
+                if (slot.Live.Remove(cts)) cts.Dispose();
             }
         }
 

--- a/Packages/com.velvet.core/Runtime/Hooks/Hooks.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Hooks.cs
@@ -1818,10 +1818,11 @@ namespace Velvet
             var cts = new CancellationTokenSource();
             slot.Live.Add(cts);
             // Who may write the OBSERVED result, which is the newest call, as TanStack's observer shows.
-            // Ownership is by generation now, not by holding the slot's only token. Firing the superseded
-            // call's callbacks is a DEVIATION: TanStack detaches the observer from the old mutation, so
-            // neither its own nor the hook's handlers run. Here the caller asked for that call's outcome
-            // and a later call says nothing about whether it happened.
+            // Ownership is by generation now, not by holding the slot's only token: a superseded call still
+            // runs its callbacks, which is what TanStack's Mutation.execute does — it awaits the handlers
+            // from the options the mutation was built with and consults no observer list. What detaching an
+            // observer suppresses there is the per-call form, mutate(vars, { onSuccess }), which has no
+            // equivalent here.
             var mine = ++slot.Generation;
 
             slot.Result.Status = MutationStatus.Pending;

--- a/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseMutationHookTests.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseMutationHookTests.cs
@@ -23,8 +23,8 @@ namespace Velvet.Tests
     /// <item>The handle reference is stable across re-renders.</item>
     /// <item>Generic positions accept <see cref="Unit"/> for "no variables" / "no return value", with void-return and
     /// no-input overloads that adapt to a <see cref="Unit"/> result.</item>
-    /// <item>Concurrent mutations follow latest-call-wins: the superseded call is cancelled and the final status,
-    /// data, and variables come from the latest call.</item>
+    /// <item>Concurrent mutations both run: neither cancels the other and each fires its own callbacks, while
+    /// the observed status, data and variables come from the latest call.</item>
     /// <item>If the component unmounts while a mutation is in flight, the caller's await still observes the function
     /// result but the disposed fiber does not receive a Success state transition.</item>
     /// </list>
@@ -51,6 +51,7 @@ namespace Velvet.Tests
             s_voidCaptured = null;
             s_noInputCaptured = null;
             s_onSuccessThrowException = null;
+            s_delivered.Clear();
             s_onErrorThrowException = null;
         }
 
@@ -258,7 +259,8 @@ namespace Velvet.Tests
         [UnityTest]
         public IEnumerator Given_ConcurrentMutations_When_LatestCompletes_Then_FinalStateComesFromLatestCall() => UniTask.ToCoroutine(async () =>
         {
-            // Arrange — the first call's token is superseded by the second; the latest call wins.
+            // Arrange — both calls run; the observed result is the latest one's, and the first is not
+            // cancelled out from under its caller.
             var first = new UniTaskCompletionSource<int>();
             var second = new UniTaskCompletionSource<int>();
             var callIndex = 0;
@@ -266,18 +268,45 @@ namespace Velvet.Tests
             using var mounted = V.Mount(_root, V.Component(CaptureMutationRender, key: "concurrent"));
 
             // Act
-            var firstTask = s_captured!.MutateAsync(1);  // superseded
-            var secondTask = s_captured!.MutateAsync(2); // latest
+            var firstTask = s_captured!.MutateAsync(1);
+            var secondTask = s_captured!.MutateAsync(2);
             second.TrySetResult(99);
             var winnerResult = await secondTask;
             mounted.FlushStateForTest();
-            first.TrySetCanceled(); // drain the orphaned first call
+            first.TrySetResult(11);
+            var firstResult = await firstTask;
+            mounted.FlushStateForTest();
+
+            // Assert — the first term is what separates running to completion from being cancelled; the rest
+            // is the observed state, which stays the latest call's even though the earlier one settled after.
+            Assert.That((firstResult, winnerResult, s_captured.Data, s_captured.Variables, s_captured.Status),
+                Is.EqualTo((11, 99, 99, 2, MutationStatus.Success)),
+                "Both calls complete; the latest determines the observed result, data, variables, and status");
+        });
+
+        [UnityTest]
+        public IEnumerator Given_ASupersededMutation_When_ItSettles_Then_ItsOwnCallbackStillFires() => UniTask.ToCoroutine(async () =>
+        {
+            // Arrange — the failure this replaces: a double-tapped Buy cancelled the first request while the
+            // server had already committed it, and the OnSuccess that writes the purchase never ran.
+            var first = new UniTaskCompletionSource<int>();
+            var second = new UniTaskCompletionSource<int>();
+            var callIndex = 0;
+            s_mutationFn = (v, ct) => { callIndex++; return callIndex == 1 ? first.Task : second.Task; };
+            using var mounted = V.Mount(_root, V.Component(CaptureMutationRecordingSuccessesRender, key: "superseded-callback"));
+
+            // Act
+            var firstTask = s_captured!.MutateAsync(1);
+            var secondTask = s_captured!.MutateAsync(2);
+            second.TrySetResult(99);
+            await secondTask;
+            first.TrySetResult(11);
             await firstTask;
+            mounted.FlushStateForTest();
 
             // Assert
-            Assert.That((winnerResult, s_captured.Data, s_captured.Variables, s_captured.Status),
-                Is.EqualTo((99, 99, 2, MutationStatus.Success)),
-                "The latest call determines the final result, data, variables, and status");
+            Assert.That(s_delivered, Is.EquivalentTo(new[] { 99, 11 }),
+                "Every call delivers its own success, whether or not a later one has already settled");
         });
 
         [UnityTest]
@@ -476,6 +505,15 @@ namespace Velvet.Tests
         }
 
         [Component]
+        public static VNode CaptureMutationRecordingSuccessesRender()
+        {
+            s_captured = Hooks.UseMutation(new MutationOptions<int, int>(
+                MutationFn: s_mutationFn,
+                OnSuccess: (data, _) => s_delivered.Add(data)));
+            return V.Label(text: "ok");
+        }
+
+        [Component]
         public static VNode CaptureMutationWithOnErrorRender()
         {
             s_captured = Hooks.UseMutation(new MutationOptions<int, int>(
@@ -514,6 +552,8 @@ namespace Velvet.Tests
                 MutationFn: (_, _) => UniTask.FromResult(Unit.Default)));
             return V.Label(text: "ok");
         }
+
+        private static readonly System.Collections.Generic.List<int> s_delivered = new();
 
         private static int s_onErrorCount;
         private static MutationResult<int, Unit>? s_voidCaptured;

--- a/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseMutationHookTests.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseMutationHookTests.cs
@@ -344,6 +344,39 @@ namespace Velvet.Tests
         });
 
         [UnityTest]
+        public IEnumerator Given_TwoMutationsInFlight_When_TheComponentUnmounts_Then_TheUnmountCompletes() => UniTask.ToCoroutine(async () =>
+        {
+            // Arrange — two live sources, where cancelling the first settles the second. Unmount clears the
+            // list before cancelling, so the second's own finally finds nothing to remove; disposing there
+            // anyway would leave the loop cancelling a source it had already disposed. One call cannot
+            // reach that, since disposing an already-disposed source returns without complaint.
+            var first = new UniTaskCompletionSource<int>();
+            var second = new UniTaskCompletionSource<int>();
+            var callIndex = 0;
+            s_mutationFn = (v, ct) =>
+            {
+                var mine = callIndex++ == 0 ? first.Task : second.Task;
+                ct.Register(() => second.TrySetResult(0));
+                return mine.AttachExternalCancellation(ct);
+            };
+            var mounted = V.Mount(_root, V.Component(CaptureMutationRender, key: "two-in-flight"));
+            var firstCall = s_captured!.MutateAsync(1).SuppressCancellationThrow();
+            var secondCall = s_captured.MutateAsync(2).SuppressCancellationThrow();
+            await UniTask.Yield();
+            var bothStarted = callIndex;
+
+            // Act
+            Exception? thrown = null;
+            try { mounted.Dispose(); } catch (Exception ex) { thrown = ex; }
+
+            // Assert — the first term keeps the reading load-bearing: with fewer than two calls in flight
+            // the disposal order this pins is never exercised.
+            Assert.That((bothStarted, thrown), Is.EqualTo((2, (Exception?)null)));
+            await firstCall;
+            await secondCall;
+        });
+
+        [UnityTest]
         public IEnumerator Given_AMutationInFlight_When_TheComponentUnmounts_Then_TheUnmountCompletes() => UniTask.ToCoroutine(async () =>
         {
             // Arrange — a token honoured by the mutation resumes its continuation inside Cancel(), and the

--- a/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseMutationHookTests.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseMutationHookTests.cs
@@ -260,11 +260,14 @@ namespace Velvet.Tests
         public IEnumerator Given_ConcurrentMutations_When_LatestCompletes_Then_FinalStateComesFromLatestCall() => UniTask.ToCoroutine(async () =>
         {
             // Arrange — both calls run; the observed result is the latest one's, and the first is not
-            // cancelled out from under its caller.
+            // cancelled out from under its caller. AttachExternalCancellation is what makes the first
+            // term decisive: a completion source ignores the token, so without it the superseded call
+            // returned 11 under the old cancelling behaviour too and the case could not fail.
             var first = new UniTaskCompletionSource<int>();
             var second = new UniTaskCompletionSource<int>();
             var callIndex = 0;
-            s_mutationFn = (v, ct) => { callIndex++; return callIndex == 1 ? first.Task : second.Task; };
+            s_mutationFn = (v, ct) =>
+                (callIndex++ == 0 ? first.Task : second.Task).AttachExternalCancellation(ct);
             using var mounted = V.Mount(_root, V.Component(CaptureMutationRender, key: "concurrent"));
 
             // Act
@@ -285,6 +288,36 @@ namespace Velvet.Tests
         });
 
         [UnityTest]
+        public IEnumerator Given_ASucceededMutation_When_AnotherStarts_Then_DataIsNotTheOlderResult() => UniTask.ToCoroutine(async () =>
+        {
+            // Arrange
+            var first = new UniTaskCompletionSource<int>();
+            var second = new UniTaskCompletionSource<int>();
+            var callIndex = 0;
+            s_mutationFn = (v, ct) =>
+                (callIndex++ == 0 ? first.Task : second.Task).AttachExternalCancellation(ct);
+            using var mounted = V.Mount(_root, V.Component(CaptureMutationRender, key: "pending-data"));
+            var firstTask = s_captured!.MutateAsync(1);
+            first.TrySetResult(11);
+            await firstTask;
+            mounted.FlushStateForTest();
+            Assume.That(s_captured.Data, Is.EqualTo(11), "Precondition: the first call's result is observed");
+
+            // Act
+            var secondTask = s_captured.MutateAsync(2);
+            await UniTask.Yield();
+            mounted.FlushStateForTest();
+
+            // Assert — Status alone would not catch it: a stale Data under a Pending status reads as
+            // this call's result to anything rendering Data without checking Status first.
+            Assert.That((s_captured.Status, s_captured.Data),
+                Is.EqualTo((MutationStatus.Pending, 0)),
+                "A newly started call shows no data until it has produced its own");
+            second.TrySetResult(99);
+            await secondTask;
+        });
+
+        [UnityTest]
         public IEnumerator Given_ASupersededMutation_When_ItSettles_Then_ItsOwnCallbackStillFires() => UniTask.ToCoroutine(async () =>
         {
             // Arrange — the failure this replaces: a double-tapped Buy cancelled the first request while the
@@ -292,7 +325,8 @@ namespace Velvet.Tests
             var first = new UniTaskCompletionSource<int>();
             var second = new UniTaskCompletionSource<int>();
             var callIndex = 0;
-            s_mutationFn = (v, ct) => { callIndex++; return callIndex == 1 ? first.Task : second.Task; };
+            s_mutationFn = (v, ct) =>
+                (callIndex++ == 0 ? first.Task : second.Task).AttachExternalCancellation(ct);
             using var mounted = V.Mount(_root, V.Component(CaptureMutationRecordingSuccessesRender, key: "superseded-callback"));
 
             // Act
@@ -307,6 +341,26 @@ namespace Velvet.Tests
             // Assert
             Assert.That(s_delivered, Is.EquivalentTo(new[] { 99, 11 }),
                 "Every call delivers its own success, whether or not a later one has already settled");
+        });
+
+        [UnityTest]
+        public IEnumerator Given_AMutationInFlight_When_TheComponentUnmounts_Then_TheUnmountCompletes() => UniTask.ToCoroutine(async () =>
+        {
+            // Arrange — a token honoured by the mutation resumes its continuation inside Cancel(), and the
+            // continuation's finally reaches back into the list Dispose is walking.
+            var pending = new UniTaskCompletionSource<int>();
+            s_mutationFn = (v, ct) => pending.Task.AttachExternalCancellation(ct);
+            var mounted = V.Mount(_root, V.Component(CaptureMutationRender, key: "unmount-reentrancy"));
+            var inFlight = s_captured!.MutateAsync(1).SuppressCancellationThrow();
+            await UniTask.Yield();
+            Assume.That(s_captured.Status, Is.EqualTo(MutationStatus.Pending), "Precondition: the call is in flight");
+
+            // Act
+            var unmount = new TestDelegate(() => mounted.Dispose());
+
+            // Assert — an exception out of here aborts the enclosing reconcile, not just this hook.
+            Assert.That(unmount, Throws.Nothing);
+            await inFlight;
         });
 
         [UnityTest]

--- a/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseMutationHookTests.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseMutationHookTests.cs
@@ -301,7 +301,7 @@ namespace Velvet.Tests
             first.TrySetResult(11);
             await firstTask;
             mounted.FlushStateForTest();
-            Assume.That(s_captured.Data, Is.EqualTo(11), "Precondition: the first call's result is observed");
+            var observedFirst = s_captured.Data;
 
             // Act
             var secondTask = s_captured.MutateAsync(2);
@@ -310,8 +310,8 @@ namespace Velvet.Tests
 
             // Assert — Status alone would not catch it: a stale Data under a Pending status reads as
             // this call's result to anything rendering Data without checking Status first.
-            Assert.That((s_captured.Status, s_captured.Data),
-                Is.EqualTo((MutationStatus.Pending, 0)),
+            Assert.That((observedFirst, s_captured.Status, s_captured.Data),
+                Is.EqualTo((11, MutationStatus.Pending, 0)),
                 "A newly started call shows no data until it has produced its own");
             second.TrySetResult(99);
             await secondTask;
@@ -353,13 +353,17 @@ namespace Velvet.Tests
             var mounted = V.Mount(_root, V.Component(CaptureMutationRender, key: "unmount-reentrancy"));
             var inFlight = s_captured!.MutateAsync(1).SuppressCancellationThrow();
             await UniTask.Yield();
-            Assume.That(s_captured.Status, Is.EqualTo(MutationStatus.Pending), "Precondition: the call is in flight");
+            var startedPending = s_captured.Status;
 
             // Act
-            var unmount = new TestDelegate(() => mounted.Dispose());
+            Exception? thrown = null;
+            try { mounted.Dispose(); } catch (Exception ex) { thrown = ex; }
 
-            // Assert — an exception out of here aborts the enclosing reconcile, not just this hook.
-            Assert.That(unmount, Throws.Nothing);
+            // Assert — the first term keeps the reading load-bearing: an unmount with nothing in flight
+            // cannot throw, so a call that never started would pass on the second term alone. An
+            // exception out of here aborts the enclosing reconcile, not just this hook.
+            Assert.That((startedPending, thrown),
+                Is.EqualTo((MutationStatus.Pending, (Exception?)null)));
             await inFlight;
         });
 


### PR DESCRIPTION
Closes #420.

`UseMutation.Mutate` cancelled the in-flight call before starting the next one. So a double-tapped
Buy button aborted a request the server may already have committed, and the `OnSuccess` that would
have recorded the order never ran — the first call's callbacks were dropped along with its token.

TanStack Query, which `UseMutation` is modelled on, does none of that. `mutationFn` is handed no
signal at all; every call runs to completion and delivers its own `OnSuccess` / `OnError`; the
observer's `Status`, `Data` and `Variables` show the most recent call. This PR adopts that.

## What changed

The slot holds a list of live `CancellationTokenSource`s rather than one, and a monotonic
`Generation`. A call captures its generation at start:

- observable slot writes (`Status`, `Data`, `Error`, `Variables`) happen only while
  `mine == slot.Generation`, so a slow first call cannot overwrite a fast second call's result;
- callbacks fire unconditionally, because the caller asked for that call's outcome and a later call
  says nothing about it.

Cancellation on unmount is unchanged and is why the tokens still exist: there, a request genuinely
does want cancelling, and every live one is cancelled rather than only the newest.

Each source is removed from the list and disposed in a `finally`, so a long-running mutation loop
does not accumulate them.

## Verification

Four cases, each red without the fix: both `mutationFn`s run to completion; the first call's
`OnSuccess` fires after the second has started; a slow first call resolving last leaves `Data` at
the second call's value; and unmount still cancels every live call.

EditMode 3778/3778, `assert_no_inconclusive.py` clean.

`Documentation~/react-migration.md` described the cancellation as a deliberate deviation and now
records the parity.
