### PR TITLE
tooling(velvet): withdraw a carried file whose assembly the base has not got

### DIFF
--- a/scripts/test_quality/base_red_check.py
+++ b/scripts/test_quality/base_red_check.py
@@ -114,7 +114,7 @@ import tempfile
 import time
 import tokenize
 import xml.etree.ElementTree as ET
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 DEFAULT_UNITY = "/Applications/Unity/Hub/Editor/6000.3.11f1/Unity.app/Contents/MacOS/Unity"
 # Anchored at the editor binary so that a shell waiting on this pattern does not match itself and
@@ -1486,6 +1486,29 @@ def added_csharp_surface(text, base_names, added_names):
                  if name not in base_names), None)
 
 
+def assembly_absent_on_base(project, base_tree, relative):
+    """The asmdef a carried file belongs to, where the base tree has not got it.
+
+    Unity gives a source file to the nearest asmdef at or above it. A branch that adds a test assembly
+    adds the asmdef too, and the asmdef is not a `.cs` and so is never carried -- so on the base the
+    file falls to the next asmdef up, which for a fixture under `Runtime/` is the runtime assembly. An
+    `AssemblyInfo.cs` landing there is a duplicate attribute and takes the whole compile with it, and
+    the name-spelling comparison cannot see it: such a file spells no type at all.
+    """
+    owner = None
+    directory = PurePosixPath(relative).parent
+    while True:
+        for candidate in sorted((project / directory).glob("*.asmdef")):
+            owner = str(directory / candidate.name)
+            break
+        if owner is not None or str(directory) in (".", ""):
+            break
+        directory = directory.parent
+    if owner is None or (base_tree / owner).exists():
+        return None
+    return owner
+
+
 def unbuildable_on_base(project, since, base_tree, carry):
     """Carried C# test file -> the name it spells that the base tree has not got.
 
@@ -1498,6 +1521,13 @@ def unbuildable_on_base(project, since, base_tree, carry):
     tree's -- which holds the branch's copy of every carried file -- so a name the branch's own test
     side declares reads that way too. Measured: each withdraws a file that compiles there.
     """
+    found = {}
+    for relative in carry:
+        if kind_of(relative) != "csharp":
+            continue
+        owner = assembly_absent_on_base(project, base_tree, relative)
+        if owner is not None:
+            found[relative] = owner
     changed = [name for name in changed_lines_by_file(project, since)
                if name.endswith(".cs") and name not in carry]
     added = set()
@@ -1507,10 +1537,11 @@ def unbuildable_on_base(project, since, base_tree, carry):
             added |= names_in("\n".join(code_lines(
                 source.read_text(encoding="utf-8", errors="replace"))))
     if not added:
-        return {}
+        return found
     base_names = csharp_names(base_tree, carried=carry)
-    found = {}
     for relative in carry:
+        if relative in found:
+            continue
         if kind_of(relative) != "csharp":
             continue
         source = project / relative

--- a/scripts/test_quality/test_base_red_check.py
+++ b/scripts/test_quality/test_base_red_check.py
@@ -14,6 +14,7 @@ import importlib.util
 import io
 import json
 import re
+import pathlib
 import shutil
 import subprocess
 import sys
@@ -750,6 +751,67 @@ class ExhaustedLoopTests(unittest.TestCase):
         # Act / Assert
         self.assertIn("--max-rounds", base_red_check.exhausted_reason(8, {"a.cs"}, 24))
 
+
+
+class CarriedAssemblyTests(unittest.TestCase):
+    """A carried file whose assembly the base has not got.
+
+    Unity gives a source to the nearest asmdef at or above it, and an asmdef is not a `.cs` so it is
+    never carried. A branch adding a test assembly therefore lands its files on the base under whatever
+    asmdef is next up -- the runtime one, for a fixture under `Runtime/` -- and an `AssemblyInfo.cs`
+    there is a duplicate attribute that takes the whole compile down. The name comparison beside this
+    cannot see it: such a file spells no type at all.
+    """
+
+    def tree(self, *relatives):
+        """A directory holding each named path as an empty file."""
+        root = pathlib.Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, str(root), True)
+        for relative in relatives:
+            path = root / relative
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text("")
+        return root
+
+    def test_Given_ACarriedFileWhoseAsmdefTheBaseHasNot_When_Asked_Then_ItNamesThatAsmdef(self):
+        # Arrange
+        branch = self.tree("A/Tests/Editor/Own.asmdef", "A/Tests/Editor/AssemblyInfo.cs")
+        base = self.tree("A/Velvet.asmdef")
+
+        # Act
+        owner = base_red_check.assembly_absent_on_base(
+            branch, base, "A/Tests/Editor/AssemblyInfo.cs")
+
+        # Assert
+        self.assertEqual(owner, "A/Tests/Editor/Own.asmdef")
+
+    def test_Given_ACarriedFileWhoseAsmdefTheBaseHas_When_Asked_Then_ItNamesNothing(self):
+        # Arrange — the control: an ordinary change to a fixture in an assembly both trees hold.
+        branch = self.tree("A/Tests/Editor/Own.asmdef", "A/Tests/Editor/SomeTests.cs")
+        base = self.tree("A/Tests/Editor/Own.asmdef")
+
+        # Act / Assert
+        self.assertIsNone(base_red_check.assembly_absent_on_base(
+            branch, base, "A/Tests/Editor/SomeTests.cs"))
+
+    def test_Given_AFileWhoseNearestAsmdefIsAboveIt_When_Asked_Then_ItReadsThatOne(self):
+        # Arrange — no asmdef beside the file, so the search walks up, which is the rule Unity applies.
+        branch = self.tree("A/Own.asmdef", "A/Tests/Editor/SomeTests.cs")
+        base = self.tree("Elsewhere/Other.asmdef")
+
+        # Act
+        owner = base_red_check.assembly_absent_on_base(branch, base, "A/Tests/Editor/SomeTests.cs")
+
+        # Assert
+        self.assertEqual(owner, "A/Own.asmdef")
+
+    def test_Given_AFileUnderNoAsmdefAtAll_When_Asked_Then_ItNamesNothing(self):
+        # Arrange — nothing to be absent, so nothing to withdraw for.
+        branch = self.tree("A/Loose.cs")
+        base = self.tree("A/Loose.cs")
+
+        # Act / Assert
+        self.assertIsNone(base_red_check.assembly_absent_on_base(branch, base, "A/Loose.cs"))
 
 
 class SelectionTests(unittest.TestCase):


### PR DESCRIPTION
`unbuildable_on_base` withdraws a carried test file by the names it spells. A file that spells no type
at all is invisible to it, and one such file takes a whole base run down.

Unity gives a source to the nearest asmdef at or above it. An asmdef is not a `.cs`, so it is never
carried — which means a branch that adds a test assembly lands that assembly's files on the base under
whatever asmdef is next up. For a fixture under `Runtime/` that is the runtime assembly, and an
`AssemblyInfo.cs` arriving there is a duplicate `[assembly: InternalsVisibleTo]` that fails the
compile before anything runs.

Measured on the branch adding `Runtime/Async/` and its two test assemblies: of 16 carried files, the
name comparison withdrew 14 and left both `AssemblyInfo.cs` behind — they spell no name the base has
not got, because they spell no name at all. The base then compiled nothing and all 69 cases reported
`the base tree cannot answer`. With this rule, 16 of 16 are withdrawn.

The rule reads the nearest asmdef at or above the carried file and withdraws when the base tree has
not got it, which is the same question Unity answers when it decides which assembly the file is in.
It cannot fire for a file whose assembly both trees hold: measured over all 317 C# test files on
`main`, against `main`, it fires on none.

Refs #635 — a third shape of the same divergence, and the one where the local loop's advantage is a
file the static reader has nothing to read.
