### PR TITLE
tooling(velvet): give the operator the aggregate floor cannot see a floor of its own

### DIFF
--- a/scripts/test_quality/test_mutation_check.py
+++ b/scripts/test_quality/test_mutation_check.py
@@ -225,6 +225,32 @@ class GenerationAcrossLinesTests(unittest.TestCase):
         # Assert
         self.assertEqual(lines, [1, 2, 3, 4, 5, 6, 7, 8, 9])
 
+    # GREEN_ON_BASE(characterization): the generator already clears this floor, and what the case
+    # separates is a future widening rather than this change.
+    def test_Given_TheRepositorysOwnSources_When_LinesAreRemoved_Then_ThatOperatorHoldsItsOwn(self):
+        # Arrange — `total > 8000` clears with room for this operator to lose a third of its output
+        # twice over, so it cannot say which one went quiet. Shortening STATEMENT_BOUNDARY to
+        # (";", "}") takes `line removed` from 2926 to 2058 package-wide and the whole suite stays
+        # green but for one case written for the join operator, which catches it by accident.
+        #
+        # 2500 sits below the band the shipped generator holds — 2788 to 2926 over the last eighty
+        # first-parent commits, largest single-commit fall 8 — and well above what that widening
+        # produces.
+        sources = [path for path in RUNTIME.rglob("*.cs")
+                   if "/Tests/" not in path.as_posix() and "/Plugins/" not in path.as_posix()]
+
+        # Act
+        removed = sum(
+            1
+            for path in sources
+            for mutant in mutation_check.mutations_for(
+                path, path.read_text(),
+                set(range(1, len(path.read_text().splitlines()) + 1)))
+            if mutant.operator == "line removed")
+
+        # Assert — the source count rides along because an empty scan clears any floor by arithmetic.
+        self.assertEqual((len(sources) > 200, removed > 2500), (True, True))
+
     def test_Given_TheRepositorysOwnSources_When_MutantsAreGenerated_Then_TheTotalHoldsAFloor(self):
         # Arrange — the count is what moved: 2097 across these files before the loop variable stopped
         # rebinding the file's source, and over eleven thousand after. A floor rather than the exact

--- a/scripts/test_quality/test_mutation_check.py
+++ b/scripts/test_quality/test_mutation_check.py
@@ -225,46 +225,30 @@ class GenerationAcrossLinesTests(unittest.TestCase):
         # Assert
         self.assertEqual(lines, [1, 2, 3, 4, 5, 6, 7, 8, 9])
 
-    # GREEN_ON_BASE(characterization): the generator already clears this floor, and what the case
-    # separates is a future widening rather than this change.
-    def test_Given_TheRepositorysOwnSources_When_LinesAreRemoved_Then_ThatOperatorHoldsItsOwn(self):
-        # Arrange — `total > 8000` clears with room for this operator to lose a third of its output
-        # twice over, so it cannot say which one went quiet. Shortening STATEMENT_BOUNDARY to
-        # (";", "}") takes `line removed` from 2926 to 2058 package-wide and the whole suite stays
-        # green but for one case written for the join operator, which catches it by accident.
+    # GREEN_ON_BASE(characterization): the total already cleared its floor, and the per-operator one
+    # this adds beside it is cleared by the shipped generator too. What either separates is a later
+    # narrowing, which only running them says anything about.
+    def test_Given_TheRepositorysOwnSources_When_MutantsAreGenerated_Then_EachTotalHoldsItsFloor(self):
+        # Arrange — floors rather than the exact numbers, which every edit to the package moves.
         #
-        # 2500 sits below the band the shipped generator holds — 2788 to 2926 over the last eighty
-        # first-parent commits, largest single-commit fall 8 — and well above what that widening
-        # produces.
+        # The second floor is why there are two: dropping "{" and ":" from STATEMENT_BOUNDARY takes
+        # `line removed` down by more than a third and leaves the total above 8000, so the aggregate
+        # clears while the operator that fell has gone quiet. 2500 is under what the generator
+        # produces today with room for ordinary drift, and above what that narrowing leaves.
         sources = [path for path in RUNTIME.rglob("*.cs")
                    if "/Tests/" not in path.as_posix() and "/Plugins/" not in path.as_posix()]
 
-        # Act
-        removed = sum(
-            1
-            for path in sources
-            for mutant in mutation_check.mutations_for(
-                path, path.read_text(),
-                set(range(1, len(path.read_text().splitlines()) + 1)))
-            if mutant.operator == "line removed")
+        # Act — one scan for both, since a second would only re-read the same files.
+        mutants = [mutant
+                   for path in sources
+                   for mutant in mutation_check.mutations_for(
+                       path, path.read_text(),
+                       set(range(1, len(path.read_text().splitlines()) + 1)))]
+        removed = sum(1 for mutant in mutants if mutant.operator == "line removed")
 
         # Assert — the source count rides along because an empty scan clears any floor by arithmetic.
-        self.assertEqual((len(sources) > 200, removed > 2500), (True, True))
-
-    def test_Given_TheRepositorysOwnSources_When_MutantsAreGenerated_Then_TheTotalHoldsAFloor(self):
-        # Arrange — the count is what moved: 2097 across these files before the loop variable stopped
-        # rebinding the file's source, and over eleven thousand after. A floor rather than the exact
-        # number, which every edit to the package moves.
-        sources = [path for path in (RUNTIME).rglob("*.cs")
-                   if "/Tests/" not in path.as_posix() and "/Plugins/" not in path.as_posix()]
-
-        # Act
-        total = sum(len(mutation_check.mutations_for(
-            path, path.read_text(), set(range(1, len(path.read_text().splitlines()) + 1))))
-            for path in sources)
-
-        # Assert — the source count rides along because an empty scan clears any floor by arithmetic.
-        self.assertEqual((len(sources) > 200, total > 8000), (True, True))
+        self.assertEqual((len(sources) > 200, len(mutants) > 8000, removed > 2500),
+                         (True, True, True))
 
 
 class StatementChainCutTests(unittest.TestCase):


### PR DESCRIPTION
The generator's only floor is the package-wide mutant total, and it clears with enough room that a
single operator can lose most of its output without moving it. Dropping `{` and `:` from
`STATEMENT_BOUNDARY` takes `line removed` down by more than a third — measured at 2947 today and 1804
after — and the total falls from 11125 to 9920, still over the 8000 the floor asks for. The suite
stays green but for one case written for the join operator, which catches it by accident.

So the floor gets a second element: `line removed` on its own. 2500 is under what the generator
produces today with room for ordinary drift, and above what that narrowing leaves. Both ride in the
tuple the existing case already asserts, over the scan it already runs — a second scan of the package
would only re-read the same files.

The two floors are a floor rather than an exact count for the same reason as before: every edit to
the package moves the number, and a count that has to be updated on every edit stops being read.

No documentation impact: CONTRIBUTING.md names what a campaign refuses, not what the generator emits.

Closes #751
