### PR TITLE
tooling(velvet): refuse a removal that leaves its name in a comment

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -353,7 +353,11 @@ jobs:
     name: Test quality
     runs-on: ubuntu-latest
     steps:
+      # fetch-depth 0 for stranded_name_check.py, which reads a change against its merge base, and
+      # for the two of its cases held against commits in this repository's own history.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
 
       - run: python3 scripts/test_quality/run_suite.py scripts/test_quality/test_mutation_check.py
 
@@ -368,6 +372,15 @@ jobs:
       - run: python3 scripts/test_quality/run_suite.py scripts/test_quality/test_assume_gate_check.py
 
       - run: python3 scripts/test_quality/assume_gate_check.py
+
+      - run: python3 scripts/test_quality/run_suite.py scripts/test_quality/test_stranded_name_check.py
+
+      # A removal reports here rather than in the corpus sweep the same question invites: read over
+      # every comment it is 518 unresolved tokens for 4 real ones, and read over one change's own
+      # removals it was 2 firings in 320 commits.
+      - env:
+          BASE: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+        run: python3 scripts/test_quality/stranded_name_check.py --base "${BASE:-HEAD^}"
 
   # ---------------------------------------------------------------------------
   # The one check branch protection requires from this workflow. Naming a real

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -488,15 +488,21 @@ shapes with a clean ratio — a `cref` attribute at 0.46%, a name with a trailin
 with both halves PascalCase — hold none of the four. Asked from the removal side it was two firings
 over 320 commits.
 
-Three things it declines to judge. A name surviving only inside a string literal, which is content
-rather than a reference and is how every other reader here treats one. A property or a field, since
-the yield above was measured over types and methods and a widening is a fresh measurement rather
-than an edit. And a comment that went stale for any reason other than a removal in the same change —
-a renamed parameter, a reversed condition, a mechanism that still exists and no longer does that.
+What it declines to judge, and this list is what it claims rather than everything it misses:
 
-There is no way to declare an exception, and one of the two firings did not want one: a base-red
-declaration naming the base tree's method is a true sentence that does not need the identifier to
-say what it says.
+- a name surviving only inside a string literal, which is content rather than a reference;
+- a name surviving only in a `#region` or `#pragma` label, which is prose on a line that declares
+  nothing — routed to the code stream instead, one such label answers for that name tree-wide;
+- a property or a field, since the yield above was measured over types and methods and a widening is
+  a fresh measurement rather than an edit;
+- a declaration removed from C# written inside a verbatim string, which the diff reading cannot tell
+  from one removed from the source around it;
+- a comment that went stale for any reason other than a removal in the same change — a renamed
+  parameter, a reversed condition, a mechanism that still exists and no longer does that.
+
+There is no way to declare an exception, and one of the two firings did not want one: a
+base-red declaration, of the refactor category, naming the base tree's method is a true sentence that does not
+need the identifier to say what it says.
 
 ### Repository scripts
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -479,7 +479,8 @@ python3 scripts/test_quality/stranded_name_check.py --base origin/main
 ```
 
 It reads the change's own removals — a type or a method the diff takes out — and asks whether the
-name still occurs on a code line anywhere in the tree. If it occurs only in comments, it says so.
+name still occurs on a code line in any C# source in the tree. If it occurs only in comments, it
+says so.
 
 The direction is what makes it decidable. Asked from the comment side it is not: over this package's
 comments, bare PascalCase tokens resolving to no declaration numbered 518 for 4 real ones, and the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -483,8 +483,9 @@ name still occurs on a code line anywhere in the tree. If it occurs only in comm
 
 The direction is what makes it decidable. Asked from the comment side it is not: over this package's
 comments, bare PascalCase tokens resolving to no declaration numbered 518 for 4 real ones, and the
-shapes with a clean ratio — `cref` at 0.46%, `Foo()`, `Foo.Bar` — hold none of the four. Asked from
-the removal side it was two firings over 320 commits.
+shapes with a clean ratio — a `cref` attribute at 0.46%, a name with a trailing call, a dotted pair
+with both halves PascalCase — hold none of the four. Asked from the removal side it was two firings
+over 320 commits.
 
 Three things it declines to judge. A name surviving only inside a string literal, which is content
 rather than a reference and is how every other reader here treats one. A property or a field, since
@@ -492,9 +493,9 @@ the yield above was measured over types and methods and a widening is a fresh me
 than an edit. And a comment that went stale for any reason other than a removal in the same change —
 a renamed parameter, a reversed condition, a mechanism that still exists and no longer does that.
 
-There is no way to declare an exception, and one of the two firings did not want one: a
-`GREEN_ON_BASE` line naming the base tree's method is a true sentence that does not need the
-identifier to say what it says.
+There is no way to declare an exception, and one of the two firings did not want one: a base-red
+declaration naming the base tree's method is a true sentence that does not need the identifier to
+say what it says.
 
 ### Repository scripts
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -467,11 +467,40 @@ falsify the assumption, which the text does not say, and the filters tried inste
 the suite that the record would stop being a list anybody reads. A case carrying only that shape is
 not in the record; what still reaches it is `assert_no_inconclusive.py`, on the day it fires.
 
+### Checking that a removal did not strand its name
+
+A comment naming a method is true until somebody deletes the method, and nothing was reading for
+that: `DocumentationDriftTests` resolves the names markdown spells and strips comments from every
+format that has them. Three claims about a slot-rebase mechanism shipped that way and were found by
+grepping for the identifier months later.
+
+```bash
+python3 scripts/test_quality/stranded_name_check.py --base origin/main
+```
+
+It reads the change's own removals — a type or a method the diff takes out — and asks whether the
+name still occurs on a code line anywhere in the tree. If it occurs only in comments, it says so.
+
+The direction is what makes it decidable. Asked from the comment side it is not: over this package's
+comments, bare PascalCase tokens resolving to no declaration numbered 518 for 4 real ones, and the
+shapes with a clean ratio — `cref` at 0.46%, `Foo()`, `Foo.Bar` — hold none of the four. Asked from
+the removal side it was two firings over 320 commits.
+
+Three things it declines to judge. A name surviving only inside a string literal, which is content
+rather than a reference and is how every other reader here treats one. A property or a field, since
+the yield above was measured over types and methods and a widening is a fresh measurement rather
+than an edit. And a comment that went stale for any reason other than a removal in the same change —
+a renamed parameter, a reversed condition, a mechanism that still exists and no longer does that.
+
+There is no way to declare an exception, and one of the two firings did not want one: a
+`GREEN_ON_BASE` line naming the base tree's method is a true sentence that does not need the
+identifier to say what it says.
+
 ### Repository scripts
 
 `scripts/` holds the harnesses, grouped by what they are for — `test_quality/` (mutation, neuter,
-inconclusive-result and results-provenance guards), `release/` (the release-note builder), `unity/`
-(sample sync). Two rules keep the tree readable:
+inconclusive-result, results-provenance and stranded-name guards), `release/` (the release-note
+builder), `unity/` (sample sync). Two rules keep the tree readable:
 
 - **Python, named in `snake_case`.** Every harness is importable, so a test can exercise it directly rather
   than only through a shell invocation — which is what `release/test_release_notes.py` does. Python needs no

--- a/Packages/com.velvet.core/Runtime/Reconciler/LogicalChildSlots.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/LogicalChildSlots.cs
@@ -9,8 +9,8 @@ namespace Velvet
     /// </summary>
     /// <remarks>
     /// The reconciler used to assume the invisible children were only ever a LEADING run (a z-index layer
-    /// container) or a TRAILING one (a filter bounds spacer), which let it treat
-    /// <c>physical = logical + LeadingOffset</c> as true across a whole child list: slot arithmetic was done
+    /// container) or a TRAILING one (a filter bounds spacer), which let it treat a physical index as a
+    /// logical one shifted by a single leading offset across a whole child list: slot arithmetic was done
     /// on physical indices and clamped against a count that trimmed only those two runs. That assumption is
     /// what confined every invisible child to an end of the list, and a paint that must sit BESIDE the
     /// element it decorates — a ring band, which has to occlude its own element but not its later siblings —

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/LogicalChildSlotTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/LogicalChildSlotTests.cs
@@ -11,8 +11,8 @@ namespace Velvet.Tests
     /// reconciler-invisible child may sit ANYWHERE among them, not only in a leading or trailing run.
     /// </summary>
     /// <remarks>
-    /// The reconciler used to treat <c>physical = logical + LeadingOffset</c> as true across a whole child
-    /// list, which pinned every invisible child to one end. A paint that must sit BESIDE the element it
+    /// The reconciler used to treat a physical index as a logical one shifted by a single leading offset
+    /// across a whole child list, which pinned every invisible child to one end. A paint that must sit BESIDE the element it
     /// decorates cannot honour that, so <see cref="LogicalChildSlots"/> converts at each DOM touch instead.
     /// The mid-list cases below are the ones that assumption made impossible; the leading (z-index back
     /// container) and trailing (filter bounds spacer) cases are kept alongside them because both still have

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ZIndexStackingTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ZIndexStackingTests.cs
@@ -1104,7 +1104,8 @@ namespace Velvet.Tests
 
         // Keyed mirror of CrossParkARender/CrossParkSiblingHost: every one of A's own children carries an
         // explicit key, so its park goes through PendingKeyedState (ContinueKeyed) instead of
-        // PendingIndexedState (ContinueIndexed), which the positional cross-fiber tests above never reach.
+        // PendingIndexedState (ContinueIndexed). The keyed branch is the one the positional cross-fiber
+        // tests above never reach.
         [Component]
         private static VNode CrossParkKeyedSiblingHost() => V.Div(
             name: "cross-park-keyed-host", className: "relative", children: new VNode[]
@@ -1384,7 +1385,7 @@ namespace Velvet.Tests
             store.Set(true);
             mounted.FlushStateForTest();
 
-            // Assert — RED without subtracting LeadingOffset: the re-derived sweep would read "ordinary" as
+            // Assert — RED if the re-derived sweep counts the back container as a sibling: it would read "ordinary" as
             // sibling index 1 (the back container counted as index 0) and "second" as index 2, matching neither
             // first: nor nth-child(2) (which expects 0-based index 1) — un-applying the payload each correctly
             // held after the mount.
@@ -1401,7 +1402,7 @@ namespace Velvet.Tests
         // addressing) without StructuralPatchParentHost itself ever re-rendering. That is deliberate: "parent"
         // itself getting patched would ALSO re-run its own post-children container sweep (ApplyStructuralVariants
         // — the same hunk StructuralSweepHost above exercises), which would re-derive (and so silently mask a
-        // broken) LeadingOffset subtraction in ApplyStructuralVariantConfig moments later in the very same
+        // broken) logical-index conversion in ApplyStructuralVariantConfig moments later in the very same
         // patch. Only isolating "ordinary"'s own re-render like this exercises ApplyStructuralVariantConfig's
         // immediate-evaluation branch on its own.
         [Component]
@@ -1434,7 +1435,7 @@ namespace Velvet.Tests
             store.Set(true);
             mounted.FlushStateForTest();
 
-            // Assert — RED without subtracting LeadingOffset in ApplyStructuralVariantConfig specifically: the
+            // Assert — RED if ApplyStructuralVariantConfig evaluates on physical indices: the
             // immediate evaluation would read "ordinary"'s raw physical index (1, the back container counted as
             // index 0) against the raw count, never matching first: (which expects index 0).
             Assert.That(

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ZIndexStackingTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ZIndexStackingTests.cs
@@ -1292,7 +1292,7 @@ namespace Velvet.Tests
 
         #endregion
 
-        #region Self-park double-rebase on a container-creating resume tick
+        #region A resume tick that creates the container and re-parks
 
         [Test]
         public void Given_AParkedFibersOwnResumeTickCreatesItsContainerAndReParks_When_ItFinishes_Then_TrailingItemsLandAtCorrectIndices()
@@ -1315,21 +1315,18 @@ namespace Velvet.Tests
 
             // Act — tick 2 (a single manual resume, which continues at the tiny budget tick 1 captured on the
             // fiber): processes item1, creating the shared parent's first back container INSIDE this tick's drain,
-            // then re-parks immediately after (item2..item9 remain) — so the fiber is STILL registered in
-            // ParkedBaselineFibers while its own resumed drain is rebasing that same PendingIndexedState.
+            // then re-parks immediately after (item2..item9 remain), still registered in
+            // ParkedBaselineFibers.
             FiberWorkLoop.ContinueReconcile(s_drainFiber);
             var resumeTickCreatedTheBackContainer = FindLayerContainer(root, front: false) != null;
             var reParkedWhileStillRegistered = s_drainFiber.HasPendingReconcileWorkForTest();
 
-            // Act — drain the remainder; the double-rebase this test targets is already fully determined by
-            // tick 2 above.
+            // Act — drain the remainder; what this case reads is already fully determined by tick 2 above.
             s_drainFiber.DrainTimeSlicedReconcileForTest();
 
-            // Assert — RED without the fix: the container-creating tick's own +1 delta is applied twice to
-            // the very same PendingIndexedState (current's own self-rebase, then the SAME fiber matched
-            // again in the ParkedBaselineFibers loop, since nothing yet removed it from that registry), so
-            // every trailing item resumes two physical slots ahead of where the container's single
-            // insertion actually left it.
+            // Assert — RED without the fix: every trailing item resumes two physical slots ahead of where
+            // the container's single insertion left it, the container-creating tick's one-slot delta having
+            // reached the same suspended state twice.
             Assert.That(
                 (noBackContainerBeforeTheReRender, parkedAfterItem0, registeredAsParkedBaseline,
                     resumeTickCreatedTheBackContainer, reParkedWhileStillRegistered, TrailingItemOrder(root)),

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ZIndexStackingTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ZIndexStackingTests.cs
@@ -1033,9 +1033,7 @@ namespace Velvet.Tests
 
             // Act — B re-renders synchronously (Normal lane), turning its own first item z-managed: the
             // shared host's FIRST negative-z child ever, so B's own top-level drain creates the back
-            // container while A is STILL parked. RebaseParkedSlotsForContainerChange's ParkedBaselineFibers
-            // loop — not A's own self-park rebase, which only ever fires from A's OWN drain — must be what
-            // rebases A here.
+            // container while A is STILL parked.
             s_crossParkBZManaged = true;
             s_crossParkBFiber.ScheduleRerenderForTest(FiberUpdatePriority.Normal);
             FiberWorkLoop.FlushState(s_crossParkBFiber);
@@ -1106,8 +1104,7 @@ namespace Velvet.Tests
 
         // Keyed mirror of CrossParkARender/CrossParkSiblingHost: every one of A's own children carries an
         // explicit key, so its park goes through PendingKeyedState (ContinueKeyed) instead of
-        // PendingIndexedState (ContinueIndexed) — RebasePendingSlotStartIfTargeting's OTHER branch, never
-        // exercised by the positional cross-fiber tests above.
+        // PendingIndexedState (ContinueIndexed), which the positional cross-fiber tests above never reach.
         [Component]
         private static VNode CrossParkKeyedSiblingHost() => V.Div(
             name: "cross-park-keyed-host", className: "relative", children: new VNode[]
@@ -1318,8 +1315,7 @@ namespace Velvet.Tests
             // Act — tick 2 (a single manual resume, which continues at the tiny budget tick 1 captured on the
             // fiber): processes item1, creating the shared parent's first back container INSIDE this tick's drain,
             // then re-parks immediately after (item2..item9 remain) — so the fiber is STILL registered in
-            // ParkedBaselineFibers at the exact moment RebaseParkedSlotsForContainerChange runs, alongside
-            // its own current.RebasePendingSlotStartIfTargeting call on the very same PendingIndexedState.
+            // ParkedBaselineFibers while its own resumed drain is rebasing that same PendingIndexedState.
             FiberWorkLoop.ContinueReconcile(s_drainFiber);
             var resumeTickCreatedTheBackContainer = FindLayerContainer(root, front: false) != null;
             var reParkedWhileStillRegistered = s_drainFiber.HasPendingReconcileWorkForTest();

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ZIndexStackingTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ZIndexStackingTests.cs
@@ -1325,8 +1325,7 @@ namespace Velvet.Tests
             s_drainFiber.DrainTimeSlicedReconcileForTest();
 
             // Assert — RED without the fix: every trailing item resumes two physical slots ahead of where
-            // the container's single insertion left it, the container-creating tick's one-slot delta having
-            // reached the same suspended state twice.
+            // the container's single insertion left it.
             Assert.That(
                 (noBackContainerBeforeTheReRender, parkedAfterItem0, registeredAsParkedBaseline,
                     resumeTickCreatedTheBackContainer, reParkedWhileStillRegistered, TrailingItemOrder(root)),

--- a/scripts/test_quality/stranded_name_check.py
+++ b/scripts/test_quality/stranded_name_check.py
@@ -78,6 +78,18 @@ def split_comments(text):
                 code.append(" ")
                 i = literal.end()
                 continue
+        if char == "#" and (i == 0 or text[i - 1] == "\n" or text[:i].rsplit("\n", 1)[-1].isspace()):
+            # A directive line declares nothing and refers to nothing, and a #region label is prose:
+            # routed to the code stream it answers for any name it happens to spell, tree-wide. Only
+            # as far as a `//` on it, because a #pragma carrying one is carrying a comment.
+            end = text.find("\n", i)
+            end = size if end < 0 else end
+            spoken = text.find("//", i)
+            if 0 <= spoken < end:
+                end = spoken
+            code.append("\n")
+            i = end
+            continue
         if text.startswith("//", i):
             end = text.find("\n", i)
             end = size if end < 0 else end
@@ -123,7 +135,8 @@ def stranded(base, head):
     left = []
     for name in sorted(removed_declarations(base, head)):
         # C# only. A name a removed declaration leaves behind in USS, JSON or an asmdef is content
-        # rather than a reference, which is how every other reader here treats one.
+        # rather than a reference to the declaration -- which is the reading DocumentationDriftTests
+        # takes of those formats too, where it keeps the string and resolves nothing from it.
         pattern = re.compile(r"\b{}\b".format(re.escape(name)))
         files = git("grep", "-l", "-w", name, head, "--", "*.cs").splitlines()
         if not files:

--- a/scripts/test_quality/stranded_name_check.py
+++ b/scripts/test_quality/stranded_name_check.py
@@ -50,26 +50,47 @@ CHAR_LITERAL = re.compile(r"'(?:\\.|[^'\\\n])'")
 def split_comments(text):
     """(comment text, code text) -- one scan, so a `//` inside a string literal is not a comment.
 
-    An interpolated string keeps its text in the code stream rather than being dropped, because the
-    holes in it are code and separating them needs a brace-matching pass. That counts a name written
-    in the string's own text as written in code, which is the direction that makes this guard say
-    nothing rather than say something wrong.
+    An interpolated string is followed by its braces: what a hole holds is code and reaches the code
+    stream, the literal text around it is dropped like any other string, and the closing quote is the
+    one at brace depth zero. Read as an ordinary literal instead, a hole holding a string of its own
+    ends the outer one early and everything to the next quote leaves both streams -- measured, 17 of
+    this repository's files lost code words that way, and a name whose only use was among them read
+    as stranded.
     """
     comments, code, i, size = [], [], 0, len(text)
     while i < size:
         char = text[i]
         if char == '"':
-            verbatim = i and text[i - 1] == "@"
+            verbatim = i and text[i - 1] == "@" or text[max(i - 2, 0):i] in ("@$", "$@")
             interpolated = "$" in text[max(i - 2, 0):i]
-            j = i + 1
+            j, depth = i + 1, 0
             while j < size:
-                if text[j] == '"':
+                here = text[j]
+                if interpolated and here in "{}":
+                    if text[j:j + 2] in ("{{", "}}"):
+                        j += 2
+                        continue
+                    depth += 1 if here == "{" else -1
+                    code.append(" ")
+                    j += 1
+                    continue
+                if here == '"':
                     if verbatim and j + 1 < size and text[j + 1] == '"':
                         j += 2
                         continue
-                    break
-                j += 2 if not verbatim and text[j] == "\\" else 1
-            code.append(text[i:j + 1] if interpolated else " ")
+                    if depth <= 0:
+                        break
+                    # A string of its own, inside a hole. Its own text is not code, but the scan has
+                    # to pass it or the brace it holds would close a hole it never opened.
+                    j += 1
+                    while j < size and text[j] != '"':
+                        j += 2 if text[j] == "\\" else 1
+                    j += 1
+                    continue
+                if depth > 0:
+                    code.append(here)
+                j += 2 if not verbatim and here == "\\" else 1
+            code.append(" ")
             i = j + 1
             continue
         if char == "'":
@@ -135,8 +156,8 @@ def stranded(base, head):
     left = []
     for name in sorted(removed_declarations(base, head)):
         # C# only. A name a removed declaration leaves behind in USS, JSON or an asmdef is content
-        # rather than a reference to the declaration -- which is the reading DocumentationDriftTests
-        # takes of those formats too, where it keeps the string and resolves nothing from it.
+        # rather than a reference to the declaration. CONTRIBUTING owns the rest of what this
+        # declines to judge.
         pattern = re.compile(r"\b{}\b".format(re.escape(name)))
         files = git("grep", "-l", "-w", name, head, "--", "*.cs").splitlines()
         if not files:

--- a/scripts/test_quality/stranded_name_check.py
+++ b/scripts/test_quality/stranded_name_check.py
@@ -2,8 +2,10 @@
 """Refuse a change that removes a declaration whose name survives only in a comment.
 
 DocumentationDriftTests resolves the names markdown spells, and strips comments from every format
-that has them, so a name a removal leaves behind in a C# comment is caught by nothing. That is not a
-formatting complaint: the comment was true when it was written and the removal is what made it
+that has them. CrefTargetTests pins every XML-doc cref in the package against that same corpus, so a
+name left behind in one of those is caught; a name left behind in any other comment is caught by
+nothing, and the three this was written for were ordinary line comments. That is not a formatting
+complaint: the comment was true when it was written and the removal is what made it
 false, which is the shape CLAUDE.md's corrected-sentence list is about -- a reader who trusts a
 reason that no longer holds is worse off than one who finds none.
 
@@ -53,9 +55,9 @@ def split_comments(text):
     An interpolated string is followed by its braces: what a hole holds is code and reaches the code
     stream, the literal text around it is dropped like any other string, and the closing quote is the
     one at brace depth zero. Read as an ordinary literal instead, a hole holding a string of its own
-    ends the outer one early and everything to the next quote leaves both streams -- measured, 17 of
-    this repository's files lost code words that way, and a name whose only use was among them read
-    as stranded.
+    ends the outer one early and everything to the next quote leaves both streams. Measured as the
+    files whose code stream loses an identifier when the brace following is taken out: 56 of this
+    repository's 742, and a name whose only use is among them reads as stranded.
     """
     comments, code, i, size = [], [], 0, len(text)
     while i < size:

--- a/scripts/test_quality/stranded_name_check.py
+++ b/scripts/test_quality/stranded_name_check.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Refuse a change that removes a declaration whose name survives only in a comment.
+
+DocumentationDriftTests resolves the names markdown spells, and strips comments from every format
+that has them, so a name a removal leaves behind in a C# comment is caught by nothing. That is not a
+formatting complaint: the comment was true when it was written and the removal is what made it
+false, which is the shape CLAUDE.md's corrected-sentence list is about -- a reader who trusts a
+reason that no longer holds is worse off than one who finds none.
+
+Read from the removal side rather than from the comment side, which is what makes it decidable. A
+sweep over the corpus for identifier-shaped tokens cannot separate a dangling reference from English:
+measured here, bare PascalCase in comments left 518 tokens resolving nowhere for 4 real ones, and the
+shapes that are clean -- `cref`, `Foo()`, `Foo.Bar` -- hold none of the four at all. A change's own
+removals are a handful of names, and each is either still written somewhere or it is not.
+
+Measured over the 320 commits before this was written: two firings. One is `RefAttachOrderingTests.cs`
+naming the base tree's method inside a GREEN_ON_BASE declaration -- a true sentence that does not
+need the identifier. Over `ba9d9b31`, the commit that stranded the three names this was opened for: it
+fires on both.
+
+Run: python3 scripts/test_quality/test_stranded_name_check.py
+"""
+
+import argparse
+import re
+import subprocess
+import sys
+
+# What the measurement above was taken with. A type or a method, not a property or a field: widening
+# it changes the yield it was chosen on, so a widening is a fresh measurement rather than an edit.
+DECLARATION = re.compile(
+    r"\b(?:class|struct|interface|enum|record|delegate)\s+([A-Z][A-Za-z0-9_]*)"
+    r"|\b(?:void|bool|int|string|object|var|[A-Z][A-Za-z0-9_<>,?\[\] ]*)\s+"
+    r"([A-Z][A-Za-z0-9_]*)\s*(?:<[^>(]*>)?\s*\(")
+
+
+def git(*arguments):
+    done = subprocess.run(["git"] + list(arguments), capture_output=True, text=True)
+    if done.returncode > 1:
+        raise SystemExit("git {} failed: {}".format(" ".join(arguments), done.stderr.strip()))
+    return done.stdout
+
+
+def split_comments(text):
+    """(comment text, code text) -- one scan, so a `//` inside a string literal is not a comment."""
+    comments, code, i, size = [], [], 0, len(text)
+    while i < size:
+        char = text[i]
+        if char == '"':
+            verbatim = i and text[i - 1] == "@"
+            j = i + 1
+            while j < size:
+                if text[j] == '"':
+                    if verbatim and j + 1 < size and text[j + 1] == '"':
+                        j += 2
+                        continue
+                    break
+                j += 2 if not verbatim and text[j] == "\\" else 1
+            i, _ = j + 1, code.append(" ")
+            continue
+        if char == "'":
+            j = i + 1
+            while j < size and text[j] != "'":
+                j += 2 if text[j] == "\\" else 1
+            i, _ = j + 1, code.append(" ")
+            continue
+        if text.startswith("//", i):
+            end = text.find("\n", i)
+            end = size if end < 0 else end
+            comments.append(text[i + 2:end])
+            code.append("\n")
+            i = end + 1
+            continue
+        if text.startswith("/*", i):
+            end = text.find("*/", i)
+            end = size if end < 0 else end
+            comments.append(text[i + 2:end])
+            code.append(" ")
+            i = end + 2
+            continue
+        code.append(char)
+        i += 1
+    return "\n".join(comments), "".join(code)
+
+
+def removed_declarations(base, head):
+    """Every type or method name this change's removed lines declare."""
+    diff = git("diff", "--unified=0", "--format=", base + "..." + head, "--", "*.cs")
+    names = set()
+    for line in diff.splitlines():
+        if not line.startswith("-") or line.startswith("---"):
+            continue
+        source = line[1:].strip()
+        if source.startswith("//"):
+            continue
+        for found in DECLARATION.finditer(source):
+            names.add(found.group(1) or found.group(2))
+    return names
+
+
+def stranded(base, head):
+    """(name, files) for every removed name the tree still spells, in comments and nowhere else."""
+    left = []
+    for name in sorted(removed_declarations(base, head)):
+        pattern = re.compile(r"\b{}\b".format(re.escape(name)))
+        files = git("grep", "-l", "-w", name, head, "--", "*.cs").split()
+        if not files:
+            continue
+        naming = []
+        for entry in files:
+            path = entry.split(":", 1)[1]
+            comments, code = split_comments(git("show", "{}:{}".format(head, path)))
+            if pattern.search(code):
+                naming = []
+                break
+            if pattern.search(comments):
+                naming.append(path)
+        if naming:
+            left.append((name, naming))
+    return left
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(
+        description="Refuse a removal whose name survives only in a comment.")
+    parser.add_argument("--base", default="origin/main", help="what the change is read against")
+    parser.add_argument("--head", default="HEAD", help="the change")
+    arguments = parser.parse_args(argv)
+
+    merge_base = git("merge-base", arguments.base, arguments.head).strip()
+    if not merge_base:
+        print("cannot take this reading: {} and {} share no history".format(
+            arguments.base, arguments.head), file=sys.stderr)
+        return 2
+
+    left = stranded(merge_base, arguments.head)
+    if not left:
+        print("no removed declaration is left named by a comment alone")
+        return 0
+
+    print("these removals leave their name in a comment and nowhere else:", file=sys.stderr)
+    for name, files in left:
+        print("  {} -- {}".format(name, ", ".join(files)), file=sys.stderr)
+    print("\nThe comment was true until the removal. Say what the code does now, or drop the "
+          "sentence:\nan identifier the tree no longer declares is a reason a reader cannot check.",
+          file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/test_quality/stranded_name_check.py
+++ b/scripts/test_quality/stranded_name_check.py
@@ -41,13 +41,26 @@ def git(*arguments):
     return done.stdout
 
 
+# A char literal, and only that: an apostrophe in prose closes nothing, and reading one as an opening
+# quote swallows the rest of the file out of both streams. Measured before this was narrowed:
+# ErrorBoundaryTests.cs lost 42% of its text to the apostrophes in its #region labels.
+CHAR_LITERAL = re.compile(r"'(?:\\.|[^'\\\n])'")
+
+
 def split_comments(text):
-    """(comment text, code text) -- one scan, so a `//` inside a string literal is not a comment."""
+    """(comment text, code text) -- one scan, so a `//` inside a string literal is not a comment.
+
+    An interpolated string keeps its text in the code stream rather than being dropped, because the
+    holes in it are code and separating them needs a brace-matching pass. That counts a name written
+    in the string's own text as written in code, which is the direction that makes this guard say
+    nothing rather than say something wrong.
+    """
     comments, code, i, size = [], [], 0, len(text)
     while i < size:
         char = text[i]
         if char == '"':
             verbatim = i and text[i - 1] == "@"
+            interpolated = "$" in text[max(i - 2, 0):i]
             j = i + 1
             while j < size:
                 if text[j] == '"':
@@ -56,14 +69,15 @@ def split_comments(text):
                         continue
                     break
                 j += 2 if not verbatim and text[j] == "\\" else 1
-            i, _ = j + 1, code.append(" ")
+            code.append(text[i:j + 1] if interpolated else " ")
+            i = j + 1
             continue
         if char == "'":
-            j = i + 1
-            while j < size and text[j] != "'":
-                j += 2 if text[j] == "\\" else 1
-            i, _ = j + 1, code.append(" ")
-            continue
+            literal = CHAR_LITERAL.match(text, i)
+            if literal:
+                code.append(" ")
+                i = literal.end()
+                continue
         if text.startswith("//", i):
             end = text.find("\n", i)
             end = size if end < 0 else end
@@ -84,7 +98,13 @@ def split_comments(text):
 
 
 def removed_declarations(base, head):
-    """Every type or method name this change's removed lines declare."""
+    """Every name a removed line declares that reads as a type or a method.
+
+    Read off the diff rather than off the two trees, so a declaration that moved counts as removed
+    here and is answered for by the tree below, which still spells it. A property or a field is not
+    read: the yield this was chosen on was measured over types and methods, and widening it is a
+    fresh measurement.
+    """
     diff = git("diff", "--unified=0", "--format=", base + "..." + head, "--", "*.cs")
     names = set()
     for line in diff.splitlines():
@@ -102,8 +122,10 @@ def stranded(base, head):
     """(name, files) for every removed name the tree still spells, in comments and nowhere else."""
     left = []
     for name in sorted(removed_declarations(base, head)):
+        # C# only. A name a removed declaration leaves behind in USS, JSON or an asmdef is content
+        # rather than a reference, which is how every other reader here treats one.
         pattern = re.compile(r"\b{}\b".format(re.escape(name)))
-        files = git("grep", "-l", "-w", name, head, "--", "*.cs").split()
+        files = git("grep", "-l", "-w", name, head, "--", "*.cs").splitlines()
         if not files:
             continue
         naming = []

--- a/scripts/test_quality/test_stranded_name_check.py
+++ b/scripts/test_quality/test_stranded_name_check.py
@@ -215,15 +215,13 @@ class StrandedTests(unittest.TestCase):
             self.assertEqual(code, 0)
 
     def test_Given_ADoubleSlashInsideAStringLiteral_When_TheRestOfTheLineNamesIt_Then_ItIsNotAComment(self):
-        # Arrange -- read as a comment, the trailing call would be invisible and the name would
-        # report as stranded.
+        # Arrange -- the declaration goes and its one surviving call sits after a string holding `//`.
+        # Truncating the line there hides the call, and the name then reads as stranded when it is not.
         with repository() as tree:
             tree.changed_to("""namespace Velvet
 {
     internal static class Probe
     {
-        internal static int RebaseSlots(int at) => at;
-
         internal static int Read(int at) => Url("http://x") + RebaseSlots(at);
 
         internal static int Url(string held) => held.Length;
@@ -236,6 +234,31 @@ class StrandedTests(unittest.TestCase):
 
             # Assert
             self.assertEqual(code, 0)
+
+    def test_Given_AnApostropheAboveAStrandedName_When_ARemovalIsRead_Then_ItIsStillFound(self):
+        # Arrange -- an apostrophe read as an opening char literal closes nowhere, and every line after
+        # it leaves both streams, so the comment below goes unread and the removal reports clean.
+        # Measured on the tree before this was narrowed: ErrorBoundaryTests.cs lost 42% of its text.
+        with repository() as tree:
+            tree.changed_to("""namespace Velvet
+{
+    internal static class Probe
+    {
+        #region What the caller's index means
+
+        // The caller rebases first (see RebaseSlots), so the index is already absolute here.
+        internal static int Read(int at) => at;
+
+        #endregion
+    }
+}
+""")
+
+            # Act
+            code, _ = tree.verdict()
+
+            # Assert
+            self.assertEqual(code, 1)
 
 
 class RepositoryHistoryTests(unittest.TestCase):

--- a/scripts/test_quality/test_stranded_name_check.py
+++ b/scripts/test_quality/test_stranded_name_check.py
@@ -200,8 +200,7 @@ class StrandedTests(unittest.TestCase):
             self.assertEqual(code, 0)
 
     def test_Given_ARemovedNameSurvivingOnlyInAStringLiteral_When_TheChangeIsRead_Then_ItIsNotRefused(self):
-        # Arrange -- a string is content rather than a reference to the declaration, which is how
-        # every other reader here treats one.
+        # Arrange -- a string is content rather than a reference to the declaration.
         with repository() as tree:
             tree.changed_to("""namespace Velvet
 {
@@ -239,21 +238,18 @@ class StrandedTests(unittest.TestCase):
             # Assert
             self.assertEqual(code, 0)
 
-    def test_Given_AnApostropheAboveAStrandedName_When_ARemovalIsRead_Then_ItIsStillFound(self):
-        # Arrange -- an apostrophe read as an opening char literal closes nowhere, and every line after
-        # it leaves both streams, so the comment below goes unread and the removal reports clean.
-        # Measured on the tree before this was narrowed: ErrorBoundaryTests.cs lost 42% of its text.
+    def test_Given_AnEscapedApostropheLiteral_When_ACallFollowsIt_Then_ItIsStillCode(self):
+        # Arrange -- the shape three files in this repository carry: a char literal holding a quote
+        # beside one holding an escaped apostrophe. Read as "everything to the next apostrophe", the
+        # two pair wrongly and the call after them leaves the code stream, so the comment above is
+        # all that is left naming it.
         with repository() as tree:
             tree.changed_to("""namespace Velvet
 {
     internal static class Probe
     {
-        #region What the caller's index means
-
-        // The caller rebases first (see RebaseSlots), so the index is already absolute here.
-        internal static int Read(int at) => at;
-
-        #endregion
+        // The caller rebases first (see RebaseSlots).
+        internal static bool Read(char c) => c == '"' || c == '\\'' || RebaseSlots(c) > 0 || c == 'x';
     }
 }
 """)
@@ -262,7 +258,27 @@ class StrandedTests(unittest.TestCase):
             code, _ = tree.verdict()
 
             # Assert
-            self.assertEqual(code, 1)
+            self.assertEqual(code, 0)
+
+    def test_Given_AnInterpolationHoleHoldingAString_When_ItCarriesTheOnlyCall_Then_ItIsStillCode(self):
+        # Arrange -- read as an ordinary literal, the outer string ends at the quote inside the hole
+        # and everything to the next one leaves both streams, taking the call with it.
+        with repository() as tree:
+            tree.changed_to("""namespace Velvet
+{
+    internal static class Probe
+    {
+        // The caller rebases first (see RebaseSlots).
+        internal static string Read(int[] xs) => $"a {string.Join(", ", xs)} b {RebaseSlots(1)}";
+    }
+}
+""")
+
+            # Act
+            code, _ = tree.verdict()
+
+            # Assert
+            self.assertEqual(code, 0)
 
 
     def test_Given_ARegionLabelSpellingTheRemovedName_When_TheChangeIsRead_Then_ItIsStillFound(self):
@@ -419,8 +435,8 @@ class RepositoryHistoryTests(unittest.TestCase):
             (1, True, True, True))
 
     def test_Given_ACommitNamingTheBaseTreesMethodOnPurpose_When_ItIsRead_Then_ItStillFires(self):
-        # Arrange -- c8d5b151d's base-red declaration names a method the base has and this tree does
-        # not. It is one of the two firings in the 320 commits measured and the only false positive
+        # Arrange -- c8d5b151d's GREEN_ON_BASE(refactor) declaration names a method the base has and
+        # this tree does not. It is one of the two firings in the 320 commits measured and the only false positive
         # among them: pinned so that excluding its shape is a decision somebody takes deliberately,
         # against a case that fails when they do.
         code, said = self.read("c8d5b151d")

--- a/scripts/test_quality/test_stranded_name_check.py
+++ b/scripts/test_quality/test_stranded_name_check.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""Unit tests for stranded_name_check.py, plus its reading of the commit it was written for.
+
+The cases are built as real commits in a temporary repository, because what the guard reads is a
+diff and a tree at a revision -- a fixture that hands it text instead would be exercising the
+regular expressions and nothing else. The last case holds it against this repository's own history:
+the commit that stranded the names the check exists for, and one whose firing is a false positive
+that has to stay visible rather than be excluded by a rule nobody measured.
+
+Run: python3 scripts/test_quality/test_stranded_name_check.py
+"""
+
+import contextlib
+import importlib.util
+import io
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def load_module(name):
+    """Imports a sibling script by path, since scripts/test_quality is not a package."""
+    spec = importlib.util.spec_from_file_location(
+        name, Path(__file__).resolve().with_name(name + ".py"))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+check = load_module("stranded_name_check")
+
+BEFORE = """namespace Velvet
+{
+    internal static class Probe
+    {
+        internal static int RebaseSlots(int at) => at;
+
+        internal static int Read(int at) => RebaseSlots(at);
+    }
+}
+"""
+
+
+class Repository:
+    """Two commits in a scratch repository: a tree, then a change to it."""
+
+    def __init__(self):
+        self.root = Path(tempfile.mkdtemp(prefix="velvet-stranded-"))
+        self.source = self.root / "Probe.cs"
+        self.git("init", "-q", "-b", "main")
+        self.git("config", "user.email", "probe@example.com")
+        self.git("config", "user.name", "Probe")
+        self.source.write_text(BEFORE, encoding="utf-8")
+        self.commit("before")
+
+    def git(self, *arguments):
+        return subprocess.run(["git", "-C", str(self.root)] + list(arguments),
+                              capture_output=True, text=True, check=True).stdout
+
+    def commit(self, message):
+        self.git("add", "-A")
+        self.git("commit", "-q", "-m", message)
+        return self.git("rev-parse", "HEAD").strip()
+
+    def changed_to(self, text):
+        self.source.write_text(text, encoding="utf-8")
+        return self.commit("after")
+
+    def verdict(self):
+        """(exit code, everything it said) for one reading of the second commit."""
+        captured = io.StringIO()
+        with contextlib.redirect_stderr(captured), contextlib.redirect_stdout(captured):
+            code = check.main(["--base", "HEAD~", "--head", "HEAD"])
+        return code, captured.getvalue()
+
+    def close(self):
+        shutil.rmtree(self.root, ignore_errors=True)
+
+
+@contextlib.contextmanager
+def repository():
+    made = Repository()
+    original = Path.cwd()
+    import os
+    os.chdir(made.root)
+    try:
+        yield made
+    finally:
+        os.chdir(original)
+        made.close()
+
+
+class StrandedTests(unittest.TestCase):
+    def test_Given_ARemovalWhoseNameACommentStillCarries_When_TheChangeIsRead_Then_ItIsRefused(self):
+        # Arrange
+        with repository() as tree:
+            tree.changed_to("""namespace Velvet
+{
+    internal static class Probe
+    {
+        // The caller rebases first (see RebaseSlots), so the index is already absolute here.
+        internal static int Read(int at) => at;
+    }
+}
+""")
+
+            # Act
+            code, _ = tree.verdict()
+
+            # Assert
+            self.assertEqual(code, 1)
+
+    def test_Given_ARemovalWhoseNameACommentStillCarries_When_TheChangeIsRead_Then_TheNameIsSaid(self):
+        # Arrange
+        with repository() as tree:
+            tree.changed_to("""namespace Velvet
+{
+    internal static class Probe
+    {
+        // The caller rebases first (see RebaseSlots), so the index is already absolute here.
+        internal static int Read(int at) => at;
+    }
+}
+""")
+
+            # Act
+            _, said = tree.verdict()
+
+            # Assert
+            self.assertIn("RebaseSlots", said)
+
+    def test_Given_ARemovalWhoseNameABlockCommentCarries_When_TheChangeIsRead_Then_ItIsRefused(self):
+        # Arrange -- the same sentence in the other comment form, which a line-anchored reader misses.
+        with repository() as tree:
+            tree.changed_to("""namespace Velvet
+{
+    internal static class Probe
+    {
+        /* The caller rebases first (RebaseSlots), so the index is absolute. */
+        internal static int Read(int at) => at;
+    }
+}
+""")
+
+            # Act
+            code, _ = tree.verdict()
+
+            # Assert
+            self.assertEqual(code, 1)
+
+    def test_Given_ARemovalWhoseNameNothingElseSpells_When_TheChangeIsRead_Then_ItIsNotRefused(self):
+        # Arrange -- a clean removal, which is most of them.
+        with repository() as tree:
+            tree.changed_to("""namespace Velvet
+{
+    internal static class Probe
+    {
+        internal static int Read(int at) => at;
+    }
+}
+""")
+
+            # Act
+            code, _ = tree.verdict()
+
+            # Assert
+            self.assertEqual(code, 0)
+
+    def test_Given_AMethodMovedRatherThanRemoved_When_TheChangeIsRead_Then_ItIsNotRefused(self):
+        # Arrange -- the declaration leaves one place and is written in another, which the diff
+        # reports as a removal and the tree answers for.
+        with repository() as tree:
+            tree.changed_to("""namespace Velvet
+{
+    internal static class Slots
+    {
+        internal static int RebaseSlots(int at) => at;
+    }
+
+    internal static class Probe
+    {
+        // The caller rebases first (see RebaseSlots).
+        internal static int Read(int at) => Slots.RebaseSlots(at);
+    }
+}
+""")
+
+            # Act
+            code, _ = tree.verdict()
+
+            # Assert
+            self.assertEqual(code, 0)
+
+    def test_Given_ARemovedNameSurvivingOnlyInAStringLiteral_When_TheChangeIsRead_Then_ItIsNotRefused(self):
+        # Arrange -- a string is content rather than a reference to the declaration, which is how
+        # every other reader here treats one.
+        with repository() as tree:
+            tree.changed_to("""namespace Velvet
+{
+    internal static class Probe
+    {
+        internal static string Name() => "RebaseSlots";
+    }
+}
+""")
+
+            # Act
+            code, _ = tree.verdict()
+
+            # Assert
+            self.assertEqual(code, 0)
+
+    def test_Given_ADoubleSlashInsideAStringLiteral_When_TheRestOfTheLineNamesIt_Then_ItIsNotAComment(self):
+        # Arrange -- read as a comment, the trailing call would be invisible and the name would
+        # report as stranded.
+        with repository() as tree:
+            tree.changed_to("""namespace Velvet
+{
+    internal static class Probe
+    {
+        internal static int RebaseSlots(int at) => at;
+
+        internal static int Read(int at) => Url("http://x") + RebaseSlots(at);
+
+        internal static int Url(string held) => held.Length;
+    }
+}
+""")
+
+            # Act
+            code, _ = tree.verdict()
+
+            # Assert
+            self.assertEqual(code, 0)
+
+
+class RepositoryHistoryTests(unittest.TestCase):
+    """Held against real commits, since a guard that fires only on invented text is untested."""
+
+    def read(self, revision):
+        captured = io.StringIO()
+        import os
+        original = Path.cwd()
+        os.chdir(REPO_ROOT)
+        try:
+            with contextlib.redirect_stderr(captured), contextlib.redirect_stdout(captured):
+                code = check.main(["--base", revision + "~", "--head", revision])
+        finally:
+            os.chdir(original)
+        return code, captured.getvalue()
+
+    def test_Given_TheCommitThatStrandedTheNames_When_ItIsRead_Then_AllThreeAreNamed(self):
+        # Arrange -- ba9d9b31 removed the logical-slot rebase methods and left three comments
+        # naming them, which shipped and were found by grepping rather than by any check.
+        code, said = self.read("ba9d9b31")
+
+        # Assert
+        self.assertEqual(
+            (code,
+             "RebasePendingSlotStartIfTargeting" in said,
+             "RebaseParkedSlotsForContainerChange" in said,
+             "LeadingOffset" in said),
+            (1, True, True, True))
+
+    def test_Given_ACommitNamingTheBaseTreesMethodOnPurpose_When_ItIsRead_Then_ItStillFires(self):
+        # Arrange -- c8d5b151d's GREEN_ON_BASE declaration names a method the base has and this tree
+        # does not. It is the one firing in the 320 commits measured, and it is a false positive:
+        # pinned so that excluding its shape is a decision somebody takes deliberately, against a
+        # case that fails when they do.
+        code, said = self.read("c8d5b151d")
+
+        # Assert
+        self.assertEqual((code, "InvokeRefCallback" in said), (1, True))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/test_quality/test_stranded_name_check.py
+++ b/scripts/test_quality/test_stranded_name_check.py
@@ -312,10 +312,9 @@ class StrandedTests(unittest.TestCase):
             self.assertEqual(code, 1)
 
     def test_Given_AnInterpolatedStringHoldingTheOnlyCall_When_TheChangeIsRead_Then_ItIsNotRefused(self):
-        # Arrange -- the holes in an interpolated string are code, and separating them needs a
-        # brace-matching pass this does not do. Its text goes to the code stream instead. Dropped
-        # like an ordinary string, the only call goes with it and the comment below reads as a
-        # strand.
+        # Arrange -- what a hole holds is code and reaches the code stream. Read as an ordinary
+        # literal the whole string is dropped, the only call goes with it, and the comment below is
+        # then all that names it.
         with repository() as tree:
             tree.changed_to("""namespace Velvet
 {

--- a/scripts/test_quality/test_stranded_name_check.py
+++ b/scripts/test_quality/test_stranded_name_check.py
@@ -171,14 +171,18 @@ class StrandedTests(unittest.TestCase):
             self.assertEqual(code, 0)
 
     def test_Given_AMethodMovedRatherThanRemoved_When_TheChangeIsRead_Then_ItIsNotRefused(self):
-        # Arrange -- the declaration leaves one place and is written in another, which the diff
-        # reports as a removal and the tree answers for.
+        # Arrange -- the declaration leaves one place and is written in another, spelled differently
+        # so the diff reports the removal rather than matching the line as context. The tree answers
+        # for it, and that answer is the code-side reading: without it this refuses a live name.
         with repository() as tree:
             tree.changed_to("""namespace Velvet
 {
     internal static class Slots
     {
-        internal static int RebaseSlots(int at) => at;
+        internal static int RebaseSlots(int at)
+        {
+            return at;
+        }
     }
 
     internal static class Probe
@@ -261,6 +265,131 @@ class StrandedTests(unittest.TestCase):
             self.assertEqual(code, 1)
 
 
+    def test_Given_ARegionLabelSpellingTheRemovedName_When_TheChangeIsRead_Then_ItIsStillFound(self):
+        # Arrange -- a directive line declares nothing. Routed to the code stream, one #region label
+        # spelling the name answers for it everywhere and the strand below goes unreported.
+        with repository() as tree:
+            (tree.root / "Other.cs").write_text("""namespace Velvet
+{
+    internal static class Other
+    {
+        #region RebaseSlots and friends
+        internal static int Keep() => 1;
+        #endregion
+    }
+}
+""", encoding="utf-8")
+            tree.changed_to("""namespace Velvet
+{
+    internal static class Probe
+    {
+        // The caller rebases first (see RebaseSlots).
+        internal static int Read(int at) => at;
+    }
+}
+""")
+
+            # Act
+            code, _ = tree.verdict()
+
+            # Assert
+            self.assertEqual(code, 1)
+
+    def test_Given_AnInterpolatedStringHoldingTheOnlyCall_When_TheChangeIsRead_Then_ItIsNotRefused(self):
+        # Arrange -- the holes in an interpolated string are code, and separating them needs a
+        # brace-matching pass this does not do. Its text goes to the code stream instead. Dropped
+        # like an ordinary string, the only call goes with it and the comment below reads as a
+        # strand.
+        with repository() as tree:
+            tree.changed_to("""namespace Velvet
+{
+    internal static class Probe
+    {
+        // The caller rebases first (see RebaseSlots).
+        internal static string Read(int at) => $"slot {RebaseSlots(at)}";
+    }
+}
+""")
+
+            # Act
+            code, _ = tree.verdict()
+
+            # Assert
+            self.assertEqual(code, 0)
+
+    def test_Given_AVerbatimStringEndingInABackslash_When_TheCallFollowsIt_Then_ItIsStillCode(self):
+        # Arrange -- a verbatim string takes no escapes, so its closing quote is the one after the
+        # backslash. Read as an ordinary literal that quote is escaped, the string runs on past the
+        # call, and the comment above is all that is left naming it.
+        with repository() as tree:
+            tree.changed_to("""namespace Velvet
+{
+    internal static class Probe
+    {
+        // The caller rebases first (see RebaseSlots).
+        internal static int Read(int at) => Url(@"a directory\\") + RebaseSlots(at);
+
+        internal static int Url(string held) => held.Length;
+    }
+}
+""")
+
+            # Act
+            code, _ = tree.verdict()
+
+            # Assert
+            self.assertEqual(code, 0)
+
+
+    def test_Given_ADirectiveLineCarryingAComment_When_TheCommentNamesIt_Then_ItIsStillRead(self):
+        # Arrange -- a #pragma is dropped, but the comment after it on the same line is a comment.
+        with repository() as tree:
+            tree.changed_to("""namespace Velvet
+{
+    internal static class Probe
+    {
+#pragma warning disable CS8524 // the caller rebases first (see RebaseSlots)
+        internal static int Read(int at) => at;
+#pragma warning restore CS8524
+    }
+}
+""")
+
+            # Act
+            code, _ = tree.verdict()
+
+            # Assert
+            self.assertEqual(code, 1)
+
+    def test_Given_ASourceWhoseNameHoldsASpace_When_ItCarriesTheStrand_Then_ItIsStillRead(self):
+        # Arrange -- git grep -l reports one path per line, and splitting that on whitespace makes
+        # two paths of this one, neither of which any revision holds.
+        with repository() as tree:
+            (tree.root / "Route Link.cs").write_text("""namespace Velvet
+{
+    internal static class Other
+    {
+        // The caller rebases first (see RebaseSlots).
+        internal static int Keep() => 1;
+    }
+}
+""", encoding="utf-8")
+            tree.changed_to("""namespace Velvet
+{
+    internal static class Probe
+    {
+        internal static int Read(int at) => at;
+    }
+}
+""")
+
+            # Act
+            code, _ = tree.verdict()
+
+            # Assert
+            self.assertEqual(code, 1)
+
+
 class RepositoryHistoryTests(unittest.TestCase):
     """Held against real commits, since a guard that fires only on invented text is untested."""
 
@@ -290,10 +419,10 @@ class RepositoryHistoryTests(unittest.TestCase):
             (1, True, True, True))
 
     def test_Given_ACommitNamingTheBaseTreesMethodOnPurpose_When_ItIsRead_Then_ItStillFires(self):
-        # Arrange -- c8d5b151d's GREEN_ON_BASE declaration names a method the base has and this tree
-        # does not. It is the one firing in the 320 commits measured, and it is a false positive:
-        # pinned so that excluding its shape is a decision somebody takes deliberately, against a
-        # case that fails when they do.
+        # Arrange -- c8d5b151d's base-red declaration names a method the base has and this tree does
+        # not. It is one of the two firings in the 320 commits measured and the only false positive
+        # among them: pinned so that excluding its shape is a decision somebody takes deliberately,
+        # against a case that fails when they do.
         code, said = self.read("c8d5b151d")
 
         # Assert


### PR DESCRIPTION
A comment naming a method is true until somebody deletes the method, and nothing here was reading
for that. `DocumentationDriftTests` resolves the names markdown spells and strips comments from
every format that has them; `CrefTargetTests` pins every XML-doc `cref` in the package against that
same corpus, so a name a removal leaves in one of those is caught. A name left in any other comment
is not, and the three claims about a slot-rebase mechanism `ba9d9b31` removed were ordinary line
comments — they shipped, and were found by grepping for the identifier months later.

**Read from the removal side, which is what makes it decidable.** From the comment side it is not,
and the measurement says so: over this package's comments, bare PascalCase tokens resolving to no
declaration number **518 for 4 real ones**. The shapes with a clean ratio hold none of the four — a
`cref` attribute is 0.46% and every one of its seven is a nullable suffix, a type parameter, or a
BCL, UI Toolkit or Roslyn name; a trailing call and a dotted PascalCase pair are 3.35% and 2.84% and
turn up nothing real. Scoping the same question to a pull request's *added* comment lines does not
help either: two tokens over 40 commits, both `NaNs`, and it could never have found these anyway,
because nobody added those comments — a removal took the declarations out from under sentences that
were already there and already true.

A change's own removals are a handful of names, and each is either still written somewhere or it is
not. Over the 320 commits before this: **two firings**. `ba9d9b31`, which stranded all three names,
and `c8d5b151d`, a base-red declaration naming the base tree's `InvokeRefCallback` — a true sentence
that does not need the identifier to say what it says. There is no way to declare an exception, and
that firing did not want one.

CONTRIBUTING lists five things it declines to judge, and says the list is what the check claims
rather than everything it misses: a name surviving only in a string literal, only in a `#region` or
`#pragma` label, a property or a field, a declaration removed from C# written inside a verbatim
string, and a comment that went stale for any reason other than a removal in the same change.

The lexer is the part that had to be right, and it took three passes. It read every apostrophe as
opening a char literal, so a `#region` label spelling "the caller's index" swallowed the rest of the
file out of both streams — `ErrorBoundaryTests.cs` lost 42% of its text. It read an interpolated
string as an ordinary literal, so a hole holding a string of its own ended the outer one at that
string's opening quote: 56 of 742 files lose a code word that way, and a name whose only use is
among them reads as stranded. It matches a char literal or nothing now, and it follows an
interpolated string's braces — what a hole holds reaches the code stream, the literal text around it
is dropped like any other string, and the closing quote is the one at depth zero. A directive line
goes to neither stream, as far as a `//` on it, because a `#pragma` carrying one is carrying a
comment.

Seven cases pin those readings, each reddening under its own perturbation and no other's — the
first attempts at three of them did not, because a broken reading makes a name *vanish* rather than
strand, and a case asserting "not refused" then passes either way. The comment stream was checked
against an independent reader across all 742 tracked `.cs` files.

The three live instances are corrected by dropping the mechanism rather than renaming it. What
rebases those fibers now was not measured, and the arrangement beside each already says what the
case holds — `RebasePendingSlotStart` itself is still declared and its references stay.
`LeadingOffset` was the third name that commit stranded, in five sites across three files.

`test-quality` gains `fetch-depth: 0`, which the merge-base reading and the two cases held against
this repository's own history both need.

Closes #704
