### PR TITLE
test(velvet): pin that a portal child patches its own element after a neighbour grows

### DIFF
--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/PortalNeighbourGrowthTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/PortalNeighbourGrowthTests.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Linq;
+using NUnit.Framework;
+using UnityEngine.UIElements;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Specifies that a component rendered inside one <c>V.Portal</c> keeps patching its own element
+    /// after a neighbouring portal on the same target grows. Several portals sharing one container is
+    /// what <c>Documentation~/portals.md</c> states is supported, and the growth moves the second
+    /// portal's range without moving what its own child addresses.
+    /// </summary>
+    internal sealed class PortalNeighbourGrowthTests
+    {
+        private MountedTree? _mounted;
+        private static Action<int>? s_grow;
+        private static Action<int>? s_change;
+
+        [SetUp]
+        public void SetUp()
+        {
+            s_grow = null;
+            s_change = null;
+            RuntimeStateProbe.ClearPortalRegistry();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _mounted?.Dispose();
+            _mounted = null;
+            RuntimeStateProbe.ClearPortalRegistry();
+        }
+
+        private static string Names(VisualElement parent) =>
+            string.Join("|", parent.Children().Select(child => child.name));
+
+        [Component]
+        private static VNode ModalChildRender()
+        {
+            var (tick, setTick) = Hooks.UseState(0);
+            s_change = setTick;
+            return V.Div(name: tick == 0 ? "content" : "changed");
+        }
+
+        // The growth is on the portal's own children array, which is what reaches
+        // PortalSlotTracker.ShiftSlotStartsAfter -- a component inside the portal growing instead is an
+        // inline-mount delta and takes the fiber sibling chain.
+        [Component]
+        private static VNode SharedTargetHostRender()
+        {
+            var (count, setCount) = Hooks.UseState(1);
+            s_grow = setCount;
+            return V.Fragment(children: new VNode?[]
+            {
+                V.Portal("shared", children: Enumerable.Range(0, count)
+                    .Select(index => (VNode?)V.Div(name: index == 0 ? "toast-one" : "toast-two")).ToArray()),
+                V.Portal("shared", children: new VNode?[] { V.Component(ModalChildRender, key: "modal") }),
+            });
+        }
+
+        // GREEN_ON_BASE(characterization): the base already patches the right element, and nothing said
+        // so. What holds it up is `ComponentRegistry`'s refresh of `MountSlotStart` from the reconcile
+        // site — measured, by deleting that line, which fails this case.
+        [Test]
+        public void Given_TwoPortalsOnOneTarget_When_TheFirstGrowsAndTheSecondsChildRerenders_Then_ItPatchesItsOwnElement()
+        {
+            // Arrange
+            var target = new VisualElement();
+            FiberPortalRegistry.Register("shared", target);
+            _mounted = V.Mount(new VisualElement(), V.Component(SharedTargetHostRender, key: "host"));
+            _mounted.FlushEffectsForTest();
+            Assume.That(Names(target), Is.EqualTo("toast-one|content"), "Precondition: both portals mounted in order");
+            s_grow!.Invoke(2);
+            _mounted.FlushStateForTest();
+            _mounted.FlushEffectsForTest();
+            Assume.That(Names(target), Is.EqualTo("toast-one|toast-two|content"),
+                        "Precondition: the first portal grew and the second's element moved with it");
+
+            // Act — the second portal's own child re-renders on its own state.
+            s_change!.Invoke(1);
+            _mounted.FlushStateForTest();
+            _mounted.FlushEffectsForTest();
+
+            // Assert
+            Assert.That(Names(target), Is.EqualTo("toast-one|toast-two|changed"));
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/PortalNeighbourGrowthTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/PortalNeighbourGrowthTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3dfd8fb0acda848258ab3a06605eb920


### PR DESCRIPTION
Several `V.Portal`s sharing one container is documented as supported, and nothing pinned what happens
to the second one's child when the first grows. This adds the two shapes that reach it by different
paths, and both hold on `main`:

- the first portal's **own children array** grows 1 → 2, which is what reaches
  `PortalSlotTracker.ShiftSlotStartsAfter` and moves the second portal's recorded `SlotStart`;
- the second portal's stateful component child then re-renders alone, at whatever coordinate it holds.

What keeps that patch on its own element is `ComponentRegistry.cs:190` —
`existingFiber.MountSlotStart = site.SlotStart;` — which refreshes an inline component's coordinate
from the reconcile site whenever a parent reconcile reaches it. Measured: deleting that line fails
this case. Nothing named it before, so the line was one edit away from being read as redundant.

This is characterization coverage rather than a fix. #599 reports the second portal's child patching
into the neighbour's element, and neither shape reproduces that on `main`; the comment there records
what the two measurements found and what question is left.

Refs #599 — the coverage half of it. Whether a shape exists that still patches the wrong element
stays open there.
