### PR TITLE
feat(velvet): declare a text field's placeholder, length limit, read-only and delayed flags

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -10,8 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `V.TextField` declares four more of the text-input surface: `placeholder:`, `maxLength:`,
-  `isReadOnly:` and `isDelayed:` — HTML's `placeholder`, `maxlength` and `readonly`, plus the
-  commit-on-Enter-or-blur behaviour. Reaching them previously meant writing the UI Toolkit properties
+  `isReadOnly:` and `isDelayed:` — HTML's `placeholder`, `maxlength` and `readonly`, plus a value that
+  catches up with the typed text on Enter, on the field losing focus, and on a render taking
+  `isDelayed:` off. That last one reports through `onValueChanged:`, so turning the flag off mid-edit
+  hands the component the pending text instead of stranding it on screen.
+  Reaching them previously meant writing the UI Toolkit properties
   by hand from `refCallback:`, which left them outside the diff and so unable to change with state.
   Each is undeclared when null: a member no render has declared is left alone, and one a render
   declared and a later one dropped restores the value the field carried before any render declared it.

--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -18,16 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- A `TextField`'s `isPasswordField` was written back to `false` by any render that declared another
-  text-input prop, so a mask a `refCallback:` had switched on came off on the next render that changed
-  the field's placeholder, length limit, read-only or delayed flag. A member no render declares is now
-  nobody's to write.
-
-- A pooled widget carried the props a previous consumer had declared on it into its next mount: the
-  recorded value a dropped `Focusable`, `TabIndex`, `DelegatesFocus` or text-input prop restores
-  belongs to the tree that declared it, and survived into the tree that recycled the element. The
-  next consumer's own assignment to the same property was then overwritten on the first re-render
-  that dropped a prop or changed a neighbouring one.
+- A pooled widget carried the `Focusable` default recorded under a previous consumer into its next
+  mount, so a render that dropped a declared `Focusable` prop handed the element that consumer's
+  focusability rather than the one it carried when this consumer first declared the prop. The record
+  is forgotten on the pool return every poolable type passes through.
 
 - A `TabIndex` or `DelegatesFocus` prop that a later render stopped declaring was written back as `0`
   or `false` rather than as the value the element was constructed with — neither of which is the

--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -14,9 +14,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   commit-on-Enter-or-blur behaviour. Reaching them previously meant writing the UI Toolkit properties
   by hand from `refCallback:`, which left them outside the diff and so unable to change with state.
   Each is undeclared when null: a member no render has declared is left alone, and one a render
-  declared and a later one dropped restores what the element was constructed with.
+  declared and a later one dropped restores the value the field carried before any render declared it.
+  The same four arrive on `Velvet.Experimental.VTextField` as `Placeholder`, `MaxLength`, `IsReadOnly`
+  and `IsDelayed`.
+
+### Changed
+
+- `V.TextField`'s four new parameters sit between `isPasswordField:` and `enabled:`, so a call passing
+  arguments positionally past `isPasswordField` now binds them to different parameters. Every argument
+  there but a `null` literal changes type across the shift, so such a call fails to compile rather than
+  rebinding silently; pass them by name.
 
 ### Fixed
+
+- A `TextField`'s `isPasswordField` was written back to `false` by any render that stopped declaring
+  it, so a mask a `refCallback:` had switched on came off on the first render that dropped the prop.
+  A member a render declared and a later one dropped now restores what the field carried when the
+  prop was first declared, and one no render has declared is nobody's to write.
 
 - A pooled widget carried the `Focusable` default recorded under a previous consumer into its next
   mount, so a render that dropped a declared `Focusable` prop handed the element that consumer's

--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -13,10 +13,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `isReadOnly:` and `isDelayed:` — HTML's `placeholder`, `maxlength` and `readonly`, plus the
   commit-on-Enter-or-blur behaviour. Reaching them previously meant writing the UI Toolkit properties
   by hand from `refCallback:`, which left them outside the diff and so unable to change with state.
-  Each is undeclared when null and restores what the element was constructed with once a later render
-  stops declaring it.
+  Each is undeclared when null: a member no render has declared is left alone, and one a render
+  declared and a later one dropped restores what the element was constructed with.
 
 ### Fixed
+
+- A `TextField`'s `isPasswordField` was written back to `false` by any render that declared another
+  text-input prop, so a mask a `refCallback:` had switched on came off as soon as the field's
+  placeholder or label changed. A member no render declares is now nobody's to write.
+
+- A pooled widget carried the props a previous consumer had declared on it into its next mount: the
+  recorded value a dropped `Focusable`, `TabIndex`, `DelegatesFocus` or text-input prop restores
+  belongs to the tree that declared it, and survived into the tree that recycled the element. The
+  next consumer's own assignment to the same property was then overwritten on the first re-render
+  that dropped a prop or changed a neighbouring one.
 
 - A `TabIndex` or `DelegatesFocus` prop that a later render stopped declaring was written back as `0`
   or `false` rather than as the value the element was constructed with — neither of which is the

--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `V.TextField` declares four more of the text-input surface: `placeholder:`, `maxLength:`,
+  `isReadOnly:` and `isDelayed:` — HTML's `placeholder`, `maxlength` and `readonly`, plus the
+  commit-on-Enter-or-blur behaviour. Reaching them previously meant writing the UI Toolkit properties
+  by hand from `refCallback:`, which left them outside the diff and so unable to change with state.
+  Each is undeclared when null and restores what the element was constructed with once a later render
+  stops declaring it.
+
 ### Fixed
 
 - A `TabIndex` or `DelegatesFocus` prop that a later render stopped declaring was written back as `0`

--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -19,8 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - A `TextField`'s `isPasswordField` was written back to `false` by any render that declared another
-  text-input prop, so a mask a `refCallback:` had switched on came off as soon as the field's
-  placeholder or label changed. A member no render declares is now nobody's to write.
+  text-input prop, so a mask a `refCallback:` had switched on came off on the next render that changed
+  the field's placeholder, length limit, read-only or delayed flag. A member no render declares is now
+  nobody's to write.
 
 - A pooled widget carried the props a previous consumer had declared on it into its next mount: the
   recorded value a dropped `Focusable`, `TabIndex`, `DelegatesFocus` or text-input prop restores

--- a/Packages/com.velvet.core/Documentation~/README.md
+++ b/Packages/com.velvet.core/Documentation~/README.md
@@ -16,7 +16,7 @@ The guides below go deeper on one subject each; [setup.md](setup.md) is the one 
 | File | Contents |
 |------|----------|
 | [setup.md](setup.md) | Getting the bundled utility stylesheet onto a panel — `VelvetStyleUtilities.AttachTo`, which utilities stop working without it and which are unaffected because Velvet resolves them itself (with the command that answers it per class), and the scene-reference alternative |
-| [react-migration.md](react-migration.md) | Naming alignment and API mapping for developers coming from React |
+| [react-migration.md](react-migration.md) | Naming alignment and API mapping for developers coming from React, including which `V.TextField` parameters are undeclared rather than reset when null |
 | [memoization.md](memoization.md) | The `[MemoizeMethod]` attribute — usage, constraints, and diagnostic IDs (Source Generator-driven partial-method memoization) |
 | [styling-flexbox-and-gap.md](styling-flexbox-and-gap.md) | Flexbox direction (the engine's raw flex default is a column; the `.flex` utility corrects it to row), what still ties once a variant outranks the base direction (the bare `flex`, two utilities at one priority), and `gap-*` / `divide-*` gotchas vs Tailwind — the inter-child margin and border polyfills, their edge flip on `flex-row-reverse` / `flex-col-reverse` (and the `space-*-reverse` / `divide-*-reverse` markers), the wrap half-margin hybrid, and the `grow-[N]` / `shrink-[N]` arbitrary factors a proportional split needs |
 | [styling-z-index.md](styling-z-index.md) | `z-*` stacking for `absolute` descendants — the layer-container + placeholder mechanism, sibling-scope-only comparison, and the in-flow/negative-z/`peer-` deviations from CSS |

--- a/Packages/com.velvet.core/Documentation~/focus.md
+++ b/Packages/com.velvet.core/Documentation~/focus.md
@@ -53,9 +53,8 @@ Three focus-related element props ride `FiberElementProps` alongside the existin
 stops declaring one: dropping the prop hands the element back the value it was constructed with, so a
 `V.Div` that carried `Focusable = true` for one render stops being a Tab stop again, and a control
 that is focusable by construction keeps its own default. The same holds for the other two, and it has
-to: a `Label` reached through `V.Custom` is built out of the tab ring, a `TextField` is built
-delegating focus to the input beneath it, and a UI Toolkit composite field mounted through `V.Custom`
-is built doing neither — so a constant would hand one type another type's answer.
+to: a `Label` reached through `V.Custom` is built out of the tab ring, while a `TextField` is built
+delegating focus to the input beneath it — so a constant would hand one type another type's answer.
 
 ## Focus-visible styling and state
 

--- a/Packages/com.velvet.core/Documentation~/react-migration.md
+++ b/Packages/com.velvet.core/Documentation~/react-migration.md
@@ -196,7 +196,7 @@ Since C# has no JSX syntax, Velvet builds the VNode tree through `V.*` method ca
 | `<div className="x">` | `V.Div(className: "x")` | Unity has no HTML elements. Produces a `VisualElement` |
 | `<span>` | `V.Div()` | No span-equivalent element. Substitute a generic `VisualElement` |
 | `<button onClick={fn}>` | `V.Button(onClick: fn)` | Produces a UI Toolkit `Button` type |
-| `<input type="text">` | `V.TextField()` | |
+| `<input type="text">` | `V.TextField()` | `placeholder` / `maxlength` / `readonly` are the `placeholder:` / `maxLength:` / `isReadOnly:` parameters. `isDelayed:` has no HTML counterpart: it holds the value back until Enter or blur instead of updating per keystroke |
 | `<input type="checkbox">` | `V.Toggle()` | |
 | `<input type="range">` | `V.Slider()` | |
 | `<p>` / `<h1>` | `V.Label()` | UI Toolkit `Label` type |

--- a/Packages/com.velvet.core/Documentation~/react-migration.md
+++ b/Packages/com.velvet.core/Documentation~/react-migration.md
@@ -202,6 +202,12 @@ Since C# has no JSX syntax, Velvet builds the VNode tree through `V.*` method ca
 | `<p>` / `<h1>` | `V.Label()` | UI Toolkit `Label` type |
 | `<>{children}</>` | `V.Fragment(children)` | No shorthand `<>` syntax |
 
+`V.TextField`'s `placeholder:`, `maxLength:`, `isReadOnly:` and `isDelayed:` are **undeclared** when
+null, not reset: null is not `placeholder=""`, not `maxLength: -1` and not `isReadOnly: false`. A
+member no render has declared is left wherever a `refCallback:` put it, and one a render declared and
+a later render dropped goes back to the value the field carried before any render declared it. The
+three focus props follow the same rule — [focus.md](focus.md) states it for those.
+
 ### 2-2. Conditionals and Lists
 
 | React | Velvet | Notes |

--- a/Packages/com.velvet.core/Documentation~/react-migration.md
+++ b/Packages/com.velvet.core/Documentation~/react-migration.md
@@ -196,7 +196,7 @@ Since C# has no JSX syntax, Velvet builds the VNode tree through `V.*` method ca
 | `<div className="x">` | `V.Div(className: "x")` | Unity has no HTML elements. Produces a `VisualElement` |
 | `<span>` | `V.Div()` | No span-equivalent element. Substitute a generic `VisualElement` |
 | `<button onClick={fn}>` | `V.Button(onClick: fn)` | Produces a UI Toolkit `Button` type |
-| `<input type="text">` | `V.TextField()` | `placeholder` / `maxlength` / `readonly` are the `placeholder:` / `maxLength:` / `isReadOnly:` parameters. `isDelayed:` has no HTML counterpart: it holds the value back until Enter or blur instead of updating per keystroke |
+| `<input type="text">` | `V.TextField()` | `placeholder` / `maxlength` / `readonly` are the `placeholder:` / `maxLength:` / `isReadOnly:` parameters. `isDelayed:` has no HTML counterpart: it holds the value back instead of updating per keystroke — see below for what releases it |
 | `<input type="checkbox">` | `V.Toggle()` | |
 | `<input type="range">` | `V.Slider()` | |
 | `<p>` / `<h1>` | `V.Label()` | UI Toolkit `Label` type |
@@ -207,6 +207,11 @@ null, not reset: null is not `placeholder=""`, not `maxLength: -1` and not `isRe
 member no render has declared is left wherever a `refCallback:` put it, and one a render declared and
 a later render dropped goes back to the value the field carried before any render declared it. The
 three focus props follow the same rule — [focus.md](focus.md) states it for those.
+
+A field holding `isDelayed:` releases the typed text into its value on Enter, on losing focus, and on
+a render taking the flag off — that third one whether the render declares `isDelayed: false` or drops
+the parameter. The render-driven release reports through `onValueChanged:`, so a component that turns
+the flag off mid-edit receives the pending text rather than stranding it on screen.
 
 ### 2-2. Conditionals and Lists
 

--- a/Packages/com.velvet.core/PublicAPI.txt
+++ b/Packages/com.velvet.core/PublicAPI.txt
@@ -108,7 +108,7 @@
 [Velvet] ctor Velvet.StyleSlotRecipe.ctor(System.Collections.Generic.Dictionary`2[System.String, System.String], System.Collections.Generic.Dictionary`2[System.String, System.Collections.Generic.Dictionary`2[System.String, System.Collections.Generic.Dictionary`2[System.String, System.String]]], System.Collections.Generic.Dictionary`2[System.String, System.String]?, Velvet.StyleSlotRecipe+SlotCompoundVariant[]?): System.Void
 [Velvet] ctor Velvet.StyleTransitionConfig.ctor(): System.Void
 [Velvet] ctor Velvet.SuspenseNode.ctor(): System.Void
-[Velvet] ctor Velvet.TextFieldSettings.ctor(System.Nullable`1[System.Boolean]): System.Void
+[Velvet] ctor Velvet.TextFieldSettings.ctor(System.Nullable`1[System.Boolean], System.String?, System.Nullable`1[System.Int32], System.Nullable`1[System.Boolean], System.Nullable`1[System.Boolean]): System.Void
 [Velvet] ctor Velvet.TextNode.ctor(): System.Void
 [Velvet] ctor Velvet.VelvetFontFamily.ctor(): System.Void
 [Velvet] ctor Velvet.VelvetFontFamily.ctor(System.String, Velvet.VelvetFontWeightEntry[]): System.Void
@@ -493,7 +493,7 @@
 [Velvet] method Velvet.V.Slider(System.String?, System.Nullable`1[System.Single], System.Nullable`1[System.Single], System.Nullable`1[System.Single], System.Action`1[System.Single]?, System.String?, System.String?, System.Nullable`1[System.Boolean], System.Func`2[UnityEngine.UIElements.VisualElement, System.Action]?, System.Action`1[UnityEngine.UIElements.VisualElement]?, System.String?, System.String?, System.String?, System.Collections.Generic.IReadOnlyDictionary`2[System.String, System.String]?, System.Collections.Generic.IReadOnlyDictionary`2[System.String, System.String]?): Velvet.ElementNode
 [Velvet] method Velvet.V.Suspense(Velvet.VNode?, Velvet.VNode?[], System.String?): Velvet.SuspenseNode
 [Velvet] method Velvet.V.Text(System.String?): Velvet.TextNode
-[Velvet] method Velvet.V.TextField(System.String?, System.String?, System.Action`1[System.String]?, System.String?, System.String?, System.String?, System.Nullable`1[System.Boolean], System.Nullable`1[System.Boolean], System.Func`2[UnityEngine.UIElements.VisualElement, System.Action]?, System.String?, System.String?, System.String?, System.Collections.Generic.IReadOnlyDictionary`2[System.String, System.String]?, System.Collections.Generic.IReadOnlyDictionary`2[System.String, System.String]?): Velvet.ElementNode
+[Velvet] method Velvet.V.TextField(System.String?, System.String?, System.Action`1[System.String]?, System.String?, System.String?, System.String?, System.Nullable`1[System.Boolean], System.String?, System.Nullable`1[System.Int32], System.Nullable`1[System.Boolean], System.Nullable`1[System.Boolean], System.Nullable`1[System.Boolean], System.Func`2[UnityEngine.UIElements.VisualElement, System.Action]?, System.String?, System.String?, System.String?, System.Collections.Generic.IReadOnlyDictionary`2[System.String, System.String]?, System.Collections.Generic.IReadOnlyDictionary`2[System.String, System.String]?): Velvet.ElementNode
 [Velvet] method Velvet.V.Toggle(System.String?, System.Nullable`1[System.Boolean], System.Action`1[System.Boolean]?, System.String?, System.String?, System.String?, System.Nullable`1[System.Boolean], System.Func`2[UnityEngine.UIElements.VisualElement, System.Action]?, System.String?, System.String?, System.String?, System.Collections.Generic.IReadOnlyDictionary`2[System.String, System.String]?, System.Collections.Generic.IReadOnlyDictionary`2[System.String, System.String]?): Velvet.ElementNode
 [Velvet] method Velvet.V.VirtualList`1(System.Collections.Generic.IReadOnlyList`1[T], System.Func`2[T, System.String], System.Single, System.Func`2[T, Velvet.VNode], System.Int32, System.String?, System.String?, System.String?): Velvet.VirtualListNode
 [Velvet] method Velvet.V.When(System.Boolean, System.Func`1[Velvet.VNode]?): Velvet.VNode?
@@ -656,9 +656,13 @@
 [Velvet] property Velvet.Experimental.VSlider.OnChange: System.Action`1[System.Single]?
 [Velvet] property Velvet.Experimental.VSlider.Value: System.Nullable`1[System.Single]
 [Velvet] property Velvet.Experimental.VTextField.Enabled: System.Nullable`1[System.Boolean]
+[Velvet] property Velvet.Experimental.VTextField.IsDelayed: System.Nullable`1[System.Boolean]
 [Velvet] property Velvet.Experimental.VTextField.IsPasswordField: System.Nullable`1[System.Boolean]
+[Velvet] property Velvet.Experimental.VTextField.IsReadOnly: System.Nullable`1[System.Boolean]
 [Velvet] property Velvet.Experimental.VTextField.Label: System.String?
+[Velvet] property Velvet.Experimental.VTextField.MaxLength: System.Nullable`1[System.Int32]
 [Velvet] property Velvet.Experimental.VTextField.OnChange: System.Action`1[System.String]?
+[Velvet] property Velvet.Experimental.VTextField.Placeholder: System.String?
 [Velvet] property Velvet.Experimental.VTextField.Value: System.String?
 [Velvet] property Velvet.Experimental.VToggle.Enabled: System.Nullable`1[System.Boolean]
 [Velvet] property Velvet.Experimental.VToggle.Label: System.String?
@@ -834,7 +838,11 @@
 [Velvet] property Velvet.StyleTransitionConfig.When: Velvet.TransitionWhen
 [Velvet] property Velvet.SuspenseNode.Children: Velvet.VNode?[]
 [Velvet] property Velvet.SuspenseNode.Fallback: Velvet.VNode
+[Velvet] property Velvet.TextFieldSettings.IsDelayed: System.Nullable`1[System.Boolean]
 [Velvet] property Velvet.TextFieldSettings.IsPassword: System.Nullable`1[System.Boolean]
+[Velvet] property Velvet.TextFieldSettings.IsReadOnly: System.Nullable`1[System.Boolean]
+[Velvet] property Velvet.TextFieldSettings.MaxLength: System.Nullable`1[System.Int32]
+[Velvet] property Velvet.TextFieldSettings.Placeholder: System.String?
 [Velvet] property Velvet.TextNode.Text: System.String
 [Velvet] property Velvet.VNode.Key: System.String?
 [Velvet] property Velvet.VelvetFonts.DefaultFamily: System.String?

--- a/Packages/com.velvet.core/Runtime/Component/Experimental/VBuilders.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Experimental/VBuilders.cs
@@ -258,7 +258,8 @@ namespace Velvet.Experimental
         /// <summary>When true, the field cannot be edited.</summary>
         public bool? IsReadOnly { get; set; }
 
-        /// <summary>When true, the value is not updated until the user presses Enter or the field loses focus.</summary>
+        /// <summary>When true, the value is not updated per keystroke but on Enter, on the field losing focus,
+        /// and on a later render taking the flag off.</summary>
         public bool? IsDelayed { get; set; }
 
         /// <summary>When false, disables user input.</summary>

--- a/Packages/com.velvet.core/Runtime/Component/Experimental/VBuilders.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Experimental/VBuilders.cs
@@ -249,6 +249,18 @@ namespace Velvet.Experimental
         /// <summary>When true, masks the input as a password field.</summary>
         public bool? IsPasswordField { get; set; }
 
+        /// <summary>A short hint shown in the empty field.</summary>
+        public string? Placeholder { get; set; }
+
+        /// <summary>Maximum number of characters the field accepts, -1 for no limit.</summary>
+        public int? MaxLength { get; set; }
+
+        /// <summary>When true, the field cannot be edited.</summary>
+        public bool? IsReadOnly { get; set; }
+
+        /// <summary>When true, the value is not updated until the user presses Enter or the field loses focus.</summary>
+        public bool? IsDelayed { get; set; }
+
         /// <summary>When false, disables user input.</summary>
         public bool? Enabled { get; set; }
 
@@ -258,7 +270,8 @@ namespace Velvet.Experimental
         /// <inheritdoc/>
         public override VNode Build() =>
             V.TextField(className: Class, value: Value, onValueChanged: OnChange, key: Key, name: Name,
-                label: Label, isPasswordField: IsPasswordField, enabled: Enabled);
+                label: Label, isPasswordField: IsPasswordField, placeholder: Placeholder, maxLength: MaxLength,
+                isReadOnly: IsReadOnly, isDelayed: IsDelayed, enabled: Enabled);
     }
 
     /// <summary>

--- a/Packages/com.velvet.core/Runtime/Component/V.cs
+++ b/Packages/com.velvet.core/Runtime/Component/V.cs
@@ -549,7 +549,7 @@ namespace Velvet
         /// <param name="placeholder">A short hint shown in the empty field (HTML <c>placeholder</c>). An empty string declares an empty hint.</param>
         /// <param name="maxLength">Maximum number of characters the field accepts, -1 for no limit (HTML <c>maxlength</c>).</param>
         /// <param name="isReadOnly">When true, the field cannot be edited (HTML <c>readonly</c>).</param>
-        /// <param name="isDelayed">When true, the value is not updated until the user presses Enter or the field loses focus, rather than per keystroke.</param>
+        /// <param name="isDelayed">When true, the value is not updated per keystroke but on Enter, on the field losing focus, and on a later render taking the flag off.</param>
         /// <param name="enabled">When false, disables user input.</param>
         /// <param name="refCallback">Callback invoked on mount with the created VisualElement; returned Action runs on unmount.</param>
         /// <param name="whileHoverClass">USS class toggled while the pointer hovers the element.</param>

--- a/Packages/com.velvet.core/Runtime/Component/V.cs
+++ b/Packages/com.velvet.core/Runtime/Component/V.cs
@@ -534,6 +534,11 @@ namespace Velvet
         /// <summary>
         /// Creates a TextField.
         /// </summary>
+        /// <remarks>
+        /// <paramref name="placeholder"/>, <paramref name="maxLength"/>, <paramref name="isReadOnly"/> and
+        /// <paramref name="isDelayed"/> are undeclared when null rather than reset to a default;
+        /// <c>Documentation~/react-migration.md</c> owns what a null and a dropped one each do.
+        /// </remarks>
         /// <param name="className">CSS-like utility class string. Multiple classes separated by spaces.</param>
         /// <param name="value">Current text value (controlled).</param>
         /// <param name="onValueChanged">Handler invoked when the input text changes.</param>
@@ -541,7 +546,7 @@ namespace Velvet
         /// <param name="name">Element name assigned to <see cref="VisualElement.name"/> for query/debug.</param>
         /// <param name="label">Label text shown next to the field.</param>
         /// <param name="isPasswordField">When true, masks the input as a password field.</param>
-        /// <param name="placeholder">A short hint shown in the empty field (HTML <c>placeholder</c>). An empty string declares an empty hint; null leaves the field's own.</param>
+        /// <param name="placeholder">A short hint shown in the empty field (HTML <c>placeholder</c>). An empty string declares an empty hint.</param>
         /// <param name="maxLength">Maximum number of characters the field accepts, -1 for no limit (HTML <c>maxlength</c>).</param>
         /// <param name="isReadOnly">When true, the field cannot be edited (HTML <c>readonly</c>).</param>
         /// <param name="isDelayed">When true, the value is not updated until the user presses Enter or the field loses focus, rather than per keystroke.</param>

--- a/Packages/com.velvet.core/Runtime/Component/V.cs
+++ b/Packages/com.velvet.core/Runtime/Component/V.cs
@@ -541,6 +541,10 @@ namespace Velvet
         /// <param name="name">Element name assigned to <see cref="VisualElement.name"/> for query/debug.</param>
         /// <param name="label">Label text shown next to the field.</param>
         /// <param name="isPasswordField">When true, masks the input as a password field.</param>
+        /// <param name="placeholder">A short hint shown in the empty field (HTML <c>placeholder</c>). An empty string declares an empty hint; null leaves the field's own.</param>
+        /// <param name="maxLength">Maximum number of characters the field accepts, -1 for no limit (HTML <c>maxlength</c>).</param>
+        /// <param name="isReadOnly">When true, the field cannot be edited (HTML <c>readonly</c>).</param>
+        /// <param name="isDelayed">When true, the value is not updated until the user presses Enter or the field loses focus, rather than per keystroke.</param>
         /// <param name="enabled">When false, disables user input.</param>
         /// <param name="refCallback">Callback invoked on mount with the created VisualElement; returned Action runs on unmount.</param>
         /// <param name="whileHoverClass">USS class toggled while the pointer hovers the element.</param>
@@ -557,6 +561,10 @@ namespace Velvet
             string? name = null,
             string? label = null,
             bool? isPasswordField = null,
+            string? placeholder = null,
+            int? maxLength = null,
+            bool? isReadOnly = null,
+            bool? isDelayed = null,
             bool? enabled = null,
             Func<VisualElement, Action>? refCallback = null,
             string? whileHoverClass = null,
@@ -567,15 +575,18 @@ namespace Velvet
         {
             var events = SingleEvent(onValueChanged != null ? new ChangeEventBinding<string> { Handler = onValueChanged } : null);
 
+            var declaresTextField = isPasswordField.HasValue || placeholder != null || maxLength.HasValue
+                                    || isReadOnly.HasValue || isDelayed.HasValue;
+
             FiberElementProps? props = null;
-            if (value != null || label != null || isPasswordField.HasValue || enabled.HasValue)
+            if (value != null || label != null || declaresTextField || enabled.HasValue)
             {
                 props = VNodePool.RentProps();
                 props.FieldValue = value;
                 props.Text = label;
                 props.Enabled = enabled;
-                props.TextField = isPasswordField.HasValue
-                    ? new TextFieldSettings(isPasswordField)
+                props.TextField = declaresTextField
+                    ? new TextFieldSettings(isPasswordField, placeholder, maxLength, isReadOnly, isDelayed)
                     : null;
             }
             props = WithAttributes(props, data, aria);

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberElementCleaner.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberElementCleaner.cs
@@ -130,6 +130,7 @@ namespace Velvet
         // unrelated mount.
         private static void ReturnToPool(VisualElement element)
         {
+            FiberPropApplier.ForgetRecordedDefaults(element);
             var type = element.GetType();
             if (type == typeof(TextField))
             {

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberElementProps.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberElementProps.cs
@@ -150,9 +150,17 @@ namespace Velvet
         ScrollerVisibility? HorizontalScrollerVisibility = null,
         ScrollView.TouchScrollBehavior? TouchScrollBehavior = null);
 
-    /// <summary>TextField.isPasswordField.</summary>
+    /// <summary>
+    /// TextField.isPasswordField, textEdition.placeholder, maxLength, isReadOnly and isDelayed.
+    /// A null member is undeclared, and <see cref="FiberPropApplier.ApplyTextField"/> restores what the
+    /// element was constructed with; an empty <see cref="Placeholder"/> is a declared empty placeholder.
+    /// </summary>
     public sealed record TextFieldSettings(
-        bool? IsPassword = null);
+        bool? IsPassword = null,
+        string? Placeholder = null,
+        int? MaxLength = null,
+        bool? IsReadOnly = null,
+        bool? IsDelayed = null);
 
     /// <summary>List of choices for DropdownField / RadioButtonGroup.</summary>
     public sealed record ChoicesSettings(

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberElementProps.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberElementProps.cs
@@ -152,8 +152,9 @@ namespace Velvet
 
     /// <summary>
     /// TextField.isPasswordField, textEdition.placeholder, maxLength, isReadOnly and isDelayed.
-    /// A null member is undeclared, and <see cref="FiberPropApplier.ApplyTextField"/> restores what the
-    /// element was constructed with; an empty <see cref="Placeholder"/> is a declared empty placeholder.
+    /// A null member is undeclared: <see cref="FiberPropApplier.ApplyTextField"/> leaves a member no render
+    /// has declared untouched, and restores what the element was constructed with once a render that did
+    /// declare one drops it. An empty <see cref="Placeholder"/> is a declared empty placeholder.
     /// </summary>
     public sealed record TextFieldSettings(
         bool? IsPassword = null,

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberPropApplier.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberPropApplier.cs
@@ -295,12 +295,27 @@ namespace Velvet
             if (declared is { } value)
             {
                 built.IsDelayed ??= new Recorded<bool>(field.isDelayed);
-                field.isDelayed = value;
+                WriteDelayed(field, value);
             }
             else if (built.IsDelayed != null)
             {
-                field.isDelayed = built.IsDelayed.Value;
+                WriteDelayed(field, built.IsDelayed.Value);
             }
+        }
+
+        // Ordering: an edit the field is still holding is committed before the flag comes off. The flag's
+        // contract is that the value lags the typed text until Enter or blur, so clearing it first strands
+        // that edit — displayed, never reported, and with nothing later to re-sync it, since a render
+        // repeating the same FieldValue does not reach ApplyFieldValue at all.
+        // TextFieldInputPropTests measures the commit on both a redeclared and a dropped flag.
+        private static void WriteDelayed(TextField field, bool value)
+        {
+            if (!value && field.isDelayed)
+            {
+                field.value = field.text;
+            }
+
+            field.isDelayed = value;
         }
 
         private static bool Declares(TextFieldSettings? settings)

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberPropApplier.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberPropApplier.cs
@@ -307,7 +307,12 @@ namespace Velvet
         // contract is that the value lags the typed text until Enter or blur, so clearing it first strands
         // that edit — displayed, never reported, and with nothing later to re-sync it, since a render
         // repeating the same FieldValue does not reach ApplyFieldValue at all.
-        // TextFieldInputPropTests measures the commit on both a redeclared and a dropped flag.
+        // The notifying setter is the point of the write, not an incidental way of making it: reporting
+        // the commit is the half that "never reported" names, and SetValueWithoutNotify would leave it.
+        // Every other prop-path write to a field is the silent one — FiberNodePatcher.RaiseCheckedSignal
+        // names that policy and what it costs — so this is the exception, and nothing else here fails if
+        // it stops notifying. DelayedFlagCommitReportTests measures the report on a real panel;
+        // TextFieldInputPropTests measures the commit itself on both routes off the flag.
         private static void WriteDelayed(TextField field, bool value)
         {
             if (!value && field.isDelayed)

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberPropApplier.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberPropApplier.cs
@@ -201,6 +201,11 @@ namespace Velvet
             svEl.touchScrollBehavior = Resolve(settings?.TouchScrollBehavior, ScrollView.TouchScrollBehavior.Clamped);
         }
 
+        // Same recorded-default shape, and the same reason, as ApplyFocusable: a dropped member restores what
+        // this element was constructed with. The type guard below does not narrow that to one answer — it
+        // admits any subclass of TextField, which V.Custom<T> can name, and such a subclass may be built with
+        // a placeholder or a length limit no constant here could name. TextFieldInputPropTests measures the
+        // difference on one.
         public static void ApplyTextField(VisualElement element, TextFieldSettings? settings)
         {
             if (element is not TextField tfEl)
@@ -208,8 +213,63 @@ namespace Velvet
                 return;
             }
 
-            tfEl.isPasswordField = settings?.IsPassword ?? false;
+            if (Declares(settings))
+            {
+                RecordTextFieldDefaults(tfEl);
+            }
+
+            // No record means no member was ever declared, so the field still carries its own defaults.
+            if (!s_textFieldDefaults.TryGetValue(tfEl, out var built))
+            {
+                return;
+            }
+
+            tfEl.isPasswordField = settings?.IsPassword ?? built.IsPassword;
+            tfEl.textEdition.placeholder = settings?.Placeholder ?? built.Placeholder;
+            tfEl.maxLength = settings?.MaxLength ?? built.MaxLength;
+            tfEl.isReadOnly = settings?.IsReadOnly ?? built.IsReadOnly;
+            tfEl.isDelayed = settings?.IsDelayed ?? built.IsDelayed;
         }
+
+        private static bool Declares(TextFieldSettings? settings)
+            => settings != null
+               && (settings.IsPassword.HasValue
+                   || settings.Placeholder != null
+                   || settings.MaxLength.HasValue
+                   || settings.IsReadOnly.HasValue
+                   || settings.IsDelayed.HasValue);
+
+        // One snapshot covers all five because it is taken before the prop path writes any of them. A writer
+        // outside that path owes this first, under the rule RecordFocusableDefault states; the pool's reset
+        // is the standing exception, writing back the constructed values PooledElementSurfaceResetTests
+        // compares it against, so a record taken before or after it reads the same.
+        internal static void RecordTextFieldDefaults(TextField textField)
+        {
+            if (!s_textFieldDefaults.TryGetValue(textField, out _))
+            {
+                s_textFieldDefaults.Add(textField, new TextFieldDefaults(textField));
+            }
+        }
+
+        private sealed class TextFieldDefaults
+        {
+            public readonly bool IsPassword;
+            public readonly string Placeholder;
+            public readonly int MaxLength;
+            public readonly bool IsReadOnly;
+            public readonly bool IsDelayed;
+
+            public TextFieldDefaults(TextField textField)
+            {
+                IsPassword = textField.isPasswordField;
+                Placeholder = textField.textEdition.placeholder;
+                MaxLength = textField.maxLength;
+                IsReadOnly = textField.isReadOnly;
+                IsDelayed = textField.isDelayed;
+            }
+        }
+
+        private static readonly ConditionalWeakTable<TextField, TextFieldDefaults> s_textFieldDefaults = new();
 
         // Applies choices to DropdownField / RadioButtonGroup. A null Choices prop (or no settings at
         // all) resets the widget to an empty choice list instead of stranding a prior render's options,

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberPropApplier.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberPropApplier.cs
@@ -81,34 +81,37 @@ namespace Velvet
         {
             if (!s_focusableDefaults.TryGetValue(element, out _))
             {
-                s_focusableDefaults.Add(element, new FocusableDefault(element.focusable));
+                s_focusableDefaults.Add(element, new Recorded<bool>(element.focusable));
             }
         }
 
-        private sealed class FocusableDefault
+        // A box rather than a nullable field: "never recorded" has to stay distinguishable from the
+        // recorded value itself, and for a reference-typed member a nullable field cannot separate them.
+        private sealed class Recorded<T>
         {
-            public readonly bool Value;
+            public readonly T Value;
 
-            public FocusableDefault(bool value) => Value = value;
+            public Recorded(T value) => Value = value;
         }
 
-        private sealed class TabIndexDefault
+        private static readonly ConditionalWeakTable<VisualElement, Recorded<bool>> s_focusableDefaults = new();
+        private static readonly ConditionalWeakTable<VisualElement, Recorded<int>> s_tabIndexDefaults = new();
+        private static readonly ConditionalWeakTable<VisualElement, Recorded<bool>> s_delegatesFocusDefaults = new();
+
+        // A record belongs to one tenancy of an element, not to the element: the tree a pooled element serves
+        // next declared none of these props, so a record left over from the previous tenancy would restore
+        // that tenancy's reading over whatever the new one put there. Called from
+        // FiberElementCleaner.ReturnToPool, which is the single gate every poolable type passes through.
+        internal static void ForgetRecordedDefaults(VisualElement element)
         {
-            public readonly int Value;
-
-            public TabIndexDefault(int value) => Value = value;
+            s_focusableDefaults.Remove(element);
+            s_tabIndexDefaults.Remove(element);
+            s_delegatesFocusDefaults.Remove(element);
+            if (element is TextField textField)
+            {
+                s_textFieldDefaults.Remove(textField);
+            }
         }
-
-        private sealed class DelegatesFocusDefault
-        {
-            public readonly bool Value;
-
-            public DelegatesFocusDefault(bool value) => Value = value;
-        }
-
-        private static readonly ConditionalWeakTable<VisualElement, FocusableDefault> s_focusableDefaults = new();
-        private static readonly ConditionalWeakTable<VisualElement, TabIndexDefault> s_tabIndexDefaults = new();
-        private static readonly ConditionalWeakTable<VisualElement, DelegatesFocusDefault> s_delegatesFocusDefaults = new();
 
         // Same shape and same reason as ApplyFocusable: what an absent prop restores is the element's own
         // constructed value, which differs by type, so the 0 / false these coalesced to were another
@@ -151,7 +154,7 @@ namespace Velvet
         {
             if (!s_tabIndexDefaults.TryGetValue(element, out _))
             {
-                s_tabIndexDefaults.Add(element, new TabIndexDefault(element.tabIndex));
+                s_tabIndexDefaults.Add(element, new Recorded<int>(element.tabIndex));
             }
         }
 
@@ -159,7 +162,7 @@ namespace Velvet
         {
             if (!s_delegatesFocusDefaults.TryGetValue(element, out _))
             {
-                s_delegatesFocusDefaults.Add(element, new DelegatesFocusDefault(element.delegatesFocus));
+                s_delegatesFocusDefaults.Add(element, new Recorded<bool>(element.delegatesFocus));
             }
         }
 
@@ -201,11 +204,13 @@ namespace Velvet
             svEl.touchScrollBehavior = Resolve(settings?.TouchScrollBehavior, ScrollView.TouchScrollBehavior.Clamped);
         }
 
-        // Same recorded-default shape, and the same reason, as ApplyFocusable: a dropped member restores what
-        // this element was constructed with. The type guard below does not narrow that to one answer — it
-        // admits any subclass of TextField, which V.Custom<T> can name, and such a subclass may be built with
-        // a placeholder or a length limit no constant here could name. TextFieldInputPropTests measures the
-        // difference on one.
+        // Same recorded-default shape, and the same reason, as ApplyFocusable, with one record per member
+        // rather than one per element: a member no render has ever declared carries no record and is not
+        // written at all, so a value a refCallback assigned survives a re-render that redeclares only its
+        // neighbours. A member a render did declare and a later one dropped restores what this element was
+        // constructed with. The type guard below does not narrow that to one answer — it admits any subclass
+        // of TextField, which V.Custom<T> can name, and such a subclass may be built with a placeholder or a
+        // length limit no constant here could name. TextFieldInputPropTests measures both.
         public static void ApplyTextField(VisualElement element, TextFieldSettings? settings)
         {
             if (element is not TextField tfEl)
@@ -213,22 +218,87 @@ namespace Velvet
                 return;
             }
 
-            if (Declares(settings))
-            {
-                RecordTextFieldDefaults(tfEl);
-            }
-
-            // No record means no member was ever declared, so the field still carries its own defaults.
             if (!s_textFieldDefaults.TryGetValue(tfEl, out var built))
             {
-                return;
+                if (!Declares(settings))
+                {
+                    return;
+                }
+
+                built = new TextFieldDefaults();
+                s_textFieldDefaults.Add(tfEl, built);
             }
 
-            tfEl.isPasswordField = settings?.IsPassword ?? built.IsPassword;
-            tfEl.textEdition.placeholder = settings?.Placeholder ?? built.Placeholder;
-            tfEl.maxLength = settings?.MaxLength ?? built.MaxLength;
-            tfEl.isReadOnly = settings?.IsReadOnly ?? built.IsReadOnly;
-            tfEl.isDelayed = settings?.IsDelayed ?? built.IsDelayed;
+            ApplyPasswordFlag(tfEl, settings?.IsPassword, built);
+            ApplyPlaceholder(tfEl, settings?.Placeholder, built);
+            ApplyMaxLength(tfEl, settings?.MaxLength, built);
+            ApplyReadOnlyFlag(tfEl, settings?.IsReadOnly, built);
+            ApplyDelayedFlag(tfEl, settings?.IsDelayed, built);
+        }
+
+        private static void ApplyPasswordFlag(TextField field, bool? declared, TextFieldDefaults built)
+        {
+            if (declared is { } value)
+            {
+                built.IsPassword ??= new Recorded<bool>(field.isPasswordField);
+                field.isPasswordField = value;
+            }
+            else if (built.IsPassword != null)
+            {
+                field.isPasswordField = built.IsPassword.Value;
+            }
+        }
+
+        private static void ApplyPlaceholder(TextField field, string? declared, TextFieldDefaults built)
+        {
+            if (declared != null)
+            {
+                built.Placeholder ??= new Recorded<string>(field.textEdition.placeholder);
+                field.textEdition.placeholder = declared;
+            }
+            else if (built.Placeholder != null)
+            {
+                field.textEdition.placeholder = built.Placeholder.Value;
+            }
+        }
+
+        private static void ApplyMaxLength(TextField field, int? declared, TextFieldDefaults built)
+        {
+            if (declared is { } value)
+            {
+                built.MaxLength ??= new Recorded<int>(field.maxLength);
+                field.maxLength = value;
+            }
+            else if (built.MaxLength != null)
+            {
+                field.maxLength = built.MaxLength.Value;
+            }
+        }
+
+        private static void ApplyReadOnlyFlag(TextField field, bool? declared, TextFieldDefaults built)
+        {
+            if (declared is { } value)
+            {
+                built.IsReadOnly ??= new Recorded<bool>(field.isReadOnly);
+                field.isReadOnly = value;
+            }
+            else if (built.IsReadOnly != null)
+            {
+                field.isReadOnly = built.IsReadOnly.Value;
+            }
+        }
+
+        private static void ApplyDelayedFlag(TextField field, bool? declared, TextFieldDefaults built)
+        {
+            if (declared is { } value)
+            {
+                built.IsDelayed ??= new Recorded<bool>(field.isDelayed);
+                field.isDelayed = value;
+            }
+            else if (built.IsDelayed != null)
+            {
+                field.isDelayed = built.IsDelayed.Value;
+            }
         }
 
         private static bool Declares(TextFieldSettings? settings)
@@ -239,34 +309,13 @@ namespace Velvet
                    || settings.IsReadOnly.HasValue
                    || settings.IsDelayed.HasValue);
 
-        // One snapshot covers all five because it is taken before the prop path writes any of them. A writer
-        // outside that path owes this first, under the rule RecordFocusableDefault states; the pool's reset
-        // is the standing exception, writing back the constructed values PooledElementSurfaceResetTests
-        // compares it against, so a record taken before or after it reads the same.
-        internal static void RecordTextFieldDefaults(TextField textField)
-        {
-            if (!s_textFieldDefaults.TryGetValue(textField, out _))
-            {
-                s_textFieldDefaults.Add(textField, new TextFieldDefaults(textField));
-            }
-        }
-
         private sealed class TextFieldDefaults
         {
-            public readonly bool IsPassword;
-            public readonly string Placeholder;
-            public readonly int MaxLength;
-            public readonly bool IsReadOnly;
-            public readonly bool IsDelayed;
-
-            public TextFieldDefaults(TextField textField)
-            {
-                IsPassword = textField.isPasswordField;
-                Placeholder = textField.textEdition.placeholder;
-                MaxLength = textField.maxLength;
-                IsReadOnly = textField.isReadOnly;
-                IsDelayed = textField.isDelayed;
-            }
+            public Recorded<bool>? IsPassword;
+            public Recorded<string>? Placeholder;
+            public Recorded<int>? MaxLength;
+            public Recorded<bool>? IsReadOnly;
+            public Recorded<bool>? IsDelayed;
         }
 
         private static readonly ConditionalWeakTable<TextField, TextFieldDefaults> s_textFieldDefaults = new();

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberPropApplier.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberPropApplier.cs
@@ -98,9 +98,11 @@ namespace Velvet
         private static readonly ConditionalWeakTable<VisualElement, Recorded<int>> s_tabIndexDefaults = new();
         private static readonly ConditionalWeakTable<VisualElement, Recorded<bool>> s_delegatesFocusDefaults = new();
 
-        // A record belongs to one tenancy of an element, not to the element: the tree a pooled element serves
-        // next declared none of these props, so a record left over from the previous tenancy would restore
-        // that tenancy's reading over whatever the new one put there. Called from
+        // A record is the applier's claim on a member: while one stands, dropping the prop writes the
+        // recorded value back, and for a TextField so does redeclaring a neighbour, since the bag's presence
+        // is what admits the members this render left undeclared. Recording is idempotent, so the next
+        // tenancy's first declared write leaves a record the previous tenancy took — and the restore then
+        // puts that tenancy's reading over whatever this one wrote. Called from
         // FiberElementCleaner.ReturnToPool, which is the single gate every poolable type passes through.
         internal static void ForgetRecordedDefaults(VisualElement element)
         {

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ConstructedFocusDefaultTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ConstructedFocusDefaultTests.cs
@@ -6,11 +6,12 @@ namespace Velvet.Tests
     // A prop that stops being declared restores what the element was constructed with, not a constant.
     // Which constant would be wrong depends on the type, and the two values are pinned by the tuples
     // below rather than asserted anywhere in prose. No pool is involved: declaring the prop on one
-    // render and not the next is enough, through V.Custom<Label> or a Motion node over one.
+    // render and not the next is enough, through V.Custom<Label> or a Motion node over one. What a pool
+    // return does to the same records is the last three cases.
     internal sealed class ConstructedFocusDefaultTests
     {
         [Test]
-        public void Given_a_label_whose_declared_tab_index_is_dropped_When_the_prop_is_applied_Then_it_reads_the_one_it_was_built_with()
+        public void Given_ALabelWhoseDeclaredTabIndexIsDropped_When_ThePropIsApplied_Then_ItReadsTheOneItWasBuiltWith()
         {
             // Arrange
             var label = new Label();
@@ -26,7 +27,7 @@ namespace Velvet.Tests
         }
 
         [Test]
-        public void Given_a_field_whose_declared_focus_delegation_is_dropped_When_the_prop_is_applied_Then_it_reads_the_one_it_was_built_with()
+        public void Given_AFieldWhoseDeclaredFocusDelegationIsDropped_When_ThePropIsApplied_Then_ItReadsTheOneItWasBuiltWith()
         {
             // Arrange
             var field = new TextField();
@@ -42,7 +43,7 @@ namespace Velvet.Tests
         }
 
         [Test]
-        public void Given_a_label_that_never_declared_a_tab_index_When_the_absent_prop_is_applied_Then_nothing_is_written()
+        public void Given_ALabelThatNeverDeclaredATabIndex_When_TheAbsentPropIsApplied_Then_NothingIsWritten()
         {
             // Arrange
             var label = new Label();
@@ -55,7 +56,7 @@ namespace Velvet.Tests
         }
 
         [Test]
-        public void Given_a_field_that_never_declared_focus_delegation_When_the_absent_prop_is_applied_Then_nothing_is_written()
+        public void Given_AFieldThatNeverDeclaredFocusDelegation_When_TheAbsentPropIsApplied_Then_NothingIsWritten()
         {
             // Arrange
             var field = new TextField();
@@ -68,7 +69,7 @@ namespace Velvet.Tests
         }
 
         [Test]
-        public void Given_a_declared_value_written_twice_When_it_is_dropped_Then_the_record_is_the_first_reading_not_the_second()
+        public void Given_ADeclaredValueWrittenTwice_When_ItIsDropped_Then_TheRecordIsTheFirstReadingNotTheSecond()
         {
             // Arrange
             var label = new Label();
@@ -80,6 +81,54 @@ namespace Velvet.Tests
 
             // Assert
             Assert.That(label.tabIndex, Is.EqualTo(-1));
+        }
+
+        // The three below stand in for the pool cycle a record must not cross: the return drops the record,
+        // so what stands on the element afterwards is what an absent prop leaves alone. Each table is asked
+        // separately because dropping it is a line per table.
+        [Test]
+        public void Given_AFocusableRecordForgottenAsAtAPoolReturn_When_TheAbsentPropIsApplied_Then_TheStandingValueIsLeftAlone()
+        {
+            // Arrange
+            var element = new VisualElement { focusable = false };
+            FiberPropApplier.ApplyFocusable(element, true);
+            FiberPropApplier.ForgetRecordedDefaults(element);
+
+            // Act
+            FiberPropApplier.ApplyFocusable(element, null);
+
+            // Assert
+            Assert.That(element.focusable, Is.True);
+        }
+
+        [Test]
+        public void Given_ATabIndexRecordForgottenAsAtAPoolReturn_When_TheAbsentPropIsApplied_Then_TheStandingValueIsLeftAlone()
+        {
+            // Arrange
+            var label = new Label();
+            FiberPropApplier.ApplyTabIndex(label, 3);
+            FiberPropApplier.ForgetRecordedDefaults(label);
+
+            // Act
+            FiberPropApplier.ApplyTabIndex(label, null);
+
+            // Assert
+            Assert.That(label.tabIndex, Is.EqualTo(3));
+        }
+
+        [Test]
+        public void Given_AFocusDelegationRecordForgottenAsAtAPoolReturn_When_TheAbsentPropIsApplied_Then_TheStandingValueIsLeftAlone()
+        {
+            // Arrange
+            var field = new TextField();
+            FiberPropApplier.ApplyDelegatesFocus(field, false);
+            FiberPropApplier.ForgetRecordedDefaults(field);
+
+            // Act
+            FiberPropApplier.ApplyDelegatesFocus(field, null);
+
+            // Assert
+            Assert.That(field.delegatesFocus, Is.False);
         }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/DelayedFlagCommitReportTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/DelayedFlagCommitReportTests.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine.UIElements;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins that the edit a delayed field is holding is not merely written to <c>value</c> when a render
+    /// takes <c>isDelayed:</c> off, but REPORTED — the write goes through the notifying setter, so
+    /// <c>onValueChanged:</c> receives the pending text.
+    /// </summary>
+    /// <remarks>
+    /// A real panel is what separates the two: the setter dispatches only for an element with one, so a
+    /// detached root — which is what <c>TextFieldInputPropTests</c> reconciles into — cannot tell a
+    /// notifying write from a silent one. A panel also lets the ARRANGEMENT report, so each assertion
+    /// carries the count taken before the render as well as what arrived after it; without that term a
+    /// report the arrangement caused passes for the one the render owes, and the fixture then reads
+    /// backwards — green with the commit silenced and red with it working.
+    /// </remarks>
+    [TestFixture]
+    internal sealed class DelayedFlagCommitReportTests : PanelTestBase
+    {
+        private Reconciler _reconciler;
+        private VisualElement _root;
+
+        [SetUp]
+        public override void SetUp()
+        {
+            base.SetUp();
+            _reconciler = new Reconciler();
+            _root = new VisualElement();
+            _window.rootVisualElement.Add(_root);
+        }
+
+        [TearDown]
+        public override void TearDown()
+        {
+            _reconciler?.Dispose();
+            _reconciler = null;
+            _root = null;
+            base.TearDown();
+        }
+
+        [Test]
+        public void Given_AnEditADelayedFieldIsHolding_When_ALaterRenderDeclaresTheFlagFalse_Then_OnValueChangedReceivesIt()
+        {
+            // Arrange
+            var reported = new List<string>();
+            MountHoldingAnEdit(reported, out var oldTree);
+            var newTree = new VNode[] { V.TextField(onValueChanged: reported.Add, isDelayed: false) };
+            var whileHeld = reported.Count;
+
+            // Act
+            _reconciler.Reconcile(_root, oldTree, newTree);
+
+            // Assert
+            Assert.That((whileHeld, string.Join("|", reported)), Is.EqualTo((0, "typed")));
+        }
+
+        [Test]
+        public void Given_AnEditADelayedFieldIsHolding_When_ALaterRenderDropsTheFlag_Then_OnValueChangedReceivesIt()
+        {
+            // Arrange
+            var reported = new List<string>();
+            MountHoldingAnEdit(reported, out var oldTree);
+            var newTree = new VNode[] { V.TextField(onValueChanged: reported.Add) };
+            var whileHeld = reported.Count;
+
+            // Act
+            _reconciler.Reconcile(_root, oldTree, newTree);
+
+            // Assert
+            Assert.That((whileHeld, string.Join("|", reported)), Is.EqualTo((0, "typed")));
+        }
+
+        // The state a delayed field is in mid-edit: text on the inner element, a value that has not
+        // received it. Written without notifying, which is what typing does — ITextEdition.UpdateText
+        // sends an InputEvent and sets the text silently. The notifying setter TextFieldInputPropTests
+        // can use on a detached root would fire onValueChanged here, from the arrangement, and this
+        // fixture would then measure a report no render made.
+        private void MountHoldingAnEdit(List<string> reported, out VNode[] oldTree)
+        {
+            oldTree = new VNode[] { V.TextField(onValueChanged: reported.Add, isDelayed: true) };
+            _reconciler.Reconcile(_root, Array.Empty<VNode>(), oldTree);
+            var element = (TextField)_root.ElementAt(0);
+            ((INotifyValueChanged<string>)(TextElement)element.textEdition).SetValueWithoutNotify("typed");
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/DelayedFlagCommitReportTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/DelayedFlagCommitReportTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8e6ccd07546774bc4b1c9e01344fea5b

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/TextFieldInputPropTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/TextFieldInputPropTests.cs
@@ -14,6 +14,9 @@ namespace Velvet.Tests
     /// <item>Each, once dropped by a later render, restores what the element was constructed with. The
     /// drops are measured on a subclass built away from every default, so an implementation coalescing
     /// to UI Toolkit's own constants fails them.</item>
+    /// <item>A member no render has declared — including the password flag, which predates the other
+    /// four — is left where a <c>refCallback:</c> put it when a later render redeclares its
+    /// neighbours.</item>
     /// </list>
     /// </summary>
     [TestFixture]
@@ -36,7 +39,7 @@ namespace Velvet.Tests
         }
 
         [Test]
-        public void Given_a_declared_placeholder_When_the_field_is_reconciled_Then_the_element_shows_it()
+        public void Given_ADeclaredPlaceholder_When_TheFieldIsReconciled_Then_TheElementCarriesIt()
         {
             // Arrange
             var tree = new VNode[] { V.TextField(placeholder: "Search") };
@@ -49,7 +52,7 @@ namespace Velvet.Tests
         }
 
         [Test]
-        public void Given_a_declared_max_length_When_the_field_is_reconciled_Then_the_element_carries_it()
+        public void Given_ADeclaredMaxLength_When_TheFieldIsReconciled_Then_TheElementCarriesIt()
         {
             // Arrange
             var tree = new VNode[] { V.TextField(maxLength: 12) };
@@ -62,7 +65,7 @@ namespace Velvet.Tests
         }
 
         [Test]
-        public void Given_a_declared_read_only_flag_When_the_field_is_reconciled_Then_the_element_refuses_edits()
+        public void Given_ADeclaredReadOnlyFlag_When_TheFieldIsReconciled_Then_TheElementCarriesIt()
         {
             // Arrange
             var tree = new VNode[] { V.TextField(isReadOnly: true) };
@@ -75,7 +78,7 @@ namespace Velvet.Tests
         }
 
         [Test]
-        public void Given_a_declared_delayed_flag_When_the_field_is_reconciled_Then_the_element_commits_on_blur()
+        public void Given_ADeclaredDelayedFlag_When_TheFieldIsReconciled_Then_TheElementCarriesIt()
         {
             // Arrange
             var tree = new VNode[] { V.TextField(isDelayed: true) };
@@ -88,7 +91,7 @@ namespace Velvet.Tests
         }
 
         [Test]
-        public void Given_a_placeholder_declared_empty_When_the_field_is_reconciled_Then_the_element_shows_no_hint()
+        public void Given_APlaceholderDeclaredEmpty_When_TheFieldIsReconciled_Then_TheElementCarriesAnEmptyOne()
         {
             // Arrange — an empty string is a declared empty hint, not an absent one, so it has to reach a
             // field built with a hint of its own and clear it.
@@ -108,7 +111,7 @@ namespace Velvet.Tests
         }
 
         [Test]
-        public void Given_a_declared_placeholder_When_a_later_render_drops_it_Then_the_element_reads_the_one_it_was_built_with()
+        public void Given_ADeclaredPlaceholder_When_ALaterRenderDropsIt_Then_TheElementReadsTheOneItWasBuiltWith()
         {
             // Arrange
             var oldTree = new VNode[]
@@ -134,7 +137,7 @@ namespace Velvet.Tests
         }
 
         [Test]
-        public void Given_a_declared_max_length_When_a_later_render_drops_it_Then_the_element_reads_the_one_it_was_built_with()
+        public void Given_ADeclaredMaxLength_When_ALaterRenderDropsIt_Then_TheElementReadsTheOneItWasBuiltWith()
         {
             // Arrange
             var oldTree = new VNode[]
@@ -159,7 +162,7 @@ namespace Velvet.Tests
         }
 
         [Test]
-        public void Given_a_declared_read_only_flag_When_a_later_render_drops_it_Then_the_element_reads_the_one_it_was_built_with()
+        public void Given_ADeclaredReadOnlyFlag_When_ALaterRenderDropsIt_Then_TheElementReadsTheOneItWasBuiltWith()
         {
             // Arrange
             var oldTree = new VNode[]
@@ -184,7 +187,7 @@ namespace Velvet.Tests
         }
 
         [Test]
-        public void Given_a_declared_delayed_flag_When_a_later_render_drops_it_Then_the_element_reads_the_one_it_was_built_with()
+        public void Given_ADeclaredDelayedFlag_When_ALaterRenderDropsIt_Then_TheElementReadsTheOneItWasBuiltWith()
         {
             // Arrange
             var oldTree = new VNode[]
@@ -209,7 +212,7 @@ namespace Velvet.Tests
         }
 
         [Test]
-        public void Given_a_field_that_never_declared_any_of_them_When_absent_settings_are_applied_Then_nothing_is_written()
+        public void Given_AFieldThatNeverDeclaredAnyOfThem_When_AbsentSettingsAreApplied_Then_NothingIsWritten()
         {
             // Arrange
             var field = new PrefilledTextField();
@@ -221,6 +224,157 @@ namespace Velvet.Tests
             Assert.That(
                 (field.textEdition.placeholder, field.maxLength, field.isReadOnly, field.isDelayed),
                 Is.EqualTo((PrefilledTextField.BuiltPlaceholder, PrefilledTextField.BuiltMaxLength, true, true)));
+        }
+
+        // The five below share one sequence: a render declares one member, the refCallback — which the
+        // create path invokes after applying props, so the record is taken before it — assigns another, and
+        // a second render redeclares only the first. The undeclared member is nobody's to write, so it has
+        // to survive. One callback instance stands in both trees, so the patch does not re-run it
+        // (ReconcilerContext.InvokeRefCallback's identity skip) and a second assignment cannot stand in for
+        // a survival.
+        [Test]
+        public void Given_APasswordFlagWrittenFromARefCallback_When_ALaterRenderRedeclaresThePlaceholder_Then_TheFlagSurvives()
+        {
+            // Arrange
+            Func<VisualElement, Action> setFlag = el =>
+            {
+                ((TextField)el).isPasswordField = true;
+                return () => { };
+            };
+            var oldTree = new VNode[] { V.TextField(placeholder: "Search", refCallback: setFlag) };
+            var newTree = new VNode[] { V.TextField(placeholder: "Find", refCallback: setFlag) };
+            Reconciler.Reconcile(Root, Array.Empty<VNode>(), oldTree);
+            var element = (TextField)Root!.ElementAt(0);
+
+            // Act
+            Reconciler.Reconcile(Root, oldTree, newTree);
+
+            // Assert — the identity term separates a survival from a remount, whose fresh element would
+            // run the callback again and read true however the applier behaved.
+            Assert.That(
+                (ReferenceEquals(Root!.ElementAt(0), element), element.isPasswordField),
+                Is.EqualTo((true, true)));
+        }
+
+        [Test]
+        public void Given_APlaceholderWrittenFromARefCallback_When_ALaterRenderRedeclaresTheMaxLength_Then_TheHintSurvives()
+        {
+            // Arrange
+            Func<VisualElement, Action> setHint = el =>
+            {
+                ((TextField)el).textEdition.placeholder = "from ref";
+                return () => { };
+            };
+            var oldTree = new VNode[] { V.TextField(maxLength: 12, refCallback: setHint) };
+            var newTree = new VNode[] { V.TextField(maxLength: 13, refCallback: setHint) };
+            Reconciler.Reconcile(Root, Array.Empty<VNode>(), oldTree);
+            var element = (TextField)Root!.ElementAt(0);
+
+            // Act
+            Reconciler.Reconcile(Root, oldTree, newTree);
+
+            // Assert — same identity term, and for the same reason.
+            Assert.That(
+                (ReferenceEquals(Root!.ElementAt(0), element), element.textEdition.placeholder),
+                Is.EqualTo((true, "from ref")));
+        }
+
+        [Test]
+        public void Given_AMaxLengthWrittenFromARefCallback_When_ALaterRenderRedeclaresThePlaceholder_Then_TheLimitSurvives()
+        {
+            // Arrange
+            Func<VisualElement, Action> setLimit = el =>
+            {
+                ((TextField)el).maxLength = 4;
+                return () => { };
+            };
+            var oldTree = new VNode[] { V.TextField(placeholder: "Search", refCallback: setLimit) };
+            var newTree = new VNode[] { V.TextField(placeholder: "Find", refCallback: setLimit) };
+            Reconciler.Reconcile(Root, Array.Empty<VNode>(), oldTree);
+            var element = (TextField)Root!.ElementAt(0);
+
+            // Act
+            Reconciler.Reconcile(Root, oldTree, newTree);
+
+            // Assert — same identity term, and for the same reason.
+            Assert.That(
+                (ReferenceEquals(Root!.ElementAt(0), element), element.maxLength),
+                Is.EqualTo((true, 4)));
+        }
+
+        [Test]
+        public void Given_AReadOnlyFlagWrittenFromARefCallback_When_ALaterRenderRedeclaresThePlaceholder_Then_TheFlagSurvives()
+        {
+            // Arrange
+            Func<VisualElement, Action> setFlag = el =>
+            {
+                ((TextField)el).isReadOnly = true;
+                return () => { };
+            };
+            var oldTree = new VNode[] { V.TextField(placeholder: "Search", refCallback: setFlag) };
+            var newTree = new VNode[] { V.TextField(placeholder: "Find", refCallback: setFlag) };
+            Reconciler.Reconcile(Root, Array.Empty<VNode>(), oldTree);
+            var element = (TextField)Root!.ElementAt(0);
+
+            // Act
+            Reconciler.Reconcile(Root, oldTree, newTree);
+
+            // Assert — same identity term, and for the same reason.
+            Assert.That(
+                (ReferenceEquals(Root!.ElementAt(0), element), element.isReadOnly),
+                Is.EqualTo((true, true)));
+        }
+
+        [Test]
+        public void Given_ADelayedFlagWrittenFromARefCallback_When_ALaterRenderRedeclaresThePlaceholder_Then_TheFlagSurvives()
+        {
+            // Arrange
+            Func<VisualElement, Action> setFlag = el =>
+            {
+                ((TextField)el).isDelayed = true;
+                return () => { };
+            };
+            var oldTree = new VNode[] { V.TextField(placeholder: "Search", refCallback: setFlag) };
+            var newTree = new VNode[] { V.TextField(placeholder: "Find", refCallback: setFlag) };
+            Reconciler.Reconcile(Root, Array.Empty<VNode>(), oldTree);
+            var element = (TextField)Root!.ElementAt(0);
+
+            // Act
+            Reconciler.Reconcile(Root, oldTree, newTree);
+
+            // Assert — same identity term, and for the same reason.
+            Assert.That(
+                (ReferenceEquals(Root!.ElementAt(0), element), element.isDelayed),
+                Is.EqualTo((true, true)));
+        }
+
+        [Test]
+        public void Given_APooledFieldWhoseLastTenantDeclaredAPlaceholder_When_ItsNextTenantWritesOneFromARefCallback_Then_TheHintSurvives()
+        {
+            // Arrange — the first tenancy records a placeholder default and then unmounts, which is what
+            // hands the element to the shared pool; the second declares only the length limit.
+            var declaring = new VNode[] { V.TextField(placeholder: "previous tenant") };
+            Reconciler.Reconcile(Root, Array.Empty<VNode>(), declaring);
+            var pooled = (TextField)Root!.ElementAt(0);
+            Reconciler.Reconcile(Root, declaring, Array.Empty<VNode>());
+            Func<VisualElement, Action> setHint = el =>
+            {
+                ((TextField)el).textEdition.placeholder = "from ref";
+                return () => { };
+            };
+            var oldTree = new VNode[] { V.TextField(maxLength: 12, refCallback: setHint) };
+            var newTree = new VNode[] { V.TextField(maxLength: 13, refCallback: setHint) };
+            Reconciler.Reconcile(Root, Array.Empty<VNode>(), oldTree);
+
+            // Act
+            Reconciler.Reconcile(Root, oldTree, newTree);
+
+            // Assert — the identity term is what makes this a reading of the recycled element; a fresh one
+            // would carry no record from either tenancy and satisfy the hint on its own.
+            Assert.That(
+                (ReferenceEquals(Root!.ElementAt(0), pooled),
+                    ((TextField)Root!.ElementAt(0)).textEdition.placeholder),
+                Is.EqualTo((true, "from ref")));
         }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/TextFieldInputPropTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/TextFieldInputPropTests.cs
@@ -64,6 +64,41 @@ namespace Velvet.Tests
             Assert.That(((TextField)Root!.ElementAt(0)).maxLength, Is.EqualTo(12));
         }
 
+        // The limit is written through TextField's own maxLength. Writing textEdition.maxLength instead
+        // was rejected: it clips the displayed text when the limit narrows and leaves it clipped when the
+        // limit widens again, and restoring a dropped limit is a widening whenever the element was built
+        // with a looser one than the render declared — so that spelling strands the field showing a
+        // truncated value. This is the reading that separates the two.
+        [Test]
+        public void Given_AMaxLengthThatClippedTheValue_When_ALaterRenderDropsIt_Then_TheClippedCharactersComeBack()
+        {
+            // Arrange
+            var oldTree = new VNode[]
+            {
+                V.Custom<PrefilledTextField>(props: new FiberElementProps
+                {
+                    FieldValue = "abcdefgh",
+                    TextField = new TextFieldSettings(MaxLength: 3),
+                }),
+            };
+            var newTree = new VNode[]
+            {
+                V.Custom<PrefilledTextField>(props: new FiberElementProps { FieldValue = "abcdefgh" }),
+            };
+            Reconciler.Reconcile(Root, Array.Empty<VNode>(), oldTree);
+            var element = (TextField)Root!.ElementAt(0);
+            var whileClipped = element.Q<TextElement>()!.text;
+
+            // Act
+            Reconciler.Reconcile(Root, oldTree, newTree);
+
+            // Assert — the clipped reading is folded in because the restored one alone is what an
+            // implementation that never clipped in the first place would also produce.
+            Assert.That(
+                (whileClipped, element.Q<TextElement>()!.text),
+                Is.EqualTo(("abc", "abcdefgh")));
+        }
+
         [Test]
         public void Given_ADeclaredReadOnlyFlag_When_TheFieldIsReconciled_Then_TheElementCarriesIt()
         {

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/TextFieldInputPropTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/TextFieldInputPropTests.cs
@@ -17,6 +17,8 @@ namespace Velvet.Tests
     /// <item>A member no render has declared — including the password flag, which predates the other
     /// four — is left where a <c>refCallback:</c> put it when a later render redeclares its
     /// neighbours.</item>
+    /// <item>An edit a delayed field is still holding reaches the value before the flag comes off,
+    /// whichever render takes it off.</item>
     /// </list>
     /// </summary>
     [TestFixture]
@@ -244,6 +246,44 @@ namespace Velvet.Tests
             Assert.That(
                 (ReferenceEquals(Root!.ElementAt(0), element), whileDeclared, element.isDelayed),
                 Is.EqualTo((true, false, true)));
+        }
+
+        // The two below arrange the state a delayed field is in mid-edit — text on the inner element, a
+        // value that has not received it — and ask what the flag coming off does with it. Both routes out of
+        // the flag are asked: a render redeclaring it false, and a render dropping it onto a constructed
+        // default of false.
+        [Test]
+        public void Given_AnEditTheDelayedFieldHasNotCommitted_When_ALaterRenderDeclaresTheFlagFalse_Then_TheValueReceivesIt()
+        {
+            // Arrange
+            var oldTree = new VNode[] { V.TextField(isDelayed: true) };
+            var newTree = new VNode[] { V.TextField(isDelayed: false) };
+            Reconciler.Reconcile(Root, Array.Empty<VNode>(), oldTree);
+            var element = (TextField)Root!.ElementAt(0);
+            ((TextElement)element.textEdition).text = "typed";
+
+            // Act
+            Reconciler.Reconcile(Root, oldTree, newTree);
+
+            // Assert
+            Assert.That(element.value, Is.EqualTo("typed"));
+        }
+
+        [Test]
+        public void Given_AnEditTheDelayedFieldHasNotCommitted_When_ALaterRenderDropsTheFlag_Then_TheValueReceivesIt()
+        {
+            // Arrange
+            var oldTree = new VNode[] { V.TextField(isDelayed: true) };
+            var newTree = new VNode[] { V.TextField() };
+            Reconciler.Reconcile(Root, Array.Empty<VNode>(), oldTree);
+            var element = (TextField)Root!.ElementAt(0);
+            ((TextElement)element.textEdition).text = "typed";
+
+            // Act
+            Reconciler.Reconcile(Root, oldTree, newTree);
+
+            // Assert
+            Assert.That(element.value, Is.EqualTo("typed"));
         }
 
         [Test]

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/TextFieldInputPropTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/TextFieldInputPropTests.cs
@@ -1,0 +1,226 @@
+using System;
+using NUnit.Framework;
+using UnityEngine.UIElements;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Specifies the four text-input props <c>V.TextField</c> declares beyond the password flag —
+    /// placeholder, maxLength, isReadOnly, isDelayed.
+    /// <list type="bullet">
+    /// <item>Each reaches the element through a reconcile of the factory's node, not only through a
+    /// direct applier call.</item>
+    /// <item>Each, once dropped by a later render, restores what the element was constructed with. The
+    /// drops are measured on a subclass built away from every default, so an implementation coalescing
+    /// to UI Toolkit's own constants fails them.</item>
+    /// </list>
+    /// </summary>
+    [TestFixture]
+    internal sealed class TextFieldInputPropTests : ReconcilerTestFixture
+    {
+        // Built away from TextField's own defaults on all four members, so the value a drop must restore
+        // differs from the constant an implementation would otherwise coalesce to.
+        internal sealed class PrefilledTextField : TextField
+        {
+            public const string BuiltPlaceholder = "built-in hint";
+            public const int BuiltMaxLength = 8;
+
+            public PrefilledTextField()
+            {
+                textEdition.placeholder = BuiltPlaceholder;
+                maxLength = BuiltMaxLength;
+                isReadOnly = true;
+                isDelayed = true;
+            }
+        }
+
+        [Test]
+        public void Given_a_declared_placeholder_When_the_field_is_reconciled_Then_the_element_shows_it()
+        {
+            // Arrange
+            var tree = new VNode[] { V.TextField(placeholder: "Search") };
+
+            // Act
+            Reconciler.Reconcile(Root, Array.Empty<VNode>(), tree);
+
+            // Assert
+            Assert.That(((TextField)Root!.ElementAt(0)).textEdition.placeholder, Is.EqualTo("Search"));
+        }
+
+        [Test]
+        public void Given_a_declared_max_length_When_the_field_is_reconciled_Then_the_element_carries_it()
+        {
+            // Arrange
+            var tree = new VNode[] { V.TextField(maxLength: 12) };
+
+            // Act
+            Reconciler.Reconcile(Root, Array.Empty<VNode>(), tree);
+
+            // Assert
+            Assert.That(((TextField)Root!.ElementAt(0)).maxLength, Is.EqualTo(12));
+        }
+
+        [Test]
+        public void Given_a_declared_read_only_flag_When_the_field_is_reconciled_Then_the_element_refuses_edits()
+        {
+            // Arrange
+            var tree = new VNode[] { V.TextField(isReadOnly: true) };
+
+            // Act
+            Reconciler.Reconcile(Root, Array.Empty<VNode>(), tree);
+
+            // Assert
+            Assert.That(((TextField)Root!.ElementAt(0)).isReadOnly, Is.True);
+        }
+
+        [Test]
+        public void Given_a_declared_delayed_flag_When_the_field_is_reconciled_Then_the_element_commits_on_blur()
+        {
+            // Arrange
+            var tree = new VNode[] { V.TextField(isDelayed: true) };
+
+            // Act
+            Reconciler.Reconcile(Root, Array.Empty<VNode>(), tree);
+
+            // Assert
+            Assert.That(((TextField)Root!.ElementAt(0)).isDelayed, Is.True);
+        }
+
+        [Test]
+        public void Given_a_placeholder_declared_empty_When_the_field_is_reconciled_Then_the_element_shows_no_hint()
+        {
+            // Arrange — an empty string is a declared empty hint, not an absent one, so it has to reach a
+            // field built with a hint of its own and clear it.
+            var tree = new VNode[]
+            {
+                V.Custom<PrefilledTextField>(props: new FiberElementProps
+                {
+                    TextField = new TextFieldSettings(Placeholder: string.Empty),
+                }),
+            };
+
+            // Act
+            Reconciler.Reconcile(Root, Array.Empty<VNode>(), tree);
+
+            // Assert
+            Assert.That(((TextField)Root!.ElementAt(0)).textEdition.placeholder, Is.Empty);
+        }
+
+        [Test]
+        public void Given_a_declared_placeholder_When_a_later_render_drops_it_Then_the_element_reads_the_one_it_was_built_with()
+        {
+            // Arrange
+            var oldTree = new VNode[]
+            {
+                V.Custom<PrefilledTextField>(props: new FiberElementProps
+                {
+                    TextField = new TextFieldSettings(Placeholder: "declared"),
+                }),
+            };
+            var newTree = new VNode[] { V.Custom<PrefilledTextField>() };
+            Reconciler.Reconcile(Root, Array.Empty<VNode>(), oldTree);
+            var element = (TextField)Root!.ElementAt(0);
+            var whileDeclared = element.textEdition.placeholder;
+
+            // Act
+            Reconciler.Reconcile(Root, oldTree, newTree);
+
+            // Assert — the identity term separates a restore from a remount, which would satisfy the
+            // reading while the tree holds a different element.
+            Assert.That(
+                (ReferenceEquals(Root!.ElementAt(0), element), whileDeclared, element.textEdition.placeholder),
+                Is.EqualTo((true, "declared", PrefilledTextField.BuiltPlaceholder)));
+        }
+
+        [Test]
+        public void Given_a_declared_max_length_When_a_later_render_drops_it_Then_the_element_reads_the_one_it_was_built_with()
+        {
+            // Arrange
+            var oldTree = new VNode[]
+            {
+                V.Custom<PrefilledTextField>(props: new FiberElementProps
+                {
+                    TextField = new TextFieldSettings(MaxLength: 3),
+                }),
+            };
+            var newTree = new VNode[] { V.Custom<PrefilledTextField>() };
+            Reconciler.Reconcile(Root, Array.Empty<VNode>(), oldTree);
+            var element = (TextField)Root!.ElementAt(0);
+            var whileDeclared = element.maxLength;
+
+            // Act
+            Reconciler.Reconcile(Root, oldTree, newTree);
+
+            // Assert — same identity term, and for the same reason.
+            Assert.That(
+                (ReferenceEquals(Root!.ElementAt(0), element), whileDeclared, element.maxLength),
+                Is.EqualTo((true, 3, PrefilledTextField.BuiltMaxLength)));
+        }
+
+        [Test]
+        public void Given_a_declared_read_only_flag_When_a_later_render_drops_it_Then_the_element_reads_the_one_it_was_built_with()
+        {
+            // Arrange
+            var oldTree = new VNode[]
+            {
+                V.Custom<PrefilledTextField>(props: new FiberElementProps
+                {
+                    TextField = new TextFieldSettings(IsReadOnly: false),
+                }),
+            };
+            var newTree = new VNode[] { V.Custom<PrefilledTextField>() };
+            Reconciler.Reconcile(Root, Array.Empty<VNode>(), oldTree);
+            var element = (TextField)Root!.ElementAt(0);
+            var whileDeclared = element.isReadOnly;
+
+            // Act
+            Reconciler.Reconcile(Root, oldTree, newTree);
+
+            // Assert — same identity term, and for the same reason.
+            Assert.That(
+                (ReferenceEquals(Root!.ElementAt(0), element), whileDeclared, element.isReadOnly),
+                Is.EqualTo((true, false, true)));
+        }
+
+        [Test]
+        public void Given_a_declared_delayed_flag_When_a_later_render_drops_it_Then_the_element_reads_the_one_it_was_built_with()
+        {
+            // Arrange
+            var oldTree = new VNode[]
+            {
+                V.Custom<PrefilledTextField>(props: new FiberElementProps
+                {
+                    TextField = new TextFieldSettings(IsDelayed: false),
+                }),
+            };
+            var newTree = new VNode[] { V.Custom<PrefilledTextField>() };
+            Reconciler.Reconcile(Root, Array.Empty<VNode>(), oldTree);
+            var element = (TextField)Root!.ElementAt(0);
+            var whileDeclared = element.isDelayed;
+
+            // Act
+            Reconciler.Reconcile(Root, oldTree, newTree);
+
+            // Assert — same identity term, and for the same reason.
+            Assert.That(
+                (ReferenceEquals(Root!.ElementAt(0), element), whileDeclared, element.isDelayed),
+                Is.EqualTo((true, false, true)));
+        }
+
+        [Test]
+        public void Given_a_field_that_never_declared_any_of_them_When_absent_settings_are_applied_Then_nothing_is_written()
+        {
+            // Arrange
+            var field = new PrefilledTextField();
+
+            // Act
+            FiberPropApplier.ApplyTextField(field, null);
+
+            // Assert
+            Assert.That(
+                (field.textEdition.placeholder, field.maxLength, field.isReadOnly, field.isDelayed),
+                Is.EqualTo((PrefilledTextField.BuiltPlaceholder, PrefilledTextField.BuiltMaxLength, true, true)));
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/TextFieldInputPropTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/TextFieldInputPropTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 472b5277e816f47e2929ce8e1f74ffa2


### PR DESCRIPTION
Closes part of #432 — the four knobs that map one-to-one onto HTML input attributes. The TextArea / `inputMode` / extra-events half is still a design question and stays in the issue.

`V.TextField` exposed one knob of UI Toolkit's text-input surface. `placeholder`, `maxLength`, `readOnly` and `isDelayed` are the four with no naming ambiguity, and each is reachable today only by dropping to `V.Custom<TextField>` and mutating the element.

A prop a later render stops declaring restores what the element was constructed with rather than a constant, through the `ConditionalWeakTable` recorded-default shape `ApplyFocusable` established — the defect PR #578 fixed, not repeated.

No pool change was needed: all four are already scrubbed by `FiberPrimitiveElementPool`'s TextField reset, which PR #576 derived from the whole writable surface rather than from a list of props.

EditMode 3787/3787.