### PR TITLE
fix(velvet): read a match's base off the pattern the branch already parsed

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -63,6 +63,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Matching a URL no longer parses each route's path again to build the match's base. A branch already
+  holds its whole pattern, parsed once when the tree was built; resolving the base walked
+  `ParseRouteSegments` instead, which is an iterator, so every level of every match allocated an
+  enumerator and a list. The branch records how many segments each of its routes contributed and the
+  resolution reads that slice. Measured over a two-level route with a blocker registered: four fewer
+  allocated blocks per navigation.
+
 - Matching a URL no longer allocates an array for every route branch it walks past. The record of
   which path segment each pattern segment took is a buffer on the tree now, rewritten per probe,
   where it was a fresh array per probe — and `Match` probes the ranked branches until one matches, so

--- a/Packages/com.velvet.core/Runtime/Routing/RouteTree.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/RouteTree.cs
@@ -63,13 +63,19 @@ namespace Velvet
         {
             public readonly RouteDefinition[] Chain;
             public readonly List<RouteSegment> Pattern;
+
+            /// <summary>How many of <see cref="Pattern"/>'s segments each chain entry contributed, so a
+            /// match reads its slice rather than parsing the route's path again.</summary>
+            public readonly int[] SegmentCounts;
+
             public int Score;
             public int Order;
 
-            public RouteBranch(RouteDefinition[] chain, List<RouteSegment> pattern)
+            public RouteBranch(RouteDefinition[] chain, List<RouteSegment> pattern, int[] segmentCounts)
             {
                 Chain = chain;
                 Pattern = pattern;
+                SegmentCounts = segmentCounts;
             }
         }
 
@@ -144,18 +150,21 @@ namespace Velvet
         private RouteBranch BuildBranch(List<RouteDefinition> chain)
         {
             var pattern = new List<RouteSegment>();
-            foreach (var route in chain)
+            var counts = new int[chain.Count];
+            for (var index = 0; index < chain.Count; index++)
             {
-                foreach (var seg in ParseRouteSegments(route))
+                var before = pattern.Count;
+                foreach (var seg in ParseRouteSegments(chain[index]))
                 {
                     pattern.Add(seg);
                 }
+                counts[index] = pattern.Count - before;
             }
 
             var leaf = chain[chain.Count - 1];
             var isIndexLeaf = leaf.Path == "";
 
-            return new RouteBranch(chain.ToArray(), pattern)
+            return new RouteBranch(chain.ToArray(), pattern, counts)
             {
                 Score = ComputeScore(pattern, isIndexLeaf),
                 Order = _branchCounter++,
@@ -307,7 +316,7 @@ namespace Velvet
 
             // A paramless successful match still exposes a (shared, empty) dictionary at every level,
             // preserving the pre-lazy contract that RouteMatch.Params is never null.
-            matches = BuildMatches(branch.Chain, captured ?? new Dictionary<string, string>(), taken);
+            matches = BuildMatches(branch, captured ?? new Dictionary<string, string>(), taken);
             return true;
         }
 
@@ -422,8 +431,9 @@ namespace Velvet
         }
 
         private static List<RouteMatch> BuildMatches(
-            RouteDefinition[] chain, Dictionary<string, string> captured, int[] taken)
+            RouteBranch branch, Dictionary<string, string> captured, int[] taken)
         {
+            var chain = branch.Chain;
             var matches = new List<RouteMatch>(chain.Length);
             var cumulativeId = string.Empty;
             // Each level stores a cumulative base because route-relative `..` pops a whole route level,
@@ -433,11 +443,13 @@ namespace Velvet
             // chain order, so a route's slice starts where the routes above it ended.
             var patternOffset = 0;
 
-            foreach (var route in chain)
+            for (var level = 0; level < chain.Length; level++)
             {
+                var route = chain[level];
                 cumulativeId = AppendRouteId(cumulativeId, route);
 
-                var resolvedSegment = ResolveRouteSegments(route, captured, taken, ref patternOffset);
+                var resolvedSegment = ResolveRouteSegments(
+                    branch.Pattern, branch.SegmentCounts[level], captured, taken, ref patternOffset);
                 if (resolvedSegment.Length > 0)
                 {
                     cumulativeResolved = cumulativeResolved.Length == 0
@@ -468,14 +480,18 @@ namespace Velvet
         /// `taken` needs the two readings to agree segment for segment, and they did not — one dropped
         /// the empty part in `a//b` and the other kept it.
         /// </remarks>
+        // Read off the branch's already-parsed pattern rather than the route's path: `ParseRouteSegments`
+        // is an iterator, and calling it here allocated an enumerator per route on every match.
         private static string ResolveRouteSegments(
-            RouteDefinition route, IReadOnlyDictionary<string, string> captured, int[] taken,
-            ref int patternOffset)
+            List<RouteSegment> pattern, int count, IReadOnlyDictionary<string, string> captured,
+            int[] taken, ref int patternOffset)
         {
-            var resolved = new List<string>();
+            var resolved = ScratchSegments;
+            resolved.Clear();
 
-            foreach (var seg in ParseRouteSegments(route))
+            for (var step = 0; step < count; step++)
             {
+                var seg = pattern[patternOffset];
                 var index = patternOffset++;
 
                 // `taken` is not read for a splat or a param: the first resolves from the captured
@@ -516,6 +532,11 @@ namespace Velvet
 
             return string.Join("/", resolved);
         }
+
+        // One list for every level of every match. BuildMatches reads the string this returns before it
+        // asks for the next level, so nothing outlives a call. Static because RouteTree runs no caller
+        // code between filling it and joining it.
+        private static readonly List<string> ScratchSegments = new();
 
         private static string AppendRouteId(string parentId, RouteDefinition route)
         {


### PR DESCRIPTION
Building a match's base walked `ParseRouteSegments`, which is an iterator method, once per level of
every match — so each level allocated an enumerator, and a `List<string>` beside it, to re-derive
something the branch already holds. `RouteBranch.Pattern` is the whole chain's segments, parsed once
when the tree was built, and `taken` is already indexed over exactly that list.

The branch now records how many of those segments each of its routes contributed, computed in
`BuildBranch` where the concatenation happens, and the resolution reads its slice with the offset it
was already carrying. The list it fills is one list rather than one per level: `BuildMatches` reads
the string each level returns before asking for the next, and `RouteTree` runs no caller code in
between.

Measured on a two-level route with a blocker registered, over the navigation allocation fixture on the
branch that has one: **104 blocks to 100**. That fixture is the only allocation reading routing has and
it does not live on `main`, which is how this and #881 both got in.

EditMode 4243 passed / 0 failed, PlayMode 184 / 0. Behaviour is unchanged and no case moved: the
segments read are the same segments, from the list they were parsed into rather than from a second
parse of the same path.

No issue: found by the same pin that found #881, one layer under it.
