### PR TITLE
tooling(velvet): refuse a message read from outside the worktree it describes

### DIFF
--- a/.claude/hooks/refuse/message_outside_its_worktree.py
+++ b/.claude/hooks/refuse/message_outside_its_worktree.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Refuse a commit message or pull-request body read from outside the worktree it describes.
+
+An implementer wrote its commit message to the session scratchpad, another agent overwrote that path
+between the write and the `git commit --amend -F`, and the commit landed carrying a message closing
+two issues the branch does not touch. It was caught because the author read the message back; nothing
+in the repository would have.
+
+The failure is silent by construction. `-F` reports success, the tree is right, the diff is right,
+and only the prose is another change's — which a squash merge then makes the permanent record.
+
+Measured over one session's transcripts, of every `-F` and `--body-file` naming a path under the
+session scratchpad: 163 total, 0 inside the worktree they describe, 163 at the shared root, with
+`msg.txt` reused 21 times and `commitmsg.txt` 14. The collision was not bad luck; it is what a
+generic path shared between concurrent agents produces.
+
+A worktree is per-agent here, so a message inside the one it describes cannot be another agent's.
+That is the whole rule, and every one of the 163 reaches it by changing a path.
+
+`pr_body_of_another_branch.py` asks whether the body says anything; this asks where it lives. Kept
+apart because the remedies differ and a guard that refuses two things names one of them first.
+
+Exit 2 refuses; exit 1 lets the tool through, so nothing here may raise.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "lib"))
+
+from shell_commands import (  # noqa: E402
+    UNRESOLVED_CD, git_invocations, leading_cd, program_invocations, unexpanded)
+
+HOOK_TOOLS = {"Bash"}
+
+# `git commit -F <path>` and its long spelling. `-m` holds the message itself and is not a path.
+MESSAGE_FLAGS = ("-F", "--file")
+BODY_FILE_FLAGS = ("-F", "--body-file")
+
+# The commands that put prose somewhere it outlives the tree it was written in.
+GH_WORDS = (("pr", "create"), ("pr", "edit"), ("pr", "new"),
+            ("issue", "create"), ("issue", "edit"), ("issue", "comment"), ("pr", "comment"))
+
+# An operand the shell has not expanded names no path this can resolve, and answering about the
+# literal would pass every one of them. Refused, because the shape being refused is precisely a path
+# written once and read later.
+UNEXPANDED_POLICY = "refuse"
+UNEXPANDED_PROBE = 'git commit -F "$MSG"'
+
+# A git that will not name a worktree leaves this with no question to ask rather than an unanswered
+# one, and it costs nothing: `git commit` and `gh pr create` both need a repository themselves, so a
+# command this stands down over fails on its own a moment later. The unexpanded case above is the
+# opposite, and refuses, because there the command is fine and only the reading is blind.
+UNREADABLE_POLICY = "allow"
+UNREADABLE_PROBE = {"command": "git commit -F /tmp/velvet-message-probe.txt"}
+
+
+def valued(operands, flags):
+    """The last value given to any of `flags`, or None. `--flag=value` counts."""
+    found = None
+    index = 0
+    while index < len(operands):
+        token = operands[index]
+        flag, separator, attached = token.partition("=")
+        if flag in flags:
+            if separator:
+                found = attached
+                index += 1
+            else:
+                found = operands[index + 1] if index + 1 < len(operands) else None
+                index += 2
+            continue
+        index += 1
+    return found
+
+
+def worktree_of(directory):
+    """The top of the worktree `directory` sits in, or None when git will not say."""
+    try:
+        done = subprocess.run(["git", "-C", str(directory), "rev-parse", "--show-toplevel"],
+                              capture_output=True, text=True, timeout=10)
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if done.returncode != 0:
+        return None
+    top = done.stdout.strip()
+    return Path(top).resolve() if top else None
+
+
+def inside(path, root, cwd):
+    """Whether `path` resolves under `root`. A relative path is read from `cwd`, as the shell will."""
+    try:
+        resolved = (Path(cwd) / path).resolve() if not os.path.isabs(path) else Path(path).resolve()
+    except OSError:
+        return False
+    return resolved == root or root in resolved.parents
+
+
+def refuse(what, path, root):
+    sys.stderr.write(
+        f"Refusing `{what}`: {path}\nis outside {root}, the worktree it describes.\n\n"
+        "A path several agents share is one another agent can overwrite between the write and the "
+        "read,\nand the failure is silent — the command succeeds, the tree is right, and only the "
+        "prose is\nanother change's. A worktree is per-agent, so a file inside it is nobody else's "
+        "to write.\n\n"
+        f"Write it under {root} and pass that path.\n")
+    return 2
+
+
+def judge(command, cwd):
+    """0, or 2 with the reason written to stderr."""
+    moved = leading_cd(command)
+    if moved is UNRESOLVED_CD:
+        # The tree the command runs in cannot be read, so neither can the question.
+        sys.stderr.write(
+            "Refusing this command: it changes into a directory the shell has not expanded, so "
+            "which\nworktree the message belongs to cannot be read here.\n\n"
+            "Spell the directory out.\n")
+        return 2
+    here = os.path.join(cwd, moved) if moved else cwd
+    root = worktree_of(here)
+    if root is None:
+        return 0
+
+    asked = [("git commit", operands, MESSAGE_FLAGS)
+             for _, _, operands in git_invocations(command, ("commit",))]
+    for words in GH_WORDS:
+        for operands in program_invocations(command, "gh", words):
+            asked.append(("gh " + " ".join(words), operands, BODY_FILE_FLAGS))
+
+    for what, operands, flags in asked:
+        path = valued(operands, flags)
+        if path is None:
+            continue
+        if unexpanded(path):
+            sys.stderr.write(
+                f"Refusing `{what}`: the message path is still unexpanded, so which worktree it\n"
+                "belongs to cannot be read here.\n\n"
+                f"Spell the path out, under {root}.\n")
+            return 2
+        if not inside(path, root, here):
+            return refuse(what, path, root)
+    return 0
+
+
+def main():
+    try:
+        event = json.load(sys.stdin)
+    except Exception:
+        return 0
+    try:
+        if not isinstance(event, dict) or event.get("tool_name") not in HOOK_TOOLS:
+            return 0
+        command = event.get("tool_input", {}).get("command") or ""
+        if not isinstance(command, str):
+            return 0
+        return judge(command, event.get("cwd") or ".")
+    except Exception as failure:  # noqa: BLE001 - a raise here turns the guard off silently
+        print(f"message_outside_its_worktree: {failure}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/hooks/refuse/message_outside_its_worktree.py
+++ b/.claude/hooks/refuse/message_outside_its_worktree.py
@@ -121,9 +121,6 @@ def judge(command, cwd):
             "Spell the directory out.\n")
         return 2
     here = os.path.join(cwd, moved) if moved else cwd
-    root = worktree_of(here)
-    if root is None:
-        return 0
 
     asked = [("git commit", operands, MESSAGE_FLAGS)
              for _, _, operands in git_invocations(command, ("commit",))]
@@ -131,16 +128,25 @@ def judge(command, cwd):
         for operands in program_invocations(command, "gh", words):
             asked.append(("gh " + " ".join(words), operands, BODY_FILE_FLAGS))
 
-    for what, operands, flags in asked:
-        path = valued(operands, flags)
-        if path is None:
-            continue
+    named = [(what, valued(operands, flags)) for what, operands, flags in asked]
+    named = [(what, path) for what, path in named if path is not None]
+    if not named:
+        return 0
+
+    # Asked before the worktree, because a path the shell has not expanded is unreadable in any tree
+    # and the worktree reading stands down where git will not answer.
+    for what, path in named:
         if unexpanded(path):
             sys.stderr.write(
                 f"Refusing `{what}`: the message path is still unexpanded, so which worktree it\n"
                 "belongs to cannot be read here.\n\n"
-                f"Spell the path out, under {root}.\n")
+                "Spell the path out, inside the worktree the change is in.\n")
             return 2
+
+    root = worktree_of(here)
+    if root is None:
+        return 0
+    for what, path in named:
         if not inside(path, root, here):
             return refuse(what, path, root)
     return 0

--- a/.claude/hooks/refuse/pr_body_of_another_branch.py
+++ b/.claude/hooks/refuse/pr_body_of_another_branch.py
@@ -131,7 +131,8 @@ def judge_inline(text, command):
             command,
             "the body is assembled by the shell, so the description this\n"
             "can read is not the one that will be posted.\n\n"
-            "Write it to a file in a step of its own and pass `--body-file <path>`.")
+            "Write it to a file in a step of its own, inside the worktree it describes, and pass\n"
+            "`--body-file <path>`.")
     return refuse_command(command, NO_ANSWER)
 
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -128,6 +128,11 @@
             "type": "command",
             "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/refuse/pr_body_of_another_branch.py\"",
             "timeout": 15000
+          },
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/refuse/message_outside_its_worktree.py\"",
+            "timeout": 15000
           }
         ]
       },

--- a/.github/workflows/generators.yml
+++ b/.github/workflows/generators.yml
@@ -146,6 +146,11 @@ jobs:
       - name: Unsettled pull request guard tests
         run: python3 scripts/hooks/test_unsettled_pr.py
 
+      # Silent when it stops matching, like every refuse guard, and the shapes it must let through
+      # are as much of the subject as the ones it refuses.
+      - name: Message-location guard tests
+        run: python3 scripts/hooks/test_message_outside_its_worktree.py
+
       # Holds the body guards' record of which gh options take a value against the gh on the runner,
       # which needs no licence and no token, only `--help`. The script owns what a disagreement
       # costs in either direction.

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/HookWiringCoverageTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/HookWiringCoverageTests.cs
@@ -584,6 +584,8 @@ namespace Velvet.Tests
              "\"cwd\":\"%SCRATCH%\",\"tool_input\":{\"command\":\"git checkout -b probe\"}"),
             ("a commit scoped by an unexpanded pathspec",
              "\"cwd\":\"%SCRATCH%\",\"tool_input\":{\"command\":\"git commit -m probe -- $PATHS\"}"),
+            ("a commit message read from an unexpanded path",
+             "\"cwd\":\"%SCRATCH%\",\"tool_input\":{\"command\":\"git commit -F $MSG\"}"),
             ("an issue creation carrying no metadata",
              "\"cwd\":\"%SCRATCH%\",\"tool_input\":{\"command\":\"gh issue create --title probe\"}"),
             ("a background command naming a repository path relatively",

--- a/scripts/hooks/test_message_outside_its_worktree.py
+++ b/scripts/hooks/test_message_outside_its_worktree.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Unit tests for .claude/hooks/refuse/message_outside_its_worktree.py.
+
+The defect is silent: `-F` succeeds, the tree is right, the diff is right, and only the prose is
+another change's — so the cases hold the refusals and, just as much, the shapes that must still go
+through, because a guard that refuses too much is one somebody turns off.
+
+Run: python3 scripts/hooks/test_message_outside_its_worktree.py
+"""
+
+import json
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GUARD = REPO_ROOT / ".claude/hooks/refuse/message_outside_its_worktree.py"
+
+
+class Verdicts(unittest.TestCase):
+    def setUp(self):
+        self.root = Path(tempfile.mkdtemp(prefix="message-worktree-")).resolve()
+        self.addCleanup(shutil.rmtree, self.root, ignore_errors=True)
+        subprocess.run(["git", "-C", str(self.root), "init", "--quiet"],
+                       check=True, capture_output=True)
+        self.elsewhere = Path(tempfile.mkdtemp(prefix="message-shared-")).resolve()
+        self.addCleanup(shutil.rmtree, self.elsewhere, ignore_errors=True)
+
+    def judge(self, command, cwd=None):
+        """The guard's verdict, as (exit code, stderr)."""
+        event = {"tool_name": "Bash", "cwd": str(cwd or self.root),
+                 "tool_input": {"command": command}}
+        done = subprocess.run(["python3", str(GUARD)], input=json.dumps(event),
+                              capture_output=True, text=True, timeout=30)
+        return done.returncode, done.stderr
+
+    def test_Given_ACommitMessageAtASharedPath_When_Judged_Then_ItIsRefused(self):
+        # Arrange — the shape that landed one change's message on another: a generic path outside
+        # every worktree, written by whichever agent wrote it last.
+        code, said = self.judge(f"git commit -F {self.elsewhere}/msg.txt")
+
+        # Act / Assert
+        self.assertEqual((code, "outside" in said), (2, True))
+
+    def test_Given_ACommitMessageInsideTheWorktree_When_Judged_Then_ItIsLetThrough(self):
+        # Arrange — a worktree is per-agent here, so a file inside it is nobody else's to write.
+        code, said = self.judge(f"git commit -F {self.root}/msg.txt")
+
+        # Act / Assert
+        self.assertEqual((code, said), (0, ""))
+
+    def test_Given_ARelativeMessagePath_When_Judged_Then_ItIsReadFromTheWorktree(self):
+        # Arrange — the shell resolves it from the command's directory, and so does this.
+        code, said = self.judge("git commit -F msg.txt")
+
+        # Act / Assert
+        self.assertEqual((code, said), (0, ""))
+
+    def test_Given_APullRequestBodyAtASharedPath_When_Judged_Then_ItIsRefused(self):
+        # Arrange — the same defect through the other door, and the one a squash merge does not even
+        # need: the body is the description a reader is handed.
+        code, said = self.judge(
+            f"gh pr create --title t --body-file {self.elsewhere}/pr-body.md")
+
+        # Act / Assert
+        self.assertEqual((code, "outside" in said), (2, True))
+
+    def test_Given_AnInlineMessage_When_Judged_Then_ItIsLetThrough(self):
+        # Arrange — `-m` carries the message itself, so there is no path for anyone to overwrite.
+        code, said = self.judge('git commit -m "a message nobody shares"')
+
+        # Act / Assert
+        self.assertEqual((code, said), (0, ""))
+
+    def test_Given_AnUnexpandedMessagePath_When_Judged_Then_ItIsRefusedRatherThanPassed(self):
+        # Arrange — the literal names no path, and answering about it would pass every one of them,
+        # which for a guard over "a path written once and read later" is the whole subject.
+        code, said = self.judge('git commit -F "$MSG"')
+
+        # Act / Assert
+        self.assertEqual((code, "unexpanded" in said), (2, True))
+
+    def test_Given_ALeadingCdIntoTheWorktree_When_Judged_Then_ThatIsTheTreeItIsAskedAbout(self):
+        # Arrange — PreToolUse fires before the command runs, so the event's directory is where the
+        # call started rather than where the message belongs.
+        code, said = self.judge(f"cd {self.root} && git commit -F {self.root}/msg.txt",
+                                cwd=self.elsewhere)
+
+        # Act / Assert
+        self.assertEqual((code, said), (0, ""))
+
+    def test_Given_ACommandOutsideAnyRepository_When_Judged_Then_ItIsNotThisGuardsToRefuse(self):
+        # Arrange — no worktree, so no worktree the message belongs to.
+        code, said = self.judge(f"git commit -F {self.elsewhere}/msg.txt", cwd=self.elsewhere)
+
+        # Act / Assert
+        self.assertEqual((code, said), (0, ""))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/hooks/test_message_outside_its_worktree.py
+++ b/scripts/hooks/test_message_outside_its_worktree.py
@@ -29,7 +29,12 @@ class Verdicts(unittest.TestCase):
         self.addCleanup(shutil.rmtree, self.elsewhere, ignore_errors=True)
 
     def judge(self, command, cwd=None):
-        """The guard's verdict, as (exit code, stderr)."""
+        """The guard's verdict, as (exit code, stderr).
+
+        Cases below match on words the refusal writes, never on a substring of the guard's own name:
+        a tree without the guard exits 2 from python with the path in the message, and `outside` is
+        in that path. Measured -- two cases passed on the base that way.
+        """
         event = {"tool_name": "Bash", "cwd": str(cwd or self.root),
                  "tool_input": {"command": command}}
         done = subprocess.run(["python3", str(GUARD)], input=json.dumps(event),
@@ -42,7 +47,7 @@ class Verdicts(unittest.TestCase):
         code, said = self.judge(f"git commit -F {self.elsewhere}/msg.txt")
 
         # Act / Assert
-        self.assertEqual((code, "outside" in said), (2, True))
+        self.assertEqual((code, "the worktree it describes" in said), (2, True))
 
     def test_Given_ACommitMessageInsideTheWorktree_When_Judged_Then_ItIsLetThrough(self):
         # Arrange — a worktree is per-agent here, so a file inside it is nobody else's to write.
@@ -65,7 +70,7 @@ class Verdicts(unittest.TestCase):
             f"gh pr create --title t --body-file {self.elsewhere}/pr-body.md")
 
         # Act / Assert
-        self.assertEqual((code, "outside" in said), (2, True))
+        self.assertEqual((code, "the worktree it describes" in said), (2, True))
 
     def test_Given_AnInlineMessage_When_Judged_Then_ItIsLetThrough(self):
         # Arrange — `-m` carries the message itself, so there is no path for anyone to overwrite.
@@ -90,6 +95,15 @@ class Verdicts(unittest.TestCase):
 
         # Act / Assert
         self.assertEqual((code, said), (0, ""))
+
+    def test_Given_AnUnexpandedPathOutsideAnyRepository_When_Judged_Then_ItIsStillRefused(self):
+        # Arrange — the worktree reading stands down where git will not answer, and asking it first
+        # took the unexpanded reading down with it. That is how the guard's own declared policy
+        # disagreed with it: `PreExpansionPolicyTests` poses each probe where no worktree answers.
+        code, said = self.judge('git commit -F "$MSG"', cwd=self.elsewhere)
+
+        # Act / Assert
+        self.assertEqual((code, "unexpanded" in said), (2, True))
 
     def test_Given_ACommandOutsideAnyRepository_When_Judged_Then_ItIsNotThisGuardsToRefuse(self):
         # Arrange — no worktree, so no worktree the message belongs to.


### PR DESCRIPTION
An implementer wrote its commit message to the session scratchpad, another agent overwrote that path
between the write and the `git commit --amend -F`, and the commit landed carrying a message closing
two issues the branch does not touch. It was caught because the author read the message back
afterwards; nothing in the repository would have.

The failure is silent by construction. `-F` reports success, the tree is right, the diff is right,
and only the prose is another change's — which a squash merge then makes the permanent record on
`main`.

Measured over one session's transcripts, of every `git commit … -F <path>` and
`gh pr … --body-file <path>` naming a path under the session scratchpad:

| | |
|---|---|
| total | 163 |
| inside the worktree they describe | 0 |
| at the shared scratchpad root | 163 |

`msg.txt` reused 21 times, `commitmsg.txt` 14, `pr-body.md` 11. Twenty-one writes to one path from
agents that run concurrently: the collision was not bad luck.

A worktree is per-agent here, so a message inside the one it describes is nobody else's to write.
That is the whole rule, and every one of the 163 reaches it by changing a path — this pull request's
own body among them.

Its own guard rather than a clause in `pr_body_of_another_branch.py`: that one asks whether the body
*says* anything, this asks where it *lives*, and a guard that refuses two things names one of them
first. What did change there is its advice, which sent the reader to write a file anywhere.

The unexpanded case refuses rather than passing — a literal path names nothing to resolve, and "a
path written once and read later" is the whole subject. A git that will not name a worktree is the
opposite and stands down: `git commit` and `gh pr create` both need a repository themselves, so a
command this lets past fails on its own a moment later. `unreadable_state_check.py` holds that pair
against the guard's declared policy.

Eight cases, half of them shapes that must still go through — an inline `-m`, a relative path, a
leading `cd` into the worktree — because a guard that refuses too much is one somebody turns off.

No documentation impact: the guard's advice is its own text, and CONTRIBUTING.md does not say where a
message is written.

Closes #729

Two things the checks caught, both worth stating:

`PreExpansionPolicyTests` poses each guard's declared probe where no worktree answers, and the
worktree reading stood down there — taking the unexpanded reading with it, so the guard disagreed
with its own declared policy. The unexpanded question is asked first now: a path the shell has not
expanded is unreadable in any tree.

`base_red_check` found two cases passing on the base. A tree without the guard exits 2 from python
with the missing path in the message, and `outside` is a substring of `message_outside_its_worktree.py`
— so a case matching on `outside` was reading the guard's own filename out of the error saying it was
not there. They match on words the refusal writes now.
