### PR TITLE
test(velvet): drop the hop the suspend resolution does not take

### DIFF
--- a/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouterTests.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouterTests.cs
@@ -555,8 +555,9 @@ namespace Velvet.Tests
             router.NavigateSync("/deferred");
             Assume.That(router.GetLoaderData("/deferred"), Is.Null, "Precondition: unresolved at commit time");
             tcs.TrySetResult("deferred-data");
-            await UniTask.Yield();
-            Assume.That(router.GetLoaderData("/deferred"), Is.EqualTo("deferred-data"), "Precondition: resolved after commit");
+            // No hop between the two, for the reason the failure case below gives.
+            Assume.That(router.GetLoaderData("/deferred"), Is.EqualTo("deferred-data"),
+                "Precondition: resolved synchronously with the result being set");
             router.NavigateSync("/other");
 
             // Act
@@ -586,8 +587,12 @@ namespace Velvet.Tests
             // Suspend-mode failures route through OnSuspendLoaderFailed, which logs the exception.
             LogAssert.Expect(UnityEngine.LogType.Exception, new System.Text.RegularExpressions.Regex("deferred-failure"));
             tcs.TrySetException(new InvalidOperationException("deferred-failure"));
-            await UniTask.Yield();
-            Assume.That(router.CurrentLoaderErrors.Count, Is.EqualTo(1), "Precondition: the failure was recorded after commit");
+            // No hop between the two: the completion source resumes the loader's `await` inline, the
+            // catch announces inline, and the Router's handler writes the error inline. A wait here
+            // would let a future hop through unnoticed, and one hop is not the same amount of progress
+            // on a runner as on the machine that counted it.
+            Assume.That(router.CurrentLoaderErrors.Count, Is.EqualTo(1),
+                "Precondition: the failure was recorded synchronously with the exception being set");
             router.NavigateSync("/other");
 
             // Act

--- a/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouterTests.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouterTests.cs
@@ -538,6 +538,8 @@ namespace Velvet.Tests
             Assert.That(router.CurrentLoaderErrors["/boom"].Message, Does.Contain("boom-error"));
         }
 
+        // GREEN_ON_BASE(characterization): the base already resolves inline, for the reason the failure
+        // case below gives, and passing on both sides is what says the wait was buying nothing.
         [UnityTest]
         public IEnumerator Given_SuspendLoaderResolvedAfterCommit_When_GoBackToIt_Then_RestoresPostResolutionData()
             => UniTask.ToCoroutine(async () =>
@@ -568,6 +570,9 @@ namespace Velvet.Tests
                 "The Back cache hit restores the post-resolution snapshot, not the stale pre-resolution one");
         });
 
+        // GREEN_ON_BASE(characterization): the base already records the failure inline, which is what
+        // makes the wait this drops unnecessary — passing on both sides is the evidence. Measured:
+        // yielding once before `Announce` in `RunSuspendLoader` fails this case and no other.
         [UnityTest]
         public IEnumerator Given_SuspendLoaderFailedAfterCommit_When_GoBackToIt_Then_RestoresCachedError()
             => UniTask.ToCoroutine(async () =>


### PR DESCRIPTION
`Given_SuspendLoaderFailedAfterCommit_When_GoBackToIt_Then_RestoresCachedError` waited one
continuation hop between setting the loader's exception and requiring the failure to be recorded. One
hop is not the same amount of progress on a CI runner as on the machine that counted it, which is how
the case failed once there and never locally.

The recording does not need a hop. `NavigateSync` drives `RunSuspendLoader` to its `await task` before
it returns, so the continuation is registered by the time the test sets the exception;
`UniTaskCompletionSource.TrySetException` resumes it inline; the catch reaches `Announce`, which is a
direct `subscribers?.Invoke`; and the Router's `OnSuspendLoaderFailed` handler writes
`_loaderErrors` inline. Nothing on that path defers.

So the wait goes, and the `Assume` beside it becomes the thing that says so — with the hop removed it
is red the moment any step on that path stops being inline. Measured: adding a single
`await UniTask.Yield()` before `Announce` in `RouteLoaderRunner.RunSuspendLoader` fails this case and
no other; the fixture is 51/51 with it removed, over three runs.

Its sibling `Given_SuspendLoaderResolvedAfterCommit_When_GoBackToIt_Then_RestoresCachedData` had the
same shape on the completion path and is the same change.

Those two are the whole set the issue asks to enumerate. Of the 38 `await UniTask.Yield()` calls in
the package, across three files, exactly two are followed by an assertion — a wait before an
unsubscribe or before a further act is a step in the arrangement, not a claim about how long something
takes. The one in
`Given_ASubscriberThatThrowsOnASuspendResolution_When_GoBackToThatEntry_Then_TheCacheStillServesIt`
stays for that reason: what follows it is `router.OnLocationChanged -= Throwing`, and the order of
those two is what the case is about.

Closes #585
