### PR TITLE
refactor(velvet): drop the four host members nothing reaches

### DIFF
--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberElementCleaner.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberElementCleaner.cs
@@ -28,20 +28,6 @@ namespace Velvet
             ReturnOccupantToPool(element, poolable);
         }
 
-        // Removes an element from its parent directly (by element reference, not index).
-        public void RemoveElementDirect(VisualElement parent, VisualElement element)
-        {
-            if (element?.parent != parent)
-            {
-                return;
-            }
-
-            var poolable = PoolableOccupantOf(element);
-            CleanupElement(element);
-            element.RemoveFromHierarchy();
-            ReturnOccupantToPool(element, poolable);
-        }
-
         // Resolves the poolable occupant of a slot: a clip-path-* leaf sits inside a
         // structural wrapper, and the wrapper — not the widget — is the slot's element. Must run
         // BEFORE CleanupElement, which consumes the wrapper map entry.
@@ -680,7 +666,7 @@ namespace Velvet
         //
         // Descendant elements are NOT returned to VNodePool here because the descendant DOM remove is bulk
         // (parent.RemoveAt) and individual children are not surfaced. Pool return is limited to the top-level
-        // element of RemoveElement, RemoveElementDirect, and CleanupPortal.
+        // element of RemoveElement and CleanupPortal.
         private void CleanupElementCore(VisualElement element)
         {
             var isWrapper = _ctx.WrapperToInnerMap.TryGetValue(element, out var innerElement);

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberElementCleaner.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberElementCleaner.cs
@@ -8,20 +8,10 @@ namespace Velvet
     internal sealed class FiberElementCleaner
     {
         private readonly ReconcilerContext _ctx;
-        private IReconcilerHost _host = null!;
 
         public FiberElementCleaner(ReconcilerContext ctx)
         {
             _ctx = ctx;
-        }
-
-        internal void SetHost(IReconcilerHost host)
-        {
-            if (_host != null)
-            {
-                throw new System.InvalidOperationException("[FiberElementCleaner] SetHost called twice");
-            }
-            _host = host;
         }
 
         public void RemoveElement(VisualElement parent, int index)

--- a/Packages/com.velvet.core/Runtime/Reconciler/IReconcilerHost.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/IReconcilerHost.cs
@@ -2,9 +2,10 @@ using UnityEngine.UIElements;
 
 namespace Velvet
 {
-    // Facade the Patcher and the Factory reach ChildReconciler through, instead of referencing it
-    // directly. Every member here is called on one of their `_host` fields; a member nothing calls is
-    // reachable from nowhere else, because this interface is implemented explicitly and by one type.
+    // Facade the Patcher and the Factory reach ChildReconciler and FiberElementCleaner through, instead
+    // of referencing them directly. Every member here is called on one of their `_host` fields; a member
+    // nothing calls is reachable from nowhere else, because this interface is implemented explicitly and
+    // by one type.
     internal interface IReconcilerHost
     {
         // Used by Patcher only, for a registry Portal whose id now names a different element.

--- a/Packages/com.velvet.core/Runtime/Reconciler/IReconcilerHost.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/IReconcilerHost.cs
@@ -1,21 +1,12 @@
-using System.Collections.Generic;
 using UnityEngine.UIElements;
 
 namespace Velvet
 {
-    // Facade interface used by Reconciler subsystems (FiberNodeFactory,
-    // FiberElementCleaner, FiberNodePatcher) instead of referencing one another directly.
-    // Centralizes the host-platform element operations (create / remove / patch) behind one
-    // injection point so the reconciler core stays decoupled from concrete VisualElement handling.
+    // Facade the Patcher and the Factory reach ChildReconciler through, instead of referencing it
+    // directly. Every member here is called on one of their `_host` fields; a member nothing calls is
+    // reachable from nowhere else, because this interface is implemented explicitly and by one type.
     internal interface IReconcilerHost
     {
-        // Operations provided by FiberNodeFactory
-        VisualElement CreateElement(VNode node);                                           // Used by Patcher
-        List<(string key, VNode node)> BuildKeyedMapCopy(VNode?[] children);               // Used by ChildReconciler
-
-        // Operations provided by FiberElementCleaner
-        void RemoveElement(VisualElement parent, int index);                               // Used by Patcher only
-        void RemoveElementDirect(VisualElement parent, VisualElement element);
         // Used by Patcher only, for a registry Portal whose id now names a different element.
         void ReleasePortalRangeForRetarget(VisualElement placeholder);
 

--- a/Packages/com.velvet.core/Runtime/Reconciler/Reconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Reconciler.cs
@@ -72,7 +72,6 @@ namespace Velvet
 
             _factory.SetHost(this);
             _patcher.SetHost(this);
-            _cleaner.SetHost(this);
             // The root Reconciler owns the bridge so internal elements (FiberVirtualListController etc.)
             // can re-enter the reconciler via _ctx.ReconcilerBridge. Inherited contexts already have a
             // bridge assigned; skipping the set avoids the fail-fast double-call check.
@@ -479,14 +478,6 @@ namespace Velvet
         #endregion
 
         #region IReconcilerHost
-
-        VisualElement IReconcilerHost.CreateElement(VNode node) => _factory.CreateElement(node);
-
-        List<(string key, VNode node)> IReconcilerHost.BuildKeyedMapCopy(VNode?[] children) => _factory.BuildKeyedMapCopy(children);
-
-        void IReconcilerHost.RemoveElement(VisualElement parent, int index) => _cleaner.RemoveElement(parent, index);
-
-        void IReconcilerHost.RemoveElementDirect(VisualElement parent, VisualElement element) => _cleaner.RemoveElementDirect(parent, element);
 
         void IReconcilerHost.ReleasePortalRangeForRetarget(VisualElement placeholder)
             => _cleaner.ReleasePortalRangeForRetarget(placeholder);

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/ReconcilerPerformanceBenchmarks.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/PlayMode/ReconcilerPerformanceBenchmarks.cs
@@ -301,7 +301,7 @@ namespace Velvet.Tests.Performance
         #region B-1-d: Pooled-widget recycle (mount -> unmount -> remount)
 
         // Pins the primitive-element pool's recycle path: VNodePool.ReturnLabel / ReturnButton (invoked
-        // when RemoveElement/RemoveElementDirect reclaims an unmounted Label/Button) run
+        // when RemoveElement reclaims an unmounted Label/Button) run
         // FiberLabelPoolHelper/FiberButtonPoolHelper's ResetXForReuse, which calls
         // FiberElementPoolReset.ResetClassListAndCommon on every single recycle — an unintended per-recycle
         // heap allocation on that path is what this measurement exists to catch. The Button half carries an


### PR DESCRIPTION
`IReconcilerHost` is `internal`, implemented explicitly, and implemented once. Explicit implementation
means a member is reachable only through the interface, so counting every variable of that type is a
complete census. There are three, all fields: `FiberNodeFactory._host`, `FiberNodePatcher._host` and
`FiberElementCleaner._host`. Between them they call `ReconcileChildren` seven times,
`ReleasePortalRangeForRetarget` once and `NotifyContextValueChange` once. Nothing calls the other
four.

`CreateElement`, `BuildKeyedMapCopy`, `RemoveElement` and `RemoveElementDirect` go, with their
forwarders on `Reconciler`. Three of the four carried a `// Used by …` comment naming a caller that
does not have one: the Patcher holds an `IReconcilerHost` and never calls `CreateElement` or
`RemoveElement` on it, and `ChildReconciler` holds no `IReconcilerHost` at all. Every real removal goes
to the concrete collaborator instead — `_cleaner.RemoveElement` at eight sites in `ChildReconciler` and
one in `GeneralPathReconciler`. The concrete methods on `FiberNodeFactory` and `FiberElementCleaner`
stay; only the interface's way of reaching them goes.

`FiberElementCleaner._host` goes with them. Its only reader was `SetHost`'s own called-twice guard, and
with the two members the cleaner backed removed there is nothing for the field to serve. `SetHost` and
the `_cleaner.SetHost(this)` call in `Reconciler`'s constructor go too; the Factory's and the Patcher's
stay, since both still call through theirs.

The interface's header said it centralizes create/remove/patch behind one injection point. Two thirds
of that is what just went, so it now says what the file is: the facade the Patcher and the Factory
reach `ChildReconciler` through, and why a census of it is complete.

No `Documentation~` guide names `IReconcilerHost` or any of the four, so none changes.

EditMode 4190 passed / 0 failed, PlayMode 161 / 0.

Closes #745
