### PR TITLE
tooling(velvet): refuse a major that says nothing about the breaking work in flight

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -9,7 +9,12 @@ The `UPM` workflow does the tagging, the `upm` branch split and the GitHub relea
 do is decide what the release contains, so the whole job here is getting `CHANGELOG.md` right and
 then dispatching.
 
-`Packages/com.velvet.core/CHANGELOG.md` is the single source of truth for the release note.
+`Packages/com.velvet.core/CHANGELOG.md` is the single source of truth for the release note — of the
+note, and not of what the release is for. A breaking entry is written for the next major and lives on
+its own branch until that branch merges, so the set a major was assembled to carry is only partly in
+the file. Before closing a major, list the open pull requests adding to `## [Unreleased — breaking]`
+and say in the body which the version carries; `breaking_in_flight_check.py` refuses one that names
+none of them.
 `scripts/release/release_notes.py` turns one version's section into the published body — Highlights, install
 instructions, the long-form entries collapsed, the compare link. Nothing about a release is written
 twice, and nothing is written straight into the GitHub release.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -221,6 +221,21 @@ jobs:
           python3 scripts/release/published_check.py --result HEAD \
             ${BASE:+--base "$BASE"}
 
+      - run: python3 scripts/release/test_breaking_in_flight_check.py
+
+      # Every other reading here is of one tree, so a branch carrying a breaking entry is invisible
+      # to all of them — which is how v3.0.0 shipped twelve of the thirteen written for it. Skipped
+      # on merge_group, where no body is left to name anything: the pull request already answered.
+      - if: github.event_name == 'pull_request'
+        env:
+          BASE: ${{ github.event.pull_request.base.sha }}
+          BODY: ${{ github.event.pull_request.body }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          printf '%s' "$BODY" > /tmp/pr-body.md
+          python3 scripts/release/breaking_in_flight_check.py \
+            --base "$BASE" --result HEAD --body-file /tmp/pr-body.md
+
   # ---------------------------------------------------------------------------
   # A test written to pin a change has to be red without it, and nothing here asked. The Python half
   # of that question is answered outright: base_red_check.py checks out the merge base, copies this

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -625,7 +625,12 @@ behaviour a working application would notice changing.
    bullet in `### Highlights` belongs to a major and to no other release; `test_release_notes.py`
    refuses each of those. Give the version a row in `SECURITY.md`'s supported-versions table, and
    decide there what happens to the series it succeeds: `supported_versions_check.py` refuses a
-   release the table does not cover with one row marked supported.
+   release the table does not cover with one row marked supported. A major also answers for the
+   breaking work still in flight: an entry written for it sits on its own branch until that branch
+   merges, so the CHANGELOG holds only the part that has landed. Name every open pull request adding
+   to `## [Unreleased — breaking]` and say which the version carries —
+   `breaking_in_flight_check.py` refuses one that names none of them, and "not this one" is a
+   decision it accepts.
 2. Merge to `main` (the `upm` branch is updated automatically).
 3. Run the **UPM** workflow via *Actions ▸ UPM ▸ Run workflow*, entering the same version.
    This tags `vX.Y.Z` on the `upm` (package-at-root) commit and publishes a GitHub release.

--- a/scripts/release/breaking_in_flight_check.py
+++ b/scripts/release/breaking_in_flight_check.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Refuse a version-closing change that says nothing about the breaking work still in flight.
+
+Every other reading in the release path is of one tree. `published_check.py` asks what this change
+does to `## [Unreleased — breaking]`, `is_major_bump` asks what the CHANGELOG already holds, and the
+skill calls that file the single source of truth for the note. A pull request that has not merged is
+invisible to all of them, so the question "what is this major for" has no reader at all.
+
+That is how v3.0.0 shipped twelve of the thirteen breaking entries written for it. The thirteenth was
+PR #377, whose body said its entry sat "beside the twelve breaking entries already waiting for the
+next major" -- the set was recorded, on a branch, where nothing in the release path looks.
+
+So a change that closes a version is asked to name every open pull request adding to that section,
+and to say for each whether the version carries it. Naming is the whole of what is required: the
+answer "not this one" is a decision somebody made, and it is the not-deciding this exists to stop.
+
+Exit 2 when a pull request goes unnamed, 1 when the state could not be read, 0 otherwise. A read that
+did not happen is not a read that found nothing, and it must not pass.
+"""
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+CHANGELOG = "Packages/com.velvet.core/CHANGELOG.md"
+BREAKING = "Unreleased — breaking"
+VERSION_HEADING = re.compile(r"^## \[(\d+\.\d+\.\d+)\]", re.M)
+
+UNNAMED = 2
+UNREADABLE = 1
+
+
+def run(args, timeout=20):
+    try:
+        done = subprocess.run(args, capture_output=True, text=True, timeout=timeout)
+    except (OSError, subprocess.SubprocessError) as failure:
+        return None, str(failure)
+    if done.returncode != 0:
+        return None, done.stderr.strip() or f"exit {done.returncode}"
+    return done.stdout, None
+
+
+def released(text):
+    return set(VERSION_HEADING.findall(text or ""))
+
+
+def section(text, heading):
+    start = (text or "").find(f"## [{heading}]")
+    if start < 0:
+        return []
+    end = text.find("\n## [", start + 5)
+    body = text[start:] if end < 0 else text[start:end]
+    return [line for line in body.splitlines() if line.startswith("- ")]
+
+
+def at(rev, path):
+    out, _ = run(["git", "show", f"{rev}:{path}"])
+    return out
+
+
+def closing(base, result):
+    """The versions this change closes, which is the whole of when the question is asked."""
+    return sorted(released(at(result, CHANGELOG)) - released(at(base, CHANGELOG)))
+
+
+def open_pull_requests(repo):
+    out, failure = run(["gh", "pr", "list", "--state", "open", "--limit", "100",
+                        "--json", "number,title,headRefName,headRefOid"]
+                       + (["--repo", repo] if repo else []), timeout=30)
+    if out is None:
+        return None, failure
+    try:
+        return json.loads(out), None
+    except ValueError as failure:
+        return None, str(failure)
+
+
+def adds_breaking(pull, base):
+    """Whether the branch holds a breaking entry the base does not.
+
+    Read as a set difference rather than as a diff, so an entry the base already carries is not
+    charged to whichever branch happens to touch the file beside it.
+    """
+    theirs = at(pull["headRefOid"], CHANGELOG)
+    if theirs is None:
+        return None
+    return [entry for entry in section(theirs, BREAKING)
+            if entry not in section(at(base, CHANGELOG), BREAKING)]
+
+
+def unnamed(pulls, body):
+    """Pull requests the body does not name, by number."""
+    said = set(re.findall(r"#(\d+)", body or ""))
+    return [pull for pull in pulls if str(pull["number"]) not in said]
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--base", required=True, help="revision this change is measured against")
+    parser.add_argument("--result", default="HEAD", help="revision this change produces")
+    parser.add_argument("--body-file", help="file holding the pull request body")
+    parser.add_argument("--repo", help="owner/name, when gh cannot infer it")
+    args = parser.parse_args()
+
+    versions = closing(args.base, args.result)
+    if not versions:
+        print("closes no version, so nothing is asked about work in flight")
+        return 0
+
+    pulls, failure = open_pull_requests(args.repo)
+    if pulls is None:
+        sys.stderr.write(
+            "Could not list open pull requests, so nothing read what is in flight: {}\n"
+            "{} closes here, and whether the breaking work written for it is in or out went\n"
+            "unasked. A read that did not happen is not a read that found nothing.\n".format(
+                failure, ", ".join(versions)))
+        return UNREADABLE
+
+    carrying = []
+    for pull in pulls:
+        entries = adds_breaking(pull, args.base)
+        if entries is None:
+            sys.stderr.write(
+                "Could not read the CHANGELOG on #{}, so what it adds went unread: fetch it and\n"
+                "run this again.\n".format(pull["number"]))
+            return UNREADABLE
+        if entries:
+            carrying.append((pull, entries))
+
+    if not carrying:
+        print("{} closes with no breaking entry in flight".format(", ".join(versions)))
+        return 0
+
+    body = ""
+    if args.body_file:
+        try:
+            body = Path(args.body_file).read_text()
+        except OSError as failure:
+            sys.stderr.write("Could not read the body at {}: {}\n".format(args.body_file, failure))
+            return UNREADABLE
+
+    missing = unnamed([pull for pull, _ in carrying], body)
+    if not missing:
+        print("{} closes and names every open pull request adding a breaking entry".format(
+            ", ".join(versions)))
+        return 0
+
+    sys.stderr.write(
+        "{} closes here, and {} open pull request(s) add an entry to "
+        "'## [{}]' that this body does not name:\n".format(
+            ", ".join(versions), len(missing), BREAKING))
+    for pull in missing:
+        entries = dict((p["number"], e) for p, e in carrying)[pull["number"]]
+        first = entries[0][2:].strip()
+        sys.stderr.write("  #{} {}\n      {}{}\n".format(
+            pull["number"], pull["title"][:78], first[:92], "…" if len(first) > 92 else ""))
+    sys.stderr.write(
+        "\nA breaking entry is written for the next major, so the major closing here is the one it\n"
+        "was written for. Say in the body which of these the version carries and which it does not —\n"
+        "'not this one' is a decision, and going without one is what this refuses.\n")
+    return UNNAMED
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/release/test_breaking_in_flight_check.py
+++ b/scripts/release/test_breaking_in_flight_check.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Unit tests for scripts/release/breaking_in_flight_check.py.
+
+The refusal is the easy half. What the tests are mostly about is the two ways it must not pass: a
+change closing a version while a branch carries a breaking entry nobody mentioned, and a listing that
+could not be read at all — because a read that did not happen looks exactly like a read that found
+nothing, and only one of them is a reason to let a release through.
+
+Run: python3 scripts/release/test_breaking_in_flight_check.py
+"""
+
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+
+from breaking_in_flight_check import (  # noqa: E402
+    UNNAMED, UNREADABLE, released, section, unnamed,
+)
+
+CHECK = HERE / "breaking_in_flight_check.py"
+CHANGELOG = "Packages/com.velvet.core/CHANGELOG.md"
+
+OPEN = """# Changelog
+
+## [Unreleased]
+
+## [Unreleased — breaking]
+
+## [2.1.0] - 2026-08-09
+
+### Highlights
+
+- A release.
+"""
+
+CLOSED = OPEN.replace("## [Unreleased]\n", "## [Unreleased]\n\n## [3.0.0] - 2026-08-27\n")
+
+CARRYING = OPEN.replace(
+    "## [Unreleased — breaking]\n",
+    "## [Unreleased — breaking]\n\n### Changed\n\n- An API a caller has to edit around.\n")
+
+STUB_GH = """#!/bin/sh
+printf '%s' "$VELVET_IN_FLIGHT_LIST"
+exit "$VELVET_IN_FLIGHT_CODE"
+"""
+
+
+def git(cwd, *args):
+    subprocess.run(["git", "-C", str(cwd), *args], check=True, capture_output=True, text=True)
+
+
+def repository():
+    """A tree whose HEAD closes 3.0.0 over a base that did not, and a branch carrying an entry."""
+    root = Path(tempfile.mkdtemp())
+    git(root, "init", "--quiet", "--initial-branch=main")
+    git(root, "config", "user.email", "t@example.com")
+    git(root, "config", "user.name", "t")
+    (root / CHANGELOG).parent.mkdir(parents=True)
+    (root / CHANGELOG).write_text(OPEN)
+    git(root, "add", CHANGELOG)
+    git(root, "commit", "--quiet", "-m", "base")
+    base = subprocess.run(["git", "-C", str(root), "rev-parse", "HEAD"],
+                          capture_output=True, text=True).stdout.strip()
+    git(root, "checkout", "--quiet", "-b", "in-flight")
+    (root / CHANGELOG).write_text(CARRYING)
+    git(root, "commit", "--quiet", "-am", "carrying")
+    branch = subprocess.run(["git", "-C", str(root), "rev-parse", "HEAD"],
+                            capture_output=True, text=True).stdout.strip()
+    git(root, "checkout", "--quiet", "main")
+    (root / CHANGELOG).write_text(CLOSED)
+    git(root, "commit", "--quiet", "-am", "release")
+    return root, base, branch
+
+
+def run(root, base, listing, code=0, body=None):
+    stub = root / "bin"
+    stub.mkdir(exist_ok=True)
+    (stub / "gh").write_text(STUB_GH)
+    (stub / "gh").chmod(0o755)
+    env = dict(os.environ,
+               PATH=f"{stub}{os.pathsep}{os.environ['PATH']}",
+               VELVET_IN_FLIGHT_LIST=listing,
+               VELVET_IN_FLIGHT_CODE=str(code))
+    args = [sys.executable, str(CHECK), "--base", base, "--result", "HEAD"]
+    if body is not None:
+        path = root / "body.md"
+        path.write_text(body)
+        args += ["--body-file", str(path)]
+    return subprocess.run(args, cwd=str(root), capture_output=True, text=True, env=env, timeout=60)
+
+
+def listing(number, oid):
+    return ('[{"number": %d, "title": "replace the async type",'
+            ' "headRefName": "in-flight", "headRefOid": "%s"}]' % (number, oid))
+
+
+class Readings(unittest.TestCase):
+    def test_Given_ASectionHoldingItems_When_Read_Then_OnlyItsOwnAreReturned(self):
+        # Arrange / Act
+        entries = section(CARRYING, "Unreleased — breaking")
+
+        # Assert
+        self.assertEqual(entries, ["- An API a caller has to edit around."])
+
+    def test_Given_AChangelogClosingAVersion_When_Read_Then_TheVersionIsNamed(self):
+        # Arrange / Act
+        opened = released(CLOSED) - released(OPEN)
+
+        # Assert
+        self.assertEqual(opened, {"3.0.0"})
+
+    def test_Given_ABodyNamingThePullRequest_When_Read_Then_NoneIsMissing(self):
+        # Arrange — a bare number is how CONTRIBUTING asks a body to cite one.
+        missing = unnamed([{"number": 377}], "left out of this one on purpose: #377")
+
+        # Assert
+        self.assertEqual(missing, [])
+
+
+class Decisions(unittest.TestCase):
+    def test_Given_AnUnnamedBreakingEntryInFlight_When_TheVersionCloses_Then_ItIsRefused(self):
+        # Arrange
+        root, base, branch = repository()
+
+        # Act
+        done = run(root, base, listing(377, branch), body="Closes nothing in particular.")
+
+        # Assert
+        self.assertEqual((done.returncode, "#377" in done.stderr), (UNNAMED, True))
+
+    def test_Given_TheSameEntryNamedInTheBody_When_TheVersionCloses_Then_ItPasses(self):
+        # Arrange — naming it is the whole requirement; "not this one" is still a decision.
+        root, base, branch = repository()
+
+        # Act
+        done = run(root, base, listing(377, branch), body="#377 waits for the major after this.")
+
+        # Assert
+        self.assertEqual(done.returncode, 0)
+
+    def test_Given_NoBreakingEntryInFlight_When_TheVersionCloses_Then_ItPasses(self):
+        # Arrange
+        root, base, _ = repository()
+
+        # Act
+        done = run(root, base, "[]", body="A release.")
+
+        # Assert
+        self.assertEqual(done.returncode, 0)
+
+    def test_Given_AListingThatCouldNotBeRead_When_TheVersionCloses_Then_ItIsNotAPass(self):
+        # Arrange — the failure this exists to refuse looks identical to an empty listing.
+        root, base, _ = repository()
+
+        # Act
+        done = run(root, base, "", code=1, body="A release.")
+
+        # Assert
+        self.assertEqual(done.returncode, UNREADABLE)
+
+    def test_Given_AChangeClosingNoVersion_When_Decided_Then_NothingIsAsked(self):
+        # Arrange
+        root, base, branch = repository()
+
+        # Act — measured against its own HEAD, so no version opens across the pair.
+        done = run(root, "HEAD", listing(377, branch), body="No release here.")
+
+        # Assert
+        self.assertEqual(done.returncode, 0)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
No issue: v3.0.0 shipped twelve of the thirteen breaking entries written for it, and nothing in the
release path could have said so.

`published_check.py` asks what a change does to `## [Unreleased — breaking]`. `is_major_bump` asks
what the CHANGELOG already holds. The release skill calls that file the single source of truth. Every
one of those reads a single tree, so a branch carrying a breaking entry is invisible to all of them —
and the question "what is this major for" had no reader at all.

#377's body says its entry sits "beside the twelve breaking entries already waiting for the next
major". The set was recorded. It was recorded on a branch.

## What it asks

A change that closes a version has to name every open pull request adding to that section. Naming is
the whole requirement — "not this one" is a decision somebody made, and going without one is what
this refuses.

## Measured

- Replayed against `bd5f06c2`, the v3.0.0 release commit, with that pull request's real body: it
  names #377 and exits 2. With #377 cited in the body it exits 0.
- Every other CHANGELOG commit on `main` closes no version, where it is silent. The section itself has
  only existed since 2026-08-21, so 3.0.0 is the one release it could have judged — one opportunity,
  one firing, and the firing is the miss.

That is one case rather than a rate, and a refusal on n=1 needs saying out loud. What earns it here is
that the cost of the miss is a published tag: `main` holding an unreleased backport is repairable by
releasing, and a major that shipped without the work it was assembled for is not.

## The unreadable case

An unreadable listing exits 1 rather than passing. A `gh` that failed and a repository with no open
pull requests produce the same empty answer, and only one of them is a reason to let a release
through.

It runs on `pull_request` only. On `merge_group` there is no body left to name anything, and the pull
request already answered.

Documentation: CONTRIBUTING.md's release steps and the release skill both gain the rule. No CHANGELOG
entry — contributor tooling, and nothing a consumer sees changes.
