### PR TITLE
tooling(velvet): refuse a suite that reported no test, which exits 0 today

### DIFF
--- a/.github/workflows/generators.yml
+++ b/.github/workflows/generators.yml
@@ -80,7 +80,7 @@ jobs:
       # satisfied. These drive the states where it would — an absent binary, a failing build, an SDK
       # other than the pin — which a run over a healthy checkout does not reach.
       - name: Committed generator DLL check tests
-        run: python3 scripts/generators/test_deployed_dll_check.py
+        run: python3 scripts/test_quality/run_suite.py scripts/generators/test_deployed_dll_check.py
 
       - name: Cohesion report
         run: python3 scripts/test_quality/cohesion_report.py
@@ -91,12 +91,12 @@ jobs:
       # The ratchet reports what its block set says, so the set is what has to be held: a swap that
       # leaves the total alone is invisible to the step above and is what this asserts.
       - name: Duplication ratchet tests
-        run: python3 scripts/test_quality/test_duplication_check.py
+        run: python3 scripts/test_quality/run_suite.py scripts/test_quality/test_duplication_check.py
 
       # The merge gate decides from plain data so its cases run without a network — a gate exercised
       # only against live pull requests is exercised only in the states those happen to be in.
       - name: Pull request settle tests
-        run: python3 scripts/pr/test_settle.py
+        run: python3 scripts/test_quality/run_suite.py scripts/pr/test_settle.py
 
       # A PreToolUse guard whose repository reading failed exits 0, which is also what it exits with
       # nothing to report, so the difference is measured by running each guard with git or gh unable
@@ -104,14 +104,14 @@ jobs:
       # test.yml's Unity jobs are skipped without a UNITY_LICENSE secret and its aggregate counts a
       # skip as a pass, so a guard silently not running is the very shape this checks for.
       - name: Hook unreadable-state tests
-        run: python3 scripts/hooks/test_unreadable_state_check.py
+        run: python3 scripts/test_quality/run_suite.py scripts/hooks/test_unreadable_state_check.py
 
       # The reading those Stop guards share, and what it says when no way of asking answered. Held
       # apart from the check above because that one runs whole guards and this one holds the library
       # they run through: a guard could satisfy the check by hand-rolling a report, and then only
       # one of the two would say it.
       - name: Hook repository-reading tests
-        run: python3 scripts/hooks/test_hook_repository.py
+        run: python3 scripts/test_quality/run_suite.py scripts/hooks/test_hook_repository.py
 
       # Every guard over a merge, posed a pull request based on a branch that is not main. Until a
       # maintenance branch was cut, every case in this repository posed one based on main, and two
@@ -122,64 +122,69 @@ jobs:
       # A sweep that reports nothing looks the same whether the guards read the base or the directory
       # was empty, so these drive the states where it would report something.
       - name: Pull-request base check tests
-        run: python3 scripts/hooks/test_pull_request_base_check.py
+        run: python3 scripts/test_quality/run_suite.py scripts/hooks/test_pull_request_base_check.py
 
       # The reading both merge guards take their base through. The sweep above exercises its numbered
       # half through the guards themselves; the other shape is posed here, and that file says why the
       # sweep cannot hold it.
       - name: Merge target reading tests
-        run: python3 scripts/hooks/test_merge_target.py
+        run: python3 scripts/test_quality/run_suite.py scripts/hooks/test_merge_target.py
 
       # The session-start report shares that reading, and what it prints is a rebase command — so the
       # branch it names is an instruction rather than a number.
       - name: Stale base report tests
-        run: python3 scripts/hooks/test_stale_main.py
+        run: python3 scripts/test_quality/run_suite.py scripts/hooks/test_stale_main.py
 
       # `published_check.py` asks whether a closed version went unpublished; an entry waiting in a
       # maintenance line's `## [Unreleased]` belongs to no version yet, so that reading is silent
       # while the work waits. The silences are what the tests are mostly about.
       - name: Maintenance line report tests
-        run: python3 scripts/hooks/test_unreleased_maintenance_line.py
+        run: python3 scripts/test_quality/run_suite.py scripts/hooks/test_unreleased_maintenance_line.py
 
       # The zero-checks reading, which had no suite. It used to say "merge it" for a pull request
       # nothing had tested, on a path filter `pull_request` does not carry.
       - name: Unsettled pull request guard tests
-        run: python3 scripts/hooks/test_unsettled_pr.py
+        run: python3 scripts/test_quality/run_suite.py scripts/hooks/test_unsettled_pr.py
 
       # Every guard asking "is this command a git <subcommand>" reads one table, so a word it does not
       # know hides the call from all of them, unrefused and unreported.
       - name: Shell command reading tests
-        run: python3 scripts/hooks/test_shell_commands.py
+        run: python3 scripts/test_quality/run_suite.py scripts/hooks/test_shell_commands.py
+
+      # The runner itself, which no other step can vouch for: it is what every step above is read
+      # through, so a runner that stopped counting would make all of them silent together.
+      - name: Suite runner tests
+        run: python3 scripts/test_quality/run_suite.py scripts/test_quality/test_run_suite.py
 
       # The two unexpanded-operand readings, which were one list under a sentence written for one of
       # them.
       - name: Fast-checks commit guard tests
-        run: python3 scripts/hooks/test_commit_failing_fast_checks.py
+        run: python3 scripts/test_quality/run_suite.py scripts/hooks/test_commit_failing_fast_checks.py
 
       # A refuse guard that stops matching exits 0 and says nothing, which is what it does when it has
       # nothing to say. The release-time edits it must let through are the half it was measured wrong
       # about, by somebody walking the procedure by hand.
       - name: Closed-version CHANGELOG guard tests
-        run: python3 scripts/hooks/test_changelog_into_closed_version.py
+        run: python3 scripts/test_quality/run_suite.py scripts/hooks/test_changelog_into_closed_version.py
 
       # Holds the body guards' record of which gh options take a value against the gh on the runner,
       # which needs no licence and no token, only `--help`. The script owns what a disagreement
       # costs in either direction.
       - name: Pull-request body option-table tests
-        run: python3 scripts/hooks/test_pr_body_flags.py
+        run: python3 scripts/test_quality/run_suite.py scripts/hooks/test_pr_body_flags.py
 
       # Both guards decide from something the licence-free half can build: one from a pair of
       # repositories git makes here, the other from the text of an edit. Neither needs the editor,
       # and the amend guard's cases are the only place the two commands that answer its question are
       # held to each other.
       - name: Amend guard tests
-        run: python3 scripts/hooks/test_amend_of_published_commit.py
+        run: python3 scripts/test_quality/run_suite.py scripts/hooks/test_amend_of_published_commit.py
 
       - name: Declaration first-line tests
-        run: python3 scripts/hooks/test_declaration_first_line_fragment.py
+        run: python3 scripts/test_quality/run_suite.py scripts/hooks/test_declaration_first_line_fragment.py
 
       - name: Hand-rolled poller guard tests
-        run: python3 scripts/hooks/test_hand_rolled_pr_poller.py
+        run: python3 scripts/test_quality/run_suite.py scripts/hooks/test_hand_rolled_pr_poller.py
 
   # ---------------------------------------------------------------------------
   # Repository settings live only in GitHub's own state; nothing in this

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -174,13 +174,13 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - run: python3 scripts/release/test_release_notes.py
+      - run: python3 scripts/test_quality/run_suite.py scripts/release/test_release_notes.py
 
-      - run: python3 scripts/release/test_supported_versions_check.py
+      - run: python3 scripts/test_quality/run_suite.py scripts/release/test_supported_versions_check.py
 
       - run: python3 scripts/release/supported_versions_check.py
 
-      - run: python3 scripts/release/test_pin_example_check.py
+      - run: python3 scripts/test_quality/run_suite.py scripts/release/test_pin_example_check.py
 
       - run: python3 scripts/release/pin_example_check.py
 
@@ -213,7 +213,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - run: python3 scripts/release/test_published_check.py
+      - run: python3 scripts/test_quality/run_suite.py scripts/release/test_published_check.py
 
       - env:
           BASE: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
@@ -221,7 +221,7 @@ jobs:
           python3 scripts/release/published_check.py --result HEAD --timeout 30 \
             ${BASE:+--base "$BASE"}
 
-      - run: python3 scripts/release/test_breaking_in_flight_check.py
+      - run: python3 scripts/test_quality/run_suite.py scripts/release/test_breaking_in_flight_check.py
 
       # Every other reading here is of one tree, so a branch carrying a breaking entry is invisible
       # to all of them — which is how v3.0.0 shipped twelve of the thirteen written for it. Skipped
@@ -355,17 +355,17 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - run: python3 scripts/test_quality/test_mutation_check.py
+      - run: python3 scripts/test_quality/run_suite.py scripts/test_quality/test_mutation_check.py
 
-      - run: python3 scripts/test_quality/test_neuter_check.py
+      - run: python3 scripts/test_quality/run_suite.py scripts/test_quality/test_neuter_check.py
 
       - run: python3 scripts/test_quality/neuter_check.py --audit
 
-      - run: python3 scripts/test_quality/test_base_red_check.py
+      - run: python3 scripts/test_quality/run_suite.py scripts/test_quality/test_base_red_check.py
 
-      - run: python3 scripts/test_quality/test_assert_results_from_this_tree.py
+      - run: python3 scripts/test_quality/run_suite.py scripts/test_quality/test_assert_results_from_this_tree.py
 
-      - run: python3 scripts/test_quality/test_assume_gate_check.py
+      - run: python3 scripts/test_quality/run_suite.py scripts/test_quality/test_assume_gate_check.py
 
       - run: python3 scripts/test_quality/assume_gate_check.py
 

--- a/scripts/test_quality/run_suite.py
+++ b/scripts/test_quality/run_suite.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Run a Python test module and refuse a run that reported no test at all.
+
+A `test_*.py` here ends in `unittest.main()` and is invoked directly by CI. The modules under test
+end in `sys.exit(main())`, and a test module imports one at module level — so a mutation that flips
+that guard kills the process during the import, `unittest.main()` is never reached, and the module
+exits 0 having run nothing. The only output is the check's own stdout line, which reads like success.
+
+No guard placed inside the test module can close it: the death is at import, before any of it runs.
+So the count is read from outside, off unittest's own summary line.
+
+The Python lane of `base_red_check.py` is not exposed and the reason is worth keeping: under
+`python3 -m unittest` the same mutant makes argparse exit 2 with a usage message and no trailer, so
+the outcome reads as an error rather than a pass. The direct-invocation form is what loses it.
+
+    python3 scripts/test_quality/run_suite.py scripts/hooks/test_merge_target.py
+
+Exits with the suite's own code where a test ran, and 1 where none did.
+"""
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# unittest writes this to stderr whatever the verbosity, and writes nothing like it when the module
+# died before `unittest.main()`. `NO_TESTS` is what it prints for an empty but reached suite, which
+# is a different failure with the same cost and is refused with the rest.
+RAN = re.compile(r"^Ran (\d+) tests? in ", re.M)
+NO_TESTS = re.compile(r"^NO TESTS RAN", re.M)
+
+
+def counted(text):
+    """How many tests the run reported, or None when it reported no count at all."""
+    if NO_TESTS.search(text or ""):
+        return 0
+    found = RAN.search(text or "")
+    return int(found.group(1)) if found else None
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("usage: run_suite.py <test module> [args...]", file=sys.stderr)
+        return 1
+    module = sys.argv[1]
+    done = subprocess.run([sys.executable, module, *sys.argv[2:]],
+                          capture_output=True, text=True)
+    sys.stdout.write(done.stdout)
+    sys.stderr.write(done.stderr)
+
+    ran = counted(done.stderr)
+    if ran is None:
+        print(f"\n{module} reported no test count, so nothing here ran a test.\n"
+              "A module that dies during its own imports exits 0 having measured nothing, and that "
+              "reads\nthe same as a pass. Run it directly to see where it stopped.", file=sys.stderr)
+        return 1
+    if ran == 0:
+        print(f"\n{module} ran 0 tests.", file=sys.stderr)
+        return 1
+    return done.returncode
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_quality/test_run_suite.py
+++ b/scripts/test_quality/test_run_suite.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Unit tests for scripts/test_quality/run_suite.py.
+
+A module that dies during its own imports exits 0 having run nothing, and prints what the check it
+imported prints — which reads like a pass. The count is what separates them, and it is read from
+outside because no guard inside the module gets to run.
+
+Run: python3 scripts/test_quality/test_run_suite.py
+"""
+
+import importlib.util
+import subprocess
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RUNNER = REPO_ROOT / "scripts/test_quality/run_suite.py"
+
+_spec = importlib.util.spec_from_file_location("run_suite", RUNNER)
+run_suite = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(run_suite)
+
+PASSING = '''import unittest
+
+
+class T(unittest.TestCase):
+    def test_it(self):
+        self.assertTrue(True)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)
+'''
+
+FAILING = PASSING.replace("self.assertTrue(True)", "self.assertTrue(False)")
+
+DIES_ON_IMPORT = '''import sys
+
+print("the check ran")
+sys.exit(0)
+'''
+
+
+class CountReadingTests(unittest.TestCase):
+    def test_Given_unittestsOwnSummary_When_Read_Then_TheCountIsTaken(self):
+        # Act / Assert
+        self.assertEqual(run_suite.counted("Ran 12 tests in 0.5s\n\nOK\n"), 12)
+
+    def test_Given_ASingularSummary_When_Read_Then_TheCountIsTaken(self):
+        # Arrange — unittest writes "1 test", not "1 tests".
+        # Act / Assert
+        self.assertEqual(run_suite.counted("Ran 1 test in 0.0s\n\nOK\n"), 1)
+
+    def test_Given_NoSummaryAtAll_When_Read_Then_ThereIsNoCount(self):
+        # Arrange — what a module that died during its imports leaves: the check's own stdout and
+        # nothing of unittest's.
+        # Act / Assert
+        self.assertIsNone(run_suite.counted("the check ran\n"))
+
+
+class VerdictTests(unittest.TestCase):
+    def setUp(self):
+        self.root = Path(tempfile.mkdtemp(prefix="run-suite-"))
+        self.addCleanup(shutil.rmtree, self.root, ignore_errors=True)
+
+    def module(self, name, body):
+        path = self.root / name
+        path.write_text(body)
+        return path
+
+    def verdict(self, path):
+        return subprocess.run([sys.executable, str(RUNNER), str(path)],
+                              capture_output=True, text=True, timeout=60).returncode
+
+    def test_Given_ASuiteThatRuns_When_ItPasses_Then_TheRunnerPasses(self):
+        # Act / Assert
+        self.assertEqual(self.verdict(self.module("test_ok.py", PASSING)), 0)
+
+    def test_Given_ASuiteThatRuns_When_ItFails_Then_TheRunnerFails(self):
+        # Arrange — the control: a runner that refused everything would satisfy the case below.
+        # Act / Assert
+        self.assertEqual(self.verdict(self.module("test_bad.py", FAILING)), 1)
+
+    def test_Given_AModuleThatDiesDuringItsImports_When_Run_Then_ItIsRefused(self):
+        # Arrange — the shape this exists for. Directly, this exits 0 and prints only what the check
+        # it imported printed.
+        self.module("probe.py", DIES_ON_IMPORT)
+        dies = self.module("test_dies.py", '''import importlib.util, unittest
+from pathlib import Path
+spec = importlib.util.spec_from_file_location("probe", Path(__file__).with_name("probe.py"))
+probe = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(probe)
+
+
+class T(unittest.TestCase):
+    def test_it(self):
+        self.assertTrue(False)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)
+''')
+        direct = subprocess.run([sys.executable, str(dies)], capture_output=True, text=True,
+                                timeout=60).returncode
+
+        # Act / Assert — the direct exit rides along, because a runner that refused a module the
+        # plain invocation already refused would be answering a question nobody had.
+        self.assertEqual((direct, self.verdict(dies)), (0, 1))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
A `test_*.py` module here ends in `unittest.main()` and is invoked directly by CI. The modules it
tests end in `sys.exit(main())`, and a test module imports one at module level — so a mutation that
flips that guard kills the process during the import, `unittest.main()` is never reached, and the
module exits 0 having run nothing. The only output is the check's own stdout line, which reads like
success.

Reproduced: a module whose single test asserts `False` prints `the check ran` and exits 0.

No guard placed inside the test module can close it — the death is at import, before any of it runs.
So the count is read from outside, off unittest's own summary line, by a runner every step goes
through. Twenty-seven steps across the two workflows were exposed.

The runner refuses two shapes: a run reporting no count at all, which is the import death, and a run
reporting zero, which is an empty-but-reached suite — a different failure with the same cost. Where a
test ran, it exits with the suite's own code, so a failing suite still fails.

It is itself run through itself, which is not circular in the way it looks: a runner that stopped
counting would make every step above it silent together, so it is the one module where that mattering
is the whole point. Its own suite is six cases, including the control — a runner that refused
everything would satisfy the import-death case — and one that pairs the direct exit with the runner's,
because refusing a module the plain invocation already refuses would answer a question nobody had.

All twenty-seven modules pass through it locally; `test_deployed_dll_check.py` needs a dotnet build
and runs in CI only.

**The stale-`.pyc` half of the issue is not fixed here**, and is #852. It wants a decision about where
every Python invocation inherits `-B`, and the two halves share only their consequence, not their
mechanism: a runner reading unittest's count from outside cannot see a stale cache.

No documentation impact: CONTRIBUTING.md names the suites by what they check, not how they are
invoked.

Closes #649
