### PR TITLE
docs(velvet): drop a console claim the printed line contradicts

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -272,8 +272,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `Router.OnLocationChanged` subscriber can run behind that announcement — and a throw from one was
   caught by the clauses that exist for the loader itself. That counted the round's outstanding loader
   off a second time and recorded the throw as that route's loader error. So a caller reading the route's
-  loader error saw a load failure that had not happened, and the console carried the subscriber's
-  exception under the name of that failure. Filing it as a failure also ran the router's failure
+  loader error saw a load failure that had not happened. Filing it as a failure also ran the router's failure
   handler, which writes the history entry's snapshot again — this time from a round the second count
   had corrupted — so the entry stayed unsettled and a Back or Forward to it re-ran the loader instead
   of being served from the cache. What that second count costs the round itself depends on how many


### PR DESCRIPTION
No issue: a clause in an `[Unreleased]` entry says the opposite of what the code prints, and it ships in the next release note from this branch.

The entry for the subscriber-throw fix says the console "carried the subscriber's exception **under the name of that failure**". The router's failure handler is a bare `UnityEngine.Debug.LogException(ex)`. What that prints, measured against a base-arm run: the exception's own type, the subscriber's own message, and the subscriber's own method, file and line as the **top stack frame**, with `Router.RepublishCurrentLocation` beneath it. Nothing in the line names a loader failure.

The clause is deleted rather than corrected. Read the other way round it asserts something the entry does not need — the sentence before it already carries the harm, that a caller reading the route's loader error saw a load failure that had not happened, and the sentence after it carries the change.

The maintenance line's copy of this entry took **two** attempts at the clause and both were false: the first was this text, and the second said the console named nothing that would tie the exception to the subscriber, which the top stack frame contradicts. The commit that wrote the second stated the true version in its own message and the opposite in the file. `2.x` deletes it on the same reasoning, and `CLAUDE.md`'s rule — a sentence corrected twice is deleted rather than corrected again — is what says to stop here rather than write a third.

No CHANGELOG entry for this: it is an edit to an unreleased entry, not a change. No documentation impact — no guide describes what the router logs.
