### PR TITLE
tooling(velvet): derive CONTRIBUTING's CI table from the workflows it mirrors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -286,7 +286,9 @@ on every platform.
 | Workflow | Trigger | Unity license | Required to merge |
 |----------|---------|---------------|-------------------|
 | `Source generators ▸ source-generators` | push (filtered) / every PR / merge group | not required | no |
+| `Source generators ▸ repository-settings` | push (filtered) / every PR / merge group, on this repository only | not required | no |
 | `Source generators ▸ Required checks (generators)` | every PR / merge group | not required | **yes** |
+| `Test ▸ license-check` | push (filtered) / every PR / merge group | not required | no |
 | `Test ▸ unity-tests` (EditMode / PlayMode) | push (filtered) / every PR / merge group | **required** (skipped if absent) | no |
 | `Test ▸ release-notes` | push (filtered) / every PR / merge group | not required | no |
 | `Test ▸ publication` | push (filtered) / every PR / merge group | not required | no |
@@ -294,8 +296,7 @@ on every platform.
 | `Test ▸ base-red-python` | push (filtered) / every PR / merge group | not required | no |
 | `Test ▸ base-red` (EditMode / PlayMode) | every PR | **required** (skipped if absent) | no |
 | `Test ▸ Required checks (Unity)` | every PR / merge group | not required | **yes** |
-| `UPM ▸ split` | push to `main` | not required | no |
-| `UPM ▸ release` | manual (`workflow_dispatch`) | not required | no |
+| `UPM ▸ split` | push to `main` / manual (`workflow_dispatch`, which also tags and publishes the release) | not required | no |
 | `Docs` (DocFX → GitHub Pages) | push to `main` / release / manual | **required** (skipped if absent) | no |
 
 The two required checks are aggregates, and the real jobs are not required themselves. A required check

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -297,7 +297,7 @@ on every platform.
 | `Test ▸ base-red` (EditMode / PlayMode) | every PR | **required** (skipped if absent) | no |
 | `Test ▸ Required checks (Unity)` | push (filtered) / every PR / merge group | not required | **yes** |
 | `UPM ▸ split` | push to `main` / manual (`workflow_dispatch`, which also tags and publishes the release) | not required | no |
-| `Docs` (DocFX → GitHub Pages) | push to `main` / release / manual | **required** (skipped if absent) | no |
+| `Docs` (DocFX → GitHub Pages) | push (filtered) / release / manual | **required** (skipped if absent) | no |
 
 The two required checks are aggregates, and the real jobs are not required themselves. A required check
 that does not run stays `Pending` and blocks the pull request with nothing able to clear it, which is what

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -286,7 +286,7 @@ on every platform.
 | Workflow | Trigger | Unity license | Required to merge |
 |----------|---------|---------------|-------------------|
 | `Source generators ▸ source-generators` | push (filtered) / every PR / merge group | not required | no |
-| `Source generators ▸ repository-settings` | push (filtered) / every PR / merge group, on this repository only | not required | no |
+| `Source generators ▸ repository-settings` | push (filtered) / every PR / merge group; skipped when the workflow runs in a fork | not required | no |
 | `Source generators ▸ Required checks (generators)` | every PR / merge group | not required | **yes** |
 | `Test ▸ license-check` | push (filtered) / every PR / merge group | not required | no |
 | `Test ▸ unity-tests` (EditMode / PlayMode) | push (filtered) / every PR / merge group | **required** (skipped if absent) | no |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -287,7 +287,7 @@ on every platform.
 |----------|---------|---------------|-------------------|
 | `Source generators ▸ source-generators` | push (filtered) / every PR / merge group | not required | no |
 | `Source generators ▸ repository-settings` | push (filtered) / every PR / merge group; skipped when the workflow runs in a fork | not required | no |
-| `Source generators ▸ Required checks (generators)` | every PR / merge group | not required | **yes** |
+| `Source generators ▸ Required checks (generators)` | push (filtered) / every PR / merge group | not required | **yes** |
 | `Test ▸ license-check` | push (filtered) / every PR / merge group | not required | no |
 | `Test ▸ unity-tests` (EditMode / PlayMode) | push (filtered) / every PR / merge group | **required** (skipped if absent) | no |
 | `Test ▸ release-notes` | push (filtered) / every PR / merge group | not required | no |
@@ -295,7 +295,7 @@ on every platform.
 | `Test ▸ test-quality` | push (filtered) / every PR / merge group | not required | no |
 | `Test ▸ base-red-python` | push (filtered) / every PR / merge group | not required | no |
 | `Test ▸ base-red` (EditMode / PlayMode) | every PR | **required** (skipped if absent) | no |
-| `Test ▸ Required checks (Unity)` | every PR / merge group | not required | **yes** |
+| `Test ▸ Required checks (Unity)` | push (filtered) / every PR / merge group | not required | **yes** |
 | `UPM ▸ split` | push to `main` / manual (`workflow_dispatch`, which also tags and publishes the release) | not required | no |
 | `Docs` (DocFX → GitHub Pages) | push to `main` / release / manual | **required** (skipped if absent) | no |
 

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/RequiredCheckAggregationTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/RequiredCheckAggregationTests.cs
@@ -379,8 +379,14 @@ namespace Velvet.Tests
         // then have lost something true.
         private const string ForkClause = "skipped when the workflow runs in a fork";
 
+        private static readonly Regex RepositoryReferencePattern =
+            new(@"github\.repository(?:_owner)?", RegexOptions.Compiled);
+
+        // Refused for the reason EventEqualityPattern gives, one context over. `_owner` is read because
+        // the suffix defeated the equality alone, and a reference this cannot read counts as no gate: the
+        // row then reds saying the job pins no repository while it does, which sends a reader to the cell.
         private static readonly Regex RepositoryGatePattern =
-            new(@"github\.repository\s*==", RegexOptions.Compiled);
+            new(@"github\.repository(?:_owner)?\s*==", RegexOptions.Compiled);
 
         private static readonly Regex EventNameReferencePattern =
             new(@"github\.event_name", RegexOptions.Compiled);
@@ -517,9 +523,17 @@ namespace Velvet.Tests
                     continue;
                 }
 
-                if (RepositoryGatePattern.IsMatch(gate) != row.Trigger.Contains(ForkClause, StringComparison.Ordinal))
+                var pins = RepositoryGatePattern.Matches(gate).Count;
+                if (pins != RepositoryReferencePattern.Matches(gate).Count)
                 {
-                    wrong.Add(label + (RepositoryGatePattern.IsMatch(gate)
+                    wrong.Add(label + " (its job-level if: reaches for github.repository in a shape this "
+                        + "does not read: " + gate.Trim() + ")");
+                    continue;
+                }
+
+                if (pins > 0 != row.Trigger.Contains(ForkClause, StringComparison.Ordinal))
+                {
+                    wrong.Add(label + (pins > 0
                         ? " (its if: pins the repository and its trigger does not say it is skipped in a fork)"
                         : " (its trigger says it is skipped in a fork and its if: pins no repository)"));
                 }

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/RequiredCheckAggregationTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/RequiredCheckAggregationTests.cs
@@ -374,6 +374,14 @@ namespace Velvet.Tests
 
         private static readonly Regex OnKeyPattern = new(@"^  (?<event>[a-z_]+):", RegexOptions.Compiled);
 
+        // The one thing the Trigger column says that is not an event. Held both ways round, because
+        // deleting the clause is the repair a reader that stopped matching asks for, and the row would
+        // then have lost something true.
+        private const string ForkClause = "skipped when the workflow runs in a fork";
+
+        private static readonly Regex RepositoryGatePattern =
+            new(@"github\.repository\s*==", RegexOptions.Compiled);
+
         private static readonly Regex EventNameReferencePattern =
             new(@"github\.event_name", RegexOptions.Compiled);
 
@@ -383,35 +391,47 @@ namespace Velvet.Tests
         private static readonly Regex EventEqualityPattern =
             new(@"github\.event_name\s*==\s*(?<quote>['""])(?<event>[a-z_]+)\k<quote>", RegexOptions.Compiled);
 
-        /// <summary>The lines of a workflow's `on:` block.</summary>
+        // Three spellings of one key. One this misses leaves
+        // Given_EveryRowOfContributingsCiTable_When_ItsTriggerCellIsRead_Then_ItNamesWhatStartsThatJob
+        // printing an empty event set as what the row's job starts on.
+        private static readonly Regex OnKeyLinePattern =
+            new(@"^(?:on|""on""|'on'):[ \t]*(?<rest>.*)$", RegexOptions.Compiled);
+
+        /// <summary>The lines of a workflow's `on:` block, or null where it is not written as one.</summary>
         private static List<string> OnBlock(string workflow)
         {
-            var lines = workflow.Split('\n');
-            var start = Array.FindIndex(lines, line => line.TrimEnd('\r') == "on:");
+            var lines = workflow.Split('\n').Select(line => line.TrimEnd('\r')).ToList();
+            var start = lines.FindIndex(line => OnKeyLinePattern.IsMatch(line));
             if (start < 0)
             {
-                return new List<string>();
+                return null;
             }
 
-            var end = Array.FindIndex(lines, start + 1, line =>
+            // A flow sequence or a scalar puts the events on the key's own line, where the per-event keys
+            // read below do not exist. Refused rather than returned as a workflow subscribing to nothing,
+            // which is a claim this cannot make from having read nothing.
+            var rest = OnKeyLinePattern.Match(lines[start]).Groups["rest"].Value;
+            if (rest.Length > 0 && !rest.StartsWith("#", StringComparison.Ordinal))
+            {
+                return null;
+            }
+
+            var end = lines.FindIndex(start + 1, line =>
                 line.Length > 0 && !char.IsWhiteSpace(line[0]) && !line.StartsWith("#", StringComparison.Ordinal));
-            return lines.Skip(start + 1).Take((end < 0 ? lines.Length : end) - start - 1)
-                .Select(line => line.TrimEnd('\r'))
-                .ToList();
+            return lines.Skip(start + 1).Take((end < 0 ? lines.Count : end) - start - 1).ToList();
         }
 
         /// <summary>The events a workflow subscribes to, read out of its own `on:` block.</summary>
-        private static IEnumerable<string> SubscribedEvents(string workflow) =>
-            OnBlock(workflow)
+        private static IEnumerable<string> SubscribedEvents(List<string> onBlock) =>
+            onBlock
                 .Select(line => OnKeyPattern.Match(line))
                 .Where(match => match.Success)
                 .Select(match => match.Groups["event"].Value);
 
-        /// <summary>How the Trigger column spells this workflow's push subscription.</summary>
-        private static string PushPhrase(string workflow)
+        /// <summary>How the Trigger column spells the push subscription in this `on:` block.</summary>
+        private static string PushPhrase(List<string> onBlock)
         {
-            var block = OnBlock(workflow);
-            var push = block.FindIndex(line =>
+            var push = onBlock.FindIndex(line =>
                 OnKeyPattern.Match(line) is { Success: true } key && key.Groups["event"].Value == "push");
             if (push < 0)
             {
@@ -419,9 +439,9 @@ namespace Velvet.Tests
             }
 
             // paths-ignore counts, for the reason TriggerFilters in WorkflowTriggerCoverageTests gives.
-            for (var i = push + 1; i < block.Count && !OnKeyPattern.IsMatch(block[i]); i++)
+            for (var i = push + 1; i < onBlock.Count && !OnKeyPattern.IsMatch(onBlock[i]); i++)
             {
-                if (block[i].TrimStart().StartsWith("paths", StringComparison.Ordinal))
+                if (onBlock[i].TrimStart().StartsWith("paths", StringComparison.Ordinal))
                 {
                     return "push (filtered)";
                 }
@@ -464,6 +484,7 @@ namespace Velvet.Tests
 
             // Act
             var wrong = new List<string>();
+            var judged = 0;
             foreach (var row in rows)
             {
                 var workflow = workflows.FirstOrDefault(entry => entry.Name == row.Workflow);
@@ -472,8 +493,16 @@ namespace Velvet.Tests
                     continue;
                 }
 
+                judged++;
                 var label = row.Workflow + (row.Job.Length > 0 ? " ▸ " + row.Job : string.Empty);
-                var starts = SubscribedEvents(workflow.Text).Intersect(ContributorEvents, StringComparer.Ordinal)
+                var onBlock = OnBlock(workflow.Text);
+                if (onBlock == null)
+                {
+                    wrong.Add(label + " (its workflow writes `on:` in a shape this does not read)");
+                    continue;
+                }
+
+                var starts = SubscribedEvents(onBlock).Intersect(ContributorEvents, StringComparer.Ordinal)
                     .ToHashSet(StringComparer.Ordinal);
                 var job = row.Job.Length == 0
                     ? null
@@ -488,6 +517,13 @@ namespace Velvet.Tests
                     continue;
                 }
 
+                if (RepositoryGatePattern.IsMatch(gate) != row.Trigger.Contains(ForkClause, StringComparison.Ordinal))
+                {
+                    wrong.Add(label + (RepositoryGatePattern.IsMatch(gate)
+                        ? " (its if: pins the repository and its trigger does not say it is skipped in a fork)"
+                        : " (its trigger says it is skipped in a fork and its if: pins no repository)"));
+                }
+
                 if (named == 1)
                 {
                     starts.IntersectWith(new[] { equality.Groups["event"].Value });
@@ -495,7 +531,7 @@ namespace Velvet.Tests
 
                 // Spelt as the column spells it only after any gate has narrowed the events: a gate names
                 // the raw `push`, which intersects with nothing once the set holds `push (filtered)`.
-                var spelt = starts.Select(name => name == "push" ? PushPhrase(workflow.Text) : name)
+                var spelt = starts.Select(name => name == "push" ? PushPhrase(onBlock) : name)
                     .ToHashSet(StringComparer.Ordinal);
                 var claimed = TriggerPhrases
                     .Where(phrase => row.Trigger.Contains(phrase.Phrase, StringComparison.Ordinal))
@@ -512,9 +548,13 @@ namespace Velvet.Tests
                 }
             }
 
-            // Assert — the floor is on the rows for the reason
-            // Given_EveryRowOfContributingsCiTable_When_TheWorkflowsAreRead_Then_ItNamesOneThatExists gives.
-            Assert.That((rows.Count >= 2, string.Join("\n", wrong)), Is.EqualTo((true, string.Empty)));
+            // Assert — the floors are on what this judged and on the repository gates it found, rather
+            // than on the rows it was offered: a table matched to no workflow reports nothing wrong, and
+            // so does a gate reader that stopped matching once the clause it answers for has been deleted
+            // to clear the one row that reported it.
+            var pinned = workflows.Sum(entry => JobNames(entry.Text)
+                .Count(key => RepositoryGatePattern.IsMatch(JobLevelIf(AggregateBlock(entry.Text, key)) ?? string.Empty)));
+            Assert.That((judged >= 2, pinned >= 1, string.Join("\n", wrong)), Is.EqualTo((true, true, string.Empty)));
         }
 
         // Read by the output the license check publishes rather than by that job's name, so renaming the

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/RequiredCheckAggregationTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/RequiredCheckAggregationTests.cs
@@ -14,8 +14,9 @@ namespace Velvet.Tests
     /// left unwired reports for as long as anyone reads the run page and never once stops a merge.
     /// <para>
     /// Both halves are read out of the workflow rather than listed here, so a job added tomorrow is in
-    /// scope for having been added. <c>WorkflowTriggerCoverageTests</c> owns which events start these
-    /// workflows and which paths they filter on; this one owns what their results are wired into.
+    /// scope for having been added. <c>WorkflowTriggerCoverageTests</c> owns the triggers a required
+    /// workflow must carry and what its path filters decide about a file; this one owns what
+    /// CONTRIBUTING's table claims about them, and what their results are wired into.
     /// </para>
     /// </summary>
     [TestFixture]
@@ -37,16 +38,22 @@ namespace Velvet.Tests
         private static readonly Regex JobKeyPattern =
             new(@"^  ([A-Za-z_][A-Za-z0-9_-]*):\s*(#.*)?$", RegexOptions.Compiled);
 
+        // A `needs:` spelling this returns nothing for leaves
+        // Given_EveryJobARequiredAggregateNames_When_TheWorkflowIsEnumerated_Then_ItIsFound asking nothing
+        // and passing for it. The bare scalar was such a spelling, while docs.yml wrote three and test.yml
+        // one.
         private static readonly Regex NeedsListPattern =
             new(@"^\s*needs:\s*\[(?<jobs>[^\]]*)\]", RegexOptions.Compiled | RegexOptions.Multiline);
 
-        // A block sequence and a flow list are the same to Actions, and a formatter turns one into the
-        // other. Reading only the flow form left the case below asking nothing and passing for it.
         private static readonly Regex NeedsBlockPattern =
             new(@"^\s*needs:\s*(?:#[^\r\n]*)?\r?\n(?<jobs>(?:\s*-\s*[^\r\n]+\r?\n?)+)",
                 RegexOptions.Compiled | RegexOptions.Multiline);
 
-        /// <summary>The jobs an aggregate's block declares it needs, in either YAML spelling.</summary>
+        private static readonly Regex NeedsScalarPattern =
+            new(@"^[ \t]*needs:[ \t]*(?<job>[A-Za-z_][A-Za-z0-9_-]*)[ \t]*(?:#[^\r\n]*)?\r?$",
+                RegexOptions.Compiled | RegexOptions.Multiline);
+
+        /// <summary>The jobs an aggregate's block declares it needs, in whichever spelling it uses.</summary>
         private static IEnumerable<string> NeedsOf(string block)
         {
             var flow = NeedsListPattern.Match(block);
@@ -56,11 +63,15 @@ namespace Velvet.Tests
             }
 
             var sequence = NeedsBlockPattern.Match(block);
-            return sequence.Success
-                ? sequence.Groups["jobs"].Value.Split('\n')
+            if (sequence.Success)
+            {
+                return sequence.Groups["jobs"].Value.Split('\n')
                     .Select(line => line.Trim().TrimStart('-').Trim())
-                    .Where(job => job.Length > 0)
-                : Enumerable.Empty<string>();
+                    .Where(job => job.Length > 0);
+            }
+
+            var scalar = NeedsScalarPattern.Match(block);
+            return scalar.Success ? new[] { scalar.Groups["job"].Value } : Enumerable.Empty<string>();
         }
 
         private static readonly Regex ResultReferencePattern =
@@ -189,18 +200,21 @@ namespace Velvet.Tests
 
         /// <summary>
         /// Each row of CONTRIBUTING's continuous-integration table: the `Workflow ▸ job` / `Workflow` its
-        /// first cell names, and whether its last column says the check is required to merge.
+        /// first cell names, its Trigger and Unity-license cells as written, and whether its last column
+        /// says the check is required to merge.
         /// <para>
         /// Bounded by the table rather than by the section, and fenced blocks are skipped whole. Collection
         /// starts at the first separator row outside a fence and ends at the first line that is not a row,
-        /// so neither a second table nor a fenced example of one — before the table or after it — is read
-        /// as a continuous-integration row and misreported as naming no workflow. A fence is recognised by
-        /// its opening run of backticks or tildes at the line's start, which is every fence in this file.
+        /// so a fenced example of a table, and any second table below this one, are not read as
+        /// continuous-integration rows and misreported as naming no workflow. An unfenced one between the
+        /// heading and it is read: that one becomes the rows. A fence is recognised by its opening run of
+        /// backticks or tildes at the line's start, which is every fence in this file.
         /// </para>
         /// </summary>
-        private static IReadOnlyList<(string Workflow, string Job, bool Required, string Trigger)> ContributingRows()
+        private static IReadOnlyList<(string Workflow, string Job, string Trigger, string License, bool Required)>
+            ContributingRows()
         {
-            var rows = new List<(string, string, bool, string)>();
+            var rows = new List<(string, string, string, string, bool)>();
             var lines = File.ReadAllLines(Path.Combine(RepositoryRoot(), "CONTRIBUTING.md"));
             var heading = Array.FindIndex(lines, line => line.TrimEnd('\r') == "## Continuous integration");
             if (heading < 0)
@@ -241,11 +255,12 @@ namespace Velvet.Tests
                 var required = columns.Length > 4
                     && string.Equals(columns[4].Replace("*", string.Empty).Trim(), "yes", StringComparison.OrdinalIgnoreCase);
                 var trigger = columns.Length > 2 ? columns[2] : string.Empty;
+                var license = columns.Length > 3 ? columns[3] : string.Empty;
                 var cell = match.Groups["cell"].Value;
                 var arrow = cell.IndexOf('▸');
                 rows.Add(arrow < 0
-                    ? (cell.Trim(), string.Empty, required, trigger)
-                    : (cell.Substring(0, arrow).Trim(), cell.Substring(arrow + 1).Trim(), required, trigger));
+                    ? (cell.Trim(), string.Empty, trigger, license, required)
+                    : (cell.Substring(0, arrow).Trim(), cell.Substring(arrow + 1).Trim(), trigger, license, required));
             }
 
             return rows;
@@ -285,7 +300,7 @@ namespace Velvet.Tests
 
             // Act
             var dangling = new List<string>();
-            foreach (var (name, job, _, _) in rows)
+            foreach (var (name, job, _, _, _) in rows)
             {
                 var workflow = workflows.FirstOrDefault(entry => entry.Name == name);
                 if (workflow.Text == null)
@@ -333,8 +348,8 @@ namespace Velvet.Tests
 
             // Assert — the second floor is per workflow rather than a total, so one required workflow
             // collapsing to its aggregate alone cannot be covered for by the other's jobs or by a full
-            // table. It does not catch a workflow that lost *some* of its jobs to the parser; the case
-            // below is what does.
+            // table. It does not catch a workflow that lost *some* of its jobs to the parser;
+            // Given_EveryJobARequiredAggregateNames_When_TheWorkflowIsEnumerated_Then_ItIsFound does.
             var enumerated = required.All(entry => JobNames(entry.Text).Count >= 2);
             Assert.That((required.Count >= 2, enumerated, string.Join("\n", unlisted)),
                 Is.EqualTo((true, true, string.Empty)));
@@ -345,47 +360,105 @@ namespace Velvet.Tests
         // and the table does not offer them for the required workflows.
         private static readonly string[] ContributorEvents = { "push", "pull_request", "merge_group" };
 
-        // The words the Trigger column uses for those three. A cell naming none of them is reported rather
-        // than read as claiming nothing, so a row rewritten in a vocabulary this does not know fails here
-        // instead of quietly leaving the column unheld.
+        // The words the Trigger column uses for those three, and it has two for a push: a path filter is
+        // the difference between a push that starts the workflow and one that does not. A cell naming none
+        // of them is reported rather than read as claiming nothing, so a row rewritten in a vocabulary
+        // this does not know fails here instead of quietly leaving the column unheld.
         private static readonly (string Phrase, string Event)[] TriggerPhrases =
         {
-            ("push", "push"),
+            ("push (filtered)", "push (filtered)"),
+            ("push to `main`", "push"),
             ("every PR", "pull_request"),
             ("merge group", "merge_group"),
         };
 
         private static readonly Regex OnKeyPattern = new(@"^  (?<event>[a-z_]+):", RegexOptions.Compiled);
 
-        // Four spaces is a job-level key. A step's `if:` sits deeper and answers for that step alone —
-        // upm.yml gates three steps on workflow_dispatch while the job itself runs on push too.
-        private static readonly Regex JobLevelIfPattern =
-            new(@"^    if:[^\r\n]*github\.event_name\s*==\s*'(?<event>[a-z_]+)'",
-                RegexOptions.Compiled | RegexOptions.Multiline);
+        private static readonly Regex EventNameReferencePattern =
+            new(@"github\.event_name", RegexOptions.Compiled);
 
-        /// <summary>The events a workflow subscribes to, read out of its own `on:` block.</summary>
-        private static IEnumerable<string> SubscribedEvents(string workflow)
+        // An `if:` reaching for github.event_name any other way is refused rather than read past. Reading
+        // past falls back to the workflow's whole `on:` set and prints that as what the job starts on, and
+        // rewriting the cell to match the message is the repair the message asks for.
+        private static readonly Regex EventEqualityPattern =
+            new(@"github\.event_name\s*==\s*(?<quote>['""])(?<event>[a-z_]+)\k<quote>", RegexOptions.Compiled);
+
+        /// <summary>The lines of a workflow's `on:` block.</summary>
+        private static List<string> OnBlock(string workflow)
         {
             var lines = workflow.Split('\n');
             var start = Array.FindIndex(lines, line => line.TrimEnd('\r') == "on:");
             if (start < 0)
             {
-                return Enumerable.Empty<string>();
+                return new List<string>();
             }
 
             var end = Array.FindIndex(lines, start + 1, line =>
                 line.Length > 0 && !char.IsWhiteSpace(line[0]) && !line.StartsWith("#", StringComparison.Ordinal));
             return lines.Skip(start + 1).Take((end < 0 ? lines.Length : end) - start - 1)
-                .Select(line => OnKeyPattern.Match(line.TrimEnd('\r')))
+                .Select(line => line.TrimEnd('\r'))
+                .ToList();
+        }
+
+        /// <summary>The events a workflow subscribes to, read out of its own `on:` block.</summary>
+        private static IEnumerable<string> SubscribedEvents(string workflow) =>
+            OnBlock(workflow)
+                .Select(line => OnKeyPattern.Match(line))
                 .Where(match => match.Success)
                 .Select(match => match.Groups["event"].Value);
+
+        /// <summary>How the Trigger column spells this workflow's push subscription.</summary>
+        private static string PushPhrase(string workflow)
+        {
+            var block = OnBlock(workflow);
+            var push = block.FindIndex(line =>
+                OnKeyPattern.Match(line) is { Success: true } key && key.Groups["event"].Value == "push");
+            if (push < 0)
+            {
+                return "push";
+            }
+
+            // paths-ignore counts, for the reason TriggerFilters in WorkflowTriggerCoverageTests gives.
+            for (var i = push + 1; i < block.Count && !OnKeyPattern.IsMatch(block[i]); i++)
+            {
+                if (block[i].TrimStart().StartsWith("paths", StringComparison.Ordinal))
+                {
+                    return "push (filtered)";
+                }
+            }
+
+            return "push";
+        }
+
+        /// <summary>A job's own `if:`, folded continuation lines joined in, or null where it carries none.</summary>
+        private static string JobLevelIf(string block)
+        {
+            // Four spaces is a job-level key. A step's `if:` sits deeper and answers for that step alone —
+            // upm.yml gates three steps on workflow_dispatch while the job itself runs on push too.
+            const string key = "    if:";
+            var lines = block.Split('\n').Select(line => line.TrimEnd('\r')).ToList();
+            var start = lines.FindIndex(line => line.StartsWith(key, StringComparison.Ordinal));
+            if (start < 0)
+            {
+                return null;
+            }
+
+            // A folded expression puts the whole condition below the key, where a reader of that line
+            // alone finds no event named and narrows by nothing.
+            var expression = lines[start].Substring(key.Length);
+            for (var i = start + 1; i < lines.Count && lines[i].StartsWith("      ", StringComparison.Ordinal); i++)
+            {
+                expression += " " + lines[i].Trim();
+            }
+
+            return expression;
         }
 
         [Test]
         public void Given_EveryRowOfContributingsCiTable_When_ItsTriggerCellIsRead_Then_ItNamesWhatStartsThatJob()
         {
-            // Arrange — the Trigger column was as unpinned as the other two the branch holds, and it was
-            // wrong: both aggregate rows omitted push while their jobs carry no event gate at all.
+            // Arrange — the Trigger column was as unpinned as every other, and it was wrong: both aggregate
+            // rows omitted push while their jobs carry no event gate at all.
             var workflows = Workflows();
             var rows = ContributingRows();
 
@@ -399,41 +472,112 @@ namespace Velvet.Tests
                     continue;
                 }
 
+                var label = row.Workflow + (row.Job.Length > 0 ? " ▸ " + row.Job : string.Empty);
                 var starts = SubscribedEvents(workflow.Text).Intersect(ContributorEvents, StringComparer.Ordinal)
                     .ToHashSet(StringComparer.Ordinal);
                 var job = row.Job.Length == 0
                     ? null
                     : JobNames(workflow.Text).FirstOrDefault(key => Names(workflow.Text, row.Job, key));
-                var gate = job == null ? null : JobLevelIfPattern.Match(AggregateBlock(workflow.Text, job));
-                if (gate is { Success: true })
+                var gate = job == null ? string.Empty : JobLevelIf(AggregateBlock(workflow.Text, job)) ?? string.Empty;
+                var named = EventNameReferencePattern.Matches(gate).Count;
+                var equality = EventEqualityPattern.Match(gate);
+                if (named > 1 || (named == 1 && !equality.Success))
                 {
-                    starts.IntersectWith(new[] { gate.Groups["event"].Value });
+                    wrong.Add(label + " (its job-level if: reaches for github.event_name in a shape this "
+                        + "does not read: " + gate.Trim() + ")");
+                    continue;
                 }
 
+                if (named == 1)
+                {
+                    starts.IntersectWith(new[] { equality.Groups["event"].Value });
+                }
+
+                // Spelt as the column spells it only after any gate has narrowed the events: a gate names
+                // the raw `push`, which intersects with nothing once the set holds `push (filtered)`.
+                var spelt = starts.Select(name => name == "push" ? PushPhrase(workflow.Text) : name)
+                    .ToHashSet(StringComparer.Ordinal);
                 var claimed = TriggerPhrases
                     .Where(phrase => row.Trigger.Contains(phrase.Phrase, StringComparison.Ordinal))
                     .Select(phrase => phrase.Event)
                     .ToHashSet(StringComparer.Ordinal);
-                var label = row.Workflow + (row.Job.Length > 0 ? " \u25b8 " + row.Job : string.Empty);
                 if (claimed.Count == 0)
                 {
                     wrong.Add(label + " (its trigger names no event this reads)");
                 }
-                else if (!claimed.SetEquals(starts))
+                else if (!claimed.SetEquals(spelt))
                 {
                     wrong.Add(label + " (claims [" + string.Join("+", claimed.OrderBy(e => e, StringComparer.Ordinal))
-                        + "], starts on [" + string.Join("+", starts.OrderBy(e => e, StringComparer.Ordinal)) + "])");
+                        + "], starts on [" + string.Join("+", spelt.OrderBy(e => e, StringComparer.Ordinal)) + "])");
                 }
             }
 
-            // Assert — the floor is on the rows for the reason the case above gives.
+            // Assert — the floor is on the rows for the reason
+            // Given_EveryRowOfContributingsCiTable_When_TheWorkflowsAreRead_Then_ItNamesOneThatExists gives.
             Assert.That((rows.Count >= 2, string.Join("\n", wrong)), Is.EqualTo((true, string.Empty)));
         }
 
+        // Read by the output the license check publishes rather than by that job's name, so renaming the
+        // job leaves this matching and renaming the output reds every row whose license cell says required.
+        private static readonly Regex LicenseGatePattern =
+            new(@"needs\.[A-Za-z_][A-Za-z0-9_-]*\.outputs\.has_license", RegexOptions.Compiled);
+
+        private static bool WaitsOnLicense(string workflow, string job) =>
+            LicenseGatePattern.IsMatch(JobLevelIf(AggregateBlock(workflow, job)) ?? string.Empty);
+
+        // GREEN_ON_BASE(characterization): the column agreed with the workflows on both sides. Nothing
+        // derived it, which is what the branch changes — the first two columns were each found wrong the
+        // moment they were derived, so this one is held before it drifts as well.
+        [Test]
+        public void Given_EveryRowOfContributingsCiTable_When_ItsUnityLicenseCellIsRead_Then_ItMatchesTheLicenseGate()
+        {
+            // Arrange — what marks a job as needing a license is its own `if:` waiting on the license
+            // check's output, and a row naming a workflow rather than a job answers for every job in it.
+            var workflows = Workflows();
+            var rows = ContributingRows();
+
+            // Act
+            var wrong = new List<string>();
+            var judged = 0;
+            foreach (var row in rows)
+            {
+                var workflow = workflows.FirstOrDefault(entry => entry.Name == row.Workflow);
+                if (workflow.Text == null)
+                {
+                    continue;
+                }
+
+                judged++;
+                var label = row.Workflow + (row.Job.Length > 0 ? " ▸ " + row.Job : string.Empty);
+                var waits = JobNames(workflow.Text)
+                    .Where(key => row.Job.Length == 0 || Names(workflow.Text, row.Job, key))
+                    .Any(key => WaitsOnLicense(workflow.Text, key));
+                var cell = row.License.Replace("*", string.Empty).Split('(')[0].Trim();
+                var claimed = string.Equals(cell, "required", StringComparison.OrdinalIgnoreCase);
+                if (!claimed && !string.Equals(cell, "not required", StringComparison.OrdinalIgnoreCase))
+                {
+                    wrong.Add(label + " (its license cell says \"" + cell + "\", which this does not read)");
+                }
+                else if (claimed != waits)
+                {
+                    wrong.Add(label + (waits
+                        ? " (waits on the license check and is not marked required)"
+                        : " (marked required and nothing in it waits on the license check)"));
+                }
+            }
+
+            // Assert — the floors are on what this judged rather than on what it was offered: a table read
+            // whole but matched to no workflow reports nothing wrong, and so does a reader that found no
+            // gate at all, which agrees exactly with a table rewritten to "not required" throughout.
+            var gates = workflows.Sum(entry => JobNames(entry.Text).Count(key => WaitsOnLicense(entry.Text, key)));
+            Assert.That((judged >= 2, gates >= 1, string.Join("\n", wrong)), Is.EqualTo((true, true, string.Empty)));
+        }
+
         // GREEN_ON_BASE(characterization): the two namings already agree on both sides — every job key in
-        // these workflows is plain, so the base's narrower pattern found them all. What this holds is the
-        // pattern the branch widened, against being narrowed again by someone who has only the passing
-        // cases to go on.
+        // these workflows is plain, so the base's narrower pattern found them all, and both aggregates
+        // spell `needs:` as a flow list, which the base's narrower reader took as well. What this holds is
+        // the two patterns the branch widened, against being narrowed again by someone who has only the
+        // passing cases to go on.
         [Test]
         public void Given_EveryJobARequiredAggregateNames_When_TheWorkflowIsEnumerated_Then_ItIsFound()
         {
@@ -461,13 +605,12 @@ namespace Velvet.Tests
 
             // Assert — the floor is on the workflows because that is what it can hold: an aggregate whose
             // needs list went unread names no job, nothing is missing from an enumeration that returned
-            // nothing, and `RequiredWorkflows` never reads that list so its count does not move. Reading
-            // both list spellings is what keeps that state out of reach rather than the floor.
+            // nothing, and `RequiredWorkflows` never reads that list so its count does not move.
             Assert.That((required.Count >= 2, string.Join("\n", missing)), Is.EqualTo((true, string.Empty)));
         }
 
-        // GREEN_ON_BASE(characterization): this column happened to be right on both sides. The other two
-        // cases found the first column wrong, which is the reason to hold this one before it drifts too.
+        // GREEN_ON_BASE(characterization): this column happened to be right on both sides. Deriving the
+        // first column found it wrong, which is the reason to hold this one before it drifts too.
         [Test]
         public void Given_EveryRequiredCheckAggregate_When_ContributingsCiTableIsRead_Then_ItsRowIsTheOneMarkedRequired()
         {
@@ -501,8 +644,8 @@ namespace Velvet.Tests
         }
 
         // GREEN_ON_BASE(characterization): what this case asks did not change — only the reader it asks
-        // through, from a flow-list-only match to one that takes either YAML spelling. The spelling that
-        // separates the two is in neither workflow, so both answer the same here.
+        // through, which now takes a block sequence and a bare scalar as well as a flow list. Both
+        // aggregates spell `needs:` as a flow list, so every reader answers the same here.
         [Test]
         public void Given_EveryJobInARequiredWorkflow_When_TheAggregateIsRead_Then_ItDependsOnThatJob()
         {

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/RequiredCheckAggregationTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/RequiredCheckAggregationTests.cs
@@ -340,10 +340,6 @@ namespace Velvet.Tests
                 Is.EqualTo((true, true, string.Empty)));
         }
 
-        // GREEN_ON_BASE(characterization): the two namings already agree on both sides — every job key in
-        // these workflows is plain, so the base's narrower pattern found them all. What this holds is the
-        // pattern the branch widened, against being narrowed again by someone who has only the passing
-        // cases to go on.
         // The events a contributor's own work starts. `workflow_dispatch` and `release` sit outside by
         // decision rather than by omission: neither is something a pull request or a push to main causes,
         // and the table does not offer them for the required workflows.
@@ -434,6 +430,10 @@ namespace Velvet.Tests
             Assert.That((rows.Count >= 2, string.Join("\n", wrong)), Is.EqualTo((true, string.Empty)));
         }
 
+        // GREEN_ON_BASE(characterization): the two namings already agree on both sides — every job key in
+        // these workflows is plain, so the base's narrower pattern found them all. What this holds is the
+        // pattern the branch widened, against being narrowed again by someone who has only the passing
+        // cases to go on.
         [Test]
         public void Given_EveryJobARequiredAggregateNames_When_TheWorkflowIsEnumerated_Then_ItIsFound()
         {
@@ -500,6 +500,9 @@ namespace Velvet.Tests
             Assert.That((aggregates.Count >= 2, string.Join("\n", wrong)), Is.EqualTo((true, string.Empty)));
         }
 
+        // GREEN_ON_BASE(characterization): what this case asks did not change — only the reader it asks
+        // through, from a flow-list-only match to one that takes either YAML spelling. The spelling that
+        // separates the two is in neither workflow, so both answer the same here.
         [Test]
         public void Given_EveryJobInARequiredWorkflow_When_TheAggregateIsRead_Then_ItDependsOnThatJob()
         {

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/RequiredCheckAggregationTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/RequiredCheckAggregationTests.cs
@@ -130,6 +130,139 @@ namespace Velvet.Tests
                 .Select(job => relativePath + ":" + job);
         }
 
+        private static readonly Regex WorkflowNamePattern =
+            new(@"^name:\s*(?<name>.+)$", RegexOptions.Compiled | RegexOptions.Multiline);
+
+        private static readonly Regex JobNamePattern =
+            new(@"^    name:\s*(?<name>.+)$", RegexOptions.Compiled | RegexOptions.Multiline);
+
+        // The first backticked run of a table row's first cell. A row names either a workflow (`Docs`) or
+        // one of its jobs (`Test ▸ unity-tests`), and the rest of the cell is prose about the matrix.
+        private static readonly Regex TableRowPattern =
+            new(@"^\|\s*`(?<cell>[^`]+)`", RegexOptions.Compiled);
+
+        private static string Unquoted(string value) => value.Trim().Trim('"', '\'');
+
+        private static string WorkflowDisplayName(string workflow)
+        {
+            var match = WorkflowNamePattern.Match(workflow);
+            return match.Success ? Unquoted(match.Groups["name"].Value) : string.Empty;
+        }
+
+        private static string JobDisplayName(string workflow, string job)
+        {
+            var match = JobNamePattern.Match(AggregateBlock(workflow, job));
+            return match.Success ? Unquoted(match.Groups["name"].Value) : string.Empty;
+        }
+
+        /// <summary>Each `Workflow ▸ job` / `Workflow` reference in CONTRIBUTING's continuous-integration table.</summary>
+        private static IReadOnlyList<(string Workflow, string Job)> ContributingRows()
+        {
+            var rows = new List<(string, string)>();
+            var lines = File.ReadAllLines(Path.Combine(RepositoryRoot(), "CONTRIBUTING.md"));
+            var start = Array.FindIndex(lines, line => line.TrimEnd('\r') == "## Continuous integration");
+            for (var i = start + 1; start >= 0 && i < lines.Length; i++)
+            {
+                var line = lines[i].TrimEnd('\r');
+                if (line.StartsWith("##", StringComparison.Ordinal))
+                {
+                    break;
+                }
+
+                var match = TableRowPattern.Match(line);
+                if (!match.Success)
+                {
+                    continue;
+                }
+
+                var cell = match.Groups["cell"].Value;
+                var separator = cell.IndexOf('▸');
+                rows.Add(separator < 0
+                    ? (cell.Trim(), string.Empty)
+                    : (cell.Substring(0, separator).Trim(), cell.Substring(separator + 1).Trim()));
+            }
+
+            return rows;
+        }
+
+        /// <summary>Every workflow file, paired with its display name.</summary>
+        private static IReadOnlyList<(string Path, string Name, string Text)> Workflows()
+        {
+            var directory = Path.Combine(RepositoryRoot(), ".github", "workflows");
+            return Directory.EnumerateFiles(directory, "*.yml")
+                .OrderBy(path => path, StringComparer.Ordinal)
+                .Select(path =>
+                {
+                    var text = File.ReadAllText(path);
+                    return (Path.GetFileName(path), WorkflowDisplayName(text), text);
+                })
+                .ToList();
+        }
+
+        private static bool Names(string workflow, string reference, string job) =>
+            reference == job || reference == JobDisplayName(workflow, job);
+
+        [Test]
+        public void Given_EveryRowOfContributingsCiTable_When_TheWorkflowsAreRead_Then_ItNamesOneThatExists()
+        {
+            // Arrange — a row naming no job is the direction that needs no curation: it is wrong outright.
+            var workflows = Workflows();
+            var rows = ContributingRows();
+
+            // Act
+            var dangling = new List<string>();
+            foreach (var (name, job) in rows)
+            {
+                var workflow = workflows.FirstOrDefault(entry => entry.Name == name);
+                if (workflow.Text == null)
+                {
+                    dangling.Add(name + " (no workflow of that name)");
+                }
+                else if (job.Length > 0 && !JobNames(workflow.Text).Any(key => Names(workflow.Text, job, key)))
+                {
+                    dangling.Add(name + " ▸ " + job + " (no such job in " + workflow.Path + ")");
+                }
+            }
+
+            // Assert — the floors ride along for the reason the cases below give: a table nobody found, or
+            // a workflow directory that read empty, reports nothing dangling and would pass having measured
+            // nothing.
+            Assert.That((rows.Count >= 2, workflows.Count >= 2, string.Join("\n", dangling)),
+                Is.EqualTo((true, true, string.Empty)));
+        }
+
+        [Test]
+        public void Given_EveryJobOfARequiredWorkflow_When_ContributingsCiTableIsRead_Then_ItHasARow()
+        {
+            // Arrange — which jobs a contributor is owed a row for is read off the workflows rather than
+            // curated here: the ones in a workflow carrying a required aggregate are the ones that can
+            // block a merge. The rest — the docs publishing chain, the upm split — are summarised by a row
+            // per workflow, and an exemption list kept here would be the second place to edit that let the
+            // table drift in the first place.
+            var listed = ContributingRows();
+            var required = RequiredWorkflows()
+                .Select(entry => (entry.Workflow, Text: ReadWorkflow(entry.Workflow)))
+                .ToList();
+
+            // Act
+            var unlisted = new List<string>();
+            foreach (var (path, text) in required)
+            {
+                var name = WorkflowDisplayName(text);
+                foreach (var job in JobNames(text))
+                {
+                    if (!listed.Any(row => row.Workflow == name && row.Job.Length > 0 && Names(text, row.Job, job)))
+                    {
+                        unlisted.Add(path + ":" + job);
+                    }
+                }
+            }
+
+            // Assert — same floors as the cases below, for the same reason.
+            Assert.That((required.Count >= 2, listed.Count >= 2, string.Join("\n", unlisted)),
+                Is.EqualTo((true, true, string.Empty)));
+        }
+
         [Test]
         public void Given_EveryJobInARequiredWorkflow_When_TheAggregateIsRead_Then_ItDependsOnThatJob()
         {

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/RequiredCheckAggregationTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/RequiredCheckAggregationTests.cs
@@ -301,6 +301,8 @@ namespace Velvet.Tests
                 Is.EqualTo((true, true, string.Empty)));
         }
 
+        // GREEN_ON_BASE(characterization): this column happened to be right on both sides. The other two
+        // cases found the first column wrong, which is the reason to hold this one before it drifts too.
         [Test]
         public void Given_EveryRequiredCheckAggregate_When_ContributingsCiTableIsRead_Then_ItsRowIsTheOneMarkedRequired()
         {

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/RequiredCheckAggregationTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/RequiredCheckAggregationTests.cs
@@ -168,9 +168,10 @@ namespace Velvet.Tests
         /// Each row of CONTRIBUTING's continuous-integration table: the `Workflow ▸ job` / `Workflow` its
         /// first cell names, and whether its last column says the check is required to merge.
         /// <para>
-        /// Bounded by the table rather than by the section. Collection starts at the header's separator
-        /// row and ends at the first line that is not a row, so a second table or a fenced example in the
-        /// same section is not read as continuous-integration rows and misreported as a dangling one.
+        /// Bounded by the table rather than by the section, and fenced blocks are skipped whole. Collection
+        /// starts at the first separator row outside a fence and ends at the first line that is not a row,
+        /// so neither a second table nor an example of one — before the table or after it — is read as a
+        /// continuous-integration row and misreported as naming no workflow.
         /// </para>
         /// </summary>
         private static IReadOnlyList<(string Workflow, string Job, bool Required)> ContributingRows()
@@ -183,7 +184,21 @@ namespace Velvet.Tests
                 return rows;
             }
 
-            var separator = Array.FindIndex(lines, heading + 1, line => TableSeparator.IsMatch(line.TrimEnd('\r')));
+            var separator = -1;
+            var fenced = false;
+            for (var i = heading + 1; i < lines.Length && separator < 0; i++)
+            {
+                var scan = lines[i].TrimEnd('\r');
+                if (scan.StartsWith("```", StringComparison.Ordinal))
+                {
+                    fenced = !fenced;
+                }
+                else if (!fenced && TableSeparator.IsMatch(scan))
+                {
+                    separator = i;
+                }
+            }
+
             for (var i = separator + 1; separator > heading && i < lines.Length; i++)
             {
                 var line = lines[i].TrimEnd('\r');
@@ -258,11 +273,10 @@ namespace Velvet.Tests
                 }
             }
 
-            // Assert — the row floor rides along because a heading that was renamed leaves no rows to
-            // dangle, which reads the same as a table that agrees. An empty workflow directory needs no
-            // floor: it dangles every row rather than none.
-            Assert.That((rows.Count >= 2, workflows.Count >= 2, string.Join("\n", dangling)),
-                Is.EqualTo((true, true, string.Empty)));
+            // Assert — the floor is on the rows, because a heading that was renamed leaves none to dangle
+            // and reads the same as a table that agrees. A workflow directory that read empty needs none:
+            // it dangles every row rather than nothing.
+            Assert.That((rows.Count >= 2, string.Join("\n", dangling)), Is.EqualTo((true, string.Empty)));
         }
 
         [Test]
@@ -294,11 +308,42 @@ namespace Velvet.Tests
                 }
             }
 
-            // Assert — the second floor counts the jobs actually asked about, as the cases below do, rather
-            // than the rows offered to answer them. A workflow whose jobs went unenumerated reports nothing
-            // unlisted, and a full table would have covered for it.
+            // Assert — the second floor counts the jobs actually asked about rather than the rows offered
+            // to answer them, so a required workflow that collapsed to its aggregate alone cannot be
+            // covered for by a full table. It does not catch a workflow that lost *some* of its jobs to
+            // the parser; the case below is what does.
             Assert.That((required.Count >= 2, asked > required.Count, string.Join("\n", unlisted)),
                 Is.EqualTo((true, true, string.Empty)));
+        }
+
+        [Test]
+        public void Given_EveryJobARequiredAggregateNames_When_TheWorkflowIsEnumerated_Then_ItIsFound()
+        {
+            // Arrange — every case here answers over the jobs the enumerator returns, so a job it cannot
+            // see is one nothing asks about. The aggregate's own `needs:` is a second naming of the same
+            // set, written by hand in the workflow, and the two disagreeing is what says the enumerator
+            // stopped seeing something.
+            var required = RequiredWorkflows();
+
+            // Act
+            var missing = new List<string>();
+            foreach (var (path, aggregate) in required)
+            {
+                var text = ReadWorkflow(path);
+                var found = JobNames(text).ToHashSet(StringComparer.Ordinal);
+                foreach (var job in NeedsListPattern.Match(AggregateBlock(text, aggregate)).Groups["jobs"].Value
+                             .Split(',').Select(job => job.Trim()).Where(job => job.Length > 0))
+                {
+                    if (!found.Contains(job))
+                    {
+                        missing.Add(path + ":" + job);
+                    }
+                }
+            }
+
+            // Assert — the floor rides along because an aggregate whose needs list went unread names no
+            // job, and nothing is then missing from an enumeration that returned nothing either.
+            Assert.That((required.Count >= 2, string.Join("\n", missing)), Is.EqualTo((true, string.Empty)));
         }
 
         // GREEN_ON_BASE(characterization): this column happened to be right on both sides. The other two
@@ -308,21 +353,30 @@ namespace Velvet.Tests
         {
             // Arrange — the column a contributor acts on is the last one, and it was as unpinned as the
             // first. Which rows may carry a yes is the same question the fixture already answers to find
-            // the aggregates, so it is asked once rather than curated twice.
+            // the aggregates, so it is asked once rather than curated twice. Matched through the same
+            // Names as the cases above: the aggregate rows are the only ones spelt by display name today,
+            // and spelling them by key instead is legal there, so a case that accepted only one spelling
+            // would red on a table it had just been made consistent with.
             var aggregates = RequiredWorkflows()
                 .Select(entry => (Text: ReadWorkflow(entry.Workflow), entry.Aggregate))
-                .Select(entry => (Workflow: WorkflowDisplayName(entry.Text), Display: JobDisplayName(entry.Text, entry.Aggregate)))
-                .ToHashSet();
-
-            // Act
-            var wrong = ContributingRows()
-                .Where(row => row.Job.Length > 0)
-                .Where(row => aggregates.Contains((row.Workflow, row.Job)) != row.Required)
-                .Select(row => row.Workflow + " ▸ " + row.Job + (row.Required ? " (marked required)" : " (not marked required)"))
+                .Select(entry => (Workflow: WorkflowDisplayName(entry.Text), entry.Text, entry.Aggregate))
                 .ToList();
 
-            // Assert — the floor rides along because an aggregate set that read empty matches no row, and
-            // every row then correctly reads "not required", which is a pass having measured nothing.
+            // Act — every row, including one naming a workflow and no job: such a row can carry a yes too,
+            // and nothing else would notice.
+            var wrong = ContributingRows()
+                .Where(row => aggregates.Any(entry =>
+                    entry.Workflow == row.Workflow
+                    && row.Job.Length > 0
+                    && Names(entry.Text, row.Job, entry.Aggregate)) != row.Required)
+                .Select(row => row.Workflow + (row.Job.Length > 0 ? " ▸ " + row.Job : string.Empty)
+                    + (row.Required ? " (marked required)" : " (not marked required)"))
+                .ToList();
+
+            // Assert — the floor catches an aggregate set that read empty *and* a table with no yes left in
+            // it, which agree with each other and describe a repository where nothing gates a merge. Either
+            // alone reds through the message: the rows carrying a yes stop matching, or the aggregates stop
+            // being matched.
             Assert.That((aggregates.Count >= 2, string.Join("\n", wrong)), Is.EqualTo((true, string.Empty)));
         }
 

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/RequiredCheckAggregationTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/RequiredCheckAggregationTests.cs
@@ -31,8 +31,11 @@ namespace Velvet.Tests
             new(@"^\s*name:\s*(?<context>Required checks \([^)]+\))\s*$",
                 RegexOptions.Compiled | RegexOptions.Multiline);
 
+        // The trailing comment is allowed for: a job key carrying one is valid YAML and a valid job id, and
+        // a pattern that misses it drops that job out of every case here — which is the drift these exist
+        // to catch, happening inside them.
         private static readonly Regex JobKeyPattern =
-            new(@"^  ([A-Za-z_][A-Za-z0-9_-]*):\s*$", RegexOptions.Compiled);
+            new(@"^  ([A-Za-z_][A-Za-z0-9_-]*):\s*(#.*)?$", RegexOptions.Compiled);
 
         private static readonly Regex NeedsListPattern =
             new(@"^\s*needs:\s*\[(?<jobs>[^\]]*)\]", RegexOptions.Compiled | RegexOptions.Multiline);
@@ -58,8 +61,7 @@ namespace Velvet.Tests
         private static IReadOnlyList<(string Workflow, string Aggregate)> RequiredWorkflows()
         {
             var found = new List<(string, string)>();
-            var directory = Path.Combine(RepositoryRoot(), ".github", "workflows");
-            foreach (var path in Directory.EnumerateFiles(directory, "*.yml").OrderBy(path => path, StringComparer.Ordinal))
+            foreach (var path in WorkflowFiles())
             {
                 var workflow = File.ReadAllText(path);
                 foreach (var job in JobNames(workflow))
@@ -110,7 +112,11 @@ namespace Velvet.Tests
         private static string AggregateBlock(string workflow, string aggregate)
         {
             var lines = workflow.Split('\n');
-            var start = Array.FindIndex(lines, line => line.TrimEnd('\r') == "  " + aggregate + ":");
+            var start = Array.FindIndex(lines, line =>
+            {
+                var match = JobKeyPattern.Match(line.TrimEnd('\r'));
+                return match.Success && match.Groups[1].Value == aggregate;
+            });
             if (start < 0)
             {
                 return string.Empty;
@@ -136,10 +142,13 @@ namespace Velvet.Tests
         private static readonly Regex JobNamePattern =
             new(@"^    name:\s*(?<name>.+)$", RegexOptions.Compiled | RegexOptions.Multiline);
 
-        // The first backticked run of a table row's first cell. A row names either a workflow (`Docs`) or
-        // one of its jobs (`Test ▸ unity-tests`), and the rest of the cell is prose about the matrix.
+        // The first backticked run of a table row's first cell, which names either a workflow (`Docs`) or
+        // one of its jobs (`Test ▸ unity-tests`).
         private static readonly Regex TableRowPattern =
             new(@"^\|\s*`(?<cell>[^`]+)`", RegexOptions.Compiled);
+
+        // A pipe row of dashes and colons, and nothing else.
+        private static readonly Regex TableSeparator = new(@"^\|[\s:|-]+\|\s*$", RegexOptions.Compiled);
 
         private static string Unquoted(string value) => value.Trim().Trim('"', '\'');
 
@@ -155,16 +164,30 @@ namespace Velvet.Tests
             return match.Success ? Unquoted(match.Groups["name"].Value) : string.Empty;
         }
 
-        /// <summary>Each `Workflow ▸ job` / `Workflow` reference in CONTRIBUTING's continuous-integration table.</summary>
-        private static IReadOnlyList<(string Workflow, string Job)> ContributingRows()
+        /// <summary>
+        /// Each row of CONTRIBUTING's continuous-integration table: the `Workflow ▸ job` / `Workflow` its
+        /// first cell names, and whether its last column says the check is required to merge.
+        /// <para>
+        /// Bounded by the table rather than by the section. Collection starts at the header's separator
+        /// row and ends at the first line that is not a row, so a second table or a fenced example in the
+        /// same section is not read as continuous-integration rows and misreported as a dangling one.
+        /// </para>
+        /// </summary>
+        private static IReadOnlyList<(string Workflow, string Job, bool Required)> ContributingRows()
         {
-            var rows = new List<(string, string)>();
+            var rows = new List<(string, string, bool)>();
             var lines = File.ReadAllLines(Path.Combine(RepositoryRoot(), "CONTRIBUTING.md"));
-            var start = Array.FindIndex(lines, line => line.TrimEnd('\r') == "## Continuous integration");
-            for (var i = start + 1; start >= 0 && i < lines.Length; i++)
+            var heading = Array.FindIndex(lines, line => line.TrimEnd('\r') == "## Continuous integration");
+            if (heading < 0)
+            {
+                return rows;
+            }
+
+            var separator = Array.FindIndex(lines, heading + 1, line => TableSeparator.IsMatch(line.TrimEnd('\r')));
+            for (var i = separator + 1; separator > heading && i < lines.Length; i++)
             {
                 var line = lines[i].TrimEnd('\r');
-                if (line.StartsWith("##", StringComparison.Ordinal))
+                if (!line.StartsWith("|", StringComparison.Ordinal))
                 {
                     break;
                 }
@@ -175,22 +198,33 @@ namespace Velvet.Tests
                     continue;
                 }
 
+                var columns = line.Split('|');
+                var required = columns.Length > 4
+                    && string.Equals(columns[4].Replace("*", string.Empty).Trim(), "yes", StringComparison.OrdinalIgnoreCase);
                 var cell = match.Groups["cell"].Value;
-                var separator = cell.IndexOf('▸');
-                rows.Add(separator < 0
-                    ? (cell.Trim(), string.Empty)
-                    : (cell.Substring(0, separator).Trim(), cell.Substring(separator + 1).Trim()));
+                var arrow = cell.IndexOf('▸');
+                rows.Add(arrow < 0
+                    ? (cell.Trim(), string.Empty, required)
+                    : (cell.Substring(0, arrow).Trim(), cell.Substring(arrow + 1).Trim(), required));
             }
 
             return rows;
         }
 
-        /// <summary>Every workflow file, paired with its display name.</summary>
-        private static IReadOnlyList<(string Path, string Name, string Text)> Workflows()
+        /// <summary>Every workflow file. Both extensions, because GitHub Actions runs both.</summary>
+        private static IReadOnlyList<string> WorkflowFiles()
         {
             var directory = Path.Combine(RepositoryRoot(), ".github", "workflows");
             return Directory.EnumerateFiles(directory, "*.yml")
+                .Concat(Directory.EnumerateFiles(directory, "*.yaml"))
                 .OrderBy(path => path, StringComparer.Ordinal)
+                .ToList();
+        }
+
+        /// <summary>Every workflow file, paired with its display name.</summary>
+        private static IReadOnlyList<(string Path, string Name, string Text)> Workflows()
+        {
+            return WorkflowFiles()
                 .Select(path =>
                 {
                     var text = File.ReadAllText(path);
@@ -211,7 +245,7 @@ namespace Velvet.Tests
 
             // Act
             var dangling = new List<string>();
-            foreach (var (name, job) in rows)
+            foreach (var (name, job, _) in rows)
             {
                 var workflow = workflows.FirstOrDefault(entry => entry.Name == name);
                 if (workflow.Text == null)
@@ -224,9 +258,9 @@ namespace Velvet.Tests
                 }
             }
 
-            // Assert — the floors ride along for the reason the cases below give: a table nobody found, or
-            // a workflow directory that read empty, reports nothing dangling and would pass having measured
-            // nothing.
+            // Assert — the row floor rides along because a heading that was renamed leaves no rows to
+            // dangle, which reads the same as a table that agrees. An empty workflow directory needs no
+            // floor: it dangles every row rather than none.
             Assert.That((rows.Count >= 2, workflows.Count >= 2, string.Join("\n", dangling)),
                 Is.EqualTo((true, true, string.Empty)));
         }
@@ -246,11 +280,13 @@ namespace Velvet.Tests
 
             // Act
             var unlisted = new List<string>();
+            var asked = 0;
             foreach (var (path, text) in required)
             {
                 var name = WorkflowDisplayName(text);
                 foreach (var job in JobNames(text))
                 {
+                    asked++;
                     if (!listed.Any(row => row.Workflow == name && row.Job.Length > 0 && Names(text, row.Job, job)))
                     {
                         unlisted.Add(path + ":" + job);
@@ -258,9 +294,34 @@ namespace Velvet.Tests
                 }
             }
 
-            // Assert — same floors as the cases below, for the same reason.
-            Assert.That((required.Count >= 2, listed.Count >= 2, string.Join("\n", unlisted)),
+            // Assert — the second floor counts the jobs actually asked about, as the cases below do, rather
+            // than the rows offered to answer them. A workflow whose jobs went unenumerated reports nothing
+            // unlisted, and a full table would have covered for it.
+            Assert.That((required.Count >= 2, asked > required.Count, string.Join("\n", unlisted)),
                 Is.EqualTo((true, true, string.Empty)));
+        }
+
+        [Test]
+        public void Given_EveryRequiredCheckAggregate_When_ContributingsCiTableIsRead_Then_ItsRowIsTheOneMarkedRequired()
+        {
+            // Arrange — the column a contributor acts on is the last one, and it was as unpinned as the
+            // first. Which rows may carry a yes is the same question the fixture already answers to find
+            // the aggregates, so it is asked once rather than curated twice.
+            var aggregates = RequiredWorkflows()
+                .Select(entry => (Text: ReadWorkflow(entry.Workflow), entry.Aggregate))
+                .Select(entry => (Workflow: WorkflowDisplayName(entry.Text), Display: JobDisplayName(entry.Text, entry.Aggregate)))
+                .ToHashSet();
+
+            // Act
+            var wrong = ContributingRows()
+                .Where(row => row.Job.Length > 0)
+                .Where(row => aggregates.Contains((row.Workflow, row.Job)) != row.Required)
+                .Select(row => row.Workflow + " ▸ " + row.Job + (row.Required ? " (marked required)" : " (not marked required)"))
+                .ToList();
+
+            // Assert — the floor rides along because an aggregate set that read empty matches no row, and
+            // every row then correctly reads "not required", which is a pass having measured nothing.
+            Assert.That((aggregates.Count >= 2, string.Join("\n", wrong)), Is.EqualTo((true, string.Empty)));
         }
 
         [Test]

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/RequiredCheckAggregationTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/RequiredCheckAggregationTests.cs
@@ -316,6 +316,10 @@ namespace Velvet.Tests
                 Is.EqualTo((true, true, string.Empty)));
         }
 
+        // GREEN_ON_BASE(characterization): the two namings already agree on both sides — every job key in
+        // these workflows is plain, so the base's narrower pattern found them all. What this holds is the
+        // pattern the branch widened, against being narrowed again by someone who has only the passing
+        // cases to go on.
         [Test]
         public void Given_EveryJobARequiredAggregateNames_When_TheWorkflowIsEnumerated_Then_ItIsFound()
         {

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/RequiredCheckAggregationTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/RequiredCheckAggregationTests.cs
@@ -40,6 +40,29 @@ namespace Velvet.Tests
         private static readonly Regex NeedsListPattern =
             new(@"^\s*needs:\s*\[(?<jobs>[^\]]*)\]", RegexOptions.Compiled | RegexOptions.Multiline);
 
+        // A block sequence and a flow list are the same to Actions, and a formatter turns one into the
+        // other. Reading only the flow form left the case below asking nothing and passing for it.
+        private static readonly Regex NeedsBlockPattern =
+            new(@"^\s*needs:\s*(?:#[^\r\n]*)?\r?\n(?<jobs>(?:\s*-\s*[^\r\n]+\r?\n?)+)",
+                RegexOptions.Compiled | RegexOptions.Multiline);
+
+        /// <summary>The jobs an aggregate's block declares it needs, in either YAML spelling.</summary>
+        private static IEnumerable<string> NeedsOf(string block)
+        {
+            var flow = NeedsListPattern.Match(block);
+            if (flow.Success)
+            {
+                return flow.Groups["jobs"].Value.Split(',').Select(job => job.Trim()).Where(job => job.Length > 0);
+            }
+
+            var sequence = NeedsBlockPattern.Match(block);
+            return sequence.Success
+                ? sequence.Groups["jobs"].Value.Split('\n')
+                    .Select(line => line.Trim().TrimStart('-').Trim())
+                    .Where(job => job.Length > 0)
+                : Enumerable.Empty<string>();
+        }
+
         private static readonly Regex ResultReferencePattern =
             new(@"needs\.(?<job>[A-Za-z_][A-Za-z0-9_-]*)\.result", RegexOptions.Compiled);
 
@@ -170,13 +193,14 @@ namespace Velvet.Tests
         /// <para>
         /// Bounded by the table rather than by the section, and fenced blocks are skipped whole. Collection
         /// starts at the first separator row outside a fence and ends at the first line that is not a row,
-        /// so neither a second table nor an example of one — before the table or after it — is read as a
-        /// continuous-integration row and misreported as naming no workflow.
+        /// so neither a second table nor a fenced example of one — before the table or after it — is read
+        /// as a continuous-integration row and misreported as naming no workflow. A fence is recognised by
+        /// its opening run of backticks or tildes at the line's start, which is every fence in this file.
         /// </para>
         /// </summary>
-        private static IReadOnlyList<(string Workflow, string Job, bool Required)> ContributingRows()
+        private static IReadOnlyList<(string Workflow, string Job, bool Required, string Trigger)> ContributingRows()
         {
-            var rows = new List<(string, string, bool)>();
+            var rows = new List<(string, string, bool, string)>();
             var lines = File.ReadAllLines(Path.Combine(RepositoryRoot(), "CONTRIBUTING.md"));
             var heading = Array.FindIndex(lines, line => line.TrimEnd('\r') == "## Continuous integration");
             if (heading < 0)
@@ -189,7 +213,7 @@ namespace Velvet.Tests
             for (var i = heading + 1; i < lines.Length && separator < 0; i++)
             {
                 var scan = lines[i].TrimEnd('\r');
-                if (scan.StartsWith("```", StringComparison.Ordinal))
+                if (scan.StartsWith("```", StringComparison.Ordinal) || scan.StartsWith("~~~", StringComparison.Ordinal))
                 {
                     fenced = !fenced;
                 }
@@ -216,11 +240,12 @@ namespace Velvet.Tests
                 var columns = line.Split('|');
                 var required = columns.Length > 4
                     && string.Equals(columns[4].Replace("*", string.Empty).Trim(), "yes", StringComparison.OrdinalIgnoreCase);
+                var trigger = columns.Length > 2 ? columns[2] : string.Empty;
                 var cell = match.Groups["cell"].Value;
                 var arrow = cell.IndexOf('▸');
                 rows.Add(arrow < 0
-                    ? (cell.Trim(), string.Empty, required)
-                    : (cell.Substring(0, arrow).Trim(), cell.Substring(arrow + 1).Trim(), required));
+                    ? (cell.Trim(), string.Empty, required, trigger)
+                    : (cell.Substring(0, arrow).Trim(), cell.Substring(arrow + 1).Trim(), required, trigger));
             }
 
             return rows;
@@ -260,7 +285,7 @@ namespace Velvet.Tests
 
             // Act
             var dangling = new List<string>();
-            foreach (var (name, job, _) in rows)
+            foreach (var (name, job, _, _) in rows)
             {
                 var workflow = workflows.FirstOrDefault(entry => entry.Name == name);
                 if (workflow.Text == null)
@@ -294,13 +319,11 @@ namespace Velvet.Tests
 
             // Act
             var unlisted = new List<string>();
-            var asked = 0;
             foreach (var (path, text) in required)
             {
                 var name = WorkflowDisplayName(text);
                 foreach (var job in JobNames(text))
                 {
-                    asked++;
                     if (!listed.Any(row => row.Workflow == name && row.Job.Length > 0 && Names(text, row.Job, job)))
                     {
                         unlisted.Add(path + ":" + job);
@@ -308,11 +331,12 @@ namespace Velvet.Tests
                 }
             }
 
-            // Assert — the second floor counts the jobs actually asked about rather than the rows offered
-            // to answer them, so a required workflow that collapsed to its aggregate alone cannot be
-            // covered for by a full table. It does not catch a workflow that lost *some* of its jobs to
-            // the parser; the case below is what does.
-            Assert.That((required.Count >= 2, asked > required.Count, string.Join("\n", unlisted)),
+            // Assert — the second floor is per workflow rather than a total, so one required workflow
+            // collapsing to its aggregate alone cannot be covered for by the other's jobs or by a full
+            // table. It does not catch a workflow that lost *some* of its jobs to the parser; the case
+            // below is what does.
+            var enumerated = required.All(entry => JobNames(entry.Text).Count >= 2);
+            Assert.That((required.Count >= 2, enumerated, string.Join("\n", unlisted)),
                 Is.EqualTo((true, true, string.Empty)));
         }
 
@@ -320,13 +344,104 @@ namespace Velvet.Tests
         // these workflows is plain, so the base's narrower pattern found them all. What this holds is the
         // pattern the branch widened, against being narrowed again by someone who has only the passing
         // cases to go on.
+        // The events a contributor's own work starts. `workflow_dispatch` and `release` sit outside by
+        // decision rather than by omission: neither is something a pull request or a push to main causes,
+        // and the table does not offer them for the required workflows.
+        private static readonly string[] ContributorEvents = { "push", "pull_request", "merge_group" };
+
+        // The words the Trigger column uses for those three. A cell naming none of them is reported rather
+        // than read as claiming nothing, so a row rewritten in a vocabulary this does not know fails here
+        // instead of quietly leaving the column unheld.
+        private static readonly (string Phrase, string Event)[] TriggerPhrases =
+        {
+            ("push", "push"),
+            ("every PR", "pull_request"),
+            ("merge group", "merge_group"),
+        };
+
+        private static readonly Regex OnKeyPattern = new(@"^  (?<event>[a-z_]+):", RegexOptions.Compiled);
+
+        // Four spaces is a job-level key. A step's `if:` sits deeper and answers for that step alone —
+        // upm.yml gates three steps on workflow_dispatch while the job itself runs on push too.
+        private static readonly Regex JobLevelIfPattern =
+            new(@"^    if:[^\r\n]*github\.event_name\s*==\s*'(?<event>[a-z_]+)'",
+                RegexOptions.Compiled | RegexOptions.Multiline);
+
+        /// <summary>The events a workflow subscribes to, read out of its own `on:` block.</summary>
+        private static IEnumerable<string> SubscribedEvents(string workflow)
+        {
+            var lines = workflow.Split('\n');
+            var start = Array.FindIndex(lines, line => line.TrimEnd('\r') == "on:");
+            if (start < 0)
+            {
+                return Enumerable.Empty<string>();
+            }
+
+            var end = Array.FindIndex(lines, start + 1, line =>
+                line.Length > 0 && !char.IsWhiteSpace(line[0]) && !line.StartsWith("#", StringComparison.Ordinal));
+            return lines.Skip(start + 1).Take((end < 0 ? lines.Length : end) - start - 1)
+                .Select(line => OnKeyPattern.Match(line.TrimEnd('\r')))
+                .Where(match => match.Success)
+                .Select(match => match.Groups["event"].Value);
+        }
+
+        [Test]
+        public void Given_EveryRowOfContributingsCiTable_When_ItsTriggerCellIsRead_Then_ItNamesWhatStartsThatJob()
+        {
+            // Arrange — the Trigger column was as unpinned as the other two the branch holds, and it was
+            // wrong: both aggregate rows omitted push while their jobs carry no event gate at all.
+            var workflows = Workflows();
+            var rows = ContributingRows();
+
+            // Act
+            var wrong = new List<string>();
+            foreach (var row in rows)
+            {
+                var workflow = workflows.FirstOrDefault(entry => entry.Name == row.Workflow);
+                if (workflow.Text == null)
+                {
+                    continue;
+                }
+
+                var starts = SubscribedEvents(workflow.Text).Intersect(ContributorEvents, StringComparer.Ordinal)
+                    .ToHashSet(StringComparer.Ordinal);
+                var job = row.Job.Length == 0
+                    ? null
+                    : JobNames(workflow.Text).FirstOrDefault(key => Names(workflow.Text, row.Job, key));
+                var gate = job == null ? null : JobLevelIfPattern.Match(AggregateBlock(workflow.Text, job));
+                if (gate is { Success: true })
+                {
+                    starts.IntersectWith(new[] { gate.Groups["event"].Value });
+                }
+
+                var claimed = TriggerPhrases
+                    .Where(phrase => row.Trigger.Contains(phrase.Phrase, StringComparison.Ordinal))
+                    .Select(phrase => phrase.Event)
+                    .ToHashSet(StringComparer.Ordinal);
+                var label = row.Workflow + (row.Job.Length > 0 ? " \u25b8 " + row.Job : string.Empty);
+                if (claimed.Count == 0)
+                {
+                    wrong.Add(label + " (its trigger names no event this reads)");
+                }
+                else if (!claimed.SetEquals(starts))
+                {
+                    wrong.Add(label + " (claims [" + string.Join("+", claimed.OrderBy(e => e, StringComparer.Ordinal))
+                        + "], starts on [" + string.Join("+", starts.OrderBy(e => e, StringComparer.Ordinal)) + "])");
+                }
+            }
+
+            // Assert — the floor is on the rows for the reason the case above gives.
+            Assert.That((rows.Count >= 2, string.Join("\n", wrong)), Is.EqualTo((true, string.Empty)));
+        }
+
         [Test]
         public void Given_EveryJobARequiredAggregateNames_When_TheWorkflowIsEnumerated_Then_ItIsFound()
         {
-            // Arrange — every case here answers over the jobs the enumerator returns, so a job it cannot
-            // see is one nothing asks about. The aggregate's own `needs:` is a second naming of the same
-            // set, written by hand in the workflow, and the two disagreeing is what says the enumerator
-            // stopped seeing something.
+            // Arrange — a job the enumerator loses is reported by the cases beside this one as a job that
+            // does not exist, since the enumerator is their oracle for that. What none of them reds on is
+            // the pair a real change makes: a job added in a spelling the enumerator misses, or one made
+            // invisible and its row removed together. The aggregate's own `needs:` is a second naming of
+            // the same set, written by hand in the workflow, and the two disagreeing is what says so.
             var required = RequiredWorkflows();
 
             // Act
@@ -335,8 +450,7 @@ namespace Velvet.Tests
             {
                 var text = ReadWorkflow(path);
                 var found = JobNames(text).ToHashSet(StringComparer.Ordinal);
-                foreach (var job in NeedsListPattern.Match(AggregateBlock(text, aggregate)).Groups["jobs"].Value
-                             .Split(',').Select(job => job.Trim()).Where(job => job.Length > 0))
+                foreach (var job in NeedsOf(AggregateBlock(text, aggregate)))
                 {
                     if (!found.Contains(job))
                     {
@@ -345,8 +459,10 @@ namespace Velvet.Tests
                 }
             }
 
-            // Assert — the floor rides along because an aggregate whose needs list went unread names no
-            // job, and nothing is then missing from an enumeration that returned nothing either.
+            // Assert — the floor is on the workflows because that is what it can hold: an aggregate whose
+            // needs list went unread names no job, nothing is missing from an enumeration that returned
+            // nothing, and `RequiredWorkflows` never reads that list so its count does not move. Reading
+            // both list spellings is what keeps that state out of reach rather than the floor.
             Assert.That((required.Count >= 2, string.Join("\n", missing)), Is.EqualTo((true, string.Empty)));
         }
 
@@ -392,11 +508,7 @@ namespace Velvet.Tests
 
             // Act
             var unwired = aggregates
-                .SelectMany(entry => Unwired(entry.Workflow, entry.Aggregate, block => NeedsListPattern
-                    .Match(block).Groups["jobs"].Value
-                    .Split(',')
-                    .Select(job => job.Trim())
-                    .Where(job => job.Length > 0)))
+                .SelectMany(entry => Unwired(entry.Workflow, entry.Aggregate, NeedsOf))
                 .ToList();
 
             // Assert — the two counts ride along because no aggregate found, or an aggregate whose block

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/WorkflowTriggerCoverageTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/WorkflowTriggerCoverageTests.cs
@@ -33,8 +33,11 @@ namespace Velvet.Tests
         // other's filter unread, and it was excluding four scripts its own jobs run and the two
         // AdditionalFiles Roslyn reads at compile time — the exact failure this fixture describes, in the
         // workflow it did not look at. A workflow added tomorrow is asked the same question for existing.
+        // Both extensions, because GitHub Actions runs both and a workflow spelled the other way would
+        // otherwise be outside every question here.
         private static IEnumerable<string> Workflows() =>
             Directory.EnumerateFiles(Path.GetFullPath(".github/workflows"), "*.yml")
+                .Concat(Directory.EnumerateFiles(Path.GetFullPath(".github/workflows"), "*.yaml"))
                 .Select(RepoRelative)
                 .OrderBy(path => path, StringComparer.Ordinal);
 


### PR DESCRIPTION
Closes #569.

`CONTRIBUTING.md`'s continuous-integration table is what a contributor reads to know what a pull request
runs, and nothing derived it from the workflows. All four of its columns are derived here, and three of
them were wrong. Measured against the four workflow files as they stand:

- `UPM ▸ release` names no job. `upm.yml` declares exactly one, `split`, and `workflow_dispatch` is a
  trigger of that job rather than a second one.
- `generators.yml`'s `repository-settings` and `test.yml`'s `license-check` have no row, and both are jobs
  a required aggregate `needs`.
- Both aggregate rows said the check runs on every PR and every merge-group entry and not on a push. Both
  jobs carry `if: always()` and no event gate, in workflows whose `on:` includes push, and both have run
  on a push to main.
- The `Docs` row said "push to `main`". `docs.yml`'s push carries a `paths:` list, so a push touching only
  `CONTRIBUTING.md` or `scripts/` rebuilds nothing — which is what every other filtered row spells
  "push (filtered)".

`test-quality` is named in the issue as missing and is not — it was added since. That is the drift running
the other way, and it is why this is a guard rather than a correction.

## The decision the issue asked for first

Row → job needed no decision: a row naming a job that does not exist is wrong outright.

Job → row did, because listing every job would make the table longer and less useful, and an exclusion list
in the fixture would be the second place to edit that let the mirror drift in the first place. The rule
here is read off what the workflows already declare:

> **A job in a workflow that carries a required-check aggregate is owed a row.**

That set is exactly "the jobs that can block a merge", which is what the table is for. It puts
`repository-settings` and `license-check` in scope, and leaves `docs.yml`'s `compile`/`build`/`deploy` and
`upm.yml`'s `split` out — which is the summarising the table already does, one row per workflow. Nothing is
exempted by name.

`RequiredCheckAggregationTests` already derives which workflows are required and already parses job keys
and blocks, so the new cases reuse its helpers rather than adding a second parser.

## What each column is read against

**Workflow ▸ job.** The row names a workflow that exists and a job that workflow declares, and every job of
a workflow carrying a required aggregate has a row.

**Trigger.** The events a row claims are the ones its workflow subscribes to, narrowed by a job-level `if:`
naming an event. The comparison is over push, pull_request and merge_group — the events a contributor's own
work starts — and a row whose Trigger names none of them is reported rather than read as claiming nothing,
so rewriting the column in other words fails here instead of quietly leaving it unheld. A push is spelt two
ways and which one is read from the file: "push (filtered)" where the `push:` subscription carries `paths:`
or `paths-ignore:`, "push to `main`" where it does not. A step's `if:` is not read: `upm.yml` gates three
steps on `workflow_dispatch` while the job itself runs on push.

The column also says one thing that is not an event — that `repository-settings` is skipped in a fork —
and that is held against the job's own repository gate, in either of its spellings, both ways round, so
the clause cannot become false in silence.

Three readers on this case refuse rather than answer nothing, and all three refuse by name: the job-level
`if:` on `github.event_name`, the `on:` key, and the same `if:` on `github.repository`. The `on:` key is
read in all three spellings of the block form; a flow sequence or a scalar puts the events on the key's
own line, where the per-event keys this reads do not exist, and that shape is reported instead of returned
as a workflow subscribing to nothing. Each refusal replaces an assertion the reader had not read anything
to make — an empty event set, or an absent gate — and each of those was printed as a fact about the job.

A job-level `if:` this cannot interpret is refused rather than read past. The pattern took the *last*
`github.event_name` equality on the line, and matched nothing at all against a folded `if: >-`, a `!=`, a
`contains(...)` or double quotes — falling back to the workflow's whole `on:` set and then printing that
set as what the job starts on. Folding `base-red`'s gate makes it print `starts on
[merge_group+pull_request+push]` for a job that runs on pull requests alone, and rewriting the cell to match
that message leaves the table wrong and the guard green. The `if:` is now read whole, folded continuation
lines included, and one that reaches for `github.event_name` in any shape but a single equality fails the
case by name instead of narrowing by guesswork.

**Unity license.** A row reads *required* exactly when the named job's `if:` waits on the license check's
output, and a row naming a workflow rather than a job answers for every job in it — `unity-tests` and
`base-red` in `test.yml`, `compile` in `docs.yml`, nothing in `generators.yml` or `upm.yml`. Read by the
output the check publishes rather than by that job's name, so renaming the job leaves it matching.

**Required to merge.** A row reads **yes** exactly when it names one of the aggregates the fixture already
locates, matched by either display name or job key: the aggregate rows are the only ones spelt by display
name today, and spelling them by key is legal there.

## What the parsers could not see

The job-key pattern required the colon to end the line, so a key written `coverage-gate:  # …` — valid
YAML and a valid job id — was returned by nothing here. Such a job could be wired into the aggregate, block
a merge, and carry no row, with every case green: the drift this exists to catch, happening inside it. It
also read only `*.yml`, while GitHub Actions runs `.yaml`, so a required workflow spelled that way was
outside every case — and `WorkflowTriggerCoverageTests`' own scan had the same gap, so it is widened too.

`needs:` is read in all three spellings a job may write. A flow list, a block sequence and a bare scalar are
the same to Actions, and only the flow list was read — while `docs.yml` writes the scalar three times and
`test.yml` once. An aggregate written `needs: source-generatorz` therefore named nothing, so nothing was
missing from it, and the case that reads it passed having asked nothing.

Row collection is bounded by the table rather than by the section, so a fenced example and any second table
below this one are not read as rows and misreported as naming no workflow. An unfenced table between the
heading and this one is read, and becomes the rows.

## `UPM ▸ release` is folded, not deleted

Deleting the row would lose the one thing it said that is true — that the manual dispatch is what tags and
publishes. That moves into the `split` row's trigger cell.

## Verification

- Three cases RED without the `CONTRIBUTING.md` change, naming the drift:
  `Given_EveryJobOfARequiredWorkflow_…` reports `generators.yml:repository-settings` and
  `test.yml:license-check`; `Given_EveryRowOfContributingsCiTable_…_ItNamesOneThatExists` reports
  `UPM ▸ release (no such job in upm.yml)`; `…_ItsTriggerCellIsRead` reports both aggregate rows and
  `Docs (claims [push], starts on [push (filtered)])`. GREEN with it.
- Perturbation evidence for the behaviours a correct table and correct workflows cannot exercise, each
  measured against the reader as it stood before:
  - a job key given a trailing comment with its row removed fails `Then_ItHasARow` with
    `test.yml:test-quality`;
  - `generators.yml`'s aggregate rewritten to the scalar `needs: source-generatorz` passed
    `…_ItIsFound` before and fails it now with `.github/workflows/generators.yml:source-generatorz`;
  - `base-red`'s gate widened to `(… == 'pull_request' || … == 'merge_group')`, with its cell rewritten to
    the "merge group" the old reader printed, passed `…_ItsTriggerCellIsRead` before and now fails it by
    naming the shape; folding the same gate printed the false `starts on [merge_group+pull_request+push]`
    before and passes now, which is the fold being read rather than the fallback agreeing by accident;
  - `upm.yml`'s push given a `paths:` list fails `…_ItsTriggerCellIsRead` with
    `UPM ▸ split (claims [push], starts on [push (filtered)])`;
  - `docs.yml`'s `compile` stripped of its license gate, and `Test ▸ unity-tests`' cell flipped to
    "not required", fail `…_ItsUnityLicenseCellIsRead` in opposite directions;
  - marking `Test ▸ Required checks (Unity)` as not required fails `Then_ItsRowIsTheOneMarkedRequired`;
  - changing all four workflow display names — the state a display-name reader that stopped matching
    leaves — passed `…_ItsTriggerCellIsRead` while it floored on the rows it was offered, and fails it now
    on the rows it judged;
  - quoting `generators.yml`'s key as `"on":` printed `starts on []` for three rows before and passes now;
    `upm.yml`'s `on:` written as a flow sequence printed the same empty set before and is now reported as
    a shape the reader does not read;
  - `repository-settings` gated with `github.repository_owner == '…'` instead reported the row as pinning
    no repository, and failed the gate floor beside it, while the job pinned one — it passes now; a job
    written `if: github.repository != '…'` reported nothing at all before and is now refused by name.
- Each case carries a floor, because a heading that was renamed leaves no rows to disagree with and reads
  the same as a table that agrees. The floors say what they gate rather than being copied across:
  `Then_ItHasARow`'s second floor is per workflow rather than a total, so one required workflow collapsing
  to its aggregate alone cannot be covered for by the other's jobs or by a full table; the license case
  floors on the gates it found, because a reader that found none agrees exactly with a table whose license
  cells all read "not required". Removing all three gates and agreeing the table with them leaves that
  case's message empty and fails it on the floor alone.
- Four cases are declared `GREEN_ON_BASE(characterization)` — the license column, the required column, and
  the two that ask through a widened reader. Each pins a state both sides already share rather than
  changing one.
- Full EditMode 3885/3885 and PlayMode 161/161, `assert_no_inconclusive.py` clean on both, no compile
  diagnostic in either run log.
- `base_red_check.py --base origin/main`: three cases red on the base, four declared and green as declared.

## A limit this does not close

Row cells are read by fixed column index and the header row is never read, so inserting a column into the
table shifts every cell one to the left of the case that judges it. All three column cases red when that
happens, on messages that point at the cells rather than at the header — loud, but not self-explaining.
Deriving the indices from the header is a parser that wants its own verification, and it is not in here.

`CONTRIBUTING.md` owns the CI table and is the file changed; no `Documentation~` guide states any of it. No
CHANGELOG entry: nothing a package consumer can observe changes.
