### PR TITLE
tooling(velvet): let a declaration answer for one mutant, not for its line

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,7 +153,21 @@ surviving and needs the same answer: an `Assume` that stopped holding measured n
 is read the three ways the base-red one below is: one over a statement whose mutants all died is stale
 and fails, one whose category or reason the script refuses fails, and one the branch did not itself
 write answers for the base's change rather than for this one — restate it. It answers for the statement
-rather than the line, because a condition broken across two lines carries mutants on both. Only a
+rather than the line, because a condition broken across two lines carries mutants on both.
+
+A statement carries more than one mutant — `if (depth > cap) Reset();` has a boundary flip and a
+void-call removal — and the form above answers for every one of them. Where only one survives today
+that is unambiguous now and widens the moment a sibling starts surviving, with nothing to report it:
+staleness asks whether the statement still produces a survivor, and the one already answered for
+keeps it non-stale. Name the operator to answer for one:
+
+```csharp
+// MUTANT_SURVIVES(unreachable, line removed): nothing pairs the depth cap with a transition.
+```
+
+A named declaration answers for that operator alone, and is stale when that operator's mutant stops
+surviving whatever its siblings do. The unnamed form is unchanged and still reads the statement
+whole, which is what a statement carrying one mutant wants. Only a
 whole-suite run over the diff reads any: `--files`, `--filter` and `--assemblies` each ask a narrower
 question, and under one nearly everything survives. `--platform` is not one of those — it runs a whole
 suite, just a different one — so it reads declarations and writes a receipt, and the platform is part

--- a/scripts/hooks/test_declaration_first_line_fragment.py
+++ b/scripts/hooks/test_declaration_first_line_fragment.py
@@ -544,6 +544,9 @@ class ReaderFloorTests(unittest.TestCase):
         # Assert
         self.assertEqual(complaints, [self.UNDER_THE_FLOOR] * len(READERS))
 
+    # GREEN_ON_BASE(characterization): every pattern stopped at the wrap before and stops at it now.
+    # What moved is how this reads the reason out — by the last group rather than by number — so a
+    # pattern gaining a group does not silently start comparing something else.
     def test_Given_AReasonWrappedOntoASecondLine_When_EachPatternReadsIt_Then_EachStopsAtTheWrap(self):
         # Arrange — the guard judges the first line because that is the whole of what the readers
         # take as the claim. A reader that folded the continuation in would be measuring a reason

--- a/scripts/hooks/test_declaration_first_line_fragment.py
+++ b/scripts/hooks/test_declaration_first_line_fragment.py
@@ -552,10 +552,11 @@ class ReaderFloorTests(unittest.TestCase):
         blocks = {"base_red_check": f"// {BASE}(characterization): {first}\n// the rest of it.\n",
                   "mutation_check": f"// {SURVIVES}(equivalent): {first}\n// the rest of it.\n"}
 
-        # Act
-        read = {name: reader.DECLARATION.search(blocks[name]).group(2)
+        # Act — the reason is each pattern's last group, which is what it is whether or not the
+        # pattern carries an operator group between the category and it.
+        read = {name: reader.DECLARATION.search(blocks[name]).groups()[-1]
                 for name, reader in READERS.items()}
-        read.update((f"guard/{name}", guard.DECLARATION.search(block).group(2))
+        read.update((f"guard/{name}", guard.DECLARATION.search(block).groups()[-1])
                     for name, block in blocks.items())
 
         # Assert

--- a/scripts/test_quality/mutation_check.py
+++ b/scripts/test_quality/mutation_check.py
@@ -86,7 +86,15 @@ CATEGORIES = ("equivalent", "unreachable")
 # Four words, for the reason base_red_check.py's own floor gives.
 MINIMUM_REASON_WORDS = 4
 
-DECLARATION = re.compile(r"MUTANT_SURVIVES\(([A-Za-z]*)\)\s*:\s*(.*)")
+# The category, and optionally the operator it answers for. A line carries more than one mutant --
+# `if (depth > cap) Reset();` carries a boundary flip and a void-call removal -- and a declaration
+# keyed by line alone answers for every one of them. Measured: 4 of this package's 10 declarations sit
+# on such a line, one of them over five mutants. Where only one of them survives today the
+# declaration is unambiguous now and widens the moment a sibling starts surviving, and the staleness
+# guard cannot report that: it asks whether the LINE still produces a survivor, and the one already
+# answered for keeps it non-stale.
+DECLARATION = re.compile(
+    r"MUTANT_SURVIVES\(([A-Za-z]*)(?:\s*,\s*([^)]*?))?\)\s*:\s*(.*)")
 
 # How many unreached line numbers a file lists before the rest become a count. The count stays exact
 # either way; what this bounds is a whole-file `--files` run printing several hundred of them.
@@ -133,8 +141,13 @@ def folded_reason(tail, wrapped):
 
 
 class Declaration:
-    def __init__(self, category, reason, line, claim=None, through=None, written_here=True):
+    def __init__(self, category, reason, line, claim=None, through=None, written_here=True,
+                 operator=None):
         self.category = category
+        # Which operator's mutant this answers for, or None for every one on its line. Named where
+        # the line carries more than one, so an answer written for the removal there does not sign
+        # off the boundary flip beside it the day that starts surviving.
+        self.operator = operator
         self.reason = reason
         self.claim = reason if claim is None else claim
         self.line = line
@@ -231,9 +244,10 @@ def declarations_in(text):
             subject += 1
         if subject >= len(lines) or not lines[subject].strip():
             continue
-        claim, reason = folded_reason(match.group(2), lines[index + 1:subject])
+        claim, reason = folded_reason(match.group(3), lines[index + 1:subject])
+        named = (match.group(2) or "").strip() or None
         declaration = Declaration(match.group(1), reason, line=index + 1, claim=claim,
-                                  through=subject)
+                                  through=subject, operator=named)
         # Extends while the statement's own parentheses are still open, which is what a condition
         # broken across lines leaves and what a finished statement does not.
         depth = 0
@@ -1178,6 +1192,11 @@ def answered(mutants, deferred, declared):
         if mutant.verdict not in SURVIVING:
             continue
         declaration = declared.get((mutant.path, mutant.line))
+        if declaration is not None and declaration.operator not in (None, mutant.operator):
+            # Named for a different mutant on this line, so it says nothing about this one.
+            unanswered.append((mutant, "the declaration above answers for '{}', not for this".format(
+                declaration.operator)))
+            continue
         if declaration is None:
             unanswered.append((mutant, "nothing above this line answers for it"))
         elif not declaration.written_here:
@@ -1189,15 +1208,26 @@ def answered(mutants, deferred, declared):
     # Grouped by the declaration rather than by the line, because one covering a condition broken
     # over two lines has a survivor on either of them and is stale only when neither carries one.
     settled = surviving | deferred
+    # A named declaration is settled by a survivor of its own operator rather than by any survivor on
+    # the line: without that, a sibling still surviving would keep a stale one from being reported,
+    # which is the widening this naming exists to close read from the other side.
+    named = {(mutant.path, mutant.line, mutant.operator)
+             for mutant in mutants if mutant.verdict in SURVIVING}
     covers = {}
     for (path, subject), declaration in declared.items():
         covers.setdefault((path, declaration.line), [declaration, []])[1].append(subject)
-    stale = [(path, min(subjects), declaration)
-             for (path, _), (declaration, subjects) in sorted(covers.items(),
-                                                              key=lambda item: (str(item[0][0]),
-                                                                                item[0][1]))
-             if declaration.written_here
-             and not any((path, subject) in settled for subject in subjects)]
+    stale = []
+    for (path, _), (declaration, subjects) in sorted(
+            covers.items(), key=lambda item: (str(item[0][0]), item[0][1])):
+        if not declaration.written_here:
+            continue
+        if declaration.operator is None:
+            answered_here = any((path, subject) in settled for subject in subjects)
+        else:
+            answered_here = any((path, subject, declaration.operator) in named
+                                or (path, subject) in deferred for subject in subjects)
+        if not answered_here:
+            stale.append((path, min(subjects), declaration))
     return unanswered, stale
 
 

--- a/scripts/test_quality/test_mutation_check.py
+++ b/scripts/test_quality/test_mutation_check.py
@@ -1487,6 +1487,9 @@ class DeclarationFormatTests(unittest.TestCase):
     approved exemption, so the two have to agree.
     """
 
+    # GREEN_ON_BASE(characterization): the guide and the script agreed before and agree after. What
+    # this change adds is a second example in the guide, and green on both sides is what says the
+    # pattern reads it — a case that went red would mean the guide had stopped being readable.
     def test_Given_TheDeclarationTheGuideShows_When_TheScriptsOwnPatternReadsIt_Then_ItIsAccepted(self):
         # Arrange
         # The reason is the pattern's last group whether or not it carries an operator group, so this

--- a/scripts/test_quality/test_mutation_check.py
+++ b/scripts/test_quality/test_mutation_check.py
@@ -103,8 +103,17 @@ def survivor(path, line, verdict=None, operator="equality"):
 
 def declaration(line, category="equivalent", reason="a reason of four words", written_here=True,
                 operator=None):
-    return mutation_check.Declaration(category, reason, line, written_here=written_here,
-                                      operator=operator)
+    """A declaration, naming an operator where the tree under test can carry one.
+
+    A tree whose `Declaration` takes no operator gets one that answers for its whole line, which is
+    the state the cases below exist to separate — so they compare against it and fail, rather than
+    raising and separating nothing.
+    """
+    try:
+        return mutation_check.Declaration(category, reason, line, written_here=written_here,
+                                          operator=operator)
+    except TypeError:
+        return mutation_check.Declaration(category, reason, line, written_here=written_here)
 
 
 class CodeMaskTests(unittest.TestCase):
@@ -1429,6 +1438,9 @@ class NamedDeclarationTests(unittest.TestCase):
         self.assertEqual(unanswered,
                          ["the declaration above answers for 'line removed', not for this"])
 
+    # GREEN_ON_BASE(characterization): the base answers this too, by reading the line whole. It is
+    # the control the two red cases need: a reading that refused every named declaration would
+    # satisfy them both.
     def test_Given_ADeclarationNamingThisOperator_When_ASurvivorLands_Then_ItIsAnswered(self):
         # Arrange — the control, without which a reading that refused every named declaration would
         # satisfy the case above.
@@ -1441,6 +1453,8 @@ class NamedDeclarationTests(unittest.TestCase):
         # Assert
         self.assertEqual((unanswered, stale), ([], []))
 
+    # GREEN_ON_BASE(characterization): the unnamed form is what every declaration written before
+    # this uses, and the change must not move it.
     def test_Given_ADeclarationNamingNoOperator_When_ASurvivorLands_Then_ItStillAnswers(self):
         # Arrange — every declaration written before this reads the line whole, and none of them
         # changes meaning.
@@ -1475,8 +1489,11 @@ class DeclarationFormatTests(unittest.TestCase):
 
     def test_Given_TheDeclarationTheGuideShows_When_TheScriptsOwnPatternReadsIt_Then_ItIsAccepted(self):
         # Arrange
-        shown = [mutation_check.Declaration(match.group(1), match.group(3).strip(), 0,
-                                            operator=(match.group(2) or "").strip() or None)
+        # The reason is the pattern's last group whether or not it carries an operator group, so this
+        # reads the same on a tree that has one and a tree that has not.
+        shown = [declaration(0, category=match.group(1), reason=match.groups()[-1].strip(),
+                             operator=(match.groups()[1] or "").strip() or None
+                             if len(match.groups()) > 2 else None)
                  for match in mutation_check.DECLARATION.finditer(GUIDE.read_text())]
 
         # Act

--- a/scripts/test_quality/test_mutation_check.py
+++ b/scripts/test_quality/test_mutation_check.py
@@ -95,14 +95,16 @@ def code_parens(fragment):
     return seen.count("(") - seen.count(")")
 
 
-def survivor(path, line, verdict=None):
-    mutant = mutation_check.Mutant(path, line, 0, "a", "b", "equality")
+def survivor(path, line, verdict=None, operator="equality"):
+    mutant = mutation_check.Mutant(path, line, 0, "a", "b", operator)
     mutant.verdict = verdict or mutation_check.SURVIVED
     return mutant
 
 
-def declaration(line, category="equivalent", reason="a reason of four words", written_here=True):
-    return mutation_check.Declaration(category, reason, line, written_here=written_here)
+def declaration(line, category="equivalent", reason="a reason of four words", written_here=True,
+                operator=None):
+    return mutation_check.Declaration(category, reason, line, written_here=written_here,
+                                      operator=operator)
 
 
 class CodeMaskTests(unittest.TestCase):
@@ -1400,6 +1402,70 @@ class VerdictTests(unittest.TestCase):
         self.assertEqual(stale, [])
 
 
+class NamedDeclarationTests(unittest.TestCase):
+    """A declaration that names the operator it answers for, and what it stops answering for.
+
+    A line carries more than one mutant, and one keyed by line alone answers for every one. Where
+    only one of them survives today the answer is unambiguous now and widens the moment a sibling
+    starts surviving — and the staleness guard cannot report that, because it asks whether the line
+    still produces a survivor and the one already answered for keeps it non-stale.
+    """
+
+    def decide(self, mutants, declared, deferred=frozenset()):
+        unanswered, stale = mutation_check.answered(mutants, set(deferred), declared)
+        return ([complaint for _, complaint in unanswered],
+                [held.line for _, _, held in stale])
+
+    def test_Given_ADeclarationNamingAnotherOperator_When_ASurvivorLands_Then_ItIsUnanswered(self):
+        # Arrange — the shape the naming exists for: the removal is answered, and the boundary flip
+        # beside it starts surviving.
+        mutants = [survivor(Path("probe.cs"), 12, operator="boundary")]
+        declared = {(Path("probe.cs"), 12): declaration(12, operator="line removed")}
+
+        # Act
+        unanswered, _ = self.decide(mutants, declared)
+
+        # Assert
+        self.assertEqual(unanswered,
+                         ["the declaration above answers for 'line removed', not for this"])
+
+    def test_Given_ADeclarationNamingThisOperator_When_ASurvivorLands_Then_ItIsAnswered(self):
+        # Arrange — the control, without which a reading that refused every named declaration would
+        # satisfy the case above.
+        mutants = [survivor(Path("probe.cs"), 12, operator="boundary")]
+        declared = {(Path("probe.cs"), 12): declaration(12, operator="boundary")}
+
+        # Act
+        unanswered, stale = self.decide(mutants, declared)
+
+        # Assert
+        self.assertEqual((unanswered, stale), ([], []))
+
+    def test_Given_ADeclarationNamingNoOperator_When_ASurvivorLands_Then_ItStillAnswers(self):
+        # Arrange — every declaration written before this reads the line whole, and none of them
+        # changes meaning.
+        mutants = [survivor(Path("probe.cs"), 12, operator="boundary")]
+        declared = {(Path("probe.cs"), 12): declaration(12)}
+
+        # Act
+        unanswered, stale = self.decide(mutants, declared)
+
+        # Assert
+        self.assertEqual((unanswered, stale), ([], []))
+
+    def test_Given_ANamedDeclarationWhoseOwnMutantDied_When_ASiblingSurvives_Then_ItIsStale(self):
+        # Arrange — the same widening read from the other side: a sibling still surviving would keep
+        # a stale named declaration from being reported if staleness read the line whole.
+        mutants = [survivor(Path("probe.cs"), 12, operator="boundary")]
+        declared = {(Path("probe.cs"), 12): declaration(12, operator="line removed")}
+
+        # Act
+        _, stale = self.decide(mutants, declared)
+
+        # Assert
+        self.assertEqual(stale, [12])
+
+
 class DeclarationFormatTests(unittest.TestCase):
     """What the guide shows and what the tree holds, against what the script will actually accept.
 
@@ -1409,7 +1475,8 @@ class DeclarationFormatTests(unittest.TestCase):
 
     def test_Given_TheDeclarationTheGuideShows_When_TheScriptsOwnPatternReadsIt_Then_ItIsAccepted(self):
         # Arrange
-        shown = [mutation_check.Declaration(match.group(1), match.group(2).strip(), 0)
+        shown = [mutation_check.Declaration(match.group(1), match.group(3).strip(), 0,
+                                            operator=(match.group(2) or "").strip() or None)
                  for match in mutation_check.DECLARATION.finditer(GUIDE.read_text())]
 
         # Act


### PR DESCRIPTION
A `MUTANT_SURVIVES` declaration is keyed by line, and a line carries more than one mutant.
`if (depth > cap) Reset();` has a boundary flip and a void-call removal; one declaration answers for
both.

Where only one of them survives today that is unambiguous now and widens the moment a sibling starts
surviving — a test deleted, a fixture rewritten — and **the staleness guard cannot report it**. The
reason is structural: it asks whether the *line* still produces a survivor, and the one already
answered for keeps the line non-stale.

Measured before building: of this package's ten declarations, **four sit on a line carrying more than
one mutant**, one of them over five.

A declaration may now name the operator it answers for, and then answers for that one alone:

```csharp
// MUTANT_SURVIVES(unreachable, line removed): nothing pairs the depth cap with a transition.
```

Staleness follows it. A named declaration is stale when its own operator's mutant stops surviving,
whatever its siblings do — without that, a sibling still surviving would keep a stale one from being
reported, which is the same widening read from the other side.

The unnamed form is unchanged and still reads the statement whole, which is what a statement carrying
one mutant wants. Every declaration written before this keeps its meaning; none needed editing.

Four cases: a declaration named for another operator leaves this survivor unanswered; one named for
this operator answers it; an unnamed one still answers; and a named one whose own mutant died is
stale while a sibling survives. The second is the control — a reading that refused every named
declaration would satisfy the first.

CONTRIBUTING.md's mutation section gains the form and what it costs, beside the statement-not-line
paragraph it extends.

Two readers keyed the reason by group number and had to move: this pattern's own suite and
`test_declaration_first_line_fragment.py`, which reads every declaration pattern in the tree through
one comparison. Both read the last group now, which is the reason whether or not a pattern carries an
operator group before it — so a third pattern gaining a group later moves neither.

Closes #672
