### PR TITLE
docs(velvet): audit the Store feature, and drop a sentence naming the wrong comparer

### DIFF
--- a/Packages/com.velvet.core/Runtime/Store/StoreShallowEqualityComparer.cs
+++ b/Packages/com.velvet.core/Runtime/Store/StoreShallowEqualityComparer.cs
@@ -2,18 +2,12 @@ using System.Collections.Generic;
 
 namespace Velvet
 {
-    /// <summary>
-    /// Shallow equality comparers for selector return values that are sequences.
-    /// Elements are compared with <c>Object.is</c> semantics (see <see cref="Sequence{T}"/> for the
-    /// exact per-type rules) at matching positions with matching lengths; deep equality is
-    /// intentionally not performed.
-    /// </summary>
     /// <remarks>
-    /// Use this for selectors that return an array/list slice, where a fresh list instance with the
-    /// same elements should not be treated as a change. The canonical form is
-    /// <c>UseStore(store, s =&gt; s.Items, StoreShallowEqualityComparer.Sequence&lt;Item&gt;())</c>.
-    /// Tuple / record selectors do not need this helper — <see cref="EqualityComparer{T}.Default"/>
-    /// already performs member-wise equality for <c>ValueTuple</c> and value-type records.
+    /// For a selector returning a list, where a fresh instance of the same elements should not read as a
+    /// change: <c>UseStore(store, s =&gt; s.Items, StoreShallowEqualityComparer.Sequence&lt;Item&gt;())</c>.
+    /// A selector returning a tuple or a value-type record needs no comparer —
+    /// <see cref="Hooks.UseStore{TStore,TSel}"/> documents which selector shapes its default already
+    /// answers for.
     /// </remarks>
     public static class StoreShallowEqualityComparer
     {


### PR DESCRIPTION
The first feature of the audit #600 sequences, taken whole: `Runtime/Store/` — five files, 441 lines,
every comment read and each claim checked in the code rather than remembered.

**One false claim, and it is the shape the issue warns about.**
`StoreShallowEqualityComparer`'s remarks said a tuple or record selector needs no comparer because
`EqualityComparer<T>.Default` already does member-wise equality. `UseStore`'s default is not
`EqualityComparer<T>.Default` — it is `ObjectIsEqualityComparer`, under which a fresh `record class`
instance of equal content *does* read as a change. So the sentence named the wrong comparer and
reached the wrong conclusion for one of the two shapes it covers.

`Hooks.UseStore`'s own `<param>` states this correctly and at length. The remarks now point there
instead of restating it, which is the single-source rule this repository already holds for guides.

The class summary above it went with it: "shallow equality comparers for selector return values that
are sequences", over `StoreShallowEqualityComparer.Sequence<T>()`, restated the declaration, and the
per-type rules it forwarded to are spelled out on the method itself two lines below.

**Everything else in the feature is true and worth keeping**, checked rather than assumed:

- `StoreStateNotifier`'s two sentences — the snapshot keeps subscription changes out of the in-flight
  pass, and callbacks read the live `Value` so a nested `Notify` supersedes. Both are invariants the
  loop's shape depends on: it iterates the array while `Subscribe`/`Dispose` only null the cache, and
  it passes the property rather than the parameter.
- `Store.TryApply`'s "StoreTests pins both branches". `TestState` is a `sealed record` and
  `StructState` a `record struct`, so both arms of `AreEqualObjects`' value-type/reference-type split
  have a state type in the fixture. I read this as false at first, having grepped for the two-word
  spelling `record class`.
- The three "registration precedes the immediate callback" notes: ordering constraints a reader would
  otherwise reverse.
- `StoreLogger.LogError`'s "carries no `[Conditional]` of its own, unlike the two above": the two
  above carry two each, this one none.

Ten comment lines out of the feature's 138, and the one that mattered was one sentence long — which is
the issue's own finding about where the false ones are.

EditMode 4248 passed / 0 failed.

Refs #600 — one feature of the audit it sequences. The rest stay open there.
