### PR TITLE
test(velvet): say what the shape is rather than what will one day have it

### DIFF
--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/PublicApiSurfaceTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/PublicApiSurfaceTests.cs
@@ -97,8 +97,8 @@ namespace Velvet.Tests
                 + "it. An unloaded assembly would report the same empty surface, so both are read at once.");
         }
 
-        /// <summary>A generic with a nested type, which the repository's own surface gains with
-        /// `VelvetTask` and did not carry when this rendering was written.</summary>
+        /// <summary>A generic with a nested type, a shape the rendering had no instance of when it was
+        /// written and so had never been asked to spell.</summary>
         private sealed class OwnerWithNested<T>
         {
             internal struct Nested


### PR DESCRIPTION
`OwnerWithNested<T>`'s doc comment named a type this repository does not have, as something its
surface "gains with" one day. A comment about a future is a comment nothing can make true or false,
and the shape it describes is decidable from the class itself.

It has a second cost, which is what brought me to it. `base_red_check.csharp_names` reads the base's
C# raw rather than masked, on purpose — a name the base spells anywhere is one it decides is present,
and erring towards leaving a carried file in the run is the survivable direction. A comment naming a
type the base does not have therefore suppresses the static withdrawal for every carried file that
names it. Measured: this is the only place `origin/main` spells `VelvetTask`, and while it stands, a
branch adding that type has no carried module withdrawn ahead of the round.

No issue: found while splitting #377 into a change base-red can answer.
