### PR TITLE
fix(velvet): let a nested Suspense keep its own children offscreen

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -66,7 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   fallback occupied — the fallback left the tree and the half-loaded content took its place. Each
   boundary now keeps the answer it gave for the children it suspended over, so an outer boundary
   resolving says nothing about an inner one that has not. An outer boundary that suspends still hides
-  the inner boundary's fallback along with everything else it covers, and releases it again on resolve.
+  the inner boundary's fallback, and releases it again on resolve.
 - Two `V.Suspense` boundaries in one component's render no longer share a single suspended mark. One
   showing its fallback while a second, placed after it, rendered its children left the component
   unmarked, so a state update inside the first one's hidden children stopped being deferred and

--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -59,6 +59,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   so a subscription a closing modal's top-level component opened outlived the modal. The disposal
   follows the portal the component was written under, so on a container several portals share, one of
   them closing leaves the others' components mounted and takes only its own.
+- A `V.Suspense` nested inside another one's children no longer loses its fallback when the outer
+  boundary resolves. The outer boundary's expansion wrote its own answer over every fiber it had
+  created, the inner boundary's hidden children included, so a state update inside content the inner
+  boundary was still waiting on stopped being deferred and committed into the slot range the inner
+  fallback occupied — the fallback left the tree and the half-loaded content took its place. Each
+  boundary now keeps the answer it gave for the children it suspended over, so an outer boundary
+  resolving says nothing about an inner one that has not. An outer boundary that suspends still hides
+  the inner boundary's fallback along with everything else it covers, and releases it again on resolve.
 - Two `V.Suspense` boundaries in one component's render no longer share a single suspended mark. One
   showing its fallback while a second, placed after it, rendered its children left the component
   unmarked, so a state update inside the first one's hidden children stopped being deferred and

--- a/Packages/com.velvet.core/Runtime/Component/ComponentFiber.cs
+++ b/Packages/com.velvet.core/Runtime/Component/ComponentFiber.cs
@@ -187,8 +187,9 @@ namespace Velvet
         /// <summary>
         /// True while this fiber is a primary (hidden) child of a wrapper-less Suspense that is currently
         /// showing its fallback. Written by <c>GeneralPathReconciler.ExpandSuspenseInline</c> over the
-        /// fibers that expansion created — which is not the same as per-Suspense, since an enclosing
-        /// Suspense's expansion writes over an inner one's fibers too. <see cref="FiberWorkLoop.FlushState"/>'s
+        /// fibers that expansion created, less the ones a nested Suspense that suspended created: that
+        /// boundary owns its own primary subtree, so an enclosing one resolving leaves it
+        /// hidden. <see cref="FiberWorkLoop.FlushState"/>'s
         /// offscreen guard defers a lane flush for offscreen fibers (their slot is occupied by the
         /// fallback). It is per-fiber rather than per-boundary because one component fiber can render
         /// several Suspense nodes: that Suspense's own visible fallback subtree, and a sibling Suspense's

--- a/Packages/com.velvet.core/Runtime/Component/V.cs
+++ b/Packages/com.velvet.core/Runtime/Component/V.cs
@@ -2183,8 +2183,9 @@ namespace Velvet
         #region Suspense
 
         /// <summary>
-        /// Boundary that displays <paramref name="fallback"/> while any descendant declares a pending async
-        /// resource via <c>Use&lt;T&gt;()</c>, until the resource resolves.
+        /// Boundary that displays <paramref name="fallback"/> while a descendant declares a pending async
+        /// resource via <c>Use&lt;T&gt;()</c>, until the resource resolves. A descendant behind a nested
+        /// <c>V.Suspense()</c> is caught by that boundary instead, so it does not raise this one's fallback.
         /// On error, the failure is propagated to the nearest Error Boundary
         /// (a component that overrides <c>RenderFallback</c>).
         /// </summary>

--- a/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
@@ -1022,15 +1022,15 @@ namespace Velvet
                     }
                     // Mark THIS Suspense's primary children (the fibers added during the children
                     // expansion) as offscreen iff suspended. The offscreen guard in FlushState defers
-                    // their lane flush while suspended (their slot is occupied by the fallback), but the
-                    // fallback subtree — expanded below, so this loop never reaches it — remains flushable
-                    // (the fallback renders normally; only the primary subtree is offscreen).
+                    // their lane flush while suspended (their slot is occupied by the fallback). The
+                    // fallback subtree is expanded below, so this loop never reaches it and this Suspense
+                    // leaves it flushable; what marks a nested Suspense's fallback subtree is the
+                    // enclosing expansion, whose own fallback occupies that slot too.
                     //
                     // A nested Suspense that suspended has already answered for the fibers it created, and
                     // this delta contains them, so its answer stands. Skipping by "the fiber's nearest
                     // boundary is a nested one" instead would also skip that boundary's fallback subtree
-                    // and its plain children, which an enclosing fallback hides too and which no expansion
-                    // would then be left to clear.
+                    // and its plain children, which no expansion would then be left to clear.
                     foreach (var f in newFibers)
                     {
                         if (fibersBefore.Contains(f)) continue;

--- a/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
@@ -1028,9 +1028,7 @@ namespace Velvet
                     // enclosing expansion, whose own fallback occupies that slot too.
                     //
                     // A nested Suspense that suspended has already answered for the fibers it created, and
-                    // this delta contains them, so its answer stands. Skipping by "the fiber's nearest
-                    // boundary is a nested one" instead would also skip that boundary's fallback subtree
-                    // and its plain children, which no expansion would then be left to clear.
+                    // this delta contains them, so its answer stands.
                     foreach (var f in newFibers)
                     {
                         if (fibersBefore.Contains(f)) continue;

--- a/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
@@ -421,6 +421,12 @@ namespace Velvet
             public int SlotStart;
             public List<ComponentFiber> OldFibers = null!;
             public HashSet<ComponentFiber> NewFibers = null!;
+            // Filled by a Suspense expansion that suspended and read by every enclosing one in this walk,
+            // which leaves those fibers' marks alone: NewFibers is one set for the whole walk, so an
+            // enclosing delta contains a nested Suspense's primary subtree, and an enclosing Suspense
+            // resolving is not the inner one resolving. Held on the walk rather than rented per expansion,
+            // since the enclosing loop reads it after the inner one has returned its own buffers.
+            public readonly HashSet<ComponentFiber> OffscreenPrimaries = new();
             public ProviderPairTable? Providers;
             public ProviderPairTable? OldProvidersForPairing;
             public GeneralCommitState? Commit;
@@ -444,6 +450,7 @@ namespace Velvet
                 OldProvidersForPairing = null;
                 Commit = null;
                 NewProviderOrdinal = 0;
+                OffscreenPrimaries.Clear();
             }
         }
 
@@ -973,6 +980,7 @@ namespace Velvet
         {
             var result = walk.Result;
             var newFibers = walk.NewFibers;
+            var offscreenPrimaries = walk.OffscreenPrimaries;
             var commit = walk.Commit;
             var boundaryFiber = _ctx.FiberStack.Current;
             var suspenseKey = FiberKeying.SuspenseKey(position.Scope, suspense.Key, nodeIndex);
@@ -1015,11 +1023,19 @@ namespace Velvet
                     // Mark THIS Suspense's primary children (the fibers added during the children
                     // expansion) as offscreen iff suspended. The offscreen guard in FlushState defers
                     // their lane flush while suspended (their slot is occupied by the fallback), but the
-                    // fallback subtree — expanded below and never marked — remains flushable (the
-                    // fallback renders normally; only the primary subtree is offscreen).
+                    // fallback subtree — expanded below, so this loop never reaches it — remains flushable
+                    // (the fallback renders normally; only the primary subtree is offscreen).
+                    //
+                    // A nested Suspense that suspended has already answered for the fibers it created, and
+                    // this delta contains them, so its answer stands. Skipping by "the fiber's nearest
+                    // boundary is a nested one" instead would also skip that boundary's fallback subtree
+                    // and its plain children, which an enclosing fallback hides too and which no expansion
+                    // would then be left to clear.
                     foreach (var f in newFibers)
                     {
-                        if (!fibersBefore.Contains(f)) f.IsOffscreen = suspended;
+                        if (fibersBefore.Contains(f)) continue;
+                        if (!offscreenPrimaries.Contains(f)) f.IsOffscreen = suspended;
+                        if (suspended) offscreenPrimaries.Add(f);
                     }
                     // Rollback and fallback expansion must run while fibersBefore is still live
                     // (rented from the pool, contents intact). Performing them after the finally

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/SuspenseBoundaryTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/SuspenseBoundaryTests.cs
@@ -499,10 +499,10 @@ namespace Velvet.Tests
         [Test]
         public void Given_TwoSuspenseNodesOnOneBoundaryFiber_When_TheOuterSuspendsAndAnInnerChildUpdates_Then_OuterFallbackKeepsItsSlot()
         {
-            // Arrange — no component sits between the two V.Suspense nodes, so one boundary fiber owns
-            // both records and FindNearestSuspenseBoundary answers with it for the inner one's children.
-            // The inner Suspense resolves, so it claims nothing and marks its children visible; the outer
-            // then suspends on its own second child and marks them over
+            // Arrange — the host's two Suspense nodes share one boundary fiber, for the reason
+            // SameFiberNestedHostRender states, so FindNearestSuspenseBoundary answers with that fiber for
+            // the inner one's children. The inner Suspense resolves, so it claims nothing and marks its
+            // children visible; the outer then suspends on its own second child and marks them over
             var source = new UniTaskCompletionSource<string>();
             s_sameFiberOuterFactory = _ => source.Task;
             using var mounted = V.Mount(_root, V.Component(SameFiberNestedHostRender, key: "host"));
@@ -513,7 +513,7 @@ namespace Velvet.Tests
 
             // Assert
             Assert.That(_root.FindLabelByText("outer-loading"), Is.Not.Null,
-                "A resolved inner Suspense's children are offscreen under the suspended enclosing one, so their flush does not patch over its fallback");
+                "Where one boundary fiber owns both Suspense nodes, a resolved inner one's children are offscreen under the suspended enclosing one, so their flush does not patch over its fallback");
         }
 
         #endregion

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/SuspenseBoundaryTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/SuspenseBoundaryTests.cs
@@ -22,8 +22,11 @@ namespace Velvet.Tests
     /// <item>A nested boundary catches its own descendant's suspension, so an outer boundary does not over-suspend
     /// when only the inner boundary's primary is pending.</item>
     /// <item>Sibling Suspense boundaries are tracked independently: resolving one boundary's child leaves the
-    /// other sibling's fallback unchanged, and one showing its fallback while a later sibling renders its
-    /// children keeps its own hidden descendants deferred without deferring that sibling's.</item>
+    /// other sibling's fallback unchanged, and one showing its fallback keeps its own hidden descendants
+    /// deferred without deferring the other's, whichever of the two expanded first.</item>
+    /// <item>A nested boundary owns its own descendants' visibility: an enclosing boundary that resolves leaves
+    /// the inner boundary's primary subtree deferred, while an enclosing boundary that suspends defers the
+    /// inner boundary's visible fallback subtree too and releases it again on resolve.</item>
     /// <item>A <c>Hooks.Use</c> resource that faults — synchronously or asynchronously — routes the exception to
     /// the nearest enclosing error boundary rather than the fallback.</item>
     /// <item>An unrelated parent re-render does not remove a still-pending child's fallback.</item>
@@ -63,6 +66,7 @@ namespace Velvet.Tests
             ResetTwoUses();
             ResetSiblingBoundaries();
             ResetOffscreenSibling();
+            ResetNestedOffscreen();
             ResetSuspenseHost();
             ResetParentRerender();
             ResetRootless();
@@ -388,6 +392,103 @@ namespace Velvet.Tests
             // Assert
             Assert.That(_root.FindLabelByText("sibling-1"), Is.Not.Null,
                 "A descendant of the resolved sibling Suspense is not offscreen, so its own flush still commits");
+        }
+
+        // GREEN_ON_BASE(characterization): the snapshot exclusion is the only thing separating these two
+        // in this order, since the resolved one expands first and claims nothing.
+        [Test]
+        public void Given_ResolvedBoundaryFollowedBySuspendedSibling_When_TheResolvedOnesDescendantUpdates_Then_ItRerenders()
+        {
+            // Arrange — the mirror order: the resolved Suspense expands first, so the suspended one's
+            // marking pass runs with the resolved one's children already in the walk's fiber set
+            var source = new UniTaskCompletionSource<string>();
+            s_offscreenFactory = _ => source.Task;
+            using var mounted = V.Mount(_root, V.Component(ResolvedFirstSiblingHostRender, key: "host"));
+
+            // Act
+            s_resolvedSiblingSetter.Invoke(1);
+            mounted.FlushStateForTest();
+
+            // Assert — the fallback term is folded in rather than assumed: with no boundary showing a
+            // fallback the offscreen walk never runs, and the update would commit whatever the marking did
+            Assert.That(
+                (_root.FindLabelByText("loading-D") != null, _root.FindLabelByText("sibling-1") != null),
+                Is.EqualTo((true, true)),
+                "While the later sibling holds its fallback up, the earlier resolved sibling's descendant is not offscreen and its own flush still commits");
+        }
+
+        #endregion
+
+        #region Nested boundary ownership of offscreen primaries
+
+        [Test]
+        public void Given_NestedBoundaries_When_InnerPrimaryDescendantUpdatesWhileOuterResolved_Then_InnerFallbackKeepsItsSlot()
+        {
+            // Arrange — only the inner boundary suspends, so the outer commits the inner's fallback as its
+            // own resolved output and its expansion covers the inner's offscreen primary subtree
+            var source = new UniTaskCompletionSource<string>();
+            s_nestedInnerFactory = _ => source.Task;
+            using var mounted = V.Mount(_root, V.Component(NestedPrimaryHostRender, key: "host"));
+            Assume.That(_root.FindLabelByText("inner-loading"), Is.Not.Null,
+                "Precondition: the inner boundary is showing its fallback");
+
+            // Act — a state update on a fiber inside the inner boundary's offscreen primary subtree
+            s_nestedPrimarySetter.Invoke(1);
+            mounted.FlushStateForTest();
+
+            // Assert
+            Assert.That(_root.FindLabelByText("inner-loading"), Is.Not.Null,
+                "An enclosing boundary resolving leaves the inner boundary's primary offscreen, so that primary's flush does not patch over the inner fallback");
+        }
+
+        // GREEN_ON_BASE(characterization): an enclosing boundary that suspends still hides an inner
+        // boundary's visible fallback subtree, which the nested-ownership skip must not reach.
+        [Test]
+        public void Given_NestedBoundariesBothSuspended_When_InnerFallbackDescendantUpdates_Then_OuterFallbackKeepsItsSlot()
+        {
+            // Arrange — a second suspending child suspends the OUTER boundary as well, so the inner
+            // boundary's fallback sits inside the rolled-back primary whose slot the outer fallback holds
+            var innerSource = new UniTaskCompletionSource<string>();
+            var outerSource = new UniTaskCompletionSource<string>();
+            s_nestedInnerFactory = _ => innerSource.Task;
+            s_nestedOuterFactory = _ => outerSource.Task;
+            using var mounted = V.Mount(_root, V.Component(NestedBothSuspendHostRender, key: "host"));
+            Assume.That(_root.FindLabelByText("outer-loading"), Is.Not.Null,
+                "Precondition: the outer boundary is showing its fallback");
+
+            // Act — a state update on a fiber inside the inner boundary's own fallback subtree
+            s_nestedFallbackSetter.Invoke(1);
+            mounted.FlushStateForTest();
+
+            // Assert
+            Assert.That(_root.FindLabelByText("outer-loading"), Is.Not.Null,
+                "The inner boundary's fallback is offscreen under the suspended outer boundary, so its flush does not patch over the outer fallback");
+        }
+
+        // GREEN_ON_BASE(characterization): the mark an enclosing suspend wrote on an inner boundary's
+        // fallback subtree is released when that enclosing boundary resolves.
+        [Test]
+        public void Given_NestedBoundariesBothSuspended_When_OuterResolvesAndInnerFallbackDescendantUpdates_Then_ItRerenders()
+        {
+            // Arrange — the outer resolves while the inner is still pending, which puts the inner
+            // boundary's fallback back on screen
+            var innerSource = new UniTaskCompletionSource<string>();
+            var outerSource = new UniTaskCompletionSource<string>();
+            s_nestedInnerFactory = _ => innerSource.Task;
+            s_nestedOuterFactory = _ => outerSource.Task;
+            using var mounted = V.Mount(_root, V.Component(NestedBothSuspendHostRender, key: "host"));
+            outerSource.TrySetResult("outer-ready");
+            mounted.FlushStateForTest();
+            Assume.That(_root.FindLabelByText("inner-fallback-0"), Is.Not.Null,
+                "Precondition: the outer revealed its children and the inner boundary is still showing its fallback");
+
+            // Act
+            s_nestedFallbackSetter.Invoke(1);
+            mounted.FlushStateForTest();
+
+            // Assert
+            Assert.That(_root.FindLabelByText("inner-fallback-1"), Is.Not.Null,
+                "A visible inner fallback flushes its own state update once the enclosing boundary has resolved");
         }
 
         #endregion
@@ -933,6 +1034,106 @@ namespace Velvet.Tests
                     children: new VNode[] { V.Component(ResolvedSiblingStatefulChildRender, key: "sibling") },
                     key: "b"),
             });
+
+        // The same two boundaries in the opposite order, so the suspended one's marking pass is the one
+        // that has to leave the other's children alone.
+        [Component]
+        private static VNode ResolvedFirstSiblingHostRender()
+            => V.Div(children: new VNode[]
+            {
+                V.Suspense(
+                    fallback: V.Label(text: "loading-C"),
+                    children: new VNode[] { V.Component(ResolvedSiblingStatefulChildRender, key: "sibling") },
+                    key: "c"),
+                V.Suspense(
+                    fallback: V.Label(text: "loading-D"),
+                    children: new VNode[] { V.Component(OffscreenSuspendingChildRender, key: "suspending") },
+                    key: "d"),
+            });
+
+        #endregion
+
+        #region NestedOffscreen components (a V.Suspense inside another V.Suspense's children)
+
+        private static Func<CancellationToken, UniTask<string>> s_nestedInnerFactory;
+        private static Func<CancellationToken, UniTask<string>> s_nestedOuterFactory;
+        private static Action<int> s_nestedPrimarySetter;
+        private static Action<int> s_nestedFallbackSetter;
+
+        private static void ResetNestedOffscreen()
+        {
+            s_nestedInnerFactory = null;
+            s_nestedOuterFactory = null;
+            s_nestedPrimarySetter = null;
+            s_nestedFallbackSetter = null;
+        }
+
+        // Renders before its suspending sibling so its fiber is created — and its setter captured — while
+        // the inner boundary's primary expansion is still in progress.
+        [Component]
+        private static VNode NestedPrimaryStatefulChildRender()
+        {
+            var (tick, setTick) = Hooks.UseState(0);
+            s_nestedPrimarySetter = setTick;
+            return V.Label(text: $"inner-primary-{tick}");
+        }
+
+        [Component]
+        private static VNode NestedInnerSuspendingChildRender()
+        {
+            var value = Hooks.Use(s_nestedInnerFactory, "nested-inner");
+            return V.Label(text: value);
+        }
+
+        [Component]
+        private static VNode NestedOuterSuspendingChildRender()
+        {
+            var value = Hooks.Use(s_nestedOuterFactory, "nested-outer");
+            return V.Label(text: value);
+        }
+
+        [Component]
+        private static VNode NestedStatefulFallbackRender()
+        {
+            var (tick, setTick) = Hooks.UseState(0);
+            s_nestedFallbackSetter = setTick;
+            return V.Label(text: $"inner-fallback-{tick}");
+        }
+
+        [Component]
+        private static VNode NestedPrimaryMiddleRender()
+            => V.Suspense(
+                fallback: V.Label(text: "inner-loading"),
+                children: new VNode[]
+                {
+                    V.Component(NestedPrimaryStatefulChildRender, key: "stateful"),
+                    V.Component(NestedInnerSuspendingChildRender, key: "suspending"),
+                });
+
+        // Nothing under the outer boundary suspends except through the inner one, which catches it — so the
+        // outer commits the inner's fallback as its own resolved output.
+        [Component]
+        private static VNode NestedPrimaryHostRender()
+            => V.Suspense(
+                fallback: V.Label(text: "outer-loading"),
+                children: new VNode[] { V.Component(NestedPrimaryMiddleRender, key: "middle") });
+
+        [Component]
+        private static VNode NestedStatefulFallbackMiddleRender()
+            => V.Suspense(
+                fallback: V.Component(NestedStatefulFallbackRender, key: "fb"),
+                children: new VNode[] { V.Component(NestedInnerSuspendingChildRender, key: "suspending") });
+
+        // The second child suspends outside the inner boundary, so the outer boundary suspends as well.
+        [Component]
+        private static VNode NestedBothSuspendHostRender()
+            => V.Suspense(
+                fallback: V.Label(text: "outer-loading"),
+                children: new VNode[]
+                {
+                    V.Component(NestedStatefulFallbackMiddleRender, key: "middle"),
+                    V.Component(NestedOuterSuspendingChildRender, key: "outer-suspending"),
+                });
 
         #endregion
 

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/SuspenseBoundaryTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/SuspenseBoundaryTests.cs
@@ -22,11 +22,14 @@ namespace Velvet.Tests
     /// <item>A nested boundary catches its own descendant's suspension, so an outer boundary does not over-suspend
     /// when only the inner boundary's primary is pending.</item>
     /// <item>Sibling Suspense boundaries are tracked independently: resolving one boundary's child leaves the
-    /// other sibling's fallback unchanged, and one showing its fallback keeps its own hidden descendants
-    /// deferred without deferring the other's, whichever of the two expanded first.</item>
+    /// other sibling's fallback unchanged. With the suspended one expanded first, it keeps its own hidden
+    /// descendants deferred without deferring the resolved sibling's; with the resolved one expanded first,
+    /// the later suspension does not reach back over the children already expanded.</item>
     /// <item>A nested boundary owns its own descendants' visibility: an enclosing boundary that resolves leaves
     /// the inner boundary's primary subtree deferred, while an enclosing boundary that suspends defers the
-    /// inner boundary's visible fallback subtree too and releases it again on resolve.</item>
+    /// inner boundary's visible fallback subtree too and releases it again on resolve. Where one component
+    /// fiber owns both Suspense nodes, a suspended enclosing one also defers a resolved inner one's
+    /// children.</item>
     /// <item>A <c>Hooks.Use</c> resource that faults — synchronously or asynchronously — routes the exception to
     /// the nearest enclosing error boundary rather than the fallback.</item>
     /// <item>An unrelated parent re-render does not remove a still-pending child's fallback.</item>
@@ -489,6 +492,28 @@ namespace Velvet.Tests
             // Assert
             Assert.That(_root.FindLabelByText("inner-fallback-1"), Is.Not.Null,
                 "A visible inner fallback flushes its own state update once the enclosing boundary has resolved");
+        }
+
+        // GREEN_ON_BASE(characterization): the enclosing expansion's mark over a resolved inner
+        // Suspense's children is the only thing deferring them here.
+        [Test]
+        public void Given_TwoSuspenseNodesOnOneBoundaryFiber_When_TheOuterSuspendsAndAnInnerChildUpdates_Then_OuterFallbackKeepsItsSlot()
+        {
+            // Arrange — no component sits between the two V.Suspense nodes, so one boundary fiber owns
+            // both records and FindNearestSuspenseBoundary answers with it for the inner one's children.
+            // The inner Suspense resolves, so it claims nothing and marks its children visible; the outer
+            // then suspends on its own second child and marks them over
+            var source = new UniTaskCompletionSource<string>();
+            s_sameFiberOuterFactory = _ => source.Task;
+            using var mounted = V.Mount(_root, V.Component(SameFiberNestedHostRender, key: "host"));
+
+            // Act
+            s_sameFiberInnerSetter.Invoke(1);
+            mounted.FlushStateForTest();
+
+            // Assert
+            Assert.That(_root.FindLabelByText("outer-loading"), Is.Not.Null,
+                "A resolved inner Suspense's children are offscreen under the suspended enclosing one, so their flush does not patch over its fallback");
         }
 
         #endregion
@@ -1057,15 +1082,19 @@ namespace Velvet.Tests
 
         private static Func<CancellationToken, UniTask<string>> s_nestedInnerFactory;
         private static Func<CancellationToken, UniTask<string>> s_nestedOuterFactory;
+        private static Func<CancellationToken, UniTask<string>> s_sameFiberOuterFactory;
         private static Action<int> s_nestedPrimarySetter;
         private static Action<int> s_nestedFallbackSetter;
+        private static Action<int> s_sameFiberInnerSetter;
 
         private static void ResetNestedOffscreen()
         {
             s_nestedInnerFactory = null;
             s_nestedOuterFactory = null;
+            s_sameFiberOuterFactory = null;
             s_nestedPrimarySetter = null;
             s_nestedFallbackSetter = null;
+            s_sameFiberInnerSetter = null;
         }
 
         // Renders before its suspending sibling so its fiber is created — and its setter captured — while
@@ -1123,6 +1152,37 @@ namespace Velvet.Tests
             => V.Suspense(
                 fallback: V.Component(NestedStatefulFallbackRender, key: "fb"),
                 children: new VNode[] { V.Component(NestedInnerSuspendingChildRender, key: "suspending") });
+
+        [Component]
+        private static VNode SameFiberInnerStatefulChildRender()
+        {
+            var (tick, setTick) = Hooks.UseState(0);
+            s_sameFiberInnerSetter = setTick;
+            return V.Label(text: $"inner-child-{tick}");
+        }
+
+        [Component]
+        private static VNode SameFiberOuterSuspendingChildRender()
+        {
+            var value = Hooks.Use(s_sameFiberOuterFactory, "same-fiber-outer");
+            return V.Label(text: value);
+        }
+
+        // Both V.Suspense nodes expand under the same FiberStack.Current — no component is written between
+        // them to push another — so one boundary fiber holds both records.
+        [Component]
+        private static VNode SameFiberNestedHostRender()
+            => V.Suspense(
+                fallback: V.Label(text: "outer-loading"),
+                children: new VNode[]
+                {
+                    V.Suspense(
+                        fallback: V.Label(text: "inner-loading"),
+                        children: new VNode[] { V.Component(SameFiberInnerStatefulChildRender, key: "inner-child") },
+                        key: "inner"),
+                    V.Component(SameFiberOuterSuspendingChildRender, key: "outer-suspending"),
+                },
+                key: "outer");
 
         // The second child suspends outside the inner boundary, so the outer boundary suspends as well.
         [Component]


### PR DESCRIPTION
Closes #609.

## What was wrong

`ExpandSuspenseInline` marks its own primary subtree offscreen by taking the delta of `walk.NewFibers` against a snapshot taken before that expansion:

```csharp
foreach (var f in newFibers)
{
    if (!fibersBefore.Contains(f)) f.IsOffscreen = suspended;
}
```

`NewFibers` is one set for the whole inline expansion, and an inner `V.Suspense` completes inside the outer one's children expansion — so the inner boundary's fibers are absent from the outer's snapshot and land in the outer's delta, where the outer wrote its own answer over them.

The case that reaches a user is the ordinary one: an inner boundary catches its own descendant's suspension, so the outer never suspends. Its `false` then cleared the marking the inner had just written, `FiberWorkLoop.FlushState` stopped deferring the inner boundary's hidden children, and a state update inside them committed into the slot range the inner fallback occupied — the fallback left the tree and the still-loading content took its place.

Pre-existing: `git show 533d122^` carries the byte-identical loop, so #607 neither introduced nor fixed it. It documented it — `ComponentFiber.IsOffscreen`'s XML doc said the flag "is not the same as per-Suspense, since an enclosing Suspense's expansion writes over an inner one's fibers too". That sentence is replaced by one describing the code left behind.

React bails at a nested hidden boundary in four separate traversals, `reappearLayoutEffects` (the outer-resolves direction) among them, so it cannot produce this.

## What changed

An expansion that suspends records the fibers it marked, on the walk (`InlineWalk.OffscreenPrimaries`). An enclosing expansion in the same walk leaves those alone and writes its own answer over the rest of its delta as before. The record lives on the walk, so it is cleared when the walk returns to the pool and nothing survives into the next reconcile; renting a set per expansion would not do, since the enclosing loop reads it after the inner expansion has returned its buffers.

### The predicate, and the two that were measured and rejected

`AnyPrimaryChildStillPending`'s `if (fiber.IsSuspenseBoundary) continue;` twelve lines above is not it — it answers a question about pending children, and for two Suspense nodes under one boundary fiber `FindNearestSuspenseBoundary` returns the same fiber, so it cannot separate them at all.

The obvious replacement is "skip a fiber whose nearest boundary is a nested one". Both spellings of it fix #609 and both break something else. Each was implemented and run against the fixture rather than argued about:

| predicate | `SuspenseBoundaryTests` |
|---|---|
| skip unconditionally | 1 failed — `..._When_InnerFallbackDescendantUpdates_Then_OuterFallbackKeepsItsSlot` (`Expected: not null / But was: null`) |
| skip only when clearing | 1 failed — `..._When_OuterResolvesAndInnerFallbackDescendantUpdates_Then_ItRerenders` (same text) |
| this branch | 0 failed |

A boundary never marks its own fallback subtree — it marks, rolls back, then expands the fallback — so an enclosing expansion is the only thing that answers for those fibers, and a tree-position predicate cannot tell them from the nested boundary's hidden primaries. The record can: it holds precisely the fibers a suspended expansion marked, so the nested boundary's fallback subtree, and any plain child of that boundary rendered outside the Suspense, still get the enclosing answer.

Worth knowing for anyone revisiting this: the natural `if (!suspended) { … }` spelling of the second variant does not compile. `ExpandSuspenseInline` is already at the nesting limit, and it fails with `error VEL500: Member 'ExpandSuspenseInline' nests 5 levels deep; the limit is 4`.

## Tests

Three cases over a `V.Suspense` nested in another's children — the shape no other fixture in the repository has:

- `Given_NestedBoundaries_When_InnerPrimaryDescendantUpdatesWhileOuterResolved_Then_InnerFallbackKeepsItsSlot` — red before this change: `Expected: not null / But was: null`, the inner fallback Label gone from the tree because the hidden primary's flush patched over it.
- `Given_NestedBoundariesBothSuspended_When_InnerFallbackDescendantUpdates_Then_OuterFallbackKeepsItsSlot` — green on the base, declared as characterization, and the case that separates this predicate from the unconditional one.
- `Given_NestedBoundariesBothSuspended_When_OuterResolvesAndInnerFallbackDescendantUpdates_Then_ItRerenders` — green on the base, declared as characterization, and the case that separates it from the clearing-only one.

A fourth came out of `mutation_check`, which is the part of this worth reading. Removing the snapshot exclusion — `if (fibersBefore.Contains(f)) continue;` — survived: no test failed with it gone. It survived **because of this change**. On the base, deleting that line reddened the suspended-then-resolved sibling case, since the resolved sibling's pass then wrote over the suspended one's children; with the new record those same fibers are claimed and skipped anyway, so the deletion stopped being visible there.

The exclusion is still load-bearing, in the mirror ordering the fixture did not have: a boundary that resolves first claims nothing, so when the second one suspends the snapshot is the only thing keeping its mark off the first one's children. `Given_ResolvedBoundaryFollowedBySuspendedSibling_When_TheResolvedOnesDescendantUpdates_Then_ItRerenders` pins that. With it, all three mutants are killed and none survives.

Its assertion folds the fallback term in rather than assuming it. With no boundary showing a fallback, `FlushState` never reaches the offscreen walk and the update commits whatever the marking did, so a case that only asserted the re-render would pass with the arrangement broken.

## Documentation

No guide change. No `Documentation~` page describes the flush-deferral guard or how boundaries nest; `react-migration.md`'s `V.Suspense` row says "Equivalent" of the mapping, which this brings closer to true rather than changing. `V.Suspense`'s own remark covers sibling boundaries under one component, which is a different question and still accurate. CHANGELOG has an entry under `[Unreleased]` / Fixed: a fallback leaving the tree is user-visible.

## If #408 lands

`IsOffscreen` likely disappears into boundary-owned hidden state, and this fix disappears with it. That is expected, and not a reason to widen the change now.
