### PR TITLE
fix(velvet): record the out-of-range variant throw, and fail the build on an unclassified kind

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -40,7 +40,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   produce a wrong layout instead of a stack trace. The classification switches this comes from are now
   exhaustive by compilation rather than by review — `Runtime/csc.rsp` compiles CS8509 as an error — so a
   `StyleVariantKind` member added without an arm fails the build rather than warning into a log that
-  nothing gates on.
+  nothing gates on. That response file ships with the package, so a project compiling `Velvet.asmdef`
+  compiles CS8509 as an error too; it applies to Velvet's own sources only, and none of the switches it
+  reaches is over an engine-owned enum.
 
 ### Fixed
 

--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -34,6 +34,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   arguments positionally past `isPasswordField` now binds them to different parameters. Every argument
   there but a `null` literal changes type across the shift, so such a call fails to compile rather than
   rebinding silently; pass them by name.
+- `StyleVariantClass.BreakpointPx` and `IsResponsive` throw for a value naming no `StyleVariantKind`,
+  where they answered `0f` and `false` before 2.0.1. Every named kind is answered as it was; only a cast
+  outside the enum's range reaches the throw, and a silent `0f` there is how such a cast survives to
+  produce a wrong layout instead of a stack trace. The classification switches this comes from are now
+  exhaustive by compilation rather than by review — `Runtime/csc.rsp` compiles CS8509 as an error — so a
+  `StyleVariantKind` member added without an arm fails the build rather than warning into a log that
+  nothing gates on.
 
 ### Fixed
 

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/ExhaustiveSwitchSeverityTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/ExhaustiveSwitchSeverityTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Text.RegularExpressions;
 using NUnit.Framework;
 
@@ -13,8 +14,15 @@ namespace Velvet.Tests
     /// covers, and a catch-all arm silences that in turn. So the suppression is held to an assembly whose
     /// <c>csc.rsp</c> raises CS8509 to an error, and to opening no arm for a new member to fall into.
     /// <para>
-    /// The second half reaches a catch-all written on its own line, which is how every arm in these
-    /// switches is written. An arm sharing a line with the one before it is not reached.
+    /// The arms are read out of the switch expressions themselves rather than off the lines, because these
+    /// switches are not written one arm per line — <c>PriorityFor</c> in
+    /// <c>StyleRelationalVariantManipulator</c> puts the pattern on one line and its <c>=&gt;</c> on the
+    /// next, and a catch-all written in that style is what a line reading misses. Comment and string
+    /// content is blanked first, so a catch-all quoted in either is not one.
+    /// <para/>
+    /// A region opened by a file-scoped suppression runs to the end of the file, so an unrelated switch
+    /// expression inside it is read as well. Scoping the suppression to the switch it means is the answer
+    /// to that, and it is what every region here already does.
     /// </para>
     /// </summary>
     [TestFixture]
@@ -22,16 +30,18 @@ namespace Velvet.Tests
     {
         private const string PackageRoot = "Packages/com.velvet.core";
         private const string Severity = "-warnaserror:CS8509";
-        private const string SuppressedCode = "CS8524";
 
         private static readonly Regex PragmaDirective = new(
-            @"^\s*#pragma\s+warning\s+(?<kind>disable|restore)\s+(?<codes>.*)$", RegexOptions.Compiled);
+            @"^[ \t]*#pragma\s+warning\s+(?<kind>disable|restore)(?<codes>[^\r\n]*)$",
+            RegexOptions.Compiled | RegexOptions.Multiline);
 
         // `_` and `var x` are catch-alls outright; two bare identifiers are a type pattern (`StyleVariantKind
         // other =>`), which is what someone writes to get the offending value in scope. A constant arm carries
-        // a '.' in its single token, so it does not match.
+        // a '.' in its single token, so it does not match. Anchored on the arm list's opening brace or a
+        // comma, so it reads patterns rather than anything else an arm's body contains.
         private static readonly Regex CatchAllArm = new(
-            @"^\s*(_|var\s+[A-Za-z_]\w*|[A-Za-z_][\w.]*\s+[A-Za-z_]\w*)\s*(=>|when\b)", RegexOptions.Compiled);
+            @"[{,]\s*(_|var\s+[A-Za-z_]\w*|[A-Za-z_][\w.]*\s+[A-Za-z_]\w*)\s*(=>|when\b)",
+            RegexOptions.Compiled);
 
         // Test material is out of scope and deliberately carries no severity flag. TestUtilities is named
         // because it holds no `/Tests/` segment while being test material by every other reckoning —
@@ -48,52 +58,94 @@ namespace Velvet.Tests
                 .Where(IsProduction)
                 .OrderBy(path => path, StringComparer.Ordinal);
 
-        private static string Codes(Match directive)
+        /// <summary>
+        /// The source with comment and string-literal content replaced by spaces, same length and same
+        /// newlines. Every index below is therefore an index into the original too.
+        /// </summary>
+        // One alternation scanned left to right, so whichever of the five opens first at a position claims
+        // the run: a `//` inside a string belongs to the string, and a quote inside a comment to the comment.
+        private static readonly Regex CommentOrLiteral = new(
+            @"//[^\r\n]*|/\*.*?\*/|@""(?:[^""]|"""")*""|""(?:\\.|[^""\\])*""|'(?:\\.|[^'\\])*'",
+            RegexOptions.Compiled | RegexOptions.Singleline);
+
+        private static string Redacted(string source)
         {
-            var codes = directive.Groups["codes"].Value;
-            var comment = codes.IndexOf("//", StringComparison.Ordinal);
-            return comment < 0 ? codes : codes.Substring(0, comment);
+            var blanked = new StringBuilder(source);
+            foreach (Match run in CommentOrLiteral.Matches(source))
+            {
+                for (var i = run.Index; i < run.Index + run.Length; i++)
+                {
+                    blanked[i] = source[i] == '\n' || source[i] == '\r' ? source[i] : ' ';
+                }
+            }
+
+            return blanked.ToString();
         }
 
         /// <summary>
-        /// Each region a production source suppresses <see cref="SuppressedCode"/> over, as (path, 1-based
-        /// opening line, body).
+        /// The brace-delimited arm list of each switch EXPRESSION in <paramref name="redacted"/>. A switch
+        /// statement is `switch (` and never reaches the brace test, so it is not one of these.
+        /// </summary>
+        private static IEnumerable<(int Start, int End)> SwitchArmLists(string redacted)
+        {
+            foreach (Match keyword in Regex.Matches(redacted, @"\bswitch\b"))
+            {
+                var i = keyword.Index + keyword.Length;
+                while (i < redacted.Length && char.IsWhiteSpace(redacted[i])) { i++; }
+                if (i >= redacted.Length || redacted[i] != '{') { continue; }
+
+                var depth = 0;
+                for (var j = i; j < redacted.Length; j++)
+                {
+                    if (redacted[j] == '{') { depth++; }
+                    else if (redacted[j] == '}' && --depth == 0) { yield return (i, j); break; }
+                }
+            }
+        }
+
+        private static int LineOf(string text, int index) =>
+            text.Take(index).Count(c => c == '\n') + 1;
+
+        /// <summary>
+        /// Each region a production source suppresses CS8524 over, as (path, source, 1-based opening line,
+        /// start, end).
         /// <para>
-        /// Read line by line rather than as a disable/restore pair, because a pair requires the restore to
-        /// exist: a file-scoped suppression written without one is legal C# and dropped the whole file out
-        /// of both cases. An unclosed region runs to end of file; a directive for another code inside one
-        /// does not end it.
+        /// Read directive by directive rather than as a disable/restore pair, because a pair requires the
+        /// restore to exist: a file-scoped suppression written without one is legal C# and dropped the whole
+        /// file out of both cases. An unclosed region runs to end of file; a directive for another code
+        /// inside one does not end it. A directive naming no code at all suppresses everything, so it opens
+        /// or closes a region like one that names this code.
         /// </para>
         /// </summary>
-        private static IEnumerable<(string Path, int Line, string Body)> SuppressedRegions()
+        private static IEnumerable<(string Path, string Redacted, int Line, int Start, int End)> SuppressedRegions()
         {
             foreach (var path in ProductionSources())
             {
-                var lines = File.ReadAllLines(path);
+                var redacted = Redacted(File.ReadAllText(path));
                 var open = -1;
-                for (var i = 0; i < lines.Length; i++)
+                var openLine = 0;
+                foreach (Match directive in PragmaDirective.Matches(redacted))
                 {
-                    var directive = PragmaDirective.Match(lines[i]);
-                    if (!directive.Success || !Codes(directive).Contains(SuppressedCode, StringComparison.Ordinal))
-                    {
-                        continue;
-                    }
+                    var codes = directive.Groups["codes"].Value;
+                    var named = Regex.Matches(codes, @"\d+").Select(m => m.Value).ToList();
+                    if (named.Count > 0 && !named.Contains("8524")) { continue; }
 
                     if (open >= 0)
                     {
-                        yield return (path, open + 1, string.Join("\n", lines.Skip(open + 1).Take(i - open - 1)));
+                        yield return (path, redacted, openLine, open, directive.Index);
                         open = -1;
                     }
 
                     if (directive.Groups["kind"].Value == "disable")
                     {
-                        open = i;
+                        open = directive.Index + directive.Length;
+                        openLine = LineOf(redacted, directive.Index);
                     }
                 }
 
                 if (open >= 0)
                 {
-                    yield return (path, open + 1, string.Join("\n", lines.Skip(open + 1)));
+                    yield return (path, redacted, openLine, open, redacted.Length);
                 }
             }
         }
@@ -139,10 +191,10 @@ namespace Velvet.Tests
             Assert.That((suppressing.Count >= 2, string.Join("\n", unguarded)), Is.EqualTo((true, string.Empty)));
         }
 
-        // GREEN_ON_BASE(characterization): no such region carries a catch-all on either side; what the
-        // branch adds is the error that makes adding one the tempting answer.
+        // GREEN_ON_BASE(characterization): no switch in these regions carries a catch-all on either side;
+        // what the branch adds is the error that makes adding one the tempting answer.
         [Test]
-        public void Given_EveryRegionSuppressingCs8524_When_ItsArmsAreRead_Then_NoneOpensACatchAll()
+        public void Given_EverySwitchInARegionSuppressingCs8524_When_ItsArmsAreRead_Then_NoneOpensACatchAll()
         {
             // Arrange — this is the escape from the case above: a member added without an arm fails the
             // build, and answering that with a catch-all makes it build and silently classify as whatever
@@ -150,12 +202,23 @@ namespace Velvet.Tests
             var regions = SuppressedRegions().ToList();
 
             // Act
-            var falling = regions
-                .Where(region => region.Body.Split('\n').Any(line => CatchAllArm.IsMatch(line)))
-                .Select(region => Path.GetFileName(region.Path) + ":" + region.Line)
-                .ToList();
+            var falling = new List<string>();
+            foreach (var region in regions)
+            {
+                foreach (var (start, end) in SwitchArmLists(region.Redacted))
+                {
+                    if (start < region.Start || end > region.End) { continue; }
+                    var arm = CatchAllArm.Match(region.Redacted, start, end - start);
+                    if (arm.Success)
+                    {
+                        falling.Add(Path.GetFileName(region.Path) + ":" + LineOf(region.Redacted, arm.Index));
+                    }
+                }
+            }
 
-            // Assert — same floor, for the same reason.
+            // Assert — the floor is on the regions rather than on the switches, because a region holding no
+            // switch expression is a suppression with nothing to suppress and worth seeing as a failure of
+            // this reading rather than as agreement.
             Assert.That((regions.Count >= 2, string.Join("\n", falling)), Is.EqualTo((true, string.Empty)));
         }
     }

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/ExhaustiveSwitchSeverityTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/ExhaustiveSwitchSeverityTests.cs
@@ -31,14 +31,18 @@ namespace Velvet.Tests
         private const string PackageRoot = "Packages/com.velvet.core";
         private const string Severity = "-warnaserror:CS8509";
 
+        // The `\r?` is what keeps a CRLF working tree from matching no directive at all and leaving both
+        // cases green over nothing: .NET's `$` matches before `\n` and not before `\r\n`. `.gitattributes`
+        // pins these sources to LF, so this is belt and braces rather than a state reachable here.
         private static readonly Regex PragmaDirective = new(
-            @"^[ \t]*#pragma\s+warning\s+(?<kind>disable|restore)(?<codes>[^\r\n]*)$",
+            @"^[ \t]*#pragma\s+warning\s+(?<kind>disable|restore)(?<codes>[^\r\n]*)\r?$",
             RegexOptions.Compiled | RegexOptions.Multiline);
 
         // `_` and `var x` are catch-alls outright; two bare identifiers are a type pattern (`StyleVariantKind
-        // other =>`), which is what someone writes to get the offending value in scope. A constant arm carries
-        // a '.' in its single token, so it does not match. Anchored on the arm list's opening brace or a
-        // comma, so it reads patterns rather than anything else an arm's body contains.
+        // other =>`), which is what someone writes to get the offending value in scope. A constant arm is one
+        // token where this needs two, which is what excludes it; the '.' the alternative allows is there so a
+        // qualified type pattern still matches. Anchored on the arm list's opening brace or a comma, so it
+        // reads patterns rather than anything else an arm's body contains.
         private static readonly Regex CatchAllArm = new(
             @"[{,]\s*(_|var\s+[A-Za-z_]\w*|[A-Za-z_][\w.]*\s+[A-Za-z_]\w*)\s*(=>|when\b)",
             RegexOptions.Compiled);

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/ExhaustiveSwitchSeverityTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/ExhaustiveSwitchSeverityTests.cs
@@ -10,8 +10,12 @@ namespace Velvet.Tests
     /// <summary>
     /// Holds the two halves of what suppressing CS8524 declares. Suppressing it says the arms cover the
     /// enum and the only uncovered input is a cast; CS8509 is then the sole report of a member no arm
-    /// covers, and a discard arm silences that in turn. So the suppression is held to an assembly whose
-    /// <c>csc.rsp</c> raises CS8509 to an error, and to having no discard arm to fall into.
+    /// covers, and a catch-all arm silences that in turn. So the suppression is held to an assembly whose
+    /// <c>csc.rsp</c> raises CS8509 to an error, and to opening no arm for a new member to fall into.
+    /// <para>
+    /// The second half reaches a catch-all written on its own line, which is how every arm in these
+    /// switches is written. An arm sharing a line with the one before it is not reached.
+    /// </para>
     /// </summary>
     [TestFixture]
     internal sealed class ExhaustiveSwitchSeverityTests
@@ -20,41 +24,76 @@ namespace Velvet.Tests
         private const string Severity = "-warnaserror:CS8509";
         private const string SuppressedCode = "CS8524";
 
-        // Matched rather than searched for as a literal, so a site suppressing a second code alongside —
-        // `disable CS8524, CS0618`, the natural spelling once one is needed — stays in scope instead of
-        // dropping out while the other sites keep the set non-empty.
-        private static readonly Regex SuppressedBlock = new(
-            @"#pragma\s+warning\s+disable\s+(?<codes>[^\r\n]*)\r?\n(?<body>.*?)#pragma\s+warning\s+restore",
-            RegexOptions.Compiled | RegexOptions.Singleline);
+        private static readonly Regex PragmaDirective = new(
+            @"^\s*#pragma\s+warning\s+(?<kind>disable|restore)\s+(?<codes>.*)$", RegexOptions.Compiled);
 
-        private static readonly Regex DiscardArm = new(@"^\s*_\s*(=>|when\b)", RegexOptions.Compiled);
+        // `_` and `var x` are catch-alls outright; two bare identifiers are a type pattern (`StyleVariantKind
+        // other =>`), which is what someone writes to get the offending value in scope. A constant arm carries
+        // a '.' in its single token, so it does not match.
+        private static readonly Regex CatchAllArm = new(
+            @"^\s*(_|var\s+[A-Za-z_]\w*|[A-Za-z_][\w.]*\s+[A-Za-z_]\w*)\s*(=>|when\b)", RegexOptions.Compiled);
 
         // Test material is out of scope and deliberately carries no severity flag. TestUtilities is named
         // because it holds no `/Tests/` segment while being test material by every other reckoning —
-        // base_red_check.py's `is_test_side` counts it by name for the same reason. Skipping them is also
-        // what keeps this file, which spells out the pragma it looks for, from matching itself.
+        // base_red_check.py's `is_test_side` counts it by name for the same reason.
         private static bool IsProduction(string path) =>
             !path.Contains("/Tests/", StringComparison.Ordinal)
             && !path.Contains("/TestUtilities/", StringComparison.Ordinal)
             && !path.Contains("Generators~", StringComparison.Ordinal)
             && !path.Contains("Samples~", StringComparison.Ordinal);
 
-        private static IEnumerable<(string File, Match Block)> SuppressingBlocks()
+        private static IEnumerable<string> ProductionSources() =>
+            Directory.EnumerateFiles(Path.GetFullPath(PackageRoot), "*.cs", SearchOption.AllDirectories)
+                .Select(path => path.Replace('\\', '/'))
+                .Where(IsProduction)
+                .OrderBy(path => path, StringComparer.Ordinal);
+
+        private static string Codes(Match directive)
         {
-            foreach (var path in Directory
-                         .EnumerateFiles(Path.GetFullPath(PackageRoot), "*.cs", SearchOption.AllDirectories)
-                         .Select(path => path.Replace('\\', '/'))
-                         .Where(IsProduction)
-                         .OrderBy(path => path, StringComparer.Ordinal))
+            var codes = directive.Groups["codes"].Value;
+            var comment = codes.IndexOf("//", StringComparison.Ordinal);
+            return comment < 0 ? codes : codes.Substring(0, comment);
+        }
+
+        /// <summary>
+        /// Each region a production source suppresses <see cref="SuppressedCode"/> over, as (path, 1-based
+        /// opening line, body).
+        /// <para>
+        /// Read line by line rather than as a disable/restore pair, because a pair requires the restore to
+        /// exist: a file-scoped suppression written without one is legal C# and dropped the whole file out
+        /// of both cases. An unclosed region runs to end of file; a directive for another code inside one
+        /// does not end it.
+        /// </para>
+        /// </summary>
+        private static IEnumerable<(string Path, int Line, string Body)> SuppressedRegions()
+        {
+            foreach (var path in ProductionSources())
             {
-                foreach (Match block in SuppressedBlock.Matches(File.ReadAllText(path)))
+                var lines = File.ReadAllLines(path);
+                var open = -1;
+                for (var i = 0; i < lines.Length; i++)
                 {
-                    var codes = block.Groups["codes"].Value;
-                    var comment = codes.IndexOf("//", StringComparison.Ordinal);
-                    if ((comment < 0 ? codes : codes.Substring(0, comment)).Contains(SuppressedCode, StringComparison.Ordinal))
+                    var directive = PragmaDirective.Match(lines[i]);
+                    if (!directive.Success || !Codes(directive).Contains(SuppressedCode, StringComparison.Ordinal))
                     {
-                        yield return (Path.GetFileName(path), block);
+                        continue;
                     }
+
+                    if (open >= 0)
+                    {
+                        yield return (path, open + 1, string.Join("\n", lines.Skip(open + 1).Take(i - open - 1)));
+                        open = -1;
+                    }
+
+                    if (directive.Groups["kind"].Value == "disable")
+                    {
+                        open = i;
+                    }
+                }
+
+                if (open >= 0)
+                {
+                    yield return (path, open + 1, string.Join("\n", lines.Skip(open + 1)));
                 }
             }
         }
@@ -80,13 +119,7 @@ namespace Velvet.Tests
         public void Given_EveryProductionSourceSuppressingCs8524_When_ItsAssemblyIsAsked_Then_Cs8509IsAnError()
         {
             // Arrange
-            var suppressing = Directory
-                .EnumerateFiles(Path.GetFullPath(PackageRoot), "*.cs", SearchOption.AllDirectories)
-                .Select(path => path.Replace('\\', '/'))
-                .Where(IsProduction)
-                .Where(path => SuppressedBlock.Matches(File.ReadAllText(path))
-                    .Any(block => block.Groups["codes"].Value.Contains(SuppressedCode, StringComparison.Ordinal)))
-                .ToList();
+            var suppressing = SuppressedRegions().Select(region => region.Path).Distinct().ToList();
 
             // Act
             var unguarded = new List<string>();
@@ -106,26 +139,24 @@ namespace Velvet.Tests
             Assert.That((suppressing.Count >= 2, string.Join("\n", unguarded)), Is.EqualTo((true, string.Empty)));
         }
 
-        // GREEN_ON_BASE(characterization): no such block carries a discard arm on either side; what the
+        // GREEN_ON_BASE(characterization): no such region carries a catch-all on either side; what the
         // branch adds is the error that makes adding one the tempting answer.
         [Test]
-        public void Given_EveryBlockSuppressingCs8524_When_ItsArmsAreRead_Then_NoneFallsToADiscard()
+        public void Given_EveryRegionSuppressingCs8524_When_ItsArmsAreRead_Then_NoneOpensACatchAll()
         {
             // Arrange — this is the escape from the case above: a member added without an arm fails the
-            // build, and answering that with a discard arm makes it build and silently classify as
-            // whatever the discard says.
-            var blocks = SuppressingBlocks().ToList();
+            // build, and answering that with a catch-all makes it build and silently classify as whatever
+            // the catch-all says.
+            var regions = SuppressedRegions().ToList();
 
             // Act
-            var falling = blocks
-                .Where(entry => entry.Block.Groups["body"].Value
-                    .Split('\n')
-                    .Any(line => DiscardArm.IsMatch(line)))
-                .Select(entry => entry.File)
+            var falling = regions
+                .Where(region => region.Body.Split('\n').Any(line => CatchAllArm.IsMatch(line)))
+                .Select(region => Path.GetFileName(region.Path) + ":" + region.Line)
                 .ToList();
 
             // Assert — same floor, for the same reason.
-            Assert.That((blocks.Count >= 2, string.Join("\n", falling)), Is.EqualTo((true, string.Empty)));
+            Assert.That((regions.Count >= 2, string.Join("\n", falling)), Is.EqualTo((true, string.Empty)));
         }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/ExhaustiveSwitchSeverityTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/ExhaustiveSwitchSeverityTests.cs
@@ -2,30 +2,62 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using NUnit.Framework;
 
 namespace Velvet.Tests
 {
     /// <summary>
-    /// Holds every production source that suppresses CS8524 — the discard-less classification switches — to
-    /// an assembly whose <c>csc.rsp</c> raises CS8509 to an error. Suppressing CS8524 is how a site declares
-    /// that its arms are meant to cover the enum; CS8509 is the only thing that then reports a member no arm
-    /// covers, and measured on this project it is a warning nothing gates on: the same probe member compiled
-    /// clean without the flag and failed the build with it.
+    /// Holds the two halves of what suppressing CS8524 declares. Suppressing it says the arms cover the
+    /// enum and the only uncovered input is a cast; CS8509 is then the sole report of a member no arm
+    /// covers, and a discard arm silences that in turn. So the suppression is held to an assembly whose
+    /// <c>csc.rsp</c> raises CS8509 to an error, and to having no discard arm to fall into.
     /// </summary>
     [TestFixture]
     internal sealed class ExhaustiveSwitchSeverityTests
     {
         private const string PackageRoot = "Packages/com.velvet.core";
-        private const string Suppression = "#pragma warning disable CS8524";
         private const string Severity = "-warnaserror:CS8509";
+        private const string SuppressedCode = "CS8524";
 
-        // Test assemblies are out of scope and deliberately carry no severity flag, and skipping them is also
-        // what keeps this file — which names the token it searches for — from matching itself.
+        // Matched rather than searched for as a literal, so a site suppressing a second code alongside —
+        // `disable CS8524, CS0618`, the natural spelling once one is needed — stays in scope instead of
+        // dropping out while the other sites keep the set non-empty.
+        private static readonly Regex SuppressedBlock = new(
+            @"#pragma\s+warning\s+disable\s+(?<codes>[^\r\n]*)\r?\n(?<body>.*?)#pragma\s+warning\s+restore",
+            RegexOptions.Compiled | RegexOptions.Singleline);
+
+        private static readonly Regex DiscardArm = new(@"^\s*_\s*(=>|when\b)", RegexOptions.Compiled);
+
+        // Test material is out of scope and deliberately carries no severity flag. TestUtilities is named
+        // because it holds no `/Tests/` segment while being test material by every other reckoning —
+        // base_red_check.py's `is_test_side` counts it by name for the same reason. Skipping them is also
+        // what keeps this file, which spells out the pragma it looks for, from matching itself.
         private static bool IsProduction(string path) =>
             !path.Contains("/Tests/", StringComparison.Ordinal)
+            && !path.Contains("/TestUtilities/", StringComparison.Ordinal)
             && !path.Contains("Generators~", StringComparison.Ordinal)
             && !path.Contains("Samples~", StringComparison.Ordinal);
+
+        private static IEnumerable<(string File, Match Block)> SuppressingBlocks()
+        {
+            foreach (var path in Directory
+                         .EnumerateFiles(Path.GetFullPath(PackageRoot), "*.cs", SearchOption.AllDirectories)
+                         .Select(path => path.Replace('\\', '/'))
+                         .Where(IsProduction)
+                         .OrderBy(path => path, StringComparer.Ordinal))
+            {
+                foreach (Match block in SuppressedBlock.Matches(File.ReadAllText(path)))
+                {
+                    var codes = block.Groups["codes"].Value;
+                    var comment = codes.IndexOf("//", StringComparison.Ordinal);
+                    if ((comment < 0 ? codes : codes.Substring(0, comment)).Contains(SuppressedCode, StringComparison.Ordinal))
+                    {
+                        yield return (Path.GetFileName(path), block);
+                    }
+                }
+            }
+        }
 
         private static string? AssemblyDirectoryOf(string file)
         {
@@ -52,9 +84,9 @@ namespace Velvet.Tests
                 .EnumerateFiles(Path.GetFullPath(PackageRoot), "*.cs", SearchOption.AllDirectories)
                 .Select(path => path.Replace('\\', '/'))
                 .Where(IsProduction)
-                .Where(path => File.ReadAllText(path).Contains(Suppression, StringComparison.Ordinal))
+                .Where(path => SuppressedBlock.Matches(File.ReadAllText(path))
+                    .Any(block => block.Groups["codes"].Value.Contains(SuppressedCode, StringComparison.Ordinal)))
                 .ToList();
-            Assume.That(suppressing, Is.Not.Empty);
 
             // Act
             var unguarded = new List<string>();
@@ -69,8 +101,31 @@ namespace Velvet.Tests
                 }
             }
 
-            // Assert
-            Assert.That(unguarded, Is.Empty);
+            // Assert — the floor rides along because a package root that read empty reports nothing
+            // unguarded and would pass having measured nothing.
+            Assert.That((suppressing.Count >= 2, string.Join("\n", unguarded)), Is.EqualTo((true, string.Empty)));
+        }
+
+        // GREEN_ON_BASE(characterization): no such block carries a discard arm on either side; what the
+        // branch adds is the error that makes adding one the tempting answer.
+        [Test]
+        public void Given_EveryBlockSuppressingCs8524_When_ItsArmsAreRead_Then_NoneFallsToADiscard()
+        {
+            // Arrange — this is the escape from the case above: a member added without an arm fails the
+            // build, and answering that with a discard arm makes it build and silently classify as
+            // whatever the discard says.
+            var blocks = SuppressingBlocks().ToList();
+
+            // Act
+            var falling = blocks
+                .Where(entry => entry.Block.Groups["body"].Value
+                    .Split('\n')
+                    .Any(line => DiscardArm.IsMatch(line)))
+                .Select(entry => entry.File)
+                .ToList();
+
+            // Assert — same floor, for the same reason.
+            Assert.That((blocks.Count >= 2, string.Join("\n", falling)), Is.EqualTo((true, string.Empty)));
         }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/ExhaustiveSwitchSeverityTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/ExhaustiveSwitchSeverityTests.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using NUnit.Framework;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Holds every production source that suppresses CS8524 — the discard-less classification switches — to
+    /// an assembly whose <c>csc.rsp</c> raises CS8509 to an error. Suppressing CS8524 is how a site declares
+    /// that its arms are meant to cover the enum; CS8509 is the only thing that then reports a member no arm
+    /// covers, and measured on this project it is a warning nothing gates on: the same probe member compiled
+    /// clean without the flag and failed the build with it.
+    /// </summary>
+    [TestFixture]
+    internal sealed class ExhaustiveSwitchSeverityTests
+    {
+        private const string PackageRoot = "Packages/com.velvet.core";
+        private const string Suppression = "#pragma warning disable CS8524";
+        private const string Severity = "-warnaserror:CS8509";
+
+        // Test assemblies are out of scope and deliberately carry no severity flag, and skipping them is also
+        // what keeps this file — which names the token it searches for — from matching itself.
+        private static bool IsProduction(string path) =>
+            !path.Contains("/Tests/", StringComparison.Ordinal)
+            && !path.Contains("Generators~", StringComparison.Ordinal)
+            && !path.Contains("Samples~", StringComparison.Ordinal);
+
+        private static string? AssemblyDirectoryOf(string file)
+        {
+            var package = Path.GetFullPath(PackageRoot);
+            for (var dir = Directory.GetParent(file); dir != null; dir = dir.Parent)
+            {
+                if (Directory.EnumerateFiles(dir.FullName, "*.asmdef").Any())
+                {
+                    return dir.FullName;
+                }
+                if (string.Equals(dir.FullName, package, StringComparison.Ordinal))
+                {
+                    break;
+                }
+            }
+            return null;
+        }
+
+        [Test]
+        public void Given_EveryProductionSourceSuppressingCs8524_When_ItsAssemblyIsAsked_Then_Cs8509IsAnError()
+        {
+            // Arrange
+            var suppressing = Directory
+                .EnumerateFiles(Path.GetFullPath(PackageRoot), "*.cs", SearchOption.AllDirectories)
+                .Select(path => path.Replace('\\', '/'))
+                .Where(IsProduction)
+                .Where(path => File.ReadAllText(path).Contains(Suppression, StringComparison.Ordinal))
+                .ToList();
+            Assume.That(suppressing, Is.Not.Empty);
+
+            // Act
+            var unguarded = new List<string>();
+            foreach (var file in suppressing)
+            {
+                var assembly = AssemblyDirectoryOf(file);
+                var rsp = assembly == null ? null : Path.Combine(assembly, "csc.rsp");
+                if (rsp == null || !File.Exists(rsp)
+                    || !File.ReadAllText(rsp).Contains(Severity, StringComparison.Ordinal))
+                {
+                    unguarded.Add(Path.GetFileName(file));
+                }
+            }
+
+            // Assert
+            Assert.That(unguarded, Is.Empty);
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/ExhaustiveSwitchSeverityTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/ExhaustiveSwitchSeverityTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 51e4e2a734714945a803a160dd8bc566

--- a/Packages/com.velvet.core/Runtime/Styling/StyleVariantClass.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleVariantClass.cs
@@ -20,6 +20,10 @@ namespace Velvet
     /// what left <c>checked:</c>, the two focus-within relationals and <c>peer-checked:</c> unclassified and
     /// inert as the inner of a stacked variant. Those sites suppress CS8524 instead: it asks for an arm
     /// covering an out-of-range cast, which no named member can supply.
+    /// <para/>
+    /// That signal is load-bearing, so <c>Runtime/csc.rsp</c> compiles CS8509 as an error: a member added
+    /// without an arm has to fail the build, and a warning nothing gates on is a member reaching a site that
+    /// never learned it.
     /// </remarks>
     public enum StyleVariantKind
     {
@@ -239,12 +243,15 @@ namespace Velvet
         /// <summary>
         /// True for the responsive min-width variants (<c>sm:</c>…<c>2xl:</c>) — read off
         /// <see cref="BreakpointPx"/> rather than listing them again, so the two cannot disagree.
+        /// A value that names no kind throws, for the reason given there.
         /// </summary>
         public static bool IsResponsive(StyleVariantKind kind) => BreakpointPx(kind) > 0f;
 
         /// <summary>
         /// Min-width (px) at which a responsive variant activates. The default breakpoints:
-        /// sm 640, md 768, lg 1024, xl 1280, 2xl 1536. Returns 0 for non-responsive kinds.
+        /// sm 640, md 768, lg 1024, xl 1280, 2xl 1536. Returns 0 for every other named kind, and throws
+        /// for a value that names no kind — a cast outside the enum's range is a caller error, and a
+        /// silent 0 is how one survives to produce a wrong layout instead of a stack trace.
         /// </summary>
 #pragma warning disable CS8524 // no discard arm — see the remarks on StyleVariantKind
         public static float BreakpointPx(StyleVariantKind kind) => kind switch

--- a/Packages/com.velvet.core/Runtime/Styling/StyleVariantClass.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleVariantClass.cs
@@ -22,8 +22,9 @@ namespace Velvet
     /// covering an out-of-range cast, which no named member can supply.
     /// <para/>
     /// That signal is load-bearing, so <c>Runtime/csc.rsp</c> compiles CS8509 as an error: a member added
-    /// without an arm has to fail the build, and a warning nothing gates on is a member reaching a site that
-    /// never learned it.
+    /// without an arm at one of these sites fails this assembly's build rather than warning into a log
+    /// nothing gates on. Answering that error with a discard arm would put the silence back, so
+    /// <c>ExhaustiveSwitchSeverityTests</c> holds both halves at once.
     /// </remarks>
     public enum StyleVariantKind
     {

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/StyleVariantKindClassificationTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/StyleVariantKindClassificationTests.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Specifies what the discard-less classification switches over <see cref="StyleVariantKind"/> answer:
+    /// every named member is classified by each of them, and a value naming no member is refused rather
+    /// than answered. The compiler raises CS8509 for the first and CS8524 for the second, and the enum's
+    /// own remarks lean on that; these cases are what makes either survive a discard arm being added.
+    /// </summary>
+    [TestFixture]
+    internal sealed class StyleVariantKindClassificationTests
+    {
+        private static IEnumerable<StyleVariantKind> NamedKinds() =>
+            Enum.GetValues(typeof(StyleVariantKind)).Cast<StyleVariantKind>();
+
+        private static StyleVariantKind UnnamedKind() =>
+            (StyleVariantKind)(NamedKinds().Cast<int>().Max() + 1);
+
+        private static List<StyleVariantKind> Unclassified(Action<StyleVariantKind> classify)
+        {
+            var refused = new List<StyleVariantKind>();
+            foreach (var kind in NamedKinds())
+            {
+                try
+                {
+                    classify(kind);
+                }
+                catch (Exception)
+                {
+                    refused.Add(kind);
+                }
+            }
+            return refused;
+        }
+
+        // GREEN_ON_BASE(characterization): a discard arm added later silences CS8509 and leaves this red.
+        [Test]
+        public void Given_EveryNamedKind_When_BreakpointPxIsAsked_Then_NoneIsUnclassified()
+        {
+            // Act
+            var refused = Unclassified(kind => StyleVariantClass.BreakpointPx(kind));
+
+            // Assert
+            Assert.That(refused, Is.Empty);
+        }
+
+        // GREEN_ON_BASE(characterization): a discard arm added later silences CS8509 and leaves this red.
+        [Test]
+        public void Given_EveryNamedKind_When_RelationalOfIsAsked_Then_NoneIsUnclassified()
+        {
+            // Act
+            var refused = Unclassified(kind => StyleVariantClass.RelationalOf(kind));
+
+            // Assert
+            Assert.That(refused, Is.Empty);
+        }
+
+        // GREEN_ON_BASE(characterization): pins the delegation both summaries claim, against either growing
+        // its own arms.
+        [Test]
+        public void Given_EveryNamedKind_When_BothResponsiveQuestionsAreAsked_Then_TheyAgree()
+        {
+            // Act
+            var disagreeing = NamedKinds()
+                .Where(kind => StyleVariantClass.IsResponsive(kind) != StyleVariantClass.BreakpointPx(kind) > 0f)
+                .ToList();
+
+            // Assert
+            Assert.That(disagreeing, Is.Empty);
+        }
+
+        // GREEN_ON_BASE(characterization): the refusal is the recorded behaviour, so a discard arm returning
+        // zero cannot come back unnoticed.
+        [Test]
+        public void Given_AValueNamingNoKind_When_BreakpointPxIsAsked_Then_ItIsRefused()
+        {
+            // Arrange
+            var unnamed = UnnamedKind();
+            Assume.That(Enum.IsDefined(typeof(StyleVariantKind), unnamed), Is.False);
+
+            // Assert
+            Assert.That(() => StyleVariantClass.BreakpointPx(unnamed), Throws.Exception);
+        }
+
+        // GREEN_ON_BASE(characterization): the refusal is the recorded behaviour, so a discard arm returning
+        // false cannot come back unnoticed.
+        [Test]
+        public void Given_AValueNamingNoKind_When_IsResponsiveIsAsked_Then_ItIsRefused()
+        {
+            // Arrange
+            var unnamed = UnnamedKind();
+            Assume.That(Enum.IsDefined(typeof(StyleVariantKind), unnamed), Is.False);
+
+            // Assert
+            Assert.That(() => StyleVariantClass.IsResponsive(unnamed), Throws.Exception);
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/StyleVariantKindClassificationTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/StyleVariantKindClassificationTests.cs
@@ -1,71 +1,31 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using NUnit.Framework;
 
 namespace Velvet.Tests
 {
     /// <summary>
-    /// Specifies what the discard-less classification switches over <see cref="StyleVariantKind"/> answer:
-    /// every named member is classified by each of them, and a value naming no member is refused rather
-    /// than answered. The compiler raises CS8509 for the first and CS8524 for the second, and the enum's
-    /// own remarks lean on that; these cases are what makes either survive a discard arm being added.
+    /// Specifies what the classification surface answers for a value that names no
+    /// <see cref="StyleVariantKind"/>, and that the two responsive questions stay one question.
+    /// Coverage of the named members is the compiler's job — <c>Runtime/csc.rsp</c> raises CS8509 to an
+    /// error, so a member no arm covers does not build — and asking it here as well would only pass,
+    /// since no tree that fails it can be compiled to run the case.
     /// </summary>
     [TestFixture]
     internal sealed class StyleVariantKindClassificationTests
     {
-        private static IEnumerable<StyleVariantKind> NamedKinds() =>
-            Enum.GetValues(typeof(StyleVariantKind)).Cast<StyleVariantKind>();
-
         private static StyleVariantKind UnnamedKind() =>
-            (StyleVariantKind)(NamedKinds().Cast<int>().Max() + 1);
+            (StyleVariantKind)(Enum.GetValues(typeof(StyleVariantKind)).Cast<int>().Max() + 1);
 
-        private static List<StyleVariantKind> Unclassified(Action<StyleVariantKind> classify)
-        {
-            var refused = new List<StyleVariantKind>();
-            foreach (var kind in NamedKinds())
-            {
-                try
-                {
-                    classify(kind);
-                }
-                catch (Exception)
-                {
-                    refused.Add(kind);
-                }
-            }
-            return refused;
-        }
-
-        // GREEN_ON_BASE(characterization): a discard arm added later silences CS8509 and leaves this red.
-        [Test]
-        public void Given_EveryNamedKind_When_BreakpointPxIsAsked_Then_NoneIsUnclassified()
-        {
-            // Act
-            var refused = Unclassified(kind => StyleVariantClass.BreakpointPx(kind));
-
-            // Assert
-            Assert.That(refused, Is.Empty);
-        }
-
-        // GREEN_ON_BASE(characterization): a discard arm added later silences CS8509 and leaves this red.
-        [Test]
-        public void Given_EveryNamedKind_When_RelationalOfIsAsked_Then_NoneIsUnclassified()
-        {
-            // Act
-            var refused = Unclassified(kind => StyleVariantClass.RelationalOf(kind));
-
-            // Assert
-            Assert.That(refused, Is.Empty);
-        }
-
-        // GREEN_ON_BASE(characterization): pins the delegation both summaries claim, against either growing
-        // its own arms.
+        // GREEN_ON_BASE(characterization): pins the delegation both summaries claim, against either
+        // growing its own arms.
         [Test]
         public void Given_EveryNamedKind_When_BothResponsiveQuestionsAreAsked_Then_TheyAgree()
         {
             // Act
-            var disagreeing = NamedKinds()
+            var disagreeing = Enum.GetValues(typeof(StyleVariantKind))
+                .Cast<StyleVariantKind>()
                 .Where(kind => StyleVariantClass.IsResponsive(kind) != StyleVariantClass.BreakpointPx(kind) > 0f)
                 .ToList();
 
@@ -73,30 +33,34 @@ namespace Velvet.Tests
             Assert.That(disagreeing, Is.Empty);
         }
 
-        // GREEN_ON_BASE(characterization): the refusal is the recorded behaviour, so a discard arm returning
-        // zero cannot come back unnoticed.
+        // GREEN_ON_BASE(characterization): the refusal is the behaviour the CHANGELOG now records, and
+        // naming the type is what separates it from a member that throws for a reason of its own.
         [Test]
         public void Given_AValueNamingNoKind_When_BreakpointPxIsAsked_Then_ItIsRefused()
         {
             // Arrange
             var unnamed = UnnamedKind();
-            Assume.That(Enum.IsDefined(typeof(StyleVariantKind), unnamed), Is.False);
+            Assume.That(Enum.IsDefined(typeof(StyleVariantKind), unnamed), Is.False,
+                "the probe value has to name no member for the refusal to be what is measured");
 
             // Assert
-            Assert.That(() => StyleVariantClass.BreakpointPx(unnamed), Throws.Exception);
+            Assert.That(() => StyleVariantClass.BreakpointPx(unnamed),
+                Throws.InstanceOf<SwitchExpressionException>());
         }
 
-        // GREEN_ON_BASE(characterization): the refusal is the recorded behaviour, so a discard arm returning
-        // false cannot come back unnoticed.
+        // GREEN_ON_BASE(characterization): the refusal is the behaviour the CHANGELOG now records, and
+        // naming the type is what separates it from a member that throws for a reason of its own.
         [Test]
         public void Given_AValueNamingNoKind_When_IsResponsiveIsAsked_Then_ItIsRefused()
         {
             // Arrange
             var unnamed = UnnamedKind();
-            Assume.That(Enum.IsDefined(typeof(StyleVariantKind), unnamed), Is.False);
+            Assume.That(Enum.IsDefined(typeof(StyleVariantKind), unnamed), Is.False,
+                "the probe value has to name no member for the refusal to be what is measured");
 
             // Assert
-            Assert.That(() => StyleVariantClass.IsResponsive(unnamed), Throws.Exception);
+            Assert.That(() => StyleVariantClass.IsResponsive(unnamed),
+                Throws.InstanceOf<SwitchExpressionException>());
         }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/StyleVariantKindClassificationTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/StyleVariantKindClassificationTests.cs
@@ -47,8 +47,10 @@ namespace Velvet.Tests
             Assert.That(refused, Is.Empty);
         }
 
-        // GREEN_ON_BASE(characterization): pins the delegation both summaries claim, against either
-        // growing its own arms. Also the only enumeration of BreakpointPx over the named members.
+        // GREEN_ON_BASE(characterization): the only enumeration of BreakpointPx over the named members,
+        // and it separates the two the moment a responsive kind reaches one of them and not the other. It
+        // does not pin the delegation itself: a rewritten IsResponsive listing the same five kinds agrees
+        // with BreakpointPx and keeps this green.
         [Test]
         public void Given_EveryNamedKind_When_BothResponsiveQuestionsAreAsked_Then_TheyAgree()
         {
@@ -69,13 +71,8 @@ namespace Velvet.Tests
         [Test]
         public void Given_AValueNamingNoKind_When_BreakpointPxIsAsked_Then_ItIsRefused()
         {
-            // Arrange
-            var unnamed = UnnamedKind();
-            Assume.That(Enum.IsDefined(typeof(StyleVariantKind), unnamed), Is.False,
-                "the probe value has to name no member for the refusal to be what is measured");
-
             // Assert
-            Assert.That(() => StyleVariantClass.BreakpointPx(unnamed),
+            Assert.That(() => StyleVariantClass.BreakpointPx(UnnamedKind()),
                 Throws.InstanceOf<SwitchExpressionException>());
         }
 
@@ -86,13 +83,8 @@ namespace Velvet.Tests
         [Test]
         public void Given_AValueNamingNoKind_When_IsResponsiveIsAsked_Then_ItIsRefused()
         {
-            // Arrange
-            var unnamed = UnnamedKind();
-            Assume.That(Enum.IsDefined(typeof(StyleVariantKind), unnamed), Is.False,
-                "the probe value has to name no member for the refusal to be what is measured");
-
             // Assert
-            Assert.That(() => StyleVariantClass.IsResponsive(unnamed),
+            Assert.That(() => StyleVariantClass.IsResponsive(UnnamedKind()),
                 Throws.InstanceOf<SwitchExpressionException>());
         }
     }

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/StyleVariantKindClassificationTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/StyleVariantKindClassificationTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using NUnit.Framework;
@@ -6,11 +7,16 @@ using NUnit.Framework;
 namespace Velvet.Tests
 {
     /// <summary>
-    /// Specifies what the classification surface answers for a value that names no
-    /// <see cref="StyleVariantKind"/>, and that the two responsive questions stay one question.
-    /// Coverage of the named members is the compiler's job — <c>Runtime/csc.rsp</c> raises CS8509 to an
-    /// error, so a member no arm covers does not build — and asking it here as well would only pass,
-    /// since no tree that fails it can be compiled to run the case.
+    /// Specifies what <see cref="StyleVariantClass.BreakpointPx"/> and <see cref="StyleVariantClass.IsResponsive"/>
+    /// answer for a value that names no <see cref="StyleVariantKind"/>, and that the two of them stay one
+    /// question. <see cref="StyleVariantClass.RelationalOf"/> is enumerated over the named members, which
+    /// nothing else does — <see cref="StyleVariantClass.BreakpointPx"/> is enumerated by the agreement case
+    /// beside it.
+    /// <para>
+    /// That enumeration is not redundant with CS8509 being an error, because nothing here establishes that
+    /// the flag reaches the compiler: <c>ExhaustiveSwitchSeverityTests</c> reads the response file, not the
+    /// build.
+    /// </para>
     /// </summary>
     [TestFixture]
     internal sealed class StyleVariantKindClassificationTests
@@ -18,8 +24,31 @@ namespace Velvet.Tests
         private static StyleVariantKind UnnamedKind() =>
             (StyleVariantKind)(Enum.GetValues(typeof(StyleVariantKind)).Cast<int>().Max() + 1);
 
+        // GREEN_ON_BASE(characterization): the only enumeration of RelationalOf. Its other defence is the
+        // compiler flag, and no case here establishes that the flag reaches the build.
+        [Test]
+        public void Given_EveryNamedKind_When_RelationalOfIsAsked_Then_NoneIsRefused()
+        {
+            // Act
+            var refused = new List<StyleVariantKind>();
+            foreach (var kind in Enum.GetValues(typeof(StyleVariantKind)).Cast<StyleVariantKind>())
+            {
+                try
+                {
+                    StyleVariantClass.RelationalOf(kind);
+                }
+                catch (SwitchExpressionException)
+                {
+                    refused.Add(kind);
+                }
+            }
+
+            // Assert
+            Assert.That(refused, Is.Empty);
+        }
+
         // GREEN_ON_BASE(characterization): pins the delegation both summaries claim, against either
-        // growing its own arms.
+        // growing its own arms. Also the only enumeration of BreakpointPx over the named members.
         [Test]
         public void Given_EveryNamedKind_When_BothResponsiveQuestionsAreAsked_Then_TheyAgree()
         {
@@ -33,8 +62,10 @@ namespace Velvet.Tests
             Assert.That(disagreeing, Is.Empty);
         }
 
-        // GREEN_ON_BASE(characterization): the refusal is the behaviour the CHANGELOG now records, and
-        // naming the type is what separates it from a member that throws for a reason of its own.
+        // GREEN_ON_BASE(characterization): the refusal is the behaviour the CHANGELOG now records. The type
+        // is named to separate it from a member throwing for a reason of its own; it is the compiler's
+        // signature for the absent arm rather than a contract, so a deliberate move to
+        // ArgumentOutOfRangeException updates this line rather than being blocked by it.
         [Test]
         public void Given_AValueNamingNoKind_When_BreakpointPxIsAsked_Then_ItIsRefused()
         {
@@ -48,8 +79,10 @@ namespace Velvet.Tests
                 Throws.InstanceOf<SwitchExpressionException>());
         }
 
-        // GREEN_ON_BASE(characterization): the refusal is the behaviour the CHANGELOG now records, and
-        // naming the type is what separates it from a member that throws for a reason of its own.
+        // GREEN_ON_BASE(characterization): the refusal is the behaviour the CHANGELOG now records. The type
+        // is named to separate it from a member throwing for a reason of its own; it is the compiler's
+        // signature for the absent arm rather than a contract, so a deliberate move to
+        // ArgumentOutOfRangeException updates this line rather than being blocked by it.
         [Test]
         public void Given_AValueNamingNoKind_When_IsResponsiveIsAsked_Then_ItIsRefused()
         {

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/StyleVariantKindClassificationTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/StyleVariantKindClassificationTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3d6e8c594d3b43ebb03dc7e7dbec2690

--- a/Packages/com.velvet.core/Runtime/csc.rsp
+++ b/Packages/com.velvet.core/Runtime/csc.rsp
@@ -1,2 +1,3 @@
 -langversion:preview
 -nullable:enable
+-warnaserror:CS8509


### PR DESCRIPTION
Closes #486.

`StyleVariantClass.BreakpointPx` and `IsResponsive` stopped answering `0f` and `false` for a value naming
no `StyleVariantKind` in 2.0.1, when the classification switches lost their discard arms. The change was
never recorded, on the grounds that no legitimate call site can reach it. Both members are public and take
an enum, so reaching it needs only a cast — "no legitimate call site" is a claim about other people's code,
not one this package can make, and the CHANGELOG carries the entry now.

**Throwing stays.** A discard arm would answer the cast, and cost the signal the enum's remarks are built
on: a member added to `StyleVariantKind` would fall into the discard instead of raising CS8509 at every
site that has to learn it.

## The signal was advisory

CS8509 is what that design depends on, and nothing gated on it — no `csc.rsp` carried `-warnaserror`, and
no workflow step reads the compiler's warnings. Measured on one tree, with a `StyleVariantKind` member no
switch covers:

| `-warnaserror:CS8509` | editor exit | `error CS8509` | `warning CS8509` |
|---|---|---|---|
| present | 1 | 12 | 0 |
| absent | 0 | 0 | 8 |

Both name the same four sites — `StyleVariantClass` twice, `StyleArbitraryModel` and
`StyleStackedVariantManipulator` — so severity is the whole difference, and without it an unclassified
member compiles clean and the suite runs green. `Runtime/csc.rsp` now carries the flag.

The flag ships with the package, so a consumer's build of `Velvet.asmdef` compiles CS8509 as an error too,
and it is the first thing in that file that can make their build fail rather than warn. It reaches player
builds as well as the editor compile — `Library/Bee/artifacts/…/Velvet.rsp` appends the file's flags after
Unity's own `/nowarn` list on both targets.

The trade is taken because the rsp applies only to Velvet's own sources, which are fixed in a released
package, so nothing a consumer writes can raise the diagnostic, and every discard-less switch expression in
the package is over an enum Velvet declares itself — a future Unity adding a member to an engine enum
cannot turn a consumer's build red. What is left is an editor-version-dependent input: `Velvet.rsp`
attaches three editor-shipped source generators (`Unity.SourceGenerators`,
`Unity.Properties.SourceGenerator`, `Unity.UIToolkit.SourceGenerator`) whose output compiles into
`Velvet.dll` under this flag. None emits into Velvet today — the package declares no `[UxmlElement]`,
`[UxmlAttribute]` or `[GeneratePropertyBag]` — so it is a vector rather than a defect, and it is the
concrete reason to disagree with this change if anyone wants to. A consumer who hit it could embed the
package and edit the rsp, which is ugly but not a dead end.

## Coverage

`ExhaustiveSwitchSeverityTests` holds both halves of what suppressing CS8524 declares. The first case holds
every production source that suppresses it to an assembly whose `csc.rsp` raises CS8509 to an error — red
on the merge base. The second holds those regions to opening **no catch-all arm**, which is the escape from
the first: a member added without an arm now fails the build, and answering that error with `_ => …`,
`var other => …` or `StyleVariantKind other => …` puts the silence straight back. A type pattern is two
bare identifiers where a constant arm carries a dot, which is what separates them; measured against the
seven regions that exist, no false positive.

Regions are found by a line scan rather than a disable/restore pair, because a pair requires the restore to
exist and a file-scoped suppression written without one is legal C#. Measured: such a suppression over a
discard-less switch in `Editor/`, whose response file carries no severity flag, is reported by the first
case. Both cases read the same list, so they cannot decide membership differently.

`StyleVariantKindClassificationTests` pins the refusal for a value naming no kind, by exception type,
enumerates `RelationalOf` over the named members — which nothing else does — and pins that `IsResponsive`
still reads off `BreakpointPx`, which is what enumerates `BreakpointPx`.

That enumeration is not made redundant by CS8509 being an error, because nothing here establishes that the
flag reaches the compiler: the severity case reads the response file, not the build.

Evidence the pair has teeth: adding `_ => 0f` to `BreakpointPx` — the answer a developer reaches for when
the CS8509 error appears — fails the catch-all case and both refusal cases, while `Then_Cs8509IsAnError`
and `Then_TheyAgree` correctly stay green.

`BreakpointPx`'s summary claimed it returns 0 for non-responsive kinds — true of every named kind, false of
the cast that reaches the throw. It now states both.

## Where the CHANGELOG entry went

#486 suggests the entry belongs with the change that introduced it. `changelog_into_closed_version.py`
refuses that, for the reason it would produce: an entry filed into a dated section claims a version that
shipped without it, and is missing from the version that will ship with it. So it is under `[Unreleased]`
and names 2.0.1 in its text.

## Verification

- EditMode 3885/3885, `assert_no_inconclusive.py` clean, no `error CS` in the run log.
- `base_red_check.py --base origin/main`: the severity case red on the base, the five declared cases green
  as declared.
- No mutation campaign: the production change is one compiler flag and three doc summaries, with no
  executable line to mutate.

No `Documentation~` guide states either member's behaviour; `docs/` is generated from the XML comments this
changes.
