### PR TITLE
test(velvet): make the escape-hatch case arrange the identity change it is named for

### DIFF
--- a/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseAsyncTests.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseAsyncTests.cs
@@ -458,6 +458,9 @@ namespace Velvet.Tests
             // Assert — LogAssert.Expect verifies the footgun warning was emitted
         }
 
+        // GREEN_ON_BASE(characterization): the base already reuses the resource when the explicit key
+        // matches, and this says so with the factory identity changing underneath it — the arrangement
+        // the case it replaces named and did not build.
         [Test]
         public void Given_AnExplicitKeyBesideAFreshLambdaEachRender_When_ReRendered_Then_TheFactoryRunsOnce()
         {
@@ -479,6 +482,9 @@ namespace Velvet.Tests
             Assert.That((runsAfterMount, s_explicitKeyFactoryRuns), Is.EqualTo((1, 1)));
         }
 
+        // GREEN_ON_BASE(characterization): the base already logs nothing here. It reads the same run
+        // as the case above from the console rather than from the factory, which is where a user meets
+        // the hatch.
         [Test]
         public void Given_AnExplicitKey_When_TheFactoryIdentityChanges_Then_NoWarningIsLogged()
         {
@@ -498,6 +504,9 @@ namespace Velvet.Tests
             LogAssert.NoUnexpectedReceived();
         }
 
+        // GREEN_ON_BASE(characterization): the base already gates the warning on the caller having
+        // passed the key. Measured: deleting `!resourceKeyExplicit &&` from `UseCore` leaves the whole
+        // EditMode suite green apart from this case, which nothing in it did before.
         [Test]
         public void Given_AnExplicitKeyThatChangesEachRender_When_ReRendered_Then_NoWarningIsLogged()
         {

--- a/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseAsyncTests.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseAsyncTests.cs
@@ -474,17 +474,17 @@ namespace Velvet.Tests
             s_explicitKeySetTick.Invoke(1);
             mounted.FlushStateForTest();
 
-            // Assert — the mount run rides along, because a factory that never ran would satisfy a bare
-            // count of one after the re-render.
+            // Assert — the mount run rides along, because a count of one after the re-render alone also
+            // holds for a resource that never started at mount and started here.
             Assert.That((runsAfterMount, s_explicitKeyFactoryRuns), Is.EqualTo((1, 1)));
         }
 
         [Test]
         public void Given_AnExplicitKey_When_TheFactoryIdentityChanges_Then_NoWarningIsLogged()
         {
-            // Arrange — the gate rather than the hatch: the warning is written behind
-            // `!resourceKeyExplicit`, so this says the explicit key reaches that gate. It is green on a
-            // build where the hatch itself is broken, which is why the case above exists beside it.
+            // Arrange — the key matches, so the resource is reused and the branch the warning is written
+            // in is not entered at all. That is what the hatch promises a user who reads the console;
+            // the case below is the one that reaches the warning's own gate.
             s_explicitKeyFactoryRuns = 0;
             s_explicitKeySetTick = null;
             s_explicitKeyValue = 42;
@@ -496,6 +496,34 @@ namespace Velvet.Tests
 
             // Assert
             LogAssert.NoUnexpectedReceived();
+        }
+
+        [Test]
+        public void Given_AnExplicitKeyThatChangesEachRender_When_ReRendered_Then_NoWarningIsLogged()
+        {
+            // Arrange — an explicit key that differs across renders is the only arrangement that reaches
+            // the warning's `!resourceKeyExplicit` gate: the resource is rebuilt, as it is for a changed
+            // implicit key, and the caller chose the key, so nothing is being warned about.
+            s_changingKeySetTick = null;
+            using var mounted = V.Mount(_root, V.Component(ChangingExplicitKeyRender, key: "changing"));
+
+            // Act
+            s_changingKeySetTick.Invoke(1);
+            mounted.FlushStateForTest();
+
+            // Assert
+            LogAssert.NoUnexpectedReceived();
+        }
+
+        private static Action<int> s_changingKeySetTick;
+
+        [Component]
+        private static VNode ChangingExplicitKeyRender()
+        {
+            var (tick, setTick) = Hooks.UseState(0);
+            s_changingKeySetTick = setTick;
+            _ = Hooks.Use<int>((CancellationToken _) => UniTask.FromResult(tick), resourceKey: tick.ToString());
+            return V.Label(text: tick.ToString());
         }
 
         private static int s_inlineLambdaFactoryRender;

--- a/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseAsyncTests.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseAsyncTests.cs
@@ -459,11 +459,33 @@ namespace Velvet.Tests
         }
 
         [Test]
-        public void Given_ExplicitResourceKey_When_InlineLambdaFactoryReRenders_Then_DoesNotWarn()
+        public void Given_AnExplicitKeyBesideAFreshLambdaEachRender_When_ReRendered_Then_TheFactoryRunsOnce()
         {
-            // Arrange — an explicit resourceKey is the documented escape hatch: it silences the footgun warning even
-            // when the factory is a fresh inline lambda. No LogAssert.Expect — any leaked warning fails the test.
-            s_explicitKeyFactoryRender = 0;
+            // Arrange — the escape hatch, in the arrangement that distinguishes it: the factory is an
+            // inline lambda, so its identity differs on the second render and only the key can name the
+            // same resource. The sibling cases hold the key equal with a stable factory.
+            s_explicitKeyFactoryRuns = 0;
+            s_explicitKeySetTick = null;
+            s_explicitKeyValue = 42;
+            using var mounted = V.Mount(_root, V.Component(ExplicitResourceKeyFactoryRender, key: "explicit"));
+            var runsAfterMount = s_explicitKeyFactoryRuns;
+
+            // Act
+            s_explicitKeySetTick.Invoke(1);
+            mounted.FlushStateForTest();
+
+            // Assert — the mount run rides along, because a factory that never ran would satisfy a bare
+            // count of one after the re-render.
+            Assert.That((runsAfterMount, s_explicitKeyFactoryRuns), Is.EqualTo((1, 1)));
+        }
+
+        [Test]
+        public void Given_AnExplicitKey_When_TheFactoryIdentityChanges_Then_NoWarningIsLogged()
+        {
+            // Arrange — the gate rather than the hatch: the warning is written behind
+            // `!resourceKeyExplicit`, so this says the explicit key reaches that gate. It is green on a
+            // build where the hatch itself is broken, which is why the case above exists beside it.
+            s_explicitKeyFactoryRuns = 0;
             s_explicitKeySetTick = null;
             s_explicitKeyValue = 42;
             using var mounted = V.Mount(_root, V.Component(ExplicitResourceKeyFactoryRender, key: "explicit"));
@@ -472,7 +494,8 @@ namespace Velvet.Tests
             s_explicitKeySetTick.Invoke(1);
             mounted.FlushStateForTest();
 
-            // Assert — the absence of any logged warning is the assertion
+            // Assert
+            LogAssert.NoUnexpectedReceived();
         }
 
         private static int s_inlineLambdaFactoryRender;
@@ -490,7 +513,7 @@ namespace Velvet.Tests
             return V.Label(text: tick.ToString());
         }
 
-        private static int s_explicitKeyFactoryRender;
+        private static int s_explicitKeyFactoryRuns;
         private static Action<int> s_explicitKeySetTick;
         private static int s_explicitKeyValue;
 
@@ -499,10 +522,16 @@ namespace Velvet.Tests
         {
             var (tick, setTick) = Hooks.UseState(0);
             s_explicitKeySetTick = setTick;
-            s_explicitKeyFactoryRender++;
-            // The factory is an inline lambda (identity changes per render) but the explicit resourceKey is stable,
-            // so the footgun warning must not fire.
-            _ = Hooks.Use<int>((CancellationToken _) => UniTask.FromResult(s_explicitKeyValue), resourceKey: "stable-key");
+            // `tick` is captured so the lambda is a fresh delegate each render. A body that reads only
+            // static state is cached in a static field by the compiler and has one identity for the life
+            // of the process, which arranges none of what this component is for.
+            _ = Hooks.Use<int>(
+                (CancellationToken _) =>
+                {
+                    s_explicitKeyFactoryRuns++;
+                    return UniTask.FromResult(s_explicitKeyValue + tick);
+                },
+                resourceKey: "stable-key");
             return V.Label(text: tick.ToString());
         }
 


### PR DESCRIPTION
`Given_ExplicitResourceKey_When_InlineLambdaFactoryReRenders_Then_DoesNotWarn` carried no assertion,
and the comment standing in for one — "No LogAssert.Expect — any leaked warning fails the test" —
described a mechanism the test framework does not have for a warning.

It is worse than an absent assertion, and this is the part the issue did not have: the case arranged
none of what it is named for either. `ExplicitResourceKeyFactoryRender`'s factory read only static
fields, so the C# compiler caches the lambda in a static field and it has **one identity for the life
of the process**. Measured: deleting `resourceKey: "stable-key"` from that component leaves the whole
fixture green and logs no additional warning, because the factory identity the warning is gated on
never changed. The sibling that does warn,
`Given_NoResourceKey_When_InlineLambdaFactoryReRenders_Then_WarnsOnSecondRender`, captures the
render-local `tick`, which is what makes its lambda fresh.

The factory now captures `tick` too, so it is a new delegate each render and only the key can name
the same resource. Three cases stand where the empty one did:

- `Given_AnExplicitKeyBesideAFreshLambdaEachRender_When_ReRendered_Then_TheFactoryRunsOnce` — what the
  hatch delivers. The mount run rides along in the tuple, because a count of one after the re-render
  alone also holds for a resource that never started at mount and started there.
- `Given_AnExplicitKey_When_TheFactoryIdentityChanges_Then_NoWarningIsLogged` — the same arrangement,
  read from the console rather than from the factory. The key matches, so the resource is reused and
  the branch the warning lives in is not entered.
- `Given_AnExplicitKeyThatChangesEachRender_When_ReRendered_Then_NoWarningIsLogged` — the warning's own
  `!resourceKeyExplicit` gate, which nothing reached. A matching explicit key takes the key-equal
  branch and never gets there; reaching it needs an explicit key that *differs* across renders, so the
  resource is rebuilt and the caller chose the key. Measured: deleting `!resourceKeyExplicit &&` from
  `UseCore` leaves all 4189 cases green without this one, and fails only this one with it.

The first two go red when `resourceKey` is removed from that component, where the case they replace
stayed green — measured, and the warning count over the fixture goes from one to three at the same
time. `LogAssert.NoUnexpectedReceived()` does catch the leaked warning; what does not is the implicit
failing-log path the deleted comment appealed to.

`s_explicitKeyFactoryRender` goes with them: it counted component renders, nothing read it, and the
count the hatch is about is of factory runs.

No `Documentation~` guide changes: the escape hatch's behaviour is unchanged, only what the suite
says about it.

Closes #767
