### PR TITLE
fix(velvet): retire an AnimatePresence's state when its node stops being rendered

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -23,16 +23,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   behind per removal, and a poolable parent rented back for a fresh presence at the same position
   picked the stale entry up again.
   A presence written directly in a `V.Portal`'s own children — so its children expand straight into
-  the registered target element — is outside what this release answers for, and reads here as it
-  does on 2.1.1. Nothing records which portal expanded an entry, so closing the portal retires none;
-  and the fiber term a reopen records is not the term the mount recorded, so the reopen starts a
-  second entry rather than finding the mount's, which stays behind unchanged. Closing the portal
-  empties the target and the first reopen shows only the new child; the second reopen brings a child
+  the registered target element — is outside what this release answers for. Closing the portal
+  empties the target and leaves the entry behind, and the fiber term the first reopen records is not
+  the term the mount recorded, so it starts a second entry rather than finding the mount's, which
+  stays behind unchanged; that reopen shows only the new child. The second reopen brings a child
   whose key changed between opens back beside the new one, while one stable child key was measured
   holding exactly one child after each of three reopens. Leaving the portal open and hiding only the
   presence reads differently again: the departed child stays in the target straight away, and is
   beside the new one on the next show. Placing the presence under an element inside the portal's
-  children is covered, and `Documentation~/motion.md` owns the placement advice.
+  children covers the close, not that hide, which leaves the departed child under the wrapper the
+  same way. `Documentation~/motion.md` owns the placement advice.
 
 ## [2.1.2] - 2026-08-23
 

--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -10,27 +10,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - A `V.AnimatePresence` that stops being rendered takes its bookkeeping with it. That bookkeeping is
-  keyed by the component the presence renders in, the parent element its children expand into, and
-  the presence's position, and only the component being disposed or the whole tree being unmounted
-  retired it. So a `cond ? V.AnimatePresence(…) : null` flipping to `null` left an entry holding the
-  committed children, and per key the exit anchor and the Motion element it had recorded, well after
-  the removal had taken those elements out of the tree: measured on a presence under a `V.Button`,
-  the entry left behind named both the departed child's element and the Button, which had already
-  gone back to the element pool. Rendering the presence again at that position then started from
-  that stale set — children that had left were spliced back into the DOM as exiting ghosts, and
-  `initial: false` no longer suppressed the enter, since the second mount was not taken for a first
-  render. The entry also survived its parent element being torn down, one left behind per removal,
-  and a poolable parent rented back for a fresh presence at the same position picked the stale entry
-  up again. A presence written directly in a `V.Portal`'s own children — so its children expand
-  straight into the registered target element — is outside what this release answers for, and reads
-  the same here as it does on 2.1.1: the entry is keyed on that target, which the caller owns and
-  the portal closing does not touch, and nothing here records which portal expanded an entry.
-  Closing the portal leaves the entry behind, and a later open brings the departed child back beside
-  the new one. Measured over two open/close cycles of a portal holding one keyed child: one entry
-  after the first close, two after the reopen, and after the second cycle the target held both the
-  departed child and the new one. Hiding a presence inside a portal left open reads the same way —
-  the departed child was still in the target afterwards, and beside the new one once the presence
-  returned. Placing the presence under an element inside the portal's children is covered.
+  keyed by three terms — the fiber the expansion ran under, the parent element its children expand
+  into, and the presence's position — and only that fiber being unregistered or the whole tree being
+  unmounted retired it. So a `cond ? V.AnimatePresence(…) : null` flipping to `null` left an entry
+  holding the committed children, and per key the exit anchor and the Motion element it had
+  recorded, well after the removal had taken those elements out of the tree: measured on a presence
+  under a `V.Button`, the entry left behind named both the departed child's element and the Button,
+  which had already gone back to the element pool. Rendering the presence again at that position
+  then started from that stale set — children that had left were spliced back into the DOM as
+  exiting ghosts, and `initial: false` no longer suppressed the enter, since the second mount was
+  not taken for a first render. The entry also survived its parent element being torn down, one left
+  behind per removal, and a poolable parent rented back for a fresh presence at the same position
+  picked the stale entry up again.
+  A presence written directly in a `V.Portal`'s own children — so its children expand straight into
+  the registered target element — is outside what this release answers for, and reads here as it
+  does on 2.1.1. Nothing records which portal expanded an entry, so closing the portal retires none;
+  and the fiber term a reopen records is not the term the mount recorded, so the reopen starts a
+  second entry rather than finding the mount's, which stays behind unchanged. Closing the portal
+  empties the target and the first reopen shows only the new child; the second reopen brings a child
+  whose key changed between opens back beside the new one, while one stable child key was measured
+  holding exactly one child after each of three reopens. Leaving the portal open and hiding only the
+  presence reads differently again: the departed child stays in the target straight away, and is
+  beside the new one on the next show. Placing the presence under an element inside the portal's
+  children is covered, and `Documentation~/motion.md` owns the placement advice.
 
 ## [2.1.1] - 2026-08-21
 

--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -10,22 +10,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - A `V.AnimatePresence` that stops being rendered takes its bookkeeping with it. That bookkeeping is
-  keyed by the component the presence renders in, the parent element its children expand into, and the
-  presence's position, and only the component being disposed or the whole tree being unmounted retired
-  it. So a `cond ? V.AnimatePresence(…) : null` flipping to `null` left an entry holding the committed
-  children, and per key the exit anchor and the Motion element it had recorded, well after the removal
-  had taken those elements out of the tree: measured on a presence under a `V.Button`, the entry left
-  behind named both the departed child's element and the Button, which had already gone back to the
-  element pool. Rendering the presence again at that position then started from that stale set —
-  children that had left were spliced back into the DOM as exiting ghosts, and `initial: false` no
-  longer suppressed the enter, since the second mount was not taken for a first render. The entry also
-  survived its parent element being torn down, one left behind per removal, and a poolable parent
-  rented back for a fresh presence at the same position picked the stale entry up again. A presence
-  written inside a `V.Portal`'s own children reaches the same table by a route this release does not
-  answer for and keeps its entry when the portal closes: the entry is keyed by the container the portal
-  renders into, that container belongs to the caller rather than to the portal, and nothing here records
-  which portal expanded an entry. Reopening the portal starts a fresh entry rather than resurrecting the
-  departed child, so what is left there is the retention.
+  keyed by the component the presence renders in, the parent element its children expand into, and
+  the presence's position, and only the component being disposed or the whole tree being unmounted
+  retired it. So a `cond ? V.AnimatePresence(…) : null` flipping to `null` left an entry holding the
+  committed children, and per key the exit anchor and the Motion element it had recorded, well after
+  the removal had taken those elements out of the tree: measured on a presence under a `V.Button`,
+  the entry left behind named both the departed child's element and the Button, which had already
+  gone back to the element pool. Rendering the presence again at that position then started from
+  that stale set — children that had left were spliced back into the DOM as exiting ghosts, and
+  `initial: false` no longer suppressed the enter, since the second mount was not taken for a first
+  render. The entry also survived its parent element being torn down, one left behind per removal,
+  and a poolable parent rented back for a fresh presence at the same position picked the stale entry
+  up again. A presence written directly in a `V.Portal`'s own children — so its children expand
+  straight into the registered target element — is outside what this release answers for, and reads
+  the same here as it does on 2.1.1: the entry is keyed on that target, which the caller owns and
+  the portal closing does not touch, and nothing here records which portal expanded an entry.
+  Closing the portal leaves the entry behind, and a later open brings the departed child back beside
+  the new one. Measured over two open/close cycles of a portal holding one keyed child: one entry
+  after the first close, two after the reopen, and after the second cycle the target held both the
+  departed child and the new one. Hiding a presence inside a portal left open reads the same way —
+  the departed child was still in the target afterwards, and beside the new one once the presence
+  returned. Placing the presence under an element inside the portal's children is covered.
 
 ## [2.1.1] - 2026-08-21
 

--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this package are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- A `V.AnimatePresence` that stops being rendered takes its bookkeeping with it. That bookkeeping is
+  keyed by the component the presence renders in, the parent element its children expand into, and the
+  presence's position, and only the component being disposed or the whole tree being unmounted retired
+  it. So a `cond ? V.AnimatePresence(…) : null` flipping to `null` left an entry holding the committed
+  children, and per key the exit anchor and the Motion element it had recorded, well after the removal
+  had taken those elements out of the tree: measured on a presence under a `V.Button`, the entry left
+  behind named both the departed child's element and the Button, which had already gone back to the
+  element pool. Rendering the presence again at that position then started from that stale set —
+  children that had left were spliced back into the DOM as exiting ghosts, and `initial: false` no
+  longer suppressed the enter, since the second mount was not taken for a first render. The entry also
+  survived its parent element being torn down, one left behind per removal, and a poolable parent
+  rented back for a fresh presence at the same position picked the stale entry up again. A presence
+  written inside a `V.Portal`'s own children reaches the same table by a route this release does not
+  answer for and keeps its entry when the portal closes: the entry is keyed by the container the portal
+  renders into, that container belongs to the caller rather than to the portal, and nothing here records
+  which portal expanded an entry. Reopening the portal starts a fresh entry rather than resurrecting the
+  departed child, so what is left there is the retention.
+
 ## [2.1.1] - 2026-08-21
 
 ### Highlights

--- a/Packages/com.velvet.core/Documentation~/motion.md
+++ b/Packages/com.velvet.core/Documentation~/motion.md
@@ -68,9 +68,14 @@ V.Div(name: "row", className: "flex flex-row gap-x-2", children: new VNode[]
 - **Framer's splice semantics:** while a ghost exits, surviving siblings keep their positions;
   the ghost holds its slot until the exit completes (the default `Sync` mode).
 - **Inside `V.Portal(targetId:)`:** put the presence under an element in the portal's children
-  rather than directly in them. A presence whose children expand straight into the registered
-  target keeps its departed child there across a close, and a later open brings that child back
-  alongside the new one.
+  rather than directly in them, and give each portal its own such element. A presence expanding
+  straight into the registered target keeps state that closing the portal does not clear: the
+  close empties the target, and the second reopen brings a child whose key changed between opens
+  back beside the new one. Hiding the presence while the portal stays open reads
+  differently — the departed child is left in the target straight away, and the next show puts the
+  new child beside it. And two portals expanding a presence into one target at the same position
+  share a single set of that state, which puts a duplicate child in the target on the first mount;
+  a wrapper element per portal separates them.
 - Re-adding a key mid-exit cancels the exit and returns the element to its resting variant —
   including inline geometry the pose had overwritten.
 - **What an exit animates:** under the default Tween driver, any USS-transitionable property the

--- a/Packages/com.velvet.core/Documentation~/motion.md
+++ b/Packages/com.velvet.core/Documentation~/motion.md
@@ -68,14 +68,17 @@ V.Div(name: "row", className: "flex flex-row gap-x-2", children: new VNode[]
 - **Framer's splice semantics:** while a ghost exits, surviving siblings keep their positions;
   the ghost holds its slot until the exit completes (the default `Sync` mode).
 - **Inside `V.Portal(targetId:)`:** put the presence under an element in the portal's children
-  rather than directly in them, and give each portal its own such element. A presence expanding
-  straight into the registered target keeps state that closing the portal does not clear: the
-  close empties the target, and the second reopen brings a child whose key changed between opens
-  back beside the new one. Hiding the presence while the portal stays open reads
-  differently — the departed child is left in the target straight away, and the next show puts the
-  new child beside it. And two portals expanding a presence into one target at the same position
-  share a single set of that state, which puts a duplicate child in the target on the first mount;
-  a wrapper element per portal separates them.
+  rather than directly in them, and give each portal its own such element. Expanding straight into
+  the registered target keeps state that closing the portal does not clear: with one portal feeding
+  the target, the close empties it and the second reopen brings a child whose key changed between
+  opens back beside the new one; and two portals expanding into one target at the same position
+  share a single set of that state, which puts a duplicate child in the target on the first
+  mount — keyed and unkeyed alike. The wrapper element answers both, measured over three
+  close/reopen cycles and on two portals carrying a keyed presence.
+  It does not answer hiding the presence while the portal stays open. Measured with a wrapper and
+  without, that route leaves the departed child where the presence expanded and puts the new child
+  beside it on the next show, where the same hide outside a portal empties the wrapper and takes
+  the state with it. Close the portal rather than hiding a presence inside it.
 - Re-adding a key mid-exit cancels the exit and returns the element to its resting variant —
   including inline geometry the pose had overwritten.
 - **What an exit animates:** under the default Tween driver, any USS-transitionable property the

--- a/Packages/com.velvet.core/Documentation~/motion.md
+++ b/Packages/com.velvet.core/Documentation~/motion.md
@@ -70,9 +70,9 @@ V.Div(name: "row", className: "flex flex-row gap-x-2", children: new VNode[]
 - **Inside `V.Portal(targetId:)`:** put the presence under an element in the portal's children
   rather than directly in them, and give each portal its own such element. Expanding straight into
   the registered target keeps state that closing the portal does not clear: with one portal feeding
-  the target, the close empties it and the second reopen brings a child whose key changed between
-  opens back beside the new one; and two portals expanding into one target at the same position
-  share a single set of that state, which puts a duplicate child in the target on the first
+  the target, the close empties the target and the second reopen brings a child whose key changed
+  between opens back beside the new one; and two portals expanding into one target at the same
+  position share a single set of that state, which puts a duplicate child in the target on the first
   mount — keyed and unkeyed alike. The wrapper element answers both, measured over three
   close/reopen cycles and on two portals carrying a keyed presence.
   It does not answer hiding the presence while the portal stays open. Measured with a wrapper and

--- a/Packages/com.velvet.core/Documentation~/motion.md
+++ b/Packages/com.velvet.core/Documentation~/motion.md
@@ -67,6 +67,10 @@ V.Div(name: "row", className: "flex flex-row gap-x-2", children: new VNode[]
   parent, so put `flex` / `gap-*` / wrapping on the parent.
 - **Framer's splice semantics:** while a ghost exits, surviving siblings keep their positions;
   the ghost holds its slot until the exit completes (the default `Sync` mode).
+- **Inside `V.Portal(targetId:)`:** put the presence under an element in the portal's children
+  rather than directly in them. A presence whose children expand straight into the registered
+  target keeps its departed child there across a close, and a later open brings that child back
+  alongside the new one.
 - Re-adding a key mid-exit cancels the exit and returns the element to its resting variant —
   including inline geometry the pose had overwritten.
 - **What an exit animates:** under the default Tween driver, any USS-transitionable property the

--- a/Packages/com.velvet.core/Runtime/Reconciler/ChildReconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ChildReconciler.cs
@@ -52,6 +52,11 @@ namespace Velvet
         // Pool while suspended).
         internal KeyedReconcileState? PendingKeyedState { get; private set; }
 
+        // The presence reproductions the state above still owes a removal pass, carried until the slice
+        // that resumes it runs them. Instance state rather than context state like the lists it feeds,
+        // because the park it answers for is this instance's own while the context is shared.
+        private readonly List<(ComponentFiber? boundary, VisualElement? parent, string presenceKey)> _presenceOwedByThisPark = new();
+
         public ChildReconciler(ReconcilerContext ctx, FiberNodePatcher patcher, FiberNodeFactory factory, FiberElementCleaner cleaner)
         {
             _ctx = ctx;
@@ -168,6 +173,14 @@ namespace Velvet
             // directly and bypasses this path, so discarding here does not break a Continue run.
             // Nested calls entered via PatchNode during ContinueXxx also pass through here, but at
             // that point ContinueXxx has already taken ownership of pending (= null), so this is a no-op.
+            // The presence reproductions that state owed go with it, since no slice will run its removals
+            // now — gated on the state so that stays a no-op too: the owed span is still in flight during
+            // a ContinueXxx, and dropping it there would strand the entry.
+            if (PendingIndexedState != null || PendingKeyedState != null)
+            {
+                _ctx.SettlePresenceReproductionsOwedByAPark(
+                    ReconcilerContext.PresenceRemovalOutcome.Skipped, _presenceOwedByThisPark);
+            }
             PendingIndexedState = null;
             DiscardPendingKeyedState();
 
@@ -197,6 +210,11 @@ namespace Velvet
                 OldProviders = oldProviders,
             };
             VNode?[] oldNodes;
+            // The presence reproductions this container's own walk takes, retirable only once the removal
+            // pass below has run — see ReconcilerContext.EndPresenceReproductionScope.
+            var presenceScope = _ctx.BeginPresenceReproductionScope();
+            // Only an exception unwinding out of the try below reads this, since both branches assign first.
+            var removals = ReconcilerContext.PresenceRemovalOutcome.Skipped;
             try
             {
                 // Old side is always expanded structurally into the flat leaf array used for matching.
@@ -209,7 +227,9 @@ namespace Velvet
                     // (CreateElement / PatchNode) while its ancestor Providers are still pushed, so
                     // element descendants render in-scope without a pre-captured snapshot. Orphan
                     // effect-cleanup + sweep and the LIS reorder are performed inside.
-                    _general.ReconcileGeneral(parent, oldNodes, newChildren, slotStart, in pairing);
+                    removals = _general.ReconcileGeneral(parent, oldNodes, newChildren, slotStart, in pairing)
+                        ? ReconcilerContext.PresenceRemovalOutcome.Ran
+                        : ReconcilerContext.PresenceRemovalOutcome.Skipped;
                 }
                 else
                 {
@@ -228,10 +248,12 @@ namespace Velvet
                         ReconcileIndexed(parent, oldNodes, newNodes, frameBudgetMs, slotStart, slotLimit);
                     }
                     _general.SweepOrphans(oldFibers, newFibers);
+                    removals = FastPathRemovalOutcome();
                 }
             }
             finally
             {
+                _ctx.EndPresenceReproductionScope(presenceScope, removals, _presenceOwedByThisPark);
                 _ctx.BufferPool.ReturnProviderTable(oldProviders);
                 _ctx.BufferPool.ReturnFiberList(oldFibers);
                 _ctx.BufferPool.ReturnFiberSet(newFibers);
@@ -450,6 +472,18 @@ namespace Velvet
             return (registryTarget, children);
         }
 
+        // Neither time-sliced strategy finishes its removals in one gated call the way the general path
+        // does, so returning from it is not proof they ran: an abort raised while a descendant of a patched
+        // leaf rendered stops the state machine between phases, and an exhausted frame budget parks it. The
+        // two differ in who pays the debt — the abort's next pass expands both sides again, while a park is
+        // resumed from the old side this one already expanded — which is why the outcome is three-valued.
+        private ReconcilerContext.PresenceRemovalOutcome FastPathRemovalOutcome()
+            => PendingIndexedState != null || PendingKeyedState != null
+                ? ReconcilerContext.PresenceRemovalOutcome.OwedByAContinuation
+                : _ctx.IsAborted
+                    ? ReconcilerContext.PresenceRemovalOutcome.Skipped
+                    : ReconcilerContext.PresenceRemovalOutcome.Ran;
+
         // Resumes a suspended IndexedReconcile.
         // Does nothing when PendingIndexedState is null.
         internal void ContinueIndexed(double frameBudgetMs)
@@ -458,8 +492,20 @@ namespace Velvet
 
             var state = PendingIndexedState.Value;
             PendingIndexedState = null;
-            ReconcileIndexedFrom(state.Parent, state.OldNodes, state.NewNodes,
-                state.ResumePhase, state.ResumeIndex, frameBudgetMs, state.SlotStart, state.SlotLimit);
+            // Skipped rather than derived after the call, so a resume that unwinds settles as a diff whose
+            // removals did not run: the leaves its span names are still in the tree, and the entry naming
+            // them has to outlive the slice.
+            var removals = ReconcilerContext.PresenceRemovalOutcome.Skipped;
+            try
+            {
+                ReconcileIndexedFrom(state.Parent, state.OldNodes, state.NewNodes,
+                    state.ResumePhase, state.ResumeIndex, frameBudgetMs, state.SlotStart, state.SlotLimit);
+                removals = FastPathRemovalOutcome();
+            }
+            finally
+            {
+                _ctx.SettlePresenceReproductionsOwedByAPark(removals, _presenceOwedByThisPark);
+            }
         }
 
         // Resumes a suspended KeyedReconcile.
@@ -470,7 +516,17 @@ namespace Velvet
 
             var state = PendingKeyedState;
             PendingKeyedState = null;
-            ReconcileKeyedFrom(state, frameBudgetMs);
+            // Same initialiser discipline as ContinueIndexed.
+            var removals = ReconcilerContext.PresenceRemovalOutcome.Skipped;
+            try
+            {
+                ReconcileKeyedFrom(state, frameBudgetMs);
+                removals = FastPathRemovalOutcome();
+            }
+            finally
+            {
+                _ctx.SettlePresenceReproductionsOwedByAPark(removals, _presenceOwedByThisPark);
+            }
         }
 
         // Shifts the captured SlotStart of whichever time-sliced state is currently parked by

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberElementCleaner.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberElementCleaner.cs
@@ -196,6 +196,7 @@ namespace Velvet
             CleanupFocusAndNavigationResources(element);
             CleanupDndResources(element);
             CleanupControllerResources(element);
+            _ctx.PrunePresenceParentElementState(element);
         }
 
         // Refs, animation/layout scheduling, the event + component registries, and every

--- a/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
@@ -109,7 +109,8 @@ namespace Velvet
         // Components render, and each emitted host leaf is matched against oldNodes
         // and committed via CommitLeaf while the live stack still reflects its ancestor
         // Providers. Removals and the LIS reorder run afterwards in FinalizeGeneralCommit.
-        internal void ReconcileGeneral(
+        // Returns whether the removal pass ran, which an abort raised anywhere earlier in the pass skips.
+        internal bool ReconcileGeneral(
             VisualElement? parent,
             VNode?[] oldNodes,
             VNode?[] newChildren,
@@ -168,8 +169,10 @@ namespace Velvet
                 // mirroring the flat path: a deleted FunctionComponent's effect cleanups fire while its
                 // Ref.Current is still valid, then the DOM is removed. The sweep (full dispose) runs after.
                 RunOrphanEffectCleanups(oldFibers, newFibers);
-                if (!_ctx.IsAborted) FinalizeGeneralCommit(commit);
+                var removalsRan = !_ctx.IsAborted;
+                if (removalsRan) FinalizeGeneralCommit(commit);
                 SweepOrphans(oldFibers, newFibers);
+                return removalsRan;
             }
             finally
             {
@@ -1233,6 +1236,7 @@ namespace Velvet
 
             if (!walk.IsNewSide)
             {
+                _ctx.MarkPresenceReproduced(stateKey);
                 ReproduceCommittedPresence(walk, stateKey, presencePosition);
                 return;
             }
@@ -1337,6 +1341,10 @@ namespace Velvet
                 {
                     foreach (var completion in tally.Deferred) completion();
                 }
+
+                // Marked here rather than beside stateKey above, so an expansion that unwound is not
+                // counted as having rendered this presence again.
+                _ctx.MarkPresenceReRendered(stateKey);
             }
             finally
             {

--- a/Packages/com.velvet.core/Runtime/Reconciler/Reconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Reconciler.cs
@@ -229,6 +229,8 @@ namespace Velvet
                 // EffectiveKeys is scoped to one top-level pass. VNode references are fresh
                 // per render, so unconsumed entries would otherwise accumulate across renders.
                 _ctx.EffectiveKeys.Clear();
+                // Scoped to one top-level pass: that is the span holding both readings it compares.
+                _ctx.RetirePresenceStatesNotReRendered();
                 // Return the inline children's old trees (queued by SubsumeFiberIntoThisPass) to the
                 // VNode pool now that the whole pass is done using them as patch baselines — deferred
                 // to here to avoid a mid-pass use-after-return that duplicates re-expanded subtrees.

--- a/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
@@ -1078,13 +1078,13 @@ namespace Velvet
             _suspenseFallbackKeys.Remove(boundary);
         }
 
-        // Per-AnimatePresence state for the DOM-less (wrapper-less) expansion, keyed by
-        // (boundary fiber, the AnimatePresence's scoped position key). The keyed children are expanded
-        // directly into the parent's slot range (no wrapper element); this state records, per
-        // AnimatePresence, the leaf
-        // composition currently committed to the DOM so the old-side structural walk can reproduce it for
-        // the diff, plus which keys are mid-exit (kept mounted as ghosts) and which have finished exiting
-        // (dropped on the next render). Pruned when the boundary fiber is disposed.
+        // Per-AnimatePresence state for the DOM-less (wrapper-less) expansion, keyed as PresenceStates below
+        // is. The keyed children are expanded directly into the parent's slot range (no wrapper element);
+        // this state records, per AnimatePresence, the leaf composition currently committed to the DOM so
+        // the old-side structural walk can reproduce it for the diff, plus which keys are mid-exit (kept
+        // mounted as ghosts) and which have finished exiting (dropped on the next render). PresenceStateOwner
+        // enumerates what it is pruned with; RetirePresenceStatesNotReRendered and the whole-table clear in
+        // Reconciler.ReleaseHostsAndScopes are the other two ways it ends.
         internal sealed class PresenceBoundaryState
         {
             // Keyed children currently in the DOM (in DOM order), including exiting ghosts.
@@ -1148,21 +1148,144 @@ namespace Velvet
         // Motion's resting set and be clobbered by the wrapper's own class patching.
         internal VisualElement? PresenceAnchorMotionElement;
 
-        // Removes all DOM-less AnimatePresence state keyed by boundary. Invoked from
-        // ComponentRegistry when the boundary fiber is unregistered, so a boundary that
-        // unmounts while a child is exiting leaves no dangling fiber reference in PresenceStates.
-        internal void PrunePresenceBoundaryState(ComponentFiber boundary)
+        // The two subjects a prune retires a DOM-less AnimatePresence entry for. A presence whose node
+        // stops being rendered outlives both, which is what RetirePresenceStatesNotReRendered answers for.
+        private enum PresenceStateOwner
+        {
+            // The fiber that rendered the AnimatePresence, unregistered.
+            Boundary,
+
+            // The element its children expand into, leaving the DOM.
+            ParentElement,
+        }
+
+        // One collect-then-remove for the two, so a third owner is a case rather than a third copy of the
+        // loop. Collected first because Remove mutates the dictionary this walks.
+        private void PrunePresenceStates(PresenceStateOwner owner, object subject)
         {
             if (PresenceStates.Count == 0) return;
             List<(ComponentFiber? boundary, VisualElement? parent, string presenceKey)>? stale = null;
             foreach (var key in PresenceStates.Keys)
             {
-                if (key.boundary == boundary) (stale ??= new()).Add(key);
+#pragma warning disable CS8524 // no discard arm, so a third owner fails the build rather than falling in here
+                var owned = owner switch
+                {
+                    PresenceStateOwner.Boundary => ReferenceEquals(key.boundary, subject),
+                    PresenceStateOwner.ParentElement => ReferenceEquals(key.parent, subject),
+                };
+#pragma warning restore CS8524
+                if (owned) (stale ??= new()).Add(key);
             }
             if (stale != null)
             {
                 foreach (var key in stale) PresenceStates.Remove(key);
             }
+        }
+
+        // Invoked from ComponentRegistry when the boundary fiber is unregistered, so a boundary that
+        // unmounts while a child is exiting leaves no dangling fiber reference in PresenceStates.
+        internal void PrunePresenceBoundaryState(ComponentFiber boundary)
+            => PrunePresenceStates(PresenceStateOwner.Boundary, boundary);
+
+        // Called from FiberElementCleaner, which owns which teardowns reach it. The reproduction reading
+        // below cannot answer for this route: a real element is an opaque leaf to the expansion that
+        // emitted it, so the walk dropping one never descends to the presences inside.
+        internal void PrunePresenceParentElementState(VisualElement parent)
+            => PrunePresenceStates(PresenceStateOwner.ParentElement, parent);
+
+        // The presence entries one top-level pass reproduced on its old side, and the ones its new side
+        // rendered again. The case this exists for is the one neither prune above can see: an
+        // AnimatePresence node stops being rendered while its boundary fiber and its parent element both
+        // go on living, and the difference between the two readings is what says so.
+        private readonly List<(ComponentFiber? boundary, VisualElement? parent, string presenceKey)> _presenceReproduced = new();
+        private readonly List<(ComponentFiber? boundary, VisualElement? parent, string presenceKey)> _presenceRetirable = new();
+        private readonly HashSet<(ComponentFiber? boundary, VisualElement? parent, string presenceKey)> _presenceReRendered = new();
+
+        internal void MarkPresenceReproduced((ComponentFiber? boundary, VisualElement? parent, string presenceKey) key)
+            => _presenceReproduced.Add(key);
+
+        internal void MarkPresenceReRendered((ComponentFiber? boundary, VisualElement? parent, string presenceKey) key)
+            => _presenceReRendered.Add(key);
+
+        // Opens the span of reproductions one container's reconcile takes, closed by
+        // EndPresenceReproductionScope. Nested containers reconcile inside that span and close their own
+        // first, so the tail this returns is exactly the enclosing container's own.
+        internal int BeginPresenceReproductionScope() => _presenceReproduced.Count;
+
+        // What a container's removal pass — GeneralPathReconciler's FinalizeGeneralCommit, or the
+        // time-sliced diff's own removal phase — did about the slots an absent presence held. Until it has
+        // run, the reproduced leaves are still in the DOM and the entry is what the next old side names
+        // them from, so the entry must not retire. The reading is per container rather than per pass: an
+        // abort holds for the rest of the pass, while every container that finalized before it emptied its
+        // slots for real.
+        internal enum PresenceRemovalOutcome
+        {
+            // Emptied, so the span may retire.
+            Ran,
+
+            // Skipped, with nothing left to run it. The span is dropped rather than carried.
+            Skipped,
+
+            // Parked mid-diff. ContinueIndexed / ContinueKeyed resume from the old side this pass already
+            // expanded, so no walk names these presences a second time — dropping the span would leave the
+            // entry to outlive the leaves it names rather than defer its retirement.
+            OwedByAContinuation,
+        }
+
+        // Where a span an outcome describes belongs: the pass's own retirable list, the parked
+        // container's carry list, or nowhere.
+        private List<(ComponentFiber? boundary, VisualElement? parent, string presenceKey)>? DestinationFor(
+            PresenceRemovalOutcome outcome,
+            List<(ComponentFiber? boundary, VisualElement? parent, string presenceKey)> owedByThisPark)
+        {
+#pragma warning disable CS8524 // no discard arm, so a fourth outcome fails the build rather than being dropped
+            return outcome switch
+            {
+                PresenceRemovalOutcome.Ran => _presenceRetirable,
+                PresenceRemovalOutcome.OwedByAContinuation => owedByThisPark,
+                PresenceRemovalOutcome.Skipped => null,
+            };
+#pragma warning restore CS8524
+        }
+
+        internal void EndPresenceReproductionScope(
+            int scope,
+            PresenceRemovalOutcome outcome,
+            List<(ComponentFiber? boundary, VisualElement? parent, string presenceKey)> owedByThisPark)
+        {
+            var destination = DestinationFor(outcome, owedByThisPark);
+            if (destination != null)
+            {
+                for (var i = scope; i < _presenceReproduced.Count; i++)
+                {
+                    destination.Add(_presenceReproduced[i]);
+                }
+            }
+            _presenceReproduced.RemoveRange(scope, _presenceReproduced.Count - scope);
+        }
+
+        // Closes what a park left owed, once the slice that resumed it has run. Its outcome is read the
+        // same way the container's own was, so a slice that parked again leaves the span where it is.
+        // Dropping it is a discarded park's reading — the diff that owed those removals is the one nobody
+        // finishes, so the entry must stay live (see PresenceRemovalOutcome.Skipped).
+        internal void SettlePresenceReproductionsOwedByAPark(
+            PresenceRemovalOutcome outcome,
+            List<(ComponentFiber? boundary, VisualElement? parent, string presenceKey)> owed)
+        {
+            if (outcome == PresenceRemovalOutcome.OwedByAContinuation) return;
+            DestinationFor(outcome, owed)?.AddRange(owed);
+            owed.Clear();
+        }
+
+        internal void RetirePresenceStatesNotReRendered()
+        {
+            foreach (var key in _presenceRetirable)
+            {
+                if (!_presenceReRendered.Contains(key)) PresenceStates.Remove(key);
+            }
+            _presenceReproduced.Clear();
+            _presenceRetirable.Clear();
+            _presenceReRendered.Clear();
         }
 
         // Tree-wide auto-batching scheduler. Coalesces setState across every fiber that shares this

--- a/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
@@ -1150,7 +1150,7 @@ namespace Velvet
 
         private enum PresenceStateOwner
         {
-            // The fiber that rendered the AnimatePresence, unregistered.
+            // The key's fiber term — whichever fiber the expansion ran under — unregistered.
             Boundary,
 
             // The element its children expand into, leaving the DOM.

--- a/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
@@ -1148,8 +1148,6 @@ namespace Velvet
         // Motion's resting set and be clobbered by the wrapper's own class patching.
         internal VisualElement? PresenceAnchorMotionElement;
 
-        // The two subjects a prune retires a DOM-less AnimatePresence entry for. A presence whose node
-        // stops being rendered outlives both, which is what RetirePresenceStatesNotReRendered answers for.
         private enum PresenceStateOwner
         {
             // The fiber that rendered the AnimatePresence, unregistered.

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/AnimatePresenceStateRetirementTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/AnimatePresenceStateRetirementTests.cs
@@ -1,0 +1,623 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using NUnit.Framework;
+using UnityEngine.UIElements;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins the retirement of an AnimatePresence boundary's per-expansion state. The entry is keyed by
+    /// (boundary fiber, parent element, scoped position key) and holds the committed VNodes plus each
+    /// key's exit anchor and Motion element, so it outliving its AnimatePresence node pins elements that
+    /// have already gone back to the pool — and, where the node is rendered again at the same position,
+    /// hands the next expansion a committed set describing leaves the DOM no longer has: the departed
+    /// children are spliced back in as exiting ghosts.
+    /// <list type="bullet">
+    /// <item>The node ceasing to be rendered while its boundary fiber and parent element both live on
+    /// retires the entry, so a later render at the same position starts from an empty committed set.</item>
+    /// <item>The parent element being torn down retires it too — that route reaches no reconcile walk,
+    /// since a real element is an opaque leaf to the enclosing expansion. A poolable parent rented back
+    /// re-forms the very key the prior state was recorded under, which is what makes the route load-bearing
+    /// rather than merely tidy.</item>
+    /// <item>A presence the same pass rendered again is not retired, and a presence beside a container
+    /// holding one reads that per entry rather than per pass.</item>
+    /// <item>A presence replaced by a flat list of host leaves retires through the time-sliced diff's own
+    /// removals, the reading a container that never reaches the general walk's finalize takes.</item>
+    /// <item>An abort stops the removal pass of the container it reaches and holds for the rest of the
+    /// pass, so whether an entry may retire is read per container: one whose own removals ran retires even
+    /// though a later container's did not. On the fast path the removals are the time-sliced diff's own,
+    /// and an abort between its phases leaves them unrun.</item>
+    /// <item>An exhausted frame budget leaves those removals unrun as well, and parts from the abort
+    /// there. The next pass expands both sides again, so an abort's reading is retaken; a park is resumed
+    /// from the old side this pass already expanded, so nothing retakes it and the reading is carried to
+    /// the slice that finishes the removals — through a resume that parks again as well as one that does
+    /// not. A park a fresh pass discards carries nothing, since the diff that owed those removals is the
+    /// one nobody finishes, and neither does a resume that unwinds — what that one owed must not reach
+    /// the next park's resume and retire an entry still naming its leaf.</item>
+    /// <item>Both suspended states are read, since a presence with committed children puts their keys on
+    /// the container's old side and one with none does not — the two park in different strategies, and
+    /// each strategy's resume settles what its own call was handed.</item>
+    /// <item>A pass that walks neither side of a presence retires nothing of it.</item>
+    /// </list>
+    /// </summary>
+    [TestFixture]
+    internal sealed class AnimatePresenceStateRetirementTests
+    {
+        private readonly record struct PresenceState(bool Shown, string ChildKey, int Nonce);
+
+        private sealed class PresenceStore : Store<PresenceState>
+        {
+            public PresenceStore() : base(new PresenceState(true, "a", 0)) { }
+
+            public void Set(bool shown, string childKey)
+                => SetState(previous => new PresenceState(shown, childKey, previous.Nonce));
+
+            // Re-renders the declaring component without changing what it renders, which is what puts the
+            // presence through a pass as an old-side reproduction the new side repeats.
+            public void Touch() => SetState(previous => previous with { Nonce = previous.Nonce + 1 });
+
+            protected override void ResetCore() => SetState(_ => new PresenceState(true, "a", 0));
+        }
+
+        private readonly record struct TickState(int Value);
+
+        private sealed class TickStore : Store<TickState>
+        {
+            public TickStore() : base(new TickState(0)) { }
+            public void Bump() => SetState(previous => new TickState(previous.Value + 1));
+            protected override void ResetCore() => SetState(_ => new TickState(0));
+        }
+
+        private static PresenceStore s_store;
+        private static TickStore s_ticks;
+
+        // Distinguishes the arranged throw from any other InvalidOperationException the pass could raise,
+        // so the case cannot record an unwind it did not cause.
+        private const string ResumeUnwindMessage = "arranged unwind out of a resumed diff";
+
+        private static readonly Dictionary<string, string> s_fade = new()
+        {
+            ["visible"] = "opacity-100",
+            ["hidden"] = "opacity-0",
+        };
+
+        private VisualElement _root;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _root = new VisualElement();
+            s_store = null;
+            s_ticks = null;
+        }
+
+        [Component]
+        private static VNode SiblingHost()
+        {
+            var state = Hooks.UseStore(s_store, s => s);
+            return V.Div(name: "host", children: new VNode[] { state.Shown ? Presence(state.ChildKey) : null });
+        }
+
+        [Component]
+        private static VNode UnrelatedSibling()
+        {
+            var tick = Hooks.UseStore(s_ticks, s => s.Value);
+            return V.Label(text: tick.ToString());
+        }
+
+        [Component]
+        private static VNode SiblingPairHost()
+        {
+            var state = Hooks.UseStore(s_store, s => s);
+            return V.Div(name: "outer", children: new VNode[]
+            {
+                V.Div(name: "host", children: new VNode[] { state.Shown ? Presence(state.ChildKey) : null }),
+                V.Component(UnrelatedSibling, key: "tick"),
+            });
+        }
+
+        // A presence and a container holding another one, side by side: the outer container's own old-side
+        // reproduction is already recorded when the inner container opens its scope, which is what makes an
+        // inner scope begin anywhere but at the start of the list.
+        [Component]
+        private static VNode PresenceBesideAContainerHoldingAnother()
+        {
+            var state = Hooks.UseStore(s_store, s => s);
+            return V.Div(name: "host", children: new VNode[]
+            {
+                state.Shown ? Presence(state.ChildKey) : null,
+                // Keyed, so the departing presence's slot leaves the inner container standing rather than
+                // rebuilt as a fresh element: a rebuild reaches the teardown route the pooled-parent case
+                // measures, and the survivor here would be one that case's mechanism produced.
+                V.Div(name: "inner", key: "inner", children: new VNode[] { Presence("kept") }),
+            });
+        }
+
+        [Component]
+        private static VNode PooledButtonHost()
+        {
+            var state = Hooks.UseStore(s_store, s => s);
+            VNode inner = V.Button(name: "inner", children: new VNode[] { Presence(state.ChildKey) });
+            return V.Div(name: "outer", children: new VNode[] { state.Shown ? inner : null });
+        }
+
+        // The presence is replaced by a flat list of host leaves, which needs no inline expansion — so the
+        // new side takes the time-sliced diff rather than the general walk, and the removals that empty
+        // its slots run there instead.
+        [Component]
+        private static VNode FastPathHost()
+        {
+            var state = Hooks.UseStore(s_store, s => s);
+            return V.Div(name: "host", children: state.Shown
+                ? new VNode[] { Presence(state.ChildKey) }
+                : new VNode[] { V.Label(text: "gone") });
+        }
+
+        // A presence beside a boundary that catches on the same update. Its own container finalizes
+        // before the boundary aborts the pass.
+        [Component]
+        private static VNode PresenceBesideAThrowingBoundary()
+        {
+            var state = Hooks.UseStore(s_store, s => s);
+            return V.Div(name: "outer", children: new VNode[]
+            {
+                V.Div(name: "host", children: new VNode[] { state.Shown ? Presence(state.ChildKey) : null }),
+                state.Shown ? null : V.Component(CatchingBoundary, key: "boundary"),
+            });
+        }
+
+        // The presence's own container takes the fast path on the new side. The leaf replacing the
+        // presence's FIRST sibling raises the abort, and the presence's own leaf is still in the tail when
+        // the diff stops — so the container's removals do not run, whatever returning from the strategy
+        // suggests.
+        [Component]
+        private static VNode FastPathHostAbortingBeforeItsRemovalPhase()
+        {
+            var state = Hooks.UseStore(s_store, s => s);
+            return V.Div(name: "host", children: state.Shown
+                ? new VNode[] { V.Label(text: "first"), Presence(state.ChildKey) }
+                : new VNode[]
+                {
+                    V.Div(name: "replacement", children: new VNode[] { V.Component(CatchingBoundary, key: "boundary") }),
+                });
+        }
+
+        [Component(IsErrorBoundary = true)]
+        private static VNode CatchingBoundary()
+        {
+            Hooks.UseFallback(_ => V.Label(text: "caught"));
+            return V.Component(Thrower, key: "thrower");
+        }
+
+        [Component]
+        private static VNode Thrower() => throw new InvalidOperationException("boom");
+
+        [Test]
+        public void Given_AnAnimatePresenceThatStoppedBeingRendered_When_ItIsRenderedAgainUnderANewChildKey_Then_TheDepartedChildIsNotResurrected()
+        {
+            // Arrange — one presence committed under a parent element that stays mounted throughout, so
+            // no element teardown reaches its entry.
+            using var store = new PresenceStore();
+            s_store = store;
+            using var mounted = V.Mount(_root, V.Component(SiblingHost, key: "host"));
+            var scheduler = mounted.Root.Reconciler.Context.BatchScheduler;
+            var host = _root.Q<VisualElement>("host");
+            store.Set(false, "a");
+            scheduler.DrainImmediateForTest();
+
+            // Act — the presence returns carrying a different keyed child.
+            store.Set(true, "b");
+            scheduler.DrainImmediateForTest();
+
+            // Assert — a surviving committed set would splice "a" back in as an exiting ghost. Names rather
+            // than a count, so the one element left standing is identified.
+            Assert.That(NamesOf(host), Is.EqualTo("item-b"));
+        }
+
+        [Test]
+        public void Given_APresenceBesideAContainerHoldingAnother_When_TheOuterOneStopsBeingRendered_Then_OnlyItsOwnEntryRetires()
+        {
+            // Arrange — one entry per parent element, and the inner container's scope opens over a list the
+            // outer container's own reproduction is already in.
+            using var store = new PresenceStore();
+            s_store = store;
+            using var mounted = V.Mount(_root, V.Component(PresenceBesideAContainerHoldingAnother, key: "host"));
+            var ctx = mounted.Root.Reconciler.Context;
+            var recorded = ctx.PresenceStates.Count;
+
+            // Act
+            store.Set(false, "a");
+            ctx.BatchScheduler.DrainImmediateForTest();
+
+            // Assert — that the two were recorded separately is folded in: one shared entry would make the
+            // survivor indistinguishable from the departure.
+            Assert.That((recorded, ctx.PresenceStates.Count), Is.EqualTo((2, 1)));
+        }
+
+        [Test]
+        public void Given_APooledPresenceParent_When_ItIsRentedBackForAFreshAnimatePresence_Then_TheDepartedChildIsNotResurrected()
+        {
+            // Arrange — a Button parent returns to the element pool on removal and is rented back on the
+            // next mount, so the reused instance re-forms the very key its prior state was recorded under.
+            using var store = new PresenceStore();
+            s_store = store;
+            using var mounted = V.Mount(_root, V.Component(PooledButtonHost, key: "host"));
+            var scheduler = mounted.Root.Reconciler.Context.BatchScheduler;
+            var pooled = _root.Q<VisualElement>("inner");
+            store.Set(false, "a");
+            scheduler.DrainImmediateForTest();
+
+            // Act
+            store.Set(true, "b");
+            scheduler.DrainImmediateForTest();
+
+            // Assert — that the pool did hand the same instance back rides along, since a fresh parent
+            // would form a different key and clear the case of the state it exists to catch.
+            var reused = _root.Q<VisualElement>("inner");
+            Assert.That((ReferenceEquals(pooled, reused), NamesOf(reused)), Is.EqualTo((true, "item-b")));
+        }
+
+        [Test]
+        public void Given_APresenceReplacedByPlainLeaves_When_TheNewSideTakesTheFastPath_Then_ItsBoundaryStateIsRetired()
+        {
+            // Arrange — the container reconciles through the indexed/keyed diff rather than the general
+            // walk, so what says its slots were emptied is not the general path's own finalize.
+            using var store = new PresenceStore();
+            s_store = store;
+            using var mounted = V.Mount(_root, V.Component(FastPathHost, key: "host"));
+            var ctx = mounted.Root.Reconciler.Context;
+            var recorded = ctx.PresenceStates.Count;
+
+            // Act
+            store.Set(false, "a");
+            ctx.BatchScheduler.DrainImmediateForTest();
+
+            // Assert — that the expansion recorded a state at all is folded in: an expansion that recorded
+            // none would satisfy the retirement on its own.
+            Assert.That((recorded, ctx.PresenceStates.Count), Is.EqualTo((1, 0)));
+        }
+
+        [Test]
+        public void Given_APresenceContainerThatFinalized_When_ALaterBoundaryAbortsTheSamePass_Then_ItsBoundaryStateStillRetires()
+        {
+            // Arrange — an abort holds for the rest of the pass, so a reading taken per pass would spare
+            // this entry; the container it names emptied its own slots before the abort was raised.
+            using var store = new PresenceStore();
+            s_store = store;
+            using var mounted = V.Mount(_root, V.Component(PresenceBesideAThrowingBoundary, key: "host"));
+            var ctx = mounted.Root.Reconciler.Context;
+            var recorded = ctx.PresenceStates.Count;
+
+            // Act — the presence leaves and the boundary catches, in one update.
+            store.Set(false, "a");
+            ctx.BatchScheduler.DrainImmediateForTest();
+
+            // Assert — same fold as the fast-path case above. Nothing reproduces this presence again, so a
+            // pass that skipped it is the last one this route can act on.
+            Assert.That((recorded, ctx.PresenceStates.Count), Is.EqualTo((1, 0)));
+        }
+
+        // GREEN_ON_BASE(characterization): on the base an entry ended with its boundary fiber and nothing
+        // else. A container whose removals did not run could strand none of them, and that has to stay true.
+        [Test]
+        public void Given_APresenceOnAFastPathContainer_When_ItsDiffAbortsBeforeTheRemovalPhase_Then_ItsBoundaryStateSurvives()
+        {
+            // Arrange — the fast path interleaves its removals with the diff, so whether they ran has to
+            // be asked of the strategy afterwards rather than taken from the call returning.
+            using var store = new PresenceStore();
+            s_store = store;
+            using var mounted = V.Mount(_root, V.Component(FastPathHostAbortingBeforeItsRemovalPhase, key: "host"));
+            var ctx = mounted.Root.Reconciler.Context;
+            var host = _root.Q<VisualElement>("host");
+
+            // Act — the presence leaves and the leaf replacing its first sibling catches, in one update.
+            store.Set(false, "a");
+            ctx.BatchScheduler.DrainImmediateForTest();
+
+            // Assert — that the abort really did leave the presence's leaf standing is folded in: had the
+            // removals emptied the slot, retiring the entry would be right and nothing would be measured.
+            Assert.That((host.Q<VisualElement>("item-a") != null, ctx.PresenceStates.Count),
+                Is.EqualTo((true, 1)));
+        }
+
+        // GREEN_ON_BASE(characterization): the base had no retirement route a parked container could reach.
+        // Same reading as the abort case above, for the other way the fast path leaves its removals owed.
+        [Test]
+        public void Given_APresenceOnAFastPathContainer_When_ItsDiffParksBeforeItsRemovals_Then_ItsBoundaryStateSurvives()
+        {
+            // Arrange — a hundred rows against a budget that yields after one node, so the park lands in
+            // the diff's first phase with the presence's leaf still in the tail a later phase would take.
+            using var reconciler = new Reconciler();
+            var root = new VisualElement();
+            var committed = RowsWith(Presence("a"));
+            reconciler.Reconcile(root, Array.Empty<VNode>(), committed, frameBudgetMs: 0);
+            var ctx = reconciler.Context;
+
+            // Act — the presence is gone from the new side, and the budget parks the diff.
+            reconciler.Reconcile(root, committed, Rows("moved-"), frameBudgetMs: 0.001);
+
+            // Assert — that the park really did leave the presence's leaf standing is folded in: a diff
+            // that ran to completion would have emptied the slot, and retiring the entry would be right.
+            // The strategy is pinned for the reason ParkedInTheKeyedState carries.
+            Assert.That(
+                (ParkedInTheKeyedState(reconciler), root.Q<VisualElement>("item-a") != null, ctx.PresenceStates.Count),
+                Is.EqualTo((true, true, 1)));
+        }
+
+        [Test]
+        public void Given_APresenceOnAParkedFastPathContainer_When_TheResumeFinishesTheDiff_Then_ItsBoundaryStateIsRetired()
+        {
+            // Arrange — the same park as the case above, left where that case stops reading.
+            using var reconciler = new Reconciler();
+            var root = new VisualElement();
+            var committed = RowsWith(Presence("a"));
+            reconciler.Reconcile(root, Array.Empty<VNode>(), committed, frameBudgetMs: 0);
+            var ctx = reconciler.Context;
+            reconciler.Reconcile(root, committed, Rows("moved-"), frameBudgetMs: 0.001);
+            var parked = reconciler.HasPendingWork;
+
+            // Act — the continuation runs the removals the park left owed.
+            reconciler.ContinueReconcile();
+
+            // Assert — that the diff really did park is folded in: a first slice that ran to completion
+            // would retire the entry through the container's own reading and measure nothing of the resume.
+            Assert.That((parked, root.Q<VisualElement>("item-a") != null, ctx.PresenceStates.Count),
+                Is.EqualTo((true, false, 0)));
+        }
+
+        [Test]
+        public void Given_APresenceOnAParkedFastPathContainer_When_TheResumeParksAgain_Then_ItsBoundaryStateRetiresAtTheSliceThatFinishes()
+        {
+            // Arrange — the park, then a resume slice on a budget small enough to park a second time.
+            using var reconciler = new Reconciler();
+            var root = new VisualElement();
+            var committed = RowsWith(Presence("a"));
+            reconciler.Reconcile(root, Array.Empty<VNode>(), committed, frameBudgetMs: 0);
+            var ctx = reconciler.Context;
+            reconciler.Reconcile(root, committed, Rows("moved-"), frameBudgetMs: 0.001);
+            reconciler.ContinueReconcile(frameBudgetMs: 0.001);
+            var parkedAgain = reconciler.HasPendingWork;
+
+            // Act — the slice that finishes the diff.
+            reconciler.ContinueReconcile();
+
+            // Assert — that the middle slice parked rather than finishing is folded in: without it this
+            // is a second reading of the single-slice resume beside it.
+            Assert.That((parkedAgain, ctx.PresenceStates.Count), Is.EqualTo((true, 0)));
+        }
+
+        [Test]
+        public void Given_AnEmptyPresenceOnAParkedFastPathContainer_When_TheIndexedResumeFinishesTheDiff_Then_ItsBoundaryStateIsRetired()
+        {
+            // Arrange — a presence with nothing committed reproduces no leaf at all, so the container's
+            // old side carries no key and the diff parks in the indexed strategy. The keyed resume beside
+            // this one reaches its settle through the other strategy's call, and only through that one.
+            using var reconciler = new Reconciler();
+            var root = new VisualElement();
+            var committed = RowsWith(V.AnimatePresence(key: "presence", children: Array.Empty<VNode>()));
+            reconciler.Reconcile(root, Array.Empty<VNode>(), committed, frameBudgetMs: 0);
+            var ctx = reconciler.Context;
+            reconciler.Reconcile(root, committed, Rows("moved-"), frameBudgetMs: 0.001);
+            var parkedIndexed = ParkedInTheIndexedState(reconciler);
+
+            // Act — the continuation runs the removals the park left owed.
+            reconciler.ContinueReconcile();
+
+            // Assert — that the park landed in the indexed state is folded in: parking in the keyed one
+            // would make this a second reading of the keyed resume rather than a reading of this one.
+            Assert.That((parkedIndexed, ctx.PresenceStates.Count), Is.EqualTo((true, 0)));
+        }
+
+        [Test]
+        public void Given_AParkedFastPathContainer_When_ItsKeyedResumeUnwinds_Then_ALaterParksResumeLeavesTheStrandedEntryAlone()
+        {
+            // Arrange — one reconciler, two roots. The first root's resume throws partway through the
+            // diff, leaving its removals unrun and its leaf in the tree; the second root then parks and
+            // resumes cleanly, which is the slice that settles whatever the first left owed.
+            using var reconciler = new Reconciler();
+            var ctx = reconciler.Context;
+            var first = new VisualElement { name = "first" };
+            var firstCommitted = RowsWith(Presence("a"));
+            reconciler.Reconcile(first, Array.Empty<VNode>(), firstCommitted, frameBudgetMs: 0);
+            reconciler.Reconcile(first, firstCommitted, RowsThrowingAt("moved-", 99), frameBudgetMs: 0.001);
+            var firstParked = reconciler.HasPendingWork;
+            var unwound = UnwindOfTheResume(reconciler);
+            var second = new VisualElement { name = "second" };
+            var secondCommitted = RowsWith(Presence("b"));
+            reconciler.Reconcile(second, Array.Empty<VNode>(), secondCommitted, frameBudgetMs: 0);
+            reconciler.Reconcile(second, secondCommitted, Rows("gone-"), frameBudgetMs: 0.001);
+            var secondParked = reconciler.HasPendingWork;
+
+            // Act — the continuation finishes the second root's diff, and only that one.
+            reconciler.ContinueReconcile();
+
+            // Assert — the first root's entry is the one left, since the unwound diff never emptied its
+            // slots. Both parks and the unwind are folded in: each is what puts the span in play, and
+            // without it the survivor would be right for the wrong reason.
+            Assert.That((firstParked, unwound, secondParked, PresenceParentNamesOf(ctx)),
+                Is.EqualTo((true, true, true, "first")));
+        }
+
+        [Test]
+        public void Given_AnEmptyPresenceOnAParkedFastPathContainer_When_ItsIndexedResumeUnwinds_Then_ALaterParksResumeLeavesTheStrandedEntryAlone()
+        {
+            // Arrange — the same two roots as the keyed unwind above, with the first root's presence
+            // committing no child so its container parks in the indexed strategy instead. Resuming that
+            // park runs ContinueIndexed, so its own bracket is the only one on the unwinding path.
+            using var reconciler = new Reconciler();
+            var ctx = reconciler.Context;
+            var first = new VisualElement { name = "first" };
+            var firstCommitted = RowsWith(V.AnimatePresence(key: "presence", children: Array.Empty<VNode>()));
+            reconciler.Reconcile(first, Array.Empty<VNode>(), firstCommitted, frameBudgetMs: 0);
+            reconciler.Reconcile(first, firstCommitted, RowsThrowingAt("moved-", 99), frameBudgetMs: 0.001);
+            var firstParkedIndexed = ParkedInTheIndexedState(reconciler);
+            var unwound = UnwindOfTheResume(reconciler);
+            var second = new VisualElement { name = "second" };
+            var secondCommitted = RowsWith(Presence("b"));
+            reconciler.Reconcile(second, Array.Empty<VNode>(), secondCommitted, frameBudgetMs: 0);
+            reconciler.Reconcile(second, secondCommitted, Rows("gone-"), frameBudgetMs: 0.001);
+            var secondParked = reconciler.HasPendingWork;
+
+            // Act — the continuation finishes the second root's diff, and only that one.
+            reconciler.ContinueReconcile();
+
+            // Assert — same reading as the keyed unwind above, through the other strategy's resume: that
+            // the park landed in the indexed state is folded in, since parking in the keyed one would make
+            // this a second reading of that case rather than a reading of this one.
+            Assert.That((firstParkedIndexed, unwound, secondParked, PresenceParentNamesOf(ctx)),
+                Is.EqualTo((true, true, true, "first")));
+        }
+
+        [Test]
+        public void Given_AParkDiscardedByAFreshPass_When_ALaterParkResumes_Then_OnlyTheLaterParksEntryRetires()
+        {
+            // Arrange — one reconciler, two roots. The first root's diff parks and is then discarded by a
+            // fresh pass on the second, whose own diff parks in turn.
+            using var reconciler = new Reconciler();
+            var ctx = reconciler.Context;
+            var first = new VisualElement { name = "first" };
+            var firstCommitted = RowsWith(Presence("a"));
+            reconciler.Reconcile(first, Array.Empty<VNode>(), firstCommitted, frameBudgetMs: 0);
+            reconciler.Reconcile(first, firstCommitted, Rows("moved-"), frameBudgetMs: 0.001);
+            var firstParked = reconciler.HasPendingWork;
+            var second = new VisualElement { name = "second" };
+            var secondCommitted = RowsWith(Presence("b"));
+            reconciler.Reconcile(second, Array.Empty<VNode>(), secondCommitted, frameBudgetMs: 0);
+            reconciler.Reconcile(second, secondCommitted, Rows("gone-"), frameBudgetMs: 0.001);
+            var secondParked = reconciler.HasPendingWork;
+
+            // Act — the continuation finishes the second root's diff, and only that one.
+            reconciler.ContinueReconcile();
+
+            // Assert — the first root's entry has to be the one left, since the discarded diff never
+            // emptied its slots. Both parks are folded in: without either, nothing is owed across a discard.
+            Assert.That((firstParked, secondParked, PresenceParentNamesOf(ctx)),
+                Is.EqualTo((true, true, "first")));
+        }
+
+        // GREEN_ON_BASE(characterization): a pass that walks neither side of a presence says nothing of it.
+        // This is the live state a retirement route must not reach, held to what the base already did.
+        [Test]
+        public void Given_APassThatWalksNeitherSideOfAPresence_When_ItCompletes_Then_TheLiveBoundaryStateSurvivesIt()
+        {
+            // Arrange — the sibling owns its own store, so its update reconciles its own slot alone.
+            using var store = new PresenceStore();
+            using var ticks = new TickStore();
+            s_store = store;
+            s_ticks = ticks;
+            using var mounted = V.Mount(_root, V.Component(SiblingPairHost, key: "host"));
+            var scheduler = mounted.Root.Reconciler.Context.BatchScheduler;
+            var host = _root.Q<VisualElement>("host");
+
+            // Act — a pass that reproduces the presence, then a top-level pass it takes no part in, then
+            // the swap that reads its state. The middle pass is the one under test; the first is what puts
+            // the presence through a reproduction, so a route keyed on one has something to act on.
+            store.Touch();
+            scheduler.DrainImmediateForTest();
+            ticks.Bump();
+            scheduler.DrainImmediateForTest();
+            store.Set(true, "b");
+            scheduler.DrainImmediateForTest();
+
+            // Assert — the departing key holds its slot as an exiting ghost, which it can only do out of
+            // the committed set the sibling's pass left alone.
+            Assert.That(NamesOf(host), Is.EqualTo("item-a,item-b"));
+        }
+
+        #region Helpers
+
+        private static VNode Presence(string childKey) => V.AnimatePresence(key: "presence", children: new VNode[]
+        {
+            V.Motion(name: "item-" + childKey, key: childKey,
+                variants: s_fade, animate: "visible", exit: "hidden",
+                transition: new StyleTransitionConfig { DurationSec = 0.3f }),
+        });
+
+        private static string NamesOf(VisualElement parent)
+        {
+            var names = new List<string>();
+            for (var i = 0; i < parent.childCount; i++) names.Add(parent.ElementAt(i).name);
+            return string.Join(",", names);
+        }
+
+        // The parent element each surviving entry is keyed on, in table order. A count says how many are
+        // left but not which, and the two-root case turns on which of two entries the pass spared.
+        private static string PresenceParentNamesOf(ReconcilerContext ctx)
+        {
+            var names = new List<string>();
+            foreach (var key in ctx.PresenceStates.Keys) names.Add(key.parent?.name ?? "<none>");
+            return string.Join(",", names);
+        }
+
+        private static VNode[] Rows(string prefix)
+        {
+            var rows = new VNode[100];
+            for (var i = 0; i < rows.Length; i++) rows[i] = V.Div(name: prefix + i);
+            return rows;
+        }
+
+        // One row whose child expansion throws, so a resume that reaches it unwinds out of the strategy
+        // rather than parking or finishing. A memo factory rather than a component: FiberRenderer routes a
+        // component's own throw to FiberErrorBoundary.OnRenderError, which unwinds nothing, and the memo
+        // factory runs outside that try. The memo sits under the row rather than beside it so the container
+        // keeps the fast path: only the nested walk of that row's own children resolves it, and the
+        // container's own children stay a flat list of host leaves.
+        private static VNode[] RowsThrowingAt(string prefix, int index)
+        {
+            var rows = Rows(prefix);
+            rows[index] = V.Div(name: prefix + index, children: new VNode[]
+            {
+                V.Memoized(() => throw new InvalidOperationException(ResumeUnwindMessage)),
+            });
+            return rows;
+        }
+
+        // Runs the resume the arranged throw is waiting on, and reports whether it unwound. The filter is
+        // on the arranged message so any other InvalidOperationException still leaves the case.
+        private static bool UnwindOfTheResume(Reconciler reconciler)
+        {
+            try
+            {
+                reconciler.ContinueReconcile();
+                return false;
+            }
+            catch (InvalidOperationException e) when (e.Message == ResumeUnwindMessage)
+            {
+                return true;
+            }
+        }
+
+        private static VNode[] RowsWith(VNode tail)
+        {
+            var rows = Rows("row-");
+            var all = new VNode[rows.Length + 1];
+            Array.Copy(rows, all, rows.Length);
+            all[rows.Length] = tail;
+            return all;
+        }
+
+        // Which of the two suspended states the container parked in. Read by reflection rather than from a
+        // member on the reconciler, since production types here carry nothing test-only. A case that stands
+        // opposite the other strategy's reading pins which state it parked in, so a change moving it onto
+        // the other's fails rather than leaving the pair measuring one term twice.
+        private static bool ParkedInTheIndexedState(Reconciler reconciler)
+            => PendingState(reconciler, "PendingIndexedState") != null;
+
+        private static bool ParkedInTheKeyedState(Reconciler reconciler)
+            => PendingState(reconciler, "PendingKeyedState") != null;
+
+        private static object PendingState(Reconciler reconciler, string property)
+        {
+            var child = typeof(Reconciler)
+                .GetField("_childReconciler", BindingFlags.Instance | BindingFlags.NonPublic)!
+                .GetValue(reconciler)!;
+            return child.GetType()
+                .GetProperty(property, BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)!
+                .GetValue(child);
+        }
+
+        #endregion
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/AnimatePresenceStateRetirementTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/AnimatePresenceStateRetirementTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b6c9d7c0e9304909b692bd34f7eb4542


### PR DESCRIPTION
No issue: #605 is closed, by `main`'s own fix in #643. This carries that issue's main finding to the `2.x` maintenance line, written against `2.x`'s model rather than backported, since `main`'s fix stands on a portal-ownership model this line does not have.

A `PresenceStates` entry gained when an `AnimatePresence` boundary commits had two removal sites: `PrunePresenceBoundaryState`, called when the boundary *fiber* is unregistered, and the whole-table `PresenceStates.Clear()` in `Reconciler.ReleaseHostsAndScopes`. A component rendering `cond ? V.AnimatePresence(…) : null` whose `cond` flips false keeps its fiber and releases no hosts, so neither fires. The entry survives holding `Committed` VNodes, `ExitAnchors` and `MotionElements` — **pinning elements already back in the pool.**

Measured with a presence inside a `V.Button` inside `cond ? … : null`: after the flip the Button is out of the tree, one entry is still recorded, and it names the Button as its parent and the departed child's detached Motion element as its Motion element. On the fixed tree, no entry.

The second reading is what a user sees. With `V.AnimatePresence(initial: false, …)` over a Motion whose `initial` resolves to `opacity-0` and `animate` to `opacity-100`, a presence rendered again after leaving the tree replays its enter: `opacity-0` on the base, `opacity-100` fixed. `PlayPresenceEnter` gates on `!pass.FirstRender || presence.Initial`, so the stale entry is what makes `firstRender` false — and `Documentation~/motion.md` promises that suppression.

## Why retirement rather than a read-time test

The narrower fix is the parent-element prune plus a validate-on-read in `ExpandAnimatePresenceInline` that treats an all-detached committed set as `firstRender`. Four arms over the same probes:

| probe | v2.1.1 (`c64a168`) | parent prune only | + validate-on-read | this PR |
| --- | --- | --- | --- | --- |
| presence under a live `V.Div`, close then reopen | entries 1 → 1, `item-a,item-b` | 1 → 1, `item-a,item-b` | 1 → 1, `item-b` | 1 → **0**, `item-b` |
| `initial: false`, second open | replayed | replayed | suppressed | suppressed |
| presence under a pooled `V.Button` | entries 1 | entries **0** | 0 | 0 |
| `V.Portal`, **changing** child key, second reopen | `item-b,item-c` | `item-b,item-c` | **`item-c`** | `item-b,item-c` |
| `V.Portal`, **stable** child key, `initial: false`, three cycles | suppressions 1, 2, 2, 2 | 1, 2, 2, 2 | **1, 2, 3, 4** | 1, 2, 2, 2 |

Row 1 is the report: the entry itself, one per position a presence has departed from, holding elements the pool has taken back. A read-time test leaves it there. Rows 4 and 5 are what this shape costs — the narrow arm covers a `V.Portal(targetId:)` route this PR ships a caveat for instead.

The read-time test's own coverage is conditional. It asks whether the recorded elements are still attached, and a departed element the pool has handed back **is** attached: on a presence whose Motion renders as a `Button`, after the close and one fresh `V.Button` elsewhere, the narrow arm's stale entry reads `motion[a]=…:filler0:parent=host`, so the test reads "not stale".

Retirement is also what makes the outcome plumbing non-optional. Five of the fourteen cases stand on a container whose removal pass did not run — an abort between the fast path's phases, an exhausted frame budget, two resumes that unwind, and a park a fresh pass discards — and in each the reproduced leaves are still in the tree, so retiring those entries would leave the next old-side walk unable to name them. `PresenceRemovalOutcome` is what tells the three readings apart.

## Evidence

14 cases, **3 passed / 11 failed** on the base; the three that pass are declared `GREEN_ON_BASE(characterization)` and assert an entry survives. 14/14 with the fix. Fourteen mutation cuts applied one at a time: every cut reddens at least one case, and every case is reddened by at least one cut. EditMode 3839/3839, PlayMode 161/161, 0 failed / 0 inconclusive / 0 skipped, read through `main`'s `assert_results_from_this_tree.py --project` (absent on `2.x` — see #769) and `2.x`'s `assert_no_inconclusive.py`.

## CHANGELOG and documentation

`## [Unreleased]` opens above the released `## [2.1.2]`, entry under `### Fixed`, version not closed and `package.json` left at 2.1.2. `Documentation~/motion.md` gains one bullet under *Exits (`AnimatePresence`)* carrying the `V.Portal(targetId:)` limits below. `Documentation~/portals.md` is untouched: its shared-semantics list is prefaced "The boundary behaves the same in all three forms", and only `V.Portal(targetId:)` was measured.

## Left open, deliberately

**The `V.Portal(targetId:)` route.** For a presence written directly in a portal's children the entry counts and target contents are the same on `c64a168` and on the fixed tree. Closing the portal leaves the entry with the target emptied. The first reopen records a *second* entry, because the fiber term it composes is not the one the mount recorded — same parent element, same scope. The second reopen splices a child whose key changed between opens back into the target beside the new one.

Wrapping the presence in an element inside the portal covers the close and the two-portal collision — 1 → 0 across the close against 1 → 1 — but **not** the hide, where the portal stays open and only the presence inside it stops being rendered. Instrumenting `RetirePresenceStatesNotReRendered` says where the two part: retirement runs and removes nothing, because the key the old-side walk composes is not the one the table holds. That retirable fiber term is what the next show records as the second entry. Fixing it is the portal fiber-term question this PR scopes out.

**Two portals rendering a presence at the same scoped position into the same registered target share one entry** — one entry whose committed set holds both children, and a target left holding three children for the two that were rendered. Measured on the fixed tree and with the change reverted alike; a key collision rather than a retirement question.

**`NavigatorAttachments`** — the first of the two smaller findings #605 lists beside it, the second of which the issue itself struck — is unchanged and still has no per-key removal here. The Suspense tables have a related shape: both shrink when a fallback is hidden through `SetSuspenseFallbackShown`, `_suspenseFallbackKeys` carries a fiber-unregistration prune on top of that, and `_rootlessSuspenseFallbackKeys` carries none. Those hold strings rather than elements, so there is no pool ghosting, and no failing case was constructed for them — the shape is reported, not a defect.
