### PR TITLE
docs(velvet): anchor a finding to text rather than to a line number

### DIFF
--- a/.claude/agents/velvet-reviewer.md
+++ b/.claude/agents/velvet-reviewer.md
@@ -41,11 +41,12 @@ Run `git status --short` and **read any untracked file** rather than assuming it
 
 ## Your own findings are claims too
 
-Item 1 asks you to hold the change to that standard. Hold your report to it as well — four ways a finding here has been wrong:
+Item 1 asks you to hold the change to that standard. Hold your report to it as well — five ways a finding here has been wrong:
 
 - **An absence in a binary is not an absence.** A search of the test runner's assemblies for a marker literal returned zero, and the finding said the runner never writes it. It writes it by concatenation, so there was no literal to find, and the whole finding was false. Interpolation, `nameof` and resource lookups hide a string the same way. Run the thing and read what it produced before reporting that it produces nothing.
 - **A reason can be true and still not be the one.** A mutant was argued to survive because the only two tests reading a counter never drain inside their measured window — true, and not the operative fact: mounting itself ends in a drain, so it had already happened before either reading was taken. A verdict argued from what a test *reads* misses what ran before the reading.
 - **Say which findings you measured and which you derived.** A round that could not take a suite run said so and marked one claim as derived rather than measured. That sentence is worth more than the finding it sits on, because it tells the coordinator exactly what to re-take.
+- **A location goes stale faster than the finding it points at.** Anchor each one to a quoted line or to an identifier rather than to a line number: the tree that takes the fix is not the tree you read, and one change to this file moved every heading in it down the page. A path is the same claim with a cheaper check — `ls` it before writing it down, since `unreadable_state_check.py` has sat under `scripts/hooks/` since the commit that added it and has been cited under `scripts/test_quality/`.
 - **A remedy is a hypothesis, and a cheaper one to get wrong than a finding.** One round proposed deleting a fallback its own reordering had made redundant; deleting it would have opened a window where the state reads null. Propose the fix if you have one, label it untested, and leave the choice to whoever measures it.
 
 ## Reporting


### PR DESCRIPTION
No issue: found while checking which recurring disciplines this repository already states and which are still carried outside it.

A finding that names a line number points at the tree the reviewer read, not the tree the fix lands in. The reviewer definition already holds the section for claims a report makes about itself, so the rule goes there.

Both examples in the added sentence are measured rather than asserted:

- The heading drift is one commit's, db33d5e: `## Constraints` 10→12, `## What to look for, in priority order` 18→33, `## Reporting` 26→42. Every heading in the file moved.
- `unreadable_state_check.py` was added at `scripts/hooks/` and has never been anywhere else — `git log --diff-filter=A --all -- '*unreadable_state_check.py'` returns the one commit.

Checked by hand before pushing, and `DocumentationDriftTests` answers the second one again in the EditMode suite this pull request runs — path filtering applies to `push` only, so a change under `.claude/` still starts both workflows:

- The count above the list read "four ways a finding here has been wrong" and now reads five.
- The three backticked spans the sentence adds resolve under `DocumentationDriftTests`'s path scan: both directories exist, and the bare file name is a suffix of a tracked path. No wrong path is written down as a backticked span, which would have failed that scan.
