### PR TITLE
tooling(velvet): read the body when the check runs, so its own remedy works

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -226,13 +226,17 @@ jobs:
       # Every other reading here is of one tree, so a branch carrying a breaking entry is invisible
       # to all of them — which is how v3.0.0 shipped twelve of the thirteen written for it. Skipped
       # on merge_group, where no body is left to name anything: the pull request already answered.
+      # The body is read here rather than taken from the event, because what this refusal asks for is
+      # an edit to it. `pull_request` does not fire on `edited` — and cannot be made to, since both
+      # gated triggers are held childless — so an event-carried body makes the refusal unclearable
+      # except by a push, and `gh run rerun` replays the same payload it already refused.
       - if: github.event_name == 'pull_request'
         env:
           BASE: ${{ github.event.pull_request.base.sha }}
-          BODY: ${{ github.event.pull_request.body }}
+          NUMBER: ${{ github.event.pull_request.number }}
           GH_TOKEN: ${{ github.token }}
         run: |
-          printf '%s' "$BODY" > /tmp/pr-body.md
+          gh pr view "$NUMBER" --json body -q .body > /tmp/pr-body.md
           python3 scripts/release/breaking_in_flight_check.py \
             --base "$BASE" --result HEAD --body-file /tmp/pr-body.md
 

--- a/scripts/release/breaking_in_flight_check.py
+++ b/scripts/release/breaking_in_flight_check.py
@@ -161,7 +161,8 @@ def main():
     sys.stderr.write(
         "\nA breaking entry is written for the next major, so the major closing here is the one it\n"
         "was written for. Say in the body which of these the version carries and which it does not —\n"
-        "'not this one' is a decision, and going without one is what this refuses.\n")
+        "'not this one' is a decision, and going without one is what this refuses. The body is read\n"
+        "when this runs, so re-running it after the edit is enough.\n")
     return UNNAMED
 
 


### PR DESCRIPTION
`breaking_in_flight_check.py` refuses a version-closing pull request whose body does not say what it
does with the breaking entries in flight, and the remedy it prints is an edit to that body. The
workflow passed the body as `github.event.pull_request.body`, which is the body **as the triggering
event carried it**, so the edit started no run — `pull_request` does not fire on `edited` — and
`gh run rerun` replayed the same payload and printed the same refusal over text that already answered
it. Measured on #819: only a push cleared it.

Subscribing to `edited` is the direct answer and this repository refuses it on purpose:
`WorkflowTriggerCoverageTests` fails on any indented child under `pull_request` or `merge_group`,
because judging per key is what let a branch filter through while a path filter was being watched
for.

So the step reads the body when it runs. That is a check answering about a state its own trigger did
not carry, which is the property the payload form gave for free — but a refusal whose remedy does not
work is the more expensive of the two, and this one is asking for a decision rather than for a tree.
The read fails the step outright rather than falling through to an empty body, so an API that will
not answer reports itself instead of arriving as "you did not name it".

The refusal now says a re-run is enough, which it was not before.

No documentation impact: CONTRIBUTING.md names what the check refuses, not where it reads the body.

Closes #829
