### PR TITLE
docs(velvet): stop citing the dependency rule for a reading only the props bail takes

### DIFF
--- a/Packages/com.velvet.core/Runtime/Component/ComponentAttribute.cs
+++ b/Packages/com.velvet.core/Runtime/Component/ComponentAttribute.cs
@@ -32,11 +32,13 @@ namespace Velvet
         /// decided by the per-type rule <see cref="MemoNode.Dependencies"/> states. A props value that is
         /// not a props bag — a value type, a string, a collection — is compared whole under that same rule
         /// instead of through a member set, so two distinct collections of equal content are a change.
-        /// A value type is decided by its own <c>Equals</c>, which reads what it holds, and
-        /// the <c>float</c> and <c>double</c> fields it carries — directly, or inside a value type it
-        /// holds — are compared by raw bit pattern on top of that, so <c>+0</c> and <c>-0</c> in one of
-        /// those are a change as two <c>float</c> members are. <c>ComponentPropsComparerTests</c> is what
-        /// fails if either half stops holding.
+        /// A value type is decided by its own <c>Equals</c>, which reads what it holds, and then — on this
+        /// path alone — the <c>float</c> and <c>double</c> fields it carries, directly or inside a value
+        /// type it holds, are compared by raw bit pattern on top of that, so <c>+0</c> and <c>-0</c> in one
+        /// of those are a change as two <c>float</c> members are. That last reading is not part of the
+        /// cited rule and the dependency comparison does not take it, so the same pair reaching a hook as a
+        /// dependency is unchanged. <c>ComponentPropsComparerTests</c> is what fails if either half of the
+        /// props answer stops holding, and <c>ObjectIsTests</c> if the dependency answer starts taking it.
         /// Default is <c>false</c>.
         /// <para>
         /// This is a true opt-in gate: only a component with <c>Memoize = true</c> (or one created via

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/ObjectIsTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/ObjectIsTests.cs
@@ -22,13 +22,15 @@ namespace Velvet.Tests
     /// <c>record class</c> or list counts as changed, while the same instance counts as unchanged. A
     /// <c>record struct</c> element takes the value branch instead, so a fresh one of equal content counts
     /// as unchanged — and that branch reads on into what the element holds, a nested <c>record class</c>
-    /// included.</item>
+    /// included. Nothing is layered on that <c>Equals</c>, so a <c>float</c> the element holds does not
+    /// get the raw-bit reading an element that is itself a float gets: two elements differing only in
+    /// the sign of a zero are unchanged.</item>
     /// <item>The two overloads read the branch from different places — <see cref="ObjectIs.AreEqual{T}"/>
     /// from the static <c>T</c>, <see cref="ObjectIs.AreEqualObjects"/> from the runtime type — and an
     /// operand whose static type is <c>object</c> is where that separates their answers, for a boxed value
     /// type and for a rebuilt string alike.</item>
-    /// <item>Float elements follow raw-bit equality: <c>NaN</c> equals itself and <c>+0</c> does not equal
-    /// <c>-0</c>.</item>
+    /// <item>An element that is itself a float follows raw-bit equality: <c>NaN</c> equals itself and
+    /// <c>+0</c> does not equal <c>-0</c>.</item>
     /// <item>Nullable value types compare by value: a lifted <c>default(T) == null</c> check would otherwise
     /// misroute them to the reference-identity branch, where boxing each operand yields a fresh object every
     /// call and makes two equal values never compare equal — turning every store notification into an apparent
@@ -133,8 +135,7 @@ namespace Velvet.Tests
         // GREEN_ON_BASE(characterization): this branch changes no production code — it says which kind of
         // record the arrangement builds, where the bare word covered a struct it does not describe — so the
         // case is green on both sides. What shows it can fail is the reference fall-through of
-        // AreEqualObjects cut to return true, measured: this case reddens beside the fresh-list case in
-        // this fixture.
+        // AreEqualObjects cut to return true: measured, this case reddens.
         [Test]
         public void Given_FreshRecordInstanceSameContent_When_AreEqualDeps_Then_AreNotEqual()
         {
@@ -144,11 +145,9 @@ namespace Velvet.Tests
                 Is.False);
         }
 
-        // GREEN_ON_BASE(characterization): this case adds no production change — it pins the value branch a
-        // boxed element takes, which the base already has — so it is green on both sides. What shows it can
-        // fail is that branch of AreEqualObjects cut to return false, measured: this case reddens beside the
-        // int and enum element cases, the nested case below and the boxed overload-split case, which share
-        // the branch.
+        // GREEN_ON_BASE(characterization): this case adds no production change — it pins the value branch
+        // a boxed element takes, which the base already has — so it is green on both sides. What shows it can
+        // fail is that branch of AreEqualObjects cut to return false: measured, this case reddens.
         [Test]
         public void Given_FreshRecordStructElementSameContent_When_AreEqualDeps_Then_AreEqual()
         {
@@ -163,12 +162,12 @@ namespace Velvet.Tests
 
         // GREEN_ON_BASE(characterization): this case adds no production change — it pins where the value
         // branch stops, which the base already decides this way — so it is green on both sides. What shows
-        // it can fail is a float-leaf reading added to that branch, the one the props bail carries: this
-        // case is the only one in the fixture that reddens under it.
+        // it can fail is a float-leaf reading added to that branch, the one the props bail carries:
+        // measured, this case reddens.
         [Test]
         public void Given_FloatBearingRecordStructElement_When_OnlyTheZeroSignDiffers_Then_AreEqual()
         {
-            // Arrange — the same pair compared as props members is not equal, and this is where the two part
+            // Arrange
             var a = new object[] { new DepFloatStruct(0f) };
             var b = new object[] { new DepFloatStruct(-0f) };
 
@@ -178,9 +177,7 @@ namespace Velvet.Tests
 
         // GREEN_ON_BASE(characterization): this case adds no production change — it pins how far the value
         // branch reads, which the base already decides this way — so it is green on both sides. What shows
-        // it can fail is that branch of AreEqualObjects cut to return false, measured: this case reddens
-        // beside the int, enum and bare record struct element cases and the boxed overload-split case,
-        // which share the branch.
+        // it can fail is that branch of AreEqualObjects cut to return false: measured, this case reddens.
         [Test]
         public void Given_RecordStructElementHoldingFreshEqualRecordClass_When_AreEqualDeps_Then_AreEqual()
         {
@@ -255,9 +252,9 @@ namespace Velvet.Tests
             Assert.That(ObjectIs.AreEqual("a", "b"), Is.False);
         }
 
-        // GREEN_ON_BASE(characterization): the same wording correction as the deps case above, on the
-        // generic overload — green on both sides. What shows it can fail is AreEqual<T>'s reference branch
-        // cut to EqualityComparer<T>.Default, measured: this case reddens beside both overload-split cases.
+        // GREEN_ON_BASE(characterization): the same wording correction as the deps case above, on
+        // the generic overload — green on both sides. What shows it can fail is AreEqual<T>'s reference branch
+        // cut to EqualityComparer<T>.Default: measured, this case reddens.
         [Test]
         public void Given_FreshRecordInstanceSameContent_When_AreEqualGeneric_Then_AreNotEqual()
         {
@@ -358,8 +355,7 @@ namespace Velvet.Tests
 
         // GREEN_ON_BASE(characterization): this case adds no production change — it pins the split the base
         // already has between the two overloads — so it is green on both sides. What shows it can fail is
-        // AreEqual<T>'s reference guard narrowed to exclude object, measured: this case and the string one
-        // below are the only two in the fixture that redden.
+        // AreEqual<T>'s reference guard narrowed to exclude object: measured, this case reddens.
         [Test]
         public void Given_ValueTypeErasedToObject_When_ComparedBothWays_Then_TheTwoOverloadsDisagree()
         {
@@ -376,9 +372,8 @@ namespace Velvet.Tests
 
         // GREEN_ON_BASE(characterization): this case adds no production change — it pins the same split on
         // the other operand class the base already splits, a string rather than a boxed value type — so it
-        // is green on both sides. What shows it can fail is AreEqualObjects' string branch deleted,
-        // measured: this case reddens beside the string element case, and the boxed-value-type case above
-        // stays green under that cut.
+        // is green on both sides. What shows it can fail is AreEqualObjects' string branch deleted:
+        // measured, this case reddens.
         [Test]
         public void Given_StringErasedToObject_When_ComparedBothWays_Then_TheTwoOverloadsDisagree()
         {

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/ObjectIsTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/ObjectIsTests.cs
@@ -46,6 +46,8 @@ namespace Velvet.Tests
 
         private readonly record struct NestingStruct(DepRec Held);
 
+        private readonly record struct DepFloatStruct(float Value);
+
         private enum Color { Red, Green }
 
         [Test]
@@ -157,6 +159,21 @@ namespace Velvet.Tests
                     new object[] { new DepRecStruct(1) },
                     new object[] { new DepRecStruct(1) }),
                 Is.True);
+        }
+
+        // GREEN_ON_BASE(characterization): this case adds no production change — it pins where the value
+        // branch stops, which the base already decides this way — so it is green on both sides. What shows
+        // it can fail is a float-leaf reading added to that branch, the one the props bail carries: this
+        // case is the only one in the fixture that reddens under it.
+        [Test]
+        public void Given_FloatBearingRecordStructElement_When_OnlyTheZeroSignDiffers_Then_AreEqual()
+        {
+            // Arrange — the same pair compared as props members is not equal, and this is where the two part
+            var a = new object[] { new DepFloatStruct(0f) };
+            var b = new object[] { new DepFloatStruct(-0f) };
+
+            // Act + Assert
+            Assert.That(ObjectIs.AreEqualDeps(a, b), Is.True);
         }
 
         // GREEN_ON_BASE(characterization): this case adds no production change — it pins how far the value


### PR DESCRIPTION
Closes #731.

`ComponentAttribute.Memoize`'s remarks send a reader to `MemoNode.Dependencies` for the per-type rule, then add a clause that document does not carry — the `float` and `double` fields a value type holds, compared by raw bit pattern on top of its own equality. `ObjectIs.AreEqualDeps` does not take that reading: it reaches `AreEqualObjects`, whose value branch is the type's own `Equals` and stops there. So a reader following the citation lands on the rule for the other side of the split, and `ComponentAttribute.Compiler` points at the same document for the weaver — correctly, which is why the weaver's dependencies do not get the clause asserted one member above.

The remark now scopes the reading to the path that takes it and says what the other path answers instead.

**The divergence is now pinned rather than asserted.** `ObjectIsTests` gains one case: a `record struct` element whose `float` differs only in the sign of zero is **equal** as a dependency, where the same pair as a props member is not. Measured — with a float-leaf reading added to `AreEqualObjects`' value branch, exactly one of that fixture's 27 cases reddens, and it is this one.

This is what #731 asked for. The alternative it proposed — moving the leaf reading into the primitive so every caller answers alike — was priced and rejected on that issue. `ObjectIs.AreEqual<T>` is a separate family that such a move leaves untouched, so the boundary would shift from *props against the rest* to *`object`-typed against statically-typed* rather than disappearing; and the leaf reading would arrive without the caching that pays for it: `ComponentPropsComparer` consults its type-keyed leaf table at expression-build time and bakes typed field access into a delegate it caches per runtime type, and moving the reading into `ObjectIs` means moving that table and a reset hook it does not have, and compiling the same delegate again in a second place. On the IL2CPP arm there is no delegate to compile at all, so the read there is `FieldInfo.GetValue` per float-bearing element, per render, on a path that is on by default for every component. React does not arbitrate it: `shallowEqual` and `areHookInputsEqual` bottom out at the same `Object.is`, but neither descends, and a signed zero inside a JavaScript aggregate is answered by reference before the sign is consulted.

No CHANGELOG entry: no behaviour moves. The documentation index is unchanged — no guide was added or renamed, and `Documentation~/react-migration.md` defers to the attribute's remarks rather than restating the rule.

EditMode over `ObjectIsTests`, `ComponentPropsComparerTests` and `DocumentationDriftTests`: 86 passed, 0 failed, 0 inconclusive, 0 skipped; `assert_results_from_this_tree.py` and `assert_no_inconclusive.py` both clean, 0 compiler errors in the log.

