### PR TITLE
docs(velvet): try the code before writing the comment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,9 +90,17 @@ Four ways a green test has lied here:
 
 ## Comments
 
+### Not at all, first
+
+The cheapest comment is the one the code makes unnecessary, and that question comes before every rule below it: can this be carried by the code instead — a name, a type split, a method that serves one caller rather than three? A comment that is hard to write is evidence about the code, not about the comment.
+
+The most expensive comments here have been the ones covering for a shape. A method reached from three paths with different meanings needed a sentence saying which one it was written for, and that sentence was false at two of them — and at one, the behaviour was wrong too, which the comment's confidence hid. A three-valued reading whose members are reachable under different conditions per call site took three corrections, each moving the falsity rather than removing it. In both the sentence sat where the code had stopped explaining itself, and rewriting it was never going to work.
+
+So the first move is to try the code. The three kinds under *Then short* are what survives that attempt, not a licence to skip it.
+
 ### True first
 
-A comment states why — never what, and once. Before any question of economy, it has to be **true**. The commonest failure is a comment naming a *mechanism* the author never verified, in the shape "X because Y" with X observed and Y assumed; a second one is rarer and worse, calling a true statement false because it named a term that was not the operative one. Five of the six that shipped in one session are below. The sixth is not, and its absence is the entry: a single sentence about which transform a reading carries was corrected four times, each correction wrong in a new way, and the fifth attempt is this paragraph declining to make it. **When a sentence has been corrected twice and is still wrong, delete it.** Nothing in the code needed it; four rounds of review went into prose that was load-bearing for nobody.
+A comment states why — never what, and once. Before any question of economy, it has to be **true**. The commonest failure is a comment naming a *mechanism* the author never verified, in the shape "X because Y" with X observed and Y assumed; a second one is rarer and worse, calling a true statement false because it named a term that was not the operative one. Five of the six that shipped in one session are below. The sixth is not, and its absence is the entry: a single sentence about which transform a reading carries was corrected four times, each correction wrong in a new way, and the fifth attempt is this paragraph declining to make it. **When a sentence has been corrected twice and is still wrong, delete it — and ask what about the code made it hard to state.** Twice is where the evidence stops being about the sentence: a third attempt has never worked here, and the two that took four rounds each were describing a method or a reading that meant different things to different callers. Nothing in the code needed the sentence; four rounds of review went into prose that was load-bearing for nobody.
 
 - "the uniform-frame check catches an unstyled capture" — it does not; a backdrop and a font leave the frame varied
 - "without the stylesheet this class is inert, so the control holds" — that class has no USS rule at all and is written from C#


### PR DESCRIPTION
No issue: this comes from a working session where two sentences each took four review rounds, and both were describing code rather than being wrong about it.

The `Comments` section told an author to write a true comment, then a short one. It never told them to try removing the need first. Both of the expensive sentences were permitted by the three kinds that section keeps — an ordering constraint, an invariant, a rejected alternative — so the rules were not violated; they were followed all the way into four rounds of prose.

What the two had in common is the thing the section did not name. One justified a skip with a reason that holds for the caller its author had in mind and is false at two of the other three, and at one of those the behaviour is wrong as well — the confident sentence is what hid it. The other described a three-valued reading whose members are reachable under different conditions per call site, and three corrections each moved the falsity rather than removing it. In both, the sentence sat where the code had stopped explaining itself, and no rewrite was going to fix that.

So the section now opens with the attempt to remove the need, and says plainly that a comment which is hard to write is evidence about the code. The three kinds under *Then short* are what survives that attempt rather than a licence to skip it.

The corrected-twice rule already said to delete. It now also asks what about the code made the sentence hard to state, because twice is where the evidence stops being about the sentence — a third attempt has never worked here.

## Documentation

`CLAUDE.md` is the owning document for the comment standard and is the only file changed. No `Documentation~` guide covers it. No CHANGELOG entry: nothing a package consumer runs changes.

The added text carries no backticked span, so `DocumentationDriftTests` has no name or path to resolve in it — deliberate, since the two motivating examples live on unmerged branches and naming them here would resolve nowhere.
