### PR TITLE
test(velvet): let the fixture that owns ObjectIs pin its own raw-bit branches

### DIFF
--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/ObjectIsTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/ObjectIsTests.cs
@@ -236,6 +236,9 @@ namespace Velvet.Tests
         // pinned the branches this file's own header names was a test about Memoize. With these, the same
         // cut reddens the two signed-zero cases here.
 
+        // GREEN_ON_BASE(characterization): the base already distinguishes the zeros — this change adds
+        // no behaviour, it moves who says so. Measured: deleting `AreEqual<T>`'s raw-bit branches reddens
+        // nine cases in three other fixtures and none here, and reddens this one once it exists.
         [Test]
         public void Given_FloatSignedZero_When_AreEqualOfFloat_Then_AreNotEqual()
         {
@@ -254,6 +257,7 @@ namespace Velvet.Tests
             Assert.That(ObjectIs.AreEqual(float.NaN, float.NaN), Is.True);
         }
 
+        // GREEN_ON_BASE(characterization): the double half of the reading above.
         [Test]
         public void Given_DoubleSignedZero_When_AreEqualOfDouble_Then_AreNotEqual()
         {

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/ObjectIsTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/ObjectIsTests.cs
@@ -228,6 +228,49 @@ namespace Velvet.Tests
 
         #endregion
 
+        #region AreEqual<T> — raw-bit float and double
+
+        // The generic overload carries its own float and double branches, separate from the pair
+        // AreEqualObjects has. Measured before these were written: deleting them reddened nine cases
+        // across the three fixtures that own the props comparer and the Provider, and none here — so what
+        // pinned the branches this file's own header names was a test about Memoize. With these, the same
+        // cut reddens the two signed-zero cases here.
+
+        [Test]
+        public void Given_FloatSignedZero_When_AreEqualOfFloat_Then_AreNotEqual()
+        {
+            // Act + Assert — raw-bit equality distinguishes +0 from -0, unlike IEEE ==
+            Assert.That(ObjectIs.AreEqual(0f, -0f), Is.False);
+        }
+
+        // GREEN_ON_BASE(characterization): the base already answers this, and so does a build with the
+        // raw-bit branch deleted — `EqualityComparer<float>` reaches `float.Equals`, which is true for two
+        // NaNs where `==` is false. It is here because the branch's contract is both halves, and the
+        // signed-zero case beside it is the half a cut can see.
+        [Test]
+        public void Given_FloatNaN_When_AreEqualOfFloat_Then_AreEqual()
+        {
+            // Act + Assert — raw-bit equality treats NaN as equal to NaN, unlike IEEE ==
+            Assert.That(ObjectIs.AreEqual(float.NaN, float.NaN), Is.True);
+        }
+
+        [Test]
+        public void Given_DoubleSignedZero_When_AreEqualOfDouble_Then_AreNotEqual()
+        {
+            // Act + Assert
+            Assert.That(ObjectIs.AreEqual(0d, -0d), Is.False);
+        }
+
+        // GREEN_ON_BASE(characterization): the double half of the reading above.
+        [Test]
+        public void Given_DoubleNaN_When_AreEqualOfDouble_Then_AreEqual()
+        {
+            // Act + Assert
+            Assert.That(ObjectIs.AreEqual(double.NaN, double.NaN), Is.True);
+        }
+
+        #endregion
+
         #region AreEqual<T> — generic string value semantics
 
         private sealed record Rec(string Value);


### PR DESCRIPTION
`ObjectIs.AreEqual<T>` carries its own raw-bit `float` and `double` branches, separate from
`AreEqualObjects`' pair, and `ObjectIsTests` — the fixture `ObjectIs.cs`'s own header names as what
pins the difference between the two overloads — pinned neither.

Took the confirming cut the issue asks for first. Deleting `AreEqual<T>`'s two branches reddens nine
cases, across `ComponentPropsComparerTests`, `ComponentPropsComparerArmParityTests` and
`ContextProviderObjectIsTests`, and **none in `ObjectIsTests`**. So a change to those branches reddened
a test about `Memoize` and left the owning fixture green, which is what the issue reported and what the
cut confirms.

Four cases, and the same cut now reddens two of them here.

The `NaN` pair the issue asks about is worth having and does not redden under that cut: with the branch
deleted, `EqualityComparer<float>` reaches `float.Equals`, which is true for two NaNs where `==` is
false. Both are declared `GREEN_ON_BASE`, because a case that cannot go red under the cut its
neighbour goes red under should say so rather than look like coverage it is not. They earn their place
as the other half of the branch's contract: raw-bit equality is *both* "+0 is not -0" and "NaN is NaN",
and a reader of one without the other learns half of it.

EditMode 4248 passed / 0 failed.

Closes #754
