### PR TITLE
fix(velvet): restore what a run here writes, and report the rest

### DIFF
--- a/scripts/test_quality/neuter_check.py
+++ b/scripts/test_quality/neuter_check.py
@@ -171,6 +171,18 @@ def path_in_harness_output(project, path, output_dir):
         return False
 
 
+# Where a neutered run can leave something behind: the fixtures drive an editor over the project, and
+# what it rewrites is the project. A file that goes dirty outside these did not go dirty because of
+# the sweep, and this used to restore it anyway -- measured, three uncommitted edits to
+# .github/workflows/test.yml were discarded during one, logged as "restored" as they went.
+HARNESS_TERRITORY = ("Assets/", "ProjectSettings/", "Packages/manifest.json",
+                     "Packages/packages-lock.json")
+
+
+def in_harness_territory(path):
+    return any(path == one or path.startswith(one) for one in HARNESS_TERRITORY)
+
+
 def restore_foreign_dirty(project, cut, before_dirty, output_dir):
     """A cut's revert() only puts back files listed in the cut map.
 
@@ -178,6 +190,10 @@ def restore_foreign_dirty(project, cut, before_dirty, output_dir):
     run wrote. Cutting the revert of BundledShaderBuildInclusion and BundledStyleSheetBuildInclusion left
     ProjectSettings/GraphicsSettings.asset and ProjectSettings/ProjectSettings.asset modified after the
     sweep finished.
+
+    Scoped, because "went dirty because the harness wrote it" and "went dirty because a person typed
+    in it" are the same reading after the fact. Anything outside the harness's territory is reported
+    and left alone: a sweep that cannot say whose edit it is does not get to decide.
     """
     try:
         after_dirty = git_porcelain(project)
@@ -185,10 +201,17 @@ def restore_foreign_dirty(project, cut, before_dirty, output_dir):
         print(f"    failed to read git status: {exc}", flush=True)
         return
     cut_files = {edit["file"] for edit in cut["edits"]}
-    foreign = sorted(
+    went_dirty = sorted(
         path for path in set(after_dirty) - set(before_dirty) - cut_files
         if not path_in_harness_output(project, path, output_dir)
     )
+    stranger = [path for path in went_dirty if not in_harness_territory(path)]
+    if stranger:
+        print("    left alone, dirty and outside what a run here writes -- yours, or somebody's:",
+              flush=True)
+        for path in stranger:
+            print(f"      {path}", flush=True)
+    foreign = [path for path in went_dirty if in_harness_territory(path)]
     for path in foreign:
         if after_dirty[path] == "??":
             command = ["git", "-C", str(project), "clean", "-fd", "--", path]

--- a/scripts/test_quality/test_neuter_check.py
+++ b/scripts/test_quality/test_neuter_check.py
@@ -42,6 +42,36 @@ def scaffold(project):
     return project
 
 
+class WhatASweepMayRestore(unittest.TestCase):
+    """A sweep restores what a run here writes, and reports the rest rather than deciding.
+
+    "Went dirty because the harness wrote it" and "went dirty because a person typed in it" are the
+    same reading after the fact. Measured before this was scoped: three uncommitted edits to
+    .github/workflows/test.yml were discarded during a sweep, logged as "restored" as they went.
+    """
+
+    def test_Given_AProjectSettingsFile_When_ASweepDirtiesIt_Then_ItIsTheHarnessTerritory(self):
+        # Arrange -- what a neutered run leaves behind, and the reason the restore exists at all.
+        # Act / Assert
+        self.assertIs(
+            neuter_check.in_harness_territory("ProjectSettings/GraphicsSettings.asset"), True)
+
+    def test_Given_AWorkflowFile_When_ItGoesDirty_Then_ItIsNotTheHarnessTerritory(self):
+        # Arrange -- the file the sweep actually destroyed work in.
+        # Act / Assert
+        self.assertIs(neuter_check.in_harness_territory(".github/workflows/test.yml"), False)
+
+    def test_Given_ASourceUnderPackages_When_ItGoesDirty_Then_ItIsNotTheHarnessTerritory(self):
+        # Arrange -- the control on the other side: a cut's own files are put back by its revert,
+        # and everything else under Packages is somebody's edit. Only the two manifests there are
+        # written by a run.
+        # Act / Assert
+        self.assertEqual(
+            (neuter_check.in_harness_territory("Packages/com.velvet.core/Runtime/V.cs"),
+             neuter_check.in_harness_territory("Packages/manifest.json")),
+            (False, True))
+
+
 class BaselineProblem(unittest.TestCase):
     def test_Given_AFilterThatRanNoCases_When_TheBaselineIsRead_Then_ItIsRefused(self):
         # Act


### PR DESCRIPTION
`restore_foreign_dirty` ran `git restore` on **every** tracked file that went dirty during a cut run.
"Went dirty because the harness wrote it" and "went dirty because a person typed in it" are the same
reading after the fact, so it discarded three uncommitted edits to `.github/workflows/test.yml`
during one sweep — logging them as it went:

```
restored .github/workflows/test.yml
```

The purpose is real: a neutered run leaves scene and settings files behind, and cutting the revert of
the two bundled-inclusion mechanisms leaves `ProjectSettings/GraphicsSettings.asset` and
`ProjectSettings/ProjectSettings.asset` modified after the sweep. What was wrong is only that the
restore was unscoped.

It is scoped now to where a neutered run can leave something: the fixtures drive an editor over the
project, and what it rewrites is the project — `Assets/`, `ProjectSettings/`, and the two manifests
under `Packages/`. Anything dirty outside that is printed and left alone:

```
left alone, dirty and outside what a run here writes -- yours, or somebody's:
  .github/workflows/test.yml
```

That is the issue's two answers taken together rather than one of them: the restore keeps the reason
it exists, and a sweep that cannot say whose edit it is does not get to decide. It does not restore
outside the territory, so it cannot lose work there; inside it, a file the author is editing is one
the harness is also writing, and that is the sweep's own ground.

Three cases, all red on `origin/main` for want of the reading: a `ProjectSettings` file is the
territory, the workflow file is not, and — the control on the other side — a source under
`Packages/` is not while `Packages/manifest.json` is.

`neuter_check.py --audit` is unchanged: 30 mechanisms, 40 cuts across 25 fixtures, 2 recorded
uncovered, 394 recorded holes.

Closes #641
