### PR TITLE
docs(velvet): delete what the declaration says, and one line the code contradicts

### DIFF
--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/ObjectIsTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/ObjectIsTests.cs
@@ -236,9 +236,8 @@ namespace Velvet.Tests
         // pinned the branches this file's own header names was a test about Memoize. With these, the same
         // cut reddens the two signed-zero cases here.
 
-        // GREEN_ON_BASE(characterization): the base already distinguishes the zeros — this change adds
-        // no behaviour, it moves who says so. Measured: deleting `AreEqual<T>`'s raw-bit branches reddens
-        // nine cases in three other fixtures and none here, and reddens this one once it exists.
+        // GREEN_ON_BASE(characterization): the base already distinguishes the zeros; what moves is who
+        // says so, for the reason the region header gives.
         [Test]
         public void Given_FloatSignedZero_When_AreEqualOfFloat_Then_AreNotEqual()
         {
@@ -246,10 +245,9 @@ namespace Velvet.Tests
             Assert.That(ObjectIs.AreEqual(0f, -0f), Is.False);
         }
 
-        // GREEN_ON_BASE(characterization): the base already answers this, and so does a build with the
-        // raw-bit branch deleted — `EqualityComparer<float>` reaches `float.Equals`, which is true for two
-        // NaNs where `==` is false. It is here because the branch's contract is both halves, and the
-        // signed-zero case beside it is the half a cut can see.
+        // GREEN_ON_BASE(characterization): green under the cut too — `EqualityComparer<float>` reaches
+        // `float.Equals`, true for two NaNs. Here because the contract is both halves, and the case
+        // beside it is the half a cut can see.
         [Test]
         public void Given_FloatNaN_When_AreEqualOfFloat_Then_AreEqual()
         {

--- a/Packages/com.velvet.core/Runtime/Routing/RouteTree.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/RouteTree.cs
@@ -267,8 +267,6 @@ namespace Velvet
 
         #region Branch matching
 
-        /// <summary>One branch probe's state: everything the walk carries that does not change as it
-        /// descends, plus the two things it fills in.</summary>
         private ref struct Walk
         {
             public readonly List<RouteSegment> Pattern;
@@ -471,17 +469,10 @@ namespace Velvet
             return matches;
         }
 
-        /// <summary>
-        /// The path this route contributes to a match's base, with any segment the match skipped left
-        /// out. Advances <paramref name="patternOffset"/> past this route's share of the branch pattern.
-        /// </summary>
-        /// <remarks>
-        /// Walks <see cref="ParseRouteSegments"/> rather than splitting the path again: indexing into
-        /// `taken` needs the two readings to agree segment for segment, and they did not — one dropped
-        /// the empty part in `a//b` and the other kept it.
-        /// </remarks>
-        // Read off the branch's already-parsed pattern rather than the route's path: `ParseRouteSegments`
-        // is an iterator, and calling it here allocated an enumerator per route on every match.
+        // Read off the branch's already-parsed pattern rather than the route's path. Two readings of one
+        // path do not agree segment for segment -- one drops the empty part in `a//b` and the other keeps
+        // it -- and `taken` is indexed over the pattern, so the pattern is the reading that can be
+        // indexed. Re-parsing here also allocated an enumerator per route on every match.
         private static string ResolveRouteSegments(
             List<RouteSegment> pattern, int count, IReadOnlyDictionary<string, string> captured,
             int[] taken, ref int patternOffset)

--- a/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouterTests.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouterTests.cs
@@ -592,10 +592,7 @@ namespace Velvet.Tests
             // Suspend-mode failures route through OnSuspendLoaderFailed, which logs the exception.
             LogAssert.Expect(UnityEngine.LogType.Exception, new System.Text.RegularExpressions.Regex("deferred-failure"));
             tcs.TrySetException(new InvalidOperationException("deferred-failure"));
-            // No hop between the two: the completion source resumes the loader's `await` inline, the
-            // catch announces inline, and the Router's handler writes the error inline. A wait here
-            // would let a future hop through unnoticed, and one hop is not the same amount of progress
-            // on a runner as on the machine that counted it.
+            // No hop between the two: a wait here would let a future one through unnoticed.
             Assume.That(router.CurrentLoaderErrors.Count, Is.EqualTo(1),
                 "Precondition: the failure was recorded synchronously with the exception being set");
             router.NavigateSync("/other");


### PR DESCRIPTION
Three comments that fail `CLAUDE.md`'s deletion test, and one of them was false.

**`ResolveRouteSegments`' remarks said it walks `ParseRouteSegments`.** It stopped doing that when the
resolution moved onto the branch's already-parsed pattern, and the comment two lines below it says so
— so the file carried a sentence and its contradiction, three lines apart. What survives is the
reason the pattern is the reading that can be indexed: two readings of one path do not agree segment
for segment, one drops the empty part in `a//b` and the other keeps it, and `taken` is indexed over
the pattern. The two blocks become one.

**`Walk`'s summary restated its own fields.** "Everything the walk carries that does not change as it
descends, plus the two things it fills in", over four fields two of which are `readonly`. Deleted.

**A four-line note above an `Assume` restated the `Assume`'s own message**, plus a mechanism that
sentence's own case is what pins — measured, by adding a yield — and a justification tied to a CI
failure that turned out not to have happened. One line left: a wait there would let a future hop
through unnoticed, which is the part a future edit could break.

Two `GREEN_ON_BASE` reasons in `ObjectIsTests` also lose a measurement their region header states four
lines above them.

Comments only, no behaviour. EditMode 4248 passed / 0 failed.

No issue: found reading back what this session's own changes added.
