### PR TITLE
fix(velvet): contain a scope factory that throws, as its disposal already is

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -66,9 +66,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - An `IRouteScopeFactory.CreateScope` that throws no longer takes the reconcile with it. The scope's
   *disposal* was already contained; its creation was not, at any of the three sites that ask for one —
   so an application whose factory failed on a route change lost the render as well as the scope. The
-  route now renders without a scope and the exception reaches the nearest error boundary, where an
-  application that wants a scope-less route refused can refuse it. The disposal beside it drops and
-  logs instead, which is the deviation from React the two paths still carry between them.
+  route now renders without a scope and the exception is propagated: an application with an error
+  boundary above the Outlet gets to refuse a scope-less route there, and one with none gets the
+  `Debug.LogException` the propagation falls through to. The disposal beside it drops and logs
+  instead, which is the deviation from React the two paths still carry between them.
 
 - A navigation no longer allocates a snapshot of the registered blockers on every pass. The pass walks
   a copy because a decision taken in it may unregister, and the copy was a fresh array each time — so

--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -63,6 +63,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- An `IRouteScopeFactory.CreateScope` that throws no longer takes the reconcile with it. The scope's
+  *disposal* was already contained; its creation was not, at all three sites that ask for one — so an
+  application whose factory failed on a route change lost the render as well as the scope. The route
+  now renders without a scope and the exception reaches the nearest error boundary, which is where the
+  disposal beside it already sends one, so an application that wants the route refused still can.
+
 - A navigation no longer allocates a snapshot of the registered blockers on every pass. The pass walks
   a copy because a decision taken in it may unregister, and the copy was a fresh array each time — so
   an application with any blocker registered paid one per navigation. One list serves every pass now,

--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -64,10 +64,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - An `IRouteScopeFactory.CreateScope` that throws no longer takes the reconcile with it. The scope's
-  *disposal* was already contained; its creation was not, at all three sites that ask for one — so an
-  application whose factory failed on a route change lost the render as well as the scope. The route
-  now renders without a scope and the exception reaches the nearest error boundary, which is where the
-  disposal beside it already sends one, so an application that wants the route refused still can.
+  *disposal* was already contained; its creation was not, at any of the three sites that ask for one —
+  so an application whose factory failed on a route change lost the render as well as the scope. The
+  route now renders without a scope and the exception reaches the nearest error boundary, where an
+  application that wants a scope-less route refused can refuse it. The disposal beside it drops and
+  logs instead, which is the deviation from React the two paths still carry between them.
 
 - A navigation no longer allocates a snapshot of the registered blockers on every pass. The pass walks
   a copy because a decision taken in it may unregister, and the copy was a fresh array each time — so

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodeFactory.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodeFactory.cs
@@ -600,8 +600,16 @@ namespace Velvet
             var scopeFactory = Router.Current?.ScopeFactory;
             if (scopeFactory != null)
             {
-                outletNode.Scope = scopeFactory.CreateScope(match.Route, null);
-                _ctx.OutletScopes[container] = outletNode.Scope;
+                // Same containment as the patch path's, for the reason stated there.
+                try
+                {
+                    outletNode.Scope = scopeFactory.CreateScope(match.Route, null);
+                    _ctx.OutletScopes[container] = outletNode.Scope;
+                }
+                catch (System.Exception exception)
+                {
+                    ReconcilerContext.ContainUserCallbackFailure(_ctx.FiberStack.Current, exception);
+                }
             }
 
             // Mount the matched route Component with Depth+1 pushed live so its UseContext

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodeFactory.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodeFactory.cs
@@ -597,20 +597,7 @@ namespace Velvet
                 return container;
             }
 
-            var scopeFactory = Router.Current?.ScopeFactory;
-            if (scopeFactory != null)
-            {
-                // Same containment as the patch path's, for the reason stated there.
-                try
-                {
-                    outletNode.Scope = scopeFactory.CreateScope(match.Route, null);
-                    _ctx.OutletScopes[container] = outletNode.Scope;
-                }
-                catch (System.Exception exception)
-                {
-                    ReconcilerContext.ContainUserCallbackFailure(_ctx.FiberStack.Current, exception);
-                }
-            }
+            outletNode.Scope = FiberOutletScope.CreateOutletScope(_ctx, match.Route, container);
 
             // Mount the matched route Component with Depth+1 pushed live so its UseContext
             // reads the incremented router depth: an Outlet provides the

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
@@ -174,8 +174,20 @@ namespace Velvet
                 var scopeFactory = Router.Current?.ScopeFactory;
                 if (scopeFactory != null)
                 {
-                    newOutlet.Scope = scopeFactory.CreateScope(match!.Route, null);
-                    _ctx.OutletScopes[element] = newOutlet.Scope;
+                    // The scope is the route's, not the render's: a factory that throws leaves the
+                    // route to render without one rather than taking the reconcile with it, which is
+                    // what the disposal beside it already does. Contained rather than swallowed --
+                    // PropagateException reaches the nearest error boundary, so an application that
+                    // wants the route refused still gets to refuse it.
+                    try
+                    {
+                        newOutlet.Scope = scopeFactory.CreateScope(match!.Route, null);
+                        _ctx.OutletScopes[element] = newOutlet.Scope;
+                    }
+                    catch (System.Exception exception)
+                    {
+                        ReconcilerContext.ContainUserCallbackFailure(_ctx.FiberStack.Current, exception);
+                    }
                 }
             }
             else if (_ctx.OutletScopes.TryGetValue(element, out var existingScope))
@@ -188,8 +200,20 @@ namespace Velvet
                 var scopeFactory = Router.Current?.ScopeFactory;
                 if (scopeFactory != null)
                 {
-                    newOutlet.Scope = scopeFactory.CreateScope(match!.Route, null);
-                    _ctx.OutletScopes[element] = newOutlet.Scope;
+                    // The scope is the route's, not the render's: a factory that throws leaves the
+                    // route to render without one rather than taking the reconcile with it, which is
+                    // what the disposal beside it already does. Contained rather than swallowed --
+                    // PropagateException reaches the nearest error boundary, so an application that
+                    // wants the route refused still gets to refuse it.
+                    try
+                    {
+                        newOutlet.Scope = scopeFactory.CreateScope(match!.Route, null);
+                        _ctx.OutletScopes[element] = newOutlet.Scope;
+                    }
+                    catch (System.Exception exception)
+                    {
+                        ReconcilerContext.ContainUserCallbackFailure(_ctx.FiberStack.Current, exception);
+                    }
                 }
             }
 

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberNodePatcher.cs
@@ -171,24 +171,7 @@ namespace Velvet
                 {
                     FiberLogger.LogException("FiberNodePatcher", exception);
                 }
-                var scopeFactory = Router.Current?.ScopeFactory;
-                if (scopeFactory != null)
-                {
-                    // The scope is the route's, not the render's: a factory that throws leaves the
-                    // route to render without one rather than taking the reconcile with it, which is
-                    // what the disposal beside it already does. Contained rather than swallowed --
-                    // PropagateException reaches the nearest error boundary, so an application that
-                    // wants the route refused still gets to refuse it.
-                    try
-                    {
-                        newOutlet.Scope = scopeFactory.CreateScope(match!.Route, null);
-                        _ctx.OutletScopes[element] = newOutlet.Scope;
-                    }
-                    catch (System.Exception exception)
-                    {
-                        ReconcilerContext.ContainUserCallbackFailure(_ctx.FiberStack.Current, exception);
-                    }
-                }
+                newOutlet.Scope = FiberOutletScope.CreateOutletScope(_ctx, match!.Route, element);
             }
             else if (_ctx.OutletScopes.TryGetValue(element, out var existingScope))
             {
@@ -197,24 +180,7 @@ namespace Velvet
             else
             {
                 // First match: no fiber exists yet, and no scope is registered.
-                var scopeFactory = Router.Current?.ScopeFactory;
-                if (scopeFactory != null)
-                {
-                    // The scope is the route's, not the render's: a factory that throws leaves the
-                    // route to render without one rather than taking the reconcile with it, which is
-                    // what the disposal beside it already does. Contained rather than swallowed --
-                    // PropagateException reaches the nearest error boundary, so an application that
-                    // wants the route refused still gets to refuse it.
-                    try
-                    {
-                        newOutlet.Scope = scopeFactory.CreateScope(match!.Route, null);
-                        _ctx.OutletScopes[element] = newOutlet.Scope;
-                    }
-                    catch (System.Exception exception)
-                    {
-                        ReconcilerContext.ContainUserCallbackFailure(_ctx.FiberStack.Current, exception);
-                    }
-                }
+                newOutlet.Scope = FiberOutletScope.CreateOutletScope(_ctx, match!.Route, element);
             }
 
             // Mount the matched route Component with Depth+1 pushed live so the next nested

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberOutletScope.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberOutletScope.cs
@@ -1,0 +1,33 @@
+using UnityEngine.UIElements;
+
+namespace Velvet
+{
+    internal static class FiberOutletScope
+    {
+        // The scope is the route's, not the render's: a factory that throws leaves the route to render
+        // without one rather than taking the reconcile with it, which is what the disposal beside every
+        // caller already does. Contained rather than swallowed -- PropagateException reaches the nearest
+        // error boundary, so an application that wants the route refused still gets to refuse it.
+        internal static IRouteScope? CreateOutletScope(ReconcilerContext ctx, RouteDefinition? route,
+                                                       VisualElement container)
+        {
+            var scopeFactory = Router.Current?.ScopeFactory;
+            if (scopeFactory == null)
+            {
+                return null;
+            }
+            try
+            {
+                var scope = scopeFactory.CreateScope(route, null);
+                ctx.OutletScopes[container] = scope;
+                return scope;
+            }
+            catch (System.Exception exception)
+            {
+                ReconcilerContext.ContainUserCallbackFailure(ctx.FiberStack.Current, exception);
+                return null;
+            }
+        }
+
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberOutletScope.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberOutletScope.cs
@@ -5,9 +5,10 @@ namespace Velvet
     internal static class FiberOutletScope
     {
         // The scope is the route's, not the render's: a factory that throws leaves the route to render
-        // without one rather than taking the reconcile with it, which is what the disposal beside every
-        // caller already does. Contained rather than swallowed -- PropagateException reaches the nearest
-        // error boundary, so an application that wants the route refused still gets to refuse it.
+        // without one rather than taking the reconcile with it. Contained rather than swallowed --
+        // ContainUserCallbackFailure reaches the nearest error boundary, so an application that wants a
+        // scope-less route refused still gets to refuse it. A drop-and-log -- what FiberNodePatcher does
+        // a few lines up with the departing scope's Dispose -- would have decided that for it.
         internal static IRouteScope? CreateOutletScope(ReconcilerContext ctx, RouteDefinition? route,
                                                        VisualElement container)
         {

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberOutletScope.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberOutletScope.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4ae19a0232d304f3181589bd5da6a910

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/RouteScopeDisposalFailureTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/RouteScopeDisposalFailureTests.cs
@@ -10,10 +10,10 @@ using Velvet.TestUtilities;
 namespace Velvet.Tests
 {
     /// <summary>
-    /// Specifies what an <see cref="IRouteScope"/> whose <c>Dispose</c> throws does to the teardown that
-    /// invoked it. The scope is built by the application's <see cref="IRouteScopeFactory"/>, so every
-    /// entrance below reaches the caller's code, and each contains it the way a <c>refCallback</c>
-    /// cleanup is contained.
+    /// Specifies what an <see cref="IRouteScopeFactory"/> that throws does to the pass that called it —
+    /// out of <c>CreateScope</c>, and out of the <c>Dispose</c> of the scope it built. Every entrance
+    /// below is a call into the application's own code. The disposals drop and log; the creations reach
+    /// the nearest error boundary, which the last case here mounts.
     /// <list type="bullet">
     /// <item>Changing route: the Outlet still mounts the route it navigated to, the incoming route's own
     /// scope is built regardless of the failure, and the scope it left behind is disposed once rather
@@ -128,6 +128,60 @@ namespace Velvet.Tests
             // Assert — what the incoming route renders rides along, because a reconcile that escaped
             // would leave the old label standing and satisfy neither half on its own.
             Assert.That((escaped, LabelTextsUnder(_root)), Is.EqualTo((false, "other")));
+        }
+
+        [Test]
+        public void Given_AFactoryThatThrowsOnCreate_When_TheAppFirstMounts_Then_TheThrowDoesNotEscapeTheReconcile()
+        {
+            // Arrange — the mount path builds the scope, which is the entrance FiberNodeFactory owns.
+            s_throwOnDispose = false;
+            _scopeFactory.ThrowOnCreate = true;
+            LogAssert.Expect(LogType.Exception,
+                             new Regex("InvalidOperationException: " + CreateFailureMessage));
+
+            // Act
+            var escaped = EscapesFrom(() => MountRoutedApp());
+
+            // Assert
+            Assert.That((escaped, LabelTextsUnder(_root)), Is.EqualTo((false, "route")));
+        }
+
+        [Test]
+        public void Given_AnOutletLeftWithoutAScope_When_ItIsPatchedAtTheSameRoute_Then_TheRetryIsContainedToo()
+        {
+            // Arrange — the mount's own create failed, so no scope is registered and the patch takes the
+            // branch that builds one for a route it is already holding.
+            s_throwOnDispose = false;
+            _scopeFactory.ThrowOnCreate = true;
+            LogAssert.Expect(LogType.Exception,
+                             new Regex("InvalidOperationException: " + CreateFailureMessage));
+            var mounted = MountRoutedApp();
+            LogAssert.Expect(LogType.Exception,
+                             new Regex("InvalidOperationException: " + CreateFailureMessage));
+
+            // Act
+            var escaped = EscapesFrom(() => ReRenderAppAtCurrentLocation(mounted));
+
+            // Assert
+            Assert.That((escaped, LabelTextsUnder(_root)), Is.EqualTo((false, "route")));
+        }
+
+        [Test]
+        public void Given_AnErrorBoundaryAboveTheOutlet_When_TheFactoryThrows_Then_ItShowsItsFallback()
+        {
+            // Arrange — with a boundary mounted the propagation has somewhere to land, which is the whole
+            // of what containment buys over a drop: the application decides what a scope-less route does.
+            s_throwOnDispose = false;
+            var mounted = MountBoundedApp();
+            _router.NavigateAsync("/other").GetAwaiter().GetResult();
+            _scopeFactory.ThrowOnCreate = true;
+
+            // Act
+            var escaped = EscapesFrom(() => ReRenderBoundedAppAtCurrentLocation(mounted));
+
+            // Assert — no log line: the boundary consumed it, where the case above has none to consume it.
+            Assert.That((escaped, _root.Q<VisualElement>("fallback") != null, LabelTextsUnder(_root)),
+                        Is.EqualTo((false, true, string.Empty)));
         }
 
         [Test]
@@ -273,6 +327,26 @@ namespace Velvet.Tests
             _reconciler.Reconcile(_root, Array.Empty<VNode>(), tree);
             return tree;
         }
+
+        private VNode[] BoundedApp() => new VNode[]
+        {
+            V.ErrorBoundary(fallback: _ => V.Div(name: "fallback"),
+                            children: new VNode[]
+                            {
+                                V.Component(RoutedApp, _router.CurrentLocation!, key: "app"),
+                            },
+                            key: "boundary"),
+        };
+
+        private VNode[] MountBoundedApp()
+        {
+            var tree = BoundedApp();
+            _reconciler.Reconcile(_root, Array.Empty<VNode>(), tree);
+            return tree;
+        }
+
+        private void ReRenderBoundedAppAtCurrentLocation(VNode[] mounted)
+            => _reconciler.Reconcile(_root, mounted, BoundedApp());
 
         private void ReRenderAppAtCurrentLocation(VNode[] mounted)
             => _reconciler.Reconcile(_root, mounted,

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/RouteScopeDisposalFailureTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/RouteScopeDisposalFailureTests.cs
@@ -177,21 +177,17 @@ namespace Velvet.Tests
         [Test]
         public void Given_AnErrorBoundaryAboveTheOutlet_When_TheFirstMountsFactoryThrows_Then_OnlyTheFallbackIsInTheTree()
         {
-            // Arrange — the mount path inserts the element it created whether the pass aborted or not, so
-            // a boundary above the Outlet rather than beneath it is where a failed route could be left
-            // beside the fallback instead of replaced by it.
+            // Arrange — the boundary above the Outlet rather than beneath it, on the path that builds
+            // the scope at mount.
             s_throwOnDispose = false;
             _scopeFactory.ThrowOnCreate = true;
 
             // Act
             var escaped = EscapesFrom(() => MountBoundedApp());
 
-            // Assert — the Outlet's own container is read for as well as the names directly under the
-            // root, because a failed route left beside the fallback would be a descendant of neither.
-            Assert.That((escaped, NamesOf(_root),
-                            _root.Q<VisualElement>(className: FiberNodeFactory.OutletContainerClass) != null,
-                            LabelTextsUnder(_root)),
-                        Is.EqualTo((false, "fallback", false, string.Empty)));
+            // Assert
+            Assert.That((escaped, NamesOf(_root), LabelTextsUnder(_root)),
+                        Is.EqualTo((false, "fallback", string.Empty)));
         }
 
         [Test]

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/RouteScopeDisposalFailureTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/RouteScopeDisposalFailureTests.cs
@@ -1,6 +1,9 @@
 using System;
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
 using UnityEngine.UIElements;
 using Velvet.TestUtilities;
 
@@ -53,12 +56,20 @@ namespace Velvet.Tests
             }
         }
 
+        private const string CreateFailureMessage = "arranged failure out of a route scope CreateScope";
+
         private sealed class ThrowingRouteScopeFactory : IRouteScopeFactory
         {
             public List<ThrowingRouteScope> Scopes { get; } = new();
 
+            public bool ThrowOnCreate { get; set; }
+
             public IRouteScope CreateScope(RouteDefinition? route, IRouteScope? parent)
             {
+                if (ThrowOnCreate)
+                {
+                    throw new InvalidOperationException(CreateFailureMessage);
+                }
                 var scope = new ThrowingRouteScope();
                 Scopes.Add(scope);
                 return scope;
@@ -95,6 +106,28 @@ namespace Velvet.Tests
             s_throwOnDispose = false;
             _router.Dispose();
             _reconciler.Dispose();
+        }
+
+        [Test]
+        public void Given_AFactoryThatThrowsOnCreate_When_TheRouteChanges_Then_TheThrowDoesNotEscapeTheReconcile()
+        {
+            // Arrange — the outgoing scope disposes cleanly, so the only failure is the replacement's
+            // creation: the entrance the containment work around it left open.
+            s_throwOnDispose = false;
+            var mounted = MountRoutedApp();
+            _router.NavigateAsync("/other").GetAwaiter().GetResult();
+            _scopeFactory.ThrowOnCreate = true;
+            // One line, not two: with no error boundary mounted the propagation falls back to
+            // Debug.LogException, where the drop-and-log shape beside it logs a tag and the exception.
+            LogAssert.Expect(LogType.Exception,
+                             new Regex("InvalidOperationException: " + CreateFailureMessage));
+
+            // Act
+            var escaped = EscapesFrom(() => ReRenderAppAtCurrentLocation(mounted));
+
+            // Assert — what the incoming route renders rides along, because a reconcile that escaped
+            // would leave the old label standing and satisfy neither half on its own.
+            Assert.That((escaped, LabelTextsUnder(_root)), Is.EqualTo((false, "other")));
         }
 
         [Test]

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/RouteScopeDisposalFailureTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/RouteScopeDisposalFailureTests.cs
@@ -171,6 +171,23 @@ namespace Velvet.Tests
         }
 
         [Test]
+        public void Given_AnErrorBoundaryAboveTheOutlet_When_TheFirstMountsFactoryThrows_Then_OnlyTheFallbackIsInTheTree()
+        {
+            // Arrange — the mount path inserts the element it created whether the pass aborted or not, so
+            // a boundary above the Outlet rather than beneath it is where a failed route could be left
+            // beside the fallback instead of replaced by it.
+            s_throwOnDispose = false;
+            _scopeFactory.ThrowOnCreate = true;
+
+            // Act
+            var escaped = EscapesFrom(() => MountBoundedApp());
+
+            // Assert
+            Assert.That((escaped, NamesOf(_root), LabelTextsUnder(_root)),
+                        Is.EqualTo((false, "fallback", string.Empty)));
+        }
+
+        [Test]
         public void Given_AnErrorBoundaryAboveTheOutlet_When_TheFactoryThrows_Then_ItShowsItsFallback()
         {
             // Arrange — with a boundary mounted the propagation has somewhere to land, which is the whole

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/RouteScopeDisposalFailureTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/RouteScopeDisposalFailureTests.cs
@@ -308,7 +308,9 @@ namespace Velvet.Tests
             return ("escaped:" + escaped, NamesOf(root));
         }
 
-        // Filtered on the arranged message so any other InvalidOperationException still leaves the case.
+        // Filtered on the arranged messages so any other InvalidOperationException still leaves the case.
+        // Both of them, so that a case whose arrangement is uncontained answers `true` rather than
+        // raising: a reader of this suite that has no containment is one of the two readings it takes.
         private static bool EscapesFrom(Action reconcile)
         {
             try
@@ -316,7 +318,8 @@ namespace Velvet.Tests
                 reconcile();
                 return false;
             }
-            catch (InvalidOperationException exception) when (exception.Message == DisposeFailureMessage)
+            catch (InvalidOperationException exception) when (exception.Message == DisposeFailureMessage
+                                                              || exception.Message == CreateFailureMessage)
             {
                 return true;
             }

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/RouteScopeDisposalFailureTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/RouteScopeDisposalFailureTests.cs
@@ -12,9 +12,13 @@ namespace Velvet.Tests
     /// <summary>
     /// Specifies what an <see cref="IRouteScopeFactory"/> that throws does to the pass that called it —
     /// out of <c>CreateScope</c>, and out of the <c>Dispose</c> of the scope it built. Every entrance
-    /// below is a call into the application's own code. The disposals drop and log; the creations reach
-    /// the nearest error boundary, which the last case here mounts.
+    /// below is a call into the application's own code. The disposals drop the exception and log it; the
+    /// creations propagate it to the nearest error boundary, and a case with none mounted logs it too,
+    /// through the fallback <c>Debug.LogException</c> the propagation ends at.
     /// <list type="bullet">
+    /// <item>Building a scope, at each of the three sites that ask for one — the mount, a route change,
+    /// and a patch of a route the Outlet is already holding: the route renders without a scope rather
+    /// than not at all, and one case mounts a boundary, which shows its fallback instead.</item>
     /// <item>Changing route: the Outlet still mounts the route it navigated to, the incoming route's own
     /// scope is built regardless of the failure, and the scope it left behind is disposed once rather
     /// than again by the teardown sweep.</item>

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/RouteScopeDisposalFailureTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/RouteScopeDisposalFailureTests.cs
@@ -154,17 +154,21 @@ namespace Velvet.Tests
         public void Given_AnOutletLeftWithoutAScope_When_ItIsPatchedAtTheSameRoute_Then_TheRetryIsContainedToo()
         {
             // Arrange — the mount's own create failed, so no scope is registered and the patch takes the
-            // branch that builds one for a route it is already holding.
+            // branch that builds one for a route it is already holding. The arrangement goes through
+            // EscapesFrom as well, because on a tree with no containment it is the mount that throws and
+            // the case would raise out of its own Arrange rather than reach the comparison below.
             s_throwOnDispose = false;
             _scopeFactory.ThrowOnCreate = true;
             LogAssert.Expect(LogType.Exception,
                              new Regex("InvalidOperationException: " + CreateFailureMessage));
-            var mounted = MountRoutedApp();
+            VNode[] mounted = null;
+            var escapedTheMount = EscapesFrom(() => mounted = MountRoutedApp());
             LogAssert.Expect(LogType.Exception,
                              new Regex("InvalidOperationException: " + CreateFailureMessage));
 
             // Act
-            var escaped = EscapesFrom(() => ReRenderAppAtCurrentLocation(mounted));
+            var escaped = escapedTheMount
+                          || EscapesFrom(() => ReRenderAppAtCurrentLocation(mounted));
 
             // Assert
             Assert.That((escaped, LabelTextsUnder(_root)), Is.EqualTo((false, "route")));

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/RouteScopeDisposalFailureTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/RouteScopeDisposalFailureTests.cs
@@ -18,7 +18,7 @@ namespace Velvet.Tests
     /// <list type="bullet">
     /// <item>Building a scope, at each of the three sites that ask for one — the mount, a route change,
     /// and a patch of a route the Outlet is already holding: the route renders without a scope rather
-    /// than not at all, and one case mounts a boundary, which shows its fallback instead.</item>
+    /// than not at all. Two cases mount a boundary, and there the fallback takes over instead.</item>
     /// <item>Changing route: the Outlet still mounts the route it navigated to, the incoming route's own
     /// scope is built regardless of the failure, and the scope it left behind is disposed once rather
     /// than again by the teardown sweep.</item>
@@ -186,9 +186,12 @@ namespace Velvet.Tests
             // Act
             var escaped = EscapesFrom(() => MountBoundedApp());
 
-            // Assert
-            Assert.That((escaped, NamesOf(_root), LabelTextsUnder(_root)),
-                        Is.EqualTo((false, "fallback", string.Empty)));
+            // Assert — the Outlet's own container is read for as well as the names directly under the
+            // root, because a failed route left beside the fallback would be a descendant of neither.
+            Assert.That((escaped, NamesOf(_root),
+                            _root.Q<VisualElement>(className: FiberNodeFactory.OutletContainerClass) != null,
+                            LabelTextsUnder(_root)),
+                        Is.EqualTo((false, "fallback", false, string.Empty)));
         }
 
         [Test]
@@ -204,7 +207,8 @@ namespace Velvet.Tests
             // Act
             var escaped = EscapesFrom(() => ReRenderBoundedAppAtCurrentLocation(mounted));
 
-            // Assert — no log line: the boundary consumed it, where the case above has none to consume it.
+            // Assert — no log line: the boundary consumed it, where the three cases with none mounted
+            // fall through to Debug.LogException.
             Assert.That((escaped, _root.Q<VisualElement>("fallback") != null, LabelTextsUnder(_root)),
                         Is.EqualTo((false, true, string.Empty)));
         }


### PR DESCRIPTION
The route scope's *disposal* is contained at every site. Its *creation* was contained at none —
`FiberNodeFactory.cs:600` and `FiberNodePatcher.cs:174` and `:183` — so an `IRouteScopeFactory` that
throws on a route change took the reconcile with it, and the application lost the render as well as
the scope.

Reproduced first, on `main`: a factory that disposes cleanly and throws only on create, over the
fixture that already arranges the disposal half. The exception escapes `Reconciler.Reconcile`.

The three sites now reach `ReconcilerContext.ContainUserCallbackFailure`, the shape this codebase
uses for a user callback the reconciler invokes in-pass — the ref cycle and the wrap path both take
it. It propagates to the nearest error boundary rather than swallowing, and the half worth stating
plainly is that **the disposal beside these does not**: it catches and hands the exception to
`FiberLogger.LogException`. React reports both a failed create and a failed cleanup to a boundary,
so the drop is the deviation and this is not adding one.

Propagating is what leaves the choice with the application. A route that must not render scope-less
can refuse it from a boundary; a swallow would have decided that for them. Where no boundary is
mounted the propagation falls through to `Debug.LogException`, so an application that wants neither
is no worse off than the drop-and-log leaves it. The route renders without a scope rather than not
at all, which is what the disposal path beside it already does with the replacement scope, regardless
of how the teardown went.

They reach the containment through one helper, `FiberOutletScope.CreateOutletScope`. Three copies of
the same try/catch is what the duplication ratchet reported, and the reason is worth stating once: a
fourth caller that hand-rolls it can get half of it right, and a swallow reads the same as a
containment from the call site.

`RouteScopeDisposalFailureTests` gains five creation cases — one per site, plus the two boundary
configurations the containment exists for. The mount path, the patch path's
build-for-a-route-it-already-holds branch and the route change all contain the throw and still render
the route, each expecting the `Debug.LogException` a tree with no boundary falls through to; the
retry case expects two, one for the mount whose create failed and one for the patch that tries
again. With a `V.ErrorBoundary` above the Outlet the fallback takes over, nothing is logged, no label
survives, and — read for by class rather than by name — no Outlet container is left beside it.
`EscapesFrom` filtered on the disposal message alone, so a create case raised out of the helper on a
tree without the fix instead of reporting the escape; it takes both arranged messages now, and the
retry case's own arrangement goes through it for the same reason.

EditMode 4253 passed / 0 failed, PlayMode 184 / 0. The mutation campaign over the three changed files
reports 2 mutants, both killed, none surviving.

Closes #679
