### PR TITLE
fix(velvet): read past an assignment to find the cd a command makes

### DIFF
--- a/.claude/hooks/lib/shell_commands.py
+++ b/.claude/hooks/lib/shell_commands.py
@@ -238,26 +238,35 @@ UNRESOLVED_CD = object()
 
 
 def leading_cd(command):
-    """The directory the first segment changes into, UNRESOLVED_CD when it cannot be read, or None.
+    """The directory the command changes into before running anything else, or None.
 
-    Unresolved rather than absent for a target the shell has not expanded: a hook that reads `$SP` as
-    a literal directory answers about a path nothing holds, and answering about the wrong tree is what
-    this exists to stop.
+    UNRESOLVED_CD, not None, for a target the shell has not expanded: a hook that reads `$SP` as a
+    literal directory answers about a path nothing holds, and answering about the wrong tree is what
+    the callers of this exist to stop. None is "it did not move", which sends the caller to the
+    event's own directory -- so anything this cannot read has to come back as the first, or a guard
+    reads a tree the command was never in and says nothing.
+
+    Every segment up to the first that runs a program is read, not the first segment alone. A
+    variable assignment is a segment of its own, and stopping at one left `SP=/tmp; cd "$SP/x"`
+    answering None -- the shape a session types whenever it names a worktree once and moves into it.
     """
-    segments = command_segments(command)
-    if not segments:
-        return None
-    tokens = tokens_of(segments[0])
-    index = leading_program(tokens)
-    if index >= len(tokens) or tokens[index] != "cd":
-        return None
-    rest = [token for token in tokens[index + 1:] if not token.startswith("-")]
-    if not rest:
-        return None
-    target = rest[0]
-    if "$" in target or "`" in target or "~" in target:
-        return UNRESOLVED_CD
-    return target
+    for segment in command_segments(command):
+        tokens = tokens_of(segment)
+        index = leading_program(tokens)
+        if index >= len(tokens):
+            # An assignment and nothing else. It runs where the last `cd` left the shell, and the
+            # next segment is still before anything this cares about.
+            continue
+        if tokens[index] != "cd":
+            return None
+        rest = [token for token in tokens[index + 1:] if not token.startswith("-")]
+        if not rest:
+            return None
+        target = rest[0]
+        if "$" in target or "`" in target or "~" in target:
+            return UNRESOLVED_CD
+        return target
+    return None
 
 
 def git_invocations(command, subcommands, git_directory=False):

--- a/scripts/hooks/test_amend_of_published_commit.py
+++ b/scripts/hooks/test_amend_of_published_commit.py
@@ -231,6 +231,30 @@ class PublishedHeadTests(GuardCase):
         # Assert
         self.assertEqual((answer[0], answer[1].splitlines()[0]), (REFUSE, PUBLISHED))
 
+    def test_Given_AnAssignmentBeforeAnUnexpandedCd_When_AnAmendFollows_Then_ItIsStillRefused(self):
+        # Arrange -- the shape a session types whenever it names a worktree once and moves into it.
+        # Read as "it did not move", the guard answers about the directory the call started in and
+        # says nothing about the tree the amend lands in.
+        # Act
+        code, text = self.answer('SP=/tmp\ncd "$SP/work" && git commit --amend', cwd=self.clone)
+
+        # Assert
+        self.assertEqual((code, "has not expanded" in text), (REFUSE, True))
+
+    def test_Given_AnAssignmentBeforeACdIntoAnUnpublishedTree_When_ItIsPosed_Then_ItIsAllowed(self):
+        # Arrange -- the same shape with a target the guard can read: the move is followed, so the
+        # tree read is the one the amend will run in and it has nothing published.
+        elsewhere = self.root / "elsewhere"
+        git(self.root, "clone", "-q", str(self.root / "remote.git"), "elsewhere")
+        commit(elsewhere, "two")
+
+        # Act
+        code, text = self.answer(f"SP={self.root}\ncd {elsewhere} && git commit --amend",
+                                 cwd=self.clone)
+
+        # Assert
+        self.assertEqual((code, text), (ALLOW, ""))
+
     def test_Given_ACdTheShellHasNotExpanded_When_AnAmendFollows_Then_ItIsRefused(self):
         # Arrange — reading `$SP` as a literal directory answers about a path nothing holds, and
         # answering about the wrong tree is what this guard exists to stop.


### PR DESCRIPTION
`leading_cd` reads the first segment of a command and nothing else. A variable assignment is a
segment of its own, so a command that names a directory once and then moves into it —

```
SP=/tmp
cd "$SP/work" && git commit --amend
```

— answers `None`, which both callers read as "it did not move". They then take the directory the
tool call started in, and a guard that exists to read the tree a command lands in reads a tree the
command was never in.

`None` is the wrong answer twice over here. The target is unexpanded, so the honest answer is
`UNRESOLVED_CD` — the bare form `cd $SP/work` already gets that, and the assignment in front of it
is the whole difference. And the resolvable form is wrong in the other direction: `SP=/x; cd
/somewhere-else && git commit --amend` reads the starting tree's `HEAD` and refuses or allows on it.

Every segment up to the first that runs a program is read now. An assignment-only segment runs
wherever the last `cd` left the shell and is passed over; the first segment that runs something is
either a `cd` — followed, or refused when its target is unexpanded — or it is not, and the command
did not move.

Two cases, both red without it: the unexpanded form answers about the wrong tree rather than
refusing, and the resolvable form refuses a tree that has nothing published. `amend_of_published_commit.py`
and `message_outside_its_worktree.py` are the two callers; 85 and 9 cases pass.

No issue: `leading_cd`'s first-segment reading is narrower than the shape its callers are pointed
at, which #696 measured one variant of and this is another.
