### PR TITLE
fix(velvet): keep a slot shift on the mount point it was measured on

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -54,6 +54,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A component inside one `V.Portal` no longer has its position rewritten by a sibling portal on a
+  different target. Two portals declared side by side are siblings in the fiber chain whatever targets
+  they name, and a child-count change committed on one shifted the recorded position of every following
+  sibling — including one mounted somewhere else. Nothing moved at the time, so the target looked
+  right; the damage showed on that sibling's next own re-render, which wrote at the shifted position
+  and left its previous element behind instead of patching it. A delta now reaches only the siblings
+  that share the target it was measured on, which is what the method's own doc said it did.
+
 - `V.NavLink` with a relative `to` takes its active class. The click path resolved the target through
   the router — `..` against the enclosing route, a bare segment appended to it — while the active
   comparison used the string as written, so `to: ".."` was compared against a current path beginning

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberCommitWork.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberCommitWork.cs
@@ -44,13 +44,12 @@ namespace Velvet
         internal static int LogicalMountPointChildCount(VisualElement? mountPoint)
             => mountPoint != null ? LogicalChildSlots.Count(mountPoint) : 0;
 
-        // Propagates an inline-mount fiber's committed child-count change to the siblings that share its
-        // MountPoint. Updates the fiber's own slot count, then shifts every following sibling's
-        // ComponentFiber.MountSlotStart by the same delta and re-bases the captured slotStart of
-        // any following sibling whose own reconcile is parked. Called both from the initial
-        // RenderAndReconcile pass and from each ContinueReconcile
-        // resume slice, since the delta is committed incrementally across slices. No-op when
-        // actualDelta is zero.
+        // Propagates an inline-mount fiber's committed child-count change to the following siblings that
+        // share its MountPoint. Updates the fiber's own slot count, then shifts each of their
+        // ComponentFiber.MountSlotStart by the same delta and re-bases the captured slotStart of one whose
+        // own reconcile is parked. Called both from the initial RenderAndReconcile pass and from each
+        // ContinueReconcile resume slice, since the delta is committed incrementally across slices. No-op
+        // when actualDelta is zero.
         internal static void PropagateInlineSlotShift(ComponentFiber fiber, int actualDelta)
         {
             if (actualDelta == 0) return;
@@ -59,6 +58,15 @@ namespace Velvet
             fiber.MountSlotCount = baseline + actualDelta;
             for (var sibling = fiber.Sibling; sibling != null; sibling = sibling.Sibling)
             {
+                // The chain is every following sibling, which for a Portal is siblings mounted on other
+                // targets too. A delta measured on one target says nothing about a coordinate into
+                // another, and shifting it moves that sibling's next write off the rows it owns.
+                // `NextInlineSiblingSlotStart` above reads the same chain under the same condition.
+                if (sibling.MountPoint != fiber.MountPoint)
+                {
+                    continue;
+                }
+
                 sibling.MountSlotStart += actualDelta;
                 // A following sibling whose own time-sliced reconcile is parked captured its slotStart as an
                 // absolute offset into the shared parent. This shift moved its already-committed rows within

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/PortalSlotShiftScopeTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/PortalSlotShiftScopeTests.cs
@@ -109,9 +109,9 @@ namespace Velvet.Tests
             Assert.That(Names(b), Is.EqualTo("own|s1"));
         }
 
-        // GREEN_ON_BASE(characterization): the same-target direction the base already gets right, and the
-        // half a guard written as "skip every sibling" would take with it. That guard passes the case
-        // above and fails only here.
+        // GREEN_ON_BASE(characterization): the same-target direction the base already gets right. It is
+        // what a guard written as "skip every sibling" would take away, and the case above would not
+        // notice that guard at all.
         [Test]
         public void Given_TwoComponentsOnOneTarget_When_TheFirstGrows_Then_TheSecondMovesWithIt()
         {

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/PortalSlotShiftScopeTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/PortalSlotShiftScopeTests.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Linq;
+using NUnit.Framework;
+using UnityEngine.UIElements;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Specifies which siblings an inline-mount fiber's committed child-count delta reaches: the ones
+    /// mounted on the same target, and no others. Two portals declared side by side are siblings in the
+    /// fiber chain whatever targets they name, so the chain alone does not say whose coordinate a delta
+    /// is a coordinate into.
+    /// </summary>
+    internal sealed class PortalSlotShiftScopeTests
+    {
+        private MountedTree? _mounted;
+        private static Action<int>? s_grow;
+        private static Action<int>? s_settle;
+
+        [SetUp]
+        public void SetUp()
+        {
+            s_grow = null;
+            s_settle = null;
+            RuntimeStateProbe.ClearPortalRegistry();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _mounted?.Dispose();
+            _mounted = null;
+            RuntimeStateProbe.ClearPortalRegistry();
+        }
+
+        private static string Names(VisualElement parent) =>
+            string.Join("|", parent.Children().Select(child => child.name));
+
+        // The growing side is a component, so its extra row is a committed child-count delta on the
+        // portal's own target rather than a change to the declaring tree's children.
+        [Component]
+        private static VNode Growing()
+        {
+            var (rows, setRows) = Hooks.UseState(1);
+            s_grow = setRows;
+            return V.Fragment(children: Enumerable.Range(0, rows)
+                .Select(index => (VNode?)V.Div(name: "g" + index)).ToArray());
+        }
+
+        // It holds state so it can re-render on its own after the other side's delta is committed --
+        // which is when a coordinate rewritten by that delta is first written at.
+        [Component]
+        private static VNode Settled()
+        {
+            var (tick, setTick) = Hooks.UseState(0);
+            s_settle = setTick;
+            return V.Div(name: "s" + tick);
+        }
+
+        [Component]
+        private static VNode TwoTargets() => V.Fragment(children: new VNode?[]
+        {
+            V.Portal("scope-a", children: new VNode?[] { V.Component(Growing, key: "grow") }),
+            V.Portal("scope-b", children: new VNode?[] { V.Component(Settled, key: "settled") }),
+        });
+
+        [Component]
+        private static VNode OneTarget() => V.Fragment(children: new VNode?[]
+        {
+            V.Portal("scope-a", children: new VNode?[]
+            {
+                V.Component(Growing, key: "grow"),
+                V.Component(Settled, key: "settled"),
+            }),
+        });
+
+        private (VisualElement A, VisualElement B) MountAndGrow(Func<VNode> host)
+        {
+            var a = new VisualElement();
+            var b = new VisualElement();
+            // `b` starts occupied so a shift shows against a non-zero base rather than against zero.
+            b.Add(new VisualElement { name = "own" });
+            FiberPortalRegistry.Register("scope-a", a);
+            FiberPortalRegistry.Register("scope-b", b);
+            _mounted = V.Mount(new VisualElement(), V.Component(host, key: "host"));
+            _mounted.FlushEffectsForTest();
+            s_grow!.Invoke(2);
+            _mounted.FlushStateForTest();
+            _mounted.FlushEffectsForTest();
+            return (a, b);
+        }
+
+        [Test]
+        public void Given_TwoPortalsOnDifferentTargets_When_OneGrows_Then_TheOthersNextWriteStaysWhereItWas()
+        {
+            // Arrange
+            var (a, b) = MountAndGrow(() => V.Component(TwoTargets, key: "two"));
+            Assume.That(Names(a), Is.EqualTo("g0|g1"), "Precondition: the growing side committed its delta");
+
+            Assume.That(Names(b), Is.EqualTo("own|s0"), "Precondition: the settled side is where it mounted");
+
+            // Act — the settled side re-renders on its own, writing at the coordinate it holds.
+            s_settle!.Invoke(1);
+            _mounted!.FlushStateForTest();
+            _mounted.FlushEffectsForTest();
+
+            // Assert
+            Assert.That(Names(b), Is.EqualTo("own|s1"));
+        }
+
+        [Test]
+        public void Given_TwoComponentsOnOneTarget_When_TheFirstGrows_Then_TheSecondMovesWithIt()
+        {
+            // Arrange & Act — the control for the case above: on one target the delta is a coordinate
+            // into the same list, and the second component's row has to follow it.
+            var (a, _) = MountAndGrow(() => V.Component(OneTarget, key: "one"));
+
+            // Assert
+            Assert.That(Names(a), Is.EqualTo("g0|g1|s0"));
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/PortalSlotShiftScopeTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/PortalSlotShiftScopeTests.cs
@@ -109,6 +109,9 @@ namespace Velvet.Tests
             Assert.That(Names(b), Is.EqualTo("own|s1"));
         }
 
+        // GREEN_ON_BASE(characterization): the same-target direction the base already gets right, and the
+        // half a guard written as "skip every sibling" would take with it. That guard passes the case
+        // above and fails only here.
         [Test]
         public void Given_TwoComponentsOnOneTarget_When_TheFirstGrows_Then_TheSecondMovesWithIt()
         {

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/PortalSlotShiftScopeTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/PortalSlotShiftScopeTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1fc20818172da4233a601ddaf7e24e2e


### PR DESCRIPTION
`PropagateInlineSlotShift` walked `fiber.Sibling` and shifted every following sibling's
`MountSlotStart` by the committed delta, with no check on which mount point that coordinate is a
coordinate into. Two `V.Portal`s declared side by side are siblings in the fiber chain whatever
targets they name, so a child-count change committed on one rewrote the recorded position of a
component mounted on another.

Nothing moves at the time, which is why it is hard to see: the other target's children stay exactly
where they were and the tree looks right. The damage lands on that component's next own re-render,
which writes at the shifted position — one row past where its element sits — and leaves the previous
element behind instead of patching it. Measured on two portals with a pre-occupied second target: the
second target reads `own|s0|s1` where `own|s1` is the whole of what that component declares.

The guard belongs on the loop rather than at the call sites, because the loop serves every inline
sibling chain and not only portals. It gates the `RebasePendingSlotStart` call with it: a parked
sibling's captured slot start is an absolute offset into its own parent, and a delta measured
elsewhere is not a correction to it.

`NextInlineSiblingSlotStart`, twelve lines above, reads the same chain under the same condition. The
method's doc comment already said "the siblings that share its MountPoint" and then described the
loop that did not; it now says what the code does.

Two cases, both directions: a sibling on another mount point that must not shift, and one on the same
mount point that must. The second is the control — a guard that skipped every sibling would pass the
first and fail it.

EditMode 4192 passed / 0 failed, PlayMode 161 / 0, mutation campaign over the change 1 killed / 0
survived.

Closes #602
