### PR TITLE
fix(velvet): let a branch probe rent the record rather than allocate one

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -63,6 +63,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Matching a URL no longer allocates an array for every route branch it walks past. The record of
+  which path segment each pattern segment took is a buffer on the tree now, rewritten per probe,
+  where it was a fresh array per probe — and `Match` probes the ranked branches until one matches, so
+  the cost was one array per branch not taken. Nothing outlives a probe: what reads the record does so
+  before the next branch is tried.
+
 - `animate-hue` and the two gradient pan modes now suspend a native transition covering the slot they
   drive, as `animate-spin` and `animate-pulse` already did. The guard matches a driver's slot against
   the element's own transitionable set, and it had no flag for `filter` or for the background-position

--- a/Packages/com.velvet.core/Runtime/Routing/RouteTree.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/RouteTree.cs
@@ -13,6 +13,12 @@ namespace Velvet
         private readonly RouteDefinition[] _routes;
         private readonly List<RouteBranch> _rankedBranches;
 
+        // One buffer for every branch probe rather than one array each. Match walks the ranked branches
+        // until one succeeds, so a per-probe array is an allocation per branch not taken. Held on the
+        // tree and not static: two trees are two navigations, and Match runs no caller code, so nothing
+        // re-enters one tree's probe while it is using this.
+        private int[] _taken = Array.Empty<int>();
+
         /// <param name="routes">Array of route definitions. null is not allowed.</param>
         public RouteTree(RouteDefinition[] routes)
         {
@@ -266,12 +272,12 @@ namespace Velvet
 
             public Dictionary<string, string>? Captured;
 
-            public Walk(List<RouteSegment> pattern, string[] segments)
+            public Walk(List<RouteSegment> pattern, string[] segments, int[] taken)
             {
                 Pattern = pattern;
                 Segments = segments;
-                Taken = new int[pattern.Count];
-                for (var index = 0; index < Taken.Length; index++)
+                Taken = taken;
+                for (var index = 0; index < pattern.Count; index++)
                 {
                     Taken[index] = -1;
                 }
@@ -280,11 +286,16 @@ namespace Velvet
             }
         }
 
-        private static bool TryMatchBranch(RouteBranch branch, string[] segments, out List<RouteMatch>? matches)
+        private bool TryMatchBranch(RouteBranch branch, string[] segments, out List<RouteMatch>? matches)
         {
             matches = null;
 
-            var walk = new Walk(branch.Pattern, segments);
+            if (_taken.Length < branch.Pattern.Count)
+            {
+                _taken = new int[branch.Pattern.Count];
+            }
+
+            var walk = new Walk(branch.Pattern, segments, _taken);
 
             if (!TryConsume(ref walk, 0, 0))
             {

--- a/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouteMatchAllocationTests.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouteMatchAllocationTests.cs
@@ -1,0 +1,53 @@
+using NUnit.Framework;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Specifies that matching a URL costs the same whether the tree has one branch or many. `Match`
+    /// walks the ranked branches until one succeeds, so anything a probe allocates is allocated again
+    /// for every branch it did not take.
+    /// </summary>
+    [TestFixture]
+    [Category("Performance")]
+    internal sealed class RouteMatchAllocationTests
+    {
+        private static RouteDefinition Leaf(string path) => new() { Path = path };
+
+        private static RouteTree Tree(int leaves)
+        {
+            var children = new RouteDefinition[leaves];
+            for (var index = 0; index < leaves; index++)
+            {
+                children[index] = Leaf("branch-" + index);
+            }
+            return new RouteTree(new[] { new RouteDefinition { Path = "/", Children = children } });
+        }
+
+        private static int Blocks(RouteTree tree, string url)
+        {
+            void Once() => tree.Match(url);
+            for (var i = 0; i < 64; i++)
+            {
+                Once();
+            }
+            return GCAllocationProbe.SampleBlocksDuring(Once);
+        }
+
+        [Test]
+        public void Given_ATreeWhoseLastBranchMatches_When_MatchedAgainstOneWhoseFirstDoes_Then_TheCostIsTheSame()
+        {
+            // Arrange — the same tree, matched at its first leaf and at its eighth. The second walks
+            // seven branches that do not match before the one that does.
+            var tree = Tree(8);
+
+            // Act
+            var first = Blocks(tree, "/branch-0");
+            var last = Blocks(tree, "/branch-7");
+
+            // Assert — the first count rides along, because two equal numbers say nothing if the probe
+            // measured nothing at all.
+            Assert.That((first > 0, last), Is.EqualTo((true, first)));
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouteMatchAllocationTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouteMatchAllocationTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8516c63a3e1a5460b8ca599c49433d47


### PR DESCRIPTION
`RouteTree.Match` walks the ranked branches until one matches, and #864 gave each probe a `Walk`
carrying `new int[pattern.Count]` — the record of which path segment each pattern segment took. So
every branch not taken cost an array, on every navigation.

Found through #377's navigation allocation pins, which read five blocks over their number after that
branch was rebased onto `main`. The pins are the only allocation reading routing has, they live on
that branch, and `main` has nothing that would have said so. That is what let it in.

The record is a buffer on the tree now, grown to the widest pattern it has been asked for and
rewritten at the head of each probe. Nothing outlives a probe: `BuildMatches` reads the record and
keeps no reference to it, and it reads it before the next branch is tried. The buffer is per tree
rather than static, because two trees are two navigations, and `Match` runs no caller code, so nothing
re-enters one tree's probe while it holds this.

`RouteMatchAllocationTests` reads the same tree at its first leaf and at its eighth — seven branches
walked past — and asserts the two cost the same. The first count rides along in the tuple, because two
equal numbers say nothing if the probe measured nothing at all. Red on `main`'s `RouteTree.cs`, green
with this.

EditMode 4243 passed / 0 failed, PlayMode 184 / 0.

No issue: found by a pin on another branch, which is why it is filed as the fix rather than as a
report.
