### PR TITLE
docs(velvet): record the V.Portal(null) break, and when the variant throw shipped

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -76,10 +76,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   guide nor `createPortal` promised the surviving half. The portals guide states the contract that now
   holds in both directions. Keeping state across such a move means lifting it above the portal — to a
   `Store`, or to a `UseState` in the component that declares the portal.
+- `V.Portal(null)` no longer compiles: a bare `null` first argument is ambiguous between
+  `Portal(string, …)` and the `Portal(VisualElement, …)` overload this version adds. Naming the
+  parameter — `V.Portal(targetId: null)` — or casting the literal says which was meant.
 - The switches that classify a `StyleVariantKind` are exhaustive by compilation rather than by review:
   `Runtime/csc.rsp` compiles CS8509 as an error, so a member added without an arm fails the build rather
   than warning into a log that nothing gates on. That response file ships with the package, so a project
   compiling `Velvet.asmdef` compiles CS8509 as an error too, applying to Velvet's own sources only.
+- `StyleVariantClass.BreakpointPx` and `StyleVariantClass.IsResponsive` throw for a `StyleVariantKind`
+  value naming no member of the enum, where they returned `0f` and `false`. Both have done so since
+  2.0.1.
 
 ### Fixed
 


### PR DESCRIPTION
Closes #689 — its last two items; PR #701 closed the first two.

`[Unreleased]` carried no entry for `V.Portal(null)` ceasing to compile. Compiled with Unity
6000.3.11f1's own Roslyn against both overload sets, the bare `null` literal compiles without error against
2.1.0's two overloads and is CS0121-ambiguous against today's three, in a nullable-enabled and a
nullable-disabled context alike. `V.Portal(default)` was already ambiguous at 2.1.0, and a `string`
variable, a string literal, a `string`-typed conditional and a `UILayer` value resolve the same way
on both sides. The entry gives spellings that resolve it.

`StyleVariantClass.BreakpointPx` and `IsResponsive` throwing for a value naming no `StyleVariantKind`
was recorded in no section at all. The change that produced it is in `v2.0.1-main` and not in
`v2.0.0-main`, so the throw shipped in released 2.0.1, and neither that version's CHANGELOG section
nor its published note carries it. The entry goes under `[Unreleased]`
naming the version it arrived in, because `changelog_into_closed_version.py` refuses one into a dated
section: a note is rebuilt from its section on demand, so an entry there would claim a version that
shipped without it. Two cases in `StyleVariantKindClassificationTests` say the CHANGELOG records this
refusal, which is true again.

