### PR TITLE
test(velvet): pin the raw-bit answer for a bare float and double props value

### DIFF
--- a/Packages/com.velvet.core/Runtime/Component/ComponentAttribute.cs
+++ b/Packages/com.velvet.core/Runtime/Component/ComponentAttribute.cs
@@ -32,7 +32,7 @@ namespace Velvet
         /// decided by the per-type rule <see cref="MemoNode.Dependencies"/> states. A props value that is
         /// not a props bag — a value type, a string, a collection — is compared whole under that same rule
         /// instead of through a member set, so two distinct collections of equal content are a change.
-        /// A value type is decided by its own <c>Equals</c>, which reads what it holds, and then — on this
+        /// Any other value type is decided by its own <c>Equals</c>, which reads what it holds, and then — on this
         /// path alone — the <c>float</c> and <c>double</c> fields it carries, directly or inside a value
         /// type it holds, are compared by raw bit pattern on top of that, so <c>+0</c> and <c>-0</c> in one
         /// of those are a change as two <c>float</c> members are. That last reading is not part of the

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/ComponentPropsComparerTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/ComponentPropsComparerTests.cs
@@ -144,8 +144,7 @@ namespace Velvet.Tests
 
         // GREEN_ON_BASE(characterization): the answer a bare string props value already gives.
         // What shows it can fail is IsPropsBag's route past the member walk deleted, so a props value
-        // that is not a bag takes that walk too, measured on this branch: eight cases in this fixture
-        // redden under it, this one among them.
+        // that is not a bag takes that walk too: measured, this case reddens.
         [Test]
         public void Given_BareStringProps_When_ContentDiffersAtEqualLength_Then_IsNotEqual()
         {
@@ -167,8 +166,8 @@ namespace Velvet.Tests
         // GREEN_ON_BASE(characterization): the raw-bit answer a bare float props value already gives.
         // The fixture reached that answer through a member and through a value type's leaf, and never
         // with the float as the props value itself. What shows the case can fail is AreEqualObjects'
-        // raw-bit float branch deleted so a boxed float falls to its own Equals, measured on this
-        // branch: two cases in this fixture redden under it, this one among them.
+        // raw-bit float branch deleted so a boxed float falls to its own Equals: measured, this case
+        // reddens.
         [Test]
         public void Given_BareFloatProps_When_OnlyTheZeroSignDiffers_Then_IsNotEqual()
         {
@@ -180,8 +179,7 @@ namespace Velvet.Tests
         // GREEN_ON_BASE(characterization): the raw-bit answer a bare double props value already gives.
         // A double is decided on a branch of its own, so the float case above does not stand in for it:
         // deleting the raw-bit float branch leaves this pair unequal. What shows this case can fail is
-        // the raw-bit double branch deleted, measured on this branch: this case is the only one in this
-        // fixture that reddens under it.
+        // the raw-bit double branch deleted: measured, this case reddens.
         [Test]
         public void Given_BareDoubleProps_When_OnlyTheZeroSignDiffers_Then_IsNotEqual()
         {

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/ComponentPropsComparerTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/ComponentPropsComparerTests.cs
@@ -26,6 +26,8 @@ namespace Velvet.Tests
     /// compared by raw bit pattern on top of that.</item>
     /// <item>A props value that is not a props bag — a value type, a string, a collection — is compared as
     /// a whole rather than through a member set.</item>
+    /// <item>A bare <c>float</c> or <c>double</c> props value is decided by raw bit pattern rather than by
+    /// its own <c>Equals</c>, so <c>+0</c> and <c>-0</c> are a change.</item>
     /// <item>Float members follow <c>Object.is</c> raw-bit equality: <c>NaN</c> equals itself and <c>+0</c>
     /// does not equal <c>-0</c>.</item>
     /// </list>
@@ -141,10 +143,9 @@ namespace Velvet.Tests
         }
 
         // GREEN_ON_BASE(characterization): the answer a bare string props value already gives.
-        // The base routed it past the member walk on a type test and this change routes it there on
-        // IsPropsBag, so the case is green on both sides. What shows it can fail is that route deleted
-        // so every props value takes the member walk, measured on this branch: six cases in this
-        // fixture redden under it, this one among them.
+        // What shows it can fail is IsPropsBag's route past the member walk deleted, so a props value
+        // that is not a bag takes that walk too, measured on this branch: eight cases in this fixture
+        // redden under it, this one among them.
         [Test]
         public void Given_BareStringProps_When_ContentDiffersAtEqualLength_Then_IsNotEqual()
         {
@@ -161,6 +162,32 @@ namespace Velvet.Tests
             // Act + Assert
             Assert.That(ComponentPropsComparer.ShallowEquals(1, 2), Is.False,
                 "A bare primitive props value is compared as a whole rather than through a member set");
+        }
+
+        // GREEN_ON_BASE(characterization): the raw-bit answer a bare float props value already gives.
+        // The fixture reached that answer through a member and through a value type's leaf, and never
+        // with the float as the props value itself. What shows the case can fail is AreEqualObjects'
+        // raw-bit float branch deleted so a boxed float falls to its own Equals, measured on this
+        // branch: two cases in this fixture redden under it, this one among them.
+        [Test]
+        public void Given_BareFloatProps_When_OnlyTheZeroSignDiffers_Then_IsNotEqual()
+        {
+            // Act + Assert
+            Assert.That(ComponentPropsComparer.ShallowEquals(0f, -0f), Is.False,
+                "A bare float props value is decided by raw bit pattern rather than by its own Equals");
+        }
+
+        // GREEN_ON_BASE(characterization): the raw-bit answer a bare double props value already gives.
+        // A double is decided on a branch of its own, so the float case above does not stand in for it:
+        // deleting the raw-bit float branch leaves this pair unequal. What shows this case can fail is
+        // the raw-bit double branch deleted, measured on this branch: this case is the only one in this
+        // fixture that reddens under it.
+        [Test]
+        public void Given_BareDoubleProps_When_OnlyTheZeroSignDiffers_Then_IsNotEqual()
+        {
+            // Act + Assert
+            Assert.That(ComponentPropsComparer.ShallowEquals(0d, -0d), Is.False,
+                "A bare double props value is decided by raw bit pattern rather than by its own Equals");
         }
 
         [Test]


### PR DESCRIPTION
Closes #748.

`ComponentPropsComparer` special-cases `float` and `double` to a raw-bit comparison before any equality the type declares — `ObjectIs.cs:71-75` and `:77-81`, both ahead of the `type.IsValueType → a.Equals(b)` fall-through at `:88`. Nothing pinned that answer for a **bare** `float` or `double` props value. The neighbouring case compares `1` against `2`, which separate under either branch and so never reach the question, and every float-leaf case in the fixture puts the floating-point value inside something.

Two cases, both `GREEN_ON_BASE(characterization)` — measured, not assumed, with `base_red_check.py --lane csharp` before annotating; the branch changes no production code, so they are green on both sides by construction.

**Each is separated by a cut the other survives, which is what earns the `double` sibling its place:**

| cut | red in this fixture |
|---|---|
| the raw-bit `float` branch deleted | 2 — the new `float` case and `Given_BareRecordStructProps_When_AFloatDiffersOnlyInZeroSign` |
| the raw-bit `double` branch deleted | 1 — the new `double` case, alone |
| `ValueEquals` deciding with `Equals` instead of `ObjectIs.AreEqualObjects` | 2 — the two new cases, and nothing else |

The third is what answers whether these add coverage rather than proxy for a neighbour: 2 of 40 red, both new.

**A count in a neighbour's declaration was false once these landed.** `Given_BareStringProps` stated that six cases redden when the non-bag route is deleted; measured, it is now eight. The declaration is corrected, and its reason narrowed — the sentence it carried described how the routing test changed in an earlier release, which is true and is not why that case reddens under the cut it names. The other counted claims in the fixture were re-measured against the new cases and all hold: seven under the value fall-through cut, one under the leaf-comparison cut, and neither new case is among either set.

The `<summary>` bullet list is the fixture's specification and had no bullet for the bare position; it gains one.

**No CHANGELOG entry** — test-only coverage of behaviour already shipped. **No `Documentation~` change** — nothing moved, and the per-type rule's owning document is untouched.

EditMode over `ComponentPropsComparerTests`, `ComponentPropsComparerArmParityTests`, `ObjectIsTests`, `DocumentationDriftTests` and `TestOnlyMemberConventionTests`: 90 passed, 0 failed, 0 inconclusive, 0 skipped, with `assert_results_from_this_tree.py` and `assert_no_inconclusive.py` both clean. `test_base_red_check.py` 207 passed; `assume_gate_check.py` unchanged at 4160 cases read.
