### PR TITLE
fix(velvet): give the guard a flag for every slot a mode drives

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -59,7 +59,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the element's own transitionable set, and it had no flag for `filter` or for the background-position
   pair — so those three reported driving nothing and their per-frame writes were left to whatever
   transition covered them. A bare `duration-*` is enough to reach this, because UI Toolkit's initial
-  `transition-property` of `all` covers every slot. What the suspension does not reach is the
+  `transition-property` of `all` covers every slot, which is how an element reaches the two new slots:
+  no bundled utility names either of them on its own. What the suspension does not reach is the
   background size and repeat the pan modes set once at attach, above the call that takes it.
 
 - A component inside one `V.Portal` no longer has its position rewritten by a sibling portal on a

--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -57,11 +57,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `animate-hue` and the two gradient pan modes now suspend a native transition covering the slot they
   drive, as `animate-spin` and `animate-pulse` already did. The guard matches a driver's slot against
   the element's own transitionable set, and it had no flag for `filter` or for the background-position
-  pair — so those three reported driving nothing and were left to whatever transition covered them.
-  UI Toolkit does not take an inline write while a transition covers that longhand; it starts a fresh
-  transition toward it, so the painted value trailed the driver for the whole loop. A bare `duration-*`
-  is enough to reach this, because UI Toolkit's initial `transition-property` of `all` covers
-  every slot.
+  pair — so those three reported driving nothing and their per-frame writes were left to whatever
+  transition covered them. A bare `duration-*` is enough to reach this, because UI Toolkit's initial
+  `transition-property` of `all` covers every slot. What the suspension does not reach is the
+  background size and repeat the pan modes set once at attach, above the call that takes it.
 
 - A component inside one `V.Portal` no longer has its position rewritten by a sibling portal on a
   different target. Two portals declared side by side are siblings in the fiber chain whatever targets

--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -54,6 +54,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `animate-hue` and the two gradient pan modes now suspend a native transition covering the slot they
+  drive, as `animate-spin` and `animate-pulse` already did. The guard matches a driver's slot against
+  the element's own transitionable set, and it had no flag for `filter` or for the background-position
+  pair — so those three reported driving nothing and were left to whatever transition covered them.
+  UI Toolkit does not take an inline write while a transition covers that longhand; it starts a fresh
+  transition toward it, so the painted value trailed the driver for the whole loop. A bare `duration-*`
+  is enough to reach this, because UI Toolkit's initial `transition-property` of `all` covers
+  every slot.
+
 - A component inside one `V.Portal` no longer has its position rewritten by a sibling portal on a
   different target. Two portals declared side by side are siblings in the fiber chain whatever targets
   they name, and a child-count change committed on one shifted the recorded position of every following

--- a/Packages/com.velvet.core/Documentation~/motion.md
+++ b/Packages/com.velvet.core/Documentation~/motion.md
@@ -334,9 +334,10 @@ Two combinations to avoid, both because something else writes the same slot ever
 
 - a mode's slot driven by a Motion channel on the same element — `animate-spin` under a Motion
   `rotate`, say. The result is whichever wrote last, not a blend.
-- a native transition covering that slot. Every mode suspends one while it runs, the way Motion's own
-  drivers do, so a transition never intercepts a driven tick. Note a transition needs no
-  `transition-*` utility — a bare `duration-*` leaves UI Toolkit's initial `all` standing, which
+- a native transition covering that slot. Every mode suspends one for the length of its run, the way
+  Motion's own drivers do. The pan modes also set background size and repeat once at attach, before
+  the suspension, so a transition covering either still takes that one write. Note a transition needs
+  no `transition-*` utility — a bare `duration-*` leaves UI Toolkit's initial `all` standing, which
   covers every slot.
 
 The suspension is element-wide (UI Toolkit's `transition-property` has no "everything except these"

--- a/Packages/com.velvet.core/Documentation~/motion.md
+++ b/Packages/com.velvet.core/Documentation~/motion.md
@@ -334,13 +334,13 @@ Two combinations to avoid, both because something else writes the same slot ever
 
 - a mode's slot driven by a Motion channel on the same element — `animate-spin` under a Motion
   `rotate`, say. The result is whichever wrote last, not a blend.
-- a native transition covering that slot. `animate-spin` and `animate-pulse` suspend one while they
-  run, the way Motion's own drivers do, so those two are safe. `animate-hue` and the gradient pair
-  are not: their slots have no flag in the guard yet. Note a transition needs no `transition-*`
-  utility — a bare `duration-*` leaves UI Toolkit's initial `all` standing, which covers every slot.
+- a native transition covering that slot. Every mode suspends one while it runs, the way Motion's own
+  drivers do, so a transition never intercepts a driven tick. Note a transition needs no
+  `transition-*` utility — a bare `duration-*` leaves UI Toolkit's initial `all` standing, which
+  covers every slot.
 
 The suspension is element-wide (UI Toolkit's `transition-property` has no "everything except these"
-spelling), so while a suspended `animate-spin` or `animate-pulse` runs, the element's *other*
+spelling), so while a suspended mode runs, the element's *other*
 transitions land instantly too. It is taken only when the element's own utility CLASSES name the slot
 the mode writes — `animate-pulse transition-colors` keeps its colour fade — and handed back as soon
 as a re-render leaves nothing transitioning that slot. Reading the classes means anything that never

--- a/Packages/com.velvet.core/Runtime/Styling/MotionNativeTransitionGuard.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/MotionNativeTransitionGuard.cs
@@ -22,7 +22,12 @@ namespace Velvet
         Color = 1 << 4,
         // Every length-valued property, grouped for the same reason as Color.
         Length = 1 << 5,
-        All = Opacity | Translate | Scale | Rotate | Color | Length,
+        // `animate-hue` writes `filter` whole, and the pan modes write one of the two background-position
+        // longhands per tick -- which of the two is the binding's own axis, so both are one slot here for
+        // the same reason Color is one: the driver reports the slot, not the channel.
+        Filter = 1 << 6,
+        BackgroundPosition = 1 << 7,
+        All = Opacity | Translate | Scale | Rotate | Color | Length | Filter | BackgroundPosition,
     }
 
     /// <summary>
@@ -232,6 +237,10 @@ namespace Velvet
             StyleLonghand.BorderBottomColor,
             StyleLonghand.BorderLeftColor);
 
+        private static readonly StyleLonghandSet s_backgroundPositionProperties = SetOf(
+            StyleLonghand.BackgroundPositionX,
+            StyleLonghand.BackgroundPositionY);
+
         private static readonly StyleLonghandSet s_lengthProperties = SetOf(
             StyleLonghand.Width,
             StyleLonghand.Height,
@@ -273,6 +282,8 @@ namespace Velvet
             if (declared.Contains(StyleLonghand.Rotate)) slots |= MotionTransitionSlots.Rotate;
             if (declared.Overlaps(s_colorProperties)) slots |= MotionTransitionSlots.Color;
             if (declared.Overlaps(s_lengthProperties)) slots |= MotionTransitionSlots.Length;
+            if (declared.Contains(StyleLonghand.Filter)) slots |= MotionTransitionSlots.Filter;
+            if (declared.Overlaps(s_backgroundPositionProperties)) slots |= MotionTransitionSlots.BackgroundPosition;
             return slots;
         }
 

--- a/Packages/com.velvet.core/Runtime/Styling/MotionNativeTransitionGuard.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/MotionNativeTransitionGuard.cs
@@ -25,6 +25,10 @@ namespace Velvet
         // `animate-hue` writes `filter` whole, and the pan modes write one of the two background-position
         // longhands per tick -- which of the two is the binding's own axis, so both are one slot here for
         // the same reason Color is one: the driver reports the slot, not the channel.
+        //
+        // No SlotsOf arm for BackgroundPosition: the bundled sheets declare no transition-property naming
+        // it, and StyleTransitionUtilities is derived from them, so the declared side reaches this slot
+        // through `all` alone. Filter has `.transition-filter` and so has an arm.
         Filter = 1 << 6,
         BackgroundPosition = 1 << 7,
         All = Opacity | Translate | Scale | Rotate | Color | Length | Filter | BackgroundPosition,
@@ -237,10 +241,6 @@ namespace Velvet
             StyleLonghand.BorderBottomColor,
             StyleLonghand.BorderLeftColor);
 
-        private static readonly StyleLonghandSet s_backgroundPositionProperties = SetOf(
-            StyleLonghand.BackgroundPositionX,
-            StyleLonghand.BackgroundPositionY);
-
         private static readonly StyleLonghandSet s_lengthProperties = SetOf(
             StyleLonghand.Width,
             StyleLonghand.Height,
@@ -283,7 +283,6 @@ namespace Velvet
             if (declared.Overlaps(s_colorProperties)) slots |= MotionTransitionSlots.Color;
             if (declared.Overlaps(s_lengthProperties)) slots |= MotionTransitionSlots.Length;
             if (declared.Contains(StyleLonghand.Filter)) slots |= MotionTransitionSlots.Filter;
-            if (declared.Overlaps(s_backgroundPositionProperties)) slots |= MotionTransitionSlots.BackgroundPosition;
             return slots;
         }
 

--- a/Packages/com.velvet.core/Runtime/Styling/MotionNativeTransitionGuard.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/MotionNativeTransitionGuard.cs
@@ -26,9 +26,9 @@ namespace Velvet
         // longhands per tick -- which of the two is the binding's own axis, so both are one slot here for
         // the same reason Color is one: the driver reports the slot, not the channel.
         //
-        // No SlotsOf arm for BackgroundPosition: the bundled sheets declare no transition-property naming
-        // it, and StyleTransitionUtilities is derived from them, so the declared side reaches this slot
-        // through `all` alone. Filter has `.transition-filter` and so has an arm.
+        // Neither has a SlotsOf arm yet: the driver reports the slot it writes, and an element reaches
+        // both through `all`. `.transition-filter` is the one utility that could name a declared side
+        // finer, which is a separate change from giving the driver a flag.
         Filter = 1 << 6,
         BackgroundPosition = 1 << 7,
         All = Opacity | Translate | Scale | Rotate | Color | Length | Filter | BackgroundPosition,
@@ -282,7 +282,6 @@ namespace Velvet
             if (declared.Contains(StyleLonghand.Rotate)) slots |= MotionTransitionSlots.Rotate;
             if (declared.Overlaps(s_colorProperties)) slots |= MotionTransitionSlots.Color;
             if (declared.Overlaps(s_lengthProperties)) slots |= MotionTransitionSlots.Length;
-            if (declared.Contains(StyleLonghand.Filter)) slots |= MotionTransitionSlots.Filter;
             return slots;
         }
 

--- a/Packages/com.velvet.core/Runtime/Styling/StyleAnimateDriver.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleAnimateDriver.cs
@@ -77,15 +77,16 @@ namespace Velvet
         public static void SyncTransitionSuspension(VisualElement element, StyleAnimateBinding binding)
             => MotionNativeTransitionGuard.SyncSuspension(element, binding, GuardedSlots(binding.Spec.Mode));
 
-        // Only the two slots named here have a flag in MotionTransitionSlots; the filter and background-position
-        // the other three modes write have none, so those are left to whatever transition covers them.
+        // The slot each mode writes on a tick, which is the only write a transition can intercept. The pan
+        // modes set background-size and background-repeat on attach rather than per tick, so neither is here.
 #pragma warning disable CS8524 // no discard arm: a new mode has to name the slots it guards
         private static MotionTransitionSlots GuardedSlots(AnimateMode mode) => mode switch
         {
             AnimateMode.Spin => MotionTransitionSlots.Rotate,
             AnimateMode.Pulse => MotionTransitionSlots.Opacity,
-            AnimateMode.None or AnimateMode.Gradient or AnimateMode.Shimmer or AnimateMode.Hue
-                => MotionTransitionSlots.None,
+            AnimateMode.Hue => MotionTransitionSlots.Filter,
+            AnimateMode.Gradient or AnimateMode.Shimmer => MotionTransitionSlots.BackgroundPosition,
+            AnimateMode.None => MotionTransitionSlots.None,
         };
 #pragma warning restore CS8524
 

--- a/Packages/com.velvet.core/Runtime/Styling/StyleAnimateDriver.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/StyleAnimateDriver.cs
@@ -77,8 +77,9 @@ namespace Velvet
         public static void SyncTransitionSuspension(VisualElement element, StyleAnimateBinding binding)
             => MotionNativeTransitionGuard.SyncSuspension(element, binding, GuardedSlots(binding.Spec.Mode));
 
-        // The slot each mode writes on a tick, which is the only write a transition can intercept. The pan
-        // modes set background-size and background-repeat on attach rather than per tick, so neither is here.
+        // The slot each mode writes on a tick. The pan modes also write background-size and
+        // background-repeat, but at attach and once -- and above this call, so a transition covering
+        // either takes that write whatever this returns.
 #pragma warning disable CS8524 // no discard arm: a new mode has to name the slots it guards
         private static MotionTransitionSlots GuardedSlots(AnimateMode mode) => mode switch
         {

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/AnimateMotionPanelTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/AnimateMotionPanelTests.cs
@@ -260,9 +260,7 @@ namespace Velvet.Tests
         [Test]
         public void Given_AHueUnderADuration_When_ItAttaches_Then_TheNativeTransitionIsSuspended()
         {
-            // Arrange — the same bare duration, over the slot `animate-hue` writes every tick. UI Toolkit
-            // starts a fresh transition toward an inline filter rather than taking it, so an unsuspended
-            // hue trails its own driver for the whole loop.
+            // Arrange — the same bare duration, over the slot `animate-hue` writes every tick.
             var (untimed, timed) = MountPair(
                 "w-[40px] h-[40px] bg-red-500 animate-hue",
                 "w-[40px] h-[40px] bg-red-500 duration-300 animate-hue");

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/AnimateMotionPanelTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/AnimateMotionPanelTests.cs
@@ -258,6 +258,45 @@ namespace Velvet.Tests
         }
 
         [Test]
+        public void Given_AHueUnderADuration_When_ItAttaches_Then_TheNativeTransitionIsSuspended()
+        {
+            // Arrange — the same bare duration, over the slot `animate-hue` writes every tick. UI Toolkit
+            // starts a fresh transition toward an inline filter rather than taking it, so an unsuspended
+            // hue trails its own driver for the whole loop.
+            var (untimed, timed) = MountPair(
+                "w-[40px] h-[40px] bg-red-500 animate-hue",
+                "w-[40px] h-[40px] bg-red-500 duration-300 animate-hue");
+
+            // Act
+            var whileHueing = timed.style.transitionProperty.keyword;
+            StyleAnimateDriver.Detach(timed, BindingOf(timed));
+
+            // Assert
+            Assert.That(
+                (untimed.style.transitionProperty.keyword, whileHueing, timed.style.transitionProperty.keyword),
+                Is.EqualTo((StyleKeyword.Null, StyleKeyword.Undefined, StyleKeyword.Null)));
+        }
+
+        [Test]
+        public void Given_AGradientPanUnderADuration_When_ItAttaches_Then_TheNativeTransitionIsSuspended()
+        {
+            // Arrange — the pan modes write one background-position longhand a tick, chosen by the binding's
+            // own axis, so the guard's slot covers both.
+            var (untimed, timed) = MountPair(
+                "w-[100px] h-[40px] bg-gradient-to-r from-red-500 to-blue-500 animate-gradient",
+                "w-[100px] h-[40px] bg-gradient-to-r from-red-500 to-blue-500 duration-300 animate-gradient");
+
+            // Act
+            var whilePanning = timed.style.transitionProperty.keyword;
+            StyleAnimateDriver.Detach(timed, BindingOf(timed));
+
+            // Assert
+            Assert.That(
+                (untimed.style.transitionProperty.keyword, whilePanning, timed.style.transitionProperty.keyword),
+                Is.EqualTo((StyleKeyword.Null, StyleKeyword.Undefined, StyleKeyword.Null)));
+        }
+
+        [Test]
         public void Given_ASuspendedSpin_When_APatchLeavesNothingTransitioningRotate_Then_TheSuspensionIsHandedBack()
         {
             // Arrange — the suspension costs the element every transition it declares, not just the one over

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/MotionNativeTransitionGuardCascadeTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/MotionNativeTransitionGuardCascadeTests.cs
@@ -64,8 +64,6 @@ namespace Velvet.Tests
             // there is no empty resolved list to read instead.
             "" => MotionTransitionSlots.None,
             "filter" => MotionTransitionSlots.Filter,
-            "background-position-x" => MotionTransitionSlots.BackgroundPosition,
-            "background-position-y" => MotionTransitionSlots.BackgroundPosition,
             _ => throw new NotSupportedException(
                 $"The cascade resolved transition-property to '{ussProperty}', which this oracle does not map."),
         };

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/MotionNativeTransitionGuardCascadeTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/MotionNativeTransitionGuardCascadeTests.cs
@@ -44,8 +44,7 @@ namespace Velvet.Tests
             return slots;
         }
 
-        // No per-frame driver writes filter, so a list naming it contends for nothing, exactly as an empty list
-        // does. An unmapped name throws rather than defaulting: silently contributing nothing would let a new
+        // An unmapped name throws rather than defaulting: silently contributing nothing would let a new
         // utility widen the cascade without any case here going red.
         private static MotionTransitionSlots SlotOf(string ussProperty) => ussProperty switch
         {
@@ -64,7 +63,9 @@ namespace Velvet.Tests
             // transition-property: none resolves to one entry that names no property, whose ToString is null;
             // there is no empty resolved list to read instead.
             "" => MotionTransitionSlots.None,
-            "filter" => MotionTransitionSlots.None,
+            "filter" => MotionTransitionSlots.Filter,
+            "background-position-x" => MotionTransitionSlots.BackgroundPosition,
+            "background-position-y" => MotionTransitionSlots.BackgroundPosition,
             _ => throw new NotSupportedException(
                 $"The cascade resolved transition-property to '{ussProperty}', which this oracle does not map."),
         };

--- a/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/MotionNativeTransitionGuardCascadeTests.cs
+++ b/Packages/com.velvet.core/Runtime/Styling/Tests/Editor/MotionNativeTransitionGuardCascadeTests.cs
@@ -44,8 +44,10 @@ namespace Velvet.Tests
             return slots;
         }
 
-        // An unmapped name throws rather than defaulting: silently contributing nothing would let a new
-        // utility widen the cascade without any case here going red.
+        // Filter maps to None because the declared side has no arm for it yet -- the driver reports the
+        // slot, and what an element declares reaches it through `all` alone. An unmapped name throws
+        // rather than defaulting: silently contributing nothing would let a new utility widen the
+        // cascade without any case here going red.
         private static MotionTransitionSlots SlotOf(string ussProperty) => ussProperty switch
         {
             "all" => MotionTransitionSlots.All,
@@ -63,7 +65,7 @@ namespace Velvet.Tests
             // transition-property: none resolves to one entry that names no property, whose ToString is null;
             // there is no empty resolved list to read instead.
             "" => MotionTransitionSlots.None,
-            "filter" => MotionTransitionSlots.Filter,
+            "filter" => MotionTransitionSlots.None,
             _ => throw new NotSupportedException(
                 $"The cascade resolved transition-property to '{ussProperty}', which this oracle does not map."),
         };


### PR DESCRIPTION
`MotionNativeTransitionGuard` suspends an element's native USS transitions while a per-frame driver
writes a slot they would otherwise intercept. `MotionTransitionSlots` had a member for opacity,
translate, scale, rotate, colour and length — and none for `filter` or background position. So
`animate-hue` and the two gradient pan modes reported driving nothing, `SyncSuspension`
short-circuited to `Release`, and a transition covering those longhands took every tick's write.

A bare `duration-*` is enough to reach it: UI Toolkit's initial `transition-property` of `all` covers
every slot, so no `transition-*` utility has to be present. That is also how an element reaches the
two new slots, because no bundled utility names either of them on its own.

Measured which longhand each mode writes per tick, since only a per-tick write is what a transition
intercepts frame after frame: Hue writes `filter`; Gradient and Shimmer write one of
`backgroundPositionX` / `backgroundPositionY`, whichever the binding's own axis names. Both new slots
follow Colour's precedent of standing for the group rather than the channel.

What the suspension does not reach is the background size and repeat the pan modes set at attach.
That write happens once, and above the call that takes the suspension, so a transition covering
either still takes it. The guide says so rather than claiming the modes are now uniformly safe.

The declared side is deliberately left alone here. `SlotsOf` gains no arm for either slot, so the
cascade oracle's reading is unchanged and no carried test module names a member the base has not got
— which is what lets `base-red` answer this in one round rather than none. `.transition-filter` is
the one bundled utility that could name a declared side finer, and giving it an arm is a change that
can be read on a base that already has the member.

Two cases, one per new slot, each red without its `GuardedSlots` arm and red on the base.
EditMode 4196 passed / 0 failed, PlayMode 161 / 0.

Closes #580
