### PR TITLE
tooling(velvet): give the local flow the static withdrawal, and predict the round budget

### DIFF
--- a/scripts/test_quality/base_red_check.py
+++ b/scripts/test_quality/base_red_check.py
@@ -1903,10 +1903,12 @@ def budget_shortfall(standing, budget):
     A lower bound rather than an estimate. One round withdraws one file, so a run where none of the
     carried files builds needs at least as many rounds as there are of them, and saying so before
     the first round costs nothing where saying it afterwards costs the whole budget. Measured on the
-    branch replacing UniTask: 26 files the static pass could not reach, against a default of 8.
+    branch replacing UniTask: 23 carried files on the EditMode side, against a default of 8.
 
     It cannot say the budget IS enough -- a round that compiles ends the loop, and which round that
-    is depends on which file the log names first.
+    is depends on which file the log names first. Nor is the bound tight the other way: a file the
+    static reading in `--emit` would have withdrawn still counts here, because the local flow does
+    not take that reading.
     """
     if standing <= budget:
         return ""
@@ -2145,21 +2147,9 @@ def main():
     ever_wrote = not any(kind_of(case.path) == "csharp" for case in cases)
     rounds_spent = 0
     put_back = set()
-    unbuildable = {}
     try:
         print("  building the base tree at {}".format(base_tree), flush=True)
         build_base_tree(project, since, base_tree, carry, drop, args.warm_library)
-
-        # The same static withdrawal --emit performs, for the same reason and so that the two flows
-        # answer alike. Without it the loop rediscovers each of these from a compile log, one round
-        # per file: measured on the branch replacing UniTask, 4 of 30 carried C# files come off here
-        # and the loop was spending a round on each of them.
-        unbuildable = unbuildable_on_base(project, since, base_tree, carry)
-        for relative, name in sorted(unbuildable.items()):
-            withdraw(base_tree, relative)
-            print("  withdrawn: {} spells {}, which the base has not got, so the base builds no "
-                  "fixture\n             of its assembly and the run would report none of them"
-                  .format(relative, name), flush=True)
 
         python_lane = [case for case in cases + control if kind_of(case.path) == "python"]
         if python_lane:
@@ -2184,10 +2174,14 @@ def main():
             # Accumulated across platforms, unlike `withdrawn`: what the message below is evidence
             # for is that the base built none of the carried set, which both lanes are asking about.
             wanted = [case for case in cases + control
-                      if kind_of(case.path) == "csharp" and platform_of(case.path) == platform
-                      and case.path not in unbuildable]
+                      if kind_of(case.path) == "csharp" and platform_of(case.path) == platform]
             withdrawn = set()
-            note = budget_shortfall(len({case.path for case in wanted}), args.max_rounds)
+            # Every carried file a round on this platform could be spent withdrawing: its own, and
+            # the ones belonging to no platform, which are the shared helpers that compile into both.
+            note = budget_shortfall(
+                len([name for name in carry if name.endswith(".cs")
+                     and platform_of(name) in (platform, None)]),
+                args.max_rounds)
             if note:
                 print(note, flush=True)
             for attempt in range(1, args.max_rounds + 1):
@@ -2234,7 +2228,7 @@ def main():
         print("no round wrote a result, so nothing any of them was asked was measured", flush=True)
         if rounds_spent >= args.max_rounds:
             print(exhausted_reason(rounds_spent, put_back, len(carry)), flush=True)
-    offenders = report(cases, control, reported, canaries, ever_wrote, unbuildable)
+    offenders = report(cases, control, reported, canaries, ever_wrote)
     print("\nlogs: {}".format(output), flush=True)
     return 1 if offenders else 0
 

--- a/scripts/test_quality/base_red_check.py
+++ b/scripts/test_quality/base_red_check.py
@@ -1897,6 +1897,24 @@ def local_remedy(since, cases):
                 "".join(" --platform " + platform for platform in platforms), since or "origin/main"))
 
 
+def budget_shortfall(standing, budget):
+    """What the loop can say before spending a round, or "" when the budget could be enough.
+
+    A lower bound rather than an estimate. One round withdraws one file, so a run where none of the
+    carried files builds needs at least as many rounds as there are of them, and saying so before
+    the first round costs nothing where saying it afterwards costs the whole budget. Measured on the
+    branch replacing UniTask: 26 files the static pass could not reach, against a default of 8.
+
+    It cannot say the budget IS enough -- a round that compiles ends the loop, and which round that
+    is depends on which file the log names first.
+    """
+    if standing <= budget:
+        return ""
+    return ("  {} carried file(s) are not statically withdrawable and one round withdraws one, so\n"
+            "  --max-rounds {} cannot reach a compiling base if none of them builds:\n"
+            "  --max-rounds {}".format(standing, budget, standing))
+
+
 def exhausted_reason(spent, withdrawn, carried):
     """What a loop that ran out of rounds without ever compiling the base has to say for itself.
 
@@ -2127,9 +2145,21 @@ def main():
     ever_wrote = not any(kind_of(case.path) == "csharp" for case in cases)
     rounds_spent = 0
     put_back = set()
+    unbuildable = {}
     try:
         print("  building the base tree at {}".format(base_tree), flush=True)
         build_base_tree(project, since, base_tree, carry, drop, args.warm_library)
+
+        # The same static withdrawal --emit performs, for the same reason and so that the two flows
+        # answer alike. Without it the loop rediscovers each of these from a compile log, one round
+        # per file: measured on the branch replacing UniTask, 4 of 30 carried C# files come off here
+        # and the loop was spending a round on each of them.
+        unbuildable = unbuildable_on_base(project, since, base_tree, carry)
+        for relative, name in sorted(unbuildable.items()):
+            withdraw(base_tree, relative)
+            print("  withdrawn: {} spells {}, which the base has not got, so the base builds no "
+                  "fixture\n             of its assembly and the run would report none of them"
+                  .format(relative, name), flush=True)
 
         python_lane = [case for case in cases + control if kind_of(case.path) == "python"]
         if python_lane:
@@ -2154,8 +2184,12 @@ def main():
             # Accumulated across platforms, unlike `withdrawn`: what the message below is evidence
             # for is that the base built none of the carried set, which both lanes are asking about.
             wanted = [case for case in cases + control
-                      if kind_of(case.path) == "csharp" and platform_of(case.path) == platform]
+                      if kind_of(case.path) == "csharp" and platform_of(case.path) == platform
+                      and case.path not in unbuildable]
             withdrawn = set()
+            note = budget_shortfall(len({case.path for case in wanted}), args.max_rounds)
+            if note:
+                print(note, flush=True)
             for attempt in range(1, args.max_rounds + 1):
                 rounds_spent = max(rounds_spent, attempt)
                 put_back |= withdrawn
@@ -2200,7 +2234,7 @@ def main():
         print("no round wrote a result, so nothing any of them was asked was measured", flush=True)
         if rounds_spent >= args.max_rounds:
             print(exhausted_reason(rounds_spent, put_back, len(carry)), flush=True)
-    offenders = report(cases, control, reported, canaries, ever_wrote)
+    offenders = report(cases, control, reported, canaries, ever_wrote, unbuildable)
     print("\nlogs: {}".format(output), flush=True)
     return 1 if offenders else 0
 

--- a/scripts/test_quality/test_base_red_check.py
+++ b/scripts/test_quality/test_base_red_check.py
@@ -718,8 +718,8 @@ class BudgetShortfallTests(unittest.TestCase):
     """What the loop can say before spending a round, rather than after spending all of them.
 
     The reading beside this one is the loop's history, which costs the whole budget to produce. This
-    is the same number read off the carried set, and it is a lower bound: a round that compiles ends
-    the loop, so a budget that clears the bound may still be enough or not.
+    is read off the carried set instead, before a round is spent, and it is a lower bound: a round
+    that compiles ends the loop, so a budget that clears the bound may still be enough or not.
     """
 
     def test_Given_FewerFilesThanRounds_When_TheBudgetIsRead_Then_ItSaysNothing(self):
@@ -733,11 +733,11 @@ class BudgetShortfallTests(unittest.TestCase):
         self.assertEqual(base_red_check.budget_shortfall(8, 8), "")
 
     def test_Given_MoreFilesThanRounds_When_TheBudgetIsRead_Then_ItNamesTheFlagAndTheBound(self):
-        # Arrange — the shape measured on the branch replacing UniTask.
-        said = base_red_check.budget_shortfall(26, 8)
+        # Arrange — the EditMode side of the branch replacing UniTask: 23 carried files, default 8.
+        said = base_red_check.budget_shortfall(23, 8)
 
         # Act / Assert
-        self.assertEqual(("--max-rounds 26" in said, "--max-rounds 8" in said), (True, True))
+        self.assertEqual(("--max-rounds 23" in said, "--max-rounds 8" in said), (True, True))
 
 
 class ExhaustedLoopTests(unittest.TestCase):

--- a/scripts/test_quality/test_base_red_check.py
+++ b/scripts/test_quality/test_base_red_check.py
@@ -714,6 +714,32 @@ class DeclarationTests(unittest.TestCase):
             "characterization", "the ordering the base already commits to").complaint)
 
 
+class BudgetShortfallTests(unittest.TestCase):
+    """What the loop can say before spending a round, rather than after spending all of them.
+
+    The reading beside this one is the loop's history, which costs the whole budget to produce. This
+    is the same number read off the carried set, and it is a lower bound: a round that compiles ends
+    the loop, so a budget that clears the bound may still be enough or not.
+    """
+
+    def test_Given_FewerFilesThanRounds_When_TheBudgetIsRead_Then_ItSaysNothing(self):
+        # Arrange — the budget could be enough, and this cannot say that it is.
+        # Act / Assert
+        self.assertEqual(base_red_check.budget_shortfall(3, 8), "")
+
+    def test_Given_AsManyFilesAsRounds_When_TheBudgetIsRead_Then_ItSaysNothing(self):
+        # Arrange — the boundary: eight files can come off in eight rounds.
+        # Act / Assert
+        self.assertEqual(base_red_check.budget_shortfall(8, 8), "")
+
+    def test_Given_MoreFilesThanRounds_When_TheBudgetIsRead_Then_ItNamesTheFlagAndTheBound(self):
+        # Arrange — the shape measured on the branch replacing UniTask.
+        said = base_red_check.budget_shortfall(26, 8)
+
+        # Act / Assert
+        self.assertEqual(("--max-rounds 26" in said, "--max-rounds 8" in said), (True, True))
+
+
 class ExhaustedLoopTests(unittest.TestCase):
     """What the withdrawing loop says when it runs out of rounds having compiled nothing.
 


### PR DESCRIPTION
`base_red_check`'s two flows did not do the same thing. `--emit`, the one CI takes, performs a static
withdrawal before the round: `unbuildable_on_base` names each carried file that spells something the
base has not got, puts it back, and the round is spent on what is left. The local flow skipped that
entirely and rediscovered those files from a compile log, at one round apiece.

Measured on `refactor/velvet-task-replaces-unitask` against its merge base: 31 carried files, 30 of
them C#, and **4 come off statically**. The local loop was spending a round on each of the four
before it began on the rest.

The remaining 26 are not a gap in the reader, and this does not try to close them. That branch's
carried cases name `VelvetTask` — and so does the merge base, because the split that landed first
(#876, #877, #878) put the type on `main`. What the branch changes is not which names exist but
which **type a signature carries**: a carried case writing `VelvetTask t = Foo();` does not compile
against the base's `UniTask Foo()`, under a name both trees spell. `added_csharp_surface` is a
name-spelling comparison and says so; reaching a signature change means resolving types.

So the budget is what binds, and the number that predicts it is readable **before** the first round
rather than after the last. One round withdraws one file, so a loop whose carried files all fail to
build needs at least as many rounds as there are of them. `budget_shortfall` says that, names
`--max-rounds`, and gives the bound. It is a lower bound and not an estimate — a round that compiles
ends the loop, and which round that is depends on which file the log names first, so it declines to
say a budget *is* enough.

What this does not do is give CI a way to accept a reading it cannot afford. That is the other half
of #865 and it is a policy question — a receipt, committed and keyed on the carried set's digest, is
the shape this repository already uses for `mutation_check.py`, and it is what #377 needs. The
measurement behind that choice is on the issue.

`test_base_red_check.py` gains three cases over `budget_shortfall`, including the boundary where the
file count equals the budget. 240 pass.

No issue: half of #865, which stays open for the receipt that would let CI accept a reading it
cannot afford to take.
