### PR TITLE
fix(velvet): let a blocker pass rent its snapshot rather than allocate one

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -63,6 +63,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A navigation no longer allocates a snapshot of the registered blockers on every pass. The pass walks
+  a copy because a decision taken in it may unregister, and the copy was a fresh array each time — so
+  an application with any blocker registered paid one per navigation. One list serves every pass now,
+  and a pass that begins while another holds it takes its own copy, since a blocker runs caller code
+  and that caller may navigate again.
+
 - Matching a URL no longer parses each route's path again to build the match's base. A branch already
   holds its whole pattern, parsed once when the tree was built; resolving the base walked
   `ParseRouteSegments` instead, which is an iterator, so every level of every match allocated an

--- a/Packages/com.velvet.core/Runtime/Routing/RouteBlockerManager.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/RouteBlockerManager.cs
@@ -10,6 +10,12 @@ namespace Velvet
     {
         private readonly List<BlockerEntry> _blockers = new();
 
+        // The pass below walks a snapshot, and one list serves every pass rather than one array each.
+        // A pass runs caller code, so a second pass could start while this holds the first's snapshot:
+        // `CheckAsync` takes its own copy when this one is already in use.
+        private readonly List<BlockerEntry> _snapshot = new();
+        private bool _snapshotInUse;
+
         #region Register
 
         /// <summary>
@@ -46,39 +52,55 @@ namespace Velvet
             // RemoveSettledRegistrations, both of which remove from _blockers. Over the live list the entry
             // after a removed one is skipped and never consulted; over the snapshot it is visited, and the
             // IsRegistered guards are what decide whether it may still act.
-            foreach (var entry in _blockers.ToArray())
+            List<BlockerEntry> walking;
+            var borrowed = !_snapshotInUse;
+            if (borrowed)
             {
-                if (!entry.IsRegistered)
-                {
-                    continue;
-                }
+                _snapshotInUse = true;
+                walking = _snapshot;
+                walking.Clear();
+                walking.AddRange(_blockers);
+            }
+            else
+            {
+                walking = new List<BlockerEntry>(_blockers);
+            }
 
-                if (entry.State.Status == RouteBlockerStatus.Proceeding)
+            try
+            {
+                foreach (var entry in walking)
                 {
-                    continue;
-                }
+                    if (!entry.IsRegistered)
+                    {
+                        continue;
+                    }
 
-                bool blocked;
-                if (entry.SyncCheck != null)
-                {
-                    blocked = entry.SyncCheck(attempt);
-                }
-                else if (entry.AsyncCheck != null)
-                {
-                    blocked = await entry.AsyncCheck(attempt, cancellationToken);
-                }
-                else
-                {
-                    continue;
-                }
+                    if (entry.State.Status == RouteBlockerStatus.Proceeding)
+                    {
+                        continue;
+                    }
 
-                // After the await and before Block: the token is this navigation's own, so a newer
-                // navigation taking over mid-await means the caller discards this result as Cancelled,
-                // and a Blocked written here would strand a confirm UI until some unrelated later
-                // navigation resets it.
-                if (cancellationToken.IsCancellationRequested)
-                {
-                    return anyBlocked;
+                    bool blocked;
+                    if (entry.SyncCheck != null)
+                    {
+                        blocked = entry.SyncCheck(attempt);
+                    }
+                    else if (entry.AsyncCheck != null)
+                    {
+                        blocked = await entry.AsyncCheck(attempt, cancellationToken);
+                    }
+                    else
+                    {
+                        continue;
+                    }
+
+                    // After the await and before Block: the token is this navigation's own, so a newer
+                    // navigation taking over mid-await means the caller discards this result as Cancelled,
+                    // and a Blocked written here would strand a confirm UI until some unrelated later
+                    // navigation resets it.
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        return anyBlocked;
                 }
 
                 if (blocked && entry.IsRegistered)
@@ -88,6 +110,15 @@ namespace Velvet
                 }
             }
             return anyBlocked;
+            }
+            finally
+            {
+                if (borrowed)
+                {
+                    _snapshot.Clear();
+                    _snapshotInUse = false;
+                }
+            }
         }
 
         #endregion

--- a/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/BlockerPassAllocationTests.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/BlockerPassAllocationTests.cs
@@ -1,0 +1,50 @@
+using Cysharp.Threading.Tasks;
+using NUnit.Framework;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Specifies that a blocker pass costs the same whether the manager holds registrations or none.
+    /// The pass walks a snapshot so a decision taken in it may unregister, and a snapshot taken per
+    /// pass is an allocation on every navigation an application registers a blocker for.
+    /// </summary>
+    [TestFixture]
+    [Category("Performance")]
+    internal sealed class BlockerPassAllocationTests
+    {
+        private static RouteBlockerManager Manager(int blockers)
+        {
+            var manager = new RouteBlockerManager();
+            for (var index = 0; index < blockers; index++)
+            {
+                manager.Register((_, __) => UniTask.FromResult(false), new RouteBlockerState());
+            }
+            return manager;
+        }
+
+        private static int Blocks(int blockers)
+        {
+            var manager = Manager(blockers);
+            var attempt = new NavigationAttempt();
+            void Once() => manager.CheckAsync(attempt, () => { }).GetAwaiter().GetResult();
+            for (var i = 0; i < 64; i++)
+            {
+                Once();
+            }
+            return GCAllocationProbe.SampleBlocksDuring(Once);
+        }
+
+        [Test]
+        public void Given_APassOverTwoRegistrations_When_Compared_To_APassOverNone_Then_TheCostIsTheSame()
+        {
+            // Arrange & Act
+            var none = Blocks(0);
+            var two = Blocks(2);
+
+            // Assert — the empty count rides along, because two equal numbers say nothing if the probe
+            // measured nothing at all.
+            Assert.That((none > 0, two), Is.EqualTo((true, none)));
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/BlockerPassAllocationTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/BlockerPassAllocationTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e34a73033a09049c6983671538bdb26d


### PR DESCRIPTION
`RouteBlockerManager.CheckAsync` walks a snapshot of the registered blockers, because a decision taken
in the pass reaches `Unregister` or `RemoveSettledRegistrations` and both remove from the live list.
The snapshot was `_blockers.ToArray()` — a fresh array on every pass, so an application with any
blocker registered paid one allocation per navigation.

One list serves every pass now. A pass that begins while another already holds it takes its own copy
instead of sharing: a blocker runs caller code, and that caller may navigate again from inside the
check, which is the one way two passes overlap. The borrowed list is cleared and handed back in a
`finally`, so a blocker that throws does not strand it.

`BlockerPassAllocationTests` compares a pass over two registrations with a pass over none and asserts
the two cost the same. The empty count rides along in the tuple, because two equal numbers say nothing
if the probe measured nothing at all. Red on `main`'s `RouteBlockerManager.cs`, green with this.

EditMode 4243 passed / 0 failed, PlayMode 184 / 0.

This is the last of three found by the navigation allocation pins on #377, after #881 and #882 — that
fixture is the only allocation reading routing has and it does not live on `main`.

No issue: found by a pin on another branch.
