### PR TITLE
tooling(velvet): refuse rather than allow where a guard cannot read what it judges

### DIFF
--- a/.claude/hooks/refuse/background_relative_path.py
+++ b/.claude/hooks/refuse/background_relative_path.py
@@ -34,6 +34,9 @@ HOOK_TOOLS = {"Bash"}
 UNEXPANDED_POLICY = "allow"
 UNEXPANDED_PROBE = 'python3 $DIR/scripts/pr/settle.py watch'
 
+UNREADABLE_POLICY = "none"
+UNREADABLE_PROBE = {"command": "python3 scripts/pr/settle.py watch", "run_in_background": True}
+
 # The repository's own top-level directories, which a command reaching one of them relatively is
 # reaching through the session's directory rather than through a stated one. Derived from the
 # checkout so a directory added later is covered by existing.

--- a/.claude/hooks/refuse/blind_git_add.py
+++ b/.claude/hooks/refuse/blind_git_add.py
@@ -37,6 +37,9 @@ HOOK_TOOLS = {"Bash"}
 UNEXPANDED_POLICY = "allow"
 UNEXPANDED_PROBE = 'git add $FILES'
 
+UNREADABLE_POLICY = "refuse"
+UNREADABLE_PROBE = {"command": "git add -A"}
+
 SWEEPING = {"-A", "--all", "--no-ignore-removal", ".", ":/", "*"}
 
 

--- a/.claude/hooks/refuse/branch_from_unmerged.py
+++ b/.claude/hooks/refuse/branch_from_unmerged.py
@@ -115,6 +115,9 @@ def creations(command):
 UNEXPANDED_POLICY = "refuse"
 UNEXPANDED_PROBE = 'git -C "$D" branch feat/x'
 
+UNREADABLE_POLICY = "refuse"
+UNREADABLE_PROBE = {"command": "git branch tooling/probe"}
+
 
 def git(cwd, *args):
     return subprocess.run(

--- a/.claude/hooks/refuse/changelog_into_closed_version.py
+++ b/.claude/hooks/refuse/changelog_into_closed_version.py
@@ -141,6 +141,15 @@ def in_scope(path, cwd):
 # unexpanded.
 UNEXPANDED_POLICY = "n/a"
 
+# The probe's anchor is a released heading, which is the one line this guard's whole premise says
+# nobody edits.
+UNREADABLE_POLICY = "refuse"
+UNREADABLE_PROBE = {
+    "file_path": "Packages/com.velvet.core/CHANGELOG.md",
+    "old_string": "## [2.0.0] - 2026-08-02\n",
+    "new_string": "## [2.0.0] - 2026-08-02\n\n- an entry nobody released\n",
+}
+
 
 def main():
     try:

--- a/.claude/hooks/refuse/commit_failing_fast_checks.py
+++ b/.claude/hooks/refuse/commit_failing_fast_checks.py
@@ -41,19 +41,38 @@ COMMIT_ALL_FLAGS = {"-a", "--all"}
 UNEXPANDED_POLICY = "refuse"
 UNEXPANDED_PROBE = 'git commit -m x $PATHS'
 
+UNREADABLE_POLICY = "refuse"
+UNREADABLE_PROBE = {"command": "git commit -m probe"}
+
+
+# What a reading that did not answer resolves to. Every reader below otherwise reports it as an
+# empty result, and an empty result is "this commit records nothing that could fail a check".
+UNREADABLE = object()
+
 
 def git(cwd, *args):
-    return subprocess.run(["git", "-C", cwd, *args], capture_output=True, text=True, timeout=30)
+    """A finished `git`, or None when it could not be run at all.
+
+    Same reason `lib/repository.py` answers None rather than raising: a hook that raises exits 1,
+    and 1 lets the tool through.
+    """
+    try:
+        return subprocess.run(["git", "-C", cwd, *args], capture_output=True, text=True, timeout=30)
+    except (OSError, subprocess.SubprocessError):
+        return None
 
 
 def git_bytes(cwd, *args):
-    result = subprocess.run(["git", "-C", cwd, *args], capture_output=True, timeout=30)
+    try:
+        result = subprocess.run(["git", "-C", cwd, *args], capture_output=True, timeout=30)
+    except (OSError, subprocess.SubprocessError):
+        return None
     return result.stdout if result.returncode == 0 else None
 
 
 def repo_root(cwd):
     result = git(cwd, "rev-parse", "--show-toplevel")
-    return result.stdout.strip() if result.returncode == 0 else cwd
+    return result.stdout.strip() if result and result.returncode == 0 else cwd
 
 
 def commit_invocations(command):
@@ -102,8 +121,8 @@ def staged_paths(cwd):
     # R is included: a rename reports it, and dropping it left a file renamed and broken in one
     # staged change checked by nothing.
     result = git(cwd, "diff", "--cached", "--name-only", "--diff-filter=ACMR")
-    if result.returncode != 0:
-        return []
+    if result is None or result.returncode != 0:
+        return UNREADABLE
     return [line for line in result.stdout.splitlines() if line.strip()]
 
 
@@ -112,20 +131,27 @@ def worktree_paths(cwd, pathspecs):
     if pathspecs:
         args += ["--", *pathspecs]
     result = git(cwd, *args)
-    if result.returncode != 0:
-        return []
+    if result is None or result.returncode != 0:
+        return UNREADABLE
     return [line for line in result.stdout.splitlines() if line.strip()]
 
 
 def committed_content(cwd, commits_all, pathspecs):
-    """path -> bytes the commit would record."""
+    """path -> bytes the commit would record, or UNREADABLE when git did not answer."""
+    staged = staged_paths(cwd)
+    if staged is UNREADABLE:
+        return UNREADABLE
     content = {}
-    for path in staged_paths(cwd):
+    for path in staged:
         blob = git_bytes(cwd, "show", ":" + path)
-        if blob is not None:
-            content[path] = blob
+        if blob is None:
+            return UNREADABLE
+        content[path] = blob
     if commits_all or pathspecs:
-        for path in worktree_paths(cwd, pathspecs):
+        worktree = worktree_paths(cwd, pathspecs)
+        if worktree is UNREADABLE:
+            return UNREADABLE
+        for path in worktree:
             try:
                 with open(os.path.join(cwd, path), "rb") as handle:
                     content[path] = handle.read()
@@ -259,6 +285,13 @@ def carried_neuters(content, edits):
 def audit(cwd, commits_all, pathspecs):
     root = repo_root(cwd)
     content = committed_content(root, commits_all, pathspecs)
+    if content is UNREADABLE:
+        sys.stderr.write(
+            "Refusing `git commit`: what this commit would record could not be read.\n\n"
+            "Every check below reads that content, so they would all run over nothing and pass, and "
+            "the commit would be recorded with none of them having seen it.\n\n"
+            "Retry when git answers.\n")
+        return 2
     if not content:
         return 0
 

--- a/.claude/hooks/refuse/edit_while_a_ready_pr_sits.py
+++ b/.claude/hooks/refuse/edit_while_a_ready_pr_sits.py
@@ -31,6 +31,9 @@ from deferrals import DEFERRALS, deferred, unusable
 # for the shell to expand and nothing here reads one.
 UNEXPANDED_POLICY = "n/a"
 
+UNREADABLE_POLICY = "none"
+UNREADABLE_PROBE = {"file_path": "CHANGELOG.md", "old_string": "a", "new_string": "b"}
+
 READY_STATE = Path.home() / ".velvet-pr-ready"
 HEARTBEAT = Path.home() / ".velvet-pr-watch.heartbeat"
 

--- a/.claude/hooks/refuse/merge_branch_held_by_worktree.py
+++ b/.claude/hooks/refuse/merge_branch_held_by_worktree.py
@@ -33,13 +33,24 @@ HOOK_TOOLS = {"Bash"}
 UNEXPANDED_POLICY = "refuse"
 UNEXPANDED_PROBE = 'gh pr merge $PR --squash --delete-branch'
 
+UNREADABLE_POLICY = "refuse"
+UNREADABLE_PROBE = {"command": "gh pr merge 1 --squash --delete-branch"}
+
+
+# What a reading that did not answer resolves to. An empty answer and "nothing holds this branch"
+# arrive as the same falsy value otherwise, and only one of them means the merge is safe.
+UNREADABLE = object()
+
 
 def held_branches(cwd):
-    """Branch names a worktree has checked out, which git refuses to delete while it does."""
-    result = subprocess.run(["git", "-C", cwd, "worktree", "list", "--porcelain"],
-                            capture_output=True, text=True)
+    """Branch names a worktree has checked out, or None when the list could not be read."""
+    try:
+        result = subprocess.run(["git", "-C", cwd, "worktree", "list", "--porcelain"],
+                                capture_output=True, text=True, timeout=20)
+    except (OSError, subprocess.SubprocessError):
+        return None
     if result.returncode != 0:
-        return {}
+        return None
     held, path = {}, None
     for line in result.stdout.splitlines():
         if line.startswith("worktree "):
@@ -50,29 +61,29 @@ def held_branches(cwd):
 
 
 def branch_of(cwd, operands):
-    """The branch a `gh pr merge` invocation would merge, or None when it cannot be read offline."""
+    """The branch a `gh pr merge` invocation would merge, or UNREADABLE when it did not answer.
+
+    Read over REST for the reason stale_merge.py states, and read from git when no number is given:
+    the head of the current branch's pull request is that branch, which needs no API at all.
+    """
     number = next((token for token in operands if token.isdigit()), None)
-    args = ["pr", "view", "--json", "headRefName"]
-    if number:
-        args.insert(2, number)
-    out = repository.gh(args, cwd=cwd)
-    if out is None:
-        return None
-    try:
-        return json.loads(out)["headRefName"]
-    except Exception:
-        return None
+    if number is None:
+        branch = (repository.git(["rev-parse", "--abbrev-ref", "HEAD"], cwd=cwd) or "").strip()
+        return branch if branch and branch != "HEAD" else UNREADABLE
+    ref = repository.gh(["api", "repos/{owner}/{repo}/pulls/" + number, "--jq", ".head.ref"],
+                        cwd=cwd)
+    return (ref or "").strip() or UNREADABLE
 
 
 def blocked(command, cwd):
-    """(branch, worktree path) for each merge whose branch this cannot clear.
+    """(branch, why this merge cannot clear it) for each merge whose branch is not clear.
 
     The unexpanded operand is answered before the worktree list is consulted. Returning early on an
     empty list put the refusal behind "some worktree exists", so the policy held on a checkout that
     happened to have one and lapsed on a runner that did not — which is the guard being exercised
     only in the states its environment happens to be in.
     """
-    held = None
+    held, read = None, False
     found = []
     for operands in program_invocations(command, "gh", ("pr", "merge")):
         named = [token for token in operands if not token.startswith("-")]
@@ -80,11 +91,18 @@ def blocked(command, cwd):
             found.append(("the branch named by an unexpanded operand",
                           "unreadable — resolve it, or name the pull request"))
             continue
+        if not read:
+            held, read = held_branches(cwd), True
         if held is None:
-            held = held_branches(cwd)
+            found.append(("the branch this merge would delete",
+                          "unreadable — git did not list the worktrees"))
+            continue
         branch = branch_of(cwd, operands)
-        if branch and branch in held:
-            found.append((branch, held[branch]))
+        if branch is UNREADABLE:
+            found.append(("the branch this merge would delete",
+                          "unreadable — its name did not come back"))
+        elif branch in held:
+            found.append((branch, "held by " + held[branch]))
     return found
 
 
@@ -101,13 +119,14 @@ def main():
     if not found:
         return 0
 
-    lines = "\n".join(f"  {branch}  held by {path}" for branch, path in found)
+    lines = "\n".join(f"  {branch}  {why}" for branch, why in found)
     sys.stderr.write(
-        "Refusing `gh pr merge`: a worktree holds the branch it would delete.\n\n"
+        "Refusing `gh pr merge`: the branch it would delete is not clear.\n\n"
         f"{lines}\n\n"
         "The delete is not atomic with the merge. The remote head goes and the merge lands, then the "
         "local delete fails because git will not remove a branch a worktree has checked out, and gh "
-        "prints that failure after having already merged. Nothing is left to retry.\n\n"
+        "prints that failure after having already merged. Nothing is left to retry — which is also "
+        "why an unread answer is refused rather than taken for an empty one.\n\n"
         "Remove the worktree first, then merge:\n"
         "  git worktree remove --force <path>\n"
     )

--- a/.claude/hooks/refuse/merge_onto_unpublished_release.py
+++ b/.claude/hooks/refuse/merge_onto_unpublished_release.py
@@ -25,6 +25,12 @@ HOOK_TOOLS = {"Bash"}
 # pull request is named.
 UNEXPANDED_POLICY = "n/a"
 
+# A base whose release state cannot be read leaves nothing to decide from, and answering either way
+# would be a guess. The merge is still refused: unreadable_state_check.py accepts an "allow" only
+# where another guard in this directory refuses the same probe.
+UNREADABLE_POLICY = "allow"
+UNREADABLE_PROBE = {"command": "gh pr merge 1 --squash --delete-branch"}
+
 # Repository state any session can move — the scope rule shared_git_state.py states.
 HOOK_SCOPE = "session"
 

--- a/.claude/hooks/refuse/merge_unproven_head.py
+++ b/.claude/hooks/refuse/merge_unproven_head.py
@@ -40,6 +40,12 @@ TERMINAL_PASS = frozenset({"pass", "skipping"})
 UNEXPANDED_POLICY = "refuse"
 UNEXPANDED_PROBE = 'gh pr merge $PR --squash --delete-branch'
 
+# gh answers None both for a check list it could not read and for a number that is not a pull
+# request, and nothing here separates them. The merge is still refused — same backing rule as
+# merge_onto_unpublished_release.py states.
+UNREADABLE_POLICY = "allow"
+UNREADABLE_PROBE = {"command": "gh pr merge 1 --squash --delete-branch"}
+
 
 def gh_json(cwd, args):
     out = repository.gh(args, cwd=cwd)

--- a/.claude/hooks/refuse/merge_without_branch_deletion.py
+++ b/.claude/hooks/refuse/merge_without_branch_deletion.py
@@ -31,6 +31,9 @@ HOOK_TOOLS = {"Bash"}
 UNEXPANDED_POLICY = "allow"
 UNEXPANDED_PROBE = 'gh pr merge $PR --squash --delete-branch'
 
+UNREADABLE_POLICY = "none"
+UNREADABLE_PROBE = {"command": "gh pr merge 1 --squash"}
+
 DELETE_FLAGS = ("--delete-branch", "-d")
 
 

--- a/.claude/hooks/refuse/metadata_less_create.py
+++ b/.claude/hooks/refuse/metadata_less_create.py
@@ -69,6 +69,9 @@ def creations(command):
 UNEXPANDED_POLICY = "allow"
 UNEXPANDED_PROBE = 'gh issue create --title $T --label bug --assignee @me'
 
+UNREADABLE_POLICY = "refuse"
+UNREADABLE_PROBE = {"command": "gh issue create --title probe"}
+
 
 def labels(cwd):
     listing = repository.gh(["label", "list", "--json", "name", "--jq", ".[].name"], cwd=cwd)

--- a/.claude/hooks/refuse/pr_body_of_another_branch.py
+++ b/.claude/hooks/refuse/pr_body_of_another_branch.py
@@ -71,6 +71,9 @@ HOOK_TOOLS = {"Bash"}
 UNEXPANDED_POLICY = "refuse"
 UNEXPANDED_PROBE = 'gh pr create --title t --body-file $BODY'
 
+UNREADABLE_POLICY = "none"
+UNREADABLE_PROBE = {"command": "gh pr create --title t --body-file velvet-no-such-body.md"}
+
 BODY_FILE_FLAGS = ("--body-file", "-F")
 BODY_FLAGS = ("--body", "-b")
 # Neither opens a pull request, so neither posts a description.

--- a/.claude/hooks/refuse/shared_git_state.py
+++ b/.claude/hooks/refuse/shared_git_state.py
@@ -53,6 +53,9 @@ RESTORE_FLAGS = {
 UNEXPANDED_POLICY = "refuse"
 UNEXPANDED_PROBE = 'git checkout $BRANCH'
 
+UNREADABLE_POLICY = "refuse"
+UNREADABLE_PROBE = {"command": "git checkout main"}
+
 # A glob is the other operand the shell rewrites, and it cannot take the same refusal: `git checkout
 # '*.cs'` is an ordinary restore, and refusing it is the over-refusal this guard was rewritten to
 # remove. It is expanded instead, so the question is asked about the operand git receives.

--- a/.claude/hooks/refuse/stale_merge.py
+++ b/.claude/hooks/refuse/stale_merge.py
@@ -28,6 +28,10 @@ HOOK_TOOLS = {"Bash"}
 # having run, and the merge is what cannot be taken back.
 UNEXPANDED_POLICY = "refuse"
 UNEXPANDED_PROBE = 'gh pr merge $PR --squash --delete-branch'
+
+UNREADABLE_POLICY = "refuse"
+UNREADABLE_PROBE = {"command": "gh pr merge 1 --squash --delete-branch"}
+
 UNRESOLVED = object()
 
 
@@ -50,10 +54,55 @@ def merge_targets(command):
     return targets
 
 
-def git(*args):
-    return subprocess.run(
-        ["git", *args], stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, timeout=30
-    )
+def git(cwd, *args):
+    """A finished `git`, or None when it could not be run at all.
+
+    Same reason `lib/repository.py` answers None rather than raising: a hook that raises exits 1,
+    and 1 lets the tool through.
+    """
+    try:
+        return subprocess.run(
+            ["git", "-C", cwd, *args],
+            stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, timeout=30,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+
+def head_of(cwd, pr):
+    """The branch a pull request would merge, or None when that could not be read.
+
+    Read over REST rather than through `gh pr view --json`, which is GraphQL. The two endpoints
+    meter separately, and an exhausted GraphQL quota emptied this reading here while `gh` went on
+    working everywhere else. The braces are gh's own placeholders, not a format string.
+
+    With no number the pull request is the current branch's, and its head ref is that branch, so git
+    answers it without an API at all.
+    """
+    if not pr:
+        finished = git(cwd, "rev-parse", "--abbrev-ref", "HEAD")
+        if finished is None or finished.returncode != 0:
+            return None
+        branch = finished.stdout.decode().strip()
+        return branch if branch and branch != "HEAD" else None
+    try:
+        finished = subprocess.run(
+            ["gh", "api", "repos/{owner}/{repo}/pulls/" + pr, "--jq", ".head.ref"],
+            cwd=cwd, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, timeout=20,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return finished.stdout.decode().strip() or None if finished.returncode == 0 else None
+
+
+UNREADABLE_REFUSAL = (
+    "Refusing `gh pr merge`: whether the branch contains the current main could not be read.\n\n"
+    "  {}\n\n"
+    "An unread answer and a branch that is up to date leave this guard looking the same from "
+    "outside, and the merge is what cannot be taken back. Retry when the reading works, or see "
+    "every merge precondition at once:\n"
+    "  python3 scripts/pr/settle.py merge <pr> --dry-run\n"
+)
 
 
 def branch_base(name):
@@ -89,26 +138,34 @@ def main():
             "  python3 scripts/pr/settle.py merge <pr> --dry-run\n")
         return 2
     pr = targets[0]
+    cwd = payload.get("cwd") or "."
 
-    try:
-        view = ["gh", "pr", "view"]
-        if pr:
-            view.append(pr)
-        view += ["--json", "headRefName", "--jq", ".headRefName"]
-        head = subprocess.run(
-            view,
-            stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, timeout=20,
-        ).stdout.decode().strip()
-    except Exception:
-        return 0
-    if not head:
+    head = head_of(cwd, pr)
+    if head is None:
+        sys.stderr.write(UNREADABLE_REFUSAL.format(
+            "the head branch of " + ("PR #" + pr if pr else "the current branch's pull request")
+            + " came back empty"))
+        return 2
+
+    fetched = git(cwd, "fetch", "-q", "origin", "main", head)
+    if fetched is None or fetched.returncode != 0:
+        sys.stderr.write(UNREADABLE_REFUSAL.format(
+            "origin/main and origin/{} could not be fetched".format(head)))
+        return 2
+
+    # 0 is contained and 1 is behind; any other code is git declining to answer. Both of the shorter
+    # readings are wrong about it: `== 0` lets a git that never answered stand for a branch that is
+    # up to date, and `!= 0` refuses naming a commit count nothing produced.
+    ancestry = git(cwd, "merge-base", "--is-ancestor", "origin/main", "origin/" + head)
+    if ancestry is None or ancestry.returncode not in (0, 1):
+        sys.stderr.write(UNREADABLE_REFUSAL.format(
+            "origin/main's ancestry against origin/{} could not be read".format(head)))
+        return 2
+    if ancestry.returncode == 0:
         return 0
 
-    git("fetch", "-q", "origin", "main", head)
-    if git("merge-base", "--is-ancestor", "origin/main", "origin/" + head).returncode == 0:
-        return 0
-
-    behind = git("rev-list", "--count", "origin/{}..origin/main".format(head)).stdout.decode().strip()
+    counted = git(cwd, "rev-list", "--count", "origin/{}..origin/main".format(head))
+    behind = counted.stdout.decode().strip() if counted else ""
     base = branch_base(head)
     # gh merges the current branch's pull request when no number is given, and naming it "#" reads
     # as a number nobody typed.

--- a/.github/workflows/generators.yml
+++ b/.github/workflows/generators.yml
@@ -87,6 +87,14 @@ jobs:
       - name: Pull request settle tests
         run: python3 scripts/pr/test_settle.py
 
+      # A PreToolUse guard whose repository reading failed exits 0, which is also what it exits with
+      # nothing to report, so the difference is measured by running each guard with git or gh unable
+      # to answer. Here rather than beside the EditMode fixtures that read the same directory:
+      # test.yml's Unity jobs are skipped without a UNITY_LICENSE secret and its aggregate counts a
+      # skip as a pass, so a guard silently not running is the very shape this checks for.
+      - name: Hook unreadable-state tests
+        run: python3 scripts/hooks/test_unreadable_state_check.py
+
   # ---------------------------------------------------------------------------
   # Repository settings live only in GitHub's own state; nothing in this
   # repository reads them back. contents:read is enough for the rulesets

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -201,6 +201,21 @@ the fixture's `GatePayloads` happens to pose anything about — a guard added si
 extended wants a row added to it rather than a change to itself — and for a guard that exits neither
 0 nor 2 under any of them, which is one raising rather than deciding.
 
+A guard's readings are the other way it goes quiet. Exiting 0 lets the tool through, so a `gh` that
+could not answer and a repository with nothing to report reach the caller as the same event — which
+is how an exhausted GitHub GraphQL quota emptied `gh pr view --json headRefName` while the separate
+REST quota stayed healthy, leaving `gh` working everywhere else and two merge guards alone silent.
+Each guard therefore declares an `UNREADABLE_POLICY` of `"refuse"`, `"allow"` or `"none"`, and an
+`UNREADABLE_PROBE` holding a tool input to pose it. `scripts/hooks/test_unreadable_state_check.py`
+runs every guard with `git` or `gh` unable to answer and compares the verdict against the
+declaration, rather than reading the source for the shape: which direction a `return 0` means is a
+property of the call site, and `shared_git_state.py`'s refusal is the answer it gives when git cannot
+be asked. `"none"` claims the probe reaches neither program, and fails if either is invoked.
+`"allow"` needs a comment above it saying what holds instead, and fails unless another guard in the
+directory refuses the same probe — otherwise the tool call is guarded by nothing at all. It runs in
+the licence-free `source-generators` job rather than beside the fixtures above, which are skipped
+entirely on a checkout with no `UNITY_LICENSE` secret.
+
 ### Source generators
 
 The Roslyn source generators live under `Packages/com.velvet.core/Generators~/` and target a

--- a/scripts/hooks/test_unreadable_state_check.py
+++ b/scripts/hooks/test_unreadable_state_check.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""Unit tests for unreadable_state_check.py, plus the check over this repository's own guards.
+
+Each synthetic guard below is one shape a failed reading takes in `.claude/hooks/refuse` today: a
+`return 0` after an empty read, a helper answering None that the caller reads as "nothing found", a
+successful call that printed nothing, and — the one a reading over the source gets wrong — a git
+exit code of 1 that is a legitimate negative answer rather than a failure.
+
+Run: python3 scripts/hooks/test_unreadable_state_check.py
+"""
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def load_module():
+    """Imports unreadable_state_check by path, since scripts/hooks is not a package."""
+    spec = importlib.util.spec_from_file_location(
+        "unreadable_state_check", Path(__file__).with_name("unreadable_state_check.py")
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+check = load_module()
+
+PREAMBLE = '''#!/usr/bin/env python3
+"""A synthetic guard."""
+import json
+import subprocess
+import sys
+
+HOOK_TOOLS = {"Bash"}
+'''
+
+# `capture_output` keeps the stub's own stderr off this process's, so a failure the check reports
+# reads as the check's own line rather than as the stub's message.
+READ_GH = 'subprocess.run(["gh", "api", "x"], capture_output=True, text=True)'
+READ_GIT = 'subprocess.run(["git", "rev-parse", "x"], capture_output=True, text=True)'
+
+
+def guard(policy, body, reason="", probe='{"command": "probe"}'):
+    return (PREAMBLE
+            + (f"\n# {reason}\n" if reason else "\n")
+            + f'UNREADABLE_POLICY = "{policy}"\n'
+            + f"UNREADABLE_PROBE = {probe}\n\n\n"
+            + "def main():\n"
+            + "    event = json.load(sys.stdin)\n"
+            + "    if event.get('tool_name') not in HOOK_TOOLS:\n"
+            + "        return 0\n"
+            + body
+            + "\n\nsys.exit(main())\n")
+
+
+# Reads the pull request's head and treats an empty answer as nothing to refuse — stale_merge.py's
+# shape before this check existed.
+FAILS_OPEN = f"""    head = {READ_GH}.stdout.strip()
+    if not head:
+        return 0
+    return 2
+"""
+
+HOLDS = f"""    head = {READ_GH}.stdout.strip()
+    if not head:
+        return 2
+    return 2
+"""
+
+# Refuses on an error and reads a successful empty answer as an answer, which is what a renamed
+# JSON field leaves behind: the command succeeds and `--jq` selects nothing.
+HOLDS_ON_ERROR_ONLY = f"""    done = {READ_GH}
+    if done.returncode != 0:
+        return 2
+    return 0 if not done.stdout.strip() else 2
+"""
+
+READS_NOTHING = "    return 2\n"
+
+STAYS_OUT = "    return 0\n"
+
+READS_GIT = f"""    done = {READ_GIT}
+    return 2 if done.returncode != 0 else 0
+"""
+
+# shared_git_state.py's shape: git exiting 1 is `rev-parse --verify --quiet` saying the ref is not
+# there, which is an answer, and the guard's refusal is what it does with it.
+NEGATIVE_IS_AN_ANSWER = f"""    done = {READ_GIT}
+    return 0 if done.returncode == 1 else 2
+"""
+
+ALLOWS = f"""    {READ_GH}
+    return 0
+"""
+
+
+def directory(**guards):
+    root = Path(tempfile.mkdtemp(prefix="velvet-unreadable-tests-"))
+    for name, source in guards.items():
+        (root / (name + ".py")).write_text(source, encoding="utf-8")
+    return root
+
+
+def faults(root):
+    return check.faults(root, root, floor=0)
+
+
+class DeclarationTests(unittest.TestCase):
+    def test_Given_AGuardDeclaringNothing_When_TheCheckRuns_Then_ItIsReported(self):
+        # Arrange
+        root = directory(quiet=PREAMBLE + "\nsys.exit(0)\n")
+
+        # Act
+        found = [line for line in faults(root) if "UNREADABLE_POLICY must be one of" in line]
+
+        # Assert
+        self.assertEqual(len(found), 1, faults(root))
+
+    def test_Given_AGuardDeclaringAllowWithNoCommentAboveIt_When_TheCheckRuns_Then_ItIsReported(self):
+        # Arrange — the sibling is there so the missing comment is the only fault left.
+        root = directory(lenient=guard("allow", ALLOWS), holds=guard("refuse", HOLDS))
+
+        # Act
+        found = [line for line in faults(root) if "no comment above it" in line]
+
+        # Assert
+        self.assertEqual(len(found), 1, faults(root))
+
+
+class VerdictTests(unittest.TestCase):
+    def test_Given_AGuardReadingAnEmptyAnswerAsNothingToRefuse_When_TheCheckRuns_Then_ItIsReported(self):
+        # Arrange
+        root = directory(quiet=guard("refuse", FAILS_OPEN))
+
+        # Act
+        found = [line for line in faults(root) if 'answers "allow"' in line]
+
+        # Assert — every mode that reaches the read reports it, so the count rides along.
+        self.assertEqual(len(found), 2, faults(root))
+
+    def test_Given_TheSameGuardRefusingOnThatAnswer_When_TheCheckRuns_Then_NothingIsReported(self):
+        # Arrange
+        root = directory(quiet=guard("refuse", HOLDS))
+
+        # Act
+        found = faults(root)
+
+        # Assert
+        self.assertEqual(found, [])
+
+    def test_Given_AGuardHoldingOnlyWhenTheReadErrors_When_TheCheckRuns_Then_TheEmptyAnswerIsReported(self):
+        # Arrange
+        root = directory(partial=guard("refuse", HOLDS_ON_ERROR_ONLY))
+
+        # Act
+        found = [line for line in faults(root) if "gh-empty" in line]
+
+        # Assert
+        self.assertEqual(len(found), 1, faults(root))
+
+    def test_Given_AGuardWhoseRefusalIsWhatGitsNegativeAnswerMeans_When_TheCheckRuns_Then_NothingIsReported(self):
+        # Arrange
+        root = directory(negative=guard("refuse", NEGATIVE_IS_AN_ANSWER))
+
+        # Act
+        found = faults(root)
+
+        # Assert
+        self.assertEqual(found, [])
+
+
+class ScopeTests(unittest.TestCase):
+    def test_Given_AGuardDeclaringNoneThatConsultsGit_When_TheCheckRuns_Then_ItIsReported(self):
+        # Arrange
+        root = directory(reader=guard("none", READS_GIT))
+
+        # Act
+        found = [line for line in faults(root) if 'declares "none"' in line]
+
+        # Assert
+        self.assertEqual(len(found), 1, faults(root))
+
+    def test_Given_AGuardDeclaringNoneThatConsultsNeither_When_TheCheckRuns_Then_NothingIsReported(self):
+        # Arrange
+        root = directory(textual=guard("none", READS_NOTHING))
+
+        # Act
+        found = faults(root)
+
+        # Assert
+        self.assertEqual(found, [])
+
+    def test_Given_AGuardWhoseProbeReachesNeitherProgram_When_TheCheckRuns_Then_ItIsReported(self):
+        # Arrange — a "refuse" that no reading takes part in says nothing about an unreadable state.
+        root = directory(textual=guard("refuse", READS_NOTHING))
+
+        # Act
+        found = [line for line in faults(root) if "never happens" in line]
+
+        # Assert
+        self.assertEqual(len(found), 1, faults(root))
+
+
+class BackingTests(unittest.TestCase):
+    def test_Given_AGuardDeclaringAllowAndNoSiblingRefusingItsProbe_When_TheCheckRuns_Then_ItIsReported(self):
+        # Arrange
+        root = directory(lenient=guard("allow", ALLOWS, reason="nothing holds this"),
+                         elsewhere=guard("none", STAYS_OUT, probe='{"command": "other"}'))
+
+        # Act
+        found = [line for line in faults(root) if "guarded by nothing at all" in line]
+
+        # Assert
+        self.assertEqual(len(found), 2, faults(root))
+
+    def test_Given_AGuardDeclaringAllowAndASiblingRefusingItsProbe_When_TheCheckRuns_Then_NothingIsReported(self):
+        # Arrange
+        root = directory(lenient=guard("allow", ALLOWS, reason="the sibling holds this"),
+                         holds=guard("refuse", HOLDS))
+
+        # Act
+        found = faults(root)
+
+        # Assert
+        self.assertEqual(found, [])
+
+
+class RepositoryTests(unittest.TestCase):
+    def test_Given_ThisRepositorysGuards_When_EachIsPosedItsOwnProbe_Then_EachAnswersWhatItDeclares(self):
+        # Arrange
+        refuse_directory = REPO_ROOT / check.REFUSE_DIRECTORY
+
+        # Act
+        found = check.faults(refuse_directory, REPO_ROOT)
+
+        # Assert — the guard count rides along, because an empty directory disagrees with nothing.
+        self.assertEqual((len(check.guards(refuse_directory)) >= check.GUARD_FLOOR, found),
+                         (True, []))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/hooks/unreadable_state_check.py
+++ b/scripts/hooks/unreadable_state_check.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Hold every refusing guard to what it does when git or gh cannot answer.
+
+A `PreToolUse` guard lets the tool through by exiting 0, and 0 is also what it exits when a reading
+it depends on came back empty. The two are indistinguishable from outside, so a guard whose
+repository read fails goes quiet exactly when it is the only thing left between a mistake and the
+tool. It happened here: a GitHub GraphQL quota emptied `gh pr view --json headRefName` while the
+separate REST quota stayed healthy, so `gh` went on working everywhere else and two merge guards
+alone fell silent.
+
+Which way to err is each guard's own decision — `metadata_less_create.py` reads the label list only
+to write a more helpful refusal, and a guard over merges cannot allow one it did not check — so the
+guard declares it and this compares the declaration against what the guard does.
+
+Run rather than read. Which direction a `return 0` means depends on the call site:
+`shared_git_state.py` answers "yes, a commit" when git cannot be asked, and that answer is its
+refusal. A stub `git` exiting 1 reported it as failing open here, and exit 1 is what
+`git rev-parse --verify --quiet` returns for a ref that is merely absent — so the stubs below fail
+the way an unreadable state fails, and the verdict is read off the process.
+
+Run: python3 scripts/hooks/test_unreadable_state_check.py
+"""
+
+import ast
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+REFUSE_DIRECTORY = ".claude/hooks/refuse"
+
+# Raised with the tree, the way the hook fixtures' floors are: an empty directory declares nothing
+# and would otherwise pass every check below.
+GUARD_FLOOR = 14
+
+POLICY = "UNREADABLE_POLICY"
+PROBE = "UNREADABLE_PROBE"
+TOOLS = "HOOK_TOOLS"
+
+REFUSE, ALLOW, NONE = "refuse", "allow", "none"
+POLICIES = (REFUSE, ALLOW, NONE)
+
+# Each mode breaks one program the way an unreadable state breaks it, and leaves the other alone, so
+# a guard reading both is held to each read separately. git's exit 128 is its fatal code — 1 is a
+# legitimate negative answer from `rev-parse --verify --quiet` and several other plumbing commands,
+# and stubbing that reports a correct guard as failing open. gh has no such overload: it exits 1 on
+# an API error. The empty mode is the one a renamed JSON field produces, where `--jq` selects
+# nothing and the command still succeeds.
+MODES = {
+    "gh-error": {"gh": 'echo "gh: HTTP 502" >&2\nexit 1'},
+    "gh-empty": {"gh": "exit 0"},
+    "git-error": {"git": 'echo "fatal: probe" >&2\nexit 128'},
+}
+
+STUB_LOG = "VELVET_UNREADABLE_STATE_LOG"
+
+
+def guards(refuse_directory):
+    return sorted(Path(refuse_directory).glob("*.py"))
+
+
+def _assigned(module, name):
+    """The literal a top-level `name = …` holds, with the line it sits on."""
+    for node in module.body:
+        if isinstance(node, ast.Assign) and any(
+            isinstance(target, ast.Name) and target.id == name for target in node.targets
+        ):
+            try:
+                return ast.literal_eval(node.value), node.lineno
+            except ValueError:
+                return None, node.lineno
+    return None, None
+
+
+def _has_reason(source, lineno):
+    """Whether a comment sits directly above the line, with no blank line between."""
+    lines = source.splitlines()
+    index = lineno - 2
+    return index >= 0 and lines[index].lstrip().startswith("#")
+
+
+def declaration(path):
+    """(policy, probe, tool) for one guard, with every way its declaration falls short."""
+    source = Path(path).read_text(encoding="utf-8")
+    module = ast.parse(source)
+    policy, policy_line = _assigned(module, POLICY)
+    probe, _ = _assigned(module, PROBE)
+    tools, _ = _assigned(module, TOOLS)
+
+    missing = []
+    if policy not in POLICIES:
+        missing.append(f"{POLICY} must be one of {', '.join(POLICIES)}, found {policy!r}")
+    if not isinstance(probe, dict) or not probe:
+        missing.append(f"{PROBE} must be a non-empty tool_input dict, found {probe!r}")
+    if not isinstance(tools, set) or not tools:
+        missing.append(f"{TOOLS} must be a non-empty set, found {tools!r}")
+    if policy == ALLOW and not _has_reason(source, policy_line):
+        missing.append(
+            f"{POLICY} is \"{ALLOW}\" with no comment above it saying what holds instead")
+
+    tool = sorted(tools)[0] if isinstance(tools, set) and tools else None
+    return policy, probe, tool, missing
+
+
+def _stubs(mode, directory, log):
+    for name, body in MODES[mode].items():
+        script = directory / name
+        script.write_text(f'#!/bin/sh\nprintf \'{name}\\n\' >> "${STUB_LOG}"\n{body}\n')
+        script.chmod(0o755)
+
+
+def answer(hook, tool, probe, mode, cwd, home):
+    """(verdict, whether the broken program was consulted) for one guard under one mode."""
+    workspace = Path(tempfile.mkdtemp(prefix="velvet-unreadable-"))
+    try:
+        log = workspace / "consulted"
+        log.write_text("")
+        environment = dict(os.environ)
+        environment["HOME"] = str(home)
+        environment[STUB_LOG] = str(log)
+        # The session's own project would otherwise decide what a guard reads instead of `cwd`.
+        environment.pop("CLAUDE_PROJECT_DIR", None)
+        _stubs(mode, workspace, log)
+        environment["PATH"] = str(workspace) + os.pathsep + environment.get("PATH", "")
+
+        payload = json.dumps({"tool_name": tool, "cwd": str(cwd), "tool_input": probe})
+        finished = subprocess.run(
+            [sys.executable, "-B", str(hook)],
+            input=payload, text=True, capture_output=True,
+            cwd=str(cwd), env=environment, timeout=180,
+        )
+        # Not the exit code alone: blind_git_add.py refuses by printing a deny decision and exiting
+        # 0, so reading 0 as a pass would score its refusal as a guard that let the tool through.
+        denied = '"permissionDecision"' in finished.stdout and '"deny"' in finished.stdout
+        verdict = REFUSE if finished.returncode == 2 or denied else ALLOW
+        return verdict, bool(log.read_text().strip())
+    finally:
+        shutil.rmtree(workspace, ignore_errors=True)
+
+
+def _backed(hook, tool, probe, mode, cwd, home, siblings):
+    """Whether some other guard refuses this probe while the same program cannot answer."""
+    for sibling in siblings:
+        if sibling == hook:
+            continue
+        verdict, _ = answer(sibling, tool, probe, mode, cwd, home)
+        if verdict == REFUSE:
+            return sibling.name
+    return None
+
+
+def faults(refuse_directory, cwd, floor=GUARD_FLOOR):
+    """Every disagreement between what a guard declares and what it does. Empty means agreement."""
+    found = []
+    subjects = guards(refuse_directory)
+    if len(subjects) < floor:
+        found.append(f"{refuse_directory} holds {len(subjects)} guards, fewer than {floor}")
+
+    # One HOME for every run: edit_while_a_ready_pr_sits.py reads the pull-request watcher's files
+    # out of it, so a verdict would otherwise depend on what a developer's watcher last wrote.
+    home = Path(tempfile.mkdtemp(prefix="velvet-unreadable-home-"))
+    try:
+        for hook in subjects:
+            found += _guard_faults(hook, subjects, cwd, home)
+    finally:
+        shutil.rmtree(home, ignore_errors=True)
+    return found
+
+
+def _guard_faults(hook, subjects, cwd, home):
+    policy, probe, tool, missing = declaration(hook)
+    if missing:
+        return [f"{hook.name}: {reason}" for reason in missing]
+
+    found, evidence = [], []
+    for mode in MODES:
+        verdict, consulted = answer(hook, tool, probe, mode, cwd, home)
+        if not consulted:
+            # This mode broke a program the guard never reached, so its verdict says nothing about
+            # what the guard does with an unreadable state. Scoring it would hold the guard to its
+            # ordinary answer under a name about failure.
+            continue
+        evidence.append(mode)
+        if policy == NONE:
+            found.append(f"{hook.name}: declares \"{NONE}\" and consulted a broken program in {mode}")
+        elif verdict != policy:
+            found.append(f"{hook.name}: declares \"{policy}\", answers \"{verdict}\" in {mode}")
+        elif policy == ALLOW and not _backed(hook, tool, probe, mode, cwd, home, subjects):
+            found.append(
+                f"{hook.name}: declares \"{ALLOW}\" in {mode} and no other guard refuses its probe, "
+                "so the tool call is guarded by nothing at all")
+
+    if policy != NONE and not evidence:
+        found.append(
+            f"{hook.name}: declares \"{policy}\" but its probe reaches neither git nor gh, so the "
+            "declaration is about a reading that never happens")
+    return found
+
+
+def main(argv):
+    directory = Path(argv[1]) if len(argv) > 1 else REPO_ROOT / REFUSE_DIRECTORY
+    cwd = Path(argv[2]) if len(argv) > 2 else REPO_ROOT
+    found = faults(directory, cwd)
+    for line in found:
+        print(line, file=sys.stderr)
+    return 1 if found else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
A `PreToolUse` guard lets the tool through by exiting 0, and 0 is also what it exits with nothing to report. So a guard whose repository reading failed is indistinguishable, from outside, from one that ran and found nothing. An exhausted GitHub GraphQL quota emptied `gh pr view --json headRefName` while the separate REST quota stayed healthy — `gh` went on working everywhere else and two merge guards alone fell silent.

This adds a check that fails when a guard's unreadable-state path allows, and repairs the guards it found.

## 1. What the check reads

It runs each guard rather than reading it. A reading over the source cannot answer the question, and this is measured rather than assumed: the first instrument here stubbed `git` to exit 1, and it reported `shared_git_state.py` as failing open. It is not — exit 1 is what `git rev-parse --verify --quiet` returns for a ref that is merely absent, and that guard's `except: return True` turns "git could not be asked" into its refusal. Which direction a `return 0` means is a property of the call site.

So each guard declares `UNREADABLE_POLICY` (`"refuse"` / `"allow"` / `"none"`) with an `UNREADABLE_PROBE` holding a tool input, and `scripts/hooks/unreadable_state_check.py` poses the probe three times — `gh` erroring, `gh` succeeding with no output, `git` erroring — and compares the verdict against the declaration. A mode in which the guard never invoked the broken program is discarded rather than scored, because its verdict is then the guard's ordinary answer under a name about failure. A guard whose probe reaches neither program while declaring `"refuse"` or `"allow"` fails: the declaration would be about a reading that never happens.

**The shapes in the fourteen guards today**, which is what the modes were chosen against:

| shape | where |
|---|---|
| `return 0` right after an empty read | `stale_merge.py`: `if not head: return 0`, and `except Exception: return 0` around it |
| a reader answering `None`, read by its caller as "nothing found" | `merge_branch_held_by_worktree.py`: `branch_of` → `if branch and branch in held`; `held_branches` returning `{}` on a non-zero git |
| `continue` on an unreadable read inside a per-target loop | `merge_unproven_head.py`: `if before is None: continue` |
| a shared helper answering `None`, read as "this does not apply" | `changelog_into_closed_version.py` at `ac8b648`: `common_git_dir` → `in_this_repository` false → `return 0`; `merge_onto_unpublished_release.py` via `published_check.unpublished_reason` |
| an empty list standing for "nothing to check" | `commit_failing_fast_checks.py`: `staged_paths` / `worktree_paths` returning `[]` on a non-zero git |
| a successful call that printed nothing | what a renamed JSON field leaves behind — the `gh-empty` mode |
| **not** a fail-open, and the reason a syntactic reading misfires | `shared_git_state.py`'s `except: return True`; `metadata_less_create.py`'s label list, read only to write a better refusal |

**Not covered**, stated rather than discovered later:

- **A program that cannot be executed at all.** The stubs run and fail; they are never absent or unexecutable, so no `OSError` is raised. `branch_from_unmerged.py` and `blind_git_add.py` still call `subprocess.run(["git", …])` unguarded, and a raise there exits 1, which is a pass.
- **A guard's second and later readings.** Only the first unreadable read on the path is exercised. `stale_merge.py`'s ancestry reading is reached only when `gh` answered, so the modes here never get to it; it is repaired below, but the check is not what holds it.
- **State that is neither `git` nor `gh`.** `edit_while_a_ready_pr_sits.py` reads the watcher's files out of `$HOME`, and already refuses on an unread one with a stated reason. It declares `"none"` here, which is a claim about `git` and `gh` only.
- **Whether a probe is the strongest one available.** A probe the guard refuses for a textual reason before any reading would be caught by the "reaches neither program" clause, but a probe that reaches a *shallower* reading than the guard's real work would not be.

## 2. Where fail-open is right

`"allow"` needs two things, and the second is what makes it more than a comment. It needs a comment above the declaration saying what holds instead — the check reads for its presence — and it needs **another guard in the directory to refuse the same probe under the same broken program**. Otherwise the tool call is guarded by nothing at all, and the check says exactly that.

That is the only honest shape a fail-open takes here. `metadata_less_create.py` declares `UNEXPANDED_POLICY = "allow"` because its repository read only makes the message more helpful — and precisely because of that, its *verdict* is unchanged when the read fails, so its `UNREADABLE_POLICY` is `"refuse"`. The two questions have different answers for the same guard, which is why this is a second declaration rather than a reuse of the first: `stale_merge.py`'s `UNEXPANDED_PROBE` carries `$PR`, which short-circuits on the unexpanded branch and never reaches the reading that was broken.

Two guards declare `"allow"`: `merge_unproven_head.py` (gh answers `None` both for a check list it could not read and for a number that is not a pull request, and nothing there separates them) and `merge_onto_unpublished_release.py` (a base whose release state cannot be read leaves nothing to decide from). Both are backed by `stale_merge.py` and `merge_branch_held_by_worktree.py` refusing the same merge — which is only true because of the repairs below, and would go red the moment it stopped being true.

## 3. Where it runs

The licence-free `source-generators` job in `generators.yml`, not `HookWiringCoverageTests`.

`test.yml`'s Unity jobs are skipped outright when no `UNITY_LICENSE` secret is set, and its `Required checks (Unity)` aggregate counts a skip as a pass. A guard against silent non-running that can itself silently not run is the failure it exists to catch. `generators.yml` already carries this reasoning in its own header, for the same reason, about `CodeShapeOptInDriftTests`.

It is a new `scripts/hooks/` rather than an addition to `scripts/pr/test_settle.py`, whose subject is the merge gate: five of the fourteen guards have nothing to do with merging.

Neither home closes the push gap. `.claude/**` is in neither workflow's push path filter (#586), so a push to `main` touching only a hook starts no run. Both workflows carry unfiltered `pull_request` and `merge_group` triggers and `protect-main` requires both aggregates, so nothing reaches `main` without this having run; the gap is the post-merge run alone, and #586 owns it.

## Proof

Each guard reverted to its state on `main`, one at a time, with only the two declaration lines added and the rest of the tree repaired:

```
===== stale_merge
stale_merge.py: declares "refuse", answers "allow" in gh-error
stale_merge.py: declares "refuse", answers "allow" in gh-empty
===== merge_branch_held_by_worktree
merge_branch_held_by_worktree.py: declares "refuse", answers "allow" in gh-error
merge_branch_held_by_worktree.py: declares "refuse", answers "allow" in gh-empty
merge_branch_held_by_worktree.py: declares "refuse", answers "allow" in git-error
===== changelog_into_closed_version at ac8b648
changelog_into_closed_version.py: declares "refuse", answers "allow" in git-error
```

The third was asked for at `c6284a8`, and that commit does not carry the defect: its scoping is `in_this_repository`, pure path arithmetic with no git in it. `common_git_dir` arrives at `ac8b648`, and `3c79289` repairs it. Posed at `c6284a8` the check reports `declares "refuse" but its probe reaches neither git nor gh` — a declaration fault, not the fail-open. The guard now on `main` is the repaired one and declares `"refuse"`.

`scripts/hooks/test_unreadable_state_check.py` holds the check itself against a synthetic guard for each shape, including the two that must **not** be reported: a refusal that is what git's negative answer means, and a guard that consults neither program.

## Repairs

`stale_merge.py` and `merge_branch_held_by_worktree.py` read the head over `gh api repos/{owner}/{repo}/pulls/{n} --jq .head.ref`, which does not share the exhausted quota (gh fills the braces itself). With no number the pull request is the current branch's and its head ref is that branch, so git answers it with no API at all. An empty answer gets its own branch, which says the reading did not answer and holds. `stale_merge.py` also stops reading `merge-base --is-ancestor`'s exit code as a two-way answer: 0 is contained, 1 is behind, and anything else is git declining — `== 0` let a git that never answered stand for a branch that is up to date.

`commit_failing_fast_checks.py` was found by the check, not by the brief. `staged_paths` and `worktree_paths` returned `[]` on a non-zero git, so "git could not list what this commit records" became "this commit records nothing that could fail a check", and every fast check ran over nothing and passed.

## Behaviour

Every guard was fed the same twenty-one payloads on this branch and on `main`. With `gh` working, two differ, both `gh pr merge` with no number: `merge_branch_held_by_worktree.py` now refuses because the current branch is held by the checkout you are standing in — which is always true, and `--delete-branch` would indeed fail — and `stale_merge.py` refuses from a detached HEAD, where there is no branch to name. `main` allowed both through the reading that failed. With `gh` unauthenticated, six differ, and they are the fix.

## Documentation

`CONTRIBUTING.md`'s hooks section gains the declaration and what each value claims, beside the wiring rules it already owns.

No `CHANGELOG.md` entry: nothing here changes the package's behaviour. `CLAUDE.md` names contributor tooling as the case that does not get one.

Closes #594
