### PR TITLE
test(velvet): bound every await on a stub, so a wedge fails instead of hanging

### DIFF
--- a/Packages/com.velvet.core/AssemblyGraph.txt
+++ b/Packages/com.velvet.core/AssemblyGraph.txt
@@ -2,7 +2,7 @@ Unity.Velvet.CodeGen refs Velvet platforms Editor
 Velvet refs UniTask,Unity.Addressables,Unity.ResourceManager platforms all
 Velvet.Editor refs Velvet platforms Editor
 Velvet.Samples.StarterApp refs UniTask,Velvet platforms all
-Velvet.TestUtilities refs UnityEngine.TestRunner,Velvet platforms all
+Velvet.TestUtilities refs UniTask,UnityEngine.TestRunner,Velvet platforms all
 Velvet.Tests.Async.Editor refs UnityEditor.TestRunner,UnityEngine.TestRunner,Velvet,Velvet.TestUtilities platforms Editor
 Velvet.Tests.Async.PlayMode refs UnityEditor.TestRunner,UnityEngine.TestRunner,Velvet,Velvet.TestUtilities platforms all
 Velvet.Tests.BuildInclusion.Editor refs UnityEditor.TestRunner,UnityEngine.TestRunner,Velvet,Velvet.Editor platforms Editor

--- a/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseTransitionTests.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseTransitionTests.cs
@@ -626,9 +626,6 @@ namespace Velvet.Tests
 
         // GREEN_ON_BASE(characterization): an async action's isPending clears on completion either way.
         // What this branch changed is how many lanes it leaves behind, so the case gained a second flush.
-        // GREEN_ON_BASE(refactor): the wait this bounds is the same wait, and a run where the code
-        // under test arrives cannot tell the two apart. What the bound changes is the run where it
-        // does not: a hang becomes a failure naming the wait.
         [Test]
         public void Given_AsyncStartTransition_When_TaskCompletesAndFlushes_Then_IsPendingClears()
         {
@@ -998,9 +995,6 @@ namespace Velvet.Tests
         // GREEN_ON_BASE(characterization): the post-await write re-renders the parent either way.
         // The parent's render is what reaches the child. What this pins is that the completion's own request
         // coalesces into that render rather than costing a second one.
-        // GREEN_ON_BASE(refactor): the wait this bounds is the same wait, and a run where the code
-        // under test arrives cannot tell the two apart. What the bound changes is the run where it
-        // does not: a hang becomes a failure naming the wait.
         [Test]
         public void Given_AnAsyncTransitionWhoseContinuationWritesTheParentToo_When_ItCompletes_Then_TheChildStillRendersOnce()
         {
@@ -1410,9 +1404,6 @@ namespace Velvet.Tests
 
         // GREEN_ON_BASE(characterization): an explicitly wrapped update kept transition priority on the base.
         // Only the comment naming the mechanism changed, since the carve-out it named is gone.
-        // GREEN_ON_BASE(refactor): the wait this bounds is the same wait, and a run where the code
-        // under test arrives cannot tell the two apart. What the bound changes is the run where it
-        // does not: a hang becomes a failure naming the wait.
         [Test]
         public void Given_AnAwaitingAsyncTransition_When_AClickReusesTheSameStarter_Then_ItsUpdateStaysOnTheTransitionLane()
         {
@@ -1436,9 +1427,6 @@ namespace Velvet.Tests
 
         // GREEN_ON_BASE(characterization): the base gave a discrete-resumed continuation that same priority.
         // It was the deliberate cost of a carve-out this branch removes instead.
-        // GREEN_ON_BASE(refactor): the wait this bounds is the same wait, and a run where the code
-        // under test arrives cannot tell the two apart. What the bound changes is the run where it
-        // does not: a hang becomes a failure naming the wait.
         [Test]
         public void Given_AnAwaitingAsyncTransition_When_AClickCompletesItsAwaitedTask_Then_TheResumedUpdateTakesUrgentPriority()
         {
@@ -1467,9 +1455,6 @@ namespace Velvet.Tests
         // One is therefore all the click could cost there — for want of the request rather than by
         // coalescing with it. Red against this branch's own previous head, which asked for that render at a
         // fixed Normal: Expected 1 But was 2.
-        // GREEN_ON_BASE(refactor): the wait this bounds is the same wait, and a run where the code
-        // under test arrives cannot tell the two apart. What the bound changes is the run where it
-        // does not: a hang becomes a failure naming the wait.
         [Test]
         public void Given_AnAwaitingAsyncTransition_When_AClickCompletesItsAwaitedTask_Then_TheComponentRendersOnceForIt()
         {

--- a/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseTransitionTests.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseTransitionTests.cs
@@ -243,11 +243,11 @@ namespace Velvet.Tests
             var joinedStarted = false;
             s_transitionStarter.Invoke(async () =>
             {
-                await outerGate.Task;
+                await outerGate.Task.Bounded();
                 s_transitionStarter.Invoke(async () =>
                 {
                     joinedStarted = true;
-                    await joinedGate.Task;
+                    await joinedGate.Task.Bounded();
                 });
             });
 
@@ -304,7 +304,7 @@ namespace Velvet.Tests
             Func<Cysharp.Threading.Tasks.UniTask> asyncUpdates = async () =>
             {
                 s_transitionSetValue.Invoke(1);
-                await gate.Task;
+                await gate.Task.Bounded();
                 s_transitionSetValue.Invoke(2);
             };
 
@@ -324,7 +324,7 @@ namespace Velvet.Tests
             var gate = new Cysharp.Threading.Tasks.UniTaskCompletionSource();
             Func<Cysharp.Threading.Tasks.UniTask> asyncUpdates = async () =>
             {
-                await gate.Task;
+                await gate.Task.Bounded();
                 s_transitionSetValue.Invoke(1);
             };
             s_transitionStarter.Invoke(asyncUpdates);
@@ -348,7 +348,7 @@ namespace Velvet.Tests
             var gate = new Cysharp.Threading.Tasks.UniTaskCompletionSource();
             Func<Cysharp.Threading.Tasks.UniTask> asyncUpdates = async () =>
             {
-                await gate.Task;
+                await gate.Task.Bounded();
                 s_transitionSetValue.Invoke(1);
             };
             s_transitionStarter.Invoke(asyncUpdates);
@@ -533,7 +533,7 @@ namespace Velvet.Tests
             var gate = new Cysharp.Threading.Tasks.UniTaskCompletionSource();
             Func<Cysharp.Threading.Tasks.UniTask> asyncUpdates = async () =>
             {
-                await gate.Task;
+                await gate.Task.Bounded();
                 s_transitionSetValue.Invoke(1);
                 s_transitionStarter.Invoke(() => s_transitionSetValue.Invoke(2));
             };
@@ -559,7 +559,7 @@ namespace Velvet.Tests
             // Arrange — the action parks on its await having scheduled nothing, so the fiber carries no lane
             using var mounted = V.Mount(_root, V.Component(TransitionRender, key: "transition"));
             var gate = new Cysharp.Threading.Tasks.UniTaskCompletionSource();
-            Func<Cysharp.Threading.Tasks.UniTask> asyncUpdates = async () => await gate.Task;
+            Func<Cysharp.Threading.Tasks.UniTask> asyncUpdates = async () => await gate.Task.Bounded();
             s_transitionStarter.Invoke(asyncUpdates);
             var awaitingBeforeTheAct = s_transitionFiber.IsTransitionPending;
 
@@ -587,7 +587,7 @@ namespace Velvet.Tests
             Func<Cysharp.Threading.Tasks.UniTask> asyncUpdates = async () =>
             {
                 s_transitionSetValue.Invoke(1);
-                await gate.Task;
+                await gate.Task.Bounded();
             };
             s_transitionStarter.Invoke(asyncUpdates);
             mounted.GetSchedulerForTest().DrainDelayedForTest();
@@ -614,7 +614,7 @@ namespace Velvet.Tests
             Func<Cysharp.Threading.Tasks.UniTask> asyncUpdates = async () =>
             {
                 s_transitionSetValue.Invoke(1);
-                await gate.Task;
+                await gate.Task.Bounded();
                 s_transitionSetValue.Invoke(2);
             };
             s_transitionStarter.Invoke(asyncUpdates);
@@ -695,7 +695,7 @@ namespace Velvet.Tests
             var gate = new Cysharp.Threading.Tasks.UniTaskCompletionSource();
             Func<Cysharp.Threading.Tasks.UniTask> asyncUpdates = async () =>
             {
-                await gate.Task;
+                await gate.Task.Bounded();
                 s_twoSetValue.Invoke(1);
             };
             s_twoStarterA.Invoke(asyncUpdates);
@@ -736,7 +736,7 @@ namespace Velvet.Tests
             // synchronous transition that does write, so the fiber carries B's transition lane while A awaits
             using var mounted = V.Mount(_root, V.Component(TwoTransitionRender, key: "two"));
             var gateA = new Cysharp.Threading.Tasks.UniTaskCompletionSource();
-            Func<Cysharp.Threading.Tasks.UniTask> actionA = async () => await gateA.Task;
+            Func<Cysharp.Threading.Tasks.UniTask> actionA = async () => await gateA.Task.Bounded();
             s_twoStarterA.Invoke(actionA);
             s_twoStartB.Invoke(() => s_twoSetValueB.Invoke(1));
             var inFlightBeforeTheAct = s_twoFiber.TransitionSlots[0].IsAsyncInFlight;
@@ -763,10 +763,10 @@ namespace Velvet.Tests
             var gateB = new Cysharp.Threading.Tasks.UniTaskCompletionSource();
             Func<Cysharp.Threading.Tasks.UniTask> actionA = async () =>
             {
-                await gateA.Task;
+                await gateA.Task.Bounded();
                 s_twoSetValue.Invoke(1);
             };
-            Func<Cysharp.Threading.Tasks.UniTask> actionB = async () => await gateB.Task;
+            Func<Cysharp.Threading.Tasks.UniTask> actionB = async () => await gateB.Task.Bounded();
             s_twoStarterA.Invoke(actionA);
             s_twoStarterB.Invoke(actionB);
             var bothInFlightBeforeTheAct = s_twoFiber.TransitionSlots[0].IsAsyncInFlight
@@ -797,7 +797,7 @@ namespace Velvet.Tests
             // completion behind it both run with B's transition scope open around them
             using var mounted = V.Mount(_root, V.Component(TwoTransitionRender, key: "two"));
             var gate = new Cysharp.Threading.Tasks.UniTaskCompletionSource();
-            Func<Cysharp.Threading.Tasks.UniTask> actionA = async () => await gate.Task;
+            Func<Cysharp.Threading.Tasks.UniTask> actionA = async () => await gate.Task.Bounded();
             s_twoStarterA.Invoke(actionA);
             var pendingBeforeTheAct = s_twoFiber.TransitionSlots[0].IsPending;
 
@@ -906,7 +906,7 @@ namespace Velvet.Tests
             Func<Cysharp.Threading.Tasks.UniTask> asyncUpdates = async () =>
             {
                 s_propSetterChildSetCount.Invoke(1);
-                await gate.Task;
+                await gate.Task.Bounded();
             };
             s_propSetterChildStart.Invoke(asyncUpdates);
             mounted.GetSchedulerForTest().DrainDelayedForTest();
@@ -934,7 +934,7 @@ namespace Velvet.Tests
             Func<Cysharp.Threading.Tasks.UniTask> asyncUpdates = async () =>
             {
                 s_propSetterChildSetCount.Invoke(1);
-                await gate.Task;
+                await gate.Task.Bounded();
             };
             s_propSetterChildStart.Invoke(asyncUpdates);
             mounted.GetSchedulerForTest().DrainDelayedForTest();
@@ -966,7 +966,7 @@ namespace Velvet.Tests
             Func<Cysharp.Threading.Tasks.UniTask> asyncUpdates = async () =>
             {
                 s_propSetterChildSetCount.Invoke(1);
-                await gate.Task;
+                await gate.Task.Bounded();
                 s_propSetterChildSetCount.Invoke(2);
             };
             s_propSetterChildStart.Invoke(asyncUpdates);
@@ -1347,7 +1347,7 @@ namespace Velvet.Tests
             // Arrange — the async action parks on its await without having scheduled anything
             using var mounted = V.Mount(_root, V.Component(ClickableTransitionRender, key: "clickable"));
             var gate = new Cysharp.Threading.Tasks.UniTaskCompletionSource();
-            Func<Cysharp.Threading.Tasks.UniTask> asyncUpdates = async () => await gate.Task;
+            Func<Cysharp.Threading.Tasks.UniTask> asyncUpdates = async () => await gate.Task.Bounded();
             s_clickableStarter.Invoke(asyncUpdates);
             Assume.That(s_clickableFiber.IsTransitionPending, Is.True, "Precondition: the async transition is awaiting");
 
@@ -1368,7 +1368,7 @@ namespace Velvet.Tests
             // Arrange — the slot's async action parks on its await, so a further call on it joins that owner
             using var mounted = V.Mount(_root, V.Component(ClickableTransitionRender, key: "clickable"));
             var gate = new Cysharp.Threading.Tasks.UniTaskCompletionSource();
-            Func<Cysharp.Threading.Tasks.UniTask> asyncUpdates = async () => await gate.Task;
+            Func<Cysharp.Threading.Tasks.UniTask> asyncUpdates = async () => await gate.Task.Bounded();
             s_clickableStarter.Invoke(asyncUpdates);
             Assume.That(s_clickableFiber.IsTransitionPending, Is.True, "Precondition: the async transition is awaiting");
 
@@ -1394,7 +1394,7 @@ namespace Velvet.Tests
             s_clickableGate = gate;
             Func<Cysharp.Threading.Tasks.UniTask> asyncUpdates = async () =>
             {
-                await gate.Task;
+                await gate.Task.Bounded();
                 s_clickableSetValue.Invoke(v => v + 1);
             };
             s_clickableStarter.Invoke(asyncUpdates);
@@ -1423,7 +1423,7 @@ namespace Velvet.Tests
             s_clickableGate = gate;
             Func<Cysharp.Threading.Tasks.UniTask> asyncUpdates = async () =>
             {
-                await gate.Task;
+                await gate.Task.Bounded();
                 s_clickableSetValue.Invoke(v => v + 1);
             };
             s_clickableStarter.Invoke(asyncUpdates);
@@ -1448,7 +1448,7 @@ namespace Velvet.Tests
             using var mounted = V.Mount(_root, V.Component(ClickableTransitionRender, key: "clickable"));
             var gate = new Cysharp.Threading.Tasks.UniTaskCompletionSource();
             s_clickableGate = gate;
-            Func<Cysharp.Threading.Tasks.UniTask> asyncUpdates = async () => await gate.Task;
+            Func<Cysharp.Threading.Tasks.UniTask> asyncUpdates = async () => await gate.Task.Bounded();
             s_clickableStarter.Invoke(asyncUpdates);
             var rendersBeforeTheClick = s_clickableRenderCount;
 
@@ -1507,7 +1507,7 @@ namespace Velvet.Tests
             var fiber = FiberRenderer.CreateRoot(TransitionRender);
             FiberRenderer.Mount(fiber, _root);
             var gate = new Cysharp.Threading.Tasks.UniTaskCompletionSource();
-            Func<Cysharp.Threading.Tasks.UniTask> asyncUpdates = async () => await gate.Task;
+            Func<Cysharp.Threading.Tasks.UniTask> asyncUpdates = async () => await gate.Task.Bounded();
             s_transitionStarter.Invoke(asyncUpdates);
             Assume.That(fiber.IsTransitionPending, Is.True, "Precondition: the async transition is awaiting");
             var slotBeforeUnmount = fiber.TransitionSlots[0];
@@ -1572,7 +1572,7 @@ namespace Velvet.Tests
             starter.Invoke(async () =>
             {
                 s_outlivedSetValue.Invoke(1);
-                await gate.Task;
+                await gate.Task.Bounded();
             });
 
             // Assert — same four terms as the synchronous case, for the same three reasons

--- a/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseTransitionTests.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseTransitionTests.cs
@@ -233,6 +233,9 @@ namespace Velvet.Tests
                 "The nested transition's update commits on flush, for the render count a single transition costs");
         }
 
+        // GREEN_ON_BASE(refactor): the wait this bounds is the same wait, and a run where the code
+        // under test arrives cannot tell the two apart. What the bound changes is the run where it
+        // does not: a hang becomes a failure naming the wait.
         [Test]
         public void Given_AnAsyncTransitionStartsAJoinedAsyncCall_When_TheOuterActionCompletes_Then_IsPendingWaitsForTheJoinedCall()
         {
@@ -295,6 +298,9 @@ namespace Velvet.Tests
 
         #region Async startTransition
 
+        // GREEN_ON_BASE(refactor): the wait this bounds is the same wait, and a run where the code
+        // under test arrives cannot tell the two apart. What the bound changes is the run where it
+        // does not: a hang becomes a failure naming the wait.
         [Test]
         public void Given_AsyncStartTransition_When_Awaiting_Then_IsPendingStaysTrue()
         {
@@ -315,6 +321,9 @@ namespace Velvet.Tests
             Assert.IsTrue(s_transitionFiber.IsTransitionPending, "isPending stays true while the async transition is awaiting");
         }
 
+        // GREEN_ON_BASE(refactor): the wait this bounds is the same wait, and a run where the code
+        // under test arrives cannot tell the two apart. What the bound changes is the run where it
+        // does not: a hang becomes a failure naming the wait.
         [Test]
         public void Given_AsyncStartTransitionAwaitingBeforeAnyUpdate_When_ACleanFiberFlushFires_Then_IsPendingStaysTrue()
         {
@@ -340,6 +349,9 @@ namespace Velvet.Tests
                 "A flush on a clean fiber must not wipe an awaiting async transition's pending flag");
         }
 
+        // GREEN_ON_BASE(refactor): the wait this bounds is the same wait, and a run where the code
+        // under test arrives cannot tell the two apart. What the bound changes is the run where it
+        // does not: a hang becomes a failure naming the wait.
         [Test]
         public void Given_AnAsyncTransition_When_ItsContinuationSetsStateAfterTheAwait_Then_ThatUpdateIsNotOnTheTransitionLane()
         {
@@ -524,6 +536,9 @@ namespace Velvet.Tests
                 "An async callback that throws leaves no scope open behind it either");
         }
 
+        // GREEN_ON_BASE(refactor): the wait this bounds is the same wait, and a run where the code
+        // under test arrives cannot tell the two apart. What the bound changes is the run where it
+        // does not: a hang becomes a failure naming the wait.
         [Test]
         public void Given_AnAsyncTransitionsContinuation_When_ItWrapsOneOfTwoUpdatesAgain_Then_OnlyTheWrappedOneTakesTheTransitionLane()
         {
@@ -553,6 +568,9 @@ namespace Velvet.Tests
                 "Re-wrapping is what puts a post-await update back in the transition, and it covers only that update");
         }
 
+        // GREEN_ON_BASE(refactor): the wait this bounds is the same wait, and a run where the code
+        // under test arrives cannot tell the two apart. What the bound changes is the run where it
+        // does not: a hang becomes a failure naming the wait.
         [Test]
         public void Given_AnAwaitingAsyncTransition_When_AnUnrelatedSetterRuns_Then_ThatUpdateTakesTheNormalLane()
         {
@@ -576,6 +594,9 @@ namespace Velvet.Tests
                 "An update outside the transition's callback keeps its own priority while that transition awaits");
         }
 
+        // GREEN_ON_BASE(refactor): the wait this bounds is the same wait, and a run where the code
+        // under test arrives cannot tell the two apart. What the bound changes is the run where it
+        // does not: a hang becomes a failure naming the wait.
         [Test]
         public void Given_AnAsyncTransitionWhoseWorkAlreadyCommitted_When_ItsTaskCompletes_Then_ADrainRendersTheComponentNotPending()
         {
@@ -605,6 +626,9 @@ namespace Velvet.Tests
 
         // GREEN_ON_BASE(characterization): an async action's isPending clears on completion either way.
         // What this branch changed is how many lanes it leaves behind, so the case gained a second flush.
+        // GREEN_ON_BASE(refactor): the wait this bounds is the same wait, and a run where the code
+        // under test arrives cannot tell the two apart. What the bound changes is the run where it
+        // does not: a hang becomes a failure naming the wait.
         [Test]
         public void Given_AsyncStartTransition_When_TaskCompletesAndFlushes_Then_IsPendingClears()
         {
@@ -687,6 +711,9 @@ namespace Velvet.Tests
                 "Both slots clear after the transition flush completes");
         }
 
+        // GREEN_ON_BASE(refactor): the wait this bounds is the same wait, and a run where the code
+        // under test arrives cannot tell the two apart. What the bound changes is the run where it
+        // does not: a hang becomes a failure naming the wait.
         [Test]
         public void Given_OneSlotsAsyncTransitionAwaiting_When_ASecondSlotStartsItsOwn_Then_TheSecondSlotReportsPending()
         {
@@ -729,6 +756,9 @@ namespace Velvet.Tests
                 "A transition that queued nothing settles when its callback returns, whatever another slot left queued");
         }
 
+        // GREEN_ON_BASE(refactor): the wait this bounds is the same wait, and a run where the code
+        // under test arrives cannot tell the two apart. What the bound changes is the run where it
+        // does not: a hang becomes a failure naming the wait.
         [Test]
         public void Given_AnAwaitingAsyncTransitionThatQueuedNothing_When_AnotherSlotsCallbackQueuesWork_Then_ItStillClearsOnItsOwnCompletion()
         {
@@ -754,6 +784,9 @@ namespace Velvet.Tests
                 "A slot's pending flag answers for what its own callback queued, not for another slot's");
         }
 
+        // GREEN_ON_BASE(refactor): the wait this bounds is the same wait, and a run where the code
+        // under test arrives cannot tell the two apart. What the bound changes is the run where it
+        // does not: a hang becomes a failure naming the wait.
         [Test]
         public void Given_TwoAsyncTransitionsInFlight_When_OneContinuationSetsState_Then_TheOtherSlotClearsOnItsOwnCompletion()
         {
@@ -789,6 +822,9 @@ namespace Velvet.Tests
                 "A slot settles on what its own callback queued, not on what another slot's action wrote");
         }
 
+        // GREEN_ON_BASE(refactor): the wait this bounds is the same wait, and a run where the code
+        // under test arrives cannot tell the two apart. What the bound changes is the run where it
+        // does not: a hang becomes a failure naming the wait.
         [Test]
         public void Given_AnAsyncTransitionsCompletion_When_ItIsReachedInsideAnotherSlotsScope_Then_ItsRenderIsNotDeferred()
         {
@@ -896,6 +932,9 @@ namespace Velvet.Tests
                 "The parent commit renders the child pending before the terminal clear renders it again");
         }
 
+        // GREEN_ON_BASE(refactor): the wait this bounds is the same wait, and a run where the code
+        // under test arrives cannot tell the two apart. What the bound changes is the run where it
+        // does not: a hang becomes a failure naming the wait.
         [Test]
         public void Given_AnAsyncTransitionOnTheParentsStateThatAlreadyCommitted_When_ItsTaskCompletes_Then_TheChildsIndicatorComesDown()
         {
@@ -924,6 +963,9 @@ namespace Velvet.Tests
                 "The completion takes the indicator down on the component that declared the transition");
         }
 
+        // GREEN_ON_BASE(refactor): the wait this bounds is the same wait, and a run where the code
+        // under test arrives cannot tell the two apart. What the bound changes is the run where it
+        // does not: a hang becomes a failure naming the wait.
         [Test]
         public void Given_AnAsyncTransitionOnTheParentsStateThatAlreadyCommitted_When_ItsTaskCompletes_Then_TheChildRendersOnceForIt()
         {
@@ -956,6 +998,9 @@ namespace Velvet.Tests
         // GREEN_ON_BASE(characterization): the post-await write re-renders the parent either way.
         // The parent's render is what reaches the child. What this pins is that the completion's own request
         // coalesces into that render rather than costing a second one.
+        // GREEN_ON_BASE(refactor): the wait this bounds is the same wait, and a run where the code
+        // under test arrives cannot tell the two apart. What the bound changes is the run where it
+        // does not: a hang becomes a failure naming the wait.
         [Test]
         public void Given_AnAsyncTransitionWhoseContinuationWritesTheParentToo_When_ItCompletes_Then_TheChildStillRendersOnce()
         {
@@ -1341,6 +1386,9 @@ namespace Velvet.Tests
 
         #region Discrete updates during an in-flight async transition
 
+        // GREEN_ON_BASE(refactor): the wait this bounds is the same wait, and a run where the code
+        // under test arrives cannot tell the two apart. What the bound changes is the run where it
+        // does not: a hang becomes a failure naming the wait.
         [Test]
         public void Given_AnAwaitingAsyncTransition_When_AClickSetsStateOnTheSameComponent_Then_ItCommitsInsideTheClick()
         {
@@ -1362,6 +1410,9 @@ namespace Velvet.Tests
 
         // GREEN_ON_BASE(characterization): an explicitly wrapped update kept transition priority on the base.
         // Only the comment naming the mechanism changed, since the carve-out it named is gone.
+        // GREEN_ON_BASE(refactor): the wait this bounds is the same wait, and a run where the code
+        // under test arrives cannot tell the two apart. What the bound changes is the run where it
+        // does not: a hang becomes a failure naming the wait.
         [Test]
         public void Given_AnAwaitingAsyncTransition_When_AClickReusesTheSameStarter_Then_ItsUpdateStaysOnTheTransitionLane()
         {
@@ -1385,6 +1436,9 @@ namespace Velvet.Tests
 
         // GREEN_ON_BASE(characterization): the base gave a discrete-resumed continuation that same priority.
         // It was the deliberate cost of a carve-out this branch removes instead.
+        // GREEN_ON_BASE(refactor): the wait this bounds is the same wait, and a run where the code
+        // under test arrives cannot tell the two apart. What the bound changes is the run where it
+        // does not: a hang becomes a failure naming the wait.
         [Test]
         public void Given_AnAwaitingAsyncTransition_When_AClickCompletesItsAwaitedTask_Then_TheResumedUpdateTakesUrgentPriority()
         {
@@ -1413,6 +1467,9 @@ namespace Velvet.Tests
         // One is therefore all the click could cost there — for want of the request rather than by
         // coalescing with it. Red against this branch's own previous head, which asked for that render at a
         // fixed Normal: Expected 1 But was 2.
+        // GREEN_ON_BASE(refactor): the wait this bounds is the same wait, and a run where the code
+        // under test arrives cannot tell the two apart. What the bound changes is the run where it
+        // does not: a hang becomes a failure naming the wait.
         [Test]
         public void Given_AnAwaitingAsyncTransition_When_AClickCompletesItsAwaitedTask_Then_TheComponentRendersOnceForIt()
         {
@@ -1440,6 +1497,9 @@ namespace Velvet.Tests
         // The case above cannot fall to nought: the continuation's own write renders the component whether or
         // not the completion asked for anything, so it separates the lane the request takes and not whether one
         // was made. Dropping the write is what leaves the request alone in the handler.
+        // GREEN_ON_BASE(refactor): the wait this bounds is the same wait, and a run where the code
+        // under test arrives cannot tell the two apart. What the bound changes is the run where it
+        // does not: a hang becomes a failure naming the wait.
         [Test]
         public void Given_AnAwaitingAsyncTransitionThatWroteNothing_When_AClickCompletesItsAwaitedTask_Then_TheClearedFlagStillCostsARender()
         {
@@ -1499,6 +1559,9 @@ namespace Velvet.Tests
 
         #region Ownership across unmount
 
+        // GREEN_ON_BASE(refactor): the wait this bounds is the same wait, and a run where the code
+        // under test arrives cannot tell the two apart. What the bound changes is the run where it
+        // does not: a hang becomes a failure naming the wait.
         [Test]
         public void Given_AFiberUnmountedWhileItsAsyncTransitionAwaits_When_ItIsMountedAgain_Then_TheSlotStartsUnownedAndTheNextTransitionReportsPending()
         {
@@ -1556,6 +1619,9 @@ namespace Velvet.Tests
                 "A starter outliving the component that declared it still marks what its callback writes");
         }
 
+        // GREEN_ON_BASE(refactor): the wait this bounds is the same wait, and a run where the code
+        // under test arrives cannot tell the two apart. What the bound changes is the run where it
+        // does not: a hang becomes a failure naming the wait.
         [Test]
         public void Given_AnAsyncStarterWhoseComponentIsDisposed_When_ItsActionWritesLiveStateBeforeSuspending_Then_ThatWriteTakesTheTransitionLane()
         {

--- a/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseTransitionTests.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Tests/Editor/UseTransitionTests.cs
@@ -626,6 +626,8 @@ namespace Velvet.Tests
 
         // GREEN_ON_BASE(characterization): an async action's isPending clears on completion either way.
         // What this branch changed is how many lanes it leaves behind, so the case gained a second flush.
+        // The wait it makes is bounded now: same wait where the code under test arrives, a failure
+        // naming it where that stops happening.
         [Test]
         public void Given_AsyncStartTransition_When_TaskCompletesAndFlushes_Then_IsPendingClears()
         {
@@ -995,6 +997,8 @@ namespace Velvet.Tests
         // GREEN_ON_BASE(characterization): the post-await write re-renders the parent either way.
         // The parent's render is what reaches the child. What this pins is that the completion's own request
         // coalesces into that render rather than costing a second one.
+        // The wait it makes is bounded now: same wait where the code under test arrives, a failure
+        // naming it where that stops happening.
         [Test]
         public void Given_AnAsyncTransitionWhoseContinuationWritesTheParentToo_When_ItCompletes_Then_TheChildStillRendersOnce()
         {
@@ -1404,6 +1408,8 @@ namespace Velvet.Tests
 
         // GREEN_ON_BASE(characterization): an explicitly wrapped update kept transition priority on the base.
         // Only the comment naming the mechanism changed, since the carve-out it named is gone.
+        // The wait it makes is bounded now: same wait where the code under test arrives, a failure
+        // naming it where that stops happening.
         [Test]
         public void Given_AnAwaitingAsyncTransition_When_AClickReusesTheSameStarter_Then_ItsUpdateStaysOnTheTransitionLane()
         {
@@ -1427,6 +1433,8 @@ namespace Velvet.Tests
 
         // GREEN_ON_BASE(characterization): the base gave a discrete-resumed continuation that same priority.
         // It was the deliberate cost of a carve-out this branch removes instead.
+        // The wait it makes is bounded now: same wait where the code under test arrives, a failure
+        // naming it where that stops happening.
         [Test]
         public void Given_AnAwaitingAsyncTransition_When_AClickCompletesItsAwaitedTask_Then_TheResumedUpdateTakesUrgentPriority()
         {
@@ -1455,6 +1463,8 @@ namespace Velvet.Tests
         // One is therefore all the click could cost there — for want of the request rather than by
         // coalescing with it. Red against this branch's own previous head, which asked for that render at a
         // fixed Normal: Expected 1 But was 2.
+        // The wait it makes is bounded now: same wait where the code under test arrives, a failure
+        // naming it where that stops happening.
         [Test]
         public void Given_AnAwaitingAsyncTransition_When_AClickCompletesItsAwaitedTask_Then_TheComponentRendersOnceForIt()
         {

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/AutoBatchingTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/AutoBatchingTests.cs
@@ -399,6 +399,9 @@ namespace Velvet.Tests
                 "Each fiber renders exactly once for setStates batched after an await");
         }
 
+        // GREEN_ON_BASE(refactor): the wait this bounds is the same wait, and a run where the code
+        // under test arrives cannot tell the two apart. What the bound changes is the run where it
+        // does not: a hang becomes a failure naming the wait.
         [Test]
         public void Given_TwoSettersAfterTheSameAwait_When_BatchDrained_Then_EachCommitsItsLatestValue()
         {

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/AutoBatchingTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/AutoBatchingTests.cs
@@ -399,9 +399,6 @@ namespace Velvet.Tests
                 "Each fiber renders exactly once for setStates batched after an await");
         }
 
-        // GREEN_ON_BASE(refactor): the wait this bounds is the same wait, and a run where the code
-        // under test arrives cannot tell the two apart. What the bound changes is the run where it
-        // does not: a hang becomes a failure naming the wait.
         [Test]
         public void Given_TwoSettersAfterTheSameAwait_When_BatchDrained_Then_EachCommitsItsLatestValue()
         {

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/AutoBatchingTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/AutoBatchingTests.cs
@@ -443,7 +443,7 @@ namespace Velvet.Tests
         private static async UniTask RunAsync(
             UniTaskCompletionSource gate, Action body)
         {
-            await gate.Task;
+            await gate.Task.Bounded();
             body();
         }
 

--- a/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouterCancellationUnwindTests.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouterCancellationUnwindTests.cs
@@ -36,6 +36,9 @@ namespace Velvet.Tests
             Router.Current?.Dispose();
         }
 
+        // GREEN_ON_BASE(refactor): the wait this bounds is the same wait, and a run where the code
+        // under test arrives cannot tell the two apart. What the bound changes is the run where it
+        // does not: a hang becomes a failure naming the wait.
         [UnityTest]
         public IEnumerator Given_BlockerHonorsToken_When_CancelledDuringBackAwait_Then_HistoryIndexIsUnchanged()
             => UniTask.ToCoroutine(async () =>
@@ -61,6 +64,9 @@ namespace Velvet.Tests
                 "A cancelled Back leaves the history pointing at the entry the user never left");
         });
 
+        // GREEN_ON_BASE(refactor): the wait this bounds is the same wait, and a run where the code
+        // under test arrives cannot tell the two apart. What the bound changes is the run where it
+        // does not: a hang becomes a failure naming the wait.
         [UnityTest]
         public IEnumerator Given_GuardRedirect_When_CancelledDuringRedirectBlockerAwait_Then_NothingIsRecorded()
             => UniTask.ToCoroutine(async () =>
@@ -92,6 +98,9 @@ namespace Velvet.Tests
                 + "still leaves the stack describing a navigation that never happened");
         });
 
+        // GREEN_ON_BASE(refactor): the wait this bounds is the same wait, and a run where the code
+        // under test arrives cannot tell the two apart. What the bound changes is the run where it
+        // does not: a hang becomes a failure naming the wait.
         [UnityTest]
         public IEnumerator Given_BlockerHonorsToken_When_CancelledWithNoFollowUpNavigation_Then_StatusReturnsToIdle()
             => UniTask.ToCoroutine(async () =>
@@ -118,6 +127,9 @@ namespace Velvet.Tests
                 "With no navigation left in flight, UseNavigation must not keep reporting one");
         });
 
+        // GREEN_ON_BASE(refactor): the wait this bounds is the same wait, and a run where the code
+        // under test arrives cannot tell the two apart. What the bound changes is the run where it
+        // does not: a hang becomes a failure naming the wait.
         [UnityTest]
         public IEnumerator Given_SupersededBackUnwindsLate_When_NewerBackHasCommitted_Then_TheCommittedStateSurvives()
             => UniTask.ToCoroutine(async () =>
@@ -148,6 +160,9 @@ namespace Velvet.Tests
                 "A late unwind must leave the newer navigation's own position and status standing");
         });
 
+        // GREEN_ON_BASE(refactor): the wait this bounds is the same wait, and a run where the code
+        // under test arrives cannot tell the two apart. What the bound changes is the run where it
+        // does not: a hang becomes a failure naming the wait.
         [UnityTest]
         public IEnumerator Given_SupersededRedirectUnwindsLate_When_NewerNavigationHasPushed_Then_ItsHistorySurvives()
             => UniTask.ToCoroutine(async () =>
@@ -182,6 +197,9 @@ namespace Velvet.Tests
                 "A late unwind must leave the newer navigation's own entries and status exactly as it left them");
         });
 
+        // GREEN_ON_BASE(refactor): the wait this bounds is the same wait, and a run where the code
+        // under test arrives cannot tell the two apart. What the bound changes is the run where it
+        // does not: a hang becomes a failure naming the wait.
         [UnityTest]
         public IEnumerator Given_SupersededBlockerReturnsLate_When_NewerBackHasCommitted_Then_IndexAndStatusSurvive()
             => UniTask.ToCoroutine(async () =>
@@ -212,6 +230,9 @@ namespace Velvet.Tests
                 + "the newer navigation established");
         });
 
+        // GREEN_ON_BASE(refactor): the wait this bounds is the same wait, and a run where the code
+        // under test arrives cannot tell the two apart. What the bound changes is the run where it
+        // does not: a hang becomes a failure naming the wait.
         [UnityTest]
         public IEnumerator Given_SupersededByAnUnmatchedPath_When_ItResumes_Then_TheStatusIsStillRestored()
             => UniTask.ToCoroutine(async () =>
@@ -241,6 +262,9 @@ namespace Velvet.Tests
                 "Only an attempt that took the claim may stop the parked one from restoring the status");
         });
 
+        // GREEN_ON_BASE(refactor): the wait this bounds is the same wait, and a run where the code
+        // under test arrives cannot tell the two apart. What the bound changes is the run where it
+        // does not: a hang becomes a failure naming the wait.
         [UnityTest]
         public IEnumerator Given_SupersededRedirectReturnsLate_When_NewerNavigationHasPushed_Then_ItsHistorySurvives()
             => UniTask.ToCoroutine(async () =>
@@ -274,6 +298,9 @@ namespace Velvet.Tests
                 "A redirect that returns Cancelled after being superseded must commit nothing of its own");
         });
 
+        // GREEN_ON_BASE(refactor): the wait this bounds is the same wait, and a run where the code
+        // under test arrives cannot tell the two apart. What the bound changes is the run where it
+        // does not: a hang becomes a failure naming the wait.
         [UnityTest]
         public IEnumerator Given_BlockerParkedAcrossDispose_When_DisposeCancelsIt_Then_TheDeadRouterIsNotWritten()
             => UniTask.ToCoroutine(async () =>

--- a/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouterCancellationUnwindTests.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouterCancellationUnwindTests.cs
@@ -48,7 +48,7 @@ namespace Velvet.Tests
             using var registration = router.RouteBlockerManager.Register(check, new RouteBlockerState());
             using var callerCts = new CancellationTokenSource();
             var nav = router.GoBack(callerCts.Token);
-            await entered.Task;
+            await entered.Task.Bounded();
             Assume.That(router.CurrentLocation?.Path, Is.EqualTo("/about"),
                 "Precondition: the Back is still parked in the blocker and has committed nothing");
 
@@ -80,7 +80,7 @@ namespace Velvet.Tests
             using var registration = router.RouteBlockerManager.Register(check, new RouteBlockerState());
             using var callerCts = new CancellationTokenSource();
             var nav = router.NavigateAsync("/guarded", NavigationMode.Push, callerCts.Token);
-            await entered.Task;
+            await entered.Task.Bounded();
 
             // Act
             callerCts.Cancel();
@@ -105,7 +105,7 @@ namespace Velvet.Tests
             using var registration = router.RouteBlockerManager.Register(check, new RouteBlockerState());
             using var callerCts = new CancellationTokenSource();
             var nav = router.NavigateAsync("/about", NavigationMode.Push, callerCts.Token);
-            await entered.Task;
+            await entered.Task.Bounded();
             Assume.That(router.CurrentLocation?.Path, Is.EqualTo("/home"),
                 "Precondition: the cancelled navigation never commits a location");
 
@@ -133,7 +133,7 @@ namespace Velvet.Tests
             var (check, entered, resumeCancelled, _) = MakeDeferredBlocker();
             using var registration = router.RouteBlockerManager.Register(check, new RouteBlockerState());
             var superseded = router.GoBack();
-            await entered.Task;
+            await entered.Task.Bounded();
             await router.GoBack();
             Assume.That(router.CurrentLocation?.Path, Is.EqualTo("/about"),
                 "Precondition: the newer Back committed while the superseded one was still parked");
@@ -166,7 +166,7 @@ namespace Velvet.Tests
             var (check, entered, resumeCancelled, _) = MakeDeferredBlocker();
             using var registration = router.RouteBlockerManager.Register(check, new RouteBlockerState());
             var superseded = router.NavigateAsync("/guarded");
-            await entered.Task;
+            await entered.Task.Bounded();
             await router.NavigateAsync("/x");
             Assume.That(router.CurrentLocation?.Path, Is.EqualTo("/x"),
                 "Precondition: the newer navigation committed while the redirect was still parked");
@@ -197,7 +197,7 @@ namespace Velvet.Tests
             var (check, entered, _, resumeUnblocked) = MakeDeferredBlocker();
             using var registration = router.RouteBlockerManager.Register(check, new RouteBlockerState());
             var superseded = router.GoBack();
-            await entered.Task;
+            await entered.Task.Bounded();
             await router.GoBack();
             Assume.That(router.CurrentLocation?.Path, Is.EqualTo("/about"),
                 "Precondition: the newer Back committed while the superseded one was still parked");
@@ -227,7 +227,7 @@ namespace Velvet.Tests
             var (check, entered, resumeCancelled, _) = MakeDeferredBlocker();
             using var registration = router.RouteBlockerManager.Register(check, new RouteBlockerState());
             var superseded = router.GoBack();
-            await entered.Task;
+            await entered.Task.Bounded();
             var unmatched = await router.NavigateAsync("/no-such-route");
             Assume.That(unmatched, Is.EqualTo(NavigationResult.NotFound),
                 "Precondition: the superseding navigation returned without reaching the claim");
@@ -260,7 +260,7 @@ namespace Velvet.Tests
             var (check, entered, _, resumeUnblocked) = MakeDeferredBlocker();
             using var registration = router.RouteBlockerManager.Register(check, new RouteBlockerState());
             var superseded = router.NavigateAsync("/guarded");
-            await entered.Task;
+            await entered.Task.Bounded();
             await router.NavigateAsync("/x");
             Assume.That(router.CurrentLocation?.Path, Is.EqualTo("/x"),
                 "Precondition: the newer navigation committed while the redirect was still parked");
@@ -289,7 +289,7 @@ namespace Velvet.Tests
             using var registration = router.RouteBlockerManager.Register(check, new RouteBlockerState());
             var statusEvents = 0;
             var parked = router.GoBack();
-            await entered.Task;
+            await entered.Task.Bounded();
             router.OnStatusChanged += _ => statusEvents++;
 
             // Act

--- a/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouterTests.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouterTests.cs
@@ -1085,7 +1085,7 @@ namespace Velvet.Tests
             var (check, entered) = MakeOneShotBlocker();
             using var _ = router.RouteBlockerManager.Register(check, new RouteBlockerState());
             var firstNav = router.NavigateAsync("/about");
-            await entered.Task;
+            await entered.Task.Bounded();
             var secondNav = router.NavigateAsync("/home");
 
             // Act
@@ -1106,7 +1106,7 @@ namespace Velvet.Tests
             var (check, entered) = MakeOneShotBlocker();
             using var _ = router.RouteBlockerManager.Register(check, new RouteBlockerState());
             var firstNav = router.NavigateAsync("/about");
-            await entered.Task;
+            await entered.Task.Bounded();
             var secondNav = router.NavigateAsync("/home");
 
             // Act
@@ -1127,7 +1127,7 @@ namespace Velvet.Tests
             var (check, entered) = MakeOneShotBlocker();
             using var _ = router.RouteBlockerManager.Register(check, new RouteBlockerState());
             var firstNav = router.NavigateAsync("/about");
-            await entered.Task;
+            await entered.Task.Bounded();
             var secondNav = router.NavigateAsync("/home");
 
             // Act
@@ -1153,7 +1153,7 @@ namespace Velvet.Tests
             using var _ = router.RouteBlockerManager.Register(check, new RouteBlockerState());
             using var callerCts = new CancellationTokenSource();
             var nav = router.NavigateAsync("/about", cancellationToken: callerCts.Token);
-            await entered.Task;
+            await entered.Task.Bounded();
 
             // Act
             callerCts.Cancel();

--- a/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouterTests.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouterTests.cs
@@ -1072,6 +1072,9 @@ namespace Velvet.Tests
 
         #region Concurrent navigation cancellation
 
+        // GREEN_ON_BASE(refactor): the wait this bounds is the same wait, and a run where the code
+        // under test arrives cannot tell the two apart. What the bound changes is the run where it
+        // does not: a hang becomes a failure naming the wait.
         [UnityTest]
         public IEnumerator Given_ConcurrentNavigationDuringBlockerAwait_When_SecondTakesOver_Then_FirstReturnsCancelled()
             => UniTask.ToCoroutine(async () =>
@@ -1096,6 +1099,9 @@ namespace Velvet.Tests
             Assert.That(firstResult, Is.EqualTo(NavigationResult.Cancelled));
         });
 
+        // GREEN_ON_BASE(refactor): the wait this bounds is the same wait, and a run where the code
+        // under test arrives cannot tell the two apart. What the bound changes is the run where it
+        // does not: a hang becomes a failure naming the wait.
         [UnityTest]
         public IEnumerator Given_ConcurrentNavigationDuringBlockerAwait_When_SecondTakesOver_Then_SecondSucceeds()
             => UniTask.ToCoroutine(async () =>
@@ -1117,6 +1123,9 @@ namespace Velvet.Tests
             Assert.That(secondResult, Is.EqualTo(NavigationResult.Success));
         });
 
+        // GREEN_ON_BASE(refactor): the wait this bounds is the same wait, and a run where the code
+        // under test arrives cannot tell the two apart. What the bound changes is the run where it
+        // does not: a hang becomes a failure naming the wait.
         [UnityTest]
         public IEnumerator Given_ConcurrentNavigationDuringBlockerAwait_When_SecondTakesOver_Then_CommitsLatestLocation()
             => UniTask.ToCoroutine(async () =>
@@ -1139,6 +1148,9 @@ namespace Velvet.Tests
                 "The final committed location reflects the latest nav, not the cancelled first");
         });
 
+        // GREEN_ON_BASE(refactor): the wait this bounds is the same wait, and a run where the code
+        // under test arrives cannot tell the two apart. What the bound changes is the run where it
+        // does not: a hang becomes a failure naming the wait.
         [UnityTest]
         public IEnumerator Given_CallerCancelsTokenDuringBlockerAwait_When_Cancelled_Then_ReturnsCancelledInsteadOfThrowing()
             => UniTask.ToCoroutine(async () =>

--- a/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouterUnfinishedNavigationTests.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouterUnfinishedNavigationTests.cs
@@ -39,7 +39,7 @@ namespace Velvet.Tests
             var (check, entered, _, _) = MakeDeferredBlocker();
             using var registration = router.RouteBlockerManager.Register(check, new RouteBlockerState());
             var parked = router.GoBack();
-            await entered.Task;
+            await entered.Task.Bounded();
             Assume.That(router.CurrentLocation?.Path, Is.EqualTo("/settings"),
                 "Precondition: the Back is still parked in the blocker and has committed nothing");
 
@@ -69,7 +69,7 @@ namespace Velvet.Tests
             var (check, entered, _, resumeUnblocked) = MakeDeferredBlocker();
             using var registration = router.RouteBlockerManager.Register(check, new RouteBlockerState());
             var parked = router.GoForward();
-            await entered.Task;
+            await entered.Task.Bounded();
             await router.NavigateAsync("/contact");
             Assume.That(RouterHistoryProbe.PathsOf(router), Is.EqualTo("/home,/about,/contact"),
                 "Precondition: the Push truncated the entry the parked Forward had resolved onto");
@@ -105,7 +105,7 @@ namespace Velvet.Tests
             var (check, entered, _, _) = MakeDeferredBlocker();
             using var registration = router.RouteBlockerManager.Register(check, new RouteBlockerState());
             var parked = router.NavigateAsync("/guarded");
-            await entered.Task;
+            await entered.Task.Bounded();
 
             // Act
             await router.NavigateAsync("/x");

--- a/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouterUnfinishedNavigationTests.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouterUnfinishedNavigationTests.cs
@@ -21,6 +21,9 @@ namespace Velvet.Tests
             Router.Current?.Dispose();
         }
 
+        // GREEN_ON_BASE(refactor): the wait this bounds is the same wait, and a run where the code
+        // under test arrives cannot tell the two apart. What the bound changes is the run where it
+        // does not: a hang becomes a failure naming the wait.
         [UnityTest]
         public IEnumerator Given_ABackParkedInABlocker_When_APushCommitsMeanwhile_Then_TheEntryTheUserIsOnSurvives()
             => UniTask.ToCoroutine(async () =>
@@ -51,6 +54,9 @@ namespace Velvet.Tests
                 "A navigation that has not committed must not move the position a later Push builds on");
         });
 
+        // GREEN_ON_BASE(refactor): the wait this bounds is the same wait, and a run where the code
+        // under test arrives cannot tell the two apart. What the bound changes is the run where it
+        // does not: a hang becomes a failure naming the wait.
         [UnityTest]
         public IEnumerator Given_AForwardParkedInABlocker_When_APushTakesOverItsSlot_Then_ItCommitsNothing()
             => UniTask.ToCoroutine(async () =>
@@ -86,6 +92,9 @@ namespace Velvet.Tests
                 + "that destination used to occupy");
         });
 
+        // GREEN_ON_BASE(refactor): the wait this bounds is the same wait, and a run where the code
+        // under test arrives cannot tell the two apart. What the bound changes is the run where it
+        // does not: a hang becomes a failure naming the wait.
         [UnityTest]
         public IEnumerator Given_ARedirectParkedInABlocker_When_ANewerNavigationCommits_Then_NoEntryForTheRedirectingPathRemains()
             => UniTask.ToCoroutine(async () =>

--- a/Packages/com.velvet.core/TestUtilities/BoundedAwait.cs
+++ b/Packages/com.velvet.core/TestUtilities/BoundedAwait.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Runtime.CompilerServices;
+using Cysharp.Threading.Tasks;
+
+namespace Velvet.TestUtilities
+{
+    /// <summary>
+    /// Awaits a rendezvous with the code under test, and fails rather than waits forever when the code
+    /// under test stops arriving.
+    /// </summary>
+    /// <remarks>
+    /// An unbounded <c>await source.Task</c> is a case that cannot report the defect it exists to find: a
+    /// change that stops reaching the completion leaves the await pending, the case never returns, and the
+    /// run hangs where it should have gone red. A mutation campaign then reads the wedge as a timeout,
+    /// which is unmeasured rather than survived, and the branch cannot earn a receipt at all.
+    /// <para>
+    /// The bound is generous rather than tuned. What separates a wedge from a slow rendezvous here is not
+    /// a hand-picked margin — every one of these completes in the same frame the code under test reaches
+    /// it, or never — so any bound above scheduling noise reports the same thing, and a large one cannot
+    /// redden a healthy run on a loaded machine.
+    /// </para>
+    /// </remarks>
+    public static class BoundedAwait
+    {
+        private const int DefaultSeconds = 20;
+
+        public static async UniTask Bounded(this UniTask task, [CallerMemberName] string caller = "",
+                                            [CallerLineNumber] int line = 0, int seconds = DefaultSeconds)
+        {
+            var finished = await UniTask.WhenAny(task, UniTask.Delay(TimeSpan.FromSeconds(seconds)));
+            if (finished != 0)
+            {
+                throw new TimeoutException(
+                    $"{caller} (line {line}) waited {seconds}s for a completion the code under test never "
+                    + "reached. An await that cannot end is a case that cannot fail.");
+            }
+        }
+
+        public static async UniTask<T> Bounded<T>(this UniTask<T> task, [CallerMemberName] string caller = "",
+                                                  [CallerLineNumber] int line = 0, int seconds = DefaultSeconds)
+        {
+            var (index, result, _) = await UniTask.WhenAny(task, UniTask.Delay(TimeSpan.FromSeconds(seconds))
+                .ContinueWith(() => default(T)!));
+            if (index != 0)
+            {
+                throw new TimeoutException(
+                    $"{caller} (line {line}) waited {seconds}s for a completion the code under test never "
+                    + "reached. An await that cannot end is a case that cannot fail.");
+            }
+            return result;
+        }
+    }
+}

--- a/Packages/com.velvet.core/TestUtilities/BoundedAwait.cs.meta
+++ b/Packages/com.velvet.core/TestUtilities/BoundedAwait.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5e52a84f1f346458a8cc034128c19d0f

--- a/Packages/com.velvet.core/TestUtilities/Velvet.TestUtilities.asmdef
+++ b/Packages/com.velvet.core/TestUtilities/Velvet.TestUtilities.asmdef
@@ -3,7 +3,8 @@
     "rootNamespace": "Velvet.TestUtilities",
     "references": [
         "Velvet",
-        "UnityEngine.TestRunner"
+        "UnityEngine.TestRunner",
+        "UniTask"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],


### PR DESCRIPTION
41 `await <source>.Task` sites across five fixtures had no bound. Each is a rendezvous with a stub the
code under test completes — so a change that stops reaching the completion leaves the await pending,
the case never returns, and the run hangs where it should have gone red.

`BoundedAwait.Bounded()` wraps each in a `WhenAny` against a delay and throws naming the caller and
the line. The bound is generous rather than tuned: every one of these completes in the same frame the
code under test reaches it, or never, so any bound above scheduling noise reports the same thing and a
large one cannot redden a healthy run on a loaded machine.

Measured, with the wedge the issue names — inverting `RouteBlockerManager`'s `Proceeding` skip so no
blocker predicate is ever invoked, which makes every routing rendezvous unreachable at once:

| | before | after |
|---|---|---|
| `RouterCancellationUnwindTests` under that change | hangs to the campaign's 900s timeout | **9 failed in 199s**, each naming the wait |

That is the difference between `TIMED_OUT` — which lands in `unmeasured` and denies the whole branch a
mutation receipt — and a killed mutant, which is what a survivable region is supposed to report.

`Velvet.TestUtilities` gains a `UniTask` reference for the helper's signature, and `AssemblyGraph.txt`
is regenerated for it.

`VelvetTaskEditModeContinuationTests`' two sites are left alone: they await a `VelvetTask`, not a
`UniTask`, and giving that its own bound belongs with the migration rather than here.

EditMode 4248 passed / 0 failed, PlayMode 184 / 0.

Closes #657
