### PR TITLE
chore(velvet): reopen the Unreleased section the release closed

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this package are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [Unreleased — breaking]
 
 ## [3.0.0] - 2026-08-27


### PR DESCRIPTION
No issue: v3.0.0 renamed `## [Unreleased]` to the version it closed, and nothing reopened one.

The release skill's step 1 says to do that rename **last**, once nothing further is going into the
section, because `changelog_into_closed_version.py` refuses a write into a dated section and the rename
is what dates it. What it does not say is that the next cycle then has nowhere to file an entry.

Measured on `main` at `bd5f06c2`: the CHANGELOG opens `## [Unreleased — breaking]` — empty, as a drained
major leaves it — and then `## [3.0.0] - 2026-08-27`. There is no `## [Unreleased]`, so an entry written
next has to open the section as part of an unrelated change.

Nothing caught it. `test_release_notes.py` passes 31 cases against a CHANGELOG with no open section, and
`published_check.py` answers clean on both its questions, because every reading is about a version that
exists rather than about one being written.

**This does not repair a branch that already carries an entry.** #762 and #377 append theirs at the tail
of what was `## [Unreleased]`, and the release moved that tail inside `## [3.0.0]`, so a three-way merge
takes the entry there and conflicts — measured, against this branch as much as against `main`. Reopening
the heading does not attract it, which is the same reading `CONTRIBUTING.md`'s maintenance-line section
records for a picked bullet. Those two want their hunk taken out and the entry written fresh under the
new section, which is that section's own instruction.

What this fixes is the next entry, not the two already written.

One heading, above the breaking section and below the preamble, so the two open sections sit in the order
the release step reads them.
