### PR TITLE
ci(velvet): run the result asserter the maintenance line was missing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -134,6 +134,14 @@ jobs:
         if: always()
         run: python3 scripts/test_quality/assert_no_inconclusive.py "${{ matrix.testMode }}-results"
 
+      # The step above asks what the results say; this one asks whether they are this checkout's to
+      # read. A run that will not compile writes no XML at all, so what is left at that path is
+      # whatever last wrote there — and a cherry-pick applying clean onto a tree that then does not
+      # compile is the shape a maintenance line produces most.
+      - name: Assert the results are this checkout's
+        if: always()
+        run: python3 scripts/test_quality/assert_results_from_this_tree.py "${{ matrix.testMode }}-results"
+
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
@@ -212,6 +220,8 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - run: python3 scripts/test_quality/test_mutation_check.py
+
+      - run: python3 scripts/test_quality/test_assert_results_from_this_tree.py
 
       - run: python3 scripts/test_quality/test_neuter_check.py
 

--- a/scripts/test_quality/assert_results_from_this_tree.py
+++ b/scripts/test_quality/assert_results_from_this_tree.py
@@ -1,0 +1,396 @@
+#!/usr/bin/env python3
+"""Refuse a Unity test run whose results are not a reading of this worktree.
+
+A results file is written where the caller points, and nothing ties it to the run that reads it.
+Measured on a worktree seeded with another checkout's `Library`, with that checkout's extra
+fixture deleted here and a compile error introduced: Unity exited 1 and wrote no results, leaving
+"Scripts have compiler errors" in the log, and the file already at that path went on reporting one
+passing case named for a fixture no source in the tree declares -- under a -testFilter naming
+something else, which is what makes it read as a result rather than as a failure to run. Unity's
+exit code is the caller's to notice, and nobody was reading it.
+
+Three readings, and the run has to survive all of them:
+
+  - the log names the results file, which is how a run says the file is its own;
+  - the log carries no line rendered as a compiler error, whichever analyzer raised it;
+  - every fixture reported is a type some source here declares, unless the assembly reporting it is
+    a resolved package's and not this worktree's.
+
+The third asks nothing of the log, so it is what stands where a results file IS the run's own and
+the tree is not the one it was taken from -- a checkout that moved between the run and the reading,
+or a project pointed at from somewhere else.
+
+Every reading it cannot take is a refusal. A guard that exits 0 because git, the log or the results
+went unread is indistinguishable from one that exits 0 having checked, which is the failure this
+whole file exists to make impossible.
+
+Run: python3 scripts/test_quality/test_assert_results_from_this_tree.py
+"""
+
+import argparse
+import importlib.util
+import json
+import re
+import subprocess
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+# Not the CS ID space: an analyzer under Generators~ raises its own at error severity, which fails
+# the compile with no CS code in the log to find it by. Matched on the rendering a diagnostic line
+# carries rather than on a list of ID prefixes -- the test module reads the identifiers the
+# analyzers declare and holds this pattern to matching every one.
+#
+# The whole shape is read, and the test module has a case per way of giving one up. Drop the
+# separator and a run's own prose -- "mount error: the target was null" -- refuses the run that
+# printed it. Allow a capital as well and the `] Error:` lines Unity's own subsystems print refuse
+# a run that compiled cleanly.
+COMPILE_ERROR = re.compile(r": error ")
+
+SAVED_RESULTS = re.compile(r"^Saving results to: (.+?)\s*$", re.MULTILINE)
+
+# NUnit names a fixture by its runtime type, so a nested one is joined with a + and a generic one
+# carries its arity: Velvet.Tests.PoolHelperTestsBase`1 is how the cases a generic base declares are
+# reported, under that base rather than under the closed types that run them.
+CLR_NESTING = re.compile(r"\+")
+CLR_ARITY = re.compile(r"`\d+")
+
+
+def _sibling(name):
+    """Imports a sibling script by path, since scripts/test_quality is not a package."""
+    path = Path(__file__).resolve().with_name(name + ".py")
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# The masking and the brace profile a type is read off below are base_red_check.py's, which owns why
+# a declaration is taken off a masked line rather than a raw one. Its namespace reading is not
+# taken: that one keeps the last name it saw, and `declared_types` stacks them instead because two
+# block namespaces nest to the name NUnit reports.
+_base_red_check = _sibling("base_red_check")
+
+
+class Unreadable(Exception):
+    """A reading the check could not take."""
+
+
+# --------------------------------------------------------------------------------------------------
+# What this worktree holds
+# --------------------------------------------------------------------------------------------------
+
+def worktree_files(project, pathspec):
+    """Every file matching a pathspec that git tracks or does not ignore.
+
+    Asked of git rather than walked, so a fixture written a minute ago and never added counts as
+    this worktree's while everything under the directories .gitignore names -- Library/PackageCache
+    above all, which holds a resolved package's own fixtures -- does not.
+    """
+    finished = subprocess.run(
+        ["git", "-C", str(project), "ls-files", "-z", "--cached", "--others", "--exclude-standard",
+         "--", pathspec],
+        capture_output=True, text=True)
+    if finished.returncode != 0:
+        raise Unreadable("git could not list {} under {}: {}".format(
+            pathspec, project, finished.stderr.strip() or finished.returncode))
+    return [project / name for name in finished.stdout.split("\0") if name]
+
+
+def assembly_name(path):
+    # utf-8-sig: a package ships an assembly definition with a byte-order mark, and json refuses one.
+    try:
+        declared = json.loads(path.read_text(encoding="utf-8-sig", errors="replace"))["name"]
+    except (OSError, ValueError, KeyError) as error:
+        raise Unreadable("{}: unreadable assembly definition ({})".format(path, error))
+    return declared
+
+
+def declared_assemblies(project):
+    """The assemblies this worktree's own assembly definitions name."""
+    names = {assembly_name(path) for path in worktree_files(project, "*.asmdef")}
+    if not names:
+        raise Unreadable("{}: no assembly definition here, so no assembly is this worktree's to "
+                         "answer for".format(project))
+    return names
+
+
+def resolved_assemblies(project):
+    """The assemblies the packages this project resolved name, read out of the imported package cache.
+
+    Read rather than listed. A package's own fixtures run alongside this repository's --
+    Unity.Addressables.DocExampleCode.Editor.Tests does -- and a list of the exceptions written here
+    would be a mirror of the manifest with nothing failing when it drifts.
+    """
+    library = project / "Library"
+    if not library.is_dir():
+        raise Unreadable(
+            "{}: no Library, so which assemblies came from a package cannot be read. Run this "
+            "against the project the tests ran in.".format(project))
+    return {assembly_name(path) for path in library.rglob("*.asmdef")}
+
+
+def _unwind(stack, entering):
+    """Drops every scope whose body opened and whose depth has come back."""
+    while stack and stack[-1][2] and entering <= stack[-1][1]:
+        stack.pop()
+
+
+def _opened(stack, entering, peak, leaving):
+    """Marks the innermost scope as having a body, and drops it when that body also closed here."""
+    if stack and not stack[-1][2] and peak > stack[-1][1]:
+        stack[-1][2] = True
+        if leaving <= stack[-1][1]:
+            stack.pop()
+
+
+def declared_types(text):
+    """Every class, struct or record a C# source declares, fully qualified with its enclosing scopes.
+
+    Same stack discipline as base_red_check.py's case reader, which owns why a scope leaves the
+    stack on the depth its body opened at. Namespaces are on a stack of their own rather than a
+    last-seen name, because two block namespaces nest to the name NUnit reports and a name that
+    reads one level short refuses a fixture that is right here.
+    """
+    code = _base_red_check.code_lines(text)
+    profile = _base_red_check.brace_profile(text)
+
+    file_scoped = None
+    namespaces = []
+    types = []
+    found = set()
+    for index, line in enumerate(code):
+        entering, peak, leaving = profile[index]
+        closes_here = peak == entering and line.rstrip().endswith(";")
+        _unwind(types, entering)
+        _unwind(namespaces, entering)
+        match = _base_red_check.CSHARP_NAMESPACE.search(line)
+        if match:
+            # A file-scoped namespace is held apart from the stack rather than pushed onto it as a
+            # scope that never opens: the first brace anywhere below would otherwise be read as its
+            # body opening, and the type that brace belongs to would take it back off again.
+            if closes_here:
+                file_scoped = match.group(1)
+            else:
+                namespaces.append([match.group(1), entering, False])
+        match = _base_red_check.CSHARP_TYPE.search(line)
+        if match and not closes_here:
+            types.append([match.group(1), entering, False])
+            found.add(".".join(([file_scoped] if file_scoped else [])
+                               + [name for name, _, _ in namespaces]
+                               + [name for name, _, _ in types]))
+        _opened(namespaces, entering, peak, leaving)
+        _opened(types, entering, peak, leaving)
+    return found
+
+
+def types_here(project):
+    """Every class, struct or record any C# source in this worktree declares."""
+    sources = worktree_files(project, "*.cs")
+    if not sources:
+        raise Unreadable("{}: no C# source here, so no fixture could be attributed to this "
+                         "worktree".format(project))
+    found = set()
+    for path in sources:
+        try:
+            found |= declared_types(path.read_text(encoding="utf-8", errors="replace"))
+        except OSError as error:
+            raise Unreadable("{}: unreadable source ({})".format(path, error))
+    return found
+
+
+# --------------------------------------------------------------------------------------------------
+# What the run wrote
+# --------------------------------------------------------------------------------------------------
+
+def named_files(arguments, suffix):
+    """Every file of one suffix a caller named, a directory argument contributing its own.
+
+    A directory means one run's output, so it is not descended into: the other harnesses under
+    scripts/ write their own runs into subdirectories of the same Logs, and those are readings of a
+    base tree rather than of this one.
+    """
+    found = []
+    for argument in arguments:
+        path = Path(argument)
+        if path.is_dir():
+            found.extend(sorted(path.glob("*" + suffix)))
+        elif path.is_file() and path.name.endswith(suffix):
+            found.append(path)
+        elif not path.exists():
+            raise Unreadable("{}: no such file or directory".format(path))
+    return found
+
+
+def read_text(path):
+    try:
+        return Path(path).read_text(encoding="utf-8", errors="replace")
+    except OSError as error:
+        raise Unreadable("{}: unreadable ({})".format(path, error))
+
+
+def fixtures_by_assembly(path):
+    """{assembly: {fixture}} for one results file, or None when it is not a test run.
+
+    The assembly a fixture is reported under is the one whose suite encloses it.
+    """
+    try:
+        root = ET.parse(str(path)).getroot()
+    except (ET.ParseError, OSError) as error:
+        raise Unreadable("{}: unreadable test results ({})".format(path, error))
+    if root.tag != "test-run":
+        return None
+
+    found = {}
+
+    def walk(node, assembly):
+        if node.get("type") == "Assembly":
+            assembly = Path(node.get("name") or "").stem
+        for case in node.findall("test-case"):
+            name = CLR_ARITY.sub("", CLR_NESTING.sub(".", case.get("classname") or ""))
+            if name:
+                # No suite above it says which assembly ran it, so whether that assembly is this
+                # worktree's cannot be read -- and read alongside cases that do carry one, the file
+                # would pass on the strength of the ones that could be attributed.
+                if assembly is None:
+                    raise Unreadable("{}: {} is reported under no assembly suite".format(path, name))
+                found.setdefault(assembly, set()).add(name)
+        for child in node:
+            walk(child, assembly)
+
+    walk(root, None)
+    return found
+
+
+# --------------------------------------------------------------------------------------------------
+# The readings
+# --------------------------------------------------------------------------------------------------
+
+def compile_errors(logs):
+    """Every line any log renders as a compiler error, as (log, line).
+
+    Distinct: the reproduction's three diagnostics came back as nine lines, and the repetition
+    buries the other two readings under them.
+    """
+    found = []
+    for path in logs:
+        for line in read_text(path).splitlines():
+            if COMPILE_ERROR.search(line) and (path, line.strip()) not in found:
+                found.append((path, line.strip()))
+    return found
+
+
+def unclaimed_results(results, logs):
+    """Every results file no log says a run wrote.
+
+    Compared by name, not by path: game-ci runs the editor in a container and the log carries the
+    path it had there, which is not where the check reads the file from afterwards. So two runs
+    writing a results file of the same name are one reading here, and what separates them is the
+    recipe giving each worktree its own Logs directory rather than anything this function can see.
+    """
+    claimed = {Path(name).name
+               for path in logs
+               for name in SAVED_RESULTS.findall(read_text(path))}
+    return [path for path in results if Path(path).name not in claimed]
+
+
+def foreign_fixtures(reported, ours, resolved, types):
+    """(assemblies of this worktree's that ran, every fixture checked that no source here declares).
+
+    An assembly this worktree names is checked even where a package names one too, since of the two
+    answers available for such a name, only checking it can refuse a stranger. One that is NEITHER
+    -- another checkout's test assembly, reported out of a seeded Library no asmdef here names -- is
+    checked too: that is the shape a seeded Library reports, and skipping it would take the stranger
+    it carries out of scope along with it. It does not count toward the floor, which asks whether
+    anything of this worktree's ran and cannot take a stranger for an answer.
+    """
+    found = []
+    ran = []
+    for assembly, fixtures in sorted(reported.items()):
+        if assembly not in ours and assembly in resolved:
+            continue
+        if assembly in ours:
+            ran.append(assembly)
+        found.extend((assembly, fixture) for fixture in sorted(fixtures) if fixture not in types)
+    return ran, found
+
+
+def refusals(project, results, logs):
+    """Every reason the results are not this worktree's reading. Empty means none of them said so."""
+    # First, and returning on its own: a run that did not compile wrote no results, so every reading
+    # below would refuse it for the absence rather than for the cause, and the caller would be told
+    # a file is missing while the diagnostic explaining why sits unread in the log beside it.
+    diagnostics = ["{}: the run did not compile this tree -- {}".format(path, line)
+                   for path, line in compile_errors(logs)]
+    if diagnostics:
+        return diagnostics, 0, []
+
+    if not results:
+        raise Unreadable("no results file, and no diagnostic in the log to say why")
+
+    ours = declared_assemblies(project)
+    resolved = resolved_assemblies(project)
+    types = types_here(project)
+
+    # Only the files that parse as a test run, so a coverage report sitting in the same directory is
+    # not asked which run wrote it.
+    runs = [(path, reported) for path, reported in
+            ((path, fixtures_by_assembly(path)) for path in results) if reported is not None]
+
+    found = []
+    for path in unclaimed_results([path for path, _ in runs], logs):
+        found.append("{}: no log names this file, so it is some earlier run's".format(path))
+
+    ours_ran = []
+    for path, reported in runs:
+        ran, foreign = foreign_fixtures(reported, ours, resolved, types)
+        ours_ran.extend(ran)
+        for assembly, fixture in foreign:
+            found.append("{}: {} reports {}, which no source in this worktree declares".format(
+                path, assembly, fixture))
+
+    if not found:
+        if not runs:
+            raise Unreadable("no test run among: {}".format(
+                ", ".join(str(path) for path in results)))
+        if not ours_ran:
+            raise Unreadable("no assembly of this worktree's ran, so nothing here was measured")
+    return found, len(runs), ours_ran
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(
+        description="Refuse a Unity test run whose results are not this worktree's reading.")
+    parser.add_argument("results", nargs="+",
+                        help="a results XML, or a directory holding one (and its editor log)")
+    parser.add_argument("--project", default=".", help="the project the tests ran in")
+    parser.add_argument("--log", action="append", default=[],
+                        help="the editor log the run wrote; repeatable")
+    args = parser.parse_args(argv)
+
+    try:
+        results = named_files(args.results, ".xml")
+        logs = named_files(args.log, ".log") + named_files(args.results, ".log")
+        if not logs:
+            raise Unreadable(
+                "no editor log among: {}. A run whose compile nobody read is not a "
+                "result -- pass -logFile and name it with --log.".format(
+                    " ".join(args.results + args.log)))
+        found, runs, ours_ran = refusals(Path(args.project), results, logs)
+    except Unreadable as error:
+        print("cannot take this reading: {}".format(error), file=sys.stderr)
+        return 2
+
+    if not found:
+        print("checked {} test run(s) against {}: {} assembl(ies) of this worktree, {} log(s) "
+              "rendering no compiler error".format(runs, args.project, len(ours_ran), len(logs)))
+        return 0
+
+    print("these results are not this worktree's reading:", file=sys.stderr)
+    for line in found:
+        print("  {}".format(line), file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/test_quality/base_red_check.py
+++ b/scripts/test_quality/base_red_check.py
@@ -1,0 +1,2084 @@
+#!/usr/bin/env python3
+"""Run this branch's changed test cases against the merge base and report every one that passes there.
+
+A test is written to separate a behaviour from its absence. The only reading that shows it does is the
+one taken before the change it pins: green on the branch and green on the base together mean the case
+would have passed whatever the branch did to production code. Nothing in this repository asked that
+question, so it stayed a matter of attentiveness. Three of the four branches this was first run over
+had a case that passed on the base and had been reported as pinning something.
+
+What runs is the branch's test file over the base's production code: the base commit is checked out,
+the branch's test-side files are copied onto it, and the changed cases are executed there. Which cases
+those are is settled by each case's own code against the base's, not by which lines a diff calls
+changed: over a large rewrite the aligner describes untouched text as re-added, and a comment edited
+inside a case body is a changed line there. `authored` keeps both out of a gate their authors never
+asked for, and `kept_out` is what stops that being silent -- otherwise a branch that changed no test
+file and one that rewrote a fixture's remarks end to end leave the same empty plan.
+
+**Success here means every changed case was measured on a base tree that demonstrably answers.** Not
+that nothing failed: most of what can go wrong with a run like this ends in a reading nobody took,
+and a reading nobody took must never be a pass. That is one sentence and it decides the shape of
+everything below, because the verdict that carries the evidence -- a case the base could not build --
+is indistinguishable, from the results file alone, from a base that built nothing, ran nothing, or
+was never asked. So each of those is closed separately:
+
+*The tree is read by cases the branch did not carry.* `canary_fixtures` picks fixtures of the base's
+own for a platform and `python_canaries` picks cases of the base's own for that lane. At least one has
+to exist and pass. A tree where nothing built reports every case as uncompilable,
+which is not a failure here, so without that reading such a run comes back green having measured
+nothing at all. The Python lane needs the same reading in its own spelling: a case that stopped before
+it disagreed is not a failure here either, so a lane in which none of them answered exits green
+without one. Separately and before both, a run that left no results file withdraws every platform
+outright: that is the ordinary shape of a licence failure, an editor crash or a timeout, and it is the
+case the canary exists for rather than a case to disarm it in.
+
+*A case is measured under the name the runner reports it by.* A name nothing answers to yields no
+reading, and no reading falls through to the same passing verdict. So the type a case is written in
+is read off the code rather than off the raw line -- `class` occurs in prose and in assertion
+messages -- a type leaves the stack when its body closes, and a case written in an abstract fixture
+is named for each concrete heir. `test_base_red_check.py` holds every C# case in this repository to
+a name the tree declares in full: every owner segment, nested as the name nests them.
+
+*A surface that exists only on the branch is evidence, not an error.* C# reports that at compile
+time. Python reports it while loading or running the case, so its spelling is accepted only when the
+trace names a repository file, module, top-level name or callee's parameter that static comparison
+finds absent on the base and present on the branch. That reading holds only where the same file
+passes on the branch, which is the condition running this after the branch's own suite satisfies.
+For C#, a round that reports no case of a fixture is one where something the branch carried did not
+build: that file is withdrawn and the run repeated, so the rest is still measured rather than lost
+behind it. Which file is picked off the editor log, over every carried file rather than only the
+ones holding cases, since a shared helper takes its whole assembly down with it. A runner that hands
+back a results file and nothing else takes one round, and a compile failure there is an empty
+directory -- which is what an editor that never started leaves as well. So the Python lane's
+comparison is taken statically before that round: `unbuildable_on_base` withdraws a carried file
+spelling a name the base has not got and a production file the branch changed does have, ahead of
+the run rather than behind an error list that round will not produce. That withdrawal is a static
+approximation of what a compiler would say, so it does not outlive the round it stands beside: one
+that wrote no results file takes its platform down, withdrawals included. What the
+comparison cannot reach -- a signature the branch changed under a name both trees
+spell -- leaves a run that measured nothing, which fails, and the refusal names the loop that
+separates it.
+
+*A case that stopped before it disagreed answered nothing.* Red on the base means the base ran the
+case and the case said no. Except for the statically proven branch-only surface above, a case that
+dies before comparing said nothing at all. That includes a C# fixture that compiles on the base and
+throws while reflecting for private production state, and every Python exception whose missing
+surface is not present on the branch. A case reported
+Inconclusive or Skipped there did not run to a verdict either, nor did one the runner refused as
+non-runnable or one whose run was cancelled. Counting any of those as red hands back the evidence the
+gate exists to demand, in the exact shape it was written to refuse: the branch adds a helper, every
+case in the module that reaches for it dies there, and the run reports them all as pinning something.
+So they take a verdict of their own, which says the base could not answer, fails the gate, and leaves
+the red count to the cases that were answered.
+
+*An exception is not that reading by itself.* A branch that fixes a crash leaves the base throwing
+inside the production code the fix repairs, which is the base disagreeing in the plainest way there
+is -- and it arrives under the same label as the case that died in its own scaffolding. What
+separates them is the first frame of the throw that names a file of this tree: production code, or
+the test side. Read over the throw the *body* left, since a case carries what its scaffolding threw
+as well as its own -- a setup, a teardown or a test action, each reaching what the case never asked
+about. A throw naming no such file keeps the non-answer, so what this reads as red is bounded by
+what the results file carries.
+
+*And a scaffolding throw does not always say so in the trace.* One carrying a result state of its
+own -- which is what Unity's end-of-scope log check raises, and so what a fixture whose teardown
+disposes a base tree's crashing mount produces -- replaces the case's trace outright, marker and
+body's frames together, and arrives under the status a failed assertion carries with no label beside
+it. The section survives at the head of the message, which is built after that replacement. This reads
+it only where the trace does not lead back to the case method, so an assertion beginning with those
+words remains a body's disagreement. Behind a body's own message it is not read: a case that disagreed
+did so whatever its scaffolding went on to do.
+
+*A case that belongs on the base says so*, above itself, with a reason:
+
+    // GREEN_ON_BASE(characterization): the keyed-reorder order this refactor must not change.
+
+A declaration is per case and answers for the change under it, so it is read three ways: one over a
+case that goes red on the base is stale and fails, one whose category or reason is malformed fails,
+and one the branch did not itself write is a declaration for a change the base already carries and
+does not answer for this one. A declaration therefore cannot outlive what it describes.
+
+Run: python3 scripts/test_quality/base_red_check.py --base origin/main
+"""
+
+import argparse
+import ast
+import importlib.util
+import io
+import json
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import tokenize
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+DEFAULT_UNITY = "/Applications/Unity/Hub/Editor/6000.3.11f1/Unity.app/Contents/MacOS/Unity"
+# Anchored at the editor binary so that a shell waiting on this pattern does not match itself and
+# report a busy machine forever on an idle one.
+UNITY_RUNNING = "^/Applications/.*/MacOS/Unity -runTests"
+
+PASSED_ON_BASE = "passed on the base"
+RED_ON_BASE = "red on the base"
+COULD_NOT_COMPILE = "could not compile there"
+COULD_NOT_LOAD = "could not load there"
+COULD_NOT_ANSWER = "could not answer there"
+DECLARED_KEPT = "declared, and green as declared"
+DECLARED_STALE = "declared, and not as declared"
+NOT_REPORTED = "no result was written"
+BASE_UNSOUND = "the base tree cannot answer"
+
+FAILING_VERDICTS = (PASSED_ON_BASE, COULD_NOT_ANSWER, DECLARED_STALE, NOT_REPORTED, BASE_UNSOUND)
+
+# The one reading below that no runner reports: a case its scaffolding failed arrives under a status
+# and a label that name a disagreement, so the reading has to be taken rather than read off.
+SCAFFOLDED = "Scaffolded"
+
+# What a case that stopped before it disagreed with anything comes back as, and what to print for
+# each. `reading_of` and `python_outcome` each name a non-answer out of this one dict, so a reading
+# is worded the same whichever lane took it.
+NOT_AN_ANSWER = {
+    "Error": "it raised there rather than failing an assertion",
+    "Inconclusive": "an assumption of its own was false there",
+    "Skipped": "it was skipped there",
+    "Invalid": "the runner would not run it there",
+    "Cancelled": "its run was cancelled there",
+    SCAFFOLDED: "its scaffolding failed it there, so its body reached no verdict",
+    "Unavailable": "it reached a Python surface only the branch provides",
+}
+
+# Which of those a results file spells as a `label` beside the result rather than as the result
+# itself. Kept apart from the readings so that there is a set to hold against NUnit's own, which the
+# dict above is not: its keys are results and labels together. A label missing from here reads as the
+# result beside it, which for all three is `Failed` -- a disagreement, and over a declaration a
+# correct declaration told to delete itself. `ResultStateVocabularyTests` fails when this stops
+# matching the labels NUnit pairs with a failing status.
+NOT_A_VERDICT_LABEL = ("Cancelled", "Error", "Invalid")
+
+CATEGORIES = ("characterization", "refactor")
+
+# The reason has to say something a reviewer can disagree with, and a word count is the only part of
+# that a script can hold. Four words rules out "n/a" and "see above" without pretending to judge prose.
+MINIMUM_REASON_WORDS = 4
+
+DECLARATION = re.compile(r"GREEN_ON_BASE\(([A-Za-z]*)\)\s*:\s*(.*)")
+
+# The Python lane has no -testPlatform to be named by, and the soundness plumbing keys on one.
+PYTHON_LANE = "python"
+
+# unittest's closing line, which is where it separates an assertion that disagreed from an exception
+# that stopped the case.
+UNITTEST_SUMMARY = re.compile(r"^(OK|FAILED)(?:\s*\((.*)\))?\s*$", re.MULTILINE)
+
+
+def speak_under_a_pipe(stream=None):
+    """Puts stdout where a reader watching a phase can see it, which `PipeOutputTests` holds it to.
+
+    Everything below prints across phases that take minutes -- a worktree, a Library copy, a wait for
+    another editor, an editor run -- so a reader that cannot see a line until the process ends cannot
+    tell a run in progress from a wedged one, and both readings have been acted on here. Line
+    buffering rather than a flush per call, so a print written after this one is covered by having
+    been written.
+    """
+    stream = sys.stdout if stream is None else stream
+    if hasattr(stream, "reconfigure"):
+        stream.reconfigure(line_buffering=True)
+
+
+def _sibling(name):
+    """Imports a sibling script by path, since scripts/test_quality is not a package."""
+    path = Path(__file__).resolve().with_name(name + ".py")
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# Which offsets the C# compiler sees as code is one question with one answer, and mutation_check.py
+# owns it. Everything here that reads C# structure -- braces, types, namespaces, attributes -- reads
+# it through that mask, so a brace or a `class` inside a string or a comment names nothing here.
+# How a declaration's reason is read, and which lines one may be read off at all, come from there for
+# the same reason: CONTRIBUTING.md says the two markers are read one way, which a second copy of
+# either here would be free to stop being.
+_mutation_check = _sibling("mutation_check")
+code_mask = _mutation_check.code_mask
+line_spans = _mutation_check.line_spans
+folded_reason = _mutation_check.folded_reason
+csharp_comment_spans = _mutation_check.comment_spans
+declared_lines = _mutation_check.declared_lines
+comment_lines = _mutation_check.comment_lines
+
+
+class Declaration:
+    def __init__(self, category, reason, claim=None, written_here=True, line=None, through=None):
+        self.category = category
+        self.reason = reason
+        self.claim = reason if claim is None else claim
+        # A declaration says a case belongs on the base *because of the change under it*. One the
+        # branch did not write was written for a change the base already carries, and it answers for
+        # that one. Without this the first branch to declare a case green silences every later branch
+        # that edits it, however unlike the reason the declaration gives their change is.
+        self.written_here = written_here
+        self.line = line
+        self.through = line if through is None else through
+
+    def written_in(self, lines):
+        """Whether the branch wrote any line of the span `folded_reason` reads the reason over."""
+        return any(number in lines for number in range(self.line, self.through + 1))
+
+    @property
+    def complaint(self):
+        if self.category not in CATEGORIES:
+            return "category {!r} is not one of {}".format(self.category, ", ".join(CATEGORIES))
+        if len(self.claim.split()) < MINIMUM_REASON_WORDS:
+            return "the reason's first line is under {} words".format(MINIMUM_REASON_WORDS)
+        return None
+
+
+class Case:
+    """One test case, and where in the file it starts and ends."""
+
+    def __init__(self, name, path, first_line, last_line, declaration=None):
+        self.name = name
+        self.path = path
+        self.first_line = first_line
+        self.last_line = last_line
+        self.declaration = declaration
+        self.abstract_owner = None
+        self.verdict = None
+        self.detail = ""
+
+    @property
+    def key(self):
+        """How the run reports this case. A Python module is not qualified by anything else."""
+        return self.name if kind_of(self.path) == "csharp" else "{}::{}".format(self.path, self.name)
+
+    @property
+    def fixture(self):
+        """The class, as the run names it -- the unit -testFilter takes and the control is read over."""
+        return self.key.rsplit(".", 1)[0]
+
+    def __repr__(self):
+        return "Case({!r}, {}-{})".format(self.name, self.first_line, self.last_line)
+
+
+# --------------------------------------------------------------------------------------------------
+# Reading a test file
+# --------------------------------------------------------------------------------------------------
+
+# A dot before `Tests` as readily as a slash: the package splits its assemblies as `<Area>/Tests/
+# Editor`, and the sample splits its own as `<Name>.Tests/Editor`. Anchoring on the slash alone reads
+# the second spelling as production, which leaves the fixtures under it carried onto no base tree and
+# their cases in scope of nothing. `RepositoryTests` fails when a fixture Unity compiles reads that
+# way, and `assume_gate_check.py` takes its lane reading from here.
+CSHARP_TEST_DIR = re.compile(r"[./]Tests/(Editor|PlayMode)/")
+CSHARP_ATTRIBUTE = re.compile(r"^\s*\[")
+CSHARP_CASE_ATTRIBUTE = re.compile(r"\[\s*(Test|UnityTest|TestCase|TestCaseSource|Theory)\b")
+CSHARP_METHOD = re.compile(r"\b([A-Za-z_][A-Za-z0-9_]*)\s*\(")
+# `record` takes an optional `class` or `struct` after it, so the name sits one token further along
+# than the other two spellings put it.
+CSHARP_DECLARES = r"\b(?:class|struct|record(?:\s+(?:class|struct))?)\s+"
+CSHARP_TYPE = re.compile(CSHARP_DECLARES + r"([A-Za-z_][A-Za-z0-9_]*)")
+CSHARP_ABSTRACT = re.compile(r"\babstract\s+(?:partial\s+)?(?:class|record)\b")
+CSHARP_BASES = re.compile(CSHARP_DECLARES + r"[A-Za-z_][A-Za-z0-9_]*\s*(?:<[^>]*>)?\s*:\s*([^{]+)")
+CSHARP_IDENTIFIER = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+CSHARP_NAMESPACE = re.compile(r"\bnamespace\s+([A-Za-z_][A-Za-z0-9_.]*)")
+
+
+def platform_of(relative):
+    """The -testPlatform value for a file, from the directory this repository splits asmdefs by.
+
+    Tests/Editor holds the EditMode assembly: the directory is named for the platform the asmdef is
+    restricted to, and the runner takes the name of the mode.
+    """
+    match = CSHARP_TEST_DIR.search("/" + relative.strip("/"))
+    if not match:
+        return None
+    return "EditMode" if match.group(1) == "Editor" else "PlayMode"
+
+
+def kind_of(relative):
+    """Which lane a repository-relative path belongs to, or None when it holds no test case."""
+    if relative.endswith(".cs") and platform_of(relative):
+        return "csharp"
+    if relative.endswith(".py") and Path(relative).name.startswith("test_"):
+        return "python"
+    return None
+
+
+def measured_by(relative):
+    """Which run a case's verdict comes back from -- its C# test platform, or the Python lane.
+
+    The soundness reading is per run and not per language: each of them can come back having answered
+    nothing, and the canary that says so is chosen and read the same way for both.
+    """
+    return PYTHON_LANE if kind_of(relative) == "python" else platform_of(relative)
+
+
+def is_test_side(relative):
+    """Whether a file is the branch's test material rather than the production code under test.
+
+    This is what gets carried onto the base tree. TestUtilities is in because a changed helper is
+    part of the case that calls it, and a base tree without it compiles neither.
+    """
+    return kind_of(relative) is not None or "/TestUtilities/" in "/" + relative
+
+
+def masked_lines(text, mask):
+    """Each line with every offset the mask reads as blank spaced out.
+
+    Blanked rather than removed, so a masked line is as long as the raw one and the two can be
+    indexed together -- which `csharp_cases` and `assume_gate_check.py` do, a declaration living in a
+    comment and everything else not, and `MaskedLineTests` fails when one stops matching. Stripping
+    the terminator off the end instead of cutting at the raw line's length does not hold that: a mask
+    that swallows the terminator -- a line comment on a CRLF file, or a verbatim string or block
+    comment crossing to the next line -- leaves a space in its place, which no strip removes and
+    which moves every offset after it.
+    """
+    return ["".join(text[start + offset] if mask[start + offset] else " "
+                    for offset in range(len(raw)))
+            for raw, (start, _) in zip(text.splitlines(), line_spans(text))]
+
+
+def code_lines(text):
+    """Each line with every comment, string and character literal blanked to spaces."""
+    return masked_lines(text, code_mask(text))
+
+
+def brace_profile(text):
+    """(depth entering, deepest within, depth leaving) per line, counting only what the compiler sees.
+
+    The peak is what separates a type whose body opens on the line below from one that opens and
+    closes on its own line: both leave the depth exactly where they found it.
+    """
+    mask = code_mask(text)
+    profile = []
+    depth = 0
+    for start, end in line_spans(text):
+        entering = depth
+        peak = depth
+        for offset in range(start, end):
+            if not mask[offset]:
+                continue
+            if text[offset] == "{":
+                depth += 1
+                peak = max(peak, depth)
+            elif text[offset] == "}":
+                depth -= 1
+        profile.append((entering, peak, depth))
+    return profile
+
+
+def comment_block_start(lines, index, prose):
+    """The first line of the contiguous comment block directly above `index`, or `index` itself.
+
+    Directly above and nothing between: a blank line or any code ends the block. A comment further up
+    belongs to whatever sits under it, and reaching past the gap would let one case's prose cover a
+    neighbour nobody wrote it for. The block counts as part of the case, so editing the declaration
+    below re-poses the question the declaration answers.
+
+    `prose` is which lines a comment opens, not which lines begin with an opener. Reaching over a
+    string literal whose line begins with `//` -- a C# fixture this repository holds as Python data --
+    widens the case to cover the field holding it, and what a case covers is what `outside` subtracts:
+    the run then stops reporting that the file's other cases are no longer the base's own text.
+    """
+    probe = index
+    while probe > 0 and probe in prose:
+        probe -= 1
+    return probe
+
+
+def leading_declaration(lines, index, declared, prose):
+    """The declaration in the comment block `comment_block_start` delimits, if there is one.
+
+    `declared` is the same reading `orphaned_declarations` counts the written side over, so a marker
+    the one accepts is a marker the other counts.
+    """
+    for probe in range(comment_block_start(lines, index, prose), index):
+        match = declared.get(probe + 1)
+        if match:
+            claim, reason = folded_reason(match.group(2), lines[probe + 1:index])
+            return Declaration(match.group(1), reason, claim=claim, line=probe + 1, through=index)
+    return None
+
+
+def python_comment_spans(text):
+    """(start, end) for each span a Python comment covers.
+
+    Tokenised rather than matched on a comment opener at the head of a line, which is a different
+    reading and a wrong one here: a C# fixture inside a Python string has lines that open with `//`.
+    """
+    try:
+        tokens = list(tokenize.generate_tokens(io.StringIO(text).readline))
+    except (tokenize.TokenError, IndentationError, SyntaxError):
+        return []
+    starts = [start for start, _ in line_spans(text)]
+    spans = []
+    for token in tokens:
+        if token.type == tokenize.COMMENT:
+            opened = starts[token.start[0] - 1] + token.start[1]
+            spans.append((opened, opened + len(token.string)))
+    return spans
+
+
+def comment_spans_of(relative, text):
+    """Where a comment stands in a file, per its language -- what both readings above are taken from.
+
+    A string literal is where that distinction earns its keep: this repository's test modules hold
+    C# fixtures as Python text, markers and all, and a marker there is a fixture's material. The C#
+    half is `mutation_check`'s, beside the mask everything else here reads structure through.
+    """
+    return python_comment_spans(text) if relative.endswith(".py") else csharp_comment_spans(text)
+
+
+def orphaned_declarations(relative, text):
+    """(declarations the file writes, declarations its cases carry). Equal, or one of them is lost.
+
+    One written above a helper, one with a blank line between it and its case, one left in the block
+    over the case before: each silences nothing and looks like it does. The case it was meant for
+    then fails as green on the base, under advice to write the declaration already above it.
+
+    Compared per file rather than over the tree. Summed, a file that writes one nothing carries is
+    cancelled by a file that carries one nothing wrote, and two defects report as none.
+    """
+    written = declared_lines(text, DECLARATION, comment_spans_of(relative, text))
+    return len(written), sum(1 for case in cases_in(relative, text) if case.declaration)
+
+
+def member_end(lines, ends, signature):
+    """The last line of the member whose signature line is `signature`.
+
+    A body that opens a brace ends where the depth comes back; one that does not ends at its
+    semicolon. Both spellings are in this repository's fixtures, the second as an expression-bodied
+    single assertion.
+    """
+    outer = ends[signature - 1] if signature > 0 else 0
+    opened = False
+    for index in range(signature, len(lines)):
+        if ends[index] > outer:
+            opened = True
+        elif opened:
+            return index
+        elif lines[index].rstrip().endswith(";"):
+            return index
+    return len(lines) - 1
+
+
+def csharp_cases(text, path="?"):
+    """Every test case in a C# fixture, named as Unity's -testFilter takes it.
+
+    Read off the code lines rather than the raw ones. `class` occurs in this repository's assertion
+    messages and in its prose, and a scan that cannot tell those apart from a declaration names the
+    cases under a type the runner has never heard of -- which reports nothing, and no reading is one
+    of the passing verdicts below.
+
+    A type leaves the stack when the depth its body opened at comes back, not only when the next
+    declaration displaces it. Without that a nested helper class declared after the last one, as an
+    abstract args type or a fake, owns every case under it for the rest of the file.
+
+    A declaration that opens no body never joins the stack: the unwinding above is keyed on a body
+    closing, so one that never opens is never popped, and it holds down every type under it too.
+    """
+    lines = text.splitlines()
+    code = code_lines(text)
+    spans = csharp_comment_spans(text)
+    declared = declared_lines(text, DECLARATION, spans)
+    prose = comment_lines(text, spans)
+    profile = brace_profile(text)
+    ends = [leaving for _, _, leaving in profile]
+
+    namespace = None
+    types = []
+    cases = []
+    index = 0
+    while index < len(lines):
+        entering, peak, leaving = profile[index]
+        line = code[index]
+        while types and types[-1][3] and entering <= types[-1][1]:
+            types.pop()
+        found = CSHARP_NAMESPACE.search(line)
+        if found:
+            namespace = found.group(1)
+        found = CSHARP_TYPE.search(line)
+        if found and not (peak == entering and line.rstrip().endswith(";")):
+            types.append([found.group(1), entering, bool(CSHARP_ABSTRACT.search(line)), False])
+        if types and not types[-1][3] and peak > types[-1][1]:
+            types[-1][3] = True
+            if leaving <= types[-1][1]:
+                types.pop()
+
+        if CSHARP_ATTRIBUTE.match(line):
+            block = index
+            while index < len(lines) and (CSHARP_ATTRIBUTE.match(code[index])
+                                          or not code[index].strip()):
+                index += 1
+            attributes = "\n".join(code[block:index])
+            signature = code[index] if index < len(lines) else ""
+            name = CSHARP_METHOD.search(signature)
+            if CSHARP_CASE_ATTRIBUTE.search(attributes) and name:
+                owner = ".".join(part for part, _, _, _ in types)
+                qualified = ".".join(part for part in (namespace, owner, name.group(1)) if part)
+                case = Case(qualified, path, comment_block_start(lines, block, prose) + 1,
+                            member_end(code, ends, index) + 1,
+                            leading_declaration(lines, block, declared, prose))
+                case.abstract_owner = types[-1][0] if types and types[-1][2] else None
+                cases.append(case)
+            continue
+        index += 1
+    return cases
+
+
+def opens_at(node):
+    """Where a definition starts, which is its first decorator where it carries one.
+
+    An argument written in a decorator is code of the definition it sits on, so a range over that
+    definition opens there rather than at the keyword below it.
+    """
+    return min([node.lineno] + [one.lineno for one in getattr(node, "decorator_list", ())])
+
+
+def python_cases(text, path="?"):
+    """Every unittest case in a Python test module, named as `python3 -m unittest` takes it."""
+    try:
+        tree = ast.parse(text)
+    except SyntaxError:
+        return []
+    lines = text.splitlines()
+    spans = python_comment_spans(text)
+    declared = declared_lines(text, DECLARATION, spans)
+    prose = comment_lines(text, spans)
+    cases = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ClassDef):
+            continue
+        for member in node.body:
+            if not isinstance(member, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            if not member.name.startswith("test"):
+                continue
+            opens = opens_at(member)
+            cases.append(Case("{}.{}".format(node.name, member.name), path,
+                              comment_block_start(lines, opens - 1, prose) + 1, member.end_lineno,
+                              leading_declaration(lines, opens - 1, declared, prose)))
+    return cases
+
+
+def concrete_heirs(corpus):
+    """Simple class name -> the qualified names of the concrete classes that inherit it.
+
+    A case written in an abstract fixture runs, and is reported, under each class deriving from it,
+    never under the one it is written in. Filtering on the name in the file therefore matches nothing
+    and the case reads as one the base could not build, which is not a failure -- so without this a
+    branch could rewrite an inherited case and the run would come back green having asked nothing.
+    """
+    heirs = {}
+    for relative, text in corpus.items():
+        namespace = None
+        for line in code_lines(text):
+            found = CSHARP_NAMESPACE.search(line)
+            if found:
+                namespace = found.group(1)
+            declared = CSHARP_TYPE.search(line)
+            bases = CSHARP_BASES.search(line)
+            if not declared or not bases or CSHARP_ABSTRACT.search(line):
+                continue
+            qualified = ".".join(part for part in (namespace, declared.group(1)) if part)
+            for base in {match.group(0) for match in CSHARP_IDENTIFIER.finditer(bases.group(1))}:
+                heirs.setdefault(base, set()).add(qualified)
+    return heirs
+
+
+def as_the_runner_names_them(cases, heirs):
+    """Rewrites each case written in an abstract fixture into one case per concrete heir."""
+    resolved = []
+    for case in cases:
+        if not case.abstract_owner:
+            resolved.append(case)
+            continue
+        method = case.name.rsplit(".", 1)[-1]
+        for owner in sorted(heirs.get(case.abstract_owner, ())):
+            heir = Case(owner + "." + method, case.path, case.first_line, case.last_line,
+                        case.declaration)
+            resolved.append(heir)
+    return resolved
+
+
+def cases_in(relative, text):
+    kind = kind_of(relative)
+    if kind == "csharp":
+        return csharp_cases(text, relative)
+    if kind == "python":
+        return python_cases(text, relative)
+    return []
+
+
+def touched(cases, changed_lines):
+    """The cases the branch wrote: the ones a changed line lands inside. `None` is a whole new file.
+
+    A case the branch left alone is not a claim about it, whatever else in the file moved. Whether it
+    is worth anything as a control is a separate question `collect` answers, and `outside` is half of
+    what that answer is read from.
+    """
+    if changed_lines is None:
+        return list(cases)
+    return [case for case in cases
+            if changed_lines & set(range(case.first_line, case.last_line + 1))]
+
+
+def case_text(text, case):
+    return "\n".join(text.splitlines()[case.first_line - 1:case.last_line])
+
+
+def outside_comments(relative, text):
+    """Each line with its comments blanked to spaces and its literals left standing.
+
+    `code_lines` blanks the literals along with them, and a case whose only change is the value it
+    compares against would read there as untouched.
+    """
+    mask = [True] * len(text)
+    for start, end in comment_spans_of(relative, text):
+        for offset in range(start, end):
+            mask[offset] = False
+    return masked_lines(text, mask)
+
+
+def spanned_code(lines, case):
+    """A case's own lines out of a blanked file, empty ones dropped and trailing spaces cut.
+
+    Both are what a blanked comment leaves behind: one taken off the end of a statement leaves the
+    spaces it occupied, and one that grew by a line leaves a line that is only spaces. Keeping
+    either makes a comment edit read as a changed case.
+    """
+    return "\n".join(line.rstrip() for line in lines[case.first_line - 1:case.last_line]
+                     if line.strip())
+
+
+def authored(relative, cases, before, after):
+    """(the cases whose code this branch changed, the ones it left standing while editing their text).
+
+    Two readings a line number does not carry. A changed line is a proxy for authorship, and which
+    lines a diff calls changed is git's choice rather than the file's: over a large rewrite the
+    aligner is free to describe an untouched tail as deleted and re-added, and every case in it then
+    reads as this branch's. `AuthorshipTests` holds the smallest form of that. And a comment inside a
+    case is not what its run decides on, so a branch that only rewrote one wrote nothing separating
+    that case from its absence.
+
+    The cost of believing either is a green-on-base verdict asking an author to sharpen a case they
+    did not write. `touched` says a case the branch left alone is not a claim about it whatever else
+    in the file moved; this is what holds that when what moved is the case, or only the text in it.
+
+    A case whose text the branch left alone as well is in neither list. The second list is what an
+    empty plan gets explained by, and a case nobody wrote over explains nothing.
+    """
+    if before is None:
+        return list(cases), []
+    held = {case.name: case for case in cases_in(relative, before)}
+    was, here = outside_comments(relative, before), outside_comments(relative, after)
+    written, aside = [], []
+    for case in cases:
+        earlier = held.get(case.name)
+        if earlier is None or spanned_code(was, earlier) != spanned_code(here, case):
+            written.append(case)
+        elif case_text(before, earlier) != case_text(after, case):
+            aside.append(case)
+    return written, aside
+
+
+def outside(cases, changed_lines):
+    """The changed lines inside no case at all -- a SetUp, a field, a helper, a using, a doc comment.
+
+    A change to what several cases share can make an untouched one stop separating anything, and no
+    diff says which. Selecting the file whole on that ground was tried and puts every case a fixture
+    has on trial for a line added to SetUp, so it is reported instead of acted on. What it does
+    settle is that the file's untouched cases are no longer the base's text and cannot read the tree.
+    """
+    if changed_lines is None:
+        return set()
+    accounted = set()
+    for case in cases:
+        accounted |= set(range(case.first_line, case.last_line + 1))
+    return changed_lines - accounted
+
+
+# --------------------------------------------------------------------------------------------------
+# Reading the branch
+# --------------------------------------------------------------------------------------------------
+
+def git(project, *arguments, check=True):
+    return subprocess.run(["git", "-C", str(project), *arguments],
+                          capture_output=True, text=True, check=check)
+
+
+def merge_base(project, base):
+    result = git(project, "merge-base", base, "HEAD", check=False)
+    if result.returncode != 0:
+        raise SystemExit("cannot resolve a merge base with {}: {}".format(base, result.stderr.strip()))
+    return result.stdout.strip()
+
+
+def changed_lines_by_file(project, since):
+    """Repository-relative path -> the lines the branch wrote, or None for a file it added whole.
+
+    Diffed against the working tree rather than against HEAD, so a branch whose change is not
+    committed yet is still measured -- which is the state a run before a commit is in.
+    """
+    diff = git(project, "diff", "--unified=0", "--diff-filter=d", since).stdout
+    changed = {}
+    current = None
+    for line in diff.splitlines():
+        if line.startswith("+++ b/"):
+            current = line[6:]
+        elif line.startswith("+++ ") or line.startswith("diff --git"):
+            current = None
+        elif line.startswith("@@") and current is not None:
+            match = re.search(r"\+(\d+)(?:,(\d+))?", line)
+            if match:
+                start = int(match.group(1))
+                count = int(match.group(2) or 1)
+                changed.setdefault(current, set()).update(range(start, start + count))
+    for name in git(project, "diff", "--name-only", "--diff-filter=A", since).stdout.splitlines():
+        changed[name] = None
+    for name in git(project, "ls-files", "--others", "--exclude-standard").stdout.splitlines():
+        changed[name] = None
+    return changed
+
+
+def deleted_files(project, since):
+    """The paths the base holds and the branch does not, so the base tree stops holding them either.
+
+    A rename is one of them. Git reports a rename as R rather than as A+D whenever it can pair the
+    two halves, so a filter that reads only D leaves the base's copy in place beside the carried one
+    -- two files declaring one fixture class, which either refuses to build or reports the same name
+    twice for the results to collapse into one.
+    """
+    gone = git(project, "diff", "--name-only", "--diff-filter=D", since).stdout.splitlines()
+    for line in git(project, "diff", "--name-status", "--diff-filter=R", since).stdout.splitlines():
+        fields = line.split("\t")
+        if len(fields) >= 3:
+            gone.append(fields[1])
+    return gone
+
+
+# --------------------------------------------------------------------------------------------------
+# Building the base tree
+# --------------------------------------------------------------------------------------------------
+
+def clone_tree(source, destination):
+    """Copies a Library into the base tree, asking the filesystem to share the blocks if it will.
+
+    The base tree is a checkout the machine has never imported, and the import is most of what a base
+    run costs. A byte copy of a Library this size is its own kind of slow, so `cp -c` is tried first
+    and the plain copy is what happens when it is refused.
+    """
+    if sys.platform == "darwin":
+        result = subprocess.run(["cp", "-Rc", str(source), str(destination)],
+                                capture_output=True, text=True)
+        if result.returncode == 0:
+            return
+    shutil.copytree(str(source), str(destination), symlinks=True, dirs_exist_ok=True)
+
+
+def build_base_tree(project, commit, destination, carry, drop, warm_library=None):
+    git(project, "worktree", "add", "--detach", str(destination), commit)
+    for relative in drop:
+        for name in (relative, relative + ".meta"):
+            target = destination / name
+            if target.exists():
+                target.unlink()
+    for relative in carry:
+        for name in (relative, relative + ".meta"):
+            origin = project / name
+            if not origin.exists():
+                continue
+            target = destination / name
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(str(origin), str(target))
+    if warm_library and Path(warm_library).is_dir():
+        clone_tree(Path(warm_library), destination / "Library")
+
+
+def withdraw(base_tree, relative):
+    """Puts one carried file back to what the base commit holds, or removes one the base never had.
+
+    A file whose fixtures the base named nothing of is withdrawn so the rest of its assembly builds.
+    Its own cases are then decided by that silence rather than by the run which follows.
+    """
+    for name in (relative, relative + ".meta"):
+        target = base_tree / name
+        held = git(base_tree, "show", "HEAD:" + name, check=False)
+        if held.returncode == 0:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(held.stdout)
+        elif target.exists():
+            target.unlink()
+
+
+# --------------------------------------------------------------------------------------------------
+# Running
+# --------------------------------------------------------------------------------------------------
+
+def unity_busy():
+    result = subprocess.run(["ps", "-Ao", "command="], capture_output=True, text=True)
+    return sum(1 for line in result.stdout.splitlines() if re.match(UNITY_RUNNING, line))
+
+
+def wait_for_quiet(seconds):
+    """Waits rather than sharing the machine, for the reason mutation_check.py waits.
+
+    Announced the way `neuter_check.wait_for_quiet` announces it: once, and only where there is
+    something to wait for.
+    """
+    deadline = time.time() + seconds
+    announced = False
+    while unity_busy():
+        if time.time() > deadline:
+            return False
+        if not announced:
+            print("  another Unity run is in flight; waiting for the machine")
+            announced = True
+        time.sleep(5)
+    return True
+
+
+COMPILE_ERROR = re.compile(r"^(?:.*?[\\/])?((?:Assets|Packages)[\\/][^(]+)\(\d+,\d+\): error CS")
+
+
+def compile_error_files(log_text):
+    """The repository-relative sources a Unity log blames a compile error on."""
+    named = []
+    for line in log_text.splitlines():
+        match = COMPILE_ERROR.match(line.strip())
+        if match:
+            relative = match.group(1).replace("\\", "/")
+            if relative not in named:
+                named.append(relative)
+    return named
+
+
+def next_to_withdraw(log_text, carry, withdrawn, silent):
+    """Which carried file to put back before asking the base again, after a round reported nothing.
+
+    Every carried file is a candidate, not only the ones holding cases. This repository's conventions
+    put a second fixture's shared reach into TestUtilities, that compiles into the same assembly as
+    the fixtures, and one the base cannot build takes every one of them down with it -- so a choice
+    made only over case-bearing files withdraws innocent fixtures one per round until there are none
+    left, and the run ends having measured nothing with nothing saying so.
+    """
+    return next((name for name in compile_error_files(log_text)
+                 if name in carry and name not in withdrawn), silent[0])
+
+
+def run_unity(unity, tree, platform, fixtures, results, log, timeout):
+    command = [
+        unity, "-runTests", "-batchmode", "-projectPath", str(tree),
+        "-testPlatform", platform, "-testResults", str(results), "-logFile", str(log),
+        "-testFilter", ";".join(sorted(fixtures)),
+    ]
+    started = time.time()
+    try:
+        subprocess.run(command, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        pass
+    return time.time() - started
+
+
+# The source a stack-trace frame names, matched under the two roots a Unity project's own code sits
+# under so that what comes back is the repository-relative path `is_test_side` reads.
+STACK_FRAME_SOURCE = re.compile(r"\bin\s+\.?/?((?:Assets|Packages)/[^\s:]+):\d+")
+
+# The sections a runner opens around one test case. Both readings below are built from this tuple, so
+# a name cannot reach one and miss the other. `ScaffoldingSectionRecordingTests` holds it against the
+# prefixes the runner's own wrapping commands are constructed with, and owns which commands those are.
+SCAFFOLD_SECTIONS = ("AfterTest", "BeforeTest", "SetUp", "TearDown")
+
+# Where a case's own trace stops and a section its scaffolding left begins. A throw out of one is
+# recorded onto the case rather than beside it, under the label a throw from the body would have
+# carried and without a site naming which of them threw.
+#
+# Named one by one rather than matched as any `--word`, since an opener of that shape can belong to
+# the throw itself and cutting there would lose the body's own trace.
+SCAFFOLD_SECTION = re.compile(
+    r"^--(?:{})\b".format("|".join(SCAFFOLD_SECTIONS)), re.MULTILINE)
+
+# The same section at the head of the message, which is the reading that survives where the marker
+# does not. A `ResultStateException` out of a scaffold -- what Unity's end-of-scope log check raises,
+# and what a fixture disposing a base tree's crashing mount produces -- takes a branch that replaces
+# the trace whole, marker and the body's own frames together, and the message is built after that
+# replacement. `ScaffoldingSectionRecordingTests` holds that, and holds the result and label such a
+# case arrives under against the ones a body that disagreed arrives under.
+#
+# At the head and nowhere else -- a body that disagreed leaves its own message in front, and that case
+# disagreed whatever its scaffolding went on to do. `scaffolded` anchors it, and an `^` here as well
+# would leave neither able to fail on its own.
+SCAFFOLD_MESSAGE = re.compile(r"(?:{}) : ".format("|".join(SCAFFOLD_SECTIONS)))
+
+
+def threw_in_production(case):
+    """Whether the throw that stopped this case came from production code rather than its own body.
+
+    Two shapes arrive under one label and only one of them answered nothing. A fixture reflecting
+    from the test assembly for private production state the base has not got gets null back and
+    throws where it would have compared: that reached for what the branch adds. A branch that fixes
+    a crash leaves the base throwing inside the production code the fix repairs: that is the base
+    disagreeing.
+
+    The separator is the first frame that names a file of this tree, over the section the body left.
+    A teardown or a test action runs around the body and reaches what the case never asked about, so
+    reading past the first marker credits the branch with a disagreement the case never had --
+    hardest where the body passed and a marker is all there is. A setup lands on the same side from
+    the other direction: its section stands where the body's would, and a case whose setup crashed
+    in production never ran the body a verdict would be about.
+
+    Frames naming no file of this tree are skipped rather than decided on, since they place the
+    throw on neither side. A throw naming none at all keeps the non-answer, because the verdicts
+    that fail a run are not ones to take from a reading nobody could complete.
+    """
+    trace = case.find("./failure/stack-trace")
+    text = (trace.text or "") if trace is not None else ""
+    for match in STACK_FRAME_SOURCE.finditer(SCAFFOLD_SECTION.split(text, maxsplit=1)[0]):
+        return not is_test_side(match.group(1))
+    return False
+
+
+def scaffolded(case):
+    """Whether a runner recorded this case's failure out of its scaffolding rather than its body.
+
+    The message names the section after its marker was replaced. A trace leading back to the case
+    method says the body supplied those words itself; the replacement trace does not carry that frame.
+    """
+    message = case.find("./failure/message")
+    match = (SCAFFOLD_MESSAGE.match((message.text or "").strip())
+             if message is not None else None)
+    if match is None:
+        return False
+    trace = case.find("./failure/stack-trace")
+    name = (case.get("fullname") or case.get("name") or "").split("(")[0].rsplit(".", 1)[-1]
+    body = re.search(r"(?:\.|<){}(?:\s*\(|>)".format(re.escape(name)),
+                     (trace.text or "") if trace is not None else "")
+    return body is None
+
+
+def reading_of(case):
+    """One reported case's reading: its label where that names one, and its result otherwise.
+
+    The label is preferred so that a case which never reached a verdict is not read as the base
+    disagreeing with it -- the same line `python_outcome` draws off a unittest trailer. Which throws
+    those are is `threw_in_production`'s question.
+
+    A scaffolding failure is read ahead of both, since the shape no label distinguishes is also the
+    shape whose trace has been replaced, leaving the message to carry the reading.
+
+    Never over a passing case: nothing read here can reach `passed on the base`, so reading anything
+    there could only ever turn that verdict into silence.
+    """
+    result = case.get("result")
+    label = case.get("label")
+    if result == "Passed":
+        return result
+    if scaffolded(case):
+        return SCAFFOLDED
+    if label not in NOT_A_VERDICT_LABEL:
+        return result
+    if label == "Error" and threw_in_production(case):
+        return result
+    return label
+
+
+def unity_results(results):
+    """Reported case name -> the reading, in the one vocabulary `decide` takes for either lane."""
+    if not results.exists():
+        return {}
+    try:
+        root = ET.parse(str(results)).getroot()
+    except ET.ParseError:
+        return {}
+    return {case.get("fullname") or case.get("name"): reading_of(case)
+            for case in root.iter("test-case")}
+
+
+def python_outcome(output):
+    """One unittest invocation's verdict, in the words the results file uses for the other lane.
+
+    Read off the trailer rather than the exit status, which is one bit over three readings: an
+    exception and a failed assertion both exit non-zero and only one of them is the base disagreeing,
+    and a skip exits zero and is not the base agreeing.
+
+    No trailer at all is the same reading as an exception rather than one of its own. A module whose
+    own top level raises something the loader does not wrap prints none, which is the shape of a case
+    reaching for what the branch added; `UnittestTrailerTests` holds which deaths print one. A lane
+    where nothing printed a trailer is the canary's question, not this one's.
+    """
+    summary = None
+    for match in UNITTEST_SUMMARY.finditer(output):
+        summary = match
+    if summary is None:
+        return "Error"
+    counts = summary.group(2) or ""
+    if summary.group(1) == "OK":
+        return "Skipped" if "skipped=" in counts else "Passed"
+    if "failures=" in counts:
+        return "Failed"
+    if "errors=" in counts:
+        return "Error"
+    # A count neither of those names -- an unexpected success is the one unittest can print -- is a
+    # trailer this cannot read. Falling back to either neighbour picks a side of the very line this
+    # exists to draw, and the two sides are not symmetric: one of them exits zero.
+    return "Unreadable"
+
+
+MISSING_MODULE = re.compile(r"ModuleNotFoundError: No module named ['\"]([^'\"]+)['\"]")
+MISSING_FILE = re.compile(
+    r"FileNotFoundError: \[Errno 2\] No such file or directory: ['\"]([^'\"]+)['\"]")
+MISSING_ATTRIBUTE = re.compile(
+    r"AttributeError: module ['\"]([^'\"]+)['\"] has no attribute ['\"]([^'\"]+)['\"]")
+# The quote has to follow `from` directly, which is what leaves a circular import out of this
+# reading. `PythonNamedSurfaceTests` pins that against the message Python prints for one.
+MISSING_MEMBER = re.compile(
+    r"ImportError: cannot import name ['\"]([^'\"]+)['\"] from ['\"]([^'\"]+)['\"]")
+# What `mock.patch` raises for a name it was asked to replace and did not find. It writes the module
+# as a repr rather than as a bare name, which is why this is a pattern of its own rather than a
+# widening of the one above.
+MISSING_PATCH_TARGET = re.compile(
+    r"AttributeError: <module ['\"]([^'\"]+)['\"][^>]*> does not have the attribute "
+    r"['\"]([^'\"]+)['\"]")
+MISSING_KEYWORD = re.compile(
+    r"TypeError: (\w+)\(\) got an unexpected keyword argument ['\"]([^'\"]+)['\"]")
+
+
+def top_level_names(text):
+    """Names a Python module binds without executing it."""
+    try:
+        tree = ast.parse(text)
+    except SyntaxError:
+        return set()
+
+    def targets(node):
+        if isinstance(node, ast.Name):
+            return {node.id}
+        if isinstance(node, (ast.Tuple, ast.List)):
+            return set().union(*(targets(item) for item in node.elts)) if node.elts else set()
+        return set()
+
+    names = set()
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            names.add(node.name)
+        elif isinstance(node, ast.Assign):
+            for target in node.targets:
+                names.update(targets(target))
+        elif isinstance(node, ast.AnnAssign):
+            names.update(targets(node.target))
+        elif isinstance(node, (ast.Import, ast.ImportFrom)):
+            names.update(alias.asname or alias.name.split(".")[0] for alias in node.names)
+    return names
+
+
+def climbed(path, levels):
+    """A climb past the repository root is a fold that failed, rather than the root itself."""
+    for _ in range(levels):
+        if path == Path("."):
+            return None
+        path = path.parent
+    return path
+
+
+def path_bindings(parsed):
+    """Name -> the expressions a module assigns to it, over the whole file rather than its top level.
+
+    An insert can sit inside a case body, and the path it hands over can be bound there or above it,
+    so neither the statement nor its name is reliably at the top level.
+    """
+    found = {}
+    for node in ast.walk(parsed):
+        if isinstance(node, ast.Assign) and len(node.targets) == 1 and isinstance(
+                node.targets[0], ast.Name):
+            found.setdefault(node.targets[0].id, []).append(node.value)
+    return found
+
+
+def folded_path(node, home, bound, seen=frozenset()):
+    """The repository-relative paths an expression rooted at `Path(__file__)` folds to.
+
+    `home` is the file the expression was read out of, so `__file__` is that path and each `.parent`
+    or `.parents[n]` climbs from it. Anything the fold does not recognise contributes nothing, so an
+    insert it cannot read leaves that directory out rather than guessing at one.
+    """
+    if isinstance(node, ast.Name):
+        if node.id == "__file__":
+            return {home}
+        if node.id in seen:
+            return set()
+        return set().union(*(folded_path(value, home, bound, seen | {node.id})
+                             for value in bound.get(node.id, ())))
+    if isinstance(node, ast.Call):
+        if isinstance(node.func, ast.Name) and node.func.id in ("str", "Path", "PurePosixPath"):
+            return folded_path(node.args[0], home, bound, seen) if node.args else set()
+        if isinstance(node.func, ast.Attribute) and node.func.attr == "resolve":
+            return folded_path(node.func.value, home, bound, seen)
+        return set()
+    if isinstance(node, ast.Attribute) and node.attr == "parent":
+        return {up for up in (climbed(path, 1)
+                              for path in folded_path(node.value, home, bound, seen)) if up}
+    if isinstance(node, ast.Subscript):
+        owner, index = node.value, node.slice
+        if (isinstance(owner, ast.Attribute) and owner.attr == "parents"
+                and isinstance(index, ast.Constant) and isinstance(index.value, int)):
+            return {up for up in (climbed(path, index.value + 1)
+                                  for path in folded_path(owner.value, home, bound, seen)) if up}
+        return set()
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Div):
+        if not (isinstance(node.right, ast.Constant) and isinstance(node.right.value, str)):
+            return set()
+        return {path / node.right.value
+                for path in folded_path(node.left, home, bound, seen)}
+    return set()
+
+
+def import_directories(case, tree):
+    """The repository directories an import in the case is looked for under, its own first.
+
+    Only the case's own file is read, so an insert a module it imports performs reaches nothing here.
+    `scripts/hooks/test_amend_of_published_commit.py` is the file this is written for: it puts
+    `.claude/hooks/lib` on the path itself, and a module named through that sits beside no case.
+    """
+    home = Path(case.path)
+    found = [home.parent]
+    source = tree / case.path
+    try:
+        parsed = ast.parse(source.read_text(encoding="utf-8", errors="replace")
+                           if source.is_file() else "")
+    except SyntaxError:
+        return found
+    bound = path_bindings(parsed)
+    for node in ast.walk(parsed):
+        if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+                and node.func.attr in ("insert", "append") and node.args):
+            continue
+        owner = node.func.value
+        if not (isinstance(owner, ast.Attribute) and owner.attr == "path"
+                and isinstance(owner.value, ast.Name) and owner.value.id == "sys"):
+            continue
+        for directory in sorted(folded_path(node.args[-1], home, bound)):
+            if directory not in found:
+                found.append(directory)
+    return found
+
+
+def module_relatives(case, module, tree):
+    """The files the module named in a traceback could be, one per directory the run searches."""
+    parts = module.split(".")
+    return [directory.joinpath(*parts).with_suffix(".py")
+            for directory in import_directories(case, tree)]
+
+
+def added_top_level_name(base, branch, name):
+    if not base.is_file() or not branch.is_file():
+        return False
+    return (name not in top_level_names(base.read_text(encoding="utf-8", errors="replace"))
+            and name in top_level_names(branch.read_text(encoding="utf-8", errors="replace")))
+
+
+def takes_keyword(text, function, keyword):
+    """Whether a module's definitions of `function` accept `keyword`.
+
+    A `**kwargs` catch-all accepts every keyword, so any definition carrying one answers yes.
+    Recording the catch-all's own name in a set of accepted keywords instead reads a base that would
+    have taken the call as one that could not, which credits the branch with a surface it did not
+    add.
+    """
+    try:
+        tree = ast.parse(text)
+    except SyntaxError:
+        return False
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == function:
+            taken = node.args
+            if taken.kwarg or any(argument.arg == keyword for argument in
+                                  taken.posonlyargs + taken.args + taken.kwonlyargs):
+                return True
+    return False
+
+
+def added_keyword(output, base_tree, branch_tree, case):
+    """Whether the call that raised named a parameter the branch added to a module the case can reach.
+
+    A parameter is a surface the same way a name is, and the exception is the only place Python says
+    so -- the trace names the caller, never the callee's module, so which one holds the definition is
+    read by looking, over the directories the run imports from. One base-side definition accepting the
+    keyword is enough to refuse: the reading has to be that the base could not have taken this call,
+    not that some module somewhere could not.
+
+    The name readings are gated on `reaches_surface` and this one is not, deliberately. A keyword is
+    a single token: each of those compares a set of spellings that includes the module's own name, so
+    a case naming the module qualifies however it spells the member, while a keyword appears at the
+    call site and nowhere else. Cases here drive their subject through a
+    helper class the fixture does not derive from -- `Polled`, `Workspace`, `StubbedCampaign` -- so
+    the call site sits outside every line the case reaches, and gating this would refuse those cases
+    with no declaration able to clear the verdict. What it costs is a call made at class scope
+    answering for the whole file, which `KeywordAtClassScopeTests` records.
+    """
+    missing = MISSING_KEYWORD.search(output)
+    if not missing:
+        return False
+    function, keyword = missing.group(1), missing.group(2)
+    found = False
+    for directory in import_directories(case, base_tree):
+        for module in sorted((branch_tree / directory).glob("*.py")) if (
+                branch_tree / directory).is_dir() else []:
+            base = base_tree / directory / module.name
+            if takes_keyword(base.read_text(encoding="utf-8", errors="replace") if base.is_file()
+                             else "", function, keyword):
+                return False
+            found = found or takes_keyword(
+                module.read_text(encoding="utf-8", errors="replace"), function, keyword)
+    return found
+
+
+def fixture_classes(parsed, owner):
+    """`owner` and the classes it derives from, over the ones this file declares by bare name.
+
+    A shared base class is where unittest puts scaffolding two fixtures need, so a `setUp` there is
+    as much an heir's reach as one written in its own body. A dotted base is left alone because its
+    last segment is not a spelling this file binds: resolving `helpers.Shared` to a `Shared` declared
+    here picks a class the fixture never derived from.
+    """
+    declared = {node.name: node for node in ast.walk(parsed) if isinstance(node, ast.ClassDef)}
+    found, pending = set(), [owner]
+    while pending:
+        name = pending.pop()
+        if name in found or name not in declared:
+            continue
+        found.add(name)
+        pending.extend(base.id for base in declared[name].bases if isinstance(base, ast.Name))
+    return found
+
+
+def reaching_lines(text, case_name):
+    """The lines of a test module whose text one case could have reached.
+
+    Module level, the classes its fixture is built out of outside their other cases, and the case
+    itself. Import statements are left out: `from module import name` is evaluated once for the file,
+    so a name spelled only there belongs to no case in particular. A string constant standing alone
+    is left out too -- a docstring is that shape, and it looks up no name.
+    """
+    try:
+        parsed = ast.parse(text)
+    except SyntaxError:
+        return set()
+    owner, method = case_name.rsplit(".", 1) if "." in case_name else ("", case_name)
+    owners = fixture_classes(parsed, owner)
+    reaching = set(range(1, len(text.splitlines()) + 1))
+    for node in ast.walk(parsed):
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            reaching -= set(range(node.lineno, (node.end_lineno or node.lineno) + 1))
+        elif (isinstance(node, ast.Expr) and isinstance(node.value, ast.Constant)
+                and isinstance(node.value.value, str)):
+            reaching -= set(range(node.lineno, (node.end_lineno or node.lineno) + 1))
+        elif isinstance(node, ast.ClassDef) and node.name not in owners:
+            reaching -= set(range(opens_at(node), node.end_lineno + 1))
+        elif isinstance(node, ast.ClassDef):
+            for member in node.body:
+                if (isinstance(member, (ast.FunctionDef, ast.AsyncFunctionDef))
+                        and member.name.startswith("test") and member.name != method):
+                    reaching -= set(range(opens_at(member), member.end_lineno + 1))
+    return reaching - comment_lines(text, python_comment_spans(text))
+
+
+def imported_from(text, module):
+    """Every alias the file binds out of `module`, as (the name the case spells, the module's own)."""
+    try:
+        parsed = ast.parse(text)
+    except SyntaxError:
+        return []
+    bound = []
+    for node in ast.walk(parsed):
+        if isinstance(node, ast.ImportFrom) and node.module == module and not node.level:
+            bound.extend((alias.asname or alias.name, alias.name) for alias in node.names)
+        elif isinstance(node, ast.Import):
+            bound.extend((alias.asname or alias.name.split(".")[0], alias.name)
+                         for alias in node.names if alias.name == module)
+    return bound
+
+
+def surface_spellings(case, base_tree, branch_tree, module, name=None):
+    """How the case's own file could be spelling the branch-only surface, not just how Python named it.
+
+    A traceback names one missing name however many of them an import list holds, so a case reaching
+    another of them would read as reaching nothing at all. `name` is the one it named; the rest are
+    read off the import list and kept only where the same comparison holds. A module the base has not
+    got is every name its imports bind, since none of them resolves there.
+    """
+    spellings = {name} if name else set()
+    source = base_tree / case.path
+    if not source.is_file():
+        return spellings
+    bound = imported_from(source.read_text(encoding="utf-8", errors="replace"), module)
+    if name is None:
+        return spellings | {spelled for spelled, _ in bound} | {module.split(".")[0]}
+    for relative in module_relatives(case, module, base_tree):
+        base, branch = base_tree / relative, branch_tree / relative
+        spellings |= {spelled for spelled, attribute in bound
+                      if added_top_level_name(base, branch, attribute)}
+    return spellings
+
+
+def reaches_surface(case, tree, name):
+    """Whether this case, rather than the file it sits in, is the one that reached `name`.
+
+    A module that will not load takes every case in it down together, so without this the tolerance
+    below answers for cases that never touched the branch's surface -- and each of those is a reading
+    nobody took being recorded as a pass, which is what this whole check exists to refuse.
+    Scaffolding counts as the case's own reach: a `setUpClass` naming the surface fails for each case
+    of its fixture, which is that dependence written once.
+    """
+    source = tree / case.path
+    if not source.is_file():
+        return False
+    text = source.read_text(encoding="utf-8", errors="replace")
+    lines = text.splitlines()
+    return any(name in names_in(lines[number - 1])
+               for number in reaching_lines(text, case.name) if number <= len(lines))
+
+
+def added_python_surface(output, base_tree, branch_tree, case):
+    """Whether the traceback names a file or module member present only on the branch.
+
+    The branch's own suite is the precondition that the surface exists and works there. Both sides are
+    inspected here so an arbitrary exception, missing environment file or misspelled member remains a
+    non-answer and fails the gate.
+    """
+    missing = MISSING_FILE.search(output)
+    if missing:
+        path = Path(missing.group(1))
+        try:
+            relative = path.resolve().relative_to(base_tree.resolve())
+        except ValueError:
+            return False
+        return not (base_tree / relative).exists() and (branch_tree / relative).is_file()
+
+    missing = MISSING_MODULE.search(output)
+    if missing:
+        module = missing.group(1)
+        return any(reaches_surface(case, base_tree, spelled) for spelled in
+                   surface_spellings(case, base_tree, branch_tree, module)) and any(
+            not (base_tree / relative).exists() and (branch_tree / relative).is_file()
+            for relative in module_relatives(case, module, base_tree))
+
+    missing = MISSING_ATTRIBUTE.search(output) or MISSING_PATCH_TARGET.search(output)
+    if missing:
+        module, name = missing.group(1), missing.group(2)
+    else:
+        missing = MISSING_MEMBER.search(output)
+        if not missing:
+            return added_keyword(output, base_tree, branch_tree, case)
+        module, name = missing.group(2), missing.group(1)
+    return any(reaches_surface(case, base_tree, spelled) for spelled in
+               surface_spellings(case, base_tree, branch_tree, module, name)) and any(
+        added_top_level_name(base_tree / relative, branch_tree / relative, name)
+        for relative in module_relatives(case, module, base_tree))
+
+
+IDENTIFIER = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+
+
+def names_in(text):
+    return set(IDENTIFIER.findall(text))
+
+
+def csharp_names(tree, carried=()):
+    """Every identifier the base commit spelled, over the C# files the base tree still holds.
+
+    A test file the branch deleted is one the base tree stops holding, and reading that one back out
+    of the commit is what would leave a case naming a production surface the branch adds -- where the
+    base's only spelling of that name was the deleted file's -- in a run whose compile it takes down.
+
+    `carried` names the files whose text on disk is the branch's, which is the text being judged:
+    each is read back out of the commit instead. Leaving them out altogether asks a different
+    question -- whether the branch spelled a name occurring in no *other* file -- and answers yes to
+    an identifier the fixture declared before this branch, which the base builds perfectly well.
+
+    Raw rather than masked, and that asymmetry is the point: on the base this decides that a name is
+    *present*, so counting a comment's spelling suppresses a withdrawal that a masked read would have
+    taken. Erring towards leaving a file in the run is the direction a wrong reading here is
+    survivable in.
+    """
+    found = set()
+    for relative in git(tree, "ls-files").stdout.splitlines():
+        if not relative.endswith(".cs"):
+            continue
+        if relative in carried:
+            held = held_at(tree, "HEAD", relative)
+            if held is not None:
+                found |= names_in(held)
+            continue
+        path = tree / relative
+        if path.exists():
+            found |= names_in(path.read_text(encoding="utf-8", errors="replace"))
+    return found
+
+
+def added_csharp_surface(text, base_names, added_names):
+    """The name a carried C# file spells that the base has not got, or None.
+
+    `added_python_surface` reads the same fact off a traceback, which C# leaves nowhere a single round
+    can reach -- the module docstring owns why. What is left is the comparison itself, and
+    `csharp_names` owns what "the base has not got" is read over. Requiring the branch to spell the
+    name too, in a file it changed and does not carry, is what keeps the names a carried file
+    resolves out of an assembly from reading as ones the branch added -- bar one the changed
+    production file spells as well, which is among the approximations `unbuildable_on_base` records.
+    """
+    return next((name for name in sorted(names_in("\n".join(code_lines(text))) & added_names)
+                 if name not in base_names), None)
+
+
+def unbuildable_on_base(project, since, base_tree, carry):
+    """Carried C# test file -> the name it spells that the base tree has not got.
+
+    Read before the run rather than after, because after is a silence that names nothing.
+
+    Both sides are spellings rather than what a compiler would resolve, and two of the ways they part
+    company withdraw a file the base builds. `added` is what a changed production file spells rather
+    than what it declares, so a type the branch first reaches for in production and in a carried case
+    at once reads as one the base has not got. `base_names` is the base commit's text rather than the
+    tree's -- which holds the branch's copy of every carried file -- so a name the branch's own test
+    side declares reads that way too. Measured: each withdraws a file that compiles there.
+    """
+    changed = [name for name in changed_lines_by_file(project, since)
+               if name.endswith(".cs") and name not in carry]
+    added = set()
+    for relative in changed:
+        source = project / relative
+        if source.exists():
+            added |= names_in("\n".join(code_lines(
+                source.read_text(encoding="utf-8", errors="replace"))))
+    if not added:
+        return {}
+    base_names = csharp_names(base_tree, carried=carry)
+    found = {}
+    for relative in carry:
+        if kind_of(relative) != "csharp":
+            continue
+        source = project / relative
+        if not source.exists():
+            continue
+        name = added_csharp_surface(source.read_text(encoding="utf-8", errors="replace"),
+                                    base_names, added)
+        if name is not None:
+            found[relative] = name
+    return found
+
+
+def run_python(tree, branch_tree, cases, transcript):
+    """Runs one case at a time, so a module-level failure cannot report as some other case's verdict."""
+    outcome = {}
+    for case in cases:
+        module = Path(case.path)
+        identifier = "{}.{}".format(module.stem, case.name)
+        result = subprocess.run([sys.executable, "-m", "unittest", "-v", identifier],
+                                cwd=str(tree / module.parent), capture_output=True, text=True)
+        printed = result.stdout + result.stderr
+        transcript.append("$ python3 -m unittest {} (in {})\n{}".format(
+            identifier, module.parent, printed))
+        verdict = python_outcome(printed)
+        if verdict in ("Error", "Unreadable") and added_python_surface(
+                printed, tree, branch_tree, case):
+            verdict = "Unavailable"
+        outcome[case.key] = verdict
+    return outcome
+
+
+# --------------------------------------------------------------------------------------------------
+# Deciding
+# --------------------------------------------------------------------------------------------------
+
+def outcome_for(name, reported):
+    """What the base run said about one case, over however many entries the name covers.
+
+    A [TestCase] method comes back as one entry per argument list, named `Method(1)`, so an exact
+    lookup would find the method absent and fail closed on a case that ran perfectly well. The method
+    passed on the base only where every one of its argument lists did.
+    """
+    results = [result for key, result in reported.items()
+               if key == name or key.startswith(name + "(")]
+    if not results:
+        return None
+    if all(result == "Passed" for result in results):
+        return "Passed"
+    # An argument list that disagreed outranks one that stopped before it could. The method is red
+    # on the base as soon as any list ran there and said no, and taking whichever came first would
+    # leave dict order to decide whether a declaration over such a method reads as stale -- a
+    # failing verdict against a non-failing one, off the order two entries happen to sit in.
+    unpassed = [result for result in results if result != "Passed"]
+    return next((result for result in unpassed if answered(result)), unpassed[0])
+
+
+def canary_fixtures(base_tree, platform, carry, wanted=3):
+    """Fixtures of the base tree's own that the branch did not touch, in the order git lists them.
+
+    Which ones is not the question: `canaries_for` owns why they run at all, and the bar is one of
+    them passing.
+    """
+    found = []
+    # Tracked, not walked. Walking took the first three fixtures out of Library/PackageCache, which
+    # compile into Unity's own assemblies and answer to no filter this project can pose -- so the
+    # canary found nothing passing and withdrew the very branch it was there to vouch for.
+    for relative in git(base_tree, "ls-files").stdout.splitlines():
+        if kind_of(relative) != "csharp" or platform_of(relative) != platform or relative in carry:
+            continue
+        path = base_tree / relative
+        if not path.exists():
+            continue
+        cases = csharp_cases(path.read_text(encoding="utf-8", errors="replace"), relative)
+        if cases:
+            found.append(cases[0].fixture)
+        if len(found) == wanted:
+            break
+    return found
+
+
+def python_canaries(base_tree, carry, wanted=3):
+    """Cases of the base tree's own Python modules that the branch did not carry, git's order.
+
+    The C# lane's `canary_fixtures` owns why a lane needs these at all. One case per module rather than
+    every case of one, so that one unimportable module is not the whole reading.
+    """
+    found = []
+    for relative in git(base_tree, "ls-files").stdout.splitlines():
+        if kind_of(relative) != "python" or relative in carry:
+            continue
+        path = base_tree / relative
+        if not path.exists():
+            continue
+        cases = python_cases(path.read_text(encoding="utf-8", errors="replace"), relative)
+        if cases:
+            found.append(cases[0])
+        if len(found) == wanted:
+            break
+    return found
+
+
+def fixtures_that_ran(reported):
+    """The fixtures the base run named at least one case of."""
+    return {name.split("(")[0].rsplit(".", 1)[0] for name in reported}
+
+
+def unsound_platforms(canaries, reported):
+    """Platform -> why its canaries say the base tree answered nothing at all.
+
+    One passing case is the whole bar. Which of them passes is not the question -- the question is
+    whether anything on this platform built and ran, since a tree where nothing did reports every
+    case as uncompilable, and uncompilable is not a failure here.
+    """
+    broken = {}
+    for platform, fixtures in canaries.items():
+        if not fixtures:
+            broken[platform] = "no base-tree canary was available there"
+            continue
+        ran = [result for name, result in reported.items()
+               if name.split("(")[0].rsplit(".", 1)[0] in fixtures]
+        if not any(result == "Passed" for result in ran):
+            broken[platform] = "none of {} passed there".format(
+                ", ".join(re.split(r"[.:]", fixture)[-1] for fixture in fixtures))
+    return broken
+
+
+def unsound_fixtures(control, reported):
+    """Fixture -> the control case that says the base tree is answering about itself.
+
+    A control case is one the branch left alone, so the base tree holds exactly the text the base's
+    own green run held. Anything but green from it is the environment.
+    """
+    broken = {}
+    for case in control:
+        result = outcome_for(case.key, reported)
+        if result not in (None, "Passed") and case.fixture not in broken:
+            broken[case.fixture] = "{} is {} there".format(case.name.rsplit(".", 1)[-1], result.lower())
+    return broken
+
+
+def answered(result):
+    """Whether the base ran the case to a verdict about behaviour -- it agreed, or it disagreed.
+
+    A case that raised, one that hit an Assume of its own, one that was skipped, one whose summary
+    could not be read and one nothing reported at all each stopped before that, and the verdicts
+    below say which.
+    """
+    return result is not None and result not in NOT_AN_ANSWER and result != "Unreadable"
+
+
+def decide(case, result, fixture_ran):
+    """One case's verdict from what the base run said about it.
+
+    `fixture_ran` is what separates the two ways a case can be missing, and it is why nothing here
+    reads the editor log. A fixture that reported nothing built nothing -- the branch's test names a
+    symbol the base has not got, which is the evidence this is looking for. A fixture that reported
+    its other cases and not this one resolved the name wrongly, and a name nobody answered to is a
+    reading nobody took.
+    """
+    declaration = case.declaration
+    if declaration is not None and not declaration.written_here:
+        if result == "Passed":
+            return PASSED_ON_BASE, "its declaration is the base's own; restate it for this change"
+        declaration = None
+    if declaration is not None:
+        complaint = declaration.complaint
+        if complaint:
+            return DECLARED_STALE, complaint
+        if result == "Passed":
+            return DECLARED_KEPT, "{}: {}".format(declaration.category, declaration.reason)
+        # Only a run that reached a verdict can call a declaration stale. "Remove the declaration"
+        # is advice about a case the base measured, and a case it never measured falls through to
+        # the reading that says so -- otherwise a declaration is refused for the environment
+        # skipping the case, and the fix it asks for is to delete something correct.
+        if answered(result):
+            return DECLARED_STALE, "it is {} on the base; remove the declaration".format(
+                result.lower())
+    if result == "Unavailable":
+        return COULD_NOT_LOAD, NOT_AN_ANSWER[result]
+    if result == "Passed":
+        return PASSED_ON_BASE, "nothing this branch changed decides it"
+    if result in NOT_AN_ANSWER:
+        return COULD_NOT_ANSWER, NOT_AN_ANSWER[result]
+    if result == "Unreadable":
+        return NOT_REPORTED, "its run printed a summary this could not read"
+    if result is None and not fixture_ran:
+        return COULD_NOT_COMPILE, "the base built none of this fixture"
+    if result is None:
+        return NOT_REPORTED, "its fixture ran and nothing answered to this name"
+    return RED_ON_BASE, result.lower()
+
+
+def canaries_for(base_tree, cases, carry, only=None):
+    """Platform -> the base's own fixtures to read that platform's tree by.
+
+    Every platform, not only the ones the branch left no control case on. A control answers for its
+    own fixture, and a fixture the base named nothing of is legitimate evidence there -- so where a
+    run comes back empty, the controls say uncompilable and nothing says the run happened at all.
+    """
+    chosen = {}
+    for platform in sorted({platform_of(case.path) for case in cases
+                            if kind_of(case.path) == "csharp"}):
+        if not only or platform in only:
+            chosen[platform] = canary_fixtures(base_tree, platform, carry)
+    return chosen
+
+
+def as_plan(since, cases, control, shared, canaries, withdrawn=None):
+    """The reading, in a form a second invocation can decide from.
+
+    A run split across two invocations is what lets the editor be somebody else's -- CI reaches Unity
+    only through an action, so the tree is built and read here, the action runs, and the verdict is
+    taken from the results file it leaves.
+    """
+    def entry(case):
+        return {
+            "name": case.name, "path": case.path, "key": case.key, "fixture": case.fixture,
+            # Positional, in the constructor's order, and the claim rides along: the far side
+            # decides, and a declaration reaching it without one has its floor measured over the fold.
+            "declaration": (None if case.declaration is None
+                            else [case.declaration.category, case.declaration.reason,
+                                  case.declaration.claim, case.declaration.written_here]),
+        }
+
+    return {"since": since, "shared": shared, "canaries": canaries,
+            "withdrawn": withdrawn or {},
+            "cases": [entry(case) for case in cases],
+            "control": [entry(case) for case in control]}
+
+
+def from_plan(entries):
+    cases = []
+    for entry in entries:
+        declaration = None if entry["declaration"] is None else Declaration(*entry["declaration"])
+        case = Case(entry["name"], entry["path"], 0, 0, declaration)
+        cases.append(case)
+    return cases
+
+
+def results_from(where):
+    """(what the run reported, whether it wrote a results file at all).
+
+    The second half is not the first being empty. A round that wrote nothing did not get as far as
+    running, and this treats that as the base failing to build what was carried onto it -- which is
+    evidence, and not the same as a round that ran and reported no case of some fixture.
+    """
+    path = Path(where)
+    files = [file for file in (sorted(path.glob("*.xml")) if path.is_dir() else [path])
+             if file.exists()]
+    reported = {}
+    for file in files:
+        reported.update(unity_results(file))
+    return reported, bool(files)
+
+
+def report(cases, control, reported, canaries=None, wrote=True, unbuildable=None,
+           single_round=None):
+    """Prints each case's verdict and returns the ones that fail the run.
+
+    `wrote` is whether the run produced a results file at all, and for a C# case it outranks
+    everything below it, `unbuildable` included. COULD_NOT_COMPILE off the run says the base built
+    the rest and not this, which takes a base that built something; COULD_NOT_COMPILE off
+    `unbuildable` is a static approximation of a compiler question, accepted only beside a round
+    that got as far as writing.
+    A branch whose every changed case sits in a withdrawn file would otherwise pass on a licence
+    failure, an editor crash or a timeout.
+
+    `unbuildable` outranks the rest of them, for the reason `added_python_surface` is read before a
+    Python case's outcome: the file was taken out before the run, so a verdict off what that run said
+    under its fixture name is a verdict about the base's own text standing in its place.
+
+    `single_round` is the merge base when this invocation decided from one round it did not itself
+    run, and absent when the loop below it ran to a fixed point here -- which is what the remedy the
+    first case prints would be sending its reader to do again.
+    """
+    unsound = unsound_fixtures(control, reported)
+    withdrawn = unsound_platforms(canaries or {}, reported)
+    unbuildable = unbuildable or {}
+    unmeasured = {}
+    if not wrote:
+        unmeasured = {platform: "the run wrote no results file, so nothing was measured"
+                      for platform in {platform_of(case.path) for case in cases
+                                       if kind_of(case.path) == "csharp"}}
+    ran = fixtures_that_ran(reported)
+    for case in cases:
+        if measured_by(case.path) in unmeasured:
+            case.verdict, case.detail = BASE_UNSOUND, unmeasured[measured_by(case.path)]
+        elif case.path in unbuildable:
+            case.verdict, case.detail = COULD_NOT_COMPILE, "the base has no {}".format(
+                unbuildable[case.path])
+        elif case.fixture in unsound:
+            case.verdict, case.detail = BASE_UNSOUND, unsound[case.fixture]
+        elif measured_by(case.path) in withdrawn:
+            case.verdict, case.detail = BASE_UNSOUND, withdrawn[measured_by(case.path)]
+        else:
+            case.verdict, case.detail = decide(case, outcome_for(case.key, reported),
+                                               case.fixture in ran)
+    print("\n--- what the base said ---")
+    for case in cases:
+        print("{:<32} {}  ({})".format(case.verdict, case.name, case.detail))
+    # Three counts, never one. A case the base could not build names a symbol the branch adds, which
+    # is the strongest pin this takes, and folding it into the readings nobody took would tell the
+    # author of a correct test that the run measured nothing. A tolerated case is not a failure, so
+    # a run that tolerated all of them exits zero and says so in silence unless this count speaks.
+    tolerated = [case for case in cases if case.verdict == COULD_NOT_LOAD]
+    if tolerated:
+        print("\n{} of {} case(s) reached a surface only the branch provides, so the base could not "
+              "load them\nand each is counted as depending on this change".format(
+                  len(tolerated), len(cases)))
+    silent = [case for case in cases if case.verdict == COULD_NOT_ANSWER]
+    if silent:
+        print("\nthe base could not answer for {} of {} case(s), so they carry no reading either "
+              "way".format(len(silent), len(cases)))
+    unbuilt = [case for case in cases if case.verdict == COULD_NOT_COMPILE]
+    if unbuilt:
+        print("\n{} of {} case(s) sit in a fixture the base built none of, so the reading is that "
+              "fixture's rather than each case's".format(len(unbuilt), len(cases)))
+    offenders = [case for case in cases if case.verdict in FAILING_VERDICTS]
+    # Split by whether a behavioural verdict exists, because one remedy does not cover both. Offering
+    # a declaration where the run produced none sends the author to sharpen a case that may be perfectly
+    # sharp -- a neighbour's Assume is enough to land one here.
+    unanswered = [case for case in offenders
+                  if case.verdict in (COULD_NOT_ANSWER, NOT_REPORTED, BASE_UNSOUND)]
+    answered = [case for case in offenders if case not in unanswered]
+    if answered:
+        print("\n{} case(s) the base already answers. Green on both sides separates nothing: sharpen "
+              "the\ncase until it goes red without this branch, or say why it belongs "
+              "there:".format(len(answered)))
+        print("  // GREEN_ON_BASE({}): <why>".format("|".join(CATEGORIES)))
+    if unanswered:
+        print("\n{} case(s) yielded no base verdict, so none of them carries a reading either way. A\n"
+              "declaration does not answer for that -- the detail beside each says what happened."
+              .format(len(unanswered)))
+    if single_round and not wrote and any(case.verdict == BASE_UNSOUND for case in unanswered):
+        print(local_remedy(single_round, unanswered))
+    return offenders
+
+
+def local_remedy(since, cases):
+    """What to run when a single round came back silent and the reading has to be taken another way.
+
+    A base that builds none of what was carried onto it and an editor that never started are the same
+    empty directory, and the withdrawing loop is what separates them. Naming the command is the
+    difference between a refusal an author can act on and one they can only look at.
+    """
+    platforms = sorted({platform_of(case.path) for case in cases
+                        if kind_of(case.path) == "csharp"})
+    return ("\nThe editor wrote nothing, which a single round cannot tell from an editor that never\n"
+            "started. Take the reading where the loop runs -- it withdraws by the editor's own error\n"
+            "list and asks again until something answers:\n"
+            "  python3 scripts/test_quality/base_red_check.py --lane csharp{} --base {} \\\n"
+            "    --warm-library Library".format(
+                "".join(" --platform " + platform for platform in platforms), since or "origin/main"))
+
+
+def held_at(project, commit, relative):
+    """A file's text at a commit, or None where the commit has not got it."""
+    result = git(project, "show", "{}:{}".format(commit, relative), check=False)
+    return result.stdout if result.returncode == 0 else None
+
+
+def corpus_of(project):
+    """Every tracked C# test file's text, for the questions one file cannot answer about itself."""
+    names = git(project, "ls-files").stdout.splitlines()
+    return {relative: (project / relative).read_text(encoding="utf-8", errors="replace")
+            for relative in names
+            if kind_of(relative) == "csharp" and (project / relative).exists()}
+
+
+def changed_test_files(project, by_file, lane):
+    """(path, the lines the branch wrote there, its text) for each test file of the lane it changed.
+
+    Shared with `kept_out` so the report and the plan do not come to answer over different files: a
+    case named as kept out while the plan posed it would be advice to sharpen a case about to run.
+    """
+    for relative, lines in sorted(by_file.items()):
+        if kind_of(relative) is None or (lane != "both" and kind_of(relative) != lane):
+            continue
+        source = project / relative
+        if source.exists():
+            yield relative, lines, source.read_text()
+
+
+def kept_out(project, since, lane):
+    """Path -> how many of its cases a line reading gave the branch and a reading of their code took.
+
+    Without this, a run that plans nothing prints the same lines whether the branch changed no test
+    file at all or rewrote a fixture's remarks end to end -- two states an author reads differently,
+    and nothing else in the output separates them.
+    """
+    found = {}
+    for relative, lines, text in changed_test_files(project,
+                                                    changed_lines_by_file(project, since), lane):
+        aside = authored(relative, touched(cases_in(relative, text), lines),
+                         held_at(project, since, relative), text)[1]
+        if aside:
+            found[relative] = len(aside)
+    return found
+
+
+def collect(project, base, lane):
+    """(merge base, changed cases, control cases, shared lines by file, carried helpers) for a branch."""
+    since = merge_base(project, base)
+    heirs = concrete_heirs(corpus_of(project))
+    by_file = changed_lines_by_file(project, since)
+    # A helper this branch rewrote is carried onto the base tree, so no case that calls it is running
+    # the base's own text any more. Its verdict is still worth taking -- a case going red because the
+    # branch sharpened what it shares is the strongest evidence this check can be handed -- but it is
+    # no longer a reading of the tree, and `canary_fixtures` reads the tree by the base's own files.
+    shared_helper = sorted(name for name in by_file
+                           if kind_of(name) is None and is_test_side(name))
+    changed, control, shared = [], [], {}
+    for relative, lines, text in changed_test_files(project, by_file, lane):
+        cases = cases_in(relative, text)
+        for case in cases:
+            if case.declaration is not None and lines is not None:
+                case.declaration.written_here = case.declaration.written_in(lines)
+        wanted = {case.name for case in authored(relative, touched(cases, lines),
+                                                 held_at(project, since, relative), text)[0]}
+        changed.extend(as_the_runner_names_them(
+            [case for case in cases if case.name in wanted], heirs))
+        loose = outside(cases, lines)
+        if not loose and not shared_helper:
+            control.extend(as_the_runner_names_them(
+                [case for case in cases if case.name not in wanted], heirs))
+        if loose:
+            shared[relative] = len(loose)
+    return since, changed, control, shared, shared_helper
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--project", default=".", help="repository root (default: cwd)")
+    parser.add_argument("--base", default="origin/main", help="what to take a merge base with")
+    parser.add_argument("--lane", choices=["python", "csharp", "both"], default="both",
+                        help="which test surface to measure (default: both)")
+    parser.add_argument("--platform", choices=["EditMode", "PlayMode"], action="append",
+                        help="restrict the C# lane to these platforms")
+    parser.add_argument("--warm-library", help="a Library directory to clone into the base tree")
+    parser.add_argument("--base-tree", help="build the base tree here and leave it behind")
+    parser.add_argument("--unity", default=DEFAULT_UNITY, help="editor binary")
+    parser.add_argument("--timeout", type=int, default=3600, help="seconds before a base run is killed")
+    parser.add_argument("--busy-timeout", type=int, default=1800,
+                        help="seconds to wait for another Unity run to finish")
+    parser.add_argument("--max-rounds", type=int, default=8,
+                        help="uncompilable files to withdraw before the C# lane gives up (default: 8)")
+    parser.add_argument("--plan", action="store_true", help="print the cases and exit without running")
+    parser.add_argument("--emit", help="build the base tree, write the reading here and stop, for a "
+                                       "runner that reaches Unity through something other than the "
+                                       "editor binary. Needs --base-tree")
+    parser.add_argument("--verdict", help="decide from an --emit reading and a results file or "
+                                          "directory, without building or running anything")
+    parser.add_argument("--results", help="what --verdict reads the run from")
+    parser.add_argument("--output", default="", help="directory for the base run's logs and results")
+    args = parser.parse_args()
+    speak_under_a_pipe()
+
+    if args.verdict:
+        plan = json.loads(Path(args.verdict).read_text())
+        if not plan["cases"]:
+            print("no changed test case in the reading")
+            return 0
+        if not args.results:
+            raise SystemExit("--verdict needs --results")
+        reported, wrote = results_from(args.results)
+        if not wrote:
+            print("the base run wrote no result, so nothing it was asked was measured")
+        return 1 if report(from_plan(plan["cases"]), from_plan(plan["control"]), reported,
+                           plan["canaries"], wrote, plan.get("withdrawn"),
+                           plan.get("since")) else 0
+
+    project = Path(args.project).resolve()
+    since, cases, control, shared, shared_helper = collect(project, args.base, args.lane)
+    print("merge base {}".format(since[:12]))
+    for relative, count in sorted(kept_out(project, since, args.lane).items()):
+        print("  out of scope: {} case(s) of {} hold a line this branch changed and no code it "
+              "changed".format(count, relative))
+    if not cases:
+        print("no changed test case in scope of --lane {}".format(args.lane))
+        return 0
+
+    for case in cases:
+        print("  {}{}".format(case.name,
+                              " [{}]".format(case.declaration.category)
+                              if case.declaration and case.declaration.written_here else ""))
+    print("  ({} control case(s) alongside)".format(len(control)))
+    for relative, count in sorted(shared.items()):
+        print("  no control: {} line(s) of {} sit in no case -- a SetUp, a field, a helper, a using. "
+              "The\n              cases beside them are this branch's text too, so none of them reads "
+              "the base tree.".format(count, relative))
+    for relative in shared_helper:
+        print("  no control: {} is carried onto the base, so every case that calls it is this "
+              "branch's\n              text there. The base's own fixtures are what read the tree."
+              .format(relative))
+    for relative in sorted({case.path for case in cases}):
+        source = project / relative
+        if not source.exists():
+            continue
+        written, carried = orphaned_declarations(relative, source.read_text())
+        if written > carried:
+            print("  orphaned: {} of {} declaration(s) in {} sit above no case, so nothing reads "
+                  "them".format(written - carried, written, relative))
+    if args.plan:
+        return 0
+
+    changed = changed_lines_by_file(project, since)
+    carry = sorted(name for name in changed if is_test_side(name) and (project / name).exists())
+    drop = sorted(name for name in deleted_files(project, since) if is_test_side(name))
+
+    if args.emit:
+        if not args.base_tree:
+            raise SystemExit("--emit needs --base-tree to say where the base is built")
+        base_tree = Path(args.base_tree).resolve()
+        print("  building the base tree at {}".format(base_tree))
+        build_base_tree(project, since, base_tree, carry, drop, args.warm_library)
+        # Before the run rather than after it, because there is no after: one round of a C# compile
+        # failure is an empty artifacts directory, and every fixture in the tree is behind it.
+        unbuildable = unbuildable_on_base(project, since, base_tree, carry)
+        for relative, name in sorted(unbuildable.items()):
+            withdraw(base_tree, relative)
+            print("  withdrawn: {} spells {}, which the base has not got, so the base builds no "
+                  "fixture\n             of its assembly and the run would report none of them"
+                  .format(relative, name))
+        canaries = canaries_for(base_tree, cases, carry, args.platform)
+        Path(args.emit).write_text(
+            json.dumps(as_plan(since, cases, control, shared, canaries, unbuildable), indent=2))
+        # The fixtures, not the cases: a run over the fixture brings the control cases with it, and
+        # they are what says whether the tree it built can answer at all. A withdrawn file's is left
+        # out because `report` decides its cases without reading any of them -- what stands in its
+        # place is the base's own text under the same fixture name, so the round would be spent on a
+        # result nothing consults.
+        wanted = {case.fixture for case in cases + control if kind_of(case.path) == "csharp"
+                  and case.path not in unbuildable
+                  and (not args.platform or platform_of(case.path) in args.platform)}
+        for chosen in canaries.values():
+            wanted.update(chosen)
+        print("fixtures={}".format(";".join(sorted(wanted))))
+        return 0
+
+    holder = None
+    if args.base_tree:
+        base_tree = Path(args.base_tree).resolve()
+    else:
+        holder = tempfile.mkdtemp(prefix="base-red-")
+        base_tree = Path(holder) / "tree"
+    output = Path(args.output).resolve() if args.output else project / "Logs" / "base_red_check"
+    output.mkdir(parents=True, exist_ok=True)
+
+    reported = {}
+    transcript = []
+    canaries = {}
+    ever_wrote = not any(kind_of(case.path) == "csharp" for case in cases)
+    try:
+        print("  building the base tree at {}".format(base_tree))
+        build_base_tree(project, since, base_tree, carry, drop, args.warm_library)
+
+        python_lane = [case for case in cases + control if kind_of(case.path) == "python"]
+        if python_lane:
+            guards = python_canaries(base_tree, carry)
+            canaries[PYTHON_LANE] = [case.fixture for case in guards]
+            print("  running {} Python case(s) there, one process each".format(
+                len(python_lane) + len(guards)))
+            reported.update(run_python(base_tree, project, python_lane + guards, transcript))
+
+        platforms = sorted({platform_of(case.path) for case in cases
+                            if kind_of(case.path) == "csharp"})
+        if args.platform:
+            platforms = [name for name in platforms if name in args.platform]
+        if platforms and not wait_for_quiet(args.busy_timeout):
+            raise SystemExit("another Unity test run is still in flight")
+        canaries.update(canaries_for(base_tree, cases, carry, platforms))
+        for platform in platforms:
+            wanted = [case for case in cases + control
+                      if kind_of(case.path) == "csharp" and platform_of(case.path) == platform]
+            withdrawn = set()
+            for attempt in range(1, args.max_rounds + 1):
+                live = [case for case in wanted if case.path not in withdrawn]
+                fixtures = sorted({case.fixture for case in live} | set(canaries[platform]))
+                if not fixtures:
+                    break
+                results = output / "{}-{}.xml".format(platform, attempt)
+                log = output / "{}-{}.log".format(platform, attempt)
+                for stale in (results, log):
+                    if stale.exists():
+                        stale.unlink()
+                wall = run_unity(args.unity, base_tree, platform, fixtures, results, log, args.timeout)
+                seen, wrote = results_from(results)
+                ever_wrote = ever_wrote or wrote
+                reported.update(seen)
+                print("{} attempt {}: {} case(s) over {} fixture(s) in {:.0f}s".format(
+                    platform, attempt, len(seen), len(fixtures), wall))
+
+                # One file per attempt. A round that reports nothing says only that something the
+                # tree holds did not build, never which file, so withdrawing every silent one at
+                # once would take out the files that were merely standing next to the offender and
+                # leave their cases unmeasured behind somebody else's error.
+                ran = fixtures_that_ran(seen)
+                silent = sorted({case.path for case in live if case.fixture not in ran})
+                if not silent:
+                    break
+                offender = next_to_withdraw(
+                    log.read_text(errors="replace") if log.exists() else "",
+                    carry, withdrawn, silent)
+                withdraw(base_tree, offender)
+                withdrawn.add(offender)
+    finally:
+        if holder is not None:
+            git(project, "worktree", "remove", "--force", str(base_tree), check=False)
+            shutil.rmtree(holder, ignore_errors=True)
+
+    if transcript:
+        (output / "python.log").write_text("\n".join(transcript))
+
+    if not ever_wrote:
+        print("no round wrote a result, so nothing any of them was asked was measured")
+    offenders = report(cases, control, reported, canaries, ever_wrote)
+    print("\nlogs: {}".format(output))
+    return 1 if offenders else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_quality/mutation_check.py
+++ b/scripts/test_quality/mutation_check.py
@@ -1,23 +1,51 @@
 #!/usr/bin/env python3
-"""Report every mutation of this branch's changed lines that no test failed on.
+"""Refuse a mutation of this branch's changed lines that no test failed on and nobody answered for.
 
 A test that asserts nothing passes whether or not the code under test works, and the suite is
 green either way, so nothing in CI can see it. Mutating the code the branch touched and rerunning
 the suite is the only check that asks the question directly: change the behaviour, and if the
 suite still passes, no test was measuring it.
 
-A mutant surviving is a question, not a verdict: it is either a test that stopped asking, or a
-mutation the behaviour does not depend on. Both need a person to read them.
+A mutant surviving is a question, and a run that only prints the question leaves answering it to
+whoever feels like it. So a survivor either goes away -- the test that should have noticed gets
+written -- or it is answered above the line it lives on, with a reason a reviewer can disagree with:
+
+    // MUTANT_SURVIVES(equivalent): both spellings clamp to the same bound, so nothing can differ.
+
+A declaration answers for the change written under it, so it is read the three ways `base_red_check.py`
+reads `GREEN_ON_BASE`: one over a statement whose mutants all died is stale and fails, one whose category
+or reason is malformed fails, and one the branch did not itself write answers for a change the base
+already carries rather than for this one.
+
+**Success means every mutant was measured, and every survivor answered for.** Not that nothing was
+reported: most of what goes wrong with a campaign ends in a mutant nobody asked about, and a mutant
+nobody asked about must never be a pass. So the ways a run can measure less than it looks like it
+measured each fail on their own -- a cap that left mutants unrun, an editor killed at --timeout, a
+build that rejected the mutation, an assembly the editor never rebuilt, a second editor sharing the
+machine, and a file whose comment and string mask swallowed code, which generates no mutant there and
+says nothing.
+
+It is not success over the whole change, and the difference is most of one: the operators reach a
+minority of the code lines a branch touches, so the reach is printed beside every verdict rather than
+folded into it, and a change nothing reaches at all refuses.
 
 The default scope is the whole platform suite rather than the fixtures nearest the mutated file,
 so that nothing is reported as surviving merely because the fixture that would have killed it was
 out of scope.
+
+A campaign holds a mutation in the working tree while the suite runs, so it records what it holds
+before writing it and clears that record only after putting the original back. Nothing else in the
+tree says a campaign is running: the mutation is a plausible one-line change in a file the branch is
+already touching, and two of them reached a commit that way.
 """
 
 import argparse
+import bisect
 import hashlib
 import json
+import os
 import re
+import signal
 import subprocess
 import sys
 import time
@@ -29,11 +57,42 @@ DEFAULT_UNITY = "/Applications/Unity/Hub/Editor/6000.3.11f1/Unity.app/Contents/M
 # report a busy machine forever on an idle one.
 UNITY_RUNNING = "^/Applications/.*/MacOS/Unity -runTests"
 
+# At the project root and not in .gitignore, so `git status` names it beside the file it explains.
+# Under Logs/ it would be correct and unread: what a resumed session looks at is `git status`, and a
+# mutation there reads as an interrupted implementation.
+SENTINEL = "MUTATION_IN_PROGRESS.json"
+
+PACKAGE = "Packages/com.velvet.core"
+REFUSAL_BASELINE = "scripts/test_quality/logic_refusal_baseline.txt"
+
 KILLED = "killed"
+TIMED_OUT = "not measured (timed out)"
 SURVIVED = "survived"
 INCONCLUSIVE = "survived (inconclusive)"
 UNCOMPILABLE = "uncompilable"
 NOT_BUILT = "not rebuilt"
+
+SURVIVING = (SURVIVED, INCONCLUSIVE)
+
+CATEGORIES = ("equivalent", "unreachable")
+
+# Four words, for the reason base_red_check.py's own floor gives.
+MINIMUM_REASON_WORDS = 4
+
+DECLARATION = re.compile(r"MUTANT_SURVIVES\(([A-Za-z]*)\)\s*:\s*(.*)")
+
+# How many unreached line numbers a file lists before the rest become a count. The count stays exact
+# either way; what this bounds is a whole-file `--files` run printing several hundred of them.
+LINES_LISTED = 25
+
+# A record exists and cannot be read. Every reader treats it as a campaign holding something whose
+# name is unavailable, which is the only reading that does not let a mutation through.
+UNREADABLE = object()
+
+# What `--carried` and `--receipt` exit with when they refuse, so a caller can tell a refusal from a
+# script that could not take the reading at all. Both stop the tool; only one is about a campaign.
+CARRIED_REFUSAL = 3
+RECEIPT_REFUSAL = 3
 
 
 class Mutant:
@@ -55,28 +114,182 @@ class Mutant:
         return "{}:{} {} -> {} ({})".format(where, self.line, self.before, self.after, self.operator)
 
 
-def code_mask(text):
-    """True at every offset that the compiler sees as code.
+def folded_reason(tail, wrapped):
+    """(the marker line's own claim, that claim with the comment lines under it folded onto it).
+
+    The reason spans the block so that a branch which rewrote only its wrapped half wrote the
+    declaration. The floor is measured on the claim rather than on that span, over which a comment
+    line that is not the reason at all would count toward it.
+    """
+    folded = [tail] + [line.strip().lstrip("/#") for line in wrapped]
+    return " ".join(tail.split()), " ".join(" ".join(folded).split())
+
+
+class Declaration:
+    def __init__(self, category, reason, line, claim=None, through=None, written_here=True):
+        self.category = category
+        self.reason = reason
+        self.claim = reason if claim is None else claim
+        self.line = line
+        self.through = line if through is None else through
+        # Whether the branch wrote it, for the reason base_red_check.py's own field carries.
+        self.written_here = written_here
+
+    def written_in(self, lines):
+        """Whether the branch wrote any line of the span `folded_reason` reads the reason over."""
+        return any(number in lines for number in range(self.line, self.through + 1))
+
+    @property
+    def complaint(self):
+        if self.category not in CATEGORIES:
+            return "category {!r} is not one of {}".format(self.category, ", ".join(CATEGORIES))
+        if len(self.claim.split()) < MINIMUM_REASON_WORDS:
+            return "the reason's first line is under {} words".format(MINIMUM_REASON_WORDS)
+        return None
+
+    def __repr__(self):
+        return "Declaration({!r}, line {})".format(self.category, self.line)
+
+
+def comment_spans(text):
+    """(start, end) for each span `mask_spans` read as a comment."""
+    return [(start, end) for start, end, kind in mask_spans(text)
+            if kind in (LINE_COMMENT, BLOCK_COMMENT)]
+
+
+def declared_lines(text, marker, spans):
+    """1-based line -> the `marker` match that opens inside one of `spans`, for each line holding one.
+
+    A string literal is what this rules out. A marker there is the material of whatever asserts over
+    the declaration syntax, and adopting it as an answer for the statement beneath silences that
+    statement instead of reporting it.
+
+    Membership is the match's own offset rather than its line's, because one line can carry a literal
+    and a comment at once -- a verbatim string closing above a trailing remark is the shape in this
+    repository's own fixtures. Asked by the line, both the reading and the count that exists to catch
+    a lost declaration accept such a marker, so the file balances and nothing reports it.
+    """
+    starts = [start for start, _ in line_spans(text)]
+    found = {}
+    for match in marker.finditer(text):
+        if any(start <= match.start() < end for start, end in spans):
+            found.setdefault(bisect.bisect_right(starts, match.start()), match)
+    return found
+
+
+def comment_lines(text, spans):
+    """The 1-based lines whose first non-space character sits inside one of `spans`.
+
+    Which lines are prose rather than which hold a marker, so a block comment's continuation counts
+    and a remark trailing a statement does not.
+    """
+    found = set()
+    for number, (start, end) in enumerate(line_spans(text), start=1):
+        line = text[start:end]
+        if not line.strip():
+            continue
+        head = start + len(line) - len(line.lstrip())
+        if any(opened <= head < closed for opened, closed in spans):
+            found.add(number)
+    return found
+
+
+def declarations_in(text):
+    """(a line it answers for, the declaration) for every one in a file, once per line it covers.
+
+    A declaration answers for the statement under it, reached past any further comment lines of the
+    same block. A blank line ends the block: prose further up belongs to whatever sits under it, and
+    reaching past the gap would let one line's answer cover a neighbour nobody wrote it for.
+
+    The statement rather than the line, because a condition spread over two lines carries mutants on
+    both -- `if (a == null ||` and `b <= 0)` -- and one declaration over it would answer for the first
+    only, leaving the same survivor UNANSWERED on one line and the declaration STALE on the other.
+    """
+    lines = text.splitlines()
+    mask = code_mask(text)
+    spans = line_spans(text)
+    declared = declared_lines(text, DECLARATION, comment_spans(text))
+
+    def seen(number):
+        start, end = spans[number]
+        return "".join(text[offset] for offset in range(start, end) if mask[offset])
+
+    found = []
+    for index in range(len(lines)):
+        match = declared.get(index + 1)
+        if not match:
+            continue
+        subject = index + 1
+        while subject < len(lines) and lines[subject].strip() and not seen(subject).strip():
+            subject += 1
+        if subject >= len(lines) or not lines[subject].strip():
+            continue
+        claim, reason = folded_reason(match.group(2), lines[index + 1:subject])
+        declaration = Declaration(match.group(1), reason, line=index + 1, claim=claim,
+                                  through=subject)
+        # Extends while the statement's own parentheses are still open, which is what a condition
+        # broken across lines leaves and what a finished statement does not.
+        depth = 0
+        last = subject
+        while last < len(lines):
+            depth += seen(last).count("(") - seen(last).count(")")
+            if depth <= 0:
+                break
+            last += 1
+        for number in range(subject, min(last, len(lines) - 1) + 1):
+            found.append((number + 1, declaration))
+    return found
+
+
+# The furthest offset from an opening quote at which a closing one can still sit: `'\U0001F600'` is
+# the longest character literal C# can spell.
+CHARACTER_LITERAL_REACH = len("'\\U0001F600'") - 1
+
+
+DIRECTIVE = "preprocessor directive"
+LINE_COMMENT = "line comment"
+BLOCK_COMMENT = "block comment"
+STRING = "string literal"
+VERBATIM = "verbatim string literal"
+CHARACTER = "character literal"
+
+# The four `mask_spans` below reads as ending on the line they open on. A span of one of them that
+# reaches the next line is therefore the scanner having read something as a construct it is not, and
+# every offset it covers is blanked out of the mask -- which generates no mutant there and reports
+# nothing. A raw string literal is the shape that would land here legitimately; the scanner does not
+# read one, so refusing is the answer rather than trusting the mask over that file.
+SINGLE_LINE_CONSTRUCTS = (DIRECTIVE, LINE_COMMENT, STRING, CHARACTER)
+
+
+def mask_spans(text):
+    """(start, end, kind) for the spans this reads as something other than code.
 
     Mutating a comment or a string literal produces a mutant that cannot change behaviour, and
-    each one still costs a full compile-and-run cycle.
+    each one still costs a full compile-and-run cycle. Whether the reading is right about a file is
+    what `mask_defects` puts a floor under; a raw string literal is a shape it does not read at all.
     """
-    mask = [True] * len(text)
+    spans = []
     i = 0
     n = len(text)
     while i < n:
         two = text[i:i + 2]
-        if two == "//":
+        if text[i] == "#" and not text[text.rfind("\n", 0, i) + 1:i].strip():
+            # A preprocessor line is blanked whole. Nothing downstream of this mask reads a directive,
+            # and none of them can hold a brace or a type; what one can hold is `#region Boundary's
+            # own tree`, whose apostrophe opens a character literal against the rule below.
             end = text.find("\n", i)
             end = n if end < 0 else end
-            for j in range(i, end):
-                mask[j] = False
+            spans.append((i, end, DIRECTIVE))
+            i = end
+        elif two == "//":
+            end = text.find("\n", i)
+            end = n if end < 0 else end
+            spans.append((i, end, LINE_COMMENT))
             i = end
         elif two == "/*":
             end = text.find("*/", i + 2)
             end = n if end < 0 else end + 2
-            for j in range(i, end):
-                mask[j] = False
+            spans.append((i, end, BLOCK_COMMENT))
             i = end
         elif text[i] == '"' or two in ('@"', '$"') or text[i:i + 3] == '$@"':
             start = i
@@ -95,19 +308,50 @@ def code_mask(text):
                     i += 1
                     break
                 i += 1
-            for j in range(start, min(i, n)):
-                mask[j] = False
+            spans.append((start, min(i, n), VERBATIM if verbatim else STRING))
         elif text[i] == "'":
+            # An apostrophe with no closing one inside a literal's reach is not a literal. Consuming
+            # to the next one anywhere in the file instead blanks arbitrary code, and nothing after
+            # this reports a wrongly blanked offset: no mutant is generated there and no brace
+            # counted, so both halves come back looking like a file with less in it than it has.
             start = i
             i += 1
-            while i < n and text[i] != "'":
+            while i < n and i - start <= CHARACTER_LITERAL_REACH and text[i] != "'":
                 i += 2 if text[i] == "\\" else 1
+            if i >= n or i - start > CHARACTER_LITERAL_REACH or text[i] != "'":
+                i = start + 1
+                continue
             i += 1
-            for j in range(start, min(i, n)):
-                mask[j] = False
+            spans.append((start, min(i, n), CHARACTER))
         else:
             i += 1
+    return spans
+
+
+def code_mask(text):
+    """True at each offset `mask_spans` did not read as a comment, a literal or a directive."""
+    mask = [True] * len(text)
+    for start, end, _ in mask_spans(text):
+        for offset in range(start, end):
+            mask[offset] = False
     return mask
+
+
+def mask_defects(text):
+    """(first line, last line, kind) for every span blanked through a construct that ends on its own line.
+
+    What this catches is the mask reading something as a construct it is not. It cannot see the
+    converse -- code read as code that the compiler treats otherwise -- so it is a floor rather than a
+    proof that the mask is right about a file.
+    """
+    starts = [start for start, _ in line_spans(text)]
+    defects = []
+    for start, end, kind in mask_spans(text):
+        if kind in SINGLE_LINE_CONSTRUCTS and "\n" in text[start:end]:
+            first = sum(1 for offset in starts if offset <= start)
+            last = sum(1 for offset in starts if offset < end)
+            defects.append((first, last, kind))
+    return defects
 
 
 # Spacing is what separates a comparison from a generic argument list and a binary operator from
@@ -127,9 +371,21 @@ OPERATORS = [
 
 WORD_OPERATORS = [("true", "false", "literal"), ("false", "true", "literal")]
 
-# A call whose value is discarded is there for its side effect, so deleting the statement removes
-# exactly one behaviour and leaves the rest of the method intact.
-VOID_CALL = re.compile(r"^[A-Za-z_][A-Za-z0-9_.]*(\.[A-Za-z_][A-Za-z0-9_]*)*\s*\([^;]*\)\s*;$")
+# An identifier, a parenthesised head, a semicolon-terminated tail. The word in front of the
+# parenthesis is no part of that, so what the removal takes is everything the line runs rather than
+# one call -- which is what its verdict is named for.
+REMOVABLE_LINE = re.compile(r"^[A-Za-z_][A-Za-z0-9_.]*(\.[A-Za-z_][A-Za-z0-9_]*)*\s*\([^;]*\)\s*;$")
+
+# `return (value, done);` has the shape above and is not a line whose code can go: what replaces it
+# is an empty statement, so what the line returns goes with it. A word rather than a prefix, because
+# `returns.Add(instr);` is a call whose name starts with one.
+CONTROL_KEYWORD = re.compile(r"^(?:return|throw|yield)\b")
+
+# Where a statement may begin. A line matching REMOVABLE_LINE is only removable when the code before
+# it finished a statement: `=> Fragment(...)` and `= new(...)` both match the pattern and are the tail
+# of a declaration, so deleting them leaves a member with no body. Measured with the C# parser over
+# every mutant this package generates, that was 77 of them.
+STATEMENT_BOUNDARY = (";", "{", "}", ":")
 
 # Every operator above keeps the clause it lands in participating in the condition, so a clause no test
 # reaches survives all of them: swapping its comparison or its join still leaves some test's own clause
@@ -139,16 +395,65 @@ VOID_CALL = re.compile(r"^[A-Za-z_][A-Za-z0-9_.]*(\.[A-Za-z_][A-Za-z0-9_]*)*\s*\
 LOGIC_JOINS = (" && ", " || ")
 GUARD_STATEMENT = re.compile(r"^if \(.+\)\s*(?:return[^;]*|continue|break);$")
 
+# A removal that carries off a declaration leaves the reads of that name unresolved, so the mutant
+# compiles nowhere and the campaign scores it unmeasured and fails. `var (state, setState) =
+# UseState(...)` is the shape REMOVABLE_LINE reads as a removable line: `var` satisfies its leading
+# identifier, and the argument list the pattern looks for runs from the deconstruction's `(` to the
+# initializer's last `)`.
+# Three spellings of C# rather than a reading of it -- a deconstruction, an `out` argument, a pattern
+# variable. The `out` arm refuses the argument that declares nothing along with the one that does,
+# because what a removal carries off at `out existingField` is the assignment rather than the
+# declaration: the name survives the cut, and whether anything still writes it on the paths that read
+# it is definite assignment, which a pattern over the text cannot decide. A discard and a member
+# access are the two exemptions.
+# The pattern arm reads the name directly behind `var`, behind one type token, or behind one closed
+# brace or bracket group; a designation standing behind a type and a group both, or behind a
+# parenthesised pattern, is not read as one.
+# `MutantDeclarationRemovalTests` is the reading -- of the declaration and of the `out` assignment
+# both -- so a spelling missing from here is one red line there, and so is any narrowing that lets a
+# removal carry off an `out` argument spelled as a bare name.
+# The last two arms are read on their own by `binds_a_name_conditionally`, which asks which paths
+# reach a binding rather than whether a removal carries one off.
+DECONSTRUCTION = re.compile(r"\bvar\s*\(")
+OUT_ARGUMENT = re.compile(r"\bout\b(?!\s*(?:_|[A-Za-z_]\w*(?:\.[A-Za-z_]\w*)+)\s*[,)])")
+PATTERN_DESIGNATION = re.compile(
+    r"\bis\s+(?:not\s+)?(?!not\b)"
+    r"(?:var\s+|[A-Za-z_][\w.<>\[\]?]*\s+|[{\[][^;]*[}\]]\s+)[A-Za-z_]")
+DECLARES_A_NAME = re.compile("|".join(
+    (DECONSTRUCTION.pattern, OUT_ARGUMENT.pattern, PATTERN_DESIGNATION.pattern)))
+
+# `out spec` naming a variable rather than declaring one, which is the spelling a flip need not
+# strand: unlike a declaration, the name can have been written before the statement runs.
+OUT_BARE_NAME = re.compile(r"\bout\s+([A-Za-z_]\w*)\s*[,)]")
+
+# What has to stand in front of a write for `assigned_above` to read it as the block's own. `:` is a
+# STATEMENT_BOUNDARY and is left out here because a write standing behind one need not have run: a
+# ternary's arm is entered on one side of its condition only. Inside a switch the same exclusion
+# refuses a write standing first in the flip's own arm, which does reach the flip on every path -- a
+# cost of the reading rather than its reason, since the arm above the flip's is SWITCH_LABEL's.
+ASSIGNMENT_LEAD = (";", "{", "}")
+
+# The label the walk cannot pass: the arm behind one is entered without the arm above it having run.
+# `default` is spelled with its colon because the word is also an expression.
+SWITCH_LABEL = re.compile(r"^(?:case\b|default\s*:)")
+
+
+# Braces and brackets count towards depth as well as parentheses. A property pattern puts a colon
+# inside braces at the enclosing parenthesis depth -- `is { Count: > 0 }` -- so a model that reads
+# parentheses alone sees that colon as the clause's own and cuts the brace away from its partner.
+OPENING = "([{"
+CLOSING = ")]}"
+
 
 def encloses_its_own_groups(line, start, mask, limit):
-    """Whether every parenthesis the line opens it also closes, and it closes none it did not open."""
+    """Whether every group the line opens it also closes, and it closes none it did not open."""
     depth = 0
     for index in range(limit):
         if not mask[start + index]:
             continue
-        if line[index] == "(":
+        if line[index] in OPENING:
             depth += 1
-        elif line[index] == ")":
+        elif line[index] in CLOSING:
             depth -= 1
             if depth < 0:
                 return False
@@ -179,9 +484,9 @@ def clause_cuts(line, start, mask, limit):
             index += 1
             continue
         character = line[index]
-        if character == "(":
+        if character in OPENING:
             depth += 1
-        elif character == ")":
+        elif character in CLOSING:
             depth -= 1
         else:
             join = next((candidate for candidate in LOGIC_JOINS
@@ -199,19 +504,213 @@ def clause_cuts(line, start, mask, limit):
         while probe < limit:
             if mask[start + probe]:
                 character = line[probe]
-                if character == "(":
+                if character in OPENING:
                     level += 1
-                elif character == ")":
+                elif character in CLOSING:
                     if level == depth:
                         break
                     level -= 1
+                elif level != depth:
+                    # Everything below ends the clause, and only at the join's own depth: a comma one
+                    # level in belongs to an argument list the clause is calling, and stopping there
+                    # cut `s.StartsWith("rgb(", …)` in half.
+                    pass
+                elif character in ";,":
+                    # A chain that is a whole statement rather than a condition closes no group, so
+                    # without these the probe runs to the end of the line and takes the terminator or
+                    # the separator with it: `var ok = a && b;` came back as `var ok = a`, and an
+                    # object initializer's `Memoize = a || b,` lost the comma that ended the member.
+                    break
+                elif character == "?" and line[probe + 1:probe + 2] not in (".", "?", "[", ">"):
+                    # A ternary's own punctuation belongs to the expression around the chain, not to
+                    # the chain: `x = a || b ? c : d` cut to `x = a` where the type came from the
+                    # ternary. The four spellings excluded are `?.`, `??`, `?[` and a nullable type.
+                    break
+                elif character == ":" and ":" not in (line[probe + 1:probe + 2],
+                                                      line[probe - 1:probe]):
+                    # The other half of one, reached when the chain sits inside a ternary's branch.
+                    break
                 elif level == depth and any(line.startswith(c, probe) for c in LOGIC_JOINS):
                     break
             probe += 1
-        text = line[column:probe]
+        # Trailing space left behind rather than taken: a cut ending at a `?` would otherwise
+        # close up against it and leave `index >= 0? count`, which compiles and reads as a typo.
+        text = line[column:probe].rstrip()
         if text.strip() != join.strip():
             cuts.append((column, text))
     return cuts
+
+
+def code_only(text, mask, start, end):
+    """What the compiler sees between two offsets, with the comments and the literals taken out."""
+    return "".join(text[offset] for offset in range(start, end) if mask[offset])
+
+
+def code_above(text, mask, spans, number):
+    """The nearest code the mask leaves above line `number`, or "" at the top of the file."""
+    for above in range(number - 2, -1, -1):
+        seen = code_only(text, mask, *spans[above]).strip()
+        if seen:
+            return seen
+    return ""
+
+
+def code_below(text, mask, spans, number):
+    """The nearest code the mask leaves below line `number`, or "" at the end of the file."""
+    for below in range(number, len(spans)):
+        seen = code_only(text, mask, *spans[below]).strip()
+        if seen:
+            return seen
+    return ""
+
+
+def deletable_line(text, mask, spans, number):
+    """Whether removing line `number`'s code leaves what surrounds it standing.
+
+    Two ways it is not, both measured with the C# parser over every mutant this package generates.
+    The code above has to have ended a statement -- `=> Fragment(...)` and `= new(...)` both match
+    the removal pattern and are the tail of a declaration, so deleting them leaves a member with no
+    body, which was 77 mutants. And an `if (...) Call();` whose next line is an `else` takes the
+    `if` with it and strands the `else`, which was six more.
+    """
+    if not code_above(text, mask, spans, number).endswith(STATEMENT_BOUNDARY):
+        return False
+    return not code_below(text, mask, spans, number).startswith("else")
+
+
+def groups_left_open(code):
+    return sum(code.count(mark) for mark in OPENING) - sum(code.count(mark) for mark in CLOSING)
+
+
+def statement_span(text, mask, spans, number):
+    """The first and last line of the statement holding line `number`, one-based and inclusive.
+
+    Bounded by the code the mask leaves rather than by the raw lines, in both directions, so a comment
+    between two continuation lines does not end a statement.
+
+    A brace the statement itself holds -- a list or property pattern, a lambda body -- is in
+    STATEMENT_BOUNDARY, so a walk stopping at every boundary reads one statement as two. The group
+    count is what carries the span past it. Downwards it stops counting once the groups balance,
+    because the brace after a balanced condition opens the block it guards rather than continuing it.
+    """
+    first = number
+    open_groups = groups_left_open(code_only(text, mask, *spans[number - 1]))
+    while first > 1:
+        if (open_groups >= 0
+                and code_only(text, mask, *spans[first - 2]).strip().endswith(STATEMENT_BOUNDARY)):
+            break
+        first -= 1
+        open_groups += groups_left_open(code_only(text, mask, *spans[first - 1]))
+    last = number
+    while last < len(spans):
+        if (open_groups <= 0
+                and code_only(text, mask, *spans[last - 1]).strip().endswith(STATEMENT_BOUNDARY)):
+            break
+        carrying = open_groups > 0
+        last += 1
+        if carrying:
+            open_groups += groups_left_open(code_only(text, mask, *spans[last - 1]))
+    return first, last
+
+
+def assigned_above(text, mask, spans, number, name):
+    """Whether a write to `name` above line `number` reaches it on every path.
+
+    Three readings of the text, none of them definite assignment. The write is in the block holding
+    line `number` rather than one nested in it; the code in front of it ended a statement; and no
+    switch label stands between the two. The brace count is the first of those on its own, and a
+    braceless body opens no brace for it -- so without the second, the write `if (fallback)` guards
+    reads the same as an unguarded one.
+
+    A write in an enclosing block reaches line `number` on every path too and is passed over anyway,
+    since a walk that left the block would have to tell a member's own writes from a field
+    initialiser, which a local of the same name shadows.
+    """
+    # `else` stands where a declaration's type stands, so the pattern would otherwise read the
+    # braceless body written on the header's own line as one -- and that body has no line above it
+    # for the lead below to refuse.
+    written = re.compile(r"^(?:(?!else\b)[\w.<>\[\]?]+\s+)?" + re.escape(name)
+                         + r"\s*(?<![-+*/%&|^!<>=])=(?![=>])")
+    depth = 0
+    for above in range(number - 1, 0, -1):
+        code = code_only(text, mask, *spans[above - 1]).strip()
+        depth += code.count("}") - code.count("{")
+        if depth < 0:
+            return False
+        if depth != 0:
+            continue
+        if SWITCH_LABEL.match(code):
+            return False
+        if not written.match(code):
+            continue
+        lead = code_above(text, mask, spans, above)
+        if not lead or lead.endswith(ASSIGNMENT_LEAD):
+            return True
+    return False
+
+
+def binds_a_name_conditionally(text, mask, spans, number):
+    """Whether the statement holding line `number` binds a name on only some of the paths through it.
+
+    Flipping a join there can leave a read of that name unassigned, and the mutant then compiles
+    nowhere -- the outcome DECLARES_A_NAME refuses for a removal, reached by a rewrite. Whether such a
+    read exists is definite assignment, which a pattern over the text cannot decide, so what is refused
+    is the statement that could strand one rather than the statement that does. The answer is the
+    statement's rather than one join's, because a join in front of the binding strands it as surely as
+    one behind, and because the read left unassigned can sit in the block the condition guards, which
+    no reading of the condition alone reaches.
+
+    A pattern designation binds only where the pattern matched, so each one this reads counts. An `out`
+    argument is refused from the first join along, since flipping a join cannot stop a condition's first
+    clause from running -- a reading of the clauses rather than of what runs inside one, and
+    `Generators~/README.md` is where that gap is measured. An `out` naming a variable rather than
+    declaring one is exempt where `assigned_above` finds a write, which is that reading's own.
+    """
+    first, last = statement_span(text, mask, spans, number)
+    statement = " ".join(code_only(text, mask, *spans[line - 1]).strip()
+                         for line in range(first, last + 1))
+    if PATTERN_DESIGNATION.search(statement):
+        return True
+    for found in OUT_ARGUMENT.finditer(statement):
+        named = OUT_BARE_NAME.match(statement, found.start())
+        if named and assigned_above(text, mask, spans, first, named.group(1)):
+            continue
+        if any(statement.find(join, 0, found.start()) >= 0 for join in LOGIC_JOINS):
+            return True
+    return False
+
+
+def flip_refused(text, mask, spans, number):
+    """Whether line `number` carries a join the statement's bindings keep the logic operator off.
+
+    The raw line is asked first, so the statement walk is not taken on a line holding no join for it
+    to answer about.
+    """
+    start, end = spans[number - 1]
+    return (any(join in text[start:end] for join in LOGIC_JOINS)
+            and binds_a_name_conditionally(text, mask, spans, number))
+
+
+def refusal_census(project):
+    """A tab-separated path and line count for each source a campaign may mutate that it fires in.
+
+    Recorded per file rather than counted in total, for the reason `duplication_check.py` records a
+    set: a total nets out, so a widening that silences one file passes behind sources that grew.
+    `Generators~/README.md` carries why it records the refusal rather than what the operator emits,
+    and what the floor this replaces could not see.
+    """
+    rows = []
+    for path in sorted((project / PACKAGE).rglob("*.cs")):
+        if not mutable(path, project):
+            continue
+        text = path.read_text()
+        mask = code_mask(text)
+        spans = line_spans(text)
+        refused = sum(1 for number in range(1, len(spans) + 1)
+                      if flip_refused(text, mask, spans, number))
+        if refused:
+            rows.append("{}\t{}".format(relative_to(path, project).as_posix(), refused))
+    return rows
 
 
 def line_spans(text):
@@ -232,7 +731,10 @@ def mutations_for(path, text, target_lines):
             continue
         start, end = spans[number - 1]
         line = text[start:end]
+        flippable = not flip_refused(text, mask, spans, number)
         for before, after, operator in OPERATORS:
+            if operator == "logic" and not flippable:
+                continue
             index = line.find(before)
             while index >= 0:
                 if all(mask[start + index:start + index + len(before)]):
@@ -243,13 +745,52 @@ def mutations_for(path, text, target_lines):
                 if all(mask[start + match.start():start + match.end()]):
                     found.append(Mutant(path, number, match.start(), before, after, operator))
         stripped = line.strip()
-        if VOID_CALL.match(stripped) and not stripped.startswith(("return", "throw", "yield")):
-            found.append(Mutant(path, number, 0, stripped, ";", "void call removed"))
         limit = len(line.rstrip())
-        for column, text in clause_cuts(line, start, mask, limit):
-            found.append(Mutant(path, number, column, text, "", "clause removed"))
-        if GUARD_STATEMENT.match(stripped) and all(mask[start:start + limit]):
+        # The masked code rather than the raw line: `;$` fails wherever anything follows the
+        # semicolon, and a trailing comment or a semicolon inside a literal is not something the
+        # compiler sees a difference in.
+        code = code_only(text, mask, start, end)
+        statement = code.strip()
+        if (REMOVABLE_LINE.match(statement) and not CONTROL_KEYWORD.match(statement)
+                and not DECLARES_A_NAME.search(code)
+                and deletable_line(text, mask, spans, number)):
+            # Spliced over the code the mask leaves rather than over the raw line: taking the line
+            # whole carries off a block comment's opening, or its closing, when only one of the two
+            # is on this line.
+            columns = [index for index in range(limit)
+                       if mask[start + index] and not line[index].isspace()]
+            found.append(Mutant(path, number, columns[0],
+                                line[columns[0]:columns[-1] + 1], ";", "line removed"))
+        # `cut`, not `text`: binding the file's source here left every line processed after the
+        # first cut read out of a clause string, so one `||` early in a range silenced the rest.
+        for column, cut in clause_cuts(line, start, mask, limit):
+            if DECLARES_A_NAME.search(code_only(text, mask, start + column, start + column + len(cut))):
+                continue
+            found.append(Mutant(path, number, column, cut, "", "clause removed"))
+        if (GUARD_STATEMENT.match(stripped) and all(mask[start:start + limit])
+                and not DECLARES_A_NAME.search(code_only(text, mask, start, start + limit))):
             found.append(Mutant(path, number, line.index(stripped), stripped, "", "guard removed"))
+    return found
+
+
+def code_line_numbers(text, numbers):
+    """The changed lines the compiler sees something on beyond block punctuation.
+
+    This is the denominator every verdict is quoted against, because the operators above reach a
+    minority of it -- a method written as a run of assignments generates nothing at all -- and a
+    campaign reporting only that nothing survived reads as a statement about the whole change.
+    Generators~/README.md ▸ Mutation testing carries what that minority measures.
+    """
+    spans = line_spans(text)
+    mask = code_mask(text)
+    found = []
+    for number in sorted(numbers):
+        if number > len(spans):
+            continue
+        start, end = spans[number - 1]
+        seen = "".join(text[offset] for offset in range(start, end) if mask[offset])
+        if seen.strip(" \t\r\n{};"):
+            found.append(number)
     return found
 
 
@@ -257,10 +798,8 @@ def apply_mutation(text, mutant):
     spans = line_spans(text)
     start, end = spans[mutant.line - 1]
     line = text[start:end]
-    if mutant.operator in ("clause removed", "guard removed"):
-        mutated = line[:mutant.column] + line[mutant.column + len(mutant.before):]
-    elif mutant.operator == "void call removed":
-        mutated = line.replace(mutant.before, ";", 1)
+    if mutant.operator in ("clause removed", "guard removed", "line removed"):
+        mutated = line[:mutant.column] + mutant.after + line[mutant.column + len(mutant.before):]
     elif mutant.operator == "literal":
         mutated = (
             line[:mutant.column]
@@ -284,17 +823,22 @@ def assembly_of(path):
     return None
 
 
-def changed_files_and_lines(project, base):
-    merge_base = subprocess.run(
+def merge_base_of(project, base):
+    found = subprocess.run(
         ["git", "-C", str(project), "merge-base", base, "HEAD"],
         capture_output=True, text=True,
     )
-    if merge_base.returncode != 0:
-        raise SystemExit("cannot resolve a merge base with {}: {}".format(base, merge_base.stderr.strip()))
+    if found.returncode != 0:
+        raise SystemExit("cannot resolve a merge base with {}: {}".format(base, found.stderr.strip()))
+    return found.stdout.strip()
+
+
+def changed_files_and_lines(project, base):
+    since = merge_base_of(project, base)
     # Diffing the merge base against the working tree rather than against HEAD, so a branch whose
     # change is not committed yet is still measured.
     diff = subprocess.run(
-        ["git", "-C", str(project), "diff", "--unified=0", merge_base.stdout.strip()],
+        ["git", "-C", str(project), "diff", "--unified=0", since],
         capture_output=True, text=True, check=True,
     ).stdout
     # A file the branch has created and not yet staged is in no diff, and a new file is where a
@@ -330,7 +874,7 @@ def mutable(path, project):
         relative = path.relative_to(project).as_posix()
     except ValueError:
         return False
-    if not relative.startswith("Packages/com.velvet.core/"):
+    if not relative.startswith(PACKAGE + "/"):
         return False
     # Generators~ is outside the Unity build and has its own mutation run; see its README.
     if "/Generators~/" in relative:
@@ -341,6 +885,84 @@ def mutable(path, project):
 
 def sha(path):
     return hashlib.sha256(path.read_bytes()).hexdigest() if path.exists() else ""
+
+
+# --------------------------------------------------------------------------------------------------
+# Holding a mutation
+# --------------------------------------------------------------------------------------------------
+
+class Holder:
+    """The one mutation on disk, recorded before it is written and released after it is undone.
+
+    The order is the whole mechanism, and it is chosen so that no interruption can leave a mutation
+    with nothing naming it: the record is written first and removed last, so an interruption leaves
+    either nothing, or a record over a file that may or may not be mutated -- and rewriting the
+    original is correct in both of those. The other order leaves the state this exists to end, a
+    mutated production file that reads as somebody's unfinished edit.
+
+    A `finally` alone does not reach it. SIGTERM runs no Python at all under the default handler,
+    which is what `TaskStop`, a timeout and a killed session all send.
+    """
+
+    def __init__(self, sentinel):
+        self.sentinel = Path(sentinel)
+        self.child = None
+
+    def hold(self, source, original, mutated, description):
+        # Refusing rather than overwriting: two campaigns started close enough together both reach
+        # here, and the second overwriting the first ends with one restoring the other's file.
+        if self.sentinel.exists():
+            raise SystemExit("{} already records a held mutation; two campaigns are running over one "
+                             "tree".format(self.sentinel))
+        self.sentinel.write_text(json.dumps({
+            "source": str(source),
+            "original": original,
+            "original_sha": hashlib.sha256(original.encode()).hexdigest(),
+            "mutated_sha": hashlib.sha256(mutated.encode()).hexdigest(),
+            "mutation": description,
+            "pid": os.getpid(),
+            "since": time.strftime("%Y-%m-%dT%H:%M:%S"),
+        }, indent=2))
+
+    def release(self):
+        """Puts back whatever the record names and removes it. Safe to call when there is no record."""
+        if not self.sentinel.exists():
+            return None
+        try:
+            held = json.loads(self.sentinel.read_text())
+            Path(held["source"]).write_text(held["original"])
+        except (OSError, ValueError, KeyError) as failure:
+            # Leaving the record is the point: what it names is still on disk, and a run that removed
+            # it would take the only thing saying so with it.
+            print("could not restore from {}: {}".format(self.sentinel, failure), file=sys.stderr)
+            return None
+        self.sentinel.unlink()
+        return held
+
+    def outstanding(self):
+        """None when no campaign holds anything, UNREADABLE when one does and this cannot say what.
+
+        The three are kept apart because every reader has to fail closed on the middle one, and a
+        placeholder dict standing in for it fails open in whichever reader compares its fields.
+        """
+        if not self.sentinel.exists():
+            return None
+        try:
+            return json.loads(self.sentinel.read_text())
+        except (OSError, ValueError):
+            return UNREADABLE
+
+    def guard(self):
+        """Restores on the signals that end a campaign, then dies of the signal rather than of this."""
+        def handler(number, _frame):
+            if self.child is not None and self.child.poll() is None:
+                self.child.kill()
+            self.release()
+            signal.signal(number, signal.SIG_DFL)
+            os.kill(os.getpid(), number)
+
+        for number in (signal.SIGINT, signal.SIGTERM, signal.SIGHUP):
+            signal.signal(number, handler)
 
 
 def unity_busy():
@@ -363,11 +985,15 @@ def wait_for_quiet(seconds):
     return True
 
 
-def run_suite(unity, project, platform, scope, results, log, timeout):
+def run_suite(unity, project, platform, scope, results, log, timeout, holder=None):
     """Returns the wall clock and whether the editor had to be killed.
 
     A mutation can turn a loop bound into one that never terminates, and the run would otherwise
     wait on it for as long as the machine is left alone.
+
+    The editor is held rather than waited on, so that a signal arriving here reaps it before the
+    restore: an editor left running over a tree somebody has just put back writes a results file
+    for a mutant that is no longer on disk.
     """
     command = [
         unity, "-runTests", "-batchmode", "-projectPath", str(project),
@@ -375,11 +1001,35 @@ def run_suite(unity, project, platform, scope, results, log, timeout):
     ]
     command += scope
     start = time.time()
+    child = subprocess.Popen(command)
+    if holder is not None:
+        holder.child = child
     try:
-        subprocess.run(command, timeout=timeout)
+        child.wait(timeout=timeout)
         return time.time() - start, False
     except subprocess.TimeoutExpired:
+        child.kill()
+        child.wait()
         return time.time() - start, True
+    finally:
+        if holder is not None:
+            holder.child = None
+
+
+# Anchored on a source path and a position, so an assertion message quoting the words "error CS" is
+# not one. The code is not pinned to CS: this repository's own analyzers report VEL500 and VEL501 as
+# errors, and a build they stop writes no results file at all -- which reads, from the results alone,
+# exactly like an editor that crashed.
+BUILD_ERROR = re.compile(
+    r"^(?:.*?[\\/])?((?:Assets|Packages)[\\/][^(]+)\(\d+,\d+\): error [A-Z]+\d+", re.MULTILINE)
+
+
+def build_error(log):
+    """The first source a Unity log blames a build error on, or None."""
+    if not log.exists():
+        return None
+    found = BUILD_ERROR.search(log.read_text(errors="replace"))
+    return found.group(1).replace("\\", "/") if found else None
 
 
 def failing_names(results):
@@ -394,10 +1044,154 @@ def failing_names(results):
 def read_counts(results):
     if not results.exists():
         return None
-    root = ET.parse(str(results)).getroot()
+    try:
+        root = ET.parse(str(results)).getroot()
+    except ET.ParseError:
+        # A killed editor leaves a part-written file. Raising here ends an hours-long campaign one
+        # line before the verdict that would have classified it.
+        return None
     if root.tag != "test-run":
         return None
     return {key: int(root.get(key, "0")) for key in ("total", "passed", "failed", "inconclusive")}
+
+
+# --------------------------------------------------------------------------------------------------
+# Deciding
+# --------------------------------------------------------------------------------------------------
+
+def relative_to(path, project):
+    try:
+        return path.relative_to(project)
+    except ValueError:
+        return path
+
+
+def refusal(code, message):
+    """Prints a refusal and hands back the status to exit with.
+
+    A distinct status rather than 1, because a caller has to tell a campaign holding something from
+    this script failing to run at all -- both stop a commit, and only one of them is about a campaign.
+    """
+    print(message)
+    return code
+
+
+def scope_digest(base, targets, project, platform):
+    """What a campaign measured, in a form a later check can compare a tree against.
+
+    Not the head tree: the campaign diffs the merge base against the **working tree**, so an
+    uncommitted edit to a mutated file changes what it measured and moves no tree sha at all --
+    measured, and it is a receipt that would validate a run taken before the edit. Nor the head tree
+    for a second reason: 16 of 44 commits over five recent branches changed no mutable production
+    file, and each would have voided a receipt over a change no operator can see.
+
+    What it does not cover is a test-side change. Removing a test can make a killed mutant survive,
+    and this stays valid across it; including tests would void the receipt on the ordinary act of
+    adding one after the run, which is most of a branch's commits.
+    """
+    parts = [base, platform]
+    for path in sorted(targets, key=str):
+        # Repository-relative, so a receipt does not depend on where the checkout sits: a resolved
+        # path and an unresolved one reach the same file and digest differently.
+        parts.append("{}:{}".format(relative_to(path, project).as_posix(),
+                                    hashlib.sha256(path.read_bytes()).hexdigest()))
+    return hashlib.sha256("\n".join(parts).encode()).hexdigest()
+
+
+def receipt_path(output, digest):
+    return output / "receipts" / "{}.json".format(digest)
+
+
+PASSING_RECEIPTS = ("pass", "unreachable")
+
+
+def write_receipt(output, digest, base, verdict, detail):
+    path = receipt_path(output, digest)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({
+        "digest": digest, "base": base, "verdict": verdict, "detail": detail,
+        "at": time.strftime("%Y-%m-%dT%H:%M:%S"),
+    }, indent=2))
+    return path
+
+
+def read_receipt(output, digest):
+    path = receipt_path(output, digest)
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text())
+    except (OSError, ValueError):
+        return None
+
+
+def reach(mutants, unreached, project):
+    """What the campaign was able to ask about, printed beside whatever it then answers.
+
+    The lines are named rather than counted, because the count alone is a number nobody has to act on.
+    """
+    reached = {(mutant.path, mutant.line) for mutant in mutants}
+    left = sum(len(lines) for lines in unreached.values())
+    report = ["{} mutant(s) over {} changed code line(s); {} line(s) no operator reaches".format(
+        len(mutants), len(reached) + left, left)]
+    for path, lines in sorted(unreached.items(), key=lambda item: str(item[0])):
+        where = relative_to(path, project)
+        shown = ",".join(str(number) for number in lines[:LINES_LISTED])
+        rest = "" if len(lines) <= LINES_LISTED else " and {} more".format(len(lines) - LINES_LISTED)
+        report.append("  unreached  {}:{}{}".format(where, shown, rest))
+    return "\n".join(report)
+
+
+def declarations_for(targets, changed):
+    """(path, subject line) -> the declaration answering for it, over every file being mutated.
+
+    `changed` is the branch's own lines, and a declaration outside them was written for a change the
+    base already carries.
+    """
+    found = {}
+    for path in targets:
+        for subject, declaration in declarations_in(path.read_text()):
+            declaration.written_here = declaration.written_in(changed.get(path, set()))
+            found[(path, subject)] = declaration
+    return found
+
+
+def answered(mutants, deferred, declared):
+    """(the survivors nothing answers for, the declarations nothing is left for them to answer).
+
+    A declaration is stale when the line under it produced no survivor -- because the mutants there
+    all died, or because there were none to begin with. Both mean it describes a state the tree is
+    no longer in, and a declaration that outlives what it describes silences whatever lands there
+    next. A line the cap left unrun is neither: it says nothing about that line at all, and the cap
+    fails the run on its own.
+    """
+    surviving = {(mutant.path, mutant.line) for mutant in mutants if mutant.verdict in SURVIVING}
+    unanswered = []
+    for mutant in mutants:
+        if mutant.verdict not in SURVIVING:
+            continue
+        declaration = declared.get((mutant.path, mutant.line))
+        if declaration is None:
+            unanswered.append((mutant, "nothing above this line answers for it"))
+        elif not declaration.written_here:
+            unanswered.append((mutant, "its declaration is the base's own; restate it for this change"))
+        elif declaration.complaint:
+            unanswered.append((mutant, declaration.complaint))
+        else:
+            mutant.detail = "{}: {}".format(declaration.category, declaration.reason)
+    # Grouped by the declaration rather than by the line, because one covering a condition broken
+    # over two lines has a survivor on either of them and is stale only when neither carries one.
+    settled = surviving | deferred
+    covers = {}
+    for (path, subject), declaration in declared.items():
+        covers.setdefault((path, declaration.line), [declaration, []])[1].append(subject)
+    stale = [(path, min(subjects), declaration)
+             for (path, _), (declaration, subjects) in sorted(covers.items(),
+                                                              key=lambda item: (str(item[0][0]),
+                                                                                item[0][1]))
+             if declaration.written_here
+             and not any((path, subject) in settled for subject in subjects)]
+    return unanswered, stale
 
 
 def main():
@@ -414,15 +1208,130 @@ def main():
     parser.add_argument("--max", type=int, default=40,
                         help="run only the first this many mutants, in file order (default: 40)")
     parser.add_argument("--list", action="store_true", help="print the mutants and exit")
+    parser.add_argument("--refusals", action="store_true",
+                        help="print the join refusal's census over the package and exit; redirect it "
+                             "over " + REFUSAL_BASELINE + " to record a deliberate change to it")
     parser.add_argument("--timeout", type=int, default=900,
-                        help="seconds before a mutant run is killed and counted as killed (default: 900)")
+                        help="seconds before a mutant run is killed; a killed run is not measured and fails (default: 900)")
     parser.add_argument("--busy-timeout", type=int, default=1800,
                         help="seconds to wait for another Unity run to finish (default: 1800)")
     parser.add_argument("--output", default="", help="directory for the per-mutant logs and XML")
     parser.add_argument("--unity", default=DEFAULT_UNITY, help="editor binary (default: the pinned macOS one)")
+    parser.add_argument("--restore", action="store_true",
+                        help="put back the mutation an interrupted campaign left, and stop")
+    parser.add_argument("--carried", nargs="*",
+                        help="paths something is about to record; refuses when one of them is the "
+                             "source a campaign is holding a mutation in")
+    parser.add_argument("--emit-lines",
+                        help="write every mutant this package generates as {path, line, text} and "
+                             "stop, for a reader that parses them with something other than this "
+                             "script's own model of C#")
+    parser.add_argument("--receipt", action="store_true",
+                        help="ask whether a finished campaign covers this tree's mutable change, and "
+                             "stop. Refuses when one is owed and none was run")
     args = parser.parse_args()
 
     project = Path(args.project).resolve()
+    holder = Holder(project / SENTINEL)
+
+    if args.carried is not None:
+        # A campaign's mutation reads as an ordinary edit in a file the branch is already touching,
+        # and `git add -u` stages it with the rest. Naming it in `git status` was not enough on its
+        # own: this was written after one reached a commit that way with the record sitting beside it.
+        outstanding = holder.outstanding()
+        if outstanding is None:
+            return 0
+        if outstanding is UNREADABLE:
+            # Which file it names is exactly what cannot be read, so every path is a candidate. A
+            # record is damaged by things the campaign never does -- somebody clearing what
+            # `git status` reported, a permission change, a directory left in its place.
+            sys.exit(refusal(CARRIED_REFUSAL,
+                             "a mutation campaign is holding something, and {} cannot be read to "
+                             "say what.\nNo file here can be recorded until that is resolved:\n"
+                             "  python3 scripts/test_quality/mutation_check.py --restore".format(
+                                 holder.sentinel)))
+        # Resolved on both sides: a macOS temporary directory reaches the same file through /var and
+        # through /private/var, and comparing the spellings finds no match where there is one.
+        held = Path(outstanding.get("source", "")).resolve()
+        for name in args.carried:
+            candidate = Path(name)
+            candidate = candidate if candidate.is_absolute() else project / name
+            if candidate.resolve() == held:
+                sys.exit(refusal(CARRIED_REFUSAL,
+                                 "a mutation campaign is holding {} -- {}\n"
+                                 "Recording it now captures the campaign's edit, not yours. Wait for "
+                                 "the campaign,\nor put the file back with\n"
+                                 "  python3 scripts/test_quality/mutation_check.py --restore".format(
+                                     name, outstanding.get("mutation", "<unnamed>"))))
+        return 0
+
+    if args.restore:
+        outstanding = holder.outstanding()
+        if outstanding is None:
+            print("no mutation is outstanding")
+            return 0
+        if outstanding is not UNREADABLE:
+            # A record survives a SIGKILL, so an author can see the modified file, keep working on it
+            # for an hour and then run this. Writing the recorded original back would take that hour
+            # with it, and the word this prints afterwards is "restored".
+            source = Path(outstanding.get("source", ""))
+            on_disk = hashlib.sha256(source.read_bytes()).hexdigest() if source.exists() else ""
+            known = (outstanding.get("mutated_sha"), outstanding.get("original_sha"))
+            if on_disk and on_disk not in known:
+                raise SystemExit(
+                    "{} holds neither the mutation {} recorded nor the original it replaced, so "
+                    "something\nelse has written it since. Nothing here can tell your work from the "
+                    "campaign's:\nkeep what is there, or take the original out of the record by "
+                    "hand.".format(source, holder.sentinel))
+        held = holder.release()
+        if held is None:
+            raise SystemExit("{} names a mutation this could not put back; read it and restore by "
+                             "hand".format(holder.sentinel))
+        print("restored {} ({})".format(held["source"], held["mutation"]))
+        return 0
+
+    # Before anything is read, because everything below reads the working tree: the baseline would be
+    # taken over somebody else's mutation, every mutant would be applied on top of it, and the restore
+    # at the end would write it back as though it were the author's own code.
+    outstanding = holder.outstanding()
+    if outstanding is not None:
+        names = ("<unreadable>", "<unreadable>") if outstanding is UNREADABLE else (
+            outstanding.get("source", "<unnamed>"), outstanding.get("mutation", "<unnamed>"))
+        raise SystemExit(
+            "a campaign is holding a mutation in this tree, so nothing here can be measured:\n"
+            "  {} -- {}\n"
+            "Wait for it if one is running; otherwise put it back with\n"
+            "  python3 scripts/test_quality/mutation_check.py --restore".format(*names))
+
+    if args.refusals:
+        print("\n".join(refusal_census(project)))
+        return 0
+
+    # Presence, not truth, the same as --carried above: the flag selects a mode, and an empty operand
+    # read as absence falls through to the campaign -- which mutates a source, under a flag whose whole
+    # contract is that it writes none.
+    if args.emit_lines is not None:
+        # The applied line only, not the applied file: 11301 whole files is gigabytes, and the reader
+        # holds the originals anyway. What it gets from here is this script's edit, not its opinion
+        # of whether the edit parses -- that is the half it exists to answer independently.
+        emitted = []
+        for source in sorted(project.glob("Packages/com.velvet.core/**/*.cs")):
+            if not mutable(source, project):
+                continue
+            text = source.read_text()
+            numbers = set(range(1, len(text.splitlines()) + 1))
+            for mutant in mutations_for(source, text, numbers):
+                applied = apply_mutation(text, mutant).splitlines()
+                emitted.append({
+                    "path": relative_to(source, project).as_posix(),
+                    "line": mutant.line,
+                    "operator": mutant.operator,
+                    "text": applied[mutant.line - 1] if mutant.line <= len(applied) else "",
+                })
+        Path(args.emit_lines).write_text(json.dumps(emitted, indent=1))
+        print("{} mutant(s) written to {}".format(len(emitted), args.emit_lines))
+        return 0
+
     output = Path(args.output).resolve() if args.output else project / "Logs" / "mutation_check"
     output.mkdir(parents=True, exist_ok=True)
     scope = []
@@ -431,6 +1340,13 @@ def main():
     if args.filter:
         scope += ["-testFilter", args.filter]
 
+    # A declaration answers for a change measured against the whole suite. Every narrowing asks a
+    # different question -- whether this file, this fixture or this assembly notices -- and under one
+    # nearly everything survives, so a declaration earned there would be well-formed, branch-written
+    # and indistinguishable in the tree from one earned against the suite. `--filter` and
+    # `--assemblies` still take the diff's scope; what they lose is the right to sign anything off.
+    whole = not (args.files or args.filter or args.assemblies)
+    changed = {} if args.files else changed_files_and_lines(project, args.base)
     if args.files:
         targets = {}
         for name in args.files:
@@ -440,37 +1356,111 @@ def main():
             else:
                 print("skipping {}: not a mutable package source".format(name))
     else:
-        targets = {
-            path: lines
-            for path, lines in changed_files_and_lines(project, args.base).items()
-            if mutable(path, project)
-        }
+        targets = {path: lines for path, lines in changed.items() if mutable(path, project)}
+
+    # A file the mask misreads has offsets no mutant is ever generated from, and the campaign reports
+    # that as a line with nothing to ask rather than as a reading it could not take.
+    blinded = [(path, defects) for path in sorted(targets) for defects in [mask_defects(path.read_text())]
+               if defects]
+    if blinded:
+        raise SystemExit("\n".join(
+            ["the comment-and-string mask swallows code in these files, so mutants there are missing "
+             "with nothing saying which:"]
+            + ["  {} lines {}-{} read as a {}".format(path, first, last, kind)
+               for path, defects in blinded for first, last, kind in defects]))
+
+    if args.receipt:
+        # What is owed is decided the way the campaign decides it, by generating the mutants -- which
+        # needs no editor. A production file changed only in its documentation comments has a target
+        # and nothing to ask of it, and keying on the target alone left such a branch owing a receipt
+        # no campaign could ever write.
+        owed, nothing_reached = {}, {}
+        for path, lines in sorted(targets.items()):
+            text = path.read_text()
+            found = mutations_for(path, text, lines)
+            covered = {mutant.line for mutant in found}
+            left = [number for number in code_line_numbers(text, lines) if number not in covered]
+            if found:
+                owed[path] = found
+            if left:
+                nothing_reached[path] = left
+        if not targets or not (owed or nothing_reached):
+            print("no mutable change; no campaign is owed")
+            return 0
+        since = merge_base_of(project, args.base)
+        digest = scope_digest(since, targets, project, args.platform)
+        held = read_receipt(output, digest)
+        if held is None:
+            return refusal(RECEIPT_REFUSAL,
+                           "no campaign has measured this tree's mutable change:\n"
+                           + "\n".join("  {}".format(relative_to(path, project))
+                                       for path in sorted(targets, key=str))
+                           + "\nRun it, and this passes on the reading it leaves:\n"
+                             "  python3 scripts/test_quality/mutation_check.py --base {}".format(
+                                 args.base))
+        if held.get("verdict") not in PASSING_RECEIPTS:
+            return refusal(RECEIPT_REFUSAL, "the campaign over this tree ended {}: {}".format(
+                held.get("verdict"), held.get("detail")))
+        print("campaign {} over {}: {}".format(held.get("verdict"), digest[:12], held.get("detail")))
+        return 0
 
     mutants = []
+    unreached = {}
     for path, lines in sorted(targets.items()):
-        mutants.extend(mutations_for(path, path.read_text(), lines))
+        text = path.read_text()
+        found = mutations_for(path, text, lines)
+        mutants.extend(found)
+        covered = {mutant.line for mutant in found}
+        left = [number for number in code_line_numbers(text, lines) if number not in covered]
+        if left:
+            unreached[path] = left
+    coverage = reach(mutants, unreached, project)
+
     if not mutants:
+        # Which of the two happens is decided by the lines, not by the kind of change: a change that
+        # touched no code line at all has nothing to ask and passes, and one that touched code lines
+        # no operator reaches refuses, because the verdict would be about no line. A rename lands on
+        # either side depending on what its lines carry -- measured, twice, on both.
+        if unreached:
+            print(coverage)
+            left = sum(len(lines) for lines in unreached.values())
+            # Recorded, because the branch cannot earn a passing run and this is the reading it got.
+            # A campaign nothing can ask anything of is a finished campaign, not an absent one.
+            if whole and not args.list:
+                write_receipt(output,
+                              scope_digest(merge_base_of(project, args.base), targets, project,
+                                           args.platform),
+                              args.base, "unreachable",
+                              "no operator reaches any of {} changed code line(s)".format(left))
+            raise SystemExit(
+                "no operator reaches any of the {} changed code line(s) above, so a verdict here "
+                "would\nbe about nothing. Read them, and widen the operators or say in the pull "
+                "request why\nthe change is not something a mutation can ask about.".format(left))
         print("no mutable change found")
         return 0
     if args.list:
         for mutant in mutants:
             print(mutant.describe(project))
-        print("{} mutant(s); a run covers the first {}".format(len(mutants), args.max))
+        print(coverage)
+        print("a run covers the first {}".format(args.max))
         return 0
 
-    truncated = len(mutants) > args.max
+    deferred = {(mutant.path, mutant.line) for mutant in mutants[args.max:]}
+    truncated = len(mutants) - args.max
     mutants = mutants[:args.max]
 
     if not wait_for_quiet(args.busy_timeout):
         raise SystemExit("another Unity test run is still in flight after {}s".format(args.busy_timeout))
 
-    print("{} mutant(s) over {} file(s)".format(len(mutants), len(targets)))
-    if truncated:
-        print("(capped by --max; raise it to cover the rest)")
+    print(coverage)
 
+    # Before the baseline, not before the loop: the guard reaps the editor as well as restoring, and
+    # the baseline's editor outliving a killed campaign holds the project lock against the next one.
+    holder.guard()
     baseline_results = output / "baseline.xml"
     baseline_wall, baseline_timed_out = run_suite(args.unity, project, args.platform, scope,
-                                                  baseline_results, output / "baseline.log", args.timeout)
+                                                  baseline_results, output / "baseline.log",
+                                                  args.timeout, holder)
     if baseline_timed_out:
         raise SystemExit("the baseline run did not finish within --timeout, so no mutant can be timed")
     baseline = read_counts(baseline_results)
@@ -497,23 +1487,40 @@ def main():
     try:
         for index, mutant in enumerate(mutants, start=1):
             print("[{}/{}] {}".format(index, len(mutants), mutant.describe(project)), flush=True)
-            mutant.path.write_text(apply_mutation(originals[mutant.path], mutant))
             results = output / "mutant-{:03d}.xml".format(index)
             log = output / "mutant-{:03d}.log".format(index)
             if results.exists():
                 results.unlink()
-            wait_for_quiet(args.busy_timeout)
+            # Queue first, mutate second. The wait runs to --busy-timeout, half an hour by default,
+            # and there is nothing the campaign needs on disk across it.
+            if not wait_for_quiet(args.busy_timeout):
+                raise SystemExit("another Unity test run is still in flight after {}s, so this "
+                                 "mutant's failures would not all be its own".format(args.busy_timeout))
+            mutated = apply_mutation(originals[mutant.path], mutant)
+            holder.hold(mutant.path, originals[mutant.path], mutated, mutant.describe(project))
+            mutant.path.write_text(mutated)
             wall, timed_out = run_suite(args.unity, project, args.platform, scope, results, log,
-                                        args.timeout)
-            mutant.path.write_text(originals[mutant.path])
+                                        args.timeout, holder)
+            if holder.release() is None:
+                # The record is still there naming a file still mutated. Going on would apply the
+                # next mutation over this one and end by restoring the wrong text.
+                raise SystemExit("could not put {} back, so the campaign cannot continue; the record "
+                                 "at {} names what is outstanding".format(mutant.path, holder.sentinel))
 
             counts = read_counts(results)
             dll = assemblies_dir / "{}.dll".format(assembly_of(mutant.path))
+            blamed = build_error(log)
             if timed_out:
-                mutant.verdict = KILLED
-                mutant.detail = "the run did not finish; the mutation left something not terminating"
-            elif "error CS" in (log.read_text(errors="replace") if log.exists() else ""):
+                # Not killed. A mutation that leaves a loop unbounded and a --timeout shorter than the
+                # suite reach here identically, and nothing in the results tells them apart: a killed
+                # editor writes no verdict either way. One of the two is a mutant nobody asked about,
+                # so the run refuses and says which reading to take.
+                mutant.verdict = TIMED_OUT
+                mutant.detail = ("the editor was killed at --timeout {}s; raise it, or read the log "
+                                 "for a mutation that does not terminate".format(args.timeout))
+            elif blamed:
                 mutant.verdict = UNCOMPILABLE
+                mutant.detail = "the build stopped in {}".format(blamed)
             elif counts is None:
                 mutant.verdict = UNCOMPILABLE
                 mutant.detail = "the runner wrote no result"
@@ -536,19 +1543,23 @@ def main():
             print("      {} ({}) in {:.0f}s; {:.0f}s left at {:.0f}s each".format(
                 mutant.verdict, mutant.detail or "-", wall, average * (len(mutants) - index), average))
     finally:
+        holder.release()
         for path, text in originals.items():
             path.write_text(text)
 
+    declared = declarations_for(targets, changed) if whole else {}
+    unanswered, stale = answered(mutants, deferred, declared)
+
     print("\n--- mutants no test killed ---")
-    survivors = [m for m in mutants if m.verdict in (SURVIVED, INCONCLUSIVE)]
+    survivors = [m for m in mutants if m.verdict in SURVIVING]
     for mutant in survivors:
         print("{}  [{}] {}".format(mutant.describe(project), mutant.verdict, mutant.detail))
     if not survivors:
         print("(none)")
 
-    unmeasured = [m for m in mutants if m.verdict == NOT_BUILT]
+    unmeasured = [m for m in mutants if m.verdict in (NOT_BUILT, TIMED_OUT, UNCOMPILABLE)]
     if unmeasured:
-        print("\n--- mutants the editor never compiled; nothing was asked of the suite ---")
+        print("\n--- mutants nothing was asked of the suite about ---")
         for mutant in unmeasured:
             print("{}  {}".format(mutant.describe(project), mutant.detail))
 
@@ -559,8 +1570,39 @@ def main():
     for mutant in mutants:
         tally[mutant.verdict] = tally.get(mutant.verdict, 0) + 1
     print("\n" + ", ".join("{}: {}".format(key, value) for key, value in sorted(tally.items())))
+    # Repeated under the tally, not only before the run: the tally is what gets quoted, and quoted
+    # alone it reads as a statement about the diff rather than about the lines an operator reached.
+    print(coverage)
     print("logs: {}".format(output))
-    return 1 if survivors or unmeasured else 0
+
+    for mutant, complaint in unanswered:
+        print("\nUNANSWERED  {}\n            {}".format(mutant.describe(project), complaint))
+    for path, subject, declaration in stale:
+        print("\nSTALE       {}:{} declares a survivor, and line {} has none"
+              .format(relative_to(path, project), declaration.line, subject))
+    if unanswered and not whole:
+        print("\nA survivor is a test that stopped asking, or a mutation nothing can depend on. This "
+              "run is\nnarrowed by --files, --filter or --assemblies, so it reads no declaration and "
+              "signs\nnothing off: it asks what this scope covers, and the survivors above are the "
+              "answer.")
+    elif unanswered:
+        print("\nA survivor is a test that stopped asking, or a mutation nothing can depend on. Write "
+              "the\ntest, or say which it is above the line:")
+        print("  // MUTANT_SURVIVES({}): <why>".format("|".join(CATEGORIES)))
+    if truncated > 0:
+        print("\n{} further mutant(s) were never run: --max is {}. Raise it, or the lines they sit on "
+              "went\nunmeasured with the run still reporting.".format(truncated, args.max))
+
+    failed = unanswered or stale or unmeasured or truncated > 0
+    # Only a whole-suite run over the diff leaves a reading anything else can stand on. A narrowed
+    # one asked a different question, and its answer must not be able to sign a branch off.
+    if whole:
+        detail = "{} mutant(s), {} survivor(s) unanswered, {} line(s) unreached".format(
+            len(mutants), len(unanswered), sum(len(lines) for lines in unreached.values()))
+        written = write_receipt(output, scope_digest(merge_base_of(project, args.base), targets, project, args.platform),
+                                args.base, "fail" if failed else "pass", detail)
+        print("\nreceipt: {}".format(written))
+    return 1 if failed else 0
 
 
 if __name__ == "__main__":

--- a/scripts/test_quality/test_assert_results_from_this_tree.py
+++ b/scripts/test_quality/test_assert_results_from_this_tree.py
@@ -1,0 +1,588 @@
+#!/usr/bin/env python3
+"""Unit tests for assert_results_from_this_tree.py, plus two of its readings held against real sources.
+
+The cases over its verdict are built from a results file and a log rather than from an editor run,
+because what the guard has to survive is the state an editor run leaves behind when it does not
+finish -- a results file at a path a later run never reached. Two readings are held against material
+nothing here invents instead: the type reader against this repository's own fixtures, and the log
+pattern against every diagnostic identifier the analyzer sources declare.
+
+Run: python3 scripts/test_quality/test_assert_results_from_this_tree.py
+"""
+
+import contextlib
+import importlib.util
+import io
+import json
+import re
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# A diagnostic identifier as the analyzer sources declare one, in the two spellings they use:
+# a bare string literal in a descriptor and a const beside the fixer that consumes it.
+ANALYZER_ID = re.compile(r'"((?:VEL|USS)\d{3})"')
+
+
+def load_module(name):
+    """Imports a sibling script by path, since scripts/test_quality is not a package."""
+    spec = importlib.util.spec_from_file_location(
+        name, Path(__file__).resolve().with_name(name + ".py"))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+check = load_module("assert_results_from_this_tree")
+base_red_check = load_module("base_red_check")
+
+FIXTURE_SOURCE = """using NUnit.Framework;
+
+namespace Velvet.Tests
+{
+    internal sealed class ProbeTests
+    {
+        [Test]
+        public void Given_A_When_B_Then_C() => Assert.Pass();
+
+        internal sealed class Inner
+        {
+            [Test]
+            public void Given_D_When_E_Then_F() => Assert.Pass();
+        }
+    }
+
+    internal abstract class ProbeTestsBase<TElement>
+    {
+        [Test]
+        public void Given_G_When_H_Then_I() => Assert.Pass();
+    }
+}
+"""
+
+
+def results_xml(assemblies):
+    """An NUnit results file shaped the way Unity writes one: fixtures under an assembly suite."""
+    body = []
+    for assembly, fixtures in assemblies:
+        cases = "".join(
+            '<test-suite type="TestFixture" name="{fixture}" fullname="{fixture}">'
+            '<test-case name="Case" fullname="{fixture}.Case" classname="{fixture}" '
+            'result="Passed" /></test-suite>'.format(fixture=fixture)
+            for fixture in fixtures)
+        body.append('<test-suite type="Assembly" name="{}.dll" fullname="/x/{}.dll">{}</test-suite>'
+                    .format(assembly, assembly, cases))
+    return ('<?xml version="1.0" encoding="utf-8"?><test-run id="2" total="1" passed="1" failed="0" '
+            'inconclusive="0" skipped="0">{}</test-run>'.format("".join(body)))
+
+
+class Workspace:
+    """A project the guard can be pointed at: a git worktree, an asmdef, a source, a package cache."""
+
+    def __init__(self, sources=None, assemblies=("Velvet.Tests.Probe.Editor",),
+                 packages=("Unity.Package.Tests",), library=True, csharp=True):
+        self.root = Path(tempfile.mkdtemp(prefix="velvet-provenance-"))
+        self.project = self.root / "project"
+        (self.project / "Runtime").mkdir(parents=True)
+        (self.project / ".gitignore").write_text("/Library/\n", encoding="utf-8")
+        subprocess.run(["git", "init", "-q", str(self.project)], check=True, capture_output=True)
+
+        for name in assemblies:
+            (self.project / "Runtime" / (name + ".asmdef")).write_text(
+                json.dumps({"name": name}), encoding="utf-8")
+        if csharp:
+            (self.project / "Runtime" / "ProbeTests.cs").write_text(
+                FIXTURE_SOURCE if sources is None else sources, encoding="utf-8")
+
+        if library:
+            for name in packages:
+                cached = self.project / "Library" / "PackageCache" / name / "Tests"
+                cached.mkdir(parents=True)
+                (cached / (name + ".asmdef")).write_text(json.dumps({"name": name}),
+                                                         encoding="utf-8")
+
+        self.run_directory = self.root / "run"
+        self.run_directory.mkdir()
+        self.results = self.run_directory / "results.xml"
+        self.log = self.run_directory / "run.log"
+
+    def wrote(self, assemblies=(("Velvet.Tests.Probe.Editor", ["Velvet.Tests.ProbeTests"]),),
+              log=None, results=None):
+        self.results.write_text(results if results is not None else results_xml(assemblies),
+                                encoding="utf-8")
+        self.log.write_text(
+            "Saving results to: {}\n".format(self.results) if log is None else log,
+            encoding="utf-8")
+        return self
+
+    def verdict(self, *arguments):
+        """(exit code, everything it said) for one invocation over this workspace."""
+        captured = io.StringIO()
+        argv = list(arguments) or [str(self.results), "--log", str(self.log),
+                                   "--project", str(self.project)]
+        with contextlib.redirect_stderr(captured), contextlib.redirect_stdout(captured):
+            code = check.main(argv)
+        return code, captured.getvalue()
+
+    def close(self):
+        shutil.rmtree(self.root, ignore_errors=True)
+
+
+@contextlib.contextmanager
+def workspace(**arguments):
+    made = Workspace(**arguments)
+    try:
+        yield made
+    finally:
+        made.close()
+
+
+class ProvenanceTests(unittest.TestCase):
+    def test_Given_AFixtureNoSourceHereDeclares_When_TheResultsAreRead_Then_TheyAreRefused(self):
+        # Arrange -- reported under an assembly this project declares, and declared by no source
+        # here, which is the reading that stands when the log says nothing is wrong.
+        with workspace() as tree:
+            tree.wrote([("Velvet.Tests.Probe.Editor", ["Velvet.Tests.ZzScratchDiagnosticsTests"])])
+
+            # Act
+            code, said = tree.verdict()
+
+            # Assert
+            self.assertEqual((code, "ZzScratchDiagnosticsTests" in said), (1, True))
+
+    def test_Given_EveryFixtureDeclaredHere_When_TheResultsAreRead_Then_TheyAreNotRefused(self):
+        # Arrange
+        with workspace() as tree:
+            tree.wrote()
+
+            # Act
+            code, said = tree.verdict()
+
+            # Assert
+            self.assertEqual((code, said.strip().startswith("checked 1 test run")), (0, True))
+
+    def test_Given_AFixtureOfAResolvedPackagesOwnAssembly_When_TheResultsAreRead_Then_ItIsNotRefused(self):
+        # Arrange -- Unity.Addressables.DocExampleCode.Editor.Tests reports a case here, out of a
+        # source that is the package's rather than this project's.
+        with workspace() as tree:
+            tree.wrote([("Velvet.Tests.Probe.Editor", ["Velvet.Tests.ProbeTests"]),
+                        ("Unity.Package.Tests", ["Some.Package.OwnTests"])])
+
+            # Act
+            code, _ = tree.verdict()
+
+            # Assert
+            self.assertEqual(code, 0)
+
+    def test_Given_AnAssemblyBothThisTreeAndAPackageDeclare_When_ItReportsAStranger_Then_ItIsRefused(self):
+        # Arrange -- of the two readings available for a name both declare, only checking it can
+        # refuse a stranger.
+        with workspace(assemblies=("Unity.Package.Tests",)) as tree:
+            tree.wrote([("Unity.Package.Tests", ["Velvet.Tests.ZzScratchDiagnosticsTests"])])
+
+            # Act
+            code, _ = tree.verdict()
+
+            # Assert
+            self.assertEqual(code, 1)
+
+    def test_Given_AnAssemblyNeitherThisTreeNorAPackageNames_When_ItReportsAStrangerBesideOurs_Then_ItIsRefused(self):
+        # Arrange -- the shape a seeded Library reports: this tree's own assemblies compile and run,
+        # and the Library carries a test assembly no asmdef here names, holding another checkout's
+        # fixture. One of ours has to report alongside it, or the floor refuses for want of anything
+        # of this worktree's having run and the fixture reading is never reached.
+        with workspace() as tree:
+            tree.wrote([("Velvet.Tests.Probe.Editor", ["Velvet.Tests.ProbeTests"]),
+                        ("Velvet.Tests.Scratch.Editor", ["Velvet.Tests.ZzScratchDiagnosticsTests"])])
+
+            # Act
+            code, said = tree.verdict()
+
+            # Assert
+            self.assertEqual((code, "ZzScratchDiagnosticsTests" in said), (1, True))
+
+    def test_Given_ANestedFixtureDeclaredHere_When_ItIsReportedWithAPlus_Then_ItIsNotRefused(self):
+        # Arrange
+        with workspace() as tree:
+            tree.wrote([("Velvet.Tests.Probe.Editor", ["Velvet.Tests.ProbeTests+Inner"])])
+
+            # Act
+            code, _ = tree.verdict()
+
+            # Assert
+            self.assertEqual(code, 0)
+
+    def test_Given_AGenericFixtureDeclaredHere_When_ItIsReportedWithItsArity_Then_ItIsNotRefused(self):
+        # Arrange -- the cases a generic base declares report under the base, which NUnit names by
+        # its runtime type.
+        with workspace() as tree:
+            tree.wrote([("Velvet.Tests.Probe.Editor", ["Velvet.Tests.ProbeTestsBase`1"])])
+
+            # Act
+            code, _ = tree.verdict()
+
+            # Assert
+            self.assertEqual(code, 0)
+
+
+class LogTests(unittest.TestCase):
+    def test_Given_ALogCarryingACompilerDiagnostic_When_TheRunIsRead_Then_ItIsRefused(self):
+        # Arrange -- every fixture here is this project's own, so the log is the only reading left
+        # that can refuse.
+        with workspace() as tree:
+            tree.wrote(log="Saving results to: {}\nStore.cs(637,1): error CS1002: ; expected\n"
+                           .format(tree.results))
+
+            # Act
+            code, said = tree.verdict()
+
+            # Assert
+            self.assertEqual((code, "error CS1002" in said), (1, True))
+
+    def test_Given_ALogNamingNoResultsFile_When_TheRunIsRead_Then_TheResultsAreRefused(self):
+        # Arrange -- what an aborted run leaves: the file at the path is the previous run's. Aborted
+        # over something other than a compile error, so this reading is the only one that can refuse.
+        with workspace() as tree:
+            tree.wrote(log="Aborting batchmode due to failure:\nSomething went wrong.\n")
+
+            # Act
+            code, said = tree.verdict()
+
+            # Assert
+            self.assertEqual((code, "some earlier run" in said), (1, True))
+
+    def test_Given_ALogNamingTheResultsUnderTheContainersPath_When_TheRunIsRead_Then_ItIsNotRefused(self):
+        # Arrange -- game-ci runs the editor in a container, so the path in the log is not the path
+        # the check reads the file from afterwards.
+        with workspace() as tree:
+            tree.wrote(log="Saving results to: /github/workspace/EditMode-results/results.xml\n")
+
+            # Act
+            code, _ = tree.verdict()
+
+            # Assert
+            self.assertEqual(code, 0)
+
+    def test_Given_ALogCarryingAnAnalyzerDiagnosticAtErrorSeverity_When_TheRunIsRead_Then_ItIsRefused(self):
+        # Arrange -- an analyzer under Generators~ raising its own at error severity fails the
+        # compile with no CS code in the log to find it by.
+        with workspace() as tree:
+            tree.wrote(log="Saving results to: {}\nV.cs(9,5): error VEL501: Member 'R' makes 21 "
+                           "branching decisions; the limit is 20\n".format(tree.results))
+
+            # Act
+            code, said = tree.verdict()
+
+            # Assert
+            self.assertEqual((code, "VEL501" in said), (1, True))
+
+    def test_Given_ALogCarryingUnitysOwnCapitalisedErrorLine_When_TheRunIsRead_Then_ItIsNotRefused(self):
+        # Arrange -- chatter a log that compiled carries anyway. What this case pins is the capital:
+        # it dies under a reading that reaches `Error:`, whether by IGNORECASE or by an alternation,
+        # and a widening to the bare lowercase word leaves it green -- that one is what the case
+        # over a run's own output catches.
+        with workspace() as tree:
+            tree.wrote(log="Saving results to: {}\n[Licensing::Module] Error: Access token is "
+                           "unavailable; failed to update\n".format(tree.results))
+
+            # Act
+            code, _ = tree.verdict()
+
+            # Assert
+            self.assertEqual(code, 0)
+
+    def test_Given_ALogWhoseOwnOutputSaysErrorWithoutTheSeparator_When_TheRunIsRead_Then_ItIsNotRefused(self):
+        # Arrange -- a case's expected-log message reaches the editor log, so a pattern reading the
+        # bare word would fail a run for what one of its own cases printed on purpose.
+        with workspace() as tree:
+            tree.wrote(log="Saving results to: {}\n[Velvet] mount error: the target was null\n"
+                           .format(tree.results))
+
+            # Act
+            code, _ = tree.verdict()
+
+            # Assert
+            self.assertEqual(code, 0)
+
+    def test_Given_ADirectoryHoldingBothFiles_When_ItIsTheOnlyArgument_Then_TheLogIsFoundInIt(self):
+        # Arrange -- how CI names them: one artifacts directory, no --log.
+        with workspace() as tree:
+            tree.wrote(log="Saving results to: {}\nStore.cs(1,1): error CS1002: ; expected\n"
+                           .format(tree.results))
+
+            # Act
+            code, said = tree.verdict(str(tree.run_directory), "--project", str(tree.project))
+
+            # Assert
+            self.assertEqual((code, "error CS1002" in said), (1, True))
+
+    def test_Given_AnotherRunsOutputInASubdirectory_When_TheDirectoryIsNamed_Then_ItIsNotSweptIn(self):
+        # Arrange -- base_red_check.py writes its own runs under the same Logs, and those are
+        # readings of a base tree whose fixtures are not this one's to answer for.
+        with workspace() as tree:
+            tree.wrote()
+            nested = tree.run_directory / "base_red_check"
+            nested.mkdir()
+            (nested / "EditMode-1.xml").write_text(
+                results_xml([("Velvet.Tests.Probe.Editor", ["Velvet.Tests.SomeoneElsesTests"])]),
+                encoding="utf-8")
+
+            # Act
+            code, _ = tree.verdict(str(tree.run_directory), "--project", str(tree.project))
+
+            # Assert
+            self.assertEqual(code, 0)
+
+
+    def test_Given_NoResultsFileAndADiagnosticInTheLog_When_TheRunIsRead_Then_TheDiagnosticIsWhatItSays(self):
+        # Arrange -- what an aborted CI job leaves: an artifacts directory holding the log alone.
+        with workspace() as tree:
+            tree.wrote(log="V.cs(9,5): error VEL500: Member 'R' nests 5 levels deep\n")
+            tree.results.unlink()
+
+            # Act
+            code, said = tree.verdict(str(tree.run_directory), "--project", str(tree.project))
+
+            # Assert
+            self.assertEqual((code, "VEL500" in said), (1, True))
+
+
+class UnreadableTests(unittest.TestCase):
+    """Every reading the guard cannot take is a refusal, since exiting 0 unread looks like a pass."""
+
+    def test_Given_NoEditorLogAtAll_When_TheRunIsRead_Then_TheReadingIsRefused(self):
+        # Arrange
+        with workspace() as tree:
+            tree.wrote()
+
+            # Act
+            code, _ = tree.verdict(str(tree.results), "--project", str(tree.project))
+
+            # Assert
+            self.assertEqual(code, 2)
+
+    def test_Given_NoLibraryToReadTheResolvedPackagesFrom_When_TheRunIsRead_Then_TheReadingIsRefused(self):
+        # Arrange -- without it, a package's own fixtures and a stranger's are the same reading.
+        with workspace(library=False) as tree:
+            tree.wrote()
+
+            # Act
+            code, _ = tree.verdict()
+
+            # Assert
+            self.assertEqual(code, 2)
+
+    def test_Given_AnAssemblyNeitherThisTreeNorAPackageNames_When_ItIsAllThatRan_Then_TheReadingIsRefused(self):
+        # Arrange -- a test asmdef renamed here, reported out of a Library seeded before the rename.
+        # Its fixture is one this tree does declare, so only the floor can catch it.
+        with workspace() as tree:
+            tree.wrote([("Velvet.Tests.Renamed.Editor", ["Velvet.Tests.ProbeTests"])])
+
+            # Act
+            code, _ = tree.verdict()
+
+            # Assert
+            self.assertEqual(code, 2)
+
+    def test_Given_NoResultsFileAndNothingInTheLogToSayWhy_When_TheRunIsRead_Then_TheRefusalSaysBoth(self):
+        # Arrange -- a run that wrote nothing and explained nothing. The floor below refuses this
+        # reading too, for want of a test run, so only the wording separates a missing file from a
+        # file that turned out to hold no run.
+        with workspace() as tree:
+            tree.wrote(log="Refreshing native plugins compatible for Editor\n")
+            tree.results.unlink()
+
+            # Act
+            code, said = tree.verdict(str(tree.run_directory), "--project", str(tree.project))
+
+            # Assert
+            self.assertEqual((code, "no results file" in said), (2, True))
+
+    def test_Given_NoAssemblyDefinitionHere_When_TheRunIsRead_Then_TheRefusalNamesIt(self):
+        # Arrange -- with none, no assembly is this worktree's, and the floor below refuses the same
+        # reading for a different reason, so only the wording separates a project holding no asmdef
+        # from a run that loaded none of them.
+        with workspace(assemblies=()) as tree:
+            tree.wrote()
+
+            # Act
+            code, said = tree.verdict()
+
+            # Assert
+            self.assertEqual((code, "no assembly definition here" in said), (2, True))
+
+    def test_Given_NoCSharpSourceHere_When_TheRunIsRead_Then_TheReadingIsRefused(self):
+        # Arrange -- an empty set of declared types makes every reported fixture foreign, which would
+        # refuse for the wrong reason and name every fixture in the run doing it.
+        with workspace(csharp=False) as tree:
+            tree.wrote()
+
+            # Act
+            code, _ = tree.verdict()
+
+            # Assert
+            self.assertEqual(code, 2)
+
+    def test_Given_AnXmlThatIsNoTestRun_When_ItIsAllThatWasNamed_Then_TheRefusalNamesIt(self):
+        # Arrange -- a coverage report has no test-case in it. The floor below refuses this reading
+        # too, for want of an assembly, so only the wording says the file was never a run at all.
+        with workspace() as tree:
+            tree.wrote(results='<?xml version="1.0"?><coverage />')
+
+            # Act
+            code, said = tree.verdict()
+
+            # Assert
+            self.assertEqual((code, "no test run among" in said), (2, True))
+
+    def test_Given_ResultsNamingNoAssemblyOfThisTree_When_TheRunIsRead_Then_TheReadingIsRefused(self):
+        # Arrange -- a run where this project's assemblies never loaded measured nothing of it, and
+        # every fixture check below passes for want of anything to check.
+        with workspace() as tree:
+            tree.wrote([("Unity.Package.Tests", ["Some.Package.OwnTests"])])
+
+            # Act
+            code, _ = tree.verdict()
+
+            # Assert
+            self.assertEqual(code, 2)
+
+    def test_Given_AResultsPathThatIsNotThere_When_ARealOneIsNamedBesideIt_Then_TheReadingIsRefused(self):
+        # Arrange -- beside a real one, since a lone absent path leaves nothing to read either way
+        # and the refusal would be the empty argument list's rather than this file's.
+        with workspace() as tree:
+            tree.wrote()
+
+            # Act
+            code, _ = tree.verdict(str(tree.results), str(tree.run_directory / "absent.xml"),
+                                   "--log", str(tree.log), "--project", str(tree.project))
+
+            # Assert
+            self.assertEqual(code, 2)
+
+    def test_Given_ACaseUnderNoAssemblySuite_When_OneUnderAnAssemblyIsReadBesideIt_Then_TheReadingIsRefused(self):
+        # Arrange -- the loose case names a fixture this tree does declare, so the alternative of
+        # sorting the unattributed bucket alongside the rest would have exited 0 on a file half of
+        # which could not be attributed at all.
+        with workspace() as tree:
+            loose = ('<test-case name="Case" fullname="Velvet.Tests.ProbeTests.Case" '
+                     'classname="Velvet.Tests.ProbeTests" result="Passed" />')
+            tree.wrote(results=results_xml([("Velvet.Tests.Probe.Editor",
+                                             ["Velvet.Tests.ProbeTests"])])
+                       .replace("</test-run>", loose + "</test-run>"))
+
+            # Act
+            code, said = tree.verdict()
+
+            # Assert
+            self.assertEqual((code, "no assembly suite" in said), (2, True))
+
+    def test_Given_AResultsFileNoParserCanRead_When_TheRunIsRead_Then_TheReadingIsRefused(self):
+        # Arrange
+        with workspace() as tree:
+            tree.wrote(results="<test-run>truncated")
+
+            # Act
+            code, _ = tree.verdict()
+
+            # Assert
+            self.assertEqual(code, 2)
+
+    def test_Given_ADirectoryGitCannotBeAskedAbout_When_TheRunIsRead_Then_TheRefusalNamesGit(self):
+        # Arrange -- git answering nothing and a project holding nothing refuse alike, so the
+        # refusal has to say which, or the reader goes looking for an asmdef that is right there.
+        with workspace() as tree:
+            tree.wrote()
+            shutil.rmtree(tree.project / ".git")
+
+            # Act
+            code, said = tree.verdict()
+
+            # Assert
+            self.assertEqual((code, "git could not list" in said), (2, True))
+
+
+class TypeReadingTests(unittest.TestCase):
+    def test_Given_TwoBlockNamespaces_When_TheTypeInsideIsRead_Then_BothQualifyIt(self):
+        # Arrange -- the name NUnit reports for such a type carries both, and a reader holding only
+        # the last one it saw names it one level short and refuses a fixture that is right here.
+        text = "namespace A\n{\n    namespace B\n    {\n        class C { }\n    }\n}\n"
+
+        # Act
+        names = check.declared_types(text)
+
+        # Assert
+        self.assertEqual(sorted(names), ["A.B.C"])
+
+    def test_Given_AFileScopedNamespace_When_ATypeBelowItIsRead_Then_ItStillQualifiesIt(self):
+        # Arrange -- it opens no body, so a reader dropping a scope on depth alone loses it at the
+        # first closing brace in the file.
+        text = "namespace Velvet.Tests;\n\nclass D\n{\n    class E { }\n}\n\nclass F { }\n"
+
+        # Act
+        names = check.declared_types(text)
+
+        # Assert
+        self.assertEqual(sorted(names),
+                         ["Velvet.Tests.D", "Velvet.Tests.D.E", "Velvet.Tests.F"])
+
+
+class DiagnosticIdTests(unittest.TestCase):
+    def test_Given_EveryDiagnosticIdTheAnalyzersHereDeclare_When_RaisedAsAnError_Then_TheLogReadingMatchesIt(self):
+        # Arrange -- read off the analyzer sources rather than listed, since which of them is an
+        # error is not fixed: a descriptor can be declared at error severity, and any of them can be
+        # promoted to one by warnaserror or by a severity entry.
+        #
+        # What this holds is that the reading is keyed on the rendering rather than on an ID space:
+        # it dies when the pattern is narrowed back to one, `: error CS` above all. It is not
+        # coverage of a newly declared identifier and cannot be -- the pattern never reads the name,
+        # which is exactly why adding one needs no change here.
+        generators = REPO_ROOT / "Packages" / "com.velvet.core" / "Generators~" / "src"
+        ids = sorted({found for path in generators.rglob("*.cs")
+                      for found in ANALYZER_ID.findall(
+                          path.read_text(encoding="utf-8", errors="replace"))})
+
+        # Act
+        unmatched = [name for name in ids
+                     if not check.COMPILE_ERROR.search(
+                         "Packages/x/Foo.cs(1,1): error {}: something".format(name))]
+
+        # Assert -- the count rides along because an empty corpus leaves nothing unmatched.
+        self.assertEqual((len(ids) > 20, unmatched), (True, []))
+
+
+class RepositoryTests(unittest.TestCase):
+    """The type reader against this repository's own fixtures, rather than against invented ones."""
+
+    def test_Given_EveryFixtureThisRepositoryDeclares_When_TheTypesAreRead_Then_EachIsNamed(self):
+        # Arrange -- the two readers share base_red_check.py's masking and brace profile, so this
+        # holds them to naming the same fixtures and cannot see a defect below that line. What reads
+        # the names NUnit itself reports is the guard running over each suite's real results, which
+        # both Unity jobs do wherever a licence is configured.
+        names = subprocess.run(["git", "-C", str(REPO_ROOT), "ls-files"],
+                               capture_output=True, text=True, check=True).stdout.splitlines()
+        declared = set()
+        fixtures = set()
+
+        # Act
+        for relative in names:
+            path = REPO_ROOT / relative
+            if not relative.endswith(".cs") or not path.exists():
+                continue
+            text = path.read_text(encoding="utf-8", errors="replace")
+            declared |= check.declared_types(text)
+            # Off the qualified case name rather than Case.fixture, which qualifies a file outside
+            # the Tests/Editor convention by its path instead of by its type.
+            fixtures |= {case.name.rsplit(".", 1)[0]
+                         for case in base_red_check.csharp_cases(text, relative)}
+
+        # Assert -- the count rides along because an empty corpus leaves nothing unnamed.
+        self.assertEqual((len(fixtures) > 100, sorted(fixtures - declared)), (True, []))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/test_quality/test_mutation_check.py
+++ b/scripts/test_quality/test_mutation_check.py
@@ -30,6 +30,13 @@ def load_module():
 mutation_check = load_module()
 
 
+def code_parens(fragment):
+    """How far the fragment's parentheses are out of balance, counting only what the compiler sees."""
+    mask = mutation_check.code_mask(fragment)
+    seen = [fragment[offset] for offset in range(len(fragment)) if mask[offset]]
+    return seen.count("(") - seen.count(")")
+
+
 def mutants_of(text, operator=None):
     lines = set(range(1, len(text.splitlines()) + 1))
     found = mutation_check.mutations_for(Path("probe.cs"), text, lines)
@@ -158,12 +165,14 @@ class GenerationHealthTests(unittest.TestCase):
         # Arrange — an unbalanced cut compiles nowhere, and uncompilable noise hides real survivors.
         sources = [path for path in RUNTIME.rglob("*.cs") if "/Tests/" not in path.as_posix()]
 
-        # Act
+        # Act — counted through the mask rather than over the raw text. A cut carrying
+        # `StartsWith("rgb(", ...)` holds a parenthesis the compiler never sees, and reading it raw
+        # reports a balanced cut as broken; every operator here reads code the same way.
         unbalanced = []
         for path in sources:
             text = path.read_text()
             for mutant in mutants_of(text, "clause removed"):
-                if mutant.before.count("(") != mutant.before.count(")"):
+                if code_parens(mutant.before) != 0:
                     unbalanced.append(f"{path.name}:{mutant.line} {mutant.before.strip()}")
 
         # Assert — the source count rides along because an empty scan satisfies "none unbalanced".


### PR DESCRIPTION
Closes #769.

`assert_results_from_this_tree.py` was born on 2026-08-13; this line was cut from `f935358` four days
earlier. So `2.x` runs one of `main`'s two result asserters, and the class the missing one catches has
never been guarded here.

CLAUDE.md states what it is for: a run that will not compile writes no results XML at all, so what is
left at that path is whatever last wrote there — measured once as a filter nobody posed reporting a
fixture the tree does not hold. On this line that reading passes CI.

Not hypothetical here. A cherry-pick can apply with zero conflicts and leave the tree uncompilable,
which is exactly what building 2.1.2 hit: #747 and #766 both applied clean and the tree then failed
with twenty-two `CS0103`s. A Unity run against that tree writes no XML, and nothing on this line says
so.

## What came with it, and what did not

The asserter reads through `base_red_check.py`, which reads through `mutation_check.py`. Both come
across as libraries; `mutation_check.py`'s newer version is the one `base_red_check` needs
(`folded_reason` does not exist in this line's copy).

`base_red_check.py` is **not** wired as a check here and its own suite does not pass against this
tree, so the suite does not come. #769 says the reconciliation has to be per script with a reason each
time, and that is this one's.

`main`'s `test_mutation_check.py` does not come either: four of its cases need a baseline file, a
commit hook and a guide this line does not carry.

## A defect the newer module exposed

This line's own balance guard counted parentheses over the raw cut text:

```python
if mutant.before.count("(") != mutant.before.count(")"):
```

`StyleColorValueParser.cs:217` here reads `s.StartsWith("rgb(", StringComparison.Ordinal)` — a literal
`main`'s copy of that file does not have. The generator masks it correctly and produces a balanced
cut; the guard, reading raw, called it broken. `main`'s suite already counts through the mask and its
comment says why, and that reading comes across with the module.

Four suites pass on the result: the asserter's, `mutation_check`'s, `neuter_check`'s and
`duplication_check`'s.

## What still differs between the lines

Everything else `main` added to `scripts/test_quality/` since 2026-08-09. This takes the one the issue
names as first, and leaves the rest as the per-script decisions they are. No CHANGELOG entry — CI, and
nothing a consumer sees changes.
