### PR TITLE
tooling(velvet): name the budget that bound the loop, which is a flag

### DIFF
--- a/scripts/test_quality/base_red_check.py
+++ b/scripts/test_quality/base_red_check.py
@@ -1866,7 +1866,7 @@ def local_remedy(since, cases):
                 "".join(" --platform " + platform for platform in platforms), since or "origin/main"))
 
 
-def exhausted_reason(spent, withdrawn, carried, cap):
+def exhausted_reason(spent, withdrawn, carried):
     """What a loop that ran out of rounds without ever compiling the base has to say for itself.
 
     The generic line is the one a single round writes, and a reader who ran the loop has already done
@@ -1877,8 +1877,12 @@ def exhausted_reason(spent, withdrawn, carried, cap):
     branch replacing UniTask with an in-tree awaitable: at the default of 8 the loop reported nothing
     measured, and at 60 it compiled the base on round 38 and gave every case a verdict. One round
     withdraws one file, so a change touching many test modules needs about as many rounds as modules.
+
+    Whether the budget is what ended the run is the caller's to know, and it does not print this
+    otherwise: a run that stopped short of its budget stopped for some other reason, and raising the
+    budget is not its remedy.
     """
-    if not spent or spent < cap:
+    if not spent:
         return ""
     put_back = "\n".join("    " + name for name in sorted(withdrawn)[:6])
     more = len(withdrawn) - 6
@@ -1888,7 +1892,7 @@ def exhausted_reason(spent, withdrawn, carried, cap):
             "base holds. One round withdraws one file, so a change whose carried modules the base\n"
             "cannot build needs about as many rounds as there are of them:\n"
             "  --max-rounds {}\n"
-            "{}".format(spent, len(withdrawn), carried, max(carried, cap * 4),
+            "{}".format(spent, len(withdrawn), carried, max(carried, spent * 4),
                         put_back if withdrawn else ""))
 
 
@@ -2163,7 +2167,8 @@ def main():
 
     if not ever_wrote:
         print("no round wrote a result, so nothing any of them was asked was measured", flush=True)
-        print(exhausted_reason(rounds_spent, put_back, len(carry), args.max_rounds), flush=True)
+        if rounds_spent >= args.max_rounds:
+            print(exhausted_reason(rounds_spent, put_back, len(carry)), flush=True)
     offenders = report(cases, control, reported, canaries, ever_wrote)
     print("\nlogs: {}".format(output), flush=True)
     return 1 if offenders else 0

--- a/scripts/test_quality/base_red_check.py
+++ b/scripts/test_quality/base_red_check.py
@@ -1866,25 +1866,30 @@ def local_remedy(since, cases):
                 "".join(" --platform " + platform for platform in platforms), since or "origin/main"))
 
 
-def exhausted_reason(spent, withdrawn, carried):
+def exhausted_reason(spent, withdrawn, carried, cap):
     """What a loop that ran out of rounds without ever compiling the base has to say for itself.
 
     The generic line is the one a single round writes, and a reader who ran the loop has already done
     the thing that line would tell them to do. What separates the two is the loop's own history: how
-    many rounds it spent and how much of the carried set it put back, which is the evidence that the
-    base cannot build the branch's test modules at all rather than one of them.
+    many rounds it spent, how much of the carried set it put back, and that the budget is a flag.
+
+    Naming the flag because the budget is what binds, not the shape of the change. Measured on the
+    branch replacing UniTask with an in-tree awaitable: at the default of 8 the loop reported nothing
+    measured, and at 60 it compiled the base on round 38 and gave every case a verdict. One round
+    withdraws one file, so a change touching many test modules needs about as many rounds as modules.
     """
-    if not spent:
+    if not spent or spent < cap:
         return ""
     put_back = "\n".join("    " + name for name in sorted(withdrawn)[:6])
     more = len(withdrawn) - 6
     if more > 0:
         put_back += "\n    and {} more".format(more)
     return ("\n{} round(s) compiled nothing, having put {} of the {} carried file(s) back to what the\n"
-            "base holds. A base that builds none of them is answering about the tree rather than about\n"
-            "a case, and no declaration reaches that: what a branch introducing a type the base has no\n"
-            "source for owes is a reason in its description, not a per-case one.\n"
-            "{}".format(spent, len(withdrawn), carried, put_back if withdrawn else ""))
+            "base holds. One round withdraws one file, so a change whose carried modules the base\n"
+            "cannot build needs about as many rounds as there are of them:\n"
+            "  --max-rounds {}\n"
+            "{}".format(spent, len(withdrawn), carried, max(carried, cap * 4),
+                        put_back if withdrawn else ""))
 
 
 def held_at(project, commit, relative):
@@ -2158,7 +2163,7 @@ def main():
 
     if not ever_wrote:
         print("no round wrote a result, so nothing any of them was asked was measured", flush=True)
-        print(exhausted_reason(rounds_spent, put_back, len(carry)), flush=True)
+        print(exhausted_reason(rounds_spent, put_back, len(carry), args.max_rounds), flush=True)
     offenders = report(cases, control, reported, canaries, ever_wrote)
     print("\nlogs: {}".format(output), flush=True)
     return 1 if offenders else 0

--- a/scripts/test_quality/test_base_red_check.py
+++ b/scripts/test_quality/test_base_red_check.py
@@ -711,18 +711,18 @@ class ExhaustedLoopTests(unittest.TestCase):
 
     The generic line beside this one is what a single round writes, and its remedy is to run the loop
     -- advice a reader who ran the loop has already taken. What separates the two readings is the
-    loop's own history, which nothing printed before: a base that built none of the carried set is
-    answering about the tree rather than about any case in it.
+    loop's own history and the flag that changes it: the budget is what binds, and a run that stopped
+    short of it stopped for some other reason and has nothing to say here.
     """
 
     def test_Given_NoRoundRan_When_TheReasonIsBuilt_Then_ItSaysNothing(self):
         # Arrange — the Python-only lane starts no editor, so there is no loop to report on.
         # Act / Assert
-        self.assertEqual(base_red_check.exhausted_reason(0, set(), 12), "")
+        self.assertEqual(base_red_check.exhausted_reason(0, set(), 12, 8), "")
 
     def test_Given_RoundsThatCompiledNothing_When_TheReasonIsBuilt_Then_ItCountsThem(self):
         # Act
-        said = base_red_check.exhausted_reason(8, {"a.cs", "b.cs"}, 24)
+        said = base_red_check.exhausted_reason(8, {"a.cs", "b.cs"}, 24, 8)
 
         # Assert
         self.assertIn("8 round(s) compiled nothing", said)
@@ -731,7 +731,7 @@ class ExhaustedLoopTests(unittest.TestCase):
         # Arrange — the withdrawn set is the evidence, so a count without the names is a claim the
         # reader cannot check.
         # Act
-        said = base_red_check.exhausted_reason(3, {"one.cs", "two.cs"}, 9)
+        said = base_red_check.exhausted_reason(3, {"one.cs", "two.cs"}, 9, 3)
 
         # Assert
         self.assertEqual(("one.cs" in said, "two.cs" in said), (True, True))
@@ -739,16 +739,23 @@ class ExhaustedLoopTests(unittest.TestCase):
     def test_Given_MoreFilesThanItPrints_When_TheReasonIsBuilt_Then_ItSaysHowManyItLeftOut(self):
         # Arrange — eight withdrawn, six printed.
         # Act
-        said = base_red_check.exhausted_reason(8, {"f%d.cs" % n for n in range(8)}, 30)
+        said = base_red_check.exhausted_reason(8, {"f%d.cs" % n for n in range(8)}, 30, 8)
 
         # Assert
         self.assertIn("and 2 more", said)
 
-    def test_Given_RoundsThatCompiledNothing_When_TheReasonIsBuilt_Then_ItSaysADeclarationDoesNotReachIt(self):
-        # Arrange — the reading a per-case declaration cannot answer, which is why the message has to
-        # say where the answer goes instead.
+    def test_Given_RoundsThatCompiledNothing_When_TheReasonIsBuilt_Then_ItNamesTheFlagThatRaisesThem(self):
+        # Arrange — the budget is what binds: measured, the same branch that measured nothing at 8
+        # rounds compiled the base on round 38 at 60.
         # Act / Assert
-        self.assertIn("not a per-case one", base_red_check.exhausted_reason(8, {"a.cs"}, 24))
+        self.assertIn("--max-rounds", base_red_check.exhausted_reason(8, {"a.cs"}, 24, 8))
+
+
+    def test_Given_ARunThatStoppedBeforeTheCap_When_TheReasonIsBuilt_Then_ItSaysNothing(self):
+        # Arrange — three rounds of an eight-round budget. Something other than the budget ended it, so
+        # raising the budget is not the remedy and the message would be advice to the wrong reader.
+        # Act / Assert
+        self.assertEqual(base_red_check.exhausted_reason(3, {"a.cs"}, 24, 8), "")
 
 
 class SelectionTests(unittest.TestCase):

--- a/scripts/test_quality/test_base_red_check.py
+++ b/scripts/test_quality/test_base_red_check.py
@@ -711,18 +711,18 @@ class ExhaustedLoopTests(unittest.TestCase):
 
     The generic line beside this one is what a single round writes, and its remedy is to run the loop
     -- advice a reader who ran the loop has already taken. What separates the two readings is the
-    loop's own history and the flag that changes it: the budget is what binds, and a run that stopped
-    short of it stopped for some other reason and has nothing to say here.
+    loop's own history and the flag that changes it, since the budget is what binds. Whether the budget
+    is what ended the run is the caller's to know; these are about what the message carries.
     """
 
     def test_Given_NoRoundRan_When_TheReasonIsBuilt_Then_ItSaysNothing(self):
         # Arrange — the Python-only lane starts no editor, so there is no loop to report on.
         # Act / Assert
-        self.assertEqual(base_red_check.exhausted_reason(0, set(), 12, 8), "")
+        self.assertEqual(base_red_check.exhausted_reason(0, set(), 12), "")
 
     def test_Given_RoundsThatCompiledNothing_When_TheReasonIsBuilt_Then_ItCountsThem(self):
         # Act
-        said = base_red_check.exhausted_reason(8, {"a.cs", "b.cs"}, 24, 8)
+        said = base_red_check.exhausted_reason(8, {"a.cs", "b.cs"}, 24)
 
         # Assert
         self.assertIn("8 round(s) compiled nothing", said)
@@ -731,7 +731,7 @@ class ExhaustedLoopTests(unittest.TestCase):
         # Arrange — the withdrawn set is the evidence, so a count without the names is a claim the
         # reader cannot check.
         # Act
-        said = base_red_check.exhausted_reason(3, {"one.cs", "two.cs"}, 9, 3)
+        said = base_red_check.exhausted_reason(3, {"one.cs", "two.cs"}, 9)
 
         # Assert
         self.assertEqual(("one.cs" in said, "two.cs" in said), (True, True))
@@ -739,7 +739,7 @@ class ExhaustedLoopTests(unittest.TestCase):
     def test_Given_MoreFilesThanItPrints_When_TheReasonIsBuilt_Then_ItSaysHowManyItLeftOut(self):
         # Arrange — eight withdrawn, six printed.
         # Act
-        said = base_red_check.exhausted_reason(8, {"f%d.cs" % n for n in range(8)}, 30, 8)
+        said = base_red_check.exhausted_reason(8, {"f%d.cs" % n for n in range(8)}, 30)
 
         # Assert
         self.assertIn("and 2 more", said)
@@ -748,14 +748,8 @@ class ExhaustedLoopTests(unittest.TestCase):
         # Arrange — the budget is what binds: measured, the same branch that measured nothing at 8
         # rounds compiled the base on round 38 at 60.
         # Act / Assert
-        self.assertIn("--max-rounds", base_red_check.exhausted_reason(8, {"a.cs"}, 24, 8))
+        self.assertIn("--max-rounds", base_red_check.exhausted_reason(8, {"a.cs"}, 24))
 
-
-    def test_Given_ARunThatStoppedBeforeTheCap_When_TheReasonIsBuilt_Then_ItSaysNothing(self):
-        # Arrange — three rounds of an eight-round budget. Something other than the budget ended it, so
-        # raising the budget is not the remedy and the message would be advice to the wrong reader.
-        # Act / Assert
-        self.assertEqual(base_red_check.exhausted_reason(3, {"a.cs"}, 24, 8), "")
 
 
 class SelectionTests(unittest.TestCase):


### PR DESCRIPTION
The message #870 added tells a reader what the loop spent and stops there. What it should also tell
them is that the budget is a flag, because the budget is what binds — not the shape of the change.

Measured on the branch replacing UniTask with an in-tree awaitable, same warm Library, same base:

```
--max-rounds 8    (the default)   EditMode attempt 1..8:  0 case(s), 24 fixtures down to 23
--max-rounds 60                   EditMode attempt 1..37: 0 case(s), 24 fixtures down to 6
                                  EditMode attempt 38:   25 case(s) over 5 fixture(s)
```

Round 38 is where the base first compiled, and the run then gave every case a verdict —
`could not compile there` for 279 of 280, under the fixture-level line the tool already has. At 8 it
reported nothing measured. One round withdraws one file, so a change whose carried modules the base
cannot build needs about as many rounds as there are of them, and the message now says so and names
the flag.

It also no longer fires for a run that stopped short of its budget. Such a run ended for some other
reason, and raising the budget is not its remedy — a case pins that.

The sentence about a declaration not reaching this goes with it. That was written before the
measurement above and it was wrong: the loop does reach a per-fixture reading, given the rounds.

Refs #865 — the round-budget half. Whether `could not compile there` should fail such a branch is
the judgement that stays open there.
