### PR TITLE
tooling(velvet): stop reading an absent check list as nothing to run

### DIFF
--- a/.claude/hooks/stop/unsettled_pr.py
+++ b/.claude/hooks/stop/unsettled_pr.py
@@ -155,26 +155,24 @@ def judge(pr):
         return unread(pr, "its checks")
 
     if not checks:
-        # Zero checks is legitimate when nothing the PR touches matches a workflow's path filter —
-        # a docs-only or .claude/-only change reports none and is ready to merge. It is a problem
-        # when the head never got a run it should have, and the tell is the merge state: a
-        # conflicting PR reports DIRTY (or UNKNOWN while GitHub is still computing) and never starts
-        # CI at all, which is the shape that went unwatched for seven hours.
+        # No pull request here is entitled to zero checks. Both required workflows subscribe to
+        # `pull_request` with no path filter — the filters are the push trigger's alone — so a head
+        # with none is one whose run never started, whatever the merge state says. Measured: three
+        # `.claude/`-only pull requests, #676 to #678, report fourteen checks each.
+        #
+        # This branch used to read CLEAN as ready and say "merge it", on a path filter that does not
+        # exist. The state was reachable once, through a `pull_request: branches: [main]` filter that
+        # left a maintenance-line pull request with no required check at all, and there the advice was
+        # to merge something nothing had tested. #776 removed the filter; the advice goes with it.
         state = merge_state(pr)
         if state is None:
             return unread(pr, "its merge state")
-        if state == "CLEAN":
-            # Ready, and ready is the state that reads as finished. A docs-only or .claude/-only
-            # change reports no checks at all and so never reached the merge reminder below, which
-            # is the same hole one level down from the one that left eight green PRs sitting.
-            return (f"  PR #{pr} — no checks apply to it and it is unmerged. Merge it, or say what "
-                    "it is waiting on and arm\n    something that brings you back when that arrives.")
         if state in EXPECTED_WITHOUT_CHECKS:
             return None
-        return (f"  PR #{pr} — no checks reported and merge state is {state or 'unnamed'}. A "
-                "conflicting PR never starts CI, so\n    this is not 'still running'. Rebase it, or "
-                "check the head SHA against\n    'gh run list --branch <b> --json headSha' if you "
-                "expected a run.")
+        return (f"  PR #{pr} — no check ever ran for its head, and the merge state is "
+                f"{state or 'unnamed'}.\n    Every workflow subscribes to pull_request without a "
+                "path filter, so this is a run that\n    did not start rather than one nothing "
+                "matched. Push again, or read\n    'gh run list --branch <b> --json headSha'.")
 
     pending = [check for check in checks if check.get("bucket") == "pending"]
     if not pending:

--- a/.claude/hooks/stop/unsettled_pr.py
+++ b/.claude/hooks/stop/unsettled_pr.py
@@ -155,15 +155,11 @@ def judge(pr):
         return unread(pr, "its checks")
 
     if not checks:
-        # No pull request here is entitled to zero checks. Both required workflows subscribe to
-        # `pull_request` with no path filter — the filters are the push trigger's alone — so a head
-        # with none is one whose run never started, whatever the merge state says. Measured: three
-        # `.claude/`-only pull requests, #676 to #678, report fourteen checks each.
-        #
-        # This branch used to read CLEAN as ready and say "merge it", on a path filter that does not
-        # exist. The state was reachable once, through a `pull_request: branches: [main]` filter that
-        # left a maintenance-line pull request with no required check at all, and there the advice was
-        # to merge something nothing had tested. #776 removed the filter; the advice goes with it.
+        # No pull request here is entitled to zero checks, so a head with none is one whose run never
+        # started, whatever the merge state says. `WorkflowTriggerCoverageTests` is what holds that:
+        # it fails when either required workflow stops subscribing to `pull_request`, and when either
+        # subscription gains a path filter. This branch used to read CLEAN as ready and say "merge
+        # it", which was advice to merge something nothing had tested.
         state = merge_state(pr)
         if state is None:
             return unread(pr, "its merge state")

--- a/.github/workflows/generators.yml
+++ b/.github/workflows/generators.yml
@@ -135,6 +135,11 @@ jobs:
       - name: Stale base report tests
         run: python3 scripts/hooks/test_stale_main.py
 
+      # The zero-checks reading, which had no suite. It used to say "merge it" for a pull request
+      # nothing had tested, on a path filter `pull_request` does not carry.
+      - name: Unsettled pull request guard tests
+        run: python3 scripts/hooks/test_unsettled_pr.py
+
       # Holds the body guards' record of which gh options take a value against the gh on the runner,
       # which needs no licence and no token, only `--help`. The script owns what a disagreement
       # costs in either direction.

--- a/scripts/hooks/test_unreadable_state_check.py
+++ b/scripts/hooks/test_unreadable_state_check.py
@@ -639,6 +639,8 @@ class ZeroCheckTests(unittest.TestCase):
         # Act / Assert
         self.assertEqual((check.SELF_REPORT in said, "its merge state" in said), (True, True))
 
+    # GREEN_ON_BASE(refactor): only the sentence these name the absence of is renamed here. What
+    # they hold either side of it is that the unread-state guard speaks instead of it.
     def test_Given_AnEmptyAnswerFromTheCheckRead_When_Judged_Then_ItIsNotTakenForNone(self):
         # Arrange — the exit code is 0 and the output is empty, so nothing about the exit says the
         # read failed; the rollup naming a check is what says the empty answer was not one.
@@ -647,6 +649,8 @@ class ZeroCheckTests(unittest.TestCase):
         # Act / Assert
         self.assertEqual((check.SELF_REPORT in said, "no check ever ran for its head" in said), (True, False))
 
+    # GREEN_ON_BASE(refactor): only the sentence these name the absence of is renamed here. What
+    # they hold either side of it is that the unread-state guard speaks instead of it.
     def test_Given_AnEmptyListFromTheCheckRead_When_Judged_Then_ItIsNotTakenForNone(self):
         # Arrange — the same question as the case above with the other spelling of empty, so the
         # rollup is what decides however the emptiness arrives rather than for one shape of it.
@@ -655,6 +659,8 @@ class ZeroCheckTests(unittest.TestCase):
         # Act / Assert
         self.assertEqual((check.SELF_REPORT in said, "no check ever ran for its head" in said), (True, False))
 
+    # GREEN_ON_BASE(refactor): only the sentence these name the absence of is renamed here. What
+    # they hold either side of it is that the unread-state guard speaks instead of it.
     def test_Given_ARollupThatIsNotAList_When_ItIsRead_Then_ItIsNotTakenForNone(self):
         # Arrange — the merge state answers CLEAN, so a rollup misread as empty produces the
         # run-did-not-start sentence about a list nothing here understood.
@@ -663,6 +669,8 @@ class ZeroCheckTests(unittest.TestCase):
         # Act / Assert
         self.assertEqual((check.SELF_REPORT in said, "no check ever ran for its head" in said), (True, False))
 
+    # GREEN_ON_BASE(refactor): only the sentence these name the absence of is renamed here. What
+    # they hold either side of it is that the unread-state guard speaks instead of it.
     def test_Given_AnUnreadCheckListBesideAReadableMergeState_When_Judged_Then_NoneIsNotReportedAsZero(self):
         # Arrange — the merge state answers CLEAN, so a check read taken for an empty one produces
         # the run-did-not-start sentence, about a list nothing here read.

--- a/scripts/hooks/test_unreadable_state_check.py
+++ b/scripts/hooks/test_unreadable_state_check.py
@@ -605,8 +605,8 @@ class ZeroCheckTests(unittest.TestCase):
         # Arrange — the rollup says zero, so the answer was "none" and the reading did not fail.
         said = self.said(NO_CHECKS_AND_A_ROLLUP)
 
-        # Act / Assert — the zero-check reminder, and not the sentence for a guard that read nothing.
-        self.assertEqual(("no checks apply to it" in said, check.SELF_REPORT in said), (True, False))
+        # Act / Assert — the run-did-not-start sentence, not the one for a guard that read nothing.
+        self.assertEqual(("no check ever ran for its head" in said, check.SELF_REPORT in said), (True, False))
 
     def test_Given_TheSameFailureWithNoRollupEither_When_ItIsJudged_Then_ThePullRequestIsNamed(self):
         # Arrange — nothing answered at all. This one carries the per-pull-request half rather than
@@ -645,7 +645,7 @@ class ZeroCheckTests(unittest.TestCase):
         said = self.said(AN_EMPTY_ANSWER_AND_A_ROLLUP_WITH_CHECKS)
 
         # Act / Assert
-        self.assertEqual((check.SELF_REPORT in said, "no checks apply to it" in said), (True, False))
+        self.assertEqual((check.SELF_REPORT in said, "no check ever ran for its head" in said), (True, False))
 
     def test_Given_AnEmptyListFromTheCheckRead_When_Judged_Then_ItIsNotTakenForNone(self):
         # Arrange — the same question as the case above with the other spelling of empty, so the
@@ -653,23 +653,23 @@ class ZeroCheckTests(unittest.TestCase):
         said = self.said(AN_EMPTY_LIST_AND_A_ROLLUP_WITH_CHECKS)
 
         # Act / Assert
-        self.assertEqual((check.SELF_REPORT in said, "no checks apply to it" in said), (True, False))
+        self.assertEqual((check.SELF_REPORT in said, "no check ever ran for its head" in said), (True, False))
 
     def test_Given_ARollupThatIsNotAList_When_ItIsRead_Then_ItIsNotTakenForNone(self):
         # Arrange — the merge state answers CLEAN, so a rollup misread as empty produces the
-        # zero-check reminder about a list nothing here understood.
+        # run-did-not-start sentence about a list nothing here understood.
         said = self.said(NO_CHECKS_AND_A_NULL_ROLLUP)
 
         # Act / Assert
-        self.assertEqual((check.SELF_REPORT in said, "no checks apply to it" in said), (True, False))
+        self.assertEqual((check.SELF_REPORT in said, "no check ever ran for its head" in said), (True, False))
 
     def test_Given_AnUnreadCheckListBesideAReadableMergeState_When_Judged_Then_NoneIsNotReportedAsZero(self):
         # Arrange — the merge state answers CLEAN, so a check read taken for an empty one produces
-        # the zero-check reminder: "no checks apply to it", about a list nothing here read.
+        # the run-did-not-start sentence, about a list nothing here read.
         said = self.said(NO_CHECKS_AND_A_MERGE_STATE)
 
         # Act / Assert
-        self.assertEqual((check.SELF_REPORT in said, "no checks apply to it" in said), (True, False))
+        self.assertEqual((check.SELF_REPORT in said, "no check ever ran for its head" in said), (True, False))
 
 
 # Two open pull requests, neither carrying a check, both readable. What varies between the cases

--- a/scripts/hooks/test_unsettled_pr.py
+++ b/scripts/hooks/test_unsettled_pr.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Unit tests for the zero-checks reading in .claude/hooks/stop/unsettled_pr.py.
+
+No pull request in this repository is entitled to zero checks: both required workflows subscribe to
+`pull_request` without a path filter, so a head with none is a run that did not start. The guard used
+to read a CLEAN one as ready and say "merge it", justified by a path filter that does not exist — and
+the state was reachable once, through the `pull_request: branches: [main]` filter #776 removed, where
+that advice named a pull request nothing had tested.
+
+What the cases hold is that the advice never says merge, and that the two states which do explain an
+absent list still say nothing.
+
+Run: python3 scripts/hooks/test_unsettled_pr.py
+"""
+
+import importlib.util
+import json
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GUARD = REPO_ROOT / ".claude/hooks/stop/unsettled_pr.py"
+
+_spec = importlib.util.spec_from_file_location("unsettled_pr", GUARD)
+unsettled_pr = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(unsettled_pr)
+
+
+class ZeroChecks(unittest.TestCase):
+    def judge_with(self, state, checks="[]"):
+        """`judge` with gh answering a fixed check list and merge state."""
+        def stub(args):
+            if "checks" in args:
+                return checks, "", 0
+            if "statusCheckRollup" in args:
+                # An empty list is the only answer that says "there are none"; the guard reads it
+                # whole rather than through a length, because jq cannot tell absent from empty.
+                return json.dumps({"statusCheckRollup": []}), "", 0
+            # `--jq` is asked for, so gh prints the value rather than the object.
+            return state, "", 0
+
+        original = unsettled_pr.gh
+        unsettled_pr.gh = stub
+        try:
+            return unsettled_pr.judge("1")
+        finally:
+            unsettled_pr.gh = original
+
+    def test_Given_ACleanPullRequestWithNoChecks_When_Judged_Then_ItDoesNotSayMerge(self):
+        # Arrange — the advice this replaces named a pull request nothing had tested.
+        said = self.judge_with("CLEAN")
+
+        # Act / Assert
+        self.assertEqual((said is None, "Merge it" in (said or "")), (False, False))
+
+    def test_Given_ACleanPullRequestWithNoChecks_When_Judged_Then_ItSaysTheRunDidNotStart(self):
+        # Act / Assert
+        self.assertIn("no check ever ran for its head", self.judge_with("CLEAN"))
+
+    def test_Given_AStateThatExplainsAnAbsentList_When_Judged_Then_NothingIsSaid(self):
+        # Arrange — BLOCKED is one of the three; a list absent for a reason it names is not a run
+        # that did not start.
+        # Act / Assert
+        self.assertIsNone(self.judge_with("BLOCKED"))
+
+    def test_Given_AConflictingPullRequest_When_Judged_Then_ItIsStillNamed(self):
+        # Act / Assert
+        self.assertIn("DIRTY", self.judge_with("DIRTY"))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/hooks/test_unsettled_pr.py
+++ b/scripts/hooks/test_unsettled_pr.py
@@ -57,12 +57,16 @@ class ZeroChecks(unittest.TestCase):
         # Act / Assert
         self.assertIn("no check ever ran for its head", self.judge_with("CLEAN"))
 
+    # GREEN_ON_BASE(characterization): the three states that explain an absent list are what this
+    # change had to leave alone while removing the fourth, and nothing else says they still do.
     def test_Given_AStateThatExplainsAnAbsentList_When_Judged_Then_NothingIsSaid(self):
         # Arrange — BLOCKED is one of the three; a list absent for a reason it names is not a run
         # that did not start.
         # Act / Assert
         self.assertIsNone(self.judge_with("BLOCKED"))
 
+    # GREEN_ON_BASE(characterization): DIRTY is the state the whole reading was built for, and the
+    # branch that names it is the one being rewritten.
     def test_Given_AConflictingPullRequest_When_Judged_Then_ItIsStillNamed(self):
         # Act / Assert
         self.assertIn("DIRTY", self.judge_with("DIRTY"))


### PR DESCRIPTION
The Stop guard read a pull request with zero checks and a CLEAN merge state as ready, and said so:
*"no checks apply to it and it is unmerged. Merge it."* The path filter that justified it is not
there — both required workflows subscribe to `pull_request` unfiltered, so no head in this repository
is entitled to zero checks, and one with none is a run that never started.

The state was reachable while a `pull_request: branches: [main]` filter left a maintenance-line pull
request with no required check at all. There the advice named something nothing had tested. Removing
the filter closed the way in; this removes the advice that was waiting at the end of it.

The three merge states that explain an absent list are untouched, and a conflicting head is still
named. What changes is the fourth reading, which now says the run did not start and points at the
head SHA rather than at the merge button.

The reading had no suite. It has one now, and `generators.yml` runs it beside the other hook suites.

No documentation impact: the guard's advice is its own text, and CONTRIBUTING.md describes neither
the reading nor the states it turns on.

Closes #735
