### PR TITLE
tooling(velvet): give an unexpanded -C the remedy that reaches it

### DIFF
--- a/.claude/hooks/refuse/commit_failing_fast_checks.py
+++ b/.claude/hooks/refuse/commit_failing_fast_checks.py
@@ -381,8 +381,20 @@ def main():
 
     cwd = event.get("cwd") or "."
     for directory, commits_all, pathspecs in commits:
-        unresolved = [token for token in list(pathspecs) + ([directory] if directory else [])
-                      if unexpanded(token)]
+        # The two operand kinds are refused apart, because the remedy for one does not reach the
+        # other: naming the paths leaves a `-C` unresolved, and the reader told to do it tries
+        # something that cannot help. Measured on an agent's own `git -C "$SP" commit`.
+        if directory and unexpanded(directory):
+            sys.stderr.write(
+                "Refusing `git commit`: the tree it runs in is named by an operand the shell has "
+                "not\nexpanded yet.\n\n"
+                f"  -C {directory}\n\n"
+                "Every check below reads the content the commit would record, and which repository "
+                "holds\nthat content is what `-C` decides — so this cannot read the tree at all, "
+                "rather than reading\nthe wrong one.\n\n"
+                "Spell the directory out.\n")
+            return 2
+        unresolved = [token for token in pathspecs if unexpanded(token)]
         if unresolved:
             sys.stderr.write(
                 "Refusing `git commit`: it is scoped by an operand the shell has not expanded yet.\n\n"

--- a/.github/workflows/generators.yml
+++ b/.github/workflows/generators.yml
@@ -146,6 +146,11 @@ jobs:
       - name: Unsettled pull request guard tests
         run: python3 scripts/hooks/test_unsettled_pr.py
 
+      # The two unexpanded-operand readings, which were one list under a sentence written for one of
+      # them.
+      - name: Fast-checks commit guard tests
+        run: python3 scripts/hooks/test_commit_failing_fast_checks.py
+
       # Holds the body guards' record of which gh options take a value against the gh on the runner,
       # which needs no licence and no token, only `--help`. The script owns what a disagreement
       # costs in either direction.

--- a/scripts/hooks/test_commit_failing_fast_checks.py
+++ b/scripts/hooks/test_commit_failing_fast_checks.py
@@ -51,6 +51,8 @@ class UnexpandedOperands(unittest.TestCase):
         # absence too.
         self.assertEqual((code, "Name the paths" in said), (2, False))
 
+    # GREEN_ON_BASE(characterization): the base gives every unexpanded operand this sentence, which
+    # is why the other two exist. It is the half the split had to leave where it was.
     def test_Given_AnUnexpandedPathspec_When_Refused_Then_ItKeepsItsOwnRemedy(self):
         # Arrange — the reading the sentence was written for, which this must leave where it is.
         code, said = self.judge('git commit -m "x" -- "$FILES"')

--- a/scripts/hooks/test_commit_failing_fast_checks.py
+++ b/scripts/hooks/test_commit_failing_fast_checks.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Unit tests for the unexpanded-operand readings in .claude/hooks/refuse/commit_failing_fast_checks.py.
+
+The two operand kinds are refused apart because the remedy for one does not reach the other. They were
+folded into one list under a sentence written for a pathspec, and an agent's own `git -C "$SP" commit`
+was refused with `$SP` printed under advice to name the paths or commit the index — two things that
+cannot resolve a `-C`.
+
+Run: python3 scripts/hooks/test_commit_failing_fast_checks.py
+"""
+
+import json
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GUARD = REPO_ROOT / ".claude/hooks/refuse/commit_failing_fast_checks.py"
+
+
+class UnexpandedOperands(unittest.TestCase):
+    def setUp(self):
+        self.root = Path(tempfile.mkdtemp(prefix="fast-checks-")).resolve()
+        self.addCleanup(shutil.rmtree, self.root, ignore_errors=True)
+        subprocess.run(["git", "-C", str(self.root), "init", "--quiet"],
+                       check=True, capture_output=True)
+
+    def judge(self, command):
+        """The guard's verdict, as (exit code, stderr)."""
+        event = {"tool_name": "Bash", "cwd": str(self.root),
+                 "tool_input": {"command": command}}
+        done = subprocess.run(["python3", str(GUARD)], input=json.dumps(event),
+                              capture_output=True, text=True, timeout=60)
+        return done.returncode, done.stderr
+
+    def test_Given_AnUnexpandedDirectory_When_Refused_Then_TheRemedyIsToSpellItOut(self):
+        # Arrange — naming the paths leaves the `-C` unresolved, and so does committing the index.
+        code, said = self.judge('git -C "$SP" commit -m "x"')
+
+        # Act / Assert
+        self.assertEqual((code, "Spell the directory out" in said), (2, True))
+
+    def test_Given_AnUnexpandedDirectory_When_Refused_Then_ThePathspecSentenceIsNotUsed(self):
+        # Arrange — the sentence it used to get, which is false of a `-C`: the checks do not run over
+        # nothing, they cannot find the tree to run over at all.
+        code, said = self.judge('git -C "$SP" commit -m "x"')
+
+        # Act / Assert — the refusal rides along, because a run that said nothing satisfies the
+        # absence too.
+        self.assertEqual((code, "Name the paths" in said), (2, False))
+
+    def test_Given_AnUnexpandedPathspec_When_Refused_Then_ItKeepsItsOwnRemedy(self):
+        # Arrange — the reading the sentence was written for, which this must leave where it is.
+        code, said = self.judge('git commit -m "x" -- "$FILES"')
+
+        # Act / Assert
+        self.assertEqual((code, "Name the paths" in said), (2, True))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
`commit_failing_fast_checks.py` folded the `-C` value into the same unexpanded-operand list as the
pathspecs, and printed one explanation and one remedy beneath both — written only for a pathspec:

> a pathspec that is still a variable names no file — so they would all run over nothing and pass

> Name the paths, or commit the index and let the checks read that.

Neither is true of `git -C $VAR commit`, and neither is reachable: naming the paths does not resolve
the `-C`, and committing the index does not either. Hit live, on an agent's own `git -C "$SP" commit`,
which was shown `$SP` under advice to do two things that could not help.

The same shape #661 fixed one guard over: `amend_of_published_commit.py` split "not a git repository"
on whether git had quoted a path back — true for `--git-dir=`, false for `-C` — and showed a reader
the selector it had written before telling it to write one. There, as here, one operand kind got the
sentence and the other was folded in without one.

Refused apart now. A `-C` this cannot resolve means the tree cannot be read at all, rather than read
wrongly, and the remedy is to spell the directory out. The pathspec reading keeps its own words.

The guard had no suite. It has three cases and a job that runs them: the new remedy, that the pathspec
sentence is not what a `-C` gets, and the pathspec reading itself — that last declared, because the
base gives it to every operand, which is the defect.

No documentation impact: the guard's advice is its own text.

Closes #714
