### PR TITLE
tooling(velvet): report the interval since anything stamped, and the state it cannot express

### DIFF
--- a/scripts/pr/settle.py
+++ b/scripts/pr/settle.py
@@ -521,8 +521,9 @@ def retire(lock, unasked):
     went on to other work would hold it while nothing was watching.
     """
     lock.close()
-    print(f"Retiring after {int(unasked)}s in which nothing stamped {watcher_state.ASKED}, which is "
-          f"how a guard records reading the watcher's state.\n"
+    print(f"Retiring {int(unasked)}s since anything last stamped {watcher_state.ASKED}, which is "
+          f"how a guard records reading the watcher's state — floored by this watcher's own start, "
+          f"so a first stamp that never came reads the same as one that stopped.\n"
           f"\nFrom here a pending check blocks a Stop again, and an edit is refused until something "
           f"is watching. Both are what a live watcher was forgiving. Start another when that is what "
           f"you want:\n"

--- a/scripts/pr/settle.py
+++ b/scripts/pr/settle.py
@@ -520,13 +520,12 @@ def retire(lock, unasked, ever_asked=None):
     """The lock goes back here rather than at the exit: `watch` returns to a caller, and one that
     went on to other work would hold it while nothing was watching.
 
-    `ever_asked` is whether the file has ever carried a stamp. Never is a third state, and it is the
-    one a reader cannot act on from the interval alone: a guard resolves `watcher_state` from its own
-    checkout, so one at a commit predating `note_asked` reads this watcher on every turn and cannot
-    record having done it. Measured on this machine, on the first watcher started after that merge.
+    `ever_asked` is whether a stamp is readable there at all. None is a third state the interval
+    cannot express: a guard resolves `watcher_state` from its own checkout, so one at a commit
+    predating `note_asked` reads this watcher on every turn and cannot record having done it.
     """
     lock.close()
-    never = ("\nThat file has never carried a stamp. A guard resolves the stamping code from its own "
+    never = ("\nThat file carries no stamp at all. A guard resolves the stamping code from its own "
              "checkout,\nso one at a commit predating it reads this watcher every turn and cannot "
              "record having done it —\npull there before reading this as nobody watching."
              if ever_asked is False else "")

--- a/scripts/pr/settle.py
+++ b/scripts/pr/settle.py
@@ -516,14 +516,23 @@ def unasked_for(started, now=None):
     return now - started if ago is None else min(ago, now - started)
 
 
-def retire(lock, unasked):
+def retire(lock, unasked, ever_asked=None):
     """The lock goes back here rather than at the exit: `watch` returns to a caller, and one that
     went on to other work would hold it while nothing was watching.
+
+    `ever_asked` is whether the file has ever carried a stamp. Never is a third state, and it is the
+    one a reader cannot act on from the interval alone: a guard resolves `watcher_state` from its own
+    checkout, so one at a commit predating `note_asked` reads this watcher on every turn and cannot
+    record having done it. Measured on this machine, on the first watcher started after that merge.
     """
     lock.close()
+    never = ("\nThat file has never carried a stamp. A guard resolves the stamping code from its own "
+             "checkout,\nso one at a commit predating it reads this watcher every turn and cannot "
+             "record having done it —\npull there before reading this as nobody watching."
+             if ever_asked is False else "")
     print(f"Retiring {int(unasked)}s since anything last stamped {watcher_state.ASKED}, which is "
           f"how a guard records reading the watcher's state — floored by this watcher's own start, "
-          f"so a first stamp that never came reads the same as one that stopped.\n"
+          f"so a first stamp that never came reads the same as one that stopped.{never}\n"
           f"\nFrom here a pending check blocks a Stop again, and an edit is refused until something "
           f"is watching. Both are what a live watcher was forgiving. Start another when that is what "
           f"you want:\n"
@@ -563,7 +572,7 @@ def watch(project, base):
         # watcher whose calls all fail goes unread like any other.
         unasked = unasked_for(started)
         if unasked >= watcher_state.RETIRE_AFTER:
-            return retire(lock, unasked)
+            return retire(lock, unasked, watcher_state.asked_ago() is not None)
         try:
             pull_requests = open_pull_requests(project)
         except RuntimeError as error:

--- a/scripts/pr/test_settle.py
+++ b/scripts/pr/test_settle.py
@@ -532,15 +532,14 @@ class RetirementTests(unittest.TestCase):
                           "blocks a Stop again" in said,
                           "python3 scripts/pr/settle.py watch" in said), (True, True, True))
 
-    def test_Given_NothingEverStamped_When_ItRetires_Then_ItNamesTheReaderThatCouldNotRecord(self):
+    def test_Given_NoStampAtAll_When_ItRetires_Then_ItNamesTheReaderThatCouldNotRecord(self):
         # Arrange — a guard resolves the stamping code from its own checkout, so one at a commit
-        # predating it reads the watcher every turn and cannot record having done it. Measured on
-        # this machine, on the first watcher started after that merge: the file never existed while
-        # the guards ran for two hours.
+        # predating it reads the watcher every turn and cannot record having done it, and the file
+        # it would have written stays absent however long the reading goes on.
         said = watch_until().output
 
         # Act / Assert
-        self.assertIn("has never carried a stamp", said)
+        self.assertIn("carries no stamp at all", said)
 
     def test_Given_AStampThatWentStale_When_ItRetires_Then_ItSaysNothingAboutTheThirdState(self):
         # Arrange — a file that exists and is old is the reader having stopped, which the sentence
@@ -548,7 +547,7 @@ class RetirementTests(unittest.TestCase):
         said = watch_until(seed_asked=0).output
 
         # Act / Assert
-        self.assertNotIn("has never carried a stamp", said)
+        self.assertNotIn("carries no stamp at all", said)
 
     def test_Given_ARetiringWatcher_When_ItStops_Then_ItLetsGoOfTheLock(self):
         # Act

--- a/scripts/pr/test_settle.py
+++ b/scripts/pr/test_settle.py
@@ -532,6 +532,24 @@ class RetirementTests(unittest.TestCase):
                           "blocks a Stop again" in said,
                           "python3 scripts/pr/settle.py watch" in said), (True, True, True))
 
+    def test_Given_NothingEverStamped_When_ItRetires_Then_ItNamesTheReaderThatCouldNotRecord(self):
+        # Arrange — a guard resolves the stamping code from its own checkout, so one at a commit
+        # predating it reads the watcher every turn and cannot record having done it. Measured on
+        # this machine, on the first watcher started after that merge: the file never existed while
+        # the guards ran for two hours.
+        said = watch_until().output
+
+        # Act / Assert
+        self.assertIn("has never carried a stamp", said)
+
+    def test_Given_AStampThatWentStale_When_ItRetires_Then_ItSaysNothingAboutTheThirdState(self):
+        # Arrange — a file that exists and is old is the reader having stopped, which the sentence
+        # above would misdescribe as a checkout that cannot record.
+        said = watch_until(seed_asked=0).output
+
+        # Act / Assert
+        self.assertNotIn("has never carried a stamp", said)
+
     def test_Given_ARetiringWatcher_When_ItStops_Then_ItLetsGoOfTheLock(self):
         # Act
         watched = watch_until()

--- a/scripts/pr/test_settle.py
+++ b/scripts/pr/test_settle.py
@@ -525,8 +525,10 @@ class RetirementTests(unittest.TestCase):
         # three leaves whoever reads it to work out the rest.
         said = watch_until().output
 
-        # Act / Assert
-        self.assertEqual(("nothing stamped" in said,
+        # Act / Assert — "since anything last stamped" rather than "nothing stamped": the file is
+        # normally there and normally old, and a reader who has been editing all session reads the
+        # second as the stamping being broken when what happened is that they stopped.
+        self.assertEqual(("since anything last stamped" in said,
                           "blocks a Stop again" in said,
                           "python3 scripts/pr/settle.py watch" in said), (True, True, True))
 

--- a/scripts/pr/test_settle.py
+++ b/scripts/pr/test_settle.py
@@ -541,13 +541,15 @@ class RetirementTests(unittest.TestCase):
         # Act / Assert
         self.assertIn("carries no stamp at all", said)
 
-    def test_Given_AStampThatWentStale_When_ItRetires_Then_ItSaysNothingAboutTheThirdState(self):
+    def test_Given_AStampThatWentStale_When_ItRetires_Then_ItReportsTheIntervalAndNothingMore(self):
         # Arrange — a file that exists and is old is the reader having stopped, which the sentence
-        # above would misdescribe as a checkout that cannot record.
+        # for the third state would misdescribe as a checkout that cannot record.
         said = watch_until(seed_asked=0).output
 
-        # Act / Assert
-        self.assertNotIn("carries no stamp at all", said)
+        # Act / Assert — paired, because the absence alone is also what a message that never gained
+        # the sentence looks like.
+        self.assertEqual(("since anything last stamped" in said,
+                          "carries no stamp at all" in said), (True, False))
 
     def test_Given_ARetiringWatcher_When_ItStops_Then_ItLetsGoOfTheLock(self):
         # Act


### PR DESCRIPTION
A retiring watcher said it was *"retiring after Ns in which nothing stamped ASKED"*, and that reads
as the stamping being broken. Two things it cannot be read as are the two that are usually true: the
interval is floored by the watcher's own start, so a first stamp that never arrived looks exactly
like one that stopped, and a reader who simply stopped editing gets the same sentence as one whose
guards cannot record what they read.

It now says how long since anything last stamped, and names the floor. Where no stamp is readable at
all it adds the third state and its remedy — a guard resolves the stamping code from its own
checkout, so one at a commit predating it reads the watcher on every turn and cannot record having
done it, and pulling there is the fix rather than starting another watcher.

The stale case is asserted against the interval it does report, not only against the sentence it does
not: an absence alone is also what a message that never gained the sentence looks like.

No documentation impact: CONTRIBUTING.md names the watcher and what retiring costs, not its wording.

Closes #739
Closes #742
