### PR TITLE
tooling(velvet): read the heartbeat once, and survive bytes that are not UTF-8

### DIFF
--- a/scripts/pr/test_settle.py
+++ b/scripts/pr/test_settle.py
@@ -848,12 +848,43 @@ class HeartbeatTests(unittest.TestCase):
                 # Act / Assert
                 self.assertEqual(settle.watch(Path("."), "main"), 1)
 
+    # A truncated write, a disk fault, a file written by something else. The three readers answer
+    # different questions, so each gets its own case rather than one standing in for the others.
+    CORRUPT = b"\xff\xfe1000 1\n"
+
+    def test_Given_AHeartbeatThatIsNotUtf8_When_LivenessIsRead_Then_ItAnswersRatherThanRaising(self):
+        # Arrange — a UnicodeDecodeError is a ValueError, so it goes past an OSError catch and out of
+        # whichever PreToolUse or Stop hook was asking.
+        with self.heartbeat(self.CORRUPT):
+            # Act / Assert
+            self.assertFalse(settle.watcher_state.alive(now=1060))
+
+    def test_Given_AHeartbeatThatIsNotUtf8_When_TheUnreadableReadingIsAsked_Then_ItAnswersRatherThanRaising(self):
+        # Arrange — this reading exists to separate "nothing is watching" from "the reading failed",
+        # and raising is neither.
+        with self.heartbeat(self.CORRUPT):
+            # Act / Assert
+            self.assertFalse(settle.watcher_state.unreadable_beat(now=1060))
+
+    def test_Given_AHeartbeatThatIsNotUtf8_When_AnotherWatcherIsLookedFor_Then_ItAnswersRatherThanRaising(self):
+        # Arrange — this one decides whether a second watcher may start, so a raise here refuses the
+        # recovery the other two name.
+        with self.heartbeat(self.CORRUPT):
+            # Act / Assert
+            self.assertFalse(settle.watcher_state.beating_elsewhere(os.getpid(), now=1060))
+
     @contextlib.contextmanager
     def heartbeat(self, text):
-        """Both files a read touches: reading the first is what writes the second."""
+        """Both files a read touches: reading the first is what writes the second.
+
+        `text` may be bytes, which is how a heartbeat corrupted outside this process arrives.
+        """
         with tempfile.TemporaryDirectory(prefix="settle-beat-") as directory:
             path = Path(directory) / "beat"
-            path.write_text(text)
+            if isinstance(text, bytes):
+                path.write_bytes(text)
+            else:
+                path.write_text(text)
             with contextlib.ExitStack() as stack:
                 stack.enter_context(mock.patch.object(settle.watcher_state, "HEARTBEAT", path))
                 stack.enter_context(mock.patch.object(settle.watcher_state, "ASKED",

--- a/scripts/pr/test_settle.py
+++ b/scripts/pr/test_settle.py
@@ -852,26 +852,38 @@ class HeartbeatTests(unittest.TestCase):
     # different questions, so each gets its own case rather than one standing in for the others.
     CORRUPT = b"\xff\xfe1000 1\n"
 
+    def answered(self, reading):
+        """What the reading returned, or the name of what it raised instead.
+
+        The claim is that it answers, and an answer and a raise are the two outcomes to tell apart —
+        so the raise is turned into a value rather than left to end the case, which reports the same
+        way whether the reading raised or the file was never written.
+        """
+        with self.heartbeat(self.CORRUPT):
+            try:
+                return reading()
+            except Exception as raised:  # noqa: BLE001
+                return type(raised).__name__
+
     def test_Given_AHeartbeatThatIsNotUtf8_When_LivenessIsRead_Then_ItAnswersRatherThanRaising(self):
         # Arrange — a UnicodeDecodeError is a ValueError, so it goes past an OSError catch and out of
         # whichever PreToolUse or Stop hook was asking.
-        with self.heartbeat(self.CORRUPT):
-            # Act / Assert
-            self.assertFalse(settle.watcher_state.alive(now=1060))
+        # Act / Assert
+        self.assertIs(self.answered(lambda: settle.watcher_state.alive(now=1060)), False)
 
     def test_Given_AHeartbeatThatIsNotUtf8_When_TheUnreadableReadingIsAsked_Then_ItAnswersRatherThanRaising(self):
         # Arrange — this reading exists to separate "nothing is watching" from "the reading failed",
         # and raising is neither.
-        with self.heartbeat(self.CORRUPT):
-            # Act / Assert
-            self.assertFalse(settle.watcher_state.unreadable_beat(now=1060))
+        # Act / Assert
+        self.assertIs(self.answered(lambda: settle.watcher_state.unreadable_beat(now=1060)), False)
 
     def test_Given_AHeartbeatThatIsNotUtf8_When_AnotherWatcherIsLookedFor_Then_ItAnswersRatherThanRaising(self):
         # Arrange — this one decides whether a second watcher may start, so a raise here refuses the
         # recovery the other two name.
-        with self.heartbeat(self.CORRUPT):
-            # Act / Assert
-            self.assertFalse(settle.watcher_state.beating_elsewhere(os.getpid(), now=1060))
+        # Act / Assert
+        self.assertIs(
+            self.answered(lambda: settle.watcher_state.beating_elsewhere(os.getpid(), now=1060)),
+            False)
 
     @contextlib.contextmanager
     def heartbeat(self, text):

--- a/scripts/pr/watcher_state.py
+++ b/scripts/pr/watcher_state.py
@@ -120,6 +120,23 @@ def asked_ago(now=None):
     return stamp_age(text, time.time() if now is None else now)
 
 
+def beat_text():
+    """The heartbeat's text, or None when there is nothing readable to answer from.
+
+    A file whose bytes are not UTF-8 raises `UnicodeDecodeError`, which is a `ValueError` and so goes
+    straight past an `OSError` catch. Every reader below runs inside a `PreToolUse` or `Stop` hook,
+    where a raise exits non-zero for a reason having nothing to do with what the guard judges — and
+    the same shape had already killed `settle.py watch` at startup from a corrupt ready file.
+
+    One reader rather than the catch repeated three times, because that is what left the widening to
+    be done three times and done once.
+    """
+    try:
+        return HEARTBEAT.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+
+
 def alive(now=None):
     """Whether the process that wrote the heartbeat is running and wrote it recently.
 
@@ -127,9 +144,8 @@ def alive(now=None):
     without being told to.
     """
     note_asked(now)
-    try:
-        text = HEARTBEAT.read_text(encoding="utf-8")
-    except OSError:
+    text = beat_text()
+    if text is None:
         return False
     read = written(text)
     return (read is not None
@@ -145,9 +161,8 @@ def unreadable_beat(now=None):
     Something is watching; what failed is the reading. Separating the two is what lets a guard name
     the recovery, which is to end that watcher rather than to start another.
     """
-    try:
-        text = HEARTBEAT.read_text(encoding="utf-8")
-    except OSError:
+    text = beat_text()
+    if text is None:
         return False
     return stamped(text, time.time() if now is None else now) is not None and written(text) is None
 
@@ -161,9 +176,8 @@ def beating_elsewhere(mine, now=None):
     answers for, and is believed only while that process exists — otherwise a watcher restarted
     inside the window would refuse itself.
     """
-    try:
-        text = HEARTBEAT.read_text(encoding="utf-8")
-    except OSError:
+    text = beat_text()
+    if text is None:
         return False
     if stamped(text, time.time() if now is None else now) is None:
         return False


### PR DESCRIPTION
`watcher_state`'s three heartbeat readers — `alive`, `unreadable_beat` and `beating_elsewhere` — each
read the file under `except OSError` alone. A `UnicodeDecodeError` is a `ValueError`, so bytes that
are not UTF-8 go straight past it. Every guard that consults them runs as a `PreToolUse` or a `Stop`
hook, where the raise surfaces as a hook exiting non-zero for a reason having nothing to do with what
it judges.

The same shape was measured one file over: a `~/.velvet-pr-ready` holding `b"\xff\xfe700 1\n"` killed
`settle.py watch` at startup every time until the file was deleted. Widening that catch did not reach
these three.

The read is now one function the three share, rather than the catch written out three times — which
is what left the widening to be done three times and done once.

Three cases, one per reader, because they answer different questions and a single case would pin
whichever one it happened to drive. Each asserts what the reading returned, with a raise turned into
a value: an answer and a raise are the two outcomes to tell apart, and a case that ends on the raise
reports the same way as one whose file was never written.

No documentation impact: CONTRIBUTING.md names the watcher and what it costs to have none, not how
its heartbeat is read.

Closes #730
