### PR TITLE
tooling(velvet): retire the pull-request watcher when nothing reads it

### DIFF
--- a/scripts/pr/settle.py
+++ b/scripts/pr/settle.py
@@ -453,8 +453,34 @@ def beat():
     watcher_state.HEARTBEAT.write_text(watcher_state.beat(os.getpid()))
 
 
+def unasked_for(started, now=None):
+    """Seconds since a reader last recorded asking, counted from this watcher's own start.
+
+    A stamp left before this watcher started says nothing about whether anything reads this one, so
+    the interval runs from the later of the two.
+    """
+    now = time.time() if now is None else now
+    ago = watcher_state.asked_ago(now)
+    return now - started if ago is None else min(ago, now - started)
+
+
+def retire(lock, unasked):
+    """The lock goes back here rather than at the exit: `watch` returns to a caller, and one that
+    went on to other work would hold it while nothing was watching.
+    """
+    lock.close()
+    print(f"Retiring after {int(unasked)}s in which nothing stamped {watcher_state.ASKED}, which is "
+          f"how a guard records reading the watcher's state.\n"
+          f"\nFrom here a pending check blocks a Stop again, and an edit is refused until something "
+          f"is watching. Both are what a live watcher was forgiving. Start another when that is what "
+          f"you want:\n"
+          f"\n  python3 scripts/pr/settle.py watch\n", flush=True)
+    return 0
+
+
 def watch(project, base):
-    """Emit each check that reaches a terminal state, once, and hold the heartbeat open meanwhile."""
+    """Emit each check that reaches a terminal state, once, and hold the heartbeat open until
+    nothing reads it."""
     lock, holder = hold_the_watch()
     if lock is None:
         print(f"Refusing to watch: process {holder or 'unknown'} already holds "
@@ -478,7 +504,13 @@ def watch(project, base):
 
     seen = set()
     ready_since = {}
+    started = time.time()
     while True:
+        # Before the readings, so the error path that sleeps and continues cannot skip it — a
+        # watcher whose calls all fail goes unread like any other.
+        unasked = unasked_for(started)
+        if unasked >= watcher_state.RETIRE_AFTER:
+            return retire(lock, unasked)
         try:
             pull_requests = open_pull_requests(project)
             state = project_state(project, base)

--- a/scripts/pr/settle.py
+++ b/scripts/pr/settle.py
@@ -421,15 +421,24 @@ def read_ready_state():
 
     Retirement makes a restart ordinary rather than a machine reboot, and a `since` that began
     empty would hand every green pull request a new clock — the one
-    `refuse/edit_while_a_ready_pr_sits.py` reads to decide that a pull request has sat. A stamp in
-    the future is dropped rather than carried, for the reason `watcher_state.stamp_age` gives about
-    the one in the heartbeat.
+    `refuse/edit_while_a_ready_pr_sits.py` reads to decide that a pull request has sat.
+
+    Carried only while the heartbeat says the watcher that wrote it was polling inside the staleness
+    window, because a wider gap is one this watcher cannot answer for: the record's own rule is to
+    drop an entry the moment its pull request stops being ready, and a pull request that left the
+    ready set and returned unseen would be carried here as having sat throughout. Read before this
+    watcher's first beat, which is what leaves that heartbeat naming the watcher that wrote the
+    record. A stamp in the future is dropped for the reason `watcher_state.stamp_age` gives about the
+    one in the heartbeat.
     """
     try:
+        beat = watcher_state.HEARTBEAT.read_text(encoding="utf-8")
         text = watcher_state.READY_STATE.read_text(encoding="utf-8")
-    except OSError:
+    except (OSError, UnicodeDecodeError):
         return {}
     now = int(time.time())
+    if watcher_state.stamped(beat, now) is None:
+        return {}
     carried = {}
     for line in text.splitlines():
         fields = line.split()

--- a/scripts/pr/settle.py
+++ b/scripts/pr/settle.py
@@ -423,21 +423,23 @@ def read_ready_state():
     empty would hand every green pull request a new clock — the one
     `refuse/edit_while_a_ready_pr_sits.py` reads to decide that a pull request has sat.
 
-    Carried only while the heartbeat says the watcher that wrote it was polling inside the staleness
-    window, because a wider gap is one this watcher cannot answer for: the record's own rule is to
-    drop an entry the moment its pull request stops being ready, and a pull request that left the
-    ready set and returned unseen would be carried here as having sat throughout. Read before this
-    watcher's first beat, which is what leaves that heartbeat naming the watcher that wrote the
-    record. A stamp in the future is dropped for the reason `watcher_state.stamp_age` gives about the
-    one in the heartbeat.
+    Carried only while the record was itself written inside the staleness window, because a wider
+    gap is one nothing polled through: the record's own rule is to drop an entry the moment its pull
+    request stops being ready, so a pull request that left the ready set and returned unseen would
+    be carried here as having sat throughout. Dated by the file rather than by the heartbeat beside
+    it, which a watcher that beat and then died before its first record would leave fresh over
+    somebody else's. The window runs from the last poll rather than from the retirement, which
+    leaves a replacement about two of its three polls — one started later carries nothing. A stamp
+    in the future is dropped, and the window is bounded below as well as above, for the reason
+    `watcher_state.stamp_age` gives about the one in the heartbeat.
     """
     try:
-        beat = watcher_state.HEARTBEAT.read_text(encoding="utf-8")
         text = watcher_state.READY_STATE.read_text(encoding="utf-8")
+        written = watcher_state.READY_STATE.stat().st_mtime
     except (OSError, UnicodeDecodeError):
         return {}
     now = int(time.time())
-    if watcher_state.stamped(beat, now) is None:
+    if not 0 <= now - written < watcher_state.STALE_AFTER:
         return {}
     carried = {}
     for line in text.splitlines():

--- a/scripts/pr/settle.py
+++ b/scripts/pr/settle.py
@@ -416,6 +416,28 @@ def write_ready_state(ready, since):
         "".join(f"{number} {since[number]}\n" for number in sorted(since)))
 
 
+def read_ready_state():
+    """When each recorded pull request first read as ready, out of the file a watcher left behind.
+
+    Retirement makes a restart ordinary rather than a machine reboot, and a `since` that began
+    empty would hand every green pull request a new clock — the one
+    `refuse/edit_while_a_ready_pr_sits.py` reads to decide that a pull request has sat. A stamp in
+    the future is dropped rather than carried, for the reason `watcher_state.stamp_age` gives about
+    the one in the heartbeat.
+    """
+    try:
+        text = watcher_state.READY_STATE.read_text(encoding="utf-8")
+    except OSError:
+        return {}
+    now = int(time.time())
+    carried = {}
+    for line in text.splitlines():
+        fields = line.split()
+        if len(fields) == 2 and all(field.isdigit() for field in fields) and int(fields[1]) <= now:
+            carried[int(fields[0])] = int(fields[1])
+    return carried
+
+
 def hold_the_watch():
     """(the open lock, the pid holding it). No lock means another watcher already has it.
 
@@ -503,7 +525,7 @@ def watch(project, base):
         return 1
 
     seen = set()
-    ready_since = {}
+    ready_since = read_ready_state()
     started = time.time()
     while True:
         # Before the readings, so the error path that sleeps and continues cannot skip it — a

--- a/scripts/pr/test_settle.py
+++ b/scripts/pr/test_settle.py
@@ -389,6 +389,12 @@ class HeartbeatDuringAPollTests(unittest.TestCase):
 CLOCK_START = 100000
 
 
+# The staleness window in seconds, written out rather than spelled from `watcher_state.STALE_AFTER`:
+# an arrangement naming the symbol moves with a change to it, and this branch made that width decide
+# a second file besides the heartbeat.
+STALE_SECONDS = 180
+
+
 class FakeClock:
     """Time that moves only when the watcher sleeps, so a poll cycle costs no wall clock.
 
@@ -458,7 +464,9 @@ def watch_until(between_polls=None, asked=None, listing_answers=True, seed_ready
             # The clock the watcher reads is fabricated, so the record's own timestamp is set to
             # match it rather than to whatever the filesystem would have written.
             os.utime(ready_state, (seed_ready_at, seed_ready_at))
-        if seed_asked is not None:
+        if isinstance(seed_asked, bytes):
+            (Path(directory) / "asked").write_bytes(seed_asked)
+        elif seed_asked is not None:
             (Path(directory) / "asked").write_text(f"{int(seed_asked)}\n", encoding="utf-8")
         with fabricated_readings({1: fabricate(1)} if states is None else states) as stack:
             for name in ("READY_STATE", "HEARTBEAT", "LOCK", "ASKED"):
@@ -564,13 +572,14 @@ class RetirementTests(unittest.TestCase):
     def test_Given_AReadyRecordWrittenOutsideTheWindow_When_OneStarts_Then_ThatAgeIsNotCarried(self):
         # Arrange — a record older than the staleness window is one nothing polled through, so the
         # pull request may have left the ready set and returned inside it; one dated ahead of the
-        # clock would sit inside the window for as long as it stayed ahead. The first arm is here
-        # because the other two alone would pass on a watcher that carried nothing at all.
+        # clock would sit inside the window for as long as it stayed ahead. The two arms a second
+        # apart are the window's own edge, and the inner one is what goes red on a watcher that
+        # carried nothing at all.
         seeded = f"1 {CLOCK_START - 900}\n"
-        carried = (watch_until(seed_ready=seeded, seed_ready_at=CLOCK_START).ready.split(),
+        carried = (watch_until(seed_ready=seeded,
+                               seed_ready_at=CLOCK_START - STALE_SECONDS + 1).ready.split(),
                    watch_until(seed_ready=seeded,
-                               seed_ready_at=CLOCK_START - settle.watcher_state.STALE_AFTER
-                               ).ready.split(),
+                               seed_ready_at=CLOCK_START - STALE_SECONDS).ready.split(),
                    watch_until(seed_ready=seeded, seed_ready_at=CLOCK_START + 9000).ready.split())
 
         # Act / Assert — a dropped age is redated to the run's own start.
@@ -583,6 +592,15 @@ class RetirementTests(unittest.TestCase):
         # age it is negative, which is younger than any interval, so a watcher that believed it
         # would poll for as long as the stamp stays ahead — the shape this branch exists to remove.
         watched = watch_until(seed_asked=CLOCK_START + 14400)
+
+        # Act / Assert
+        self.assertEqual(watched.code, 0)
+
+    def test_Given_ARecordOfTheLastReadThatIsNotText_When_OneStarts_Then_ItStartsAnyway(self):
+        # Arrange — read at the top of every poll rather than once, so raising here ends a watcher
+        # at its first, and the command the guards name as the way out of a refusal is the one that
+        # would keep failing. The sibling case covers the ready record, one `try` block away.
+        watched = watch_until(seed_asked=b"\xff\xfe1787240000\n")
 
         # Act / Assert
         self.assertEqual(watched.code, 0)

--- a/scripts/pr/test_settle.py
+++ b/scripts/pr/test_settle.py
@@ -391,7 +391,9 @@ CLOCK_START = 100000
 
 # The staleness window in seconds, written out rather than spelled from `watcher_state.STALE_AFTER`:
 # an arrangement naming the symbol moves with a change to it, and this branch made that width decide
-# a second file besides the heartbeat.
+# a second file besides the heartbeat. It reaches the heartbeat's own window only through the carry
+# that shares the width, so a later `read_ready_state` with a width of its own leaves that one
+# pinned by nothing.
 STALE_SECONDS = 180
 
 
@@ -514,7 +516,7 @@ class RetirementTests(unittest.TestCase):
         self.assertEqual(ended, (0, None))
 
     def test_Given_ARetiringWatcher_When_ItStops_Then_ItSaysTheCauseTheCostAndTheCure(self):
-        # Arrange — the guards start refusing the moment it goes, so a message carrying one of the
+        # Arrange — a guard starts refusing the moment it goes, so a message carrying one of the
         # three leaves whoever reads it to work out the rest.
         said = watch_until().output
 
@@ -540,7 +542,7 @@ class RetirementTests(unittest.TestCase):
         self.assertEqual(watched.polls, 120)
 
     def test_Given_ARecordFromLongBeforeThisWatcher_When_ItStarts_Then_ThatIsNotWhatRetiresIt(self):
-        # Arrange — the recovery the guards print is `settle.py watch`, and a Bash call that runs it
+        # Arrange — the recovery a guard prints is `settle.py watch`, and a Bash call that runs it
         # stamps nothing, so the record a replacement finds can be hours old.
         watched = watch_until(seed_asked=CLOCK_START - 14400)
 
@@ -597,9 +599,8 @@ class RetirementTests(unittest.TestCase):
         self.assertEqual(watched.code, 0)
 
     def test_Given_ARecordOfTheLastReadThatIsNotText_When_OneStarts_Then_ItStartsAnyway(self):
-        # Arrange — read at the top of every poll rather than once, so raising here ends a watcher
-        # at its first, and the command the guards name as the way out of a refusal is the one that
-        # would keep failing. The sibling case covers the ready record, one `try` block away.
+        # Arrange — a record the poll cannot decode; `watcher_state.asked_ago` owns why that must
+        # not raise. The sibling case covers the ready record, one `try` block away.
         watched = watch_until(seed_asked=b"\xff\xfe1787240000\n")
 
         # Act / Assert

--- a/scripts/pr/test_settle.py
+++ b/scripts/pr/test_settle.py
@@ -426,20 +426,24 @@ def keeping_the_lock(handles):
     return held
 
 
-# Half again the sixty polls the interval takes, written out rather than derived from it: with a
-# bound of three times RETIRE_AFTER, raising that interval to a hundred polls left every case here
-# green, because the bound moved with it.
+# The clock's two bounds, one either side of the sixty polls the interval takes: at ninety a watcher
+# that retires has already stopped, and at thirty one that has not retired is still going. Written
+# out rather than derived from that interval, because a derived bound moves with it — measured, a
+# bound of three times RETIRE_AFTER left every case here green at an interval of a hundred polls, and
+# one of half it leaves the case below green at ten.
 CLOCK_BOUND = 90
+EARLY_BOUND = 30
 
 
 def watch_until(between_polls=None, asked=None, listing_answers=True, seed_ready=None,
-                states=None):
+                states=None, bound=CLOCK_BOUND):
     """Run `watch` over green pull requests and a clock only its own sleep advances.
 
     `asked` sends the record somewhere else, for a case about it not being written; `seed_ready`
-    writes a ready file for the run to find, the way a watcher that has already stopped leaves one.
+    writes a ready file for the run to find, the way a watcher that has already stopped leaves one;
+    `bound` is how many polls the clock allows before it gives up on the run.
     """
-    clock = FakeClock(CLOCK_BOUND, between_polls)
+    clock = FakeClock(bound, between_polls)
     printed = io.StringIO()
     handles = []
     with tempfile.TemporaryDirectory(prefix="settle-retire-") as directory:
@@ -505,6 +509,17 @@ class RetirementTests(unittest.TestCase):
 
         # Assert
         self.assertTrue(watched.lock_released)
+
+    # GREEN_ON_BASE(characterization): a base with no retirement is still polling in any window.
+    # What this pins is the interval's other side, which had no case at all: lowering the interval
+    # shipped green, and that cut is what reddens this.
+    def test_Given_NothingReadingItsState_When_FewerPollsPassThanTheInterval_Then_ItIsStillWatching(self):
+        # Arrange — retiring early is this branch's own harm one step earlier: the watcher goes
+        # while a session is still working, and the next edit is refused for it.
+        watched = watch_until(bound=EARLY_BOUND)
+
+        # Act / Assert — None is a run the clock gave up on, which is a watcher that had not retired.
+        self.assertIsNone(watched.code)
 
     def test_Given_ReadingsThatNeverAnswer_When_TheIntervalPasses_Then_ItStillRetires(self):
         # Arrange — the wedge that reads to a guard as nothing watching: each poll fails, prints,

--- a/scripts/pr/test_settle.py
+++ b/scripts/pr/test_settle.py
@@ -262,8 +262,11 @@ def poll(states, listing_answers=True):
                     mock.patch.object(settle, "open_pull_requests", refuse_to_answer))
             for name, path in (("READY_STATE", ready_state),
                                ("HEARTBEAT", heartbeat),
-                               ("LOCK", Path(directory) / "lock")):
-                stack.enter_context(mock.patch.object(settle.watcher_state, name, path))
+                               ("LOCK", Path(directory) / "lock"),
+                               ("ASKED", Path(directory) / "asked")):
+                # `create` so the redirect survives being carried onto a tree without the name, where
+                # the alternative is a case that stops before it disagrees.
+                stack.enter_context(mock.patch.object(settle.watcher_state, name, path, create=True))
             stack.enter_context(mock.patch.object(settle.time, "sleep", side_effect=Polled))
             stack.enter_context(contextlib.redirect_stdout(printed))
             try:
@@ -407,8 +410,9 @@ class FakeClock:
 
 
 # How a run of `watch` ended: its exit code, or None where it was still polling when the clock gave
-# up, what it printed on the way out, and whether the lock was free by then.
-Watched = collections.namedtuple("Watched", "code output lock_released")
+# up, what it printed on the way out, whether the lock was free by then, and the ready record it
+# left.
+Watched = collections.namedtuple("Watched", "code output lock_released ready")
 
 
 def keeping_the_lock(handles):
@@ -422,23 +426,37 @@ def keeping_the_lock(handles):
     return held
 
 
-def watch_until(between_polls=None, asked=None):
-    """Run `watch` over one green pull request and a clock only its own sleep advances.
+# Half again the sixty polls the interval takes, written out rather than derived from it: with a
+# bound of three times RETIRE_AFTER, raising that interval to a hundred polls left every case here
+# green, because the bound moved with it.
+CLOCK_BOUND = 90
 
-    The clock's bound is three times the retirement interval, so it cannot be what a case reads as
-    retirement. `asked` sends the record somewhere else, for a case about it not being written.
+
+def watch_until(between_polls=None, asked=None, listing_answers=True, seed_ready=None,
+                states=None):
+    """Run `watch` over green pull requests and a clock only its own sleep advances.
+
+    `asked` sends the record somewhere else, for a case about it not being written; `seed_ready`
+    writes a ready file for the run to find, the way a watcher that has already stopped leaves one.
     """
-    clock = FakeClock(3 * settle.watcher_state.RETIRE_AFTER // settle.watcher_state.POLL_SECONDS,
-                      between_polls)
+    clock = FakeClock(CLOCK_BOUND, between_polls)
     printed = io.StringIO()
     handles = []
     with tempfile.TemporaryDirectory(prefix="settle-retire-") as directory:
-        with fabricated_readings({1: fabricate(1)}) as stack:
+        ready_state = Path(directory) / "ready_state"
+        if seed_ready is not None:
+            ready_state.write_text(seed_ready, encoding="utf-8")
+        with fabricated_readings({1: fabricate(1)} if states is None else states) as stack:
             for name in ("READY_STATE", "HEARTBEAT", "LOCK", "ASKED"):
+                # `create` for the reason `poll` gives over the same redirect.
                 stack.enter_context(mock.patch.object(settle.watcher_state, name,
-                                                      Path(directory) / name.lower()))
+                                                      Path(directory) / name.lower(), create=True))
             if asked is not None:
-                stack.enter_context(mock.patch.object(settle.watcher_state, "ASKED", asked))
+                stack.enter_context(mock.patch.object(settle.watcher_state, "ASKED", asked,
+                                                      create=True))
+            if not listing_answers:
+                stack.enter_context(mock.patch.object(settle, "open_pull_requests",
+                                                     refuse_to_answer))
             stack.enter_context(mock.patch.object(settle, "hold_the_watch",
                                                   keeping_the_lock(handles)))
             stack.enter_context(mock.patch.object(settle.time, "sleep", clock.sleep))
@@ -452,7 +470,8 @@ def watch_until(between_polls=None, asked=None):
             # the handle is held until the reading rather than left to fall out of scope.
             released = handles[0].closed
             handles[0].close()
-    return Watched(code, printed.getvalue(), released)
+        recorded = ready_state.read_text(encoding="utf-8") if ready_state.exists() else ""
+    return Watched(code, printed.getvalue(), released, recorded)
 
 
 class RetirementTests(unittest.TestCase):
@@ -486,6 +505,26 @@ class RetirementTests(unittest.TestCase):
 
         # Assert
         self.assertTrue(watched.lock_released)
+
+    def test_Given_ReadingsThatNeverAnswer_When_TheIntervalPasses_Then_ItStillRetires(self):
+        # Arrange — the wedge that reads to a guard as nothing watching: each poll fails, prints,
+        # sleeps and comes back, so the retirement is reached on that path or not at all.
+        watched = watch_until(listing_answers=False)
+
+        # Act / Assert
+        self.assertEqual(watched.code, 0)
+
+    def test_Given_AReadyRecordAnEarlierWatcherLeft_When_OneStarts_Then_OnlyTheUsableAgeIsCarried(self):
+        # Arrange — two pull requests recorded ready before this run started, one of them stamped
+        # ahead of the clock. Retirement makes restarts ordinary, and a run that began its record
+        # empty would date every green pull request to its own start, which is the age
+        # `refuse/edit_while_a_ready_pr_sits.py` refuses on; carrying the second forward would date
+        # one of them permanently ahead of that age instead.
+        watched = watch_until(seed_ready="1 900\n2 9999999999\n",
+                              states={1: fabricate(1), 2: fabricate(2)})
+
+        # Act / Assert — the clock's start is 1000, so the second is redated and the first is not.
+        self.assertEqual(watched.ready.split(), ["1", "900", "2", "1000"])
 
     def test_Given_AGuardAskingEachPoll_When_TheRecordCannotBeWritten_Then_ItStillGetsItsAnswer(self):
         # Arrange — a directory the write cannot reach. The retirement is folded in beside the

--- a/scripts/pr/test_settle.py
+++ b/scripts/pr/test_settle.py
@@ -381,6 +381,133 @@ class HeartbeatDuringAPollTests(unittest.TestCase):
         self.assertIn(f" {os.getpid()}", outcome.beat or "")
 
 
+class FakeClock:
+    """Time that moves only when the watcher sleeps, so a poll cycle costs no wall clock.
+
+    Bounded, because a watcher that fails to retire would hang the run rather than fail it, and a
+    hang reports nothing.
+    """
+
+    def __init__(self, limit, between_polls=None):
+        self.now = 1000.0
+        self.polls = 0
+        self.limit = limit
+        self.between_polls = between_polls
+
+    def time(self):
+        return self.now
+
+    def sleep(self, seconds):
+        self.polls += 1
+        if self.polls > self.limit:
+            raise Polled
+        self.now += seconds
+        if self.between_polls is not None:
+            self.between_polls(self.now)
+
+
+# How a run of `watch` ended: its exit code, or None where it was still polling when the clock gave
+# up, what it printed on the way out, and whether the lock was free by then.
+Watched = collections.namedtuple("Watched", "code output lock_released")
+
+
+def keeping_the_lock(handles):
+    """`hold_the_watch`, with the handle it opened kept where the run can be read after it ends."""
+    took_it = settle.hold_the_watch
+
+    def held():
+        handle, holder = took_it()
+        handles.append(handle)
+        return handle, holder
+    return held
+
+
+def watch_until(between_polls=None, asked=None):
+    """Run `watch` over one green pull request and a clock only its own sleep advances.
+
+    The clock's bound is three times the retirement interval, so it cannot be what a case reads as
+    retirement. `asked` sends the record somewhere else, for a case about it not being written.
+    """
+    clock = FakeClock(3 * settle.watcher_state.RETIRE_AFTER // settle.watcher_state.POLL_SECONDS,
+                      between_polls)
+    printed = io.StringIO()
+    handles = []
+    with tempfile.TemporaryDirectory(prefix="settle-retire-") as directory:
+        with fabricated_readings({1: fabricate(1)}) as stack:
+            for name in ("READY_STATE", "HEARTBEAT", "LOCK", "ASKED"):
+                stack.enter_context(mock.patch.object(settle.watcher_state, name,
+                                                      Path(directory) / name.lower()))
+            if asked is not None:
+                stack.enter_context(mock.patch.object(settle.watcher_state, "ASKED", asked))
+            stack.enter_context(mock.patch.object(settle, "hold_the_watch",
+                                                  keeping_the_lock(handles)))
+            stack.enter_context(mock.patch.object(settle.time, "sleep", clock.sleep))
+            stack.enter_context(mock.patch.object(settle.time, "time", clock.time))
+            stack.enter_context(contextlib.redirect_stdout(printed))
+            try:
+                code = settle.watch(Path("."), "main")
+            except Polled:
+                code = None
+            # Read before this closes it: what a case asks is whether the code let the lock go, so
+            # the handle is held until the reading rather than left to fall out of scope.
+            released = handles[0].closed
+            handles[0].close()
+    return Watched(code, printed.getvalue(), released)
+
+
+class RetirementTests(unittest.TestCase):
+    """When a watcher stops.
+
+    One polled for seven days past the session that started it, on the order of ten thousand polls
+    nobody read. `watcher_state.ASKED` owns what decides when one stops.
+    """
+
+    def test_Given_OneRunReadAndOneNot_When_BothPassTheRetirementInterval_Then_OnlyTheUnreadStops(self):
+        # Arrange — either arm alone settles nothing: a watcher retiring on its own elapsed time
+        # would pass the unread one, and one that never retires passes the read one.
+        ended = (watch_until().code,
+                 watch_until(between_polls=settle.watcher_state.alive).code)
+
+        # Act / Assert — None is what a watcher still polling at the clock's bound leaves.
+        self.assertEqual(ended, (0, None))
+
+    def test_Given_ARetiringWatcher_When_ItStops_Then_ItSaysWhyAndHowToStartAnother(self):
+        # Arrange — the guards start refusing the moment it goes, so a message carrying one of the
+        # two leaves whoever reads it to work out either the cause or the cure.
+        said = watch_until().output
+
+        # Act / Assert
+        self.assertEqual(("Retiring" in said, "python3 scripts/pr/settle.py watch" in said),
+                         (True, True))
+
+    def test_Given_ARetiringWatcher_When_ItStops_Then_ItLetsGoOfTheLock(self):
+        # Act
+        watched = watch_until()
+
+        # Assert
+        self.assertTrue(watched.lock_released)
+
+    def test_Given_AGuardAskingEachPoll_When_TheRecordCannotBeWritten_Then_ItStillGetsItsAnswer(self):
+        # Arrange — a directory the write cannot reach. The retirement is folded in beside the
+        # answers because with the record landing this watcher would still be polling, so the pair
+        # is what says the guard was answered while nothing was being written down.
+        answers = []
+        with tempfile.TemporaryDirectory(prefix="settle-nowrite-") as directory:
+            unwritable = Path(directory) / "home"
+            unwritable.mkdir()
+            os.chmod(unwritable, 0o500)
+            try:
+                # Act
+                watched = watch_until(
+                    between_polls=lambda now: answers.append(settle.watcher_state.alive(now)),
+                    asked=unwritable / "asked")
+            finally:
+                os.chmod(unwritable, 0o700)
+
+        # Assert
+        self.assertEqual((set(answers), watched.code), ({True}, 0))
+
+
 class ForkMergeTests(unittest.TestCase):
     """What `settle.py merge` does with a head this checkout has no ref for."""
 
@@ -515,7 +642,8 @@ class WatcherLockTests(unittest.TestCase):
 
 
 class HeartbeatTests(unittest.TestCase):
-    """What a reader may conclude from the file, which is what both guards conclude from it."""
+    """What a reader may conclude from the file, which is what both guards conclude from it, and
+    what the reading leaves behind for the watcher."""
 
     def test_Given_AHeartbeatFromALiveProcess_When_ItIsFresh_Then_TheWatcherReadsAsAlive(self):
         # Arrange
@@ -588,10 +716,14 @@ class HeartbeatTests(unittest.TestCase):
 
     @contextlib.contextmanager
     def heartbeat(self, text):
+        """Both files a read touches: reading the first is what writes the second."""
         with tempfile.TemporaryDirectory(prefix="settle-beat-") as directory:
             path = Path(directory) / "beat"
             path.write_text(text)
-            with mock.patch.object(settle.watcher_state, "HEARTBEAT", path):
+            with contextlib.ExitStack() as stack:
+                stack.enter_context(mock.patch.object(settle.watcher_state, "HEARTBEAT", path))
+                stack.enter_context(mock.patch.object(settle.watcher_state, "ASKED",
+                                                     Path(directory) / "asked"))
                 yield
 
 

--- a/scripts/pr/test_settle.py
+++ b/scripts/pr/test_settle.py
@@ -437,12 +437,12 @@ CLOCK_BOUND = 180
 
 
 def watch_until(between_polls=None, asked=None, listing_answers=True, seed_ready=None,
-                states=None, bound=CLOCK_BOUND, seed_beat=None, seed_asked=None):
+                states=None, bound=CLOCK_BOUND, seed_ready_at=None, seed_asked=None):
     """Run `watch` over green pull requests and a clock only its own sleep advances.
 
     `asked` sends the record somewhere else, for a case about it not being written; `bound` is how
-    many polls the clock allows before it gives up. The three `seed_` arguments write what a watcher
-    that has already stopped leaves behind: its ready record, the heartbeat that dates it, and the
+    many polls the clock allows before it gives up. The `seed_` arguments write what a watcher that
+    has already stopped leaves behind: its ready record, when that record was written, and the
     record of the last read.
     """
     clock = FakeClock(bound, between_polls)
@@ -454,9 +454,10 @@ def watch_until(between_polls=None, asked=None, listing_answers=True, seed_ready
             ready_state.write_bytes(seed_ready)
         elif seed_ready is not None:
             ready_state.write_text(seed_ready, encoding="utf-8")
-        if seed_beat is not None:
-            (Path(directory) / "heartbeat").write_text(
-                settle.watcher_state.beat(os.getpid(), now=seed_beat), encoding="utf-8")
+        if seed_ready_at is not None:
+            # The clock the watcher reads is fabricated, so the record's own timestamp is set to
+            # match it rather than to whatever the filesystem would have written.
+            os.utime(ready_state, (seed_ready_at, seed_ready_at))
         if seed_asked is not None:
             (Path(directory) / "asked").write_text(f"{int(seed_asked)}\n", encoding="utf-8")
         with fabricated_readings({1: fabricate(1)} if states is None else states) as stack:
@@ -504,14 +505,15 @@ class RetirementTests(unittest.TestCase):
         # Act / Assert — None is what a watcher still polling at the clock's bound leaves.
         self.assertEqual(ended, (0, None))
 
-    def test_Given_ARetiringWatcher_When_ItStops_Then_ItSaysWhyAndHowToStartAnother(self):
+    def test_Given_ARetiringWatcher_When_ItStops_Then_ItSaysTheCauseTheCostAndTheCure(self):
         # Arrange — the guards start refusing the moment it goes, so a message carrying one of the
-        # two leaves whoever reads it to work out either the cause or the cure.
+        # three leaves whoever reads it to work out the rest.
         said = watch_until().output
 
         # Act / Assert
-        self.assertEqual(("Retiring" in said, "python3 scripts/pr/settle.py watch" in said),
-                         (True, True))
+        self.assertEqual(("nothing stamped" in said,
+                          "blocks a Stop again" in said,
+                          "python3 scripts/pr/settle.py watch" in said), (True, True, True))
 
     def test_Given_ARetiringWatcher_When_ItStops_Then_ItLetsGoOfTheLock(self):
         # Act
@@ -552,31 +554,44 @@ class RetirementTests(unittest.TestCase):
         # `refuse/edit_while_a_ready_pr_sits.py` refuses on; carrying the second forward would date
         # one of them permanently ahead of that age instead.
         watched = watch_until(
-            seed_ready=f"1 {CLOCK_START - 900}\n2 {CLOCK_START + 9000}\n", seed_beat=CLOCK_START,
-            states={1: fabricate(1), 2: fabricate(2)})
+            seed_ready=f"1 {CLOCK_START - 900}\n2 {CLOCK_START + 9000}\n",
+            seed_ready_at=CLOCK_START, states={1: fabricate(1), 2: fabricate(2)})
 
         # Act / Assert — a dropped age is redated to the run's own start, and a carried one is not.
         self.assertEqual(watched.ready.split(),
                          ["1", str(CLOCK_START - 900), "2", str(CLOCK_START)])
 
-    def test_Given_AReadyRecordAndTheBeatBesideIt_When_OneIsStale_Then_ThatAgeIsNotCarried(self):
-        # Arrange — a gap wider than the staleness window is one no watcher was polling through, so
-        # the pull request may have left the ready set and returned inside it. Both arms, because
-        # the fresh one alone would pass on a watcher that carried nothing at all.
-        carried = (watch_until(seed_ready=f"1 {CLOCK_START - 900}\n",
-                               seed_beat=CLOCK_START).ready.split(),
-                   watch_until(seed_ready=f"1 {CLOCK_START - 900}\n",
-                               seed_beat=CLOCK_START - settle.watcher_state.STALE_AFTER).ready.split())
+    def test_Given_AReadyRecordWrittenOutsideTheWindow_When_OneStarts_Then_ThatAgeIsNotCarried(self):
+        # Arrange — a record older than the staleness window is one nothing polled through, so the
+        # pull request may have left the ready set and returned inside it; one dated ahead of the
+        # clock would sit inside the window for as long as it stayed ahead. The first arm is here
+        # because the other two alone would pass on a watcher that carried nothing at all.
+        seeded = f"1 {CLOCK_START - 900}\n"
+        carried = (watch_until(seed_ready=seeded, seed_ready_at=CLOCK_START).ready.split(),
+                   watch_until(seed_ready=seeded,
+                               seed_ready_at=CLOCK_START - settle.watcher_state.STALE_AFTER
+                               ).ready.split(),
+                   watch_until(seed_ready=seeded, seed_ready_at=CLOCK_START + 9000).ready.split())
 
         # Act / Assert — a dropped age is redated to the run's own start.
-        self.assertEqual(carried,
-                         (["1", str(CLOCK_START - 900)], ["1", str(CLOCK_START)]))
+        self.assertEqual(carried, (["1", str(CLOCK_START - 900)],
+                                   ["1", str(CLOCK_START)],
+                                   ["1", str(CLOCK_START)]))
+
+    def test_Given_ARecordStampedAheadOfThisWatcher_When_ItStarts_Then_ItStillRetires(self):
+        # Arrange — a millisecond epoch, a forward clock step or a hand-written stamp. Read as an
+        # age it is negative, which is younger than any interval, so a watcher that believed it
+        # would poll for as long as the stamp stays ahead — the shape this branch exists to remove.
+        watched = watch_until(seed_asked=CLOCK_START + 14400)
+
+        # Act / Assert
+        self.assertEqual(watched.code, 0)
 
     def test_Given_AReadyRecordThatIsNotText_When_OneStarts_Then_ItStartsAnyway(self):
         # Arrange — until the record was read back at all, a file like this was simply overwritten on
         # the first poll. Reading it must not be what stops a watcher starting, every time, until
         # somebody deletes the file.
-        watched = watch_until(seed_ready=b"\xff\xfe700 1\n", seed_beat=CLOCK_START)
+        watched = watch_until(seed_ready=b"\xff\xfe700 1\n", seed_ready_at=CLOCK_START)
 
         # Act / Assert — that it reached its own ending rather than the clock's is the whole claim,
         # so this reads the exit and leaves the interval to the case that pins it.

--- a/scripts/pr/test_settle.py
+++ b/scripts/pr/test_settle.py
@@ -384,6 +384,11 @@ class HeartbeatDuringAPollTests(unittest.TestCase):
         self.assertIn(f" {os.getpid()}", outcome.beat or "")
 
 
+# Far enough from the epoch that a case can date a record hours before a run starts and still write
+# a positive stamp, which is the only kind `watcher_state.stamp_age` reads.
+CLOCK_START = 100000
+
+
 class FakeClock:
     """Time that moves only when the watcher sleeps, so a poll cycle costs no wall clock.
 
@@ -392,7 +397,7 @@ class FakeClock:
     """
 
     def __init__(self, limit, between_polls=None):
-        self.now = 1000.0
+        self.now = float(CLOCK_START)
         self.polls = 0
         self.limit = limit
         self.between_polls = between_polls
@@ -401,18 +406,18 @@ class FakeClock:
         return self.now
 
     def sleep(self, seconds):
-        self.polls += 1
-        if self.polls > self.limit:
+        if self.polls >= self.limit:
             raise Polled
+        self.polls += 1
         self.now += seconds
         if self.between_polls is not None:
             self.between_polls(self.now)
 
 
 # How a run of `watch` ended: its exit code, or None where it was still polling when the clock gave
-# up, what it printed on the way out, whether the lock was free by then, and the ready record it
-# left.
-Watched = collections.namedtuple("Watched", "code output lock_released ready")
+# up, how many polls it took, what it printed on the way out, whether the lock was free by then, and
+# the ready record it left.
+Watched = collections.namedtuple("Watched", "code polls output lock_released ready")
 
 
 def keeping_the_lock(handles):
@@ -426,30 +431,34 @@ def keeping_the_lock(handles):
     return held
 
 
-# The clock's two bounds, one either side of the sixty polls the interval takes: at ninety a watcher
-# that retires has already stopped, and at thirty one that has not retired is still going. Written
-# out rather than derived from that interval, because a derived bound moves with it — measured, a
-# bound of three times RETIRE_AFTER left every case here green at an interval of a hundred polls, and
-# one of half it leaves the case below green at ten.
-CLOCK_BOUND = 90
-EARLY_BOUND = 30
+# Where the clock gives up, past the hundred and twenty polls the interval takes, so a watcher that
+# retires has stopped before it.
+CLOCK_BOUND = 180
 
 
 def watch_until(between_polls=None, asked=None, listing_answers=True, seed_ready=None,
-                states=None, bound=CLOCK_BOUND):
+                states=None, bound=CLOCK_BOUND, seed_beat=None, seed_asked=None):
     """Run `watch` over green pull requests and a clock only its own sleep advances.
 
-    `asked` sends the record somewhere else, for a case about it not being written; `seed_ready`
-    writes a ready file for the run to find, the way a watcher that has already stopped leaves one;
-    `bound` is how many polls the clock allows before it gives up on the run.
+    `asked` sends the record somewhere else, for a case about it not being written; `bound` is how
+    many polls the clock allows before it gives up. The three `seed_` arguments write what a watcher
+    that has already stopped leaves behind: its ready record, the heartbeat that dates it, and the
+    record of the last read.
     """
     clock = FakeClock(bound, between_polls)
     printed = io.StringIO()
     handles = []
     with tempfile.TemporaryDirectory(prefix="settle-retire-") as directory:
         ready_state = Path(directory) / "ready_state"
-        if seed_ready is not None:
+        if isinstance(seed_ready, bytes):
+            ready_state.write_bytes(seed_ready)
+        elif seed_ready is not None:
             ready_state.write_text(seed_ready, encoding="utf-8")
+        if seed_beat is not None:
+            (Path(directory) / "heartbeat").write_text(
+                settle.watcher_state.beat(os.getpid(), now=seed_beat), encoding="utf-8")
+        if seed_asked is not None:
+            (Path(directory) / "asked").write_text(f"{int(seed_asked)}\n", encoding="utf-8")
         with fabricated_readings({1: fabricate(1)} if states is None else states) as stack:
             for name in ("READY_STATE", "HEARTBEAT", "LOCK", "ASKED"):
                 # `create` for the reason `poll` gives over the same redirect.
@@ -474,8 +483,9 @@ def watch_until(between_polls=None, asked=None, listing_answers=True, seed_ready
             # the handle is held until the reading rather than left to fall out of scope.
             released = handles[0].closed
             handles[0].close()
-        recorded = ready_state.read_text(encoding="utf-8") if ready_state.exists() else ""
-    return Watched(code, printed.getvalue(), released, recorded)
+        recorded = (ready_state.read_text(encoding="utf-8", errors="replace")
+                    if ready_state.exists() else "")
+    return Watched(code, clock.polls, printed.getvalue(), released, recorded)
 
 
 class RetirementTests(unittest.TestCase):
@@ -510,16 +520,22 @@ class RetirementTests(unittest.TestCase):
         # Assert
         self.assertTrue(watched.lock_released)
 
-    # GREEN_ON_BASE(characterization): a base with no retirement is still polling in any window.
-    # What this pins is the interval's other side, which had no case at all: lowering the interval
-    # shipped green, and that cut is what reddens this.
-    def test_Given_NothingReadingItsState_When_FewerPollsPassThanTheInterval_Then_ItIsStillWatching(self):
-        # Arrange — retiring early is this branch's own harm one step earlier: the watcher goes
-        # while a session is still working, and the next edit is refused for it.
-        watched = watch_until(bound=EARLY_BOUND)
+    def test_Given_NothingReadingItsState_When_ItRetires_Then_ItPolledTheIntervalOutFirst(self):
+        # Arrange — the count rather than the fact of stopping, because both directions are defects:
+        # too late is the seven days this branch is about, and too early takes the watcher out from
+        # under a session that is still working and hard-refuses its next edit.
+        watched = watch_until()
 
-        # Act / Assert — None is a run the clock gave up on, which is a watcher that had not retired.
-        self.assertIsNone(watched.code)
+        # Act / Assert
+        self.assertEqual(watched.polls, 120)
+
+    def test_Given_ARecordFromLongBeforeThisWatcher_When_ItStarts_Then_ThatIsNotWhatRetiresIt(self):
+        # Arrange — the recovery the guards print is `settle.py watch`, and a Bash call that runs it
+        # stamps nothing, so the record a replacement finds can be hours old.
+        watched = watch_until(seed_asked=CLOCK_START - 14400)
+
+        # Act / Assert
+        self.assertEqual(watched.polls, 120)
 
     def test_Given_ReadingsThatNeverAnswer_When_TheIntervalPasses_Then_ItStillRetires(self):
         # Arrange — the wedge that reads to a guard as nothing watching: each poll fails, prints,
@@ -535,11 +551,36 @@ class RetirementTests(unittest.TestCase):
         # empty would date every green pull request to its own start, which is the age
         # `refuse/edit_while_a_ready_pr_sits.py` refuses on; carrying the second forward would date
         # one of them permanently ahead of that age instead.
-        watched = watch_until(seed_ready="1 900\n2 9999999999\n",
-                              states={1: fabricate(1), 2: fabricate(2)})
+        watched = watch_until(
+            seed_ready=f"1 {CLOCK_START - 900}\n2 {CLOCK_START + 9000}\n", seed_beat=CLOCK_START,
+            states={1: fabricate(1), 2: fabricate(2)})
 
-        # Act / Assert — the clock's start is 1000, so the second is redated and the first is not.
-        self.assertEqual(watched.ready.split(), ["1", "900", "2", "1000"])
+        # Act / Assert — a dropped age is redated to the run's own start, and a carried one is not.
+        self.assertEqual(watched.ready.split(),
+                         ["1", str(CLOCK_START - 900), "2", str(CLOCK_START)])
+
+    def test_Given_AReadyRecordAndTheBeatBesideIt_When_OneIsStale_Then_ThatAgeIsNotCarried(self):
+        # Arrange — a gap wider than the staleness window is one no watcher was polling through, so
+        # the pull request may have left the ready set and returned inside it. Both arms, because
+        # the fresh one alone would pass on a watcher that carried nothing at all.
+        carried = (watch_until(seed_ready=f"1 {CLOCK_START - 900}\n",
+                               seed_beat=CLOCK_START).ready.split(),
+                   watch_until(seed_ready=f"1 {CLOCK_START - 900}\n",
+                               seed_beat=CLOCK_START - settle.watcher_state.STALE_AFTER).ready.split())
+
+        # Act / Assert — a dropped age is redated to the run's own start.
+        self.assertEqual(carried,
+                         (["1", str(CLOCK_START - 900)], ["1", str(CLOCK_START)]))
+
+    def test_Given_AReadyRecordThatIsNotText_When_OneStarts_Then_ItStartsAnyway(self):
+        # Arrange — until the record was read back at all, a file like this was simply overwritten on
+        # the first poll. Reading it must not be what stops a watcher starting, every time, until
+        # somebody deletes the file.
+        watched = watch_until(seed_ready=b"\xff\xfe700 1\n", seed_beat=CLOCK_START)
+
+        # Act / Assert — that it reached its own ending rather than the clock's is the whole claim,
+        # so this reads the exit and leaves the interval to the case that pins it.
+        self.assertEqual(watched.code, 0)
 
     def test_Given_AGuardAskingEachPoll_When_TheRecordCannotBeWritten_Then_ItStillGetsItsAnswer(self):
         # Arrange — a directory the write cannot reach. The retirement is folded in beside the

--- a/scripts/pr/watcher_state.py
+++ b/scripts/pr/watcher_state.py
@@ -1,9 +1,12 @@
-"""The files `settle.py watch` writes, and what a reader may conclude from them.
+"""The files the watcher and its readers leave for each other, and what each may conclude.
 
 Three programs touch these. The watcher writes them; `.claude/hooks/stop/unsettled_pr.py` forgives a
 pending check while one is alive; `.claude/hooks/refuse/edit_while_a_ready_pr_sits.py` refuses a
 write while a ready pull request has sat. The format lives here because it was written in three
 places and read back in two, under two different comments for the same 180 seconds.
+
+One file runs the other way: a reader stamps `ASKED`, and the watcher reads it to find out whether
+anything is still reading what it writes.
 
 A heartbeat names the process that wrote it. Nothing stopped several watchers running at once, each
 on its own poll cycle against one shared API quota and all writing this one file, so a fresh stamp
@@ -30,6 +33,17 @@ POLL_SECONDS = 60
 # Three polls, so one slow `gh` call does not read as a dead watcher.
 STALE_AFTER = 3 * POLL_SECONDS
 
+# Written where a reader asks whether a watcher is alive, so the watcher can ask whether anything
+# still reads what it writes. Not whether it is still owned: a watcher is one per machine and any
+# session's guards may read it, so an orphan is unowned rather than unread.
+ASKED = Path.home() / ".velvet-pr-watch.asked"
+
+# The stamp above is a reader's cadence rather than the watcher's own poll, which is what makes this
+# a different quantity from STALE_AFTER. Thirty polls: long enough to cover a turn that spends its
+# whole length inside long-running commands, and short enough that an unattended watcher costs tens
+# of polls rather than the ten thousand a seven-day one reached.
+RETIRE_AFTER = 30 * POLL_SECONDS
+
 
 def beat(pid, now=None):
     """One heartbeat: when it was written, and by which process."""
@@ -55,21 +69,54 @@ def running(pid):
     return True
 
 
-def stamped(text, now):
-    """Seconds since a heartbeat was written, or None when it carries no usable stamp.
+def stamp_age(text, now):
+    """Seconds since the stamp in this text's first field, or None when it carries none.
 
-    Bounded below as well as above: a stamp in the future — a millisecond epoch, a typo, a backward
-    clock step — vouches for a watcher permanently.
+    Bounded below: a stamp in the future — a millisecond epoch, a typo, a backward clock step —
+    reads as the most recent one there could be, and so vouches for its writer permanently.
     """
     fields = text.split()
     if not fields or not fields[0].isdigit():
         return None
     age = now - int(fields[0])
-    return age if 0 <= age < STALE_AFTER else None
+    return age if age >= 0 else None
+
+
+def stamped(text, now):
+    """Seconds since a heartbeat was written, or None when it is not inside the poll window."""
+    age = stamp_age(text, now)
+    return None if age is None or age >= STALE_AFTER else age
+
+
+def note_asked(now=None):
+    """Record that something has just asked whether a watcher is alive.
+
+    A failed write is swallowed. A home that cannot be written leaves the watcher retiring on its
+    own clock, which it says out loud on the way, and a reader that failed to stamp still has its own
+    answer to give.
+    """
+    try:
+        ASKED.write_text(f"{int(time.time() if now is None else now)}\n", encoding="utf-8")
+    except OSError:
+        pass
+
+
+def asked_ago(now=None):
+    """Seconds since something last asked, or None when no stamp is readable."""
+    try:
+        text = ASKED.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    return stamp_age(text, time.time() if now is None else now)
 
 
 def alive(now=None):
-    """Whether the process that wrote the heartbeat is running and wrote it recently."""
+    """Whether the process that wrote the heartbeat is running and wrote it recently.
+
+    The asking is recorded here rather than in each reader, so a reader written later is counted
+    without being told to.
+    """
+    note_asked(now)
     try:
         text = HEARTBEAT.read_text(encoding="utf-8")
     except OSError:

--- a/scripts/pr/watcher_state.py
+++ b/scripts/pr/watcher_state.py
@@ -45,8 +45,8 @@ ASKED = Path.home() / ".velvet-pr-watch.asked"
 # stamps nothing, and that stretch is what this is sized against. Two hours, chosen past two
 # measurements rather than by judgement: the 1800s wait for a quiet machine all three suite
 # harnesses take, and the longest such stretch a week of sessions on this machine produced when this
-# was chosen. Neither bounds one, and what a session gets back past one is the command the guards
-# name.
+# was chosen. Neither bounds one, and what a session gets back past one is the command a guard
+# names.
 RETIRE_AFTER = 120 * POLL_SECONDS
 
 

--- a/scripts/pr/watcher_state.py
+++ b/scripts/pr/watcher_state.py
@@ -38,11 +38,13 @@ STALE_AFTER = 3 * POLL_SECONDS
 # session's guards may read it, so an orphan is unowned rather than unread.
 ASKED = Path.home() / ".velvet-pr-watch.asked"
 
-# The stamp above is a reader's cadence rather than the watcher's own poll, which is what makes this
-# a different quantity from STALE_AFTER. Thirty polls: long enough to cover a turn that spends its
-# whole length inside long-running commands, and short enough that an unattended watcher costs tens
-# of polls rather than the ten thousand a seven-day one reached.
-RETIRE_AFTER = 30 * POLL_SECONDS
+# A reader's cadence rather than the watcher's own poll, which is what makes this a different
+# quantity from STALE_AFTER. Nothing here stamps during a stretch of Bash alone, so this caps such a
+# stretch rather than clearing it: sixty polls is twice the 1800s wait for a quiet machine that all
+# three of this repository's suite harnesses take, so that wait sits inside the interval rather than
+# on its edge. Longer stretches exist — a campaign takes that wait once per mutant — and no interval
+# covers those; what a session gets back there is the command the guards name.
+RETIRE_AFTER = 60 * POLL_SECONDS
 
 
 def beat(pid, now=None):

--- a/scripts/pr/watcher_state.py
+++ b/scripts/pr/watcher_state.py
@@ -42,11 +42,11 @@ ASKED = Path.home() / ".velvet-pr-watch.asked"
 # quantity from STALE_AFTER. An editing tool stamps; the turn boundary stamps only while some open
 # pull request has a check still pending, since that is the branch of `stop/unsettled_pr.py` that
 # asks whether a watcher is alive. So a session running commands with every pull request green
-# stamps nothing, and that stretch is what this is sized against. Two measurements rather than a
-# judgement: past the 1800s wait for a quiet machine all three suite harnesses take, and past the
-# longest run without an editing tool a week of sessions here produced — 1567 runs, the longest 84
-# minutes, two over an hour and none over two. Neither bounds such a stretch, and what a session
-# gets back past one is the command the guards name.
+# stamps nothing, and that stretch is what this is sized against. Two hours, chosen past two
+# measurements rather than by judgement: the 1800s wait for a quiet machine all three suite
+# harnesses take, and the longest such stretch a week of sessions on this machine produced when this
+# was chosen. Neither bounds one, and what a session gets back past one is the command the guards
+# name.
 RETIRE_AFTER = 120 * POLL_SECONDS
 
 

--- a/scripts/pr/watcher_state.py
+++ b/scripts/pr/watcher_state.py
@@ -39,12 +39,15 @@ STALE_AFTER = 3 * POLL_SECONDS
 ASKED = Path.home() / ".velvet-pr-watch.asked"
 
 # A reader's cadence rather than the watcher's own poll, which is what makes this a different
-# quantity from STALE_AFTER. Nothing here stamps during a stretch of Bash alone, so this caps such a
-# stretch rather than clearing it: sixty polls is twice the 1800s wait for a quiet machine that all
-# three of this repository's suite harnesses take, so that wait sits inside the interval rather than
-# on its edge. Longer stretches exist — a campaign takes that wait once per mutant — and no interval
-# covers those; what a session gets back there is the command the guards name.
-RETIRE_AFTER = 60 * POLL_SECONDS
+# quantity from STALE_AFTER. An editing tool stamps; the turn boundary stamps only while some open
+# pull request has a check still pending, since that is the branch of `stop/unsettled_pr.py` that
+# asks whether a watcher is alive. So a session running commands with every pull request green
+# stamps nothing, and that stretch is what this is sized against. Two measurements rather than a
+# judgement: past the 1800s wait for a quiet machine all three suite harnesses take, and past the
+# longest run without an editing tool a week of sessions here produced — 1567 runs, the longest 84
+# minutes, two over an hour and none over two. Neither bounds such a stretch, and what a session
+# gets back past one is the command the guards name.
+RETIRE_AFTER = 120 * POLL_SECONDS
 
 
 def beat(pid, now=None):

--- a/scripts/pr/watcher_state.py
+++ b/scripts/pr/watcher_state.py
@@ -107,10 +107,15 @@ def note_asked(now=None):
 
 
 def asked_ago(now=None):
-    """Seconds since something last asked, or None when no stamp is readable."""
+    """Seconds since something last asked, or None when no stamp is readable.
+
+    A file that is not text is one of the unreadable kinds rather than a reason to raise: this is
+    read at the top of every poll, so raising here ends a watcher at its first, and the command a
+    guard names as the way out of a refusal is the one that would keep failing.
+    """
     try:
         text = ASKED.read_text(encoding="utf-8")
-    except OSError:
+    except (OSError, UnicodeDecodeError):
         return None
     return stamp_age(text, time.time() if now is None else now)
 


### PR DESCRIPTION
`settle.py watch`'s poll loop had no exit — no `break`, no `return`, no `sys.exit`. One watcher had
been polling every 60 seconds for seven days and three hours, on the order of ten thousand polls,
past the session that started it.

Orphaned is the wrong condition to stop on. The watcher is one per machine — `hold_the_watch`
refuses a second one machine-wide — and any session's guards read the heartbeat it writes, so an
orphan is unowned rather than unread. That one's heartbeat was being read while it ran.

What decides it is whether anything still reads what it writes. `alive()` is the question a guard
puts to the watcher's state, so the record is written there: `note_asked` stamps
`~/.velvet-pr-watch.asked` on each read and `asked_ago` reads its age, both beside the heartbeat and
the lock in `watcher_state.py`. No reader needed changing. `watch` retires when nothing has stamped
it for `RETIRE_AFTER`, counted from its own start so a stamp predating it vouches for nothing, and
checked before the readings so the error path that sleeps and continues cannot skip it.

`RETIRE_AFTER` is a hundred and twenty polls, and what it is sized against is a stretch it caps
rather than clears. An editing tool stamps whenever one is used. The turn boundary stamps only while
some open pull request has a check still pending, since that is the branch of `stop/unsettled_pr.py`
that asks whether a watcher is alive — so a session that runs commands without editing anything,
while nothing it has open is pending, stamps nothing at all.

Two measurements size it, both taken on this machine in the week to 2026-08-21. The first is the
1800s wait for a quiet machine that `mutation_check.py`, `neuter_check.py` and `base_red_check.py`
each take. The second is how long such a stretch runs in practice: over 28,037 tool uses, 2,528 of
them edits, there were 1,567 continuous runs with no editing tool — the longest 84 minutes, two over
an hour, none over two. At sixty polls, two of those runs would have taken the watcher out from
under a working session and hard-refused its next edit; at a hundred and twenty, none would. Neither
measurement bounds such a stretch, and what a session gets back past one is the command a guard
names.

Retirement makes a restart ordinary, so the ready record is carried across one. A run that began it
empty would redate every green pull request to its own start, and that is the age
`refuse/edit_while_a_ready_pr_sits.py` refuses on. `read_ready_state` reads the record back — but
only while the record itself was written inside the staleness window, because a wider gap is one
nothing polled through: the record's own rule is to drop an entry the moment its pull request stops
being ready, and one that left the ready set and returned unseen would otherwise be carried as
having sat throughout. That window is read off the record rather than off the heartbeat beside it,
which a watcher that beat and then died before writing a record of its own would leave fresh over
somebody else's.

Retiring gives the lock back and says what stops with it — a pending check blocks a Stop again, an
edit is refused until something is watching — beside the command that starts another.

A stamp that cannot be written is swallowed rather than raised. A hook that raises exits 1, which is
not a refusal, so a guard would fail open over a read-only home; the watcher instead retires on its
own clock and announces it.

A guard resolves `watcher_state` from its own checkout, so until a session's project directory holds
this change its reads leave no record and a watcher can retire under an active reader.

Closes #722.
