### PR TITLE
fix(velvet): stop a bytecode cache being written where a later run would read it

### DIFF
--- a/.github/workflows/generators.yml
+++ b/.github/workflows/generators.yml
@@ -51,6 +51,15 @@ concurrency:
 permissions:
   contents: read
 
+# Python validates a cached bytecode file against the source's mtime in whole seconds and its size,
+# so a length-preserving edit made and undone inside one second leaves the cache valid and the next
+# run executes the previous state's bytecode. base_red_check withdraws a carried file and asks the
+# tree again, which is exactly that window. -B is not the fix -- it stops the write and not the
+# read, so a cache written by one invocation is still read by the next; the setting has to reach
+# every invocation, and at job level it does.
+env:
+  PYTHONDONTWRITEBYTECODE: "1"
+
 jobs:
   # ---------------------------------------------------------------------------
   # Source-generator tests (.NET / xUnit). No Unity license required.

--- a/.github/workflows/generators.yml
+++ b/.github/workflows/generators.yml
@@ -91,6 +91,8 @@ jobs:
       - name: Committed generator DLL check tests
         run: python3 scripts/test_quality/run_suite.py scripts/generators/test_deployed_dll_check.py
 
+      - run: python3 scripts/test_quality/run_suite.py scripts/hooks/test_workflow_bytecode_env.py
+
       - name: Cohesion report
         run: python3 scripts/test_quality/cohesion_report.py
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,15 @@ permissions:
   contents: read
   checks: write
 
+# Python validates a cached bytecode file against the source's mtime in whole seconds and its size,
+# so a length-preserving edit made and undone inside one second leaves the cache valid and the next
+# run executes the previous state's bytecode. base_red_check withdraws a carried file and asks the
+# tree again, which is exactly that window. -B is not the fix -- it stops the write and not the
+# read, so a cache written by one invocation is still read by the next; the setting has to reach
+# every invocation, and at job level it does.
+env:
+  PYTHONDONTWRITEBYTECODE: "1"
+
 jobs:
   # ---------------------------------------------------------------------------
   # Detect whether a Unity license secret is configured. Secrets cannot be

--- a/.github/workflows/upm.yml
+++ b/.github/workflows/upm.yml
@@ -24,6 +24,10 @@ concurrency:
   group: upm
   cancel-in-progress: false
 
+# Same reason test.yml gives: the setting is worth nothing unless every invocation carries it.
+env:
+  PYTHONDONTWRITEBYTECODE: "1"
+
 jobs:
   split:
     name: Split package to upm branch

--- a/scripts/hooks/test_workflow_bytecode_env.py
+++ b/scripts/hooks/test_workflow_bytecode_env.py
@@ -38,6 +38,10 @@ class WorkflowBytecodeEnvTests(unittest.TestCase):
         return sorted(path for path in WORKFLOWS.glob("*.yml")
                       if runs_python(path.read_text(encoding="utf-8")))
 
+    # GREEN_ON_BASE(construction): the floor under the case below, and a floor is green wherever the
+    # thing it measures exists -- the base runs python3 in its workflows too. Deleting
+    # `runs_python`'s substring test so it selects nothing leaves the case below passing over an
+    # empty set, and this is what fails then.
     def test_Given_TheWorkflowsHere_When_TheyAreRead_Then_SomeRunPython(self):
         # Arrange -- the floor: a case over an empty set would pass having asked nothing.
         # Act / Assert

--- a/scripts/hooks/test_workflow_bytecode_env.py
+++ b/scripts/hooks/test_workflow_bytecode_env.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Every workflow that runs Python sets PYTHONDONTWRITEBYTECODE, at job level.
+
+Python validates a cached bytecode file against the source's mtime in whole seconds and its size, so
+a length-preserving edit made and undone inside one second leaves the cache valid and the next run
+executes the previous state's bytecode against the current source. `base_red_check.py` withdraws a
+carried file and asks the tree again, which is that window.
+
+`-B` on an invocation is not the remedy and was measured not to be: with a stale cache in place, a
+plain run and a `-B` run both answer from the cache, because the flag stops the write and not the
+read. So a cache one invocation writes is read by the next, and the setting is worth nothing unless
+every invocation carries it. At job level every one does, which is why this reads the workflow rather
+than the call sites.
+
+What it cannot reach is a developer's own shell, where the cache also sits wherever
+`sys.pycache_prefix` points -- outside the worktree on macOS, and surviving `git clean`.
+
+Run: python3 scripts/hooks/test_workflow_bytecode_env.py
+"""
+
+import unittest
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOWS = REPO_ROOT / ".github" / "workflows"
+
+SETTING = "PYTHONDONTWRITEBYTECODE"
+
+
+def runs_python(text):
+    return "python3 " in text
+
+
+class WorkflowBytecodeEnvTests(unittest.TestCase):
+    def workflows_running_python(self):
+        return sorted(path for path in WORKFLOWS.glob("*.yml")
+                      if runs_python(path.read_text(encoding="utf-8")))
+
+    def test_Given_TheWorkflowsHere_When_TheyAreRead_Then_SomeRunPython(self):
+        # Arrange -- the floor: a case over an empty set would pass having asked nothing.
+        # Act / Assert
+        self.assertGreater(len(self.workflows_running_python()), 0)
+
+    def test_Given_AWorkflowThatRunsPython_When_ItIsRead_Then_ItSetsTheSettingAtJobLevel(self):
+        # Arrange -- job level rather than step level, because a step that forgets it writes the
+        # cache every later step reads.
+        without = [path.name for path in self.workflows_running_python()
+                   if (yaml.safe_load(path.read_text(encoding="utf-8")).get("env") or {})
+                   .get(SETTING) != "1"]
+
+        # Act / Assert
+        self.assertEqual(without, [])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Python validates a cached bytecode file against the source's **mtime in whole seconds** and its
**size**. A length-preserving edit made and undone inside one second leaves the cache valid, and the
next run executes the previous state's bytecode against the current source. `base_red_check.py`
withdraws a carried file and asks the tree again, which is exactly that window.

**`-B` is not the remedy, and it was measured not to be.** With a stale cache in place:

```
plain    -> 1     (the compiled body)
with -B  -> 1     (the same)
```

The flag stops the *write*, not the *read*. So a cache one invocation writes is read by the next,
and the setting is worth nothing unless every invocation carries it — 152 of them at shell level in
this repository, and each new one would have to remember. At job level every invocation inherits it,
which is where it goes: `test.yml`, `generators.yml` and `upm.yml` each gain one `env:` block.

The cache is also invisible where it matters most. `sys.pycache_prefix` put it under
`~/Library/Caches` on the machine this was measured on, so it sits **outside the worktree**, a search
for `__pycache__` finds nothing, and `git clean` does not remove it. Deleting it there was what
finally made the source on disk decide:

```
after removing the real cache -> 2
```

`scripts/hooks/test_workflow_bytecode_env.py` holds it: every workflow whose text runs `python3` sets
`PYTHONDONTWRITEBYTECODE` at job level, with a floor case so an empty set cannot pass for a clean
one. Red without the `env:` blocks.

What this does not reach is a developer's own shell, and the suite's docstring says so rather than
implying the hole is closed. A per-invocation `-B` would not have reached it either, for the reason
measured above.

Closes #852
