### PR TITLE
test(velvet): give a case green by construction a category of its own

### DIFF
--- a/.claude/hooks/refuse/declaration_first_line_fragment.py
+++ b/.claude/hooks/refuse/declaration_first_line_fragment.py
@@ -2,9 +2,10 @@
 """Refuse a GREEN_ON_BASE or MUTANT_SURVIVES declaration whose first line breaks off mid-clause.
 
 Only the first line of a declaration is a claim on its own, and it is the whole of what the readers
-take as the reason: both stop the capture at the newline and measure their four-word floor on what
-stands before it. So where the sentence runs on past it, the wrap position is part of what the
-declaration says.
+measure their four-word floor on: both stop the capture at the newline. A reader may still fold the
+continuation in for a different question -- `base_red_check` looks for a `construction` reason's
+backtick over the folded form -- but nothing reads the wrap as a sentence boundary, so where the
+sentence runs on past it, the wrap position is part of what the declaration says.
 
 The floor is not what this adds. A first line under four words is refused by the readers already,
 by name, and saying so twice would buy nothing. What gets through them is a line long enough to

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -368,8 +368,8 @@ Three kinds of case belong on the base, and say so above themselves with a reaso
 ```
 
 ```csharp
-// GREEN_ON_BASE(construction): both sides here are the repository's own content. Perturb a reference
-// to `WalkRoott` and this is what reddens.
+// GREEN_ON_BASE(construction): both sides here are the repository's own content. Misspell the
+// reference as `published_check.unpublished_reasonn` and this is what reddens.
 ```
 
 `characterization` pins behaviour the base already has; `refactor` rides with a change meant to preserve

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -357,7 +357,7 @@ after the replacement. The check reads it only where the trace does not lead bac
 the same words at the head of a body's assertion remain that body's disagreement. Behind a body's own
 message it is not read, because a case that disagreed did so whatever its scaffolding went on to do.
 
-Two kinds of case belong on the base, and say so above themselves with a reason a reviewer can weigh:
+Three kinds of case belong on the base, and say so above themselves with a reason a reviewer can weigh:
 
 ```csharp
 // GREEN_ON_BASE(characterization): the keyed-reorder order this refactor must not change.
@@ -367,8 +367,20 @@ Two kinds of case belong on the base, and say so above themselves with a reason 
 # GREEN_ON_BASE(refactor): the settle-path names this rename preserves.
 ```
 
+```csharp
+// GREEN_ON_BASE(construction): both sides here are the repository's own content. Perturb a reference
+// to `WalkRoott` and this is what reddens.
+```
+
 `characterization` pins behaviour the base already has; `refactor` rides with a change meant to preserve
-it. A declaration answers for the change written under it, and it is read three ways so it cannot outlive
+it. `construction` is for neither: a guard that reads two of the repository's own sources against each
+other is green on the base because both sides there are the base's content and they agree, so nothing
+about the base's behaviour is pinned and the change is not behaviour-preserving. What shows such a case
+can fail is a perturbation, which no base run can perform — so its reason has to name one, in backticks,
+and the check refuses one that names nothing. The rule is on this category alone: asked of the other
+two it would rewrite the corpus rather than check it, most of whose reasons name nothing in backticks.
+
+A declaration answers for the change written under it, and it is read three ways so it cannot outlive
 what it describes: one over a case that turns out red on the base fails the check, one whose category or
 reason the script refuses fails it, and one the branch did not itself write is a declaration for a change
 the base already carries and does not cover this one — restate it. A reason may wrap onto the comment

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/BaseRedDeclarationTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/BaseRedDeclarationTests.cs
@@ -15,9 +15,9 @@ namespace Velvet.Tests
     /// contributor copies, so a format change that leaves it behind teaches the wrong shape.
     /// </summary>
     /// <remarks>
-    /// Both what the script accepts — its categories and how long a reason has to be — are read out of it
-    /// rather than listed here. A second copy is a second thing to update, and the failure of the copy
-    /// that nobody updated is silence.
+    /// Everything the script accepts on — its categories, how long a reason has to be, and which
+    /// categories must name a perturbation — is read out of it rather than listed here. A second copy is
+    /// a second thing to update, and the failure of the copy that nobody updated is silence.
     /// </remarks>
     [TestFixture]
     internal sealed class BaseRedDeclarationTests
@@ -36,7 +36,57 @@ namespace Velvet.Tests
         private static readonly Regex Declaration =
             new(@"GREEN_ON_BASE\(([A-Za-z]*)\)\s*:\s*(.*)", RegexOptions.Compiled);
 
+        private static readonly Regex PerturbationTuple =
+            new(@"NAMES_A_PERTURBATION\s*=\s*\(([^)]*)\)", RegexOptions.Compiled);
+
+        private static readonly Regex Backticked = new("`[^`]+`", RegexOptions.Compiled);
+
+        // The script folds a wrapped reason before it looks for the backtick, so the guide's example
+        // has to be read the same way -- `Declaration`'s `(.*)` stops at the newline, and the example
+        // carries its backtick on the wrap.
+        private static readonly Regex CommentContinuation =
+            new(@"^\s*(?://|#)\s?(.*)$", RegexOptions.Compiled);
+
         private static string Read(string path) => File.ReadAllText(Path.GetFullPath(path));
+
+        private static IReadOnlyList<string> PerturbationCategories()
+        {
+            var tuple = PerturbationTuple.Match(Read(Script));
+            return tuple.Success
+                ? Quoted.Matches(tuple.Groups[1].Value).Select(match => match.Groups[1].Value).ToList()
+                : new List<string>();
+        }
+
+        private static List<(string Category, string Reason, string Folded)> ShownInTheGuide()
+        {
+            var lines = Read(Guide).Split('\n');
+            var shown = new List<(string, string, string)>();
+            for (var index = 0; index < lines.Length; index++)
+            {
+                var match = Declaration.Match(lines[index]);
+                if (!match.Success)
+                {
+                    continue;
+                }
+
+                var reason = match.Groups[2].Value.TrimEnd('\r');
+                var folded = reason;
+                for (var next = index + 1; next < lines.Length; next++)
+                {
+                    var carried = CommentContinuation.Match(lines[next].TrimEnd('\r'));
+                    if (!carried.Success || Declaration.IsMatch(lines[next]))
+                    {
+                        break;
+                    }
+
+                    folded += " " + carried.Groups[1].Value;
+                }
+
+                shown.Add((match.Groups[1].Value, reason, folded));
+            }
+
+            return shown;
+        }
 
         private static IReadOnlyList<string> Categories()
         {
@@ -112,17 +162,19 @@ namespace Velvet.Tests
             var categories = Categories();
             var minimum = MinimumReasonWords();
 
+            var namesAPerturbation = PerturbationCategories();
+
             // Act
-            var shown = Declaration.Matches(Read(Guide)).Cast<Match>()
-                .Select(match => (Category: match.Groups[1].Value, Reason: match.Groups[2].Value))
-                .ToList();
+            var shown = ShownInTheGuide();
 
             // Assert — the count rides along because a guide that shows no example passes on the rest.
             // A floor rather than an exact number: the guide shows one spelling per lane, and pinning
             // how many lanes there are is a mirror that goes stale when a third one arrives.
             Assert.That((shown.Count >= 1, shown.All(sample => categories.Contains(sample.Category)
                     && sample.Reason.Split((char[])null, StringSplitOptions.RemoveEmptyEntries)
-                        .Length >= minimum)),
+                        .Length >= minimum
+                    && (!namesAPerturbation.Contains(sample.Category)
+                        || Backticked.IsMatch(sample.Folded)))),
                 Is.EqualTo((true, true)),
                 $"{Guide} shows an example {Script} would not accept");
         }

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/BaseRedDeclarationTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/BaseRedDeclarationTests.cs
@@ -152,6 +152,9 @@ namespace Velvet.Tests
                 $"{Script} declares no MINIMUM_REASON_WORDS this fixture can read");
         }
 
+        // GREEN_ON_BASE(construction): the guide and the script are both the base's own content and they
+        // agree there, whichever conditions the script holds. Drop the backticks from the guide's
+        // `construction` example and this case reddens; the base has no such example to drop.
         [Test]
         public void Given_TheDeclarationTheGuideShows_When_TheScriptsOwnPatternReadsIt_Then_ItIsAccepted()
         {

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/DocumentationDriftTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/DocumentationDriftTests.cs
@@ -504,9 +504,9 @@ namespace Velvet.Tests
                     : IdentifierTokenPattern.Matches(JsxElementPattern.Replace(span.Reference, " "))
                         .Select(token => (span.Path, span.Reference, Token: token.Value)));
 
-        // GREEN_ON_BASE(construction): both sides of the comparison are the base's own content — this
-        // repository's markdown and this repository's scripts — and they agree there. Perturb a
-        // reference to `WalkRoott` and this case is what reddens; no base run can perform that.
+        // GREEN_ON_BASE(construction): both sides of this comparison are the base's own content, and on
+        // the base they agree — this repository's markdown against its scripts. Misspell a reference as
+        // `published_check.unpublished_reasonn` and this case reddens; no base run can perform that.
         [Test]
         public void Given_MarkdownNamingAScriptSymbol_When_TheSymbolIsSoughtInThatScript_Then_ItIsDefinedThere()
         {

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/DocumentationDriftTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/DocumentationDriftTests.cs
@@ -504,10 +504,9 @@ namespace Velvet.Tests
                     : IdentifierTokenPattern.Matches(JsxElementPattern.Replace(span.Reference, " "))
                         .Select(token => (span.Path, span.Reference, Token: token.Value)));
 
-        // GREEN_ON_BASE(characterization): the base's own markdown names no wrong symbol, so it is green there.
-        // Not a behaviour the base has — the case is new — but a property of content the base already
-        // holds on both sides of the comparison. What shows it can fail is a reference perturbed to a name
-        // no script defines, measured, rather than the base run.
+        // GREEN_ON_BASE(construction): both sides of the comparison are the base's own content — this
+        // repository's markdown and this repository's scripts — and they agree there. Perturb a
+        // reference to `WalkRoott` and this case is what reddens; no base run can perform that.
         [Test]
         public void Given_MarkdownNamingAScriptSymbol_When_TheSymbolIsSoughtInThatScript_Then_ItIsDefinedThere()
         {

--- a/scripts/hooks/test_declaration_first_line_fragment.py
+++ b/scripts/hooks/test_declaration_first_line_fragment.py
@@ -548,9 +548,9 @@ class ReaderFloorTests(unittest.TestCase):
     # What moved is how this reads the reason out — by the last group rather than by number — so a
     # pattern gaining a group does not silently start comparing something else.
     def test_Given_AReasonWrappedOntoASecondLine_When_EachPatternReadsIt_Then_EachStopsAtTheWrap(self):
-        # Arrange — the guard judges the first line because that is the whole of what the readers
-        # take as the claim. A reader that folded the continuation in would be measuring a reason
-        # this guard never saw.
+        # Arrange — the guard judges the first line because that is what the readers measure their
+        # four-word floor on, and these are the patterns that decide it. A reader that folds the
+        # continuation in for a different question does not move the floor.
         first = "the base already separates these two and"
         blocks = {"base_red_check": f"// {BASE}(characterization): {first}\n// the rest of it.\n",
                   "mutation_check": f"// {SURVIVES}(equivalent): {first}\n// the rest of it.\n"}

--- a/scripts/test_quality/base_red_check.py
+++ b/scripts/test_quality/base_red_check.py
@@ -168,9 +168,9 @@ CATEGORIES = ("characterization", "refactor", "construction")
 #
 # So its reason has to name that perturbation, and naming is the part a script can hold: a backticked
 # span, which is how this repository writes an identifier or a command in prose. The rule is only on
-# this category. Measured over the 298 declarations on `main` when it was added, 275 carry no backtick
-# at all -- asking the same of `characterization` or `refactor` would rewrite the corpus rather than
-# check it.
+# this category. Measured with this reader over the 286 declarations on `main` when it was added, 263
+# carry no backtick at all -- asking the same of `characterization` or `refactor` would rewrite the
+# corpus rather than check it.
 NAMES_A_PERTURBATION = ("construction",)
 
 BACKTICKED = re.compile(r"`[^`]+`")

--- a/scripts/test_quality/base_red_check.py
+++ b/scripts/test_quality/base_red_check.py
@@ -158,7 +158,22 @@ NOT_AN_ANSWER = {
 # matching the labels NUnit pairs with a failing status.
 NOT_A_VERDICT_LABEL = ("Cancelled", "Error", "Invalid")
 
-CATEGORIES = ("characterization", "refactor")
+CATEGORIES = ("characterization", "refactor", "construction")
+
+# `construction` is for a case the base answers green because both sides of what it compares are the
+# base's own content -- a guard reading this repository's markdown against its scripts, or a generated
+# table against the stylesheets it derives from. Nothing about the base's behaviour is pinned and the
+# change is not behaviour-preserving, so neither of the other two fits; what shows the case can fail is
+# a perturbation, which no base run can perform.
+#
+# So its reason has to name that perturbation, and naming is the part a script can hold: a backticked
+# span, which is how this repository writes an identifier or a command in prose. The rule is only on
+# this category. Measured over the 298 declarations on `main` when it was added, 275 carry no backtick
+# at all -- asking the same of `characterization` or `refactor` would rewrite the corpus rather than
+# check it.
+NAMES_A_PERTURBATION = ("construction",)
+
+BACKTICKED = re.compile(r"`[^`]+`")
 
 # The reason has to say something a reviewer can disagree with, and a word count is the only part of
 # that a script can hold. Four words rules out "n/a" and "see above" without pretending to judge prose.
@@ -235,6 +250,9 @@ class Declaration:
             return "category {!r} is not one of {}".format(self.category, ", ".join(CATEGORIES))
         if len(self.claim.split()) < MINIMUM_REASON_WORDS:
             return "the reason's first line is under {} words".format(MINIMUM_REASON_WORDS)
+        if self.category in NAMES_A_PERTURBATION and not BACKTICKED.search(self.reason):
+            return ("a {} reason names the perturbation that would fail the case, in backticks; "
+                    "this one names nothing".format(self.category))
         return None
 
 

--- a/scripts/test_quality/test_base_red_check.py
+++ b/scripts/test_quality/test_base_red_check.py
@@ -670,6 +670,41 @@ class DeclarationTests(unittest.TestCase):
         self.assertIsNone(
             base_red_check.Declaration("refactor", "a pure rename of the applier").complaint)
 
+    def test_Given_AConstructionReasonNamingNothing_When_TheDeclarationIsChecked_Then_ItIsComplainedAbout(self):
+        # Arrange — enough words, a known category, and no perturbation a reader could apply.
+        reason = "both sides here are the base's own content"
+
+        # Act
+        complaint = base_red_check.Declaration("construction", reason).complaint
+
+        # Assert
+        self.assertIn("perturbation", complaint)
+
+    def test_Given_AConstructionReasonNamingOne_When_TheDeclarationIsChecked_Then_ThereIsNoComplaint(self):
+        # Act / Assert
+        self.assertIsNone(base_red_check.Declaration(
+            "construction", "misspell `WalkRoot` in the guide and this is the case that reddens").complaint)
+
+    def test_Given_AConstructionReasonNamingOneOnAContinuationLine_When_Checked_Then_ThereIsNoComplaint(self):
+        # Arrange — the first line is the claim the word floor reads; the perturbation may be named
+        # anywhere in the folded reason, which is what the rule is asked of.
+        first = "the guide and the script agree because both are the base's"
+        folded = first + " own content; drop `--lane` from the command and this reddens"
+
+        # Act / Assert
+        self.assertIsNone(
+            base_red_check.Declaration("construction", folded, claim=first).complaint)
+
+    # GREEN_ON_BASE(characterization): the base already lets a backtick-free reason through, and this
+    # says the new rule did not widen to it. A rule written on the category set rather than on one
+    # member passes the three cases above and fails here.
+    def test_Given_ACharacterizationReasonNamingNothing_When_Checked_Then_ThereIsNoComplaint(self):
+        # Arrange — the control: the rule is on `construction` alone, because 275 of the 298
+        # declarations that existed when it was added carry no backtick.
+        # Act / Assert
+        self.assertIsNone(base_red_check.Declaration(
+            "characterization", "the ordering the base already commits to").complaint)
+
 
 class SelectionTests(unittest.TestCase):
     def test_Given_ALineInsideOneCase_When_TheFileIsSelected_Then_OnlyThatCaseIsTaken(self):

--- a/scripts/test_quality/test_base_red_check.py
+++ b/scripts/test_quality/test_base_red_check.py
@@ -699,7 +699,7 @@ class DeclarationTests(unittest.TestCase):
     # says the new rule did not widen to it. A rule written on the category set rather than on one
     # member passes the three cases above and fails here.
     def test_Given_ACharacterizationReasonNamingNothing_When_Checked_Then_ThereIsNoComplaint(self):
-        # Arrange — the control: the rule is on `construction` alone, because 275 of the 298
+        # Arrange — the control: the rule is on `construction` alone, because 263 of the 286
         # declarations that existed when it was added carry no backtick.
         # Act / Assert
         self.assertIsNone(base_red_check.Declaration(


### PR DESCRIPTION
`GREEN_ON_BASE` had two categories, and a guard that reads two of the repository's own sources against
each other fits neither. `DocumentationDriftTests.Given_MarkdownNamingAScriptSymbol_When_TheSymbolIsSoughtInThatScript_Then_ItIsDefinedThere`
compares this repository's markdown against its scripts: on the base both sides are the base's own
content and they agree, so nothing about the base's *behaviour* is pinned, and the change is not
behaviour-preserving either. It was declared `characterization` because that was the closer of the two,
and its reason then spent three lines saying it was not really one.

`construction` is the third category. What separates it is that the evidence the case can fail is a
perturbation the base run structurally cannot perform, so its reason has to name one — in backticks,
which is how prose here writes an identifier or a command — and the check refuses one that names
nothing.

The rule is on `construction` alone. Measured with `base_red_check`'s own reader over the 286
declarations on `main`: 263 carry no backtick anywhere in their reason. Asked of `characterization` or
`refactor` the rule would not be a check, it would be a rewrite of the corpus. The reason is read
folded, so the perturbation may be named on a continuation line rather than on the marker's own.

`BaseRedDeclarationTests` reads the new condition out of the script the way it already reads the
categories and the word floor, so the guide's example cannot drift into one the script would refuse.
It folds the guide's continuation lines to do it: the pattern it had stops at the newline, and the
example carries its backtick on the wrap.

One reclassification, not two. The issue also names
`test_base_red_check.VerdictTests.test_Given_AMalformedDeclarationOnACaseGreenOnTheBase_When_ItIsDecided_Then_ItFailsTheRun`,
but that case compares nothing of the repository's own content: it constructs a `Declaration` with an
invented category and asserts the verdict fails. The base's refusal of an unknown category is a
behaviour, and the case pins that this change's addition to `CATEGORIES` left it alone. It stays where
it is.

`declaration_first_line_fragment.py`'s docstring said the first line is the whole of what the readers
take as the reason. That is now false — the backtick is looked for over the folded form — so it says
what remains true: the first line is what the four-word floor is measured on, and no reader treats the
wrap as a sentence boundary.

Closes #648
