### PR TITLE
tooling(velvet): pin every PreToolUse hook's tool set against its matcher

### DIFF
--- a/.claude/hooks/refuse/background_relative_path.py
+++ b/.claude/hooks/refuse/background_relative_path.py
@@ -25,6 +25,9 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lib"))
 from shell_commands import unexpanded  # noqa: E402  (path set above)
 
 
+HOOK_TOOLS = {"Bash"}
+
+
 # Nothing here reads a path's contents: a token the shell will still rewrite may or may not be
 # relative, and a background command that gets it wrong fails silently, so the guard errs toward
 # allowing rather than refusing every command carrying a variable.
@@ -64,7 +67,7 @@ def main():
         event = json.load(sys.stdin)
     except Exception:
         return 0
-    if event.get("tool_name") != "Bash":
+    if event.get("tool_name") not in HOOK_TOOLS:
         return 0
 
     tool_input = event.get("tool_input", {})

--- a/.claude/hooks/refuse/blind_git_add.py
+++ b/.claude/hooks/refuse/blind_git_add.py
@@ -19,6 +19,9 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lib"))
 from shell_commands import git_invocations
 
+
+HOOK_TOOLS = {"Bash"}
+
 # The sweeping forms. `-u` is not among them: it stages tracked modifications and cannot pick up a
 # file that arrived by accident, which is what both incidents were.
 #
@@ -53,7 +56,7 @@ def main():
         event = json.load(sys.stdin)
     except Exception:
         return 0
-    if event.get("tool_name") != "Bash":
+    if event.get("tool_name") not in HOOK_TOOLS:
         return 0
     command = event.get("tool_input", {}).get("command", "")
     if not sweeps(command):

--- a/.claude/hooks/refuse/branch_from_unmerged.py
+++ b/.claude/hooks/refuse/branch_from_unmerged.py
@@ -23,6 +23,9 @@ from deferrals import deferred
 from shell_commands import command_segments, git_invocation, tokens_of, without_redirections
 from velvet_hooks import BRANCH_BASES
 
+
+HOOK_TOOLS = {"Bash"}
+
 CHECKOUT_CREATE = ("-b", "-B")
 SWITCH_CREATE = ("-c", "-C", "--create", "--force-create")
 
@@ -220,7 +223,7 @@ def main():
         event = json.load(sys.stdin)
     except Exception:
         return 0
-    if event.get("tool_name") != "Bash":
+    if event.get("tool_name") not in HOOK_TOOLS:
         return 0
 
     made = creations(event.get("tool_input", {}).get("command", ""))

--- a/.claude/hooks/refuse/commit_failing_fast_checks.py
+++ b/.claude/hooks/refuse/commit_failing_fast_checks.py
@@ -21,6 +21,9 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lib"))
 from shell_commands import git_invocations, unexpanded
 
+
+HOOK_TOOLS = {"Bash"}
+
 NEUTER_CUTS = "scripts/test_quality/neuter_cuts.json"
 
 # `git commit` options that take a value, so their argument is not mistaken for a pathspec.
@@ -287,7 +290,7 @@ def main():
         event = json.load(sys.stdin)
     except Exception:
         return 0
-    if event.get("tool_name") != "Bash":
+    if event.get("tool_name") not in HOOK_TOOLS:
         return 0
 
     commits = commit_invocations(event.get("tool_input", {}).get("command", ""))

--- a/.claude/hooks/refuse/edit_while_a_ready_pr_sits.py
+++ b/.claude/hooks/refuse/edit_while_a_ready_pr_sits.py
@@ -41,7 +41,7 @@ GRACE = 900
 # Two polls plus a margin: one missed poll is a slow API call, two is a watcher that stopped.
 HEARTBEAT_TTL = 180
 
-HELD_TOOLS = {"Edit", "Write", "NotebookEdit"}
+HOOK_TOOLS = {"Edit", "Write", "NotebookEdit"}
 
 
 def watcher_age():
@@ -76,7 +76,7 @@ def main():
         event = json.load(sys.stdin)
     except Exception:
         return 0
-    if event.get("tool_name") not in HELD_TOOLS:
+    if event.get("tool_name") not in HOOK_TOOLS:
         return 0
 
     age = watcher_age()

--- a/.claude/hooks/refuse/merge_branch_held_by_worktree.py
+++ b/.claude/hooks/refuse/merge_branch_held_by_worktree.py
@@ -25,6 +25,9 @@ from shell_commands import program_invocations, unexpanded
 import repository
 
 
+HOOK_TOOLS = {"Bash"}
+
+
 # An operand the shell has not expanded yet resolves to nothing readable, and a merge guard errs
 # toward refusing: allowing means --delete-branch half-fails after the merge has already landed.
 UNEXPANDED_POLICY = "refuse"
@@ -90,7 +93,7 @@ def main():
         event = json.load(sys.stdin)
     except Exception:
         return 0
-    if event.get("tool_name") != "Bash":
+    if event.get("tool_name") not in HOOK_TOOLS:
         return 0
 
     cwd = event.get("cwd") or "."

--- a/.claude/hooks/refuse/merge_onto_unpublished_release.py
+++ b/.claude/hooks/refuse/merge_onto_unpublished_release.py
@@ -18,6 +18,9 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "scripts" / "releas
 import published_check
 
 
+HOOK_TOOLS = {"Bash"}
+
+
 # No operand takes part in the verdict: the base holds an unpublished release or it does not, whatever
 # pull request is named.
 UNEXPANDED_POLICY = "n/a"
@@ -33,7 +36,7 @@ def main():
         event = json.load(sys.stdin)
     except Exception:
         return 0
-    if event.get("tool_name") != "Bash":
+    if event.get("tool_name") not in HOOK_TOOLS:
         return 0
 
     command = event.get("tool_input", {}).get("command", "")

--- a/.claude/hooks/refuse/merge_unproven_head.py
+++ b/.claude/hooks/refuse/merge_unproven_head.py
@@ -30,6 +30,9 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lib"))
 from shell_commands import program_invocations, unexpanded
 import repository
 
+
+HOOK_TOOLS = {"Bash"}
+
 TERMINAL_PASS = frozenset({"pass", "skipping"})
 
 # An operand the shell has not expanded yet resolves to nothing readable, and a merge guard errs
@@ -91,7 +94,7 @@ def main():
         event = json.load(sys.stdin)
     except Exception:
         return 0
-    if event.get("tool_name") != "Bash":
+    if event.get("tool_name") not in HOOK_TOOLS:
         return 0
 
     cwd = event.get("cwd") or "."

--- a/.claude/hooks/refuse/merge_without_branch_deletion.py
+++ b/.claude/hooks/refuse/merge_without_branch_deletion.py
@@ -23,6 +23,9 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lib"))
 from shell_commands import program_invocations
 
+
+HOOK_TOOLS = {"Bash"}
+
 # The verdict is whether the command carries the flag, which is its own text. An operand the shell has
 # not expanded cannot add or remove one, so nothing is resolved and nothing goes unchecked.
 UNEXPANDED_POLICY = "allow"
@@ -46,7 +49,7 @@ def main():
         event = json.load(sys.stdin)
     except Exception:
         return 0
-    if event.get("tool_name") != "Bash":
+    if event.get("tool_name") not in HOOK_TOOLS:
         return 0
 
     left = merges_without_deletion(event.get("tool_input", {}).get("command", ""))

--- a/.claude/hooks/refuse/metadata_less_create.py
+++ b/.claude/hooks/refuse/metadata_less_create.py
@@ -24,6 +24,9 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lib"))
 from shell_commands import program_invocations
 import repository
 
+
+HOOK_TOOLS = {"Bash"}
+
 # Anchored at a command position — start of input, or after a separator or newline — so the same
 # text quoted inside an argument or named in a body does not trip it. This file argues for a
 # refusal by naming the command it refuses, which is exactly the text that would.
@@ -65,7 +68,7 @@ def main():
         event = json.load(sys.stdin)
     except Exception:
         return 0
-    if event.get("tool_name") != "Bash":
+    if event.get("tool_name") not in HOOK_TOOLS:
         return 0
     command = event.get("tool_input", {}).get("command", "")
     # Flags read off tokens rather than searched for in the whole command: the flag name occurring

--- a/.claude/hooks/refuse/shared_git_state.py
+++ b/.claude/hooks/refuse/shared_git_state.py
@@ -23,6 +23,9 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lib"))
 from shell_commands import git_invocations, unexpanded
 
+
+HOOK_TOOLS = {"Bash"}
+
 # Registered on the event in .claude/settings.json rather than narrowed to the agents expected to
 # run git, which would leave every other session unguarded. `HookWiringCoverageTests` reads this
 # declaration to check that the registration is still there.
@@ -151,6 +154,8 @@ def main():
     try:
         event = json.load(sys.stdin)
     except Exception:
+        return 0
+    if event.get("tool_name") not in HOOK_TOOLS:
         return 0
     command = (event.get("tool_input") or {}).get("command", "")
     if not isinstance(command, str) or not command:

--- a/.claude/hooks/refuse/stale_merge.py
+++ b/.claude/hooks/refuse/stale_merge.py
@@ -21,6 +21,8 @@ from shell_commands import program_invocations, unexpanded
 from velvet_hooks import BRANCH_BASES
 
 
+HOOK_TOOLS = {"Bash"}
+
 # What an operand the shell has not expanded yet resolves to, which is nothing this can read. A merge
 # guard errs toward refusing: allowing means the branch is merged with the check it exists for never
 # having run, and the merge is what cannot be taken back.
@@ -70,6 +72,8 @@ def main():
     try:
         payload = json.load(sys.stdin)
     except ValueError:
+        return 0
+    if payload.get("tool_name") not in HOOK_TOOLS:
         return 0
 
     command = (payload.get("tool_input") or {}).get("command") or ""

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,11 +133,16 @@ in `.claude/settings.json`, where it runs for every session. An agent's frontmat
 that: a guard named there and nowhere else is absent from the main session and from every other
 agent type. Such a guard says so with a `HOOK_SCOPE = "session"` line.
 
+A `PreToolUse` guard is reached only for the tools its `"matcher"` names, and acts only on the tools
+its own gate admits. It declares the second as a `HOOK_TOOLS = {...}` set and gates on that set
+rather than on a literal, so the two halves are one edit apart instead of two.
+
 Every failure mode here is silence, so the wiring is asserted rather than trusted.
 `HookWiringCoverageTests` pairs each script against the settings and agent frontmatter that run it,
-in both directions, fails on a script name a hook builds a path from that no file answers to, and
-fails on a `HOOK_SCOPE = "session"` guard that the settings do not register or that an agent
-registers a second time.
+in both directions, fails on a script name a hook builds a path from that no file answers to, fails
+on a `HOOK_SCOPE = "session"` guard that the settings do not register or that an agent registers a
+second time, and fails when a `PreToolUse` guard's `HOOK_TOOLS` and its matcher name different tools
+or when the guard declares a set its gate never reads.
 
 ### Source generators
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,8 +149,9 @@ when the guard declares a set its gate never reads, and when its gate answers no
 is posed under a tool it is routed — which is the shape an inverted gate takes, since such a gate
 returns before its readings for exactly the tools it exists to read. A gate reading no tool name at
 all answers under both, and fails the other way round. That first one also fails for a guard none of
-the payloads happens to pose anything about, and a guard added since the table was last extended
-wants a row added there rather than a change to itself.
+the fixture's `GatePayloads` happens to pose anything about — a guard added since that table was last
+extended wants a row added to it rather than a change to itself — and for a guard that exits neither
+0 nor 2 under any of them, which is one raising rather than deciding.
 
 ### Source generators
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,16 +136,21 @@ agent type. Such a guard says so with a `HOOK_SCOPE = "session"` line.
 A `PreToolUse` guard is reached only for the tools its `"matcher"` names, and acts only on the tools
 its own gate admits. It declares the second as a `HOOK_TOOLS = {...}` set and gates on that set
 rather than on a literal, which is what leaves the two halves comparable. Register it under the tool
-names themselves: `"*"` names no set a check can read, so a guard covering several tools spells them
-out in the matcher.
+names themselves: a matcher naming no set a check can read is refused — `"*"`, an empty string, and a
+`PreToolUse` entry carrying no `"matcher"` key at all, which is the shape the `SessionStart`, `Stop`
+and `SubagentStop` entries take. A guard covering several tools spells them out in the matcher.
 
 Every failure mode here is silence, so the wiring is asserted rather than trusted.
 `HookWiringCoverageTests` pairs each script against the settings and agent frontmatter that run it,
 in both directions, fails on a script name a hook builds a path from that no file answers to, fails
 on a `HOOK_SCOPE = "session"` guard that the settings do not register or that an agent registers a
 second time, and fails when a `PreToolUse` guard's `HOOK_TOOLS` and its matcher name different tools,
-when the guard declares a set its gate never reads, or when its gate answers a payload posed under a
-tool nothing routes to it rather than under one that is.
+when the guard declares a set its gate never reads, and when its gate answers none of the payloads it
+is posed under a tool it is routed — which is the shape an inverted gate takes, since such a gate
+returns before its readings for exactly the tools it exists to read. A gate reading no tool name at
+all answers under both, and fails the other way round. That first one also fails for a guard none of
+the payloads happens to pose anything about, and a guard added since the table was last extended
+wants a row added there rather than a change to itself.
 
 ### Source generators
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,14 +135,17 @@ agent type. Such a guard says so with a `HOOK_SCOPE = "session"` line.
 
 A `PreToolUse` guard is reached only for the tools its `"matcher"` names, and acts only on the tools
 its own gate admits. It declares the second as a `HOOK_TOOLS = {...}` set and gates on that set
-rather than on a literal, so the two halves are one edit apart instead of two.
+rather than on a literal, which is what leaves the two halves comparable. Register it under the tool
+names themselves: `"*"` names no set a check can read, so a guard covering several tools spells them
+out in the matcher.
 
 Every failure mode here is silence, so the wiring is asserted rather than trusted.
 `HookWiringCoverageTests` pairs each script against the settings and agent frontmatter that run it,
 in both directions, fails on a script name a hook builds a path from that no file answers to, fails
 on a `HOOK_SCOPE = "session"` guard that the settings do not register or that an agent registers a
-second time, and fails when a `PreToolUse` guard's `HOOK_TOOLS` and its matcher name different tools
-or when the guard declares a set its gate never reads.
+second time, and fails when a `PreToolUse` guard's `HOOK_TOOLS` and its matcher name different tools,
+when the guard declares a set its gate never reads, or when its gate answers a payload posed under a
+tool nothing routes to it rather than under one that is.
 
 ### Source generators
 

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/HookWiringCoverageTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/HookWiringCoverageTests.cs
@@ -620,8 +620,8 @@ namespace Velvet.Tests
                 + "— what an inverted gate does — a GatePayloads table holding nothing that guard "
                 + "decides about, which is what a guard added since the table was last extended wants a "
                 + "row for, or a guard exiting neither 0 nor 2 under any of them, which is one raising "
-                + "rather than deciding. Answering one posed under a tool nothing routes is a gate reading something "
-                + $"other than the event's tool name:\n{string.Join("\n", wrong)}");
+                + "rather than deciding. Answering one posed under a tool nothing routes is a gate "
+                + $"reading something other than the event's tool name:\n{string.Join("\n", wrong)}");
         }
 
         private static IEnumerable<string> GateFaults(string hook, string tool)
@@ -691,8 +691,8 @@ namespace Velvet.Tests
         {
             ScratchDirectory = Directory.CreateDirectory(Path.Combine(
                 Path.GetTempPath(), "velvet-hook-gate-" + Guid.NewGuid().ToString("N"))).FullName;
-            // Each baseline was measured with HOME pointing at the directory being replaced here, and
-            // a hook reading its state out of HOME writes something else under the new one.
+            // A baseline is comparable only with answers measured under the same HOME, and the
+            // directory HOME is pointed at is replaced here.
             LoadingOutput.Clear();
         }
 

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/HookWiringCoverageTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/HookWiringCoverageTests.cs
@@ -14,7 +14,9 @@ namespace Velvet.Tests
     /// shows up as a failure: a guard that stops being invoked reports exactly what a guard that passes
     /// reports. Pairing by file name cannot separate the two files that do the running: an agent
     /// definition runs a hook for one agent type, the settings for every session. A guard over state any
-    /// session can move declares <c>HOOK_SCOPE</c>, and is paired against the settings alone.
+    /// session can move declares <c>HOOK_SCOPE</c>, and is paired against the settings alone. A
+    /// <c>PreToolUse</c> guard declares the tools it acts on as <c>HOOK_TOOLS</c>, and is paired
+    /// against the matcher that decides which tools reach it.
     /// </summary>
     [TestFixture]
     internal sealed class HookWiringCoverageTests
@@ -117,13 +119,14 @@ namespace Velvet.Tests
                 .Select(RelativeToHookDirectory)
                 .ToList();
 
-        // Folded into both assertions below rather than left to an `Assume`: deleting the declaration
-        // empties both checks, and an `Assume` would report that as inconclusive, which the runner
-        // does not count as a failure.
-        private static IEnumerable<string> UndeclaredScope(List<string> declared) =>
-            declared.Count == 0
-                ? new[] { "no hook declares HOOK_SCOPE, so neither scope check has a subject left" }
-                : Enumerable.Empty<string>();
+        // Folded into the assertions below rather than left to an `Assume`: deleting a declaration
+        // empties every check keyed on it, and an `Assume` would report that as inconclusive, which
+        // the runner does not count as a failure.
+        private static IEnumerable<string> NothingToCheck(int subjects, string reason) =>
+            subjects == 0 ? new[] { reason } : Enumerable.Empty<string>();
+
+        private const string NoScopeDeclared =
+            "no hook declares HOOK_SCOPE, so neither scope check has a subject left";
 
         [Test]
         public void Given_TheHooksDeclaringSessionScope_When_TheSettingsAreRead_Then_EveryOneIsRegisteredThere()
@@ -138,7 +141,7 @@ namespace Velvet.Tests
                 StringComparer.Ordinal);
 
             // Act
-            var unregistered = UndeclaredScope(declared)
+            var unregistered = NothingToCheck(declared.Count, NoScopeDeclared)
                 .Concat(declared.Where(hook => !registered.Contains(hook)))
                 .ToList();
 
@@ -156,7 +159,7 @@ namespace Velvet.Tests
             var scoped = new HashSet<string>(declared, StringComparer.Ordinal);
 
             // Act
-            var narrowed = UndeclaredScope(declared)
+            var narrowed = NothingToCheck(declared.Count, NoScopeDeclared)
                 .Concat(from file in AgentDefinitions()
                         from Match match in HookReferencePattern.Matches(FrontMatter(File.ReadAllText(file)))
                         where scoped.Contains(match.Groups[1].Value)
@@ -168,6 +171,200 @@ namespace Velvet.Tests
             Assert.That(narrowed, Is.Empty,
                 "the same guard registered on the event and on an agent fires twice, and a reader has "
                 + $"nothing telling them which of the two was meant:\n{string.Join("\n", narrowed)}");
+        }
+
+        // Which tools a `PreToolUse` guard acts on is written twice — the settings matcher routes them
+        // to it, and the hook's own gate decides which of what arrives it reads. Same one-place reason
+        // as HOOK_SCOPE above: the declaration is a line in the hook, and this fixture compares it
+        // against the registration rather than holding a table of its own.
+        private static readonly Regex ToolSetPattern =
+            new(@"^HOOK_TOOLS\s*=\s*\{([^}]*)\}\s*$", RegexOptions.Compiled | RegexOptions.Multiline);
+
+        private static readonly Regex QuotedName = new(@"""([^""]*)""", RegexOptions.Compiled);
+
+        // Sorted because each side means a set: the order a matcher's alternation or a Python literal
+        // happens to be written in is not part of what either says.
+        private static string Sorted(IEnumerable<string> names) =>
+            string.Join("|", names.Select(name => name.Trim()).Where(name => name.Length > 0)
+                .OrderBy(name => name, StringComparer.Ordinal));
+
+        /// <summary>The tools a hook declares, or null when it declares none.</summary>
+        private static string DeclaredTools(string hookName)
+        {
+            var path = Path.GetFullPath(HookDirectory + "/" + hookName);
+            if (!File.Exists(path))
+            {
+                return null;
+            }
+
+            var declaration = ToolSetPattern.Match(File.ReadAllText(path));
+            return declaration.Success
+                ? Sorted(from Match name in QuotedName.Matches(declaration.Groups[1].Value)
+                         select name.Groups[1].Value)
+                : null;
+        }
+
+        /// <summary>Each PreToolUse hook path in the settings, with the matcher that routes tools to it.</summary>
+        private static List<(string Hook, string Matcher)> PreToolUseRegistrations()
+        {
+            var settings = Path.GetFullPath(SettingsFile);
+            var text = File.Exists(settings) ? File.ReadAllText(settings) : string.Empty;
+            return (from entry in JsonObjects(JsonArrayValue(text, "PreToolUse"))
+                    let matcher = MatcherPattern.Match(entry)
+                    from Match reference in HookReferencePattern.Matches(entry)
+                    select (reference.Groups[1].Value, matcher.Success ? matcher.Groups[1].Value : string.Empty))
+                .Distinct()
+                .ToList();
+        }
+
+        private static readonly Regex MatcherPattern =
+            new(@"""matcher""\s*:\s*""([^""]*)""", RegexOptions.Compiled);
+
+        // A hand-rolled reader because this assembly references no JSON library. It tracks string
+        // state, so a bracket inside a matcher's regex or inside a command does not end a span.
+        private static string JsonArrayValue(string text, string key)
+        {
+            var at = text.IndexOf("\"" + key + "\"", StringComparison.Ordinal);
+            var open = at < 0 ? -1 : text.IndexOf('[', at);
+            if (open < 0)
+            {
+                return string.Empty;
+            }
+
+            var depth = 0;
+            foreach (var (index, character) in OutsideStrings(text, open))
+            {
+                if (character == '[')
+                {
+                    depth++;
+                }
+                else if (character == ']' && --depth == 0)
+                {
+                    return text.Substring(open + 1, index - open - 1);
+                }
+            }
+
+            return string.Empty;
+        }
+
+        private static IEnumerable<string> JsonObjects(string text)
+        {
+            var depth = 0;
+            var start = 0;
+            foreach (var (index, character) in OutsideStrings(text, 0))
+            {
+                if (character == '{' && depth++ == 0)
+                {
+                    start = index;
+                }
+                else if (character == '}' && --depth == 0)
+                {
+                    yield return text.Substring(start, index - start + 1);
+                }
+            }
+        }
+
+        private static IEnumerable<(int Index, char Character)> OutsideStrings(string text, int from)
+        {
+            var inString = false;
+            for (var index = from; index < text.Length; index++)
+            {
+                var character = text[index];
+                if (inString)
+                {
+                    if (character == '\\')
+                    {
+                        index++;
+                    }
+                    else if (character == '"')
+                    {
+                        inString = false;
+                    }
+                }
+                else if (character == '"')
+                {
+                    inString = true;
+                }
+                else
+                {
+                    yield return (index, character);
+                }
+            }
+        }
+
+        private const string NoRegistrationRead =
+            "no PreToolUse registration was read out of " + SettingsFile
+            + ", so neither tool-set check has a subject left";
+
+        [Test]
+        public void Given_ThePreToolUseRegistrations_When_EachHookIsRead_Then_EveryOneDeclaresItsToolSet()
+        {
+            // Arrange
+            var registrations = PreToolUseRegistrations();
+
+            // Act
+            var silent = NothingToCheck(registrations.Count, NoRegistrationRead)
+                .Concat(from registration in registrations
+                        where DeclaredTools(registration.Hook) == null
+                        select $"{HookDirectory}/{registration.Hook} is routed {registration.Matcher}")
+                .ToList();
+
+            // Assert
+            Assert.That(silent, Is.Empty,
+                "a hook declaring no tool set leaves the matcher as the only written statement of which "
+                + "tools it acts on, and its gate free to disagree with that in a literal nothing "
+                + $"compares:\n{string.Join("\n", silent)}");
+        }
+
+        [Test]
+        public void Given_ThePreToolUseRegistrations_When_EachMatcherIsComparedWithTheHooksOwnSet_Then_TheyNameTheSameTools()
+        {
+            // Arrange
+            var registrations = PreToolUseRegistrations();
+
+            // Act
+            var apart = NothingToCheck(registrations.Count, NoRegistrationRead)
+                .Concat(from registration in registrations
+                        let routed = Sorted(registration.Matcher.Split('|'))
+                        let declared = DeclaredTools(registration.Hook)
+                        where declared != routed
+                        select $"{HookDirectory}/{registration.Hook}: matcher routes {routed}, "
+                               + $"HOOK_TOOLS admits {declared ?? "nothing"}")
+                .ToList();
+
+            // Assert
+            Assert.That(apart, Is.Empty,
+                "a tool named on one side alone is silent both ways round — dropped from the set it "
+                + "reaches the hook and falls through, dropped from the matcher it never arrives and "
+                + $"the set goes on claiming it:\n{string.Join("\n", apart)}");
+        }
+
+        [Test]
+        public void Given_TheHooksDeclaringAToolSet_When_TheirSourceIsRead_Then_EveryOneComparesToolNameAgainstIt()
+        {
+            // Arrange
+            var declaring = Directory
+                .GetFiles(Path.GetFullPath(HookDirectory), "*.py", SearchOption.AllDirectories)
+                .Where(hook => !hook.Contains("__pycache__", StringComparison.Ordinal))
+                .Where(hook => ToolSetPattern.IsMatch(File.ReadAllText(hook)))
+                .ToList();
+
+            // Act — the gate has to read the declared name, not merely sit beside it. A set the gate
+            // does not consult drifts against a literal spelled out in the comparison, and the two
+            // checks above go on comparing the declaration to the matcher while the hook admits
+            // something else.
+            var unread = NothingToCheck(declaring.Count, "no hook declares HOOK_TOOLS")
+                .Concat(from hook in declaring
+                        where !File.ReadLines(hook).Any(line =>
+                            line.Contains("tool_name", StringComparison.Ordinal)
+                            && line.Contains("HOOK_TOOLS", StringComparison.Ordinal))
+                        select $"{RepoRelative(hook)} declares HOOK_TOOLS and gates on something else")
+                .ToList();
+
+            // Assert
+            Assert.That(unread, Is.Empty,
+                "a declaration nothing reads is the same silence as no declaration:\n"
+                + string.Join("\n", unread));
         }
 
         // Read from the front matter alone: the body below it is the agent's prompt, where a guard can

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/HookWiringCoverageTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/HookWiringCoverageTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Text.RegularExpressions;
 using NUnit.Framework;
 
@@ -16,7 +17,7 @@ namespace Velvet.Tests
     /// definition runs a hook for one agent type, the settings for every session. A guard over state any
     /// session can move declares <c>HOOK_SCOPE</c>, and is paired against the settings alone. A
     /// <c>PreToolUse</c> guard declares the tools it acts on as <c>HOOK_TOOLS</c>, and is paired
-    /// against the matcher that decides which tools reach it.
+    /// against the matcher that decides which tools reach it and against its own gate's behaviour.
     /// </summary>
     [TestFixture]
     internal sealed class HookWiringCoverageTests
@@ -112,11 +113,16 @@ namespace Velvet.Tests
             new(@"^HOOK_SCOPE\s*=\s*""session""\s*$", RegexOptions.Compiled | RegexOptions.Multiline);
 
         private static List<string> SessionScopedHooks() =>
+            HookScripts()
+                .Where(hook => SessionScopePattern.IsMatch(File.ReadAllText(hook)))
+                .Select(RelativeToHookDirectory)
+                .ToList();
+
+        private static List<string> HookScripts() =>
             Directory
                 .GetFiles(Path.GetFullPath(HookDirectory), "*.py", SearchOption.AllDirectories)
                 .Where(hook => !hook.Contains("__pycache__", StringComparison.Ordinal))
-                .Where(hook => SessionScopePattern.IsMatch(File.ReadAllText(hook)))
-                .Select(RelativeToHookDirectory)
+                .OrderBy(hook => hook, StringComparer.Ordinal)
                 .ToList();
 
         // Folded into the assertions below rather than left to an `Assume`: deleting a declaration
@@ -186,9 +192,13 @@ namespace Velvet.Tests
         // happens to be written in is not part of what either says.
         private static string Sorted(IEnumerable<string> names) =>
             string.Join("|", names.Select(name => name.Trim()).Where(name => name.Length > 0)
+                .Distinct(StringComparer.Ordinal)
                 .OrderBy(name => name, StringComparer.Ordinal));
 
-        /// <summary>The tools a hook declares, or null when it declares none.</summary>
+        private static List<string> DeclaringHooks() =>
+            HookScripts().Where(hook => ToolSetPattern.IsMatch(File.ReadAllText(hook))).ToList();
+
+        /// <summary>The tools a hook declares, or null when it names none.</summary>
         private static string DeclaredTools(string hookName)
         {
             var path = Path.GetFullPath(HookDirectory + "/" + hookName);
@@ -198,27 +208,57 @@ namespace Velvet.Tests
             }
 
             var declaration = ToolSetPattern.Match(File.ReadAllText(path));
-            return declaration.Success
-                ? Sorted(from Match name in QuotedName.Matches(declaration.Groups[1].Value)
-                         select name.Groups[1].Value)
-                : null;
+            if (!declaration.Success)
+            {
+                return null;
+            }
+
+            // An empty literal names no tool, so it says what a missing declaration says and the gate
+            // reading it admits nothing. Answered as "declares none" so that it cannot compare equal
+            // to a matcher that names nothing either — two sides saying nothing are equal strings,
+            // and reading that as agreement is the whole check going quiet.
+            var declared = Sorted(from Match name in QuotedName.Matches(declaration.Groups[1].Value)
+                                  select name.Groups[1].Value);
+            return declared.Length > 0 ? declared : null;
         }
 
-        /// <summary>Each PreToolUse hook path in the settings, with the matcher that routes tools to it.</summary>
-        private static List<(string Hook, string Matcher)> PreToolUseRegistrations()
+        /// <summary>Each PreToolUse hook path in the settings, with every matcher entry that routes to it.</summary>
+        private static List<(string Hook, List<string> Matchers)> PreToolUseRegistrations()
         {
             var settings = Path.GetFullPath(SettingsFile);
             var text = File.Exists(settings) ? File.ReadAllText(settings) : string.Empty;
+            // Grouped by hook, because one guard may be registered under several entries and every one
+            // of them reaches the same gate. Compared entry by entry, each would be held to the whole
+            // declared set on its own and a guard split across two entries could not be written green.
             return (from entry in JsonObjects(JsonArrayValue(text, "PreToolUse"))
                     let matcher = MatcherPattern.Match(entry)
                     from Match reference in HookReferencePattern.Matches(entry)
-                    select (reference.Groups[1].Value, matcher.Success ? matcher.Groups[1].Value : string.Empty))
+                    select (Hook: reference.Groups[1].Value,
+                            Matcher: matcher.Success ? matcher.Groups[1].Value : string.Empty))
                 .Distinct()
+                .GroupBy(registration => registration.Hook, StringComparer.Ordinal)
+                .Select(hook => (hook.Key, hook.Select(registration => registration.Matcher).ToList()))
                 .ToList();
         }
 
         private static readonly Regex MatcherPattern =
             new(@"""matcher""\s*:\s*""([^""]*)""", RegexOptions.Compiled);
+
+        // A matcher is a regular expression, and the comparison below reads it as an alternation of
+        // plain tool names. `*` — the documented all-tools form — has no answer here that would stay
+        // true: giving one means holding Claude Code's whole tool list in this fixture, where nothing
+        // updates it when the product gains a tool. It is refused instead, so a guard acting on
+        // several tools names them; an empty matcher is the same form and refused the same way.
+        private static readonly Regex ToolNamePattern = new(@"^[A-Za-z0-9_]+$", RegexOptions.Compiled);
+
+        /// <summary>The tools a hook's matcher entries route to it, or null when one names no set.</summary>
+        private static string RoutedTools(IEnumerable<string> matchers)
+        {
+            var names = matchers.SelectMany(matcher => matcher.Split('|')).ToList();
+            return names.Count > 0 && names.All(name => ToolNamePattern.IsMatch(name))
+                ? Sorted(names)
+                : null;
+        }
 
         // A hand-rolled reader because this assembly references no JSON library. It tracks string
         // state, so a bracket inside a matcher's regex or inside a command does not end a span.
@@ -306,12 +346,13 @@ namespace Velvet.Tests
             var silent = NothingToCheck(registrations.Count, NoRegistrationRead)
                 .Concat(from registration in registrations
                         where DeclaredTools(registration.Hook) == null
-                        select $"{HookDirectory}/{registration.Hook} is routed {registration.Matcher}")
+                        select $"{HookDirectory}/{registration.Hook} is routed "
+                               + Quoted(registration.Matchers))
                 .ToList();
 
             // Assert
             Assert.That(silent, Is.Empty,
-                "a hook declaring no tool set leaves the matcher as the only written statement of which "
+                "a hook naming no tool leaves the matcher as the only written statement of which "
                 + "tools it acts on, and its gate free to disagree with that in a literal nothing "
                 + $"compares:\n{string.Join("\n", silent)}");
         }
@@ -322,13 +363,15 @@ namespace Velvet.Tests
             // Arrange
             var registrations = PreToolUseRegistrations();
 
-            // Act
+            // Act — a side that names no set is reported rather than compared with the other.
             var apart = NothingToCheck(registrations.Count, NoRegistrationRead)
                 .Concat(from registration in registrations
-                        let routed = Sorted(registration.Matcher.Split('|'))
+                        let routed = RoutedTools(registration.Matchers)
                         let declared = DeclaredTools(registration.Hook)
-                        where declared != routed
-                        select $"{HookDirectory}/{registration.Hook}: matcher routes {routed}, "
+                        where routed == null || declared == null
+                              || !string.Equals(routed, declared, StringComparison.Ordinal)
+                        select $"{HookDirectory}/{registration.Hook}: matcher {Quoted(registration.Matchers)} "
+                               + $"routes {routed ?? "no set of tool names"}, "
                                + $"HOOK_TOOLS admits {declared ?? "nothing"}")
                 .ToList();
 
@@ -339,23 +382,22 @@ namespace Velvet.Tests
                 + $"the set goes on claiming it:\n{string.Join("\n", apart)}");
         }
 
+        private static string Quoted(IEnumerable<string> matchers) =>
+            string.Join(" and ", matchers.Select(matcher => "\"" + matcher + "\""));
+
         [Test]
         public void Given_TheHooksDeclaringAToolSet_When_TheirSourceIsRead_Then_EveryOneComparesToolNameAgainstIt()
         {
             // Arrange
-            var declaring = Directory
-                .GetFiles(Path.GetFullPath(HookDirectory), "*.py", SearchOption.AllDirectories)
-                .Where(hook => !hook.Contains("__pycache__", StringComparison.Ordinal))
-                .Where(hook => ToolSetPattern.IsMatch(File.ReadAllText(hook)))
-                .ToList();
+            var declaring = DeclaringHooks();
 
             // Act — the gate has to read the declared name, not merely sit beside it. A set the gate
             // does not consult drifts against a literal spelled out in the comparison, and the two
             // checks above go on comparing the declaration to the matcher while the hook admits
             // something else.
-            var unread = NothingToCheck(declaring.Count, "no hook declares HOOK_TOOLS")
+            var unread = NothingToCheck(declaring.Count, NoToolSetDeclared)
                 .Concat(from hook in declaring
-                        where !File.ReadLines(hook).Any(line =>
+                        where !WithoutProse(File.ReadAllText(hook)).Split('\n').Any(line =>
                             line.Contains("tool_name", StringComparison.Ordinal)
                             && line.Contains("HOOK_TOOLS", StringComparison.Ordinal))
                         select $"{RepoRelative(hook)} declares HOOK_TOOLS and gates on something else")
@@ -366,6 +408,61 @@ namespace Velvet.Tests
                 "a declaration nothing reads is the same silence as no declaration:\n"
                 + string.Join("\n", unread));
         }
+
+        private const string NoToolSetDeclared = "no hook declares HOOK_TOOLS";
+
+        /// <summary>A hook's source with its comments and its triple-quoted spans dropped.</summary>
+        private static string WithoutProse(string source)
+        {
+            // Prose satisfied the reading above: a comment naming tool_name and HOOK_TOOLS together
+            // passed it while the hook's gate compared a literal. Only the triple-quoted spans go
+            // with the comments — the gate's own subject is the string "tool_name", so dropping every
+            // string literal would take the line being looked for along with the prose.
+            var kept = new StringBuilder(source.Length);
+            var index = 0;
+            while (index < source.Length)
+            {
+                var character = source[index];
+                if (character == '#')
+                {
+                    while (index < source.Length && source[index] != '\n')
+                    {
+                        index++;
+                    }
+                }
+                else if (TripleQuoteAt(source, index))
+                {
+                    var end = source.IndexOf(source.Substring(index, 3), index + 3, StringComparison.Ordinal);
+                    index = end < 0 ? source.Length : end + 3;
+                    kept.Append('\n');
+                }
+                else if (character == '"' || character == '\'')
+                {
+                    var end = index + 1;
+                    while (end < source.Length && source[end] != character)
+                    {
+                        end += source[end] == '\\' ? 2 : 1;
+                    }
+
+                    end = Math.Min(end, source.Length - 1);
+                    kept.Append(source, index, end - index + 1);
+                    index = end + 1;
+                }
+                else
+                {
+                    kept.Append(character);
+                    index++;
+                }
+            }
+
+            return kept.ToString();
+        }
+
+        private static bool TripleQuoteAt(string source, int index) =>
+            index + 2 < source.Length
+            && (source[index] == '"' || source[index] == '\'')
+            && source[index + 1] == source[index]
+            && source[index + 2] == source[index];
 
         // Read from the front matter alone: the body below it is the agent's prompt, where a guard can
         // be named without being wired — the distinction WiringFiles draws for skills and guides.
@@ -408,10 +505,7 @@ namespace Velvet.Tests
                     .SelectMany(directory => Directory.GetFiles(directory, "*", SearchOption.AllDirectories))
                     .Select(Path.GetFileName),
                 StringComparer.Ordinal);
-            var hooks = Directory
-                .GetFiles(Path.GetFullPath(HookDirectory), "*.py", SearchOption.AllDirectories)
-                .Where(hook => !hook.Contains("__pycache__", StringComparison.Ordinal))
-                .ToList();
+            var hooks = HookScripts();
             Assume.That(hooks, Is.Not.Empty, "no hook scripts were found to read");
 
             // Act
@@ -439,8 +533,8 @@ namespace Velvet.Tests
         private static readonly (string Label, string Payload, bool MayRefuse)[] Payloads =
         {
             ("a Read event", "{\"tool_name\":\"Read\",\"tool_input\":{\"file_path\":\"README.md\"}}", false),
-            ("an unclaimed Bash command", "{\"tool_name\":\"Bash\",\"cwd\":\"CWD\",\"tool_input\":{\"command\":\"ls\"}}", false),
-            ("a merge", "{\"tool_name\":\"Bash\",\"cwd\":\"CWD\",\"tool_input\":{\"command\":\"gh pr merge 1 --squash --delete-branch\"}}", true),
+            ("an unclaimed Bash command", "{\"tool_name\":\"Bash\",\"cwd\":\"%PROJECT%\",\"tool_input\":{\"command\":\"ls\"}}", false),
+            ("a merge", "{\"tool_name\":\"Bash\",\"cwd\":\"%PROJECT%\",\"tool_input\":{\"command\":\"gh pr merge 1 --squash --delete-branch\"}}", true),
         };
 
         [Test]
@@ -468,10 +562,112 @@ namespace Velvet.Tests
                 "these guards did not reach a verdict, and a hook that does not reach one is not consulted");
         }
 
+        // One payload each declaring guard has an answer to, between them. Which guard answers which
+        // is not asserted: the check below needs each guard to answer something under a tool name it
+        // is routed and nothing at all under one it is not, so a payload no guard answers costs a run
+        // rather than a wrong verdict.
+        //
+        // %SCRATCH% is an empty directory this fixture makes. Pointed at the checkout instead, a guard
+        // reading branch state answers one way on main and another on a branch, and the probe would
+        // pass or fail with whichever tree the suite happened to run in. %PROJECT% is named by the one
+        // payload whose guard reads the repository's own top-level directories.
+        private static readonly (string Label, string Body)[] GatePayloads =
+        {
+            ("a merge naming an unexpanded pull request",
+             "\"cwd\":\"%SCRATCH%\",\"tool_input\":{\"command\":\"gh pr merge $PR --squash\"}"),
+            ("a sweeping git add",
+             "\"cwd\":\"%SCRATCH%\",\"tool_input\":{\"command\":\"git add -A\"}"),
+            ("a stash",
+             "\"cwd\":\"%SCRATCH%\",\"tool_input\":{\"command\":\"git stash\"}"),
+            ("a branch creation",
+             "\"cwd\":\"%SCRATCH%\",\"tool_input\":{\"command\":\"git checkout -b probe\"}"),
+            ("a commit scoped by an unexpanded pathspec",
+             "\"cwd\":\"%SCRATCH%\",\"tool_input\":{\"command\":\"git commit -m probe -- $PATHS\"}"),
+            ("an issue creation carrying no metadata",
+             "\"cwd\":\"%SCRATCH%\",\"tool_input\":{\"command\":\"gh issue create --title probe\"}"),
+            ("a background command naming a repository path relatively",
+             "\"cwd\":\"%PROJECT%\",\"tool_input\":{\"command\":\"python3 scripts/release/release_notes.py\","
+             + "\"run_in_background\":true}"),
+        };
+
+        // No matcher in the settings routes this, so a guard that answers under it has a gate that is
+        // reading something other than the event's tool name.
+        private const string UnroutedTool = "VelvetNoToolIsCalledThis";
+
+        [Test]
+        public void Given_TheHooksDeclaringAToolSet_When_EachIsPosedUnderARoutedNameAndAnUnroutedOne_Then_OnlyTheRoutedOneAnswers()
+        {
+            // Arrange
+            var probes = (from hook in DeclaringHooks()
+                          from tool in (DeclaredTools(RelativeToHookDirectory(hook)) ?? string.Empty)
+                              .Split(new[] { '|' }, StringSplitOptions.RemoveEmptyEntries)
+                          select (Hook: hook, Tool: tool)).ToList();
+
+            // Act — which way the gate points is what nothing else here reads. Every check above holds
+            // for a gate with its `not` dropped: the declaration is there, it equals the matcher, and
+            // the line still names both. What separates the two is that the inverted gate returns
+            // before its readings for exactly the tools it exists to read, and runs them for the rest.
+            var wrong = NothingToCheck(probes.Count, "no hook declares a tool to pose a payload under")
+                .Concat(probes.SelectMany(probe => GateFaults(probe.Hook, probe.Tool)))
+                .ToList();
+
+            // Assert
+            Assert.That(wrong, Is.Empty,
+                "a gate reaching its readings for the tools it is not routed, or returning before them "
+                + $"for the tools it is, admits the opposite of what it declares:\n{string.Join("\n", wrong)}");
+        }
+
+        private static IEnumerable<string> GateFaults(string hook, string tool)
+        {
+            var answering = GatePayloads.FirstOrDefault(
+                payload => Answered(hook, Posed(payload.Body, tool)));
+            if (answering.Body == null)
+            {
+                yield return $"{RepoRelative(hook)} answers nothing posed as {tool}";
+            }
+            else if (Answered(hook, Posed(answering.Body, UnroutedTool)))
+            {
+                yield return $"{RepoRelative(hook)} answers {answering.Label} posed as {UnroutedTool}, "
+                             + "which nothing routes to it";
+            }
+        }
+
+        private static string Posed(string body, string toolName) =>
+            "{\"tool_name\":\"" + toolName + "\"," + body + "}";
+
+        /// <summary>Whether a hook answered a payload rather than returning before its readings.</summary>
+        private static bool Answered(string hook, string payload)
+        {
+            // Not the exit code alone. blind_git_add.py refuses by printing a deny decision and exiting
+            // 0, so a reading that took 0 for silence would score its refusal as a gate that returned.
+            var answer = Answer(hook, payload, ScratchDirectory);
+            return answer.Exit == 2
+                   || (answer.Exit == 0
+                       && (answer.Output.Trim().Length > 0 || answer.Error.Trim().Length > 0));
+        }
+
         private const string RefuseDirectory = HookDirectory + "/refuse";
 
+        private const string ProjectToken = "%PROJECT%";
+        private const string ScratchToken = "%SCRATCH%";
+
+        private static string ScratchDirectory;
+
+        [OneTimeSetUp]
+        public void MakeScratchDirectory() =>
+            ScratchDirectory = Directory.CreateDirectory(Path.Combine(
+                Path.GetTempPath(), "velvet-hook-gate-" + Guid.NewGuid().ToString("N"))).FullName;
+
+        [OneTimeTearDown]
+        public void RemoveScratchDirectory() => Directory.Delete(ScratchDirectory, true);
+
+        private static string Resolved(string payload) =>
+            payload
+                .Replace(ProjectToken, Path.GetFullPath(".").Replace("\\", "\\\\"))
+                .Replace(ScratchToken, ScratchDirectory.Replace("\\", "\\\\"));
+
         /// <summary>Runs one hook against a payload and returns its exit code with whatever it wrote.</summary>
-        private static (int Exit, string Error) Answer(string hook, string payload)
+        private static (int Exit, string Output, string Error) Answer(string hook, string payload, string home = null)
         {
             var start = new System.Diagnostics.ProcessStartInfo("python3")
             {
@@ -483,24 +679,31 @@ namespace Velvet.Tests
             };
             start.ArgumentList.Add("-B");
             start.ArgumentList.Add(hook);
+            if (home != null)
+            {
+                // edit_while_a_ready_pr_sits.py reads the pull-request watcher's files out of the home
+                // directory, so a caller wanting an answer that does not depend on what the developer's
+                // watcher last wrote supplies one of its own.
+                start.Environment["HOME"] = home;
+            }
 
             using var process = System.Diagnostics.Process.Start(start);
             if (process == null)
             {
-                return (-1, "python3 did not start");
+                return (-1, string.Empty, "python3 did not start");
             }
 
-            process.StandardInput.Write(payload.Replace("CWD", Path.GetFullPath(".").Replace("\\", "\\\\")));
+            process.StandardInput.Write(Resolved(payload));
             process.StandardInput.Close();
             var error = process.StandardError.ReadToEnd();
-            process.StandardOutput.ReadToEnd();
+            var output = process.StandardOutput.ReadToEnd();
             if (!process.WaitForExit(60000))
             {
                 process.Kill();
-                return (-1, "timed out");
+                return (-1, string.Empty, "timed out");
             }
 
-            return (process.ExitCode, error);
+            return (process.ExitCode, output, error);
         }
 
         private static List<(string Name, string Source)> ReadWiring() =>

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/HookWiringCoverageTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/HookWiringCoverageTests.cs
@@ -617,9 +617,10 @@ namespace Velvet.Tests
             // Assert
             Assert.That(wrong, Is.Empty,
                 "answering none of them is a gate returning before its readings for a tool it is routed "
-                + "— what an inverted gate does — or a GatePayloads table holding nothing that guard "
+                + "— what an inverted gate does — a GatePayloads table holding nothing that guard "
                 + "decides about, which is what a guard added since the table was last extended wants a "
-                + "row for. Answering one posed under a tool nothing routes is a gate reading something "
+                + "row for, or a guard exiting neither 0 nor 2 under any of them, which is one raising "
+                + "rather than deciding. Answering one posed under a tool nothing routes is a gate reading something "
                 + $"other than the event's tool name:\n{string.Join("\n", wrong)}");
         }
 
@@ -661,12 +662,17 @@ namespace Velvet.Tests
         private static readonly Dictionary<string, string> LoadingOutput =
             new(StringComparer.Ordinal);
 
-        /// <summary>What a hook writes with no event to read, measured once per hook.</summary>
+        /// <summary>What a hook writes for an event naming no tool, measured once per hook.</summary>
         private static string Loading(string hook)
         {
             if (!LoadingOutput.TryGetValue(hook, out var written))
             {
-                written = Wrote(Answer(hook, "this is no event", ScratchDirectory));
+                // The payload has to parse. One that does not measures what a hook writes when it
+                // cannot read the event, and a hook letting that error raise then has a traceback
+                // subtracted from the silence it keeps for every payload it can read — so each of
+                // those scores as an answer, including under the name nothing routes, which the check
+                // above reads as a gate not reading the tool name at all.
+                written = Wrote(Answer(hook, "{}", ScratchDirectory));
                 LoadingOutput[hook] = written;
             }
 
@@ -681,9 +687,14 @@ namespace Velvet.Tests
         private static string ScratchDirectory;
 
         [OneTimeSetUp]
-        public void MakeScratchDirectory() =>
+        public void MakeScratchDirectory()
+        {
             ScratchDirectory = Directory.CreateDirectory(Path.Combine(
                 Path.GetTempPath(), "velvet-hook-gate-" + Guid.NewGuid().ToString("N"))).FullName;
+            // Each baseline was measured with HOME pointing at the directory being replaced here, and
+            // a hook reading its state out of HOME writes something else under the new one.
+            LoadingOutput.Clear();
+        }
 
         [OneTimeTearDown]
         public void RemoveScratchDirectory() => Directory.Delete(ScratchDirectory, true);

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/HookWiringCoverageTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/HookWiringCoverageTests.cs
@@ -213,10 +213,9 @@ namespace Velvet.Tests
                 return null;
             }
 
-            // An empty literal names no tool, so it says what a missing declaration says and the gate
-            // reading it admits nothing. Answered as "declares none" so that it cannot compare equal
-            // to a matcher that names nothing either — two sides saying nothing are equal strings,
-            // and reading that as agreement is the whole check going quiet.
+            // An empty literal is a gate that admits no tool at all, which is the silence the
+            // declaration check below reports. Answered as "declares none" rather than as an empty
+            // set, because an empty string is not null and that check would pass the hook.
             var declared = Sorted(from Match name in QuotedName.Matches(declaration.Groups[1].Value)
                                   select name.Groups[1].Value);
             return declared.Length > 0 ? declared : null;
@@ -245,10 +244,11 @@ namespace Velvet.Tests
             new(@"""matcher""\s*:\s*""([^""]*)""", RegexOptions.Compiled);
 
         // A matcher is a regular expression, and the comparison below reads it as an alternation of
-        // plain tool names. `*` — the documented all-tools form — has no answer here that would stay
+        // plain tool names. A matcher naming no tool of its own has no answer here that would stay
         // true: giving one means holding Claude Code's whole tool list in this fixture, where nothing
         // updates it when the product gains a tool. It is refused instead, so a guard acting on
-        // several tools names them; an empty matcher is the same form and refused the same way.
+        // several tools names them — `*`, an empty matcher, and a registration carrying no "matcher"
+        // key, which reaches here as the empty one.
         private static readonly Regex ToolNamePattern = new(@"^[A-Za-z0-9_]+$", RegexOptions.Compiled);
 
         /// <summary>The tools a hook's matcher entries route to it, or null when one names no set.</summary>
@@ -588,6 +588,9 @@ namespace Velvet.Tests
             ("a background command naming a repository path relatively",
              "\"cwd\":\"%PROJECT%\",\"tool_input\":{\"command\":\"python3 scripts/release/release_notes.py\","
              + "\"run_in_background\":true}"),
+            ("a pull request created from a body file that is not there",
+             "\"cwd\":\"%SCRATCH%\",\"tool_input\":"
+             + "{\"command\":\"gh pr create --title x --body-file velvet-no-such-body.md\"}"),
         };
 
         // No matcher in the settings routes this, so a guard that answers under it has a gate that is
@@ -613,8 +616,11 @@ namespace Velvet.Tests
 
             // Assert
             Assert.That(wrong, Is.Empty,
-                "a gate reaching its readings for the tools it is not routed, or returning before them "
-                + $"for the tools it is, admits the opposite of what it declares:\n{string.Join("\n", wrong)}");
+                "answering none of them is a gate returning before its readings for a tool it is routed "
+                + "— what an inverted gate does — or a GatePayloads table holding nothing that guard "
+                + "decides about, which is what a guard added since the table was last extended wants a "
+                + "row for. Answering one posed under a tool nothing routes is a gate reading something "
+                + $"other than the event's tool name:\n{string.Join("\n", wrong)}");
         }
 
         private static IEnumerable<string> GateFaults(string hook, string tool)
@@ -623,7 +629,8 @@ namespace Velvet.Tests
                 payload => Answered(hook, Posed(payload.Body, tool)));
             if (answering.Body == null)
             {
-                yield return $"{RepoRelative(hook)} answers nothing posed as {tool}";
+                yield return $"{RepoRelative(hook)} answers none of the {GatePayloads.Length} "
+                             + $"payloads posed as {tool}";
             }
             else if (Answered(hook, Posed(answering.Body, UnroutedTool)))
             {
@@ -640,10 +647,30 @@ namespace Velvet.Tests
         {
             // Not the exit code alone. blind_git_add.py refuses by printing a deny decision and exiting
             // 0, so a reading that took 0 for silence would score its refusal as a gate that returned.
+            // What a hook writes merely by being loaded is subtracted rather than scored: a warning
+            // raised at import lands before the gate reads the tool name, so it would answer under
+            // every name including the one nothing routes, and the check above would read that as a
+            // gate pointing the wrong way.
             var answer = Answer(hook, payload, ScratchDirectory);
-            return answer.Exit == 2
-                   || (answer.Exit == 0
-                       && (answer.Output.Trim().Length > 0 || answer.Error.Trim().Length > 0));
+            return answer.Exit == 2 || (answer.Exit == 0 && Wrote(answer) != Loading(hook));
+        }
+
+        private static string Wrote((int Exit, string Output, string Error) answer) =>
+            answer.Output.Trim() + "\n" + answer.Error.Trim();
+
+        private static readonly Dictionary<string, string> LoadingOutput =
+            new(StringComparer.Ordinal);
+
+        /// <summary>What a hook writes with no event to read, measured once per hook.</summary>
+        private static string Loading(string hook)
+        {
+            if (!LoadingOutput.TryGetValue(hook, out var written))
+            {
+                written = Wrote(Answer(hook, "this is no event", ScratchDirectory));
+                LoadingOutput[hook] = written;
+            }
+
+            return written;
         }
 
         private const string RefuseDirectory = HookDirectory + "/refuse";
@@ -695,15 +722,17 @@ namespace Velvet.Tests
 
             process.StandardInput.Write(Resolved(payload));
             process.StandardInput.Close();
-            var error = process.StandardError.ReadToEnd();
-            var output = process.StandardOutput.ReadToEnd();
+            // Drained together: reading one to EOF first deadlocks against a guard that fills the
+            // other's pipe buffer, and the wait below never runs to time that out.
+            var output = process.StandardOutput.ReadToEndAsync();
+            var error = process.StandardError.ReadToEndAsync();
             if (!process.WaitForExit(60000))
             {
                 process.Kill();
                 return (-1, string.Empty, "timed out");
             }
 
-            return (process.ExitCode, output, error);
+            return (process.ExitCode, output.Result, error.Result);
         }
 
         private static List<(string Name, string Source)> ReadWiring() =>


### PR DESCRIPTION
Closes #574.

A hook decides which tools it handles; `.claude/settings.json` decides which reach it. Nothing compared them, and both drift directions are silent: trim a tool from the hook's set and the matcher still routes it, so the hook returns 0 and the guard is off for that tool with the suite still green; trim it from the matcher and the set keeps claiming a tool the hook never sees.

The issue asked for a measurement first, and it corrected the issue's own generalisation. "Every Bash-matcher hook checks `tool_name`" is false — two of the eleven do not check at all and rely on the matcher. And the new CHANGELOG guard on `tooling/changelog-closed-section` admitted `("Edit", "Write")` behind an `Edit|Write|NotebookEdit` matcher, which is a live mismatch rather than a hypothetical one.

Every PreToolUse hook declares `HOOK_TOOLS` and gates on it, the same one-place shape as the existing `HOOK_SCOPE`. `HookWiringCoverageTests` asserts the declaration exists, equals its matcher's alternation, and is actually read by the hook — a declaration nothing reads is the same silence as no declaration.

## The gate probe's payload table is hand-kept, and the guard after this one has the same problem

The gate probe poses each declaring hook a payload under a tool it is routed and the same payload under a name nothing routes. The payloads are a table in the fixture, and a guard the table poses nothing about answers none of them — which the fixture reported as a gate admitting the opposite of what it declares.

That is not hypothetical. `DeclaringHooks()` scans `.claude/hooks/**/*.py` and enrols anything declaring `HOOK_TOOLS`, so `pr_body_of_another_branch.py` joins the moment both branches land. Measured against all seven payloads with `cwd` an empty directory, that guard exits 0 with both streams empty every time. Whichever of the two landed second would have reddened `HookWiringCoverageTests` on `main`, against a correct gate.

One row fixes this instance — `gh pr create --title x --body-file velvet-no-such-body.md`, which that guard answers with exit 2 and "does not exist" under `Bash` and is silent under the unrouted name. The general question is what happens to the guard after that one.

The answer is not another mechanism. The check already fails loudly when a guard answers nothing, so nothing here is silent; what was wrong is where the failure pointed. It named the guard, and described only one of the two things that produce it. It now writes out both readings — a gate that returns before its readings for a tool it is routed, and a `GatePayloads` table holding nothing that guard decides about — and says that a guard added since the table was last extended wants a row there rather than a change to itself. CONTRIBUTING states the same, beside the rest of what the fixture fails on.

Deriving the payloads instead of listing them is what would remove the table, and there is nothing to derive them from: what a guard decides about is the guard's own subject, and reading it back out of the guard is the same mirror problem one level down.

## Also in this round

- **What counts as an answer.** Exit 0 plus anything on either stream counted text written before `main()` reads `tool_name`. A module-level `warnings.warn` — or any import-time `DeprecationWarning` out of a hook or its `lib/` — made every payload answer, including the one posed under the unrouted name, and the probe then reported a correct gate as reading something other than the event's tool name. What a hook writes with no event to read is now measured once per hook and subtracted. Scoring stdout alone closes the same hole, and it silences `merge_onto_unpublished_release.py`, whose only answer under any payload is `published_check.py`'s except-path note on stderr.
- **A pipe-ordering deadlock in the runner.** `Answer` read stderr to EOF before stdout, with the timed wait after both, so a guard writing past the pipe buffer blocked with nothing left to time it out. Measured against a child writing 2 MB: blocked past 15 s in that order, and returning the whole 2 MB when both streams are drained together.
- **`DeclaredTools`' null return** was justified by a collision `RoutedTools` can no longer produce. The null is load-bearing for the other reading: an empty string is not null, and the declaration check would pass a hook whose gate admits no tool at all.
- **Two CONTRIBUTING corrections.** It described the unrouted-name branch as what catches an inverted gate; such a gate answers nothing under the tools it is routed, so it is caught before that branch is reached. And it called `*` a documented all-tools form, which is a claim about Claude Code's matcher semantics that nothing here pins. What is decided here is that a matcher naming no set a check can read is refused — `*`, an empty string, and a `PreToolUse` entry carrying no `"matcher"` key at all, which is the shape the `SessionStart`, `Stop` and `SubagentStop` entries take.

EditMode 3788/3788, PlayMode 161/161, `assert_no_inconclusive.py` clean on both. Merged with `tooling/pr-body-provenance` onto `main`: EditMode 3792/3792, clean.
