### PR TITLE
fix(velvet): read the offscreen mark past a boundary showing no fallback

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -54,6 +54,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A `V.Suspense` inside another one no longer lets the outer's fallback be patched away while its own
+  resource is still pending. A component's flush is deferred while the slot it writes into is held by a
+  fallback, and the check for that stopped at the nearest enclosing Suspense — which is set on every
+  expanded boundary, resolved or not. With a resolved boundary between the component and the one that
+  actually suspended, the check found a boundary showing no fallback and never read the mark the outer
+  expansion had written, so the component flushed into the outer fallback's slot and replaced it. The
+  walk now continues past a boundary that is not showing a fallback.
+
 - `V.NavLink` with a relative `to` takes its active class. The click path resolved the target through
   the router — `..` against the enclosing route, a bare segment appended to it — while the active
   comparison used the string as written, so `to: ".."` was compared against a current path beginning

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberWorkLoop.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberWorkLoop.cs
@@ -218,14 +218,17 @@ namespace Velvet
                 // fiber carries no offscreen mark and may flush normally (the fallback renders while the
                 // primary is offscreen).
                 //
-                // Every enclosing boundary, not the nearest: IsSuspenseBoundary is set whenever a Suspense
-                // is expanded, whether or not it suspended, so a resolved one between the fiber and the
+                // Every enclosing boundary, not the nearest: a Suspense is marked a boundary whenever it is
+                // expanded, whether or not it suspended, so a resolved one between the fiber and the
                 // boundary that did suspend is what a nearest-only reading stops at — and the mark it
                 // stops short of is the one an outer expansion wrote.
+                //
+                // No IsSuspenseBoundary test beside the lookup: only a fiber ExpandSuspenseInline marked
+                // as one is ever recorded as showing a fallback, in the same branch that marks it.
                 var offscreen = fiber.IsOffscreen;
                 for (var f = fiber.Parent; f != null; f = f.Parent)
                 {
-                    if (offscreen && f.IsSuspenseBoundary && context.IsBoundaryShowingFallback(f)) return;
+                    if (offscreen && context.IsBoundaryShowingFallback(f)) return;
                     if (f.IsOffscreen) offscreen = true;
                 }
             }

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberWorkLoop.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberWorkLoop.cs
@@ -213,18 +213,20 @@ namespace Velvet
             var context = fiber.Reconciler?.Context;
             if (context is { AnyBoundaryShowingFallback: true })
             {
-                var enclosingBoundary = ComponentBoundarySearch.FindNearestSuspenseBoundary(fiber);
-                if (enclosingBoundary != null && !ReferenceEquals(enclosingBoundary, fiber)
-                    && context.IsBoundaryShowingFallback(enclosingBoundary))
+                // Defer only PRIMARY (offscreen) descendants — their slot is occupied by the fallback, so
+                // an independent flush would write into the fallback's range. A visible fallback-subtree
+                // fiber carries no offscreen mark and may flush normally (the fallback renders while the
+                // primary is offscreen).
+                //
+                // Every enclosing boundary, not the nearest: IsSuspenseBoundary is set whenever a Suspense
+                // is expanded, whether or not it suspended, so a resolved one between the fiber and the
+                // boundary that did suspend is what a nearest-only reading stops at — and the mark it
+                // stops short of is the one an outer expansion wrote.
+                var offscreen = fiber.IsOffscreen;
+                for (var f = fiber.Parent; f != null; f = f.Parent)
                 {
-                    // Defer only PRIMARY (offscreen) descendants — their slot is occupied by the
-                    // fallback, so an independent flush would write into the fallback's range. A visible
-                    // fallback-subtree fiber (no offscreen ancestor up to the boundary) may flush
-                    // normally (the fallback renders while the primary is offscreen).
-                    for (var f = fiber; f != null && !ReferenceEquals(f, enclosingBoundary); f = f.Parent)
-                    {
-                        if (f.IsOffscreen) return;
-                    }
+                    if (offscreen && f.IsSuspenseBoundary && context.IsBoundaryShowingFallback(f)) return;
+                    if (f.IsOffscreen) offscreen = true;
                 }
             }
 

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/SuspenseBoundaryTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/SuspenseBoundaryTests.cs
@@ -380,6 +380,26 @@ namespace Velvet.Tests
         // for this boundary, so these children now reach the offscreen walk and what keeps them flushing
         // is its per-fiber check: widen that marking to the boundary and this case goes red.
         [Test]
+        public void Given_AResolvedBoundaryInsideASuspendedOne_When_ItsOffscreenDescendantUpdates_Then_TheOuterFallbackSurvives()
+        {
+            // Arrange — the stateful fiber's nearest boundary is the inner Suspense, which resolved and so
+            // shows no fallback; the mark on that fiber was written by the outer one, which did suspend.
+            var source = new UniTaskCompletionSource<string>();
+            s_offscreenFactory = _ => source.Task;
+            using var mounted = V.Mount(_root, V.Component(NestedBoundaryHostRender, key: "host"));
+            Assume.That(_root.FindLabelByText("loading-outer"), Is.Not.Null,
+                "Precondition: the outer Suspense is showing its fallback");
+
+            // Act
+            s_offscreenSetter.Invoke(1);
+            mounted.FlushStateForTest();
+
+            // Assert
+            Assert.That(_root.FindLabelByText("loading-outer"), Is.Not.Null,
+                "A flush that read past the inner boundary finds the outer's mark and does not patch its fallback away");
+        }
+
+        [Test]
         public void Given_SuspendedBoundaryFollowedByResolvedSibling_When_ResolvedSiblingsDescendantUpdates_Then_ItRerenders()
         {
             // Arrange — the same boundary fiber owns both Suspense nodes, so keeping the suspended one's
@@ -1090,6 +1110,30 @@ namespace Velvet.Tests
                     fallback: V.Label(text: "loading-B"),
                     children: new VNode[] { V.Component(ResolvedSiblingStatefulChildRender, key: "sibling") },
                     key: "b"),
+            });
+
+        // A Suspense of its own between the stateful fiber and the one that suspends, and it resolves:
+        // IsSuspenseBoundary is set on expansion whether or not a boundary suspended, so this is the fiber
+        // a nearest-boundary reading stops at.
+        [Component]
+        private static VNode NestedResolvedBoundaryRender()
+            => V.Suspense(
+                fallback: V.Label(text: "inner-loading"),
+                children: new VNode[] { V.Component(OffscreenStatefulChildRender, key: "stateful") },
+                key: "inner");
+
+        [Component]
+        private static VNode NestedBoundaryHostRender()
+            => V.Div(children: new VNode[]
+            {
+                V.Suspense(
+                    fallback: V.Label(text: "loading-outer"),
+                    children: new VNode[]
+                    {
+                        V.Component(NestedResolvedBoundaryRender, key: "middle"),
+                        V.Component(OffscreenSuspendingChildRender, key: "suspending"),
+                    },
+                    key: "outer"),
             });
 
         // The same two boundaries in the opposite order, so the suspended one's marking pass is the one


### PR DESCRIPTION
A component's flush is deferred while the slot it writes into is held by a Suspense fallback.
`FlushState` found that slot's owner with `FindNearestSuspenseBoundary`, and if the nearest boundary
was showing no fallback it skipped the guard entirely — never reading the offscreen mark at all.

A Suspense is marked a boundary whenever it is expanded, resolved or not. So a resolved Suspense
between the component and the one that actually suspended is where the reader stops, and the mark it
stops short of is the one the outer expansion wrote:

```
Inner()  -> V.Label($"primary-{tick}")                                 // stateful, no pending resource
Middle() -> V.Suspense(fallback: "inner-loading", children: [ Inner ])  // resolves
Host()   -> V.Suspense(fallback: "loading-outer", children: [ Middle, Suspending ])
```

`Middle` resolves and records nothing, `Host` suspends and marks `Inner` offscreen, and `setTick` on
`Inner` then flushed into the slot `"loading-outer"` occupies — patching the outer fallback away while
its own resource was still pending.

The nearest-boundary lookup is replaced by one walk to the root that carries the offscreen marks up
with it and returns at the first boundary showing a fallback with a mark seen below it. Same cost:
`IsBoundaryShowingFallback` is a dictionary lookup, and the old code walked the ancestors too.

No `IsSuspenseBoundary` test beside that lookup. `ExpandSuspenseInline` marks the fiber a boundary and
records its fallback decision in the same `IsNewSide` branch, the mark first, so only a fiber already
marked can be recorded as showing a fallback. A surviving mutant said the test was redundant and the
reading is what says why.

The new case is red on `main`'s `FiberWorkLoop.cs` and green with the change. EditMode 4191 passed / 0
failed, PlayMode 161 / 0, mutation campaign over the change 5 killed / 0 survived.

Closes #623
