### PR TITLE
tooling(velvet): render a type nested in a generic as itself, not as its owner

### DIFF
--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/PublicApiSurfaceTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/PublicApiSurfaceTests.cs
@@ -107,6 +107,9 @@ namespace Velvet.Tests
             }
         }
 
+        // GREEN_ON_BASE(characterization): the rendering under test sits in this same file, which
+        // the base lane carries with the cases, so no base run can separate them. Restoring the
+        // first-backtick cut by hand and re-running the fixture fails both, which is the reading.
         [Test]
         public void Given_ATypeNestedInsideAGeneric_When_Rendered_Then_ItIsNotItsOwner()
         {
@@ -122,6 +125,9 @@ namespace Velvet.Tests
                         Is.EqualTo((true, true, true)));
         }
 
+        // GREEN_ON_BASE(characterization): the rendering under test sits in this same file, which
+        // the base lane carries with the cases, so no base run can separate them. Restoring the
+        // first-backtick cut by hand and re-running the fixture fails both, which is the reading.
         [Test]
         public void Given_ATypeNestedInsideAGeneric_When_Rendered_Then_ItsOwnerIsNamedInIt()
         {

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/PublicApiSurfaceTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/PublicApiSurfaceTests.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
 using NUnit.Framework;
 using Velvet.Editor.DevTools;
 using Velvet.TestUtilities;
@@ -253,6 +254,45 @@ namespace Velvet.Tests
             }
         }
 
+        /// <summary>A public generic with a nested type, which the repository's own surface gains with
+        /// `VelvetTask` and did not carry when this rendering was written.</summary>
+        private sealed class OwnerWithNested<T>
+        {
+            internal struct Nested
+            {
+                internal T Held;
+            }
+        }
+
+        [Test]
+        public void Given_ATypeNestedInsideAGeneric_When_Rendered_Then_ItIsNotItsOwner()
+        {
+            // Arrange — the two rendered the same line, so the nested type's members were recorded
+            // against its owner and an addition to either produced the same diff.
+            var owner = FormatType(typeof(OwnerWithNested<>));
+            var nested = FormatType(typeof(OwnerWithNested<>.Nested));
+
+            // Act / Assert — the owner naming itself rides along, because two renderings that both
+            // collapsed to something else would differ from each other and be no more use.
+            Assert.That((owner.Contains("OwnerWithNested"), nested.Contains("Nested"), owner != nested),
+                        Is.EqualTo((true, true, true)));
+        }
+
+        [Test]
+        public void Given_ATypeNestedInsideAGeneric_When_Rendered_Then_ItsOwnerIsNamedInIt()
+        {
+            // Arrange — the non-generic case already rendered the owner in front of the `+`, and this
+            // is the same spelling one arity marker along. What the marker looked like is read off the
+            // owner rather than written down, so this says nothing about how the runtime spells one.
+            var owner = FormatType(typeof(OwnerWithNested<>));
+            var nested = FormatType(typeof(OwnerWithNested<>.Nested));
+
+            // Act / Assert
+            Assert.That(nested.StartsWith(owner.Substring(0, owner.IndexOf('`')), StringComparison.Ordinal)
+                        && nested.Contains("+Nested"),
+                        Is.True, $"owner={owner} nested={nested}");
+        }
+
         private static string RenderType(Type type) => "type " + FormatType(type);
 
         private static string RenderConstructor(
@@ -459,6 +499,10 @@ namespace Velvet.Tests
             return formatted;
         }
 
+        // `Owner`1+Nested`2` carries one per segment, and the arity below is read off the type rather
+        // than off the name.
+        private static readonly Regex ArityMarker = new(@"`\d+", RegexOptions.Compiled);
+
         private static string FormatType(Type type) => FormatType(type, null);
 
         private static string FormatType(Type type, NullableAnnotationProbe.AnnotationReader reader)
@@ -487,9 +531,14 @@ namespace Velvet.Tests
             {
                 var annotation = Annotate(type, reader);
                 var definition = type.IsGenericTypeDefinition ? type : type.GetGenericTypeDefinition();
-                var definitionName = definition.FullName ?? definition.Name;
-                var tickIndex = definitionName.IndexOf('`', StringComparison.Ordinal);
-                var baseName = tickIndex >= 0 ? definitionName[..tickIndex] : definitionName;
+                // Every arity marker rather than the text before the first one. A type nested inside a
+                // generic spells its FullName `Owner`1+Nested`, so cutting at the first backtick dropped
+                // `+Nested` and rendered the nested type as its owner -- same line, same members recorded
+                // against the wrong type, and a reviewer's diff unable to tell an addition on one from an
+                // addition on the other. The non-generic owner was already correct, which is why nothing
+                // reported it.
+                var definitionName = ArityMarker.Replace(definition.FullName ?? definition.Name, "");
+                var baseName = definitionName;
                 var arity = definition.GetGenericArguments().Length;
 
                 // A signature written in terms of the declaring type's own parameters arrives here as the

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/PublicApiSurfaceTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/PublicApiSurfaceTests.cs
@@ -97,6 +97,47 @@ namespace Velvet.Tests
                 + "it. An unloaded assembly would report the same empty surface, so both are read at once.");
         }
 
+        /// <summary>A generic with a nested type, which the repository's own surface gains with
+        /// `VelvetTask` and did not carry when this rendering was written.</summary>
+        private sealed class OwnerWithNested<T>
+        {
+            internal struct Nested
+            {
+                internal T Held;
+            }
+        }
+
+        [Test]
+        public void Given_ATypeNestedInsideAGeneric_When_Rendered_Then_ItIsNotItsOwner()
+        {
+            // Arrange — the two rendered the same line, so the nested type's members were recorded
+            // against its owner and an addition to either produced the same diff.
+            var owner = PublicApiSurface.FormatType(typeof(OwnerWithNested<>));
+            var nested = PublicApiSurface.FormatType(
+                typeof(OwnerWithNested<>.Nested));
+
+            // Act / Assert — the owner naming itself rides along, because two renderings that both
+            // collapsed to something else would differ from each other and be no more use.
+            Assert.That((owner.Contains("OwnerWithNested"), nested.Contains("Nested"), owner != nested),
+                        Is.EqualTo((true, true, true)));
+        }
+
+        [Test]
+        public void Given_ATypeNestedInsideAGeneric_When_Rendered_Then_ItsOwnerIsNamedInIt()
+        {
+            // Arrange — the non-generic case already rendered the owner in front of the `+`, and this
+            // is the same spelling one arity marker along. What the marker looks like is read off the
+            // owner rather than written down, so this says nothing about how the runtime spells one.
+            var owner = PublicApiSurface.FormatType(typeof(OwnerWithNested<>));
+            var nested = PublicApiSurface.FormatType(
+                typeof(OwnerWithNested<>.Nested));
+
+            // Act / Assert
+            Assert.That(nested.StartsWith(owner.Substring(0, owner.IndexOf('`')), StringComparison.Ordinal)
+                        && nested.Contains("+Nested"),
+                        Is.True, $"owner={owner} nested={nested}");
+        }
+
         private static string BuildDriftMessage(IReadOnlyList<string> added, IReadOnlyList<string> removed)
         {
             var message = "Public API surface drifted from Packages/com.velvet.core/PublicAPI.txt.";
@@ -252,45 +293,6 @@ namespace Velvet.Tests
                     yield return line;
                 }
             }
-        }
-
-        /// <summary>A public generic with a nested type, which the repository's own surface gains with
-        /// `VelvetTask` and did not carry when this rendering was written.</summary>
-        private sealed class OwnerWithNested<T>
-        {
-            internal struct Nested
-            {
-                internal T Held;
-            }
-        }
-
-        [Test]
-        public void Given_ATypeNestedInsideAGeneric_When_Rendered_Then_ItIsNotItsOwner()
-        {
-            // Arrange — the two rendered the same line, so the nested type's members were recorded
-            // against its owner and an addition to either produced the same diff.
-            var owner = FormatType(typeof(OwnerWithNested<>));
-            var nested = FormatType(typeof(OwnerWithNested<>.Nested));
-
-            // Act / Assert — the owner naming itself rides along, because two renderings that both
-            // collapsed to something else would differ from each other and be no more use.
-            Assert.That((owner.Contains("OwnerWithNested"), nested.Contains("Nested"), owner != nested),
-                        Is.EqualTo((true, true, true)));
-        }
-
-        [Test]
-        public void Given_ATypeNestedInsideAGeneric_When_Rendered_Then_ItsOwnerIsNamedInIt()
-        {
-            // Arrange — the non-generic case already rendered the owner in front of the `+`, and this
-            // is the same spelling one arity marker along. What the marker looked like is read off the
-            // owner rather than written down, so this says nothing about how the runtime spells one.
-            var owner = FormatType(typeof(OwnerWithNested<>));
-            var nested = FormatType(typeof(OwnerWithNested<>.Nested));
-
-            // Act / Assert
-            Assert.That(nested.StartsWith(owner.Substring(0, owner.IndexOf('`')), StringComparison.Ordinal)
-                        && nested.Contains("+Nested"),
-                        Is.True, $"owner={owner} nested={nested}");
         }
 
         private static string RenderType(Type type) => "type " + FormatType(type);
@@ -503,7 +505,7 @@ namespace Velvet.Tests
         // than off the name.
         private static readonly Regex ArityMarker = new(@"`\d+", RegexOptions.Compiled);
 
-        private static string FormatType(Type type) => FormatType(type, null);
+        internal static string FormatType(Type type) => FormatType(type, null);
 
         private static string FormatType(Type type, NullableAnnotationProbe.AnnotationReader reader)
         {


### PR DESCRIPTION
`PublicApiSurfaceTests.FormatType` renders a type nested inside a public generic identically to its
owner, so the guard cannot tell an addition or a removal on one from the other.

`definition.FullName` for such a type is `Owner`1+Nested`, and the code cut at the **first** backtick —
which is the owner's arity marker — so `+Nested` was dropped and the nested type came out as the
owner. The arity appended after that is read off the type, and a type nested in a generic inherits its
owner's parameters, so the two rendered the same line. The non-generic case was already correct,
rendering `Owner+Nested`, which is why nothing reported it.

Measured on the `VelvetTask` branch, which adds the repository's first such type: `PublicAPI.txt`
carries `[Velvet] type Velvet.VelvetTask`1[T]` twice — the only duplicated line in the file — and the
`Awaiter`'s three members are recorded against `VelvetTask<T>`, which declares none of them.

Every arity marker is stripped now rather than the text before the first one taken. Nothing changes
for a type that is not nested: `Velvet.Foo`1` loses its marker and gets one back with the arguments,
as before.

The two cases assert the property the guard needs — the owner and the nested type render differently,
and the nested rendering carries the owner's name with `+Nested` behind it — rather than a spelling of
`FullName` written down here. What the marker looks like is read off the owner's own rendering, so
neither case claims anything about how the runtime spells one.

No documentation impact: `PublicAPI.txt` is generated, and this changes no line in it — the repository
has no type of this shape until #377 lands.

Closes #760
