### PR TITLE
tooling(velvet): claim the alias gh gives the command these guards are for

### DIFF
--- a/.claude/hooks/refuse/metadata_less_create.py
+++ b/.claude/hooks/refuse/metadata_less_create.py
@@ -54,12 +54,20 @@ def carries(operands, flags):
     return False
 
 
+# `new` is gh's own alias for `create`, on both subcommands -- measured, `gh pr new --help` and
+# `gh issue new --help` each print a usage. A guard that claims one spelling is skippable by typing
+# the other, which for this one costs the label and the assignee and for its neighbour costs the only
+# place a mutation receipt is ever asked for.
+CREATE_SPELLINGS = ("create", "new")
+
+
 def creations(command):
     """(kind, operands) for each `gh issue create` / `gh pr create` the command runs."""
     found = []
     for kind in ("issue", "pr"):
-        for operands in program_invocations(command, "gh", (kind, "create")):
-            found.append((kind, operands))
+        for spelling in CREATE_SPELLINGS:
+            for operands in program_invocations(command, "gh", (kind, spelling)):
+                found.append((kind, operands))
     return found
 
 

--- a/.claude/hooks/refuse/pr_without_mutation_receipt.py
+++ b/.claude/hooks/refuse/pr_without_mutation_receipt.py
@@ -123,7 +123,11 @@ def main():
     if not isinstance(event, dict) or event.get("tool_name") not in HOOK_TOOLS:
         return 0
     command = event.get("tool_input", {}).get("command", "")
-    invocations = program_invocations(command, "gh", ("pr", "create"))
+    # `new` is gh's own alias for `create` -- measured, `gh pr new --help` prints a usage. This gate
+    # is asked once and nowhere else: not by CI, and not by `settle.py`, which merges over the REST
+    # API. An alias that skips it removes the only place it is ever posed.
+    invocations = (program_invocations(command, "gh", ("pr", "create"))
+                   + program_invocations(command, "gh", ("pr", "new")))
     if not invocations:
         return 0
 

--- a/.github/workflows/generators.yml
+++ b/.github/workflows/generators.yml
@@ -146,6 +146,11 @@ jobs:
       - name: Unsettled pull request guard tests
         run: python3 scripts/test_quality/run_suite.py scripts/hooks/test_unsettled_pr.py
 
+      # gh's own alias for `create`. A guard claiming one spelling is skippable by typing the other,
+      # and for the receipt gate that is the only place it is ever asked.
+      - name: Create alias guard tests
+        run: python3 scripts/test_quality/run_suite.py scripts/hooks/test_create_aliases.py
+
       # Every guard asking "is this command a git <subcommand>" reads one table, so a word it does not
       # know hides the call from all of them, unrefused and unreported.
       - name: Shell command reading tests

--- a/scripts/hooks/test_create_aliases.py
+++ b/scripts/hooks/test_create_aliases.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Unit tests for the create-spelling claims in the metadata and receipt guards.
+
+`new` is gh's own alias for `create`, on both `pr` and `issue`. A guard that claims one spelling is
+skippable by typing the other — measured, `gh pr create --title x` was refused and `gh pr new
+--title x` was not. For the receipt guard that matters most: the gate is asked once, at open time,
+and nothing downstream re-asks — not CI, and not `settle.py`, which merges over the REST API.
+
+Run: python3 scripts/hooks/test_create_aliases.py
+"""
+
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+METADATA = REPO_ROOT / ".claude/hooks/refuse/metadata_less_create.py"
+RECEIPT = REPO_ROOT / ".claude/hooks/refuse/pr_without_mutation_receipt.py"
+
+
+def judge(guard, command):
+    """The guard's exit code for `command`, run in this repository."""
+    event = {"tool_name": "Bash", "cwd": str(REPO_ROOT), "tool_input": {"command": command}}
+    return subprocess.run([sys.executable, str(guard)], input=json.dumps(event),
+                          capture_output=True, text=True, timeout=90).returncode
+
+
+class MetadataSpellingTests(unittest.TestCase):
+    def test_Given_APullRequestOpenedAsNew_When_ItCarriesNoMetadata_Then_ItIsRefused(self):
+        # Act / Assert
+        self.assertEqual(judge(METADATA, "gh pr new --title x"), 2)
+
+    def test_Given_AnIssueOpenedAsNew_When_ItCarriesNoMetadata_Then_ItIsRefused(self):
+        # Arrange — `gh issue new` prints a usage too, so the alias is on both subcommands.
+        # Act / Assert
+        self.assertEqual(judge(METADATA, "gh issue new --title x"), 2)
+
+    def test_Given_APullRequestOpenedAsCreate_When_ItCarriesNoMetadata_Then_ItIsStillRefused(self):
+        # Arrange — the half that already worked, and what the widening must not lose.
+        # Act / Assert
+        self.assertEqual(judge(METADATA, "gh pr create --title x"), 2)
+
+    def test_Given_ANewCarryingItsMetadata_When_Judged_Then_ItGoesThrough(self):
+        # Arrange — the control: a widening that refused every `new` would satisfy the cases above.
+        # Act / Assert
+        self.assertEqual(judge(METADATA, "gh pr new --title x --label tooling --assignee @me"), 0)
+
+
+class ReceiptSpellingTests(unittest.TestCase):
+    """The gate this one holds is posed once and nowhere else."""
+
+    def test_Given_APullRequestOpenedAsNew_When_NoCampaignMeasuredIt_Then_ItIsRefused(self):
+        # Act / Assert
+        self.assertEqual(judge(RECEIPT, "gh pr new --title x --label tooling"), 2)
+
+    def test_Given_APullRequestOpenedAsCreate_When_NoCampaignMeasuredIt_Then_ItIsStillRefused(self):
+        # Arrange — the half that already worked.
+        # Act / Assert
+        self.assertEqual(judge(RECEIPT, "gh pr create --title x --label tooling"), 2)
+
+    def test_Given_ACommandThatOpensNothing_When_Judged_Then_ItIsNotThisGuardsToRefuse(self):
+        # Arrange — the control on the other side.
+        # Act / Assert
+        self.assertEqual(judge(RECEIPT, "gh pr list"), 0)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/hooks/test_create_aliases.py
+++ b/scripts/hooks/test_create_aliases.py
@@ -37,11 +37,15 @@ class MetadataSpellingTests(unittest.TestCase):
         # Act / Assert
         self.assertEqual(judge(METADATA, "gh issue new --title x"), 2)
 
+    # GREEN_ON_BASE(characterization): the base refuses this too, and it is the half the
+    # widening could take with it — only running it says whether it did.
     def test_Given_APullRequestOpenedAsCreate_When_ItCarriesNoMetadata_Then_ItIsStillRefused(self):
         # Arrange — the half that already worked, and what the widening must not lose.
         # Act / Assert
         self.assertEqual(judge(METADATA, "gh pr create --title x"), 2)
 
+    # GREEN_ON_BASE(characterization): the base lets this through, and a widening that
+    # refused every `new` would satisfy the red cases above while breaking this.
     def test_Given_ANewCarryingItsMetadata_When_Judged_Then_ItGoesThrough(self):
         # Arrange — the control: a widening that refused every `new` would satisfy the cases above.
         # Act / Assert
@@ -55,11 +59,15 @@ class ReceiptSpellingTests(unittest.TestCase):
         # Act / Assert
         self.assertEqual(judge(RECEIPT, "gh pr new --title x --label tooling"), 2)
 
+    # GREEN_ON_BASE(characterization): the base refuses this too, and it is the half the
+    # widening could take with it — only running it says whether it did.
     def test_Given_APullRequestOpenedAsCreate_When_NoCampaignMeasuredIt_Then_ItIsStillRefused(self):
         # Arrange — the half that already worked.
         # Act / Assert
         self.assertEqual(judge(RECEIPT, "gh pr create --title x --label tooling"), 2)
 
+    # GREEN_ON_BASE(characterization): the base lets this through, and a widening that
+    # refused every `new` would satisfy the red cases above while breaking this.
     def test_Given_ACommandThatOpensNothing_When_Judged_Then_ItIsNotThisGuardsToRefuse(self):
         # Arrange — the control on the other side.
         # Act / Assert


### PR DESCRIPTION
`gh pr new` is gh's own alias for `gh pr create`, and two refuse hooks matched on `("pr", "create")`
alone:

```
$ gh pr create --title x
Refusing `gh pr create`: it sets no --label.

$ gh pr new --title x
(exit 0)
```

`gh issue new` prints a usage too, so the alias is on both subcommands and the metadata guard needed
both.

**For `pr_without_mutation_receipt.py` that is the whole gate.** It is asked once, at open time, and
nothing downstream re-asks — not CI, and not `scripts/pr/settle.py`, which merges over the REST API
that no hook matcher sees. An alias that skips it removes the only place a mutation receipt is ever
posed. `metadata_less_create.py` is the cheaper half of the same hole: a pull request opened as `new`
carries no label and no assignee.

#673 widened `pr_body_of_another_branch.py` the same way and measured the effect over all 333 merged
bodies — the verdicts it changed were none, so the widening changes which commands are asked rather
than which pass. These two did not get that treatment because that branch's subject was the body.

Seven cases across the two guards: each alias refused, each `create` spelling still refused, and two
controls — a `new` carrying its metadata goes through, and a command that opens nothing is not this
guard's to refuse. Without those, a widening that refused every `new` would satisfy the rest.

No documentation impact: each guard's advice is its own text.

Closes #685
