### PR TITLE
test(velvet): derive the arbitrary-longhand rows instead of trusting them

### DIFF
--- a/Packages/com.velvet.core/Runtime/Styling/StyleArbitraryLonghands.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleArbitraryLonghands.cs
@@ -4,13 +4,14 @@ namespace Velvet
     // pins. Two vocabularies describe one cascade — an inline layer and a USS class contend for the same
     // storage slot — and only this translation lets StyleClassProjection compare them.
     //
-    // Every row is re-derived by StyleArbitraryLonghandTableTests, which applies each property to a bare
-    // element and fails when a row stops matching the slots that came away written.
-    //
     // The filter family and FilterCustom map to nothing on purpose. Filters COMPOSE rather than override, so
     // "a class already claims filter" is not a reason to drop a layer; and re-resolving a filter property
     // hands the composed list to the transition driver and restarts its tween. Their string-keyed identity
     // (a registered custom-filter name, not an ArbitraryProperty) therefore never has to be modelled at all.
+    //
+    // Both halves are held to what the properties actually write by StyleArbitraryLonghandTableTests, which
+    // probes each one: a mapped row that stops matching fails, and so does a filter row that stops being
+    // empty.
     internal static class StyleArbitraryLonghands
     {
         private static readonly StyleLonghandSet[] s_sets = Build();

--- a/Packages/com.velvet.core/Runtime/Styling/StyleArbitraryLonghands.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleArbitraryLonghands.cs
@@ -4,6 +4,9 @@ namespace Velvet
     // pins. Two vocabularies describe one cascade — an inline layer and a USS class contend for the same
     // storage slot — and only this translation lets StyleClassProjection compare them.
     //
+    // Every row is re-derived by StyleArbitraryLonghandTableTests, which applies each property to a bare
+    // element and fails when a row stops matching the slots that came away written.
+    //
     // The filter family and FilterCustom map to nothing on purpose. Filters COMPOSE rather than override, so
     // "a class already claims filter" is not a reason to drop a layer; and re-resolving a filter property
     // hands the composed list to the transition driver and restarts its tween. Their string-keyed identity

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/StyleArbitraryLonghandTableTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/StyleArbitraryLonghandTableTests.cs
@@ -12,22 +12,26 @@ namespace Velvet.Tests
     /// Pins <see cref="StyleArbitraryLonghands"/> — the map from each <see cref="ArbitraryProperty"/> to the
     /// <see cref="StyleLonghand"/> slots it writes — by re-deriving it rather than restating it: every member
     /// is applied to a bare element through <see cref="StyleArbitraryValueResolver.Apply"/> and the inline
-    /// slots that came away non-<see cref="StyleKeyword.Null"/> are compared against its declared row.
+    /// slots that came away non-<see cref="StyleKeyword.Null"/> are read back beside its declared row.
     /// <see cref="StyleClassProjection"/> reads that map to decide whether an inline arbitrary layer and a
-    /// USS utility class are contending for one slot, so a row that names the wrong slot costs the class its
-    /// win with no diagnostic: with the transform-origin row pointed at another slot,
-    /// <c>origin-[10%_20%] md:origin-top-left</c> keeps painting the bracket pivot, because the layer's slot
-    /// set no longer overlaps what the class claims and no floor is recorded.
+    /// USS utility class are contending for one slot. What a wrong row costs a user is stated on the one
+    /// case that covered a row before this fixture, in <see cref="VariantClassProjectionPanelTests"/>.
     /// </summary>
     /// <remarks>
     /// Panel-free by design, like <see cref="MotionPropertyChannelTests"/>: every reading is of the INLINE
     /// style the resolver writes, which needs no layout pass, no stylesheet and no panel. The composed-filter
-    /// family is held out of the map on purpose and gets its own case below rather than a silent skip. GWT,
-    /// one assert per case.
+    /// family is held out of the map on purpose and gets its own case below rather than a silent skip — its
+    /// rows are the inverse claim, failing when one is filled IN.
     /// </remarks>
     [TestFixture]
     internal sealed class StyleArbitraryLonghandTableTests
     {
+        // The members whose row is compared to their probe directly — everything the composed-filter family
+        // does not hold out. A literal rather than the complement of the family, so a family that swallowed
+        // a mapped member cannot shrink both sides of the comparison together. Updated deliberately when an
+        // ArbitraryProperty is added.
+        private const int MappedPropertyCount = 60;
+
         private readonly List<UnityEngine.Object> _spawned = new();
 
         [TearDown]
@@ -50,12 +54,11 @@ namespace Velvet.Tests
         {
             // Arrange
             var family = ComposedFilterFamily();
-            var properties = Enum.GetValues(typeof(ArbitraryProperty)).Cast<ArbitraryProperty>().ToList();
 
             // Act
             var compared = 0;
             var disagreements = new List<string>();
-            foreach (var property in properties)
+            foreach (ArbitraryProperty property in Enum.GetValues(typeof(ArbitraryProperty)))
             {
                 if (family.Contains(property))
                 {
@@ -74,7 +77,7 @@ namespace Velvet.Tests
             // leave this green with nothing derived. The disagreements are joined into the message for the
             // reason MotionPropertyChannelTests joins its own.
             Assert.That((compared, string.Join("; ", disagreements)),
-                Is.EqualTo((properties.Count - family.Count, string.Empty)));
+                Is.EqualTo((MappedPropertyCount, string.Empty)));
         }
 
         // GREEN_ON_BASE(characterization): the family is already held out on purpose; the case pins that
@@ -99,25 +102,52 @@ namespace Velvet.Tests
                 }
             }
 
-            // Assert
-            Assert.That((family.Count > 0, string.Join("; ", offenders)), Is.EqualTo((true, string.Empty)));
+            // Assert — the family's size is the enum's less the mapped count, so a family that gained or lost
+            // a member fails here rather than quietly changing which members the case above compares.
+            Assert.That((family.Count, string.Join("; ", offenders)),
+                Is.EqualTo((Enum.GetValues(typeof(ArbitraryProperty)).Length - MappedPropertyCount,
+                    string.Empty)));
         }
 
-        // GREEN_ON_BASE(characterization): the reading instrument the two cases above depend on already
-        // covers the whole vocabulary; the case keeps a later gap from reading as agreement.
+        // GREEN_ON_BASE(characterization): the vocabulary already reaches every inline slot one-to-one; the
+        // case keeps a later gap or a mis-aimed accessor from reading as agreement.
         [Test]
-        public void Given_TheLonghandVocabulary_When_EachMemberIsMappedToItsInlineSlot_Then_EveryOneResolves()
+        public void Given_EveryInlineStyleSlot_When_ReachedThroughTheLonghandVocabulary_Then_ExactlyOneLonghandReachesEach()
         {
-            // Arrange / Act
+            // Arrange — the probe sees a write only through this mapping, so a slot no longhand reaches is one
+            // a property could write unobserved, and two longhands reaching one slot means at least one of
+            // them is aimed at the wrong accessor. Deprecated slots are held out of the reach requirement:
+            // the vocabulary derives from the bundled stylesheets and does not carry them.
+            var reached = new Dictionary<string, List<string>>();
+            foreach (var slot in s_inlineSlots)
+            {
+                var name = slot.Value.Accessor.Name;
+                if (!reached.TryGetValue(name, out var owners))
+                {
+                    reached[name] = owners = new List<string>();
+                }
+                owners.Add(slot.Key.ToString());
+            }
+
+            // Act
             var unresolved = Enum.GetValues(typeof(StyleLonghand)).Cast<StyleLonghand>()
                 .Where(longhand => !s_inlineSlots.ContainsKey(longhand))
                 .Select(longhand => longhand.ToString())
                 .ToList();
+            var shared = reached.Where(entry => entry.Value.Count > 1)
+                .Select(entry => $"{entry.Key} <- {string.Join("+", entry.Value)}")
+                .ToList();
+            var unreached = typeof(IStyle).GetProperties()
+                .Where(property => IsStyleSlot(property)
+                    && property.GetCustomAttribute<ObsoleteAttribute>() == null
+                    && !reached.ContainsKey(property.Name))
+                .Select(property => property.Name)
+                .ToList();
 
-            // Assert — an empty vocabulary would likewise report nothing unresolved, so the population the
-            // mapping did reach is part of the claim.
-            Assert.That((s_inlineSlots.Count > 0, string.Join(",", unresolved)),
-                Is.EqualTo((true, string.Empty)));
+            // Assert — an empty vocabulary leaves every slot unreached and an empty IStyle leaves every
+            // longhand unresolved, so neither side can go vacuous without the other reporting it.
+            Assert.That((string.Join(",", unresolved), string.Join(",", shared), string.Join(",", unreached)),
+                Is.EqualTo((string.Empty, string.Empty, string.Empty)));
         }
 
         // The members routed to the composed filter applier, taken from the resolver's own membership set so
@@ -183,22 +213,24 @@ namespace Velvet.Tests
             s_inlineSlots = BuildInlineSlots();
 
         // A longhand missing from this map would make every property that writes it read as writing nothing,
-        // and a row naming neither would then agree with the probe; the vocabulary case above is what fails
-        // when one stops resolving.
+        // and a row naming neither would then agree with the probe; the slot-reach case above is what fails
+        // when one stops resolving or lands on another longhand's accessor.
         private static Dictionary<StyleLonghand, (PropertyInfo, PropertyInfo)> BuildInlineSlots()
         {
             var slots = new Dictionary<StyleLonghand, (PropertyInfo, PropertyInfo)>();
             foreach (StyleLonghand longhand in Enum.GetValues(typeof(StyleLonghand)))
             {
                 var accessor = typeof(IStyle).GetProperty(AccessorName(longhand));
-                var keyword = accessor?.PropertyType.GetProperty("keyword");
-                if (accessor != null && keyword != null)
+                if (accessor != null && IsStyleSlot(accessor))
                 {
-                    slots[longhand] = (accessor, keyword);
+                    slots[longhand] = (accessor, accessor.PropertyType.GetProperty("keyword"));
                 }
             }
             return slots;
         }
+
+        private static bool IsStyleSlot(PropertyInfo property) =>
+            property.PropertyType.GetProperty("keyword")?.PropertyType == typeof(StyleKeyword);
 
         private static string AccessorName(StyleLonghand longhand)
         {

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/StyleArbitraryLonghandTableTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/StyleArbitraryLonghandTableTests.cs
@@ -1,0 +1,213 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins <see cref="StyleArbitraryLonghands"/> — the map from each <see cref="ArbitraryProperty"/> to the
+    /// <see cref="StyleLonghand"/> slots it writes — by re-deriving it rather than restating it: every member
+    /// is applied to a bare element through <see cref="StyleArbitraryValueResolver.Apply"/> and the inline
+    /// slots that came away non-<see cref="StyleKeyword.Null"/> are compared against its declared row.
+    /// <see cref="StyleClassProjection"/> reads that map to decide whether an inline arbitrary layer and a
+    /// USS utility class are contending for one slot, so a row that names the wrong slot costs the class its
+    /// win with no diagnostic: with the transform-origin row pointed at another slot,
+    /// <c>origin-[10%_20%] md:origin-top-left</c> keeps painting the bracket pivot, because the layer's slot
+    /// set no longer overlaps what the class claims and no floor is recorded.
+    /// </summary>
+    /// <remarks>
+    /// Panel-free by design, like <see cref="MotionPropertyChannelTests"/>: every reading is of the INLINE
+    /// style the resolver writes, which needs no layout pass, no stylesheet and no panel. The composed-filter
+    /// family is held out of the map on purpose and gets its own case below rather than a silent skip. GWT,
+    /// one assert per case.
+    /// </remarks>
+    [TestFixture]
+    internal sealed class StyleArbitraryLonghandTableTests
+    {
+        private readonly List<UnityEngine.Object> _spawned = new();
+
+        [TearDown]
+        public void TearDown()
+        {
+            foreach (var spawned in _spawned)
+            {
+                if (spawned != null)
+                {
+                    UnityEngine.Object.DestroyImmediate(spawned);
+                }
+            }
+            _spawned.Clear();
+        }
+
+        // GREEN_ON_BASE(characterization): every row already agrees with what the property writes; the
+        // case exists so a later row cannot drift away from it unnoticed.
+        [Test]
+        public void Given_EveryArbitraryPropertyOutsideTheFilterFamily_When_ItsInlineWritesAreProbed_Then_TheyMatchItsDeclaredRow()
+        {
+            // Arrange
+            var family = ComposedFilterFamily();
+            var properties = Enum.GetValues(typeof(ArbitraryProperty)).Cast<ArbitraryProperty>().ToList();
+
+            // Act
+            var compared = 0;
+            var disagreements = new List<string>();
+            foreach (var property in properties)
+            {
+                if (family.Contains(property))
+                {
+                    continue;
+                }
+                compared++;
+                var declared = DeclaredRow(property);
+                var written = ProbeInlineWrites(property);
+                if (declared != written)
+                {
+                    disagreements.Add($"{property}: row=[{declared}] writes=[{written}]");
+                }
+            }
+
+            // Assert — the compared population rides along so a loop that stopped reaching the members cannot
+            // leave this green with nothing derived. The disagreements are joined into the message for the
+            // reason MotionPropertyChannelTests joins its own.
+            Assert.That((compared, string.Join("; ", disagreements)),
+                Is.EqualTo((properties.Count - family.Count, string.Empty)));
+        }
+
+        // GREEN_ON_BASE(characterization): the family is already held out on purpose; the case pins that
+        // decision against what its members actually write.
+        [Test]
+        public void Given_TheComposedFilterFamily_When_ItsRowsAreReadBesideWhatItWrites_Then_EveryRowIsEmpty()
+        {
+            // Arrange — the family is held out of the map on purpose, on the grounds StyleArbitraryLonghands'
+            // own header states. Reading what each member writes beside its row is what keeps "empty" a
+            // decision rather than a member that turns out to write nothing at all.
+            var family = ComposedFilterFamily();
+
+            // Act
+            var offenders = new List<string>();
+            foreach (var property in family)
+            {
+                var declared = DeclaredRow(property);
+                var written = ProbeInlineWrites(property);
+                if (declared.Length != 0 || written != nameof(StyleLonghand.Filter))
+                {
+                    offenders.Add($"{property}: row=[{declared}] writes=[{written}]");
+                }
+            }
+
+            // Assert
+            Assert.That((family.Count > 0, string.Join("; ", offenders)), Is.EqualTo((true, string.Empty)));
+        }
+
+        // GREEN_ON_BASE(characterization): the reading instrument the two cases above depend on already
+        // covers the whole vocabulary; the case keeps a later gap from reading as agreement.
+        [Test]
+        public void Given_TheLonghandVocabulary_When_EachMemberIsMappedToItsInlineSlot_Then_EveryOneResolves()
+        {
+            // Arrange / Act
+            var unresolved = Enum.GetValues(typeof(StyleLonghand)).Cast<StyleLonghand>()
+                .Where(longhand => !s_inlineSlots.ContainsKey(longhand))
+                .Select(longhand => longhand.ToString())
+                .ToList();
+
+            // Assert — an empty vocabulary would likewise report nothing unresolved, so the population the
+            // mapping did reach is part of the claim.
+            Assert.That((s_inlineSlots.Count > 0, string.Join(",", unresolved)),
+                Is.EqualTo((true, string.Empty)));
+        }
+
+        // The members routed to the composed filter applier, taken from the resolver's own membership set so
+        // a filter added there is covered without anyone remembering.
+        private static HashSet<ArbitraryProperty> ComposedFilterFamily()
+        {
+            var field = typeof(StyleArbitraryValueResolver)
+                    .GetField("s_filterSet", BindingFlags.NonPublic | BindingFlags.Static)
+                ?? throw new InvalidOperationException(
+                    "StyleArbitraryValueResolver.s_filterSet no longer exists to derive the family from");
+            var family = new HashSet<ArbitraryProperty>((HashSet<ArbitraryProperty>)field.GetValue(null));
+            // filter-[name:args] is keyed by the registered name rather than by this property, so it never
+            // reaches the projection as a layer at all and the resolver's set does not carry it.
+            family.Add(ArbitraryProperty.FilterCustom);
+            return family;
+        }
+
+        private static string DeclaredRow(ArbitraryProperty property)
+        {
+            var row = StyleArbitraryLonghands.Of(property);
+            return Join(Enum.GetValues(typeof(StyleLonghand)).Cast<StyleLonghand>().Where(row.Contains));
+        }
+
+        private string ProbeInlineWrites(ArbitraryProperty property)
+        {
+            var probe = new VisualElement();
+            StyleArbitraryValueResolver.Apply(probe, ProbeValue(property));
+            var style = probe.style;
+            return Join(s_inlineSlots
+                .Where(slot => (StyleKeyword)slot.Value.Keyword.GetValue(slot.Value.Accessor.GetValue(style))
+                    != StyleKeyword.Null)
+                .Select(slot => slot.Key));
+        }
+
+        private static string Join(IEnumerable<StyleLonghand> longhands) =>
+            string.Join("+", longhands.Select(longhand => longhand.ToString())
+                .OrderBy(name => name, StringComparer.Ordinal));
+
+        // The magnitude and the colour are arbitrary: which slots the payload lands in is what is under test.
+        private ArbitraryStyle ProbeValue(ArbitraryProperty property)
+        {
+            if (property == ArbitraryProperty.FilterCustom)
+            {
+                var definition = ScriptableObject.CreateInstance<FilterFunctionDefinition>();
+                definition.parameters = new[]
+                {
+                    new FilterParameterDeclaration
+                    {
+                        name = "amount",
+                        interpolationDefaultValue = new FilterParameter(0.5f),
+                    },
+                };
+                _spawned.Add(definition);
+                return new ArbitraryStyle(property,
+                    new CustomFilterValue("probe", definition, new[] { new FilterParameter(0.5f) }));
+            }
+            return MotionPropertyClassParser.IsColor(property)
+                ? new ArbitraryStyle(property, Color.red)
+                : new ArbitraryStyle(property, 7f, LengthUnit.Pixel);
+        }
+
+        private static readonly Dictionary<StyleLonghand, (PropertyInfo Accessor, PropertyInfo Keyword)>
+            s_inlineSlots = BuildInlineSlots();
+
+        // A longhand missing from this map would make every property that writes it read as writing nothing,
+        // and a row naming neither would then agree with the probe; the vocabulary case above is what fails
+        // when one stops resolving.
+        private static Dictionary<StyleLonghand, (PropertyInfo, PropertyInfo)> BuildInlineSlots()
+        {
+            var slots = new Dictionary<StyleLonghand, (PropertyInfo, PropertyInfo)>();
+            foreach (StyleLonghand longhand in Enum.GetValues(typeof(StyleLonghand)))
+            {
+                var accessor = typeof(IStyle).GetProperty(AccessorName(longhand));
+                var keyword = accessor?.PropertyType.GetProperty("keyword");
+                if (accessor != null && keyword != null)
+                {
+                    slots[longhand] = (accessor, keyword);
+                }
+            }
+            return slots;
+        }
+
+        private static string AccessorName(StyleLonghand longhand)
+        {
+            if (longhand == StyleLonghand.UnityFontStyle)
+            {
+                return "unityFontStyleAndWeight";
+            }
+            var name = longhand.ToString();
+            return char.ToLowerInvariant(name[0]) + name.Substring(1);
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/StyleArbitraryLonghandTableTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/StyleArbitraryLonghandTableTests.cs
@@ -28,8 +28,8 @@ namespace Velvet.Tests
     {
         // The members whose row is compared to their probe directly — everything the composed-filter family
         // does not hold out. A literal rather than the complement of the family, so a family that swallowed
-        // a mapped member cannot shrink both sides of the comparison together. Updated deliberately when an
-        // ArbitraryProperty is added.
+        // a mapped member cannot shrink both sides of the comparison together. Updated deliberately when a
+        // MAPPED property is added; a filter member added to the resolver's set leaves it where it is.
         private const int MappedPropertyCount = 60;
 
         private readonly List<UnityEngine.Object> _spawned = new();
@@ -57,7 +57,7 @@ namespace Velvet.Tests
 
             // Act
             var compared = 0;
-            var disagreements = new List<string>();
+            var problems = new List<string>();
             foreach (ArbitraryProperty property in Enum.GetValues(typeof(ArbitraryProperty)))
             {
                 if (family.Contains(property))
@@ -69,15 +69,18 @@ namespace Velvet.Tests
                 var written = ProbeInlineWrites(property);
                 if (declared != written)
                 {
-                    disagreements.Add($"{property}: row=[{declared}] writes=[{written}]");
+                    problems.Add($"{property}: row=[{declared}] writes=[{written}]");
                 }
             }
+            if (compared != MappedPropertyCount)
+            {
+                problems.Add($"compared {compared} members, MappedPropertyCount says {MappedPropertyCount}");
+            }
 
-            // Assert — the compared population rides along so a loop that stopped reaching the members cannot
-            // leave this green with nothing derived. The disagreements are joined into the message for the
-            // reason MotionPropertyChannelTests joins its own.
-            Assert.That((compared, string.Join("; ", disagreements)),
-                Is.EqualTo((MappedPropertyCount, string.Empty)));
+            // Assert — the population is folded into the message rather than compared beside it, so the
+            // failure names the literal a maintainer has to update. The problems are joined into one string
+            // for the reason MotionPropertyChannelTests joins its own.
+            Assert.That(string.Join("; ", problems), Is.Empty);
         }
 
         // GREEN_ON_BASE(characterization): the family is already held out on purpose; the case pins that
@@ -91,22 +94,27 @@ namespace Velvet.Tests
             var family = ComposedFilterFamily();
 
             // Act
-            var offenders = new List<string>();
+            var problems = new List<string>();
             foreach (var property in family)
             {
                 var declared = DeclaredRow(property);
                 var written = ProbeInlineWrites(property);
                 if (declared.Length != 0 || written != nameof(StyleLonghand.Filter))
                 {
-                    offenders.Add($"{property}: row=[{declared}] writes=[{written}]");
+                    problems.Add($"{property}: row=[{declared}] writes=[{written}]");
                 }
             }
+            // The same inequality the case above states from the other side, so nothing can move one
+            // population without moving the other: it is one partition check, carried by both cases so
+            // neither depends on the other having run.
+            var room = Enum.GetValues(typeof(ArbitraryProperty)).Length - MappedPropertyCount;
+            if (family.Count != room)
+            {
+                problems.Add($"{family.Count} filter members, MappedPropertyCount leaves room for {room}");
+            }
 
-            // Assert — the family's size is the enum's less the mapped count, so a family that gained or lost
-            // a member fails here rather than quietly changing which members the case above compares.
-            Assert.That((family.Count, string.Join("; ", offenders)),
-                Is.EqualTo((Enum.GetValues(typeof(ArbitraryProperty)).Length - MappedPropertyCount,
-                    string.Empty)));
+            // Assert
+            Assert.That(string.Join("; ", problems), Is.Empty);
         }
 
         // GREEN_ON_BASE(characterization): the vocabulary already reaches every inline slot one-to-one; the
@@ -116,8 +124,11 @@ namespace Velvet.Tests
         {
             // Arrange — the probe sees a write only through this mapping, so a slot no longhand reaches is one
             // a property could write unobserved, and two longhands reaching one slot means at least one of
-            // them is aimed at the wrong accessor. Deprecated slots are held out of the reach requirement:
-            // the vocabulary derives from the bundled stylesheets and does not carry them.
+            // them is aimed at the wrong accessor. A newly unreached slot is added to the hand-kept
+            // vocabulary in Generators~/src/Velvet.StyleTable/UssPropertyVocabulary.cs, not to the bundled
+            // stylesheets. The one slot IStyle exposes that the vocabulary omits is a SHORTHAND, which
+            // StyleLonghand holds none of; the ObsoleteAttribute filter that skips it here is the one
+            // PooledElementStyleGhostTests applies, on the reason stated there.
             var reached = new Dictionary<string, List<string>>();
             foreach (var slot in s_inlineSlots)
             {

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/StyleArbitraryLonghandTableTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/StyleArbitraryLonghandTableTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 81e01cdbd1416449389db9e953c9d5a2


### PR DESCRIPTION
`StyleArbitraryLonghands` maps each `ArbitraryProperty` onto the `StyleLonghand` slots it writes, and `StyleClassProjection` reads that map to decide whether an inline arbitrary layer and a USS utility class are contending for one slot. Nothing derived it, and a wrong row is silent: what it costs a user is stated on `VariantClassProjectionPanelTests.Given_AnArbitraryPivotAndAVariantKeywordPivot_When_TheVariantApplies_Then_TheKeywordWins`, which was the only case covering any row.

The rows are re-derived now rather than reviewed, the way `MotionPropertyChannelTests` pins the sibling slot table: each member is applied to a bare element through `StyleArbitraryValueResolver.Apply`, and the inline slots that came away non-`Null` are read back beside its declared row. The loop iterates the enum, so a member added later is covered without anyone remembering, and the composed-filter family is taken from the resolver's own membership set for the same reason.

## The probe surface

69 `ArbitraryProperty` members, and every one of them can be applied to a bare `VisualElement` and read back — the shorthands that fan out to several edges, the axis pairs that compose onto one engine property, `TransitionDuration` and `FilterCustom` included. **Nothing is excluded from probing.**

- **60** are compared against their declared row directly.
- **9** need a different reading: the composed-filter family, the eight built-ins plus `FilterCustom`. Each writes the single `filter` slot, and each declares the empty row on purpose — filters compose rather than override, so a class already claiming `filter` is no reason to retire a layer. They get their own case instead of a silent skip, and that case is the inverse claim: it fails when a row is filled **in**, and it reads what each member writes beside its row so "empty" stays a decision rather than a member that turns out to write nothing.
- The probe sees a write only through a mapping from `StyleLonghand` to its `IStyle` accessor, so a third case runs that mapping the other way: each of the **89** style-valued `IStyle` properties is reached by exactly one longhand, bar one. That one is `unityBackgroundScaleMode`, which the vocabulary omits because it is a **shorthand** — `UssPropertyVocabulary.Shorthands` lists it, and `StyleLonghand` holds longhands only. Its `[Obsolete]` marker, which is what the case filters on, is a coincidence: it is the only one of the ten shorthands that exists as an `IStyle` property at all. The filter is the one `PooledElementStyleGhostTests` already applies.

This case closes the mapping's own two blind spots, a longhand that stops resolving and an accessor aimed at the wrong slot. It does not by itself establish that every write goes through `IStyle`; nothing here pins that.

No row turned out to be wrong. The map is correct as it stands; what it lacked was anything that would say otherwise.

## How much was covered before

Two rows were set wrong and the whole EditMode suite run against each:

- **transform-origin → `StyleLonghand.Translate`**: two cases fail — the new one, and `VariantClassProjectionPanelTests.Given_AnArbitraryPivotAndAVariantKeywordPivot_When_TheVariantApplies_Then_TheKeywordWins` with `Expected: (0, 0)` / `But was: (100, 0)`, the bracket pivot still painting. That is the one indirect pin this row had.
- **inset-x → `Top, Bottom`** (copied from the `InsetY` line below it): one case fails, the new one. All 3881 others stay green.

## Red on a wrong row

Each perturbation was applied and reverted, and each case reports the problems it found as one joined string:

| perturbed | case | reported |
| --- | --- | --- |
| `TransformOrigin` row → `StyleLonghand.Translate` | 1 | `TransformOrigin: row=[Translate] writes=[TransformOrigin]` |
| `InsetX` row → `Top, Bottom` | 1 | `InsetX: row=[Bottom+Top] writes=[Left+Right]` |
| `FilterBlur` given the `Filter` slot it composes into | 2 | `FilterBlur: row=[Filter] writes=[Filter]` |
| `BuildFilter` made to return null for `FilterBlur` | 2 | `FilterBlur: row=[] writes=[]` |
| the family swallows a mapped member (`Opacity`) | 1 | `compared 59 members, MappedPropertyCount says 60` — alone, no row problem beside it |
| the family loses a member (`FilterCustom`) | 2 | `8 filter members, MappedPropertyCount leaves room for 9` — alone, no row problem beside it |
| a 70th **mapped** property added to the enum | 1, 2 | `compared 61 members, MappedPropertyCount says 60` and `9 filter members, MappedPropertyCount leaves room for 10` |
| the one accessor that is not its longhand's camelCase name, aimed at `unityFontDefinition` | 3 | `unityFontDefinition <- UnityFontDefinition+UnityFontStyle` and `unityFontStyleAndWeight` unreached |
| that same accessor removed | 3 | `UnityFontStyle` unresolved and `unityFontStyleAndWeight` unreached |

Every term of every assertion discriminates. The two population terms are **one inequality**, not two checks — case 1 fires iff `enum − family ≠ 60` and case 2 iff `family ≠ enum − 60` — so no change can move one without the other; each case carries it so neither depends on the other having run. Both name `MappedPropertyCount` in the failure, because the literal needing an update is what a maintainer has to act on.

The three cases are green on the merge base by construction — they cross-check two sources the base already carries — and each declares `GREEN_ON_BASE(characterization)` with its reason.

## Documentation and changelog

No `Documentation~` guide names `StyleArbitraryLonghands`, `StyleClassProjection` or the map itself, and no behaviour changes here, so there is no guide to update and no changelog entry. The only production edit is a comment in `StyleArbitraryLonghands.cs` stating what the new case holds each half of the map to.

Closes #572
