### PR TITLE
tooling(velvet): read whether the line reached main from its entries, not its ancestry

### DIFF
--- a/.claude/hooks/report/unreleased_maintenance_line.py
+++ b/.claude/hooks/report/unreleased_maintenance_line.py
@@ -92,22 +92,48 @@ def waiting(text):
     return [line for line in body.splitlines() if line.startswith("- ")]
 
 
-def unmerged_into_main(cwd, line):
-    """Whether `main` has not taken this line, and by how much.
+def items(text):
+    """Every CHANGELOG item in the text, with its runs of whitespace flattened.
 
-    Asked of the ancestry rather than of each commit: a merge is what the practice prescribes, and
-    once it has happened there is nothing left to interpret. A line `main` already contains answers
-    None however many commits it carries.
+    A wrapped item is one item however the paragraph was rewrapped on the way across, and the first
+    line alone would call a rewrapped one missing.
     """
-    contained = subprocess.run(
-        ["git", "-C", str(cwd), "merge-base", "--is-ancestor", line, "origin/main"],
-        capture_output=True, text=True)
-    if contained.returncode == 0:
+    found, held = [], None
+    for line in (text or "").splitlines():
+        if line.startswith("- "):
+            if held is not None:
+                found.append(" ".join(held.split()))
+            held = line[2:]
+        elif held is not None:
+            if not line.strip():
+                found.append(" ".join(held.split()))
+                held = None
+            else:
+                held += " " + line
+    if held is not None:
+        found.append(" ".join(held.split()))
+    return found
+
+
+def unmerged_into_main(cwd, line):
+    """The items this line's CHANGELOG carries that `main`'s does not, or None.
+
+    Read of the content rather than of the ancestry, because nothing that reaches `main` here can
+    leave an ancestry: both branches refuse a direct push, so every change arrives through a pull
+    request and `settle.py` squashes it, which writes a commit whose only parent is `main`. Measured
+    after the line was merged forward -- `merge-base --is-ancestor` was still false, and `git cherry`
+    reported all eight commits outstanding, the squash having combined their patches into one whose
+    id matches none of them.
+
+    Weaker than an ancestry: an item reworded on the way across reads as missing. That is a line too
+    many on a report, where the ancestry reading was a report nobody could ever clear.
+    """
+    there = answer(["show", f"origin/main:{CHANGELOG}"], cwd, READ_TIMEOUT)
+    here = answer(["show", f"{line}:{CHANGELOG}"], cwd, READ_TIMEOUT)
+    if there is None or here is None:
         return None
-    counted = answer(["rev-list", "--count", f"origin/main..{line}"], cwd, READ_TIMEOUT)
-    if counted is None:
-        return None
-    return counted.strip()
+    outstanding = [item for item in items(here) if item not in set(items(there))]
+    return outstanding or None
 
 
 def report(cwd):
@@ -134,13 +160,15 @@ def main():
     answer(["fetch", "--quiet", "origin", "+refs/heads/*:refs/remotes/origin/*"], cwd, FETCH_TIMEOUT)
     said = list(report(cwd))
     for line in lines(cwd):
-        behind = unmerged_into_main(cwd, line)
-        if behind:
+        outstanding = unmerged_into_main(cwd, line)
+        if outstanding:
             said.append(
-                "main does not contain {}: {} commit(s) of it sit outside.\n"
+                "main does not carry {} CHANGELOG {} that {} does, starting with:\n"
+                "  {}{}\n"
                 "A fix made on the line has to reach main, or a branch cut from main reproduces what\n"
-                "it fixed. Merge the line forward — git then records that it did, and this stops\n"
-                "asking.".format(line, behind))
+                "it fixed. Carry them across — `cherry-pick -x` names where each came from.".format(
+                    len(outstanding), "entry" if len(outstanding) == 1 else "entries", line,
+                    outstanding[0][:96], "…" if len(outstanding[0]) > 96 else ""))
     if said:
         print("\n\n".join(said))
     return 0

--- a/scripts/hooks/test_unreleased_maintenance_line.py
+++ b/scripts/hooks/test_unreleased_maintenance_line.py
@@ -129,8 +129,11 @@ class LineMainHasNotTaken(unittest.TestCase):
         # Act
         done = run(clone)
 
-        # Assert
-        self.assertNotIn("main does not carry", done.stdout)
+        # Assert — the first reading rides along, because a run that printed nothing at all satisfies
+        # the absence too. "main does not" covers the ancestry wording as well as this one, which is
+        # what the base prints here.
+        self.assertEqual(("holds 1 unreleased CHANGELOG entry" in done.stdout,
+                          "main does not" in done.stdout), (True, False))
 
     def test_Given_ALineMainHasMerged_When_Reported_Then_NothingIsSaid(self):
         # Arrange — once the merge has happened there is nothing left to interpret, and a report that

--- a/scripts/hooks/test_unreleased_maintenance_line.py
+++ b/scripts/hooks/test_unreleased_maintenance_line.py
@@ -90,7 +90,11 @@ def repository(branch, changelog, merged=True):
     else:
         (origin / CHANGELOG).write_text(changelog)
         git(origin, "commit", "--quiet", "--allow-empty", "-am", "more")
-    if merged and branch != "main":
+    if merged == "squash" and branch != "main":
+        # What every merge onto main here actually is: the content arrives, the parent does not.
+        git(origin, "merge", "--quiet", "--squash", branch)
+        git(origin, "commit", "--quiet", "-m", "carry the line forward")
+    elif merged and branch != "main":
         git(origin, "merge", "--quiet", "--no-edit", "-m", "merge forward", branch)
     clone = root / "clone"
     subprocess.run(["git", "clone", "--quiet", str(origin), str(clone)],
@@ -99,22 +103,34 @@ def repository(branch, changelog, merged=True):
 
 
 class LineMainHasNotTaken(unittest.TestCase):
-    """The second reading, asked of git's ancestry rather than of what a pull request says.
+    """The second reading, asked of the CHANGELOG rather than of git's ancestry.
 
-    #777 measured two per-commit readings failing, and a third that works by reading prose. This one
-    is the question the practice already answers: merge the line forward, and git records that it did.
+    Every merge onto main here is a squash, which writes a commit whose only parent is main — so an
+    ancestry reading is false forever whatever anyone does, and a patch-id reading is too, the squash
+    having combined the line's patches into one whose id matches none of them.
     """
 
-    def test_Given_ALineMainHasNotMerged_When_Reported_Then_ItIsNamedWithACount(self):
-        # Arrange — a line carrying a commit main cannot reach, which is what a fix made there and
-        # never carried forward looks like.
-        clone = repository("2.x", EMPTY, merged=False)
+    def test_Given_ALineMainHasNotTaken_When_Reported_Then_ItsOutstandingEntriesAreNamed(self):
+        # Arrange — a line carrying an entry main does not, which is what a fix made there and never
+        # carried forward looks like.
+        clone = repository("2.x", WAITING, merged=False)
 
         # Act
         done = run(clone)
 
         # Assert
-        self.assertIn("main does not contain origin/2.x: 1 commit(s)", done.stdout)
+        self.assertIn("main does not carry 1 CHANGELOG entry that origin/2.x does", done.stdout)
+
+    def test_Given_ALineCarriedForwardBySquash_When_Reported_Then_NothingIsSaidAboutIt(self):
+        # Arrange — the content is on main and the ancestry is not, which is every forward merge this
+        # repository can perform.
+        clone = repository("2.x", WAITING, merged="squash")
+
+        # Act
+        done = run(clone)
+
+        # Assert
+        self.assertNotIn("main does not carry", done.stdout)
 
     def test_Given_ALineMainHasMerged_When_Reported_Then_NothingIsSaid(self):
         # Arrange — once the merge has happened there is nothing left to interpret, and a report that


### PR DESCRIPTION
The maintenance-line report asked `git merge-base --is-ancestor origin/2.x origin/main`. Nothing that
reaches `main` here can make that true: both branches refuse a direct push, so every change arrives
through a pull request and `settle.py` squashes it, writing a commit whose only parent is `main`.

Measured after #819 merged the line forward — `main`'s CHANGELOG carries the `2.1.1`, `2.1.2` and
`2.1.3` sections and the code landed with them — the reading was still false, and `git cherry`, the
usual answer to a lost ancestry, reported all eight commits outstanding: the squash combined their
patches into one whose id matches none of them. So the report said "unmerged" for as long as the
branch exists, whatever anyone did about it, which is the shape a reader learns to skip.

It reads the CHANGELOG instead. Every change on the line writes an entry, so "every entry the line's
CHANGELOG carries also appears in `main`'s" asks the same question of the artefact that records
changes, and a squash preserves it exactly. Items are compared with their whitespace flattened and
their wrapped continuations joined, because a paragraph rewrapped on the way across is the same item.

Weaker than an ancestry: an item *reworded* on the way across still reads as missing. That is a line
too many on a report, against a reading nobody could ever clear.

Measured on this repository at the time of writing: two entries outstanding, which is exactly the two
commits the line holds that `main` has not taken.

The squash case is what the suite gained — the state the old reading could not answer for — and it is
paired with the first reading, because a run that printed nothing at all satisfies an absence too.

No documentation impact: CONTRIBUTING.md names the report, not what it reads.

Closes #830
