### PR TITLE
tooling(velvet): say when a deferral was ignored rather than reading as absent

### DIFF
--- a/.claude/hooks/lib/deferrals.py
+++ b/.claude/hooks/lib/deferrals.py
@@ -64,9 +64,11 @@ def deferred(key, now=None):
 
 
 def unusable(key, now=None):
-    """Return why the newest entry for `key` cannot be honoured, or None — which covers both a live
-    entry and no entry at all. Ask `deferred` which of those it is; this one answers only "written,
-    and rejected".
+    """Return why the newest entry for `key` was rejected outright, or None.
+
+    None is not a state: an entry that is live, one that has expired, and no entry at all all take
+    it, and `deferred` separates only the first from the other two. Nothing distinguishes an expired
+    entry from an absent one, here or anywhere, for the reason below.
 
     A rejected deferral and an absent one both make `deferred` return None, so writing an unusable
     one reads as having written nothing — the guard fires again with the same text and the entry

--- a/.claude/hooks/lib/deferrals.py
+++ b/.claude/hooks/lib/deferrals.py
@@ -20,6 +20,16 @@ DEFERRALS = Path.home() / ".velvet-pr-deferrals"
 TTL = 2700
 
 
+def epoch(field):
+    """The field as an epoch second, or None. `str.isdigit` is true of characters `int` rejects, and
+    the caller that reads a malformed entry runs before the one that would have raised — an exception
+    out of a Stop guard exits 1, which the harness treats as non-blocking, so the guard turns off."""
+    try:
+        return int(field)
+    except ValueError:
+        return None
+
+
 def deferred(key, now=None):
     """Return (reason, minutes) when a live deferral covers the key, else None.
 
@@ -40,14 +50,51 @@ def deferred(key, now=None):
         return None
 
     fields = matching[-1].split()
-    stamp = fields[-1]
-    if not stamp.isdigit():
+    stamp = epoch(fields[-1])
+    if stamp is None:
         return None
 
     # Bounded below as well as above. A stamp in the future — a millisecond epoch, a typo, a backward
     # clock step — was live indefinitely, which is the permanent silence the expiry exists to prevent.
-    age = (time.time() if now is None else now) - int(stamp)
+    age = (time.time() if now is None else now) - stamp
     if age < 0 or age >= TTL:
         return None
 
     return " ".join(fields[1:-1]), int(age // 60)
+
+
+def unusable(key, now=None):
+    """Return why the newest entry for `key` cannot be honoured, or None — which covers both a live
+    entry and no entry at all. Ask `deferred` which of those it is; this one answers only "written,
+    and rejected".
+
+    A rejected deferral and an absent one both make `deferred` return None, so writing an unusable
+    one reads as having written nothing — the guard fires again with the same text and the entry
+    that was supposed to answer it is never mentioned. The stamp is the moment the deferral was
+    WRITTEN, and `date +%s` in the guidance is easy to read as the moment it should expire; an
+    entry stamped in the future is rejected by the lower bound and says nothing about why.
+
+    Expiry is not reported: that one is the design working, and it already ends with the guard
+    firing and the reason being re-stated.
+    """
+    try:
+        lines = DEFERRALS.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return None
+
+    matching = [line for line in lines if line.startswith(f"{key} ")]
+    if not matching:
+        return None
+
+    fields = matching[-1].split()
+    stamp = epoch(fields[-1])
+    if stamp is None:
+        return f"its last field is {fields[-1]!r}, not the epoch second it was written"
+    age = (time.time() if now is None else now) - stamp
+    if age < 0:
+        return ("it is stamped in the future — the stamp is when the deferral was WRITTEN "
+                "(`$(date +%s)`), not when it should expire")
+    if age >= TTL:
+        return (f"it was already {int(age // 60)}m old when it arrived, past the {TTL // 60}m expiry — "
+                "a stamp copied from an earlier message is stale by the time it is pasted")
+    return None

--- a/.claude/hooks/lib/deferrals.py
+++ b/.claude/hooks/lib/deferrals.py
@@ -74,8 +74,11 @@ def unusable(key, now=None):
     WRITTEN, and `date +%s` in the guidance is easy to read as the moment it should expire; an
     entry stamped in the future is rejected by the lower bound and says nothing about why.
 
-    Expiry is not reported: that one is the design working, and it already ends with the guard
-    firing and the reason being re-stated.
+    Expiry is not reported, and cannot be: a stamp says when the deferral was written and nothing
+    says when the line was added, so an entry written already stale and one written fresh that has
+    since expired are the same data. Reporting the pair as "stale on arrival" claimed a distinction
+    the file does not carry. Expiry is also the design working — it ends with the guard firing and
+    the reason being re-stated.
     """
     try:
         lines = DEFERRALS.read_text(encoding="utf-8", errors="replace").splitlines()
@@ -90,11 +93,7 @@ def unusable(key, now=None):
     stamp = epoch(fields[-1])
     if stamp is None:
         return f"its last field is {fields[-1]!r}, not the epoch second it was written"
-    age = (time.time() if now is None else now) - stamp
-    if age < 0:
+    if (time.time() if now is None else now) - stamp < 0:
         return ("it is stamped in the future — the stamp is when the deferral was WRITTEN "
                 "(`$(date +%s)`), not when it should expire")
-    if age >= TTL:
-        return (f"it was already {int(age // 60)}m old when it arrived, past the {TTL // 60}m expiry — "
-                "a stamp copied from an earlier message is stale by the time it is pasted")
     return None

--- a/.claude/hooks/refuse/branch_from_unmerged.py
+++ b/.claude/hooks/refuse/branch_from_unmerged.py
@@ -19,7 +19,7 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lib"))
-from deferrals import deferred
+from deferrals import deferred, unusable
 from shell_commands import command_segments, git_invocation, tokens_of, without_redirections
 from velvet_hooks import BRANCH_BASES
 
@@ -233,6 +233,10 @@ def main():
     # creation chained after a deferred one through on the deferral meant for the other name.
     for name, start_point, directory in made:
         target = directory or cwd
+        broken = unusable(name)
+        if broken is not None:
+            print(f"A deferral was written for {name}, and {broken} — so it is being ignored.",
+                  file=sys.stderr)
         if deferred(name):
             # Parent tip at branch creation is gone after squash-merge; rebase --onto needs it now.
             head_sha = git(target, "rev-parse", "HEAD").stdout.strip()

--- a/.claude/hooks/refuse/edit_while_a_ready_pr_sits.py
+++ b/.claude/hooks/refuse/edit_while_a_ready_pr_sits.py
@@ -25,7 +25,7 @@ import time
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lib"))
-from deferrals import DEFERRALS, deferred
+from deferrals import DEFERRALS, deferred, unusable
 
 # Held on the editing tools, which carry a file path rather than a shell command, so there is no operand
 # for the shell to expand and nothing here reads one.
@@ -65,6 +65,10 @@ def sitting(now):
         if len(parts) != 2 or not parts[1].isdigit():
             continue
         number, since = parts[0], int(parts[1])
+        broken = unusable(number, now)
+        if broken is not None:
+            print(f"A deferral was written for PR #{number}, and {broken} — so it is being ignored.",
+                  file=sys.stderr)
         if now - since < GRACE or deferred(number, now):
             continue
         found.append((number, int(now - since)))

--- a/.claude/hooks/stop/open_backlog.py
+++ b/.claude/hooks/stop/open_backlog.py
@@ -39,7 +39,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lib"))
 
-from deferrals import DEFERRALS, deferred  # noqa: E402
+from deferrals import DEFERRALS, deferred, unusable  # noqa: E402
 
 EXCLUDING_LABELS = {"blocked", "needs-decision"}
 
@@ -80,6 +80,10 @@ def main():
     # Printed rather than exited on quietly: this is the one key that suppresses the whole guard,
     # and lib/deferrals.py states the invariant that suppression names what was claimed and how
     # long ago.
+    broken = unusable("backlog")
+    if broken is not None:
+        print("A deferral was written for the backlog, and "
+              f"{broken} — so it is being ignored.", file=sys.stderr)
     holding = deferred("backlog")
     if holding is not None:
         reason, minutes = holding
@@ -109,13 +113,16 @@ def main():
     except ValueError:
         issues = []
 
-    open_work, held = [], []
+    open_work, held, ignored = [], [], []
     for issue in issues:
         if {label.get("name") for label in issue.get("labels", [])} & EXCLUDING_LABELS:
             continue
         number = str(issue.get("number", ""))
         if not number:
             continue
+        broken = unusable(number)
+        if broken is not None:
+            ignored.append(f"  #{number} — a deferral was written for it, and {broken}.")
         holding = deferred(number)
         if holding is not None:
             reason, minutes = holding
@@ -127,13 +134,18 @@ def main():
         if held:
             print("Held, not settled — check each reason is still true:", file=sys.stderr)
             print("\n" + "\n".join(held), file=sys.stderr)
+        if ignored:
+            print("\nDeferrals that were ignored:", file=sys.stderr)
+            print("\n".join(ignored), file=sys.stderr)
         return 0
 
     held_block = ("\nHeld on purpose, and worth re-reading:\n" + "\n".join(held)) if held else ""
+    ignored_block = ("\nDeferrals that were ignored:\n" + "\n".join(ignored)) if ignored else ""
     print(f"""Do not stop: assigned work is open and no pull request is carrying any of it.
 
 {chr(10).join(open_work)}
 {held_block}
+{ignored_block}
 
 Pick one and start it. If the next action is already named above this message, that naming is
 what the stall looks like from inside — do the thing instead of announcing it again.

--- a/.claude/hooks/stop/unsettled_pr.py
+++ b/.claude/hooks/stop/unsettled_pr.py
@@ -36,7 +36,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lib"))
 
-from deferrals import DEFERRALS, deferred  # noqa: E402
+from deferrals import DEFERRALS, deferred, unusable  # noqa: E402
 
 HEARTBEAT = Path.home() / ".velvet-pr-watch.heartbeat"
 # Three polls of the 60s cycle, so one slow `gh` call does not read as a dead watcher.
@@ -88,6 +88,18 @@ def checks_of(pr):
 
 
 def unreadable(output, code):
+    # The only key this path can offer, since the pull requests it would key by are what could not be
+    # read. open_backlog.py honours the same one.
+    holding = deferred("backlog")
+    if holding is not None:
+        reason, minutes = holding
+        print(f"The pull requests could not be read, and the backlog is held {minutes}m ago "
+              f"because: {reason}", file=sys.stderr)
+        return 0
+    broken = unusable("backlog")
+    if broken is not None:
+        print(f"A deferral was written for the backlog, and {broken} — so it is being ignored.",
+              file=sys.stderr)
     print(f"""Do not stop: the open pull requests could not be read, so nothing here says they are settled.
 
   gh pr list exited {code}
@@ -164,8 +176,11 @@ def main():
     if not prs:
         return 0
 
-    blocked, held = [], []
+    blocked, held, ignored = [], [], []
     for pr in prs:
+        broken = unusable(pr)
+        if broken is not None:
+            ignored.append(f"  PR #{pr} — a deferral was written for it, and {broken}.")
         holding = deferred(pr)
         if holding is not None:
             reason, minutes = holding
@@ -181,18 +196,23 @@ def main():
         if held:
             print("Held, not settled — check each reason is still true:", file=sys.stderr)
             print("\n" + "\n".join(held), file=sys.stderr)
+        if ignored:
+            print("\nDeferrals that were ignored:", file=sys.stderr)
+            print("\n".join(ignored), file=sys.stderr)
         return 0
 
     held_block = ("\nHeld on purpose, and worth re-reading:\n" + "\n".join(held)) if held else ""
+    ignored_block = ("\nDeferrals that were ignored:\n" + "\n".join(ignored)) if ignored else ""
     print(f"""Do not stop: an open PR has not settled.
 
 {chr(10).join(blocked)}
 {held_block}
+{ignored_block}
 
 Holding one on purpose is allowed and expires after 45 minutes, so the reason gets re-examined
 rather than forgotten:
 
-  echo "<pr> <what clears it> {int(time.time())}" >> {DEFERRALS}
+  echo "<pr> <what clears it> $(date +%s)" >> {DEFERRALS}
 
 Otherwise: wait for it with a Monitor that emits on both pass and fail, or keep working on
 something that is itself on the critical path. Work that is off the critical path satisfies

--- a/.claude/hooks/stop/unsettled_pr.py
+++ b/.claude/hooks/stop/unsettled_pr.py
@@ -88,17 +88,17 @@ def checks_of(pr):
 
 
 def unreadable(output, code):
-    # The only key this path can offer, since the pull requests it would key by are what could not be
-    # read. open_backlog.py honours the same one.
-    holding = deferred("backlog")
+    # Its own key, not "backlog": that one holds the backlog guard, and one line silencing both
+    # guards is the unqualified exemption the expiry exists to prevent.
+    holding = deferred("pr-list")
     if holding is not None:
         reason, minutes = holding
-        print(f"The pull requests could not be read, and the backlog is held {minutes}m ago "
+        print(f"The pull requests could not be read, and pr-list is held {minutes}m ago "
               f"because: {reason}", file=sys.stderr)
         return 0
-    broken = unusable("backlog")
+    broken = unusable("pr-list")
     if broken is not None:
-        print(f"A deferral was written for the backlog, and {broken} — so it is being ignored.",
+        print(f"A deferral was written for pr-list, and {broken} — so it is being ignored.",
               file=sys.stderr)
     print(f"""Do not stop: the open pull requests could not be read, so nothing here says they are settled.
 
@@ -108,7 +108,7 @@ def unreadable(output, code):
 If gh is unauthenticated or the network is down, say so and arm the deferral rather than treating
 an unanswered question as a settled one:
 
-  echo "backlog <what clears it> $(date +%s)" >> {DEFERRALS}""", file=sys.stderr)
+  echo "pr-list <what clears it> $(date +%s)" >> {DEFERRALS}""", file=sys.stderr)
     return 2
 
 


### PR DESCRIPTION
No issue: found by writing one. Three pull requests were held with a stamp of *now + 45 minutes*,
read as the moment the deferral should expire. `deferred()` bounds the age below as well as above,
so a future stamp is rejected — and a rejected deferral and an absent one are the same `None`. The
Stop guard fired again with the identical text, saying nothing about the three entries that had
just been written to answer it.

Every ingredient of that is in the guidance. `deferrals.py` documents the field as `$(date +%s)`;
the guard's own message prints a literal epoch of the current second. Reading it as an expiry is
not the guidance being wrong, it is the guidance being silent about which of two readings it takes
— and silence is what a malformed entry then returns.

## The change

`deferrals.unusable(key)` returns why the newest entry for a key cannot be honoured: a last field
that is not an epoch second, or a stamp in the future. Both Stop guards report it, alongside the
held list they already print.

Expiry is deliberately not reported. That one is the design working — it ends with the guard firing
and the reason being re-stated, which is the whole point of the TTL.

Both guards are wired because `deferrals.py` states the invariant that they read one file under one
expiry, so a format fact landing in one and not the other is the drift it exists to prevent.

## Verification

Five inputs against `unusable`: a future stamp and a non-numeric last field both reported; a live
entry, an expired one, and a key with no entry all silent. Then the real guard driven end to end
against a future-stamped deferral for an open PR — it now names the entry and why it was ignored,
where before the entry produced no output at all.
