### PR TITLE
fix(velvet): abandon a reset mutation's call, and commit its outcome after the handlers

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -122,6 +122,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A composite field pooled without a label lost the class its constructor adds for that case, so a
   recycled one no longer matched a fresh one's class list.
 
+- `UseMutation`'s `Reset` now abandons the call in flight instead of only clearing what it had written
+  so far. Pressing Save and then Reset used to leave the save owning the handle, so when it landed it
+  wrote `Success` and its result straight back over the idle state the user had asked for. The
+  abandoned call is still not cancelled and still delivers its own `OnSuccess` / `OnError` — what it
+  no longer does is write the handle, which is what v5's `reset()` detaching the observer amounts to.
+
+- A `UseMutation` handle no longer shows `Data` for a call it reports as failed. The result was
+  written before `OnSuccess` ran, so a handler that threw — which correctly makes the mutation an
+  error — left that result on show underneath the error, and a view rendering `Data` without checking
+  `Status` first showed it. The outcome is now committed after the handlers on both paths, which is
+  where v5 dispatches it: a handler reads the handle as the call still pending, and `Data` stands only
+  under `Status == Success`.
+
 ## [2.1.0] - 2026-08-09
 
 ### Highlights

--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -132,7 +132,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   written before `OnSuccess` ran, so a handler that threw — which correctly makes the mutation an
   error — left that result on show underneath the error, and a view rendering `Data` without checking
   `Status` first showed it. The outcome is now committed after the handlers on both paths, which is
-  where v5 dispatches it: a handler reads the handle as the call still pending, and `Data` stands only
+  where v5 dispatches it, so a handler no longer reads its own call's outcome and `Data` stands only
   under `Status == Success`.
 
 ## [2.1.0] - 2026-08-09

--- a/Packages/com.velvet.core/Documentation~/react-migration.md
+++ b/Packages/com.velvet.core/Documentation~/react-migration.md
@@ -118,8 +118,10 @@ handle, so resetting a save while it is in flight leaves the handle idle when th
 **When the outcome is committed.** After the handlers, which is when v5 dispatches it. A handler
 therefore never reads its own call's outcome: `Status` / `Data` / `Error` still show whatever the
 handle showed before it ran — this call pending on the ordinary path, a newer call's outcome where
-that call has already settled, `Idle` for a call `Reset` abandoned. `Variables` is not part of that:
-it is written when the call starts and no outcome touches it. Each outcome is written whole: `Data`
+that call has already settled, `Idle` for a call `Reset` abandoned. `Variables` is not an outcome —
+it is written when a call starts, and neither outcome touches it — but a handler reads it under the
+same rule: `Reset` clears it and a later call overwrites it, so a superseded call's handler reads the
+newer call's variables and a reset one's reads none. Each outcome is written whole: `Data`
 is what one call produced and `Error` is how one call failed, so `Data` stands only under
 `Status == Success` and `Error` only under `Status == Error` — a pending or reset handle has neither.
 

--- a/Packages/com.velvet.core/Documentation~/react-migration.md
+++ b/Packages/com.velvet.core/Documentation~/react-migration.md
@@ -103,8 +103,8 @@ TanStack Query's `useMutation` equivalent. Returns a handle with `Mutate` (fire-
 delivers its own `OnSuccess` / `OnError`, and `Status` / `Data` / `Error` / `Variables` are one
 snapshot following the newest — so a double-tapped button does not lose the first call's follow-up
 write. Starting a call resets all four to that call's own — `Data` included, so a pending call never
-shows the previous one's result. Not cancelling on re-entry and following the newest are v5's
-behaviour.
+shows the previous one's result. Not cancelling on re-entry, following the newest, and clearing
+`Data` when a call starts are all v5's behaviour.
 
 The `CancellationToken` handed to `MutationFn` has **no v5 counterpart** — a v5 `mutationFn` receives
 only its variables. It is cancelled when the component unmounts, which is what a Unity web request
@@ -116,10 +116,12 @@ and still delivers its own `OnSuccess` / `OnError`, but neither its result nor i
 handle, so resetting a save while it is in flight leaves the handle idle when the save lands.
 
 **When the outcome is committed.** After the handlers, which is when v5 dispatches it. A handler
-therefore reads the handle as the call still pending, and the four snapshots become that call's only
-once `OnSuccess` / `OnError` has returned. Each outcome is written whole: `Data` is what one call
-produced and `Error` is how one call failed, so `Data` stands only under `Status == Success` and
-`Error` only under `Status == Error` — a pending or reset handle has neither.
+therefore never reads its own call's outcome: `Status` / `Data` / `Error` still show whatever the
+handle showed before it ran — this call pending on the ordinary path, a newer call's outcome where
+that call has already settled, `Idle` for a call `Reset` abandoned. `Variables` is not part of that:
+it is written when the call starts and no outcome touches it. Each outcome is written whole: `Data`
+is what one call produced and `Error` is how one call failed, so `Data` stands only under
+`Status == Success` and `Error` only under `Status == Error` — a pending or reset handle has neither.
 
 **Callback error semantics** (TanStack Query v5 parity):
 

--- a/Packages/com.velvet.core/Documentation~/react-migration.md
+++ b/Packages/com.velvet.core/Documentation~/react-migration.md
@@ -110,10 +110,21 @@ The `CancellationToken` handed to `MutationFn` has **no v5 counterpart** — a v
 only its variables. It is cancelled when the component unmounts, which is what a Unity web request
 wants, and it is never cancelled by a later call.
 
+**`Reset`.** Puts the handle back to `Idle` and abandons whatever is in flight, as v5's `reset()`
+detaches the observer from the mutation. The abandoned call is not cancelled: it runs to completion
+and still delivers its own `OnSuccess` / `OnError`, but neither its result nor its failure reaches the
+handle, so resetting a save while it is in flight leaves the handle idle when the save lands.
+
+**When the outcome is committed.** After the handlers, which is when v5 dispatches it. A handler
+therefore reads the handle as the call still pending, and the four snapshots become that call's only
+once `OnSuccess` / `OnError` has returned. Each outcome is written whole: `Data` is what one call
+produced and `Error` is how one call failed, so `Data` stands only under `Status == Success` and
+`Error` only under `Status == Error` — a pending or reset handle has neither.
+
 **Callback error semantics** (TanStack Query v5 parity):
 
-- A throwing **`onSuccess`** handler makes the mutation an **error**: `Status` becomes `Error`, `Error` holds the handler's exception, `onError` runs with that exception, and `MutateAsync` rethrows it to the caller. This matches React Query — the success state is not committed when the handler throws.
-- A throwing **`onError`** handler does **not** change the mutation outcome already written to the slot (`Status` / `Error` stay the mutation's). The handler exception is routed to the same unobserved-exception channel as `.Forget()` (logged via `Debug.LogException` when no custom handler is registered). `MutateAsync` still rethrows the **mutation** exception, not the handler's.
+- A throwing **`onSuccess`** handler makes the mutation an **error**: `Status` becomes `Error`, `Error` holds the handler's exception, `onError` runs with that exception, and `MutateAsync` rethrows it to the caller. This matches React Query — the success state is not committed when the handler throws, so `Data` is left empty as well.
+- A throwing **`onError`** handler does **not** change the mutation outcome (`Status` / `Error` still become the mutation's own, after the handler has returned). The handler exception is routed to the same unobserved-exception channel as `.Forget()` (logged via `Debug.LogException` when no custom handler is registered). `MutateAsync` still rethrows the **mutation** exception, not the handler's.
 
 ### 1-3. State Management (React + Zustand)
 

--- a/Packages/com.velvet.core/Runtime/Hooks/HookMutation.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/HookMutation.cs
@@ -57,7 +57,7 @@ namespace Velvet
     public sealed class MutationResult<TVariables, TData>
     {
         /// <summary>Current lifecycle status of the mutation.</summary>
-        public MutationStatus Status { get; internal set; } = MutationStatus.Idle;
+        public MutationStatus Status { get; private set; } = MutationStatus.Idle;
         /// <summary>True when no mutation has run yet (or it was reset).</summary>
         public bool IsIdle => Status == MutationStatus.Idle;
         /// <summary>True while a mutation is in flight.</summary>
@@ -66,13 +66,52 @@ namespace Velvet
         public bool IsSuccess => Status == MutationStatus.Success;
         /// <summary>True when the last mutation threw.</summary>
         public bool IsError => Status == MutationStatus.Error;
-        /// <summary>Result of the most recent call, or default until that call has produced one. Starting
-        /// a call clears it, so a pending or failed call never shows an earlier call's result.</summary>
-        public TData? Data { get; internal set; }
-        /// <summary>Exception from the last failed mutation, or null.</summary>
-        public Exception? Error { get; internal set; }
+        /// <summary>Result of the most recent call, and default under every status but
+        /// <see cref="MutationStatus.Success"/>: starting a call clears it, so a pending call never shows an
+        /// earlier call's result, and a call that fails — its <c>OnSuccess</c> throwing included — leaves
+        /// none behind.</summary>
+        public TData? Data { get; private set; }
+        /// <summary>Exception from the last failed mutation, and null under every other status.</summary>
+        public Exception? Error { get; private set; }
         /// <summary>Variables passed to the most recent mutation invocation, or default.</summary>
-        public TVariables? Variables { get; internal set; }
+        public TVariables? Variables { get; private set; }
+
+        // Each of these writes a whole outcome rather than the field it is named for: Data belongs to
+        // a call that succeeded and Error to one that failed, so no sequence of them leaves either
+        // standing under a status that disowns it. The setters are private to keep the writing here,
+        // and MutationStateTransitionTests holds that reach and this invariant together, so a
+        // transition added later answers for both without being enumerated anywhere.
+        internal void MarkPending(TVariables variables)
+        {
+            Status = MutationStatus.Pending;
+            Variables = variables;
+            Error = null;
+            // The handle follows the newest call, and the previous call's result reads as this one's
+            // while this one is still pending.
+            Data = default;
+        }
+
+        internal void MarkSuccess(TData data)
+        {
+            Data = data;
+            Error = null;
+            Status = MutationStatus.Success;
+        }
+
+        internal void MarkFailed(Exception error)
+        {
+            Data = default;
+            Error = error;
+            Status = MutationStatus.Error;
+        }
+
+        internal void MarkIdle()
+        {
+            Status = MutationStatus.Idle;
+            Data = default;
+            Error = null;
+            Variables = default;
+        }
 
         internal Action<TVariables>? MutateAction;
         internal Func<TVariables, UniTask<TData>>? MutateAsyncFunc;
@@ -92,7 +131,9 @@ namespace Velvet
 
         /// <summary>
         /// Resets status to <see cref="MutationStatus.Idle"/> and clears <see cref="Data"/> / <see cref="Error"/> /
-        /// <see cref="Variables"/>. In-flight mutations are not cancelled by Reset.
+        /// <see cref="Variables"/>. In-flight mutations are not cancelled by Reset, and they no longer write
+        /// this handle: a call reset out of runs to completion and delivers its own <c>OnSuccess</c> /
+        /// <c>OnError</c>, but its outcome is not the one the handle shows.
         /// </summary>
         public void Reset() => ResetAction?.Invoke();
     }

--- a/Packages/com.velvet.core/Runtime/Hooks/HookSlots.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/HookSlots.cs
@@ -167,8 +167,9 @@ namespace Velvet
         public Action<TData, TVariables>? OnSuccess { get; set; }
         public Action<Exception, TVariables>? OnError { get; set; }
         // Every call in flight, not just the newest: two Mutate calls run side by side, so unmounting has
-        // more than one token to cancel. The newest is identified by Generation instead, which is what
-        // decides who may write the observed Status / Data — the callbacks are every call's own.
+        // more than one token to cancel. Who may write the observed Status / Data is Generation's to say
+        // instead: a call writes only while it still holds the current value, and Reset advances that too,
+        // so every call then in flight has lost it. The callbacks are every call's own either way.
         public List<CancellationTokenSource> Live { get; } = new();
 
         public long Generation { get; set; }

--- a/Packages/com.velvet.core/Runtime/Hooks/Hooks.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Hooks.cs
@@ -1831,9 +1831,9 @@ namespace Velvet
             {
                 var data = await slot.MutationFn(variables, cts.Token);
                 if (fiber.IsDisposed) return data;
-                // The handler runs before the outcome is committed, which is where TanStack dispatches
-                // it: what OnSuccess reads is this call still pending, and a handler that throws leaves
-                // the call a failure with nothing of its own written.
+                // The handler runs before this call's outcome is committed, which is where TanStack
+                // dispatches it: what OnSuccess reads is the handle as it stands rather than its own
+                // result, and a handler that throws leaves the call a failure with nothing written.
                 slot.OnSuccess?.Invoke(data, variables);
                 if (mine == slot.Generation) slot.Result.MarkSuccess(data);
                 RequestRender(fiber);

--- a/Packages/com.velvet.core/Runtime/Hooks/Hooks.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Hooks.cs
@@ -1824,24 +1824,18 @@ namespace Velvet
             // mutate(vars, { onSuccess }), which has no equivalent here.
             var mine = ++slot.Generation;
 
-            slot.Result.Status = MutationStatus.Pending;
-            slot.Result.Variables = variables;
-            slot.Result.Error = null;
-            // Data goes with them. The observer shows the newest call, and a `Data` left over from the
-            // previous one reads as this call's result while it is still pending.
-            slot.Result.Data = default!;
+            slot.Result.MarkPending(variables);
             RequestRender(fiber);
 
             try
             {
                 var data = await slot.MutationFn(variables, cts.Token);
                 if (fiber.IsDisposed) return data;
-                if (mine == slot.Generation)
-                {
-                    slot.Result.Data = data;
-                    slot.Result.Status = MutationStatus.Success;
-                }
+                // The handler runs before the outcome is committed, which is where TanStack dispatches
+                // it: what OnSuccess reads is this call still pending, and a handler that throws leaves
+                // the call a failure with nothing of its own written.
                 slot.OnSuccess?.Invoke(data, variables);
+                if (mine == slot.Generation) slot.Result.MarkSuccess(data);
                 RequestRender(fiber);
                 return data;
             }
@@ -1857,11 +1851,6 @@ namespace Velvet
                     if (rethrowOnFailure) throw;
                     return default!;
                 }
-                if (mine == slot.Generation)
-                {
-                    slot.Result.Error = ex;
-                    slot.Result.Status = MutationStatus.Error;
-                }
                 try
                 {
                     slot.OnError?.Invoke(ex, variables);
@@ -1870,6 +1859,9 @@ namespace Velvet
                 {
                     UniTask.FromException(handlerEx).Forget();
                 }
+                // Below the inner catch, not inside the try: a throwing OnError must not cost the
+                // mutation the Error status. Committed after the handler for the same reason as a success.
+                if (mine == slot.Generation) slot.Result.MarkFailed(ex);
                 RequestRender(fiber);
                 if (rethrowOnFailure) throw;
                 return default!;
@@ -1888,10 +1880,8 @@ namespace Velvet
             HookMutationSlot<TVariables, TData> slot)
         {
             if (fiber.IsDisposed) return;
-            slot.Result.Status = MutationStatus.Idle;
-            slot.Result.Data = default;
-            slot.Result.Error = null;
-            slot.Result.Variables = default;
+            slot.Generation++;
+            slot.Result.MarkIdle();
             RequestRender(fiber);
         }
 

--- a/Packages/com.velvet.core/Runtime/Hooks/Hooks.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Hooks.cs
@@ -1833,7 +1833,8 @@ namespace Velvet
                 if (fiber.IsDisposed) return data;
                 // The handler runs before this call's outcome is committed, which is where TanStack
                 // dispatches it: what OnSuccess reads is the handle as it stands rather than its own
-                // result, and a handler that throws leaves the call a failure with nothing written.
+                // result, and a handler that throws leaves the call a failure with nothing of its
+                // own written.
                 slot.OnSuccess?.Invoke(data, variables);
                 if (mine == slot.Generation) slot.Result.MarkSuccess(data);
                 RequestRender(fiber);

--- a/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/MutationStateTransitionTests.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/MutationStateTransitionTests.cs
@@ -7,11 +7,11 @@ using NUnit.Framework;
 namespace Velvet.Tests
 {
     /// <summary>
-    /// Holds the invariant every state transition of <see cref="MutationResult{TVariables, TData}"/> shares:
-    /// <c>Data</c> is what one call produced and <c>Error</c> is how one call failed, so neither stands under a
+    /// Holds the invariant every write to a <see cref="MutationResult{TVariables, TData}"/> shares: <c>Data</c>
+    /// is what one call produced and <c>Error</c> is how one call failed, so neither stands under a
     /// <see cref="MutationStatus"/> that disowns it. <see cref="UseMutationHookTests"/> reads that off the paths
-    /// a mutation takes today; this reads it off the transitions themselves, so a path added later answers for
-    /// it without being enumerated anywhere.
+    /// a mutation takes today; this reads it off the writers — each constructor and each declared method — so
+    /// one added later answers for it without being enumerated anywhere.
     /// </summary>
     [TestFixture]
     internal sealed class MutationStateTransitionTests
@@ -20,17 +20,32 @@ namespace Velvet.Tests
         private static readonly Exception Stale = new InvalidOperationException("stale");
 
         [Test]
-        public void Given_AHandleShowingBothOutcomes_When_EveryDeclaredTransitionRuns_Then_NeitherStandsUnderTheOtherStatus()
+        public void Given_AHandleShowingBothOutcomes_When_EveryDeclaredWriterRuns_Then_NeitherStandsUnderTheOtherStatus()
         {
             // Arrange — the setters are what make the sweep the whole question rather than part of it: with
-            // no writer outside the type, every path that moves the observed four is one of these methods.
+            // no writer outside the type, what moves the observed four is declared on it. A property with
+            // no setter at all is the stricter case, not a laxer one, so it is not counted here.
             var type = typeof(MutationResult<string, string>);
             var writableFromOutside = string.Join(", ", new[] { "Status", "Data", "Error", "Variables" }
-                .Where(name => type.GetProperty(name)!.SetMethod is not { IsPrivate: true }));
+                .Where(name => type.GetProperty(name)!.SetMethod is { IsPrivate: false }));
 
             // Act — the arranged handle carries a result and a failure at once, so a transition that writes
-            // only the field it is named for leaves the other one behind for the sweep to find.
+            // only the field it is named for leaves the other one behind for the sweep to find. A handle as
+            // constructed is asked first and unarranged: what a seed writes there is no transition's doing,
+            // and arranging over it is what would hide it.
             var findings = new List<string>();
+            foreach (var constructor in type.GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
+            {
+                var seeds = constructor.GetParameters().Select(parameter => Argument(parameter.ParameterType)).ToArray();
+                if (seeds.Any(seed => seed is null))
+                {
+                    findings.Add("a constructor takes an argument this sweep cannot supply");
+                    continue;
+                }
+
+                Record((MutationResult<string, string>)constructor.Invoke(seeds), "a constructed handle", findings);
+            }
+
             var moved = 0;
             foreach (var transition in type
                          .GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly)
@@ -51,14 +66,7 @@ namespace Velvet.Tests
                 if (Snapshot(handle) == arranged) continue;
 
                 moved++;
-                if (handle.Data is not null && handle.Status != MutationStatus.Success)
-                {
-                    findings.Add($"{transition.Name} left Data standing under {handle.Status}");
-                }
-                if (handle.Error is not null && handle.Status != MutationStatus.Error)
-                {
-                    findings.Add($"{transition.Name} left Error standing under {handle.Status}");
-                }
+                Record(handle, transition.Name, findings);
             }
 
             // A sweep over transitions that all leave the handle alone reports the same empty finding as one
@@ -67,7 +75,19 @@ namespace Velvet.Tests
 
             // Assert
             Assert.That((writableFromOutside, string.Join("; ", findings)), Is.EqualTo(("", "")),
-                "Nothing outside the handle writes the observed state, and every transition of it leaves a whole outcome behind");
+                "Nothing outside the handle writes the observed state, and every writer of it leaves a whole outcome behind");
+        }
+
+        private static void Record(MutationResult<string, string> handle, string what, List<string> findings)
+        {
+            if (handle.Data is not null && handle.Status != MutationStatus.Success)
+            {
+                findings.Add($"{what} leaves Data standing under {handle.Status}");
+            }
+            if (handle.Error is not null && handle.Status != MutationStatus.Error)
+            {
+                findings.Add($"{what} leaves Error standing under {handle.Status}");
+            }
         }
 
         private static MutationResult<string, string> ShowingBothOutcomes()

--- a/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/MutationStateTransitionTests.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/MutationStateTransitionTests.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using NUnit.Framework;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Holds the invariant every state transition of <see cref="MutationResult{TVariables, TData}"/> shares:
+    /// <c>Data</c> is what one call produced and <c>Error</c> is how one call failed, so neither stands under a
+    /// <see cref="MutationStatus"/> that disowns it. <see cref="UseMutationHookTests"/> reads that off the paths
+    /// a mutation takes today; this reads it off the transitions themselves, so a path added later answers for
+    /// it without being enumerated anywhere.
+    /// </summary>
+    [TestFixture]
+    internal sealed class MutationStateTransitionTests
+    {
+        private const string Committed = "committed";
+        private static readonly Exception Stale = new InvalidOperationException("stale");
+
+        [Test]
+        public void Given_AHandleShowingBothOutcomes_When_EveryDeclaredTransitionRuns_Then_NeitherStandsUnderTheOtherStatus()
+        {
+            // Arrange — the setters are what make the sweep the whole question rather than part of it: with
+            // no writer outside the type, every path that moves the observed four is one of these methods.
+            var type = typeof(MutationResult<string, string>);
+            var writableFromOutside = string.Join(", ", new[] { "Status", "Data", "Error", "Variables" }
+                .Where(name => type.GetProperty(name)!.SetMethod is not { IsPrivate: true }));
+
+            // Act — the arranged handle carries a result and a failure at once, so a transition that writes
+            // only the field it is named for leaves the other one behind for the sweep to find.
+            var findings = new List<string>();
+            var moved = 0;
+            foreach (var transition in type
+                         .GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly)
+                         .Where(method => !method.IsSpecialName))
+            {
+                var arguments = transition.GetParameters().Select(parameter => Argument(parameter.ParameterType)).ToArray();
+                if (arguments.Any(argument => argument is null))
+                {
+                    findings.Add($"{transition.Name} takes an argument this sweep cannot supply");
+                    continue;
+                }
+
+                var handle = ShowingBothOutcomes();
+                var arranged = Snapshot(handle);
+                transition.Invoke(handle, arguments);
+                // One that wrote nothing answers for nothing, and a handle nothing wrote is still the
+                // incoherent one arranged above.
+                if (Snapshot(handle) == arranged) continue;
+
+                moved++;
+                if (handle.Data is not null && handle.Status != MutationStatus.Success)
+                {
+                    findings.Add($"{transition.Name} left Data standing under {handle.Status}");
+                }
+                if (handle.Error is not null && handle.Status != MutationStatus.Error)
+                {
+                    findings.Add($"{transition.Name} left Error standing under {handle.Status}");
+                }
+            }
+
+            // A sweep over transitions that all leave the handle alone reports the same empty finding as one
+            // over transitions that all keep the invariant.
+            if (moved == 0) findings.Add("no declared transition moved the arranged state");
+
+            // Assert
+            Assert.That((writableFromOutside, string.Join("; ", findings)), Is.EqualTo(("", "")),
+                "Nothing outside the handle writes the observed state, and every transition of it leaves a whole outcome behind");
+        }
+
+        private static MutationResult<string, string> ShowingBothOutcomes()
+        {
+            var handle = new MutationResult<string, string>();
+            var type = typeof(MutationResult<string, string>);
+            type.GetProperty(nameof(MutationResult<string, string>.Data))!.SetValue(handle, Committed);
+            type.GetProperty(nameof(MutationResult<string, string>.Error))!.SetValue(handle, Stale);
+            type.GetProperty(nameof(MutationResult<string, string>.Variables))!.SetValue(handle, "arranged");
+            type.GetProperty(nameof(MutationResult<string, string>.Status))!.SetValue(handle, MutationStatus.Success);
+            return handle;
+        }
+
+        private static string Snapshot(MutationResult<string, string> handle) =>
+            $"{handle.Status}|{handle.Data}|{handle.Error?.Message}|{handle.Variables}";
+
+        private static object? Argument(Type parameterType) =>
+            parameterType == typeof(string) ? "later"
+            : parameterType == typeof(Exception) ? new InvalidOperationException("swept")
+            : null;
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/MutationStateTransitionTests.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/MutationStateTransitionTests.cs
@@ -29,11 +29,29 @@ namespace Velvet.Tests
             var writableFromOutside = string.Join(", ", new[] { "Status", "Data", "Error", "Variables" }
                 .Where(name => type.GetProperty(name)!.SetMethod is { IsPrivate: false }));
 
-            // Act — the arranged handle carries a result and a failure at once, so a transition that writes
-            // only the field it is named for leaves the other one behind for the sweep to find. A handle as
-            // constructed is asked first and unarranged: what a seed writes there is no transition's doing,
-            // and arranging over it is what would hide it.
+            // Act
             var findings = new List<string>();
+            SweepConstructors(type, findings);
+            // Two arrangements, differing in the status they hold. A writer that only sets Status moves
+            // nothing under the arrangement already holding that status, and a writer that moves nothing is
+            // what the sweep has to pass over; under the other arrangement the same writer moves.
+            var moved = SweepWriters(type, MutationStatus.Success, findings)
+                        + SweepWriters(type, MutationStatus.Error, findings);
+            // A sweep over writers that all leave the handle alone reports the same empty finding as one
+            // over writers that all keep the invariant.
+            if (moved == 0) findings.Add("no declared writer moved the arranged state");
+
+            // Assert
+            Assert.That((writableFromOutside, string.Join("; ", findings)), Is.EqualTo(("", "")),
+                "Nothing outside the handle writes the observed state, and every writer of it leaves a whole outcome behind");
+        }
+
+        /// <summary>
+        /// A handle as constructed, unarranged: what a seed writes there is no transition's doing, and
+        /// arranging over it is what would hide it.
+        /// </summary>
+        private static void SweepConstructors(Type type, List<string> findings)
+        {
             foreach (var constructor in type.GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
             {
                 var seeds = constructor.GetParameters().Select(parameter => Argument(parameter.ParameterType)).ToArray();
@@ -45,37 +63,47 @@ namespace Velvet.Tests
 
                 Record((MutationResult<string, string>)constructor.Invoke(seeds), "a constructed handle", findings);
             }
+        }
 
+        /// <summary>
+        /// Every declared method against a handle carrying a result and a failure at once, so a writer that
+        /// writes only the field it is named for leaves the other one behind to be found. Returns how many
+        /// of them wrote anything.
+        /// </summary>
+        private static int SweepWriters(Type type, MutationStatus arrangedStatus, List<string> findings)
+        {
             var moved = 0;
-            foreach (var transition in type
-                         .GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly)
+            foreach (var writer in type
+                         .GetMethods(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly)
                          .Where(method => !method.IsSpecialName))
             {
-                var arguments = transition.GetParameters().Select(parameter => Argument(parameter.ParameterType)).ToArray();
+                var arguments = writer.GetParameters().Select(parameter => Argument(parameter.ParameterType)).ToArray();
                 if (arguments.Any(argument => argument is null))
                 {
-                    findings.Add($"{transition.Name} takes an argument this sweep cannot supply");
+                    findings.Add($"{writer.Name} takes an argument this sweep cannot supply");
                     continue;
                 }
 
-                var handle = ShowingBothOutcomes();
+                var handle = ShowingBothOutcomes(arrangedStatus);
                 var arranged = Snapshot(handle);
-                transition.Invoke(handle, arguments);
+                var produced = writer.Invoke(handle, arguments);
+                // A handle handed back rather than written in place — a static factory's shape — answers for
+                // the invariant whatever became of the arranged one.
+                if (produced is MutationResult<string, string> other && !ReferenceEquals(other, handle))
+                {
+                    moved++;
+                    Record(other, $"the handle {writer.Name} returns", findings);
+                }
+
                 // One that wrote nothing answers for nothing, and a handle nothing wrote is still the
                 // incoherent one arranged above.
                 if (Snapshot(handle) == arranged) continue;
 
                 moved++;
-                Record(handle, transition.Name, findings);
+                Record(handle, writer.Name, findings);
             }
 
-            // A sweep over transitions that all leave the handle alone reports the same empty finding as one
-            // over transitions that all keep the invariant.
-            if (moved == 0) findings.Add("no declared transition moved the arranged state");
-
-            // Assert
-            Assert.That((writableFromOutside, string.Join("; ", findings)), Is.EqualTo(("", "")),
-                "Nothing outside the handle writes the observed state, and every writer of it leaves a whole outcome behind");
+            return moved;
         }
 
         private static void Record(MutationResult<string, string> handle, string what, List<string> findings)
@@ -90,14 +118,14 @@ namespace Velvet.Tests
             }
         }
 
-        private static MutationResult<string, string> ShowingBothOutcomes()
+        private static MutationResult<string, string> ShowingBothOutcomes(MutationStatus status)
         {
             var handle = new MutationResult<string, string>();
             var type = typeof(MutationResult<string, string>);
             type.GetProperty(nameof(MutationResult<string, string>.Data))!.SetValue(handle, Committed);
             type.GetProperty(nameof(MutationResult<string, string>.Error))!.SetValue(handle, Stale);
             type.GetProperty(nameof(MutationResult<string, string>.Variables))!.SetValue(handle, "arranged");
-            type.GetProperty(nameof(MutationResult<string, string>.Status))!.SetValue(handle, MutationStatus.Success);
+            type.GetProperty(nameof(MutationResult<string, string>.Status))!.SetValue(handle, status);
             return handle;
         }
 

--- a/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/MutationStateTransitionTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/MutationStateTransitionTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c691ebf662dfe41009835aa7a20a2a6a

--- a/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseMutationHookTests.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseMutationHookTests.cs
@@ -27,8 +27,9 @@ namespace Velvet.Tests
     /// the observed status, data and variables come from the latest call.</item>
     /// <item>A call <c>Reset</c> abandoned still runs to completion and delivers its own callbacks, but neither
     /// its result nor its failure reaches the handle.</item>
-    /// <item>The outcome is committed after the handlers, so a handler observes the call still pending; and a
-    /// mutation whose <c>OnSuccess</c> threw leaves no data standing under the resulting error.</item>
+    /// <item>The outcome is committed after the handlers, so a handler of a call nothing has superseded or reset
+    /// observes it still pending; and a mutation whose <c>OnSuccess</c> threw leaves no data standing under the
+    /// resulting error.</item>
     /// <item>If the component unmounts while a mutation is in flight, the caller's await still observes the function
     /// result but the disposed fiber does not receive a Success state transition.</item>
     /// </list>

--- a/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseMutationHookTests.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseMutationHookTests.cs
@@ -25,6 +25,10 @@ namespace Velvet.Tests
     /// no-input overloads that adapt to a <see cref="Unit"/> result.</item>
     /// <item>Concurrent mutations both run: neither cancels the other and each fires its own callbacks, while
     /// the observed status, data and variables come from the latest call.</item>
+    /// <item>A call <c>Reset</c> abandoned still runs to completion and delivers its own callbacks, but neither
+    /// its result nor its failure reaches the handle.</item>
+    /// <item>The outcome is committed after the handlers, so a handler observes the call still pending; and a
+    /// mutation whose <c>OnSuccess</c> threw leaves no data standing under the resulting error.</item>
     /// <item>If the component unmounts while a mutation is in flight, the caller's await still observes the function
     /// result but the disposed fiber does not receive a Success state transition.</item>
     /// </list>
@@ -53,6 +57,8 @@ namespace Velvet.Tests
             s_onSuccessThrowException = null;
             s_delivered.Clear();
             s_onErrorThrowException = null;
+            s_onSuccessObserved = null;
+            s_onErrorObserved = null;
         }
 
         [Test]
@@ -183,6 +189,52 @@ namespace Velvet.Tests
             Assert.That((s_captured.Status, s_captured.Data, s_captured.Variables, s_captured.Error),
                 Is.EqualTo((MutationStatus.Idle, default(int), default(int), (Exception?)null)),
                 "Reset restores Idle and clears data, variables, and error");
+        });
+
+        [UnityTest]
+        public IEnumerator Given_AnInFlightMutation_When_ResetAndThenItSucceeds_Then_TheHandleStaysIdle() => UniTask.ToCoroutine(async () =>
+        {
+            // Arrange
+            var gate = new UniTaskCompletionSource<int>();
+            s_mutationFn = (_, _) => gate.Task;
+            using var mounted = V.Mount(_root, V.Component(CaptureMutationRecordingSuccessesRender, key: "reset-in-flight-success"));
+            var abandoned = s_captured!.MutateAsync(7);
+
+            // Act
+            s_captured.Reset();
+            gate.TrySetResult(42);
+            await abandoned;
+            mounted.FlushStateForTest();
+
+            // Assert — the first term is the abandoned call arriving, the half Reset leaves alone. Without
+            // it the handle has nothing it had to keep out, and the rest holds for the wrong reason.
+            Assert.That((string.Join(",", s_delivered), s_captured.Status, s_captured.Data),
+                Is.EqualTo(("42", MutationStatus.Idle, 0)),
+                "A call Reset abandoned delivers its own success and writes none of it to the handle");
+        });
+
+        [UnityTest]
+        public IEnumerator Given_AnInFlightMutation_When_ResetAndThenItFails_Then_TheHandleStaysIdle() => UniTask.ToCoroutine(async () =>
+        {
+            // Arrange
+            var failingException = new InvalidOperationException("simulated");
+            var gate = new UniTaskCompletionSource<int>();
+            s_mutationFn = (_, _) => gate.Task;
+            using var mounted = V.Mount(_root, V.Component(CaptureMutationRender, key: "reset-in-flight-error"));
+            var abandoned = s_captured!.MutateAsync(7);
+
+            // Act
+            s_captured.Reset();
+            gate.TrySetException(failingException);
+            Exception? rethrown = null;
+            try { await abandoned; } catch (InvalidOperationException caught) { rethrown = caught; }
+            mounted.FlushStateForTest();
+
+            // Assert — the first term is the abandoned call failing, without which the handle stays idle
+            // whatever the failure path does with it.
+            Assert.That((ReferenceEquals(rethrown, failingException), s_captured.Status, s_captured.Error),
+                Is.EqualTo((true, MutationStatus.Idle, (Exception?)null)),
+                "A call Reset abandoned rejects to its caller and writes none of its failure to the handle");
         });
 
         [Test]
@@ -508,6 +560,74 @@ namespace Velvet.Tests
         });
 
         [UnityTest]
+        public IEnumerator Given_SucceededMutation_When_OnSuccessThrows_Then_NoDataStandsUnderTheError() => UniTask.ToCoroutine(async () =>
+        {
+            // Arrange
+            s_onSuccessThrowException = new InvalidOperationException("onSuccess");
+            using var mounted = V.Mount(_root, V.Component(CaptureMutationWithThrowingOnSuccessRender, key: "onsuccess-nodata"));
+
+            // Act
+            try { await s_captured!.MutateAsync(21); } catch (InvalidOperationException) { }
+            mounted.FlushStateForTest();
+
+            // Assert — a view that renders Data without reading Status first shows the result of a call
+            // the framework has already called a failure.
+            Assert.That((s_captured!.Status, s_captured.Data), Is.EqualTo((MutationStatus.Error, 0)),
+                "A mutation whose OnSuccess threw exposes no data under its Error status");
+        });
+
+        [UnityTest]
+        public IEnumerator Given_SucceededMutation_When_OnSuccessThrowsOnFireAndForgetMutate_Then_NoDataStandsUnderTheError() => UniTask.ToCoroutine(async () =>
+        {
+            // Arrange — the handle is the only report this path makes, since a forgotten call rethrows
+            // to nobody.
+            s_onSuccessThrowException = new InvalidOperationException("onSuccess");
+            using var mounted = V.Mount(_root, V.Component(CaptureMutationWithThrowingOnSuccessRender, key: "onsuccess-forget-nodata"));
+
+            // Act
+            s_captured!.Mutate(21);
+            await UniTask.Yield();
+            await UniTask.Yield();
+            mounted.FlushStateForTest();
+
+            // Assert
+            Assert.That((s_captured!.Status, s_captured.Data), Is.EqualTo((MutationStatus.Error, 0)),
+                "A forgotten mutation whose OnSuccess threw exposes no data under its Error status");
+        });
+
+        [UnityTest]
+        public IEnumerator Given_ASucceedingMutation_When_OnSuccessRuns_Then_TheOutcomeIsNotCommittedYet() => UniTask.ToCoroutine(async () =>
+        {
+            // Arrange
+            using var mounted = V.Mount(_root, V.Component(CaptureMutationObservingInOnSuccessRender, key: "onsuccess-observes"));
+
+            // Act
+            await s_captured!.MutateAsync(21);
+            mounted.FlushStateForTest();
+
+            // Assert
+            Assert.That(s_onSuccessObserved, Is.EqualTo((MutationStatus.Pending, 0)),
+                "OnSuccess runs before the success is committed, so the handle it reads is still the pending call's");
+        });
+
+        [UnityTest]
+        public IEnumerator Given_AFailingMutation_When_OnErrorRuns_Then_TheOutcomeIsNotCommittedYet() => UniTask.ToCoroutine(async () =>
+        {
+            // Arrange
+            var failingException = new InvalidOperationException("simulated");
+            s_mutationFn = (_, _) => throw failingException;
+            using var mounted = V.Mount(_root, V.Component(CaptureMutationObservingInOnErrorRender, key: "onerror-observes"));
+
+            // Act
+            try { await s_captured!.MutateAsync(1); } catch (InvalidOperationException) { }
+            mounted.FlushStateForTest();
+
+            // Assert
+            Assert.That(s_onErrorObserved, Is.EqualTo((MutationStatus.Pending, (Exception?)null)),
+                "OnError runs before the failure is committed, so the handle it reads is still the pending call's");
+        });
+
+        [UnityTest]
         public IEnumerator Given_FailingMutation_When_OnErrorThrows_Then_StatusRemainsErrorWithMutationException() => UniTask.ToCoroutine(async () =>
         {
             // Arrange
@@ -637,6 +757,24 @@ namespace Velvet.Tests
         }
 
         [Component]
+        public static VNode CaptureMutationObservingInOnSuccessRender()
+        {
+            s_captured = Hooks.UseMutation(new MutationOptions<int, int>(
+                MutationFn: s_mutationFn,
+                OnSuccess: (_, _) => s_onSuccessObserved = (s_captured!.Status, s_captured.Data)));
+            return V.Label(text: "ok");
+        }
+
+        [Component]
+        public static VNode CaptureMutationObservingInOnErrorRender()
+        {
+            s_captured = Hooks.UseMutation(new MutationOptions<int, int>(
+                MutationFn: s_mutationFn,
+                OnError: (_, _) => s_onErrorObserved = (s_captured!.Status, s_captured.Error)));
+            return V.Label(text: "ok");
+        }
+
+        [Component]
         public static VNode CaptureUnitMutationRender()
         {
             _ = Hooks.UseMutation(new MutationOptions<Unit, Unit>(
@@ -651,5 +789,7 @@ namespace Velvet.Tests
         private static MutationResult<Unit, Unit>? s_noInputCaptured;
         private static Exception? s_onSuccessThrowException;
         private static Exception? s_onErrorThrowException;
+        private static (MutationStatus Status, int Data)? s_onSuccessObserved;
+        private static (MutationStatus Status, Exception? Error)? s_onErrorObserved;
     }
 }


### PR DESCRIPTION
Two `UseMutation` divergences from TanStack Query v5, both of which let a call write a handle that had
already moved on.

## Reset was overwritten by the call it was meant to abandon

A slot write is gated on the call's generation still being the slot's, which is what stops a superseded
call from overwriting a newer one. `Reset()` is not a call, so it never advanced the counter and the
call in flight still owned the generation: press Save, press Reset while it is in flight, and when the
save lands it writes `Success` and its result straight back over the idle state the user asked for.
`ResetMutation` now advances the generation, which is what v5's `reset()` detaching the observer from
the mutation amounts to. The abandoned call is still not cancelled and still delivers its own
`OnSuccess` / `OnError`, exactly as a superseded one does — v5's `Mutation.execute` awaits its own
callbacks and consults no observer list.

## Data landed before OnSuccess ran

The result was written before `OnSuccess`, so a handler that threw — which this codebase already,
correctly, turns into `Status == Error` — left that result on show underneath the error, and a view
rendering `Data` without checking `Status` first showed it. Both outcomes are now committed after the
handlers have run, which is where v5 dispatches them. The error write sits below the handler's own
`catch` rather than inside it, so a throwing `OnError` still cannot cost the mutation its status —
the behaviour an existing case already pins. Two consequences follow, and both are now documented
and pinned:

- A handler never reads its own call's outcome, on either path. What it does read is the handle as it
  stands: this call pending on the ordinary path, a newer call's outcome where that one has already
  settled, and `Idle` for a call `Reset` abandoned. `Variables` is not part of that — it is written
  when the call starts and no outcome touches it.
- The generation gate is read after the handler, so a `Reset` a handler makes wins over the write.

## The invariant, rather than the two cases

The whole `Status` / `Data` pair was only ever asserted after a settled, un-reset, non-throwing call,
so neither defect was visible to anything. Rather than enumerate the paths, the four state writes now
go through transition methods on `MutationResult` with the property setters private, and each writes a
whole outcome rather than the field it is named for: `Data` belongs to a call that succeeded and
`Error` to one that failed. `MutationStateTransitionTests` reads the setters to establish that nothing
outside the type writes the observed state, then applies every constructor and every method declared
on it to a handle carrying both a result and a failure — so a writer added later answers for the
invariant without being enumerated anywhere.

The invariant is v5's own reducer, not a strengthening of it: `pending` and `error` both clear `data`,
`success` clears `error`, and the idle state is `getDefaultState()`. The guide's concurrency paragraph
used to attribute only two of the three to v5; it now attributes all of them.

## Documentation

`Documentation~/react-migration.md` gains what `Reset` does to a call in flight and when an outcome is
committed, and the callback-error semantics it already carried now say that a throwing `onSuccess`
leaves no data either. No guide was added or removed, so the index table is unchanged. `CHANGELOG.md`
carries both fixes under `[Unreleased]`.

Closes #587
