### PR TITLE
fix(velvet): key the suspended mark per Suspense, not per boundary

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -38,6 +38,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Two `V.Suspense` boundaries in one component's render no longer share a single suspended mark. One
+  showing its fallback while a second, placed after it, rendered its children left the component
+  unmarked, so a state update inside the first one's hidden children stopped being deferred and
+  committed into the slot range its fallback occupied — the fallback disappeared from the tree.
+  Whether a boundary is showing a fallback is now read off the per-boundary record each `V.Suspense`
+  writes under its own position, so a sibling that resolves cannot clear it. Ordering decided it:
+  the same two boundaries with the resolved one placed first were unaffected.
+
 - A second `Mutate` call no longer cancels the first or drops its callbacks. Both run, each delivers
   its own `OnSuccess` / `OnError`, and `Status` / `Data` / `Variables` show the most recent — which
   is what TanStack Query does, and it hands `mutationFn` no signal at all. A double-tapped Buy used to

--- a/Packages/com.velvet.core/Runtime/Component/ComponentFiber.cs
+++ b/Packages/com.velvet.core/Runtime/Component/ComponentFiber.cs
@@ -185,12 +185,13 @@ namespace Velvet
         public bool IsSuspenseBoundary { get; internal set; }
 
         /// <summary>
-        /// True while this fiber is a primary (hidden) child of a wrapper-less Suspense boundary that
-        /// is currently showing its fallback. Set by <c>GeneralPathReconciler.ExpandSuspenseInline</c> when
-        /// the boundary suspends and cleared when it reveals. <see cref="FiberWorkLoop.FlushState"/>'s
+        /// True while this fiber is a primary (hidden) child of a wrapper-less Suspense that is currently
+        /// showing its fallback. Set by <c>GeneralPathReconciler.ExpandSuspenseInline</c> when that
+        /// Suspense suspends and cleared when it reveals. <see cref="FiberWorkLoop.FlushState"/>'s
         /// offscreen guard defers a lane flush for offscreen fibers (their slot is occupied by the
-        /// fallback) while still allowing the visible fallback subtree to flush (the
-        /// fallback renders normally; only the primary subtree is offscreen).
+        /// fallback). It is per-fiber rather than per-boundary because one component fiber can render
+        /// several Suspense nodes: that Suspense's own visible fallback subtree, and a sibling Suspense's
+        /// children, sit under the same boundary and must still flush.
         /// </summary>
         internal bool IsOffscreen { get; set; }
 

--- a/Packages/com.velvet.core/Runtime/Component/ComponentFiber.cs
+++ b/Packages/com.velvet.core/Runtime/Component/ComponentFiber.cs
@@ -186,8 +186,9 @@ namespace Velvet
 
         /// <summary>
         /// True while this fiber is a primary (hidden) child of a wrapper-less Suspense that is currently
-        /// showing its fallback. Set by <c>GeneralPathReconciler.ExpandSuspenseInline</c> when that
-        /// Suspense suspends and cleared when it reveals. <see cref="FiberWorkLoop.FlushState"/>'s
+        /// showing its fallback. Written by <c>GeneralPathReconciler.ExpandSuspenseInline</c> over the
+        /// fibers that expansion created — which is not the same as per-Suspense, since an enclosing
+        /// Suspense's expansion writes over an inner one's fibers too. <see cref="FiberWorkLoop.FlushState"/>'s
         /// offscreen guard defers a lane flush for offscreen fibers (their slot is occupied by the
         /// fallback). It is per-fiber rather than per-boundary because one component fiber can render
         /// several Suspense nodes: that Suspense's own visible fallback subtree, and a sibling Suspense's

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberContextSpine.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberContextSpine.cs
@@ -395,8 +395,7 @@ namespace Velvet
             var ancestor = walk.Ancestor;
             var suspenseKey = FiberKeying.SuspenseKey(fragmentKeyScope, suspense.Key, nodeIndex);
             var wasFallback = ancestor.Reconciler != null
-                && ancestor.Reconciler.Context.SuspenseFallbackShown.TryGetValue(
-                    (ancestor, suspenseKey), out var shown) && shown;
+                && ancestor.Reconciler.Context.IsSuspenseFallbackShown(ancestor, suspenseKey);
             var sub = wasFallback
                 ? (suspense.Fallback != null ? new[] { suspense.Fallback } : System.Array.Empty<VNode>())
                 : (suspense.Children ?? System.Array.Empty<VNode>());

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberKeying.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberKeying.cs
@@ -267,9 +267,9 @@ namespace Velvet
         internal static string MemoCacheKey(string? memoKey, string memoScope)
             => memoKey ?? memoScope;
 
-        // The boundary key for a SuspenseNode (also the ReconcilerContext.SuspenseFallbackShown
-        // state key suffix): the parent scope extended by the Suspense's own key (or its positional
-        // index when unkeyed).
+        // The boundary key for a SuspenseNode (also the position key its
+        // ReconcilerContext.SetSuspenseFallbackShown entry is stored under): the parent scope extended
+        // by the Suspense's own key (or its positional index when unkeyed).
         internal static string SuspenseKey(string? parentScope, string? suspenseKey, int nodeIndex)
             => ComposeFragmentScope(parentScope, suspenseKey ?? Index(nodeIndex));
 

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberWorkLoop.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberWorkLoop.cs
@@ -208,12 +208,12 @@ namespace Velvet
             // own re-render (scheduled when the resource resolved) re-attempts the primary subtree and commits
             // the reveal in one pass: a resolved resource schedules the boundary itself, not the
             // suspended child. Leave IsDirty set so that re-render picks this fiber up via the expansion.
-            var suspendedBoundaries = fiber.Reconciler?.Context.SuspendedBoundaries;
-            if (suspendedBoundaries is { Count: > 0 })
+            var context = fiber.Reconciler?.Context;
+            if (context is { AnyBoundaryShowingFallback: true })
             {
                 var enclosingBoundary = ComponentBoundarySearch.FindNearestSuspenseBoundary(fiber);
                 if (enclosingBoundary != null && !ReferenceEquals(enclosingBoundary, fiber)
-                    && suspendedBoundaries.Contains(enclosingBoundary))
+                    && context.IsBoundaryShowingFallback(enclosingBoundary))
                 {
                     // Defer only PRIMARY (offscreen) descendants — their slot is occupied by the
                     // fallback, so an independent flush would write into the fallback's range. A visible

--- a/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
@@ -962,7 +962,7 @@ namespace Velvet
         // descendant suspends during the new-side render, the partial primary output is discarded (the
         // partially-mounted fibers stay registered so a later resolve re-render reuses them with their
         // state) and the fallback subtree is expanded instead. The children-vs-fallback decision is
-        // recorded in ReconcilerContext.SuspenseFallbackShown keyed by (boundary,
+        // recorded via ReconcilerContext.SetSuspenseFallbackShown keyed by (boundary,
         // position) so the old-side structural walk reproduces the committed subtree for the diff.
         // Primary and fallback children use distinct fragment scopes so their fibers never collide.
         private void ExpandSuspenseInline(
@@ -980,7 +980,6 @@ namespace Velvet
                 position, suspenseKey, suspense.Key, nodeIndex, isFallback: false);
             var fallbackPosition = FiberKeying.SuspenseSubtree(
                 position, suspenseKey, suspense.Key, nodeIndex, isFallback: true);
-            var stateKey = (boundaryFiber, suspenseKey);
 
             if (walk.IsNewSide)
             {
@@ -1040,18 +1039,14 @@ namespace Velvet
                 {
                     _ctx.BufferPool.ReturnFiberSet(fibersBefore);
                 }
-                _ctx.SuspenseFallbackShown[stateKey] = suspended;
-                if (boundaryFiber != null)
-                {
-                    // Mark/unmark the boundary as suspended so FlushState defers an offscreen descendant's
-                    // lane flush to this boundary's re-render (which commits the reveal in one pass).
-                    if (suspended) _ctx.SuspendedBoundaries.Add(boundaryFiber);
-                    else _ctx.SuspendedBoundaries.Remove(boundaryFiber);
-                }
+                // Records this Suspense's decision under its own position key. FlushState's offscreen guard
+                // reads the boundary-level answer derived from those keys, so a sibling Suspense expanded
+                // later in this same walk cannot clear it.
+                _ctx.SetSuspenseFallbackShown(boundaryFiber, suspenseKey, suspended);
             }
             else
             {
-                var wasFallback = _ctx.SuspenseFallbackShown.TryGetValue(stateKey, out var shown) && shown;
+                var wasFallback = _ctx.IsSuspenseFallbackShown(boundaryFiber, suspenseKey);
                 var nodesToExpand = wasFallback
                     ? (suspense.Fallback != null ? new[] { suspense.Fallback } : Array.Empty<VNode>())
                     : (suspense.Children ?? Array.Empty<VNode>());

--- a/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
@@ -1003,45 +1003,74 @@ namespace Velvet
             RefCallbacks[element] = (refCallback, cleanup);
         }
 
-        // Wrapper-less Suspense fallback state, keyed by (boundary fiber, the Suspense's scoped position
-        // key). True while that Suspense is showing its fallback subtree instead of its children. The
-        // new-side walk sets it after attempting the children expansion (suspended ⇒ true); the old-side
-        // structural walk reads it to reproduce whichever subtree (children vs fallback) was committed
-        // last render, so the diff's old leaves match the DOM. Entries are pruned when the boundary fiber
-        // is disposed (registry teardown).
-        internal Dictionary<(ComponentFiber? boundary, string positionKey), bool> SuspenseFallbackShown { get; } = new();
+        // Wrapper-less Suspense fallback state: per boundary fiber, the scoped position keys of the
+        // Suspense nodes that are currently showing their fallback subtree instead of their children. The
+        // new-side walk records the decision after attempting the children expansion (suspended ⇒ the key
+        // is present); the old-side structural walk reads it to reproduce whichever subtree (children vs
+        // fallback) was committed last render, so the diff's old leaves match the DOM.
+        //
+        // Only keys showing the fallback are stored, and a boundary with none holds no entry, so both
+        // readings FlushState needs — "this boundary has a fallback up" and "any boundary does" — are
+        // derived from this table rather than tracked beside it. One component fiber can render several
+        // Suspense nodes and each is keyed by its own position, so a boundary-level flag cannot express
+        // them: whichever node expanded last would decide for all of them, and a resolved one expanded
+        // after a suspended one would clear the guard that keeps the suspended one's offscreen primary
+        // from committing into the slot its fallback occupies.
+        //
+        // A Suspense rendered with no enclosing component fiber has no boundary to key on and is held
+        // separately, so the dictionary's emptiness stays equivalent to "no boundary has a fallback up".
+        private readonly Dictionary<ComponentFiber, HashSet<string>> _suspenseFallbackKeys = new();
+        private readonly HashSet<string> _rootlessSuspenseFallbackKeys = new();
 
-        // Boundary fibers that currently have a wrapper-less Suspense showing its fallback. A dirty fiber
-        // whose nearest Suspense boundary is in this set is "offscreen": its own lane flush is deferred to
-        // the boundary's re-render, which re-attempts the primary subtree and commits the reveal in one pass
-        // (a resolved resource schedules the boundary itself, not the suspended child — committing
-        // the child independently would write into the slot range the fallback occupies). Maintained by
-        // GeneralPathReconciler.ExpandSuspenseInline; read by FiberWorkLoop.FlushState.
-        internal HashSet<ComponentFiber> SuspendedBoundaries { get; } = new();
+        // A dirty fiber whose nearest Suspense boundary has a fallback up is a candidate for the offscreen
+        // deferral in FiberWorkLoop.FlushState; this is the cheap pre-check that skips the ancestor walk.
+        internal bool AnyBoundaryShowingFallback => _suspenseFallbackKeys.Count > 0;
 
-        // Removes all wrapper-less Suspense boundary state keyed by boundary.
-        // Invoked from ComponentRegistry when the boundary fiber is unregistered, so a
-        // boundary that unmounts while suspended leaves no dangling fiber reference in
-        // SuspendedBoundaries / SuspenseFallbackShown.
-        internal void PruneSuspenseBoundaryState(ComponentFiber boundary)
+        internal bool IsBoundaryShowingFallback(ComponentFiber boundary)
+            => _suspenseFallbackKeys.ContainsKey(boundary);
+
+        internal bool IsSuspenseFallbackShown(ComponentFiber? boundary, string positionKey)
+            => boundary == null
+                ? _rootlessSuspenseFallbackKeys.Contains(positionKey)
+                : _suspenseFallbackKeys.TryGetValue(boundary, out var keys) && keys.Contains(positionKey);
+
+        internal void SetSuspenseFallbackShown(ComponentFiber? boundary, string positionKey, bool shown)
         {
-            SuspendedBoundaries.Remove(boundary);
-            if (SuspenseFallbackShown.Count == 0) return;
-            List<(ComponentFiber? boundary, string positionKey)>? stale = null;
-            foreach (var key in SuspenseFallbackShown.Keys)
+            if (boundary == null)
             {
-                if (key.boundary == boundary) (stale ??= new()).Add(key);
+                if (shown) _rootlessSuspenseFallbackKeys.Add(positionKey);
+                else _rootlessSuspenseFallbackKeys.Remove(positionKey);
+                return;
             }
-            if (stale != null)
+            if (shown)
             {
-                foreach (var key in stale) SuspenseFallbackShown.Remove(key);
+                if (!_suspenseFallbackKeys.TryGetValue(boundary, out var keys))
+                {
+                    keys = new HashSet<string>();
+                    _suspenseFallbackKeys[boundary] = keys;
+                }
+                keys.Add(positionKey);
+                return;
+            }
+            if (_suspenseFallbackKeys.TryGetValue(boundary, out var existing)
+                && existing.Remove(positionKey) && existing.Count == 0)
+            {
+                _suspenseFallbackKeys.Remove(boundary);
             }
         }
 
+        // Removes all wrapper-less Suspense boundary state keyed by boundary.
+        // Invoked from ComponentRegistry when the boundary fiber is unregistered, so a
+        // boundary that unmounts while suspended leaves no dangling fiber reference behind.
+        internal void PruneSuspenseBoundaryState(ComponentFiber boundary)
+        {
+            _suspenseFallbackKeys.Remove(boundary);
+        }
+
         // Per-AnimatePresence state for the DOM-less (wrapper-less) expansion, keyed by
-        // (boundary fiber, the AnimatePresence's scoped position key) — mirroring
-        // SuspenseFallbackShown's keying. The keyed children are expanded directly into the
-        // parent's slot range (no wrapper element); this state records, per AnimatePresence, the leaf
+        // (boundary fiber, the AnimatePresence's scoped position key). The keyed children are expanded
+        // directly into the parent's slot range (no wrapper element); this state records, per
+        // AnimatePresence, the leaf
         // composition currently committed to the DOM so the old-side structural walk can reproduce it for
         // the diff, plus which keys are mid-exit (kept mounted as ghosts) and which have finished exiting
         // (dropped on the next render). Pruned when the boundary fiber is disposed.

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/SuspenseBoundaryTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/SuspenseBoundaryTests.cs
@@ -348,8 +348,8 @@ namespace Velvet.Tests
         [Test]
         public void Given_SuspendedBoundaryFollowedByResolvedSibling_When_OffscreenDescendantUpdates_Then_FallbackSurvives()
         {
-            // Arrange — the suspended Suspense is expanded BEFORE the resolved one, so the resolved one's
-            // expansion is the last to write the per-boundary suspended mark that guards the offscreen flush
+            // Arrange — the suspended Suspense is expanded BEFORE the resolved one. That order is what used
+            // to lose the boundary's suspended mark to the resolved sibling's expansion.
             var source = new UniTaskCompletionSource<string>();
             s_offscreenFactory = _ => source.Task;
             using var mounted = V.Mount(_root, V.Component(OffscreenSiblingHostRender, key: "host"));

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/SuspenseBoundaryTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/SuspenseBoundaryTests.cs
@@ -365,6 +365,11 @@ namespace Velvet.Tests
                 "An offscreen primary descendant's flush is deferred, so the committed fallback stays in its slot");
         }
 
+        // GREEN_ON_BASE(characterization): the base reaches this outcome by never deferring at all —
+        // the boundary-wide mark this branch replaces had already been cleared by this sibling's own
+        // expansion, which is the defect the case above pins. The replacement does report a fallback up
+        // for this boundary, so these children now reach the offscreen walk and what keeps them flushing
+        // is its per-fiber check: widen that marking to the boundary and this case goes red.
         [Test]
         public void Given_SuspendedBoundaryFollowedByResolvedSibling_When_ResolvedSiblingsDescendantUpdates_Then_ItRerenders()
         {

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/SuspenseBoundaryTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/SuspenseBoundaryTests.cs
@@ -22,7 +22,8 @@ namespace Velvet.Tests
     /// <item>A nested boundary catches its own descendant's suspension, so an outer boundary does not over-suspend
     /// when only the inner boundary's primary is pending.</item>
     /// <item>Sibling Suspense boundaries are tracked independently: resolving one boundary's child leaves the
-    /// other sibling's fallback unchanged.</item>
+    /// other sibling's fallback unchanged, and one showing its fallback while a later sibling renders its
+    /// children keeps its own hidden descendants deferred without deferring that sibling's.</item>
     /// <item>A <c>Hooks.Use</c> resource that faults — synchronously or asynchronously — routes the exception to
     /// the nearest enclosing error boundary rather than the fallback.</item>
     /// <item>An unrelated parent re-render does not remove a still-pending child's fallback.</item>
@@ -61,6 +62,7 @@ namespace Velvet.Tests
             ResetAsyncChild();
             ResetTwoUses();
             ResetSiblingBoundaries();
+            ResetOffscreenSibling();
             ResetSuspenseHost();
             ResetParentRerender();
             ResetRootless();
@@ -341,6 +343,46 @@ namespace Velvet.Tests
             // Assert — boundary B is unaffected and keeps its own fallback
             Assert.That(_root.FindLabelByText("loading-B"), Is.Not.Null,
                 "Resolving one sibling boundary does not pull the other out of (or push it further into) its fallback");
+        }
+
+        [Test]
+        public void Given_SuspendedBoundaryFollowedByResolvedSibling_When_OffscreenDescendantUpdates_Then_FallbackSurvives()
+        {
+            // Arrange — the suspended Suspense is expanded BEFORE the resolved one, so the resolved one's
+            // expansion is the last to write the per-boundary suspended mark that guards the offscreen flush
+            var source = new UniTaskCompletionSource<string>();
+            s_offscreenFactory = _ => source.Task;
+            using var mounted = V.Mount(_root, V.Component(OffscreenSiblingHostRender, key: "host"));
+            Assume.That(_root.FindLabelByText("sibling-0"), Is.Not.Null,
+                "Precondition: the second Suspense renders its children, not its fallback");
+
+            // Act — a state update on a fiber inside the suspended Suspense's offscreen primary subtree
+            s_offscreenSetter.Invoke(1);
+            mounted.FlushStateForTest();
+
+            // Assert
+            Assert.That(_root.FindLabelByText("loading-A"), Is.Not.Null,
+                "An offscreen primary descendant's flush is deferred, so the committed fallback stays in its slot");
+        }
+
+        [Test]
+        public void Given_SuspendedBoundaryFollowedByResolvedSibling_When_ResolvedSiblingsDescendantUpdates_Then_ItRerenders()
+        {
+            // Arrange — the same boundary fiber owns both Suspense nodes, so keeping the suspended one's
+            // mark up must not reach the resolved one's children
+            var source = new UniTaskCompletionSource<string>();
+            s_offscreenFactory = _ => source.Task;
+            using var mounted = V.Mount(_root, V.Component(OffscreenSiblingHostRender, key: "host"));
+            Assume.That(_root.FindLabelByText("loading-A"), Is.Not.Null,
+                "Precondition: the first Suspense is showing its fallback");
+
+            // Act
+            s_resolvedSiblingSetter.Invoke(1);
+            mounted.FlushStateForTest();
+
+            // Assert
+            Assert.That(_root.FindLabelByText("sibling-1"), Is.Not.Null,
+                "A descendant of the resolved sibling Suspense is not offscreen, so its own flush still commits");
         }
 
         #endregion
@@ -826,6 +868,64 @@ namespace Velvet.Tests
                 V.Suspense(
                     fallback: V.Label(text: "loading-B"),
                     children: new VNode[] { V.Component(SiblingChildBRender, key: "childB") },
+                    key: "b"),
+            });
+
+        #endregion
+
+        #region OffscreenSibling components (a suspending V.Suspense followed by a resolving one)
+
+        private static Func<CancellationToken, UniTask<string>> s_offscreenFactory;
+        private static Action<int> s_offscreenSetter;
+        private static Action<int> s_resolvedSiblingSetter;
+
+        private static void ResetOffscreenSibling()
+        {
+            s_offscreenFactory = null;
+            s_offscreenSetter = null;
+            s_resolvedSiblingSetter = null;
+        }
+
+        // Renders before its suspending sibling so its fiber is created — and its setter captured — while
+        // the boundary's primary expansion is still in progress.
+        [Component]
+        private static VNode OffscreenStatefulChildRender()
+        {
+            var (tick, setTick) = Hooks.UseState(0);
+            s_offscreenSetter = setTick;
+            return V.Label(text: $"primary-{tick}");
+        }
+
+        [Component]
+        private static VNode ResolvedSiblingStatefulChildRender()
+        {
+            var (tick, setTick) = Hooks.UseState(0);
+            s_resolvedSiblingSetter = setTick;
+            return V.Label(text: $"sibling-{tick}");
+        }
+
+        [Component]
+        private static VNode OffscreenSuspendingChildRender()
+        {
+            var value = Hooks.Use(s_offscreenFactory, "offscreen");
+            return V.Label(text: value);
+        }
+
+        [Component]
+        private static VNode OffscreenSiblingHostRender()
+            => V.Div(children: new VNode[]
+            {
+                V.Suspense(
+                    fallback: V.Label(text: "loading-A"),
+                    children: new VNode[]
+                    {
+                        V.Component(OffscreenStatefulChildRender, key: "stateful"),
+                        V.Component(OffscreenSuspendingChildRender, key: "suspending"),
+                    },
+                    key: "a"),
+                V.Suspense(
+                    fallback: V.Label(text: "loading-B"),
+                    children: new VNode[] { V.Component(ResolvedSiblingStatefulChildRender, key: "sibling") },
                     key: "b"),
             });
 


### PR DESCRIPTION
Closes #604

## What was wrong

`ExpandSuspenseInline` recorded each `V.Suspense`'s children-vs-fallback decision under `(boundary fiber, scoped position key)`, but the mark `FiberWorkLoop.FlushState` reads to defer an offscreen descendant's lane flush was keyed by boundary alone and written unconditionally per Suspense node:

```csharp
if (suspended) _ctx.SuspendedBoundaries.Add(boundaryFiber);
else _ctx.SuspendedBoundaries.Remove(boundaryFiber);
```

One component fiber can render several Suspense nodes, and they share that boundary fiber. With a suspended node expanded before a resolved one, the resolved one's `else` cleared the mark while the first one's fallback was committed. `FlushState` then stopped deferring the first one's offscreen primary descendants, so a state update inside those hidden children committed into the slot range the fallback occupied and the committed fallback left the tree.

Ordering decided it: the same two boundaries with the resolved one placed first were measured unaffected.

## What changed

Boundary state is now one table — per boundary fiber, the position keys of the Suspense nodes currently showing their fallback. Only fallback-showing keys are stored and a boundary with none holds no entry, so both readings `FlushState` needs ("this boundary has a fallback up" and "any boundary does") are derived from it rather than tracked beside it. A sibling Suspense expanded later writes its own key and cannot clear another's. Reads that previously did two dictionary lookups now do one, and pruning a disposed boundary is a single `Remove` instead of a scan of every key.

`ComponentFiber.IsOffscreen` is kept and is not a third copy of the same fact. It is per-fiber, and it is what separates a suspended Suspense's primary subtree from that Suspense's visible fallback subtree and from a sibling Suspense's children — all of which sit under the same boundary fiber, which the boundary-keyed reading cannot distinguish. Dropping the `IsOffscreen` term from the guard turns two cases red, so it is load-bearing in both directions.

## Tests

`SuspenseBoundaryTests` gains two cases over one host rendering a suspending `V.Suspense` followed by a resolving one:

- an offscreen primary descendant's state update leaves the committed fallback in place — red before this change (`Expected: not null / But was: null` on the fallback label);
- a descendant of the resolved sibling still flushes, so keeping the first one's mark up does not over-defer.

EditMode 3854 passed / 0 failed / 0 inconclusive; PlayMode 161 / 0 / 0.

## Documentation

No guide change. No `Documentation~` page describes the flush-deferral guard, and `V.Suspense`'s own remark about sibling boundaries being tracked independently was already accurate for fallback selection — the defect was in the flush guard. CHANGELOG has an entry under `[Unreleased]` / Fixed: the lost fallback is user-visible.
