### PR TITLE
chore(velvet): record v2.1.4 on main, and ask the breaking rule only of what can change

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -610,6 +610,101 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   flow, including what changes with more than one Blocker registered, where React Router supports a
   single one.
 
+## [2.1.4] - 2026-08-30
+
+### Highlights
+
+- A `V.NavLink` whose `to` is relative navigated correctly and never lit up. The click resolved the
+  target through the router while the active comparison used the string as written, so `to: ".."`
+  was measured against a path that starts with `/` and never matched. Both sides resolve the same
+  way now.
+
+- A pending indicator could stay on screen after its transition finished, or never come up at all.
+  `isPending` answered for the lanes of the component that called `startTransition` rather than for
+  the work the callback did, so a transition whose writes all landed elsewhere read as settled the
+  moment the callback returned, and two concurrent transitions credited each other.
+
+- `startTransition(() => setItemsFromParent(heavyList))` — the shape a child uses to defer an
+  expensive update through a setter it was handed — did not defer. The update was classified against
+  the component that owns the state, which is in no transition, so it took the Normal lane, or the
+  Urgent one inside a click. `Store` writes made in the callback behaved the same way.
+
+- An update that merely happened to land while an async action was awaiting — a timer tick, a
+  `UseStore` notification, a `UseMutation` callback — was taken for the action's own continuation and
+  given the Transition lane, where it waited out the delayed tier's 100 ms instead of committing at
+  the next frame boundary. Nothing is inferred from in-flight fiber state any more.
+
+- The async action the migration guide asks callers to write — one that wraps its post-`await` update
+  in the starter again — did nothing when the component that started it had gone away. The starter
+  short-circuited before opening a scope, so every update it made, on components still alive, took
+  the Normal lane. React sets its ambient flag with no fiber in hand and this now does too.
+
+- **Breaking:** `SearchParams.Empty` hands back a fresh instance on every read instead of one shared
+  for the process. It was a `static readonly` field, and `Append` mutates in place, so the shape the
+  member invites wrote into the instance every other reader saw. Reading it is spelled the same and
+  still yields an empty `SearchParams`; what two reads no longer share is the object. A reference
+  comparison against `SearchParams.Empty` therefore no longer recognises an instance from an earlier
+  read, and binding a readonly reference to it — an explicit `in` argument, a `ref readonly` local or
+  return — stops compiling. No Velvet signature declares a `SearchParams` parameter, so reaching the
+  last of those takes a declaration of your own over the concrete type.
+
+### Fixed
+
+- `startTransition(() => setItemsFromParent(heavyList))` — a child deferring an expensive update
+  through a setter it received as a prop — had that update classified against the component that
+  *owns* the state, which was in no transition, so it took the Normal lane, or the Urgent lane
+  inside a click. The same held for a `Store` write made inside the callback.
+- A starter whose declaring component had gone away short-circuited before opening any scope, so
+  every update its callback made — on components still alive — took the Normal lane. React has no
+  such short-circuit; it sets its ambient flag with no fiber in hand. The scope now opens on that
+  path too and only the bookkeeping is skipped. That is the shape the migration guide asks callers
+  to write: an `async` action wrapping its post-`await` update in the starter again, having outlived
+  the component that started it.
+- `isPending` answered for the calling component's lanes rather than for the callback's work, so a
+  transition whose writes all landed elsewhere settled the moment its callback returned; an `async`
+  action's completion cleared the flag and scheduled nothing, stranding the indicator on screen; a
+  synchronous callback that drove a flush of its own ran the transition with the indicator down; and
+  two concurrent transitions credited each other's writes.
+- An unrelated update landing while an async action awaited — a timer tick, a `UseStore`
+  notification, a `UseMutation` callback — was indistinguishable from the action's own continuation
+  and got the Transition lane, so it waited out the delayed tier's 100 ms instead of committing at
+  the next frame boundary. Nothing is inferred from in-flight fiber state now.
+
+React sets its transition flag before the callback and restores it in a `finally`, with no `await`
+in between — so for an async scope the restore runs the moment the callback hands back its promise,
+and nothing re-establishes it for the continuation. Its lane decision reads that ambient flag rather
+than the component the update belongs to, apart from one legacy branch its current default flag set
+turns off. react.dev states the same contract from the outside and files the post-`await` case as a
+known limitation it means to fix.
+
+
+- `SearchParams.Empty` hands back a new instance on each read. It was a `static readonly` field
+  holding one instance for the whole process, and `SearchParams.Append` mutates the instance it is
+  called on, so the shape the member invites — `var next = SearchParams.Empty; next.Append("q",
+  term);` — wrote into that one instance, and a read of `SearchParams.Empty` anywhere else in the
+  process carried `q` from then on. `SearchParams` declares no member that removes a value, so the
+  written-into instance stayed that way. Reading the member is spelled the same and still yields an
+  empty `SearchParams`; what two reads no longer share is the object. A reference comparison against
+  `SearchParams.Empty` therefore no longer recognises an instance taken from an earlier read, and
+  binding a readonly reference to the member — an argument written with an explicit `in`, a
+  `ref readonly` local, a `ref readonly` return — stops compiling. Reaching that last one takes a
+  declaration over the concrete `SearchParams` type, and no Velvet signature declares a
+  `SearchParams` parameter.
+
+- `V.NavLink` with a relative `to` takes its active class. The click path resolved the target through
+  the router — `..` against the enclosing route, a bare segment appended to it — while the active
+  comparison used the string as written, so `to: ".."` was compared against a current path beginning
+  with `/` and did not match: the link navigated to the right place and stayed unhighlighted. The
+  target is now resolved through the same `Router` call the click makes, anchored at the caller's
+  Outlet depth, before it is normalised and compared. An absolute target is returned by that call
+  unchanged, so `end`, `caseSensitive`, a trailing slash and a query answer as before; with no router
+  mounted to resolve through, the target is compared as written, as it was.
+  One shape that was active is active elsewhere now: a query-only `to` such as `"?tab=1"` normalised
+  to `/`, so with `end` left false it lit up wherever the user was. It now resolves against the
+  current route and the comparison strips the query from what comes back, so it is active on that
+  route's path and under it — what an absolute `to` naming that path gives. Where clicking it takes
+  the user is unchanged.
+
 ## [2.1.3] - 2026-08-27
 
 ### Highlights

--- a/Packages/com.velvet.core/package.json
+++ b/Packages/com.velvet.core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.velvet.core",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "displayName": "Velvet",
   "description": "React-style declarative UI framework for Unity UI Toolkit. Provides virtual DOM, reconciliation engine, hooks, and component model.",
   "license": "MIT",

--- a/scripts/release/breaking_in_flight_check.py
+++ b/scripts/release/breaking_in_flight_check.py
@@ -25,6 +25,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import published_check
+
 CHANGELOG = "Packages/com.velvet.core/CHANGELOG.md"
 BREAKING = "Unreleased — breaking"
 VERSION_HEADING = re.compile(r"^## \[(\d+\.\d+\.\d+)\]", re.M)
@@ -61,9 +63,16 @@ def at(rev, path):
     return out
 
 
-def closing(base, result):
-    """The versions this change closes, which is the whole of when the question is asked."""
-    return sorted(released(at(result, CHANGELOG)) - released(at(base, CHANGELOG)))
+def closing(base, result, tags=()):
+    """The versions this change closes, which is the whole of when the question is asked.
+
+    A version the remote already tags is one this change records rather than closes -- carrying a
+    maintenance line's released section forward brings it across, and asked without the tags that
+    reads as a release, so the question goes to a body that decides nothing about it. The same
+    reading published_check.drain_reason takes, for the same reason.
+    """
+    return sorted(named for named in released(at(result, CHANGELOG)) - released(at(base, CHANGELOG))
+                  if "v" + named not in tags)
 
 
 def open_pull_requests(repo):
@@ -114,7 +123,14 @@ def main():
     parser.add_argument("--repo", help="owner/name, when gh cannot infer it")
     args = parser.parse_args()
 
-    versions = closing(args.base, args.result)
+    # Asked of the remote rather than of a local tag list, for the reason published_check gives. A
+    # checkout with no remote to ask reads as no tags, which is the stricter direction: every
+    # version then counts as closing, which is what this did before it could ask at all.
+    try:
+        tags = published_check.remote_tags(Path.cwd())
+    except Exception:
+        tags = set()
+    versions = closing(args.base, args.result, tags)
     if not versions:
         print("closes no version, so nothing is asked about work in flight")
         return 0

--- a/scripts/release/published_check.py
+++ b/scripts/release/published_check.py
@@ -294,6 +294,32 @@ def git(project, *args, timeout=5):
     return result.stdout
 
 
+BREAKING_MARKER = "**Breaking:**"
+
+
+def breaking_highlight_in(text, version):
+    """Whether that version's Highlights claim a break."""
+    import release_notes
+    return BREAKING_MARKER in "\n".join(
+        release_notes.split_highlights(
+            release_notes.extract_version_section(text, version), version)[0])
+
+
+def claims_a_break_outside_a_major(text, versions, published):
+    """Versions claiming a break that neither bump a major nor are already published.
+
+    `published` is what the remote tags. A note somebody has already installed against cannot be
+    re-versioned, so the remedy for a version published wrong is the next release rather than an
+    edit to the record of it -- and a rule asked of every version forever makes a CHANGELOG that
+    cannot carry a published mistake, which is one that has to lie about it. The same distinction
+    drain_reason draws between closing a version and recording one.
+    """
+    bumps = {version for version in versions if is_major_bump(versions, version)}
+    return [version for version in versions
+            if version not in bumps and "v" + version not in published
+            and breaking_highlight_in(text, version)]
+
+
 def remote_tags(project, remote="origin", timeout=5):
     """Tag names on the remote.
 

--- a/scripts/release/test_breaking_in_flight_check.py
+++ b/scripts/release/test_breaking_in_flight_check.py
@@ -194,5 +194,42 @@ class Decisions(unittest.TestCase):
         self.assertEqual(done.returncode, 0)
 
 
+class RecordingIsNotClosing(unittest.TestCase):
+    """A version the remote already tags is carried across, not closed.
+
+    Carrying a maintenance line's released section forward brings its heading with it, and read as a
+    release it puts the question to a body that decides nothing about it: the version shipped before
+    the pull request existed.
+    """
+
+    def setUp(self):
+        self.root, self.base, self.branch = repository()
+        # An origin to ask, pointing at the tree itself: the reading is of the remote's tags, and a
+        # checkout with none reads as none, which is the direction that asks about everything.
+        git(self.root, "remote", "add", "origin", str(self.root))
+
+    def test_Given_AVersionTheRemoteTags_When_TheChangeCarriesIt_Then_NothingIsAsked(self):
+        # Arrange -- the forward-carry: the section arrives, the tag is already out.
+        git(self.root, "tag", "v3.0.0")
+
+        # Act
+        done = run(self.root, self.base, listing(377, self.branch))
+
+        # Assert
+        self.assertEqual((done.returncode, "closes no version" in done.stdout), (0, True))
+
+    # GREEN_ON_BASE(characterization): the control, and it is what the base does for every version.
+    # Reddening it would mean this change had moved the ordinary reading rather than carved one
+    # state out of it.
+    def test_Given_AVersionNoTagNames_When_TheChangeAddsIt_Then_TheBodyIsAsked(self):
+        # Arrange -- the control: with no tag the same tree is a release, which is what every
+        # ordinary one looks like here, and the body has to decide about the work in flight.
+        # Act
+        done = run(self.root, self.base, listing(377, self.branch))
+
+        # Assert
+        self.assertEqual(done.returncode, 2)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/scripts/release/test_release_notes.py
+++ b/scripts/release/test_release_notes.py
@@ -31,23 +31,11 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 
 def breaking_highlight_in(text, version):
     """Whether that version's Highlights claim a break."""
-    return "**Breaking:**" in "\n".join(
-        split_highlights(extract_version_section(text, version), version)[0])
+    return published_check.breaking_highlight_in(text, version)
 
 
 def claims_a_break_outside_a_major(text, versions, published):
-    """Versions claiming a break that neither bump a major nor are already published.
-
-    `published` is what the remote tags. A note somebody has already installed against cannot be
-    re-versioned, so the remedy for one published wrong is the next release rather than an edit to
-    the record of it -- the same distinction published_check.drain_reason draws between closing a
-    version and recording one.
-    """
-    bumps = {version for version in versions
-             if published_check.is_major_bump(versions, version)}
-    return [version for version in versions
-            if version not in bumps and "v" + version not in published
-            and breaking_highlight_in(text, version)]
+    return published_check.claims_a_break_outside_a_major(text, versions, published)
 
 
 def named(version, entry):

--- a/scripts/release/test_release_notes.py
+++ b/scripts/release/test_release_notes.py
@@ -26,6 +26,28 @@ from release_notes import (
 )
 
 REPO = "s4k10503/velvet"
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def breaking_highlight_in(text, version):
+    """Whether that version's Highlights claim a break."""
+    return "**Breaking:**" in "\n".join(
+        split_highlights(extract_version_section(text, version), version)[0])
+
+
+def claims_a_break_outside_a_major(text, versions, published):
+    """Versions claiming a break that neither bump a major nor are already published.
+
+    `published` is what the remote tags. A note somebody has already installed against cannot be
+    re-versioned, so the remedy for one published wrong is the next release rather than an edit to
+    the record of it -- the same distinction published_check.drain_reason draws between closing a
+    version and recording one.
+    """
+    bumps = {version for version in versions
+             if published_check.is_major_bump(versions, version)}
+    return [version for version in versions
+            if version not in bumps and "v" + version not in published
+            and breaking_highlight_in(text, version)]
 
 
 def named(version, entry):
@@ -400,6 +422,58 @@ class BuildNotes(unittest.TestCase):
         self.assertIn("[the repo](https://github.com/other/repo)", notes)
 
 
+SYNTHETIC = """# Changelog
+
+## [1.1.0] - 2026-01-02
+
+### Highlights
+
+- **Breaking:** the member is a property now.
+
+### Changed
+
+- The member is a property now.
+
+## [1.0.0] - 2026-01-01
+
+### Highlights
+
+- The first release.
+
+### Added
+
+- Everything.
+"""
+
+
+class BreakOutsideAMajor(unittest.TestCase):
+    """The rule is asked of what this repository can still change, and of nothing else."""
+
+    VERSIONS = ["1.1.0", "1.0.0"]
+
+    def test_Given_AnUnpublishedMinorClaimingABreak_When_TheRuleIsAsked_Then_ItIsNamed(self):
+        # Arrange -- what the rule exists for: a releaser closing a waiting break as a minor, caught
+        # while the version can still be renumbered.
+        # Act / Assert
+        self.assertEqual(claims_a_break_outside_a_major(SYNTHETIC, self.VERSIONS, set()),
+                         ["1.1.0"])
+
+    def test_Given_ThatSameMinorAlreadyPublished_When_TheRuleIsAsked_Then_ItIsNotNamed(self):
+        # Arrange -- a tag on the remote is a note somebody has installed against; the remedy is the
+        # next release, and a record that cannot carry the mistake has to lie about it.
+        # Act / Assert
+        self.assertEqual(
+            claims_a_break_outside_a_major(SYNTHETIC, self.VERSIONS, {"v1.1.0"}), [])
+
+    def test_Given_AMajorClaimingABreak_When_TheRuleIsAsked_Then_ItIsNotNamed(self):
+        # Arrange -- the control: a rule that named every breaking highlight would satisfy the first
+        # case and forbid the one place a break belongs.
+        # Act / Assert
+        self.assertEqual(
+            claims_a_break_outside_a_major(SYNTHETIC.replace("1.1.0", "2.0.0"),
+                                           ["2.0.0", "1.0.0"], set()), [])
+
+
 class ThisRepositorysChangelog(unittest.TestCase):
     """The guards that make a release fail here rather than publish an empty note."""
 
@@ -515,8 +589,7 @@ class ThisRepositorysChangelog(unittest.TestCase):
                 if published_check.is_major_bump(self.versions, version)]
 
     def breaking_highlight(self, version):
-        return "**Breaking:**" in "\n".join(
-            split_highlights(extract_version_section(self.text, version), version)[0])
+        return breaking_highlight_in(self.text, version)
 
     # GREEN_ON_BASE(characterization): the only major bump here already names its breaks.
     def test_Given_a_major_release_When_reading_its_highlights_Then_they_name_what_breaks(self):
@@ -533,11 +606,17 @@ class ThisRepositorysChangelog(unittest.TestCase):
         # Arrange — the other half of the same rule. A releaser who spots a waiting break and closes
         # it as a minor writes the bullet anyway, which is a trace the file still carries once the
         # entry itself has moved.
-        bumps = set(self.major_bumps())
+        #
+        # Asked only of versions this repository can still change. A tag on the remote is a note
+        # somebody has already installed against, and re-versioning it is not available: the remedy
+        # for one published wrong is the next release, not an edit to the record of it. The same
+        # distinction published_check.drain_reason draws, for the same reason — recording a version
+        # is not closing one, and a CHANGELOG that cannot carry a published mistake is a CHANGELOG
+        # that has to lie about it.
+        published = published_check.remote_tags(REPO_ROOT)
 
         # Act
-        claimed = [version for version in self.versions
-                   if version not in bumps and self.breaking_highlight(version)]
+        claimed = claims_a_break_outside_a_major(self.text, self.versions, published)
 
         # Assert
         self.assertEqual(claimed, [])


### PR DESCRIPTION
`main`'s CHANGELOG stopped at 2.1.3 while the line published **2.1.4**, and `package.json` said
2.1.3. The record of what this package has released was incomplete, and the `SessionStart` report had
ten items to name. The section is carried across as published, the same way #819 carried 2.1.1–2.1.3.

That tripped main's own rule — a release that is not a major may not claim a break in its Highlights,
and 2.1.4 does:

```
AssertionError: Lists differ: ['2.1.4'] != []
```

**The rule is right about the release and can do nothing about it.** The tag is out, the note is
installed against, and the remedy for a version published wrong is the next release, not an edit to
the record of it. Asked of every version forever, it makes a CHANGELOG that cannot carry a published
mistake — which is a CHANGELOG that has to lie about one.

So it is asked of versions the remote does not already tag. That is the distinction
`published_check.drain_reason` already draws, for the same reason: recording a version is not
closing one.

What it still catches is exactly what it was written for. A releaser who closes a waiting break as a
minor is named while the version can still be renumbered — pinned on synthetic text, along with the
published case going unnamed and a major claiming a break going unnamed. The reading moved out of the
fixture into `claims_a_break_outside_a_major(text, versions, published)` so a case can hand it a
CHANGELOG rather than only this repository's own.

Related but separate: #902 stops the recurrence. 2.1.4 shipped that bullet because the dispatch ran
with `ref=2.x`, where this rule does not exist — the line's copy of the release checks is main's copy
as of the cut.

No issue: main's record of its own releases was behind the line's, which the session report names
every time.
