### PR TITLE
fix(velvet): send a run the loop cannot reach to the budget, not to the case

### DIFF
--- a/scripts/test_quality/base_red_check.py
+++ b/scripts/test_quality/base_red_check.py
@@ -895,19 +895,51 @@ def wait_for_quiet(seconds):
     return True
 
 
-COMPILE_ERROR = re.compile(r"^(?:.*?[\\/])?((?:Assets|Packages)[\\/][^(]+)\(\d+,\d+\): error CS")
+COMPILE_ERROR = re.compile(
+    r"^(?:.*?[\\/])?((?:Assets|Packages)[\\/][^(]+)\(\d+,\d+\): error (CS\d+)")
+
+# The compiler saying a name does not resolve. One of these on a carried file means withdrawing that
+# file lets the rest be measured, which is what the round loop is for.
+NAME_IS_ABSENT = frozenset({"CS0246", "CS0103", "CS0117", "CS1061", "CS0234"})
+
+
+def compile_errors_in(log_text):
+    """(repository-relative source, CS code) for each compile error a Unity log blames on a file."""
+    found = []
+    for line in log_text.splitlines():
+        match = COMPILE_ERROR.match(line.strip())
+        if match:
+            entry = (match.group(1).replace("\\", "/"), match.group(2))
+            if entry not in found:
+                found.append(entry)
+    return found
 
 
 def compile_error_files(log_text):
     """The repository-relative sources a Unity log blames a compile error on."""
     named = []
-    for line in log_text.splitlines():
-        match = COMPILE_ERROR.match(line.strip())
-        if match:
-            relative = match.group(1).replace("\\", "/")
-            if relative not in named:
-                named.append(relative)
+    for relative, _ in compile_errors_in(log_text):
+        if relative not in named:
+            named.append(relative)
     return named
+
+
+def no_withdrawal_reaches(log_text, carry):
+    """Whether nothing the base raised on a carried file is a name it has not got.
+
+    A withdrawal answers one kind of failure: a carried file spelling a name the base lacks comes
+    out, and the rest of its assembly builds. It answers none of the other kind -- an argument, a
+    return, an inferred type -- where the name resolves and the shape does not, because the file
+    that fails is the file the case is in.
+
+    This decides which remedy to print, and nothing else. It is not evidence that the base cannot
+    answer: `exhausted_reason` records a run on the branch replacing UniTask where a budget of 60
+    reached a compiling base on round 38 and gave every case a verdict, at the same default of 8
+    that reported nothing measured. So a round that wrote nothing under these codes is a budget
+    finding, and telling the author to sharpen the case is what this exists to stop.
+    """
+    blamed = [code for relative, code in compile_errors_in(log_text) if relative in carry]
+    return bool(blamed) and not any(code in NAME_IS_ABSENT for code in blamed)
 
 
 def next_to_withdraw(log_text, carry, withdrawn, silent):
@@ -1917,6 +1949,21 @@ def budget_shortfall(standing, budget):
             "  --max-rounds {}".format(standing, budget, standing))
 
 
+def shapes_remedy(carried):
+    """What to print where no withdrawal reaches what the base raised.
+
+    The generic line sends the author to sharpen the case, and there is nothing to sharpen: the base
+    holds the members these cases spell under the shapes this change replaced, so no case can be red
+    there until every carried file has come out -- at which point the budget is the whole set. That
+    is a number this can name before the rounds are spent.
+    """
+    return ("\nNothing the base raised on a carried file is a name it has not got, so no withdrawal\n"
+            "reaches it: the members resolve and their shapes differ. Every round therefore withdraws\n"
+            "a file whose cases it then cannot measure, and the base compiles only once the whole\n"
+            "carried set is out. Give it the whole set:\n"
+            "  --max-rounds {}".format(carried))
+
+
 def exhausted_reason(spent, withdrawn, carried):
     """What a loop that ran out of rounds without ever compiling the base has to say for itself.
 
@@ -2144,6 +2191,7 @@ def main():
     reported = {}
     transcript = []
     canaries = {}
+    last_log = None
     ever_wrote = not any(kind_of(case.path) == "csharp" for case in cases)
     rounds_spent = 0
     put_back = set()
@@ -2197,6 +2245,7 @@ def main():
                     if stale.exists():
                         stale.unlink()
                 wall = run_unity(args.unity, base_tree, platform, fixtures, results, log, args.timeout)
+                last_log = log
                 seen, wrote = results_from(results)
                 ever_wrote = ever_wrote or wrote
                 reported.update(seen)
@@ -2226,7 +2275,14 @@ def main():
 
     if not ever_wrote:
         print("no round wrote a result, so nothing any of them was asked was measured", flush=True)
-        if rounds_spent >= args.max_rounds:
+        # Which of the two the run hit, because the remedies differ. A name the base has not got is
+        # what a withdrawal answers, so more rounds reach it; nothing but shapes means every round
+        # withdraws a file whose case it then cannot measure, and the budget has to cover the whole
+        # carried set before the base compiles at all.
+        if last_log and last_log.exists() and no_withdrawal_reaches(
+                last_log.read_text(errors="replace"), set(carry)):
+            print(shapes_remedy(len(carry)), flush=True)
+        elif rounds_spent >= args.max_rounds:
             print(exhausted_reason(rounds_spent, put_back, len(carry)), flush=True)
     offenders = report(cases, control, reported, canaries, ever_wrote)
     print("\nlogs: {}".format(output), flush=True)

--- a/scripts/test_quality/test_base_red_check.py
+++ b/scripts/test_quality/test_base_red_check.py
@@ -740,6 +740,51 @@ class BudgetShortfallTests(unittest.TestCase):
         self.assertEqual(("--max-rounds 23" in said, "--max-rounds 8" in said), (True, True))
 
 
+SHAPES_ONLY = ("Packages/x/Runtime/Tests/Editor/A.cs(41,17): error CS1503: argument 1\n"
+               "Packages/x/Runtime/Tests/Editor/B.cs(9,1): error CS0029: cannot convert\n")
+
+WITH_A_NAME = SHAPES_ONLY + \
+    "Packages/x/Runtime/Tests/Editor/C.cs(3,3): error CS0246: the type could not be found\n"
+
+CARRIED_THREE = {"Packages/x/Runtime/Tests/Editor/A.cs", "Packages/x/Runtime/Tests/Editor/B.cs",
+                 "Packages/x/Runtime/Tests/Editor/C.cs"}
+
+
+class NoWithdrawalReachesTests(unittest.TestCase):
+    """Which of two remedies a run that compiled nothing has earned.
+
+    A withdrawal answers one kind of failure and not the other, and the difference is in the codes.
+    It decides what to print and nothing else: `exhausted_reason` records a run where a budget of 60
+    reached a compiling base on round 38 at the same default of 8 that measured nothing, so a run
+    under these codes is a budget finding rather than a base that cannot answer.
+    """
+
+    def test_Given_NothingButShapes_When_TheLogIsRead_Then_NoWithdrawalReachesIt(self):
+        # Arrange -- the file that fails is the file the case is in, so putting it back removes the
+        # case rather than the obstacle.
+        # Act / Assert
+        self.assertIs(base_red_check.no_withdrawal_reaches(SHAPES_ONLY, CARRIED_THREE), True)
+
+    def test_Given_OneNameTheBaseHasNotGot_When_TheLogIsRead_Then_AWithdrawalReachesIt(self):
+        # Arrange -- one of these and the loop has something to do, which is the other remedy.
+        # Act / Assert
+        self.assertIs(base_red_check.no_withdrawal_reaches(WITH_A_NAME, CARRIED_THREE), False)
+
+    def test_Given_ErrorsOnFilesNothingCarried_When_TheLogIsRead_Then_TheyDecideNothing(self):
+        # Arrange -- a base failing to build its own sources says nothing about which remedy the
+        # carried cases have earned.
+        # Act / Assert
+        self.assertIs(base_red_check.no_withdrawal_reaches(SHAPES_ONLY, set()), False)
+
+    def test_Given_TheRemedyForShapes_When_ItIsPrinted_Then_ItNamesTheWholeCarriedSet(self):
+        # Arrange -- the budget has to cover every carried file, since the base compiles only once
+        # they are all out.
+        said = base_red_check.shapes_remedy(31)
+
+        # Act / Assert
+        self.assertIn("--max-rounds 31", said)
+
+
 class ExhaustedLoopTests(unittest.TestCase):
     """What the withdrawing loop says when it runs out of rounds having compiled nothing.
 


### PR DESCRIPTION
A base-red run that compiled nothing has earned one of two remedies, and the guard printed one of
them for both.

A carried file that spells a name the base has not got comes out, and the rest of its assembly
builds. That is what the round loop answers, and more rounds reach it.

A carried file whose members resolve under different shapes cannot be put back without taking its
cases with it. Every round withdraws one and measures nothing, and the base compiles only once the
whole carried set is out — so the budget has to cover the set, and no amount of sharpening the case
changes that. The guard offered exactly that: sharpen the case until it goes red, or declare why it
belongs there. Neither reaches a tree the case cannot be written against.

**The compiler separates them and the reader was throwing it away.** `COMPILE_ERROR` captured the
file and dropped the `CS` number. `CS0246` and its relatives say a name does not resolve; everything
else the base raises on a carried file says the name resolved and the shape did not. Under nothing
but the second kind, the run now names the whole carried set as the budget.

**It changes which sentence is printed and nothing else** — no verdict, no exit status, no reading of
any case. That is deliberate. `exhausted_reason`'s own docstring records a run on the branch replacing
`UniTask` where a budget of 60 reached a compiling base on round 38 and gave every case a verdict, at
the same default of 8 that reported nothing measured. So a run under these codes is a budget finding,
and an earlier draft of this change that read it as a base which *cannot* answer would have hidden
the reading that works — and, measured, would have handed the same exemption to any branch that adds
an overload, since a test written against one fails the base with `CS1503` and nothing else.

Four cases: nothing but shapes, one name among them, errors on files nothing carried, and the remedy
naming the whole set. 244 pass, against 240 at the merge base.

No issue: #865 and #635 both describe base-red not answering for that branch. This does not close
either — the reading is available locally and CI still cannot take it — but it stops the guard
sending an author to sharpen a case no base can answer.
