### PR TITLE
fix(velvet): key a portal's component children on the fiber that declared it, and carry the mount point

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -37,6 +37,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A component the reconciler carries to a different container now re-renders itself into the container
+  it is in. Only its slot index followed the move, so its own `setState` reconciled its new output into
+  the container it had left — leaving the stale element behind there and writing the new one into a
+  container it no longer occupies. It also let a component that had moved out of a subtree be disposed
+  with that subtree when the subtree was later torn down. Two components at the same unkeyed position
+  in *different* containers still share one instance, which is a separate defect; what changes for them
+  is which of the two containers goes stale, since the shared instance's slot index already named the
+  last one reconciled and its container now agrees. Give each an explicit `key:` to keep them apart.
+- A `V.Component` written as a top-level child of a `V.Portal` now survives a patch of that portal's
+  children. Its mount ran in the deferred pass that follows the reconcile, which registered it under a
+  different parent from the one every later patch looks it up by, so the first patch failed to find it:
+  the component was built a second time with fresh hook state and fresh effects, the first instance's
+  effect cleanups never ran, and the element it had rendered stayed behind in the target. A modal whose
+  content component held its own `UseState` reset it whenever anything else in that portal re-rendered.
 - Registering a portal target id again with a different element now moves the portals already mounted
   into the old one, instead of leaving them writing into an element the UI has replaced. A
   `"modal-root"` that a screen owns — torn down on navigation and re-registered from the rebuilt

--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -30,6 +30,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Moving a component across a `V.Portal`'s boundary is an unmount and a remount in every case now, so
+  its state, refs and effects do not survive the move and the departing instance's cleanups run. A
+  component written into a live portal's children that a previous render had outside them — and the same
+  move back out — used to keep its instance where the portal's children were reached by a patch, while
+  the same edit against a portal that mounts or closes in that render mounted a fresh one. Which of the
+  two a given edit got was decided by whether the portal already existed, and neither the guide nor
+  `createPortal` promised the surviving half. The portals guide states the contract that now holds in
+  both directions. Keeping state across such a move means lifting it above the portal — to a `Store`, or
+  to a `UseState` in the component that declares the portal.
 - `V.TextField`'s four new parameters sit between `isPasswordField:` and `enabled:`, so a call passing
   arguments positionally past `isPasswordField` now binds them to different parameters. Every argument
   there but a `null` literal changes type across the shift, so such a call fails to compile rather than
@@ -41,23 +50,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   it is in. Its slot index and the stamp a portal teardown disposes by both followed the move and its
   container did not, so its own `setState` reconciled its new output into the container it had left —
   leaving the stale element behind there and writing the new one into a container it no longer occupies.
-  It also let a component that had moved out of a subtree be disposed with that subtree when the subtree
-  was later torn down. Two components at the same unkeyed position in *different* containers still share
-  one instance where both containers sit in the declaring component's own tree, which is a separate
-  defect; what changes for them is which of the two containers goes stale, since the shared instance's
-  slot index already named the last one reconciled and its container now agrees. Give each an explicit
-  `key:` to keep them apart.
-- A `V.Component` written as a top-level child of a `V.Portal` now survives a patch of that portal's
-  children. Its mount ran in the deferred pass that follows the reconcile, which registered it under a
-  different parent from the one every later patch looks it up by, so the first patch failed to find it:
-  the component was built a second time with fresh hook state and fresh effects, the first instance's
-  effect cleanups never ran, and the element it had rendered stayed behind in the target. A modal whose
-  content component held its own `UseState` lost it the first time anything else in that portal
-  re-rendered — once, because the instance built to replace it registers where the patch looks, so it
-  survives every patch after that. The element the first instance rendered stayed in the target for the
-  life of the tree. Where the declaring component renders the same component at the same position both
-  inside the portal and outside it, the two no longer end up sharing one instance from the first patch
-  onwards: the portal's child keeps the instance it mounted with.
+  Two components at the same unkeyed position in *different* containers still share one instance where
+  both containers sit in the declaring component's own tree, which is a separate defect; what changes
+  for them is which of the two containers goes stale, since the shared instance's slot index already
+  named the last one reconciled and its container now agrees. Give each an explicit `key:` to keep them
+  apart.
+- A `V.Component` written inside a `V.Portal` now survives a patch of that portal's children. Its mount
+  ran in the deferred pass that follows the reconcile, which registered it under a different parent from
+  the one every later patch looks it up by, so the first patch failed to find it: the component was
+  built a second time with fresh hook state and fresh effects, the first instance's effect cleanups
+  never ran, and the element it had rendered stayed behind in the target. A modal whose content
+  component held its own `UseState` lost it the first time anything else in that portal re-rendered —
+  once, because the instance built to replace it registers where the patch looks, so it survives every
+  patch after that. The element the first instance rendered stayed in the target for the life of the
+  tree.
+- A component a declaring render writes both inside a `V.Portal` and at the same position outside it now
+  keeps its own instance on each side, whichever of the two mounts first. They used to merge into one, in
+  both orders and each with its own damage. With the one outside mounted first, the first patch of the
+  portal's children replaced the portal's child with it. With the portal's mounted first, the position
+  outside took the portal's own instance over and rendered it in both places, and the next patch of that
+  portal built a second child and left the elements of the previous slot range in the target with nothing
+  to reconcile them away.
 - Registering a portal target id again with a different element now moves the portals already mounted
   into the old one, instead of leaving them writing into an element the UI has replaced. A
   `"modal-root"` that a screen owns — torn down on navigation and re-registered from the rebuilt

--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -38,19 +38,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - A component the reconciler carries to a different container now re-renders itself into the container
-  it is in. Only its slot index followed the move, so its own `setState` reconciled its new output into
-  the container it had left — leaving the stale element behind there and writing the new one into a
-  container it no longer occupies. It also let a component that had moved out of a subtree be disposed
-  with that subtree when the subtree was later torn down. Two components at the same unkeyed position
-  in *different* containers still share one instance, which is a separate defect; what changes for them
-  is which of the two containers goes stale, since the shared instance's slot index already named the
-  last one reconciled and its container now agrees. Give each an explicit `key:` to keep them apart.
+  it is in. Its slot index and the stamp a portal teardown disposes by both followed the move and its
+  container did not, so its own `setState` reconciled its new output into the container it had left —
+  leaving the stale element behind there and writing the new one into a container it no longer occupies.
+  It also let a component that had moved out of a subtree be disposed with that subtree when the subtree
+  was later torn down. Two components at the same unkeyed position in *different* containers still share
+  one instance where both containers sit in the declaring component's own tree, which is a separate
+  defect; what changes for them is which of the two containers goes stale, since the shared instance's
+  slot index already named the last one reconciled and its container now agrees. Give each an explicit
+  `key:` to keep them apart.
 - A `V.Component` written as a top-level child of a `V.Portal` now survives a patch of that portal's
   children. Its mount ran in the deferred pass that follows the reconcile, which registered it under a
   different parent from the one every later patch looks it up by, so the first patch failed to find it:
   the component was built a second time with fresh hook state and fresh effects, the first instance's
   effect cleanups never ran, and the element it had rendered stayed behind in the target. A modal whose
-  content component held its own `UseState` reset it whenever anything else in that portal re-rendered.
+  content component held its own `UseState` lost it the first time anything else in that portal
+  re-rendered — once, because the instance built to replace it registers where the patch looks, so it
+  survives every patch after that. The element the first instance rendered stayed in the target for the
+  life of the tree. Where the declaring component renders the same component at the same position both
+  inside the portal and outside it, the two no longer end up sharing one instance from the first patch
+  onwards: the portal's child keeps the instance it mounted with.
 - Registering a portal target id again with a different element now moves the portals already mounted
   into the old one, instead of leaving them writing into an element the UI has replaced. A
   `"modal-root"` that a screen owns — torn down on navigation and re-registered from the rebuilt

--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -49,8 +49,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - A component the reconciler carries to a different container now re-renders itself into the container
   it is in. Its slot index and the stamp a portal teardown disposes by both followed the move and its
-  container did not, so its own `setState` reconciled its new output into the container it had left —
-  leaving the stale element behind there and writing the new one into a container it no longer occupies.
+  container did not, so its own `setState` reconciled its new output into the container it had left,
+  while the container it had moved into kept the element from before the move.
   It also let the container it had left take it down: where the arriving container is reconciled first
   and the departing one leaves the tree in that same render, the departing subtree's teardown still
   found the carried component named as living inside it and ran its cleanups.

--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -33,12 +33,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Moving a component across a `V.Portal`'s boundary is an unmount and a remount in every case now, so
   its state, refs and effects do not survive the move and the departing instance's cleanups run. A
   component written into a live portal's children that a previous render had outside them — and the same
-  move back out — used to keep its instance where the portal's children were reached by a patch, while
-  the same edit against a portal that mounts or closes in that render mounted a fresh one. Which of the
-  two a given edit got was decided by whether the portal already existed, and neither the guide nor
-  `createPortal` promised the surviving half. The portals guide states the contract that now holds in
-  both directions. Keeping state across such a move means lifting it above the portal — to a `Store`, or
-  to a `UseState` in the component that declares the portal.
+  move back out — used to keep its instance whenever a patch of the portal's children had been the last
+  thing to register the portal-side occurrence, the render that closes the portal included; only an
+  occurrence the portal's own deferred mount had registered mounted fresh. Which of the two a given edit
+  got was decided by which of those two entrances had last put the child in the portal, and neither the
+  guide nor `createPortal` promised the surviving half. The portals guide states the contract that now
+  holds in both directions. Keeping state across such a move means lifting it above the portal — to a
+  `Store`, or to a `UseState` in the component that declares the portal.
 - `V.TextField`'s four new parameters sit between `isPasswordField:` and `enabled:`, so a call passing
   arguments positionally past `isPasswordField` now binds them to different parameters. Every argument
   there but a `null` literal changes type across the shift, so such a call fails to compile rather than
@@ -50,6 +51,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   it is in. Its slot index and the stamp a portal teardown disposes by both followed the move and its
   container did not, so its own `setState` reconciled its new output into the container it had left —
   leaving the stale element behind there and writing the new one into a container it no longer occupies.
+  It also let the container it had left take it down: where the arriving container is reconciled first
+  and the departing one leaves the tree in that same render, the departing subtree's teardown still
+  found the carried component named as living inside it and ran its cleanups.
   Two components at the same unkeyed position in *different* containers still share one instance where
   both containers sit in the declaring component's own tree, which is a separate defect; what changes
   for them is which of the two containers goes stale, since the shared instance's slot index already

--- a/Packages/com.velvet.core/Documentation~/portals.md
+++ b/Packages/com.velvet.core/Documentation~/portals.md
@@ -37,7 +37,13 @@ Registering the same element again, and
 unregistering the id, both leave a live portal where it is — an unregistered id names nothing to move
 to.
 
-Moving is an unmount and a remount, so child state, refs and effects do not survive it.
+Moving the portal is an unmount and a remount, so child state, refs and effects do not survive it.
+
+**Moving a child across the boundary is one too**, in either direction: writing a component into a
+portal's children that a render had outside them, or out of them to a position in the declaring
+component's own tree, mounts a fresh instance on the far side and runs the departing one's cleanups —
+the same as moving it between two ordinary parents. A portal's children and the tree around them are
+different positions, so nothing is carried between them, `key:` included.
 
 **Keep the container's own children out of Velvet's hands for as long as the portal is mounted**, in
 either form. A portal's range is recorded after whatever the container already held, and a child added

--- a/Packages/com.velvet.core/Documentation~/portals.md
+++ b/Packages/com.velvet.core/Documentation~/portals.md
@@ -41,9 +41,9 @@ Moving the portal is an unmount and a remount, so child state, refs and effects 
 
 **Moving a child across the boundary is one too**, in either direction: writing a component into a
 portal's children that a render had outside them, or out of them to a position in the declaring
-component's own tree, mounts a fresh instance on the far side and runs the departing one's cleanups —
-the same as moving it between two ordinary parents. A portal's children and the tree around them are
-different positions, so nothing is carried between them, `key:` included.
+component's own tree, mounts a fresh instance on the far side and runs the departing one's cleanups.
+A portal's children and the tree around them are different positions, so nothing is carried between
+them, `key:` included.
 
 **Keep the container's own children out of Velvet's hands for as long as the portal is mounted**, in
 either form. A portal's range is recorded after whatever the container already held, and a child added

--- a/Packages/com.velvet.core/Runtime/Component/ComponentRegistry.cs
+++ b/Packages/com.velvet.core/Runtime/Component/ComponentRegistry.cs
@@ -192,6 +192,10 @@ namespace Velvet
                 // PortalChildFiberContinuityTests. Null only where the caller had no container to give,
                 // which must not erase a live one.
                 if (site.MountPoint != null) existingFiber.MountPoint = site.MountPoint;
+                // Rewritten even where the reconcile reaching the fiber names no Portal, which erases the
+                // stamp a fiber below a Portal's own child was given at creation — its parent's isolated
+                // re-render is such a reconcile. Losing it costs nothing: that is the same fiber
+                // DisposeInlineFibersOwnedByPortal already reaches through the parent index.
                 existingFiber.OwningPortalPlaceholder = _ctx.CurrentPortalPlaceholder;
                 if (propsChanged || existingFiber.IsDirty || refChanged)
                 {

--- a/Packages/com.velvet.core/Runtime/Component/ComponentRegistry.cs
+++ b/Packages/com.velvet.core/Runtime/Component/ComponentRegistry.cs
@@ -176,6 +176,14 @@ namespace Velvet
                 // render here does not collide with a subsequent FlushState pass: clearing IsDirty
                 // makes the later traversal short-circuit while the rendered output is already committed.
                 existingFiber.MountSlotStart = site.SlotStart;
+                // The container half of the same carry, and it travels with the slot start above or the
+                // pair names two different containers: everything that reads MountPoint wants where the
+                // fiber's output is NOW — the isolated re-render reconciles into it at MountSlotStart,
+                // Unmount reconciles it away, the containment sweeps ask whether it is inside a departing
+                // subtree, and the rest reach it for a panel. Left at creation, a carried fiber re-renders
+                // itself into the container it has left. Null only where the caller had no container to
+                // give, which must not erase a live one.
+                if (site.MountPoint != null) existingFiber.MountPoint = site.MountPoint;
                 // Rewritten on the carry as well as at creation, and before the re-render below: a component
                 // can leave a Portal's children for a position outside them in the very render that removes
                 // the Portal, and GeneralPathReconciler carries it there in the inline walk that precedes

--- a/Packages/com.velvet.core/Runtime/Component/ComponentRegistry.cs
+++ b/Packages/com.velvet.core/Runtime/Component/ComponentRegistry.cs
@@ -22,9 +22,13 @@ namespace Velvet
         // parent ComponentFiber by tree position. The host VE does not exist when the fiber is matched
         // during begin-work, so identity is (parent fiber, position key, component identity) — never a
         // VisualElement. positionKey is the tree-position scope key, identity is ComponentNode.ResolvedIdentity.
-        private readonly Dictionary<(ComponentFiber? parentFiber, object? positionKey, object identity), ComponentFiber> _inlineInstances = new();
+        // portalScope is null for all but the one shape that needs it: a Portal's top-level child whose
+        // (parentFiber, positionKey, identity) is already taken by a fiber the declaring component
+        // rendered outside the Portal. Both occurrences are legitimate and neither may displace the
+        // other, so the Portal's takes its placeholder into the key; ResolveInline owns when.
+        private readonly Dictionary<(ComponentFiber? parentFiber, VisualElement? portalScope, object? positionKey, object identity), ComponentFiber> _inlineInstances = new();
         // O(1) reverse index inline fiber → its key, so disposal removes the entry without scanning.
-        private readonly Dictionary<ComponentFiber, (ComponentFiber? parentFiber, object? positionKey, object identity)> _inlineFiberToKey = new();
+        private readonly Dictionary<ComponentFiber, (ComponentFiber? parentFiber, VisualElement? portalScope, object? positionKey, object identity)> _inlineFiberToKey = new();
         // O(1) forward index parent fiber → its inline child fibers, so subtree disposal locates them
         // without scanning _inlineInstances (and without the re-entrant dictionary-mutation hazard when
         // FiberRenderer.Dispose recursively triggers disposal during descendant cleanup).
@@ -48,10 +52,11 @@ namespace Velvet
             _ctx = ctx;
         }
 
-        // Where one GetOrCreate call anchors its fiber and where that fiber's output lands. Anchor and
-        // PositionKey are the identity half — what the registry looks the fiber up by — and MountPoint and
-        // SlotStart the placement half; IsInline selects which spelling of both is in force, so the five are
-        // never meaningful apart. Taken by `in`: this runs once per Component per reconcile.
+        // Where one GetOrCreate call anchors its fiber and where that fiber's output lands. Anchor,
+        // PositionKey and PortalScope are the identity half — what the registry looks the fiber up by —
+        // and MountPoint and SlotStart the placement half; IsInline selects which spelling of both is in
+        // force, so the six are never meaningful apart. Taken by `in`: this runs once per Component per
+        // reconcile.
         private readonly struct FiberMountSite
         {
             internal object? Anchor { get; init; }
@@ -59,6 +64,7 @@ namespace Velvet
             internal VisualElement? MountPoint { get; init; }
             internal int SlotStart { get; init; }
             internal bool IsInline { get; init; }
+            internal VisualElement? PortalScope { get; init; }
         }
 
         // Wrapper-mounted GetOrCreate. The fiber owns the entire wrapper's
@@ -93,7 +99,8 @@ namespace Velvet
             ComponentFiber? parentFiber,
             object positionKey,
             VisualElement? mountPoint,
-            int slotStart)
+            int slotStart,
+            VisualElement? portalScope)
         {
             if (positionKey == null) throw new ArgumentNullException(nameof(positionKey));
             var site = new FiberMountSite
@@ -103,6 +110,7 @@ namespace Velvet
                 MountPoint = mountPoint,
                 SlotStart = slotStart,
                 IsInline = true,
+                PortalScope = portalScope,
             };
             return GetOrCreateCore(node, in site);
         }
@@ -113,8 +121,10 @@ namespace Velvet
             if (node.Body == null) throw new ArgumentException("ComponentNode.Body must not be null.", nameof(node));
             var identity = node.ResolvedIdentity;
 
+            var scopeToRegisterUnder = (VisualElement?)null;
             var existingFiber = site.IsInline
-                ? LookupInline((ComponentFiber)site.Anchor!, site.PositionKey, identity)
+                ? ResolveInline((ComponentFiber)site.Anchor!, site.PositionKey, identity, site.PortalScope,
+                    out scopeToRegisterUnder)
                 : LookupWrapper((VisualElement)site.Anchor!, identity);
 
             if (existingFiber != null)
@@ -122,7 +132,29 @@ namespace Velvet
                 return ReconcileExistingFiber(existingFiber, node, in site);
             }
 
-            return CreateAndMountFiber(node, identity, in site);
+            return CreateAndMountFiber(node, identity, scopeToRegisterUnder, in site);
+        }
+
+        // Which of the two keys a Portal's top-level child answers to, and which one a fresh fiber would
+        // take. Outside a Portal's own child level (portalScope null) there is one key and this is the
+        // plain lookup. Inside it, the scoped key is asked first because that is where a child driven off
+        // the plain key once already lives; a plain-key occupant is adopted only when this same Portal put
+        // it there, since the alternative — the declaring fiber's own in-tree child at the same position —
+        // must not be dragged into the target and must not be overwritten by the Portal's child either.
+        private ComponentFiber? ResolveInline(
+            ComponentFiber? parentFiber, object? positionKey, object identity, VisualElement? portalScope,
+            out VisualElement? registerUnder)
+        {
+            registerUnder = null;
+            if (portalScope == null) return LookupInline(parentFiber, null, positionKey, identity);
+
+            var scoped = LookupInline(parentFiber, portalScope, positionKey, identity);
+            if (scoped != null) return scoped;
+            var plain = LookupInline(parentFiber, null, positionKey, identity);
+            if (plain == null) return null;
+            if (ReferenceEquals(plain.OwningPortalPlaceholder, portalScope)) return plain;
+            registerUnder = portalScope;
+            return null;
         }
 
         private ComponentFiber ReconcileExistingFiber(
@@ -208,7 +240,8 @@ namespace Velvet
             return existingFiber;
         }
 
-        private ComponentFiber CreateAndMountFiber(ComponentNode node, object identity, in FiberMountSite site)
+        private ComponentFiber CreateAndMountFiber(
+            ComponentNode node, object identity, VisualElement? portalScope, in FiberMountSite site)
         {
             var anchor = site.Anchor;
             var positionKey = site.PositionKey;
@@ -231,7 +264,7 @@ namespace Velvet
             }
             catch (FiberSuspendSignal)
             {
-                RegisterFiber(anchor, positionKey, identity, fiber, isInline);
+                RegisterFiber(anchor, portalScope, positionKey, identity, fiber, isInline);
                 throw;
             }
             // Dispose BEFORE any detach: Dispose's Unmount retires the committed tree with the parent
@@ -239,7 +272,7 @@ namespace Velvet
             // detaches itself; detaching first would sever the chain and let the sweep recycle nodes
             // a surviving ancestor's slot still owes to a comeback render.
             catch { FiberRenderer.Dispose(fiber); throw; }
-            RegisterFiber(anchor, positionKey, identity, fiber, isInline);
+            RegisterFiber(anchor, portalScope, positionKey, identity, fiber, isInline);
             return fiber;
         }
 
@@ -257,8 +290,11 @@ namespace Velvet
             return ComponentPropsComparer.ShallowEquals(prev, next);
         }
 
-        private ComponentFiber? LookupInline(ComponentFiber? parentFiber, object? positionKey, object identity)
-            => _inlineInstances.TryGetValue((parentFiber, positionKey, identity), out var fiber) ? fiber : null;
+        private ComponentFiber? LookupInline(
+            ComponentFiber? parentFiber, VisualElement? portalScope, object? positionKey, object identity)
+            => _inlineInstances.TryGetValue((parentFiber, portalScope, positionKey, identity), out var fiber)
+                ? fiber
+                : null;
 
         private ComponentFiber? LookupWrapper(VisualElement? wrapper, object identity)
         {
@@ -268,13 +304,13 @@ namespace Velvet
         }
 
         private void RegisterFiber(
-            object? anchor, object? positionKey, object identity,
+            object? anchor, VisualElement? portalScope, object? positionKey, object identity,
             ComponentFiber fiber, bool isInline)
         {
             if (isInline)
             {
                 var parentFiber = (ComponentFiber)anchor!;
-                var key = (parentFiber, positionKey, identity);
+                var key = (parentFiber, portalScope, positionKey, identity);
                 _inlineInstances[key] = fiber;
                 _inlineFiberToKey[fiber] = key;
                 // Written from the same source on both halves of GetOrCreate — see the carry half in
@@ -367,12 +403,15 @@ namespace Velvet
             DisposeFiberInternal(fiber);
         }
 
-        // Inline-mounted lookup by tree-position key (parent fiber, position key, identity). Used by
-        // the old-side walk in GeneralPathReconciler to read the previously rendered
-        // ComponentFiber.PreviousTree without triggering a re-render.
-        internal ComponentFiber? TryGetFiberForInlineKey(ComponentFiber? parentFiber, object positionKey, object identity)
+        // Inline-mounted lookup by tree-position key, without the create half and without re-rendering
+        // anything: the old-side walk in GeneralPathReconciler reads the previously rendered
+        // ComponentFiber.PreviousTree through it, and FiberContextSpine matches a spine child by it.
+        // portalScope selects between the two keys a Portal's top-level child can answer to and is asked
+        // in the same order GetOrCreate asks them — see ResolveInline.
+        internal ComponentFiber? TryGetFiberForInlineKey(
+            ComponentFiber? parentFiber, object positionKey, object identity, VisualElement? portalScope)
         {
-            return _inlineInstances.TryGetValue((parentFiber, positionKey, identity), out var fiber) ? fiber : null;
+            return ResolveInline(parentFiber, positionKey, identity, portalScope, out _);
         }
 
         // Returns the inline registration key (positionKey, identity) under which

--- a/Packages/com.velvet.core/Runtime/Component/ComponentRegistry.cs
+++ b/Packages/com.velvet.core/Runtime/Component/ComponentRegistry.cs
@@ -22,10 +22,12 @@ namespace Velvet
         // parent ComponentFiber by tree position. The host VE does not exist when the fiber is matched
         // during begin-work, so identity is (parent fiber, position key, component identity) — never a
         // VisualElement. positionKey is the tree-position scope key, identity is ComponentNode.ResolvedIdentity.
-        // portalScope is null for all but the one shape that needs it: a Portal's top-level child whose
-        // (parentFiber, positionKey, identity) is already taken by a fiber the declaring component
-        // rendered outside the Portal. Both occurrences are legitimate and neither may displace the
-        // other, so the Portal's takes its placeholder into the key; ResolveInline owns when.
+        // portalScope is the Portal placeholder a child level of that Portal's own children belongs to,
+        // and null everywhere else. The declaring component's fiber is the parentFiber on both sides of
+        // a Portal, so what it renders into the Portal and what it renders outside it agree on the rest
+        // of the key; the scope is the whole of what separates them. It is part of the key rather than a
+        // fallback the lookup tries second, so which of the two mounts first cannot decide which one owns
+        // the shared spelling. ReconcilerContext.PortalChildKeyScope owns which levels carry it.
         private readonly Dictionary<(ComponentFiber? parentFiber, VisualElement? portalScope, object? positionKey, object identity), ComponentFiber> _inlineInstances = new();
         // O(1) reverse index inline fiber → its key, so disposal removes the entry without scanning.
         private readonly Dictionary<ComponentFiber, (ComponentFiber? parentFiber, VisualElement? portalScope, object? positionKey, object identity)> _inlineFiberToKey = new();
@@ -121,10 +123,8 @@ namespace Velvet
             if (node.Body == null) throw new ArgumentException("ComponentNode.Body must not be null.", nameof(node));
             var identity = node.ResolvedIdentity;
 
-            var scopeToRegisterUnder = (VisualElement?)null;
             var existingFiber = site.IsInline
-                ? ResolveInline((ComponentFiber)site.Anchor!, site.PositionKey, identity, site.PortalScope,
-                    out scopeToRegisterUnder)
+                ? LookupInline((ComponentFiber)site.Anchor!, site.PortalScope, site.PositionKey, identity)
                 : LookupWrapper((VisualElement)site.Anchor!, identity);
 
             if (existingFiber != null)
@@ -132,29 +132,7 @@ namespace Velvet
                 return ReconcileExistingFiber(existingFiber, node, in site);
             }
 
-            return CreateAndMountFiber(node, identity, scopeToRegisterUnder, in site);
-        }
-
-        // Which of the two keys a Portal's top-level child answers to, and which one a fresh fiber would
-        // take. Outside a Portal's own child level (portalScope null) there is one key and this is the
-        // plain lookup. Inside it, the scoped key is asked first because that is where a child driven off
-        // the plain key once already lives; a plain-key occupant is adopted only when this same Portal put
-        // it there, since the alternative — the declaring fiber's own in-tree child at the same position —
-        // must not be dragged into the target and must not be overwritten by the Portal's child either.
-        private ComponentFiber? ResolveInline(
-            ComponentFiber? parentFiber, object? positionKey, object identity, VisualElement? portalScope,
-            out VisualElement? registerUnder)
-        {
-            registerUnder = null;
-            if (portalScope == null) return LookupInline(parentFiber, null, positionKey, identity);
-
-            var scoped = LookupInline(parentFiber, portalScope, positionKey, identity);
-            if (scoped != null) return scoped;
-            var plain = LookupInline(parentFiber, null, positionKey, identity);
-            if (plain == null) return null;
-            if (ReferenceEquals(plain.OwningPortalPlaceholder, portalScope)) return plain;
-            registerUnder = portalScope;
-            return null;
+            return CreateAndMountFiber(node, identity, in site);
         }
 
         private ComponentFiber ReconcileExistingFiber(
@@ -209,18 +187,11 @@ namespace Velvet
                 // makes the later traversal short-circuit while the rendered output is already committed.
                 existingFiber.MountSlotStart = site.SlotStart;
                 // The container half of the same carry, and it travels with the slot start above or the
-                // pair names two different containers: everything that reads MountPoint wants where the
-                // fiber's output is NOW — the isolated re-render reconciles into it at MountSlotStart,
-                // Unmount reconciles it away, the containment sweeps ask whether it is inside a departing
-                // subtree, and the rest reach it for a panel. Left at creation, a carried fiber re-renders
-                // itself into the container it has left. Null only where the caller had no container to
-                // give, which must not erase a live one.
+                // pair names two different containers. Left at creation, a carried fiber re-renders itself
+                // into the container it has left, at the new container's slot index — the reading is in
+                // PortalChildFiberContinuityTests. Null only where the caller had no container to give,
+                // which must not erase a live one.
                 if (site.MountPoint != null) existingFiber.MountPoint = site.MountPoint;
-                // Rewritten on the carry as well as at creation, and before the re-render below: a component
-                // can leave a Portal's children for a position outside them in the very render that removes
-                // the Portal, and GeneralPathReconciler carries it there in the inline walk that precedes
-                // the removals — so a stamp written only at creation would still name the departing Portal
-                // when that Portal's teardown disposes by it.
                 existingFiber.OwningPortalPlaceholder = _ctx.CurrentPortalPlaceholder;
                 if (propsChanged || existingFiber.IsDirty || refChanged)
                 {
@@ -240,10 +211,10 @@ namespace Velvet
             return existingFiber;
         }
 
-        private ComponentFiber CreateAndMountFiber(
-            ComponentNode node, object identity, VisualElement? portalScope, in FiberMountSite site)
+        private ComponentFiber CreateAndMountFiber(ComponentNode node, object identity, in FiberMountSite site)
         {
             var anchor = site.Anchor;
+            var portalScope = site.PortalScope;
             var positionKey = site.PositionKey;
             var isInline = site.IsInline;
             var fiber = FiberRenderer.CreateChild(node.Body, node.IsErrorBoundary);
@@ -406,29 +377,32 @@ namespace Velvet
         // Inline-mounted lookup by tree-position key, without the create half and without re-rendering
         // anything: the old-side walk in GeneralPathReconciler reads the previously rendered
         // ComponentFiber.PreviousTree through it, and FiberContextSpine matches a spine child by it.
-        // portalScope selects between the two keys a Portal's top-level child can answer to and is asked
-        // in the same order GetOrCreate asks them — see ResolveInline.
         internal ComponentFiber? TryGetFiberForInlineKey(
             ComponentFiber? parentFiber, object positionKey, object identity, VisualElement? portalScope)
         {
-            return ResolveInline(parentFiber, positionKey, identity, portalScope, out _);
+            return LookupInline(parentFiber, portalScope, positionKey, identity);
         }
 
-        // Returns the inline registration key (positionKey, identity) under which
-        // fiber is registered, or false when it is not an inline-mounted
-        // fiber (root / wrapper-mounted). Used by FiberContextSpine to recognize a spine
-        // child while structurally walking an ancestor's committed tree, so the Providers that enclose
-        // that child can be re-pushed onto the live cursor for an isolated re-render.
-        internal bool TryGetInlineKey(ComponentFiber fiber, out object? positionKey, out object? identity)
+        // Returns the inline registration key under which fiber is registered, or false when it is not
+        // an inline-mounted fiber (root / wrapper-mounted). Used by FiberContextSpine to recognize a
+        // spine child while structurally walking an ancestor's committed tree, so the Providers that
+        // enclose that child can be re-pushed onto the live cursor for an isolated re-render. portalScope
+        // is handed back rather than recomputed there: an isolated re-render pushes no Portal scope, so
+        // the walk has nothing of its own to derive it from and a guess would look the child up under a
+        // key it is not registered by.
+        internal bool TryGetInlineKey(
+            ComponentFiber fiber, out object? positionKey, out object? identity, out VisualElement? portalScope)
         {
             if (fiber != null && _inlineFiberToKey.TryGetValue(fiber, out var key))
             {
                 positionKey = key.positionKey;
                 identity = key.identity;
+                portalScope = key.portalScope;
                 return true;
             }
             positionKey = null;
             identity = null;
+            portalScope = null;
             return false;
         }
 

--- a/Packages/com.velvet.core/Runtime/Component/ComponentRegistry.cs
+++ b/Packages/com.velvet.core/Runtime/Component/ComponentRegistry.cs
@@ -19,9 +19,9 @@ namespace Velvet
     internal sealed class ComponentRegistry : IDisposable
     {
         // Inline-mounted fibers (function components emit no host node) anchor on their
-        // parent ComponentFiber by tree position. The host VE does not exist when the fiber is matched
-        // during begin-work, so identity is (parent fiber, position key, component identity) — never a
-        // VisualElement. positionKey is the tree-position scope key, identity is ComponentNode.ResolvedIdentity.
+        // parent ComponentFiber by tree position, never on the element they render into: that host VE
+        // does not exist yet when the fiber is matched during begin-work. positionKey is the
+        // tree-position scope key, identity is ComponentNode.ResolvedIdentity.
         // portalScope is the Portal placeholder a child level of that Portal's own children belongs to,
         // and null everywhere else. The declaring component's fiber is the parentFiber on both sides of
         // a Portal, so what it renders into the Portal and what it renders outside it agree on the rest

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/PortalContextInheritanceTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/PortalContextInheritanceTests.cs
@@ -13,11 +13,11 @@ namespace Velvet.Tests
     /// </summary>
     /// <remarks>
     /// Covers both MOUNT-time inheritance and an ISOLATED re-render of a portal-hosted consumer (its own
-    /// setState, without the host re-rendering). The deferred drain parents portal children off the reconcile
-    /// root, so the spine's parent-walk cannot reach the host's enclosing Provider; instead the drain stamps
-    /// each top-level portal child with the context that enclosed the Portal (ComponentFiber.DetachedMountContext)
-    /// and FiberContextSpine rebuilds it on the isolated re-render. The VirtualList counterpart of the same
-    /// mechanism is exercised by VirtualListTests.
+    /// setState, without the host re-rendering). The spine's parent-walk reaches the declaring component but
+    /// not the Provider inside it, because that component's committed tree carries the Portal as an opaque
+    /// leaf; instead the drain stamps each top-level portal child with the context that enclosed the Portal
+    /// (ComponentFiber.DetachedMountContext) and FiberContextSpine rebuilds it on the isolated re-render.
+    /// The VirtualList counterpart of the same mechanism is exercised by VirtualListTests.
     /// </remarks>
     [TestFixture]
     internal sealed class PortalContextInheritanceTests

--- a/Packages/com.velvet.core/Runtime/Reconciler/ChildReconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ChildReconciler.cs
@@ -75,8 +75,8 @@ namespace Velvet
         //     prefix scan's slot always exists by construction (Pass 1 never changes childCount ahead
         //     of index i).
         //   Removal deliberately stays BEFORE CreateElement (remove-then-create), not
-        //     create-then-remove: an inline-mounted component fiber is keyed by
-        //     (parentFiber, positionKey, identity) — NOT by which VisualElement currently hosts it
+        //     create-then-remove: an inline-mounted component fiber is keyed by its tree position —
+        //     NOT by which VisualElement currently hosts it
         //     (FiberRenderer.SetupMount's comment on the registry key; ComponentRegistry.cs). If the
         //     OLD element (and the same-keyed nested fiber ComponentRegistry still has registered
         //     under it) is still present when CreateElement builds the NEW element's same-keyed

--- a/Packages/com.velvet.core/Runtime/Reconciler/ChildReconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ChildReconciler.cs
@@ -317,20 +317,23 @@ namespace Velvet
                         stack.PushRaw(contextSnapshot[s].Key, contextSnapshot[s].Value);
                     }
                 }
-                // The drain runs in the top-level reconcile finally, so FiberStack.Current is the reconcile
-                // root: the top-level Portal child fibers created below parent off it (not the component that
-                // rendered V.Portal). Snapshot its direct children before, so the fibers added by this Portal's
+                // A top-level Portal child registers in ComponentRegistry under whatever fiber is current
+                // while it mounts, and a later patch of the same Portal reaches
+                // FiberNodePatcher.PatchPortalChildren from the reconcile of the tree the declaring
+                // component itself returned — with that component's own fiber current. So the declaring
+                // fiber is the half of the registry key a patch looks the child up by, and the mount has
+                // to agree or the first patch misses its own fiber and builds a second one. This drain
+                // runs from the top-level reconcile finally instead, long after that fiber came off the
+                // stack, so it pushes the one captured at enqueue (LogicalParent) back for the nested
+                // reconcile below. Same push, for the same registry-parent reason, as the VirtualList
+                // detached-item scope (Reconciler.BeginDetachedItemScope). A Portal reconciled outside any
+                // component body has no declaring fiber, and then neither side has one to key on.
+                var declaringFiber = logicalParent is { IsDisposed: false } ? logicalParent : null;
+                // Snapshot the anchor's direct children before, so the fibers added by this Portal's
                 // reconcile can be identified afterwards and stamped with the context needed to reconstruct
                 // their enclosing Providers on an isolated re-render (the spine cannot otherwise reach them).
-                var drainAnchor = _ctx.FiberStack.Current;
-                if (drainAnchor != null)
-                {
-                    (childFibersBefore ??= new HashSet<ComponentFiber>()).Clear();
-                    for (var f = drainAnchor.Child; f != null; f = f.Sibling)
-                    {
-                        childFibersBefore.Add(f);
-                    }
-                }
+                var drainAnchor = declaringFiber ?? _ctx.FiberStack.Current;
+                CaptureAnchorChildren(drainAnchor, ref childFibersBefore);
                 // The nested Reconcile below re-enters ChildReconciler.Reconcile on THIS SAME instance, whose
                 // entry unconditionally discards PendingIndexedState/PendingKeyedState as stale state left by a
                 // finished pass — correct for a genuine fresh top-level call, but wrong here: this drain runs
@@ -361,12 +364,14 @@ namespace Velvet
                 // with the field already restored, so its own entry sets its own placeholder.
                 var enclosingPortal = _ctx.CurrentPortalPlaceholder;
                 _ctx.CurrentPortalPlaceholder = placeholder;
+                if (declaringFiber != null) _ctx.FiberStack.Push(declaringFiber);
                 try
                 {
                     Reconcile(resolvedTarget, Array.Empty<VNode>(), children, slotStart: slotStart);
                 }
                 finally
                 {
+                    if (declaringFiber != null) _ctx.FiberStack.Pop();
                     _ctx.CurrentPortalPlaceholder = enclosingPortal;
                     if (contextSnapshot != null)
                     {
@@ -378,16 +383,7 @@ namespace Velvet
                     PendingIndexedState = parkedIndexed;
                     PendingKeyedState = parkedKeyed;
                 }
-                if (drainAnchor != null)
-                {
-                    DetachedMountContext? detachedContext = null;
-                    for (var f = drainAnchor.Child; f != null; f = f.Sibling)
-                    {
-                        if (childFibersBefore!.Contains(f)) continue;
-                        detachedContext ??= new DetachedMountContext(contextSnapshot, children, drainAnchor, logicalParent);
-                        f.DetachedMountContext = detachedContext;
-                    }
-                }
+                StampDrainedChildren(drainAnchor, childFibersBefore, contextSnapshot, children, logicalParent);
                 // The growth this mount contributed, in logical slots — the same basis as slotStart.
                 var slotLength = LogicalChildSlots.Count(resolvedTarget) - slotStart;
                 _ctx.PortalState[placeholder] = new PortalSlotInfo(
@@ -397,6 +393,35 @@ namespace Velvet
             // last member this pass tears down here, never synchronously mid-diff. `this` mirrors
             // ResolveQueuedMount's own reason above (a self-caused park from THIS instance's own pass).
             FiberZLayerCoordinator.DrainTeardowns(_ctx);
+        }
+
+        // Taken by ref so one set serves the whole drain loop: each entry's snapshot is consumed by its own
+        // StampDrainedChildren call before the next entry clears it.
+        private static void CaptureAnchorChildren(ComponentFiber? anchor, ref HashSet<ComponentFiber>? before)
+        {
+            if (anchor == null) return;
+            (before ??= new HashSet<ComponentFiber>()).Clear();
+            for (var f = anchor.Child; f != null; f = f.Sibling)
+            {
+                before.Add(f);
+            }
+        }
+
+        // Stamps the fibers this drain entry just added under anchor with what an isolated re-render needs
+        // to rebuild their enclosing Providers — the same diff-against-a-before-set that
+        // FiberNodePatcher.StampNewTopLevelChildren applies on the patch half of the pair.
+        private static void StampDrainedChildren(
+            ComponentFiber? anchor, HashSet<ComponentFiber>? before,
+            List<KeyValuePair<object, object>>? contextSnapshot, VNode?[] children, ComponentFiber? logicalParent)
+        {
+            if (anchor == null) return;
+            DetachedMountContext? detachedContext = null;
+            for (var f = anchor.Child; f != null; f = f.Sibling)
+            {
+                if (before!.Contains(f)) continue;
+                detachedContext ??= new DetachedMountContext(contextSnapshot, children, anchor, logicalParent);
+                f.DetachedMountContext = detachedContext;
+            }
         }
 
         private (VisualElement Target, VNode?[] Children) ResolveLayerPortalTarget(

--- a/Packages/com.velvet.core/Runtime/Reconciler/ChildReconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ChildReconciler.cs
@@ -317,7 +317,7 @@ namespace Velvet
                         stack.PushRaw(contextSnapshot[s].Key, contextSnapshot[s].Value);
                     }
                 }
-                // A top-level Portal child registers in ComponentRegistry under whatever fiber is current
+                // A Portal child registers in ComponentRegistry under whatever fiber is current
                 // while it mounts, and a later patch of the same Portal reaches
                 // FiberNodePatcher.PatchPortalChildren from the reconcile of the tree the declaring
                 // component itself returned — with that component's own fiber current. So the declaring
@@ -366,8 +366,9 @@ namespace Velvet
                 var enclosingChildScope = _ctx.PortalChildKeyScope;
                 _ctx.CurrentPortalPlaceholder = placeholder;
                 // Pushing the declaring fiber gives this Portal's children the registry parent that
-                // fiber's own in-tree children already have, so the two can collide on a whole key. The
-                // scope is what tells such a collision apart — ComponentRegistry.ResolveInline owns it.
+                // fiber's own in-tree children already have, so the two would otherwise collide on a
+                // whole key. The scope is the member that separates them —
+                // ReconcilerContext.PortalChildKeyScope owns it.
                 _ctx.PortalChildKeyScope = placeholder;
                 if (declaringFiber != null) _ctx.FiberStack.Push(declaringFiber);
                 try

--- a/Packages/com.velvet.core/Runtime/Reconciler/ChildReconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ChildReconciler.cs
@@ -363,7 +363,12 @@ namespace Velvet
                 // reconcile creates. A nested Portal enqueued here is drained by a later turn of this loop,
                 // with the field already restored, so its own entry sets its own placeholder.
                 var enclosingPortal = _ctx.CurrentPortalPlaceholder;
+                var enclosingChildScope = _ctx.PortalChildKeyScope;
                 _ctx.CurrentPortalPlaceholder = placeholder;
+                // Pushing the declaring fiber gives this Portal's children the registry parent that
+                // fiber's own in-tree children already have, so the two can collide on a whole key. The
+                // scope is what tells such a collision apart — ComponentRegistry.ResolveInline owns it.
+                _ctx.PortalChildKeyScope = placeholder;
                 if (declaringFiber != null) _ctx.FiberStack.Push(declaringFiber);
                 try
                 {
@@ -372,6 +377,7 @@ namespace Velvet
                 finally
                 {
                     if (declaringFiber != null) _ctx.FiberStack.Pop();
+                    _ctx.PortalChildKeyScope = enclosingChildScope;
                     _ctx.CurrentPortalPlaceholder = enclosingPortal;
                     if (contextSnapshot != null)
                     {

--- a/Packages/com.velvet.core/Runtime/Reconciler/ChildReconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ChildReconciler.cs
@@ -363,22 +363,22 @@ namespace Velvet
                 // reconcile creates. A nested Portal enqueued here is drained by a later turn of this loop,
                 // with the field already restored, so its own entry sets its own placeholder.
                 var enclosingPortal = _ctx.CurrentPortalPlaceholder;
-                var enclosingChildScope = _ctx.PortalChildKeyScope;
                 _ctx.CurrentPortalPlaceholder = placeholder;
                 // Pushing the declaring fiber gives this Portal's children the registry parent that
                 // fiber's own in-tree children already have, so the two would otherwise collide on a
                 // whole key. The scope is the member that separates them —
-                // ReconcilerContext.PortalChildKeyScope owns it.
-                _ctx.PortalChildKeyScope = placeholder;
+                // ReconcilerContext.PortalChildKeyScope owns it. Entered after the push, so the nesting
+                // it records is the one the children below reconcile at.
                 if (declaringFiber != null) _ctx.FiberStack.Push(declaringFiber);
+                var enclosingChildScope = _ctx.EnterPortalChildKeyScope(placeholder);
                 try
                 {
                     Reconcile(resolvedTarget, Array.Empty<VNode>(), children, slotStart: slotStart);
                 }
                 finally
                 {
+                    _ctx.ExitPortalChildKeyScope(enclosingChildScope);
                     if (declaringFiber != null) _ctx.FiberStack.Pop();
-                    _ctx.PortalChildKeyScope = enclosingChildScope;
                     _ctx.CurrentPortalPlaceholder = enclosingPortal;
                     if (contextSnapshot != null)
                     {

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberContextSpine.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberContextSpine.cs
@@ -21,8 +21,8 @@ namespace Velvet
     // for unkeyed ComponentNodes are per-identity counters within one reconcile scope (a fiber body
     // output, or one element's children reconcile), Fragment/Provider continue the current scope, an
     // element node opens a fresh scope for its children, and a Memo resolves to its committed inner.
-    // The match against the registry's (parentFiber, positionKey, identity) key is what lets the
-    // reconstruction recognize the spine child without re-rendering. Both walkers derive every key
+    // The match against the registry's key is what lets the reconstruction recognize the spine
+    // child without re-rendering. Both walkers derive every key
     // through FiberKeying so the two stay in lockstep by construction.
     internal readonly struct FiberContextSpine
     {
@@ -338,8 +338,8 @@ namespace Velvet
             return false;
         }
 
-        // Inline-mounted ComponentNodes register under (ancestor, slotKey, identity) with the SAME
-        // position-key scheme used by ExpandInlineRecursive. A match means we have descended exactly to
+        // Inline-mounted ComponentNodes register under the SAME position-key scheme used by
+        // ExpandInlineRecursive. A match means we have descended exactly to
         // the spine child — its enclosing Providers are pushed, so stop. A sibling component is never
         // descended into: its own subtree's Providers do not enclose spineChild (a direct child fiber of
         // `ancestor`). The counter bump happens for every unkeyed ComponentNode either way, so the keying

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberContextSpine.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberContextSpine.cs
@@ -345,7 +345,8 @@ namespace Velvet
             var registry = walk.Registry;
             var identity = component.ResolvedIdentity;
             var slotKey = component.Key ?? FiberKeying.ResolveInlinePositionKey(counters, identity, registry.InlinePositionKeyBoxes);
-            var resolved = registry.TryGetFiberForInlineKey(walk.Ancestor, slotKey, identity);
+            var resolved = registry.TryGetFiberForInlineKey(
+                walk.Ancestor, slotKey, identity, walk.SpineChild.OwningPortalPlaceholder);
             return ReferenceEquals(resolved, walk.SpineChild);
         }
 

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberContextSpine.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberContextSpine.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System.Collections.Generic;
+using UnityEngine.UIElements;
 
 namespace Velvet
 {
@@ -53,6 +54,9 @@ namespace Velvet
             internal ComponentRegistry Registry { get; init; }
             internal FiberMemoCache MemoCache { get; init; }
             internal bool IsInlineSpineChild { get; init; }
+            // The Portal scope member of SpineChild's own registration key, read back from the registry
+            // rather than derived here — ComponentRegistry.TryGetInlineKey owns why.
+            internal VisualElement? PortalScope { get; init; }
         }
 
         // Pushes the Provider values that enclose target onto the live cursor and
@@ -121,6 +125,7 @@ namespace Velvet
                     }
                     if (detached.DescendantNodes is { Length: > 0 } && detached.Anchor != null)
                     {
+                        registry.TryGetInlineKey(child, out _, out _, out var detachedScope);
                         var detachedWalk = new SpineWalk
                         {
                             Ancestor = detached.Anchor,
@@ -130,6 +135,7 @@ namespace Velvet
                             Registry = registry,
                             MemoCache = memoCache,
                             IsInlineSpineChild = true,
+                            PortalScope = detachedScope,
                         };
                         var detachedCounters = new Dictionary<object, int>();
                         PushEnclosingProviders(detached.DescendantNodes, detachedCounters,
@@ -141,7 +147,7 @@ namespace Velvet
                 var tree = ancestor.PreviousTree;
                 if (tree == null || tree.Length == 0) continue;
 
-                var isInline = registry.TryGetInlineKey(child, out _, out _);
+                var isInline = registry.TryGetInlineKey(child, out _, out _, out var childScope);
                 if (!isInline && child.MountPoint == null) continue;
 
                 var walk = new SpineWalk
@@ -153,6 +159,7 @@ namespace Velvet
                     Registry = registry,
                     MemoCache = memoCache,
                     IsInlineSpineChild = isInline,
+                    PortalScope = childScope,
                 };
                 var counters = new Dictionary<object, int>();
                 PushEnclosingProviders(tree, counters, fragmentKeyScope: null, in walk);
@@ -346,7 +353,7 @@ namespace Velvet
             var identity = component.ResolvedIdentity;
             var slotKey = component.Key ?? FiberKeying.ResolveInlinePositionKey(counters, identity, registry.InlinePositionKeyBoxes);
             var resolved = registry.TryGetFiberForInlineKey(
-                walk.Ancestor, slotKey, identity, walk.SpineChild.OwningPortalPlaceholder);
+                walk.Ancestor, slotKey, identity, walk.PortalScope);
             return ReferenceEquals(resolved, walk.SpineChild);
         }
 

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberContextSpine.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberContextSpine.cs
@@ -99,9 +99,9 @@ namespace Velvet
 
                 // Detached-mount top-level child (a Portal's drained children, or a VirtualList's
                 // controller-rendered items): the subtree mounted outside the parent-walked reconcile, so
-                // `ancestor`'s committed tree either does not contain this child (Portal: parented off the
-                // reconcile root) or hides it behind a wrapper-emitting leaf the canonical descent skips
-                // (VirtualList). Rebuild from the captured snapshot instead: push the context that enclosed
+                // `ancestor`'s committed tree hides this child behind a wrapper-emitting leaf the canonical
+                // descent skips (see the default arm of PushEnclosingProvidersForNode, which is where both
+                // kinds of host land). Rebuild from the captured snapshot instead: push the context that enclosed
                 // the detached mount as the base, then — when descendant VNodes were captured (Portal) — walk
                 // them to recover any Provider placed directly inside the subtree above this child. Deeper
                 // spine edges (this child -> target) then push the in-subtree Providers normally on top.

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberCrossPanelInput.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberCrossPanelInput.cs
@@ -57,15 +57,15 @@ namespace Velvet
     // it, but not the right thing — see Continue's truncation check for how a same-panel target avoids
     // double-invoking whatever the two chains share).
     //
-    // Known limitation: resolving "which ComponentFiber logically owns this event" depends on
-    // FiberNodeFactory stamping element.userData with _ctx.FiberStack.Current at CreateElement time —
-    // which is only meaningful while a component's Body is actually rendering. A Portal/WorldSpace
-    // child that is a bare host element (e.g. V.Portal(children: [V.Div(...)])) with no enclosing
-    // V.Component gets userData stamped from whatever fiber happens to be current during the deferred
-    // drain (see ChildReconciler.DrainPendingPortalMounts), which is not reliably the logical
-    // enclosing component. Wrap portal/world-space children in a component to get correct synthetic
-    // bubbling; a bare element's own events: handlers still fire normally (native bubbling is
-    // unaffected everywhere), only its FURTHER bubbling past the portal boundary is affected.
+    // Known limitation: Continue below resolves "which ComponentFiber logically owns this event" by
+    // finding an element on the physical chain whose userData is a fiber carrying a
+    // DetachedMountContext, and the deferred mount stamps that only onto the top-level child FIBERS it
+    // created (ChildReconciler.DrainPendingPortalMounts). A Portal/WorldSpace child that is a bare host
+    // element (e.g. V.Portal(children: [V.Div(...)])) with no enclosing V.Component contributes no such
+    // fiber, so the chain carries nothing to resolve from. Wrap portal/world-space children in a
+    // component to get synthetic bubbling; a bare element's own events: handlers still fire normally
+    // (native bubbling is unaffected everywhere), only its FURTHER bubbling past the portal boundary
+    // is affected.
     internal static class FiberCrossPanelEventDispatcher
     {
         // Registers one BubbleUp listener per synthetic-bubbling-eligible event type on bridgeAnchor —

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberKeying.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberKeying.cs
@@ -12,9 +12,8 @@ namespace Velvet
     // ChildReconciler's inline-expansion (which mounts / diffs fibers and emits DOM) and
     // FiberContextSpine's spine-rewalk (which re-pushes the Providers enclosing a spine child
     // for an isolated re-render). They perform different actions per node but must agree bit-for-bit
-    // on the derived keys — otherwise a registry lookup keyed by <c>(parentFiber, positionKey,
-    // identity)</c> misses and either the spine reconstruction fails to recognize a child or a fiber's
-    // state is reset. Centralizing the derivation here makes that lockstep structural: changing a
+    // on the derived keys — otherwise a registry lookup misses and either the spine reconstruction
+    // fails to recognize a child or a fiber's state is reset. Centralizing the derivation here makes that lockstep structural: changing a
     // keying rule changes both walkers at once.
 
     // How the child array a node sits in was opened. Part of the structural path below, so two arrays opened

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodeFactory.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodeFactory.cs
@@ -522,13 +522,11 @@ namespace Velvet
 
         private VisualElement CreateForComponentNode(ComponentNode componentNode)
         {
-            // Wrapper-mount path: reached only when CreateElement is invoked on a ComponentNode the
-            // reconcile walk did not inline-expand. The walk expands every ComponentNode it reaches —
-            // a Memo's resolved inner and an AnimatePresence keyed entry included, both of which
-            // recurse back into GeneralPathReconciler.ExpandInlineRecursive — before the flat array its
-            // own CreateElement calls run over exists. What arrives here is a VNode the walk never saw:
-            // a VirtualList item, built straight from the renderer's return in
-            // IReconcilerBridge.CreateElementForController.
+            // Wrapper-mount path, reached from a VirtualList item and nothing else: the item renderer's
+            // return goes to IReconcilerBridge.CreateElementForController unexpanded, while a reconcile
+            // rules a ComponentNode out on both of its paths — the fast one runs only where
+            // GeneralPathReconciler.NeedsExpansion found none, and the general one expands each one it
+            // reaches, a Memo's resolved inner and an AnimatePresence keyed entry included.
             // A Component does not emit a DOM element; its rendered tree attaches
             // directly to the parent. Velvet needs an anchor element for fiber tracking,
             // so the wrapper is made layout-transparent so its single child can size
@@ -542,15 +540,10 @@ namespace Velvet
         {
             // A context Provider emits no DOM element of its own; descendants attach directly to
             // the parent fiber's host. Velvet maps each VNode to exactly one VisualElement so a
-            // layout-passthrough wrapper anchors the Provider subtree without imposing layout.
-            // The wrapper is what AnimatePresence's keyed map (and any BaseElementNode children
-            // list reached through MemoNode's resolved inner) tracks for this Provider entry —
-            // the wrapper element is a deliberate choice, as documented on ContextProviderNode.
-            //
-            // GeneralPathReconciler.ExpandInlineRecursive expands Provider inline (no wrapper) during
-            // a Reconcile pass, so this case is unreachable for slot-based reconciliation; it is
-            // reached only when CreateElement is invoked directly on a Provider VNode — e.g. a
-            // MemoNode resolved inner.
+            // layout-passthrough wrapper anchors the Provider subtree without imposing layout — a
+            // deliberate choice, as documented on ContextProviderNode.
+            // Reached the one way CreateForComponentNode above is, and ruled out on the reconcile
+            // paths for the same reason.
             var container = CreateLayoutPassthroughContainer();
             container.AddToClassList(ContextProviderClassName);
 

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodeFactory.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodeFactory.cs
@@ -692,8 +692,9 @@ namespace Velvet
             var placeholder = CreateHiddenPlaceholder();
             var contextSnapshot = _ctx.ComponentContextStack.SnapshotTops();
             // FiberStack.Current is the component whose Body is mid-render right now — the one that
-            // actually wrote `V.Portal(...)`/`V.WorldSpace(...)` into its returned tree. This is the
-            // only point where that's true; by drain time nothing on the stack reflects it anymore.
+            // actually wrote `V.Portal(...)`/`V.WorldSpace(...)` into its returned tree. Capturing it
+            // here is what makes it available at all: the pass that had it on the stack has unwound by
+            // drain time, and the drain pushes this captured value back rather than reading one.
             var logicalParent = _ctx.FiberStack.Current;
             _ctx.PendingPortalMounts.Enqueue((placeholder, node, target, contextSnapshot, logicalParent));
             return placeholder;

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodeFactory.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodeFactory.cs
@@ -522,13 +522,13 @@ namespace Velvet
 
         private VisualElement CreateForComponentNode(ComponentNode componentNode)
         {
-            // Wrapper-mount path: reached only when CreateElement is invoked directly on a
-            // ComponentNode the reconcile walk did not inline-expand — a MemoNode whose
-            // resolved inner is a ComponentNode, or a ComponentNode that is a direct child of
-            // an AnimatePresence keyed entry. ComponentNodes reached during a
-            // ChildReconciler.Reconcile pass (top-level or nested under an element) are
-            // inline-mounted (no wrapper VE) by GeneralPathReconciler.ExpandInlineRecursive, so this
-            // case is unreachable for them.
+            // Wrapper-mount path: reached only when CreateElement is invoked on a ComponentNode the
+            // reconcile walk did not inline-expand. The walk expands every ComponentNode it reaches —
+            // a Memo's resolved inner and an AnimatePresence keyed entry included, both of which
+            // recurse back into GeneralPathReconciler.ExpandInlineRecursive — before the flat array its
+            // own CreateElement calls run over exists. What arrives here is a VNode the walk never saw:
+            // a VirtualList item, built straight from the renderer's return in
+            // IReconcilerBridge.CreateElementForController.
             // A Component does not emit a DOM element; its rendered tree attaches
             // directly to the parent. Velvet needs an anchor element for fiber tracking,
             // so the wrapper is made layout-transparent so its single child can size

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
@@ -746,11 +746,11 @@ namespace Velvet
             HashSet<ComponentFiber>? healingChildFibersBefore = null;
             if (isHeal)
             {
-                // FiberStack.Current is genuinely the declaring fiber here (RenderAndReconcile keeps
-                // it pushed for the whole patch of its own returned tree — unlike DrainPendingPortalMounts,
-                // which runs later with the reconcile root current instead), so it doubles as both the
-                // ComponentRegistry parent new children below will actually register under AND the
-                // logical ancestor FiberCrossPanelEventDispatcher.Continue needs.
+                // FiberStack.Current is the declaring fiber here (RenderAndReconcile keeps it pushed for
+                // the whole patch of its own returned tree), so it doubles as both the ComponentRegistry
+                // parent new children below will actually register under AND the logical ancestor
+                // FiberCrossPanelEventDispatcher.Continue needs. The deferred mount arrives at the same
+                // fiber by pushing it explicitly — DrainPendingPortalMounts owns why it has to.
                 healingDeclaringFiber = CaptureDeclaringChildFibers(pooled: false, out healingChildFibersBefore);
             }
 

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
@@ -1027,19 +1027,19 @@ namespace Velvet
             // Restored rather than cleared: a Portal declared inside another Portal's children patches from
             // within this call, and what the outer one mounts after that returns is still the outer one's.
             var enclosingPortal = _ctx.CurrentPortalPlaceholder;
-            var enclosingChildScope = _ctx.PortalChildKeyScope;
             _ctx.CurrentPortalPlaceholder = placeholder;
             // The mount half sets the same scope for the same reason — DrainPendingPortalMounts owns it —
             // and the two have to agree or a patch looks this Portal's children up under a key the mount
-            // did not register them by.
-            _ctx.PortalChildKeyScope = placeholder;
+            // did not register them by. No push here: this runs from the reconcile of the tree the
+            // declaring component returned, so its fiber is already current.
+            var enclosingChildScope = _ctx.EnterPortalChildKeyScope(placeholder);
             try
             {
                 _host.ReconcileChildren(target, oldChildren, newChildren, slotStart: prevState.SlotStart);
             }
             finally
             {
-                _ctx.PortalChildKeyScope = enclosingChildScope;
+                _ctx.ExitPortalChildKeyScope(enclosingChildScope);
                 _ctx.CurrentPortalPlaceholder = enclosingPortal;
             }
             // (beforeTailCount - prevState.SlotLength) is the count of target children that do NOT belong to

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
@@ -1027,13 +1027,19 @@ namespace Velvet
             // Restored rather than cleared: a Portal declared inside another Portal's children patches from
             // within this call, and what the outer one mounts after that returns is still the outer one's.
             var enclosingPortal = _ctx.CurrentPortalPlaceholder;
+            var enclosingChildScope = _ctx.PortalChildKeyScope;
             _ctx.CurrentPortalPlaceholder = placeholder;
+            // The mount half sets the same scope for the same reason — DrainPendingPortalMounts owns it —
+            // and the two have to agree or a patch looks this Portal's children up under a key the mount
+            // did not register them by.
+            _ctx.PortalChildKeyScope = placeholder;
             try
             {
                 _host.ReconcileChildren(target, oldChildren, newChildren, slotStart: prevState.SlotStart);
             }
             finally
             {
+                _ctx.PortalChildKeyScope = enclosingChildScope;
                 _ctx.CurrentPortalPlaceholder = enclosingPortal;
             }
             // (beforeTailCount - prevState.SlotLength) is the count of target children that do NOT belong to

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberRenderer.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberRenderer.cs
@@ -206,8 +206,8 @@ namespace Velvet
 
             fiber.MountPoint = mountPoint ?? throw new ArgumentNullException(nameof(mountPoint));
             // Inline-mounted descendants share the root's ReconcilerContext so registry lookups
-            // by (anchor, slotKey, identity) resolve to the same fiber instance regardless of
-            // which fiber's Reconciler is currently running. Wrapper-mounted fibers without a
+            // resolve to the same fiber instance regardless of which fiber's Reconciler is currently
+            // running. Wrapper-mounted fibers without a
             // parent fiber (root mount path) bootstrap a fresh Reconciler that owns its ctx.
             var parentCtx = sharedContext ?? fiber.Parent?.Reconciler?.Context;
             fiber.Reconciler = parentCtx != null

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberStack.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberStack.cs
@@ -15,6 +15,10 @@ namespace Velvet
 
         public ComponentFiber? Current => _stack.TryPeek(out var top) ? top : null;
 
+        // Recorded by a frame on entry and compared against later, so it can tell its own level from one
+        // a nested render has pushed over it. ReconcilerContext.PortalChildKeyScopeHere is the reader.
+        public int Depth => _stack.Count;
+
         public void Push(ComponentFiber fiber)
         {
             if (fiber == null)

--- a/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
@@ -750,10 +750,11 @@ namespace Velvet
             if (_ctx.IsAborted) return;
             var identity = component.ResolvedIdentity;
             var slotKey = component.Key ?? FiberKeying.ResolveInlinePositionKey(positionCounters, identity, _ctx.ComponentRegistry.InlinePositionKeyBoxes);
-            // Read once and cleared for the rest of this call: the scope names the Portal whose OWN
-            // top-level children this walk is at, and everything below the component resolved here is a
-            // level further in. Restored on the way out so the Portal's remaining top-level children,
-            // which resume in this same walk, still carry it.
+            // Read once and cleared for the rest of this call: the component resolved here becomes the
+            // registry parent of everything its own output holds, and that is where the scope stops
+            // applying — ReconcilerContext.PortalChildKeyScope owns how far down it reaches and why.
+            // Restored on the way out so the Portal's remaining children, which resume in this same walk,
+            // still carry it.
             var portalScope = _ctx.PortalChildKeyScope;
             _ctx.PortalChildKeyScope = null;
             try

--- a/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
@@ -794,9 +794,8 @@ namespace Velvet
             else
             {
                 // Old-side (structural) walk: look up the previously rendered fiber by the
-                // same tree-position key the new side registered under — (parent fiber,
-                // position key, identity). FiberStack.Push mirrors the new side so nested
-                // old-side components resolve against the same parent fiber they were
+                // same registry key the new side registered under. FiberStack.Push mirrors the new
+                // side so nested old-side components resolve against the same parent fiber they were
                 // registered with; without the symmetric push the lookup parent would
                 // diverge and the diff would treat reused fibers as orphans.
                 var fiber = _ctx.ComponentRegistry.TryGetFiberForInlineKey(_ctx.FiberStack.Current, slotKey, identity, portalScope);

--- a/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
@@ -750,75 +750,65 @@ namespace Velvet
             if (_ctx.IsAborted) return;
             var identity = component.ResolvedIdentity;
             var slotKey = component.Key ?? FiberKeying.ResolveInlinePositionKey(positionCounters, identity, _ctx.ComponentRegistry.InlinePositionKeyBoxes);
-            // Read once and cleared for the rest of this call: the component resolved here becomes the
-            // registry parent of everything its own output holds, and that is where the scope stops
-            // applying — ReconcilerContext.PortalChildKeyScope owns how far down it reaches and why.
-            // Restored on the way out so the Portal's remaining children, which resume in this same walk,
-            // still carry it.
-            var portalScope = _ctx.PortalChildKeyScope;
-            _ctx.PortalChildKeyScope = null;
-            try
+            // The scope member of this component's own registry key. Read at this level and never carried
+            // into its output: ExpandFiberPreviousTree pushes the fiber below, which is where the reading
+            // stops answering — ReconcilerContext.PortalChildKeyScope owns why that has to be so.
+            var portalScope = _ctx.PortalChildKeyScopeHere;
+            var commit = walk.Commit;
+            var result = walk.Result;
+            if (walk.IsNewSide)
             {
-                var commit = walk.Commit;
-                var result = walk.Result;
-                if (walk.IsNewSide)
+                // Direct, live-context descent: the component renders
+                // in-scope of its ancestor Providers, still pushed on the live
+                // ComponentContextStack during this walk. UseContext reads that live cursor,
+                // so no per-fiber snapshot is captured here. An isolated re-render later
+                // reconstructs the enclosing Providers via FiberContextSpine.
+                var parentFiber = _ctx.FiberStack.Current;
+                // The fiber's output occupies parent.children from this slot; the
+                // emitted-leaf count so far maps 1:1 to parent's slot range. The general
+                // (commit) path commits leaves into NewElements; the structural (collect)
+                // path accumulates them in result.
+                var emittedCount = commit != null ? commit.NewElements.Count : result!.Count;
+                var currentSlotStart = walk.SlotStart + emittedCount;
+                // Two same-identity siblings sharing one explicit key resolve to the
+                // SAME registry fiber; expanding it once per sibling would emit one
+                // component's DOM twice while its slot bookkeeping tracks only the last
+                // position (with hook state shared across both copies). Mirror the
+                // leaf-level duplicate guard: warn and skip the repeat before
+                // GetOrCreate can clobber the first occurrence's slot.
+                var priorFiber = _ctx.ComponentRegistry.TryGetFiberForInlineKey(parentFiber, slotKey, identity, portalScope);
+                if (priorFiber != null && walk.NewFibers.Contains(priorFiber))
                 {
-                    // Direct, live-context descent: the component renders
-                    // in-scope of its ancestor Providers, still pushed on the live
-                    // ComponentContextStack during this walk. UseContext reads that live cursor,
-                    // so no per-fiber snapshot is captured here. An isolated re-render later
-                    // reconstructs the enclosing Providers via FiberContextSpine.
-                    var parentFiber = _ctx.FiberStack.Current;
-                    // The fiber's output occupies parent.children from this slot; the
-                    // emitted-leaf count so far maps 1:1 to parent's slot range. The general
-                    // (commit) path commits leaves into NewElements; the structural (collect)
-                    // path accumulates them in result.
-                    var emittedCount = commit != null ? commit.NewElements.Count : result!.Count;
-                    var currentSlotStart = walk.SlotStart + emittedCount;
-                    // Two same-identity siblings sharing one explicit key resolve to the
-                    // SAME registry fiber; expanding it once per sibling would emit one
-                    // component's DOM twice while its slot bookkeeping tracks only the last
-                    // position (with hook state shared across both copies). Mirror the
-                    // leaf-level duplicate guard: warn and skip the repeat before
-                    // GetOrCreate can clobber the first occurrence's slot.
-                    var priorFiber = _ctx.ComponentRegistry.TryGetFiberForInlineKey(parentFiber, slotKey, identity, portalScope);
-                    if (priorFiber != null && walk.NewFibers.Contains(priorFiber))
-                    {
-                        FiberLogger.LogWarning("GeneralPathReconciler",
-                            $"Duplicate component key detected among siblings: '{slotKey}'. " +
-                            "The repeated sibling is skipped; give each sibling a unique key.");
-                        return;
-                    }
-                    var fiber = _ctx.ComponentRegistry.GetOrCreateInline(
-                        component, parentFiber, slotKey, walk.Parent, currentSlotStart, portalScope);
-                    walk.NewFibers.Add(fiber);
-                    var preCount = emittedCount;
-                    ExpandFiberPreviousTree(walk, fiber, component, position, nodeIndex);
-                    fiber.MountSlotCount = (commit != null ? commit.NewElements.Count : result!.Count) - preCount;
+                    FiberLogger.LogWarning("GeneralPathReconciler",
+                        $"Duplicate component key detected among siblings: '{slotKey}'. " +
+                        "The repeated sibling is skipped; give each sibling a unique key.");
+                    return;
                 }
-                else
-                {
-                    // Old-side (structural) walk: look up the previously rendered fiber by the
-                    // same tree-position key the new side registered under — (parent fiber,
-                    // position key, identity). FiberStack.Push mirrors the new side so nested
-                    // old-side components resolve against the same parent fiber they were
-                    // registered with; without the symmetric push the lookup parent would
-                    // diverge and the diff would treat reused fibers as orphans.
-                    var fiber = _ctx.ComponentRegistry.TryGetFiberForInlineKey(_ctx.FiberStack.Current, slotKey, identity, portalScope);
-                    if (fiber != null)
-                    {
-                        ExpandFiberPreviousTree(walk, fiber, component, position, nodeIndex);
-                        // Post-order add: a directly-nested component must precede its
-                        // parent in oldFibers so the orphan sweep's forward walk tears the
-                        // subtree down bottom-up — a descendant's effect cleanups complete
-                        // before an ancestor's, matching the commit-phase deletion order.
-                        walk.OldFibers.Add(fiber);
-                    }
-                }
+                var fiber = _ctx.ComponentRegistry.GetOrCreateInline(
+                    component, parentFiber, slotKey, walk.Parent, currentSlotStart, portalScope);
+                walk.NewFibers.Add(fiber);
+                var preCount = emittedCount;
+                ExpandFiberPreviousTree(walk, fiber, component, position, nodeIndex);
+                fiber.MountSlotCount = (commit != null ? commit.NewElements.Count : result!.Count) - preCount;
             }
-            finally
+            else
             {
-                _ctx.PortalChildKeyScope = portalScope;
+                // Old-side (structural) walk: look up the previously rendered fiber by the
+                // same tree-position key the new side registered under — (parent fiber,
+                // position key, identity). FiberStack.Push mirrors the new side so nested
+                // old-side components resolve against the same parent fiber they were
+                // registered with; without the symmetric push the lookup parent would
+                // diverge and the diff would treat reused fibers as orphans.
+                var fiber = _ctx.ComponentRegistry.TryGetFiberForInlineKey(_ctx.FiberStack.Current, slotKey, identity, portalScope);
+                if (fiber != null)
+                {
+                    ExpandFiberPreviousTree(walk, fiber, component, position, nodeIndex);
+                    // Post-order add: a directly-nested component must precede its
+                    // parent in oldFibers so the orphan sweep's forward walk tears the
+                    // subtree down bottom-up — a descendant's effect cleanups complete
+                    // before an ancestor's, matching the commit-phase deletion order.
+                    walk.OldFibers.Add(fiber);
+                }
             }
         }
 

--- a/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
@@ -750,61 +750,74 @@ namespace Velvet
             if (_ctx.IsAborted) return;
             var identity = component.ResolvedIdentity;
             var slotKey = component.Key ?? FiberKeying.ResolveInlinePositionKey(positionCounters, identity, _ctx.ComponentRegistry.InlinePositionKeyBoxes);
-            var commit = walk.Commit;
-            var result = walk.Result;
-            if (walk.IsNewSide)
+            // Read once and cleared for the rest of this call: the scope names the Portal whose OWN
+            // top-level children this walk is at, and everything below the component resolved here is a
+            // level further in. Restored on the way out so the Portal's remaining top-level children,
+            // which resume in this same walk, still carry it.
+            var portalScope = _ctx.PortalChildKeyScope;
+            _ctx.PortalChildKeyScope = null;
+            try
             {
-                // Direct, live-context descent: the component renders
-                // in-scope of its ancestor Providers, still pushed on the live
-                // ComponentContextStack during this walk. UseContext reads that live cursor,
-                // so no per-fiber snapshot is captured here. An isolated re-render later
-                // reconstructs the enclosing Providers via FiberContextSpine.
-                var parentFiber = _ctx.FiberStack.Current;
-                // The fiber's output occupies parent.children from this slot; the
-                // emitted-leaf count so far maps 1:1 to parent's slot range. The general
-                // (commit) path commits leaves into NewElements; the structural (collect)
-                // path accumulates them in result.
-                var emittedCount = commit != null ? commit.NewElements.Count : result!.Count;
-                var currentSlotStart = walk.SlotStart + emittedCount;
-                // Two same-identity siblings sharing one explicit key resolve to the
-                // SAME registry fiber; expanding it once per sibling would emit one
-                // component's DOM twice while its slot bookkeeping tracks only the last
-                // position (with hook state shared across both copies). Mirror the
-                // leaf-level duplicate guard: warn and skip the repeat before
-                // GetOrCreate can clobber the first occurrence's slot.
-                var priorFiber = _ctx.ComponentRegistry.TryGetFiberForInlineKey(parentFiber, slotKey, identity);
-                if (priorFiber != null && walk.NewFibers.Contains(priorFiber))
+                var commit = walk.Commit;
+                var result = walk.Result;
+                if (walk.IsNewSide)
                 {
-                    FiberLogger.LogWarning("GeneralPathReconciler",
-                        $"Duplicate component key detected among siblings: '{slotKey}'. " +
-                        "The repeated sibling is skipped; give each sibling a unique key.");
-                    return;
-                }
-                var fiber = _ctx.ComponentRegistry.GetOrCreateInline(
-                    component, parentFiber, slotKey, walk.Parent, currentSlotStart);
-                walk.NewFibers.Add(fiber);
-                var preCount = emittedCount;
-                ExpandFiberPreviousTree(walk, fiber, component, position, nodeIndex);
-                fiber.MountSlotCount = (commit != null ? commit.NewElements.Count : result!.Count) - preCount;
-            }
-            else
-            {
-                // Old-side (structural) walk: look up the previously rendered fiber by the
-                // same tree-position key the new side registered under — (parent fiber,
-                // position key, identity). FiberStack.Push mirrors the new side so nested
-                // old-side components resolve against the same parent fiber they were
-                // registered with; without the symmetric push the lookup parent would
-                // diverge and the diff would treat reused fibers as orphans.
-                var fiber = _ctx.ComponentRegistry.TryGetFiberForInlineKey(_ctx.FiberStack.Current, slotKey, identity);
-                if (fiber != null)
-                {
+                    // Direct, live-context descent: the component renders
+                    // in-scope of its ancestor Providers, still pushed on the live
+                    // ComponentContextStack during this walk. UseContext reads that live cursor,
+                    // so no per-fiber snapshot is captured here. An isolated re-render later
+                    // reconstructs the enclosing Providers via FiberContextSpine.
+                    var parentFiber = _ctx.FiberStack.Current;
+                    // The fiber's output occupies parent.children from this slot; the
+                    // emitted-leaf count so far maps 1:1 to parent's slot range. The general
+                    // (commit) path commits leaves into NewElements; the structural (collect)
+                    // path accumulates them in result.
+                    var emittedCount = commit != null ? commit.NewElements.Count : result!.Count;
+                    var currentSlotStart = walk.SlotStart + emittedCount;
+                    // Two same-identity siblings sharing one explicit key resolve to the
+                    // SAME registry fiber; expanding it once per sibling would emit one
+                    // component's DOM twice while its slot bookkeeping tracks only the last
+                    // position (with hook state shared across both copies). Mirror the
+                    // leaf-level duplicate guard: warn and skip the repeat before
+                    // GetOrCreate can clobber the first occurrence's slot.
+                    var priorFiber = _ctx.ComponentRegistry.TryGetFiberForInlineKey(parentFiber, slotKey, identity, portalScope);
+                    if (priorFiber != null && walk.NewFibers.Contains(priorFiber))
+                    {
+                        FiberLogger.LogWarning("GeneralPathReconciler",
+                            $"Duplicate component key detected among siblings: '{slotKey}'. " +
+                            "The repeated sibling is skipped; give each sibling a unique key.");
+                        return;
+                    }
+                    var fiber = _ctx.ComponentRegistry.GetOrCreateInline(
+                        component, parentFiber, slotKey, walk.Parent, currentSlotStart, portalScope);
+                    walk.NewFibers.Add(fiber);
+                    var preCount = emittedCount;
                     ExpandFiberPreviousTree(walk, fiber, component, position, nodeIndex);
-                    // Post-order add: a directly-nested component must precede its
-                    // parent in oldFibers so the orphan sweep's forward walk tears the
-                    // subtree down bottom-up — a descendant's effect cleanups complete
-                    // before an ancestor's, matching the commit-phase deletion order.
-                    walk.OldFibers.Add(fiber);
+                    fiber.MountSlotCount = (commit != null ? commit.NewElements.Count : result!.Count) - preCount;
                 }
+                else
+                {
+                    // Old-side (structural) walk: look up the previously rendered fiber by the
+                    // same tree-position key the new side registered under — (parent fiber,
+                    // position key, identity). FiberStack.Push mirrors the new side so nested
+                    // old-side components resolve against the same parent fiber they were
+                    // registered with; without the symmetric push the lookup parent would
+                    // diverge and the diff would treat reused fibers as orphans.
+                    var fiber = _ctx.ComponentRegistry.TryGetFiberForInlineKey(_ctx.FiberStack.Current, slotKey, identity, portalScope);
+                    if (fiber != null)
+                    {
+                        ExpandFiberPreviousTree(walk, fiber, component, position, nodeIndex);
+                        // Post-order add: a directly-nested component must precede its
+                        // parent in oldFibers so the orphan sweep's forward walk tears the
+                        // subtree down bottom-up — a descendant's effect cleanups complete
+                        // before an ancestor's, matching the commit-phase deletion order.
+                        walk.OldFibers.Add(fiber);
+                    }
+                }
+            }
+            finally
+            {
+                _ctx.PortalChildKeyScope = portalScope;
             }
         }
 

--- a/Packages/com.velvet.core/Runtime/Reconciler/Reconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Reconciler.cs
@@ -49,8 +49,8 @@ namespace Velvet
 
         /// <summary>
         /// Inline-mounted descendants share the root Reconciler's <see cref="ReconcilerContext"/>
-        /// so that <see cref="ComponentRegistry"/> lookups by <c>(anchor, slotKey, identity)</c>
-        /// resolve to the same fiber instance regardless of which fiber's Reconciler is currently
+        /// so that <see cref="ComponentRegistry"/> lookups resolve to the same fiber instance
+        /// regardless of which fiber's Reconciler is currently
         /// running. Each fiber still has its own Reconciler (and ChildReconciler) so per-fiber
         /// time-sliced pause/resume state is independent, but the registries / stacks
         /// (ComponentRegistry / FiberStack / ComponentContextStack / BufferPool / element-keyed

--- a/Packages/com.velvet.core/Runtime/Reconciler/Reconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Reconciler.cs
@@ -374,9 +374,6 @@ namespace Velvet
                     stack.PushRaw(enclosingContext[i].Key, enclosingContext[i].Value);
                 }
             }
-            // Counted before the host gate, since an item render is a producer of its own tree whether or
-            // not there is a host to parent it under — ReconcilerContext.DetachedItemScopeDepth owns it.
-            _ctx.DetachedItemScopeDepth++;
             if (host == null) return null;
             // Item fibers created during the scope AppendChild onto FiberStack.Current; making it the host
             // links them under the host (so they share the host's ReconcilerContext / context cursor) and
@@ -413,7 +410,6 @@ namespace Velvet
         void IReconcilerBridge.EndDetachedItemScope(
             ComponentFiber? host, List<KeyValuePair<object, object>>? enclosingContext, object? scopeToken)
         {
-            _ctx.DetachedItemScopeDepth--;
             if (host != null)
             {
                 _ctx.FiberStack.Pop();

--- a/Packages/com.velvet.core/Runtime/Reconciler/Reconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Reconciler.cs
@@ -374,6 +374,9 @@ namespace Velvet
                     stack.PushRaw(enclosingContext[i].Key, enclosingContext[i].Value);
                 }
             }
+            // Counted before the host gate, since an item render is a producer of its own tree whether or
+            // not there is a host to parent it under — ReconcilerContext.DetachedItemScopeDepth owns it.
+            _ctx.DetachedItemScopeDepth++;
             if (host == null) return null;
             // Item fibers created during the scope AppendChild onto FiberStack.Current; making it the host
             // links them under the host (so they share the host's ReconcilerContext / context cursor) and
@@ -410,6 +413,7 @@ namespace Velvet
         void IReconcilerBridge.EndDetachedItemScope(
             ComponentFiber? host, List<KeyValuePair<object, object>>? enclosingContext, object? scopeToken)
         {
+            _ctx.DetachedItemScopeDepth--;
             if (host != null)
             {
                 _ctx.FiberStack.Pop();

--- a/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
@@ -779,12 +779,15 @@ namespace Velvet
         // ComponentRegistry.DisposeInlineFibersOwnedByPortal selects by.
         internal VisualElement? CurrentPortalPlaceholder { get; set; }
 
-        // The same placeholder, narrowed to the ONE level CurrentPortalPlaceholder cannot express: the
-        // Portal's own top-level children, whose ComponentRegistry parent is the declaring fiber they
-        // share with everything that fiber renders outside the Portal. Cleared before a component's own
-        // output is expanded (GeneralPathReconciler.ExpandComponentInline), so a fiber deeper in the
-        // Portal's subtree never sees it — its parent is inside the Portal already, and its own isolated
-        // re-render, which sets neither field, has to compute the same key it registered under.
+        // The same placeholder, carried down exactly as far as the declaring component's own fiber stays
+        // the ComponentRegistry parent: the Portal's top-level children, and anything a plain host
+        // element nests below them, since descending a host element pushes no fiber. Those all share a
+        // whole registry key with what the declaring component renders outside the Portal, and this is
+        // the only member that separates them — PortalChildFiberContinuityTests holds the two keys of
+        // the host-nested shape side by side. GeneralPathReconciler.ExpandComponentInline clears it for a
+        // component's own output: a fiber below that component registers under that component's fiber,
+        // which already sits on one side of the Portal only — and that component's isolated re-render
+        // sets neither field, so its children must key the same way then as at mount.
         internal VisualElement? PortalChildKeyScope { get; set; }
 
         // Portal mounts deferred until the enclosing reconcile pass completes. When a PortalNode

--- a/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
@@ -780,11 +780,11 @@ namespace Velvet
         internal VisualElement? CurrentPortalPlaceholder { get; set; }
 
         // The same placeholder, for the levels of that Portal's children whose ComponentRegistry parent is
-        // still the declaring component's own fiber: the Portal's top-level children, and anything a plain
-        // host element nests below them, since descending a host element pushes no fiber. Those all share a
-        // whole registry key with what the declaring component renders outside the Portal, and this is the
-        // only member that separates them — PortalChildFiberContinuityTests holds the two keys of the
-        // host-nested shape side by side.
+        // still the declaring component's own fiber — every level the reconcile reaches while the fiber
+        // stack stands where it did. Those all share a whole registry key with what the declaring
+        // component renders outside the Portal, and this is the only member that separates them —
+        // PortalChildFiberContinuityTests holds the two keys side by side, for a host element between the
+        // two and for a Provider.
         //
         // Both members are written only by EnterPortalChildKeyScope, and read only through
         // PortalChildKeyScopeHere. The set of levels above is not the set of levels this reconcile passes
@@ -793,35 +793,28 @@ namespace Velvet
         // second reading builds a second set of fibers over the first. The nesting recorded here is what
         // separates the two. A component body reached through FiberRenderer.PushFiber or
         // GeneralPathReconciler.ExpandFiberPreviousTree, and a VirtualList item reached through
-        // Reconciler.BeginDetachedItemScope, each push one of the two counters, so the scope stops
-        // applying at each of them without any of them naming it.
+        // Reconciler.BeginDetachedItemScope, each push a fiber, so the scope stops applying at each of
+        // them without any of them naming it.
         private VisualElement? PortalChildKeyScope { get; set; }
-        private (int Fibers, int DetachedItems) PortalChildKeyScopeNesting { get; set; }
-
-        // Item renders of a VirtualList currently on the stack. Counted rather than flagged so an item that
-        // itself renders a VirtualList still leaves the outer one's nesting distinguishable, and bumped even
-        // where that scope has no host fiber to push, which is the case FiberStack.Depth alone would miss.
-        internal int DetachedItemScopeDepth { get; set; }
-
-        private (int Fibers, int DetachedItems) RenderNesting => (FiberStack.Depth, DetachedItemScopeDepth);
+        private int PortalChildKeyScopeNesting { get; set; }
 
         // The Portal scope in force for a registry key written right here, which is PortalChildKeyScope at
         // the nesting it was entered at and nothing anywhere else.
         internal VisualElement? PortalChildKeyScopeHere
-            => RenderNesting == PortalChildKeyScopeNesting ? PortalChildKeyScope : null;
+            => FiberStack.Depth == PortalChildKeyScopeNesting ? PortalChildKeyScope : null;
 
         // Returns what restores the enclosing scope. Restored rather than cleared on the way out: a Portal
         // declared inside another Portal's children reconciles from within the outer one's, and what the
         // outer one reaches after that returns is still the outer one's.
-        internal (VisualElement? Scope, (int, int) Nesting) EnterPortalChildKeyScope(VisualElement placeholder)
+        internal (VisualElement? Scope, int Nesting) EnterPortalChildKeyScope(VisualElement placeholder)
         {
             var enclosing = (PortalChildKeyScope, PortalChildKeyScopeNesting);
             PortalChildKeyScope = placeholder;
-            PortalChildKeyScopeNesting = RenderNesting;
+            PortalChildKeyScopeNesting = FiberStack.Depth;
             return enclosing;
         }
 
-        internal void ExitPortalChildKeyScope((VisualElement? Scope, (int, int) Nesting) enclosing)
+        internal void ExitPortalChildKeyScope((VisualElement? Scope, int Nesting) enclosing)
         {
             PortalChildKeyScope = enclosing.Scope;
             PortalChildKeyScopeNesting = enclosing.Nesting;

--- a/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
@@ -779,16 +779,53 @@ namespace Velvet
         // ComponentRegistry.DisposeInlineFibersOwnedByPortal selects by.
         internal VisualElement? CurrentPortalPlaceholder { get; set; }
 
-        // The same placeholder, carried down exactly as far as the declaring component's own fiber stays
-        // the ComponentRegistry parent: the Portal's top-level children, and anything a plain host
-        // element nests below them, since descending a host element pushes no fiber. Those all share a
-        // whole registry key with what the declaring component renders outside the Portal, and this is
-        // the only member that separates them — PortalChildFiberContinuityTests holds the two keys of
-        // the host-nested shape side by side. GeneralPathReconciler.ExpandComponentInline clears it for a
-        // component's own output: a fiber below that component registers under that component's fiber,
-        // which already sits on one side of the Portal only — and that component's isolated re-render
-        // sets neither field, so its children must key the same way then as at mount.
-        internal VisualElement? PortalChildKeyScope { get; set; }
+        // The same placeholder, for the levels of that Portal's children whose ComponentRegistry parent is
+        // still the declaring component's own fiber: the Portal's top-level children, and anything a plain
+        // host element nests below them, since descending a host element pushes no fiber. Those all share a
+        // whole registry key with what the declaring component renders outside the Portal, and this is the
+        // only member that separates them — PortalChildFiberContinuityTests holds the two keys of the
+        // host-nested shape side by side.
+        //
+        // Both members are written only by EnterPortalChildKeyScope, and read only through
+        // PortalChildKeyScopeHere. The set of levels above is not the set of levels this reconcile passes
+        // through: a component body rendered anywhere below one of them renders again, later and alone,
+        // with no Portal reconcile in sight, and its children have to key the same way both times or the
+        // second reading builds a second set of fibers over the first. The nesting recorded here is what
+        // separates the two. A component body reached through FiberRenderer.PushFiber or
+        // GeneralPathReconciler.ExpandFiberPreviousTree, and a VirtualList item reached through
+        // Reconciler.BeginDetachedItemScope, each push one of the two counters, so the scope stops
+        // applying at each of them without any of them naming it.
+        private VisualElement? PortalChildKeyScope { get; set; }
+        private (int Fibers, int DetachedItems) PortalChildKeyScopeNesting { get; set; }
+
+        // Item renders of a VirtualList currently on the stack. Counted rather than flagged so an item that
+        // itself renders a VirtualList still leaves the outer one's nesting distinguishable, and bumped even
+        // where that scope has no host fiber to push, which is the case FiberStack.Depth alone would miss.
+        internal int DetachedItemScopeDepth { get; set; }
+
+        private (int Fibers, int DetachedItems) RenderNesting => (FiberStack.Depth, DetachedItemScopeDepth);
+
+        // The Portal scope in force for a registry key written right here, which is PortalChildKeyScope at
+        // the nesting it was entered at and nothing anywhere else.
+        internal VisualElement? PortalChildKeyScopeHere
+            => RenderNesting == PortalChildKeyScopeNesting ? PortalChildKeyScope : null;
+
+        // Returns what restores the enclosing scope. Restored rather than cleared on the way out: a Portal
+        // declared inside another Portal's children reconciles from within the outer one's, and what the
+        // outer one reaches after that returns is still the outer one's.
+        internal (VisualElement? Scope, (int, int) Nesting) EnterPortalChildKeyScope(VisualElement placeholder)
+        {
+            var enclosing = (PortalChildKeyScope, PortalChildKeyScopeNesting);
+            PortalChildKeyScope = placeholder;
+            PortalChildKeyScopeNesting = RenderNesting;
+            return enclosing;
+        }
+
+        internal void ExitPortalChildKeyScope((VisualElement? Scope, (int, int) Nesting) enclosing)
+        {
+            PortalChildKeyScope = enclosing.Scope;
+            PortalChildKeyScopeNesting = enclosing.Nesting;
+        }
 
         // Portal mounts deferred until the enclosing reconcile pass completes. When a PortalNode
         // (or a WorldSpaceNode — the same deferred-mount flow) is encountered during a reconcile,

--- a/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
@@ -786,9 +786,9 @@ namespace Velvet
         // PortalChildFiberContinuityTests holds the two keys side by side, for a host element between the
         // two and for a Provider.
         //
-        // Both members are written only by EnterPortalChildKeyScope, and read only through
-        // PortalChildKeyScopeHere. The set of levels above is not the set of levels this reconcile passes
-        // through: a component body rendered anywhere below one of them renders again, later and alone,
+        // Nothing outside the three members below touches the pair: Enter overwrites it and hands back
+        // what it displaced, Exit puts that back, and PortalChildKeyScopeHere is the only other read.
+        // The set of levels above is not the set of levels this reconcile passes through: a component body rendered anywhere below one of them renders again, later and alone,
         // with no Portal reconcile in sight, and its children have to key the same way both times or the
         // second reading builds a second set of fibers over the first. The nesting recorded here is what
         // separates the two. A component body reached through FiberRenderer.PushFiber or
@@ -804,8 +804,9 @@ namespace Velvet
             => FiberStack.Depth == PortalChildKeyScopeNesting ? PortalChildKeyScope : null;
 
         // Returns what restores the enclosing scope. Restored rather than cleared on the way out: a Portal
-        // declared inside another Portal's children reconciles from within the outer one's, and what the
-        // outer one reaches after that returns is still the outer one's.
+        // declared inside another Portal's children patches from within the outer one's, and what the
+        // outer one reaches after that returns is still the outer one's. The mount entrance does not
+        // nest that way — ChildReconciler.DrainPendingPortalMounts says why.
         internal (VisualElement? Scope, int Nesting) EnterPortalChildKeyScope(VisualElement placeholder)
         {
             var enclosing = (PortalChildKeyScope, PortalChildKeyScopeNesting);

--- a/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
@@ -779,6 +779,14 @@ namespace Velvet
         // ComponentRegistry.DisposeInlineFibersOwnedByPortal selects by.
         internal VisualElement? CurrentPortalPlaceholder { get; set; }
 
+        // The same placeholder, narrowed to the ONE level CurrentPortalPlaceholder cannot express: the
+        // Portal's own top-level children, whose ComponentRegistry parent is the declaring fiber they
+        // share with everything that fiber renders outside the Portal. Cleared before a component's own
+        // output is expanded (GeneralPathReconciler.ExpandComponentInline), so a fiber deeper in the
+        // Portal's subtree never sees it — its parent is inside the Portal already, and its own isolated
+        // re-render, which sets neither field, has to compute the same key it registered under.
+        internal VisualElement? PortalChildKeyScope { get; set; }
+
         // Portal mounts deferred until the enclosing reconcile pass completes. When a PortalNode
         // (or a WorldSpaceNode — the same deferred-mount flow) is encountered during a reconcile,
         // its target-side reconcile is queued here instead of

--- a/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
@@ -26,7 +26,8 @@ namespace Velvet
     // Captured on the top-level child fiber of a DETACHED mount — one whose children reconcile outside the
     // normal parent-walked reconcile, so FiberContextSpine's parent-walk cannot reach the host that carries
     // their enclosing Providers. Two cases:
-    //   Portal — children mount in the deferred drain (DrainPendingPortalMounts) under the reconcile root.
+    //   Portal — children mount in the deferred drain (DrainPendingPortalMounts), after the pass that
+    //   reconciled the declaring component's own tree has already unwound past it.
     //   VirtualList — items mount via the controller (FiberVirtualListController) on scroll, outside any pass.
     // EnclosingSnapshot is the top value of every context active outside the detached mount (the base the
     // consumer reads). DescendantNodes is the committed VNode children to walk to recover any Provider placed
@@ -41,11 +42,11 @@ namespace Velvet
         internal readonly List<KeyValuePair<object, object>>? EnclosingSnapshot;
         internal readonly VNode?[]? DescendantNodes;
         internal readonly ComponentFiber Anchor;
-        // The ComponentFiber that logically called V.Portal/V.WorldSpace (captured at enqueue time, when
-        // FiberStack.Current is genuinely correct — see PendingPortalMounts). Null for VirtualList's
-        // detached items (no portal call site to resolve) and for a bare Reconciler.Reconcile() drain
-        // with nothing on FiberStack. Distinct from Anchor: Anchor is a REGISTRY-lookup key (where the
-        // drain happened to leave the child fiber parented), not the authoring component.
+        // The ComponentFiber that logically called V.Portal/V.WorldSpace (captured at enqueue time — see
+        // PendingPortalMounts). Null for VirtualList's detached items (no portal call site to resolve)
+        // and for a bare Reconciler.Reconcile() drain with nothing on FiberStack. Anchor is the separate
+        // question of which fiber the detached mount parented the children under, which VirtualList
+        // answers with its host and a portal drain answers with this same declaring fiber.
         internal readonly ComponentFiber? LogicalParent;
 
         internal DetachedMountContext(
@@ -796,11 +797,10 @@ namespace Velvet
         // attached and the declaring panel is therefore known.
         // LogicalParent is the ComponentFiber whose Body was mid-render when V.Portal/V.WorldSpace was
         // called (_ctx.FiberStack.Current at enqueue time — the only point this is available, since the
-        // drain runs after the whole top-level reconcile pass unwinds). Captured for cross-panel
-        // synthetic event bubbling: the drained children's own fiber.Parent ends up pointing at
-        // whatever fiber happens to be on top of FiberStack at DRAIN time (see DrainPendingPortalMounts'
-        // drainAnchor), which is NOT the logically-enclosing component — LogicalParent is the correct
-        // one, stamped onto DetachedMountContext separately from Anchor.
+        // drain runs after the whole top-level reconcile pass unwinds). The drain pushes it back for its
+        // nested reconcile, so it is both the parent the children register and link under and the logical
+        // ancestor cross-panel synthetic bubbling resolves to; DrainPendingPortalMounts owns why the
+        // registry half cannot be left to whatever fiber the drain happens to find current.
         public Queue<(VisualElement Placeholder, VNode Node, VisualElement? Target,
             List<KeyValuePair<object, object>> ContextSnapshot, ComponentFiber? LogicalParent)> PendingPortalMounts { get; } = new();
 

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/FiberKeyingTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/FiberKeyingTests.cs
@@ -5,8 +5,8 @@ namespace Velvet.Tests
 {
     /// <summary>
     /// Specifies the tree-position keying contract that the inline-expansion walk and the context
-    /// spine-rewalk must derive identically for the same committed node, so a registry lookup keyed
-    /// by <c>(parentFiber, positionKey, identity)</c> never misses.
+    /// spine-rewalk must derive identically for the same committed node, so a registry lookup never
+    /// misses.
     /// <list type="bullet">
     /// <item>An unkeyed inline ComponentNode's position key is the n-th occurrence of its identity
     /// within one reconcile scope, counted independently per identity.</item>

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/PortalChildFiberContinuityTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/PortalChildFiberContinuityTests.cs
@@ -30,6 +30,10 @@ namespace Velvet.Tests
     /// <item>A consumer a component level below the portal's own children, where the scope has been
     /// dropped again, is still found by the spine on its isolated re-render and keeps its Providers.
     /// </item>
+    /// <item>A render that repeats away from the portal's own reconcile keys the same way both times: a
+    /// <c>V.VirtualList</c> item, whose renderer runs from the scroll viewport's geometry as readily as
+    /// from a patch of the portal's children, and an <c>V.Outlet</c> route Component, whose body mounts
+    /// inside the portal's reconcile and re-renders alone afterwards.</item>
     /// </list>
     /// A component that crosses the portal boundary in either direction mounts fresh on the far side, as
     /// a component changing parent does anywhere else and as the guide states of a move; the fiber the
@@ -39,7 +43,8 @@ namespace Velvet.Tests
     /// A component the reconcile carries between two containers is a separate position on this fixture:
     /// two same-identity unkeyed occurrences in different containers of one declaring component still
     /// resolve to one instance, which is an open defect, and what is pinned here is only that the one
-    /// instance's own re-render lands in the container it last occupied.
+    /// instance's own re-render lands in the container it last occupied, and that a container leaving
+    /// the tree in the render that carried the component out of it does not take the component with it.
     /// </para>
     /// </summary>
     internal sealed class PortalChildFiberContinuityTests
@@ -57,6 +62,7 @@ namespace Velvet.Tests
             s_twinSetters.Clear();
             s_contextSeen = null;
             s_deepSeen = null;
+            s_innerSetups = 0;
             RuntimeStateProbe.ClearPortalRegistry();
         }
 
@@ -65,6 +71,7 @@ namespace Velvet.Tests
         {
             _mounted?.Dispose();
             _mounted = null;
+            Router.Current?.Dispose();
             RuntimeStateProbe.ClearPortalRegistry();
         }
 
@@ -363,6 +370,49 @@ namespace Velvet.Tests
 
             // Assert — the cleanup count is folded in for the reason its opposite direction gives.
             Assert.That((Names(target), s_markCleanups), Is.EqualTo(("a", 1)));
+        }
+
+        // Phase 1 writes the component into the container the reconcile reaches FIRST and drops the one it
+        // was in, so the carry into `left` completes and only then does `right` leave the tree. A teardown
+        // reaches a fiber by the container it renders into, which is what makes the order decide whether
+        // the departing subtree takes the carried fiber with it.
+        [Component]
+        private static VNode CarryThenTeardownHost()
+        {
+            var (phase, setPhase) = Hooks.UseState(0);
+            s_setPhase = setPhase;
+            return V.Div(name: "outside", children: new VNode?[]
+            {
+                V.Div(name: "left", children: phase == 1
+                    ? new VNode?[] { V.Component(MarkedChild) }
+                    : Array.Empty<VNode?>()),
+                phase == 0
+                    ? V.Div(name: "right", children: new VNode?[] { V.Component(MarkedChild) })
+                    : null,
+            });
+        }
+
+        [Test]
+        public void Given_AComponentCarriedIntoAnotherContainer_When_TheOneItLeftIsTornDownInTheSameRender_Then_ItIsNotDisposedWithIt()
+        {
+            // Arrange — the mark is set before the move, so the element the carry writes into `left` names
+            // the instance that held it.
+            var container = new VisualElement();
+            _mounted = V.Mount(container, V.Component(CarryThenTeardownHost, key: "host"));
+            _mounted.FlushEffectsForTest();
+            s_setMark.Invoke("b");
+            _mounted.FlushStateForTest();
+
+            // Act
+            s_setPhase.Invoke(1);
+            _mounted.FlushStateForTest();
+            _mounted.FlushEffectsForTest();
+
+            // Assert — the arriving container is folded in because a cleanup count of zero is also what a
+            // render that never carried anything reports.
+            Assert.That(
+                (s_markCleanups, Names(container.Q<VisualElement>("left"))),
+                Is.EqualTo((0, "b")));
         }
 
         [Component]
@@ -678,6 +728,151 @@ namespace Velvet.Tests
             // Assert — the element name is folded in because the value read at mount is "inside" either
             // way, so only a name carrying the new tick says the re-render happened at all.
             Assert.That((s_deepSeen, Names(target)), Is.EqualTo(("inside", "deep-1")));
+        }
+
+        private static StateUpdater<string> s_setRowMark;
+
+        [Component]
+        private static VNode Row()
+        {
+            var (mark, setMark) = Hooks.UseState("a");
+            s_setRowMark = setMark;
+            return V.Div(name: "row-" + mark);
+        }
+
+        // The list's items render from the scroll viewport's geometry, outside every reconcile, and again
+        // from a patch of this portal's children — the two drives this case holds against each other. The
+        // item root is named for the host's state so a reading of it says which of the two produced it.
+        [Component]
+        private static VNode VirtualListPortalHost()
+        {
+            var (sibling, setSibling) = Hooks.UseState(0);
+            s_setSibling = setSibling;
+            return V.Portal("continuity-target", children: new VNode?[]
+            {
+                V.VirtualList(
+                    items: new[] { "only" },
+                    keySelector: item => item,
+                    itemHeight: 50f,
+                    renderer: item => V.Div(name: "item-" + sibling, children: new VNode?[] { V.Component(Row) }),
+                    overscan: 0),
+            });
+        }
+
+        // GREEN_ON_BASE(characterization): the base keys an item's components the one way there is, so the
+        // two drives agree there without being held to it. The portal scope makes them two keys, and this
+        // is what says the item render is not one of the levels that carries it.
+        [Test]
+        public void Given_AComponentInsideAVirtualListInAPortal_When_ThePortalsChildrenPatch_Then_TheItemKeepsTheInstanceItsGeometryRenderBuilt()
+        {
+            // Arrange — the viewport height a geometry pass would have left, so the patch below re-renders
+            // the range instead of returning at the controller's unknown-viewport gate.
+            var target = new VisualElement();
+            FiberPortalRegistry.Register("continuity-target", target);
+            _mounted = V.Mount(new VisualElement(), V.Component(VirtualListPortalHost, key: "host"));
+            _mounted.FlushEffectsForTest();
+            var scrollView = target.Q<ScrollView>();
+            var controller = _mounted.Root.Reconciler.Context.VirtualListControllers[scrollView];
+            typeof(FiberVirtualListController)
+                .GetField("_viewportHeight", BindingFlags.NonPublic | BindingFlags.Instance)!
+                .SetValue(controller, 200f);
+            controller.UpdateVisibleRange(scrollY: 0f, viewportHeight: 200f);
+            _mounted.FlushEffectsForTest();
+            s_setRowMark.Invoke("b");
+            _mounted.FlushStateForTest();
+
+            // Act
+            s_setSibling.Invoke(1);
+            _mounted.FlushStateForTest();
+            _mounted.FlushEffectsForTest();
+
+            // Assert — the item root's own name is what says the patch re-rendered the range at all, so
+            // the child name beside it is a reading of the instance that render resolved to rather than
+            // of one nothing touched. A second row beside the first is the replacement instance.
+            var itemRoot = scrollView.contentContainer.ElementAt(1).ElementAt(0);
+            Assert.That((itemRoot.name, Names(itemRoot)), Is.EqualTo(("item-1", "row-b")));
+        }
+
+        private static int s_innerSetups;
+        private static StateUpdater<string> s_setInnerMark;
+        private static StateUpdater<int> s_setRouteTick;
+
+        [Component]
+        private static VNode RouteInner()
+        {
+            var (mark, setMark) = Hooks.UseState("a");
+            s_setInnerMark = setMark;
+            Hooks.UseLayoutEffect(() => { s_innerSetups++; return (Action)(() => { }); }, Array.Empty<object>());
+            return V.Div(name: "inner-" + mark);
+        }
+
+        // Wrapper-mounted on the Outlet's container rather than inline-expanded, so its body's own
+        // reconcile runs inside FiberRenderer.RenderAndReconcile — once from the portal's deferred mount,
+        // and every time after that from its own state, with no portal reconcile anywhere on the stack.
+        [Component]
+        private static VNode RouteBody()
+        {
+            var (tick, setTick) = Hooks.UseState(0);
+            s_setRouteTick = setTick;
+            return V.Div(name: "route-" + tick, children: new VNode?[] { V.Component(RouteInner) });
+        }
+
+        [Component]
+        private static VNode OutletPortalHost()
+            => V.Portal("continuity-target", children: new VNode?[]
+            {
+                V.Div(name: "outlet-wrap", children: new VNode?[] { V.Outlet() }),
+            });
+
+        private void MountOutletPortalHostWith(Router router)
+        {
+            _mounted = V.Mount(new VisualElement(),
+                V.Provider(RouterContext.Location, router.CurrentLocation,
+                    children: new VNode[]
+                    {
+                        V.Provider(RouterContext.LoaderData, router.CurrentLoaderData,
+                            children: new VNode[]
+                            {
+                                V.Provider(RouterContext.Errors, router.CurrentLoaderErrors,
+                                    children: new VNode[]
+                                    {
+                                        V.Component(OutletPortalHost, key: "host"),
+                                    }),
+                            }),
+                    }));
+        }
+
+        // GREEN_ON_BASE(characterization): the base has one key for the route body's children whichever
+        // pass reaches them, so the mount and the isolated re-render agree there for want of a second key
+        // rather than by anything holding them to it.
+        [Test]
+        public void Given_AnOutletRouteInsideAPortal_When_TheRouteComponentReRendersAlone_Then_ItsOwnChildKeepsItsInstance()
+        {
+            // Arrange
+            var target = new VisualElement();
+            FiberPortalRegistry.Register("continuity-target", target);
+            var router = new Router(new[]
+            {
+                new RouteDefinition { Path = "home", Element = V.Component(RouteBody, key: "route") },
+            });
+            router.NavigateAsync("/home").GetAwaiter().GetResult();
+            MountOutletPortalHostWith(router);
+            _mounted!.FlushEffectsForTest();
+            s_setInnerMark.Invoke("b");
+            _mounted.FlushStateForTest();
+
+            // Act
+            s_setRouteTick.Invoke(1);
+            _mounted.FlushStateForTest();
+            _mounted.FlushEffectsForTest();
+
+            // Assert — the route element is located by the tick it renders, so a reading at all says the
+            // re-render happened; its children are folded in beside the mount count because a second
+            // instance shows as either a reset mark or a second element next to the first.
+            var route = target.Q<VisualElement>("route-1");
+            Assert.That(
+                (s_innerSetups, route == null ? "<no route-1>" : Names(route)),
+                Is.EqualTo((1, "inner-b")));
         }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/PortalChildFiberContinuityTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/PortalChildFiberContinuityTests.cs
@@ -1,0 +1,252 @@
+using System;
+using System.Collections;
+using System.Linq;
+using System.Reflection;
+using NUnit.Framework;
+using UnityEngine.UIElements;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Specifies that a <c>V.Component</c> written as a top-level child of a <c>V.Portal</c> is the same
+    /// component instance at mount and at every later patch of that portal's children — the logical-tree
+    /// contract <c>Documentation~/portals.md</c> opens with, applied to the one child position whose mount
+    /// runs in the deferred drain rather than in the declaring component's own reconcile.
+    /// <list type="bullet">
+    /// <item>Its mount effect runs once across a patch, and its hook state carries that patch.</item>
+    /// <item>The target holds one element for it, not one per patch.</item>
+    /// <item>A component that then leaves the portal's children takes its element out of the target with
+    /// it, rather than leaving one behind for the portal to keep.</item>
+    /// <item>The fiber the deferred mount pushes to reach that agreement comes back off the stack.</item>
+    /// <item>A fiber the reconcile carries to another container re-renders itself into the container it
+    /// is in, not the one it was created in.</item>
+    /// </list>
+    /// The move itself is still an unmount and a remount — <see cref="PortalRegistryRetargetTests"/> owns
+    /// what a portal close reaches, and the guide states the move contract.
+    /// </summary>
+    internal sealed class PortalChildFiberContinuityTests
+    {
+        private MountedTree? _mounted;
+
+        [SetUp]
+        public void SetUp()
+        {
+            s_setups = 0;
+            s_lastRenderedCount = -1;
+            RuntimeStateProbe.ClearPortalRegistry();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _mounted?.Dispose();
+            _mounted = null;
+            RuntimeStateProbe.ClearPortalRegistry();
+        }
+
+        private static int s_setups;
+        private static int s_lastRenderedCount;
+        private static StateUpdater<int> s_setCount;
+        private static StateUpdater<int> s_setSibling;
+        private static StateUpdater<int> s_setPhase;
+
+        private static string Names(VisualElement element) =>
+            string.Join("|", element.Children().Select(c => c.name));
+
+        [Component]
+        private static VNode PortalChild()
+        {
+            var (count, setCount) = Hooks.UseState(0);
+            s_setCount = setCount;
+            s_lastRenderedCount = count;
+            Hooks.UseLayoutEffect(() => { s_setups++; return (Action)(() => { }); }, Array.Empty<object>());
+            return V.Div(name: "content");
+        }
+
+        // The sibling carries the state that drives the patch, so every reading below can name a term that
+        // exists only once the portal's children have actually been patched.
+        [Component]
+        private static VNode PortalHost()
+        {
+            var (sibling, setSibling) = Hooks.UseState(0);
+            s_setSibling = setSibling;
+            return V.Portal("continuity-target", children: new VNode?[]
+            {
+                V.Component(PortalChild, key: "c"),
+                V.Div(name: "sib-" + sibling),
+            });
+        }
+
+        private VisualElement MountHostAndPatch()
+        {
+            var target = new VisualElement();
+            FiberPortalRegistry.Register("continuity-target", target);
+            _mounted = V.Mount(new VisualElement(), V.Component(PortalHost, key: "host"));
+            _mounted.FlushEffectsForTest();
+            s_setSibling.Invoke(1);
+            _mounted.FlushStateForTest();
+            _mounted.FlushEffectsForTest();
+            return target;
+        }
+
+        [Test]
+        public void Given_AComponentChildOfAPortal_When_ThePortalsChildrenPatch_Then_ItsMountEffectDoesNotRunAgain()
+        {
+            // Arrange & Act
+            var target = MountHostAndPatch();
+
+            // Assert — the sibling name is folded in because a patch that never reached the portal's
+            // children leaves the setup count at 1 on its own.
+            Assert.That((s_setups, Names(target)), Is.EqualTo((1, "content|sib-1")));
+        }
+
+        [Test]
+        public void Given_AComponentChildOfAPortal_When_ThePortalsChildrenPatch_Then_TheTargetKeepsOneElementForIt()
+        {
+            // Arrange & Act
+            var target = MountHostAndPatch();
+
+            // Assert — a second element for the same component would sit between the two named here, so
+            // the reading is the whole slot range rather than a count.
+            Assert.That(Names(target), Is.EqualTo("content|sib-1"));
+        }
+
+        [Test]
+        public void Given_APortalChildComponentHoldingState_When_ThePortalsChildrenPatch_Then_ItKeepsThatState()
+        {
+            // Arrange
+            var target = new VisualElement();
+            FiberPortalRegistry.Register("continuity-target", target);
+            _mounted = V.Mount(new VisualElement(), V.Component(PortalHost, key: "host"));
+            _mounted.FlushEffectsForTest();
+            s_setCount.Invoke(7);
+            _mounted.FlushStateForTest();
+
+            // Act
+            s_setSibling.Invoke(1);
+            _mounted.FlushStateForTest();
+
+            // Assert — the sibling name is folded in because the last render of a component that never
+            // lost its state and of one that was never re-rendered at all both report 7.
+            Assert.That((s_lastRenderedCount, Names(target)), Is.EqualTo((7, "content|sib-1")));
+        }
+
+        private static int FiberStackDepth(MountedTree mounted)
+        {
+            var stack = mounted.Root.Reconciler.Context.FiberStack;
+            var field = typeof(FiberStack).GetField("_stack", BindingFlags.NonPublic | BindingFlags.Instance);
+            return ((ICollection)field!.GetValue(stack)!).Count;
+        }
+
+        // GREEN_ON_BASE(characterization): this pins a balance the base does not have — the base's drain
+        // pushes nothing, so its stack is even for want of a push rather than by unwinding one. What the
+        // case exists to catch is the matching Pop going missing, which mutation_check.py measured as
+        // leaving the whole EditMode suite green.
+        [Test]
+        public void Given_APortalDrainedUnderItsDeclaringComponent_When_ThePassEnds_Then_TheFiberStackIsUnwound()
+        {
+            // Arrange
+            var target = new VisualElement();
+            FiberPortalRegistry.Register("continuity-target", target);
+
+            // Act
+            _mounted = V.Mount(new VisualElement(), V.Component(PortalHost, key: "host"));
+
+            // Assert — the target's contents are folded in because a tree whose portal never drained
+            // leaves the stack just as unwound.
+            Assert.That((FiberStackDepth(_mounted), Names(target)), Is.EqualTo((0, "content|sib-0")));
+        }
+
+        [Component]
+        private static VNode ReHomingHost()
+        {
+            var (phase, setPhase) = Hooks.UseState(0);
+            s_setPhase = setPhase;
+            return V.Div(children: new VNode?[]
+            {
+                V.Portal("continuity-target", children: phase == 0
+                    ? new VNode?[] { V.Component(PortalChild, key: "c") }
+                    : Array.Empty<VNode?>()),
+                phase == 1 ? V.Component(PortalChild, key: "c") : null,
+            });
+        }
+
+        private static StateUpdater<string> s_setMark;
+
+        // Its own state names its element, so a reading of the container says both which container the
+        // fiber renders into and whether it is still the fiber that held the state.
+        [Component]
+        private static VNode MarkedChild()
+        {
+            var (mark, setMark) = Hooks.UseState("a");
+            s_setMark = setMark;
+            return V.Div(name: mark);
+        }
+
+        // Phase 1 drops the portal and writes the component outside it in the SAME render, which is what
+        // makes the inline walk carry the fiber rather than dispose and rebuild it — the distinction
+        // PortalRegistryRetargetTests draws between a closing render and a portal that merely empties.
+        [Component]
+        private static VNode CarryingHost()
+        {
+            var (phase, setPhase) = Hooks.UseState(0);
+            s_setPhase = setPhase;
+            return V.Div(name: "outside", children: new VNode?[]
+            {
+                phase == 0
+                    ? V.Portal("continuity-target", children: new VNode?[] { V.Component(MarkedChild, key: "c") })
+                    : null,
+                phase == 1 ? V.Component(MarkedChild, key: "c") : null,
+            });
+        }
+
+        [Test]
+        public void Given_AFiberCarriedToAnotherContainer_When_ItReRendersItself_Then_ItWritesIntoTheContainerItIsIn()
+        {
+            // Arrange — the mark is set before the carry, so the reading after it distinguishes the carried
+            // fiber from a rebuilt one, which would be back at "a".
+            var container = new VisualElement();
+            var target = new VisualElement();
+            FiberPortalRegistry.Register("continuity-target", target);
+            _mounted = V.Mount(container, V.Component(CarryingHost, key: "host"));
+            var outside = container.Q<VisualElement>("outside");
+            s_setMark.Invoke("b");
+            _mounted.FlushStateForTest();
+            s_setPhase.Invoke(1);
+            _mounted.FlushStateForTest();
+            var afterCarry = Names(outside);
+
+            // Act — the component re-renders itself, which reconciles into its own MountPoint.
+            s_setMark.Invoke("c");
+            _mounted.FlushStateForTest();
+
+            // Assert — the post-carry reading is folded in because a rebuilt fiber would reach "c" in the
+            // right container too, and the target because the wrong container is where "c" lands without
+            // the fix rather than nowhere.
+            Assert.That((afterCarry, Names(outside), Names(target)), Is.EqualTo(("b", "c", "")));
+        }
+
+        [Test]
+        public void Given_APortalChildComponent_When_ItReHomesOutOfThePortalsChildren_Then_TheTargetKeepsNoElementForIt()
+        {
+            // Arrange
+            var container = new VisualElement();
+            var target = new VisualElement();
+            FiberPortalRegistry.Register("continuity-target", target);
+            _mounted = V.Mount(container, V.Component(ReHomingHost, key: "host"));
+            _mounted.FlushEffectsForTest();
+
+            // Act
+            s_setPhase.Invoke(1);
+            _mounted.FlushStateForTest();
+            _mounted.FlushEffectsForTest();
+
+            // Assert — the arrival outside is folded in because a component that never reached its new
+            // position empties the target just as thoroughly.
+            Assert.That(
+                (target.childCount, container.Query<VisualElement>("content").ToList().Count),
+                Is.EqualTo((0, 1)));
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/PortalChildFiberContinuityTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/PortalChildFiberContinuityTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using NUnit.Framework;
@@ -14,16 +15,23 @@ namespace Velvet.Tests
     /// contract <c>Documentation~/portals.md</c> opens with, applied to the one child position whose mount
     /// runs in the deferred drain rather than in the declaring component's own reconcile.
     /// <list type="bullet">
-    /// <item>Its mount effect runs once across a patch, and its hook state carries that patch.</item>
+    /// <item>Its mount effect runs once across a patch, and its hook state carries two.</item>
     /// <item>The target holds one element for it, not one per patch.</item>
     /// <item>A component that then leaves the portal's children takes its element out of the target with
     /// it, rather than leaving one behind for the portal to keep.</item>
     /// <item>The fiber the deferred mount pushes to reach that agreement comes back off the stack.</item>
     /// <item>A fiber the reconcile carries to another container re-renders itself into the container it
     /// is in, not the one it was created in.</item>
+    /// <item>Sharing that parent does not merge the child with a same-position component the declaring
+    /// tree renders outside the portal: each keeps its own instance and its own state.</item>
+    /// <item>The stamp the deferred mount writes onto the children it created reaches those and no other
+    /// child of the declaring fiber, so a sibling's isolated re-render still sees its own Providers.</item>
     /// </list>
-    /// The move itself is still an unmount and a remount — <see cref="PortalRegistryRetargetTests"/> owns
-    /// what a portal close reaches, and the guide states the move contract.
+    /// A component that leaves the portal's children in the render that removes the portal is carried,
+    /// state and all, which is the fifth item above. A portal that survives and re-homes its child, or
+    /// whose target id is re-registered elsewhere, unmounts and remounts it instead —
+    /// <see cref="PortalRegistryRetargetTests"/> owns what a portal close reaches, and the guide states
+    /// the move contract.
     /// </summary>
     internal sealed class PortalChildFiberContinuityTests
     {
@@ -34,6 +42,9 @@ namespace Velvet.Tests
         {
             s_setups = 0;
             s_lastRenderedCount = -1;
+            s_twinSetups = 0;
+            s_twinSetters.Clear();
+            s_contextSeen = null;
             RuntimeStateProbe.ClearPortalRegistry();
         }
 
@@ -112,8 +123,11 @@ namespace Velvet.Tests
             Assert.That(Names(target), Is.EqualTo("content|sib-1"));
         }
 
+        // Two patches rather than one: the instance a single patch builds to replace the lost one
+        // registers where every later patch looks, so its state survives from there and one patch cannot
+        // tell "kept its state" from "lost it once, then kept the replacement's".
         [Test]
-        public void Given_APortalChildComponentHoldingState_When_ThePortalsChildrenPatch_Then_ItKeepsThatState()
+        public void Given_APortalChildComponentHoldingState_When_ThePortalsChildrenPatchTwice_Then_ItKeepsThatState()
         {
             // Arrange
             var target = new VisualElement();
@@ -126,10 +140,12 @@ namespace Velvet.Tests
             // Act
             s_setSibling.Invoke(1);
             _mounted.FlushStateForTest();
+            s_setSibling.Invoke(2);
+            _mounted.FlushStateForTest();
 
             // Assert — the sibling name is folded in because the last render of a component that never
             // lost its state and of one that was never re-rendered at all both report 7.
-            Assert.That((s_lastRenderedCount, Names(target)), Is.EqualTo((7, "content|sib-1")));
+            Assert.That((s_lastRenderedCount, Names(target)), Is.EqualTo((7, "content|sib-2")));
         }
 
         private static int FiberStackDepth(MountedTree mounted)
@@ -247,6 +263,128 @@ namespace Velvet.Tests
             Assert.That(
                 (target.childCount, container.Query<VisualElement>("content").ToList().Count),
                 Is.EqualTo((0, 1)));
+        }
+
+        private static int s_twinSetups;
+        private static readonly List<StateUpdater<string>> s_twinSetters = new();
+
+        // Its own state names its element, and every setter is collected in render order so a test can
+        // drive one occurrence and read the other. The one outside the portal renders first.
+        [Component]
+        private static VNode Twin()
+        {
+            var (mark, setMark) = Hooks.UseState("a");
+            s_twinSetters.Add(setMark);
+            Hooks.UseLayoutEffect(() => { s_twinSetups++; return (Action)(() => { }); }, Array.Empty<object>());
+            return V.Div(name: "twin-" + mark);
+        }
+
+        // Both occurrences are unkeyed, first of their identity in their own reconcile scope, and rendered
+        // by this one fiber — so they agree on the whole of the tree-position key, and only the portal
+        // scope ComponentRegistry.ResolveInline hands out separates them.
+        [Component]
+        private static VNode TwinHost()
+            => V.Div(name: "twin-host", children: new VNode?[]
+            {
+                V.Div(name: "inline-slot", children: new VNode?[] { V.Component(Twin) }),
+                V.Portal("continuity-target", children: new VNode?[] { V.Component(Twin), V.Div(name: "sib") }),
+            });
+
+        private (VisualElement InlineSlot, VisualElement Target) MountTwins()
+        {
+            var container = new VisualElement();
+            var target = new VisualElement();
+            FiberPortalRegistry.Register("continuity-target", target);
+            _mounted = V.Mount(container, V.Component(TwinHost, key: "host"));
+            _mounted.FlushEffectsForTest();
+            return (container.Q<VisualElement>("inline-slot"), target);
+        }
+
+        // GREEN_ON_BASE(characterization): the base gives the two occurrences separate registry parents by
+        // accident — the drained one lands on the reconcile root — so it separates them without meaning to.
+        // Keying the drained child on the declaring fiber removes that accident, and this pins that what
+        // replaces it separates them on purpose.
+        [Test]
+        public void Given_OneComponentBothInAPortalAndOutsideIt_When_TheyMount_Then_EachRunsItsOwnMountEffect()
+        {
+            // Arrange & Act
+            var (_, target) = MountTwins();
+
+            // Assert — the target's contents are folded in so the second run is attributed: a count of two
+            // says two mount effects ran, not that one of them belongs to a child that reached the target.
+            Assert.That((s_twinSetups, Names(target)), Is.EqualTo((2, "twin-a|sib")));
+        }
+
+        // GREEN_ON_BASE(characterization): separate on the base for the accidental reason its sibling case
+        // above states, so this reads the same there and pins the same replacement.
+        [Test]
+        public void Given_OneComponentBothInAPortalAndOutsideIt_When_TheOutsideOneSetsItsState_Then_ThePortalsKeepsItsOwn()
+        {
+            // Arrange
+            var (inlineSlot, target) = MountTwins();
+
+            // Act
+            s_twinSetters[0].Invoke("b");
+            _mounted!.FlushStateForTest();
+
+            // Assert — the container outside is folded in because a setter that reached nothing at all
+            // leaves the portal's child reading "a" just as a separate instance does.
+            Assert.That((Names(inlineSlot), Names(target)), Is.EqualTo(("twin-b", "twin-a|sib")));
+        }
+
+        private static readonly ComponentContext<string> ScopeContext = ComponentContext<string>.Create("outside");
+        private static string s_contextSeen;
+        private static StateUpdater<int> s_setSiblingTick;
+
+        [Component]
+        private static VNode PlainPortalChild() => V.Div(name: "plain");
+
+        [Component]
+        private static VNode ContextReadingSibling()
+        {
+            s_contextSeen = Hooks.UseContext(ScopeContext);
+            var (tick, setTick) = Hooks.UseState(0);
+            s_setSiblingTick = setTick;
+            return V.Div(name: "sibling-" + tick);
+        }
+
+        // The sibling is an ordinary direct child fiber of the same declaring fiber the deferred mount
+        // anchors this portal's children on, so the mount's own "which of these did I just create" diff is
+        // the only thing keeping the portal's DetachedMountContext off it. Carrying that stamp would send
+        // the sibling's isolated re-render down the spine's detached arm, which rebuilds context from the
+        // snapshot taken at the portal's position — above the Provider written below it.
+        [Component]
+        private static VNode PortalAndProviderHost()
+            => V.Div(name: "scope-host", children: new VNode?[]
+            {
+                V.Portal("continuity-target", children: new VNode?[] { V.Component(PlainPortalChild) }),
+                V.Provider(ScopeContext, "inside", new VNode[] { V.Component(ContextReadingSibling, key: "s") }),
+            });
+
+        // GREEN_ON_BASE(characterization): the base anchors a drained portal child on the reconcile root,
+        // where this declaring fiber's other children are not, so its stamp cannot reach them and the case
+        // is green there for want of the anchor rather than by the diff this pins. The anchor being the
+        // declaring fiber is what makes that diff load-bearing, and removing either half of it — the
+        // before-set add, or the skip that reads it — leaves every other case in this fixture green.
+        [Test]
+        public void Given_APortalBesideAContextConsumingSibling_When_TheSiblingReRendersAlone_Then_ItStillReadsTheProviderAroundIt()
+        {
+            // Arrange
+            var container = new VisualElement();
+            var target = new VisualElement();
+            FiberPortalRegistry.Register("continuity-target", target);
+            _mounted = V.Mount(container, V.Component(PortalAndProviderHost, key: "host"));
+            _mounted.FlushEffectsForTest();
+
+            // Act
+            s_setSiblingTick.Invoke(1);
+            _mounted.FlushStateForTest();
+
+            // Assert — the sibling's own element is folded in because the value read at mount is "inside"
+            // either way, so only a name carrying the new tick says the re-render happened at all.
+            Assert.That(
+                (s_contextSeen, Names(container.Q<VisualElement>("scope-host"))),
+                Is.EqualTo(("inside", "|sibling-1")));
         }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/PortalChildFiberContinuityTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/PortalChildFiberContinuityTests.cs
@@ -666,6 +666,68 @@ namespace Velvet.Tests
                 Is.EqualTo((true, true, true, (object?)placeholder, (object?)null)));
         }
 
+        private static StateUpdater<string> s_setResidueMark;
+        private static StateUpdater<int> s_setResidueTick;
+
+        [Component]
+        private static VNode ResidueLeaf()
+        {
+            var (mark, setMark) = Hooks.UseState("a");
+            s_setResidueMark = setMark;
+            return V.Div(name: "leaf-" + mark);
+        }
+
+        // A component level between the declarer and the leaf, so the leaf's own position is expanded one
+        // fiber deeper than the declarer's re-render starts — which is the depth the drain entered its
+        // scope at, the declaring fiber having been pushed over the pass's own.
+        [Component]
+        private static VNode ResidueMiddle() => V.Div(name: "middle", children: new VNode?[]
+        {
+            V.Component(ResidueLeaf),
+        });
+
+        [Component]
+        private static VNode ResidueDeclarer()
+        {
+            var (tick, setTick) = Hooks.UseState(0);
+            s_setResidueTick = setTick;
+            return V.Div(name: "declarer-" + tick, children: new VNode?[]
+            {
+                V.Portal("continuity-target", children: new VNode?[] { V.Component(PlainPortalChild) }),
+                V.Component(ResidueMiddle),
+            });
+        }
+
+        // GREEN_ON_BASE(characterization): the base has no portal scope to leave behind, so it keeps this
+        // instance for want of a scope rather than by restoring one. What this pins is the restore: with
+        // the drain's ExitPortalChildKeyScope removed, the scope it set outlives the pass, and the next
+        // render reaching the same fiber depth keys a component nowhere near the portal as one of its
+        // children — measured as a second fiber built beside the first, the container reading
+        // "leaf-a|leaf-b" rather than "leaf-b".
+        [Test]
+        public void Given_APortalDrainedUnderItsDeclaringComponent_When_ALaterRenderReachesThatSameDepth_Then_AComponentOutsideThePortalKeepsItsInstance()
+        {
+            // Arrange
+            var container = new VisualElement();
+            var target = new VisualElement();
+            FiberPortalRegistry.Register("continuity-target", target);
+            _mounted = V.Mount(container, V.Component(ResidueDeclarer, key: "host"));
+            _mounted.FlushEffectsForTest();
+            s_setResidueMark.Invoke("b");
+            _mounted.FlushStateForTest();
+
+            // Act — the declarer re-renders alone, which expands the middle component's own children at
+            // the depth the drain recorded.
+            s_setResidueTick.Invoke(1);
+            _mounted.FlushStateForTest();
+
+            // Assert — the declarer's name carries the tick because a render that never reached the leaf
+            // leaves it reading "b" just as a kept instance does.
+            Assert.That(
+                (Names(container.Q<VisualElement>("middle")), Names(container)),
+                Is.EqualTo(("leaf-b", "declarer-1")));
+        }
+
         private static readonly ComponentContext<string> ScopeContext = ComponentContext<string>.Create("outside");
         private static string s_contextSeen;
         private static StateUpdater<int> s_setSiblingTick;

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/PortalChildFiberContinuityTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/PortalChildFiberContinuityTests.cs
@@ -625,6 +625,47 @@ namespace Velvet.Tests
                 Is.EqualTo((true, true, true, (object?)placeholder, (object?)null)));
         }
 
+        // A V.Provider is inline-expanded and pushes no fiber either, so what the scope reaches is not the
+        // list of node types the host-element case above happens to name.
+        [Component]
+        private static VNode ProviderNestedTwinHost()
+            => V.Div(name: "twin-host", children: new VNode?[]
+            {
+                V.Div(name: "inline-wrap", children: new VNode?[]
+                {
+                    V.Provider(ScopeContext, "inside", new VNode[] { V.Component(Twin) }),
+                }),
+                V.Portal("continuity-target", children: new VNode?[]
+                {
+                    V.Provider(ScopeContext, "inside", new VNode[] { V.Component(Twin) }),
+                }),
+            });
+
+        [Test]
+        public void Given_APortalChildComponentNestedUnderAProvider_When_TheSameShapeIsRenderedOutsideThePortal_Then_TheirRegistryKeysDifferOnlyInTheScope()
+        {
+            // Arrange
+            var container = new VisualElement();
+            var target = new VisualElement();
+            FiberPortalRegistry.Register("continuity-target", target);
+            _mounted = V.Mount(container, V.Component(ProviderNestedTwinHost, key: "host"));
+            _mounted.FlushEffectsForTest();
+            var placeholder = _mounted.Root.Reconciler.Context.PortalState.Keys.Single();
+
+            // Act — the Provider emits no element, so the portal's occurrence renders straight into the
+            // target rather than into a wrapper of its own.
+            var inside = InlineKeyForOutputIn(_mounted, target);
+            var outside = InlineKeyForOutputIn(_mounted, container.Q<VisualElement>("inline-wrap"));
+
+            // Assert — the three other members being equal is what says the two shapes collide this deep
+            // at all; a scope naming the placeholder on one side and nothing on the other is the whole of
+            // what holds them apart.
+            Assert.That(
+                (ReferenceEquals(inside.Parent, outside.Parent), Equals(inside.PositionKey, outside.PositionKey),
+                    ReferenceEquals(inside.Identity, outside.Identity), inside.Scope, outside.Scope),
+                Is.EqualTo((true, true, true, (object?)placeholder, (object?)null)));
+        }
+
         private static readonly ComponentContext<string> ScopeContext = ComponentContext<string>.Create("outside");
         private static string s_contextSeen;
         private static StateUpdater<int> s_setSiblingTick;

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/PortalChildFiberContinuityTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/PortalChildFiberContinuityTests.cs
@@ -10,28 +10,37 @@ using Velvet.TestUtilities;
 namespace Velvet.Tests
 {
     /// <summary>
-    /// Specifies that a <c>V.Component</c> written as a top-level child of a <c>V.Portal</c> is the same
-    /// component instance at mount and at every later patch of that portal's children — the logical-tree
-    /// contract <c>Documentation~/portals.md</c> opens with, applied to the one child position whose mount
-    /// runs in the deferred drain rather than in the declaring component's own reconcile.
+    /// Specifies that a <c>V.Component</c> written inside a <c>V.Portal</c> is the same component instance
+    /// at mount and at every later patch of that portal's children — the logical-tree contract
+    /// <c>Documentation~/portals.md</c> opens with, applied to the child positions whose mount runs in the
+    /// deferred drain rather than in the declaring component's own reconcile.
     /// <list type="bullet">
     /// <item>Its mount effect runs once across a patch, and its hook state carries two.</item>
     /// <item>The target holds one element for it, not one per patch.</item>
     /// <item>A component that then leaves the portal's children takes its element out of the target with
     /// it, rather than leaving one behind for the portal to keep.</item>
     /// <item>The fiber the deferred mount pushes to reach that agreement comes back off the stack.</item>
-    /// <item>A fiber the reconcile carries to another container re-renders itself into the container it
-    /// is in, not the one it was created in.</item>
     /// <item>Sharing that parent does not merge the child with a same-position component the declaring
-    /// tree renders outside the portal: each keeps its own instance and its own state.</item>
+    /// tree renders outside the portal — in either order of arrival, and whether the portal's occurrence
+    /// arrives with the portal's own mount or by a later patch of its children: each keeps its own
+    /// instance and its own state, and the registry keys of the two differ in the portal scope alone.
+    /// </item>
     /// <item>The stamp the deferred mount writes onto the children it created reaches those and no other
     /// child of the declaring fiber, so a sibling's isolated re-render still sees its own Providers.</item>
+    /// <item>A consumer a component level below the portal's own children, where the scope has been
+    /// dropped again, is still found by the spine on its isolated re-render and keeps its Providers.
+    /// </item>
     /// </list>
-    /// A component that leaves the portal's children in the render that removes the portal is carried,
-    /// state and all, which is the fifth item above. A portal that survives and re-homes its child, or
-    /// whose target id is re-registered elsewhere, unmounts and remounts it instead —
-    /// <see cref="PortalRegistryRetargetTests"/> owns what a portal close reaches, and the guide states
-    /// the move contract.
+    /// A component that crosses the portal boundary in either direction mounts fresh on the far side, as
+    /// a component changing parent does anywhere else and as the guide states of a move; the fiber the
+    /// side it left held is disposed with its cleanups. <see cref="PortalRegistryRetargetTests"/> owns
+    /// what a portal close reaches.
+    /// <para>
+    /// A component the reconcile carries between two containers is a separate position on this fixture:
+    /// two same-identity unkeyed occurrences in different containers of one declaring component still
+    /// resolve to one instance, which is an open defect, and what is pinned here is only that the one
+    /// instance's own re-render lands in the container it last occupied.
+    /// </para>
     /// </summary>
     internal sealed class PortalChildFiberContinuityTests
     {
@@ -42,9 +51,12 @@ namespace Velvet.Tests
         {
             s_setups = 0;
             s_lastRenderedCount = -1;
+            s_markSetups = 0;
+            s_markCleanups = 0;
             s_twinSetups = 0;
             s_twinSetters.Clear();
             s_contextSeen = null;
+            s_deepSeen = null;
             RuntimeStateProbe.ClearPortalRegistry();
         }
 
@@ -188,61 +200,6 @@ namespace Velvet.Tests
             });
         }
 
-        private static StateUpdater<string> s_setMark;
-
-        // Its own state names its element, so a reading of the container says both which container the
-        // fiber renders into and whether it is still the fiber that held the state.
-        [Component]
-        private static VNode MarkedChild()
-        {
-            var (mark, setMark) = Hooks.UseState("a");
-            s_setMark = setMark;
-            return V.Div(name: mark);
-        }
-
-        // Phase 1 drops the portal and writes the component outside it in the SAME render, which is what
-        // makes the inline walk carry the fiber rather than dispose and rebuild it — the distinction
-        // PortalRegistryRetargetTests draws between a closing render and a portal that merely empties.
-        [Component]
-        private static VNode CarryingHost()
-        {
-            var (phase, setPhase) = Hooks.UseState(0);
-            s_setPhase = setPhase;
-            return V.Div(name: "outside", children: new VNode?[]
-            {
-                phase == 0
-                    ? V.Portal("continuity-target", children: new VNode?[] { V.Component(MarkedChild, key: "c") })
-                    : null,
-                phase == 1 ? V.Component(MarkedChild, key: "c") : null,
-            });
-        }
-
-        [Test]
-        public void Given_AFiberCarriedToAnotherContainer_When_ItReRendersItself_Then_ItWritesIntoTheContainerItIsIn()
-        {
-            // Arrange — the mark is set before the carry, so the reading after it distinguishes the carried
-            // fiber from a rebuilt one, which would be back at "a".
-            var container = new VisualElement();
-            var target = new VisualElement();
-            FiberPortalRegistry.Register("continuity-target", target);
-            _mounted = V.Mount(container, V.Component(CarryingHost, key: "host"));
-            var outside = container.Q<VisualElement>("outside");
-            s_setMark.Invoke("b");
-            _mounted.FlushStateForTest();
-            s_setPhase.Invoke(1);
-            _mounted.FlushStateForTest();
-            var afterCarry = Names(outside);
-
-            // Act — the component re-renders itself, which reconciles into its own MountPoint.
-            s_setMark.Invoke("c");
-            _mounted.FlushStateForTest();
-
-            // Assert — the post-carry reading is folded in because a rebuilt fiber would reach "c" in the
-            // right container too, and the target because the wrong container is where "c" lands without
-            // the fix rather than nowhere.
-            Assert.That((afterCarry, Names(outside), Names(target)), Is.EqualTo(("b", "c", "")));
-        }
-
         [Test]
         public void Given_APortalChildComponent_When_ItReHomesOutOfThePortalsChildren_Then_TheTargetKeepsNoElementForIt()
         {
@@ -265,6 +222,236 @@ namespace Velvet.Tests
                 Is.EqualTo((0, 1)));
         }
 
+        private static StateUpdater<string> s_setMark;
+        private static int s_markSetups;
+        private static int s_markCleanups;
+
+        // Its own state names its element, so a reading of a container says both which container the
+        // fiber renders into and whether it is still the fiber that held the state.
+        [Component]
+        private static VNode MarkedChild()
+        {
+            var (mark, setMark) = Hooks.UseState("a");
+            s_setMark = setMark;
+            Hooks.UseLayoutEffect(
+                () => { s_markSetups++; return (Action)(() => { s_markCleanups++; }); }, Array.Empty<object>());
+            return V.Div(name: mark);
+        }
+
+        // Phase 1 drops the portal and writes the component outside it in the SAME render, which is the
+        // render a carry would happen in if the two positions shared a registry key.
+        [Component]
+        private static VNode ClosingPortalHost()
+        {
+            var (phase, setPhase) = Hooks.UseState(0);
+            s_setPhase = setPhase;
+            return V.Div(name: "outside", children: new VNode?[]
+            {
+                phase == 0
+                    ? V.Portal("continuity-target", children: new VNode?[] { V.Component(MarkedChild, key: "c") })
+                    : null,
+                phase == 1 ? V.Component(MarkedChild, key: "c") : null,
+            });
+        }
+
+        // GREEN_ON_BASE(characterization): a portal child and a position outside the portal are separate
+        // positions on the base too, so the fresh mount is what it already does. Keying the drained child
+        // on the declaring fiber puts the two within one key of each other, and this pins that the portal
+        // scope keeps the move a move rather than turning it into a carry of state, effects and all.
+        [Test]
+        public void Given_APortalChildComponent_When_ThePortalClosesAndItIsWrittenOutsideInTheSameRender_Then_ItMountsFreshThere()
+        {
+            // Arrange — the mark is set before the close, so a fiber that carried would read "b" at the
+            // new position instead of the initial value.
+            var container = new VisualElement();
+            var target = new VisualElement();
+            FiberPortalRegistry.Register("continuity-target", target);
+            _mounted = V.Mount(container, V.Component(ClosingPortalHost, key: "host"));
+            _mounted.FlushEffectsForTest();
+            s_setMark.Invoke("b");
+            _mounted.FlushStateForTest();
+
+            // Act
+            s_setPhase.Invoke(1);
+            _mounted.FlushStateForTest();
+            _mounted.FlushEffectsForTest();
+
+            // Assert — the cleanup count is folded in because an instance carried across would also be
+            // the one holding the mark, and only a cleanup says the one the portal held was retired.
+            Assert.That(
+                (Names(container.Q<VisualElement>("outside")), s_markCleanups), Is.EqualTo(("a", 1)));
+        }
+
+        // The portal is live from the mount and gains the keyed component by a PATCH, which is the entrance
+        // that has always reconciled a portal's children with the declaring fiber current — so this is the
+        // shape where the two occurrences shared a whole key before the scope was part of it.
+        [Component]
+        private static VNode PatchedIntoPortalHost()
+        {
+            var (phase, setPhase) = Hooks.UseState(0);
+            s_setPhase = setPhase;
+            return V.Div(name: "outside", children: new VNode?[]
+            {
+                V.Portal("continuity-target", children: phase == 0
+                    ? new VNode?[] { V.Div(name: "sib") }
+                    : new VNode?[] { V.Div(name: "sib"), V.Component(MarkedChild, key: "c") }),
+                V.Component(MarkedChild, key: "c"),
+            });
+        }
+
+        [Test]
+        public void Given_AKeyedComponentOutsideAPortal_When_TheSameKeyIsPatchedIntoThePortalsChildren_Then_EachPositionKeepsItsOwnInstance()
+        {
+            // Arrange — the one outside holds the mark, so a portal child that took its fiber over would
+            // read "b" in the target and empty the position outside.
+            var container = new VisualElement();
+            var target = new VisualElement();
+            FiberPortalRegistry.Register("continuity-target", target);
+            _mounted = V.Mount(container, V.Component(PatchedIntoPortalHost, key: "host"));
+            _mounted.FlushEffectsForTest();
+            s_setMark.Invoke("b");
+            _mounted.FlushStateForTest();
+
+            // Act
+            s_setPhase.Invoke(1);
+            _mounted.FlushStateForTest();
+            _mounted.FlushEffectsForTest();
+
+            // Assert — the container outside is folded in because the position there is what the portal's
+            // child took the instance from, so a target reading alone cannot say the two are apart. The
+            // leading empty name outside is the portal's placeholder.
+            Assert.That(
+                (Names(target), Names(container.Q<VisualElement>("outside"))),
+                Is.EqualTo(("sib|a", "|b")));
+        }
+
+        [Component]
+        private static VNode OpeningPortalHost()
+        {
+            var (phase, setPhase) = Hooks.UseState(0);
+            s_setPhase = setPhase;
+            return V.Div(name: "outside", children: new VNode?[]
+            {
+                phase == 1
+                    ? V.Portal("continuity-target", children: new VNode?[] { V.Component(MarkedChild, key: "c") })
+                    : null,
+                phase == 0 ? V.Component(MarkedChild, key: "c") : null,
+            });
+        }
+
+        // GREEN_ON_BASE(characterization): the same fresh mount the base already gives this direction, and
+        // the sibling case above gives the other one. Both are pinned because the portals guide states the
+        // two together, and a key that reached across the boundary would break whichever direction it
+        // reached in.
+        [Test]
+        public void Given_AComponentOutsideAPortal_When_APortalOpensAndItIsWrittenInsideInTheSameRender_Then_ItMountsFreshThere()
+        {
+            // Arrange — the mark is set before the move, so a fiber that carried would read "b" inside the
+            // portal instead of the initial value.
+            var container = new VisualElement();
+            var target = new VisualElement();
+            FiberPortalRegistry.Register("continuity-target", target);
+            _mounted = V.Mount(container, V.Component(OpeningPortalHost, key: "host"));
+            _mounted.FlushEffectsForTest();
+            s_setMark.Invoke("b");
+            _mounted.FlushStateForTest();
+
+            // Act
+            s_setPhase.Invoke(1);
+            _mounted.FlushStateForTest();
+            _mounted.FlushEffectsForTest();
+
+            // Assert — the cleanup count is folded in for the reason its opposite direction gives.
+            Assert.That((Names(target), s_markCleanups), Is.EqualTo(("a", 1)));
+        }
+
+        [Component]
+        private static VNode TwoContainerHost()
+            => V.Div(name: "outside", children: new VNode?[]
+            {
+                V.Div(name: "left", children: new VNode?[] { V.Component(MarkedChild) }),
+                V.Div(name: "right", children: new VNode?[] { V.Component(MarkedChild) }),
+            });
+
+        [Test]
+        public void Given_OneFiberSharedByTwoContainers_When_ItReRendersItself_Then_ItWritesIntoTheContainerItLastOccupied()
+        {
+            // Arrange
+            var container = new VisualElement();
+            _mounted = V.Mount(container, V.Component(TwoContainerHost, key: "host"));
+            _mounted.FlushEffectsForTest();
+
+            // Act — the shared instance re-renders on its own, which reconciles into its own MountPoint.
+            s_setMark.Invoke("b");
+            _mounted.FlushStateForTest();
+
+            // Assert — the left container is folded in because the two occurrences sharing one instance is
+            // what puts a container on each side of the reading: an instance that had reached only one of
+            // them would leave the other empty rather than holding the value it rendered before.
+            Assert.That(
+                (Names(container.Q<VisualElement>("left")), Names(container.Q<VisualElement>("right"))),
+                Is.EqualTo(("a", "b")));
+        }
+
+        // The in-tree occurrence appears one render AFTER the portal's, which is the order in which the
+        // portal's child is the one already holding the shared spelling of the key.
+        [Component]
+        private static VNode LateSiblingHost()
+        {
+            var (phase, setPhase) = Hooks.UseState(0);
+            s_setPhase = setPhase;
+            return V.Div(name: "outside", children: new VNode?[]
+            {
+                V.Portal("continuity-target", children: new VNode?[]
+                {
+                    V.Component(MarkedChild),
+                    V.Div(name: "sib-" + phase),
+                }),
+                phase >= 1 ? V.Component(MarkedChild) : null,
+            });
+        }
+
+        private (VisualElement Outside, VisualElement Target) MountLateSiblingHostThrough(int phase)
+        {
+            var container = new VisualElement();
+            var target = new VisualElement();
+            FiberPortalRegistry.Register("continuity-target", target);
+            _mounted = V.Mount(container, V.Component(LateSiblingHost, key: "host"));
+            _mounted.FlushEffectsForTest();
+            s_setMark.Invoke("b");
+            _mounted.FlushStateForTest();
+            for (var p = 1; p <= phase; p++)
+            {
+                s_setPhase.Invoke(p);
+                _mounted.FlushStateForTest();
+                _mounted.FlushEffectsForTest();
+            }
+            return (container.Q<VisualElement>("outside"), target);
+        }
+
+        [Test]
+        public void Given_APortalChildComponent_When_ASamePositionComponentAppearsOutsideThePortal_Then_ThePortalsChildKeepsItsOwnInstance()
+        {
+            // Arrange & Act
+            var (outside, target) = MountLateSiblingHostThrough(1);
+
+            // Assert — the container outside is folded in because a component that never reached its
+            // position there leaves the portal's child reading "b" just as a separate instance does. The
+            // leading empty name there is the portal's placeholder.
+            Assert.That((Names(target), Names(outside)), Is.EqualTo(("b|sib-1", "|a")));
+        }
+
+        [Test]
+        public void Given_APortalChildAndASamePositionComponentOutsideIt_When_ThePortalPatchesAgain_Then_TheTargetHoldsOneElementForThatChild()
+        {
+            // Arrange & Act
+            var (outside, target) = MountLateSiblingHostThrough(2);
+
+            // Assert — a second element built for the portal's child would sit inside this range, and the
+            // sibling name says the second patch reached the portal's children at all.
+            Assert.That((Names(target), Names(outside)), Is.EqualTo(("b|sib-2", "|a")));
+        }
+
         private static int s_twinSetups;
         private static readonly List<StateUpdater<string>> s_twinSetters = new();
 
@@ -281,7 +468,7 @@ namespace Velvet.Tests
 
         // Both occurrences are unkeyed, first of their identity in their own reconcile scope, and rendered
         // by this one fiber — so they agree on the whole of the tree-position key, and only the portal
-        // scope ComponentRegistry.ResolveInline hands out separates them.
+        // scope separates them.
         [Component]
         private static VNode TwinHost()
             => V.Div(name: "twin-host", children: new VNode?[]
@@ -330,6 +517,62 @@ namespace Velvet.Tests
             // Assert — the container outside is folded in because a setter that reached nothing at all
             // leaves the portal's child reading "a" just as a separate instance does.
             Assert.That((Names(inlineSlot), Names(target)), Is.EqualTo(("twin-b", "twin-a|sib")));
+        }
+
+        // A plain host element between the Portal and the component pushes no fiber, so this component's
+        // registry parent is still the declaring fiber and the shape outside the portal keys identically.
+        [Component]
+        private static VNode HostNestedTwinHost()
+            => V.Div(name: "twin-host", children: new VNode?[]
+            {
+                V.Div(name: "inline-wrap", children: new VNode?[] { V.Component(Twin) }),
+                V.Portal("continuity-target", children: new VNode?[]
+                {
+                    V.Div(name: "portal-wrap", children: new VNode?[] { V.Component(Twin) }),
+                }),
+            });
+
+        // The four members of the key one inline fiber is registered under, read off the registry's own
+        // reverse index rather than recomputed, and located by the container the fiber renders into.
+        private static (object? Parent, object? Scope, object? PositionKey, object? Identity) InlineKeyForOutputIn(
+            MountedTree mounted, VisualElement mountPoint)
+        {
+            var registry = mounted.Root.Reconciler.Context.ComponentRegistry;
+            var field = registry.GetType().GetField(
+                "_inlineFiberToKey", BindingFlags.NonPublic | BindingFlags.Instance);
+            foreach (DictionaryEntry entry in (IDictionary)field!.GetValue(registry)!)
+            {
+                if (!ReferenceEquals(((ComponentFiber)entry.Key).MountPoint, mountPoint)) continue;
+                var key = entry.Value!;
+                var type = key.GetType();
+                return (type.GetField("Item1")!.GetValue(key), type.GetField("Item2")!.GetValue(key),
+                    type.GetField("Item3")!.GetValue(key), type.GetField("Item4")!.GetValue(key));
+            }
+            throw new InvalidOperationException("no inline fiber renders into " + mountPoint.name);
+        }
+
+        [Test]
+        public void Given_APortalChildComponentNestedUnderAHostElement_When_TheSameShapeIsRenderedOutsideThePortal_Then_TheirRegistryKeysDifferOnlyInTheScope()
+        {
+            // Arrange
+            var container = new VisualElement();
+            var target = new VisualElement();
+            FiberPortalRegistry.Register("continuity-target", target);
+            _mounted = V.Mount(container, V.Component(HostNestedTwinHost, key: "host"));
+            _mounted.FlushEffectsForTest();
+            var placeholder = _mounted.Root.Reconciler.Context.PortalState.Keys.Single();
+
+            // Act
+            var inside = InlineKeyForOutputIn(_mounted, target.Q<VisualElement>("portal-wrap"));
+            var outside = InlineKeyForOutputIn(_mounted, container.Q<VisualElement>("inline-wrap"));
+
+            // Assert — the three other members being equal is what says the two shapes collide this deep
+            // at all; a scope naming the placeholder on one side and nothing on the other is the whole of
+            // what holds them apart.
+            Assert.That(
+                (ReferenceEquals(inside.Parent, outside.Parent), Equals(inside.PositionKey, outside.PositionKey),
+                    ReferenceEquals(inside.Identity, outside.Identity), inside.Scope, outside.Scope),
+                Is.EqualTo((true, true, true, (object?)placeholder, (object?)null)));
         }
 
         private static readonly ComponentContext<string> ScopeContext = ComponentContext<string>.Create("outside");
@@ -385,6 +628,56 @@ namespace Velvet.Tests
             Assert.That(
                 (s_contextSeen, Names(container.Q<VisualElement>("scope-host"))),
                 Is.EqualTo(("inside", "|sibling-1")));
+        }
+
+        private static string s_deepSeen;
+        private static StateUpdater<int> s_setDeepTick;
+
+        [Component]
+        private static VNode DeepConsumer()
+        {
+            s_deepSeen = Hooks.UseContext(ScopeContext);
+            var (tick, setTick) = Hooks.UseState(0);
+            s_setDeepTick = setTick;
+            return V.Div(name: "deep-" + tick);
+        }
+
+        // A component level between the portal and the consumer, so the consumer's registry parent is a
+        // fiber inside the portal rather than the declaring one — the level at which the portal scope has
+        // been dropped again, and the spine has to look the consumer up without it.
+        [Component]
+        private static VNode DeepMiddle()
+            => V.Provider(ScopeContext, "inside", new VNode[] { V.Component(DeepConsumer) });
+
+        [Component]
+        private static VNode DeepPortalHost()
+            => V.Div(name: "deep-host", children: new VNode?[]
+            {
+                V.Portal("continuity-target", children: new VNode?[] { V.Component(DeepMiddle) }),
+            });
+
+        // GREEN_ON_BASE(characterization): the base has no portal scope in the key at all, so its spine
+        // asks the one question there is and this reads the same there. The scope makes the question two,
+        // and asking the wrong one of a consumer this deep loses the Provider — measured, with the whole
+        // of PortalContextInheritanceTests still green, because its consumers are the portal's own
+        // children rather than a level below one.
+        [Test]
+        public void Given_AConsumerBelowAComponentInsideAPortal_When_ItReRendersAlone_Then_ItStillReadsTheProviderAroundIt()
+        {
+            // Arrange
+            var container = new VisualElement();
+            var target = new VisualElement();
+            FiberPortalRegistry.Register("continuity-target", target);
+            _mounted = V.Mount(container, V.Component(DeepPortalHost, key: "host"));
+            _mounted.FlushEffectsForTest();
+
+            // Act
+            s_setDeepTick.Invoke(1);
+            _mounted.FlushStateForTest();
+
+            // Assert — the element name is folded in because the value read at mount is "inside" either
+            // way, so only a name carrying the new tick says the re-render happened at all.
+            Assert.That((s_deepSeen, Names(target)), Is.EqualTo(("inside", "deep-1")));
         }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/PortalChildFiberContinuityTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/PortalChildFiberContinuityTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ae9ca4354529547e383fa08dd398b51f

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/PortalRegistryRetargetTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/PortalRegistryRetargetTests.cs
@@ -33,9 +33,11 @@ namespace Velvet.Tests
     /// orders and after either range has moved the other. A component rendering nothing at all is
     /// disposed on the same terms — as the portal's only child, and as a trailing one adding no slot
     /// to a range its siblings gave.</item>
-    /// <item>A component that leaves the portal's children for a position outside it survives the portal
-    /// closing, while a sibling that stayed under the portal is disposed by that same close — whether the
-    /// leaver left in an earlier render or in the very render that closes the portal.</item>
+    /// <item>A component written outside the portal in the render that leaves the portal's children is
+    /// left standing at its new position by the close, while a sibling that stayed under the portal is
+    /// disposed by that same close — whether the leaver left in an earlier render or in the very render
+    /// that closes the portal. It is a fresh instance there, which
+    /// <see cref="PortalChildFiberContinuityTests"/> owns.</item>
     /// <item>A component the portal's child mounted on its own, in a re-render no portal reconcile was in
     /// flight for, is disposed with the portal all the same.</item>
     /// </list>
@@ -580,12 +582,11 @@ namespace Velvet.Tests
             return V.Div(name: "staying");
         }
 
-        // The "c" component is written into the portal's children by a PATCH rather than by the mount, which
-        // is what gives it the same registry key its position outside the portal takes: both register under
-        // the fiber declaring the portal, and an explicit key makes the position within that fiber
-        // irrelevant. "stay" never leaves the portal, so the close has a disposal of its own to make:
-        // without one, a close that takes nothing further and a close that takes nothing at all produce the
-        // same reading.
+        // The "c" component is written into the portal's children by a PATCH rather than by the mount, and
+        // an explicit key makes its position within the declaring fiber irrelevant, so the two occurrences
+        // of it agree on every part of the registry key except the portal scope. "stay" never leaves the
+        // portal, so the close has a disposal of its own to make: without one, a close that takes nothing
+        // further and a close that takes nothing at all produce the same reading.
         [Component]
         private static VNode ReHomingPortalHost()
         {
@@ -637,13 +638,17 @@ namespace Velvet.Tests
                 Is.EqualTo((true, 0, 1)));
         }
 
+        // GREEN_ON_BASE(characterization): the close reaching no further than its own children is what the
+        // base does too. What the reading no longer carries is the cleanup count: the component leaves one
+        // position for another and mounts fresh at the new one, so a cleanup runs in this render for the
+        // move rather than for the close, and counting it here cannot tell the two apart.
         [Test]
-        public void Given_AComponentReHomedInThePortalsClosingRender_When_ThatRenderCommits_Then_ItSurvivesTheClose()
+        public void Given_AComponentWrittenOutsideAPortalInItsClosingRender_When_ThatRenderCommits_Then_TheCloseLeavesItsNewPositionAlone()
         {
             // Arrange — the same host driven straight from phase 1 to phase 3, so the component leaves the
-            // portal's children and the portal goes in ONE render. The inline walk carries the fiber to its
-            // outside position before FinalizeGeneralCommit removes the portal; the phase-2 stop above puts
-            // the removal first instead, which is why it cannot stand in for this.
+            // portal's children and the portal goes in ONE render. The inline walk reaches its outside
+            // position before FinalizeGeneralCommit removes the portal; the phase-2 stop above puts the
+            // removal first instead, which is why it cannot stand in for this.
             var container = new VisualElement();
             var target = new VisualElement();
             FiberPortalRegistry.Register("notify-target", target);
@@ -651,7 +656,6 @@ namespace Velvet.Tests
             s_setRehomePhase.Invoke(1);
             _mounted.FlushStateForTest();
             _mounted.FlushEffectsForTest();
-            s_childCleanups = 0;
             s_stayingCleanups = 0;
 
             // Act
@@ -659,10 +663,12 @@ namespace Velvet.Tests
             _mounted.FlushStateForTest();
             _mounted.FlushEffectsForTest();
 
-            // Assert — the same reading as the phase-2 stop above, and folded for the same reasons.
+            // Assert — the staying child's disposal is folded in because a close that reaches nothing at all
+            // leaves the new position standing just as well, and the element is the reading because a close
+            // that took the new position too would have unmounted it.
             Assert.That(
-                (s_stayingCleanups > 0, s_childCleanups, container.Query<VisualElement>("content").ToList().Count),
-                Is.EqualTo((true, 0, 1)));
+                (s_stayingCleanups > 0, container.Query<VisualElement>("content").ToList().Count),
+                Is.EqualTo((true, 1)));
         }
 
         private static StateUpdater<bool> s_setLateChildShown;


### PR DESCRIPTION
A `V.Component` written as a top-level child of a `V.Portal` did not survive a patch of that
portal's children. Its hook state reset, its effects re-ran, its previous instance's cleanups never
ran at all, and the element it had rendered stayed behind in the target.

`Documentation~/portals.md` opens by promising that a portal's children "stay part of the logical
tree — context, state and re-renders flow from the call site". That held for every child position
except this one.

## Why the lookup missed

`ComponentRegistry` keys an inline-mounted fiber on `(parentFiber, positionKey, identity)`. A
portal's top-level children mount in `ChildReconciler.DrainPendingPortalMounts`, which runs from the
top-level reconcile's `finally` — long after the declaring component's own fiber came off
`FiberStack`, so `FiberStack.Current` there is the reconcile root. Every later patch of the same
portal reaches `FiberNodePatcher.PatchPortalChildren` from the reconcile of the tree the declaring
component itself returned, with that component's own fiber current.

The registry's inline table across a mount and the first patch, on `main`:

```
after mount:     parent=F(<Mount>b__0)  pos=c  ident=DiagChild  -> F252644992(DiagChild)
after 1 patch:   parent=F(<Mount>b__0)  pos=c  ident=DiagChild  -> F252644992(DiagChild)
                 parent=F(HostKeyed)    pos=c  ident=DiagChild  -> F-2127519168(DiagChild)
```

Same `positionKey`, same `identity`, different `parentFiber`. The patch looks under the declaring
fiber, finds nothing, and builds a second instance. The mount-time entry is never reached again and
never disposed, so its element sits in the target for the life of the tree.

The drain now pushes the declaring fiber it already captures at enqueue (`LogicalParent`, which
`PortalState.DeclaringFiber` records anyway) around its nested reconcile, so both halves of the
portal's life agree on the registry parent. This is the same push, for the same registry-parent
reason, that `Reconciler.BeginDetachedItemScope` already does for a `V.VirtualList`'s
controller-mounted items.

## The measured cost, corrected

#611 reports the child's mount effect running 1 / 3 / 5 for 0 / 1 / 2 patches — two extra instances
per patch, without bound. That is not what happens. Measured on `main` across four host shapes — an
unkeyed child, a keyed child, a portal nested under a `V.Div`, and a portal whose only child is the
component — the count is **1 / 2 / 2 / 2**: one extra instance at the *first* patch, then stable,
because the second instance registers under the declaring fiber and every later patch finds it.

What is unbounded is not the instance count but the consequence: cleanups stay at 0 forever, and the
target keeps an element nothing owns. A portal declared as
`children: [V.Component(Child), V.Div(name: "sib-" + n)]` read `content|sib-1|sib-0` after one patch
instead of `content|sib-1`.

## #601 is a different defect, and half of it is not a defect

#611 asked whether it and #601 share a cause. They do not, and the two sentences are different:

- **#611** — the lookup is reached and misses on `parentFiber`, per the table above.
- **#601** — the key is identical on both sides, the lookup is reached, and it misses because the
  entry has *already been removed*. The departing container's own reconcile disposes the fiber as an
  orphan before the walk reaches the component's new position. An ordered event log across the
  re-home render reads `cleanup, body, setup`.

The control that separates them carries no portal at all: a keyed `V.Component` moved from
`V.Div(name: "A")` to a sibling `V.Div(name: "B")` under the same declaring component produces the
identical reading — `cleanup, body, setup`, one setup gained, one cleanup run, and a fresh fiber
under the byte-identical registry key. So a keyed component changing parent is unmounted and
remounted whether or not a portal is involved, which is what React does for a keyed element that
changes parent and what the portals guide already states of a move.

What #601 additionally observed — an element mounted in the target with no fiber registered for it —
is the leak this PR fixes, not a second mechanism. With the fix the portal target holds nothing of a
component that has re-homed out of it; before it, the target kept the mount-time instance's element.
That case is pinned here. The remaining loss of state on a re-home is left as it is.

## #610 is the other half of the same key, so it is fixed here

`ReconcileExistingFiber` is one method, and it writes three fields that all say where a fiber's
output lives. On a carry it updated `MountSlotStart` and `OwningPortalPlaceholder` and left
`MountPoint` at the container the fiber was created in — so a fiber carried elsewhere re-rendered
itself into the container it had left, at the *new* container's slot index. Splitting that into a
second pull request would mean shipping a registry whose position fields disagree with each other.

Every reader of `MountPoint` in `Runtime/` wants the current position:

| reader | what it does with the VE |
|---|---|
| `ComponentRegistry.DisposeFibersUnder`, `GeneralPathReconciler` orphan sweep | containment test for "is this fiber inside a subtree leaving the DOM" |
| `FiberRenderer.Unmount`, `FiberErrorBoundary` | reconciles the fiber's own committed output away / into a fallback |
| `FiberWorkLoop`, `FiberCommitWork` isolated re-render | `Reconcile(MountPoint, …, slotStart: MountSlotStart)` — paired with an already-current field |
| `FiberCommitWork.NextInlineSiblingSlotStart` | groups co-located siblings, compared against `MountSlotStart` |
| `FiberWorkLoop.IsHostDetachedFromRoot` | VE-root comparison deciding whether to suppress a flush |
| `FiberEffects`, `FiberBatchScheduler`, `Hooks.UseFrame`, the `schedule.Execute` sites | reaches `.panel` / `.schedule` |
| `FiberCrossPanelInput` | start element for walking outward to the logical chain |

The one that could want the creation position, `FiberContextSpine.PushOutletHost`, reads a
**wrapper-mounted** fiber's `MountPoint`. A wrapper-mounted fiber's registry key *is* its wrapper VE,
so a different container is a different key: it structurally cannot see a carried fiber.

## What this does not fix, and what it changes there

#409 — two components at the same unkeyed position in *different* containers sharing one instance —
is untouched and stays open. This is the same key failing from the other end, and #409 already names
this consequence: "the fiber's `MountPoint` stays the first container, so a `setState` in either
re-renders only the left panel".

Which container goes stale does change, and it was measured rather than reasoned:

| | `main` | here |
|---|---|---|
| mount | `left=[n0] right=[n0]` | `left=[n0] right=[n0]` |
| after `setState(1)` | `left=[n1] right=[n0]` | `left=[n0] right=[n1]` |
| after `setState(2)` | `left=[n2] right=[n0]` | `left=[n0] right=[n2]` |

Both are wrong while #409 stands. The difference is that `MountSlotStart` was *already* the right
panel's, so `main` reconciles into the left container at the right container's slot index; the two
position fields now agree, which is a precondition for fixing #409 rather than a fix of it. The
workaround is unchanged: give each occurrence a distinct `key:`.

## Tests

`PortalChildFiberContinuityTests` (EditMode). Five cases red on the base with production reverted and
the tests unchanged — the first four with all production reverted, the fifth with only
`ComponentRegistry` reverted, so it is measured against the portal fix rather than through it:

```
Given_..._Then_ItsMountEffectDoesNotRunAgain          Expected: (1, content|sib-1)  But was: (2, content|sib-1|sib-0)
Given_..._Then_TheTargetKeepsOneElementForIt          Expected: "content|sib-1"     But was: "content|sib-1|sib-0"
Given_..._Then_ItKeepsThatState                       Expected: (7, content|sib-1)  But was: (0, content|sib-1|sib-0)
Given_..._Then_TheTargetKeepsNoElementForIt           Expected: (0, 1)              But was: (1, 1)
Given_..._Then_ItWritesIntoTheContainerItIsIn         Expected: (b, c, )            But was: (b, b, c)
```

That last one reads the mark after the carry, the container the component now occupies, and the one
it left. The post-carry term is load-bearing: a fiber rebuilt instead of carried would reach `c` in
the right container too, and would read `a` there.

A sixth case pins that the fiber the drain pushes comes back off the stack. It carries a
`GREEN_ON_BASE(characterization)` declaration, because it pins a balance the base does not have —
the base pushes nothing there, so it is even for want of a push rather than by unwinding one.
`scripts/test_quality/mutation_check.py` measured that removing the matching `Pop` leaves the whole
EditMode suite green, which is why the case exists.

EditMode 3885 passed / 0 failed / 0 inconclusive; PlayMode 161 passed / 0 failed / 0 inconclusive.

## Documentation

No guide change. `Documentation~/portals.md` already states the contract this restores, and already
states that a move between containers is an unmount and a remount — the behaviour the control above
confirms is unchanged. `CHANGELOG.md` gains an entry under `[Unreleased] / Fixed`, since a component
child of a portal keeping its state across a patch is user-visible, as is a carried component
re-rendering into the container it occupies — including the note about which container goes stale in
the shared-instance case above.

Closes #611
Closes #610

