### PR TITLE
tooling(velvet): report the arrangement sweep beside the universals one

### DIFF
--- a/.claude/agents/velvet-implementer.md
+++ b/.claude/agents/velvet-implementer.md
@@ -71,4 +71,6 @@ Say what you changed, the RED evidence with its failure text, the suite counts, 
 
 For each comment the change adds, alters or removes, say which of those it was, and for anything that is not a removal, what removing it would have lost.
 
+For each case you added, report the arrangement sweep and what it returned, including a nil result. The `unity-tests` skill owns what that sweep is; do not restate it here or in your report. Five cases reached review in one session having passed the cut question above while a condition they arranged was carrying nothing, so the two are worth answering separately.
+
 If a claim in your instructions turned out to be wrong, say so plainly and show what you measured instead. That has happened repeatedly and is always worth more than politely working around it.

--- a/.claude/agents/velvet-implementer.md
+++ b/.claude/agents/velvet-implementer.md
@@ -71,6 +71,6 @@ Say what you changed, the RED evidence with its failure text, the suite counts, 
 
 For each comment the change adds, alters or removes, say which of those it was, and for anything that is not a removal, what removing it would have lost.
 
-For each case you added, report the arrangement sweep and what it returned, including a nil result. The `unity-tests` skill owns what that sweep is; do not restate it here or in your report. Five cases reached review in one session having passed the cut question above while a condition they arranged was carrying nothing, so the two are worth answering separately.
+For each case you added or changed, report the arrangement sweep and what it returned, including a nil result. The `unity-tests` skill owns what that sweep is; do not restate it here or in your report.
 
 If a claim in your instructions turned out to be wrong, say so plainly and show what you measured instead. That has happened repeatedly and is always worth more than politely working around it.


### PR DESCRIPTION
No issue: the report enumerates the universals a change swept and says nothing about the conditions its cases arrange.

Replaces #763, which tried to add this as a fourth question and was withdrawn on four counts: it
restated the `unity-tests` skill this agent loads, drifted from it at birth, carried a claim about the
C# compiler that measurement did not support, and — the one that matters here — offered as its first
example a fixture that arranged nothing, where the absence it named was the fixture's default state
rather than a condition anyone set up.

**The instruction was not what was missing.** The skill already carries the shape as one of its nine
ways a test has passed while checking nothing, and carries the sweep beside it. What was missing is a
place the answer has to appear. The question above — which single cut reddens each assertion — is
answerable, honestly and in full, by a case whose arranged condition carries nothing: the cut reddens
the case, and the thing the case is named for was never exercised.

So this asks for the sweep's result, and points at the skill for what the sweep is — the same shape
the universals paragraph three sections up already uses, and for the same reason: a condensed copy
drifts, and this file records what that cost the last time.

It is scoped to a case added **or changed**, matching that paragraph rather than the cut question
beside it, because a change that adds an arranged condition to an existing case owes the same sweep.

It sits under `## Reporting` beside the comment-disposition line, which #744 put there rather than in
the question list for exactly this reason. The list stays at three, and its introduction — "each has
caught a defect that shipped past a fully green suite" — stays true over the set it quantifies.

**It carries no count.** The first version motivated the ask with five instances from one session. Two
verify; two of the five predate the cut question they were said to have passed, by six and seven
weeks. A number in a squash message is a claim nothing pins, and the file's other `## Reporting` items
motivate without one.

No documentation impact. No CHANGELOG entry — contributor tooling.
