### PR TITLE
fix(velvet): refuse a results file and a project that are of different trees

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -429,9 +429,14 @@ is refused rather than taken. Pointing it at another worktree's results with `--
 default measured exit 0 where the two trees declare the same fixtures, and where they do not it
 names a fixture as a stranger — the sentence for a stale `Library`, about work that is fine. Where
 the results file *sits* is not the question: the story-capture recipe above writes to `/tmp` from a
-run whose project is the checkout, and a path the log names that this machine does not have is an
-artifact out of a container, which is what CI reads. What it still cannot separate is two runs of
-the same project writing a results file of the same name; what answers that is the headless recipe's
+run whose project is the checkout.
+
+Two runs are stood aside for rather than compared, because their tree is not here: one inside a
+container, which names the container's path and is what CI reads, and one whose tree has since been
+deleted — the base tree the base-red harness builds and removes. A results file of either read
+against this checkout's sources passes unremarked, and what keeps the second out of the way is the
+rule that a directory argument is not descended into. It still cannot separate two runs of the same
+project writing a results file of the same name; what answers that is the headless recipe's
 per-worktree logs directory, not the guard.
 
 Each Unity job in CI runs it after the suite, and CLAUDE.md's headless recipe runs it beside

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -421,9 +421,18 @@ leaves the previous one there to be read; the guard refuses a results file no lo
 a log carrying a line rendered as a compiler error whichever analyzer raised it, and a fixture no
 source here declares reported under any assembly but one a resolved package owns alone — the last of
 these asking nothing of the log at all. Every reading it cannot take is a refusal too, since a guard
-exiting 0 unread looks exactly like one that checked. What it cannot separate is two runs writing a
-results file of the same name; what answers that is the headless recipe's per-worktree logs
-directory, not the guard.
+exiting 0 unread looks exactly like one that checked.
+
+Before those three it asks whether the run and the sources are of one tree at all. The log names the
+project the editor opened; if that directory is on this machine and is not `--project`, the reading
+is refused rather than taken. Pointing it at another worktree's results with `--project` left to
+default measured exit 0 where the two trees declare the same fixtures, and where they do not it
+names a fixture as a stranger — the sentence for a stale `Library`, about work that is fine. Where
+the results file *sits* is not the question: the story-capture recipe above writes to `/tmp` from a
+run whose project is the checkout, and a path the log names that this machine does not have is an
+artifact out of a container, which is what CI reads. What it still cannot separate is two runs of
+the same project writing a results file of the same name; what answers that is the headless recipe's
+per-worktree logs directory, not the guard.
 
 Each Unity job in CI runs it after the suite, and CLAUDE.md's headless recipe runs it beside
 `assert_no_inconclusive.py`. `scripts/test_quality/test_assert_results_from_this_tree.py` holds it,

--- a/scripts/test_quality/assert_results_from_this_tree.py
+++ b/scripts/test_quality/assert_results_from_this_tree.py
@@ -13,16 +13,16 @@ One precondition before any of them: the log says which project the editor opene
 be the project this is pointed at. A caller who spells an absolute path to another worktree's output
 and lets --project default is naming two trees, and the third reading below is then a comparison
 across them. Measured on two worktrees of this repository declaring the same fixtures: exit 0,
-having compared one tree's sources against the other's results. The pairing is caught only in the
-direction where the tree that ran declares a fixture this one does not -- and there it reports a
-stranger, which is the sentence for a stale Library rather than for a call pointed at two trees.
+having compared one tree's sources against the other's results. Without this the pairing is caught
+in two narrow directions only -- where the tree that ran declares a fixture this one does not, and
+where it declares no assembly this one names at all -- and the first of those reports a stranger,
+which is the sentence for a stale Library rather than for a call pointed at two trees.
 
 Read off the log rather than from where the files sit. Location is not the same question: the
 story-capture recipe in CONTRIBUTING.md writes its results to /tmp from a run whose project is the
 checkout, and refusing that would be refusing a correct pairing. What the log names is the project
-the run measured, which is the thing this has to agree with. A path it names that does not exist
-here is not read -- an artifact downloaded out of a container names the container's path, and the
-run it came from is not one this machine can locate.
+the run measured, which is the thing this has to agree with. What it cannot reach is a run whose
+tree is not here to compare -- `measured_elsewhere` owns which those are.
 
 Three readings, and the run has to survive all of them:
 
@@ -336,10 +336,15 @@ PROJECT_OPENED = re.compile(r"^Successfully changed project path to:\s*(.+?)\s*$
 def measured_elsewhere(project, logs):
     """Every log whose run opened a project that is not this one, and that this machine can find.
 
-    A path the log names and this machine does not have is a run from somewhere else -- an artifact
-    out of a container names the container's path -- and there the log has nothing to say about
-    which tree is here. Only a path that resolves to a real directory is compared, so the reading
-    either separates two trees on this machine or stands aside.
+    Only a path that is a directory here is compared, and two classes of run are stood aside for by
+    that: one out of a container, which names the container's path -- what CI reads on every pull
+    request -- and one whose tree has since been deleted, which is the permanent state of the base
+    tree `base_red_check.py` builds and removes. So a results file from either is read against this
+    tree's sources without this saying anything, and what keeps the second out of reach is the rule
+    in `named_files` that a directory argument is not descended into.
+
+    A log carrying no such line is stood aside for too. Measured over this repository's logs: 68 of
+    69 carry it exactly once, and the one that does not is a shader compiler's.
     """
     root = project.resolve()
     found = []
@@ -355,9 +360,8 @@ def measured_elsewhere(project, logs):
 
 def refusals(project, results, logs):
     """Every reason the results are not this worktree's reading. Empty means none of them said so."""
-    # First, before the compile reading below: a log of another tree's run says nothing about
-    # whether this one compiled, and refusing it for the diagnostic it carries would name the wrong
-    # tree's fault.
+    # Before the compile reading below: a log of another tree's run says nothing about whether this
+    # one compiled, and refusing it for the diagnostic it carries would name the wrong tree's fault.
     crossed = measured_elsewhere(project, logs)
     if crossed:
         raise Unreadable(

--- a/scripts/test_quality/assert_results_from_this_tree.py
+++ b/scripts/test_quality/assert_results_from_this_tree.py
@@ -9,6 +9,14 @@ passing case named for a fixture no source in the tree declares -- under a -test
 something else, which is what makes it read as a result rather than as a failure to run. Unity's
 exit code is the caller's to notice, and nobody was reading it.
 
+One precondition before any of them: the results and the log have to sit inside the project named.
+A caller that spells an absolute path to a run's output and lets --project default is naming two
+trees, and every reading below is then a comparison across them. Measured on two worktrees of this
+repository declaring the same fixtures: exit 0, having compared one tree's sources against the
+other's results. It is only when the running tree declares a fixture this one does not that the
+third reading catches the pairing -- and there it reports a stranger, which is the sentence for a
+stale Library rather than for a call pointed at two trees.
+
 Three readings, and the run has to survive all of them:
 
   - the log names the results file, which is how a run says the file is its own;
@@ -315,8 +323,31 @@ def foreign_fixtures(reported, ours, resolved, types):
     return ran, found
 
 
+def elsewhere(project, named):
+    """Every named file that does not sit under the project the check was pointed at.
+
+    A run writes its results and its log under the tree it ran in, so a file outside that tree is a
+    reading of a different one. Paired the other way round the check compares this tree's sources
+    against another tree's assemblies, and what it then reports is a fixture the running tree
+    declares and this one does not -- which is the sentence it prints for the defect it exists to
+    catch, about work that is fine.
+    """
+    root = project.resolve()
+    return [path for path in named if root not in path.resolve().parents and path.resolve() != root]
+
+
 def refusals(project, results, logs):
     """Every reason the results are not this worktree's reading. Empty means none of them said so."""
+    # Before any reading of either: the two arguments have to be of one tree. A caller that names an
+    # absolute results path and lets --project default is pointing the check at two, and every
+    # reading below would then be a comparison across them.
+    strangers = elsewhere(project, results + logs)
+    if strangers:
+        raise Unreadable(
+            "{} sit(s) outside {}, so the results and the sources are of different trees. Pass "
+            "--project for the tree the run happened in.".format(
+                ", ".join(str(path) for path in strangers), project))
+
     # First, and returning on its own: a run that did not compile wrote no results, so every reading
     # below would refuse it for the absence rather than for the cause, and the caller would be told
     # a file is missing while the diagnostic explaining why sits unread in the log beside it.

--- a/scripts/test_quality/assert_results_from_this_tree.py
+++ b/scripts/test_quality/assert_results_from_this_tree.py
@@ -9,13 +9,20 @@ passing case named for a fixture no source in the tree declares -- under a -test
 something else, which is what makes it read as a result rather than as a failure to run. Unity's
 exit code is the caller's to notice, and nobody was reading it.
 
-One precondition before any of them: the results and the log have to sit inside the project named.
-A caller that spells an absolute path to a run's output and lets --project default is naming two
-trees, and every reading below is then a comparison across them. Measured on two worktrees of this
-repository declaring the same fixtures: exit 0, having compared one tree's sources against the
-other's results. It is only when the running tree declares a fixture this one does not that the
-third reading catches the pairing -- and there it reports a stranger, which is the sentence for a
-stale Library rather than for a call pointed at two trees.
+One precondition before any of them: the log says which project the editor opened, and that has to
+be the project this is pointed at. A caller who spells an absolute path to another worktree's output
+and lets --project default is naming two trees, and the third reading below is then a comparison
+across them. Measured on two worktrees of this repository declaring the same fixtures: exit 0,
+having compared one tree's sources against the other's results. The pairing is caught only in the
+direction where the tree that ran declares a fixture this one does not -- and there it reports a
+stranger, which is the sentence for a stale Library rather than for a call pointed at two trees.
+
+Read off the log rather than from where the files sit. Location is not the same question: the
+story-capture recipe in CONTRIBUTING.md writes its results to /tmp from a run whose project is the
+checkout, and refusing that would be refusing a correct pairing. What the log names is the project
+the run measured, which is the thing this has to agree with. A path it names that does not exist
+here is not read -- an artifact downloaded out of a container names the container's path, and the
+run it came from is not one this machine can locate.
 
 Three readings, and the run has to survive all of them:
 
@@ -323,30 +330,40 @@ def foreign_fixtures(reported, ours, resolved, types):
     return ran, found
 
 
-def elsewhere(project, named):
-    """Every named file that does not sit under the project the check was pointed at.
+PROJECT_OPENED = re.compile(r"^Successfully changed project path to:\s*(.+?)\s*$", re.MULTILINE)
 
-    A run writes its results and its log under the tree it ran in, so a file outside that tree is a
-    reading of a different one. Paired the other way round the check compares this tree's sources
-    against another tree's assemblies, and what it then reports is a fixture the running tree
-    declares and this one does not -- which is the sentence it prints for the defect it exists to
-    catch, about work that is fine.
+
+def measured_elsewhere(project, logs):
+    """Every log whose run opened a project that is not this one, and that this machine can find.
+
+    A path the log names and this machine does not have is a run from somewhere else -- an artifact
+    out of a container names the container's path -- and there the log has nothing to say about
+    which tree is here. Only a path that resolves to a real directory is compared, so the reading
+    either separates two trees on this machine or stands aside.
     """
     root = project.resolve()
-    return [path for path in named if root not in path.resolve().parents and path.resolve() != root]
+    found = []
+    for path in logs:
+        opened = PROJECT_OPENED.search(read_text(path))
+        if not opened:
+            continue
+        named = Path(opened.group(1))
+        if named.is_dir() and named.resolve() != root:
+            found.append((path, named))
+    return found
 
 
 def refusals(project, results, logs):
     """Every reason the results are not this worktree's reading. Empty means none of them said so."""
-    # Before any reading of either: the two arguments have to be of one tree. A caller that names an
-    # absolute results path and lets --project default is pointing the check at two, and every
-    # reading below would then be a comparison across them.
-    strangers = elsewhere(project, results + logs)
-    if strangers:
+    # First, before the compile reading below: a log of another tree's run says nothing about
+    # whether this one compiled, and refusing it for the diagnostic it carries would name the wrong
+    # tree's fault.
+    crossed = measured_elsewhere(project, logs)
+    if crossed:
         raise Unreadable(
-            "{} sit(s) outside {}, so the results and the sources are of different trees. Pass "
-            "--project for the tree the run happened in.".format(
-                ", ".join(str(path) for path in strangers), project))
+            "{}, so the run measured a tree this is not pointed at. Pass --project for the tree "
+            "the run happened in.".format(
+                "; ".join("{} is of a run in {}".format(path, named) for path, named in crossed)))
 
     # First, and returning on its own: a run that did not compile wrote no results, so every reading
     # below would refuse it for the absence rather than for the cause, and the caller would be told

--- a/scripts/test_quality/test_assert_results_from_this_tree.py
+++ b/scripts/test_quality/test_assert_results_from_this_tree.py
@@ -105,9 +105,7 @@ class Workspace:
                 (cached / (name + ".asmdef")).write_text(json.dumps({"name": name}),
                                                          encoding="utf-8")
 
-        # Under the project, as every writer of one puts it: -testResults is given a path inside the
-        # tree being run, and the guard refuses a pairing that spans two trees.
-        self.run_directory = self.project / "Logs"
+        self.run_directory = self.root / "run"
         self.run_directory.mkdir()
         self.results = self.run_directory / "results.xml"
         self.log = self.run_directory / "run.log"
@@ -117,7 +115,8 @@ class Workspace:
         self.results.write_text(results if results is not None else results_xml(assemblies),
                                 encoding="utf-8")
         self.log.write_text(
-            "Saving results to: {}\n".format(self.results) if log is None else log,
+            "Successfully changed project path to: {}\nSaving results to: {}\n".format(
+                self.project, self.results) if log is None else log,
             encoding="utf-8")
         return self
 
@@ -356,10 +355,10 @@ class LogTests(unittest.TestCase):
 class UnreadableTests(unittest.TestCase):
     """Every reading the guard cannot take is a refusal, since exiting 0 unread looks like a pass."""
 
-    def test_Given_AnotherWorktreesResults_When_TheProjectIsThisOne_Then_TheReadingIsRefused(self):
-        # Arrange -- an absolute path to the run's own output with --project left where the call
-        # started. The guard's own sentence then names a fixture the running tree declares and this
-        # one does not, which reads exactly like the defect it exists to catch.
+    def test_Given_ARunOfAnotherWorktree_When_TheProjectIsThisOne_Then_TheReadingIsRefused(self):
+        # Arrange -- an absolute path to another worktree's output with --project left where the
+        # call started. Where the two trees declare the same fixtures this was exit 0; where they
+        # do not it names a fixture as a stranger, which is the sentence for a stale Library.
         with workspace() as here, workspace() as ran:
             ran.wrote()
 
@@ -370,7 +369,7 @@ class UnreadableTests(unittest.TestCase):
             # Assert
             self.assertEqual(code, 2)
 
-    def test_Given_AnotherWorktreesResults_When_TheProjectIsThisOne_Then_TheRefusalNamesTheFile(self):
+    def test_Given_ARunOfAnotherWorktree_When_TheProjectIsThisOne_Then_TheRefusalNamesTheTree(self):
         # Arrange
         with workspace() as here, workspace() as ran:
             ran.wrote()
@@ -380,20 +379,37 @@ class UnreadableTests(unittest.TestCase):
                                    "--project", str(here.project))
 
             # Assert
-            self.assertIn(str(ran.results), said)
+            self.assertIn(str(ran.project), said)
 
-    def test_Given_ALogFromAnotherWorktree_When_TheResultsAreThisOnes_Then_TheReadingIsRefused(self):
-        # Arrange -- the compile the guard reads is then of a tree the results did not come from.
-        with workspace() as here, workspace() as ran:
-            here.wrote()
-            ran.wrote()
+    def test_Given_ARunOfThisProjectWritingItsResultsElsewhere_When_ItIsRead_Then_ItIsNotRefused(self):
+        # Arrange -- CONTRIBUTING's story-capture recipe: -projectPath the checkout, -testResults
+        # /tmp. Where the files sit says nothing; what the run opened is the question.
+        with workspace() as tree:
+            outside = tree.root / "elsewhere"
+            outside.mkdir()
+            tree.results, tree.log = outside / "capture.xml", outside / "capture.log"
+            tree.wrote()
 
             # Act
-            code, _ = here.verdict(str(here.results), "--log", str(ran.log),
-                                   "--project", str(here.project))
+            code, _ = tree.verdict(str(tree.results), "--log", str(tree.log),
+                                   "--project", str(tree.project))
 
             # Assert
-            self.assertEqual(code, 2)
+            self.assertEqual(code, 0)
+
+    def test_Given_ALogNamingAProjectThisMachineDoesNotHave_When_ItIsRead_Then_ItIsNotRefused(self):
+        # Arrange -- an artifact downloaded out of a container names the container's path, and the
+        # run it came from is not one this machine can locate. CI reads exactly this.
+        with workspace() as tree:
+            tree.wrote(log="Successfully changed project path to: /github/workspace\n"
+                           "Saving results to: {}\n".format(tree.results))
+
+            # Act
+            code, _ = tree.verdict(str(tree.results), "--log", str(tree.log),
+                                   "--project", str(tree.project))
+
+            # Assert
+            self.assertEqual(code, 0)
 
     def test_Given_NoEditorLogAtAll_When_TheRunIsRead_Then_TheReadingIsRefused(self):
         # Arrange

--- a/scripts/test_quality/test_assert_results_from_this_tree.py
+++ b/scripts/test_quality/test_assert_results_from_this_tree.py
@@ -381,6 +381,10 @@ class UnreadableTests(unittest.TestCase):
             # Assert
             self.assertIn(str(ran.project), said)
 
+    # GREEN_ON_BASE(construction): the base has no precondition to fire, so it passes for want of
+    # one. What this holds is the shape the first attempt at one refused: replacing
+    # `measured_elsewhere` with a reading of whether each named file sits under `project` fails this
+    # case, and nothing else in the suite notices.
     def test_Given_ARunOfThisProjectWritingItsResultsElsewhere_When_ItIsRead_Then_ItIsNotRefused(self):
         # Arrange -- CONTRIBUTING's story-capture recipe: -projectPath the checkout, -testResults
         # /tmp. Where the files sit says nothing; what the run opened is the question.
@@ -397,6 +401,9 @@ class UnreadableTests(unittest.TestCase):
             # Assert
             self.assertEqual(code, 0)
 
+    # GREEN_ON_BASE(construction): the base passes for want of a precondition. Dropping the
+    # `named.is_dir()` term from `measured_elsewhere` fails this case, and it is the one CI takes on
+    # every pull request — the container path a downloaded artifact names is on no runner.
     def test_Given_ALogNamingAProjectThisMachineDoesNotHave_When_ItIsRead_Then_ItIsNotRefused(self):
         # Arrange -- an artifact downloaded out of a container names the container's path, and the
         # run it came from is not one this machine can locate. CI reads exactly this.

--- a/scripts/test_quality/test_assert_results_from_this_tree.py
+++ b/scripts/test_quality/test_assert_results_from_this_tree.py
@@ -382,9 +382,9 @@ class UnreadableTests(unittest.TestCase):
             self.assertIn(str(ran.project), said)
 
     # GREEN_ON_BASE(construction): the base has no precondition to fire, so it passes for want of
-    # one. What this holds is the shape the first attempt at one refused: replacing
-    # `measured_elsewhere` with a reading of whether each named file sits under `project` fails this
-    # case, and nothing else in the suite notices.
+    # one. What this holds is the shape the first attempt at one refused, and it is the case named
+    # for it: replacing `measured_elsewhere` with a reading of whether each named file sits under
+    # `project` fails it, along with 23 others that keep their output beside the project too.
     def test_Given_ARunOfThisProjectWritingItsResultsElsewhere_When_ItIsRead_Then_ItIsNotRefused(self):
         # Arrange -- CONTRIBUTING's story-capture recipe: -projectPath the checkout, -testResults
         # /tmp. Where the files sit says nothing; what the run opened is the question.
@@ -402,13 +402,14 @@ class UnreadableTests(unittest.TestCase):
             self.assertEqual(code, 0)
 
     # GREEN_ON_BASE(construction): the base passes for want of a precondition. Dropping the
-    # `named.is_dir()` term from `measured_elsewhere` fails this case, and it is the one CI takes on
-    # every pull request — the container path a downloaded artifact names is on no runner.
+    # `named.is_dir()` term from `measured_elsewhere` fails this case and no other, and it is the
+    # one CI takes on every pull request — the container path a run names is on no runner.
     def test_Given_ALogNamingAProjectThisMachineDoesNotHave_When_ItIsRead_Then_ItIsNotRefused(self):
-        # Arrange -- an artifact downloaded out of a container names the container's path, and the
-        # run it came from is not one this machine can locate. CI reads exactly this.
+        # Arrange -- a run inside a container names the container's path, and the tree it opened is
+        # not one this machine has. This is the shape CI reads on every pull request.
         with workspace() as tree:
-            tree.wrote(log="Successfully changed project path to: /github/workspace\n"
+            # The trailing "/." is what game-ci's own logs carry, and Path normalises it away.
+            tree.wrote(log="Successfully changed project path to: /github/workspace/.\n"
                            "Saving results to: {}\n".format(tree.results))
 
             # Act

--- a/scripts/test_quality/test_assert_results_from_this_tree.py
+++ b/scripts/test_quality/test_assert_results_from_this_tree.py
@@ -105,7 +105,9 @@ class Workspace:
                 (cached / (name + ".asmdef")).write_text(json.dumps({"name": name}),
                                                          encoding="utf-8")
 
-        self.run_directory = self.root / "run"
+        # Under the project, as every writer of one puts it: -testResults is given a path inside the
+        # tree being run, and the guard refuses a pairing that spans two trees.
+        self.run_directory = self.project / "Logs"
         self.run_directory.mkdir()
         self.results = self.run_directory / "results.xml"
         self.log = self.run_directory / "run.log"
@@ -353,6 +355,45 @@ class LogTests(unittest.TestCase):
 
 class UnreadableTests(unittest.TestCase):
     """Every reading the guard cannot take is a refusal, since exiting 0 unread looks like a pass."""
+
+    def test_Given_AnotherWorktreesResults_When_TheProjectIsThisOne_Then_TheReadingIsRefused(self):
+        # Arrange -- an absolute path to the run's own output with --project left where the call
+        # started. The guard's own sentence then names a fixture the running tree declares and this
+        # one does not, which reads exactly like the defect it exists to catch.
+        with workspace() as here, workspace() as ran:
+            ran.wrote()
+
+            # Act
+            code, _ = here.verdict(str(ran.results), "--log", str(ran.log),
+                                   "--project", str(here.project))
+
+            # Assert
+            self.assertEqual(code, 2)
+
+    def test_Given_AnotherWorktreesResults_When_TheProjectIsThisOne_Then_TheRefusalNamesTheFile(self):
+        # Arrange
+        with workspace() as here, workspace() as ran:
+            ran.wrote()
+
+            # Act
+            _, said = here.verdict(str(ran.results), "--log", str(ran.log),
+                                   "--project", str(here.project))
+
+            # Assert
+            self.assertIn(str(ran.results), said)
+
+    def test_Given_ALogFromAnotherWorktree_When_TheResultsAreThisOnes_Then_TheReadingIsRefused(self):
+        # Arrange -- the compile the guard reads is then of a tree the results did not come from.
+        with workspace() as here, workspace() as ran:
+            here.wrote()
+            ran.wrote()
+
+            # Act
+            code, _ = here.verdict(str(here.results), "--log", str(ran.log),
+                                   "--project", str(here.project))
+
+            # Assert
+            self.assertEqual(code, 2)
 
     def test_Given_NoEditorLogAtAll_When_TheRunIsRead_Then_TheReadingIsRefused(self):
         # Arrange


### PR DESCRIPTION
`assert_results_from_this_tree.py` read whatever `--project` named against whatever results it was
handed, and nothing tied the two together. A caller who spells an absolute path to another
worktree's output and lets `--project` default to where the call started is naming two trees.

Measured on two worktrees of this repository declaring the same fixtures: **exit 0**, having
compared one tree's sources against the other's results. The stranger-fixture reading catches the
pairing only in the direction where the tree that ran declares something this one does not — and
there it names that fixture, which is the sentence for a stale `Library` reporting an assembly
another checkout compiled. That is how it read in a review of #687: a real fixture named, a
confident finding, and nothing wrong with the work. The refusal that reads like a defect costs a
reader a search; the silent pass costs them the guard.

**Ask the log which project the run opened.** Unity writes the path it resolved, and that is the
tree the results are a reading of. Where the files *sit* is a different question and answering it
instead refuses correct work: the story-capture recipe in `CONTRIBUTING.md` gives `-projectPath` the
checkout and `-testResults /tmp/capture.xml`, and no `--project` value would have satisfied a
location reading. That was this branch's first attempt, and the case that fails it is in the suite.

A path the log names that this machine does not have is not compared. An artifact downloaded out of
a container names the container's path, which is exactly what CI reads on every pull request, so the
reading stands aside there rather than refusing. That term is the other new case.

Deriving `--project` from the results instead would be the opposite direction and worse: it makes
the wrong invocation *succeed*, and a silent pass is what this file exists to make impossible. So
the precondition is a refusal — `Unreadable`, exit 2 — before the compile reading, because a log of
another tree's run would otherwise be read for a diagnostic and name the wrong tree's fault.

Four cases: refused in both directions of the two-worktree pairing, and the two shapes above that it
must not refuse. The last two are green on the base for want of a check to fire, and each declares
the perturbation that fails it — replacing the log reading with a location one, and dropping the
does-this-directory-exist term.

CONTRIBUTING gains the precondition beside the three readings it already describes, and the sentence
about what the guard cannot separate is narrowed to what is still true of it.

Closes #699
