### PR TITLE
tooling(velvet): read a git call that opens a conditional, not only one that continues it

### DIFF
--- a/.claude/hooks/lib/shell_commands.py
+++ b/.claude/hooks/lib/shell_commands.py
@@ -15,11 +15,15 @@ import shlex
 
 SEPARATORS = set(";&|\n")
 
-# Words that may precede the command without changing which command it is. `then`/`do`/`else`
-# because a command inside a conditional or a loop is still that command; `builtin` alongside
-# `command` because a guard reading the word after it saw `builtin cd` as neither a move nor a
-# command word, and answered about a file in the directory the move had left.
-LEADING_WORDS = {"then", "do", "else", "elif", "!", "time", "command", "builtin", "nohup", "exec"}
+# Words that may precede the command without changing which command it is. `then`/`do`/`else` because
+# a command inside a conditional or a loop is still that command, and `if`/`while`/`until` for the same
+# reason one word earlier: the keyword that OPENS the construct was missing while the ones that
+# continue it were there, so `if git commit --amend; then ...` was seen by no guard and
+# `then git commit --amend` by all of them. `builtin` alongside `command` because a guard reading the
+# word after it saw `builtin cd` as neither a move nor a command word, and answered about a file in the
+# directory the move had left.
+LEADING_WORDS = {"if", "while", "until", "then", "do", "else", "elif",
+                 "!", "time", "command", "builtin", "nohup", "exec"}
 ENV_ASSIGNMENT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
 REDIRECTION = re.compile(r"^\d*(?:>>|>&|<&|>|<)")
 

--- a/.claude/hooks/refuse/hand_rolled_pr_poller.py
+++ b/.claude/hooks/refuse/hand_rolled_pr_poller.py
@@ -35,7 +35,8 @@ HOOK_DIRECTORY = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(HOOK_DIRECTORY / "lib"))
 sys.path.insert(0, str(HOOK_DIRECTORY.parent.parent / "scripts" / "pr"))
 
-from shell_commands import command_segments, leading_program, mask_shell_literals  # noqa: E402
+from shell_commands import (  # noqa: E402
+    ENV_ASSIGNMENT, LEADING_WORDS, command_segments, leading_program, mask_shell_literals)
 from shell_commands import tokens_of, without_redirections  # noqa: E402
 from watcher_state import HEARTBEAT, LOCK, READY_STATE, alive, unreadable_beat  # noqa: E402
 
@@ -127,15 +128,23 @@ def segment_tokens(segment):
 
 
 def command_word(tokens):
-    """Where the program a segment runs sits, past a loop head and what `leading_program` skips.
+    """Where the program a segment runs sits, past what `leading_program` skips."""
+    return leading_program(tokens)
 
-    `while` and `until` are not in `shell_commands.LEADING_WORDS`, so a command word behind one reads
-    as the keyword.
+
+def loop_head(tokens):
+    """Where a loop keyword sits in this segment, or -1.
+
+    Read off the raw tokens rather than off `leading_program`, which skips a loop head along with
+    every other word that may precede a command: this guard's subject is the keyword itself, and a
+    reading that walks past it cannot see the repetition it exists to refuse.
     """
-    index = leading_program(tokens)
-    if index < len(tokens) and tokens[index] in LOOP_HEADS:
-        index += 1 + leading_program(tokens[index + 1:])
-    return index
+    for index, token in enumerate(tokens):
+        if token in LOOP_HEADS:
+            return index
+        if not (ENV_ASSIGNMENT.match(token) or token in LEADING_WORDS):
+            return -1
+    return -1
 
 
 def handed_to_a_shell(text):
@@ -180,13 +189,14 @@ def repeats(command):
         for segment in command_segments(text):
             tokens = segment_tokens(segment)
             head = leading_program(tokens)
-            if head >= len(tokens):
-                continue
-            if tokens[head] in LOOP_HEADS:
+            looped = loop_head(tokens)
+            if looped >= 0:
                 word = command_word(tokens)
                 if word >= len(tokens) or tokens[word] != WALKS_INPUT:
                     return True
-            elif tokens[head] == LIST_LOOP and LIST_WORD not in tokens[head + 1:head + 3]:
+            if head >= len(tokens):
+                continue
+            if tokens[head] == LIST_LOOP and LIST_WORD not in tokens[head + 1:head + 3]:
                 return True
             elif os.path.basename(tokens[head]) == RE_RUNS:
                 return True

--- a/.github/workflows/generators.yml
+++ b/.github/workflows/generators.yml
@@ -146,6 +146,11 @@ jobs:
       - name: Unsettled pull request guard tests
         run: python3 scripts/hooks/test_unsettled_pr.py
 
+      # Every guard asking "is this command a git <subcommand>" reads one table, so a word it does not
+      # know hides the call from all of them, unrefused and unreported.
+      - name: Shell command reading tests
+        run: python3 scripts/hooks/test_shell_commands.py
+
       # The two unexpanded-operand readings, which were one list under a sentence written for one of
       # them.
       - name: Fast-checks commit guard tests

--- a/scripts/hooks/test_shell_commands.py
+++ b/scripts/hooks/test_shell_commands.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Unit tests for .claude/hooks/lib/shell_commands.py's command-word reading.
+
+Every refuse hook that asks "is this command a `git <subcommand>`" goes through this table, so a word
+it does not know hides the call from all of them at once — and the failure is silent in the direction
+that matters: the command runs unrefused, and nothing reports that a reading was skipped.
+
+Run: python3 scripts/hooks/test_shell_commands.py
+"""
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def load_module():
+    """Imports shell_commands by path, since .claude holds no packages."""
+    path = REPO_ROOT / ".claude/hooks/lib/shell_commands.py"
+    sys.path.insert(0, str(path.parent))
+    spec = importlib.util.spec_from_file_location("shell_commands", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+shell_commands = load_module()
+
+
+class LeadingWordTests(unittest.TestCase):
+    """Words that may sit in front of a command without changing which command it is.
+
+    The keywords that CONTINUE a construct were here and the ones that OPEN it were not, so
+    `then git commit --amend` was seen by every guard and `if git commit --amend; then …` by none —
+    and the second is the ordinary spelling.
+    """
+
+    def subcommands(self, command):
+        return [found[1] for found in shell_commands.git_invocations(command, ("commit",))]
+
+    def test_Given_AGitCallOpeningAConditional_When_TheInvocationsAreRead_Then_ItIsSeen(self):
+        # Act / Assert
+        self.assertEqual(self.subcommands("if git commit --amend; then echo x; fi"), ["commit"])
+
+    def test_Given_AGitCallOpeningAWhileLoop_When_TheInvocationsAreRead_Then_ItIsSeen(self):
+        # Act / Assert
+        self.assertEqual(self.subcommands("while git commit --amend; do echo x; done"), ["commit"])
+
+    def test_Given_AGitCallOpeningAnUntilLoop_When_TheInvocationsAreRead_Then_ItIsSeen(self):
+        # Act / Assert
+        self.assertEqual(self.subcommands("until git commit --amend; do sleep 1; done"), ["commit"])
+
+    def test_Given_AGitCallContinuingAConditional_When_TheInvocationsAreRead_Then_ItIsStillSeen(self):
+        # Arrange — the half that already worked, and the one a widening must not take with it.
+        # Act / Assert
+        self.assertEqual(self.subcommands("then git commit --amend"), ["commit"])
+
+    def test_Given_TheKeywordInsideAQuotedString_When_TheInvocationsAreRead_Then_NothingIsSeen(self):
+        # Arrange — the control on the other side: a word the shell will not run is not a command,
+        # and a reading that answered yes here would refuse an `echo`.
+        # Act / Assert
+        self.assertEqual(self.subcommands("echo 'if git commit --amend'"), [])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/hooks/test_shell_commands.py
+++ b/scripts/hooks/test_shell_commands.py
@@ -52,11 +52,15 @@ class LeadingWordTests(unittest.TestCase):
         # Act / Assert
         self.assertEqual(self.subcommands("until git commit --amend; do sleep 1; done"), ["commit"])
 
+    # GREEN_ON_BASE(characterization): the base sees this one, which is the half a widening
+    # could take with it — the same table decides both.
     def test_Given_AGitCallContinuingAConditional_When_TheInvocationsAreRead_Then_ItIsStillSeen(self):
         # Arrange — the half that already worked, and the one a widening must not take with it.
         # Act / Assert
         self.assertEqual(self.subcommands("then git commit --amend"), ["commit"])
 
+    # GREEN_ON_BASE(characterization): the base sees this one, which is the half a widening
+    # could take with it — the same table decides both.
     def test_Given_TheKeywordInsideAQuotedString_When_TheInvocationsAreRead_Then_NothingIsSeen(self):
         # Arrange — the control on the other side: a word the shell will not run is not a command,
         # and a reading that answered yes here would refuse an `echo`.

--- a/scripts/hooks/test_shell_commands.py
+++ b/scripts/hooks/test_shell_commands.py
@@ -68,5 +68,22 @@ class LeadingWordTests(unittest.TestCase):
         self.assertEqual(self.subcommands("echo 'if git commit --amend'"), [])
 
 
+class LoopHeadReaderTests(unittest.TestCase):
+    """A guard whose subject is the keyword itself cannot read it through this table.
+
+    `hand_rolled_pr_poller` decides that a command repeats by finding `while` or `until` where the
+    program word would be. Adding those to `LEADING_WORDS` walked past them, so a backgrounded poll
+    over the watcher's state stopped reading as a loop and the guard let it through — measured, and
+    what caught it was that guard's own suite rather than anything here.
+    """
+
+    def test_Given_ALoopKeyword_When_TheProgramWordIsSought_Then_TheTableWalksPastIt(self):
+        # Arrange — the property the poller guard has to compensate for, stated where the table is.
+        tokens = ["until", "gh", "pr", "checks", "702"]
+
+        # Act / Assert
+        self.assertEqual(tokens[shell_commands.leading_program(tokens)], "gh")
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
`shell_commands.git_invocations` missed any git call that opens a conditional or a loop, and every
guard reading that table inherited the hole silently.

```
git_invocations("if git commit --amend; then echo x; fi", {"commit"})  -> []
git_invocations("then git commit --amend", {"commit"})                 -> [(None, 'commit', ['--amend'])]
```

`LEADING_WORDS` carried `then`, `do`, `else` and `elif`, on the stated reason that a command inside a
conditional or a loop is still that command. It omitted `if`, `while` and `until` — the three keywords
that *open* those constructs. So the word introducing the construct hid the call and the word
continuing it did not.

Every refuse hook that asks "is this command a `git <subcommand>`" goes through this table. A
contributor writing `if git commit --amend; then …` is evading nothing — it is an ordinary shape — and
the guards did not see the call. The failure is silent in the direction that matters: the command runs
unrefused, and nothing reports that a reading was skipped.

Measured after: all five spellings are seen, and `echo 'if git commit --amend'` is not — a word the
shell will not run is not a command, and a reading that answered yes there would refuse an `echo`.
`if git add -A; then …` is now denied by `blind_git_add.py`, which is the widening doing its work,
and `if git status; then …` is denied by nothing, which is it not doing anything else.

The table had no suite. It has one, and `generators.yml` runs it beside the other hook suites.

**One guard had to change with it.** `hand_rolled_pr_poller` decides that a command repeats by finding
`while` or `until` where the program word would be, and said so in a comment: *"`while` and `until`
are not in `shell_commands.LEADING_WORDS`, so a command word behind one reads as the keyword."* With
them in the table, `leading_program` walks past them and a backgrounded poll over the watcher's state
stopped reading as a loop — the guard let it through. Its own suite caught that, and the guard now
reads the loop head off the raw tokens: its subject is the keyword itself, and a reading that walks
past it cannot see the repetition it exists to refuse. Its thirty-two cases pass, and so does every
other suite under `scripts/hooks/`.

No documentation impact: the table is a hook internal, and each guard's advice is its own text.

Closes #690
