### PR TITLE
ci(velvet): compile the package the way a player does

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -380,14 +380,53 @@ jobs:
   # not, because a superseded run and a run somebody stopped both arrive here
   # with nothing having been tested.
   # ---------------------------------------------------------------------------
+  # ---------------------------------------------------------------------------
+  # The one compile the suite never performs. EditMode and PlayMode both run inside the editor, where
+  # UNITY_EDITOR is defined, so a call to a member declared under `#if UNITY_EDITOR` from outside one
+  # compiles in every job above and in no consumer's build. Measured on a branch carrying such a call:
+  # clean with the define, CS0103 without it, and what a consumer hits is a package that will not build.
+  #
+  # Scripts rather than a player: the question is which defines the compile runs under, and a player
+  # build would answer it alongside a scene load, an asset import and a linker pass with failure modes
+  # of their own.
+  # ---------------------------------------------------------------------------
+  player-compile:
+    name: Player script compilation
+    needs: license-check
+    if: needs.license-check.outputs.has_license == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          lfs: true
+
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: Library
+          key: Library-player-${{ hashFiles('Packages/**', 'ProjectSettings/**') }}
+          restore-keys: |
+            Library-player-
+
+      - uses: game-ci/unity-builder@1d4ee0697f193f54668e98961d79907911f4b4f2 # v4
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+        with:
+          unityVersion: 6000.3.21f1
+          targetPlatform: StandaloneLinux64
+          projectPath: .
+          buildMethod: Velvet.Editor.PlayerBuild.PlayerScriptCompilation.CompileForPlayer
+          allowDirtyBuild: true
+
   required-checks:
     name: Required checks (Unity)
     if: always()
-    needs: [license-check, unity-tests, release-notes, publication, test-quality, base-red-python, base-red]
+    needs: [license-check, unity-tests, player-compile, release-notes, publication, test-quality, base-red-python, base-red]
     runs-on: ubuntu-latest
     steps:
       - env:
-          RESULTS: ${{ needs.license-check.result }} ${{ needs.unity-tests.result }} ${{ needs.release-notes.result }} ${{ needs.publication.result }} ${{ needs.test-quality.result }} ${{ needs.base-red-python.result }} ${{ needs.base-red.result }}
+          RESULTS: ${{ needs.license-check.result }} ${{ needs.unity-tests.result }} ${{ needs.player-compile.result }} ${{ needs.release-notes.result }} ${{ needs.publication.result }} ${{ needs.test-quality.result }} ${{ needs.base-red-python.result }} ${{ needs.base-red.result }}
         run: |
           failed=0
           for result in $RESULTS; do

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -558,6 +558,7 @@ on every platform.
 | `Source generators ▸ Required checks (generators)` | push (filtered) / every PR / merge group | not required | **yes** |
 | `Test ▸ license-check` | push (filtered) / every PR / merge group | not required | no |
 | `Test ▸ unity-tests` (EditMode / PlayMode) | push (filtered) / every PR / merge group | **required** (skipped if absent) | no |
+| `Test ▸ player-compile` | push (filtered) / every PR / merge group | **required** (skipped if absent) | no |
 | `Test ▸ release-notes` | push (filtered) / every PR / merge group | not required | no |
 | `Test ▸ publication` | push (filtered) / every PR / merge group | not required | no |
 | `Test ▸ test-quality` | push (filtered) / every PR / merge group | not required | no |

--- a/Packages/com.velvet.core/Editor/PlayerBuild/PlayerScriptCompilation.cs
+++ b/Packages/com.velvet.core/Editor/PlayerBuild/PlayerScriptCompilation.cs
@@ -1,0 +1,86 @@
+using System;
+using System.IO;
+using System.Linq;
+using UnityEditor;
+using UnityEditor.Build.Player;
+using UnityEditor.Compilation;
+using UnityEngine;
+
+namespace Velvet.Editor.PlayerBuild
+{
+    /// <summary>
+    /// Compiles every runtime assembly the way a player does, which is the one compile the suite never
+    /// performs.
+    /// </summary>
+    /// <remarks>
+    /// EditMode and PlayMode both run inside the editor, where <c>UNITY_EDITOR</c> is defined, so a call
+    /// to a member declared under <c>#if UNITY_EDITOR</c> from outside one compiles there and nowhere
+    /// else. Measured on a branch carrying such a call: clean with the define, <c>CS0103</c> without it.
+    /// What a consumer hits is a package that fails to build, with no workaround short of editing it.
+    /// <para>
+    /// Scripts rather than a whole player: the question is which defines the compile runs under, and a
+    /// player build would answer it alongside a scene load, an asset import and a linker pass with
+    /// failure modes of their own.
+    /// </para>
+    /// <para>
+    /// Failure is read as an assembly that did not arrive rather than off a message list, because
+    /// <see cref="ScriptCompilationResult"/> carries no messages: a compile error drops the assembly
+    /// from the result, and the editor's own log carries the diagnostic. The expected set comes from
+    /// <see cref="CompilationPipeline"/>, so a package assembly nobody built is named here rather than
+    /// counted.
+    /// </para>
+    /// </remarks>
+    public static class PlayerScriptCompilation
+    {
+        /// <summary>Exits non-zero when a player assembly did not come out, so batchmode reports it.</summary>
+        public static void CompileForPlayer()
+        {
+            var target = EditorUserBuildSettings.activeBuildTarget;
+            var group = BuildPipeline.GetBuildTargetGroup(target);
+            var output = Path.Combine(Path.GetTempPath(), "velvet-player-scripts");
+            Directory.CreateDirectory(output);
+
+            var wanted = CompilationPipeline.GetAssemblies(AssembliesType.Player)
+                .Select(assembly => Path.GetFileName(assembly.outputPath))
+                .ToList();
+
+            ScriptCompilationResult result;
+            try
+            {
+                result = PlayerBuildInterface.CompilePlayerScripts(
+                    new ScriptCompilationSettings { target = target, group = group }, output);
+            }
+            catch (Exception failure)
+            {
+                Debug.LogError($"Player script compilation did not run: {failure}");
+                EditorApplication.Exit(1);
+                return;
+            }
+
+            var built = new System.Collections.Generic.HashSet<string>(
+                result.assemblies ?? Array.Empty<string>(), StringComparer.Ordinal);
+            var missing = wanted.Where(name => !built.Contains(name)).ToList();
+
+            // An empty wanted list would leave nothing missing however the compile went, which reads as
+            // success from the comparison alone.
+            if (wanted.Count == 0)
+            {
+                Debug.LogError("No player assemblies were named, so this compared nothing.");
+                EditorApplication.Exit(1);
+                return;
+            }
+
+            if (missing.Count > 0)
+            {
+                Debug.LogError($"Player script compilation produced {built.Count} of {wanted.Count} "
+                               + "assemblies. Missing: " + string.Join(", ", missing)
+                               + "\nThe compiler's own diagnostics are above this line.");
+                EditorApplication.Exit(1);
+                return;
+            }
+
+            Debug.Log($"Player script compilation produced all {wanted.Count} assemblies for {target}.");
+            EditorApplication.Exit(0);
+        }
+    }
+}

--- a/Packages/com.velvet.core/Editor/PlayerBuild/PlayerScriptCompilation.cs
+++ b/Packages/com.velvet.core/Editor/PlayerBuild/PlayerScriptCompilation.cs
@@ -33,7 +33,16 @@ namespace Velvet.Editor.PlayerBuild
     /// </remarks>
     public static class PlayerScriptCompilation
     {
-        /// <summary>Exits non-zero when a player assembly did not come out, so batchmode reports it.</summary>
+        private const string PackageRoot = "Packages/com.velvet.core/Runtime/";
+
+        private static bool IsPackageRuntimeSource(string path)
+        {
+            var slashed = path.Replace('\\', '/');
+            return slashed.Contains(PackageRoot, StringComparison.Ordinal)
+                   && !slashed.Contains("/Tests/", StringComparison.Ordinal);
+        }
+
+        /// <summary>Exits non-zero when a package assembly did not come out, so batchmode reports it.</summary>
         public static void CompileForPlayer()
         {
             var target = EditorUserBuildSettings.activeBuildTarget;
@@ -41,7 +50,15 @@ namespace Velvet.Editor.PlayerBuild
             var output = Path.Combine(Path.GetTempPath(), "velvet-player-scripts");
             Directory.CreateDirectory(output);
 
+            // The package's own runtime assemblies, not every player assembly there is. A test
+            // assembly is gated by UNITY_INCLUDE_TESTS and is absent from a player build by design --
+            // measured, ten of them, and reading their absence as failure made the check refuse a
+            // compile that had gone exactly right. Derived from where the sources sit rather than
+            // from a list of names, so a new assembly under Runtime is covered without being added
+            // anywhere.
             var wanted = CompilationPipeline.GetAssemblies(AssembliesType.Player)
+                .Where(assembly => assembly.sourceFiles.Length > 0
+                                   && assembly.sourceFiles.All(IsPackageRuntimeSource))
                 .Select(assembly => Path.GetFileName(assembly.outputPath))
                 .ToList();
 
@@ -66,21 +83,24 @@ namespace Velvet.Editor.PlayerBuild
             // success from the comparison alone.
             if (wanted.Count == 0)
             {
-                Debug.LogError("No player assemblies were named, so this compared nothing.");
+                Debug.LogError($"No player assembly is built from {PackageRoot}, so this compared "
+                               + "nothing. Either the package moved or the reading did.");
                 EditorApplication.Exit(1);
                 return;
             }
 
             if (missing.Count > 0)
             {
-                Debug.LogError($"Player script compilation produced {built.Count} of {wanted.Count} "
-                               + "assemblies. Missing: " + string.Join(", ", missing)
+                Debug.LogError($"Player script compilation produced {wanted.Count - missing.Count} of "
+                               + $"{wanted.Count} package assemblies. Missing: "
+                               + string.Join(", ", missing)
                                + "\nThe compiler's own diagnostics are above this line.");
                 EditorApplication.Exit(1);
                 return;
             }
 
-            Debug.Log($"Player script compilation produced all {wanted.Count} assemblies for {target}.");
+            Debug.Log($"Player script compilation produced all {wanted.Count} package assemblies "
+                      + $"for {target}.");
             EditorApplication.Exit(0);
         }
     }

--- a/Packages/com.velvet.core/Editor/PlayerBuild/PlayerScriptCompilation.cs
+++ b/Packages/com.velvet.core/Editor/PlayerBuild/PlayerScriptCompilation.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using UnityEditor;
@@ -57,8 +58,8 @@ namespace Velvet.Editor.PlayerBuild
                 return;
             }
 
-            var built = new System.Collections.Generic.HashSet<string>(
-                result.assemblies ?? Array.Empty<string>(), StringComparer.Ordinal);
+            var built = new HashSet<string>(
+                result.assemblies ?? (IEnumerable<string>)Array.Empty<string>(), StringComparer.Ordinal);
             var missing = wanted.Where(name => !built.Contains(name)).ToList();
 
             // An empty wanted list would leave nothing missing however the compile went, which reads as

--- a/Packages/com.velvet.core/Editor/PlayerBuild/PlayerScriptCompilation.cs.meta
+++ b/Packages/com.velvet.core/Editor/PlayerBuild/PlayerScriptCompilation.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f80c96b64073446fa228cbbf9e3a11ec

--- a/Packages/com.velvet.core/PublicAPI.txt
+++ b/Packages/com.velvet.core/PublicAPI.txt
@@ -6,6 +6,7 @@
 [Velvet.Editor] method Velvet.Editor.DevTools.StateHistoryBuffer.GetNewestFirst(): System.Collections.Generic.IReadOnlyList`1[Velvet.Editor.DevTools.StateHistoryEntry]
 [Velvet.Editor] method Velvet.Editor.DevTools.StateHistoryBuffer.Push(Velvet.Editor.DevTools.StateHistoryEntry): System.Void
 [Velvet.Editor] method Velvet.Editor.DevTools.VelvetDevToolsWindow.ShowWindow(): System.Void
+[Velvet.Editor] method Velvet.Editor.PlayerBuild.PlayerScriptCompilation.CompileForPlayer(): System.Void
 [Velvet.Editor] method Velvet.Editor.Preview.VelvetPreviewWindow.ShowWindow(): System.Void
 [Velvet.Editor] property Velvet.Editor.DevTools.StateHistoryBuffer.Capacity: System.Int32
 [Velvet.Editor] property Velvet.Editor.DevTools.StateHistoryBuffer.Count: System.Int32
@@ -15,6 +16,7 @@
 [Velvet.Editor] type Velvet.Editor.DevTools.StateHistoryBuffer
 [Velvet.Editor] type Velvet.Editor.DevTools.StateHistoryEntry
 [Velvet.Editor] type Velvet.Editor.DevTools.VelvetDevToolsWindow
+[Velvet.Editor] type Velvet.Editor.PlayerBuild.PlayerScriptCompilation
 [Velvet.Editor] type Velvet.Editor.Preview.VelvetPreviewWindow
 [Velvet] ctor System.Runtime.CompilerServices.ModuleInitializerAttribute.ctor(): System.Void
 [Velvet] ctor Velvet.AnchoredSettings.ctor(UnityEngine.Transform?, UnityEngine.Camera?, UnityEngine.Vector2, System.Boolean, System.Boolean, System.Nullable`1[UnityEngine.LayerMask], System.Nullable`1[System.Single]): System.Void


### PR DESCRIPTION
Nothing in CI compiles the package for a player, so a `#if UNITY_EDITOR` mistake ships through a fully
green suite.

`test.yml` runs `-testPlatform EditMode` and `-testPlatform PlayMode`, and both run **inside the
editor**, where `UNITY_EDITOR` is defined. So a call to a member declared under `#if UNITY_EDITOR`
from outside one compiles in every job and in no consumer's build. Measured on the branch that
surfaced it: clean with the define, `CS0103` without it. What a consumer hits is a package that fails
to build with no workaround short of editing it.

None of the existing guards can see it. `assert_results_from_this_tree.py` verifies the assemblies came
from this tree, not that they compile under a different define set; the mutation and base-red lanes
both drive EditMode. A file can be player-broken with the whole matrix green.

The job compiles player scripts rather than building a player: the question is which defines the
compile runs under, and a player build would answer it alongside a scene load, an asset import and a
linker pass with failure modes of their own. It needs no build settings and no scene.

The comparison is over the package's own runtime assemblies, not every player assembly there is: a
test assembly is gated by `UNITY_INCLUDE_TESTS` and absent from a player build by design. Measured on
the first run, ten of them — `UnityEngine.TestRunner`, `Unity.PerformanceTesting`,
`Velvet.TestUtilities` and seven `Velvet.Tests.*.PlayMode` — so the wider reading refused a compile
that had gone exactly right. The set is derived from where an assembly's sources sit, so a new one
under `Runtime/` is covered without being added anywhere.

Failure is read as an assembly that did not arrive, not off a message list — `ScriptCompilationResult`
carries no messages, and a compile error drops the assembly from the result while the editor's log
carries the diagnostic. The expected set comes from `CompilationPipeline`, so a package assembly
nobody built is named rather than counted, and an empty expected set is refused outright: it would
leave nothing missing however the compile went.

The job inherits the existing `UNITY_LICENSE` gate and adds no new secret. It joins `required-checks`,
which counts a skipped job as passing, so a fork without the licence is unaffected.

The source-level alternative the issue prices third — refuse a call to an identifier declared under
`#if UNITY_EDITOR` — is not built here. It is a text reading of a conditional-compilation problem that
would have to follow `#if` nesting and `#else`, and the corpus holds exactly one violation, which is a
weak basis for a parser. This answers the whole class instead.

The entry point is public because `-executeMethod` needs a public static method, so it joins
`PublicAPI.txt` — two lines, a type and a method. CONTRIBUTING.md's CI table gains the job's row,
which `Given_EveryJobOfARequiredWorkflow_When_ContributingsCiTableIsRead_Then_ItHasARow` is what asks
for.

Closes #756
