### PR TITLE
fix(velvet): stop offering a budget that was measured not to reach it

### DIFF
--- a/scripts/test_quality/base_red_check.py
+++ b/scripts/test_quality/base_red_check.py
@@ -1952,16 +1952,22 @@ def budget_shortfall(standing, budget):
 def shapes_remedy(carried):
     """What to print where no withdrawal reaches what the base raised.
 
-    The generic line sends the author to sharpen the case, and there is nothing to sharpen: the base
-    holds the members these cases spell under the shapes this change replaced, so no case can be red
-    there until every carried file has come out -- at which point the budget is the whole set. That
-    is a number this can name before the rounds are spent.
+    Not a budget. This said the base compiles once the whole carried set is out and named that
+    count as `--max-rounds`, and measured on the branch replacing UniTask with an in-tree awaitable
+    it is false: given more rounds than the count, the loop spent 27, ran out of files it could
+    withdraw with three fixtures still carried, and compiled nothing. What it was left holding was
+    123 errors of one code, every one a receiver type an extension method does not take.
+
+    So the remedy is to say the harness has no reading here, and stop offering one. What to do about
+    a change base-red cannot answer for is the author's, and it is not a number.
     """
     return ("\nNothing the base raised on a carried file is a name it has not got, so no withdrawal\n"
-            "reaches it: the members resolve and their shapes differ. Every round therefore withdraws\n"
-            "a file whose cases it then cannot measure, and the base compiles only once the whole\n"
-            "carried set is out. Give it the whole set:\n"
-            "  --max-rounds {}".format(carried))
+            "reaches it: the file that fails is the file the case is in, and putting it back removes\n"
+            "the case rather than the obstacle. More rounds do not help -- measured on a change of\n"
+            "this shape, the loop ran out of files it could withdraw with {} still carried and\n"
+            "compiled nothing.\n"
+            "\nThere is no reading here to take. Whether a change base-red cannot answer for should\n"
+            "land is yours to decide, and this has nothing further to say about it.".format(carried))
 
 
 def exhausted_reason(spent, withdrawn, carried):

--- a/scripts/test_quality/test_base_red_check.py
+++ b/scripts/test_quality/test_base_red_check.py
@@ -776,13 +776,13 @@ class NoWithdrawalReachesTests(unittest.TestCase):
         # Act / Assert
         self.assertIs(base_red_check.no_withdrawal_reaches(SHAPES_ONLY, set()), False)
 
-    def test_Given_TheRemedyForShapes_When_ItIsPrinted_Then_ItNamesTheWholeCarriedSet(self):
-        # Arrange -- the budget has to cover every carried file, since the base compiles only once
-        # they are all out.
+    def test_Given_TheRemedyForShapes_When_ItIsPrinted_Then_ItOffersNoBudget(self):
+        # Arrange -- it named one, and measured on the branch replacing UniTask a budget above that
+        # count still ran out of files to withdraw with three fixtures carried and compiled nothing.
         said = base_red_check.shapes_remedy(31)
 
         # Act / Assert
-        self.assertIn("--max-rounds 31", said)
+        self.assertNotIn("--max-rounds", said)
 
 
 class ExhaustedLoopTests(unittest.TestCase):


### PR DESCRIPTION
The remedy that landed yesterday said the base compiles once the whole carried set is out, and named
that count as `--max-rounds`. **It was measured today and it is false.**

Run on the branch replacing UniTask with an in-tree awaitable, given a budget above the count it
would have named:

```
EditMode attempt 27: 0 case(s) over 3 fixture(s) in 3s
no round wrote a result, so nothing any of them was asked was measured
```

The loop spent 27 of 40 rounds, ran out of files it could withdraw with three fixtures still
carried, and compiled nothing. It stopped for want of candidates, not for want of budget, so the
number was advice that could not be taken. What the last round was left holding:

```
123 CS1929
```

— one code, every occurrence a receiver type an extension method does not take.

The sentence was an unmeasured mechanism in the shape this repository keeps getting wrong: a true
observation with an assumed consequence bolted on. *No withdrawal reaches these* was measured and
stays. *Therefore the base compiles once they are all out* was not, and goes.

What it says now is that more rounds do not help, with the measurement behind it, and that whether a
change base-red cannot answer for should land is the author's to decide. It offers no number. The
check still fails and nothing here exempts anything — the case that pinned the budget now pins its
absence.

No documentation change: `CONTRIBUTING.md` carries no copy of the claim.

No issue: it corrects a sentence this repository shipped yesterday.
