### PR TITLE
fix(velvet): file a throw from a resolution subscriber as the subscriber's own

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -271,11 +271,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   round that loader belonged to. The router answers a resolution by re-emitting the location, so a
   `Router.OnLocationChanged` subscriber can run behind that announcement — and a throw from one was
   caught by the clauses that exist for the loader itself. That counted the round's outstanding loader
-  off a second time, to a pending count of −1 which nothing afterwards raises back to zero, and
-  recorded the throw as that route's loader error. So a caller reading the route's loader error saw a
-  load failure that had not happened, the console carried the subscriber's exception under the name of
-  that failure, and the history entry stayed unsettled — a Back or Forward to it re-ran the loader
-  instead of being served from the cache. The throw is now reported as the subscriber's own and the
+  off a second time and recorded the throw as that route's loader error. So a caller reading the route's
+  loader error saw a load failure that had not happened, and the console carried the subscriber's
+  exception under the name of that failure. Filing it as a failure also ran the router's failure
+  handler, which writes the history entry's snapshot again — this time from a round the second count
+  had corrupted — so the entry stayed unsettled and a Back or Forward to it re-ran the loader instead
+  of being served from the cache. What that second count costs the round itself depends on how many
+  loaders it holds: one leaves it permanently short of settling, and two leave it reporting itself
+  settled while the second loader is still outstanding. The throw is now reported as the subscriber's own and the
   round stands as the loader left it, with its result recorded and no error. A subscriber throwing out
   of the failure announcement is reported the same way, where it used to be left to whatever observes a
   forgotten task.

--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -267,6 +267,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   gated on the key being omitted, and an omitted key is the factory delegate, which a delegate's own
   identity comparison covers either way. A key of any other reference type is still compared by
   instance, so that omitted-key behaviour is unchanged.
+- A subscriber that throws while a `LoaderMode.Suspend` loader is resolving no longer corrupts the
+  round that loader belonged to. The router answers a resolution by re-emitting the location, so a
+  `Router.OnLocationChanged` subscriber can run behind that announcement — and a throw from one was
+  caught by the clauses that exist for the loader itself. That counted the round's outstanding loader
+  off a second time, to a pending count of −1 which nothing afterwards raises back to zero, and
+  recorded the throw as that route's loader error. So a caller reading the route's loader error saw a
+  load failure that had not happened, the console carried the subscriber's exception under the name of
+  that failure, and the history entry stayed unsettled — a Back or Forward to it re-ran the loader
+  instead of being served from the cache. The throw is now reported as the subscriber's own and the
+  round stands as the loader left it, with its result recorded and no error. A subscriber throwing out
+  of the failure announcement is reported the same way, where it used to be left to whatever observes a
+  forgotten task.
 
 ## [Unreleased — breaking]
 

--- a/Packages/com.velvet.core/Runtime/Routing/RouteLoaderRunner.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/RouteLoaderRunner.cs
@@ -155,9 +155,10 @@ namespace Velvet
                 _activeSuspendTaskCount++;
                 object result;
                 // Only the await is inside: an announcement made from within it is taken for the loader by
-                // the clauses that follow — the round's pending loader counted off a second time, leaving a
-                // round that can never settle, and the general clause filing the throw as the route's load
-                // error besides.
+                // the clauses that follow — the round's pending loader counted off a second time, and the
+                // general clause filing the throw as the route's load error besides. What the second count
+                // costs depends on how many loaders the round holds: one leaves it at -1 and permanently
+                // unsettled, two leave it at 0 and settled while the second loader is still outstanding.
                 try
                 {
                     result = await task;

--- a/Packages/com.velvet.core/Runtime/Routing/RouteLoaderRunner.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/RouteLoaderRunner.cs
@@ -153,7 +153,32 @@ namespace Velvet
             try
             {
                 _activeSuspendTaskCount++;
-                var result = await task;
+                object result;
+                // Only the await is inside: an announcement made from within it is taken for the loader by
+                // the clauses that follow — the round's pending loader counted off a second time, leaving a
+                // round that can never settle, and the general clause filing the throw as the route's load
+                // error besides.
+                try
+                {
+                    result = await task;
+                }
+                catch (OperationCanceledException)
+                {
+                    round.Pending--;
+                    return;
+                }
+                catch (Exception ex)
+                {
+                    round.Pending--;
+                    // Recorded ahead of the supersession guard, as the success path records its result: Pending
+                    // is counted off whatever the round's currency, so a round that recorded nothing for a route
+                    // it counted off would report itself settled holding neither a result nor a failure for it.
+                    round.Errors[routeId] = ex;
+                    if (ownCts != _cts) return;
+                    Announce(OnSuspendLoaderFailed, routeId, ex);
+                    return;
+                }
+
                 // Counted off before the supersession check and before the event, not in the finally below: a
                 // superseded round is still owed this task's departure, and a subscriber reading the round
                 // from inside the callback — the router's history write-back does — must see it already gone.
@@ -166,25 +191,25 @@ namespace Velvet
                 // That makes this a superseded round: its own record above stands, and what must not happen
                 // is announcing it into the live state of an unrelated current location.
                 if (ownCts != _cts) return;
-                OnSuspendLoaderCompleted?.Invoke(routeId, result);
-            }
-            catch (OperationCanceledException)
-            {
-                round.Pending--;
-            }
-            catch (Exception ex)
-            {
-                round.Pending--;
-                // Recorded ahead of the supersession guard, as the success path records its result: Pending is
-                // counted off whatever the round's currency, so a round that recorded nothing for a route it
-                // counted off would report itself settled holding neither a result nor a failure for it.
-                round.Errors[routeId] = ex;
-                if (ownCts != _cts) return;
-                OnSuspendLoaderFailed?.Invoke(routeId, ex);
+                Announce(OnSuspendLoaderCompleted, routeId, result);
             }
             finally
             {
                 _activeSuspendTaskCount--;
+            }
+        }
+
+        // Reported rather than left to escape, because RunLoadersSync forgets this task: escaping hands the
+        // report to whoever observes a forgotten one instead of to the runner that made the call.
+        private static void Announce<T>(Action<string?, T>? subscribers, string? routeId, T payload)
+        {
+            try
+            {
+                subscribers?.Invoke(routeId, payload);
+            }
+            catch (Exception announcementFailure)
+            {
+                FiberLogger.LogException(nameof(RouteLoaderRunner), announcementFailure);
             }
         }
 

--- a/Packages/com.velvet.core/Runtime/Routing/Router.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/Router.cs
@@ -74,7 +74,8 @@ namespace Velvet
         /// Raised after each successful navigation with the new location. Also re-emitted (with a fresh
         /// location identity) when a Suspend-mode loader resolves within the current location. A subscriber
         /// that throws out of that re-emit is reported to the console and the resolution stands: the loader's
-        /// round settles and the route keeps the result the loader produced.
+        /// round settles and the route keeps what the loader produced. The same holds for the re-emit that
+        /// follows a loader failing, where what it keeps is that failure.
         /// </summary>
         public event Action<RouterLocation> OnLocationChanged = null!;
 

--- a/Packages/com.velvet.core/Runtime/Routing/Router.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/Router.cs
@@ -72,7 +72,9 @@ namespace Velvet
 
         /// <summary>
         /// Raised after each successful navigation with the new location. Also re-emitted (with a fresh
-        /// location identity) when a Suspend-mode loader resolves within the current location.
+        /// location identity) when a Suspend-mode loader resolves within the current location. A subscriber
+        /// that throws out of that re-emit is reported to the console and the resolution stands: the loader's
+        /// round settles and the route keeps the result the loader produced.
         /// </summary>
         public event Action<RouterLocation> OnLocationChanged = null!;
 

--- a/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouteLoaderRunnerTests.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouteLoaderRunnerTests.cs
@@ -5,8 +5,10 @@ using System.Linq;
 using System.Threading;
 using Cysharp.Threading.Tasks;
 using NUnit.Framework;
+using UnityEngine;
 using UnityEngine.TestTools;
 using Velvet;
+using Velvet.TestUtilities;
 using static Velvet.Tests.RouteTestStubs;
 
 namespace Velvet.Tests
@@ -33,6 +35,8 @@ namespace Velvet.Tests
     /// round it started from nor collects the ones that round records afterwards.</item>
     /// <item>A superseded round still records both a late success and a late failure; supersession withholds
     /// the announcement, not the record.</item>
+    /// <item>A subscriber that throws out of either announcement is reported by the runner, and leaves the
+    /// round's own accounting — its pending count and what it recorded for the route — as the loader left it.</item>
     /// </list>
     /// </summary>
     [TestFixture]
@@ -310,6 +314,127 @@ namespace Velvet.Tests
                 Is.EqualTo("results=succeeds errors=fails"),
                 "A superseded round records what its loaders did on both paths alike");
         });
+
+        #endregion
+
+        #region Announcement failures
+
+        [UnityTest]
+        public IEnumerator Given_ASuspendLoaderThatSucceeded_When_TheCompletionSubscriberThrows_Then_TheRoundStillSettles()
+            => UniTask.ToCoroutine(async () =>
+        {
+            // A round holding nothing for the route would settle too, so the result is folded in.
+            // Arrange
+            var runner = new RouteLoaderRunner();
+            var tcs = new UniTaskCompletionSource<object>();
+            runner.OnSuspendLoaderCompleted += (_, __) => throw new InvalidOperationException("handler-threw");
+            var matches = MakeMatch("test", loader: (ctx, ct) => tcs.Task, loaderMode: LoaderMode.Suspend);
+            var round = runner.RunLoadersSync(matches, CancellationToken.None);
+            ContainedFailureLog.Expect<InvalidOperationException>(nameof(RouteLoaderRunner), "handler-threw");
+
+            // Act
+            tcs.TrySetResult("deferred-data");
+            await UniTask.Yield();
+
+            // Assert
+            Assert.That($"settled={round.Settled} results=[{string.Join("|", round.Results.Keys)}]",
+                Is.EqualTo("settled=True results=[test]"),
+                "A subscriber's failure must not count this round's pending loader off a second time");
+        });
+
+        [UnityTest]
+        public IEnumerator Given_ASuspendLoaderThatSucceeded_When_TheCompletionSubscriberThrows_Then_NoLoadErrorIsRecorded()
+            => UniTask.ToCoroutine(async () =>
+        {
+            // An empty error map is also what a round that recorded nothing at all holds, so the result is
+            // folded in.
+            // Arrange
+            var runner = new RouteLoaderRunner();
+            var tcs = new UniTaskCompletionSource<object>();
+            runner.OnSuspendLoaderCompleted += (_, __) => throw new InvalidOperationException("handler-threw");
+            var matches = MakeMatch("test", loader: (ctx, ct) => tcs.Task, loaderMode: LoaderMode.Suspend);
+            var round = runner.RunLoadersSync(matches, CancellationToken.None);
+            ContainedFailureLog.Expect<InvalidOperationException>(nameof(RouteLoaderRunner), "handler-threw");
+
+            // Act
+            tcs.TrySetResult("deferred-data");
+            await UniTask.Yield();
+
+            // Assert
+            Assert.That(
+                $"errors=[{string.Join("|", round.Errors.Keys)}] results=[{string.Join("|", round.Results.Keys)}]",
+                Is.EqualTo("errors=[] results=[test]"),
+                "What failed is the subscriber, so a caller reading this route's loader error would be reading a load failure that did not happen");
+        });
+
+        [UnityTest]
+        public IEnumerator Given_ASuspendLoaderThatSucceeded_When_TheCompletionSubscriberThrowsACancellation_Then_TheRunnerStillSettlesAndReportsIt()
+            => UniTask.ToCoroutine(async () =>
+        {
+            // A cancellation is the spelling the await's other catch clause takes, so a containment written
+            // against the general one alone leaves this round short a pending count and its report to
+            // whatever observes a forgotten task.
+            // Arrange
+            var runner = new RouteLoaderRunner();
+            var tcs = new UniTaskCompletionSource<object>();
+            runner.OnSuspendLoaderCompleted += (_, __) => throw new OperationCanceledException("handler-cancelled");
+            var matches = MakeMatch("test", loader: (ctx, ct) => tcs.Task, loaderMode: LoaderMode.Suspend);
+            var round = runner.RunLoadersSync(matches, CancellationToken.None);
+            ContainedFailureLog.Expect<OperationCanceledException>(nameof(RouteLoaderRunner), "handler-cancelled");
+            using var reports = new ContainedReportProbe();
+
+            // Act
+            tcs.TrySetResult("deferred-data");
+            await UniTask.Yield();
+
+            // Assert
+            Assert.That($"settled={round.Settled} reports={reports.Count}", Is.EqualTo("settled=True reports=1"),
+                "A cancellation raised by a subscriber is that subscriber's failure, not this round's cancellation");
+        });
+
+        [UnityTest]
+        public IEnumerator Given_ASuspendLoaderThatFailed_When_TheFailureSubscriberThrows_Then_TheRunnerReportsItAndKeepsTheLoaderError()
+            => UniTask.ToCoroutine(async () =>
+        {
+            // The sibling announcement. The round's accounting is finished before it runs, so what this pins
+            // is that a subscriber's throw is reported by the runner rather than left to whatever observes
+            // the forgotten task.
+            // Arrange
+            var runner = new RouteLoaderRunner();
+            var tcs = new UniTaskCompletionSource<object>();
+            runner.OnSuspendLoaderFailed += (_, __) => throw new InvalidOperationException("handler-threw");
+            var matches = MakeMatch("fail", loader: (ctx, ct) => tcs.Task, loaderMode: LoaderMode.Suspend);
+            var round = runner.RunLoadersSync(matches, CancellationToken.None);
+            ContainedFailureLog.Expect<InvalidOperationException>(nameof(RouteLoaderRunner), "handler-threw");
+            using var reports = new ContainedReportProbe();
+
+            // Act
+            tcs.TrySetException(new InvalidOperationException("deferred-failure"));
+            await UniTask.Yield();
+
+            // Assert
+            Assert.That($"reports={reports.Count} errors=[{string.Join("|", round.Errors.Keys)}]",
+                Is.EqualTo("reports=1 errors=[fail]"),
+                "The loader's own failure is still the route's, and the subscriber's is the runner's to report");
+        });
+
+        // A report the runner made carries its tag; one published by whatever observes a task the runner
+        // forgot does not, and that is what these cases read the two apart by.
+        private sealed class ContainedReportProbe : IDisposable
+        {
+            private int _count;
+
+            internal ContainedReportProbe() => Application.logMessageReceived += Capture;
+
+            internal int Count => _count;
+
+            private void Capture(string condition, string stackTrace, LogType type)
+            {
+                if (type == LogType.Error && condition.Contains(nameof(RouteLoaderRunner))) _count++;
+            }
+
+            public void Dispose() => Application.logMessageReceived -= Capture;
+        }
 
         #endregion
 

--- a/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouterTests.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouterTests.cs
@@ -37,6 +37,8 @@ namespace Velvet.Tests
     /// <item><c>CurrentLoaderData</c> is a snapshot rather than a live view, so a Suspend loader resolving
     /// afterwards leaves the dictionary an earlier caller is holding untouched.</item>
     /// <item><c>OnLocationChanged</c> fires once per navigation with the committed location.</item>
+    /// <item>A subscriber that throws out of the re-emit a Suspend resolution drives leaves the entry settled,
+    /// so the Back cache still serves it.</item>
     /// <item>An optional <see cref="IRouteScopeFactory"/> is exposed through <c>ScopeFactory</c> and is null
     /// when not supplied.</item>
     /// <item>A concurrent navigation arriving during an async Blocker await cancels the in-flight navigation
@@ -634,6 +636,47 @@ namespace Velvet.Tests
             // Assert
             Assert.That(router.CurrentLoaderErrors["/deferred"].Message, Does.Contain("deferred-failure"),
                 "The Back cache hit restores the post-resolution error recorded by the Suspend loader");
+        });
+
+        [UnityTest]
+        public IEnumerator Given_ASubscriberThatThrowsOnASuspendResolution_When_GoBackToThatEntry_Then_TheCacheStillServesIt()
+            => UniTask.ToCoroutine(async () =>
+        {
+            // The framework puts application code behind the resolution announcement: the router answers it by
+            // re-emitting the location, and a subscriber is free to fail. The count is read on both sides of the
+            // Back because an after-only reading of one run cannot tell a Back that ran none from a Back that
+            // ran the only one.
+            // Arrange
+            var tcs = new UniTaskCompletionSource<object>();
+            var loaderRuns = 0;
+            var router = new Router(new[]
+            {
+                Route("/", children: new[]
+                {
+                    Route("deferred", loader: (ctx, ct) =>
+                    {
+                        loaderRuns++;
+                        return tcs.Task;
+                    }, loaderMode: LoaderMode.Suspend),
+                    Route("other"),
+                }),
+            });
+            router.NavigateSync("/deferred");
+            void Throwing(RouterLocation _) => throw new InvalidOperationException("subscriber-threw");
+            router.OnLocationChanged += Throwing;
+            ContainedFailureLog.Expect<InvalidOperationException>(nameof(RouteLoaderRunner), "subscriber-threw");
+            tcs.TrySetResult("deferred-data");
+            await UniTask.Yield();
+            router.OnLocationChanged -= Throwing;
+            var runsBeforeBack = loaderRuns;
+            router.NavigateSync("/other");
+
+            // Act
+            router.GoBackSync();
+
+            // Assert
+            Assert.That($"beforeBack={runsBeforeBack} afterBack={loaderRuns}", Is.EqualTo("beforeBack=1 afterBack=1"),
+                "An entry left unsettled by a failing subscriber is one the Back cache does not serve, so the loader runs again");
         });
 
         #endregion


### PR DESCRIPTION
Closes #755.

`RunSuspendLoader` wrapped its announcement in the clauses written for the loader, so a throw from a
`Router.OnLocationChanged` subscriber ran them. The router answers a Suspend-mode resolution by
re-emitting the location, so an application subscriber sits behind that announcement as a matter of
course — this is not an exotic extension point.

What that cost, measured on the base except where a bullet says otherwise:

- the round's outstanding loader was **counted off a second time**. What that costs the round depends
  on how many loaders it holds: one leaves it permanently short of settling, two leave it reporting
  itself settled while the second is still outstanding. The one-loader leg is measured in Unity; the
  two-loader leg is measured on a verbatim port of the runner and both router handlers, which
  reproduces the one-loader leg exactly;
- and filing the throw as a failure ran the router's **failure** handler, which writes the history
  entry's snapshot again — from a round the second count had corrupted. That is what left the entry
  unsettled, so a Back or Forward to it re-ran the loader instead of being served from the cache. The
  count alone does not: cutting that one write on the base leaves the cache serving the entry with the
  count still at `-1`;
- the throw was **recorded as that route's loader error**. The loader succeeded; what failed was code
  the router runs after it, and a caller reading the error saw a load failure that had not happened;
- and the console carried the subscriber's exception **under the name of that failure**.

## The fix

The `try` now holds the `await` alone. What the announcement raises is contained where the
announcement is made, and reported under the runner's own name — `RunLoadersSync` forgets this task,
so an escaping throw is handed to whoever observes a forgotten one rather than to the runner that made
the call. The failure announcement is contained the same way, where before it was left to escape.

The round then stands as the loader left it: its result recorded, no error, and settled.

## Evidence

Five cases, each naming what the subscriber's throw must not disturb — the round still settles, no
load error is recorded, a cancellation thrown by a subscriber is not read as the loader's, the failure
announcement is contained and keeps the loader's own error, and a Back to an entry whose resolution had
a throwing subscriber is still served from the cache rather than re-running the loader.

`Router.OnLocationChanged`'s own documentation states the new contract: a subscriber that throws out of
the re-emit is reported to the console and the resolution stands.

The event's own XML documentation is the owning document for this contract and moves with the change; no `Documentation~` guide covers loader semantics, so nothing there is falsified.

**On this branch's provenance.** The implementing agent stopped before reporting; the work was complete
and committed in its worktree, and the account above is read from the diff and its comments rather than
from a report I hold. What I have not seen: its suite counts, its mutation campaign's verdict, and its
universals sweep. CI's EditMode and PlayMode runs and the review round stand in for them; a review took the
campaign's receipt against `1d59c1e` and found it clean, and the prose correction after it edited a
comment in one target file and an XML doc in another, which is enough to move the byte-keyed digest
and void that receipt. The mutant set is identical either side — the same five mutants on the same
five statements — and #746 is where the keying is filed.


