### PR TITLE
fix(velvet): settle readiness as the merge decision, and let a blind guard say so

### DIFF
--- a/.claude/hooks/lib/repository.py
+++ b/.claude/hooks/lib/repository.py
@@ -60,8 +60,11 @@ def gh_answer(args, cwd=None, timeout=7):
 def gh(args, cwd=None, timeout=7):
     """Run gh and return its stdout, or None when it could not answer.
 
-    The bound is a hook's budget divided by the calls one invocation makes, not by one call:
-    merge_unproven_head makes three inside 25 s, metadata_less_create one inside 15.
+    A bound per call rather than per invocation, since a guard makes several: merge_unproven_head
+    makes three. It is a judgement about how long a tool call may pause before the pause is the
+    problem, and not a share of the timeout the settings register — that number is in seconds and
+    runs to hours, so nothing here is bounded by it. scripts/hooks/test_hook_repository.py says the
+    same of the reading below.
     """
     answer = gh_answer(args, cwd, timeout)
     return answer.stdout if answer.code == 0 else None

--- a/.claude/hooks/lib/repository.py
+++ b/.claude/hooks/lib/repository.py
@@ -83,9 +83,8 @@ OPEN_PULL_REQUEST_READS = (
 # What was asked and what came back, for a caller that has to report a failure rather than a subject.
 PullRequests = collections.namedtuple("PullRequests", "numbers attempts")
 
-# Bounded so that asking twice cannot take twice as long as anyone budgeted for asking once, and
-# held against the guards' registered timeout by scripts/hooks/test_hook_repository.py — which says
-# there what that comparison does and does not cover.
+# Bounded so that two ways of asking still fit inside a pause worth waiting through, and held to
+# that by scripts/hooks/test_hook_repository.py — which says there what the comparison covers.
 OPEN_PULL_REQUEST_TIMEOUT = 8
 
 

--- a/.claude/hooks/lib/repository.py
+++ b/.claude/hooks/lib/repository.py
@@ -83,9 +83,9 @@ OPEN_PULL_REQUEST_READS = (
 # What was asked and what came back, for a caller that has to report a failure rather than a subject.
 PullRequests = collections.namedtuple("PullRequests", "numbers attempts")
 
-# Same rule as `gh` above: the calling hook's registered timeout divided by the calls one invocation
-# makes. Adding a way of asking without re-dividing is what scripts/hooks/test_hook_repository.py
-# fails on.
+# Bounded so that asking twice cannot take twice as long as anyone budgeted for asking once, and
+# held against the guards' registered timeout by scripts/hooks/test_hook_repository.py — which says
+# there what that comparison does and does not cover.
 OPEN_PULL_REQUEST_TIMEOUT = 8
 
 
@@ -121,8 +121,11 @@ def unreadable_report(subject, attempts, key, another_way):
     reading expires, is rewritten identically, and leaves on the record a reason nothing was waiting
     on.
 
-    Both outcomes a Stop guard can have exit 2 — the guards' own docstrings own what that means, and
-    there is no second blocking code to spend — so the whole of the distinction is this text.
+    Both outcomes here exit 2, and the distinction is therefore the text alone. Putting it in the
+    exit as well would mean blocking one of the two through a form this repository has never
+    measured, and a refusal that bets on an unmeasured form and loses is a refusal that fails open —
+    which is the defect this whole family exists to remove. So the second way stays unused until
+    something here can measure it.
     """
     asked = "\n\n".join(f"  {call}\n{detail}" for call, detail in attempts)
     header = "Every way of asking failed:" if len(attempts) > 1 else "What was asked, and what came back:"

--- a/.claude/hooks/lib/repository.py
+++ b/.claude/hooks/lib/repository.py
@@ -68,11 +68,15 @@ def gh(args, cwd=None, timeout=7):
 
 
 # Two ways of asking the same question, drawn in order. `gh pr list` goes through GraphQL and
-# `gh api` through REST; scripts/pr/settle.py owns why the difference matters. Asking both means one
-# exhausted quota no longer decides whether this can be read at all — which is a smaller blast
-# radius, not an answer to what a guard says when neither way works.
+# `gh api` through REST; scripts/pr/settle.py owns why the difference matters.
+#
+# What this buys is the LISTING surviving one exhausted quota, and nothing else a caller reads. A
+# guard that reads the listing here and its subject through GraphQL is one whose listing answers
+# while everything it wanted to say is unread — so it has to block per subject rather than report on
+# one, which stop/unsettled_pr.py does and unreadable_state_check.py's gh-graphql-error mode holds it
+# to. Two ways is a smaller blast radius, not an answer to what a guard says when it cannot read.
 OPEN_PULL_REQUEST_READS = (
-    ["pr", "list", "--state", "open", "--json", "number", "--jq", ".[].number"],
+    ["pr", "list", "--state", "open", "--limit", "100", "--json", "number", "--jq", ".[].number"],
     ["api", "repos/{owner}/{repo}/pulls?state=open&per_page=100", "--jq", ".[].number"],
 )
 
@@ -95,7 +99,7 @@ def open_pull_requests(cwd=None, timeout=OPEN_PULL_REQUEST_TIMEOUT):
         answer = gh_answer(args, cwd, timeout)
         if answer.code == 0:
             return PullRequests(answer.stdout.split(), attempts)
-        attempts.append(("gh " + " ".join(args), answer.code, answer.combined))
+        attempts.append(("gh " + " ".join(args), f"exited {answer.code}\n{answer.combined}"))
     return PullRequests(None, attempts)
 
 
@@ -105,24 +109,34 @@ def open_pull_requests(cwd=None, timeout=OPEN_PULL_REQUEST_TIMEOUT):
 SELF_REPORT = "That is a fact about this guard, not about"
 
 
-def unreadable_report(subject, attempts, key):
-    """What a Stop guard prints when no way of asking could answer.
+def unreadable_report(subject, attempts, key, another_way):
+    """What a Stop guard prints when a reading it needed did not answer.
+
+    `another_way` is the caller's, not this module's: the remedy for an unread pull request is not
+    the remedy for an unread issue list, and one report written with the first in mind told a caller
+    with the second to run `gh pr view`. So is the count — one failed call is not "every way of
+    asking failed", and a report that says so about a single call is wrong about its own evidence.
 
     The deferral it invites asks about the work rather than about the reading: a deferral naming the
     reading expires, is rewritten identically, and leaves on the record a reason nothing was waiting
     on.
+
+    Both outcomes a Stop guard can have exit 2 — the guards' own docstrings own what that means, and
+    there is no second blocking code to spend — so the whole of the distinction is this text.
     """
-    asked = "\n\n".join(f"  {call} exited {code}\n{output}" for call, code, output in attempts)
+    asked = "\n\n".join(f"  {call}\n{detail}" for call, detail in attempts)
+    header = "Every way of asking failed:" if len(attempts) > 1 else "What was asked, and what came back:"
     return f"""Do not stop: this guard could not read {subject}.
 
-{SELF_REPORT} {subject}. Nothing below says they are settled and nothing below says they are not.
-Every way of asking failed:
+{SELF_REPORT} {subject}. What follows is what was asked and what came back, and nothing more — no
+part of it is a finding about {subject}.
+
+{header}
 
 {asked}
 
-Establish it another way and say what you found: `gh pr view <n>`, `gh run list --branch <b>`, or the
-output of the watcher `scripts/pr/settle.py watch` writes. A reading that failed is not a subject
-that is clear.
+Establish it another way and say what you found: {another_way}. A reading that failed is not a
+subject that is clear.
 
 If the pause is deliberate, arm the deferral for what the WORK is waiting on. The failure above is
 not that, and naming it there is how a deferral comes to record something nothing was waiting on:

--- a/.claude/hooks/lib/repository.py
+++ b/.claude/hooks/lib/repository.py
@@ -62,9 +62,8 @@ def gh(args, cwd=None, timeout=7):
 
     A bound per call rather than per invocation, since a guard makes several: merge_unproven_head
     makes three. It is a judgement about how long a tool call may pause before the pause is the
-    problem, and not a share of the timeout the settings register — that number is in seconds and
-    runs to hours, so nothing here is bounded by it. scripts/hooks/test_hook_repository.py says the
-    same of the reading below.
+    problem, and it is not derived from the timeout the settings register for these hooks — nothing
+    here reads that number.
     """
     answer = gh_answer(args, cwd, timeout)
     return answer.stdout if answer.code == 0 else None

--- a/.claude/hooks/lib/repository.py
+++ b/.claude/hooks/lib/repository.py
@@ -1,4 +1,5 @@
-"""Locating the tree a session-start guard reports on, and reading git and gh without raising.
+"""Locating the tree a guard reports on, reading git and gh without raising, and saying so when
+neither way of asking could answer.
 
 A guard that cannot answer says nothing rather than failing: a hook writing a traceback into a
 session start is noise a reader cannot act on, and every caller here already treats an unavailable
@@ -7,11 +8,23 @@ answer as "no report".
 For a PreToolUse guard the stake is higher than noise. A hook that raises exits 1, which is not a
 refusal — the tool proceeds — so a guard reaching for a program that is not installed is a guard
 that has been deleted, silently, on every machine without it. Both readers here answer None instead.
+
+A Stop guard blocks instead, and then has a second thing to get right: what it says. "I could not
+establish whether anything is unsettled" and "something is unsettled" are different claims, both
+block, and a reader who cannot tell them apart records the failed reading as what the work is waiting
+on. `unreadable_report` is the first of those, written as a statement about the guard, and it is
+shared so that two guards cannot drift into two ways of saying it.
 """
 
+import collections
 import os
 import subprocess
+import sys
 from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from deferrals import DEFERRALS  # noqa: E402
 
 
 def git(args, cwd, timeout=15):
@@ -25,19 +38,96 @@ def git(args, cwd, timeout=15):
     return result.stdout if result.returncode == 0 else None
 
 
+Answer = collections.namedtuple("Answer", "stdout combined code")
+
+
+def gh_answer(args, cwd=None, timeout=7):
+    """gh's stdout, its whole output and its exit code. A gh that never started reports exit 1.
+
+    Separate from `gh` below because a caller that has to say why a reading failed needs the output
+    and the code, and one that only wants the answer must not have to decide what an empty string
+    meant.
+    """
+    try:
+        result = subprocess.run(
+            ["gh", *args], cwd=cwd, capture_output=True, text=True, timeout=timeout,
+        )
+    except (OSError, subprocess.SubprocessError) as error:
+        return Answer("", str(error), 1)
+    return Answer(result.stdout, (result.stdout + result.stderr).strip(), result.returncode)
+
+
 def gh(args, cwd=None, timeout=7):
     """Run gh and return its stdout, or None when it could not answer.
 
     The bound is a hook's budget divided by the calls one invocation makes, not by one call:
     merge_unproven_head makes three inside 25 s, metadata_less_create one inside 15.
     """
-    try:
-        result = subprocess.run(
-            ["gh", *args], cwd=cwd, capture_output=True, text=True, timeout=timeout,
-        )
-    except (OSError, subprocess.SubprocessError):
-        return None
-    return result.stdout if result.returncode == 0 else None
+    answer = gh_answer(args, cwd, timeout)
+    return answer.stdout if answer.code == 0 else None
+
+
+# Two ways of asking the same question, drawn in order. `gh pr list` goes through GraphQL and
+# `gh api` through REST; scripts/pr/settle.py owns why the difference matters. Asking both means one
+# exhausted quota no longer decides whether this can be read at all — which is a smaller blast
+# radius, not an answer to what a guard says when neither way works.
+OPEN_PULL_REQUEST_READS = (
+    ["pr", "list", "--state", "open", "--json", "number", "--jq", ".[].number"],
+    ["api", "repos/{owner}/{repo}/pulls?state=open&per_page=100", "--jq", ".[].number"],
+)
+
+# What was asked and what came back, for a caller that has to report a failure rather than a subject.
+PullRequests = collections.namedtuple("PullRequests", "numbers attempts")
+
+# Same rule as `gh` above: the calling hook's registered timeout divided by the calls one invocation
+# makes. Adding a way of asking without re-dividing is what scripts/hooks/test_hook_repository.py
+# fails on.
+OPEN_PULL_REQUEST_TIMEOUT = 8
+
+
+def open_pull_requests(cwd=None, timeout=OPEN_PULL_REQUEST_TIMEOUT):
+    """The open pull request numbers, or None with what each way of asking answered.
+
+    An empty list is an answer and takes the ordinary path; None is the absence of one.
+    """
+    attempts = []
+    for args in OPEN_PULL_REQUEST_READS:
+        answer = gh_answer(args, cwd, timeout)
+        if answer.code == 0:
+            return PullRequests(answer.stdout.split(), attempts)
+        attempts.append(("gh " + " ".join(args), answer.code, answer.combined))
+    return PullRequests(None, attempts)
+
+
+# The sentence that separates a guard's blindness from its verdict. Owned here so two guards cannot
+# drift into two ways of saying it, and asserted by scripts/hooks/unreadable_state_check.py against
+# any Stop guard that blocks on an unreadable state.
+SELF_REPORT = "That is a fact about this guard, not about"
+
+
+def unreadable_report(subject, attempts, key):
+    """What a Stop guard prints when no way of asking could answer.
+
+    The deferral it invites asks about the work rather than about the reading: a deferral naming the
+    reading expires, is rewritten identically, and leaves on the record a reason nothing was waiting
+    on.
+    """
+    asked = "\n\n".join(f"  {call} exited {code}\n{output}" for call, code, output in attempts)
+    return f"""Do not stop: this guard could not read {subject}.
+
+{SELF_REPORT} {subject}. Nothing below says they are settled and nothing below says they are not.
+Every way of asking failed:
+
+{asked}
+
+Establish it another way and say what you found: `gh pr view <n>`, `gh run list --branch <b>`, or the
+output of the watcher `scripts/pr/settle.py watch` writes. A reading that failed is not a subject
+that is clear.
+
+If the pause is deliberate, arm the deferral for what the WORK is waiting on. The failure above is
+not that, and naming it there is how a deferral comes to record something nothing was waiting on:
+
+  echo "{key} <what the work is waiting on> $(date +%s)" >> {DEFERRALS}"""
 
 
 def project_tree():

--- a/.claude/hooks/refuse/edit_while_a_ready_pr_sits.py
+++ b/.claude/hooks/refuse/edit_while_a_ready_pr_sits.py
@@ -24,8 +24,11 @@ import sys
 import time
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lib"))
+HOOK_DIRECTORY = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(HOOK_DIRECTORY / "lib"))
+sys.path.insert(0, str(HOOK_DIRECTORY.parent.parent / "scripts" / "pr"))
 from deferrals import DEFERRALS, deferred, unusable
+from watcher_state import READY_STATE, alive
 
 # Held on the editing tools, which carry a file path rather than a shell command, so there is no operand
 # for the shell to expand and nothing here reads one.
@@ -34,25 +37,11 @@ UNEXPANDED_POLICY = "n/a"
 UNREADABLE_POLICY = "none"
 UNREADABLE_PROBE = {"file_path": "CHANGELOG.md", "old_string": "a", "new_string": "b"}
 
-READY_STATE = Path.home() / ".velvet-pr-ready"
-HEARTBEAT = Path.home() / ".velvet-pr-watch.heartbeat"
-
 # Long enough that a pull request going green mid-task is not an interruption, short enough that
 # "I will get to it" cannot outlive the task that said it.
 GRACE = 900
 
-# Two polls plus a margin: one missed poll is a slow API call, two is a watcher that stopped.
-HEARTBEAT_TTL = 180
-
 HOOK_TOOLS = {"Edit", "Write", "NotebookEdit"}
-
-
-def watcher_age():
-    """Seconds since the watching process last wrote, or None when it never has."""
-    try:
-        return time.time() - int(HEARTBEAT.read_text(encoding="utf-8").strip())
-    except (OSError, ValueError):
-        return None
 
 
 def sitting(now):
@@ -86,8 +75,7 @@ def main():
     if event.get("tool_name") not in HOOK_TOOLS:
         return 0
 
-    age = watcher_age()
-    if age is None or age > HEARTBEAT_TTL:
+    if not alive():
         sys.stderr.write(
             "Refusing to write: nothing is watching the open pull requests, so whether one is sitting "
             "green cannot be read.\n\n"

--- a/.claude/hooks/refuse/edit_while_a_ready_pr_sits.py
+++ b/.claude/hooks/refuse/edit_while_a_ready_pr_sits.py
@@ -105,7 +105,7 @@ def main():
                 "Something IS watching — what failed is the reading. A watcher started before the "
                 "heartbeat named its own process writes the older form, and starting a second one "
                 "is refused while it runs. End it and start one from this checkout:\n\n"
-                "  ps -Ao pid=,command= | grep '[s]ettle.py watch'\n"
+                "  ps -Ao pid=,command= | grep 'settle[.]py watch'\n"
                 "  kill <pid>\n"
                 f"  # its last heartbeat ages out within {STALE_AFTER}s, and until it does\n"
                 "  # `settle.py watch` refuses to start\n"

--- a/.claude/hooks/refuse/edit_while_a_ready_pr_sits.py
+++ b/.claude/hooks/refuse/edit_while_a_ready_pr_sits.py
@@ -41,6 +41,10 @@ UNREADABLE_PROBE = {"file_path": "CHANGELOG.md", "old_string": "a", "new_string"
 # "I will get to it" cannot outlive the task that said it.
 GRACE = 900
 
+# Its own deferral key. A pull request number holds one pull request; this holds the reading itself,
+# and the two are not the same claim.
+WATCHER_KEY = "watcher"
+
 HOOK_TOOLS = {"Edit", "Write", "NotebookEdit"}
 
 
@@ -75,17 +79,34 @@ def main():
     if event.get("tool_name") not in HOOK_TOOLS:
         return 0
 
+    now = time.time()
     if not alive():
+        # The one branch that can refuse every write on the machine at once, so it is the one branch
+        # that must have a way out other than the command it names. That command can itself refuse:
+        # a watcher wedged mid-poll holds the lock while its heartbeat goes stale, and then starting
+        # a replacement is exactly what `hold_the_watch` declines to do.
+        held = deferred(WATCHER_KEY, now)
+        if held is not None:
+            reason, minutes = held
+            sys.stderr.write(f"Nothing is watching the open pull requests, and {WATCHER_KEY} is held "
+                             f"{minutes}m ago because: {reason}\n")
+            return 0
+        broken = unusable(WATCHER_KEY, now)
+        if broken is not None:
+            sys.stderr.write(f"A deferral was written for {WATCHER_KEY}, and {broken} — so it is "
+                             "being ignored.\n")
         sys.stderr.write(
             "Refusing to write: nothing is watching the open pull requests, so whether one is sitting "
             "green cannot be read.\n\n"
             "An unwatched pull request and none at all look identical from here, which is the state "
             "this guard exists to stop being invisible.\n\n"
             "  python3 scripts/pr/settle.py watch\n\n"
-            "Run it in the background and this clears within a poll.\n")
+            "That reports what stops it starting, if anything does — a watcher already holding the "
+            "lock is named there with the command to end it. If the watcher is deliberately off, say "
+            "what turns it back on; the reason expires, so it gets re-read rather than forgotten:\n\n"
+            f'  echo "{WATCHER_KEY} <what turns it back on> {int(now)}" >> {DEFERRALS}\n')
         return 2
 
-    now = time.time()
     found = sitting(now)
     if not found:
         return 0

--- a/.claude/hooks/refuse/edit_while_a_ready_pr_sits.py
+++ b/.claude/hooks/refuse/edit_while_a_ready_pr_sits.py
@@ -81,10 +81,10 @@ def main():
 
     now = time.time()
     if not alive():
-        # The one branch that can refuse every write on the machine at once, so it is the one branch
-        # that must have a way out other than the command it names. That command can itself refuse:
-        # a watcher wedged mid-poll holds the lock while its heartbeat goes stale, and then starting
-        # a replacement is exactly what `hold_the_watch` declines to do.
+        # Both refusals here hold every editing tool in every session; this is the one that had no
+        # deferral, and the command it names can itself refuse — a watcher wedged mid-poll holds the
+        # lock while its heartbeat goes stale, and starting a replacement is what `hold_the_watch`
+        # declines. So the way out of this branch cannot go through the thing that is stuck.
         held = deferred(WATCHER_KEY, now)
         if held is not None:
             reason, minutes = held

--- a/.claude/hooks/refuse/edit_while_a_ready_pr_sits.py
+++ b/.claude/hooks/refuse/edit_while_a_ready_pr_sits.py
@@ -102,9 +102,10 @@ def main():
             "this guard exists to stop being invisible.\n\n"
             "  python3 scripts/pr/settle.py watch\n\n"
             "That reports what stops it starting, if anything does — a watcher already holding the "
-            "lock is named there with the command to end it. If the watcher is deliberately off, say "
-            "what turns it back on; the reason expires, so it gets re-read rather than forgotten:\n\n"
-            f'  echo "{WATCHER_KEY} <what turns it back on> {int(now)}" >> {DEFERRALS}\n')
+            "lock is named there with the command to end it. If the pause is deliberate, arm the "
+            "deferral for what the WORK is waiting on rather than for the watcher being off; the "
+            "reason expires, so it gets re-read rather than forgotten:\n\n"
+            f'  echo "{WATCHER_KEY} <what the work is waiting on> {int(now)}" >> {DEFERRALS}\n')
         return 2
 
     found = sitting(now)

--- a/.claude/hooks/refuse/edit_while_a_ready_pr_sits.py
+++ b/.claude/hooks/refuse/edit_while_a_ready_pr_sits.py
@@ -28,7 +28,7 @@ HOOK_DIRECTORY = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(HOOK_DIRECTORY / "lib"))
 sys.path.insert(0, str(HOOK_DIRECTORY.parent.parent / "scripts" / "pr"))
 from deferrals import DEFERRALS, deferred, unusable
-from watcher_state import READY_STATE, alive
+from watcher_state import READY_STATE, STALE_AFTER, alive, unreadable_beat
 
 # Held on the editing tools, which carry a file path rather than a shell command, so there is no operand
 # for the shell to expand and nothing here reads one.
@@ -95,6 +95,25 @@ def main():
         if broken is not None:
             sys.stderr.write(f"A deferral was written for {WATCHER_KEY}, and {broken} — so it is "
                              "being ignored.\n")
+        # Two states reach here and they want opposite actions: start a watcher, or end one. Saying
+        # "nothing is watching" of the second is this guard's blindness written as a fact about the
+        # watcher, and the command it would name refuses while that watcher runs.
+        if unreadable_beat(now):
+            sys.stderr.write(
+                "Refusing to write: a watcher is writing the heartbeat in a form this cannot read, "
+                "so whether a pull request is sitting green cannot be read.\n\n"
+                "Something IS watching — what failed is the reading. A watcher started before the "
+                "heartbeat named its own process writes the older form, and starting a second one "
+                "is refused while it runs. End it and start one from this checkout:\n\n"
+                "  ps -Ao pid=,command= | grep '[s]ettle.py watch'\n"
+                "  kill <pid>\n"
+                f"  # its last heartbeat ages out within {STALE_AFTER}s, and until it does\n"
+                "  # `settle.py watch` refuses to start\n"
+                "  python3 scripts/pr/settle.py watch\n\n"
+                "If the pause is deliberate, arm the deferral for what the WORK is waiting on; the "
+                "reason expires, so it gets re-read rather than forgotten:\n\n"
+                f'  echo "{WATCHER_KEY} <what the work is waiting on> {int(now)}" >> {DEFERRALS}\n')
+            return 2
         sys.stderr.write(
             "Refusing to write: nothing is watching the open pull requests, so whether one is sitting "
             "green cannot be read.\n\n"

--- a/.claude/hooks/refuse/merge_unproven_head.py
+++ b/.claude/hooks/refuse/merge_unproven_head.py
@@ -18,8 +18,9 @@ running" is how a pull request sat unnoticed for 7h45m.
 The other four merge preconditions have their own hooks: `stale_merge.py` for a branch behind its
 base, `merge_without_branch_deletion.py` for the flag, `merge_branch_held_by_worktree.py` for a
 branch git will refuse to delete, `merge_onto_unpublished_release.py` for a base holding a release
-nobody dispatched. `scripts/pr/settle.py` reports all five together, which is the
-convenience; these are what hold when nobody runs it.
+nobody dispatched. `scripts/pr/settle.py` reports these five together with two more it
+holds alone — a draft head and one on another repository, which its own docstring says why of — and
+that reporting is the convenience; these are what hold when nobody runs it.
 """
 
 import json

--- a/.claude/hooks/stop/open_backlog.py
+++ b/.claude/hooks/stop/open_backlog.py
@@ -34,12 +34,14 @@ import json
 import shutil
 import subprocess
 import sys
-import time
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lib"))
 
 from deferrals import DEFERRALS, deferred, unusable  # noqa: E402
+from repository import open_pull_requests, unreadable_report  # noqa: E402
+
+UNREADABLE_POLICY = "refuse"
 
 EXCLUDING_LABELS = {"blocked", "needs-decision"}
 
@@ -53,23 +55,15 @@ def gh(args):
     return result.stdout.strip(), (result.stdout + result.stderr).strip(), result.returncode
 
 
-def unreachable(call, code, output):
+def unreachable(subject, attempts):
     """A gh that cannot answer is not an empty answer.
 
     Every one of these used to take `|| exit 0` with stderr discarded, so an unauthenticated,
     offline or rate-limited run reported exactly what a cleared backlog reports. Refusing instead is
-    what puts the difference in front of the reader; the deferral is the way past it when the
-    network is the thing that is wrong.
+    what puts the difference in front of the reader; `lib/repository.py` owns the shape the refusal
+    takes and why it is a statement about this guard rather than about the backlog.
     """
-    print(f"""Do not stop: the backlog could not be read, so nothing here says it is clear.
-
-  gh {call} exited {code}
-{output}
-
-If gh is unauthenticated or the network is down, say so and arm the deferral rather than treating
-an unanswered question as a settled one:
-
-  echo "backlog <what clears it> $(date +%s)" >> {DEFERRALS}""", file=sys.stderr)
+    print(unreadable_report(subject, attempts, "backlog"), file=sys.stderr)
     return 2
 
 
@@ -91,23 +85,22 @@ def main():
         print(f"  held {minutes}m ago because: {reason}", file=sys.stderr)
         return 0
 
-    listing, combined, code = gh(["pr", "list", "--state", "open", "--json", "number",
-                                  "--jq", ".[].number"])
-    if code != 0:
-        return unreachable("pr list", code, combined)
-    if listing:
+    reading = open_pull_requests()
+    if reading.numbers is None:
+        return unreachable("the open pull requests", reading.attempts)
+    if reading.numbers:
         return 0
 
     me, combined, code = gh(["api", "user", "--jq", ".login"])
     if code != 0:
-        return unreachable("api user", code, combined)
+        return unreachable("the backlog", [("gh api user", code, combined)])
     if not me:
-        return unreachable("api user", 0, "  it named no login")
+        return unreachable("the backlog", [("gh api user", 0, "  it named no login")])
 
     raw, combined, code = gh(["issue", "list", "--state", "open", "--assignee", me,
                               "--json", "number,title,labels"])
     if code != 0:
-        return unreachable("issue list", code, combined)
+        return unreachable("the backlog", [("gh issue list", code, combined)])
     try:
         issues = json.loads(raw or "[]")
     except ValueError:

--- a/.claude/hooks/stop/open_backlog.py
+++ b/.claude/hooks/stop/open_backlog.py
@@ -43,6 +43,11 @@ from repository import open_pull_requests, unreadable_report  # noqa: E402
 
 UNREADABLE_POLICY = "refuse"
 
+# An open pull request is this guard's whole answer — it hands the stall to unsettled_pr.py rather
+# than reporting one twice — so a listing that answered ends the question here whatever fails after
+# it. Nothing past that point is read, so nothing past it is being reported unread.
+UNREADABLE_ALLOWS = ("gh-graphql-error",)
+
 EXCLUDING_LABELS = {"blocked", "needs-decision"}
 
 
@@ -55,7 +60,16 @@ def gh(args):
     return result.stdout.strip(), (result.stdout + result.stderr).strip(), result.returncode
 
 
-def unreachable(subject, attempts):
+# Each subject's own remedy: the guard reads two, and one report told a reader with an unread issue
+# list to run `gh pr view`.
+PULL_REQUESTS_ANOTHER_WAY = ("`gh pr view <n>`, `gh run list --branch <b>`, or the output of the "
+                             "watcher `scripts/pr/settle.py watch` writes")
+
+BACKLOG_ANOTHER_WAY = ("`gh issue list --assignee @me` from another shell, or the issue list on "
+                       "github.com")
+
+
+def unreachable(subject, attempts, another_way):
     """A gh that cannot answer is not an empty answer.
 
     Every one of these used to take `|| exit 0` with stderr discarded, so an unauthenticated,
@@ -63,7 +77,7 @@ def unreachable(subject, attempts):
     what puts the difference in front of the reader; `lib/repository.py` owns the shape the refusal
     takes and why it is a statement about this guard rather than about the backlog.
     """
-    print(unreadable_report(subject, attempts, "backlog"), file=sys.stderr)
+    print(unreadable_report(subject, attempts, "backlog", another_way), file=sys.stderr)
     return 2
 
 
@@ -87,20 +101,24 @@ def main():
 
     reading = open_pull_requests()
     if reading.numbers is None:
-        return unreachable("the open pull requests", reading.attempts)
+        return unreachable("the open pull requests", reading.attempts,
+                           PULL_REQUESTS_ANOTHER_WAY)
     if reading.numbers:
         return 0
 
     me, combined, code = gh(["api", "user", "--jq", ".login"])
     if code != 0:
-        return unreachable("the backlog", [("gh api user", code, combined)])
+        return unreachable("the backlog", [("gh api user", f"exited {code}\n{combined}")],
+                           BACKLOG_ANOTHER_WAY)
     if not me:
-        return unreachable("the backlog", [("gh api user", 0, "  it named no login")])
+        return unreachable("the backlog", [("gh api user", "answered, and named no login")],
+                           BACKLOG_ANOTHER_WAY)
 
     raw, combined, code = gh(["issue", "list", "--state", "open", "--assignee", me,
                               "--json", "number,title,labels"])
     if code != 0:
-        return unreachable("the backlog", [("gh issue list", code, combined)])
+        return unreachable("the backlog", [("gh issue list", f"exited {code}\n{combined}")],
+                           BACKLOG_ANOTHER_WAY)
     try:
         issues = json.loads(raw or "[]")
     except ValueError:

--- a/.claude/hooks/stop/unsettled_pr.py
+++ b/.claude/hooks/stop/unsettled_pr.py
@@ -94,19 +94,27 @@ def carries_no_check(pr):
 def checks_of(pr):
     """The pull request's check list, or None when the read did not answer.
 
-    `gh pr checks` exits non-zero for both "I could not read" and "there are none", so its exit code
-    cannot separate an exhausted quota from a head no workflow has run for yet. Reading the second as
-    the first blocks a pull request whose head has no check yet; reading the first as the second is
-    what let one nobody could see into the settled set. So a non-zero exit is taken to the rollup,
-    which answers 0 rather than erroring, and only an answer there makes this an empty list.
+    `gh pr checks` says "there are none" by failing, and it says "I could not read" two ways: by
+    failing, and — the shape `scripts/pr/settle.py` records for an exhausted quota — by succeeding
+    and printing nothing. So neither an empty answer nor a failed one is decided here. Both go to the
+    rollup, which answers where this errors, and only an empty list from there makes this empty.
+
+    Reading a failure as "there are none" is what let a pull request nobody could see into the
+    settled set; reading "there are none" as a failure blocks one whose head has no check yet.
     """
     out, _, code = gh(["pr", "checks", pr, "--json", "name,bucket"])
-    if code != 0:
-        return [] if carries_no_check(pr) else None
-    try:
-        return json.loads(out or "[]")
-    except ValueError:
-        return None
+    if code == 0 and out:
+        try:
+            listed = json.loads(out)
+        except ValueError:
+            return None
+        if not isinstance(listed, list):
+            return None
+        if listed:
+            return listed
+    # Every way of arriving at "there are none" ends here — the call failing, printing nothing, or
+    # printing an empty list — because none of the three is something this can tell from a failure.
+    return [] if carries_no_check(pr) else None
 
 
 def unreadable(attempts):

--- a/.claude/hooks/stop/unsettled_pr.py
+++ b/.claude/hooks/stop/unsettled_pr.py
@@ -85,9 +85,15 @@ def carries_no_check(pr):
     if code != 0:
         return False
     try:
-        rollup = json.loads(out or "{}").get("statusCheckRollup")
+        payload = json.loads(out or "{}")
     except ValueError:
         return False
+    # A payload that is not an object has no field to read, and reaching for one raises out of a
+    # Stop hook — which exits 1, which the harness does not treat as a refusal. So the shape is
+    # checked rather than assumed, the same way the list below is.
+    if not isinstance(payload, dict):
+        return False
+    rollup = payload.get("statusCheckRollup")
     return isinstance(rollup, list) and not rollup
 
 

--- a/.claude/hooks/stop/unsettled_pr.py
+++ b/.claude/hooks/stop/unsettled_pr.py
@@ -73,12 +73,22 @@ def merge_state(pr):
 def carries_no_check(pr):
     """Whether the head really carries no check, asked a way that answers instead of erroring.
 
-    The rollup is read for its length and nothing else — the buckets stay `gh pr checks`'s to name,
-    so this adds no second copy of what a conclusion means.
+    The rollup is read for whether it is an empty list and nothing else — the buckets stay
+    `gh pr checks`'s to name, so this adds no second copy of what a conclusion means.
+
+    Read whole rather than through `--jq '.statusCheckRollup | length'`: jq answers 0 for a field
+    that is absent or null exactly as it does for one that is an empty list, so the shorter form
+    turns a payload this could not understand into "there are none" — which is the reading that put
+    an unread pull request into the settled set in the first place. Only an empty list says so.
     """
-    out, _, code = gh(["pr", "view", pr, "--json", "statusCheckRollup",
-                       "--jq", ".statusCheckRollup | length"])
-    return code == 0 and out == "0"
+    out, _, code = gh(["pr", "view", pr, "--json", "statusCheckRollup"])
+    if code != 0:
+        return False
+    try:
+        rollup = json.loads(out or "{}").get("statusCheckRollup")
+    except ValueError:
+        return False
+    return isinstance(rollup, list) and not rollup
 
 
 def checks_of(pr):
@@ -212,7 +222,14 @@ def main():
         # A held PR still gets said out loud on the way past, so the claim is re-read rather than
         # trusted.
         if held:
-            print("Held, not settled — check each reason is still true:", file=sys.stderr)
+            # A held pull request is skipped above before `judge`, so every one of them held means
+            # no pull request was read this time. Under the ordinary heading that list reads as
+            # "each was checked and each is held", which is a different claim — and the count
+            # separates the two without any reading of its own.
+            print("Every open pull request is held, so none of them was read this time. What "
+                  "follows is what was claimed, not what is true of them now:"
+                  if len(held) == len(prs) else
+                  "Held, not settled — check each reason is still true:", file=sys.stderr)
             print("\n" + "\n".join(held), file=sys.stderr)
         if ignored:
             print("\nDeferrals that were ignored:", file=sys.stderr)

--- a/.claude/hooks/stop/unsettled_pr.py
+++ b/.claude/hooks/stop/unsettled_pr.py
@@ -86,7 +86,7 @@ def checks_of(pr):
 
     `gh pr checks` exits non-zero for both "I could not read" and "there are none", so its exit code
     cannot separate an exhausted quota from a head no workflow has run for yet. Reading the second as
-    the first blocks on every pull request in its first minutes; reading the first as the second is
+    the first blocks a pull request whose head has no check yet; reading the first as the second is
     what let one nobody could see into the settled set. So a non-zero exit is taken to the rollup,
     which answers 0 rather than erroring, and only an answer there makes this an empty list.
     """

--- a/.claude/hooks/stop/unsettled_pr.py
+++ b/.claude/hooks/stop/unsettled_pr.py
@@ -19,7 +19,8 @@ left to say is indistinguishable from progress.
 
 A pending check is forgiven while a watcher is demonstrably alive. The heartbeat is written by the
 watching process itself on each poll, never by the assistant, so it cannot be satisfied by intending
-to watch — if the watcher dies the file goes stale within one poll and this blocks again. The
+to watch — if the watcher dies the file goes stale within one poll and this blocks again, and
+`scripts/pr/watcher_state.py` owns what else a reader has to establish before believing it. The
 watcher must re-enumerate open PRs every cycle, or a PR opened after it started would be unwatched
 while the heartbeat still looked fresh. Zero checks is judged without the heartbeat: there, nothing
 is running for a watcher to observe.
@@ -31,16 +32,17 @@ import json
 import shutil
 import subprocess
 import sys
-import time
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lib"))
+HOOK_DIRECTORY = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(HOOK_DIRECTORY / "lib"))
+sys.path.insert(0, str(HOOK_DIRECTORY.parent.parent / "scripts" / "pr"))
 
 from deferrals import DEFERRALS, deferred, unusable  # noqa: E402
+from repository import open_pull_requests, unreadable_report  # noqa: E402
+from watcher_state import HEARTBEAT, alive  # noqa: E402
 
-HEARTBEAT = Path.home() / ".velvet-pr-watch.heartbeat"
-# Three polls of the 60s cycle, so one slow `gh` call does not read as a dead watcher.
-STALE_AFTER = 180
+UNREADABLE_POLICY = "refuse"
 
 # Merge states that explain an absent check list without anything being wrong with it.
 EXPECTED_WITHOUT_CHECKS = {"UNSTABLE", "BEHIND", "BLOCKED", ""}
@@ -53,22 +55,6 @@ def gh(args):
     except (OSError, subprocess.SubprocessError) as error:
         return "", str(error), 1
     return result.stdout.strip(), (result.stdout + result.stderr).strip(), result.returncode
-
-
-def watcher_is_alive():
-    """True while a watching process is still writing its heartbeat.
-
-    Same two bounds as the deferral expiry, and for the same reason: a malformed stamp must not
-    vouch for a watcher, and one in the future must not vouch for it permanently.
-    """
-    try:
-        beat = HEARTBEAT.read_text(encoding="utf-8").strip()
-    except OSError:
-        return False
-    if not beat.isdigit():
-        return False
-    age = time.time() - int(beat)
-    return 0 <= age < STALE_AFTER
 
 
 def merge_state(pr):
@@ -87,7 +73,8 @@ def checks_of(pr):
         return []
 
 
-def unreadable(output, code):
+def unreadable(attempts):
+    """Every way of asking failed, so this blocks on the guard's own blindness and says which."""
     # Its own key, not "backlog": that one holds the backlog guard, and one line silencing both
     # guards is the unqualified exemption the expiry exists to prevent.
     holding = deferred("pr-list")
@@ -100,15 +87,7 @@ def unreadable(output, code):
     if broken is not None:
         print(f"A deferral was written for pr-list, and {broken} — so it is being ignored.",
               file=sys.stderr)
-    print(f"""Do not stop: the open pull requests could not be read, so nothing here says they are settled.
-
-  gh pr list exited {code}
-{output}
-
-If gh is unauthenticated or the network is down, say so and arm the deferral rather than treating
-an unanswered question as a settled one:
-
-  echo "pr-list <what clears it> $(date +%s)" >> {DEFERRALS}""", file=sys.stderr)
+    print(unreadable_report("the open pull requests", attempts, "pr-list"), file=sys.stderr)
     return 2
 
 
@@ -157,7 +136,7 @@ def judge(pr):
                 "cannot go green on\n    its own. Rebase it, take it out of draft, or say what it is "
                 "waiting on.")
 
-    if watcher_is_alive():
+    if alive():
         return None
 
     names = ", ".join(check.get("name", "") for check in pending)
@@ -168,11 +147,10 @@ def main():
     if shutil.which("gh") is None:
         return 0
 
-    listing, combined, code = gh(["pr", "list", "--state", "open", "--json", "number",
-                                  "--jq", ".[].number"])
-    if code != 0:
-        return unreadable(combined, code)
-    prs = listing.split()
+    reading = open_pull_requests()
+    if reading.numbers is None:
+        return unreadable(reading.attempts)
+    prs = reading.numbers
     if not prs:
         return 0
 

--- a/.claude/hooks/stop/unsettled_pr.py
+++ b/.claude/hooks/stop/unsettled_pr.py
@@ -39,13 +39,15 @@ sys.path.insert(0, str(HOOK_DIRECTORY / "lib"))
 sys.path.insert(0, str(HOOK_DIRECTORY.parent.parent / "scripts" / "pr"))
 
 from deferrals import DEFERRALS, deferred, unusable  # noqa: E402
-from repository import open_pull_requests, unreadable_report  # noqa: E402
+from repository import SELF_REPORT, open_pull_requests, unreadable_report  # noqa: E402
 from watcher_state import HEARTBEAT, alive  # noqa: E402
 
 UNREADABLE_POLICY = "refuse"
 
-# Merge states that explain an absent check list without anything being wrong with it.
-EXPECTED_WITHOUT_CHECKS = {"UNSTABLE", "BEHIND", "BLOCKED", ""}
+# Merge states that explain an absent check list without anything being wrong with it. The empty
+# string is NOT one of them: it used to stand for both "GitHub answered nothing" and "the read
+# failed", and the second is what put a pull request nothing was read about into this set.
+EXPECTED_WITHOUT_CHECKS = {"UNSTABLE", "BEHIND", "BLOCKED"}
 
 
 def gh(args):
@@ -57,20 +59,26 @@ def gh(args):
     return result.stdout.strip(), (result.stdout + result.stderr).strip(), result.returncode
 
 
+# Both of these go through GraphQL while the listing above can fall back to REST, so the state this
+# guard has to survive is not only "nothing answered": the listing can answer and these not. A pull
+# request read that far and no further is one this guard knows nothing about, and None is how it says
+# so — an empty answer from either is a different claim and keeps its own path.
 def merge_state(pr):
+    """The pull request's merge state, or None when the read did not answer."""
     state, _, code = gh(["pr", "view", pr, "--json", "mergeStateStatus",
                          "--jq", ".mergeStateStatus"])
-    return state if code == 0 else ""
+    return state if code == 0 else None
 
 
 def checks_of(pr):
+    """The pull request's check list, or None when the read did not answer."""
     out, _, code = gh(["pr", "checks", pr, "--json", "name,bucket"])
     if code != 0:
-        return []
+        return None
     try:
         return json.loads(out or "[]")
     except ValueError:
-        return []
+        return None
 
 
 def unreadable(attempts):
@@ -87,13 +95,22 @@ def unreadable(attempts):
     if broken is not None:
         print(f"A deferral was written for pr-list, and {broken} — so it is being ignored.",
               file=sys.stderr)
-    print(unreadable_report("the open pull requests", attempts, "pr-list"), file=sys.stderr)
+    print(unreadable_report("the open pull requests", attempts, "pr-list",
+                            '`gh pr view <n>`, `gh run list --branch <b>`, or the output of the watcher `scripts/pr/settle.py watch` writes'), file=sys.stderr)
     return 2
+
+
+def unread(pr, what):
+    """A pull request this guard learned nothing about, said as a fact about the guard."""
+    return (f"  PR #{pr} — {what} could not be read. {SELF_REPORT} PR #{pr}, and nothing here says "
+            "it is\n    settled. Read it another way and say what you found.")
 
 
 def judge(pr):
     """The reason this PR blocks a Stop, or None when it does not."""
     checks = checks_of(pr)
+    if checks is None:
+        return unread(pr, "its checks")
 
     if not checks:
         # Zero checks is legitimate when nothing the PR touches matches a workflow's path filter —
@@ -102,6 +119,8 @@ def judge(pr):
         # conflicting PR reports DIRTY (or UNKNOWN while GitHub is still computing) and never starts
         # CI at all, which is the shape that went unwatched for seven hours.
         state = merge_state(pr)
+        if state is None:
+            return unread(pr, "its merge state")
         if state == "CLEAN":
             # Ready, and ready is the state that reads as finished. A docs-only or .claude/-only
             # change reports no checks at all and so never reached the merge reminder below, which
@@ -119,6 +138,8 @@ def judge(pr):
         # Nothing is running, so a watcher has nothing to observe and its heartbeat vouches for
         # nothing.
         state = merge_state(pr)
+        if state is None:
+            return unread(pr, "its merge state")
         # A cancelled check is counted here rather than nowhere. In gh's buckets it is neither
         # `pass` nor `fail`, so a run that was cancelled outright used to read as every check
         # having passed.
@@ -132,7 +153,7 @@ def judge(pr):
                     "is waiting on and arm\n    something that brings you back when that arrives.")
         # Every other merge state, rather than the ones seen so far. Listing them made an unlisted
         # state mean "settled", which is how a green DIRTY or DRAFT pull request passed both guards.
-        return (f"  PR #{pr} — checks are settled but the merge state is {state or 'unknown'}, so it "
+        return (f"  PR #{pr} — checks are settled but the merge state is {state or 'unnamed'}, so it "
                 "cannot go green on\n    its own. Rebase it, take it out of draft, or say what it is "
                 "waiting on.")
 

--- a/.claude/hooks/stop/unsettled_pr.py
+++ b/.claude/hooks/stop/unsettled_pr.py
@@ -129,9 +129,10 @@ def judge(pr):
                     "it is waiting on and arm\n    something that brings you back when that arrives.")
         if state in EXPECTED_WITHOUT_CHECKS:
             return None
-        return (f"  PR #{pr} — no checks reported and merge state is {state}. A conflicting PR never "
-                "starts CI, so\n    this is not 'still running'. Rebase it, or check the head SHA "
-                "against\n    'gh run list --branch <b> --json headSha' if you expected a run.")
+        return (f"  PR #{pr} — no checks reported and merge state is {state or 'unnamed'}. A "
+                "conflicting PR never starts CI, so\n    this is not 'still running'. Rebase it, or "
+                "check the head SHA against\n    'gh run list --branch <b> --json headSha' if you "
+                "expected a run.")
 
     pending = [check for check in checks if check.get("bucket") == "pending"]
     if not pending:

--- a/.claude/hooks/stop/unsettled_pr.py
+++ b/.claude/hooks/stop/unsettled_pr.py
@@ -70,11 +70,29 @@ def merge_state(pr):
     return state if code == 0 else None
 
 
+def carries_no_check(pr):
+    """Whether the head really carries no check, asked a way that answers instead of erroring.
+
+    The rollup is read for its length and nothing else — the buckets stay `gh pr checks`'s to name,
+    so this adds no second copy of what a conclusion means.
+    """
+    out, _, code = gh(["pr", "view", pr, "--json", "statusCheckRollup",
+                       "--jq", ".statusCheckRollup | length"])
+    return code == 0 and out == "0"
+
+
 def checks_of(pr):
-    """The pull request's check list, or None when the read did not answer."""
+    """The pull request's check list, or None when the read did not answer.
+
+    `gh pr checks` exits non-zero for both "I could not read" and "there are none", so its exit code
+    cannot separate an exhausted quota from a head no workflow has run for yet. Reading the second as
+    the first blocks on every pull request in its first minutes; reading the first as the second is
+    what let one nobody could see into the settled set. So a non-zero exit is taken to the rollup,
+    which answers 0 rather than erroring, and only an answer there makes this an empty list.
+    """
     out, _, code = gh(["pr", "checks", pr, "--json", "name,bucket"])
     if code != 0:
-        return None
+        return [] if carries_no_check(pr) else None
     try:
         return json.loads(out or "[]")
     except ValueError:

--- a/.github/workflows/generators.yml
+++ b/.github/workflows/generators.yml
@@ -95,6 +95,13 @@ jobs:
       - name: Hook unreadable-state tests
         run: python3 scripts/hooks/test_unreadable_state_check.py
 
+      # The reading those Stop guards share, and what it says when no way of asking answered. Held
+      # apart from the check above because that one runs whole guards and this one holds the library
+      # they run through: a guard could satisfy the check by hand-rolling a report, and then only
+      # one of the two would say it.
+      - name: Hook repository-reading tests
+        run: python3 scripts/hooks/test_hook_repository.py
+
   # ---------------------------------------------------------------------------
   # Repository settings live only in GitHub's own state; nothing in this
   # repository reads them back. contents:read is enough for the rulesets

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -275,8 +275,12 @@ deferral the message invited named the API error instead of whatever the work wa
 `.claude/hooks/lib/repository.py` owns both halves of the remedy: a second way of asking, drawn on a
 different quota, before blindness is declared at all, and the sentence a block has to carry when it
 is. The same check runs every guard in `.claude/hooks/stop` and requires that sentence of one that
-blocks, posing only the mode where every reading fails — an empty answer is the ordinary state
-`open_backlog.py` acts on.
+blocks. It poses two modes: nothing answers, and — the one a second way of asking creates — the
+listing answers while every per-pull-request read fails, which is where a guard can report on a
+pull request it learned nothing about. An empty answer is posed as neither, being the ordinary state
+`open_backlog.py` acts on. A guard whose own question is answered in a mode that broke somebody
+else's reading declares `UNREADABLE_ALLOWS`, with a comment and with a sibling that refuses there,
+so the exemption cannot be what ends the session.
 
 ### Source generators
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -280,7 +280,7 @@ listing answers while every per-pull-request read fails, which is where a guard 
 pull request it learned nothing about. An empty answer is posed as neither, being the ordinary state
 `open_backlog.py` acts on. A guard whose own question is answered in a mode that broke somebody
 else's reading declares `UNREADABLE_ALLOWS`, with a comment and with a sibling that refuses there,
-so the exemption cannot be what ends the session.
+so an exemption no other guard stands behind is reported rather than taken.
 
 ### Source generators
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,9 +108,12 @@ suites, and all twenty-five completed. Nothing needs doing.
 launched wedges while the editor is still alive, before anything is killed. `SIGTERM` on the editor
 reaps the editor; the wedged child does not follow it out, and no signal recovers it.
 
-Not every unreapable process here comes from Unity, and none of them blocks a later run. They
-accumulate, so `.claude/hooks/report/wedged_processes.py` reports the set at session start once it
-holds enough memory for a reboot to be worth the interruption, and says nothing below that.
+Not every unreapable process here comes from Unity, and one of them does block a later run:
+`scripts/pr/settle.py watch` holds a lock while it polls, so a wedged watcher stops the replacement —
+its refusal names the pid and the command that ends it, and every editing tool is refused meanwhile.
+The rest accumulate rather than blocking, so `.claude/hooks/report/wedged_processes.py` reports the
+set at session start once it holds enough memory for a reboot to be worth the interruption, and says
+nothing below that.
 
 ### Checking that the tests can fail
 
@@ -376,8 +379,10 @@ policy on is what would close it server-side, at the cost that buys.
 `.claude/hooks/refuse/edit_while_a_ready_pr_sits.py` refuses every editing tool once one has been ready
 for fifteen minutes, and the instruction it prints is `settle.py merge`. Ready is that command's own
 decision rather than a second reading beside it, so a pull request this window declines — like a draft
-or one that conflicts — is never recorded ready and this guard does not name it. What it does name,
-`settle.py merge` will take; hold one on purpose with the deferral its message describes.
+or one that conflicts — is not recorded ready while the window can be read. It is read by
+`published_check.unpublished_reason`, which answers None on any git failure, so an `ls-remote` that
+times out mid-poll records the green ones ready again and the stall is back for as long as that
+lasts. The deferral the hook's own message describes is still what clears it.
 
 **If the dispatch itself is what is broken, the guard has no in-band escape.** `upm.yml` runs from the
 workflow file at whatever ref is dispatched, so tagging the release commit and dispatching from the tag

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -266,6 +266,15 @@ directory refuses the same probe — otherwise the tool call is guarded by nothi
 the licence-free `source-generators` job rather than beside the fixtures above, which are skipped
 entirely on a checkout with no `UNITY_LICENSE` secret.
 
+The `Stop` guards declare the same policy and are held to one thing more, because blocking was never
+what they got wrong. They blocked, and described the pull requests rather than the reading — so the
+deferral the message invited named the API error instead of whatever the work was waiting on.
+`.claude/hooks/lib/repository.py` owns both halves of the remedy: a second way of asking, drawn on a
+different quota, before blindness is declared at all, and the sentence a block has to carry when it
+is. The same check runs every guard in `.claude/hooks/stop` and requires that sentence of one that
+blocks, posing only the mode where every reading fails — an empty answer is the ordinary state
+`open_backlog.py` acts on.
+
 ### Source generators
 
 The Roslyn source generators live under `Packages/com.velvet.core/Generators~/` and target a
@@ -365,9 +374,10 @@ policy on is what would close it server-side, at the cost that buys.
 
 **A green pull request left sitting starts refusing every edit.**
 `.claude/hooks/refuse/edit_while_a_ready_pr_sits.py` refuses every editing tool once one has been ready
-for fifteen minutes, and the instruction it prints is `settle.py merge`, which the publication guard now
-declines. Both are behaving correctly and the combination is a stall: record the deferral the hook's own
-message describes, or publish.
+for fifteen minutes, and the instruction it prints is `settle.py merge`. Ready is that command's own
+decision rather than a second reading beside it, so a pull request this window declines — like a draft
+or one that conflicts — is never recorded ready and this guard does not name it. What it does name,
+`settle.py merge` will take; hold one on purpose with the deferral its message describes.
 
 **If the dispatch itself is what is broken, the guard has no in-band escape.** `upm.yml` runs from the
 workflow file at whatever ref is dispatched, so tagging the release commit and dispatching from the tag

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,12 +108,9 @@ suites, and all twenty-five completed. Nothing needs doing.
 launched wedges while the editor is still alive, before anything is killed. `SIGTERM` on the editor
 reaps the editor; the wedged child does not follow it out, and no signal recovers it.
 
-Not every unreapable process here comes from Unity, and one of them does block a later run:
-`scripts/pr/settle.py watch` holds a lock while it polls, so a wedged watcher stops the replacement —
-its refusal names the pid and the command that ends it, and every editing tool is refused meanwhile.
-The rest accumulate rather than blocking, so `.claude/hooks/report/wedged_processes.py` reports the
-set at session start once it holds enough memory for a reboot to be worth the interruption, and says
-nothing below that.
+Not every unreapable process here comes from Unity, and none of them blocks a later run. They
+accumulate, so `.claude/hooks/report/wedged_processes.py` reports the set at session start once it
+holds enough memory for a reboot to be worth the interruption, and says nothing below that.
 
 ### Checking that the tests can fail
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -379,8 +379,8 @@ policy on is what would close it server-side, at the cost that buys.
 **A green pull request left sitting starts refusing every edit.**
 `.claude/hooks/refuse/edit_while_a_ready_pr_sits.py` refuses every editing tool once one has been ready
 for fifteen minutes, and the instruction it prints is `settle.py merge`. Ready is that command's own
-decision rather than a second reading beside it, so a pull request this window declines — like a draft
-or one that conflicts — is not recorded ready while the window can be read. It is read by
+decision rather than a second reading beside it, so a pull request this window declines is not
+recorded ready while the window can be read. It is read by
 `published_check.unpublished_reason`, which answers None on any git failure, so an `ls-remote` that
 times out mid-poll records the green ones ready again and the stall is back for as long as that
 lasts. The deferral the hook's own message describes is still what clears it.

--- a/scripts/hooks/test_hook_repository.py
+++ b/scripts/hooks/test_hook_repository.py
@@ -131,11 +131,17 @@ def stop_guard_budget():
 
 
 class ReadingBudgetTests(unittest.TestCase):
+    """A tripwire on the shared reading, and not a claim about a guard's worst case.
+
+    Neither guard's worst case is bounded by anything here: both make their own 60-second calls, and
+    unsettled_pr.py makes two of them per pull request, so what they can spend rises with the number
+    of pull requests and no fixed sum describes it. What this holds is the one part that is fixed —
+    the reading in `repository`, whose cost is the number of ways of asking times the bound each one
+    gets, and which is where a third way would be added.
+    """
+
     def test_Given_EveryWayOfAsking_When_TheirTimeoutsAreAdded_Then_TheyFitInTheGuardsOwn(self):
-        # Arrange — the rule `repository.gh`'s own bound states: the calling guard's registered
-        # timeout divided by the calls one invocation makes. This is what fails when a way of asking
-        # is added and the division stops holding, and the registered number is scaled the way that
-        # bound already reads it.
+        # Arrange — the registered number is scaled the way `repository.gh`'s own bound reads it.
         spent = (len(repository.OPEN_PULL_REQUEST_READS)
                  * repository.OPEN_PULL_REQUEST_TIMEOUT * 1000)
 
@@ -144,29 +150,49 @@ class ReadingBudgetTests(unittest.TestCase):
 
 
 class UnreadableReportTests(unittest.TestCase):
-    ATTEMPTS = [("gh pr list", 1, "HTTP 403"), ("gh api repos/x/y/pulls", 1, "HTTP 403")]
+    BOTH = [("gh pr list", "exited 1\nHTTP 403"), ("gh api repos/x/y/pulls", "exited 1\nHTTP 403")]
+    ONE = [("gh issue list", "exited 1\nHTTP 403")]
+    WAY = "`gh issue list --assignee @me` from another shell"
+
+    def report(self, attempts=None, subject="the open pull requests", key="pr-list", way="`gh pr view <n>`"):
+        return repository.unreadable_report(subject, attempts or self.BOTH, key, way)
 
     def test_Given_AReport_When_ItIsRead_Then_ItSaysTheGuardIsWhatCouldNotRead(self):
-        # Act
-        report = repository.unreadable_report("the open pull requests", self.ATTEMPTS, "pr-list")
-
-        # Assert
-        self.assertIn(repository.SELF_REPORT, report)
+        # Act / Assert
+        self.assertIn(repository.SELF_REPORT, self.report())
 
     def test_Given_AReport_When_ItIsRead_Then_EveryAttemptIsShown(self):
         # Arrange — a reader asked to establish it another way needs to know which ways were tried.
-        report = repository.unreadable_report("the open pull requests", self.ATTEMPTS, "pr-list")
+        report = self.report()
 
         # Act / Assert
-        self.assertTrue(all(call in report for call, _, _ in self.ATTEMPTS), report)
+        self.assertTrue(all(call in report for call, _ in self.BOTH), report)
 
     def test_Given_AReport_When_ItsDeferralLineIsRead_Then_ItAsksWhatTheWorkWaitsOn(self):
         # Arrange — a deferral naming the failed reading expires and is rewritten identically, so the
         # reason on the record ends up being one nothing was waiting on.
-        report = repository.unreadable_report("the open pull requests", self.ATTEMPTS, "pr-list")
+        report = self.report()
 
         # Act / Assert
         self.assertIn('echo "pr-list <what the work is waiting on>', report)
+
+    def test_Given_OneFailedCall_When_TheReportIsRead_Then_ItDoesNotCallThatEveryWayOfAsking(self):
+        # Arrange — one caller passes a single call, and a report that says every way failed about
+        # one call is wrong about the evidence directly below it. Asked beside the two-call form so
+        # dropping the sentence outright cannot satisfy this.
+        counted = ("Every way of asking failed" in self.report(self.ONE),
+                   "Every way of asking failed" in self.report(self.BOTH))
+
+        # Act / Assert
+        self.assertEqual(counted, (False, True))
+
+    def test_Given_ASubjectWithItsOwnRemedy_When_TheReportIsRead_Then_ThatRemedyIsWhatItNames(self):
+        # Arrange — one report served two subjects and told a reader with an unread issue list to
+        # run `gh pr view`, which is a remedy for the other one.
+        report = self.report(self.ONE, subject="the backlog", key="backlog", way=self.WAY)
+
+        # Act / Assert
+        self.assertEqual((self.WAY in report, "gh pr view" in report), (True, False))
 
 
 if __name__ == "__main__":

--- a/scripts/hooks/test_hook_repository.py
+++ b/scripts/hooks/test_hook_repository.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Unit tests for the pull-request reading two Stop guards share, and for what it says on failing.
+
+A guard that could not read had one way of asking and one thing to say, and what it said was a claim
+about the pull requests rather than about itself. Both halves are held here: that a second way is
+asked before blindness is declared, and that the report names the guard as what failed and asks the
+deferral about the work.
+
+Run: python3 scripts/hooks/test_hook_repository.py
+"""
+
+import contextlib
+import importlib.util
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SETTINGS = REPO_ROOT / ".claude/settings.json"
+STOP_GUARDS = ".claude/hooks/stop/"
+
+FAILS = 'echo "HTTP 403: API rate limit exceeded" >&2; exit 1'
+ANSWERS = "echo 612; echo 377"
+ANSWERS_NOTHING = "exit 0"
+
+
+def load_module():
+    """Imports .claude/hooks/lib/repository.py by path, since .claude holds no packages."""
+    path = REPO_ROOT / ".claude/hooks/lib/repository.py"
+    spec = importlib.util.spec_from_file_location("hook_repository", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+repository = load_module()
+
+
+@contextlib.contextmanager
+def gh_answering(pull_request_list, api):
+    """A `gh` on PATH whose two subcommands answer as told, yielding a log of what was asked."""
+    with tempfile.TemporaryDirectory(prefix="hook-repository-") as directory:
+        root = Path(directory)
+        asked = root / "asked"
+        asked.write_text("")
+        stub = root / "gh"
+        stub.write_text("#!/bin/sh\n"
+                        'printf "%s\\n" "$*" >> "$VELVET_GH_ASKED"\n'
+                        'case "$1" in\n'
+                        f"  pr) {pull_request_list} ;;\n"
+                        f"  api) {api} ;;\n"
+                        "esac\n")
+        stub.chmod(0o755)
+        with mock.patch.dict(os.environ, {"PATH": f"{root}{os.pathsep}{os.environ['PATH']}",
+                                          "VELVET_GH_ASKED": str(asked)}):
+            yield asked
+
+
+class OpenPullRequestTests(unittest.TestCase):
+    def test_Given_TheFirstWayFailing_When_TheSecondAnswers_Then_TheNumbersAreReturned(self):
+        # Arrange — a second way of asking is worth having only if it answers when the first cannot.
+        with gh_answering(FAILS, ANSWERS):
+            # Act / Assert
+            self.assertEqual(repository.open_pull_requests().numbers, ["612", "377"])
+
+    def test_Given_EveryWayFailing_When_TheReadingIsTaken_Then_ThereIsNoAnswerAtAll(self):
+        # Arrange — None rather than an empty list, which is what an answered read can also be.
+        with gh_answering(FAILS, FAILS):
+            # Act / Assert
+            self.assertIsNone(repository.open_pull_requests().numbers)
+
+    def test_Given_EveryWayFailing_When_TheReadingIsTaken_Then_EachAttemptIsReported(self):
+        # Arrange — a guard that declares blindness has to be able to show what it asked.
+        with gh_answering(FAILS, FAILS):
+            # Act
+            attempts = repository.open_pull_requests().attempts
+
+            # Assert
+            self.assertEqual(len(attempts), len(repository.OPEN_PULL_REQUEST_READS))
+
+    def test_Given_EveryWayFailing_When_TheReadingIsTaken_Then_MoreThanOneWasTried(self):
+        # Arrange — asked against a number rather than against the table above, which would shrink
+        # with it and agree with itself all the way down to one way of asking.
+        with gh_answering(FAILS, FAILS):
+            # Act
+            attempts = repository.open_pull_requests().attempts
+
+            # Assert
+            self.assertGreater(len(attempts), 1)
+
+    def test_Given_TheFirstWayAnswering_When_TheReadingIsTaken_Then_TheSecondIsNotAsked(self):
+        # Arrange
+        with gh_answering(ANSWERS, FAILS) as asked:
+            # Act
+            repository.open_pull_requests()
+
+            # Assert
+            self.assertEqual(asked.read_text().splitlines(),
+                             [" ".join(repository.OPEN_PULL_REQUEST_READS[0])])
+
+    def test_Given_AnAnswerNamingNoPullRequest_When_TheReadingIsTaken_Then_ItIsAnAnswer(self):
+        # Arrange — no open pull request is the state open_backlog.py exists to act on, so an empty
+        # answer must not read as the failure above.
+        with gh_answering(ANSWERS_NOTHING, FAILS):
+            # Act / Assert
+            self.assertEqual(repository.open_pull_requests().numbers, [])
+
+    def test_Given_TheWaysOfAsking_When_TheirCommandsAreCompared_Then_TheyAreNotOneQuotaTwice(self):
+        # Arrange — `gh pr list` and `gh api` is the whole of the second way; two entries under one
+        # subcommand would draw on one quota and read as two ways of asking.
+        subcommands = {read[0] for read in repository.OPEN_PULL_REQUEST_READS}
+
+        # Act / Assert
+        self.assertGreater(len(subcommands), 1)
+
+
+def stop_guard_budget():
+    """The tightest timeout the settings register for a Stop guard reading the pull requests.
+
+    Raises rather than defaulting when nothing matches: a budget nobody found would make the case
+    below pass against a number this repository does not hold.
+    """
+    settings = json.loads(SETTINGS.read_text(encoding="utf-8"))
+    return min(hook["timeout"]
+               for entry in settings.get("hooks", {}).get("Stop", [])
+               for hook in entry.get("hooks", [])
+               if STOP_GUARDS in hook.get("command", ""))
+
+
+class ReadingBudgetTests(unittest.TestCase):
+    def test_Given_EveryWayOfAsking_When_TheirTimeoutsAreAdded_Then_TheyFitInTheGuardsOwn(self):
+        # Arrange — the rule `repository.gh`'s own bound states: the calling guard's registered
+        # timeout divided by the calls one invocation makes. This is what fails when a way of asking
+        # is added and the division stops holding, and the registered number is scaled the way that
+        # bound already reads it.
+        spent = (len(repository.OPEN_PULL_REQUEST_READS)
+                 * repository.OPEN_PULL_REQUEST_TIMEOUT * 1000)
+
+        # Act / Assert
+        self.assertLess(spent, stop_guard_budget())
+
+
+class UnreadableReportTests(unittest.TestCase):
+    ATTEMPTS = [("gh pr list", 1, "HTTP 403"), ("gh api repos/x/y/pulls", 1, "HTTP 403")]
+
+    def test_Given_AReport_When_ItIsRead_Then_ItSaysTheGuardIsWhatCouldNotRead(self):
+        # Act
+        report = repository.unreadable_report("the open pull requests", self.ATTEMPTS, "pr-list")
+
+        # Assert
+        self.assertIn(repository.SELF_REPORT, report)
+
+    def test_Given_AReport_When_ItIsRead_Then_EveryAttemptIsShown(self):
+        # Arrange — a reader asked to establish it another way needs to know which ways were tried.
+        report = repository.unreadable_report("the open pull requests", self.ATTEMPTS, "pr-list")
+
+        # Act / Assert
+        self.assertTrue(all(call in report for call, _, _ in self.ATTEMPTS), report)
+
+    def test_Given_AReport_When_ItsDeferralLineIsRead_Then_ItAsksWhatTheWorkWaitsOn(self):
+        # Arrange — a deferral naming the failed reading expires and is rewritten identically, so the
+        # reason on the record ends up being one nothing was waiting on.
+        report = repository.unreadable_report("the open pull requests", self.ATTEMPTS, "pr-list")
+
+        # Act / Assert
+        self.assertIn('echo "pr-list <what the work is waiting on>', report)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/hooks/test_hook_repository.py
+++ b/scripts/hooks/test_hook_repository.py
@@ -114,9 +114,13 @@ class OpenPullRequestTests(unittest.TestCase):
         self.assertGreater(len(subcommands), 1)
 
 
-# What a Stop may spend on this reading before the pause stops being one. A judgement rather than a
-# reading of the settings: the timeout registered there is orders larger than anything anyone would
-# wait at a Stop, so comparing against it passes whatever is written here and pins nothing.
+# What a Stop may spend on this reading before the pause stops being one.
+#
+# Owned here rather than read from the settings, and that is not the mirror it might look like: a
+# mirror copies a value some other file decides, and drifts when that file changes. This decides
+# nothing twice. It is a judgement about how long a person will wait before a pause stops reading as
+# one, which no configured number states — the timeout registered for these guards is orders larger
+# than that, so comparing against it would pass whatever is written here and pin nothing.
 LONGEST_WORTH_WAITING = 20
 
 

--- a/scripts/hooks/test_hook_repository.py
+++ b/scripts/hooks/test_hook_repository.py
@@ -119,8 +119,7 @@ class OpenPullRequestTests(unittest.TestCase):
 # Owned here rather than read from the settings, and that is not the mirror it might look like: a
 # mirror copies a value some other file decides, and drifts when that file changes. This decides
 # nothing twice. It is a judgement about how long a person will wait before a pause stops reading as
-# one, which no configured number states — the timeout registered for these guards is orders larger
-# than that, so comparing against it would pass whatever is written here and pin nothing.
+# one, which no configured number states.
 LONGEST_WORTH_WAITING = 20
 
 
@@ -133,8 +132,8 @@ class ReadingBudgetTests(unittest.TestCase):
     fixed — the reading in `repository`, whose cost is the number of ways of asking times the bound
     each one gets, and which is where a third way would be added.
 
-    An earlier version compared against the timeout the settings register, having read that number in
-    the wrong unit; read in the right one it is hours, so it passes anything and fires for nothing.
+    An earlier version compared against the timeout the settings register, having read that number
+    in a unit it turned out not to be in. Nothing here reads it now.
     """
 
     def test_Given_EveryWayOfAsking_When_TheirTimeoutsAreAdded_Then_TheyStayWorthWaitingFor(self):

--- a/scripts/hooks/test_hook_repository.py
+++ b/scripts/hooks/test_hook_repository.py
@@ -11,7 +11,6 @@ Run: python3 scripts/hooks/test_hook_repository.py
 
 import contextlib
 import importlib.util
-import json
 import os
 import tempfile
 import unittest
@@ -19,8 +18,6 @@ from pathlib import Path
 from unittest import mock
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-SETTINGS = REPO_ROOT / ".claude/settings.json"
-STOP_GUARDS = ".claude/hooks/stop/"
 
 FAILS = 'echo "HTTP 403: API rate limit exceeded" >&2; exit 1'
 ANSWERS = "echo 612; echo 377"
@@ -117,36 +114,31 @@ class OpenPullRequestTests(unittest.TestCase):
         self.assertGreater(len(subcommands), 1)
 
 
-def stop_guard_budget():
-    """The tightest timeout the settings register for a Stop guard reading the pull requests.
-
-    Raises rather than defaulting when nothing matches: a budget nobody found would make the case
-    below pass against a number this repository does not hold.
-    """
-    settings = json.loads(SETTINGS.read_text(encoding="utf-8"))
-    return min(hook["timeout"]
-               for entry in settings.get("hooks", {}).get("Stop", [])
-               for hook in entry.get("hooks", [])
-               if STOP_GUARDS in hook.get("command", ""))
+# What a Stop may spend on this reading before the pause stops being one. A judgement rather than a
+# reading of the settings: the timeout registered there is orders larger than anything anyone would
+# wait at a Stop, so comparing against it passes whatever is written here and pins nothing.
+LONGEST_WORTH_WAITING = 20
 
 
 class ReadingBudgetTests(unittest.TestCase):
     """A tripwire on the shared reading, and not a claim about a guard's worst case.
 
     Neither guard's worst case is bounded by anything here: both make their own 60-second calls, and
-    unsettled_pr.py makes two of them per pull request, so what they can spend rises with the number
-    of pull requests and no fixed sum describes it. What this holds is the one part that is fixed —
-    the reading in `repository`, whose cost is the number of ways of asking times the bound each one
-    gets, and which is where a third way would be added.
+    unsettled_pr.py makes up to three of them per pull request, so what they can spend rises with the
+    number of pull requests and no fixed sum describes it. What this holds is the one part that is
+    fixed — the reading in `repository`, whose cost is the number of ways of asking times the bound
+    each one gets, and which is where a third way would be added.
+
+    An earlier version compared against the timeout the settings register, having read that number in
+    the wrong unit; read in the right one it is hours, so it passes anything and fires for nothing.
     """
 
-    def test_Given_EveryWayOfAsking_When_TheirTimeoutsAreAdded_Then_TheyFitInTheGuardsOwn(self):
-        # Arrange — the registered number is scaled the way `repository.gh`'s own bound reads it.
-        spent = (len(repository.OPEN_PULL_REQUEST_READS)
-                 * repository.OPEN_PULL_REQUEST_TIMEOUT * 1000)
+    def test_Given_EveryWayOfAsking_When_TheirTimeoutsAreAdded_Then_TheyStayWorthWaitingFor(self):
+        # Arrange
+        spent = len(repository.OPEN_PULL_REQUEST_READS) * repository.OPEN_PULL_REQUEST_TIMEOUT
 
         # Act / Assert
-        self.assertLess(spent, stop_guard_budget())
+        self.assertLessEqual(spent, LONGEST_WORTH_WAITING)
 
 
 class UnreadableReportTests(unittest.TestCase):

--- a/scripts/hooks/test_unreadable_state_check.py
+++ b/scripts/hooks/test_unreadable_state_check.py
@@ -249,7 +249,8 @@ STOP_READ = 'done = subprocess.run(["gh", "pr", "list"], capture_output=True, te
 
 def stop_guard(policy, body, allows=None, reason=""):
     return (STOP_PREAMBLE
-            + f'\n\nUNREADABLE_POLICY = "{policy}"\n'
+            + (f"\n\n# {reason}\n" if reason and allows is None else "\n\n")
+            + f'UNREADABLE_POLICY = "{policy}"\n'
             + ("" if allows is None
                else (f"\n# {reason}\n" if reason else "\n") + f"UNREADABLE_ALLOWS = {allows}\n")
             + "\n\ndef main():\n"
@@ -395,6 +396,39 @@ class StopGuardTests(unittest.TestCase):
 
         # Assert
         self.assertEqual(len(found), 1, stop_faults(root))
+
+    def test_Given_AStopGuardDeclaringAllowWithNoCommentAboveIt_When_TheCheckRuns_Then_ItIsReported(self):
+        # Arrange — the sibling is there so the missing comment is the only fault left.
+        root = directory(lenient=stop_guard("allow", STOP_FAILS_OPEN),
+                         holds=stop_guard("refuse", STOP_BLOCKS_SAYING))
+
+        # Act
+        found = [line for line in stop_faults(root) if "no comment above it" in line]
+
+        # Assert
+        self.assertEqual(len(found), 1, stop_faults(root))
+
+    def test_Given_AStopGuardDeclaringAllowAndNoSiblingRefusing_When_TheCheckRuns_Then_ItIsReported(self):
+        # Arrange — one line of a new guard otherwise reaches the silence this exists to stop.
+        root = directory(lenient=stop_guard("allow", STOP_FAILS_OPEN,
+                                            reason="nothing holds this"))
+
+        # Act
+        found = [line for line in stop_faults(root) if "no sibling refuses there" in line]
+
+        # Assert — every mode that reaches the read reports it.
+        self.assertEqual(len(found), 2, stop_faults(root))
+
+    def test_Given_AStopGuardDeclaringAllowAndASiblingRefusing_When_TheCheckRuns_Then_NothingIsReported(self):
+        # Arrange — the control: a policy nothing can declare is not a policy.
+        root = directory(lenient=stop_guard("allow", STOP_FAILS_OPEN, reason="the sibling holds this"),
+                         holds=stop_guard("refuse", STOP_BLOCKS_SAYING))
+
+        # Act
+        found = stop_faults(root)
+
+        # Assert
+        self.assertEqual(found, [])
 
     def test_Given_ThisRepositorysStopGuards_When_NoReadingAnswers_Then_EachAnswersWhatItDeclares(self):
         # Arrange
@@ -691,6 +725,48 @@ class AllHeldTests(unittest.TestCase):
 
         # Act / Assert
         self.assertEqual((NOTHING_WAS_READ in said, "PR #1" in said), (False, True))
+
+
+class UnreadableHeartbeatTests(unittest.TestCase):
+    """A watcher older than the pid field, which is what merging that change walks into.
+
+    It writes one field, so a reader that only asks `alive` gets what an absent file gives it. The
+    two want opposite actions — start a watcher, end one — and the command for the first refuses
+    while the second is running, so telling them apart is the whole of getting out.
+    """
+
+    GUARD = REPO_ROOT / ".claude/hooks/refuse/edit_while_a_ready_pr_sits.py"
+    PAYLOAD = json.dumps({"tool_name": "Edit", "cwd": str(REPO_ROOT),
+                          "tool_input": {"file_path": "CHANGELOG.md",
+                                         "old_string": "a", "new_string": "b"}})
+
+    def said(self, heartbeat):
+        home = Path(tempfile.mkdtemp(prefix="velvet-old-beat-home-"))
+        try:
+            if heartbeat is not None:
+                (home / ".velvet-pr-watch.heartbeat").write_text(heartbeat, encoding="utf-8")
+            _, _, errors, _ = check.run_guard(self.GUARD, self.PAYLOAD, "gh-empty", REPO_ROOT, home)
+            return errors
+        finally:
+            shutil.rmtree(home, ignore_errors=True)
+
+    def test_Given_AFreshHeartbeatInTheOlderForm_When_AWriteIsAttempted_Then_ItSaysSomethingIsWatching(self):
+        # Arrange — one field and a live stamp, which is what a watcher predating the pid writes.
+        said = self.said(f"{int(time.time())}\n")
+
+        # Act / Assert — the recovery is to end that watcher, so the message must not say there is
+        # none to end.
+        self.assertEqual(("Something IS watching" in said, "nothing is watching" in said),
+                         (True, False))
+
+    def test_Given_NoHeartbeatAtAll_When_AWriteIsAttempted_Then_ItStillSaysNothingIsWatching(self):
+        # Arrange — the control: the older-form message must be about the older form, not about
+        # every refusal this branch makes.
+        said = self.said(None)
+
+        # Act / Assert
+        self.assertEqual(("Something IS watching" in said, "nothing is watching" in said),
+                         (False, True))
 
 
 class WatcherDeferralTests(unittest.TestCase):

--- a/scripts/hooks/test_unreadable_state_check.py
+++ b/scripts/hooks/test_unreadable_state_check.py
@@ -428,7 +428,33 @@ NO_CHECKS_AND_A_ROLLUP = """#!/bin/sh
 case "$1 $2" in
   "pr list")   echo 51 ;;
   "pr checks") echo "no checks reported on the 'topic' branch" >&2; exit 1 ;;
-  "pr view")   case "$*" in *statusCheckRollup*) echo 0 ;; *) echo CLEAN ;; esac ;;
+  "pr view")   case "$*" in
+                 *statusCheckRollup*)
+                   case "$*" in
+                     *--jq*) echo 0 ;;
+                     *) echo '{"statusCheckRollup":[]}' ;;
+                   esac ;;
+                 *) echo CLEAN ;;
+               esac ;;
+  *)           exit 0 ;;
+esac
+"""
+
+# The rollup answers, and what it answers is not a list. This stub applies `--jq` the way gh would,
+# so a guard that asks for `| length` is handed the 0 jq gives for a null and a guard that reads the
+# payload is handed the null itself — the two readings of one answer, which is the whole question.
+NO_CHECKS_AND_A_NULL_ROLLUP = """#!/bin/sh
+case "$1 $2" in
+  "pr list")   echo 51 ;;
+  "pr checks") echo "no checks reported on the 'topic' branch" >&2; exit 1 ;;
+  "pr view")   case "$*" in
+                 *statusCheckRollup*)
+                   case "$*" in
+                     *--jq*) echo 0 ;;
+                     *) echo '{"statusCheckRollup":null}' ;;
+                   esac ;;
+                 *) echo CLEAN ;;
+               esac ;;
   *)           exit 0 ;;
 esac
 """
@@ -489,6 +515,14 @@ class ZeroCheckTests(unittest.TestCase):
         # Act / Assert
         self.assertIn(check.SELF_REPORT, said)
 
+    def test_Given_ARollupThatIsNotAList_When_ItIsRead_Then_ItIsNotTakenForNone(self):
+        # Arrange — the merge state answers CLEAN, so a rollup misread as empty produces the
+        # zero-check reminder about a list nothing here understood.
+        said = self.said(NO_CHECKS_AND_A_NULL_ROLLUP)
+
+        # Act / Assert
+        self.assertEqual((check.SELF_REPORT in said, "no checks apply to it" in said), (True, False))
+
     def test_Given_AnUnreadCheckListBesideAReadableMergeState_When_Judged_Then_NoneIsNotReportedAsZero(self):
         # Arrange — the merge state answers CLEAN, so a check read taken for an empty one produces
         # the zero-check reminder: "no checks apply to it", about a list nothing here read.
@@ -496,6 +530,61 @@ class ZeroCheckTests(unittest.TestCase):
 
         # Act / Assert
         self.assertEqual((check.SELF_REPORT in said, "no checks apply to it" in said), (True, False))
+
+
+# Two open pull requests, neither carrying a check, both readable. What varies between the cases
+# below is only how many of them a deferral holds.
+TWO_SETTLED_PULL_REQUESTS = """#!/bin/sh
+case "$1 $2" in
+  "pr list")   printf '1\n2\n' ;;
+  "pr checks") echo "no checks reported on the 'topic' branch" >&2; exit 1 ;;
+  "pr view")   case "$*" in
+                 *statusCheckRollup*) echo '{"statusCheckRollup":[]}' ;;
+                 *) echo BEHIND ;;
+               esac ;;
+  *)           exit 0 ;;
+esac
+"""
+
+NOTHING_WAS_READ = "none of them was read this time"
+
+
+class AllHeldTests(unittest.TestCase):
+    """Every open pull request deferred means the guard read none of them.
+
+    A deferral is checked before the pull request is, so the held list after checking each one and
+    the held list after checking nothing are the same list. Which of the two it is costs no reading
+    to know — the count says it — and saying it is the difference between a report about the pull
+    requests and a report about what was claimed of them.
+    """
+
+    GUARD = REPO_ROOT / ".claude/hooks/stop/unsettled_pr.py"
+
+    def said(self, deferrals):
+        home = Path(tempfile.mkdtemp(prefix="velvet-all-held-home-"))
+        try:
+            (home / ".velvet-pr-deferrals").write_text(deferrals, encoding="utf-8")
+            _, _, errors, _ = check.run_guard(self.GUARD, check.STOP_PAYLOAD, "probe", REPO_ROOT,
+                                              home, {"probe": {"gh": TWO_SETTLED_PULL_REQUESTS}})
+            return errors
+        finally:
+            shutil.rmtree(home, ignore_errors=True)
+
+    def held(self, *numbers):
+        stamp = int(time.time())
+        return "".join(f"{number} waiting on a review {stamp}\n" for number in numbers)
+
+    def test_Given_EveryOpenPullRequestHeld_When_TheSessionEnds_Then_ItSaysNoneWasRead(self):
+        # Act / Assert
+        self.assertIn(NOTHING_WAS_READ, self.said(self.held(1, 2)))
+
+    def test_Given_OnlySomeHeld_When_TheSessionEnds_Then_TheOthersWereReadAndItDoesNotSayOtherwise(self):
+        # Arrange — the control: the sentence has to be about all of them being held, not about any
+        # of them being held.
+        said = self.said(self.held(1))
+
+        # Act / Assert
+        self.assertEqual((NOTHING_WAS_READ in said, "PR #1" in said), (False, True))
 
 
 class WatcherDeferralTests(unittest.TestCase):

--- a/scripts/hooks/test_unreadable_state_check.py
+++ b/scripts/hooks/test_unreadable_state_check.py
@@ -421,6 +421,83 @@ class RepositoryTests(unittest.TestCase):
                          (True, []))
 
 
+# `gh pr checks --json` exits 1 on a head with no check at all, the same code it exits when it could
+# not read, so a guard reading the code alone cannot tell a pull request in its first minutes from an
+# exhausted quota. These stubs pose both, with the rollup answering or not.
+NO_CHECKS_AND_A_ROLLUP = """#!/bin/sh
+case "$1 $2" in
+  "pr list")   echo 51 ;;
+  "pr checks") echo "no checks reported on the 'topic' branch" >&2; exit 1 ;;
+  "pr view")   case "$*" in *statusCheckRollup*) echo 0 ;; *) echo CLEAN ;; esac ;;
+  *)           exit 0 ;;
+esac
+"""
+
+NO_CHECKS_AND_NO_ROLLUP = """#!/bin/sh
+case "$1 $2" in
+  "pr list")   echo 51 ;;
+  *)           echo "GraphQL: API rate limit already exceeded" >&2; exit 1 ;;
+esac
+"""
+
+
+# The rollup fails while the merge state answers, which is where reading a failed check read as an
+# empty one stops merely mis-wording and starts asserting a fact nothing established.
+NO_CHECKS_AND_A_MERGE_STATE = """#!/bin/sh
+case "$1 $2" in
+  "pr list")   echo 51 ;;
+  "pr checks") echo "GraphQL: API rate limit already exceeded" >&2; exit 1 ;;
+  "pr view")   case "$*" in
+                 *statusCheckRollup*) echo "GraphQL: API rate limit already exceeded" >&2; exit 1 ;;
+                 *) echo CLEAN ;;
+               esac ;;
+  *)           exit 0 ;;
+esac
+"""
+
+
+class ZeroCheckTests(unittest.TestCase):
+    """A head no workflow has run for yet, which `gh pr checks` reports by failing.
+
+    Read as a failed reading it blocks every pull request in its first minutes and takes the whole
+    zero-check branch out of reach; read as an answer without asking anything else, an exhausted
+    quota walks back in as "no checks".
+    """
+
+    GUARD = REPO_ROOT / ".claude/hooks/stop/unsettled_pr.py"
+
+    def said(self, stub):
+        home = Path(tempfile.mkdtemp(prefix="velvet-zero-check-home-"))
+        try:
+            _, _, errors, _ = check.run_guard(self.GUARD, check.STOP_PAYLOAD, "probe", REPO_ROOT,
+                                              home, {"probe": {"gh": stub}})
+            return errors
+        finally:
+            shutil.rmtree(home, ignore_errors=True)
+
+    def test_Given_AHeadWithNoCheckAtAll_When_TheRollupAnswers_Then_ItIsNotCalledUnread(self):
+        # Arrange — the rollup says zero, so the answer was "none" and the reading did not fail.
+        said = self.said(NO_CHECKS_AND_A_ROLLUP)
+
+        # Act / Assert — the zero-check reminder, and not the sentence for a guard that read nothing.
+        self.assertEqual(("no checks apply to it" in said, check.SELF_REPORT in said), (True, False))
+
+    def test_Given_TheSameFailureWithNoRollupEither_When_ItIsJudged_Then_ItIsCalledUnread(self):
+        # Arrange — nothing answered, so "there are none" is not something this established.
+        said = self.said(NO_CHECKS_AND_NO_ROLLUP)
+
+        # Act / Assert
+        self.assertIn(check.SELF_REPORT, said)
+
+    def test_Given_AnUnreadCheckListBesideAReadableMergeState_When_Judged_Then_NoneIsNotReportedAsZero(self):
+        # Arrange — the merge state answers CLEAN, so a check read taken for an empty one produces
+        # the zero-check reminder: "no checks apply to it", about a list nothing here read.
+        said = self.said(NO_CHECKS_AND_A_MERGE_STATE)
+
+        # Act / Assert
+        self.assertEqual((check.SELF_REPORT in said, "no checks apply to it" in said), (True, False))
+
+
 class WatcherDeferralTests(unittest.TestCase):
     """A refusal that holds every editing tool in every session, and the way past it.
 

--- a/scripts/hooks/test_unreadable_state_check.py
+++ b/scripts/hooks/test_unreadable_state_check.py
@@ -482,6 +482,37 @@ esac
 """
 
 
+# The head really carries no check — the rollup says so — and the merge state read then fails. This
+# is the one state that reaches `merge_state`'s own answer, and where an empty string standing for
+# both "GitHub named none" and "the read failed" makes an unread pull request settled.
+NO_CHECKS_AND_NO_MERGE_STATE = """#!/bin/sh
+case "$1 $2" in
+  "pr list")   echo 51 ;;
+  "pr checks") echo "no checks reported on the 'topic' branch" >&2; exit 1 ;;
+  "pr view")   case "$*" in
+                 *statusCheckRollup*) echo '{"statusCheckRollup":[]}' ;;
+                 *) echo "GraphQL: API rate limit already exceeded" >&2; exit 1 ;;
+               esac ;;
+  *)           exit 0 ;;
+esac
+"""
+
+
+# The merge state read succeeds and names nothing, which is what a renamed field leaves behind. It
+# is the one state that reaches EXPECTED_WITHOUT_CHECKS with an empty string in hand.
+NO_CHECKS_AND_AN_UNNAMED_MERGE_STATE = """#!/bin/sh
+case "$1 $2" in
+  "pr list")   echo 51 ;;
+  "pr checks") echo "no checks reported on the 'topic' branch" >&2; exit 1 ;;
+  "pr view")   case "$*" in
+                 *statusCheckRollup*) echo '{"statusCheckRollup":[]}' ;;
+                 *) exit 0 ;;
+               esac ;;
+  *)           exit 0 ;;
+esac
+"""
+
+
 class ZeroCheckTests(unittest.TestCase):
     """A head no workflow has run for yet, which `gh pr checks` reports by failing.
 
@@ -508,12 +539,35 @@ class ZeroCheckTests(unittest.TestCase):
         # Act / Assert — the zero-check reminder, and not the sentence for a guard that read nothing.
         self.assertEqual(("no checks apply to it" in said, check.SELF_REPORT in said), (True, False))
 
-    def test_Given_TheSameFailureWithNoRollupEither_When_ItIsJudged_Then_ItIsCalledUnread(self):
-        # Arrange — nothing answered, so "there are none" is not something this established.
+    def test_Given_TheSameFailureWithNoRollupEither_When_ItIsJudged_Then_ThePullRequestIsNamed(self):
+        # Arrange — nothing answered at all. This one carries the per-pull-request half rather than
+        # anything about `checks_of`: the two cases either side of it are what separate a failed
+        # check read from an answered-empty one, and both shapes of that read leave this green. What
+        # it holds is that the block names the pull request it could not read, rather than stopping
+        # at the listing.
         said = self.said(NO_CHECKS_AND_NO_ROLLUP)
 
         # Act / Assert
-        self.assertIn(check.SELF_REPORT, said)
+        self.assertEqual((check.SELF_REPORT in said, "PR #51" in said), (True, True))
+
+    def test_Given_AMergeStateThatAnsweredAndNamedNothing_When_Judged_Then_ItIsNotSettledEither(self):
+        # Arrange — gh exits 0 and selects nothing, which is what a renamed field leaves. Listing the
+        # empty string among the states that explain an absent check list made this pull request
+        # settled; leaving it out sends it to the reason that reports what the state was.
+        said = self.said(NO_CHECKS_AND_AN_UNNAMED_MERGE_STATE)
+
+        # Act / Assert
+        self.assertIn("merge state is unnamed", said)
+
+    def test_Given_AHeadWithNoCheckAndAnUnreadMergeState_When_Judged_Then_ItIsNotCalledSettled(self):
+        # Arrange — the rollup establishes that there are none, so the check list is an answer and
+        # the merge state is the only thing left unread. An empty string standing for both "GitHub
+        # named none" and "the read failed" puts this pull request in EXPECTED_WITHOUT_CHECKS and
+        # ends the session on it.
+        said = self.said(NO_CHECKS_AND_NO_MERGE_STATE)
+
+        # Act / Assert
+        self.assertEqual((check.SELF_REPORT in said, "its merge state" in said), (True, True))
 
     def test_Given_ARollupThatIsNotAList_When_ItIsRead_Then_ItIsNotTakenForNone(self):
         # Arrange — the merge state answers CLEAN, so a rollup misread as empty produces the

--- a/scripts/hooks/test_unreadable_state_check.py
+++ b/scripts/hooks/test_unreadable_state_check.py
@@ -498,8 +498,11 @@ esac
 """
 
 
-# The merge state read succeeds and names nothing, which is what a renamed field leaves behind. It
-# is the one state that reaches EXPECTED_WITHOUT_CHECKS with an empty string in hand.
+# The merge state read succeeds and names nothing. What produces that from a real `gh pr view` was
+# not established — a field it does not know exits 1 rather than selecting nothing — so this poses
+# the state rather than a cause of it. It is posed because it is the one state that reaches
+# EXPECTED_WITHOUT_CHECKS with an empty string in hand, and a merge state nobody named must not read
+# as one that explains an absent check list.
 NO_CHECKS_AND_AN_UNNAMED_MERGE_STATE = """#!/bin/sh
 case "$1 $2" in
   "pr list")   echo 51 ;;
@@ -507,6 +510,38 @@ case "$1 $2" in
   "pr view")   case "$*" in
                  *statusCheckRollup*) echo '{"statusCheckRollup":[]}' ;;
                  *) exit 0 ;;
+               esac ;;
+  *)           exit 0 ;;
+esac
+"""
+
+
+# `gh pr checks` succeeding and printing nothing, which is the shape scripts/pr/settle.py records
+# for an exhausted quota — and the rollup says the head does carry a check, so an empty answer taken
+# at face value states the opposite of what the one readable source says.
+AN_EMPTY_ANSWER_AND_A_ROLLUP_WITH_CHECKS = """#!/bin/sh
+case "$1 $2" in
+  "pr list")   echo 51 ;;
+  "pr checks") exit 0 ;;
+  "pr view")   case "$*" in
+                 *statusCheckRollup*) echo '{"statusCheckRollup":[{"name":"Unity tests"}]}' ;;
+                 *) echo CLEAN ;;
+               esac ;;
+  *)           exit 0 ;;
+esac
+"""
+
+
+# The third empty shape: a literal empty list on stdout with exit 0. The premise says gh fails
+# instead, so this is posed as a shape rather than as something observed — and it is posed because
+# "no check" reached without asking the rollup is the defect whichever spelling arrives in.
+AN_EMPTY_LIST_AND_A_ROLLUP_WITH_CHECKS = """#!/bin/sh
+case "$1 $2" in
+  "pr list")   echo 51 ;;
+  "pr checks") echo '[]' ;;
+  "pr view")   case "$*" in
+                 *statusCheckRollup*) echo '{"statusCheckRollup":[{"name":"Unity tests"}]}' ;;
+                 *) echo CLEAN ;;
                esac ;;
   *)           exit 0 ;;
 esac
@@ -551,9 +586,10 @@ class ZeroCheckTests(unittest.TestCase):
         self.assertEqual((check.SELF_REPORT in said, "PR #51" in said), (True, True))
 
     def test_Given_AMergeStateThatAnsweredAndNamedNothing_When_Judged_Then_ItIsNotSettledEither(self):
-        # Arrange — gh exits 0 and selects nothing, which is what a renamed field leaves. Listing the
-        # empty string among the states that explain an absent check list made this pull request
-        # settled; leaving it out sends it to the reason that reports what the state was.
+        # Arrange — gh exits 0 and names nothing; the stub above owns why that is posed as a state
+        # rather than as something with a known cause. Listing the empty string among the states
+        # that explain an absent check list made this pull request settled; leaving it out sends it
+        # to the reason that reports what the state was.
         said = self.said(NO_CHECKS_AND_AN_UNNAMED_MERGE_STATE)
 
         # Act / Assert
@@ -568,6 +604,22 @@ class ZeroCheckTests(unittest.TestCase):
 
         # Act / Assert
         self.assertEqual((check.SELF_REPORT in said, "its merge state" in said), (True, True))
+
+    def test_Given_AnEmptyAnswerFromTheCheckRead_When_Judged_Then_ItIsNotTakenForNone(self):
+        # Arrange — the exit code is 0 and the output is empty, so nothing about the exit says the
+        # read failed; the rollup naming a check is what says the empty answer was not one.
+        said = self.said(AN_EMPTY_ANSWER_AND_A_ROLLUP_WITH_CHECKS)
+
+        # Act / Assert
+        self.assertEqual((check.SELF_REPORT in said, "no checks apply to it" in said), (True, False))
+
+    def test_Given_AnEmptyListFromTheCheckRead_When_Judged_Then_ItIsNotTakenForNone(self):
+        # Arrange — the same question as the case above with the other spelling of empty, so the
+        # rollup is what decides however the emptiness arrives rather than for one shape of it.
+        said = self.said(AN_EMPTY_LIST_AND_A_ROLLUP_WITH_CHECKS)
+
+        # Act / Assert
+        self.assertEqual((check.SELF_REPORT in said, "no checks apply to it" in said), (True, False))
 
     def test_Given_ARollupThatIsNotAList_When_ItIsRead_Then_ItIsNotTakenForNone(self):
         # Arrange — the merge state answers CLEAN, so a rollup misread as empty produces the

--- a/scripts/hooks/test_unreadable_state_check.py
+++ b/scripts/hooks/test_unreadable_state_check.py
@@ -9,7 +9,8 @@ exit code of 1 that is a legitimate negative answer rather than a failure.
 The Stop guards are held to the same declaration and to one thing more, which is the shape their own
 defect took: blocking is not enough if what the block says is a claim about the subject rather than
 about the reading. The last class runs a guard from the tree rather than a synthetic one, because
-the branch it exercises is the only refusal that can hold every write on the machine at once.
+the branch it exercises refuses every editing tool in every session and, until this branch, offered
+no deferral to get past it.
 
 Run: python3 scripts/hooks/test_unreadable_state_check.py
 """
@@ -421,11 +422,11 @@ class RepositoryTests(unittest.TestCase):
 
 
 class WatcherDeferralTests(unittest.TestCase):
-    """The one refusal that can hold every write on the machine, and the way past it.
+    """A refusal that holds every editing tool in every session, and the way past it.
 
     Its own instruction can refuse: a watcher wedged mid-poll holds the lock while its heartbeat goes
-    stale, and starting a replacement is exactly what the lock declines. A branch that can refuse
-    everything needs an escape that does not go through the thing that is stuck.
+    stale, and starting a replacement is exactly what the lock declines. So the escape cannot go
+    through the thing that is stuck, which is what the deferral below is for.
     """
 
     GUARD = REPO_ROOT / ".claude/hooks/refuse/edit_while_a_ready_pr_sits.py"

--- a/scripts/hooks/test_unreadable_state_check.py
+++ b/scripts/hooks/test_unreadable_state_check.py
@@ -585,7 +585,7 @@ esac
 class ZeroCheckTests(unittest.TestCase):
     """A head no workflow has run for yet, which `gh pr checks` reports by failing.
 
-    Read as a failed reading it blocks every pull request in its first minutes and takes the whole
+    Read as a failed reading it blocks a pull request whose head has no check yet and takes the whole
     zero-check branch out of reach; read as an answer without asking anything else, an exhausted
     quota walks back in as "no checks".
     """

--- a/scripts/hooks/test_unreadable_state_check.py
+++ b/scripts/hooks/test_unreadable_state_check.py
@@ -8,13 +8,17 @@ exit code of 1 that is a legitimate negative answer rather than a failure.
 
 The Stop guards are held to the same declaration and to one thing more, which is the shape their own
 defect took: blocking is not enough if what the block says is a claim about the subject rather than
-about the reading.
+about the reading. The last class runs a guard from the tree rather than a synthetic one, because
+the branch it exercises is the only refusal that can hold every write on the machine at once.
 
 Run: python3 scripts/hooks/test_unreadable_state_check.py
 """
 
 import importlib.util
+import json
+import shutil
 import tempfile
+import time
 import unittest
 from pathlib import Path
 
@@ -242,10 +246,12 @@ import sys
 STOP_READ = 'done = subprocess.run(["gh", "pr", "list"], capture_output=True, text=True)'
 
 
-def stop_guard(policy, body):
+def stop_guard(policy, body, allows=None, reason=""):
     return (STOP_PREAMBLE
-            + f'\n\nUNREADABLE_POLICY = "{policy}"\n\n\n'
-            + "def main():\n"
+            + f'\n\nUNREADABLE_POLICY = "{policy}"\n'
+            + ("" if allows is None
+               else (f"\n# {reason}\n" if reason else "\n") + f"UNREADABLE_ALLOWS = {allows}\n")
+            + "\n\ndef main():\n"
             + body
             + "\n\nsys.exit(main())\n")
 
@@ -274,6 +280,15 @@ STOP_BLOCKS_SAYING = f"""    {STOP_READ}
 
 STOP_READS_NOTHING = "    return 2\n"
 
+# Blocks when nothing answered, and lets the session end when the listing did — open_backlog.py's
+# shape, which is right there and would be a silent pass anywhere else.
+STOP_PARTIAL_ALLOWS = f"""    listing = subprocess.run(["gh", "api", "pulls"], capture_output=True, text=True)
+    if listing.returncode == 0:
+        return 0
+    print("{check.SELF_REPORT} them", file=sys.stderr)
+    return 2
+"""
+
 
 def stop_faults(root):
     return check.stop_faults(root, root, floor=0)
@@ -287,8 +302,9 @@ class StopGuardTests(unittest.TestCase):
         # Act
         found = [line for line in stop_faults(root) if 'answers "allow"' in line]
 
-        # Assert
-        self.assertEqual(len(found), 1, stop_faults(root))
+        # Assert — a number rather than the table's own length, which would shrink with it and
+        # agree all the way down to the one mode that missed the defect this branch is about.
+        self.assertEqual(len(found), 2, stop_faults(root))
 
     def test_Given_AStopGuardBlockingWithoutSayingTheReadingFailed_When_TheCheckRuns_Then_ItIsReported(self):
         # Arrange
@@ -297,8 +313,9 @@ class StopGuardTests(unittest.TestCase):
         # Act
         found = [line for line in stop_faults(root) if "fact about its subject" in line]
 
-        # Assert
-        self.assertEqual(len(found), 1, stop_faults(root))
+        # Assert — a number rather than the table's own length, which would shrink with it and
+        # agree all the way down to the one mode that missed the defect this branch is about.
+        self.assertEqual(len(found), 2, stop_faults(root))
 
     def test_Given_AStopGuardThatSaysTheReadingFailed_When_TheCheckRuns_Then_NothingIsReported(self):
         # Arrange
@@ -330,6 +347,54 @@ class StopGuardTests(unittest.TestCase):
         # Assert
         self.assertEqual(len(found), 1, stop_faults(root))
 
+    def test_Given_AStopGuardDeclaringAnExemptionWithNoCommentAboveIt_When_TheCheckRuns_Then_ItIsReported(self):
+        # Arrange
+        root = directory(lenient=stop_guard("refuse", STOP_BLOCKS_SAYING,
+                                            allows='("gh-graphql-error",)'))
+
+        # Act
+        found = [line for line in stop_faults(root) if "no comment above it" in line]
+
+        # Assert
+        self.assertEqual(len(found), 1, stop_faults(root))
+
+    def test_Given_AnExemptionNoSiblingRefusesUnder_When_TheCheckRuns_Then_ItIsReported(self):
+        # Arrange — the exemption alone would let the session end with the failed reading unsaid.
+        root = directory(lenient=stop_guard("refuse", STOP_PARTIAL_ALLOWS,
+                                            allows='("gh-graphql-error",)',
+                                            reason="the sibling refuses there"))
+
+        # Act
+        found = [line for line in stop_faults(root) if "no sibling refuses there" in line]
+
+        # Assert
+        self.assertEqual(len(found), 1, stop_faults(root))
+
+    def test_Given_AnExemptionWithASiblingRefusingUnderIt_When_TheCheckRuns_Then_NothingIsReported(self):
+        # Arrange
+        root = directory(lenient=stop_guard("refuse", STOP_PARTIAL_ALLOWS,
+                                            allows='("gh-graphql-error",)',
+                                            reason="the sibling refuses there"),
+                         holds=stop_guard("refuse", STOP_BLOCKS_SAYING))
+
+        # Act
+        found = stop_faults(root)
+
+        # Assert
+        self.assertEqual(found, [])
+
+    def test_Given_AnExemptionForAModeTheGuardRefusesIn_When_TheCheckRuns_Then_ItIsReportedStale(self):
+        # Arrange
+        root = directory(lenient=stop_guard("refuse", STOP_BLOCKS_SAYING,
+                                            allows='("gh-graphql-error",)',
+                                            reason="claimed, and not what it does"))
+
+        # Act
+        found = [line for line in stop_faults(root) if "the declaration is stale" in line]
+
+        # Assert
+        self.assertEqual(len(found), 1, stop_faults(root))
+
     def test_Given_ThisRepositorysStopGuards_When_NoReadingAnswers_Then_EachAnswersWhatItDeclares(self):
         # Arrange
         stop_directory = REPO_ROOT / check.STOP_DIRECTORY
@@ -353,6 +418,42 @@ class RepositoryTests(unittest.TestCase):
         # Assert — the guard count rides along, because an empty directory disagrees with nothing.
         self.assertEqual((len(check.guards(refuse_directory)) >= check.GUARD_FLOOR, found),
                          (True, []))
+
+
+class WatcherDeferralTests(unittest.TestCase):
+    """The one refusal that can hold every write on the machine, and the way past it.
+
+    Its own instruction can refuse: a watcher wedged mid-poll holds the lock while its heartbeat goes
+    stale, and starting a replacement is exactly what the lock declines. A branch that can refuse
+    everything needs an escape that does not go through the thing that is stuck.
+    """
+
+    GUARD = REPO_ROOT / ".claude/hooks/refuse/edit_while_a_ready_pr_sits.py"
+    PAYLOAD = json.dumps({"tool_name": "Edit", "cwd": str(REPO_ROOT),
+                          "tool_input": {"file_path": "CHANGELOG.md",
+                                         "old_string": "a", "new_string": "b"}})
+
+    def verdict(self, deferral):
+        """The guard's exit code with no watcher state at all, under a HOME of its own."""
+        home = Path(tempfile.mkdtemp(prefix="velvet-watcher-home-"))
+        try:
+            if deferral is not None:
+                (home / ".velvet-pr-deferrals").write_text(deferral, encoding="utf-8")
+            code, _, _, _ = check.run_guard(self.GUARD, self.PAYLOAD, "gh-empty", REPO_ROOT, home)
+            return code
+        finally:
+            shutil.rmtree(home, ignore_errors=True)
+
+    def test_Given_NothingWatchingAndNoDeferral_When_AWriteIsAttempted_Then_ItIsRefused(self):
+        # Act / Assert — the control: an escape that is always open is not an escape.
+        self.assertEqual(self.verdict(None), 2)
+
+    def test_Given_NothingWatchingAndTheWatcherHeld_When_AWriteIsAttempted_Then_ItGoesThrough(self):
+        # Arrange — the deferral the guard's own message describes, armed with a live stamp.
+        deferral = f"watcher the network is down until the VPN is back {int(time.time())}\n"
+
+        # Act / Assert
+        self.assertEqual(self.verdict(deferral), 0)
 
 
 if __name__ == "__main__":

--- a/scripts/hooks/test_unreadable_state_check.py
+++ b/scripts/hooks/test_unreadable_state_check.py
@@ -6,6 +6,10 @@ Each synthetic guard below is one shape a failed reading takes in `.claude/hooks
 successful call that printed nothing, and — the one a reading over the source gets wrong — a git
 exit code of 1 that is a legitimate negative answer rather than a failure.
 
+The Stop guards are held to the same declaration and to one thing more, which is the shape their own
+defect took: blocking is not enough if what the block says is a claim about the subject rather than
+about the reading.
+
 Run: python3 scripts/hooks/test_unreadable_state_check.py
 """
 
@@ -227,6 +231,115 @@ class BackingTests(unittest.TestCase):
 
         # Assert
         self.assertEqual(found, [])
+
+
+STOP_PREAMBLE = '''#!/usr/bin/env python3
+"""A synthetic Stop guard."""
+import subprocess
+import sys
+'''
+
+STOP_READ = 'done = subprocess.run(["gh", "pr", "list"], capture_output=True, text=True)'
+
+
+def stop_guard(policy, body):
+    return (STOP_PREAMBLE
+            + f'\n\nUNREADABLE_POLICY = "{policy}"\n\n\n'
+            + "def main():\n"
+            + body
+            + "\n\nsys.exit(main())\n")
+
+
+# Lets the session end when nothing answered, which is what a cleared subject also does.
+STOP_FAILS_OPEN = f"""    {STOP_READ}
+    if done.returncode != 0:
+        return 0
+    return 2
+"""
+
+# Blocks, and describes the subject rather than the reading — the shape both Stop guards shipped.
+STOP_BLOCKS_MUTE = f"""    {STOP_READ}
+    if done.returncode != 0:
+        print("nothing here says they are settled", file=sys.stderr)
+        return 2
+    return 0
+"""
+
+STOP_BLOCKS_SAYING = f"""    {STOP_READ}
+    if done.returncode != 0:
+        print("{check.SELF_REPORT} them", file=sys.stderr)
+        return 2
+    return 0
+"""
+
+STOP_READS_NOTHING = "    return 2\n"
+
+
+def stop_faults(root):
+    return check.stop_faults(root, root, floor=0)
+
+
+class StopGuardTests(unittest.TestCase):
+    def test_Given_AStopGuardEndingTheSessionWhenNothingAnswered_When_TheCheckRuns_Then_ItIsReported(self):
+        # Arrange
+        root = directory(lenient=stop_guard("refuse", STOP_FAILS_OPEN))
+
+        # Act
+        found = [line for line in stop_faults(root) if 'answers "allow"' in line]
+
+        # Assert
+        self.assertEqual(len(found), 1, stop_faults(root))
+
+    def test_Given_AStopGuardBlockingWithoutSayingTheReadingFailed_When_TheCheckRuns_Then_ItIsReported(self):
+        # Arrange
+        root = directory(mute=stop_guard("refuse", STOP_BLOCKS_MUTE))
+
+        # Act
+        found = [line for line in stop_faults(root) if "fact about its subject" in line]
+
+        # Assert
+        self.assertEqual(len(found), 1, stop_faults(root))
+
+    def test_Given_AStopGuardThatSaysTheReadingFailed_When_TheCheckRuns_Then_NothingIsReported(self):
+        # Arrange
+        root = directory(plain=stop_guard("refuse", STOP_BLOCKS_SAYING))
+
+        # Act
+        found = stop_faults(root)
+
+        # Assert
+        self.assertEqual(found, [])
+
+    def test_Given_AStopGuardDeclaringNothing_When_TheCheckRuns_Then_ItIsReported(self):
+        # Arrange
+        root = directory(quiet=STOP_PREAMBLE + "\nsys.exit(0)\n")
+
+        # Act
+        found = [line for line in stop_faults(root) if "UNREADABLE_POLICY must be one of" in line]
+
+        # Assert
+        self.assertEqual(len(found), 1, stop_faults(root))
+
+    def test_Given_AStopGuardThatReadsNeitherProgram_When_TheCheckRuns_Then_ItIsReported(self):
+        # Arrange — a "refuse" no reading takes part in says nothing about an unreadable state.
+        root = directory(textual=stop_guard("refuse", STOP_READS_NOTHING))
+
+        # Act
+        found = [line for line in stop_faults(root) if "never reaches gh" in line]
+
+        # Assert
+        self.assertEqual(len(found), 1, stop_faults(root))
+
+    def test_Given_ThisRepositorysStopGuards_When_NoReadingAnswers_Then_EachAnswersWhatItDeclares(self):
+        # Arrange
+        stop_directory = REPO_ROOT / check.STOP_DIRECTORY
+
+        # Act
+        found = check.stop_faults(stop_directory, REPO_ROOT)
+
+        # Assert — the guard count rides along, because an empty directory disagrees with nothing.
+        self.assertEqual((len(check.guards(stop_directory)) >= check.STOP_FLOOR, found),
+                         (True, []))
 
 
 class RepositoryTests(unittest.TestCase):

--- a/scripts/hooks/unreadable_state_check.py
+++ b/scripts/hooks/unreadable_state_check.py
@@ -299,9 +299,12 @@ def stop_faults(stop_directory, cwd, floor=STOP_FLOOR):
 def _stop_guard_faults(hook, subjects, cwd, home):
     source = Path(hook).read_text(encoding="utf-8")
     module = ast.parse(source)
-    policy, _ = _assigned(module, POLICY)
+    policy, policy_line = _assigned(module, POLICY)
     if policy not in POLICIES:
         return [f"{hook.name}: {POLICY} must be one of {', '.join(POLICIES)}, found {policy!r}"]
+    if policy == ALLOW and not _has_reason(source, policy_line):
+        return [f"{hook.name}: {POLICY} is \"{ALLOW}\" with no comment above it saying what holds "
+                "instead"]
 
     allows, allows_line = _assigned(module, ALLOWS)
     if allows is not None and not _has_reason(source, allows_line):
@@ -316,9 +319,11 @@ def _stop_guard_faults(hook, subjects, cwd, home):
             continue
         evidence.append(mode)
         if mode in allows:
-            found += _exemption_faults(hook, mode, verdict, cwd, home, subjects)
+            found += _letting_go_faults(hook, mode, verdict, cwd, home, subjects, ALLOWS)
         elif policy == NONE:
             found.append(f"{hook.name}: declares \"{NONE}\" and consulted a broken program in {mode}")
+        elif policy == ALLOW:
+            found += _letting_go_faults(hook, mode, verdict, cwd, home, subjects, POLICY)
         elif verdict != policy:
             found.append(f"{hook.name}: declares \"{policy}\", answers \"{verdict}\" in {mode}")
         elif verdict == REFUSE and SELF_REPORT not in errors:
@@ -332,12 +337,13 @@ def _stop_guard_faults(hook, subjects, cwd, home):
     return found
 
 
-def _exemption_faults(hook, mode, verdict, cwd, home, subjects):
-    """What is wrong with a declared exemption: a stale one, or one nothing stands behind.
+def _letting_go_faults(hook, mode, verdict, cwd, home, subjects, claim):
+    """What is wrong with a guard that lets the session end: a stale claim, or one nothing backs.
 
-    A guard whose own question was answered may let the session end in a mode that broke somebody
-    else's reading. What it may not do is be the only guard there, which is the exemption turning
-    into the silence the whole check exists to stop.
+    Two claims arrive here and neither may be taken on its own word. A guard whose own question was
+    answered may let the session end in a mode that broke somebody else's reading, and a guard may
+    declare outright that letting go is its policy — but what neither may do is be the only guard
+    there, which is the claim turning into the silence the whole check exists to stop.
 
     The backing is measured under the empty HOME `stop_faults` makes, so it answers about the guards
     and not about a machine's deferrals — which is what makes it a verdict about this repository
@@ -345,11 +351,12 @@ def _exemption_faults(hook, mode, verdict, cwd, home, subjects):
     a live deferral would suppress still counts as backing here.
     """
     if verdict == REFUSE:
-        return [f"{hook.name}: {ALLOWS} names {mode} and it refuses there — the declaration is stale"]
+        return [f"{hook.name}: {claim} says it lets go in {mode} and it refuses there — the "
+                "declaration is stale"]
     backing = _stop_backed(hook, mode, cwd, home, subjects)
     return [] if backing else [
-        f"{hook.name}: {ALLOWS} names {mode} and no sibling refuses there, so the session ends with "
-        "the reading that failed unreported"]
+        f"{hook.name}: {claim} lets the session end in {mode} and no sibling refuses there, so it "
+        "ends with the reading that failed unreported"]
 
 
 def main(argv):

--- a/scripts/hooks/unreadable_state_check.py
+++ b/scripts/hooks/unreadable_state_check.py
@@ -24,11 +24,16 @@ fact about its subject, so the deferral it invited named the API error rather th
 was waiting on. `lib/repository.py` owns the sentence that separates the two, and a Stop guard's
 refusal has to carry it — hand-rolled, two guards say it two ways and one of them stops saying it.
 
-Only the gh-error mode is posed to a Stop guard. An empty successful answer from the pull-request
-listing is the ordinary state `open_backlog.py` exists to act on, so refusing on it would be wrong
-there and right in its sibling; what both must agree on is the case where every way of asking fails.
-The git mode is out for a different reason: it stubs git alone, so the real `gh` runs, and a check
-that reaches the network answers about the network.
+Two gh modes are posed to a Stop guard: nothing answers, and the listing answers while every
+per-pull-request read fails. The second is the one a REST fallback creates, and it is where a guard
+that reads its subject two ways can report on pull requests it learned nothing about. An empty
+successful answer is posed to neither — no open pull request is the ordinary state
+`open_backlog.py` exists to act on. The git mode is out for a different reason: it stubs git alone,
+so the real `gh` runs, and a check that reaches the network answers about the network.
+
+A guard whose own question is answered in a mode that broke somebody else's reading declares
+`UNREADABLE_ALLOWS`, with a comment and with a sibling that refuses there — an exemption no other
+guard stands behind is the silence this exists to stop.
 
 Run: python3 scripts/hooks/test_unreadable_state_check.py
 """
@@ -55,6 +60,7 @@ STOP_FLOOR = 2
 POLICY = "UNREADABLE_POLICY"
 PROBE = "UNREADABLE_PROBE"
 TOOLS = "HOOK_TOOLS"
+ALLOWS = "UNREADABLE_ALLOWS"
 
 REFUSE, ALLOW, NONE = "refuse", "allow", "none"
 POLICIES = (REFUSE, ALLOW, NONE)
@@ -73,9 +79,26 @@ MODES = {
 
 STUB_LOG = "VELVET_UNREADABLE_STATE_LOG"
 
-# Only the mode where every reading fails; the docstring owns why an empty answer is each Stop
-# guard's own question.
-STOP_MODES = ("gh-error",)
+# Its own table rather than a selection from MODES: the second mode below is about a guard that
+# reads one thing through REST and the rest through GraphQL, which no PreToolUse guard does.
+#
+# gh-graphql-error is the state that made the fallback worse than no fallback. The listing answers
+# over REST, every per-pull-request read still fails, and a guard that reads the first and reports on
+# the second has answered about pull requests it learned nothing about. An empty answer is left out
+# for the reason the docstring gives.
+STOP_MODES = {
+    "gh-error": {"gh": 'echo "gh: HTTP 502" >&2\nexit 1'},
+    "gh-graphql-error": {"gh": 'if [ "$1" = "api" ]; then\n'
+                               '  case "$2" in\n'
+                               '    *pulls*) echo 42 ;;\n'
+                               '    user) echo someone ;;\n'
+                               '    *) echo "[]" ;;\n'
+                               '  esac\n'
+                               '  exit 0\n'
+                               'fi\n'
+                               'echo "gh: API rate limit already exceeded" >&2\n'
+                               'exit 1'},
+}
 
 STOP_PAYLOAD = json.dumps({"hook_event_name": "Stop", "stop_hook_active": False})
 
@@ -139,14 +162,14 @@ def declaration(path):
     return policy, probe, tool, missing
 
 
-def _stubs(mode, directory, log):
-    for name, body in MODES[mode].items():
+def _stubs(mode, directory, log, table=None):
+    for name, body in (table or MODES)[mode].items():
         script = directory / name
         script.write_text(f'#!/bin/sh\nprintf \'{name}\\n\' >> "${STUB_LOG}"\n{body}\n')
         script.chmod(0o755)
 
 
-def run_guard(hook, payload, mode, cwd, home):
+def run_guard(hook, payload, mode, cwd, home, table=None):
     """(exit code, stdout, stderr, whether the broken program was consulted) for one run."""
     workspace = Path(tempfile.mkdtemp(prefix="velvet-unreadable-"))
     try:
@@ -157,7 +180,7 @@ def run_guard(hook, payload, mode, cwd, home):
         environment[STUB_LOG] = str(log)
         # The session's own project would otherwise decide what a guard reads instead of `cwd`.
         environment.pop("CLAUDE_PROJECT_DIR", None)
-        _stubs(mode, workspace, log)
+        _stubs(mode, workspace, log, table)
         environment["PATH"] = str(workspace) + os.pathsep + environment.get("PATH", "")
 
         finished = subprocess.run(
@@ -242,8 +265,19 @@ def _guard_faults(hook, subjects, cwd, home):
 
 def stop_answer(hook, mode, cwd, home):
     """(verdict, whether the broken program was consulted, what it printed) for one Stop guard."""
-    code, _, errors, consulted = run_guard(hook, STOP_PAYLOAD, mode, cwd, home)
+    code, _, errors, consulted = run_guard(hook, STOP_PAYLOAD, mode, cwd, home, STOP_MODES)
     return (REFUSE if code == 2 else ALLOW), consulted, errors
+
+
+def _stop_backed(hook, mode, cwd, home, siblings):
+    """Whether some other Stop guard refuses under the same mode."""
+    for sibling in siblings:
+        if sibling == hook:
+            continue
+        verdict, _, _ = stop_answer(sibling, mode, cwd, home)
+        if verdict == REFUSE:
+            return sibling.name
+    return None
 
 
 def stop_faults(stop_directory, cwd, floor=STOP_FLOOR):
@@ -256,16 +290,24 @@ def stop_faults(stop_directory, cwd, floor=STOP_FLOOR):
     home = Path(tempfile.mkdtemp(prefix="velvet-unreadable-home-"))
     try:
         for hook in subjects:
-            found += _stop_guard_faults(hook, cwd, home)
+            found += _stop_guard_faults(hook, subjects, cwd, home)
     finally:
         shutil.rmtree(home, ignore_errors=True)
     return found
 
 
-def _stop_guard_faults(hook, cwd, home):
-    policy, _ = _assigned(ast.parse(Path(hook).read_text(encoding="utf-8")), POLICY)
+def _stop_guard_faults(hook, subjects, cwd, home):
+    source = Path(hook).read_text(encoding="utf-8")
+    module = ast.parse(source)
+    policy, _ = _assigned(module, POLICY)
     if policy not in POLICIES:
         return [f"{hook.name}: {POLICY} must be one of {', '.join(POLICIES)}, found {policy!r}"]
+
+    allows, allows_line = _assigned(module, ALLOWS)
+    if allows is not None and not _has_reason(source, allows_line):
+        return [f"{hook.name}: {ALLOWS} with no comment above it saying why letting the session end "
+                "is right in those modes"]
+    allows = set(allows or ())
 
     found, evidence = [], []
     for mode in STOP_MODES:
@@ -273,7 +315,9 @@ def _stop_guard_faults(hook, cwd, home):
         if not consulted:
             continue
         evidence.append(mode)
-        if policy == NONE:
+        if mode in allows:
+            found += _exemption_faults(hook, mode, verdict, cwd, home, subjects)
+        elif policy == NONE:
             found.append(f"{hook.name}: declares \"{NONE}\" and consulted a broken program in {mode}")
         elif verdict != policy:
             found.append(f"{hook.name}: declares \"{policy}\", answers \"{verdict}\" in {mode}")
@@ -286,6 +330,21 @@ def _stop_guard_faults(hook, cwd, home):
         found.append(f"{hook.name}: declares \"{policy}\" but its run never reaches gh, the one "
                      "reading posed here, so the declaration is about something that never happens")
     return found
+
+
+def _exemption_faults(hook, mode, verdict, cwd, home, subjects):
+    """What is wrong with a declared exemption: a stale one, or one nothing stands behind.
+
+    A guard whose own question was answered may let the session end in a mode that broke somebody
+    else's reading. What it may not do is be the only guard there, which is the exemption turning
+    into the silence the whole check exists to stop.
+    """
+    if verdict == REFUSE:
+        return [f"{hook.name}: {ALLOWS} names {mode} and it refuses there — the declaration is stale"]
+    backing = _stop_backed(hook, mode, cwd, home, subjects)
+    return [] if backing else [
+        f"{hook.name}: {ALLOWS} names {mode} and no sibling refuses there, so the session ends with "
+        "the reading that failed unreported"]
 
 
 def main(argv):

--- a/scripts/hooks/unreadable_state_check.py
+++ b/scripts/hooks/unreadable_state_check.py
@@ -338,6 +338,11 @@ def _exemption_faults(hook, mode, verdict, cwd, home, subjects):
     A guard whose own question was answered may let the session end in a mode that broke somebody
     else's reading. What it may not do is be the only guard there, which is the exemption turning
     into the silence the whole check exists to stop.
+
+    The backing is measured under the empty HOME `stop_faults` makes, so it answers about the guards
+    and not about a machine's deferrals — which is what makes it a verdict about this repository
+    rather than about whoever ran it, and also the limit of what it can say: a sibling whose refusal
+    a live deferral would suppress still counts as backing here.
     """
     if verdict == REFUSE:
         return [f"{hook.name}: {ALLOWS} names {mode} and it refuses there — the declaration is stale"]

--- a/scripts/hooks/unreadable_state_check.py
+++ b/scripts/hooks/unreadable_state_check.py
@@ -18,10 +18,23 @@ refusal. A stub `git` exiting 1 reported it as failing open here, and exit 1 is 
 `git rev-parse --verify --quiet` returns for a ref that is merely absent — so the stubs below fail
 the way an unreadable state fails, and the verdict is read off the process.
 
+A `Stop` guard is held to the same declaration and to one thing more. It already blocked when it
+could not read, and what was wrong was what it said: it reported its own blindness in the shape of a
+fact about its subject, so the deferral it invited named the API error rather than whatever the work
+was waiting on. `lib/repository.py` owns the sentence that separates the two, and a Stop guard's
+refusal has to carry it — hand-rolled, two guards say it two ways and one of them stops saying it.
+
+Only the gh-error mode is posed to a Stop guard. An empty successful answer from the pull-request
+listing is the ordinary state `open_backlog.py` exists to act on, so refusing on it would be wrong
+there and right in its sibling; what both must agree on is the case where every way of asking fails.
+The git mode is out for a different reason: it stubs git alone, so the real `gh` runs, and a check
+that reaches the network answers about the network.
+
 Run: python3 scripts/hooks/test_unreadable_state_check.py
 """
 
 import ast
+import importlib.util
 import json
 import os
 import shutil
@@ -32,10 +45,12 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 REFUSE_DIRECTORY = ".claude/hooks/refuse"
+STOP_DIRECTORY = ".claude/hooks/stop"
 
 # Raised with the tree, the way the hook fixtures' floors are: an empty directory declares nothing
 # and would otherwise pass every check below.
 GUARD_FLOOR = 14
+STOP_FLOOR = 2
 
 POLICY = "UNREADABLE_POLICY"
 PROBE = "UNREADABLE_PROBE"
@@ -57,6 +72,24 @@ MODES = {
 }
 
 STUB_LOG = "VELVET_UNREADABLE_STATE_LOG"
+
+# Only the mode where every reading fails; the docstring owns why an empty answer is each Stop
+# guard's own question.
+STOP_MODES = ("gh-error",)
+
+STOP_PAYLOAD = json.dumps({"hook_event_name": "Stop", "stop_hook_active": False})
+
+
+def load_hook_library():
+    """Imports .claude/hooks/lib/repository.py by path, since .claude holds no packages."""
+    path = REPO_ROOT / ".claude/hooks/lib/repository.py"
+    spec = importlib.util.spec_from_file_location("hook_repository", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+SELF_REPORT = load_hook_library().SELF_REPORT
 
 
 def guards(refuse_directory):
@@ -113,8 +146,8 @@ def _stubs(mode, directory, log):
         script.chmod(0o755)
 
 
-def answer(hook, tool, probe, mode, cwd, home):
-    """(verdict, whether the broken program was consulted) for one guard under one mode."""
+def run_guard(hook, payload, mode, cwd, home):
+    """(exit code, stdout, stderr, whether the broken program was consulted) for one run."""
     workspace = Path(tempfile.mkdtemp(prefix="velvet-unreadable-"))
     try:
         log = workspace / "consulted"
@@ -127,19 +160,25 @@ def answer(hook, tool, probe, mode, cwd, home):
         _stubs(mode, workspace, log)
         environment["PATH"] = str(workspace) + os.pathsep + environment.get("PATH", "")
 
-        payload = json.dumps({"tool_name": tool, "cwd": str(cwd), "tool_input": probe})
         finished = subprocess.run(
             [sys.executable, "-B", str(hook)],
             input=payload, text=True, capture_output=True,
             cwd=str(cwd), env=environment, timeout=180,
         )
-        # Not the exit code alone: blind_git_add.py refuses by printing a deny decision and exiting
-        # 0, so reading 0 as a pass would score its refusal as a guard that let the tool through.
-        denied = '"permissionDecision"' in finished.stdout and '"deny"' in finished.stdout
-        verdict = REFUSE if finished.returncode == 2 or denied else ALLOW
-        return verdict, bool(log.read_text().strip())
+        return (finished.returncode, finished.stdout, finished.stderr,
+                bool(log.read_text().strip()))
     finally:
         shutil.rmtree(workspace, ignore_errors=True)
+
+
+def answer(hook, tool, probe, mode, cwd, home):
+    """(verdict, whether the broken program was consulted) for one guard under one mode."""
+    payload = json.dumps({"tool_name": tool, "cwd": str(cwd), "tool_input": probe})
+    code, out, _, consulted = run_guard(hook, payload, mode, cwd, home)
+    # Not the exit code alone: blind_git_add.py refuses by printing a deny decision and exiting
+    # 0, so reading 0 as a pass would score its refusal as a guard that let the tool through.
+    denied = '"permissionDecision"' in out and '"deny"' in out
+    return (REFUSE if code == 2 or denied else ALLOW), consulted
 
 
 def _backed(hook, tool, probe, mode, cwd, home, siblings):
@@ -201,10 +240,59 @@ def _guard_faults(hook, subjects, cwd, home):
     return found
 
 
+def stop_answer(hook, mode, cwd, home):
+    """(verdict, whether the broken program was consulted, what it printed) for one Stop guard."""
+    code, _, errors, consulted = run_guard(hook, STOP_PAYLOAD, mode, cwd, home)
+    return (REFUSE if code == 2 else ALLOW), consulted, errors
+
+
+def stop_faults(stop_directory, cwd, floor=STOP_FLOOR):
+    """Every disagreement between what a Stop guard declares and what it does. Empty means agreement."""
+    found = []
+    subjects = guards(stop_directory)
+    if len(subjects) < floor:
+        found.append(f"{stop_directory} holds {len(subjects)} guards, fewer than {floor}")
+
+    home = Path(tempfile.mkdtemp(prefix="velvet-unreadable-home-"))
+    try:
+        for hook in subjects:
+            found += _stop_guard_faults(hook, cwd, home)
+    finally:
+        shutil.rmtree(home, ignore_errors=True)
+    return found
+
+
+def _stop_guard_faults(hook, cwd, home):
+    policy, _ = _assigned(ast.parse(Path(hook).read_text(encoding="utf-8")), POLICY)
+    if policy not in POLICIES:
+        return [f"{hook.name}: {POLICY} must be one of {', '.join(POLICIES)}, found {policy!r}"]
+
+    found, evidence = [], []
+    for mode in STOP_MODES:
+        verdict, consulted, errors = stop_answer(hook, mode, cwd, home)
+        if not consulted:
+            continue
+        evidence.append(mode)
+        if policy == NONE:
+            found.append(f"{hook.name}: declares \"{NONE}\" and consulted a broken program in {mode}")
+        elif verdict != policy:
+            found.append(f"{hook.name}: declares \"{policy}\", answers \"{verdict}\" in {mode}")
+        elif verdict == REFUSE and SELF_REPORT not in errors:
+            found.append(
+                f"{hook.name}: blocks in {mode} without saying the reading is what failed, so it "
+                "reports its own blindness as a fact about its subject")
+
+    if policy != NONE and not evidence:
+        found.append(f"{hook.name}: declares \"{policy}\" but its run never reaches gh, the one "
+                     "reading posed here, so the declaration is about something that never happens")
+    return found
+
+
 def main(argv):
     directory = Path(argv[1]) if len(argv) > 1 else REPO_ROOT / REFUSE_DIRECTORY
     cwd = Path(argv[2]) if len(argv) > 2 else REPO_ROOT
-    found = faults(directory, cwd)
+    stop_directory = Path(argv[3]) if len(argv) > 3 else REPO_ROOT / STOP_DIRECTORY
+    found = faults(directory, cwd) + stop_faults(stop_directory, cwd)
     for line in found:
         print(line, file=sys.stderr)
     return 1 if found else 0

--- a/scripts/pr/settle.py
+++ b/scripts/pr/settle.py
@@ -12,11 +12,11 @@ shape is its own change. What this adds is reporting them together: one run name
 rather than costing a round of CI per reason. If a precondition is worth having here it belongs in a
 hook, because a script nobody is obliged to run guards nothing.
 
-Eight preconditions:
+Seven preconditions:
 
-- **Checks are bound to the head SHA they were read at.** `gh pr checks` answers about whatever the
-  API last recorded, which after a force-push is the previous commit's run. So the head is read, then
-  the checks, then the head again, and a change between the two readings voids the answer. The merge
+- **Checks are bound to the head SHA they were read at.** The checks API answers about whatever it
+  last recorded, which after a force-push is the previous commit's run. So the head is read, then the
+  checks, then the head again, and a change between the two readings voids the answer. The merge
   request carries that SHA as well, so a push landing after the last reading is refused by GitHub
   rather than by whoever reads the history next.
 - **The branch must contain the current base.** `mergeStateStatus` reports CLEAN for a branch whose

--- a/scripts/pr/settle.py
+++ b/scripts/pr/settle.py
@@ -12,7 +12,7 @@ shape is its own change. What this adds is reporting them together: one run name
 rather than costing a round of CI per reason. If a precondition is worth having here it belongs in a
 hook, because a script nobody is obliged to run guards nothing.
 
-Seven preconditions:
+Eight preconditions:
 
 - **Checks are bound to the head SHA they were read at.** `gh pr checks` answers about whatever the
   API last recorded, which after a force-push is the previous commit's run. So the head is read, then
@@ -31,6 +31,9 @@ Seven preconditions:
 - **The base must not hold an unpublished release.** `scripts/release/published_check.py` owns that
   decision, and CONTRIBUTING.md's release section owns what goes wrong without it.
 - **A draft is not merged**, and neither is one whose merge state is `dirty`.
+- **A head on another repository is not merged from here.** Its branch is a ref this checkout has
+  not got, so the containment reading above cannot be taken at all — and a reading nobody took is
+  not a precondition anybody met.
 
 `watch` records a pull request as ready by asking `blocking_reasons` — the same question `merge`
 decides from, not a second one beside it. Asked twice, the two disagreed: a draft with conflicts was
@@ -199,12 +202,18 @@ def pull_request(project, number):
     `fork` is what stops `branch` being handed to git: a cross-repository head names a branch on the
     fork, `origin/<it>` is not a ref here, and `contains_base` exits 128 on the lookup. A head whose
     repository is gone reads as a fork too, which is the same answer — this checkout cannot see it.
+
+    Both names come off this payload rather than one of them off `remote.origin.url`. GitHub answers
+    the same pull request for any casing of the path, so a clone made with different capitals, or a
+    repository since renamed, would make every pull request read as a fork — and then nothing is ever
+    ready and the guard that reads that never fires again.
     """
     payload = rest_json("repos/{}/pulls/{}".format(repository(project), number))
     head = payload.get("head") or {}
     home = ((head.get("repo") or {}).get("full_name") or "")
+    base_repository = ((payload.get("base") or {}).get("repo") or {}).get("full_name") or ""
     return PullRequest(head["sha"], head["ref"], bool(payload.get("draft")),
-                       payload.get("mergeable_state") or "", home != repository(project))
+                       payload.get("mergeable_state") or "", home != base_repository)
 
 
 # The bucket names this script decides from. A conclusion absent from the table falls to `fail` at
@@ -310,12 +319,15 @@ def reasons_from(before, after, results, branch, base, holds_base, held_by_workt
     if before != after:
         return reasons + [f"head moved from {before[:7]} to {after[:7]} while its checks were being read"]
 
-    # This reason changes no verdict, and that is the whole of why only `dirty` is read. A branch
-    # holding every commit on the base fast-forwards, so it cannot conflict: `dirty` implies
-    # `holds_base` is false, and the reason below it already blocks. What this adds is a message that
-    # names the conflict rather than telling a conflicting branch to merge the base in. `unknown` is
-    # left out because there is nothing for it to add — the same containment reading, taken from
-    # fetched refs rather than from GitHub, has already decided.
+    # Not merely a better message for what the containment reading already blocks. The two readings
+    # are of different base tips: `project_state` fetches once a cycle and this is a fresh read per
+    # pull request, so a branch can contain the tip that fetch saw while GitHub reports a conflict
+    # against a newer one. There the containment reason is absent and this is the only thing
+    # blocking, which is why it is read rather than left to the message.
+    #
+    # `unknown` is still left out: it is the absence of a reading rather than a reading, and a state
+    # that comes and goes would drop and re-add the entry, resetting the age
+    # `refuse/edit_while_a_ready_pr_sits.py` measures a pull request by.
     if merge_state == "dirty":
         reasons.append(f"it conflicts with {base}: resolve the conflict in the branch, which "
                        f"`settle.py update` declines to do")
@@ -422,6 +434,18 @@ def hold_the_watch():
     return handle, ""
 
 
+def beat():
+    """Record that a reading has just answered.
+
+    After the readings and never before them, and never on the path that caught their failure. A
+    watcher whose calls hang costs up to the bound on each of them, and one that stamped the file on
+    the way in would keep it inside the staleness window for the whole of that — so the guards would
+    read a live watcher while nothing was being read, and `write_ready_state` would meanwhile empty
+    the ready file. A wedge has to go stale; that is what makes it visible.
+    """
+    watcher_state.HEARTBEAT.write_text(watcher_state.beat(os.getpid()))
+
+
 def watch(project, base):
     """Emit each check that reaches a terminal state, once, and hold the heartbeat open meanwhile."""
     lock, holder = hold_the_watch()
@@ -448,7 +472,6 @@ def watch(project, base):
     seen = set()
     ready_since = {}
     while True:
-        watcher_state.HEARTBEAT.write_text(watcher_state.beat(os.getpid()))
         try:
             pull_requests = open_pull_requests(project)
             state = project_state(project, base)
@@ -456,18 +479,16 @@ def watch(project, base):
             print(f"! {error}", flush=True)
             time.sleep(watcher_state.POLL_SECONDS)
             continue
+        beat()
 
         ready = set()
         for number in pull_requests:
-            # Written again per pull request, not once per cycle: a poll over several of them takes
-            # longer than the window a reader believes a heartbeat for, and a watcher that is working
-            # must not read as one that stopped.
-            watcher_state.HEARTBEAT.write_text(watcher_state.beat(os.getpid()))
             try:
                 blocking = blocking_reasons(project, number, base, state)
             except RuntimeError as error:
                 print(f"! PR#{number}: {error}", flush=True)
                 continue
+            beat()
 
             for result in blocking.results:
                 if result["bucket"] == "pending":

--- a/scripts/pr/settle.py
+++ b/scripts/pr/settle.py
@@ -310,9 +310,12 @@ def reasons_from(before, after, results, branch, base, holds_base, held_by_workt
     if before != after:
         return reasons + [f"head moved from {before[:7]} to {after[:7]} while its checks were being read"]
 
-    # Only `dirty`. An entry that leaves the ready state loses the age `write_ready_state` kept for it,
-    # so a merge state that comes and goes without the pull request changing would keep resetting the
-    # clock `refuse/edit_while_a_ready_pr_sits.py` reads and that guard would never fire.
+    # This reason changes no verdict, and that is the whole of why only `dirty` is read. A branch
+    # holding every commit on the base fast-forwards, so it cannot conflict: `dirty` implies
+    # `holds_base` is false, and the reason below it already blocks. What this adds is a message that
+    # names the conflict rather than telling a conflicting branch to merge the base in. `unknown` is
+    # left out because there is nothing for it to add — the same containment reading, taken from
+    # fetched refs rather than from GitHub, has already decided.
     if merge_state == "dirty":
         reasons.append(f"it conflicts with {base}: resolve the conflict in the branch, which "
                        f"`settle.py update` declines to do")

--- a/scripts/pr/settle.py
+++ b/scripts/pr/settle.py
@@ -12,7 +12,7 @@ shape is its own change. What this adds is reporting them together: one run name
 rather than costing a round of CI per reason. If a precondition is worth having here it belongs in a
 hook, because a script nobody is obliged to run guards nothing.
 
-Five preconditions:
+Seven preconditions:
 
 - **Checks are bound to the head SHA they were read at.** `gh pr checks` answers about whatever the
   API last recorded, which after a force-push is the previous commit's run. So the head is read, then
@@ -30,6 +30,14 @@ Five preconditions:
 - **An empty check list is not "still running".** It means no workflow was ever triggered for that SHA.
 - **The base must not hold an unpublished release.** `scripts/release/published_check.py` owns that
   decision, and CONTRIBUTING.md's release section owns what goes wrong without it.
+- **A draft is not merged**, and neither is one whose merge state is `dirty`.
+
+`watch` records a pull request as ready by asking `blocking_reasons` — the same question `merge`
+decides from, not a second one beside it. Asked twice, the two disagreed: a draft with conflicts was
+recorded ready, and `refuse/edit_while_a_ready_pr_sits.py` reads that record out of $HOME — so it
+refused Edit and Write in sessions with nothing to do with that pull request, naming `settle.py merge`
+as the way out when nothing could make that command take it. What a guard offers as the way out is
+worth only what the readiness that raised it means, so the two are one function.
 
 Run: python3 scripts/pr/settle.py watch
      python3 scripts/pr/settle.py merge <number>
@@ -37,8 +45,10 @@ Run: python3 scripts/pr/settle.py watch
 
 import argparse
 import collections
+import fcntl
 import importlib.util
 import json
+import os
 import re
 import shutil
 import subprocess
@@ -48,30 +58,30 @@ import time
 from pathlib import Path
 
 
+def load_by_path(path, name):
+    """Imports a script by path, since scripts/ holds no packages."""
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
 def load_published_check():
-    """Imports the release guard by path, since scripts/ holds no packages.
+    """Imports the release guard by path.
 
     Its own directory goes on the path first: the module reads the CHANGELOG heading grammar out of
     release_notes.py rather than restating it, and a by-path import gives a module no siblings.
     """
     release = Path(__file__).resolve().parent.parent / "release"
     sys.path.insert(0, str(release))
-    spec = importlib.util.spec_from_file_location("published_check", release / "published_check.py")
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
+    return load_by_path(release / "published_check.py", "published_check")
 
 
 published_check = load_published_check()
 
-HEARTBEAT = Path.home() / ".velvet-pr-watch.heartbeat"
-
-# When each pull request first read as ready, so a guard can ask how long one has sat rather than
-# whether one exists. Several are usually in flight here and one of them is usually green, so the
-# existence of a ready pull request is the ordinary state and only its age is a defect.
-READY_STATE = Path.home() / ".velvet-pr-ready"
-
-POLL_SECONDS = 60
+# The three files this writes and two hooks read; watcher_state.py owns their format.
+watcher_state = load_by_path(Path(__file__).resolve().with_name("watcher_state.py"),
+                             "watcher_state")
 
 # What the checks API calls a state that will not change again. "skipping" is terminal and passing:
 # the Unity jobs are skipped wholesale on a fork with no licence, which is what lets one merge at all.
@@ -141,14 +151,29 @@ def rest_json(path):
 
 
 def open_pull_requests(project):
+    """The open pull request numbers.
+
+    Numbers alone: `mergeable_state` is not on this payload, so everything else the decision reads is
+    taken per pull request by `pull_request` anyway.
+    """
     listing = rest("repos/{}/pulls?state=open&per_page=100".format(repository(project)),
-                   '.[] | "\(.number) \(.head.ref)"')
-    return [{"number": int(n), "headRefName": ref}
-            for n, _, ref in (line.partition(" ") for line in listing.splitlines() if line)]
+                   ".[].number")
+    return [int(line) for line in listing.split()]
 
 
 def head_sha(project, number):
     return rest("repos/{}/pulls/{}".format(repository(project), number), ".head.sha")
+
+
+# Everything the decision reads off the pull request itself. `mergeable_state` is on this payload and
+# not on the listing one, so a caller that wants it has to ask per pull request anyway.
+PullRequest = collections.namedtuple("PullRequest", "sha branch draft merge_state")
+
+
+def pull_request(project, number):
+    payload = rest_json("repos/{}/pulls/{}".format(repository(project), number))
+    return PullRequest(payload["head"]["sha"], payload["head"]["ref"],
+                       bool(payload.get("draft")), payload.get("mergeable_state") or "")
 
 
 # The bucket names this script decides from. A conclusion absent from the table falls to `fail` at
@@ -162,9 +187,8 @@ _BUCKET = {"success": "pass", "neutral": "skipping", "skipped": "skipping",
 _STATUS_BUCKET = {"success": "pass", "pending": "pending", "failure": "fail", "error": "fail"}
 
 
-def checks(project, number):
-    """Check results, or an empty list when no workflow ever ran for this head."""
-    sha = head_sha(project, number)
+def checks(project, sha):
+    """Check results for one head, or an empty list when no workflow ever ran for it."""
     slug = repository(project)
     return check_results(rest_json("repos/{}/commits/{}/check-runs?per_page=100".format(slug, sha)),
                          rest_json("repos/{}/commits/{}/status?per_page=100".format(slug, sha)))
@@ -227,29 +251,39 @@ def contains_base(project, branch, base):
     """Whether the branch already holds every commit on the base.
 
     Asked of the remote refs rather than of local ones, because a local base can be behind what the
-    merge will actually happen against and would report a stale answer as a clean one.
+    merge will actually happen against and would report a stale answer as a clean one. Both refs have
+    to have been fetched first — `project_state` is where that happens for every caller here.
     """
-    gh_git(project, "fetch", "origin", base, "--quiet")
     merge_base = gh_git(project, "merge-base", f"origin/{base}", f"origin/{branch}").strip()
     base_head = gh_git(project, "rev-parse", f"origin/{base}").strip()
     return merge_base == base_head
 
 
 def reasons_from(before, after, results, branch, base, holds_base, held_by_worktree,
-                 unpublished_release):
+                 unpublished_release, draft, merge_state):
     """Every reason not to merge, decided from plain data so the decision is testable without a network.
 
     `unpublished_release` takes no default on purpose: a caller that stops supplying it would otherwise
     read as a clean base, and the only production caller is held by no test.
 
-    A moved head returns with the publication reason and nothing else: with the readings straddling a
-    force-push, nothing else read here is known to be about the same commit, so reporting the rest
-    would be reporting about two SHAs at once. The publication reason is about the base, which the
-    force-push did not touch.
+    A moved head returns with the reasons that are not about a commit and nothing else: with the
+    readings straddling a force-push, nothing else read here is known to be about the same commit, so
+    reporting the rest would be reporting about two SHAs at once. The publication reason is about the
+    base, which the force-push did not touch, and draft is a state of the pull request rather than of
+    its head.
     """
     reasons = [unpublished_release] if unpublished_release else []
+    if draft:
+        reasons.append("it is a draft: mark it ready for review first")
     if before != after:
         return reasons + [f"head moved from {before[:7]} to {after[:7]} while its checks were being read"]
+
+    # Only `dirty`. An entry that leaves the ready state loses the age `write_ready_state` kept for it,
+    # so a merge state that comes and goes without the pull request changing would keep resetting the
+    # clock `refuse/edit_while_a_ready_pr_sits.py` reads and that guard would never fire.
+    if merge_state == "dirty":
+        reasons.append(f"it conflicts with {base}: resolve the conflict in the branch, which "
+                       f"`settle.py update` declines to do")
 
     if not results:
         reasons.append(f"no check has run for {after[:7]}: a workflow was never triggered for this head")
@@ -274,22 +308,35 @@ def reasons_from(before, after, results, branch, base, holds_base, held_by_workt
 
 
 # What merge needs from the readings besides the verdict: the SHA the checks were read at, which the
-# merge request carries, and the branch it deletes afterwards.
-Blocking = collections.namedtuple("Blocking", "reasons head branch")
+# merge request carries, the branch it deletes afterwards, and the check results, which `watch` prints.
+Blocking = collections.namedtuple("Blocking", "reasons head branch results")
+
+# The readings that answer for the whole repository rather than for one pull request. Taken once and
+# handed down, so a watcher poll over N pull requests costs one fetch and one `git ls-remote --tags`
+# rather than N of each.
+ProjectState = collections.namedtuple("ProjectState", "held unpublished_release")
 
 
-def blocking_reasons(project, number, base):
+def project_state(project, base):
+    """The per-repository readings, with the fetch that both of the git ones below depend on."""
+    gh_git(project, "fetch", "origin", "--quiet")
+    return ProjectState(worktree_branches(project),
+                        published_check.unpublished_reason(project, f"origin/{base}", fetch=False))
+
+
+def blocking_reasons(project, number, base, state=None):
     """reasons_from, with every reading taken from the repository and the API."""
-    before = head_sha(project, number)
-    results = checks(project, number)
+    state = project_state(project, base) if state is None else state
+    before = pull_request(project, number)
+    results = checks(project, before.sha)
     after = head_sha(project, number)
-    branch = rest("repos/{}/pulls/{}".format(repository(project), number), ".head.ref")
-    return Blocking(reasons_from(before, after, results, branch, base,
-                                 holds_base=contains_base(project, branch, base),
-                                 held_by_worktree=branch in worktree_branches(project),
-                                 unpublished_release=published_check.unpublished_reason(
-                                     project, f"origin/{base}", fetch=True)),
-                    after, branch)
+    return Blocking(reasons_from(before.sha, after, results, before.branch, base,
+                                 holds_base=contains_base(project, before.branch, base),
+                                 held_by_worktree=before.branch in state.held,
+                                 unpublished_release=state.unpublished_release,
+                                 draft=before.draft,
+                                 merge_state=before.merge_state),
+                    after, before.branch, results)
 
 
 def write_ready_state(ready, since):
@@ -304,51 +351,94 @@ def write_ready_state(ready, since):
             del since[number]
     for number in ready:
         since.setdefault(number, int(time.time()))
-    READY_STATE.write_text("".join(f"{number} {since[number]}\n" for number in sorted(since)))
+    watcher_state.READY_STATE.write_text(
+        "".join(f"{number} {since[number]}\n" for number in sorted(since)))
+
+
+def hold_the_watch():
+    """(the open lock, the pid holding it). No lock means another watcher already has it.
+
+    flock rather than a pidfile: the kernel drops it when the holder exits, so a killed watcher
+    leaves a file behind but no lock, and the next one takes it without anything having to decide
+    whether a recorded pid is stale. The handle is returned rather than dropped — the lock lives
+    with the open file description, so keeping it open is the whole of holding it.
+    """
+    handle = open(watcher_state.LOCK, "a+", encoding="utf-8")
+    try:
+        fcntl.flock(handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError:
+        handle.seek(0)
+        holder = handle.read().strip()
+        handle.close()
+        return None, holder
+    handle.seek(0)
+    handle.truncate()
+    handle.write(f"{os.getpid()}\n")
+    handle.flush()
+    return handle, ""
 
 
 def watch(project, base):
     """Emit each check that reaches a terminal state, once, and hold the heartbeat open meanwhile."""
+    lock, holder = hold_the_watch()
+    if lock is None:
+        print(f"Refusing to watch: process {holder or 'unknown'} already holds "
+              f"{watcher_state.LOCK}. A second watcher polls the same API on its own cycle against "
+              f"the same quota, and writes the same heartbeat, so neither says which one is alive.",
+              file=sys.stderr)
+        return 1
+    # After the lock and not before: "writing the heartbeat without holding the lock" is only a
+    # reading anyone can take while this process is the one holding it.
+    if watcher_state.beating_elsewhere(os.getpid()):
+        lock.close()
+        print(f"Refusing to watch: {watcher_state.HEARTBEAT} was written inside the last "
+              f"{watcher_state.STALE_AFTER}s by something that is not holding {watcher_state.LOCK} "
+              f"— a watcher from a checkout older than the lock, either still running or only just "
+              f"stopped. Find it with `ps -Ao pid=,command= | grep '[s]ettle.py watch'` and kill "
+              f"it; if it is already gone, its last heartbeat ages out within "
+              f"{watcher_state.STALE_AFTER}s.", file=sys.stderr)
+        return 1
+
     seen = set()
     ready_since = {}
     while True:
-        HEARTBEAT.write_text(f"{int(time.time())}\n")
+        watcher_state.HEARTBEAT.write_text(watcher_state.beat(os.getpid()))
         try:
             pull_requests = open_pull_requests(project)
+            state = project_state(project, base)
         except RuntimeError as error:
             print(f"! {error}", flush=True)
-            time.sleep(POLL_SECONDS)
+            time.sleep(watcher_state.POLL_SECONDS)
             continue
 
         ready = set()
-        for entry in pull_requests:
-            number = entry["number"]
+        for number in pull_requests:
             try:
-                sha = head_sha(project, number)
-                results = checks(project, number)
+                blocking = blocking_reasons(project, number, base, state)
             except RuntimeError as error:
                 print(f"! PR#{number}: {error}", flush=True)
                 continue
 
-            for result in results:
+            for result in blocking.results:
                 if result["bucket"] == "pending":
                     continue
-                line = "PR#{} {} {} => {}".format(number, sha[:7], result["name"], result["bucket"])
+                line = "PR#{} {} {} => {}".format(number, blocking.head[:7], result["name"],
+                                                  result["bucket"])
                 if line not in seen:
                     seen.add(line)
                     print(line, flush=True)
 
-            if results and all(r["bucket"] in TERMINAL_PASS for r in results):
+            if not blocking.reasons:
                 # A pull request that finished green and sits unmerged is what this exists for as much
                 # as a pending one: a watcher reporting only state CHANGES goes silent on it forever.
                 ready.add(number)
-                line = f"PR#{number} {sha[:7]} READY: every check terminal and passing"
+                line = f"PR#{number} {blocking.head[:7]} READY: nothing blocks the merge"
                 if line not in seen:
                     seen.add(line)
                     print(line, flush=True)
 
         write_ready_state(ready, ready_since)
-        time.sleep(POLL_SECONDS)
+        time.sleep(watcher_state.POLL_SECONDS)
 
 
 def update_reasons(branch, base, holds_base, held_by_worktree):
@@ -512,8 +602,7 @@ def main():
 
     project = Path(args.project).resolve()
     if args.command == "watch":
-        watch(project, args.base)
-        return 0
+        return watch(project, args.base)
     if args.command == "update":
         return update(project, args.number, args.base)
     return merge(project, args.number, args.base, args.dry_run)

--- a/scripts/pr/settle.py
+++ b/scripts/pr/settle.py
@@ -101,7 +101,7 @@ def run(command, timeout):
     try:
         return subprocess.run(command, capture_output=True, text=True, timeout=timeout)
     except subprocess.TimeoutExpired:
-        raise RuntimeError("{} did not answer within {}s".format(" ".join(command[:3]), timeout))
+        raise RuntimeError("{} did not answer within {}s".format(" ".join(command), timeout))
 
 
 def run_quietly(command, timeout):

--- a/scripts/pr/settle.py
+++ b/scripts/pr/settle.py
@@ -471,7 +471,7 @@ def watch(project, base):
         print(f"Refusing to watch: {watcher_state.HEARTBEAT} was written inside the last "
               f"{watcher_state.STALE_AFTER}s by something that is not holding {watcher_state.LOCK} "
               f"— a watcher from a checkout older than the lock, either still running or only just "
-              f"stopped. Find it with `ps -Ao pid=,command= | grep '[s]ettle.py watch'` and kill "
+              f"stopped. Find it with `ps -Ao pid=,command= | grep 'settle[.]py watch'` and kill "
               f"it; if it is already gone, its last heartbeat ages out within "
               f"{watcher_state.STALE_AFTER}s.", file=sys.stderr)
         return 1

--- a/scripts/pr/settle.py
+++ b/scripts/pr/settle.py
@@ -5,12 +5,18 @@ Both halves existed as instructions rather than as code: `stop/unsettled_pr.py` 
 the reader to reimplement, and the merge was typed by hand. An instruction is re-derived each time,
 and that hook's own text owns what a re-derived watcher gets wrong.
 
-**Every precondition below has a refuse hook behind it**, so a `gh pr merge` typed by hand is held
-to them as well; `refuse/merge_unproven_head.py` records which hook holds which. Those hooks match on
-`gh pr merge` and do not see the `gh api -X PUT .../merge` this script sends, so teaching them that
-shape is its own change. What this adds is reporting them together: one run names everything wrong
-rather than costing a round of CI per reason. If a precondition is worth having here it belongs in a
-hook, because a script nobody is obliged to run guards nothing.
+**Five of the preconditions below have a refuse hook behind them**, so a `gh pr merge` typed by hand
+is held to those as well; `refuse/merge_unproven_head.py` records which hook holds which. Those hooks
+match on `gh pr merge` and do not see the `gh api -X PUT .../merge` this script sends, so teaching
+them that shape is its own change. What this adds is reporting them together: one run names
+everything wrong rather than costing a round of CI per reason.
+
+**Two have no hook: a draft head, and a head on another repository.** Neither is left out by
+oversight. The fork one is not a fact about the pull request at all — it says this checkout has no
+ref for that branch, so the containment reading cannot be taken here — and a hook would have to
+answer the same question from the same place. The rule that a precondition worth having belongs in a
+hook still stands for the five; these two are stated rather than made true by hooks written to make
+a sentence true.
 
 Seven preconditions:
 
@@ -100,7 +106,8 @@ GIT_TIMEOUT = 300
 
 
 def run(command, timeout):
-    """subprocess.run with a bound, reporting a timeout as the failure every caller here catches."""
+    """subprocess.run with a bound, reporting a timeout as the same RuntimeError a failed call
+    raises — so a hang reaches a caller as something it already handles rather than as a new kind."""
     try:
         return subprocess.run(command, capture_output=True, text=True, timeout=timeout)
     except subprocess.TimeoutExpired:
@@ -451,8 +458,8 @@ def watch(project, base):
     lock, holder = hold_the_watch()
     if lock is None:
         print(f"Refusing to watch: process {holder or 'unknown'} already holds "
-              f"{watcher_state.LOCK}. A second watcher polls the same API on its own cycle against "
-              f"the same quota, and writes the same heartbeat, so neither says which one is alive.\n"
+              f"{watcher_state.LOCK}. A second watcher draws on the same quota on its own cycle, "
+              f"which is the whole of what it costs now that the heartbeat names its writer.\n"
               f"\nIf that process is wedged rather than watching — every guard reading the heartbeat "
               f"says nothing is watching while this refuses to replace it — kill it and run this "
               f"again:\n\n  kill {holder or '<pid>'}\n", file=sys.stderr)

--- a/scripts/pr/settle.py
+++ b/scripts/pr/settle.py
@@ -89,8 +89,31 @@ TERMINAL_PASS = frozenset({"pass", "skipping"})
 TERMINAL_FAIL = frozenset({"fail", "cancel"})
 
 
+# Every call below can hang rather than fail — a dead TCP connection, a credential helper waiting on
+# a terminal that is gone. `watch` holds the watcher lock while it polls, so an unbounded call there
+# stops the only watcher there can be, and `hold_the_watch` then refuses the replacement.
+GH_TIMEOUT = 60
+GIT_TIMEOUT = 300
+
+
+def run(command, timeout):
+    """subprocess.run with a bound, reporting a timeout as the failure every caller here catches."""
+    try:
+        return subprocess.run(command, capture_output=True, text=True, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        raise RuntimeError("{} did not answer within {}s".format(" ".join(command[:3]), timeout))
+
+
+def run_quietly(command, timeout):
+    """The same bound for a call whose failure is reported rather than raised."""
+    try:
+        return subprocess.run(command, capture_output=True, text=True, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        return subprocess.CompletedProcess(command, 1, "", f"did not answer within {timeout}s")
+
+
 def gh(*args):
-    result = subprocess.run(["gh", *args], capture_output=True, text=True)
+    result = run(["gh", *args], GH_TIMEOUT)
     if result.returncode != 0:
         raise RuntimeError("gh {} failed: {}".format(" ".join(args), result.stderr.strip()))
     return result.stdout
@@ -112,8 +135,8 @@ def repository(project):
     repository the git readings do.
     """
     if project not in _REPOSITORY:
-        result = subprocess.run(["git", "-C", str(project), "config", "--get", "remote.origin.url"],
-                                capture_output=True, text=True)
+        result = run(["git", "-C", str(project), "config", "--get", "remote.origin.url"],
+                     GIT_TIMEOUT)
         url = result.stdout.strip()
         if result.returncode != 0 or not url:
             raise RuntimeError(f"{project} has no origin remote, so there is no repository to ask about")
@@ -167,13 +190,21 @@ def head_sha(project, number):
 
 # Everything the decision reads off the pull request itself. `mergeable_state` is on this payload and
 # not on the listing one, so a caller that wants it has to ask per pull request anyway.
-PullRequest = collections.namedtuple("PullRequest", "sha branch draft merge_state")
+PullRequest = collections.namedtuple("PullRequest", "sha branch draft merge_state fork")
 
 
 def pull_request(project, number):
+    """The pull request's own fields, in one request.
+
+    `fork` is what stops `branch` being handed to git: a cross-repository head names a branch on the
+    fork, `origin/<it>` is not a ref here, and `contains_base` exits 128 on the lookup. A head whose
+    repository is gone reads as a fork too, which is the same answer — this checkout cannot see it.
+    """
     payload = rest_json("repos/{}/pulls/{}".format(repository(project), number))
-    return PullRequest(payload["head"]["sha"], payload["head"]["ref"],
-                       bool(payload.get("draft")), payload.get("mergeable_state") or "")
+    head = payload.get("head") or {}
+    home = ((head.get("repo") or {}).get("full_name") or "")
+    return PullRequest(head["sha"], head["ref"], bool(payload.get("draft")),
+                       payload.get("mergeable_state") or "", home != repository(project))
 
 
 # The bucket names this script decides from. A conclusion absent from the table falls to `fail` at
@@ -241,7 +272,7 @@ def worktree_branches(project):
 
 
 def gh_git(project, *args):
-    result = subprocess.run(["git", "-C", str(project), *args], capture_output=True, text=True)
+    result = run(["git", "-C", str(project), *args], GIT_TIMEOUT)
     if result.returncode != 0:
         raise RuntimeError("git {} failed: {}".format(" ".join(args), result.stderr.strip()))
     return result.stdout
@@ -252,7 +283,8 @@ def contains_base(project, branch, base):
 
     Asked of the remote refs rather than of local ones, because a local base can be behind what the
     merge will actually happen against and would report a stale answer as a clean one. Both refs have
-    to have been fetched first — `project_state` is where that happens for every caller here.
+    to have been fetched first: `project_state` does it for the readings `blocking_reasons` takes,
+    and `update` fetches for itself.
     """
     merge_base = gh_git(project, "merge-base", f"origin/{base}", f"origin/{branch}").strip()
     base_head = gh_git(project, "rev-parse", f"origin/{base}").strip()
@@ -260,7 +292,7 @@ def contains_base(project, branch, base):
 
 
 def reasons_from(before, after, results, branch, base, holds_base, held_by_worktree,
-                 unpublished_release, draft, merge_state):
+                 unpublished_release, draft, merge_state, fork):
     """Every reason not to merge, decided from plain data so the decision is testable without a network.
 
     `unpublished_release` takes no default on purpose: a caller that stops supplying it would otherwise
@@ -297,7 +329,12 @@ def reasons_from(before, after, results, branch, base, holds_base, held_by_workt
     if failed:
         reasons.append("failing at {}: {}".format(after[:7], ", ".join(sorted(failed))))
 
-    if not holds_base:
+    if fork:
+        # Ahead of the containment reason rather than beside it: `holds_base` was never computed for
+        # a fork, so reporting it would be reporting a default as a reading.
+        reasons.append(f"its head is on another repository: this settles branches on origin, so "
+                       f"nothing here read whether it contains origin/{base}")
+    elif not holds_base:
         reasons.append(f"does not contain origin/{base}: merge it in and let the checks run again")
 
     if held_by_worktree:
@@ -331,11 +368,13 @@ def blocking_reasons(project, number, base, state=None):
     results = checks(project, before.sha)
     after = head_sha(project, number)
     return Blocking(reasons_from(before.sha, after, results, before.branch, base,
-                                 holds_base=contains_base(project, before.branch, base),
+                                 holds_base=(not before.fork
+                                             and contains_base(project, before.branch, base)),
                                  held_by_worktree=before.branch in state.held,
                                  unpublished_release=state.unpublished_release,
                                  draft=before.draft,
-                                 merge_state=before.merge_state),
+                                 merge_state=before.merge_state,
+                                 fork=before.fork),
                     after, before.branch, results)
 
 
@@ -358,10 +397,12 @@ def write_ready_state(ready, since):
 def hold_the_watch():
     """(the open lock, the pid holding it). No lock means another watcher already has it.
 
-    flock rather than a pidfile: the kernel drops it when the holder exits, so a killed watcher
-    leaves a file behind but no lock, and the next one takes it without anything having to decide
-    whether a recorded pid is stale. The handle is returned rather than dropped — the lock lives
-    with the open file description, so keeping it open is the whole of holding it.
+    flock rather than a pidfile: the kernel drops it when the holder exits, so the LOCK is never
+    stale and the next watcher takes it without reading anything to decide that. The pid written
+    here is read only to name a holder in a refusal. A pid judgement still happens, one file over —
+    `watcher_state.beating_elsewhere` makes it about the heartbeat, which is a different question.
+    The handle is returned rather than dropped: the lock lives with the open file description, so
+    keeping it open is the whole of holding it.
     """
     handle = open(watcher_state.LOCK, "a+", encoding="utf-8")
     try:
@@ -384,8 +425,10 @@ def watch(project, base):
     if lock is None:
         print(f"Refusing to watch: process {holder or 'unknown'} already holds "
               f"{watcher_state.LOCK}. A second watcher polls the same API on its own cycle against "
-              f"the same quota, and writes the same heartbeat, so neither says which one is alive.",
-              file=sys.stderr)
+              f"the same quota, and writes the same heartbeat, so neither says which one is alive.\n"
+              f"\nIf that process is wedged rather than watching — every guard reading the heartbeat "
+              f"says nothing is watching while this refuses to replace it — kill it and run this "
+              f"again:\n\n  kill {holder or '<pid>'}\n", file=sys.stderr)
         return 1
     # After the lock and not before: "writing the heartbeat without holding the lock" is only a
     # reading anyone can take while this process is the one holding it.
@@ -413,6 +456,10 @@ def watch(project, base):
 
         ready = set()
         for number in pull_requests:
+            # Written again per pull request, not once per cycle: a poll over several of them takes
+            # longer than the window a reader believes a heartbeat for, and a watcher that is working
+            # must not read as one that stopped.
+            watcher_state.HEARTBEAT.write_text(watcher_state.beat(os.getpid()))
             try:
                 blocking = blocking_reasons(project, number, base, state)
             except RuntimeError as error:
@@ -490,10 +537,9 @@ def update(project, number, base):
             return 1
         gh_git(work, "push", "origin", f"HEAD:{branch}")
     finally:
-        subprocess.run(["git", "-C", str(project), "worktree", "remove", str(work), "--force"],
-                       capture_output=True, text=True)
-        subprocess.run(["git", "-C", str(project), "branch", "-D", temp_branch],
-                       capture_output=True, text=True)
+        run_quietly(["git", "-C", str(project), "worktree", "remove", str(work), "--force"],
+                    GIT_TIMEOUT)
+        run_quietly(["git", "-C", str(project), "branch", "-D", temp_branch], GIT_TIMEOUT)
         shutil.rmtree(scratch, ignore_errors=True)
     print(f"PR#{number}: {base} merged into {branch} and pushed; its checks run again")
     return 0
@@ -555,11 +601,10 @@ def delete_merged_branch(project, branch):
     an exit code saying otherwise sends the reader to merge it again.
     """
     failures = []
-    present = subprocess.run(["git", "-C", str(project), "rev-parse", "--verify", "--quiet",
-                              f"refs/heads/{branch}"], capture_output=True, text=True)
+    present = run_quietly(["git", "-C", str(project), "rev-parse", "--verify", "--quiet",
+                           f"refs/heads/{branch}"], GIT_TIMEOUT)
     if present.returncode == 0:
-        deleted = subprocess.run(["git", "-C", str(project), "branch", "-D", branch],
-                                 capture_output=True, text=True)
+        deleted = run_quietly(["git", "-C", str(project), "branch", "-D", branch], GIT_TIMEOUT)
         if deleted.returncode != 0:
             failures.append(f"the local branch {branch} survived: {deleted.stderr.strip()}")
 
@@ -571,8 +616,8 @@ def delete_merged_branch(project, branch):
 
 def delete_remote_ref(project, branch):
     """Deletes the branch on the remote, and answers with what stderr said when it did not."""
-    removed = subprocess.run(["gh", "api", "-X", "DELETE", "repos/{}/git/refs/heads/{}".format(
-        repository(project), branch)], capture_output=True, text=True)
+    removed = run_quietly(["gh", "api", "-X", "DELETE", "repos/{}/git/refs/heads/{}".format(
+        repository(project), branch)], GH_TIMEOUT)
     if removed.returncode == 0 or reference_already_gone(removed.stderr):
         return ""
     return removed.stderr.strip()

--- a/scripts/pr/settle.py
+++ b/scripts/pr/settle.py
@@ -205,8 +205,8 @@ def pull_request(project, number):
 
     Both names come off this payload rather than one of them off `remote.origin.url`. GitHub answers
     the same pull request for any casing of the path, so a clone made with different capitals, or a
-    repository since renamed, would make every pull request read as a fork — and then nothing is ever
-    ready and the guard that reads that never fires again.
+    repository since renamed, would make every pull request read as a fork — and then nothing is
+    recorded ready and the guard that reads that state stops firing.
     """
     payload = rest_json("repos/{}/pulls/{}".format(repository(project), number))
     head = payload.get("head") or {}

--- a/scripts/pr/test_settle.py
+++ b/scripts/pr/test_settle.py
@@ -357,8 +357,20 @@ class HeartbeatDuringAPollTests(unittest.TestCase):
         # and the guards then read a live watcher beside a ready file this poll emptied.
         outcome = poll({1: fabricate(1)}, listing_answers=False)
 
-        # Act / Assert
-        self.assertIsNone(outcome.beat)
+        # Act / Assert — and the ready file is unwritten beside it, which is the state a guard would
+        # otherwise read as "a live watcher, and nothing ready".
+        self.assertEqual((outcome.beat, outcome.ready), (None, None))
+
+    def test_Given_APollOverSeveralPullRequests_When_ItRuns_Then_ItStampsOncePerReading(self):
+        # Arrange — the per-pull-request write, which the per-cycle one cannot stand in for: a poll
+        # over several of them can outlast the window a reader believes a stamp for, and one stamp at
+        # the top of the cycle is the whole of what such a reader would have.
+        stamps = []
+        with mock.patch.object(settle, "beat", lambda: stamps.append(1)):
+            poll({1: fabricate(1), 2: fabricate(2)})
+
+        # Act / Assert — one for the readings that open the cycle, one per pull request read.
+        self.assertEqual(len(stamps), 3)
 
     def test_Given_APollThatRead_When_ItEnds_Then_TheHeartbeatNamesThisProcess(self):
         # Arrange — the control: a heartbeat nothing ever writes is not a heartbeat.

--- a/scripts/pr/test_settle.py
+++ b/scripts/pr/test_settle.py
@@ -7,11 +7,15 @@ exercised only against live pull requests is exercised only in the states those 
 Run: python3 scripts/pr/test_settle.py
 """
 
+import collections
 import contextlib
 import importlib.util
 import io
+import os
 import subprocess
+import sys
 import tempfile
+import time
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -32,11 +36,12 @@ settle = load_module()
 
 
 def reasons(before=GREEN, after=GREEN, results=None, branch="topic", base="main",
-            holds_base=True, held_by_worktree=False, unpublished_release=None):
+            holds_base=True, held_by_worktree=False, unpublished_release=None, draft=False,
+            merge_state="clean"):
     if results is None:
         results = [{"name": "Required checks (Unity)", "bucket": "pass"}]
     return settle.reasons_from(before, after, results, branch, base, holds_base, held_by_worktree,
-                               unpublished_release)
+                               unpublished_release, draft, merge_state)
 
 
 class MergeDecisionTests(unittest.TestCase):
@@ -134,6 +139,357 @@ class MergeDecisionTests(unittest.TestCase):
 
         # Assert
         self.assertEqual(len(decided), 3)
+
+    def test_Given_ADraftWhoseChecksAllPassed_When_Decided_Then_ItBlocks(self):
+        # Arrange — a deliberate hold reads green, and green was the whole of the readiness question.
+        decided = reasons(draft=True)
+
+        # Act / Assert
+        self.assertEqual(decided, ["it is a draft: mark it ready for review first"])
+
+    def test_Given_ADraftWhoseHeadMoved_When_Decided_Then_BothAreReported(self):
+        # Arrange — a push voids what was read about the head; it does not take a pull request out of
+        # draft, so that reason survives the early return the way the publication one does.
+        decided = reasons(draft=True, after=MOVED)
+
+        # Act / Assert
+        self.assertEqual(len(decided), 2)
+
+    def test_Given_APullRequestConflictingWithTheBase_When_Decided_Then_TheConflictIsNamedBesideIt(self):
+        # Arrange — a conflicting branch does not contain the base either, so both are asked at once:
+        # the conflict alone would be reported by a branch that is merely behind.
+        decided = reasons(merge_state="dirty", holds_base=False)
+
+        # Act / Assert
+        self.assertEqual(decided, [
+            "it conflicts with main: resolve the conflict in the branch, which `settle.py update` "
+            "declines to do",
+            "does not contain origin/main: merge it in and let the checks run again"])
+
+    def test_Given_TheTwoMergeStatesThatDiffer_When_Decided_Then_OnlyTheConflictingOneBlocks(self):
+        # Arrange — `unknown` is the absence of a reading rather than a reason, and a reason that
+        # comes and goes would keep resetting the age write_ready_state carries. Asked beside `dirty`
+        # so deleting the predicate outright cannot satisfy the half about `unknown`.
+        decided = (reasons(merge_state="unknown"), len(reasons(merge_state="dirty")))
+
+        # Act / Assert
+        self.assertEqual(decided, ([], 1))
+
+
+# One pull request's whole state, so `watch` and `merge` can be posed the same table.
+Fabricated = collections.namedtuple(
+    "Fabricated", "sha after branch draft merge_state results holds_base held")
+
+PASSING = [{"name": "Required checks (Unity)", "bucket": "pass"}]
+
+
+def fabricate(number, results=PASSING, draft=False, merge_state="clean", holds_base=True,
+              held=False, moved=False):
+    sha = str(number).rjust(40, "0")
+    return Fabricated(sha=sha, after=MOVED if moved else sha, branch=f"topic-{number}", draft=draft,
+                      merge_state=merge_state, results=results, holds_base=holds_base, held=held)
+
+
+@contextlib.contextmanager
+def fabricated_readings(states):
+    """Every reading a poll takes, answered from a table of pull request states.
+
+    Patched at the readings rather than at `blocking_reasons`, so the decision itself is what runs:
+    stubbing the verdict would make the agreement below true by construction.
+    """
+    by_sha = {state.sha: state for state in states.values()}
+    by_branch = {state.branch: state for state in states.values()}
+    with contextlib.ExitStack() as stack:
+        for name, answer in (
+            ("repository", lambda *_: "owner/name"),
+            ("open_pull_requests", lambda *_: sorted(states)),
+            ("pull_request", lambda _project, number: settle.PullRequest(
+                states[number].sha, states[number].branch, states[number].draft,
+                states[number].merge_state)),
+            ("checks", lambda _project, sha: by_sha[sha].results),
+            ("head_sha", lambda _project, number: states[number].after),
+            ("contains_base", lambda _project, branch, _base: by_branch[branch].holds_base),
+            ("project_state", lambda *_: settle.ProjectState(
+                {state.branch for state in states.values() if state.held}, None)),
+        ):
+            stack.enter_context(mock.patch.object(settle, name, answer))
+        yield stack
+
+
+class Polled(Exception):
+    """Raised out of the watcher's sleep, which is the only way one poll of it ends."""
+
+
+def polled(states):
+    """The pull request numbers one poll of `watch` recorded as ready.
+
+    Every file the watcher touches is redirected, the lock included: taking the real one would make
+    this case's answer depend on whether a watcher happens to be running on the machine.
+    """
+    with tempfile.TemporaryDirectory(prefix="settle-ready-") as directory:
+        ready_state = Path(directory) / "ready"
+        with fabricated_readings(states) as stack:
+            for name, path in (("READY_STATE", ready_state),
+                               ("HEARTBEAT", Path(directory) / "beat"),
+                               ("LOCK", Path(directory) / "lock")):
+                stack.enter_context(mock.patch.object(settle.watcher_state, name, path))
+            stack.enter_context(mock.patch.object(settle.time, "sleep", side_effect=Polled))
+            stack.enter_context(contextlib.redirect_stdout(io.StringIO()))
+            try:
+                settle.watch(Path("."), "main")
+            except Polled:
+                pass
+        return {int(line.split()[0]) for line in ready_state.read_text().splitlines() if line}
+
+
+def merge_would_take(states):
+    """The pull request numbers `settle.py merge` would find nothing blocking, over the same table."""
+    with fabricated_readings(states):
+        return {number for number in states
+                if not settle.blocking_reasons(Path("."), number, "main").reasons}
+
+
+class ReadinessTests(unittest.TestCase):
+    """What the watcher records as ready, against what the merge would take.
+
+    Two readings of one question is what this is here to stop. Asked separately they disagreed on a
+    draft with conflicts, which sat in the ready state while `refuse/edit_while_a_ready_pr_sits.py`
+    refused every Edit and Write in every session and named a merge that could not take it.
+    """
+
+    # Every state the two readings could differ on, plus the ordinary green one so the table is not
+    # made of exceptions alone.
+    TABLE = {
+        1: fabricate(1),
+        2: fabricate(2, draft=True),
+        3: fabricate(3, merge_state="dirty", holds_base=False),
+        4: fabricate(4, holds_base=False),
+        5: fabricate(5, held=True),
+        6: fabricate(6, results=[{"name": "Unity", "bucket": "pending"}]),
+        7: fabricate(7, results=[{"name": "Unity", "bucket": "fail"}]),
+        8: fabricate(8, results=[]),
+        9: fabricate(9, moved=True),
+        10: fabricate(10, draft=True, merge_state="dirty", holds_base=False),
+    }
+
+    def test_Given_ATableOfPullRequestStates_When_BothReadingsAreTaken_Then_TheyNameTheSameSet(self):
+        # Act
+        recorded = polled(self.TABLE)
+
+        # Assert
+        self.assertEqual(recorded, merge_would_take(self.TABLE))
+
+    def test_Given_ADraftWhoseChecksAllPassed_When_TheWatcherPolls_Then_ItIsNotRecordedAsReady(self):
+        # Arrange — draft and nothing else, so no second reason can keep this green while the one
+        # the case is named for stops being asked. The state that raised it carried three.
+        table = {377: fabricate(377, draft=True)}
+
+        # Act / Assert
+        self.assertEqual(polled(table), set())
+
+    def test_Given_APullRequestNothingBlocks_When_TheWatcherPolls_Then_ItIsStillRecordedAsReady(self):
+        # Arrange — the state the guard exists for, which a stricter reading must not stop reporting.
+        table = {592: fabricate(592)}
+
+        # Act / Assert
+        self.assertEqual(polled(table), {592})
+
+
+class ReadyStateTests(unittest.TestCase):
+    def test_Given_AReadyPullRequestThatStoppedBeingReady_When_ItIsRecorded_Then_ItsAgeIsDropped(self):
+        # Arrange
+        since = {}
+        with tempfile.TemporaryDirectory(prefix="settle-ready-") as directory:
+            with mock.patch.object(settle.watcher_state, "READY_STATE", Path(directory) / "ready"):
+                settle.write_ready_state({7}, since)
+
+                # Act
+                settle.write_ready_state(set(), since)
+
+        # Assert
+        self.assertNotIn(7, since)
+
+
+# Holds the watcher lock and says so, then waits to be killed. A separate process because a lock is
+# a claim between processes, and what one makes of its own is the platform's business rather than
+# this decision's.
+HOLDER = """
+import fcntl, os, sys, time
+handle = open(sys.argv[1], "a+")
+fcntl.flock(handle, fcntl.LOCK_EX | fcntl.LOCK_NB)
+handle.seek(0)
+handle.truncate()
+handle.write(str(os.getpid()))
+handle.flush()
+print("held", flush=True)
+time.sleep(120)
+"""
+
+
+def refuse_to_answer(*_):
+    """Stands in for a reading in a case whose whole claim is that no reading is taken."""
+    raise RuntimeError("the watcher asked the API in a case that must not reach it")
+
+
+def exited_pid():
+    """The id of a process that has finished, which is what a killed watcher leaves in a heartbeat."""
+    done = subprocess.Popen([sys.executable, "-c", "pass"])
+    done.wait()
+    return done.pid
+
+
+@contextlib.contextmanager
+def another_watcher_holding(lock):
+    holder = subprocess.Popen([sys.executable, "-c", HOLDER, str(lock)],
+                              stdout=subprocess.PIPE, text=True)
+    try:
+        holder.stdout.readline()
+        yield holder
+    finally:
+        holder.kill()
+        holder.wait()
+        holder.stdout.close()
+
+
+class WatcherLockTests(unittest.TestCase):
+    """One watcher at a time: a second polls the same API on its own cycle against the same quota,
+    and writes the same heartbeat, so neither of them says which one is alive."""
+
+    def test_Given_AWatcherAlreadyHoldingTheLock_When_AnotherAsksForIt_Then_ItIsRefused(self):
+        # Arrange
+        with tempfile.TemporaryDirectory(prefix="settle-lock-") as directory:
+            lock = Path(directory) / "lock"
+            with mock.patch.object(settle.watcher_state, "LOCK", lock):
+                with another_watcher_holding(lock):
+                    # Act
+                    handle, _ = settle.hold_the_watch()
+
+                    # Assert
+                    self.assertIsNone(handle)
+
+    def test_Given_AWatcherAlreadyHoldingTheLock_When_AnotherAsksForIt_Then_ItIsToldWhichPid(self):
+        # Arrange
+        with tempfile.TemporaryDirectory(prefix="settle-lock-") as directory:
+            lock = Path(directory) / "lock"
+            with mock.patch.object(settle.watcher_state, "LOCK", lock):
+                with another_watcher_holding(lock) as holder:
+                    # Act
+                    _, reported = settle.hold_the_watch()
+
+                    # Assert
+                    self.assertEqual(reported, str(holder.pid))
+
+    def test_Given_ALockFileTheHolderDiedUnder_When_AWatcherAsksForIt_Then_ItTakesIt(self):
+        # Arrange — the file survives the kill carrying the dead pid, which is what a pidfile would
+        # have to decide about. Both are asked at once, since a file that never got written would
+        # also be taken and would say nothing about staleness.
+        with tempfile.TemporaryDirectory(prefix="settle-lock-") as directory:
+            lock = Path(directory) / "lock"
+            with mock.patch.object(settle.watcher_state, "LOCK", lock):
+                with another_watcher_holding(lock):
+                    pass
+                left_behind = lock.read_text().strip()
+
+                # Act
+                handle, _ = settle.hold_the_watch()
+                if handle is not None:
+                    handle.close()
+
+                # Assert
+                self.assertEqual((left_behind.isdigit(), handle is not None), (True, True))
+
+    def test_Given_AWatcherHoldingTheLock_When_ItRecordsItself_Then_TheFileNamesItsPid(self):
+        # Arrange
+        with tempfile.TemporaryDirectory(prefix="settle-lock-") as directory:
+            lock = Path(directory) / "lock"
+            with mock.patch.object(settle.watcher_state, "LOCK", lock):
+                # Act
+                handle, _ = settle.hold_the_watch()
+                handle.close()
+
+            # Assert
+            self.assertEqual(lock.read_text().strip(), str(os.getpid()))
+
+
+class HeartbeatTests(unittest.TestCase):
+    """What a reader may conclude from the file, which is what both guards conclude from it."""
+
+    def test_Given_AHeartbeatFromALiveProcess_When_ItIsFresh_Then_TheWatcherReadsAsAlive(self):
+        # Arrange
+        with self.heartbeat(settle.watcher_state.beat(os.getpid(), now=1000)):
+            # Act / Assert
+            self.assertTrue(settle.watcher_state.alive(now=1060))
+
+    def test_Given_AFreshHeartbeatFromAProcessThatIsGone_When_ItIsRead_Then_TheWatcherIsNotAlive(self):
+        # Arrange — a watcher killed between two polls leaves a stamp still inside the window, which
+        # is the whole of what the stamp alone could ever say.
+        with self.heartbeat(settle.watcher_state.beat(exited_pid(), now=1000)):
+            # Act / Assert
+            self.assertFalse(settle.watcher_state.alive(now=1060))
+
+    def test_Given_AHeartbeatNamingNoProcess_When_ItIsRead_Then_TheWatcherIsNotAlive(self):
+        # Arrange — the format the watcher wrote before it had to name itself.
+        with self.heartbeat("1000\n"):
+            # Act / Assert
+            self.assertFalse(settle.watcher_state.alive(now=1060))
+
+    def test_Given_AHeartbeatStampedInTheFuture_When_ItIsRead_Then_TheWatcherIsNotAlive(self):
+        # Arrange — a millisecond epoch or a backward clock step vouched for a watcher permanently.
+        with self.heartbeat(settle.watcher_state.beat(os.getpid(), now=9000)):
+            # Act / Assert
+            self.assertFalse(settle.watcher_state.alive(now=1060))
+
+    def test_Given_AHeartbeatOlderThanThePollWindow_When_ItIsRead_Then_TheWatcherIsNotAlive(self):
+        # Arrange
+        with self.heartbeat(settle.watcher_state.beat(os.getpid(), now=1000)):
+            # Act / Assert
+            self.assertFalse(
+                settle.watcher_state.alive(now=1000 + settle.watcher_state.STALE_AFTER))
+
+    def test_Given_AFreshHeartbeatNamingNoProcess_When_AWatcherStarts_Then_SomebodyElseIsWatching(self):
+        # Arrange — what a watcher launched from a checkout older than the lock leaves, which is the
+        # one kind the lock cannot see.
+        with self.heartbeat("1000\n"):
+            # Act / Assert
+            self.assertTrue(settle.watcher_state.beating_elsewhere(os.getpid(), now=1060))
+
+    def test_Given_AFreshHeartbeatFromAWatcherThatDied_When_AnotherStarts_Then_NobodyElseIsWatching(self):
+        # Arrange — restarting inside the window would otherwise refuse itself.
+        with self.heartbeat(settle.watcher_state.beat(exited_pid(), now=1000)):
+            # Act / Assert
+            self.assertFalse(settle.watcher_state.beating_elsewhere(os.getpid(), now=1060))
+
+    def test_Given_ANamelessHeartbeatOlderThanTheWindow_When_AWatcherStarts_Then_NobodyElseIsWatching(self):
+        # Arrange — a file left behind by a watcher that stopped is not one still being written.
+        with self.heartbeat("1000\n"):
+            # Act / Assert
+            self.assertFalse(settle.watcher_state.beating_elsewhere(
+                os.getpid(), now=1000 + settle.watcher_state.STALE_AFTER))
+
+    def test_Given_SomethingElseStillBeating_When_TheWatcherIsAsked_Then_ItDeclinesToPollAsWell(self):
+        # Arrange — the lock is free, so the heartbeat is the only thing saying anyone else is there.
+        # The readings raise rather than answer, so a watcher that starts anyway ends this case
+        # instead of polling in a loop nothing here would stop.
+        with tempfile.TemporaryDirectory(prefix="settle-lock-") as directory:
+            lock = Path(directory) / "lock"
+            with contextlib.ExitStack() as stack:
+                stack.enter_context(mock.patch.object(settle.watcher_state, "LOCK", lock))
+                stack.enter_context(self.heartbeat(f"{int(time.time())}\n"))
+                stack.enter_context(mock.patch.object(settle, "open_pull_requests", refuse_to_answer))
+                stack.enter_context(mock.patch.object(settle.time, "sleep", side_effect=Polled))
+                stack.enter_context(contextlib.redirect_stderr(io.StringIO()))
+                stack.enter_context(contextlib.redirect_stdout(io.StringIO()))
+
+                # Act / Assert
+                self.assertEqual(settle.watch(Path("."), "main"), 1)
+
+    @contextlib.contextmanager
+    def heartbeat(self, text):
+        with tempfile.TemporaryDirectory(prefix="settle-beat-") as directory:
+            path = Path(directory) / "beat"
+            path.write_text(text)
+            with mock.patch.object(settle.watcher_state, "HEARTBEAT", path):
+                yield
 
 
 class UpdateReasonsTests(unittest.TestCase):
@@ -335,12 +691,11 @@ class CheckReadTests(unittest.TestCase):
         asked = []
         with contextlib.ExitStack() as stack:
             stack.enter_context(mock.patch.object(settle, "repository", lambda *_: "owner/name"))
-            stack.enter_context(mock.patch.object(settle, "head_sha", lambda *_: GREEN))
             stack.enter_context(mock.patch.object(
                 settle, "rest_json", lambda path: (asked.append(path), NO_STATUSES)[1]))
 
             # Act
-            settle.checks(Path("."), 592)
+            settle.checks(Path("."), GREEN)
 
         # Assert
         self.assertEqual(asked, [f"repos/owner/name/commits/{GREEN}/check-runs?per_page=100",
@@ -370,7 +725,7 @@ def stubbed_readings(head=GREEN, branch="topic", title="A title", body="A body")
     """
     return [mock.patch.object(settle, "repository", lambda *_: "owner/name"),
             mock.patch.object(settle, "blocking_reasons",
-                              lambda *_: settle.Blocking([], head, branch)),
+                              lambda *_: settle.Blocking([], head, branch, [])),
             mock.patch.object(settle, "pull_request_text", lambda *_: (title, body))]
 
 

--- a/scripts/pr/test_settle.py
+++ b/scripts/pr/test_settle.py
@@ -176,16 +176,16 @@ class MergeDecisionTests(unittest.TestCase):
             "its head is on another repository: this settles branches on origin, so nothing here "
             "read whether it contains origin/main"])
 
-    def test_Given_TheTwoMergeStatesThatDiffer_When_Decided_Then_TheyBlockAlikeAndSayDifferently(self):
-        # Arrange — a conflicting branch cannot contain the base, so both states are posed with the
-        # containment reading that really accompanies them. That reading is what blocks either way,
-        # which is the point: `dirty` changes no verdict, it adds the reason that names the conflict,
-        # and `unknown` is left out because there is nothing for it to add.
-        counted = (len(reasons(merge_state="unknown", holds_base=False)),
-                   len(reasons(merge_state="dirty", holds_base=False)))
+    def test_Given_ADirtyStateBesideAContainmentThatHolds_When_Decided_Then_ItIsWhatBlocks(self):
+        # Arrange — the state the predicate earns its keep in, and the reason it is read rather than
+        # left to the message: the containment reading is of the tip the cycle's fetch saw, GitHub's
+        # is of a newer one, so a branch can hold the first and conflict with the second. Posed
+        # beside `unknown` to keep the absence of a reading from becoming a reason.
+        counted = (len(reasons(merge_state="dirty", holds_base=True)),
+                   len(reasons(merge_state="unknown", holds_base=True)))
 
         # Act / Assert
-        self.assertEqual(counted, (1, 2))
+        self.assertEqual(counted, (1, 0))
 
 
 # One pull request's whole state, so `watch` and `merge` can be posed the same table.
@@ -240,12 +240,13 @@ class Polled(Exception):
     """Raised out of the watcher's sleep, which is the only way one poll of it ends."""
 
 
-# What a poll recorded, and what it said. A pull request whose readings raised is dropped from the
-# poll rather than reported, and the two are the same ready set — the saying is where they differ.
-Poll = collections.namedtuple("Poll", "ready output")
+# What a poll recorded, what it said, and what it left in the heartbeat. A pull request whose
+# readings raised is dropped from the poll rather than reported, and the two are the same ready set
+# — the saying is where they differ.
+Poll = collections.namedtuple("Poll", "ready output beat")
 
 
-def poll(states):
+def poll(states, listing_answers=True):
     """One poll of `watch` over a table of fabricated readings.
 
     Every file the watcher touches is redirected, the lock included: taking the real one would make
@@ -254,9 +255,13 @@ def poll(states):
     printed = io.StringIO()
     with tempfile.TemporaryDirectory(prefix="settle-ready-") as directory:
         ready_state = Path(directory) / "ready"
+        heartbeat = Path(directory) / "beat"
         with fabricated_readings(states) as stack:
+            if not listing_answers:
+                stack.enter_context(
+                    mock.patch.object(settle, "open_pull_requests", refuse_to_answer))
             for name, path in (("READY_STATE", ready_state),
-                               ("HEARTBEAT", Path(directory) / "beat"),
+                               ("HEARTBEAT", heartbeat),
                                ("LOCK", Path(directory) / "lock")):
                 stack.enter_context(mock.patch.object(settle.watcher_state, name, path))
             stack.enter_context(mock.patch.object(settle.time, "sleep", side_effect=Polled))
@@ -265,8 +270,13 @@ def poll(states):
                 settle.watch(Path("."), "main")
             except Polled:
                 pass
-        recorded = {int(line.split()[0]) for line in ready_state.read_text().splitlines() if line}
-    return Poll(recorded, printed.getvalue())
+        # None rather than an empty set when the file was never written: a poll that recorded
+        # nothing and a poll that got as far as truncating the file are different facts, and this
+        # harness would otherwise report the second as the first.
+        recorded = (None if not ready_state.exists() else
+                    {int(line.split()[0]) for line in ready_state.read_text().splitlines() if line})
+        written = heartbeat.read_text() if heartbeat.exists() else None
+    return Poll(recorded, printed.getvalue(), written)
 
 
 def polled(states):
@@ -336,6 +346,26 @@ class ReadinessTests(unittest.TestCase):
 
         # Act / Assert
         self.assertEqual(polled(table), {592})
+
+
+class HeartbeatDuringAPollTests(unittest.TestCase):
+    """What the heartbeat says while a poll is failing, which is what the guards read it for."""
+
+    def test_Given_APollWhoseListingNeverAnswers_When_ItEnds_Then_NoHeartbeatVouchesForIt(self):
+        # Arrange — the wedge the call bounds exist for, reaching the guards as a file they believe.
+        # A stamp written on the way in holds it inside the staleness window for the whole of it,
+        # and the guards then read a live watcher beside a ready file this poll emptied.
+        outcome = poll({1: fabricate(1)}, listing_answers=False)
+
+        # Act / Assert
+        self.assertIsNone(outcome.beat)
+
+    def test_Given_APollThatRead_When_ItEnds_Then_TheHeartbeatNamesThisProcess(self):
+        # Arrange — the control: a heartbeat nothing ever writes is not a heartbeat.
+        outcome = poll({1: fabricate(1)})
+
+        # Act / Assert
+        self.assertIn(f" {os.getpid()}", outcome.beat or "")
 
 
 class ForkMergeTests(unittest.TestCase):
@@ -760,6 +790,37 @@ class CheckReadTests(unittest.TestCase):
         # Assert
         self.assertEqual(asked, [f"repos/owner/name/commits/{GREEN}/check-runs?per_page=100",
                                  f"repos/owner/name/commits/{GREEN}/status?per_page=100"])
+
+
+class ForkReadingTests(unittest.TestCase):
+    """Which two names decide a fork, since getting it wrong makes every pull request one."""
+
+    PAYLOAD = {"head": {"sha": GREEN, "ref": "topic", "repo": {"full_name": "Owner/Velvet"}},
+               "base": {"repo": {"full_name": "Owner/Velvet"}},
+               "draft": False, "mergeable_state": "clean"}
+
+    def read(self, payload, slug):
+        with contextlib.ExitStack() as stack:
+            stack.enter_context(mock.patch.object(settle, "repository", lambda *_: slug))
+            stack.enter_context(mock.patch.object(settle, "rest_json", lambda *_: payload))
+            return settle.pull_request(Path("."), 1)
+
+    def test_Given_AHeadOnTheSameRepository_When_TheSlugIsCasedDifferently_Then_ItIsNoFork(self):
+        # Arrange — a clone made with different capitals answers everywhere and reads back canonical,
+        # so a comparison against the remote URL's spelling calls every pull request a fork and the
+        # ready state empties for good.
+        read = self.read(self.PAYLOAD, "owner/velvet")
+
+        # Act / Assert
+        self.assertFalse(read.fork)
+
+    def test_Given_AHeadOnAnotherRepository_When_ItIsRead_Then_ItIsAFork(self):
+        # Arrange — the control: a comparison that never says fork is not a comparison.
+        payload = dict(self.PAYLOAD, head=dict(self.PAYLOAD["head"],
+                                               repo={"full_name": "somebody/velvet"}))
+
+        # Act / Assert
+        self.assertTrue(self.read(payload, "Owner/Velvet").fork)
 
 
 class RepositoryReadTests(unittest.TestCase):

--- a/scripts/pr/test_settle.py
+++ b/scripts/pr/test_settle.py
@@ -205,7 +205,7 @@ def fabricate(number, results=PASSING, draft=False, merge_state="clean", holds_b
 
 @contextlib.contextmanager
 def fabricated_readings(states):
-    """Every reading a poll takes, answered from a table of pull request states.
+    """Every reading a poll takes from git or the API, answered from a table of pull request states.
 
     Patched at the readings rather than at `blocking_reasons`, so the decision itself is what runs:
     stubbing the verdict would make the agreement below true by construction.
@@ -299,8 +299,9 @@ class ReadinessTests(unittest.TestCase):
     refused every Edit and Write in every session and named a merge that could not take it.
     """
 
-    # Every state the two readings could differ on, plus the ordinary green one so the table is not
-    # made of exceptions alone.
+    # Every per-pull-request state the two readings could differ on, plus the ordinary green one so
+    # the table is not made of exceptions alone. The publication reason is not among them: it is one
+    # reading for the whole repository, so it cannot differ between entries of a table like this.
     TABLE = {
         1: fabricate(1),
         2: fabricate(2, draft=True),

--- a/scripts/pr/test_settle.py
+++ b/scripts/pr/test_settle.py
@@ -176,14 +176,16 @@ class MergeDecisionTests(unittest.TestCase):
             "its head is on another repository: this settles branches on origin, so nothing here "
             "read whether it contains origin/main"])
 
-    def test_Given_TheTwoMergeStatesThatDiffer_When_Decided_Then_OnlyTheConflictingOneBlocks(self):
-        # Arrange — `unknown` is the absence of a reading rather than a reason, and a reason that
-        # comes and goes would keep resetting the age write_ready_state carries. Asked beside `dirty`
-        # so deleting the predicate outright cannot satisfy the half about `unknown`.
-        decided = (reasons(merge_state="unknown"), len(reasons(merge_state="dirty")))
+    def test_Given_TheTwoMergeStatesThatDiffer_When_Decided_Then_TheyBlockAlikeAndSayDifferently(self):
+        # Arrange — a conflicting branch cannot contain the base, so both states are posed with the
+        # containment reading that really accompanies them. That reading is what blocks either way,
+        # which is the point: `dirty` changes no verdict, it adds the reason that names the conflict,
+        # and `unknown` is left out because there is nothing for it to add.
+        counted = (len(reasons(merge_state="unknown", holds_base=False)),
+                   len(reasons(merge_state="dirty", holds_base=False)))
 
         # Act / Assert
-        self.assertEqual(decided, ([], 1))
+        self.assertEqual(counted, (1, 2))
 
 
 # One pull request's whole state, so `watch` and `merge` can be posed the same table.

--- a/scripts/pr/test_settle.py
+++ b/scripts/pr/test_settle.py
@@ -320,12 +320,13 @@ class ReadinessTests(unittest.TestCase):
 
     def test_Given_AForkPullRequest_When_TheWatcherPolls_Then_ItIsCarriedRatherThanDropped(self):
         # Arrange — the readings raise the way git does on `origin/<a branch on the fork>`. Both
-        # outcomes leave the same ready set, so the ready set alone separates nothing: what a drop
-        # costs is the entry, and what it shows is the error line beside it.
+        # outcomes leave the same ready set, so the ready set alone separates nothing; what a drop
+        # costs is the poll's report of it — an error line where the checks should be.
         outcome = poll({1: fabricate(1), 11: fabricate(11, fork=True)})
 
         # Act / Assert
-        self.assertEqual((outcome.ready, "! PR#11" in outcome.output), ({1}, False))
+        self.assertEqual((outcome.ready, "! PR#11" in outcome.output, "PR#11" in outcome.output),
+                         ({1}, False, True))
 
     def test_Given_APullRequestNothingBlocks_When_TheWatcherPolls_Then_ItIsStillRecordedAsReady(self):
         # Arrange — the state the guard exists for, which a stricter reading must not stop reporting.
@@ -333,6 +334,23 @@ class ReadinessTests(unittest.TestCase):
 
         # Act / Assert
         self.assertEqual(polled(table), {592})
+
+
+class ForkMergeTests(unittest.TestCase):
+    """What `settle.py merge` does with a head this checkout has no ref for."""
+
+    def test_Given_AForkPullRequest_When_TheMergeIsDecided_Then_ItIsRefusedRatherThanRaising(self):
+        # Arrange — `contains_base` is what would run on `origin/<a branch on the fork>`, and it
+        # exits 128 rather than answering, so a merge decided without the fork reading raises out of
+        # a command whose whole job is to report what blocks.
+        printed = io.StringIO()
+        with fabricated_readings({8: fabricate(8, fork=True)}):
+            with contextlib.redirect_stderr(printed):
+                # Act
+                code = settle.merge(Path("."), 8, "main", dry_run=True)
+
+        # Assert
+        self.assertEqual((code, "head is on another repository" in printed.getvalue()), (1, True))
 
 
 class ReadyStateTests(unittest.TestCase):

--- a/scripts/pr/test_settle.py
+++ b/scripts/pr/test_settle.py
@@ -37,11 +37,11 @@ settle = load_module()
 
 def reasons(before=GREEN, after=GREEN, results=None, branch="topic", base="main",
             holds_base=True, held_by_worktree=False, unpublished_release=None, draft=False,
-            merge_state="clean"):
+            merge_state="clean", fork=False):
     if results is None:
         results = [{"name": "Required checks (Unity)", "bucket": "pass"}]
     return settle.reasons_from(before, after, results, branch, base, holds_base, held_by_worktree,
-                               unpublished_release, draft, merge_state)
+                               unpublished_release, draft, merge_state, fork)
 
 
 class MergeDecisionTests(unittest.TestCase):
@@ -166,6 +166,16 @@ class MergeDecisionTests(unittest.TestCase):
             "declines to do",
             "does not contain origin/main: merge it in and let the checks run again"])
 
+    def test_Given_AHeadOnAFork_When_Decided_Then_ItBlocksWithoutClaimingAContainmentReading(self):
+        # Arrange — `holds_base` is the default nothing computed for a fork, so the case asks that
+        # the reason naming it is absent as well as that the fork reason is there.
+        decided = reasons(fork=True, holds_base=False)
+
+        # Act / Assert
+        self.assertEqual(decided, [
+            "its head is on another repository: this settles branches on origin, so nothing here "
+            "read whether it contains origin/main"])
+
     def test_Given_TheTwoMergeStatesThatDiffer_When_Decided_Then_OnlyTheConflictingOneBlocks(self):
         # Arrange — `unknown` is the absence of a reading rather than a reason, and a reason that
         # comes and goes would keep resetting the age write_ready_state carries. Asked beside `dirty`
@@ -178,16 +188,17 @@ class MergeDecisionTests(unittest.TestCase):
 
 # One pull request's whole state, so `watch` and `merge` can be posed the same table.
 Fabricated = collections.namedtuple(
-    "Fabricated", "sha after branch draft merge_state results holds_base held")
+    "Fabricated", "sha after branch draft merge_state results holds_base held fork")
 
 PASSING = [{"name": "Required checks (Unity)", "bucket": "pass"}]
 
 
 def fabricate(number, results=PASSING, draft=False, merge_state="clean", holds_base=True,
-              held=False, moved=False):
+              held=False, moved=False, fork=False):
     sha = str(number).rjust(40, "0")
     return Fabricated(sha=sha, after=MOVED if moved else sha, branch=f"topic-{number}", draft=draft,
-                      merge_state=merge_state, results=results, holds_base=holds_base, held=held)
+                      merge_state=merge_state, results=results, holds_base=holds_base, held=held,
+                      fork=fork)
 
 
 @contextlib.contextmanager
@@ -205,10 +216,12 @@ def fabricated_readings(states):
             ("open_pull_requests", lambda *_: sorted(states)),
             ("pull_request", lambda _project, number: settle.PullRequest(
                 states[number].sha, states[number].branch, states[number].draft,
-                states[number].merge_state)),
+                states[number].merge_state, states[number].fork)),
             ("checks", lambda _project, sha: by_sha[sha].results),
             ("head_sha", lambda _project, number: states[number].after),
-            ("contains_base", lambda _project, branch, _base: by_branch[branch].holds_base),
+            ("contains_base", lambda _project, branch, _base: (
+                _refuse_for_a_fork(by_branch[branch]) if by_branch[branch].fork
+                else by_branch[branch].holds_base)),
             ("project_state", lambda *_: settle.ProjectState(
                 {state.branch for state in states.values() if state.held}, None)),
         ):
@@ -216,16 +229,27 @@ def fabricated_readings(states):
         yield stack
 
 
+def _refuse_for_a_fork(state):
+    """git is what would run here on a real fork, and it exits 128 rather than answering."""
+    raise RuntimeError(f"fatal: ambiguous argument 'origin/{state.branch}': unknown revision")
+
+
 class Polled(Exception):
     """Raised out of the watcher's sleep, which is the only way one poll of it ends."""
 
 
-def polled(states):
-    """The pull request numbers one poll of `watch` recorded as ready.
+# What a poll recorded, and what it said. A pull request whose readings raised is dropped from the
+# poll rather than reported, and the two are the same ready set — the saying is where they differ.
+Poll = collections.namedtuple("Poll", "ready output")
+
+
+def poll(states):
+    """One poll of `watch` over a table of fabricated readings.
 
     Every file the watcher touches is redirected, the lock included: taking the real one would make
     this case's answer depend on whether a watcher happens to be running on the machine.
     """
+    printed = io.StringIO()
     with tempfile.TemporaryDirectory(prefix="settle-ready-") as directory:
         ready_state = Path(directory) / "ready"
         with fabricated_readings(states) as stack:
@@ -234,12 +258,18 @@ def polled(states):
                                ("LOCK", Path(directory) / "lock")):
                 stack.enter_context(mock.patch.object(settle.watcher_state, name, path))
             stack.enter_context(mock.patch.object(settle.time, "sleep", side_effect=Polled))
-            stack.enter_context(contextlib.redirect_stdout(io.StringIO()))
+            stack.enter_context(contextlib.redirect_stdout(printed))
             try:
                 settle.watch(Path("."), "main")
             except Polled:
                 pass
-        return {int(line.split()[0]) for line in ready_state.read_text().splitlines() if line}
+        recorded = {int(line.split()[0]) for line in ready_state.read_text().splitlines() if line}
+    return Poll(recorded, printed.getvalue())
+
+
+def polled(states):
+    """The pull request numbers one poll recorded as ready."""
+    return poll(states).ready
 
 
 def merge_would_take(states):
@@ -270,6 +300,7 @@ class ReadinessTests(unittest.TestCase):
         8: fabricate(8, results=[]),
         9: fabricate(9, moved=True),
         10: fabricate(10, draft=True, merge_state="dirty", holds_base=False),
+        11: fabricate(11, fork=True),
     }
 
     def test_Given_ATableOfPullRequestStates_When_BothReadingsAreTaken_Then_TheyNameTheSameSet(self):
@@ -286,6 +317,15 @@ class ReadinessTests(unittest.TestCase):
 
         # Act / Assert
         self.assertEqual(polled(table), set())
+
+    def test_Given_AForkPullRequest_When_TheWatcherPolls_Then_ItIsCarriedRatherThanDropped(self):
+        # Arrange — the readings raise the way git does on `origin/<a branch on the fork>`. Both
+        # outcomes leave the same ready set, so the ready set alone separates nothing: what a drop
+        # costs is the entry, and what it shows is the error line beside it.
+        outcome = poll({1: fabricate(1), 11: fabricate(11, fork=True)})
+
+        # Act / Assert
+        self.assertEqual((outcome.ready, "! PR#11" in outcome.output), ({1}, False))
 
     def test_Given_APullRequestNothingBlocks_When_TheWatcherPolls_Then_ItIsStillRecordedAsReady(self):
         # Arrange — the state the guard exists for, which a stricter reading must not stop reporting.

--- a/scripts/pr/watcher_state.py
+++ b/scripts/pr/watcher_state.py
@@ -80,6 +80,21 @@ def alive(now=None):
             and running(read[1]))
 
 
+def unreadable_beat(now=None):
+    """Whether something inside the window is writing a heartbeat this cannot read.
+
+    A watcher older than the pid field writes one field and nothing else, so a reader looking only at
+    `alive` sees exactly what an absent file gives it and would call that "nothing is watching".
+    Something is watching; what failed is the reading. Separating the two is what lets a guard name
+    the recovery, which is to end that watcher rather than to start another.
+    """
+    try:
+        text = HEARTBEAT.read_text(encoding="utf-8")
+    except OSError:
+        return False
+    return stamped(text, time.time() if now is None else now) is not None and written(text) is None
+
+
 def beating_elsewhere(mine, now=None):
     """Whether a watcher this process is not is still writing the heartbeat.
 

--- a/scripts/pr/watcher_state.py
+++ b/scripts/pr/watcher_state.py
@@ -8,7 +8,8 @@ places and read back in two, under two different comments for the same 180 secon
 A heartbeat names the process that wrote it. Nothing stopped several watchers running at once, each
 on its own poll cycle against one shared API quota and all writing this one file, so a fresh stamp
 meant that one of them was alive and said nothing about which. `settle.py`'s `hold_the_watch` is what
-stops the several; the pid here is what lets a reader check the claim rather than take it.
+stops the several; the pid here is what lets a reader ask whether the process that wrote the stamp
+still exists. That is all it establishes — `running` answers about a process id, not about a watcher.
 """
 
 import os

--- a/scripts/pr/watcher_state.py
+++ b/scripts/pr/watcher_state.py
@@ -1,0 +1,98 @@
+"""The files `settle.py watch` writes, and what a reader may conclude from them.
+
+Three programs touch these. The watcher writes them; `.claude/hooks/stop/unsettled_pr.py` forgives a
+pending check while one is alive; `.claude/hooks/refuse/edit_while_a_ready_pr_sits.py` refuses a
+write while a ready pull request has sat. The format lives here because it was written in three
+places and read back in two, under two different comments for the same 180 seconds.
+
+A heartbeat names the process that wrote it. Nothing stopped several watchers running at once, each
+on its own poll cycle against one shared API quota and all writing this one file, so a fresh stamp
+meant that one of them was alive and said nothing about which. `settle.py`'s `hold_the_watch` is what
+stops the several; the pid here is what lets a reader check the claim rather than take it.
+"""
+
+import os
+import time
+from pathlib import Path
+
+HEARTBEAT = Path.home() / ".velvet-pr-watch.heartbeat"
+
+# When each pull request first read as ready, so a guard can ask how long one has sat rather than
+# whether one exists. Several are usually in flight here and one of them is usually green, so the
+# existence of a ready pull request is the ordinary state and only its age is a defect.
+READY_STATE = Path.home() / ".velvet-pr-ready"
+
+LOCK = Path.home() / ".velvet-pr-watch.lock"
+
+POLL_SECONDS = 60
+
+# Three polls, so one slow `gh` call does not read as a dead watcher.
+STALE_AFTER = 3 * POLL_SECONDS
+
+
+def beat(pid, now=None):
+    """One heartbeat: when it was written, and by which process."""
+    return f"{int(time.time() if now is None else now)} {pid}\n"
+
+
+def written(text):
+    """(stamp, pid) out of a heartbeat, or None when it carries neither."""
+    fields = text.split()
+    if len(fields) != 2 or not all(field.isdigit() for field in fields):
+        return None
+    return int(fields[0]), int(fields[1])
+
+
+def running(pid):
+    """Whether a process with that id exists. One this user may not signal counts as existing."""
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def stamped(text, now):
+    """Seconds since a heartbeat was written, or None when it carries no usable stamp.
+
+    Bounded below as well as above: a stamp in the future — a millisecond epoch, a typo, a backward
+    clock step — vouches for a watcher permanently.
+    """
+    fields = text.split()
+    if not fields or not fields[0].isdigit():
+        return None
+    age = now - int(fields[0])
+    return age if 0 <= age < STALE_AFTER else None
+
+
+def alive(now=None):
+    """Whether the process that wrote the heartbeat is running and wrote it recently."""
+    try:
+        text = HEARTBEAT.read_text(encoding="utf-8")
+    except OSError:
+        return False
+    read = written(text)
+    return (read is not None
+            and stamped(text, time.time() if now is None else now) is not None
+            and running(read[1]))
+
+
+def beating_elsewhere(mine, now=None):
+    """Whether a watcher this process is not is still writing the heartbeat.
+
+    The lock cannot see a watcher launched from a checkout older than the lock itself: it takes no
+    lock, and what it does leave is a heartbeat that names no process. So a nameless one inside the
+    window is read as somebody still watching. A named one belongs to a watcher the lock already
+    answers for, and is believed only while that process exists — otherwise a watcher restarted
+    inside the window would refuse itself.
+    """
+    try:
+        text = HEARTBEAT.read_text(encoding="utf-8")
+    except OSError:
+        return False
+    if stamped(text, time.time() if now is None else now) is None:
+        return False
+    read = written(text)
+    return read is None or (read[1] != mine and running(read[1]))


### PR DESCRIPTION
Closes #598.

**#606 is not closed by this.** Its message half landed — a guard that could not read now says so
about itself, and the deferral it invites asks what the work is waiting on. Its exit half did not: a
Stop hook has a second way to block, and using it would put the distinction in the exit as well, but
nothing here can measure whether that form blocks, and a refusal that bets on an unmeasured form and
loses fails open — the defect this family exists to remove. So that half is unimplemented and
unmeasured rather than impossible, and the issue stays open on it.

## Readiness is the merge decision, asked once

`settle.py watch` decided readiness for itself — every check terminal and passing — while
`settle.py merge` decided from five more preconditions. A draft with conflicts satisfied the first
and four of the five — every one but containment — so it sat in `~/.velvet-pr-ready`, and
`.claude/hooks/refuse/edit_while_a_ready_pr_sits.py` reads that record: every Edit and Write in
every session on the machine was refused, naming a merge command that could not take it.

**"Ready" now means "`settle.py merge` would take it", because they are the same function.** `watch`
calls `blocking_reasons` per pull request and records the ones it returns no reason for. That
decision gained a draft predicate, a `dirty` one, and a fork one, all read from the pull-request
payload the script already fetched.

All three change a verdict, `dirty` included. It looks redundant — a branch holding every commit on
the base fast-forwards and cannot conflict, so a conflicting one fails the containment reading too —
but the two readings are of different base tips. `project_state` fetches once per cycle and
`mergeable_state` is a fresh read per pull request, so when another pull request merges mid-cycle a
branch can contain the tip that fetch saw while GitHub reports a conflict against the newer one.
There the containment reason is absent and `dirty` is the only thing blocking, which is why it is
read rather than left to the message. `unknown` stays out: it is the absence of a reading rather than
a reading, and a state that comes and goes would drop and re-add the entry, resetting the age the
Edit guard measures a pull request by.

Per pull request the cost is unchanged: the readings are folded into one payload carrying the head
SHA, the branch, `draft` and `mergeable_state` together, and the per-repository ones — the fetch, the
worktree list, the publication check — are taken once per cycle rather than once per pull request.

Per cycle it is not unchanged, and this is the price. `origin/main`'s `watch` called `project_state`
not at all; this one calls it every 60 seconds, so the branch adds a `git fetch origin` and a
`git ls-remote --tags` per cycle forever. That is deliberate and it has a consequence worth naming:
with `origin` unreachable those raise before the heartbeat is written, it goes stale within 180
seconds, and every editing tool in every session is refused. A wedge has to go stale for anything to
see it — but this is a wedge the old watcher could not have, because it never made the call.

`ReadinessTests` is the guard against the two drifting apart again: it drives one poll of `watch` and
the merge decision over the same table of fabricated readings and asserts they name the same set.
Measured over that table, the old rule and the merge decision disagree on seven of its eleven
entries — a draft, a conflicting branch, one behind its base, one held by a worktree, one whose head
moved mid-read, one carrying three of those at once, and a fork.

What narrows: a green pull request that is behind main, held by a worktree, or in draft is no longer
recorded ready, so the Edit guard does not refuse on it. `stop/unsettled_pr.py` still names every one
of those at Stop, so nothing goes unreported — the refusal is what stops being unclearable.

## A guard that cannot read says so about itself

`stop/unsettled_pr.py` and `stop/open_backlog.py` blocked with "the open pull requests could not be
read, so nothing here says they are settled" — the guard's own blindness in the shape of a fact about
the pull requests — and the deferral the message invited therefore named the API error rather than
what the work was waiting on.

`.claude/hooks/lib/repository.py` now owns both halves.

- `open_pull_requests` asks a second way, `gh api` over REST, before declaring blindness at all. That
  reduces the blast radius of one quota; it is not the fix for the reporting.
- `unreadable_report` is what a guard prints when no way answered. It opens with the guard as the
  subject, carries the sentence `SELF_REPORT` owns, and asks the deferral for **what the work is
  waiting on** rather than for what the read failed on.

The two outcomes no longer read alike. A guard that established something unsettled still says
"Do not stop: an open PR has not settled." and names it; a guard that established nothing says "Do
not stop: this guard could not read the open pull requests. That is a fact about this guard, not
about the open pull requests."

The exit half is not delivered, for the reason at the top of this description, and `unreadable_report`
says so where a reader meets it.

A third state was reachable and unsaid: every open pull request held. A deferral is checked before
the pull request is, so the held list after checking each one and the held list after checking none
are the same list — and the count tells them apart without a reading. When all of them are held the
report now says none was read this time.

The fallback moves one quota and no more, which is the trap it laid on the first round of this
branch: the listing survives a dead GraphQL quota and every per-pull-request read does not, so
`unsettled_pr.py` had a listing it could read and a subject it could not, and reported it settled.
`checks_of` and `merge_state` now separate "did not answer" from "answered nothing", and a pull
request read no further than the listing blocks with the same sentence one level down.

`scripts/hooks/unreadable_state_check.py` now covers `.claude/hooks/stop` as well as
`.claude/hooks/refuse`: each Stop guard declares an `UNREADABLE_POLICY`, is run under two gh modes,
and fails if it lets the session end with nothing behind it, or blocks without that sentence. A
guard may declare `"allow"` or exempt itself from a mode, and either way a sibling has to refuse
there — the declaration is on the record and backed, or it is a fault. The second mode is the
one the fallback created — the listing answers, every per-pull-request read fails — and without it
the fail-open above is invisible to the harness. A guard whose own question is answered in a mode
that broke somebody else's reading declares `UNREADABLE_ALLOWS`, with a comment and with a sibling
that refuses there, so the exemption cannot be what ends the session.

`scripts/hooks/test_hook_repository.py` holds the library itself: that a second way is tried, that it
is not the first one written twice, that an empty answer stays an answer, that the report names the
guard and asks about the work, and that every way of asking fits inside a ceiling that file owns
register for the guard. That last one is why the per-call bound is eight seconds and not sixty. It is a judgement about how
long a pause stays one. Nothing here reads the timeout the settings register for these hooks, and the
test owns its ceiling rather than mirroring a configured value.

## One watcher at a time, and a heartbeat that names it

Nothing stopped several `settle.py watch` processes running at once, each polling on its own cycle
against one shared quota and all writing one heartbeat — so a fresh stamp said that one of them was
alive and nothing about which.

`watch` takes an `flock` on `~/.velvet-pr-watch.lock` and reports the pid already holding it. flock
rather than a pidfile: the kernel drops it when the holder exits, so the lock itself is never stale
and the next watcher takes it without reading anything to decide that. A pid judgement still happens
one file over — `beating_elsewhere` makes it about the heartbeat — and that is a different question,
not a removed one.

A lock is only as good as the recovery from a holder that stops working, and the first round of this
branch had none: no `gh` or `git` call in the poll had a timeout, so one hang held the lock while the
heartbeat went stale, and then every editing tool was refused while the escape they named was a
watcher the lock would not start. Every subprocess call now has a bound and reports a timeout as the
failure the poll already catches — `gh` at 60s, `git` at 300s, and the release guard's own reads at
5s, so nothing inside the lock is unbounded. The heartbeat is written after each reading that
answered, per pull request as well as per cycle and never before one is attempted, so a long poll
does not read as a stopped watcher and a failing one does not read as a working watcher. The lock
refusal names the pid and the command that ends it. And the Edit guard's stale-heartbeat branch takes
a `watcher` deferral: both of that guard's refusals hold every editing tool in every session, and
this was the one with no way past it that did not go through the thing that is stuck.

The heartbeat now carries the writing process's id, and both readers ask whether that process is
running rather than only when the file was touched. A watcher launched from a checkout older than the
lock takes no lock, so the lock cannot see it; what it does leave is a heartbeat naming no process,
and `watch` refuses to start beside one.

`scripts/pr/watcher_state.py` owns the paths and the format, which were written in three places and
read back in two under two different comments for the same 180 seconds.

## Merging this turns the write refusal on until a watcher is restarted

The heartbeat gains a second field. A watcher started before this change writes one field, so from
the moment the hook files land `alive()` reads False and every Edit, Write and NotebookEdit is
refused in every session on the machine — while something is, in fact, watching.

The way out is to end that watcher, not to start another, and `settle.py watch` refuses to start
beside it. So the Edit guard now separates the two states and prints this one:

    ps -Ao pid=,command= | grep '[s]ettle.py watch'
    kill <pid>
    # its last heartbeat ages out within 180s, and until it does
    # `settle.py watch` refuses to start
    python3 scripts/pr/settle.py watch

Two cases pin the pair, and the older-form message is red without the branch that produces it.
Meanwhile a `watcher` deferral gets writing going again — and while one is armed the old watcher
keeps rewriting `~/.velvet-pr-ready` under the readiness rule this change replaces, so what it lists
until it is killed is the old answer.

## Documentation

CONTRIBUTING.md's guard section gains the Stop contract. Its release-window section is narrowed
rather than cleared: the publication reason is now one of the reasons readiness is decided from, but
`published_check.unpublished_reason` answers None on any git failure, so an `ls-remote` that times out
mid-poll records the green ones ready again and the stall returns for as long as that lasts. The
wedged-process section is left alone: a watcher hung on a `gh` call is in interruptible sleep and
killable, so it is not in the set that section is about, and with every call inside the lock bounded
it cannot hang there indefinitely anyway.

No CHANGELOG entry: nothing here reaches the published package.

## What the evidence is, and what it is not

Each fix was measured by reverting that production change alone and watching the case named for it
fail on its assertion — the fork reading and the fork comparison, the zero-check reading against both
of the wrong shapes it sits between, an unread merge state and one that answered and named nothing,
the partial-failure verdict, each of the two heartbeat stamps, the lock, the report's count and its
remedy, the all-held sentence, and each of the Stop check's new faults.

`base_red_check.py --lane python` reports exit 0 with every changed case red on the base, and that
number is worth nothing here: reading its own transcript, **57 cases died and none of them on an
assertion** — 51 `AttributeError`, 5 `TypeError`, 1 `RuntimeError`. This branch renames and adds
symbols, so the base cannot import what the cases name, and the Python lane has no verdict for "could
not resolve" — it records a non-zero exit as Failed, which reads identically to a behaviour the base
gets wrong. The per-fix reverts above are the evidence; the base-red exit is not.
