### PR TITLE
tooling(velvet): run a branch's changed test cases against the merge base

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -202,9 +202,108 @@ jobs:
             ${BASE:+--base "$BASE"}
 
   # ---------------------------------------------------------------------------
+  # A test written to pin a change has to be red without it, and nothing here asked. The Python half
+  # of that question is answered outright: base_red_check.py checks out the merge base, copies this
+  # branch's changed test modules onto it, and runs the changed cases there, which for Python is the
+  # whole run and costs seconds. The C# half needs an editor and is in `base-red` below.
+  #
+  # fetch-depth 0 because the merge base is what the question is asked against, and a shallow clone
+  # has no merge base to find.
+  # ---------------------------------------------------------------------------
+  base-red-python:
+    name: Base-red check (Python)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - env:
+          BASE: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+        run: |
+          python3 scripts/test_quality/base_red_check.py --lane python \
+            --base "${BASE:-HEAD^}"
+
+  # ---------------------------------------------------------------------------
+  # The C# half of the same question. It reaches Unity through the same action the suite does, so it
+  # is split in two: the first step builds the base tree and writes what it read, the action runs the
+  # fixtures over that tree, and the last step takes the verdict from the results file. Nothing in
+  # between has to hand back an editor log.
+  #
+  # needs: unity-tests is load-bearing rather than tidiness. "It did not compile on the base" is only
+  # evidence about the branch where the same file compiles ON the branch, and that job is what says so.
+  #
+  # This is one round of a loop the local harness runs to a fixed point, and the difference decides
+  # what it can catch. A base that cannot build one carried file writes no results for anything, so a
+  # single round cannot tell which file that was: it reads as the base building none of the branch's
+  # tests, which passes. The harness withdraws one carried file and asks again until something runs,
+  # which is how it separates them — so `base_red_check.py` run locally is the sharper reading of the
+  # same branch, and what stays here is the case the base DID build and answer green, which is the
+  # one this exists for.
+  # ---------------------------------------------------------------------------
+  base-red:
+    name: Base-red check (${{ matrix.testMode }})
+    needs: [license-check, unity-tests]
+    if: needs.license-check.outputs.has_license == 'true' && github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        testMode: [EditMode, PlayMode]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          lfs: true
+
+      - id: read
+        env:
+          BASE: ${{ github.event.pull_request.base.sha }}
+        run: |
+          python3 scripts/test_quality/base_red_check.py --lane csharp \
+            --platform "${{ matrix.testMode }}" --base "$BASE" \
+            --base-tree base-tree --emit plan.json | tee reading.txt
+          grep '^fixtures=' reading.txt >> "$GITHUB_OUTPUT" || true
+
+      # After the reading, not before: the tree is a worktree git refuses to create over a directory
+      # that already holds a Library.
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        if: steps.read.outputs.fixtures != ''
+        with:
+          path: base-tree/Library
+          key: BaseLibrary-${{ matrix.testMode }}-${{ github.event.pull_request.base.sha }}
+          restore-keys: |
+            BaseLibrary-${{ matrix.testMode }}-
+
+      # continue-on-error because a base that cannot build the branch's test file is the answer, not
+      # a broken job. Which of the two it was is settled by the step after this from the results file.
+      - uses: game-ci/unity-test-runner@0ff419b913a3630032cbe0de48a0099b5a9f0ed9 # v4
+        if: steps.read.outputs.fixtures != ''
+        continue-on-error: true
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+        with:
+          # The version unity-tests runs, for the reason stated there.
+          unityVersion: 6000.3.21f1
+          testMode: ${{ matrix.testMode }}
+          projectPath: base-tree
+          artifactsPath: base-results
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          customParameters: -testFilter "${{ steps.read.outputs.fixtures }}"
+
+      - if: steps.read.outputs.fixtures != ''
+        run: |
+          python3 scripts/test_quality/base_red_check.py \
+            --verdict plan.json --results base-results
+
+  # ---------------------------------------------------------------------------
   # mutation_check.py needs a licence to kill a mutant, but not to build one, and the building is
   # the half everything else rests on: an operator that emits uncompilable C# reports that mutant as
-  # noise rather than as a survivor, so a real hole hides behind it. That half runs here.
+  # noise rather than as a survivor, so a real hole hides behind it. That half runs here, and
+  # base_red_check.py's reader is here for the same reason: a case its parser misses is a case the
+  # base is never asked about, and the run comes back green having measured one fewer thing.
   # ---------------------------------------------------------------------------
   test-quality:
     name: Test quality
@@ -215,6 +314,8 @@ jobs:
       - run: python3 scripts/test_quality/test_mutation_check.py
 
       - run: python3 scripts/test_quality/test_neuter_check.py
+
+      - run: python3 scripts/test_quality/test_base_red_check.py
 
   # ---------------------------------------------------------------------------
   # The one check branch protection requires from this workflow. Naming a real
@@ -230,11 +331,11 @@ jobs:
   required-checks:
     name: Required checks (Unity)
     if: always()
-    needs: [license-check, unity-tests, release-notes, publication, test-quality]
+    needs: [license-check, unity-tests, release-notes, publication, test-quality, base-red-python, base-red]
     runs-on: ubuntu-latest
     steps:
       - env:
-          RESULTS: ${{ needs.license-check.result }} ${{ needs.unity-tests.result }} ${{ needs.release-notes.result }} ${{ needs.publication.result }} ${{ needs.test-quality.result }}
+          RESULTS: ${{ needs.license-check.result }} ${{ needs.unity-tests.result }} ${{ needs.release-notes.result }} ${{ needs.publication.result }} ${{ needs.test-quality.result }} ${{ needs.base-red-python.result }} ${{ needs.base-red.result }}
         run: |
           failed=0
           for result in $RESULTS; do

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,6 +146,43 @@ another disappears leaves identical. `scripts/test_quality/neuter_holes.txt` car
 `--report` regenerates it, so a sweep is read as a diff against it. Nothing runs the sweep automatically:
 wiring it into CI needs a licence activation this repository does not have.
 
+### Checking that a new test could have failed
+
+Both instruments above ask what happens when the production code is broken on purpose.
+`scripts/test_quality/base_red_check.py` asks the cheaper question first, and the one a pull request is
+actually claiming: was this case red before the change it says it pins? It checks out the merge base,
+copies the branch's changed test files onto it, and runs the cases the branch wrote there.
+
+```bash
+python3 scripts/test_quality/base_red_check.py --base origin/main --plan   # what it would ask, no run
+python3 scripts/test_quality/base_red_check.py --base origin/main --warm-library Library
+```
+
+A case that passes on the base fails the check. A case that could not compile there does not — it names
+something the branch adds, which is a pin doing its job — and the base tree is read before any of it is
+believed: the cases the branch did not change come from the base's own green run, so one of those going
+red means the tree is answering about itself and its fixture's verdicts are withdrawn.
+
+Two kinds of case belong on the base, and say so above themselves with a reason a reviewer can weigh:
+
+```csharp
+// GREEN_ON_BASE(characterization): the keyed-reorder order this refactor must not change.
+```
+
+`characterization` pins behaviour the base already has; `refactor` rides with a change meant to preserve
+it. The declaration is read in both directions — one over a case that turns out red on the base fails the
+check too — so it cannot outlive what it describes. The base tree is a checkout the machine has never
+imported, and that import is most of what a base run costs; `--warm-library` copies an existing `Library`
+into it, sharing blocks where the filesystem will.
+
+`Test ▸ base-red-python` runs the Python lane on every pull request and needs no licence.
+`Test ▸ base-red` runs the C# lane where one is configured, but only one round of it: a base that
+cannot build one carried file writes no results for anything, and separating that file from the ones
+standing next to it takes withdrawing it and asking again, which is what the local run does and a
+workflow does not. Run it locally on a branch whose tests are the point.
+`scripts/test_quality/test_base_red_check.py` holds the reader against every test file in this
+repository and runs in `Test ▸ test-quality`.
+
 ### Repository scripts
 
 `scripts/` holds the harnesses, grouped by what they are for — `test_quality/` (mutation, neuter,
@@ -157,8 +194,8 @@ the tree readable:
   runtime or configuration file this repository does not already have; `python3` is on the CI runner and on
   every developer machine that can run the Unity suites.
 - **A script's name reaches C#.** `NeuterCutAnchorTests`, `WorkflowTriggerCoverageTests`,
-  `StarterSampleShippingTests` and `DocumentationDriftTests` each name one, so a rename that misses a
-  reference fails a pull request instead of failing the next person to run it.
+  `StarterSampleShippingTests`, `BaseRedDeclarationTests` and `DocumentationDriftTests` each name one, so
+  a rename that misses a reference fails a pull request instead of failing the next person to run it.
 
 The same holds for `.claude/hooks/` and for the two build scripts, so nothing in this repository is
 written in shell. That is not a preference about shell: the guards under `.claude/hooks/` parse a
@@ -225,6 +262,9 @@ on every platform.
 | `Test ▸ unity-tests` (EditMode / PlayMode) | push (filtered) / every PR / merge group | **required** (skipped if absent) | no |
 | `Test ▸ release-notes` | push (filtered) / every PR / merge group | not required | no |
 | `Test ▸ publication` | push (filtered) / every PR / merge group | not required | no |
+| `Test ▸ test-quality` | push (filtered) / every PR / merge group | not required | no |
+| `Test ▸ base-red-python` | push (filtered) / every PR / merge group | not required | no |
+| `Test ▸ base-red` (EditMode / PlayMode) | every PR | **required** (skipped if absent) | no |
 | `Test ▸ Required checks (Unity)` | every PR / merge group | not required | **yes** |
 | `UPM ▸ split` | push to `main` | not required | no |
 | `UPM ▸ release` | manual (`workflow_dispatch`) | not required | no |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,10 +158,17 @@ python3 scripts/test_quality/base_red_check.py --base origin/main --plan   # wha
 python3 scripts/test_quality/base_red_check.py --base origin/main --warm-library Library
 ```
 
-A case that passes on the base fails the check. A case that could not compile there does not — it names
-something the branch adds, which is a pin doing its job — and the base tree is read before any of it is
-believed: the cases the branch did not change come from the base's own green run, so one of those going
-red means the tree is answering about itself and its fixture's verdicts are withdrawn.
+**It passes only where every changed case was measured on a base tree that demonstrably answers.** Most
+of what goes wrong with a run like this ends in a reading nobody took, and a reading nobody took is never
+a pass. So a case that passes on the base fails the check, and a case that could not compile there does
+not — it names something the branch adds, which is a pin doing its job — but that second reading is only
+believed on a tree the run proved can build and answer at all. Two things prove it. Fixtures of the
+base's own that the branch did not carry run alongside, and at least one has to pass; a run that wrote no
+results file at all fails outright rather than reading as a base that built none of the branch's tests.
+Alongside that, the cases the branch left alone in a file it changed nothing shared in are the base's own
+text, so one of those going red means the tree is answering about itself and that fixture's verdicts are
+withdrawn. Change a `[SetUp]`, a field, a private helper or anything under `TestUtilities/`, and those
+cases stop being the base's text and stop being read as the instrument — the run says which and why.
 
 Two kinds of case belong on the base, and say so above themselves with a reason a reviewer can weigh:
 
@@ -169,11 +176,17 @@ Two kinds of case belong on the base, and say so above themselves with a reason 
 // GREEN_ON_BASE(characterization): the keyed-reorder order this refactor must not change.
 ```
 
+```python
+# GREEN_ON_BASE(refactor): the settle-path names this rename preserves.
+```
+
 `characterization` pins behaviour the base already has; `refactor` rides with a change meant to preserve
-it. The declaration is read in both directions — one over a case that turns out red on the base fails the
-check too — so it cannot outlive what it describes. The base tree is a checkout the machine has never
-imported, and that import is most of what a base run costs; `--warm-library` copies an existing `Library`
-into it, sharing blocks where the filesystem will.
+it. A declaration answers for the change written under it, and it is read three ways so it cannot outlive
+what it describes: one over a case that turns out red on the base fails the check, one whose category or
+reason the script refuses fails it, and one the branch did not itself write is a declaration for a change
+the base already carries and does not cover this one — restate it. The base tree is a checkout the
+machine has never imported, and that import is most of what a base run costs; `--warm-library` copies an
+existing `Library` into it, sharing blocks where the filesystem will.
 
 `Test ▸ base-red-python` runs the Python lane on every pull request and needs no licence.
 `Test ▸ base-red` runs the C# lane where one is configured, but only one round of it: a base that

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/BaseRedDeclarationTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/BaseRedDeclarationTests.cs
@@ -1,0 +1,101 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using NUnit.Framework;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Holds the in-file declaration <c>scripts/test_quality/base_red_check.py</c> reads — the one way to say
+    /// that a case belongs on the merge base — against the categories that script accepts and the example
+    /// CONTRIBUTING.md shows. A declaration whose category the script does not know is refused by it, and
+    /// until then reads to everyone else as an approved exemption; the guide's example is what a
+    /// contributor copies, so a format change that leaves it behind teaches the wrong shape.
+    /// </summary>
+    /// <remarks>
+    /// The categories are read out of the script rather than listed here. A second copy is a second thing
+    /// to update, and the failure of the copy that nobody updated is silence.
+    /// </remarks>
+    [TestFixture]
+    internal sealed class BaseRedDeclarationTests
+    {
+        private const string Script = "scripts/test_quality/base_red_check.py";
+        private const string Guide = "CONTRIBUTING.md";
+
+        private static readonly Regex CategoryTuple =
+            new(@"CATEGORIES\s*=\s*\(([^)]*)\)", RegexOptions.Compiled);
+
+        private static readonly Regex Quoted = new("\"([^\"]+)\"", RegexOptions.Compiled);
+
+        private static readonly Regex Declaration =
+            new(@"GREEN_ON_BASE\(([A-Za-z]*)\)\s*:\s*(.*)", RegexOptions.Compiled);
+
+        private static string Read(string path) => File.ReadAllText(Path.GetFullPath(path));
+
+        private static IReadOnlyList<string> Categories()
+        {
+            var tuple = CategoryTuple.Match(Read(Script));
+            return tuple.Success
+                ? Quoted.Matches(tuple.Groups[1].Value).Select(match => match.Groups[1].Value).ToList()
+                : new List<string>();
+        }
+
+        /// <summary>Every declaration written in this repository's own C# test sources.</summary>
+        private static IEnumerable<(string File, Match Match)> Declared()
+            => from file in Directory.EnumerateFiles(Path.GetFullPath("Packages/com.velvet.core"),
+                                                     "*.cs", SearchOption.AllDirectories)
+               let text = File.ReadAllText(file)
+               from Match match in Declaration.Matches(text)
+               select (file, match);
+
+        [Test]
+        public void Given_TheScript_When_ItsCategoriesAreRead_Then_ThereIsMoreThanOne()
+        {
+            // Act
+            var categories = Categories();
+
+            // Assert — a reading that comes back empty makes every case below vacuously true, and a
+            // single category would mean the declaration says nothing beyond its own presence.
+            Assert.That(categories.Count, Is.GreaterThan(1),
+                $"{Script} declares no CATEGORIES tuple this fixture can read");
+        }
+
+        [Test]
+        public void Given_EveryDeclarationInTheCSharpSources_When_ItsCategoryIsRead_Then_TheScriptKnowsIt()
+        {
+            // Arrange
+            var categories = Categories();
+
+            // Act
+            var unknown = (from written in Declared()
+                           let category = written.Match.Groups[1].Value
+                           where !categories.Contains(category)
+                           select $"{Path.GetFileName(written.File)}: {category}").ToList();
+
+            // Assert
+            Assert.That(unknown, Is.Empty,
+                $"{Script} refuses these categories, so the case is measured rather than exempt:\n"
+                + string.Join("\n", unknown));
+        }
+
+        [Test]
+        public void Given_TheDeclarationTheGuideShows_When_TheScriptsOwnPatternReadsIt_Then_ItIsAccepted()
+        {
+            // Arrange — what a contributor copies out of the guide, read back by the thing that will
+            // judge it. The categories come from the script, so this fails on a rename of either side.
+            var categories = Categories();
+
+            // Act
+            var shown = Declaration.Matches(Read(Guide)).Cast<Match>()
+                .Select(match => (Category: match.Groups[1].Value, Reason: match.Groups[2].Value))
+                .ToList();
+
+            // Assert — the count rides along because a guide that shows no example passes on the rest.
+            Assert.That((shown.Count, shown.All(sample => categories.Contains(sample.Category)
+                                                          && sample.Reason.Split(' ').Length >= 4)),
+                Is.EqualTo((1, true)),
+                $"{Guide} shows an example {Script} would not accept");
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/BaseRedDeclarationTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/BaseRedDeclarationTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -14,8 +15,9 @@ namespace Velvet.Tests
     /// contributor copies, so a format change that leaves it behind teaches the wrong shape.
     /// </summary>
     /// <remarks>
-    /// The categories are read out of the script rather than listed here. A second copy is a second thing
-    /// to update, and the failure of the copy that nobody updated is silence.
+    /// Both what the script accepts — its categories and how long a reason has to be — are read out of it
+    /// rather than listed here. A second copy is a second thing to update, and the failure of the copy
+    /// that nobody updated is silence.
     /// </remarks>
     [TestFixture]
     internal sealed class BaseRedDeclarationTests
@@ -28,6 +30,9 @@ namespace Velvet.Tests
 
         private static readonly Regex Quoted = new("\"([^\"]+)\"", RegexOptions.Compiled);
 
+        private static readonly Regex MinimumWords =
+            new(@"MINIMUM_REASON_WORDS\s*=\s*(\d+)", RegexOptions.Compiled);
+
         private static readonly Regex Declaration =
             new(@"GREEN_ON_BASE\(([A-Za-z]*)\)\s*:\s*(.*)", RegexOptions.Compiled);
 
@@ -39,6 +44,12 @@ namespace Velvet.Tests
             return tuple.Success
                 ? Quoted.Matches(tuple.Groups[1].Value).Select(match => match.Groups[1].Value).ToList()
                 : new List<string>();
+        }
+
+        private static int MinimumReasonWords()
+        {
+            var match = MinimumWords.Match(Read(Script));
+            return match.Success ? int.Parse(match.Groups[1].Value) : 0;
         }
 
         /// <summary>Every declaration written in this repository's own C# test sources.</summary>
@@ -80,11 +91,26 @@ namespace Velvet.Tests
         }
 
         [Test]
+        public void Given_TheScript_When_ItsMinimumReasonLengthIsRead_Then_ItIsMoreThanOneWord()
+        {
+            // Act
+            var minimum = MinimumReasonWords();
+
+            // Assert — a reading that comes back zero makes every reason below long enough by
+            // arithmetic, which is the same silence a hand-copied literal fails with.
+            Assert.That(minimum, Is.GreaterThan(1),
+                $"{Script} declares no MINIMUM_REASON_WORDS this fixture can read");
+        }
+
+        [Test]
         public void Given_TheDeclarationTheGuideShows_When_TheScriptsOwnPatternReadsIt_Then_ItIsAccepted()
         {
             // Arrange — what a contributor copies out of the guide, read back by the thing that will
-            // judge it. The categories come from the script, so this fails on a rename of either side.
+            // judge it. Both the categories and the length come from the script: the script splits on
+            // whitespace and drops what falls out empty, so this must too or a reason with a trailing
+            // space is long enough here and short there.
             var categories = Categories();
+            var minimum = MinimumReasonWords();
 
             // Act
             var shown = Declaration.Matches(Read(Guide)).Cast<Match>()
@@ -92,9 +118,12 @@ namespace Velvet.Tests
                 .ToList();
 
             // Assert — the count rides along because a guide that shows no example passes on the rest.
-            Assert.That((shown.Count, shown.All(sample => categories.Contains(sample.Category)
-                                                          && sample.Reason.Split(' ').Length >= 4)),
-                Is.EqualTo((1, true)),
+            // A floor rather than an exact number: the guide shows one spelling per lane, and pinning
+            // how many lanes there are is a mirror that goes stale when a third one arrives.
+            Assert.That((shown.Count >= 1, shown.All(sample => categories.Contains(sample.Category)
+                    && sample.Reason.Split((char[])null, StringSplitOptions.RemoveEmptyEntries)
+                        .Length >= minimum)),
+                Is.EqualTo((true, true)),
                 $"{Guide} shows an example {Script} would not accept");
         }
     }

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/BaseRedDeclarationTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/BaseRedDeclarationTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e6249c208cea480cb40cfd0d36879974

--- a/scripts/test_quality/base_red_check.py
+++ b/scripts/test_quality/base_red_check.py
@@ -28,8 +28,8 @@ or a timeout, and it is the case the canary exists for rather than a case to dis
 reading, and no reading falls through to the same passing verdict. So the type a case is written in
 is read off the code rather than off the raw line -- `class` occurs in prose and in assertion
 messages -- a type leaves the stack when its body closes, and a case written in an abstract fixture
-is named for each concrete heir. `test_base_red_check.py` holds every case in this repository to a
-name a concrete class in the tree carries.
+is named for each concrete heir. `test_base_red_check.py` holds every C# case in this repository to
+a name the tree declares in full: every owner segment, nested as the name nests them.
 
 *A case that cannot compile is evidence, not an error* -- it names something the branch adds -- and
 that reading holds only where the same file compiles on the branch, which is the condition running
@@ -161,9 +161,12 @@ CSHARP_TEST_DIR = re.compile(r"/Tests/(Editor|PlayMode)/")
 CSHARP_ATTRIBUTE = re.compile(r"^\s*\[")
 CSHARP_CASE_ATTRIBUTE = re.compile(r"\[\s*(Test|UnityTest|TestCase|TestCaseSource|Theory)\b")
 CSHARP_METHOD = re.compile(r"\b([A-Za-z_][A-Za-z0-9_]*)\s*\(")
-CSHARP_TYPE = re.compile(r"\b(?:class|struct|record)\s+([A-Za-z_][A-Za-z0-9_]*)")
+# `record` takes an optional `class` or `struct` after it, so the name sits one token further along
+# than the other two spellings put it.
+CSHARP_DECLARES = r"\b(?:class|struct|record(?:\s+(?:class|struct))?)\s+"
+CSHARP_TYPE = re.compile(CSHARP_DECLARES + r"([A-Za-z_][A-Za-z0-9_]*)")
 CSHARP_ABSTRACT = re.compile(r"\babstract\s+(?:partial\s+)?(?:class|record)\b")
-CSHARP_BASES = re.compile(r"\b(?:class|record)\s+[A-Za-z_][A-Za-z0-9_]*\s*(?:<[^>]*>)?\s*:\s*([^{]+)")
+CSHARP_BASES = re.compile(CSHARP_DECLARES + r"[A-Za-z_][A-Za-z0-9_]*\s*(?:<[^>]*>)?\s*:\s*([^{]+)")
 CSHARP_IDENTIFIER = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
 CSHARP_NAMESPACE = re.compile(r"\bnamespace\s+([A-Za-z_][A-Za-z0-9_.]*)")
 
@@ -286,6 +289,9 @@ def csharp_cases(text, path="?"):
     A type leaves the stack when the depth its body opened at comes back, not only when the next
     declaration displaces it. Without that a nested helper class declared after the last one, as an
     abstract args type or a fake, owns every case under it for the rest of the file.
+
+    A declaration that opens no body never joins the stack: the unwinding above is keyed on a body
+    closing, so one that never opens is never popped, and it holds down every type under it too.
     """
     lines = text.splitlines()
     code = code_lines(text)
@@ -305,7 +311,7 @@ def csharp_cases(text, path="?"):
         if found:
             namespace = found.group(1)
         found = CSHARP_TYPE.search(line)
-        if found:
+        if found and not (peak == entering and line.rstrip().endswith(";")):
             types.append([found.group(1), entering, bool(CSHARP_ABSTRACT.search(line)), False])
         if types and not types[-1][3] and peak > types[-1][1]:
             types[-1][3] = True

--- a/scripts/test_quality/base_red_check.py
+++ b/scripts/test_quality/base_red_check.py
@@ -10,28 +10,44 @@ had a case that passed on the base and had been reported as pinning something.
 What runs is the branch's test file over the base's production code: the base commit is checked out,
 the branch's test-side files are copied onto it, and the changed cases are executed there.
 
-Three things separate a verdict from a guess.
+**Success here means every changed case was measured on a base tree that demonstrably answers.** Not
+that nothing failed: most of what can go wrong with a run like this ends in a reading nobody took,
+and a reading nobody took must never be a pass. That is one sentence and it decides the shape of
+everything below, because the verdict that carries the evidence -- a case the base could not build --
+is indistinguishable, from the results file alone, from a base that built nothing, ran nothing, or
+was never asked. So each of those is closed separately:
 
-*The instrument is read first.* The cases the branch did not change are byte-identical to the base's
-own, which was green, so they must be green here too. Where one is not, the base tree is answering
-about itself rather than about the branch, and every verdict from that fixture is withdrawn. This is
-not hypothetical: a fresh worktree of this repository has been measured failing cases that no branch
-touched, and without the reading each of those would have read as a case going red for the branch.
+*The tree is read by fixtures the branch did not carry.* `canary_fixtures` picks fixtures of the
+base's own, and where it found any, at least one has to pass. A tree where nothing built reports
+every case as uncompilable, which is not a failure here, so without that reading such a run comes
+back green having measured nothing at all. Separately and before it, a run that left no results file
+withdraws every platform outright: that is the ordinary shape of a licence failure, an editor crash
+or a timeout, and it is the case the canary exists for rather than a case to disarm it in.
+
+*A case is measured under the name the runner reports it by.* A name nothing answers to yields no
+reading, and no reading falls through to the same passing verdict. So the type a case is written in
+is read off the code rather than off the raw line -- `class` occurs in prose and in assertion
+messages -- a type leaves the stack when its body closes, and a case written in an abstract fixture
+is named for each concrete heir. `test_base_red_check.py` holds every case in this repository to a
+name a concrete class in the tree carries.
 
 *A case that cannot compile is evidence, not an error* -- it names something the branch adds -- and
 that reading holds only where the same file compiles on the branch, which is the condition running
 this after the branch's own suite satisfies. A round that reports no case of a fixture is one where
-what the branch carried did not build: that file is withdrawn and the run repeated, so the rest is
-still measured rather than lost behind it. All of that is read off the results, and the editor log
-only picks which file to withdraw first, so a runner that hands back a results file and nothing else
-can still take every verdict -- one round of it, without the withdrawing.
+something the branch carried did not build: that file is withdrawn and the run repeated, so the rest
+is still measured rather than lost behind it. Which file is picked off the editor log, over every
+carried file rather than only the ones holding cases, since a shared helper takes its whole assembly
+down with it. A runner that hands back a results file and nothing else can still take every verdict
+-- one round of it, without the withdrawing.
 
 *A case that belongs on the base says so*, above itself, with a reason:
 
     // GREEN_ON_BASE(characterization): the keyed-reorder order this refactor must not change.
 
-A declaration is per case, and it is read in both directions: one over a case that goes red on the
-base fails too, so a declaration cannot outlive what it describes.
+A declaration is per case and answers for the change under it, so it is read three ways: one over a
+case that goes red on the base is stale and fails, one whose category or reason is malformed fails,
+and one the branch did not itself write is a declaration for a change the base already carries and
+does not answer for this one. A declaration therefore cannot outlive what it describes.
 
 Run: python3 scripts/test_quality/base_red_check.py --base origin/main
 """
@@ -83,16 +99,23 @@ def _sibling(name):
 
 
 # Which offsets the C# compiler sees as code is one question with one answer, and mutation_check.py
-# owns it: a brace inside a string or a comment closes no method there and none here.
+# owns it. Everything here that reads C# structure -- braces, types, namespaces, attributes -- reads
+# it through that mask, so a brace or a `class` inside a string or a comment names nothing here.
 _mutation_check = _sibling("mutation_check")
 code_mask = _mutation_check.code_mask
 line_spans = _mutation_check.line_spans
 
 
 class Declaration:
-    def __init__(self, category, reason):
+    def __init__(self, category, reason, written_here=True, line=None):
         self.category = category
         self.reason = reason
+        # A declaration says a case belongs on the base *because of the change under it*. One the
+        # branch did not write was written for a change the base already carries, and it answers for
+        # that one. Without this the first branch to declare a case green silences every later branch
+        # that edits it, however unlike the reason the declaration gives their change is.
+        self.written_here = written_here
+        self.line = line
 
     @property
     def complaint(self):
@@ -175,21 +198,39 @@ def is_test_side(relative):
     return kind_of(relative) is not None or "/TestUtilities/" in "/" + relative
 
 
-def depths(text):
-    """Brace depth at the end of each line, counting only what the compiler sees as code."""
+def code_lines(text):
+    """Each line with every comment, string and character literal blanked to spaces.
+
+    Blanked rather than removed, so a code line is as long as the raw one and the two can be indexed
+    together -- which they are, since a declaration lives in a comment and everything else does not.
+    """
     mask = code_mask(text)
-    result = []
+    return ["".join(text[offset] if mask[offset] else " " for offset in range(start, end)).rstrip("\r\n")
+            for start, end in line_spans(text)]
+
+
+def brace_profile(text):
+    """(depth entering, deepest within, depth leaving) per line, counting only what the compiler sees.
+
+    The peak is what separates a type whose body opens on the line below from one that opens and
+    closes on its own line: both leave the depth exactly where they found it.
+    """
+    mask = code_mask(text)
+    profile = []
     depth = 0
     for start, end in line_spans(text):
+        entering = depth
+        peak = depth
         for offset in range(start, end):
             if not mask[offset]:
                 continue
             if text[offset] == "{":
                 depth += 1
+                peak = max(peak, depth)
             elif text[offset] == "}":
                 depth -= 1
-        result.append(depth)
-    return result
+        profile.append((entering, peak, depth))
+    return profile
 
 
 def comment_block_start(lines, index):
@@ -211,7 +252,7 @@ def leading_declaration(lines, index):
     for probe in range(comment_block_start(lines, index), index):
         match = DECLARATION.search(lines[probe].strip())
         if match:
-            return Declaration(match.group(1), match.group(2).strip())
+            return Declaration(match.group(1), match.group(2).strip(), line=probe + 1)
     return None
 
 
@@ -235,40 +276,55 @@ def member_end(lines, ends, signature):
 
 
 def csharp_cases(text, path="?"):
-    """Every test case in a C# fixture, named as Unity's -testFilter takes it."""
+    """Every test case in a C# fixture, named as Unity's -testFilter takes it.
+
+    Read off the code lines rather than the raw ones. `class` occurs in this repository's assertion
+    messages and in its prose, and a scan that cannot tell those apart from a declaration names the
+    cases under a type the runner has never heard of -- which reports nothing, and no reading is one
+    of the passing verdicts below.
+
+    A type leaves the stack when the depth its body opened at comes back, not only when the next
+    declaration displaces it. Without that a nested helper class declared after the last one, as an
+    abstract args type or a fake, owns every case under it for the rest of the file.
+    """
     lines = text.splitlines()
-    ends = depths(text)
-    starts = [0] + ends[:-1]
+    code = code_lines(text)
+    profile = brace_profile(text)
+    ends = [leaving for _, _, leaving in profile]
 
     namespace = None
     types = []
     cases = []
     index = 0
     while index < len(lines):
-        line = lines[index]
-        if not line.strip().startswith("//"):
-            found = CSHARP_NAMESPACE.search(line)
-            if found:
-                namespace = found.group(1)
-            found = CSHARP_TYPE.search(line)
-            if found:
-                while types and types[-1][1] >= starts[index]:
-                    types.pop()
-                types.append((found.group(1), starts[index], bool(CSHARP_ABSTRACT.search(line))))
+        entering, peak, leaving = profile[index]
+        line = code[index]
+        while types and types[-1][3] and entering <= types[-1][1]:
+            types.pop()
+        found = CSHARP_NAMESPACE.search(line)
+        if found:
+            namespace = found.group(1)
+        found = CSHARP_TYPE.search(line)
+        if found:
+            types.append([found.group(1), entering, bool(CSHARP_ABSTRACT.search(line)), False])
+        if types and not types[-1][3] and peak > types[-1][1]:
+            types[-1][3] = True
+            if leaving <= types[-1][1]:
+                types.pop()
 
         if CSHARP_ATTRIBUTE.match(line):
             block = index
-            while index < len(lines) and (CSHARP_ATTRIBUTE.match(lines[index])
-                                          or not lines[index].strip()):
+            while index < len(lines) and (CSHARP_ATTRIBUTE.match(code[index])
+                                          or not code[index].strip()):
                 index += 1
-            attributes = "\n".join(lines[block:index])
-            signature = lines[index] if index < len(lines) else ""
+            attributes = "\n".join(code[block:index])
+            signature = code[index] if index < len(lines) else ""
             name = CSHARP_METHOD.search(signature)
             if CSHARP_CASE_ATTRIBUTE.search(attributes) and name:
-                owner = ".".join(part for part, _, _ in types)
+                owner = ".".join(part for part, _, _, _ in types)
                 qualified = ".".join(part for part in (namespace, owner, name.group(1)) if part)
                 case = Case(qualified, path, comment_block_start(lines, block) + 1,
-                            member_end(lines, ends, index) + 1, leading_declaration(lines, block))
+                            member_end(code, ends, index) + 1, leading_declaration(lines, block))
                 case.abstract_owner = types[-1][0] if types and types[-1][2] else None
                 cases.append(case)
             continue
@@ -310,9 +366,7 @@ def concrete_heirs(corpus):
     heirs = {}
     for relative, text in corpus.items():
         namespace = None
-        for line in text.splitlines():
-            if line.strip().startswith("//"):
-                continue
+        for line in code_lines(text):
             found = CSHARP_NAMESPACE.search(line)
             if found:
                 namespace = found.group(1)
@@ -353,9 +407,9 @@ def cases_in(relative, text):
 def touched(cases, changed_lines):
     """The cases the branch wrote: the ones a changed line lands inside. `None` is a whole new file.
 
-    A case the branch left alone is not a claim about it, whatever else in the file moved, and it is
-    worth more as a control -- byte-identical to the base's own, so anything but green from it is the
-    environment rather than the branch. `outside` is what this costs; the two are read together.
+    A case the branch left alone is not a claim about it, whatever else in the file moved. Whether it
+    is worth anything as a control is a separate question `collect` answers, and `outside` is half of
+    what that answer is read from.
     """
     if changed_lines is None:
         return list(cases)
@@ -368,7 +422,8 @@ def outside(cases, changed_lines):
 
     A change to what several cases share can make an untouched one stop separating anything, and no
     diff says which. Selecting the file whole on that ground was tried and puts every case a fixture
-    has on trial for a line added to SetUp, so it is reported instead of acted on.
+    has on trial for a line added to SetUp, so it is reported instead of acted on. What it does
+    settle is that the file's untouched cases are no longer the base's text and cannot read the tree.
     """
     if changed_lines is None:
         return set()
@@ -422,7 +477,19 @@ def changed_lines_by_file(project, since):
 
 
 def deleted_files(project, since):
-    return git(project, "diff", "--name-only", "--diff-filter=D", since).stdout.splitlines()
+    """The paths the base holds and the branch does not, so the base tree stops holding them either.
+
+    A rename is one of them. Git reports a rename as R rather than as A+D whenever it can pair the
+    two halves, so a filter that reads only D leaves the base's copy in place beside the carried one
+    -- two files declaring one fixture class, which either refuses to build or reports the same name
+    twice for the results to collapse into one.
+    """
+    gone = git(project, "diff", "--name-only", "--diff-filter=D", since).stdout.splitlines()
+    for line in git(project, "diff", "--name-status", "--diff-filter=R", since).stdout.splitlines():
+        fields = line.split("\t")
+        if len(fields) >= 3:
+            gone.append(fields[1])
+    return gone
 
 
 # --------------------------------------------------------------------------------------------------
@@ -511,6 +578,19 @@ def compile_error_files(log_text):
             if relative not in named:
                 named.append(relative)
     return named
+
+
+def next_to_withdraw(log_text, carry, withdrawn, silent):
+    """Which carried file to put back before asking the base again, after a round reported nothing.
+
+    Every carried file is a candidate, not only the ones holding cases. This repository's conventions
+    put a second fixture's shared reach into TestUtilities, that compiles into the same assembly as
+    the fixtures, and one the base cannot build takes every one of them down with it -- so a choice
+    made only over case-bearing files withdraws innocent fixtures one per round until there are none
+    left, and the run ends having measured nothing with nothing saying so.
+    """
+    return next((name for name in compile_error_files(log_text)
+                 if name in carry and name not in withdrawn), silent[0])
 
 
 def run_unity(unity, tree, platform, fixtures, results, log, timeout):
@@ -644,12 +724,17 @@ def decide(case, result, fixture_ran):
     its other cases and not this one resolved the name wrongly, and a name nobody answered to is a
     reading nobody took.
     """
-    if case.declaration is not None:
-        complaint = case.declaration.complaint
+    declaration = case.declaration
+    if declaration is not None and not declaration.written_here:
+        if result == "Passed":
+            return PASSED_ON_BASE, "its declaration is the base's own; restate it for this change"
+        declaration = None
+    if declaration is not None:
+        complaint = declaration.complaint
         if complaint:
             return DECLARED_STALE, complaint
         if result == "Passed":
-            return DECLARED_KEPT, "{}: {}".format(case.declaration.category, case.declaration.reason)
+            return DECLARED_KEPT, "{}: {}".format(declaration.category, declaration.reason)
         return DECLARED_STALE, "it is {} on the base; remove the declaration".format(
             (result or "absent").lower())
     if result == "Passed":
@@ -687,7 +772,8 @@ def as_plan(since, cases, control, shared, canaries):
         return {
             "name": case.name, "path": case.path, "key": case.key, "fixture": case.fixture,
             "declaration": (None if case.declaration is None
-                            else [case.declaration.category, case.declaration.reason]),
+                            else [case.declaration.category, case.declaration.reason,
+                                  case.declaration.written_here]),
         }
 
     return {"since": since, "shared": shared, "canaries": canaries,
@@ -720,10 +806,20 @@ def results_from(where):
     return reported, bool(files)
 
 
-def report(cases, control, reported, canaries=None):
-    """Prints each case's verdict and returns the ones that fail the run."""
+def report(cases, control, reported, canaries=None, wrote=True):
+    """Prints each case's verdict and returns the ones that fail the run.
+
+    `wrote` is whether the run produced a results file at all, and it is read before anything in it.
+    A run that wrote nothing measured nothing, and the verdict for a case nothing measured is not
+    COULD_NOT_COMPILE -- that reading says the base built the rest and not this, which takes a base
+    that built something.
+    """
     unsound = unsound_fixtures(control, reported)
     withdrawn = unsound_platforms(canaries or {}, reported)
+    if not wrote:
+        for platform in {platform_of(case.path) for case in cases
+                         if kind_of(case.path) == "csharp"}:
+            withdrawn[platform] = "the run wrote no results file, so nothing was measured"
     ran = fixtures_that_ran(reported)
     for case in cases:
         if case.fixture in unsound:
@@ -754,26 +850,37 @@ def corpus_of(project):
 
 
 def collect(project, base, lane):
-    """(merge base, changed cases, control cases, shared-line count by file) for a branch."""
+    """(merge base, changed cases, control cases, shared lines by file, carried helpers) for a branch."""
     since = merge_base(project, base)
     heirs = concrete_heirs(corpus_of(project))
+    by_file = changed_lines_by_file(project, since)
+    # A helper this branch rewrote is carried onto the base tree, so no case that calls it is running
+    # the base's own text any more. Its verdict is still worth taking -- a case going red because the
+    # branch sharpened what it shares is the strongest evidence this check can be handed -- but it is
+    # no longer a reading of the tree, and `canary_fixtures` reads the tree by the base's own files.
+    shared_helper = sorted(name for name in by_file
+                           if kind_of(name) is None and is_test_side(name))
     changed, control, shared = [], [], {}
-    for relative, lines in sorted(changed_lines_by_file(project, since).items()):
+    for relative, lines in sorted(by_file.items()):
         if kind_of(relative) is None or (lane != "both" and kind_of(relative) != lane):
             continue
         source = project / relative
         if not source.exists():
             continue
         cases = cases_in(relative, source.read_text())
+        for case in cases:
+            if case.declaration is not None and lines is not None:
+                case.declaration.written_here = case.declaration.line in lines
         wanted = {case.name for case in touched(cases, lines)}
         changed.extend(as_the_runner_names_them(
             [case for case in cases if case.name in wanted], heirs))
-        control.extend(as_the_runner_names_them(
-            [case for case in cases if case.name not in wanted], heirs))
         loose = outside(cases, lines)
+        if not loose and not shared_helper:
+            control.extend(as_the_runner_names_them(
+                [case for case in cases if case.name not in wanted], heirs))
         if loose:
             shared[relative] = len(loose)
-    return since, changed, control, shared
+    return since, changed, control, shared, shared_helper
 
 
 def main():
@@ -812,12 +919,12 @@ def main():
             raise SystemExit("--verdict needs --results")
         reported, wrote = results_from(args.results)
         if not wrote:
-            print("the base run wrote no result, so it did not build what was carried onto it")
+            print("the base run wrote no result, so nothing it was asked was measured")
         return 1 if report(from_plan(plan["cases"]), from_plan(plan["control"]), reported,
-                           plan["canaries"] if wrote else {}) else 0
+                           plan["canaries"], wrote) else 0
 
     project = Path(args.project).resolve()
-    since, cases, control, shared = collect(project, args.base, args.lane)
+    since, cases, control, shared, shared_helper = collect(project, args.base, args.lane)
     if not cases:
         print("no changed test case in scope of --lane {}".format(args.lane))
         return 0
@@ -825,12 +932,17 @@ def main():
     print("merge base {}".format(since[:12]))
     for case in cases:
         print("  {}{}".format(case.name,
-                              " [{}]".format(case.declaration.category) if case.declaration else ""))
+                              " [{}]".format(case.declaration.category)
+                              if case.declaration and case.declaration.written_here else ""))
     print("  ({} control case(s) alongside)".format(len(control)))
     for relative, count in sorted(shared.items()):
-        print("  not judged: {} line(s) of {} sit in no case -- a SetUp, a field, a helper, a using. "
-              "A case\n              they change but whose own body they do not is left as a control."
-              .format(count, relative))
+        print("  no control: {} line(s) of {} sit in no case -- a SetUp, a field, a helper, a using. "
+              "The\n              cases beside them are this branch's text too, so none of them reads "
+              "the base tree.".format(count, relative))
+    for relative in shared_helper:
+        print("  no control: {} is carried onto the base, so every case that calls it is this "
+              "branch's\n              text there. The base's own fixtures are what read the tree."
+              .format(relative))
     if args.plan:
         return 0
 
@@ -911,10 +1023,11 @@ def main():
                 silent = sorted({case.path for case in live if case.fixture not in ran})
                 if not silent:
                     break
-                blamed = [name for name in compile_error_files(
-                    log.read_text(errors="replace") if log.exists() else "") if name in silent]
-                withdraw(base_tree, blamed[0] if blamed else silent[0])
-                withdrawn.add(blamed[0] if blamed else silent[0])
+                offender = next_to_withdraw(
+                    log.read_text(errors="replace") if log.exists() else "",
+                    carry, withdrawn, silent)
+                withdraw(base_tree, offender)
+                withdrawn.add(offender)
     finally:
         if holder is not None:
             git(project, "worktree", "remove", "--force", str(base_tree), check=False)
@@ -924,8 +1037,8 @@ def main():
         (output / "python.log").write_text("\n".join(transcript))
 
     if not ever_wrote:
-        print("no round wrote a result, so the base built none of what was carried onto it")
-    offenders = report(cases, control, reported, canaries if ever_wrote else {})
+        print("no round wrote a result, so nothing any of them was asked was measured")
+    offenders = report(cases, control, reported, canaries, ever_wrote)
     print("\nlogs: {}".format(output))
     return 1 if offenders else 0
 

--- a/scripts/test_quality/base_red_check.py
+++ b/scripts/test_quality/base_red_check.py
@@ -1,0 +1,934 @@
+#!/usr/bin/env python3
+"""Run this branch's changed test cases against the merge base and report every one that passes there.
+
+A test is written to separate a behaviour from its absence. The only reading that shows it does is the
+one taken before the change it pins: green on the branch and green on the base together mean the case
+would have passed whatever the branch did to production code. Nothing in this repository asked that
+question, so it stayed a matter of attentiveness. Three of the four branches this was first run over
+had a case that passed on the base and had been reported as pinning something.
+
+What runs is the branch's test file over the base's production code: the base commit is checked out,
+the branch's test-side files are copied onto it, and the changed cases are executed there.
+
+Three things separate a verdict from a guess.
+
+*The instrument is read first.* The cases the branch did not change are byte-identical to the base's
+own, which was green, so they must be green here too. Where one is not, the base tree is answering
+about itself rather than about the branch, and every verdict from that fixture is withdrawn. This is
+not hypothetical: a fresh worktree of this repository has been measured failing cases that no branch
+touched, and without the reading each of those would have read as a case going red for the branch.
+
+*A case that cannot compile is evidence, not an error* -- it names something the branch adds -- and
+that reading holds only where the same file compiles on the branch, which is the condition running
+this after the branch's own suite satisfies. A round that reports no case of a fixture is one where
+what the branch carried did not build: that file is withdrawn and the run repeated, so the rest is
+still measured rather than lost behind it. All of that is read off the results, and the editor log
+only picks which file to withdraw first, so a runner that hands back a results file and nothing else
+can still take every verdict -- one round of it, without the withdrawing.
+
+*A case that belongs on the base says so*, above itself, with a reason:
+
+    // GREEN_ON_BASE(characterization): the keyed-reorder order this refactor must not change.
+
+A declaration is per case, and it is read in both directions: one over a case that goes red on the
+base fails too, so a declaration cannot outlive what it describes.
+
+Run: python3 scripts/test_quality/base_red_check.py --base origin/main
+"""
+
+import argparse
+import ast
+import importlib.util
+import json
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+DEFAULT_UNITY = "/Applications/Unity/Hub/Editor/6000.3.11f1/Unity.app/Contents/MacOS/Unity"
+# Anchored at the editor binary so that a shell waiting on this pattern does not match itself and
+# report a busy machine forever on an idle one.
+UNITY_RUNNING = "^/Applications/.*/MacOS/Unity -runTests"
+
+PASSED_ON_BASE = "passed on the base"
+RED_ON_BASE = "red on the base"
+COULD_NOT_COMPILE = "could not compile there"
+DECLARED_KEPT = "declared, and green as declared"
+DECLARED_STALE = "declared, and not as declared"
+NOT_REPORTED = "no result was written"
+BASE_UNSOUND = "the base tree cannot answer"
+
+FAILING_VERDICTS = (PASSED_ON_BASE, DECLARED_STALE, NOT_REPORTED, BASE_UNSOUND)
+
+CATEGORIES = ("characterization", "refactor")
+
+# The reason has to say something a reviewer can disagree with, and a word count is the only part of
+# that a script can hold. Four words rules out "n/a" and "see above" without pretending to judge prose.
+MINIMUM_REASON_WORDS = 4
+
+DECLARATION = re.compile(r"GREEN_ON_BASE\(([A-Za-z]*)\)\s*:\s*(.*)")
+
+
+def _sibling(name):
+    """Imports a sibling script by path, since scripts/test_quality is not a package."""
+    path = Path(__file__).resolve().with_name(name + ".py")
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# Which offsets the C# compiler sees as code is one question with one answer, and mutation_check.py
+# owns it: a brace inside a string or a comment closes no method there and none here.
+_mutation_check = _sibling("mutation_check")
+code_mask = _mutation_check.code_mask
+line_spans = _mutation_check.line_spans
+
+
+class Declaration:
+    def __init__(self, category, reason):
+        self.category = category
+        self.reason = reason
+
+    @property
+    def complaint(self):
+        if self.category not in CATEGORIES:
+            return "category {!r} is not one of {}".format(self.category, ", ".join(CATEGORIES))
+        if len(self.reason.split()) < MINIMUM_REASON_WORDS:
+            return "the reason is under {} words".format(MINIMUM_REASON_WORDS)
+        return None
+
+
+class Case:
+    """One test case, and where in the file it starts and ends."""
+
+    def __init__(self, name, path, first_line, last_line, declaration=None):
+        self.name = name
+        self.path = path
+        self.first_line = first_line
+        self.last_line = last_line
+        self.declaration = declaration
+        self.abstract_owner = None
+        self.verdict = None
+        self.detail = ""
+
+    @property
+    def key(self):
+        """How the run reports this case. A Python module is not qualified by anything else."""
+        return self.name if kind_of(self.path) == "csharp" else "{}::{}".format(self.path, self.name)
+
+    @property
+    def fixture(self):
+        """The class, as the run names it -- the unit -testFilter takes and the control is read over."""
+        return self.key.rsplit(".", 1)[0]
+
+    def __repr__(self):
+        return "Case({!r}, {}-{})".format(self.name, self.first_line, self.last_line)
+
+
+# --------------------------------------------------------------------------------------------------
+# Reading a test file
+# --------------------------------------------------------------------------------------------------
+
+CSHARP_TEST_DIR = re.compile(r"/Tests/(Editor|PlayMode)/")
+CSHARP_ATTRIBUTE = re.compile(r"^\s*\[")
+CSHARP_CASE_ATTRIBUTE = re.compile(r"\[\s*(Test|UnityTest|TestCase|TestCaseSource|Theory)\b")
+CSHARP_METHOD = re.compile(r"\b([A-Za-z_][A-Za-z0-9_]*)\s*\(")
+CSHARP_TYPE = re.compile(r"\b(?:class|struct|record)\s+([A-Za-z_][A-Za-z0-9_]*)")
+CSHARP_ABSTRACT = re.compile(r"\babstract\s+(?:partial\s+)?(?:class|record)\b")
+CSHARP_BASES = re.compile(r"\b(?:class|record)\s+[A-Za-z_][A-Za-z0-9_]*\s*(?:<[^>]*>)?\s*:\s*([^{]+)")
+CSHARP_IDENTIFIER = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+CSHARP_NAMESPACE = re.compile(r"\bnamespace\s+([A-Za-z_][A-Za-z0-9_.]*)")
+
+
+def platform_of(relative):
+    """The -testPlatform value for a file, from the directory this repository splits asmdefs by.
+
+    Tests/Editor holds the EditMode assembly: the directory is named for the platform the asmdef is
+    restricted to, and the runner takes the name of the mode.
+    """
+    match = CSHARP_TEST_DIR.search("/" + relative.strip("/"))
+    if not match:
+        return None
+    return "EditMode" if match.group(1) == "Editor" else "PlayMode"
+
+
+def kind_of(relative):
+    """Which lane a repository-relative path belongs to, or None when it holds no test case."""
+    if relative.endswith(".cs") and platform_of(relative):
+        return "csharp"
+    if relative.endswith(".py") and Path(relative).name.startswith("test_"):
+        return "python"
+    return None
+
+
+def is_test_side(relative):
+    """Whether a file is the branch's test material rather than the production code under test.
+
+    This is what gets carried onto the base tree. TestUtilities is in because a changed helper is
+    part of the case that calls it, and a base tree without it compiles neither.
+    """
+    return kind_of(relative) is not None or "/TestUtilities/" in "/" + relative
+
+
+def depths(text):
+    """Brace depth at the end of each line, counting only what the compiler sees as code."""
+    mask = code_mask(text)
+    result = []
+    depth = 0
+    for start, end in line_spans(text):
+        for offset in range(start, end):
+            if not mask[offset]:
+                continue
+            if text[offset] == "{":
+                depth += 1
+            elif text[offset] == "}":
+                depth -= 1
+        result.append(depth)
+    return result
+
+
+def comment_block_start(lines, index):
+    """The first line of the contiguous comment block directly above `index`, or `index` itself.
+
+    Directly above and nothing between: a blank line or any code ends the block. A comment further up
+    belongs to whatever sits under it, and reaching past the gap would let one case's prose cover a
+    neighbour nobody wrote it for. The block counts as part of the case, so editing the declaration
+    below re-poses the question the declaration answers.
+    """
+    probe = index
+    while probe > 0 and lines[probe - 1].strip().startswith(("//", "#")):
+        probe -= 1
+    return probe
+
+
+def leading_declaration(lines, index):
+    """The declaration in the comment block `comment_block_start` delimits, if there is one."""
+    for probe in range(comment_block_start(lines, index), index):
+        match = DECLARATION.search(lines[probe].strip())
+        if match:
+            return Declaration(match.group(1), match.group(2).strip())
+    return None
+
+
+def member_end(lines, ends, signature):
+    """The last line of the member whose signature line is `signature`.
+
+    A body that opens a brace ends where the depth comes back; one that does not ends at its
+    semicolon. Both spellings are in this repository's fixtures, the second as an expression-bodied
+    single assertion.
+    """
+    outer = ends[signature - 1] if signature > 0 else 0
+    opened = False
+    for index in range(signature, len(lines)):
+        if ends[index] > outer:
+            opened = True
+        elif opened:
+            return index
+        elif lines[index].rstrip().endswith(";"):
+            return index
+    return len(lines) - 1
+
+
+def csharp_cases(text, path="?"):
+    """Every test case in a C# fixture, named as Unity's -testFilter takes it."""
+    lines = text.splitlines()
+    ends = depths(text)
+    starts = [0] + ends[:-1]
+
+    namespace = None
+    types = []
+    cases = []
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        if not line.strip().startswith("//"):
+            found = CSHARP_NAMESPACE.search(line)
+            if found:
+                namespace = found.group(1)
+            found = CSHARP_TYPE.search(line)
+            if found:
+                while types and types[-1][1] >= starts[index]:
+                    types.pop()
+                types.append((found.group(1), starts[index], bool(CSHARP_ABSTRACT.search(line))))
+
+        if CSHARP_ATTRIBUTE.match(line):
+            block = index
+            while index < len(lines) and (CSHARP_ATTRIBUTE.match(lines[index])
+                                          or not lines[index].strip()):
+                index += 1
+            attributes = "\n".join(lines[block:index])
+            signature = lines[index] if index < len(lines) else ""
+            name = CSHARP_METHOD.search(signature)
+            if CSHARP_CASE_ATTRIBUTE.search(attributes) and name:
+                owner = ".".join(part for part, _, _ in types)
+                qualified = ".".join(part for part in (namespace, owner, name.group(1)) if part)
+                case = Case(qualified, path, comment_block_start(lines, block) + 1,
+                            member_end(lines, ends, index) + 1, leading_declaration(lines, block))
+                case.abstract_owner = types[-1][0] if types and types[-1][2] else None
+                cases.append(case)
+            continue
+        index += 1
+    return cases
+
+
+def python_cases(text, path="?"):
+    """Every unittest case in a Python test module, named as `python3 -m unittest` takes it."""
+    try:
+        tree = ast.parse(text)
+    except SyntaxError:
+        return []
+    lines = text.splitlines()
+    cases = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ClassDef):
+            continue
+        for member in node.body:
+            if not isinstance(member, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            if not member.name.startswith("test"):
+                continue
+            declared = min([member.lineno] + [decorator.lineno for decorator in member.decorator_list])
+            cases.append(Case("{}.{}".format(node.name, member.name), path,
+                              comment_block_start(lines, declared - 1) + 1, member.end_lineno,
+                              leading_declaration(lines, declared - 1)))
+    return cases
+
+
+def concrete_heirs(corpus):
+    """Simple class name -> the qualified names of the concrete classes that inherit it.
+
+    A case written in an abstract fixture runs, and is reported, under each class deriving from it,
+    never under the one it is written in. Filtering on the name in the file therefore matches nothing
+    and the case reads as one the base could not build, which is not a failure -- so without this a
+    branch could rewrite an inherited case and the run would come back green having asked nothing.
+    """
+    heirs = {}
+    for relative, text in corpus.items():
+        namespace = None
+        for line in text.splitlines():
+            if line.strip().startswith("//"):
+                continue
+            found = CSHARP_NAMESPACE.search(line)
+            if found:
+                namespace = found.group(1)
+            declared = CSHARP_TYPE.search(line)
+            bases = CSHARP_BASES.search(line)
+            if not declared or not bases or CSHARP_ABSTRACT.search(line):
+                continue
+            qualified = ".".join(part for part in (namespace, declared.group(1)) if part)
+            for base in {match.group(0) for match in CSHARP_IDENTIFIER.finditer(bases.group(1))}:
+                heirs.setdefault(base, set()).add(qualified)
+    return heirs
+
+
+def as_the_runner_names_them(cases, heirs):
+    """Rewrites each case written in an abstract fixture into one case per concrete heir."""
+    resolved = []
+    for case in cases:
+        if not case.abstract_owner:
+            resolved.append(case)
+            continue
+        method = case.name.rsplit(".", 1)[-1]
+        for owner in sorted(heirs.get(case.abstract_owner, ())):
+            heir = Case(owner + "." + method, case.path, case.first_line, case.last_line,
+                        case.declaration)
+            resolved.append(heir)
+    return resolved
+
+
+def cases_in(relative, text):
+    kind = kind_of(relative)
+    if kind == "csharp":
+        return csharp_cases(text, relative)
+    if kind == "python":
+        return python_cases(text, relative)
+    return []
+
+
+def touched(cases, changed_lines):
+    """The cases the branch wrote: the ones a changed line lands inside. `None` is a whole new file.
+
+    A case the branch left alone is not a claim about it, whatever else in the file moved, and it is
+    worth more as a control -- byte-identical to the base's own, so anything but green from it is the
+    environment rather than the branch. `outside` is what this costs; the two are read together.
+    """
+    if changed_lines is None:
+        return list(cases)
+    return [case for case in cases
+            if changed_lines & set(range(case.first_line, case.last_line + 1))]
+
+
+def outside(cases, changed_lines):
+    """The changed lines inside no case at all -- a SetUp, a field, a helper, a using, a doc comment.
+
+    A change to what several cases share can make an untouched one stop separating anything, and no
+    diff says which. Selecting the file whole on that ground was tried and puts every case a fixture
+    has on trial for a line added to SetUp, so it is reported instead of acted on.
+    """
+    if changed_lines is None:
+        return set()
+    accounted = set()
+    for case in cases:
+        accounted |= set(range(case.first_line, case.last_line + 1))
+    return changed_lines - accounted
+
+
+# --------------------------------------------------------------------------------------------------
+# Reading the branch
+# --------------------------------------------------------------------------------------------------
+
+def git(project, *arguments, check=True):
+    return subprocess.run(["git", "-C", str(project), *arguments],
+                          capture_output=True, text=True, check=check)
+
+
+def merge_base(project, base):
+    result = git(project, "merge-base", base, "HEAD", check=False)
+    if result.returncode != 0:
+        raise SystemExit("cannot resolve a merge base with {}: {}".format(base, result.stderr.strip()))
+    return result.stdout.strip()
+
+
+def changed_lines_by_file(project, since):
+    """Repository-relative path -> the lines the branch wrote, or None for a file it added whole.
+
+    Diffed against the working tree rather than against HEAD, so a branch whose change is not
+    committed yet is still measured -- which is the state a run before a commit is in.
+    """
+    diff = git(project, "diff", "--unified=0", "--diff-filter=d", since).stdout
+    changed = {}
+    current = None
+    for line in diff.splitlines():
+        if line.startswith("+++ b/"):
+            current = line[6:]
+        elif line.startswith("+++ ") or line.startswith("diff --git"):
+            current = None
+        elif line.startswith("@@") and current is not None:
+            match = re.search(r"\+(\d+)(?:,(\d+))?", line)
+            if match:
+                start = int(match.group(1))
+                count = int(match.group(2) or 1)
+                changed.setdefault(current, set()).update(range(start, start + count))
+    for name in git(project, "diff", "--name-only", "--diff-filter=A", since).stdout.splitlines():
+        changed[name] = None
+    for name in git(project, "ls-files", "--others", "--exclude-standard").stdout.splitlines():
+        changed[name] = None
+    return changed
+
+
+def deleted_files(project, since):
+    return git(project, "diff", "--name-only", "--diff-filter=D", since).stdout.splitlines()
+
+
+# --------------------------------------------------------------------------------------------------
+# Building the base tree
+# --------------------------------------------------------------------------------------------------
+
+def clone_tree(source, destination):
+    """Copies a Library into the base tree, asking the filesystem to share the blocks if it will.
+
+    The base tree is a checkout the machine has never imported, and the import is most of what a base
+    run costs. A byte copy of a Library this size is its own kind of slow, so `cp -c` is tried first
+    and the plain copy is what happens when it is refused.
+    """
+    if sys.platform == "darwin":
+        result = subprocess.run(["cp", "-Rc", str(source), str(destination)],
+                                capture_output=True, text=True)
+        if result.returncode == 0:
+            return
+    shutil.copytree(str(source), str(destination), symlinks=True, dirs_exist_ok=True)
+
+
+def build_base_tree(project, commit, destination, carry, drop, warm_library=None):
+    git(project, "worktree", "add", "--detach", str(destination), commit)
+    for relative in drop:
+        for name in (relative, relative + ".meta"):
+            target = destination / name
+            if target.exists():
+                target.unlink()
+    for relative in carry:
+        for name in (relative, relative + ".meta"):
+            origin = project / name
+            if not origin.exists():
+                continue
+            target = destination / name
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(str(origin), str(target))
+    if warm_library and Path(warm_library).is_dir():
+        clone_tree(Path(warm_library), destination / "Library")
+
+
+def withdraw(base_tree, relative):
+    """Puts one carried file back to what the base commit holds, or removes one the base never had.
+
+    A file whose fixtures the base named nothing of is withdrawn so the rest of its assembly builds.
+    Its own cases are then decided by that silence rather than by the run which follows.
+    """
+    for name in (relative, relative + ".meta"):
+        target = base_tree / name
+        held = git(base_tree, "show", "HEAD:" + name, check=False)
+        if held.returncode == 0:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(held.stdout)
+        elif target.exists():
+            target.unlink()
+
+
+# --------------------------------------------------------------------------------------------------
+# Running
+# --------------------------------------------------------------------------------------------------
+
+def unity_busy():
+    result = subprocess.run(["ps", "-Ao", "command="], capture_output=True, text=True)
+    return sum(1 for line in result.stdout.splitlines() if re.match(UNITY_RUNNING, line))
+
+
+def wait_for_quiet(seconds):
+    """Waits rather than sharing the machine, for the reason mutation_check.py waits."""
+    deadline = time.time() + seconds
+    while unity_busy():
+        if time.time() > deadline:
+            return False
+        time.sleep(5)
+    return True
+
+
+COMPILE_ERROR = re.compile(r"^(?:.*?[\\/])?((?:Assets|Packages)[\\/][^(]+)\(\d+,\d+\): error CS")
+
+
+def compile_error_files(log_text):
+    """The repository-relative sources a Unity log blames a compile error on."""
+    named = []
+    for line in log_text.splitlines():
+        match = COMPILE_ERROR.match(line.strip())
+        if match:
+            relative = match.group(1).replace("\\", "/")
+            if relative not in named:
+                named.append(relative)
+    return named
+
+
+def run_unity(unity, tree, platform, fixtures, results, log, timeout):
+    command = [
+        unity, "-runTests", "-batchmode", "-projectPath", str(tree),
+        "-testPlatform", platform, "-testResults", str(results), "-logFile", str(log),
+        "-testFilter", ";".join(sorted(fixtures)),
+    ]
+    started = time.time()
+    try:
+        subprocess.run(command, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        pass
+    return time.time() - started
+
+
+def unity_results(results):
+    """Reported case name -> Passed / Failed / Inconclusive / Skipped."""
+    if not results.exists():
+        return {}
+    try:
+        root = ET.parse(str(results)).getroot()
+    except ET.ParseError:
+        return {}
+    return {case.get("fullname") or case.get("name"): case.get("result")
+            for case in root.iter("test-case")}
+
+
+def run_python(tree, cases, transcript):
+    """Runs one case at a time, so a module-level failure cannot report as some other case's verdict."""
+    outcome = {}
+    for case in cases:
+        module = Path(case.path)
+        identifier = "{}.{}".format(module.stem, case.name)
+        result = subprocess.run([sys.executable, "-m", "unittest", "-v", identifier],
+                                cwd=str(tree / module.parent), capture_output=True, text=True)
+        transcript.append("$ python3 -m unittest {} (in {})\n{}{}".format(
+            identifier, module.parent, result.stdout, result.stderr))
+        outcome[case.key] = "Passed" if result.returncode == 0 else "Failed"
+    return outcome
+
+
+# --------------------------------------------------------------------------------------------------
+# Deciding
+# --------------------------------------------------------------------------------------------------
+
+def outcome_for(name, reported):
+    """What the base run said about one case, over however many entries the name covers.
+
+    A [TestCase] method comes back as one entry per argument list, named `Method(1)`, so an exact
+    lookup would find the method absent and fail closed on a case that ran perfectly well. The method
+    passed on the base only where every one of its argument lists did.
+    """
+    results = [result for key, result in reported.items()
+               if key == name or key.startswith(name + "(")]
+    if not results:
+        return None
+    if all(result == "Passed" for result in results):
+        return "Passed"
+    return next(result for result in results if result != "Passed")
+
+
+def canary_fixtures(base_tree, platform, carry, wanted=3):
+    """Fixtures of the base tree's own that the branch did not touch, in the order git lists them.
+
+    Which ones is not the question: `canaries_for` owns why they run at all, and the bar is one of
+    them passing.
+    """
+    found = []
+    # Tracked, not walked. Walking took the first three fixtures out of Library/PackageCache, which
+    # compile into Unity's own assemblies and answer to no filter this project can pose -- so the
+    # canary found nothing passing and withdrew the very branch it was there to vouch for.
+    for relative in git(base_tree, "ls-files").stdout.splitlines():
+        if kind_of(relative) != "csharp" or platform_of(relative) != platform or relative in carry:
+            continue
+        path = base_tree / relative
+        if not path.exists():
+            continue
+        cases = csharp_cases(path.read_text(encoding="utf-8", errors="replace"), relative)
+        if cases:
+            found.append(cases[0].fixture)
+        if len(found) == wanted:
+            break
+    return found
+
+
+def fixtures_that_ran(reported):
+    """The fixtures the base run named at least one case of."""
+    return {name.split("(")[0].rsplit(".", 1)[0] for name in reported}
+
+
+def unsound_platforms(canaries, reported):
+    """Platform -> why its canaries say the base tree answered nothing at all.
+
+    One passing case is the whole bar. Which of them passes is not the question -- the question is
+    whether anything on this platform built and ran, since a tree where nothing did reports every
+    case as uncompilable, and uncompilable is not a failure here.
+    """
+    broken = {}
+    for platform, fixtures in canaries.items():
+        if not fixtures:
+            continue
+        ran = [result for name, result in reported.items()
+               if name.split("(")[0].rsplit(".", 1)[0] in fixtures]
+        if not any(result == "Passed" for result in ran):
+            broken[platform] = "none of {} passed there".format(
+                ", ".join(fixture.rsplit(".", 1)[-1] for fixture in fixtures))
+    return broken
+
+
+def unsound_fixtures(control, reported):
+    """Fixture -> the control case that says the base tree is answering about itself.
+
+    A control case is one the branch left alone, so the base tree holds exactly the text the base's
+    own green run held. Anything but green from it is the environment.
+    """
+    broken = {}
+    for case in control:
+        result = outcome_for(case.key, reported)
+        if result not in (None, "Passed") and case.fixture not in broken:
+            broken[case.fixture] = "{} is {} there".format(case.name.rsplit(".", 1)[-1], result.lower())
+    return broken
+
+
+def decide(case, result, fixture_ran):
+    """One case's verdict from what the base run said about it.
+
+    `fixture_ran` is what separates the two ways a case can be missing, and it is why nothing here
+    reads the editor log. A fixture that reported nothing built nothing -- the branch's test names a
+    symbol the base has not got, which is the evidence this is looking for. A fixture that reported
+    its other cases and not this one resolved the name wrongly, and a name nobody answered to is a
+    reading nobody took.
+    """
+    if case.declaration is not None:
+        complaint = case.declaration.complaint
+        if complaint:
+            return DECLARED_STALE, complaint
+        if result == "Passed":
+            return DECLARED_KEPT, "{}: {}".format(case.declaration.category, case.declaration.reason)
+        return DECLARED_STALE, "it is {} on the base; remove the declaration".format(
+            (result or "absent").lower())
+    if result == "Passed":
+        return PASSED_ON_BASE, "nothing this branch changed decides it"
+    if result is None and not fixture_ran:
+        return COULD_NOT_COMPILE, "the base built none of this fixture"
+    if result is None:
+        return NOT_REPORTED, "its fixture ran and nothing answered to this name"
+    return RED_ON_BASE, result.lower()
+
+
+def canaries_for(base_tree, cases, carry, only=None):
+    """Platform -> the base's own fixtures to read that platform's tree by.
+
+    Every platform, not only the ones the branch left no control case on. A control answers for its
+    own fixture, and a fixture the base named nothing of is legitimate evidence there -- so where a
+    run comes back empty, the controls say uncompilable and nothing says the run happened at all.
+    """
+    chosen = {}
+    for platform in sorted({platform_of(case.path) for case in cases
+                            if kind_of(case.path) == "csharp"}):
+        if not only or platform in only:
+            chosen[platform] = canary_fixtures(base_tree, platform, carry)
+    return chosen
+
+
+def as_plan(since, cases, control, shared, canaries):
+    """The reading, in a form a second invocation can decide from.
+
+    A run split across two invocations is what lets the editor be somebody else's -- CI reaches Unity
+    only through an action, so the tree is built and read here, the action runs, and the verdict is
+    taken from the results file it leaves.
+    """
+    def entry(case):
+        return {
+            "name": case.name, "path": case.path, "key": case.key, "fixture": case.fixture,
+            "declaration": (None if case.declaration is None
+                            else [case.declaration.category, case.declaration.reason]),
+        }
+
+    return {"since": since, "shared": shared, "canaries": canaries,
+            "cases": [entry(case) for case in cases],
+            "control": [entry(case) for case in control]}
+
+
+def from_plan(entries):
+    cases = []
+    for entry in entries:
+        declaration = None if entry["declaration"] is None else Declaration(*entry["declaration"])
+        case = Case(entry["name"], entry["path"], 0, 0, declaration)
+        cases.append(case)
+    return cases
+
+
+def results_from(where):
+    """(what the run reported, whether it wrote a results file at all).
+
+    The second half is not the first being empty. A round that wrote nothing did not get as far as
+    running, and this treats that as the base failing to build what was carried onto it -- which is
+    evidence, and not the same as a round that ran and reported no case of some fixture.
+    """
+    path = Path(where)
+    files = [file for file in (sorted(path.glob("*.xml")) if path.is_dir() else [path])
+             if file.exists()]
+    reported = {}
+    for file in files:
+        reported.update(unity_results(file))
+    return reported, bool(files)
+
+
+def report(cases, control, reported, canaries=None):
+    """Prints each case's verdict and returns the ones that fail the run."""
+    unsound = unsound_fixtures(control, reported)
+    withdrawn = unsound_platforms(canaries or {}, reported)
+    ran = fixtures_that_ran(reported)
+    for case in cases:
+        if case.fixture in unsound:
+            case.verdict, case.detail = BASE_UNSOUND, unsound[case.fixture]
+        elif platform_of(case.path) in withdrawn:
+            case.verdict, case.detail = BASE_UNSOUND, withdrawn[platform_of(case.path)]
+        else:
+            case.verdict, case.detail = decide(case, outcome_for(case.key, reported),
+                                               case.fixture in ran)
+    print("\n--- what the base said ---")
+    for case in cases:
+        print("{:<32} {}  ({})".format(case.verdict, case.name, case.detail))
+    offenders = [case for case in cases if case.verdict in FAILING_VERDICTS]
+    if offenders:
+        print("\n{} case(s) the base already answers, or cannot be answered for. Green on both sides "
+              "separates\nnothing: sharpen the case until it goes red without this branch, or say why "
+              "it belongs there:".format(len(offenders)))
+        print("  // GREEN_ON_BASE({}): <why>".format("|".join(CATEGORIES)))
+    return offenders
+
+
+def corpus_of(project):
+    """Every tracked C# test file's text, for the questions one file cannot answer about itself."""
+    names = git(project, "ls-files").stdout.splitlines()
+    return {relative: (project / relative).read_text(encoding="utf-8", errors="replace")
+            for relative in names
+            if kind_of(relative) == "csharp" and (project / relative).exists()}
+
+
+def collect(project, base, lane):
+    """(merge base, changed cases, control cases, shared-line count by file) for a branch."""
+    since = merge_base(project, base)
+    heirs = concrete_heirs(corpus_of(project))
+    changed, control, shared = [], [], {}
+    for relative, lines in sorted(changed_lines_by_file(project, since).items()):
+        if kind_of(relative) is None or (lane != "both" and kind_of(relative) != lane):
+            continue
+        source = project / relative
+        if not source.exists():
+            continue
+        cases = cases_in(relative, source.read_text())
+        wanted = {case.name for case in touched(cases, lines)}
+        changed.extend(as_the_runner_names_them(
+            [case for case in cases if case.name in wanted], heirs))
+        control.extend(as_the_runner_names_them(
+            [case for case in cases if case.name not in wanted], heirs))
+        loose = outside(cases, lines)
+        if loose:
+            shared[relative] = len(loose)
+    return since, changed, control, shared
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--project", default=".", help="repository root (default: cwd)")
+    parser.add_argument("--base", default="origin/main", help="what to take a merge base with")
+    parser.add_argument("--lane", choices=["python", "csharp", "both"], default="both",
+                        help="which test surface to measure (default: both)")
+    parser.add_argument("--platform", choices=["EditMode", "PlayMode"], action="append",
+                        help="restrict the C# lane to these platforms")
+    parser.add_argument("--warm-library", help="a Library directory to clone into the base tree")
+    parser.add_argument("--base-tree", help="build the base tree here and leave it behind")
+    parser.add_argument("--unity", default=DEFAULT_UNITY, help="editor binary")
+    parser.add_argument("--timeout", type=int, default=3600, help="seconds before a base run is killed")
+    parser.add_argument("--busy-timeout", type=int, default=1800,
+                        help="seconds to wait for another Unity run to finish")
+    parser.add_argument("--max-rounds", type=int, default=8,
+                        help="uncompilable files to withdraw before the C# lane gives up (default: 8)")
+    parser.add_argument("--plan", action="store_true", help="print the cases and exit without running")
+    parser.add_argument("--emit", help="build the base tree, write the reading here and stop, for a "
+                                       "runner that reaches Unity through something other than the "
+                                       "editor binary. Needs --base-tree")
+    parser.add_argument("--verdict", help="decide from an --emit reading and a results file or "
+                                          "directory, without building or running anything")
+    parser.add_argument("--results", help="what --verdict reads the run from")
+    parser.add_argument("--output", default="", help="directory for the base run's logs and results")
+    args = parser.parse_args()
+
+    if args.verdict:
+        plan = json.loads(Path(args.verdict).read_text())
+        if not plan["cases"]:
+            print("no changed test case in the reading")
+            return 0
+        if not args.results:
+            raise SystemExit("--verdict needs --results")
+        reported, wrote = results_from(args.results)
+        if not wrote:
+            print("the base run wrote no result, so it did not build what was carried onto it")
+        return 1 if report(from_plan(plan["cases"]), from_plan(plan["control"]), reported,
+                           plan["canaries"] if wrote else {}) else 0
+
+    project = Path(args.project).resolve()
+    since, cases, control, shared = collect(project, args.base, args.lane)
+    if not cases:
+        print("no changed test case in scope of --lane {}".format(args.lane))
+        return 0
+
+    print("merge base {}".format(since[:12]))
+    for case in cases:
+        print("  {}{}".format(case.name,
+                              " [{}]".format(case.declaration.category) if case.declaration else ""))
+    print("  ({} control case(s) alongside)".format(len(control)))
+    for relative, count in sorted(shared.items()):
+        print("  not judged: {} line(s) of {} sit in no case -- a SetUp, a field, a helper, a using. "
+              "A case\n              they change but whose own body they do not is left as a control."
+              .format(count, relative))
+    if args.plan:
+        return 0
+
+    changed = changed_lines_by_file(project, since)
+    carry = sorted(name for name in changed if is_test_side(name) and (project / name).exists())
+    drop = sorted(name for name in deleted_files(project, since) if is_test_side(name))
+
+    if args.emit:
+        if not args.base_tree:
+            raise SystemExit("--emit needs --base-tree to say where the base is built")
+        base_tree = Path(args.base_tree).resolve()
+        build_base_tree(project, since, base_tree, carry, drop, args.warm_library)
+        canaries = canaries_for(base_tree, cases, carry, args.platform)
+        Path(args.emit).write_text(
+            json.dumps(as_plan(since, cases, control, shared, canaries), indent=2))
+        # The fixtures, not the cases: a run over the fixture brings the control cases with it, and
+        # they are what says whether the tree it built can answer at all.
+        wanted = {case.fixture for case in cases + control if kind_of(case.path) == "csharp"
+                  and (not args.platform or platform_of(case.path) in args.platform)}
+        for chosen in canaries.values():
+            wanted.update(chosen)
+        print("fixtures={}".format(";".join(sorted(wanted))))
+        return 0
+
+    holder = None
+    if args.base_tree:
+        base_tree = Path(args.base_tree).resolve()
+    else:
+        holder = tempfile.mkdtemp(prefix="base-red-")
+        base_tree = Path(holder) / "tree"
+    output = Path(args.output).resolve() if args.output else project / "Logs" / "base_red_check"
+    output.mkdir(parents=True, exist_ok=True)
+
+    reported = {}
+    transcript = []
+    canaries = {}
+    ever_wrote = not any(kind_of(case.path) == "csharp" for case in cases)
+    try:
+        build_base_tree(project, since, base_tree, carry, drop, args.warm_library)
+
+        python_lane = [case for case in cases + control if kind_of(case.path) == "python"]
+        if python_lane:
+            reported.update(run_python(base_tree, python_lane, transcript))
+
+        platforms = sorted({platform_of(case.path) for case in cases
+                            if kind_of(case.path) == "csharp"})
+        if args.platform:
+            platforms = [name for name in platforms if name in args.platform]
+        if platforms and not wait_for_quiet(args.busy_timeout):
+            raise SystemExit("another Unity test run is still in flight")
+        canaries = canaries_for(base_tree, cases, carry, platforms)
+        for platform in platforms:
+            wanted = [case for case in cases + control
+                      if kind_of(case.path) == "csharp" and platform_of(case.path) == platform]
+            withdrawn = set()
+            for attempt in range(1, args.max_rounds + 1):
+                live = [case for case in wanted if case.path not in withdrawn]
+                fixtures = sorted({case.fixture for case in live} | set(canaries[platform]))
+                if not fixtures:
+                    break
+                results = output / "{}-{}.xml".format(platform, attempt)
+                log = output / "{}-{}.log".format(platform, attempt)
+                for stale in (results, log):
+                    if stale.exists():
+                        stale.unlink()
+                wall = run_unity(args.unity, base_tree, platform, fixtures, results, log, args.timeout)
+                seen, wrote = results_from(results)
+                ever_wrote = ever_wrote or wrote
+                reported.update(seen)
+                print("{} attempt {}: {} case(s) over {} fixture(s) in {:.0f}s".format(
+                    platform, attempt, len(seen), len(fixtures), wall))
+
+                # One file per attempt. A round that reports nothing says only that something the
+                # tree holds did not build, never which file, so withdrawing every silent one at
+                # once would take out the files that were merely standing next to the offender and
+                # leave their cases unmeasured behind somebody else's error.
+                ran = fixtures_that_ran(seen)
+                silent = sorted({case.path for case in live if case.fixture not in ran})
+                if not silent:
+                    break
+                blamed = [name for name in compile_error_files(
+                    log.read_text(errors="replace") if log.exists() else "") if name in silent]
+                withdraw(base_tree, blamed[0] if blamed else silent[0])
+                withdrawn.add(blamed[0] if blamed else silent[0])
+    finally:
+        if holder is not None:
+            git(project, "worktree", "remove", "--force", str(base_tree), check=False)
+            shutil.rmtree(holder, ignore_errors=True)
+
+    if transcript:
+        (output / "python.log").write_text("\n".join(transcript))
+
+    if not ever_wrote:
+        print("no round wrote a result, so the base built none of what was carried onto it")
+    offenders = report(cases, control, reported, canaries if ever_wrote else {})
+    print("\nlogs: {}".format(output))
+    return 1 if offenders else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_quality/mutation_check.py
+++ b/scripts/test_quality/mutation_check.py
@@ -55,6 +55,11 @@ class Mutant:
         return "{}:{} {} -> {} ({})".format(where, self.line, self.before, self.after, self.operator)
 
 
+# The furthest offset from an opening quote at which a closing one can still sit: `'\U0001F600'` is
+# the longest character literal C# can spell.
+CHARACTER_LITERAL_REACH = len("'\\U0001F600'") - 1
+
+
 def code_mask(text):
     """True at every offset that the compiler sees as code.
 
@@ -66,7 +71,16 @@ def code_mask(text):
     n = len(text)
     while i < n:
         two = text[i:i + 2]
-        if two == "//":
+        if text[i] == "#" and not text[text.rfind("\n", 0, i) + 1:i].strip():
+            # A preprocessor line is blanked whole. Nothing downstream of this mask reads a directive,
+            # and none of them can hold a brace or a type; what one can hold is `#region Boundary's
+            # own tree`, whose apostrophe opens a character literal against the rule below.
+            end = text.find("\n", i)
+            end = n if end < 0 else end
+            for j in range(i, end):
+                mask[j] = False
+            i = end
+        elif two == "//":
             end = text.find("\n", i)
             end = n if end < 0 else end
             for j in range(i, end):
@@ -98,10 +112,17 @@ def code_mask(text):
             for j in range(start, min(i, n)):
                 mask[j] = False
         elif text[i] == "'":
+            # An apostrophe with no closing one inside a literal's reach is not a literal. Consuming
+            # to the next one anywhere in the file instead blanks arbitrary code, and nothing after
+            # this reports a wrongly blanked offset: no mutant is generated there and no brace
+            # counted, so both halves come back looking like a file with less in it than it has.
             start = i
             i += 1
-            while i < n and text[i] != "'":
+            while i < n and i - start <= CHARACTER_LITERAL_REACH and text[i] != "'":
                 i += 2 if text[i] == "\\" else 1
+            if i >= n or i - start > CHARACTER_LITERAL_REACH or text[i] != "'":
+                i = start + 1
+                continue
             i += 1
             for j in range(start, min(i, n)):
                 mask[j] = False

--- a/scripts/test_quality/test_base_red_check.py
+++ b/scripts/test_quality/test_base_red_check.py
@@ -10,8 +10,10 @@ Run: python3 scripts/test_quality/test_base_red_check.py
 """
 
 import importlib.util
+import json
 import shutil
 import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -104,6 +106,40 @@ def python_test_files():
     return tracked("python")
 
 
+def concrete_class_names(corpus):
+    """The simple names of every class, record and struct declared without `abstract`, over a corpus.
+
+    Off the code lines, so a `class` written into an assertion message is not one of them -- which is
+    the whole point of comparing against this set.
+    """
+    found = set()
+    for text in corpus.values():
+        for line in base_red_check.code_lines(text):
+            declared = base_red_check.CSHARP_TYPE.search(line)
+            if declared and not base_red_check.CSHARP_ABSTRACT.search(line):
+                found.add(declared.group(1))
+    return found
+
+
+def unanswered_names(corpus, heirs):
+    """Every case in `corpus` whose runner name no concrete class in `corpus` can answer to.
+
+    Both ways that happens: a case the naming drops because the abstract fixture it is written in has
+    no concrete heir, and a case it keeps under a class segment nothing declares.
+    """
+    concrete = concrete_class_names(corpus)
+    unanswered = []
+    for relative, text in corpus.items():
+        for case in base_red_check.csharp_cases(text, relative):
+            named = base_red_check.as_the_runner_names_them([case], heirs)
+            if not named:
+                unanswered.append("{}: {} runs under no concrete class".format(relative, case.name))
+            unanswered += ["{}: {} names {}, which nothing declares".format(
+                relative, case.name, produced.name.rsplit(".", 2)[-2])
+                for produced in named if produced.name.rsplit(".", 2)[-2] not in concrete]
+    return unanswered
+
+
 class CSharpReadingTests(unittest.TestCase):
     def test_Given_AFixture_When_ItIsRead_Then_OnlyTheTestMethodsAreCases(self):
         # Act
@@ -138,6 +174,62 @@ class CSharpReadingTests(unittest.TestCase):
 
         # Assert
         self.assertEqual(names, ["N.Outer.Inner.Given_X_When_Y_Then_Z"])
+
+    def test_Given_AStringLiteralHoldingTheWordClass_When_ItIsRead_Then_ItOwnsNoCaseBelowIt(self):
+        # Arrange -- this repository writes "the enter-from class is applied" into assertion messages,
+        # and a scan of the raw line reads a type named `is` out of it. Every case below is then
+        # emitted under a name no runner reports, which is a reading nobody takes and a passing one.
+        text = ("namespace N\n{\n    class C\n    {\n        [Test]\n"
+                "        public void Given_A_When_B_Then_C()\n        {\n"
+                "            Assert.That(x, Is.True, \"The class is applied on mount\");\n        }\n\n"
+                "        [Test]\n        public void Given_D_When_E_Then_F() => Assert.Pass();\n"
+                "    }\n}\n")
+
+        # Act
+        names = [case.name for case in base_red_check.csharp_cases(text)]
+
+        # Assert
+        self.assertEqual(names, ["N.C.Given_A_When_B_Then_C", "N.C.Given_D_When_E_Then_F"])
+
+    def test_Given_ANestedTypeThatCloses_When_TheCasesBelowAreRead_Then_ItDoesNotQualifyThem(self):
+        # Arrange -- a helper type declared among a fixture's members, an args type or a fake, with no
+        # further declaration after it to displace it from the stack.
+        text = ("namespace N\n{\n    class C\n    {\n        abstract class Args\n        {\n"
+                "        }\n\n        [Test]\n"
+                "        public void Given_A_When_B_Then_C() => Assert.Pass();\n    }\n}\n")
+
+        # Act
+        names = [case.name for case in base_red_check.csharp_cases(text)]
+
+        # Assert
+        self.assertEqual(names, ["N.C.Given_A_When_B_Then_C"])
+
+    def test_Given_ANestedAbstractTypeThatCloses_When_TheCaseBelowIsRead_Then_ItIsNotWrittenInIt(self):
+        # Arrange -- the same shape read for the other half: a case the naming believes is inherited
+        # is rewritten into one name per concrete heir, and an args type has none, so it is dropped.
+        text = ("namespace N\n{\n    class C\n    {\n        abstract class Args\n        {\n"
+                "        }\n\n        [Test]\n"
+                "        public void Given_A_When_B_Then_C() => Assert.Pass();\n    }\n}\n")
+
+        # Act
+        case = base_red_check.csharp_cases(text)[0]
+
+        # Assert
+        self.assertIsNone(case.abstract_owner)
+
+    def test_Given_APreprocessorDirectiveHoldingAnApostrophe_When_TheFileIsRead_Then_TheCasesBelowAreToo(self):
+        # Arrange -- `#region Boundary's own mount` opens a character literal to anything reading the
+        # directive as code, and it then runs to the next apostrophe anywhere in the file, blanking
+        # every brace, attribute and type between the two.
+        text = ("namespace N\n{\n    class C\n    {\n        #region Boundary's own mount\n\n"
+                "        [Test]\n        public void Given_A_When_B_Then_C() => Assert.Pass();\n\n"
+                "        #endregion\n    }\n}\n")
+
+        # Act
+        names = [case.name for case in base_red_check.csharp_cases(text)]
+
+        # Assert
+        self.assertEqual(names, ["N.C.Given_A_When_B_Then_C"])
 
     def test_Given_ASecondFixtureAfterTheFirstCloses_When_ItIsRead_Then_TheFirstDoesNotQualifyIt(self):
         # Arrange
@@ -336,6 +428,31 @@ class VerdictTests(unittest.TestCase):
         # Assert -- a declaration nothing withdraws is one that silences a later, real green.
         self.assertEqual(verdict, base_red_check.DECLARED_STALE)
 
+    def test_Given_ADeclarationTheBranchDidNotWrite_When_TheCaseIsGreen_Then_ItStillFailsTheRun(self):
+        # Arrange -- it answers for the change that wrote it, which is already on the base. Reading it
+        # as an exemption for whatever the branch does to the case next lets one declaration silence
+        # every later green-on-base in that case for good.
+        merged = base_red_check.Declaration("refactor", "the keyed order this rename keeps",
+                                            written_here=False)
+
+        # Act
+        verdict, _ = base_red_check.decide(self.probe(merged), "Passed", fixture_ran=True)
+
+        # Assert
+        self.assertEqual(verdict, base_red_check.PASSED_ON_BASE)
+
+    def test_Given_ADeclarationTheBranchDidNotWrite_When_TheCaseIsRed_Then_ItIsReadAsUndeclared(self):
+        # Arrange -- red on the base is the outcome the check is asking for, and a declaration that
+        # answers for somebody else's change must not turn it into a complaint about this one.
+        merged = base_red_check.Declaration("refactor", "the keyed order this rename keeps",
+                                            written_here=False)
+
+        # Act
+        verdict, _ = base_red_check.decide(self.probe(merged), "Failed", fixture_ran=True)
+
+        # Assert
+        self.assertEqual(verdict, base_red_check.RED_ON_BASE)
+
     def test_Given_ACaseAbsentFromAFixtureThatRan_When_ItIsDecided_Then_ItFailsTheRun(self):
         # Act
         verdict, _ = base_red_check.decide(self.probe(), None, fixture_ran=True)
@@ -530,6 +647,211 @@ class InstrumentTests(unittest.TestCase):
         self.assertEqual(base_red_check.unsound_fixtures([case], reported), {})
 
 
+class WithdrawalTests(unittest.TestCase):
+    """Which carried file goes back when a round of the base run reported nothing of some fixture."""
+
+    HELPER = "Packages/p/TestUtilities/PanelTestBase.cs"
+    FIXTURE = "Packages/p/Runtime/A/Tests/Editor/ProbeTests.cs"
+
+    def log(self, blamed):
+        return "/tmp/base/{}(12,34): error CS0117: 'V' has no definition for 'Portal'\n".format(blamed)
+
+    def test_Given_TheLogBlamesACarriedHelper_When_TheOffenderIsChosen_Then_ItIsTheHelper(self):
+        # Arrange -- the helper holds no case, so a choice made over case-bearing files alone cannot
+        # name it, and every fixture in its assembly is silent behind it.
+        # Act
+        offender = base_red_check.next_to_withdraw(
+            self.log(self.HELPER), carry=[self.HELPER, self.FIXTURE], withdrawn=set(),
+            silent=[self.FIXTURE])
+
+        # Assert
+        self.assertEqual(offender, self.HELPER)
+
+    def test_Given_TheBlamedFileIsAlreadyWithdrawn_When_TheOffenderIsChosen_Then_ItIsNotChosenAgain(self):
+        # Arrange -- choosing it twice is a round that changes nothing, and there are only so many.
+        # Act
+        offender = base_red_check.next_to_withdraw(
+            self.log(self.HELPER), carry=[self.HELPER, self.FIXTURE], withdrawn={self.HELPER},
+            silent=[self.FIXTURE])
+
+        # Assert
+        self.assertEqual(offender, self.FIXTURE)
+
+
+class UnmeasuredRunTests(unittest.TestCase):
+    """A run that produced no results file at all, which is what a failed base run leaves behind."""
+
+    def cases(self):
+        return [base_red_check.Case("N.C.Given_A_When_B_Then_C",
+                                    "Packages/p/Runtime/A/Tests/Editor/CTests.cs", 1, 2)]
+
+    PLAN = {
+        "since": "0" * 40, "shared": {}, "canaries": {"EditMode": ["N.CanaryTests"]},
+        "cases": [{"name": "N.ProbeTests.Given_A_When_B_Then_C",
+                   "path": "Packages/p/Runtime/A/Tests/Editor/ProbeTests.cs",
+                   "key": "N.ProbeTests.Given_A_When_B_Then_C", "fixture": "N.ProbeTests",
+                   "declaration": None}],
+        "control": [],
+    }
+
+    def verdict_over(self, *results):
+        """The exit status of the --verdict lane over a directory holding `results`."""
+        holder = tempfile.mkdtemp(prefix="base-red-verdict-")
+        self.addCleanup(shutil.rmtree, holder, ignore_errors=True)
+        plan = Path(holder, "plan.json")
+        plan.write_text(json.dumps(self.PLAN))
+        written = Path(holder, "results")
+        written.mkdir()
+        for index, body in enumerate(results):
+            Path(written, "r{}.xml".format(index)).write_text(body)
+        return subprocess.run(
+            [sys.executable, str(REPO_ROOT / "scripts/test_quality/base_red_check.py"),
+             "--verdict", str(plan), "--results", str(written)],
+            capture_output=True, text=True).returncode
+
+    def test_Given_ABaseRunThatLeftNoResultsFile_When_TheVerdictLaneRuns_Then_ItRefuses(self):
+        # Arrange -- the ordinary shape of a base run that failed. game-ci's runner is continue-on-
+        # error, so a licence failure, an editor crash, an OOM and a timeout all reach this step with
+        # an empty artifacts directory, and every case then reads as one the base could not build.
+        # Act
+        status = self.verdict_over()
+
+        # Assert
+        self.assertEqual(status, 1)
+
+    def test_Given_ABaseRunWhoseCanaryPassed_When_TheCaseIsAbsent_Then_ItIsStillEvidenceNotAFailure(self):
+        # Arrange -- the counterpart, so the refusal above is not the lane refusing everything: a tree
+        # that demonstrably answers, and a case it named nothing of, is the reading this exists to take.
+        # Act
+        status = self.verdict_over(
+            '<test-run><test-case fullname="N.CanaryTests.Given_X_When_Y_Then_Z" result="Passed" />'
+            '</test-run>')
+
+        # Assert
+        self.assertEqual(status, 0)
+
+    def test_Given_ARunThatWroteNothingAndNoCanary_When_TheVerdictsAreTaken_Then_ItStillFails(self):
+        # Arrange -- the canary list is empty when the base tree offers no fixture of its own on this
+        # platform, and an empty one must not read as permission to believe an unmeasured run.
+        cases = self.cases()
+
+        # Act
+        offenders = base_red_check.report(cases, [], {}, {"EditMode": []}, wrote=False)
+
+        # Assert
+        self.assertEqual([case.verdict for case in offenders], [base_red_check.BASE_UNSOUND])
+
+    def test_Given_ARunThatWroteAnEmptyResultsFile_When_TheVerdictsAreTaken_Then_TheCanaryFailsIt(self):
+        # Arrange -- the other half of the same bar, kept beside it: a file that parses to no case is
+        # a run that happened and built nothing, and the canary is what reads that.
+        cases = self.cases()
+
+        # Act
+        offenders = base_red_check.report(cases, [], {}, {"EditMode": ["N.CanaryTests"]}, wrote=True)
+
+        # Assert
+        self.assertEqual([case.verdict for case in offenders], [base_red_check.BASE_UNSOUND])
+
+
+class BranchReadingTests(unittest.TestCase):
+    """`collect` and `deleted_files` over a real two-commit repository rather than an invented diff."""
+
+    FIXTURE = "Packages/p/Runtime/A/Tests/Editor/ProbeTests.cs"
+
+    def source(self, declaration="", first="Assert.Pass()"):
+        return ("namespace N\n{\n    class ProbeTests\n    {\n        [SetUp]\n"
+                "        public void SetUp()\n        {\n            _count = 0;\n        }\n\n"
+                + declaration +
+                "        [Test]\n        public void Given_A_When_B_Then_C() => " + first + ";\n\n"
+                "        [Test]\n        public void Given_D_When_E_Then_F() => Assert.Pass();\n"
+                "    }\n}\n")
+
+    def repository(self, before, after, rename_to=None):
+        """A repository whose HEAD~1 holds `before` and whose HEAD holds `after`."""
+        holder = tempfile.mkdtemp(prefix="base-red-branch-")
+        self.addCleanup(shutil.rmtree, holder, ignore_errors=True)
+        root = Path(holder)
+        run = lambda *arguments: subprocess.run(["git", "-C", holder, *arguments], check=True,
+                                                capture_output=True, text=True)
+        run("init", "-q")
+        run("config", "user.email", "probe@example.com")
+        run("config", "user.name", "probe")
+        path = root / self.FIXTURE
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(before)
+        run("add", self.FIXTURE)
+        run("commit", "-qm", "base")
+        if rename_to:
+            (root / rename_to).parent.mkdir(parents=True, exist_ok=True)
+            path.unlink()
+            (root / rename_to).write_text(after)
+            run("add", self.FIXTURE, rename_to)
+        else:
+            path.write_text(after)
+            run("add", self.FIXTURE)
+        run("commit", "-qm", "branch")
+        return root
+
+    def test_Given_ABranchThatChangedASetUp_When_ItIsRead_Then_ItsOtherCasesAreNotControls(self):
+        # Arrange -- the untouched case is not the base's own text any more: what it shares with the
+        # case beside it moved. Reading the tree by it converts the sharpest red-on-base evidence
+        # there is -- a tightened assertion in shared material -- into "the base cannot answer".
+        root = self.repository(self.source(),
+                               self.source(first="Assert.Fail()").replace("_count = 0", "_count = 1"))
+
+        # Act
+        _, _, control, _, _ = base_red_check.collect(root, "HEAD~1", "csharp")
+
+        # Assert
+        self.assertEqual(control, [])
+
+    def test_Given_ABranchThatChangedOneCaseOnly_When_ItIsRead_Then_TheOtherIsAControl(self):
+        # Arrange -- the counterpart, so the case above is not passing for want of any control at all.
+        root = self.repository(self.source(), self.source(first="Assert.Fail()"))
+
+        # Act
+        _, _, control, _, _ = base_red_check.collect(root, "HEAD~1", "csharp")
+
+        # Assert
+        self.assertEqual([case.name for case in control], ["N.ProbeTests.Given_D_When_E_Then_F"])
+
+    def test_Given_ADeclarationTheBaseAlreadyHeld_When_TheBranchEditsTheCase_Then_ItIsNotThisBranchs(self):
+        # Arrange -- nothing removes a declaration at merge, so one written for an earlier change sits
+        # over the case for good and silences every later branch that edits it.
+        declared = "        // " + MARKER + "(refactor): a pure rename of the applier.\n"
+        root = self.repository(self.source(declared), self.source(declared, first="Assert.Fail()"))
+
+        # Act
+        _, cases, _, _, _ = base_red_check.collect(root, "HEAD~1", "csharp")
+
+        # Assert
+        self.assertFalse(case_named(cases, "Given_A_When_B_Then_C").declaration.written_here)
+
+    def test_Given_ADeclarationTheBranchWrote_When_TheCaseIsRead_Then_ItIsThisBranchs(self):
+        # Arrange -- the counterpart, so the case above is not passing for want of reading any
+        # declaration at all.
+        declared = "        // " + MARKER + "(refactor): a pure rename of the applier.\n"
+        root = self.repository(self.source(), self.source(declared))
+
+        # Act
+        _, cases, _, _, _ = base_red_check.collect(root, "HEAD~1", "csharp")
+
+        # Assert
+        self.assertTrue(case_named(cases, "Given_A_When_B_Then_C").declaration.written_here)
+
+    def test_Given_ARenamedAndEditedTestFile_When_TheDroppedFilesAreRead_Then_TheOldPathIsAmongThem(self):
+        # Arrange -- git pairs the two halves and reports R, so neither the added nor the deleted
+        # filter names anything and the base tree ends up holding both copies of one fixture class.
+        moved = "Packages/p/Runtime/B/Tests/Editor/ProbeTests.cs"
+        root = self.repository(self.source(), self.source(first="Assert.Fail()"), rename_to=moved)
+
+        # Act
+        dropped = base_red_check.deleted_files(root, "HEAD~1")
+
+        # Assert
+        self.assertEqual(dropped, [self.FIXTURE])
+
+
 class RepositoryTests(unittest.TestCase):
     """The reader against every test file this repository has, rather than against invented ones."""
 
@@ -591,21 +913,14 @@ class RepositoryTests(unittest.TestCase):
     def test_Given_EveryCaseHere_When_ItIsNamedAsTheRunnerWould_Then_AConcreteClassCarriesIt(self):
         # Arrange -- a name no concrete class answers to is one the base run reports nothing for,
         # which reads as a case the base could not build and passes. Silence, not a failure.
+        # Read over the cases as written rather than over what the naming returned: that output holds
+        # only names whose class segment resolved, so a case it dropped and a case it misnamed are
+        # both outside anything computed from it, and both are exactly what this is looking for.
         corpus = dict(csharp_test_files())
         heirs = base_red_check.concrete_heirs(corpus)
-        concrete = {name.rsplit(".", 1)[-1]
-                    for owners in heirs.values() for name in owners} | {
-                        case.name.rsplit(".", 2)[-2]
-                        for relative, text in corpus.items()
-                        for case in base_red_check.csharp_cases(text, relative)
-                        if not case.abstract_owner}
 
         # Act
-        homeless = sorted({case.name.rsplit(".", 2)[-2]
-                           for relative, text in corpus.items()
-                           for case in base_red_check.as_the_runner_names_them(
-                               base_red_check.csharp_cases(text, relative), heirs)
-                           if case.name.rsplit(".", 2)[-2] not in concrete})
+        homeless = sorted(set(unanswered_names(corpus, heirs)))
 
         # Assert
         self.assertEqual(homeless, [])

--- a/scripts/test_quality/test_base_red_check.py
+++ b/scripts/test_quality/test_base_red_check.py
@@ -1,0 +1,627 @@
+#!/usr/bin/env python3
+"""Unit tests for base_red_check.py's reading, plus guards over this repository's own test files.
+
+Reading a branch is separable from the base run that answers it, so it is tested here and needs no
+licence. Everything the run reports rests on this half: a case the reader misses is a case nothing
+asks about, and a case whose span it gets wrong is attributed to a line somebody else changed. Both
+failures are silent -- the run comes back green having measured the wrong thing.
+
+Run: python3 scripts/test_quality/test_base_red_check.py
+"""
+
+import importlib.util
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Split so the repository scan below, which reads this file among the rest, does not find the sample
+# declaration in the fixture text and report it as one nothing carries.
+MARKER = "GREEN_ON" "_BASE"
+
+
+def load_module():
+    """Imports base_red_check by path, since scripts/test_quality is not a package."""
+    spec = importlib.util.spec_from_file_location(
+        "base_red_check", Path(__file__).resolve().with_name("base_red_check.py")
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+base_red_check = load_module()
+
+FIXTURE_TEMPLATE = """using NUnit.Framework;
+
+namespace Velvet.Tests
+{
+    internal sealed class ProbeTests
+    {
+        private int _count;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _count = 0;
+        }
+
+        // {marker}(characterization): the ordering the base already has and this keeps.
+        [Test]
+        public void Given_A_When_B_Then_C()
+        {
+            var brace = "}";
+            Assert.That(brace, Is.EqualTo("}"));
+        }
+
+        [UnityTest]
+        public void Given_D_When_E_Then_F() => Assert.That(_count, Is.Zero);
+
+        private void Helper()
+        {
+            _count++;
+        }
+    }
+}
+"""
+
+
+FIXTURE = FIXTURE_TEMPLATE.replace("{marker}", MARKER)
+
+
+def case_named(cases, suffix):
+    return next(case for case in cases if case.name.endswith(suffix))
+
+
+def tracked(lane):
+    """Every tracked file of one lane, read as text.
+
+    Tracked rather than walked: Library/PackageCache holds Unity's own fixtures, which are not this
+    repository's to hold to its conventions and which this reader is not written for.
+    """
+    names = subprocess.run(["git", "-C", str(REPO_ROOT), "ls-files"],
+                           capture_output=True, text=True, check=True).stdout.splitlines()
+    found = []
+    for relative in names:
+        if base_red_check.kind_of(relative) != lane:
+            continue
+        path = REPO_ROOT / relative
+        if path.exists():
+            found.append((relative, path.read_text(encoding="utf-8", errors="replace")))
+    return found
+
+
+def csharp_test_files():
+    """Every tracked C# file that declares at least one test case."""
+    return [(relative, text) for relative, text in tracked("csharp")
+            if base_red_check.CSHARP_CASE_ATTRIBUTE.search(text)]
+
+
+def python_test_files():
+    return tracked("python")
+
+
+class CSharpReadingTests(unittest.TestCase):
+    def test_Given_AFixture_When_ItIsRead_Then_OnlyTheTestMethodsAreCases(self):
+        # Act
+        names = [case.name for case in base_red_check.csharp_cases(FIXTURE)]
+
+        # Assert
+        self.assertEqual(names, ["Velvet.Tests.ProbeTests.Given_A_When_B_Then_C",
+                                 "Velvet.Tests.ProbeTests.Given_D_When_E_Then_F"])
+
+    def test_Given_ACaseWithABraceInAStringLiteral_When_ItIsRead_Then_ItsSpanReachesItsClosingBrace(self):
+        # Arrange
+        case = case_named(base_red_check.csharp_cases(FIXTURE), "Given_A_When_B_Then_C")
+
+        # Act / Assert -- the declaration above it is the first line, the closing brace the last.
+        self.assertEqual((case.first_line, case.last_line), (15, 21))
+
+    def test_Given_AnExpressionBodiedCase_When_ItIsRead_Then_ItEndsAtItsSemicolon(self):
+        # Arrange
+        case = case_named(base_red_check.csharp_cases(FIXTURE), "Given_D_When_E_Then_F")
+
+        # Act / Assert
+        self.assertEqual((case.first_line, case.last_line), (23, 24))
+
+    def test_Given_ANestedFixture_When_ItIsRead_Then_BothClassesQualifyTheCase(self):
+        # Arrange
+        text = ("namespace N\n{\n    class Outer\n    {\n        class Inner\n        {\n"
+                "            [Test]\n            public void Given_X_When_Y_Then_Z() => Assert.Pass();\n"
+                "        }\n    }\n}\n")
+
+        # Act
+        names = [case.name for case in base_red_check.csharp_cases(text)]
+
+        # Assert
+        self.assertEqual(names, ["N.Outer.Inner.Given_X_When_Y_Then_Z"])
+
+    def test_Given_ASecondFixtureAfterTheFirstCloses_When_ItIsRead_Then_TheFirstDoesNotQualifyIt(self):
+        # Arrange
+        text = ("namespace N\n{\n    class First\n    {\n        [Test]\n"
+                "        public void Given_A_When_B_Then_C() => Assert.Pass();\n    }\n\n"
+                "    class Second\n    {\n        [Test]\n"
+                "        public void Given_D_When_E_Then_F() => Assert.Pass();\n    }\n}\n")
+
+        # Act
+        names = [case.name for case in base_red_check.csharp_cases(text)]
+
+        # Assert
+        self.assertEqual(names, ["N.First.Given_A_When_B_Then_C", "N.Second.Given_D_When_E_Then_F"])
+
+
+class DeclarationTests(unittest.TestCase):
+    def test_Given_ADeclarationAboveTheAttributeBlock_When_TheCaseIsRead_Then_ItCarriesIt(self):
+        # Arrange
+        case = case_named(base_red_check.csharp_cases(FIXTURE), "Given_A_When_B_Then_C")
+
+        # Act / Assert
+        self.assertEqual(case.declaration.category, "characterization")
+
+    def test_Given_ABlankLineBetweenTheDeclarationAndTheCase_When_ItIsRead_Then_ItDoesNotCarry(self):
+        # Arrange
+        text = ("class C\n{\n    // " + MARKER + "(characterization): a reason with enough words.\n"
+                "\n    [Test]\n    public void Given_A_When_B_Then_C() => Assert.Pass();\n}\n")
+
+        # Act
+        case = base_red_check.csharp_cases(text)[0]
+
+        # Assert
+        self.assertIsNone(case.declaration)
+
+    def test_Given_ADeclarationOverTheCaseAbove_When_TheNextCaseIsRead_Then_ItDoesNotCarry(self):
+        # Arrange
+        text = ("class C\n{\n    // " + MARKER + "(characterization): a reason with enough words.\n"
+                "    [Test]\n    public void Given_A_When_B_Then_C() => Assert.Pass();\n\n"
+                "    [Test]\n    public void Given_D_When_E_Then_F() => Assert.Pass();\n}\n")
+
+        # Act
+        cases = base_red_check.csharp_cases(text)
+
+        # Assert
+        self.assertIsNone(case_named(cases, "Given_D_When_E_Then_F").declaration)
+
+    def test_Given_ACategoryNothingDefines_When_TheDeclarationIsChecked_Then_ItIsComplainedAbout(self):
+        # Act
+        complaint = base_red_check.Declaration("whatever", "a reason with enough words in it").complaint
+
+        # Assert
+        self.assertIn("whatever", complaint)
+
+    def test_Given_AReasonOfThreeWords_When_TheDeclarationIsChecked_Then_ItIsComplainedAbout(self):
+        # Act
+        complaint = base_red_check.Declaration("refactor", "see the above").complaint
+
+        # Assert
+        self.assertIn("under", complaint)
+
+    def test_Given_AWellFormedDeclaration_When_ItIsChecked_Then_ThereIsNoComplaint(self):
+        # Act / Assert
+        self.assertIsNone(
+            base_red_check.Declaration("refactor", "a pure rename of the applier").complaint)
+
+
+class SelectionTests(unittest.TestCase):
+    def test_Given_ALineInsideOneCase_When_TheFileIsSelected_Then_OnlyThatCaseIsTaken(self):
+        # Arrange
+        cases = base_red_check.csharp_cases(FIXTURE)
+
+        # Act
+        taken = base_red_check.touched(cases, {20})
+
+        # Assert
+        self.assertEqual([case.name for case in taken],
+                         ["Velvet.Tests.ProbeTests.Given_A_When_B_Then_C"])
+
+    def test_Given_ALineInSetUp_When_TheFileIsSelected_Then_NoCaseIsTaken(self):
+        # Arrange
+        cases = base_red_check.csharp_cases(FIXTURE)
+
+        # Act
+        taken = base_red_check.touched(cases, {12})
+
+        # Assert -- an untouched case is worth more as a control than as an accusation.
+        self.assertEqual(taken, [])
+
+    def test_Given_ALineInSetUp_When_TheUnjudgedLinesAreCounted_Then_ItIsAmongThem(self):
+        # Arrange
+        cases = base_red_check.csharp_cases(FIXTURE)
+
+        # Act / Assert
+        self.assertEqual(base_red_check.outside(cases, {12}), {12})
+
+    def test_Given_ALineInsideACase_When_TheUnjudgedLinesAreCounted_Then_ItIsNotAmongThem(self):
+        # Arrange
+        cases = base_red_check.csharp_cases(FIXTURE)
+
+        # Act / Assert
+        self.assertEqual(base_red_check.outside(cases, {20}), set())
+
+    def test_Given_AFileTheBranchAddedWhole_When_ItIsSelected_Then_EveryCaseIsTaken(self):
+        # Arrange
+        cases = base_red_check.csharp_cases(FIXTURE)
+
+        # Act
+        taken = base_red_check.touched(cases, None)
+
+        # Assert
+        self.assertEqual(len(taken), len(cases))
+
+
+class PathTests(unittest.TestCase):
+    def test_Given_AnEditorTestFile_When_ItsPlatformIsRead_Then_ItIsTheEditModeRunner(self):
+        # Act / Assert
+        self.assertEqual(base_red_check.platform_of("Packages/x/Runtime/A/Tests/Editor/BTests.cs"),
+                         "EditMode")
+
+    def test_Given_APlayModeTestFile_When_ItsPlatformIsRead_Then_ItIsThePlayModeRunner(self):
+        # Act / Assert
+        self.assertEqual(base_red_check.platform_of("Packages/x/Runtime/A/Tests/PlayMode/BTests.cs"),
+                         "PlayMode")
+
+    def test_Given_AProductionSource_When_ItsLaneIsRead_Then_ItIsInNone(self):
+        # Act / Assert
+        self.assertIsNone(base_red_check.kind_of("Packages/x/Runtime/A/Reconciler.cs"))
+
+    def test_Given_APythonTestModule_When_ItsLaneIsRead_Then_ItIsThePythonOne(self):
+        # Act / Assert
+        self.assertEqual(base_red_check.kind_of("scripts/pr/test_settle.py"), "python")
+
+    def test_Given_ASharedTestHelper_When_ItIsClassified_Then_ItIsCarriedOntoTheBase(self):
+        # Act / Assert -- it holds no case, and a case that calls it compiles without it nowhere.
+        self.assertTrue(base_red_check.is_test_side("Packages/x/TestUtilities/PanelTestBase.cs"))
+
+    def test_Given_AProductionSource_When_ItIsClassified_Then_ItIsNotCarriedOntoTheBase(self):
+        # Act / Assert -- carrying it would put the branch's own fix under the case it is measuring.
+        self.assertFalse(base_red_check.is_test_side("Packages/x/Runtime/A/Reconciler.cs"))
+
+
+class CompileErrorTests(unittest.TestCase):
+    def test_Given_AUnityCompileError_When_TheLogIsRead_Then_TheSourceIsRepositoryRelative(self):
+        # Arrange
+        log = ("/tmp/base/Packages/com.velvet.core/Runtime/A/Tests/Editor/BTests.cs(12,34): "
+               "error CS0117: 'V' does not contain a definition for 'Portal'\n")
+
+        # Act / Assert
+        self.assertEqual(base_red_check.compile_error_files(log),
+                         ["Packages/com.velvet.core/Runtime/A/Tests/Editor/BTests.cs"])
+
+    def test_Given_AWarningRatherThanAnError_When_TheLogIsRead_Then_NoSourceIsBlamed(self):
+        # Arrange
+        log = "Packages/x/Runtime/A.cs(1,1): warning CS0168: unused variable\n"
+
+        # Act / Assert
+        self.assertEqual(base_red_check.compile_error_files(log), [])
+
+
+class VerdictTests(unittest.TestCase):
+    def probe(self, declaration=None):
+        return base_red_check.Case("N.C.Given_A_When_B_Then_C", "a/Tests/Editor/CTests.cs", 1, 2,
+                                   declaration)
+
+    def test_Given_AnUndeclaredCaseGreenOnTheBase_When_ItIsDecided_Then_ItFailsTheRun(self):
+        # Act
+        verdict, _ = base_red_check.decide(self.probe(), "Passed", fixture_ran=True)
+
+        # Assert
+        self.assertIn(verdict, base_red_check.FAILING_VERDICTS)
+
+    def test_Given_AnUndeclaredCaseRedOnTheBase_When_ItIsDecided_Then_ItDoesNot(self):
+        # Act
+        verdict, _ = base_red_check.decide(self.probe(), "Failed", fixture_ran=True)
+
+        # Assert
+        self.assertNotIn(verdict, base_red_check.FAILING_VERDICTS)
+
+    def test_Given_ADeclaredCaseGreenOnTheBase_When_ItIsDecided_Then_ItDoesNotFailTheRun(self):
+        # Arrange
+        declared = self.probe(base_red_check.Declaration("characterization", "the order it already has"))
+
+        # Act
+        verdict, _ = base_red_check.decide(declared, "Passed", fixture_ran=True)
+
+        # Assert
+        self.assertNotIn(verdict, base_red_check.FAILING_VERDICTS)
+
+    def test_Given_ADeclaredCaseRedOnTheBase_When_ItIsDecided_Then_TheDeclarationIsReportedStale(self):
+        # Arrange
+        declared = self.probe(base_red_check.Declaration("characterization", "the order it already has"))
+
+        # Act
+        verdict, _ = base_red_check.decide(declared, "Failed", fixture_ran=True)
+
+        # Assert -- a declaration nothing withdraws is one that silences a later, real green.
+        self.assertEqual(verdict, base_red_check.DECLARED_STALE)
+
+    def test_Given_ACaseAbsentFromAFixtureThatRan_When_ItIsDecided_Then_ItFailsTheRun(self):
+        # Act
+        verdict, _ = base_red_check.decide(self.probe(), None, fixture_ran=True)
+
+        # Assert -- a name the runner does not answer to is a reading nobody took.
+        self.assertIn(verdict, base_red_check.FAILING_VERDICTS)
+
+    def test_Given_ACaseWhoseFixtureTheBaseNeverBuilt_When_ItIsDecided_Then_ItIsEvidenceNotAFailure(self):
+        # Act
+        verdict, _ = base_red_check.decide(self.probe(), None, fixture_ran=False)
+
+        # Assert -- it names a symbol the base has not got, which is what a pin is supposed to do.
+        self.assertNotIn(verdict, base_red_check.FAILING_VERDICTS)
+
+    def test_Given_EveryArgumentListOfAParameterisedCasePassing_When_ItIsLookedUp_Then_ItReadsPassed(self):
+        # Arrange
+        reported = {"N.C.Given_A_When_B_Then_C(1)": "Passed", "N.C.Given_A_When_B_Then_C(2)": "Passed"}
+
+        # Act / Assert
+        self.assertEqual(base_red_check.outcome_for("N.C.Given_A_When_B_Then_C", reported), "Passed")
+
+    def test_Given_OneArgumentListFailing_When_TheCaseIsLookedUp_Then_ItDoesNotReadPassed(self):
+        # Arrange
+        reported = {"N.C.Given_A_When_B_Then_C(1)": "Passed", "N.C.Given_A_When_B_Then_C(2)": "Failed"}
+
+        # Act / Assert
+        self.assertEqual(base_red_check.outcome_for("N.C.Given_A_When_B_Then_C", reported), "Failed")
+
+    def test_Given_ASiblingWhoseNameExtendsThisOne_When_TheCaseIsLookedUp_Then_ItIsNotCountedIn(self):
+        # Arrange -- a prefix match on the bare name would swallow it; only an argument list may follow.
+        reported = {"N.C.Given_A_When_B_Then_CD": "Failed"}
+
+        # Act / Assert
+        self.assertIsNone(base_red_check.outcome_for("N.C.Given_A_When_B_Then_C", reported))
+
+
+class FixtureRollupTests(unittest.TestCase):
+    def test_Given_AParameterisedEntry_When_TheFixturesThatRanAreRead_Then_TheArgumentsAreNotPartOfIt(self):
+        # Arrange -- an argument list can hold a dot, which a bare rsplit would take as the separator.
+        reported = {'N.C.Given_A_When_B_Then_C("a.b")': "Passed"}
+
+        # Act / Assert
+        self.assertEqual(base_red_check.fixtures_that_ran(reported), {"N.C"})
+
+
+class CanaryTests(unittest.TestCase):
+    """The fixtures a base tree is read by where the branch left no control case of its own."""
+
+    def tree(self, *tracked):
+        holder = tempfile.mkdtemp(prefix="base-red-canary-")
+        self.addCleanup(shutil.rmtree, holder, ignore_errors=True)
+        root = Path(holder)
+        subprocess.run(["git", "-C", holder, "init", "-q"], check=True)
+        for relative in tracked + ("Library/PackageCache/x@1/Tests/Editor/ForeignTests.cs",):
+            path = root / relative
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text("namespace N\n{\n    class {}\n    {{\n        [Test]\n"
+                            "        public void Given_A_When_B_Then_C() => Assert.Pass();\n    }}\n}}\n"
+                            .replace("{}", Path(relative).stem, 1))
+        subprocess.run(["git", "-C", holder, "add", *tracked], check=True)
+        return root
+
+    def test_Given_ATestFileGitDoesNotTrack_When_TheCanariesAreChosen_Then_ItIsNotAmongThem(self):
+        # Arrange -- Library/PackageCache holds Unity's own fixtures, which compile into assemblies
+        # this project cannot pose a filter for, so a canary taken from there never reports at all.
+        root = self.tree("Packages/p/Runtime/A/Tests/Editor/MineTests.cs")
+
+        # Act
+        canaries = base_red_check.canary_fixtures(root, "EditMode", carry=[])
+
+        # Assert
+        self.assertEqual(canaries, ["N.MineTests"])
+
+    def test_Given_TheOnlyTrackedFixtureIsOneTheBranchCarries_When_TheCanariesAreChosen_Then_NoneIs(self):
+        # Arrange -- a file the branch replaced says nothing about the tree it was copied onto.
+        carried = "Packages/p/Runtime/A/Tests/Editor/MineTests.cs"
+        root = self.tree(carried)
+
+        # Act / Assert
+        self.assertEqual(base_red_check.canary_fixtures(root, "EditMode", carry=[carried]), [])
+
+
+class InheritedCaseTests(unittest.TestCase):
+    CORPUS = {
+        "a/Tests/Editor/BaseTests.cs":
+            "namespace N\n{\n    public abstract class BaseTests<T>\n    {\n        [Test]\n"
+            "        public void Given_A_When_B_Then_C() => Assert.Pass();\n    }\n}\n",
+        "a/Tests/Editor/ButtonTests.cs":
+            "namespace N\n{\n    internal sealed class ButtonTests : BaseTests<Button> { }\n}\n",
+        "a/Tests/Editor/MiddleTests.cs":
+            "namespace N\n{\n    public abstract class MiddleTests : BaseTests<Label> { }\n}\n",
+    }
+
+    def test_Given_AConcreteSubclass_When_TheHeirsAreRead_Then_ItIsOneOfThem(self):
+        # Act
+        heirs = base_red_check.concrete_heirs(self.CORPUS)
+
+        # Assert
+        self.assertEqual(heirs.get("BaseTests"), {"N.ButtonTests"})
+
+    def test_Given_ACaseWrittenInAnAbstractFixture_When_ItIsNamed_Then_ItIsNamedForTheHeir(self):
+        # Arrange -- the runner reports it under the class that derives, never the one it is in, so a
+        # filter built from the file matches nothing and the case reads as one nothing could build.
+        path = "a/Tests/Editor/BaseTests.cs"
+        cases = base_red_check.cases_in(path, self.CORPUS[path])
+
+        # Act
+        resolved = base_red_check.as_the_runner_names_them(
+            cases, base_red_check.concrete_heirs(self.CORPUS))
+
+        # Assert
+        self.assertEqual([case.name for case in resolved],
+                         ["N.ButtonTests.Given_A_When_B_Then_C"])
+
+    def test_Given_ACaseInAConcreteFixture_When_ItIsNamed_Then_ItIsLeftAlone(self):
+        # Arrange
+        cases = base_red_check.csharp_cases(FIXTURE, "a/Tests/Editor/ProbeTests.cs")
+
+        # Act
+        resolved = base_red_check.as_the_runner_names_them(cases, {"ProbeTests": {"N.Other"}})
+
+        # Assert
+        self.assertEqual([case.name for case in resolved], [case.name for case in cases])
+
+
+class ResultsFileTests(unittest.TestCase):
+    def test_Given_ADirectoryHoldingNoResults_When_ItIsRead_Then_ItSaysNothingWasWritten(self):
+        # Arrange -- an editor that stops on a compile error writes no results at all, which is not
+        # the same reading as one that ran and named no case of some fixture.
+        holder = tempfile.mkdtemp(prefix="base-red-results-")
+        self.addCleanup(shutil.rmtree, holder, ignore_errors=True)
+
+        # Act / Assert
+        self.assertEqual(base_red_check.results_from(holder), ({}, False))
+
+    def test_Given_AResultsFileWithOneCase_When_ItIsRead_Then_ItSaysSomethingWasWritten(self):
+        # Arrange
+        holder = tempfile.mkdtemp(prefix="base-red-results-")
+        self.addCleanup(shutil.rmtree, holder, ignore_errors=True)
+        Path(holder, "r.xml").write_text(
+            '<test-run><test-case fullname="N.C.Given_A_When_B_Then_C" result="Passed" /></test-run>')
+
+        # Act / Assert
+        self.assertEqual(base_red_check.results_from(holder),
+                         ({"N.C.Given_A_When_B_Then_C": "Passed"}, True))
+
+
+class PlatformInstrumentTests(unittest.TestCase):
+    def test_Given_ACanaryThatPassed_When_ThePlatformIsRead_Then_ItIsNotWithdrawn(self):
+        # Arrange -- one passing case is the bar: the question is whether anything built and ran.
+        reported = {"N.CanaryTests.Given_A_When_B_Then_C": "Passed",
+                    "N.CanaryTests.Given_D_When_E_Then_F": "Failed"}
+
+        # Act / Assert
+        self.assertEqual(base_red_check.unsound_platforms({"EditMode": ["N.CanaryTests"]}, reported),
+                         {})
+
+    def test_Given_NoCanaryReportedAtAll_When_ThePlatformIsRead_Then_ItIsWithdrawn(self):
+        # Arrange -- a tree that built nothing reports every case as uncompilable, and uncompilable
+        # is not a failure here, so without this the run comes back green having measured nothing.
+        # Act
+        withdrawn = base_red_check.unsound_platforms({"EditMode": ["N.CanaryTests"]}, {})
+
+        # Assert
+        self.assertIn("EditMode", withdrawn)
+
+    def test_Given_APlatformTheBaseTreeOffersNoCanary_When_ItIsRead_Then_ItIsNotWithdrawn(self):
+        # Arrange -- with nothing to read the tree by there is no reading, and inventing a verdict
+        # from its absence would refuse every branch on a tree that holds no other fixture.
+        # Act / Assert
+        self.assertEqual(base_red_check.unsound_platforms({"EditMode": []}, {}), {})
+
+
+class InstrumentTests(unittest.TestCase):
+    def control(self, name, result):
+        case = base_red_check.Case(name, "a/Tests/Editor/CTests.cs", 1, 2)
+        return case, {name: result}
+
+    def test_Given_AControlCaseRedOnTheBase_When_TheInstrumentIsRead_Then_ItsFixtureIsWithdrawn(self):
+        # Arrange
+        case, reported = self.control("N.C.Given_A_When_B_Then_C", "Failed")
+
+        # Act / Assert
+        self.assertEqual(base_red_check.unsound_fixtures([case], reported).get("N.C"),
+                         "Given_A_When_B_Then_C is failed there")
+
+    def test_Given_EveryControlCaseGreen_When_TheInstrumentIsRead_Then_NoFixtureIsWithdrawn(self):
+        # Arrange
+        case, reported = self.control("N.C.Given_A_When_B_Then_C", "Passed")
+
+        # Act / Assert
+        self.assertEqual(base_red_check.unsound_fixtures([case], reported), {})
+
+
+class RepositoryTests(unittest.TestCase):
+    """The reader against every test file this repository has, rather than against invented ones."""
+
+    def test_Given_EveryCSharpFixtureHere_When_ItIsRead_Then_EachYieldsACase(self):
+        # Arrange
+        files = csharp_test_files()
+
+        # Act
+        silent = [relative for relative, text in files if not base_red_check.csharp_cases(text)]
+
+        # Assert -- the count rides along because an empty corpus reports nothing silent.
+        self.assertEqual((len(files) > 100, silent), (True, []))
+
+    def test_Given_EveryCSharpFixtureHere_When_ItIsRead_Then_NoTwoCaseSpansOverlap(self):
+        # Act
+        overlapping = []
+        for relative, text in csharp_test_files():
+            spans = sorted((case.first_line, case.last_line)
+                           for case in base_red_check.csharp_cases(text))
+            for earlier, later in zip(spans, spans[1:]):
+                if earlier[1] >= later[0]:
+                    overlapping.append("{}: {} runs into {}".format(relative, earlier, later))
+
+        # Assert -- an overlap attributes one author's line to another author's case.
+        self.assertEqual(overlapping, [])
+
+    def test_Given_EveryCSharpFixtureHere_When_ItIsRead_Then_NoCaseEndsPastTheFile(self):
+        # Act
+        past = []
+        for relative, text in csharp_test_files():
+            length = len(text.splitlines())
+            past += ["{}: {}".format(relative, case.name)
+                     for case in base_red_check.csharp_cases(text) if case.last_line > length]
+
+        # Assert
+        self.assertEqual(past, [])
+
+    def test_Given_EveryPythonModuleHere_When_ItIsRead_Then_EachYieldsACase(self):
+        # Arrange
+        files = python_test_files()
+
+        # Act
+        silent = [relative for relative, text in files if not base_red_check.python_cases(text)]
+
+        # Assert
+        self.assertEqual((len(files) > 3, silent), (True, []))
+
+    def test_Given_EveryDeclarationHere_When_ItIsRead_Then_NoneIsMalformed(self):
+        # Act
+        complaints = []
+        for relative, text in csharp_test_files() + python_test_files():
+            for case in base_red_check.cases_in(relative, text):
+                if case.declaration and case.declaration.complaint:
+                    complaints.append("{}: {}".format(case.name, case.declaration.complaint))
+
+        # Assert -- a malformed declaration reads as an opt-out and is not one.
+        self.assertEqual(complaints, [])
+
+    def test_Given_EveryCaseHere_When_ItIsNamedAsTheRunnerWould_Then_AConcreteClassCarriesIt(self):
+        # Arrange -- a name no concrete class answers to is one the base run reports nothing for,
+        # which reads as a case the base could not build and passes. Silence, not a failure.
+        corpus = dict(csharp_test_files())
+        heirs = base_red_check.concrete_heirs(corpus)
+        concrete = {name.rsplit(".", 1)[-1]
+                    for owners in heirs.values() for name in owners} | {
+                        case.name.rsplit(".", 2)[-2]
+                        for relative, text in corpus.items()
+                        for case in base_red_check.csharp_cases(text, relative)
+                        if not case.abstract_owner}
+
+        # Act
+        homeless = sorted({case.name.rsplit(".", 2)[-2]
+                           for relative, text in corpus.items()
+                           for case in base_red_check.as_the_runner_names_them(
+                               base_red_check.csharp_cases(text, relative), heirs)
+                           if case.name.rsplit(".", 2)[-2] not in concrete})
+
+        # Assert
+        self.assertEqual(homeless, [])
+
+    def test_Given_EveryDeclarationHere_When_ItIsCounted_Then_NoneIsOrphaned(self):
+        # Arrange -- one written over a helper, or too far above a case, silences nothing and looks
+        # like it does.
+        written, carried = 0, 0
+        for relative, text in csharp_test_files() + python_test_files():
+            written += sum(1 for line in text.splitlines()
+                           if base_red_check.DECLARATION.search(line))
+            carried += sum(1 for case in base_red_check.cases_in(relative, text) if case.declaration)
+
+        # Act / Assert
+        self.assertEqual(written, carried)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/test_quality/test_base_red_check.py
+++ b/scripts/test_quality/test_base_red_check.py
@@ -11,6 +11,7 @@ Run: python3 scripts/test_quality/test_base_red_check.py
 
 import importlib.util
 import json
+import re
 import shutil
 import subprocess
 import sys
@@ -106,28 +107,78 @@ def python_test_files():
     return tracked("python")
 
 
-def concrete_class_names(corpus):
-    """The simple names of every class, record and struct declared without `abstract`, over a corpus.
+DECLARED_SCOPE = re.compile(
+    r"\b(?:namespace|interface|enum|class|struct|record(?:\s+(?:class|struct))?)"
+    r"\s+([A-Za-z_][A-Za-z0-9_.]*)")
 
-    Off the code lines, so a `class` written into an assertion message is not one of them -- which is
-    the whole point of comparing against this set.
+
+def body_span(blanked, after):
+    """(first offset inside the body, offset of its closing brace) for a declaration, or None.
+
+    None is a declaration that never opens a body, which this repository writes as a positional
+    record. Nothing can be named under one.
     """
-    found = set()
+    depth = 0
+    for offset in range(after, len(blanked)):
+        character = blanked[offset]
+        if character == ";" and depth == 0:
+            return None
+        if character == "{":
+            depth += 1
+            if depth == 1:
+                opened = offset
+        elif character == "}":
+            depth -= 1
+            if depth == 0:
+                return opened, offset
+    return None
+
+
+def declared_scopes(text):
+    """Qualified name -> whether it is abstract, for every namespace and type one file declares.
+
+    Each declaration is qualified by the ones whose braces enclose it, rather than by a running stack
+    of the ones seen so far. The distinction is the point: a stack that fails to unwind emits owner
+    chains no declaration spells, and a set of legitimate chains built from a stack the same way
+    would agree with every one of them and hold nothing.
+    """
+    mask = base_red_check.code_mask(text)
+    blanked = "".join(text[offset] if mask[offset] else " " for offset in range(len(text)))
+    declared = []
+    for match in DECLARED_SCOPE.finditer(blanked):
+        body = body_span(blanked, match.end())
+        if body is None:
+            continue
+        line = blanked[blanked.rfind("\n", 0, match.start()) + 1:match.end()]
+        declared.append((match.start(), body, match.group(1),
+                         bool(base_red_check.CSHARP_ABSTRACT.search(line))))
+    scopes = {}
+    for start, _, name, abstract in declared:
+        enclosing = sorted((outer, outer_name) for outer, (inner, outer_end), outer_name, _ in declared
+                           if inner <= start <= outer_end)
+        qualified = ".".join([outer_name for _, outer_name in enclosing] + [name])
+        scopes[qualified] = abstract
+    return scopes
+
+
+def answerable_names(corpus):
+    """Every qualified type in the corpus a runner could report a case under: declared, and concrete."""
+    answerable = set()
     for text in corpus.values():
-        for line in base_red_check.code_lines(text):
-            declared = base_red_check.CSHARP_TYPE.search(line)
-            if declared and not base_red_check.CSHARP_ABSTRACT.search(line):
-                found.add(declared.group(1))
-    return found
+        answerable |= {name for name, abstract in declared_scopes(text).items() if not abstract}
+    return answerable
 
 
 def unanswered_names(corpus, heirs):
     """Every case in `corpus` whose runner name no concrete class in `corpus` can answer to.
 
     Both ways that happens: a case the naming drops because the abstract fixture it is written in has
-    no concrete heir, and a case it keeps under a class segment nothing declares.
+    no concrete heir, and a case it keeps under an owner chain nothing declares. The whole chain is
+    read, not its last segment -- every segment is part of the name `-testFilter` is given, so a
+    chain of names each of which is declared somewhere still matches nothing when nothing nests them
+    that way.
     """
-    concrete = concrete_class_names(corpus)
+    answerable = answerable_names(corpus)
     unanswered = []
     for relative, text in corpus.items():
         for case in base_red_check.csharp_cases(text, relative):
@@ -135,8 +186,8 @@ def unanswered_names(corpus, heirs):
             if not named:
                 unanswered.append("{}: {} runs under no concrete class".format(relative, case.name))
             unanswered += ["{}: {} names {}, which nothing declares".format(
-                relative, case.name, produced.name.rsplit(".", 2)[-2])
-                for produced in named if produced.name.rsplit(".", 2)[-2] not in concrete]
+                relative, case.name, produced.name.rsplit(".", 1)[0])
+                for produced in named if produced.name.rsplit(".", 1)[0] not in answerable]
     return unanswered
 
 
@@ -216,6 +267,45 @@ class CSharpReadingTests(unittest.TestCase):
 
         # Assert
         self.assertIsNone(case.abstract_owner)
+
+    def test_Given_APositionalRecordAboveAFixture_When_TheCasesAreRead_Then_ItDoesNotQualifyThem(self):
+        # Arrange -- this repository declares its store state as a positional record beside the
+        # fixture. It opens no body, so nothing closes it and nothing pops it off the type stack.
+        text = ("namespace N\n{\n    internal readonly record struct ToggleState(bool Show);\n\n"
+                "    class C\n    {\n        [Test]\n"
+                "        public void Given_A_When_B_Then_C() => Assert.Pass();\n    }\n}\n")
+
+        # Act
+        names = [case.name for case in base_red_check.csharp_cases(text)]
+
+        # Assert
+        self.assertEqual(names, ["N.C.Given_A_When_B_Then_C"])
+
+    def test_Given_PositionalRecordsAmongAFixturesMembers_When_TheCasesBelowAreRead_Then_TheyNestNothing(self):
+        # Arrange -- one bodiless declaration also blocks the ones under it from leaving the stack,
+        # so the chain grows by a segment per record rather than by one.
+        text = ("namespace N\n{\n    class C\n    {\n        private sealed record A(int X);\n"
+                "        private sealed record B(int Y);\n\n        [Test]\n"
+                "        public void Given_A_When_B_Then_C() => Assert.Pass();\n    }\n}\n")
+
+        # Act
+        names = [case.name for case in base_red_check.csharp_cases(text)]
+
+        # Assert
+        self.assertEqual(names, ["N.C.Given_A_When_B_Then_C"])
+
+    def test_Given_ARecordStructWithABody_When_ItsCaseIsRead_Then_ItIsNamedForTheTypeNotTheKeyword(self):
+        # Arrange -- `record` takes an optional `class` or `struct`, which sits where the other two
+        # spellings put the name. The repository-wide guard cannot hold this: it reads declarations
+        # through the same expression, so it would name the owner `struct` as well and agree.
+        text = ("namespace N\n{\n    record struct C\n    {\n        [Test]\n"
+                "        public void Given_A_When_B_Then_C() => Assert.Pass();\n    }\n}\n")
+
+        # Act
+        names = [case.name for case in base_red_check.csharp_cases(text)]
+
+        # Assert
+        self.assertEqual(names, ["N.C.Given_A_When_B_Then_C"])
 
     def test_Given_APreprocessorDirectiveHoldingAnApostrophe_When_TheFileIsRead_Then_TheCasesBelowAreToo(self):
         # Arrange -- `#region Boundary's own mount` opens a character literal to anything reading the

--- a/scripts/test_quality/test_mutation_check.py
+++ b/scripts/test_quality/test_mutation_check.py
@@ -40,6 +40,43 @@ def applied(text, mutant):
     return mutation_check.apply_mutation(text, mutant).splitlines()[mutant.line - 1].strip()
 
 
+class CodeMaskTests(unittest.TestCase):
+    """Which offsets count as code. Everything downstream of the mask reads only what it leaves.
+
+    Nothing reports an offset wrongly blanked: a mutant is never generated there, a brace never counted,
+    and both halves come back looking like a file with less in it than it has.
+    """
+
+    def masked_out(self, text, fragment):
+        mask = mutation_check.code_mask(text)
+        start = text.index(fragment)
+        return [text[offset] for offset in range(start, start + len(fragment)) if not mask[offset]]
+
+    def test_Given_AnApostropheInAPreprocessorDirective_When_TheMaskIsRead_Then_TheCodeBelowIsCode(self):
+        # Arrange -- `#region Boundary's own tree` is free-form text after the directive, but reading it
+        # as code opens a character literal that runs to the next apostrophe anywhere in the file.
+        text = "#region Boundary's own tree\nif (a <= b) { }\n#endregion\n"
+
+        # Act / Assert
+        self.assertEqual(self.masked_out(text, "if (a <= b) { }"), [])
+
+    def test_Given_ALoneApostropheInCode_When_TheMaskIsRead_Then_ItSwallowsNoLaterLine(self):
+        # Arrange -- twelve characters is the longest literal C# can spell, `'\\U0001F600'`, so an
+        # apostrophe with no closing one inside that reach is not one and consumes nothing.
+        text = "var x = a ' b;\nif (c <= d) { }\n"
+
+        # Act / Assert
+        self.assertEqual(self.masked_out(text, "if (c <= d) { }"), [])
+
+    # GREEN_ON_BASE(characterization): the masking the two cases above are read against.
+    def test_Given_ARealCharacterLiteral_When_TheMaskIsRead_Then_ItIsStillNotCode(self):
+        # Arrange -- the counterpart, so the two above are not passing for a mask that blanks nothing.
+        text = "var separator = ';';\n"
+
+        # Act / Assert
+        self.assertEqual(self.masked_out(text, "';'"), ["'", ";", "'"])
+
+
 class ClauseRemovalTests(unittest.TestCase):
     def test_Given_AThreeClauseCondition_When_MutantsAreGenerated_Then_EachTrailingClauseIsRemovable(self):
         # Arrange


### PR DESCRIPTION
`CLAUDE.md` asks that a regression test be verified red without the fix and green with it. Nothing
checked, so it was a matter of attentiveness. Run over four branches from recent history, three had a
case that passed on the merge base and had been reported as pinning something.

`scripts/test_quality/base_red_check.py` checks out the merge base, copies the branch's changed test
files onto it, and runs the cases the branch wrote there. A case green on both sides fails the check.

## 1. Where it runs

Measured on one machine, EditMode, warm `Library`:

| | |
|---|---|
| Full suite, 3844 cases | 84 s / 97 s |
| One fixture (27 cases), filtered | 15 s |
| A whole base check — build the tree, seed a `Library`, run the fixtures, decide | 26–47 s |
| A base tree with no `Library` at all — first import plus one fixture | 65 s |

So restricting to the changed fixtures is worth roughly 5× against the suite, and the base tree's
first import is the larger half of what remains. That settles the local shape: a base check costs
about a third of a suite run, which is cheap enough to run per branch.

CI is a different question, because the marginal cost there is a second Unity job — image, licence,
`Library` restore — not the test time. So the two lanes are split:

- **`Test ▸ base-red-python`** needs no licence and no editor, runs on every pull request and merge
  group, and is complete for the Python surface. It is in `required-checks`.
- **`Test ▸ base-red`** is a matrix job over EditMode/PlayMode, gated on `UNITY_LICENSE` and on
  `unity-tests`, and reaches Unity through the same `game-ci` action the suite does. It skips
  outright when the branch changed no C# test file. It is in `required-checks` too, because
  `RequiredCheckAggregationTests` refuses a job the aggregate does not depend on.

`--emit` / `--verdict` split the run so the editor can be somebody else's: the first builds the base
tree and writes what it read, the second decides from a results file. That split was exercised
locally end to end against the same commit as the single-shot run, and reached the same verdict.

## 2. Compilation

A new test on the base does not compile when it names a symbol the branch adds — the common case,
not the exception. **The verdict never reads the editor log**, which is what makes the reading
portable to a runner that hands back only a results file:

- a fixture the results name **no case of** is one the base did not build what was carried for. That
  is the evidence a test naming a new symbol is supposed to leave, so it is not a failure;
- a case missing while its fixture reported **its other cases** is a name that did not resolve, and a
  name nobody answered to is a reading nobody took. That fails.

What separates that from a genuine break is that the same file compiles on the branch, which
`needs: unity-tests` establishes; the reading is stated in the job's comment rather than assumed.

Two limits, stated rather than papered over:

- It does not by itself separate "the base could not build the branch's test file" from "the base
  could not build for a reason no branch owns". What closes that is the instrument reading: the cases
  the branch did **not** change come from the base's own green run, so one of those going red
  withdraws its fixture's verdicts. Where the branch adds a wholly new file and leaves no such case,
  three of the base tree's own fixtures are run alongside and at least one must pass.
- **A compile error stops the whole run, not one assembly.** Measured: breaking one test file and
  filtering to a fixture in a different assembly gives `Aborting batchmode due to failure: Scripts
  have compiler errors` and no results file at all. So a single round cannot say *which* carried file
  the base could not build — it can only say that it could not build one of them, which passes. The
  local harness withdraws one carried file per round and asks again until something runs, which is
  what turns that into a per-file verdict; a workflow does not express the loop, so CI runs one round.
  What survives in CI is the case the base **did** build and answer green — which is the case this
  exists for, and the one all three reproductions below turn on. What CI gives up is a green-on-base
  case sitting in the same assembly as an uncompilable sibling.

## 3. Legitimate green-on-base cases

A characterization test and a test riding with a pure refactor both belong and both pass on the base.
They say so in the file, directly above the case, per case:

```csharp
// GREEN_ON_BASE(characterization): the keyed-reorder order this refactor must not change.
```

The category must be one the script defines and the reason must be more than a placeholder; both are
checked. It is not a blanket opt-out in three ways: it covers one case and not its neighbours (a blank
line or any code between it and the attribute block ends it); it is read **in both directions**, so a
declaration over a case that turns out red on the base fails the check and has to be removed; and it
is prose a reviewer reads in the diff next to the case it excuses.

`BaseRedDeclarationTests` holds the categories written in C# sources, and the example this guide
shows, against the set the script actually accepts. `scripts/test_quality/test_base_red_check.py`
holds every declaration in the repository against the same reader, and fails on one that sits where
no case picks it up.

## 4. What "changed test" means

Covered, from `git diff` against the merge base (working tree included, so it runs before a commit):

- a case whose own lines the branch touched — a renamed method included, since the signature line is
  one of them, and a changed assertion likewise;
- every case of a file the branch adds whole.

Not covered, and **printed on every run** rather than left to be assumed:

- lines that fall inside no case — a `SetUp`, a field, a private helper the cases call, a `using`.
  Selecting the file whole on that ground was tried first: it puts all 27 cases of a fixture on trial
  for one line added to `SetUp`, and it consumes the untouched cases that the instrument reading needs.
  The run reports the count per file instead;
- a changed helper under `TestUtilities/`. It is carried onto the base so the cases compile, but the
  cases that call it are not selected;
- a production change with no test change at all. `mutation_check.py` is the instrument for that
  question, and this does not replace it — of the four branches below, the two whose reported defect
  was a surviving mutation rather than a green base are exactly the two this is weakest on.

## Proof against this repository's history

Each row is a real commit, `--base` its merge base, one C# base run:

| Branch state | Verdict | What it named |
|---|---|---|
| `#582` before the fix | **fails** | `Given_ConcurrentMutations_…_FinalStateComesFromLatestCall` **passed on the base** — its `mutationFn` returned a bare completion-source task, so the token it claimed to test was ignored either way. The sibling case added in the same commit came back red, so this is a reading within the commit, not a blanket one |
| `#582` after the fix | that case flips to **red on the base** | the run still fails on a fourth case in the same commit, `Given_AMutationInFlight_…_TheUnmountCompletes`, which is green on the base. The next commit on that branch rewrote exactly that case |
| `#582` after the fix, with a declaration on that case | **passes** | and with a deliberately wrong declaration over a red case, fails, naming it stale |
| `#583` | **fails** | `Given_ACheckoutAndAWorktreeOfIt_…_ItRefuses` passed on the base, along with four more in the same fixture. The guard the cases pose is absent from the base, so `python3 <missing file>` exits 2 and reads as a refusal |
| `#588` | **fails** | three of seven changed cases pass on the base |
| `#577` | **passes** | correctly: all five changed cases are red on the base. Its reported defect was mutation survival, which this does not measure |
| `#589` | **passes** | 29 cases across three fixtures, all "could not compile there"; with a fourth, compilable fixture added, the withdrawal loop converges in four rounds and measures it |

Two defects in this were found by running it, not by reading it, and both were the same shape — a
reading that comes back empty and passes:

- the fixtures it stands the base tree up against were being taken from `Library/PackageCache`, which
  compile into Unity's own assemblies and answer to no filter this project can pose, so the canary
  found nothing passing and withdrew the branch it was there to vouch for. Found by running it on
  itself;
- a case written in an abstract fixture (`PoolHelperTestsBase`, six cases, five heirs) is reported by
  the runner under each deriving class and never under the one it is written in, so the name taken
  from the file matched nothing and the case read as one the base could not build — which passes.
  `as_the_runner_names_them` resolves it, and a repository-wide case fails on any name no concrete
  class in the tree answers to.

## Documentation and CHANGELOG

`CONTRIBUTING.md` gains a section next to the mutation and neuter harnesses, and its CI table gains
rows for both new jobs — plus the `Test ▸ test-quality` row the table never had. No `Documentation~`
guide describes contributor tooling, so none changes. No `CHANGELOG.md` entry: nothing here is
observable to a package consumer.

## Known failures this does not introduce

The EditMode suite reports nine failures in `BundledStyleSheetInclusionTests` on this machine, all of
them `AssetDatabase.LoadAssetAtPath` returning null for
`Packages/com.velvet.core/Runtime/Assets/VelvetRuntimeAssets.asset`. They reproduce identically on
untouched `origin/main`, in a worktree with a copied `Library` and in one that imported from nothing,
and CI's own EditMode job is green — so they are local to this checkout shape and predate this branch.
