### PR TITLE
tooling(velvet): key a receipt on what a mutant could cover, not on every byte

### DIFF
--- a/scripts/test_quality/mutation_check.py
+++ b/scripts/test_quality/mutation_check.py
@@ -1077,25 +1077,40 @@ def refusal(code, message):
 
 
 def digestible(text):
-    """The file with its comments blanked and its blank lines dropped.
+    """The file with its comments removed, and the lines they emptied with them.
 
     What a receipt is keyed on has to move when what a campaign measured moves, and no further. A
     comment carries no mutant -- `mask_spans` reads it as something other than code, and the
     generator skips it -- so an edit to one voids a receipt over a change no operator could have
-    seen. Measured on `main`: 17 of the 127 commits touching a non-test production source over the
-    last 300 are comment-only, and a review round here is largely prose, so the ones most likely to
-    be comment-only land *after* the campaign they void.
+    seen, and a review round here is largely prose.
 
-    A string literal is masked for generation and kept here, because editing one changes behaviour
-    a mutant could have covered. A directive is kept for the same reason: it decides what compiles.
+    A string literal is masked for generation and kept here, because editing one changes behaviour a
+    mutant could have covered. A directive is kept for the same reason: it decides what compiles. A
+    blank line inside a verbatim string is part of the value, and a verbatim span is the only one
+    `mask_spans` reads across lines, so a line holding one is never dropped as empty.
     """
-    mask = [True] * len(text)
+    keep = [True] * len(text)
+    quoted = [False] * len(text)
     for start, end, kind in mask_spans(text):
-        if kind in (LINE_COMMENT, BLOCK_COMMENT):
-            for offset in range(start, end):
-                mask[offset] = False
-    kept = "".join(text[offset] for offset in range(len(text)) if mask[offset])
-    return "\n".join(line for line in kept.splitlines() if line.strip())
+        for offset in range(start, min(end, len(text))):
+            if kind in (LINE_COMMENT, BLOCK_COMMENT):
+                keep[offset] = False
+            elif kind == VERBATIM:
+                quoted[offset] = True
+
+    lines, held, spans = [], [], False
+    for offset, character in enumerate(text):
+        if character == "\n":
+            # The newline too: a line that is empty inside a verbatim string holds nothing else to
+            # ask, and it is the one this has to keep.
+            lines.append(("".join(held), spans or quoted[offset]))
+            held, spans = [], False
+            continue
+        spans = spans or quoted[offset]
+        if keep[offset]:
+            held.append(character)
+    lines.append(("".join(held), spans))
+    return "\n".join(line for line, held_a_span in lines if line.strip() or held_a_span)
 
 
 def scope_digest(base, targets, project, platform):
@@ -1122,7 +1137,7 @@ def scope_digest(base, targets, project, platform):
         # path and an unresolved one reach the same file and digest differently.
         parts.append("{}:{}".format(
             relative_to(path, project).as_posix(),
-            hashlib.sha256(digestible(path.read_text()).encode()).hexdigest()))
+            hashlib.sha256(digestible(path.read_text(encoding="utf-8")).encode()).hexdigest()))
     return hashlib.sha256("\n".join(parts).encode()).hexdigest()
 
 

--- a/scripts/test_quality/mutation_check.py
+++ b/scripts/test_quality/mutation_check.py
@@ -1133,7 +1133,7 @@ def scope_digest(base, targets, project, platform):
     and this stays valid across it; including tests would void the receipt on the ordinary act of
     adding one after the run, which is most of a branch's commits.
 
-    Nor a comment: `digestible` blanks them before the hash, so a receipt survives the prose
+    Nor a comment: `digestible` takes them out before the hash, so a receipt survives the prose
     correction a review round leaves behind. Anything narrower than the whole bytes has to be
     checked for what it stops voiding on, and this stops on exactly the spans the generator already
     refuses to mutate.

--- a/scripts/test_quality/mutation_check.py
+++ b/scripts/test_quality/mutation_check.py
@@ -1076,6 +1076,28 @@ def refusal(code, message):
     return code
 
 
+def digestible(text):
+    """The file with its comments blanked and its blank lines dropped.
+
+    What a receipt is keyed on has to move when what a campaign measured moves, and no further. A
+    comment carries no mutant -- `mask_spans` reads it as something other than code, and the
+    generator skips it -- so an edit to one voids a receipt over a change no operator could have
+    seen. Measured on `main`: 17 of the 127 commits touching a non-test production source over the
+    last 300 are comment-only, and a review round here is largely prose, so the ones most likely to
+    be comment-only land *after* the campaign they void.
+
+    A string literal is masked for generation and kept here, because editing one changes behaviour
+    a mutant could have covered. A directive is kept for the same reason: it decides what compiles.
+    """
+    mask = [True] * len(text)
+    for start, end, kind in mask_spans(text):
+        if kind in (LINE_COMMENT, BLOCK_COMMENT):
+            for offset in range(start, end):
+                mask[offset] = False
+    kept = "".join(text[offset] for offset in range(len(text)) if mask[offset])
+    return "\n".join(line for line in kept.splitlines() if line.strip())
+
+
 def scope_digest(base, targets, project, platform):
     """What a campaign measured, in a form a later check can compare a tree against.
 
@@ -1088,13 +1110,19 @@ def scope_digest(base, targets, project, platform):
     What it does not cover is a test-side change. Removing a test can make a killed mutant survive,
     and this stays valid across it; including tests would void the receipt on the ordinary act of
     adding one after the run, which is most of a branch's commits.
+
+    Nor a comment: `digestible` blanks them before the hash, so a receipt survives the prose
+    correction a review round leaves behind. Anything narrower than the whole bytes has to be
+    checked for what it stops voiding on, and this stops on exactly the spans the generator already
+    refuses to mutate.
     """
     parts = [base, platform]
     for path in sorted(targets, key=str):
         # Repository-relative, so a receipt does not depend on where the checkout sits: a resolved
         # path and an unresolved one reach the same file and digest differently.
-        parts.append("{}:{}".format(relative_to(path, project).as_posix(),
-                                    hashlib.sha256(path.read_bytes()).hexdigest()))
+        parts.append("{}:{}".format(
+            relative_to(path, project).as_posix(),
+            hashlib.sha256(digestible(path.read_text()).encode()).hexdigest()))
     return hashlib.sha256("\n".join(parts).encode()).hexdigest()
 
 

--- a/scripts/test_quality/test_mutation_check.py
+++ b/scripts/test_quality/test_mutation_check.py
@@ -2100,6 +2100,8 @@ class ReceiptTests(unittest.TestCase):
         # Assert
         self.assertEqual(code, 0)
 
+    # GREEN_ON_BASE(refactor): the byte hash refused this too. It is the shape the line-dropping
+    # this change adds could reach and must not, and only running it says whether it did.
     def test_Given_APassingCampaign_When_ABlankLineInsideAVerbatimStringGoes_Then_ItIsRefusedAgain(self):
         # Arrange — an empty line inside a verbatim string is part of the value, and it is the one
         # place where removing a line changes behaviour. The digest drops the lines a comment

--- a/scripts/test_quality/test_mutation_check.py
+++ b/scripts/test_quality/test_mutation_check.py
@@ -1946,6 +1946,21 @@ class EmitLinesTests(unittest.TestCase):
         self.assertEqual(campaign.seen, [])
 
 
+PROBE_WITH_VERBATIM = """\
+namespace Velvet
+{
+    internal static class Probe
+    {
+        internal static bool Ready(int a, int b) => a <= b && Name().Length > 0;
+
+        internal static string Name() => @"a
+
+b";
+    }
+}
+"""
+
+
 PROBE_WITH_LITERAL = """\
 namespace Velvet
 {
@@ -2074,8 +2089,7 @@ class ReceiptTests(unittest.TestCase):
 
     def test_Given_APassingCampaign_When_OnlyACommentIsAdded_Then_TheReceiptStillCovers(self):
         # Arrange — a comment carries no mutant, so voiding on one asks for a fresh campaign over a
-        # byte-identical mutant set. Measured on main: 17 of the 127 commits touching a non-test
-        # production source over the last 300 are comment-only.
+        # byte-identical mutant set.
         campaign = StubbedCampaign()
         campaign.write_receipt("pass")
         campaign.source.write_text(campaign.source.read_text() + "// an edit after the run\n")
@@ -2085,6 +2099,20 @@ class ReceiptTests(unittest.TestCase):
 
         # Assert
         self.assertEqual(code, 0)
+
+    def test_Given_APassingCampaign_When_ABlankLineInsideAVerbatimStringGoes_Then_ItIsRefusedAgain(self):
+        # Arrange — an empty line inside a verbatim string is part of the value, and it is the one
+        # place where removing a line changes behaviour. The digest drops the lines a comment
+        # emptied, so this is the shape that drop must not reach.
+        campaign = StubbedCampaign(PROBE_WITH_VERBATIM)
+        campaign.write_receipt("pass")
+        campaign.source.write_text(campaign.source.read_text().replace("a\n\nb", "a\nb"))
+
+        # Act
+        code = campaign.run_over_diff("--receipt")
+
+        # Assert
+        self.assertEqual(code, mutation_check.RECEIPT_REFUSAL)
 
     # GREEN_ON_BASE(refactor): the byte hash refused a literal edit too, and this pins that the narrower keying still does.
     def test_Given_APassingCampaign_When_AStringLiteralIsEdited_Then_ItIsRefusedAgain(self):

--- a/scripts/test_quality/test_mutation_check.py
+++ b/scripts/test_quality/test_mutation_check.py
@@ -1946,6 +1946,19 @@ class EmitLinesTests(unittest.TestCase):
         self.assertEqual(campaign.seen, [])
 
 
+PROBE_WITH_LITERAL = """\
+namespace Velvet
+{
+    internal static class Probe
+    {
+        internal static bool Ready(int a, int b) => a <= b && Name() == "ready";
+
+        internal static string Name() => "ready";
+    }
+}
+"""
+
+
 class ReceiptTests(unittest.TestCase):
     """What asks whether the campaign was run at all.
 
@@ -2045,11 +2058,42 @@ class ReceiptTests(unittest.TestCase):
         # Assert
         self.assertEqual(code, mutation_check.RECEIPT_REFUSAL)
 
+    # GREEN_ON_BASE(refactor): the byte hash refused a code edit too; what moves is the comment case beside it.
     def test_Given_APassingCampaign_When_AMutatedFileIsEditedWithoutCommitting_Then_ItIsRefusedAgain(self):
         # Arrange — the reading the head tree sha cannot take: this edit moves no tree sha at all.
         campaign = StubbedCampaign()
         campaign.write_receipt("pass")
+        campaign.source.write_text(
+            campaign.source.read_text().replace("a <= b", "a < b"))
+
+        # Act
+        code = campaign.run_over_diff("--receipt")
+
+        # Assert
+        self.assertEqual(code, mutation_check.RECEIPT_REFUSAL)
+
+    def test_Given_APassingCampaign_When_OnlyACommentIsAdded_Then_TheReceiptStillCovers(self):
+        # Arrange — a comment carries no mutant, so voiding on one asks for a fresh campaign over a
+        # byte-identical mutant set. Measured on main: 17 of the 127 commits touching a non-test
+        # production source over the last 300 are comment-only.
+        campaign = StubbedCampaign()
+        campaign.write_receipt("pass")
         campaign.source.write_text(campaign.source.read_text() + "// an edit after the run\n")
+
+        # Act
+        code = campaign.run_over_diff("--receipt")
+
+        # Assert
+        self.assertEqual(code, 0)
+
+    # GREEN_ON_BASE(refactor): the byte hash refused a literal edit too, and this pins that the narrower keying still does.
+    def test_Given_APassingCampaign_When_AStringLiteralIsEdited_Then_ItIsRefusedAgain(self):
+        # Arrange — a literal is masked for generation and kept in the digest: editing one changes
+        # behaviour a mutant could have covered, so the receipt does not carry across it.
+        campaign = StubbedCampaign(body=PROBE_WITH_LITERAL)
+        campaign.write_receipt("pass")
+        campaign.source.write_text(
+            campaign.source.read_text().replace('"ready"', '"steady"'))
 
         # Act
         code = campaign.run_over_diff("--receipt")


### PR DESCRIPTION
A mutation receipt is keyed on the bytes of every file the campaign measured, so any edit to one
voids it. That is right for a change an operator could have generated a mutant over, and wrong for a
comment: `mask_spans` reads a comment as something other than code and the generator skips it, so
the campaign that would be re-run measures a byte-identical mutant set. Of the last 300 commits on
`main` touching a non-test production source, 17 are comment-only — and a review round here is
largely prose, so the edits most likely to be comment-only land after the campaign they void.

The digest now hashes the file with its comments removed, and with the lines they emptied removed
too. String literals and preprocessor directives stay: editing either changes behaviour a mutant
could have covered, and a directive decides what compiles. A verbatim string is the one span
`mask_spans` reads across lines, so a line holding any of it survives that emptying — an empty line
inside one is part of the value.

The receipt is read at a moment no tree sha can answer for, so the cases drive a campaign over a
working tree edited after the run rather than comparing hashes.

No documentation impact: CONTRIBUTING.md names what a receipt refuses, not what it is keyed on.

Closes #746
