### PR TITLE
tooling(velvet): say a block gained a file rather than that it started repeating

### DIFF
--- a/scripts/test_quality/duplication_check.py
+++ b/scripts/test_quality/duplication_check.py
@@ -141,18 +141,19 @@ def main():
     for entry in removed:
         print(f"  - {entry}", file=sys.stderr)
 
-    if started:
-        print(f"\n{len(started)} block(s) now repeat that did not before.", file=sys.stderr)
-    if moved:
-        print(f"\n{len(moved)} block(s) already repeated and now repeat in different files. The "
-              f"repeated-block count is what it was; what moved is where.", file=sys.stderr)
+    if started or moved:
+        if started:
+            print(f"\n{len(started)} block(s) now repeat that did not before.", file=sys.stderr)
+        if moved:
+            print(f"\n{len(moved)} block(s) already repeated and now repeat in different files. The "
+                  f"repeated-block count is what it was; what moved is where.", file=sys.stderr)
         print("Update the baseline only when duplication was added deliberately:", file=sys.stderr)
         print(f"  {sys.executable} scripts/test_quality/duplication_check.py "
               f"--write-baseline {args.baseline}", file=sys.stderr)
         return 1
 
-    if removed:
-        print(f"\n{len(removed)} block(s) no longer repeat.", file=sys.stderr)
+    if stopped:
+        print(f"\n{len(stopped)} block(s) no longer repeat.", file=sys.stderr)
         print("Ratchet the baseline down so the next deliberate addition is visible:", file=sys.stderr)
         print(f"  {sys.executable} scripts/test_quality/duplication_check.py "
               f"--write-baseline {args.baseline}", file=sys.stderr)

--- a/scripts/test_quality/duplication_check.py
+++ b/scripts/test_quality/duplication_check.py
@@ -76,6 +76,11 @@ def repeated_blocks(package_root: Path) -> set[str]:
     return entries
 
 
+def block_id(entry: str) -> str:
+    """The hash an entry opens with, which is the block itself rather than where it repeats."""
+    return entry.split(None, 1)[0]
+
+
 def read_baseline(path: Path) -> set[str]:
     entries = {line.rstrip("\n") for line in path.read_text().splitlines() if line.strip()}
     if not entries:
@@ -121,6 +126,14 @@ def main():
     added = sorted(current - baseline)
     removed = sorted(baseline - current)
 
+    # An entry is a block id and the files it repeats in, so a block that gained a file leaves one on
+    # each side. Read as added alone it says a block started repeating, which is what a reader acts
+    # on -- measured, as a design question raised on a pull request over a block that had repeated in
+    # ten files for as long as the baseline has existed.
+    started = [entry for entry in added if block_id(entry) not in {block_id(e) for e in removed}]
+    stopped = [entry for entry in removed if block_id(entry) not in {block_id(e) for e in added}]
+    moved = [entry for entry in added if entry not in started]
+
     # Both directions are reported before either decides the exit code, because a change that swaps one
     # block for another is the case a count cannot see and is the reason this reads a set.
     for entry in added:
@@ -128,8 +141,11 @@ def main():
     for entry in removed:
         print(f"  - {entry}", file=sys.stderr)
 
-    if added:
-        print(f"\n{len(added)} block(s) now repeat that did not before.", file=sys.stderr)
+    if started:
+        print(f"\n{len(started)} block(s) now repeat that did not before.", file=sys.stderr)
+    if moved:
+        print(f"\n{len(moved)} block(s) already repeated and now repeat in different files. The "
+              f"repeated-block count is what it was; what moved is where.", file=sys.stderr)
         print("Update the baseline only when duplication was added deliberately:", file=sys.stderr)
         print(f"  {sys.executable} scripts/test_quality/duplication_check.py "
               f"--write-baseline {args.baseline}", file=sys.stderr)

--- a/scripts/test_quality/test_duplication_check.py
+++ b/scripts/test_quality/test_duplication_check.py
@@ -8,10 +8,14 @@ newly written area — the case the check exists for — walks past it.
 Run: python3 scripts/test_quality/test_duplication_check.py
 """
 
+import contextlib
 import importlib.util
+import io
+import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
@@ -127,6 +131,75 @@ class BlockIdReadingTests(unittest.TestCase):
 
         # Assert
         self.assertEqual(len(started), 1)
+
+
+class ExitCodeTests(unittest.TestCase):
+    """What the two arrivals cost, which is the half the block-id reading does not decide.
+
+    Separating them is only worth anything if both still stop the change; a reading that renamed one
+    of them and let it pass would report duplication more precisely and guard nothing.
+    """
+
+    def anchored(self, **files):
+        """A package whose baseline is never empty, which `read_baseline` refuses to read."""
+        return package(Anchor=block("z"), Mirror=block("z"), **files)
+
+    def run_against(self, before, after):
+        """`main` over `after`, baselined on `before`, returning (exit code, stderr)."""
+        baseline = Path(tempfile.mkdtemp()) / "baseline.txt"
+        baseline.write_text("\n".join(sorted(duplication_check.repeated_blocks(before))) + "\n")
+        argv = ["duplication_check.py", "--project", str(after.parents[1]),
+                "--baseline", str(baseline)]
+        err = io.StringIO()
+        with mock.patch.object(sys, "argv", argv), contextlib.redirect_stderr(err), \
+                contextlib.redirect_stdout(io.StringIO()):
+            return duplication_check.main(), err.getvalue()
+
+    def test_Given_ABlockThatStartedRepeating_When_Checked_Then_ItStopsTheChange(self):
+        # Arrange
+        before = self.anchored(Alpha=block("a"), Beta=block("b"))
+        after = self.anchored(Alpha=block("a"), Beta=block("a"))
+
+        # Act
+        code, said = self.run_against(before, after)
+
+        # Assert
+        self.assertEqual((code, "now repeat that did not before" in said), (1, True))
+
+    def test_Given_ABlockThatMovedFiles_When_Checked_Then_ItStopsTheChange(self):
+        # Arrange
+        before = self.anchored(Alpha=block("a"), Beta=block("a"))
+        after = self.anchored(Alpha=block("a"), Delta=block("a"))
+
+        # Act
+        code, said = self.run_against(before, after)
+
+        # Assert
+        self.assertEqual((code, "repeat in different files" in said), (1, True))
+
+    def test_Given_ABlockThatMovedFiles_When_Checked_Then_NothingIsSaidToHaveStopped(self):
+        # Arrange — the departure is the move's other half, and reporting it as a block that stopped
+        # repeating asks for a ratchet that would undo the entry the move just added.
+        before = self.anchored(Alpha=block("a"), Beta=block("a"))
+        after = self.anchored(Alpha=block("a"), Delta=block("a"))
+
+        # Act
+        _, said = self.run_against(before, after)
+
+        # Assert
+        self.assertNotIn("no longer repeat", said)
+
+    def test_Given_ABlockThatStoppedRepeating_When_Checked_Then_TheBaselineIsRatcheted(self):
+        # Arrange
+        before = self.anchored(Alpha=block("a"), Beta=block("a"))
+        after = self.anchored(Alpha=block("a"), Beta=block("b"))
+
+        # Act
+        code, said = self.run_against(before, after)
+
+        # Assert
+        self.assertEqual((code, "no longer repeat" in said),
+                         (duplication_check.BASELINE_DRIFT_EXIT, True))
 
 
 class BaselineTests(unittest.TestCase):

--- a/scripts/test_quality/test_duplication_check.py
+++ b/scripts/test_quality/test_duplication_check.py
@@ -155,6 +155,9 @@ class ExitCodeTests(unittest.TestCase):
                 contextlib.redirect_stdout(io.StringIO()):
             return duplication_check.main(), err.getvalue()
 
+    # GREEN_ON_BASE(characterization): the base stops it because every arrival stopped it. This is
+    # the half the split must not drop, and dropping it is silent — the check would still run, still
+    # report, and let new duplication through.
     def test_Given_ABlockThatStartedRepeating_When_Checked_Then_ItStopsTheChange(self):
         # Arrange
         before = self.anchored(Alpha=block("a"), Beta=block("b"))
@@ -166,8 +169,9 @@ class ExitCodeTests(unittest.TestCase):
         # Assert
         self.assertEqual((code, "now repeat that did not before" in said), (1, True))
 
-    def test_Given_ABlockThatMovedFiles_When_Checked_Then_ItStopsTheChange(self):
-        # Arrange
+    def test_Given_ABlockThatMovedFiles_When_Checked_Then_ItIsTheOnlyThingSaid(self):
+        # Arrange — a move leaves an entry on each side, and each side read alone names a different
+        # thing that did not happen: a block that started repeating, and one that stopped.
         before = self.anchored(Alpha=block("a"), Beta=block("a"))
         after = self.anchored(Alpha=block("a"), Delta=block("a"))
 
@@ -175,20 +179,14 @@ class ExitCodeTests(unittest.TestCase):
         code, said = self.run_against(before, after)
 
         # Assert
-        self.assertEqual((code, "repeat in different files" in said), (1, True))
+        self.assertEqual((code,
+                          "repeat in different files" in said,
+                          "now repeat that did not before" in said,
+                          "no longer repeat" in said),
+                         (1, True, False, False))
 
-    def test_Given_ABlockThatMovedFiles_When_Checked_Then_NothingIsSaidToHaveStopped(self):
-        # Arrange — the departure is the move's other half, and reporting it as a block that stopped
-        # repeating asks for a ratchet that would undo the entry the move just added.
-        before = self.anchored(Alpha=block("a"), Beta=block("a"))
-        after = self.anchored(Alpha=block("a"), Delta=block("a"))
-
-        # Act
-        _, said = self.run_against(before, after)
-
-        # Assert
-        self.assertNotIn("no longer repeat", said)
-
+    # GREEN_ON_BASE(characterization): a block that stopped repeating ratcheted the baseline before
+    # the arrivals were separated, and it is the reading the split had to leave where it was.
     def test_Given_ABlockThatStoppedRepeating_When_Checked_Then_TheBaselineIsRatcheted(self):
         # Arrange
         before = self.anchored(Alpha=block("a"), Beta=block("a"))

--- a/scripts/test_quality/test_duplication_check.py
+++ b/scripts/test_quality/test_duplication_check.py
@@ -88,6 +88,47 @@ class BlockSetTests(unittest.TestCase):
         self.assertEqual(len(changed), 2)
 
 
+class BlockIdReadingTests(unittest.TestCase):
+    """What separates a block that started repeating from one that gained or lost a file.
+
+    Both leave an entry on each side of the comparison, and reading the arrival alone says a block
+    started repeating — measured, as a design question raised on a pull request over a block that had
+    repeated in ten files for as long as the baseline existed.
+    """
+
+    def test_Given_AnEntry_When_ItsBlockIsRead_Then_ItIsTheHashAndNotTheFiles(self):
+        # Act / Assert
+        self.assertEqual(duplication_check.block_id("035c4cad19e4\ta.cs,b.cs"), "035c4cad19e4")
+
+    def test_Given_ABlockMovedBetweenFiles_When_TheSidesAreRead_Then_NeitherBlockStarted(self):
+        # Arrange — the same block on both sides, so its arrival is not a block that started.
+        before = duplication_check.repeated_blocks(package(Alpha=block("a"), Beta=block("a")))
+        after = duplication_check.repeated_blocks(package(Alpha=block("a"), Delta=block("a")))
+        arrived, departed = after - before, before - after
+
+        # Act
+        started = [e for e in arrived
+                   if duplication_check.block_id(e) not in {duplication_check.block_id(d)
+                                                            for d in departed}]
+
+        # Assert
+        self.assertEqual(started, [])
+
+    def test_Given_ABlockThatDidNotRepeatBefore_When_TheSidesAreRead_Then_ItStarted(self):
+        # Arrange — a second home for a block that had none, which is what the sentence is for.
+        before = duplication_check.repeated_blocks(package(Alpha=block("a"), Beta=block("b")))
+        after = duplication_check.repeated_blocks(package(Alpha=block("a"), Beta=block("a")))
+        arrived, departed = after - before, before - after
+
+        # Act
+        started = [e for e in arrived
+                   if duplication_check.block_id(e) not in {duplication_check.block_id(d)
+                                                            for d in departed}]
+
+        # Assert
+        self.assertEqual(len(started), 1)
+
+
 class BaselineTests(unittest.TestCase):
     def test_Given_ThisRepositorysPackage_When_ComparedToItsBaseline_Then_TheSetsAgree(self):
         # Arrange


### PR DESCRIPTION
An entry in the duplication baseline is a block id and the files it repeats in, so a block that
gained a file leaves one entry on each side of the comparison. The check read the arrival alone and
said the block had started repeating — which is what a reader acts on, and it sent one to redesign a
block that had repeated in ten files for as long as the baseline has existed.

The arrivals are now separated by block id: one that started repeating, and one that already repeated
and now repeats elsewhere. Both still stop the change, because the baseline needs updating either
way; what differs is which sentence the reader gets. The departure half of a move no longer also
reports as a block that stopped repeating, which would have asked for a ratchet undoing the entry the
move just added.

The exit codes are pinned rather than the helper alone. Asserting the split in the test and leaving
`main` to apply it is how the first cut of this let a newly repeating block through: the sentence was
right and the check returned 0.

No documentation impact: CONTRIBUTING.md names what the check refuses, not how it reports it.

Closes #741
