### PR TITLE
refactor(velvet): leave one resume route, since nothing ever set the other

### DIFF
--- a/Packages/com.velvet.core/Runtime/Async/Tests/Editor/VelvetTaskStructStateMachineContinuationTests.cs
+++ b/Packages/com.velvet.core/Runtime/Async/Tests/Editor/VelvetTaskStructStateMachineContinuationTests.cs
@@ -76,8 +76,9 @@ namespace Velvet.Tests
                 }
             }
 
-            public void SetStateMachine(IAsyncStateMachine stateMachine) =>
-                Builder.SetStateMachine(stateMachine);
+            public void SetStateMachine(IAsyncStateMachine stateMachine)
+            {
+            }
         }
 
         // Reaching either AwaitUnsafeOnCompleted overload takes an awaiter of the fixture's own: both
@@ -154,8 +155,9 @@ namespace Velvet.Tests
                 }
             }
 
-            public void SetStateMachine(IAsyncStateMachine stateMachine) =>
-                Builder.SetStateMachine(stateMachine);
+            public void SetStateMachine(IAsyncStateMachine stateMachine)
+            {
+            }
         }
 
         // Same no-SetStateMachine constraint as TwoYieldStructStateMachine.
@@ -196,8 +198,9 @@ namespace Velvet.Tests
                 }
             }
 
-            public void SetStateMachine(IAsyncStateMachine stateMachine) =>
-                Builder.SetStateMachine(stateMachine);
+            public void SetStateMachine(IAsyncStateMachine stateMachine)
+            {
+            }
         }
 
         // Same no-SetStateMachine constraint as TwoYieldStructStateMachine.
@@ -241,8 +244,9 @@ namespace Velvet.Tests
                 }
             }
 
-            public void SetStateMachine(IAsyncStateMachine stateMachine) =>
-                Builder.SetStateMachine(stateMachine);
+            public void SetStateMachine(IAsyncStateMachine stateMachine)
+            {
+            }
         }
 
         static async VelvetTask<int> AccumulateAcrossTwoYields()

--- a/Packages/com.velvet.core/Runtime/Async/VelvetTask.cs
+++ b/Packages/com.velvet.core/Runtime/Async/VelvetTask.cs
@@ -270,9 +270,11 @@ namespace Velvet
             where TStateMachine : IAsyncStateMachine =>
             stateMachine.MoveNext();
 
+        // Required by the compiler -- deleting it is CS0656 -- and reached by nothing: Roslyn emits no
+        // call to it from a MoveNext, and this builder's own AwaitOnCompleted does not call the state
+        // machine's. A runner resumes the copy it was handed, and there is one resume route.
         public void SetStateMachine(IAsyncStateMachine stateMachine)
         {
-            _runner?.SetStateMachine(stateMachine);
         }
 
         public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine)
@@ -355,9 +357,11 @@ namespace Velvet
             where TStateMachine : IAsyncStateMachine =>
             stateMachine.MoveNext();
 
+        // Required by the compiler -- deleting it is CS0656 -- and reached by nothing: Roslyn emits no
+        // call to it from a MoveNext, and this builder's own AwaitOnCompleted does not call the state
+        // machine's. A runner resumes the copy it was handed, and there is one resume route.
         public void SetStateMachine(IAsyncStateMachine stateMachine)
         {
-            _runner?.SetStateMachine(stateMachine);
         }
 
         public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine)

--- a/Packages/com.velvet.core/Runtime/Async/VelvetTaskStateMachineRunners.cs
+++ b/Packages/com.velvet.core/Runtime/Async/VelvetTaskStateMachineRunners.cs
@@ -11,7 +11,6 @@ namespace Velvet
 
         VelvetTask Task { get; }
 
-        void SetStateMachine(IAsyncStateMachine stateMachine);
 
         void SetResult();
 
@@ -24,7 +23,6 @@ namespace Velvet
 
         VelvetTask<T> Task { get; }
 
-        void SetStateMachine(IAsyncStateMachine stateMachine);
 
         void SetResult(T result);
 
@@ -41,7 +39,6 @@ namespace Velvet
         static readonly Stack<AsyncVelvetTaskMethod<TStateMachine>> Pool = new();
 
         TStateMachine _stateMachine = default!;
-        IAsyncStateMachine? _boxedStateMachine;
         VelvetTaskCompletionSourceCore<AsyncUnit> _core = new();
         bool _returnedToPool;
 
@@ -73,25 +70,11 @@ namespace Velvet
 
             field = runner;
             runner._stateMachine = stateMachine;
-            runner._boxedStateMachine = null;
             runner._returnedToPool = false;
         }
 
-        public void SetStateMachine(IAsyncStateMachine stateMachine) =>
-            _boxedStateMachine = stateMachine ?? throw new ArgumentNullException(nameof(stateMachine));
-
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        void Run()
-        {
-            if (_boxedStateMachine != null)
-            {
-                _boxedStateMachine.MoveNext();
-            }
-            else
-            {
-                _stateMachine.MoveNext();
-            }
-        }
+        void Run() => _stateMachine.MoveNext();
 
         public void SetResult() => _core.TrySetResult(AsyncUnit.Default);
 
@@ -128,7 +111,6 @@ namespace Velvet
             _returnedToPool = true;
             _core.Reset();
             _stateMachine = default!;
-            _boxedStateMachine = null;
             if (Pool.Count < MaxPoolSize)
             {
                 Pool.Push(this);
@@ -146,7 +128,6 @@ namespace Velvet
         static readonly Stack<AsyncVelvetTaskMethod<TStateMachine, T>> Pool = new();
 
         TStateMachine _stateMachine = default!;
-        IAsyncStateMachine? _boxedStateMachine;
         VelvetTaskCompletionSourceCore<T> _core = new();
         bool _returnedToPool;
 
@@ -176,25 +157,11 @@ namespace Velvet
 
             field = runner;
             runner._stateMachine = stateMachine;
-            runner._boxedStateMachine = null;
             runner._returnedToPool = false;
         }
 
-        public void SetStateMachine(IAsyncStateMachine stateMachine) =>
-            _boxedStateMachine = stateMachine ?? throw new ArgumentNullException(nameof(stateMachine));
-
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        void Run()
-        {
-            if (_boxedStateMachine != null)
-            {
-                _boxedStateMachine.MoveNext();
-            }
-            else
-            {
-                _stateMachine.MoveNext();
-            }
-        }
+        void Run() => _stateMachine.MoveNext();
 
         public void SetResult(T result) => _core.TrySetResult(result);
 
@@ -233,7 +200,6 @@ namespace Velvet
             _returnedToPool = true;
             _core.Reset();
             _stateMachine = default!;
-            _boxedStateMachine = null;
             if (Pool.Count < MaxPoolSize)
             {
                 Pool.Push(this);


### PR DESCRIPTION
`AsyncVelvetTaskMethod` carried two resume routes: a boxed `IAsyncStateMachine` field, and the struct
copy the runner was handed. `Run()` preferred the box when it was set. Nothing set it.

Confirmed from both directions before removing anything. The only writes to `_boxedStateMachine` in
the repository come through `IVelvetTaskStateMachineRunner.SetStateMachine`, whose only callers are
four hand-written lines in `VelvetTaskStructStateMachineContinuationTests` — the fixture aimed at
struct state machines, calling `Builder.SetStateMachine(this)` after each `AwaitOnCompleted`. That call
boxes the struct after the runner field is assigned and installs the box on the runner, which is a
repair the compiler never performs: Roslyn emits no call to `builder.SetStateMachine` from a
`MoveNext`, and this builder's own `AwaitOnCompleted` does not call the state machine's either.

So the fixture was repairing the defect it existed to find, by a route nothing else takes. That defect
is already fixed on its own terms — `Rent` publishes the runner into the caller's field before the
state machine is copied onto it, and says so — which is what leaves the boxed route reachable from
nowhere.

`VelvetTaskMethodBuilder.SetStateMachine` stays: deleting it is `CS0656`. It is a no-op now, with a
comment saying why it exists and what does not call it. The field, the interface member and the branch
in `Run()` go, and the four fixture lines go with them — a fixture that has to repair the thing it
measures is measuring the repair.

EditMode 4248 passed / 0 failed, PlayMode 184 / 0.

Closes #757
