### PR TITLE
fix(velvet): publish every line under main's release rules, not the line's own

### DIFF
--- a/.github/workflows/generators.yml
+++ b/.github/workflows/generators.yml
@@ -93,6 +93,8 @@ jobs:
 
       - run: python3 scripts/test_quality/run_suite.py scripts/hooks/test_workflow_bytecode_env.py
 
+      - run: python3 scripts/test_quality/run_suite.py scripts/release/test_publish_rules_come_from_main.py
+
       - name: Cohesion report
         run: python3 scripts/test_quality/cohesion_report.py
 

--- a/.github/workflows/upm.yml
+++ b/.github/workflows/upm.yml
@@ -44,6 +44,22 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
+      # A release dispatched on a maintenance line runs that line's copy of these checks, which is
+      # main's copy as of the cut -- so every rule main adds afterwards is one the line can ship
+      # against. Measured: main forbids a Breaking highlight outside a major, 2.x carries no such
+      # case, and v2.1.4 published one from the line. Overlaid rather than named per line, so a
+      # 3.x and a 4.x are covered by having been cut at all.
+      - name: Take the release rules from main, whatever line this is
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          git fetch --quiet --depth=1 origin main
+          git checkout --quiet FETCH_HEAD -- scripts/release
+          git reset --quiet -- scripts/release
+
+      - name: Release rules (release only)
+        if: github.event_name == 'workflow_dispatch'
+        run: python3 scripts/release/test_release_notes.py
+
       - name: Verify version matches package.json (release only)
         if: github.event_name == 'workflow_dispatch'
         env:

--- a/scripts/release/test_publish_rules_come_from_main.py
+++ b/scripts/release/test_publish_rules_come_from_main.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""The release rules a publish runs are main's, whatever line is being published.
+
+A release is dispatched on the line it belongs to -- measured, the v2.1.4 dispatch ran with
+`ref=2.x` -- so `actions/checkout` gives it that line's tree, and the release checks it runs are
+main's copy as of the cut. Every rule main adds afterwards is one the line can ship against, and one
+did: main's `test_release_notes.py` forbids a `Breaking` highlight outside a major, the 2.x copy
+carries no such case, and v2.1.4 published one.
+
+Held on the workflow rather than on a line, because naming the lines is what stops scaling: a 3.x
+and a 4.x are cut the same way and inherit the same staleness the day they are cut.
+
+Run: python3 scripts/release/test_publish_rules_come_from_main.py
+"""
+
+import unittest
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "upm.yml"
+RULES = "scripts/release/test_release_notes.py"
+
+
+def steps():
+    job = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))["jobs"]
+    return next(iter(job.values()))["steps"]
+
+
+def index_of(predicate):
+    for at, step in enumerate(steps()):
+        if predicate(step.get("run") or ""):
+            return at
+    return None
+
+
+class PublishRulesTests(unittest.TestCase):
+    def test_Given_TheDispatch_When_ItReadsTheReleaseRules_Then_ItTakesThemFromMain(self):
+        # Arrange -- the line's own copy is whatever main held on the day it was cut.
+        # Act / Assert
+        self.assertIsNotNone(index_of(lambda run: "origin main" in run and "scripts/release" in run))
+
+    def test_Given_TheDispatch_When_ItRunsTheReleaseRules_Then_TheyRunAfterTheOverlay(self):
+        # Arrange -- run before it and they are the line's copy again, which is the whole defect.
+        overlay = index_of(lambda run: "origin main" in run and "scripts/release" in run)
+        rules = index_of(lambda run: RULES in run)
+
+        # Act / Assert
+        self.assertEqual((rules is not None, overlay is not None and rules > overlay), (True, True))
+
+    def test_Given_TheOverlayAndTheRules_When_TheEventIsAPush_Then_NeitherRuns(self):
+        # Arrange -- a push to main is the mirror split, not a release, and has no version to check.
+        guarded = [step.get("if") for step in steps()
+                   if RULES in (step.get("run") or "")
+                   or ("origin main" in (step.get("run") or "")
+                       and "scripts/release" in (step.get("run") or ""))]
+
+        # Act / Assert -- the count with it, so an empty set cannot pass for two guarded steps.
+        self.assertEqual((len(guarded),
+                          [held for held in guarded if "workflow_dispatch" not in (held or "")]),
+                         (2, []))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
A release is dispatched on the line it belongs to. Measured — the run that published v2.1.4:

```
08-30T01:38 dispatch ref=2.x success
```

So `actions/checkout` hands it **that line's tree**, and the release checks it runs are main's copy
as of the day the line was cut. Every rule main adds afterwards is one the line can ship against.

**One did.** `test_release_notes.py` on main forbids a `**Breaking:**` highlight outside a major:

```
test_Given_a_release_that_is_not_a_major_When_reading_its_highlights_Then_none_claims_a_break
```

`git show origin/2.x:scripts/release/test_release_notes.py | grep -c none_claims_a_break` → **0**.
The line has no such case, and v2.1.4 published a `**Breaking:**` bullet in a patch. Nothing in the
dispatch could have caught it: the rule was not in the tree the dispatch was reading.

The fix overlays `scripts/release/` from main before anything is verified, and runs the rules there
rather than only in main's own pull-request lane. Two steps, both `workflow_dispatch`-only — a push
to `main` is the mirror split, not a release, and has no version to check.

**Nothing names a line.** `2.x` appears nowhere in the change. A 3.x and a 4.x are cut the same way
and inherit the same staleness the day they are cut, so the mechanism has to be about how a publish
reads its rules, not about which lines exist today.

`scripts/release/test_publish_rules_come_from_main.py` holds it from the workflow YAML: the overlay
exists, the rules run *after* it, and both are dispatch-guarded — with the guarded-step count in the
assertion, so an empty set cannot pass for two. All three are red against `origin/main`'s workflow.

This does not repair v2.1.4, which is published. What it repairs is that the next release from any
line is read against the rules this repository holds today.

No issue: the gap was found while carrying 2.1.4's CHANGELOG section forward onto `main`, where
main's own suite refused it.
