### PR TITLE
tooling(velvet): give a non-owner a deferral it can write truthfully

### DIFF
--- a/.claude/hooks/refuse/edit_while_a_ready_pr_sits.py
+++ b/.claude/hooks/refuse/edit_while_a_ready_pr_sits.py
@@ -141,7 +141,12 @@ def main():
         "  python3 scripts/pr/settle.py merge <pr>\n\n"
         "That reports what still blocks it, if anything does. If one is held on purpose, say what "
         f"clears it — the reason expires, so it gets re-read rather than forgotten:\n\n"
-        f'  echo "<pr> <what clears it> {int(now)}" >> {DEFERRALS}\n')
+        f'  echo "<pr> <what clears it> {int(now)}" >> {DEFERRALS}\n\n'
+        "A deferral claims somebody read the hold and judged it deliberate, so a cause invented for a "
+        "pull request you have never opened is the one shape of it that is false. Not owning it is "
+        "itself a reason, and it is one you can state truthfully — with the telling done rather than "
+        "intended, since that is the only part that moves the pull request:\n\n"
+        f'  echo "<pr> held by <owner>, who has been asked to settle it {int(now)}" >> {DEFERRALS}\n')
     return 2
 
 


### PR DESCRIPTION
The ready-PR refusal offers two ways out — merge the pull request, or write a deferral for it — and
both are moves on the pull request itself. An agent working on another branch owns neither. Twice in
one session an implementer was refused every Edit and Write by somebody else's green pull request,
and one of them named why the second exit was no better than the first: a deferral asserts that
someone read the hold and judged it deliberate, which is not a claim available to anybody who has
never opened it. Both reported the block and stopped. Their reasoning was right.

Not owning it is itself a reason, and it is one a bystander can state without inventing anything.
The refusal now offers that line beside the other, with the owner named and the asking already done
rather than merely intended — the expiry only brings a reason back to be re-read, and nothing about
a deferral moves a pull request toward merging.

Text alone. What the guard refuses, and when it fires, is unchanged, which is why the fix was priced
first of the three the issue lists: it cannot loosen the hold.

No documentation impact: the guard's advice is its own text, and nothing outside it describes the
exits.

Closes #764
