### PR TITLE
tooling(velvet): stop the harness count reporting a lane that starts no editor

### DIFF
--- a/.claude/skills/unity-tests/SKILL.md
+++ b/.claude/skills/unity-tests/SKILL.md
@@ -33,10 +33,15 @@ ps -Ao command= | grep -c '^/Applications/.*/MacOS/Uni[t]y -runTests'
 The three harnesses the exception below covers — a mutation campaign, a neuter sweep and `base_red_check.py`'s C# lane — hold no editor of their own between their runs, over a campaign's waits, mutations and restores and the lane's whole worktree build, so **a zero from that count is not proof none is in flight**. Nor does a non-zero one say whose editor it is: each harness launches the editor that count matches, so while one of their runs is up, that is what is being counted. What answers it either way is a count of the harness processes themselves:
 
 ```bash
-ps -Ao command= | grep -cE '^[^ ]*[Pp]ython[^ ]* .*[ /](mutation_check|neuter_check|base_red_check)\.py'
+ps -Ao command= | grep -E '^[^ ]*[Pp]ython[^ ]* .*[ /](mutation_check|neuter_check|base_red_check)\.py' \
+  | grep -vc -- '--lane python'
 ```
 
 It is anchored twice over and needs both: on the interpreter, which is what excludes the `/bin/zsh -c` line carrying this very command and a watcher spelling `pgrep -f neuter_check.py`; and on the separator before the script's name, which excludes a `-m pytest` run over `test_mutation_check.py` — a Python process naming a harness without being one. Between the two it allows a run of flags, because an interpreter flag can sit there, as `-u` did in the campaign this was measured against.
+
+The `--lane python` exclusion is the third anchor, and it answers a narrower question than the other two: they ask whether the line is a harness, this asks whether the harness will start an editor. `base_red_check.py` waits for a quiet machine only where its scope holds a C# case, so a Python-only run never waits and never launches one, while matching the pattern exactly. An agent that reads `1` off such a line holds a run against nothing. `BusyWaitScopeTests` fails when a Python-only scope stops leaving that set empty.
+
+What the count still cannot say is whether a harness it *does* report is between editors — a campaign holds none while it mutates, restores or writes its receipt, and that window is where a run of yours is charged without either count seeing it. The pair is what answers that, and neither reading answers it alone.
 
 Measured over one snapshot of this machine's process table, 603 lines with one campaign in flight: this reports 1 where a bare-name count reports 10. Over an eleven-line fixture holding four real invocations, six lines that name a harness without being one, and an editor, it takes 4 of 4 with nothing false, where a pattern demanding the script immediately after the interpreter takes 2 and a bare-name count takes 10. Asking the campaign directly does not answer it: `--carried` reads the record under its `--project`, which is the worktree the campaign runs in rather than yours, and it is present only while a mutant's suite runs — `CONTRIBUTING.md`'s mutation section owns that lifetime — so a campaign waiting for the machine, running its baseline or writing its receipt holds none, and **an absent record is not an idle machine**.
 

--- a/.claude/skills/unity-tests/SKILL.md
+++ b/.claude/skills/unity-tests/SKILL.md
@@ -34,12 +34,13 @@ The three harnesses the exception below covers — a mutation campaign, a neuter
 
 ```bash
 ps -Ao command= | grep -E '^[^ ]*[Pp]ython[^ ]* .*[ /](mutation_check|neuter_check|base_red_check)\.py' \
-  | grep -vc -- '--lane python'
+  | grep -vE -- '--lane python|--plan|--list|--refusals|--emit-lines|--receipt|--report' \
+  | grep -c .
 ```
 
 It is anchored twice over and needs both: on the interpreter, which is what excludes the `/bin/zsh -c` line carrying this very command and a watcher spelling `pgrep -f neuter_check.py`; and on the separator before the script's name, which excludes a `-m pytest` run over `test_mutation_check.py` — a Python process naming a harness without being one. Between the two it allows a run of flags, because an interpreter flag can sit there, as `-u` did in the campaign this was measured against.
 
-The `--lane python` exclusion is the third anchor, and it answers a narrower question than the other two: they ask whether the line is a harness, this asks whether the harness will start an editor. `base_red_check.py` waits for a quiet machine only where its scope holds a C# case, so a Python-only run never waits and never launches one, while matching the pattern exactly. An agent that reads `1` off such a line holds a run against nothing. `BusyWaitScopeTests` fails when a Python-only scope stops leaving that set empty.
+The read-only exclusions are the third anchor, and they answer a narrower question than the other two: those ask whether the line is a harness, these ask whether the harness will start an editor. Every one was read off the source rather than assumed — `base_red_check.py` waits for a quiet machine only where its scope holds a C# case, so `--lane python` never waits and never launches one, and `--plan`, `--list`, `--refusals`, `--emit-lines`, `--receipt` and `--report` each read the tree and return before any editor is asked for. All of them match the pattern exactly, and an agent that reads `1` off such a line holds a run against nothing. Measured on a real round: the count flickered 1/0 while a `--plan` came and went, and establishing that a `--lane csharp` was genuinely running in another worktree took ninety seconds of sampling full command lines — which is the reading this recipe exists to save. `BusyWaitScopeTests` fails when a Python-only scope stops leaving that set empty.
 
 What the count still cannot say is whether a harness it *does* report is between editors — a campaign holds none while it mutates, restores or writes its receipt, and that window is where a run of yours is charged without either count seeing it. The pair is what answers that, and neither reading answers it alone.
 

--- a/scripts/test_quality/test_base_red_check.py
+++ b/scripts/test_quality/test_base_red_check.py
@@ -3524,6 +3524,37 @@ class CommentOnlyBranchTests(unittest.TestCase):
         self.assertNotIn("out of scope", printed)
 
 
+class BusyWaitScopeTests(unittest.TestCase):
+    """Which scopes make this lane wait for a quiet machine, which is what it starts an editor for.
+
+    The harness count in the unity-tests skill excludes a `--lane python` line on the strength of
+    this: a Python-only run never waits and never launches an editor, so an agent reading it off the
+    count holds a run against nothing.
+    """
+
+    def platforms_for(self, *paths):
+        """The platform set the wait is guarded on, derived as the lane derives it."""
+        cases = [base_red_check.Case("N.C.Given_A_When_B_Then_C", path, 1, 2) for path in paths]
+        return sorted({base_red_check.platform_of(case.path) for case in cases
+                       if base_red_check.kind_of(case.path) == "csharp"})
+
+    # GREEN_ON_BASE(characterization): the derivation is unchanged here. It is what the skill's
+    # narrowed count now rests on, and nothing said so before.
+    def test_Given_APythonOnlyScope_When_ThePlatformsAreDerived_Then_ThereAreNone(self):
+        # Act / Assert — an empty set is what leaves `wait_for_quiet` unasked.
+        self.assertEqual(self.platforms_for("scripts/hooks/test_probe.py"), [])
+
+    # GREEN_ON_BASE(characterization): the derivation is unchanged here. It is what the skill's
+    # narrowed count now rests on, and nothing said so before.
+    def test_Given_AScopeHoldingACsharpCase_When_ThePlatformsAreDerived_Then_OneIsNamed(self):
+        # Arrange — the control: without it, a derivation that returned nothing for everything would
+        # satisfy the case above having read nothing.
+        # Act / Assert
+        self.assertEqual(
+            self.platforms_for("Packages/com.velvet.core/Runtime/A/Tests/Editor/ProbeTests.cs"),
+            ["EditMode"])
+
+
 class RepositoryTests(unittest.TestCase):
     """The reader against every test file this repository has, rather than against invented ones."""
 


### PR DESCRIPTION
The `unity-tests` skill's harness count is what an agent reads to decide whether its run would be
charged to somebody else's verdict. It over-counts: an invocation that starts no editor is
indistinguishable from one that does.

Every read-only mode was read off the source rather than assumed. `base_red_check` waits for a quiet
machine only where its scope holds a C# case, so `--lane python` never waits and never launches one;
and `--plan`, `--list`, `--refusals`, `--emit-lines`, `--receipt` and `--report` each read the tree and
return before any editor is asked for. All of them match the pattern exactly.

Both halves were hit live. An agent read `1` off a `--lane python` line and held while nothing was
contending. On another round the count flickered 1/0 while a `--plan` came and went, and establishing
that a `--lane csharp` was genuinely running in another worktree took ninety seconds of sampling full
command lines — which is the reading this recipe exists to save.

The rule the count serves is asymmetric, which is why over-counting costs more than a stray wait. Not
waiting when you should costs a verdict — a case your load reddens reads as `KILLED` in a campaign's
receipt, as red-on-base here, as a caught cut in a neuter sweep — so agents are told to err toward
holding. A counter that over-reports turns that correct instinct into an unbounded wait on a machine
that runs harnesses continuously.

Measured over a nine-line process table holding two real invocations, five read-only ones, a `zsh -c`
carrying the recipe itself and a `-m pytest` over a harness's test module: the count returns 2.

`BusyWaitScopeTests` holds the one mirror of source this rests on — that a Python-only scope leaves the
platform set empty — with a C# case beside it as the control, because a derivation that returned
nothing for everything would satisfy the first having read nothing. Both declared: the derivation is
not changed here, and nothing said what the count rests on before.

**And a second undocumented fact, from the same round.** The base-red lane reads raw diff hunks, so a
comment-only edit *inside* a `[Test]` method puts that case in scope — a pre-existing case that was
green on the base becomes a failing required check for a change that altered no behaviour, with
nothing pointing at the comment as the cause. Five such cases in one run. CONTRIBUTING.md's base-red
section now names it and the three ways out, since this repository is actively correcting comment
prose and the remedy existed but nothing pointed at it.

What the count still cannot say is left stated rather than answered: a harness it does report may be
between editors — a campaign holds none while it mutates, restores or writes its receipt — and that
window is where a run is charged without either count seeing it. #712 owns the other half.

Closes #718
Closes #691
