### PR TITLE
test(velvet): let the code under test decide the ownership refusal

### DIFF
--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/DocumentationDriftTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/DocumentationDriftTests.cs
@@ -1251,6 +1251,11 @@ namespace Velvet.Tests
         }
 
         /// <summary>Exit code and stdout from git, or -1 where it never answered.</summary>
+        // A path no file stands at, which is how git is told to read no config file rather than the
+        // machine's. Under the temporary directory so it names nothing a contributor might create.
+        private static readonly string NoSuchConfig =
+            Path.Combine(Path.GetTempPath(), "velvet-no-such-gitconfig");
+
         private static (int Exit, string Output) RunGit(
             string directory, IEnumerable<string> arguments, bool assumeForeignOwner = false)
         {
@@ -1269,6 +1274,12 @@ namespace Velvet.Tests
             if (assumeForeignOwner)
             {
                 start.Environment["GIT_TEST_ASSUME_DIFFERENT_OWNER"] = "1";
+                // Both configs point at a path that does not exist, so the refusal is decided by the
+                // code under test rather than by what the machine carries. `safe.directory = *` is what
+                // a worktree-heavy workflow drives people to set, and it lifts the very refusal these
+                // cases arrange -- one then fails on its left term and the other on its right.
+                start.Environment["GIT_CONFIG_GLOBAL"] = NoSuchConfig;
+                start.Environment["GIT_CONFIG_SYSTEM"] = NoSuchConfig;
             }
 
             try


### PR DESCRIPTION
`DocumentationDriftTests`' two git-reading cases arrange a checkout the process does not own and read
what git does with it. They inherited the contributor's git configuration, so `safe.directory = *` —
what a worktree-heavy workflow drives people to set, and this repository's own tooling takes a
worktree per agent — lifted the refusal the cases are about. Neither then posed its question: one
failed on its left term, the other on its right.

`RunGit` now points `GIT_CONFIG_GLOBAL` and `GIT_CONFIG_SYSTEM` at a path no file stands at whenever
it is asked to assume a foreign owner, so the refusal is decided by the code under test. Only under
that flag: a read that is not about ownership keeps the machine's configuration, which is what the
rest of the fixture measures against.

Measured with `GIT_CONFIG_GLOBAL` pointed at a two-line file carrying `[safe] directory = *`, over the
fixture's own filter:

| | before | after |
|---|---|---|
| with the setting | 24 passed / 2 failed | **26 / 0** |
| without it | 26 / 0 | 26 / 0 |

The unset case is the half that matters as much: the fix must not change what the cases measure on a
machine that never had the setting. Full EditMode 4242 passed / 0 failed.

#680 made both failures diagnosable, which named the cause for whoever hit it. This is the half that
stops them happening.

Closes #693
