### PR TITLE
test(velvet): pin the amend-after-cd direction the guard was reported fail-open on

### DIFF
--- a/scripts/hooks/test_amend_of_published_commit.py
+++ b/scripts/hooks/test_amend_of_published_commit.py
@@ -213,6 +213,10 @@ class PublishedHeadTests(GuardCase):
         # Assert
         self.assertEqual((code, text), (ALLOW, ""))
 
+    # GREEN_ON_BASE(characterization): the reading this holds landed with #814 and nothing asserted
+    # it. The base answers because the guard there already follows the cd; what was missing is the
+    # direction a guard that did not would read as allowed, which is why the case is worth having and
+    # why it cannot be red.
     def test_Given_AnAmendAfterACdIntoAPublishedTree_When_ItIsPosed_Then_ItIsRefused(self):
         # Arrange — the other direction of the case above, and the one a fail-open guard reads as
         # allowed: the tool call starts somewhere with nothing published and the amend lands where

--- a/scripts/hooks/test_amend_of_published_commit.py
+++ b/scripts/hooks/test_amend_of_published_commit.py
@@ -213,6 +213,20 @@ class PublishedHeadTests(GuardCase):
         # Assert
         self.assertEqual((code, text), (ALLOW, ""))
 
+    def test_Given_AnAmendAfterACdIntoAPublishedTree_When_ItIsPosed_Then_ItIsRefused(self):
+        # Arrange — the other direction of the case above, and the one a fail-open guard reads as
+        # allowed: the tool call starts somewhere with nothing published and the amend lands where
+        # the commit is.
+        elsewhere = self.root / "elsewhere"
+        git(self.root, "clone", "-q", str(self.root / "remote.git"), "elsewhere")
+        commit(elsewhere, "two")
+
+        # Act
+        answer = self.answer(f"cd {self.clone} && git commit --amend", cwd=elsewhere)
+
+        # Assert
+        self.assertEqual((answer[0], answer[1].splitlines()[0]), (REFUSE, PUBLISHED))
+
     def test_Given_ACdTheShellHasNotExpanded_When_AnAmendFollows_Then_ItIsRefused(self):
         # Arrange — reading `$SP` as a literal directory answers about a path nothing holds, and
         # answering about the wrong tree is what this guard exists to stop.


### PR DESCRIPTION
#696 reports `amend_of_published_commit.py` as fail-open for `cd <a published clone> && git commit
--amend`, and names the existing `cd /tmp` case as one that passes for the wrong reason.

Both were fixed by #814, which made the guard read the tree the amend will run in rather than the
one the call started from. `leading_cd` follows the move, `UNRESOLVED_CD` refuses a target the shell
has not expanded, and the `cd /tmp` case now says what it means — "the cd is followed, so the tree
read is the one the amend will run in. That one is not a repository, and a guard that cannot read
`HEAD` is not entitled to say it is published."

What was missing is the direction #696 actually measured. The suite covers a `cd` into a tree with
nothing published (allowed), a `cd` into no repository (unread), and an unexpanded `cd` (refused) —
all posed from the published checkout. None poses the reverse: the call starting where nothing is
published and the amend landing where the commit is. That is the one a fail-open guard reads as
allowed, so it is the one worth pinning.

It is red without the fix: reading `event["cwd"]` instead of the resolved directory leaves the guard
looking at a tree with nothing to refuse, and the case errors on the missing headline while the two
neighbouring `cd` cases fail beside it.

83 cases pass.

Closes #696
