### PR TITLE
tooling(velvet): let a loop that compiled nothing say what it spent

### DIFF
--- a/scripts/test_quality/base_red_check.py
+++ b/scripts/test_quality/base_red_check.py
@@ -1866,6 +1866,27 @@ def local_remedy(since, cases):
                 "".join(" --platform " + platform for platform in platforms), since or "origin/main"))
 
 
+def exhausted_reason(spent, withdrawn, carried):
+    """What a loop that ran out of rounds without ever compiling the base has to say for itself.
+
+    The generic line is the one a single round writes, and a reader who ran the loop has already done
+    the thing that line would tell them to do. What separates the two is the loop's own history: how
+    many rounds it spent and how much of the carried set it put back, which is the evidence that the
+    base cannot build the branch's test modules at all rather than one of them.
+    """
+    if not spent:
+        return ""
+    put_back = "\n".join("    " + name for name in sorted(withdrawn)[:6])
+    more = len(withdrawn) - 6
+    if more > 0:
+        put_back += "\n    and {} more".format(more)
+    return ("\n{} round(s) compiled nothing, having put {} of the {} carried file(s) back to what the\n"
+            "base holds. A base that builds none of them is answering about the tree rather than about\n"
+            "a case, and no declaration reaches that: what a branch introducing a type the base has no\n"
+            "source for owes is a reason in its description, not a per-case one.\n"
+            "{}".format(spent, len(withdrawn), carried, put_back if withdrawn else ""))
+
+
 def held_at(project, commit, relative):
     """A file's text at a commit, or None where the commit has not got it."""
     result = git(project, "show", "{}:{}".format(commit, relative), check=False)
@@ -2064,6 +2085,8 @@ def main():
     transcript = []
     canaries = {}
     ever_wrote = not any(kind_of(case.path) == "csharp" for case in cases)
+    rounds_spent = 0
+    put_back = set()
     try:
         print("  building the base tree at {}".format(base_tree), flush=True)
         build_base_tree(project, since, base_tree, carry, drop, args.warm_library)
@@ -2088,10 +2111,14 @@ def main():
             raise SystemExit("another Unity test run is still in flight")
         canaries.update(canaries_for(base_tree, cases, carry, platforms))
         for platform in platforms:
+            # Accumulated across platforms, unlike `withdrawn`: what the message below is evidence
+            # for is that the base built none of the carried set, which both lanes are asking about.
             wanted = [case for case in cases + control
                       if kind_of(case.path) == "csharp" and platform_of(case.path) == platform]
             withdrawn = set()
             for attempt in range(1, args.max_rounds + 1):
+                rounds_spent = max(rounds_spent, attempt)
+                put_back |= withdrawn
                 live = [case for case in wanted if case.path not in withdrawn]
                 fixtures = sorted({case.fixture for case in live} | set(canaries[platform]))
                 if not fixtures:
@@ -2131,6 +2158,7 @@ def main():
 
     if not ever_wrote:
         print("no round wrote a result, so nothing any of them was asked was measured", flush=True)
+        print(exhausted_reason(rounds_spent, put_back, len(carry)), flush=True)
     offenders = report(cases, control, reported, canaries, ever_wrote)
     print("\nlogs: {}".format(output), flush=True)
     return 1 if offenders else 0

--- a/scripts/test_quality/test_base_red_check.py
+++ b/scripts/test_quality/test_base_red_check.py
@@ -706,6 +706,53 @@ class DeclarationTests(unittest.TestCase):
             "characterization", "the ordering the base already commits to").complaint)
 
 
+class ExhaustedLoopTests(unittest.TestCase):
+    """What the withdrawing loop says when it runs out of rounds having compiled nothing.
+
+    The generic line beside this one is what a single round writes, and its remedy is to run the loop
+    -- advice a reader who ran the loop has already taken. What separates the two readings is the
+    loop's own history, which nothing printed before: a base that built none of the carried set is
+    answering about the tree rather than about any case in it.
+    """
+
+    # GREEN_ON_BASE(characterization): the base says nothing here because it has no such message at
+    # all, and this is the control that keeps the new one off a lane that starts no editor.
+    def test_Given_NoRoundRan_When_TheReasonIsBuilt_Then_ItSaysNothing(self):
+        # Arrange — the Python-only lane starts no editor, so there is no loop to report on.
+        # Act / Assert
+        self.assertEqual(base_red_check.exhausted_reason(0, set(), 12), "")
+
+    def test_Given_RoundsThatCompiledNothing_When_TheReasonIsBuilt_Then_ItCountsThem(self):
+        # Act
+        said = base_red_check.exhausted_reason(8, {"a.cs", "b.cs"}, 24)
+
+        # Assert
+        self.assertIn("8 round(s) compiled nothing", said)
+
+    def test_Given_FilesPutBack_When_TheReasonIsBuilt_Then_ItNamesThem(self):
+        # Arrange — the withdrawn set is the evidence, so a count without the names is a claim the
+        # reader cannot check.
+        # Act
+        said = base_red_check.exhausted_reason(3, {"one.cs", "two.cs"}, 9)
+
+        # Assert
+        self.assertEqual(("one.cs" in said, "two.cs" in said), (True, True))
+
+    def test_Given_MoreFilesThanItPrints_When_TheReasonIsBuilt_Then_ItSaysHowManyItLeftOut(self):
+        # Arrange — eight withdrawn, six printed.
+        # Act
+        said = base_red_check.exhausted_reason(8, {"f%d.cs" % n for n in range(8)}, 30)
+
+        # Assert
+        self.assertIn("and 2 more", said)
+
+    def test_Given_RoundsThatCompiledNothing_When_TheReasonIsBuilt_Then_ItSaysADeclarationDoesNotReachIt(self):
+        # Arrange — the reading a per-case declaration cannot answer, which is why the message has to
+        # say where the answer goes instead.
+        # Act / Assert
+        self.assertIn("not a per-case one", base_red_check.exhausted_reason(8, {"a.cs"}, 24))
+
+
 class SelectionTests(unittest.TestCase):
     def test_Given_ALineInsideOneCase_When_TheFileIsSelected_Then_OnlyThatCaseIsTaken(self):
         # Arrange

--- a/scripts/test_quality/test_base_red_check.py
+++ b/scripts/test_quality/test_base_red_check.py
@@ -715,8 +715,6 @@ class ExhaustedLoopTests(unittest.TestCase):
     answering about the tree rather than about any case in it.
     """
 
-    # GREEN_ON_BASE(characterization): the base says nothing here because it has no such message at
-    # all, and this is the control that keeps the new one off a lane that starts no editor.
     def test_Given_NoRoundRan_When_TheReasonIsBuilt_Then_ItSaysNothing(self):
         # Arrange — the Python-only lane starts no editor, so there is no loop to report on.
         # Act / Assert


### PR DESCRIPTION
The withdrawing loop can spend every round it has without compiling the base once, and says nothing
about having done so. What it prints is the line a single round prints — `no round wrote a result` —
whose remedy is to run the loop, which is advice a reader who ran the loop has already taken.

That is not hypothetical. On the branch replacing UniTask with an in-tree `VelvetTask`, every carried
test module names a type the base has no source for, so no order of withdrawals can leave a tree that
builds:

```
EditMode attempt 1..8:  0 case(s) over 24, 23, 23, 23, 23, 23, 23, 23 fixture(s), 4s each
PlayMode attempt 1..8:  0 case(s) over 15, 15, 14, 13, 12, 11, 10,  9 fixture(s), 4s each
280 case(s) yielded no base verdict
```

Four seconds a round is the compile abort rather than a run. The loop is making progress — each round
puts one more carried file back — and the progress cannot converge, because what the base lacks is
named by all of them.

So the loop now reports its own history when it ends having compiled nothing: how many rounds it
spent, how much of the carried set it put back, and the names. That is the evidence for the reading a
per-case verdict cannot carry — a base that builds none of the carried set is answering about the
tree, not about a case — and the message says where the answer goes instead, which is the branch's
description rather than a `GREEN_ON_BASE` line.

What this does not do is give such a branch a way to pass the check. Whether it should have one is the
open half of #865, and it is a design question rather than a message: the evidence a declaration would
have to carry for a whole-type migration is not the same evidence the two existing categories name,
and the corpus for it is one branch.

Refs #865 — the loop's half of it. The category question is the other half and stays open.
