### PR TITLE
test(velvet): ask git whether a path is ignored, which is the question being asked

### DIFF
--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/DocumentationCorpus.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/DocumentationCorpus.cs
@@ -126,6 +126,11 @@ namespace Velvet.Tests
                 UseShellExecute = false,
                 CreateNoWindow = true,
             };
+            // Same ownership argument the tracked-listing read takes: a checkout the process does
+            // not own is one git refuses to read at all, and a refusal here reports nothing ignored,
+            // which is a silence that lets an ignored path through as a covered one.
+            start.ArgumentList.Add("-c");
+            start.ArgumentList.Add("safe.directory=" + Path.GetFullPath("."));
             start.ArgumentList.Add("check-ignore");
             start.ArgumentList.Add("--stdin");
 
@@ -141,7 +146,16 @@ namespace Velvet.Tests
             }
             process.StandardInput.Close();
             var output = process.StandardOutput.ReadToEnd();
+            var declined = process.StandardError.ReadToEnd();
             process.WaitForExit();
+            // Exit 1 is "none of these is ignored", which is an answer. Anything above it is git
+            // declining, and a decline read as an empty answer lets every ignored path through as one a
+            // trigger has to cover.
+            if (process.ExitCode > 1)
+            {
+                throw new InvalidOperationException(
+                    $"git check-ignore declined to answer for {asked.Count} path(s): {declined.Trim()}");
+            }
 
             return output.Split('\n')
                 .Select(line => line.Trim().Replace('\\', '/'))

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/DocumentationCorpus.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/DocumentationCorpus.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -99,6 +100,55 @@ namespace Velvet.Tests
         /// is the drift that fixture pair exists to report.
         /// </para>
         /// </remarks>
+        /// <summary>Which of <paramref name="paths"/> git ignores, asked of git rather than derived.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="IgnoredRoots"/> answers a different question: it reduces each line to its first
+        /// segment, which is what a caller enumerating top-level directories needs and is wrong for a
+        /// caller asking whether one path is ignored — `docs/api/` there contributes `docs`, a directory
+        /// the repository does not ignore. Anchoring, negation and wildcards are `.gitignore` semantics,
+        /// and git is what implements them. One call for the whole set rather than one per path.
+        /// </remarks>
+        internal static HashSet<string> IgnoredAmong(IEnumerable<string> paths)
+        {
+            var asked = paths.Distinct(StringComparer.Ordinal).ToList();
+            if (asked.Count == 0)
+            {
+                return new HashSet<string>(StringComparer.Ordinal);
+            }
+
+            var start = new ProcessStartInfo("git")
+            {
+                WorkingDirectory = Path.GetFullPath("."),
+                RedirectStandardInput = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            };
+            start.ArgumentList.Add("check-ignore");
+            start.ArgumentList.Add("--stdin");
+
+            using var process = Process.Start(start);
+            if (process == null)
+            {
+                return new HashSet<string>(StringComparer.Ordinal);
+            }
+
+            foreach (var path in asked)
+            {
+                process.StandardInput.WriteLine(path);
+            }
+            process.StandardInput.Close();
+            var output = process.StandardOutput.ReadToEnd();
+            process.WaitForExit();
+
+            return output.Split('\n')
+                .Select(line => line.Trim().Replace('\\', '/'))
+                .Where(line => line.Length > 0)
+                .ToHashSet(StringComparer.Ordinal);
+        }
+
         internal static HashSet<string> IgnoredRoots() =>
             File.ReadAllLines(Path.GetFullPath(".gitignore"))
                 .Select(line => line.Trim())

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/WorkflowTriggerCoverageTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/WorkflowTriggerCoverageTests.cs
@@ -402,14 +402,43 @@ namespace Velvet.Tests
         // The one that matters here is scripts/test_quality/assert_no_inconclusive.py: no other file in the repository
         // invokes it, and its failure mode is passing a run it should have failed, which stays invisible
         // until a test starts skipping.
+        [Test]
+        public void Given_APathUnderARootAGitignoreLineNamesADirectoryOf_When_TheGuardReadsIt_Then_ItIsNotDropped()
+        {
+            // Arrange — `.gitignore` names `docs/api/`, and the first-segment reading of that line is
+            // `docs`, a directory the repository does not ignore. Everything a workflow names under it was
+            // dropped before this fixture could ask whether a trigger covers it.
+            var byFirstSegment = DocumentationCorpus.IgnoredRoots();
+            var named = Workflows()
+                .SelectMany(NamedRepoFiles)
+                .Distinct(StringComparer.Ordinal)
+                .ToList();
+            Assume.That(named, Is.Not.Empty, "Precondition: the workflows name files that exist");
+
+            // Act — the two readings over the same set: what git ignores, and what the first-segment
+            // reduction would have dropped.
+            var byGit = DocumentationCorpus.IgnoredAmong(named);
+            var byReduction = named.Where(path => byFirstSegment.Contains(path.Split('/')[0])).ToList();
+
+            // Assert — every file this fixture reads is one git does not ignore, and at least one of them
+            // the reduction would have dropped. Both halves: an empty right side would mean the reduction
+            // and git agree here and this case is measuring nothing.
+            Assert.That((string.Join(", ", byGit), byReduction.Count > 0), Is.EqualTo((string.Empty, true)));
+        }
+
         private static List<string> NamedRepoFiles(string workflow)
         {
-            var ignored = DocumentationCorpus.IgnoredRoots();
-            return PathTokenPattern.Matches(File.ReadAllText(Path.GetFullPath(workflow)))
+            var present = PathTokenPattern.Matches(File.ReadAllText(Path.GetFullPath(workflow)))
                 .Select(match => match.Value)
                 .Distinct(StringComparer.Ordinal)
                 .Where(token => File.Exists(Path.GetFullPath(token)))
-                .Where(token => !ignored.Contains(token.Split('/')[0]))
+                .ToList();
+            // Asked of git rather than of IgnoredRoots, which answers a first-segment question: `docs/api/`
+            // reduces to `docs` there, and every file this workflow names under `docs/` was dropped before
+            // the case could read it. A dropped file and a covered one are the same green.
+            var ignored = DocumentationCorpus.IgnoredAmong(present);
+            return present
+                .Where(token => !ignored.Contains(token))
                 .OrderBy(token => token, StringComparer.Ordinal)
                 .ToList();
         }

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/WorkflowTriggerCoverageTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/WorkflowTriggerCoverageTests.cs
@@ -402,30 +402,6 @@ namespace Velvet.Tests
         // The one that matters here is scripts/test_quality/assert_no_inconclusive.py: no other file in the repository
         // invokes it, and its failure mode is passing a run it should have failed, which stays invisible
         // until a test starts skipping.
-        [Test]
-        public void Given_APathUnderARootAGitignoreLineNamesADirectoryOf_When_TheGuardReadsIt_Then_ItIsNotDropped()
-        {
-            // Arrange — `.gitignore` names `docs/api/`, and the first-segment reading of that line is
-            // `docs`, a directory the repository does not ignore. Everything a workflow names under it was
-            // dropped before this fixture could ask whether a trigger covers it.
-            var byFirstSegment = DocumentationCorpus.IgnoredRoots();
-            var named = Workflows()
-                .SelectMany(NamedRepoFiles)
-                .Distinct(StringComparer.Ordinal)
-                .ToList();
-            Assume.That(named, Is.Not.Empty, "Precondition: the workflows name files that exist");
-
-            // Act — the two readings over the same set: what git ignores, and what the first-segment
-            // reduction would have dropped.
-            var byGit = DocumentationCorpus.IgnoredAmong(named);
-            var byReduction = named.Where(path => byFirstSegment.Contains(path.Split('/')[0])).ToList();
-
-            // Assert — every file this fixture reads is one git does not ignore, and at least one of them
-            // the reduction would have dropped. Both halves: an empty right side would mean the reduction
-            // and git agree here and this case is measuring nothing.
-            Assert.That((string.Join(", ", byGit), byReduction.Count > 0), Is.EqualTo((string.Empty, true)));
-        }
-
         private static List<string> NamedRepoFiles(string workflow)
         {
             var present = PathTokenPattern.Matches(File.ReadAllText(Path.GetFullPath(workflow)))


### PR DESCRIPTION
`IgnoredRoots()` reduces each `.gitignore` line to its first path segment, which is the right reading
for the caller that enumerates top-level directories and the wrong one for a caller asking whether a
path is ignored. `docs/api/` reduces to `docs`; `ProjectSettings/Packages/` to `ProjectSettings`.
Neither directory is ignored.

`WorkflowTriggerCoverageTests.NamedRepoFiles` asked it the path question, so every file a workflow
names under either root was dropped before the fixture could check that a trigger covers it — and a
dropped file and a covered one are the same green.

The live miss the issue asks for, found before the fix: **`docs/build.py`**, named at
`.github/workflows/docs.yml:135`. It is inside a YAML comment, and comments are in scope by design —
`PathTokenPattern`'s own header says a slash-bearing token counts "whether it is a step argument, an
action input or prose in a comment", with the filesystem settling whether it is a repo path. It is the
only such token today, and it was invisible.

`DocumentationCorpus.IgnoredAmong` asks git instead, one `git check-ignore --stdin` for the whole set
rather than one per path. `IgnoredRoots` keeps its caller and its meaning.

Two things the first CI run taught, both now in:

- The read takes `-c safe.directory=<checkout>`, the same argument the tracked listing takes. Without
  it a checkout the process does not own is one git declines to read, and a decline reports nothing
  ignored — which let `Library/ScriptAssemblies/UniTask.dll` through as a file a trigger must cover.
- Exit 1 is "none of these is ignored" and is an answer; anything above it is a decline, and it now
  throws rather than returning an empty set. A decline read as an empty answer is the same silence
  this change exists to remove.

Reproduced locally by creating the `Library/ScriptAssemblies` the docs workflow downloads, which is
what made CI's tree differ from a developer's.

`docs.yml` already filters on `docs/**`, so nothing was uncovered — the fixture simply could not have
said so. EditMode 4248 passed / 0 failed.

Closes #682
