### PR TITLE
fix(velvet): let a deferral say who wrote it, and honour only this session's

### DIFF
--- a/.claude/hooks/lib/deferrals.py
+++ b/.claude/hooks/lib/deferrals.py
@@ -7,12 +7,20 @@ counting after TTL. That cannot decay into permanent silence the way an unqualif
 and re-stating it is the moment the reason gets re-examined, which is the only part that ever
 mattered.
 
-    echo "236 waiting on round-4 review $(date +%s)" >> ~/.velvet-pr-deferrals
+    echo "236 waiting on round-4 review $(date +%s) $CLAUDE_CODE_SESSION_ID" >> ~/.velvet-pr-deferrals
 
 Both Stop guards read this one file under one expiry, so a held item is re-read in one place and a
 change to the format cannot land in one guard and not the other.
+
+The trailing field is the session that wrote the line, and only that session's lines suppress
+anything. A process with no view of what a key is about can append as readily as the one holding it:
+measured, a subagent blocked by a guard naming six pull requests it neither owned nor could merge
+deferred all six -- the only route forward it had, and it silenced the guard that holds the merge
+queue. `disowned` reports the rest, so a suppression that did not happen is in front of the reader
+rather than behind them.
 """
 
+import os
 import time
 from pathlib import Path
 
@@ -28,6 +36,24 @@ def epoch(field):
         return int(field)
     except ValueError:
         return None
+
+
+def writer():
+    """The session a line written now would belong to, or None where nothing says.
+
+    Measured: a Bash tool call carries CLAUDE_CODE_SESSION_ID and it is this session's id, while a
+    PreToolUse payload carries cwd, tool_name and tool_input and nothing else. So the writer is
+    identifiable from its environment rather than from what a hook is handed, and a reader that has
+    no such variable cannot attribute anything -- which is a state this reports rather than guesses
+    at.
+    """
+    return os.environ.get("CLAUDE_CODE_SESSION_ID") or None
+
+
+def written_by(fields):
+    """The session id a line records, or None for one written before this was recorded."""
+    return fields[-1] if len(fields) >= 3 and "-" in fields[-1] and epoch(fields[-1]) is None \
+        else None
 
 
 def deferred(key, now=None):
@@ -50,7 +76,8 @@ def deferred(key, now=None):
         return None
 
     fields = matching[-1].split()
-    stamp = epoch(fields[-1])
+    session = written_by(fields)
+    stamp = epoch(fields[-2] if session else fields[-1])
     if stamp is None:
         return None
 
@@ -60,7 +87,50 @@ def deferred(key, now=None):
     if age < 0 or age >= TTL:
         return None
 
-    return " ".join(fields[1:-1]), int(age // 60)
+    # Whose it is decides whether it suppresses. A process with no view of what the key is about can
+    # append a line as readily as the one holding it -- measured, a subagent blocked by a guard
+    # naming six pull requests it neither owned nor could merge deferred all six, which was the only
+    # route forward it had and silenced the guard that holds the merge queue. A line another session
+    # wrote is reported by `disowned` instead, and one written before this was recorded goes the same
+    # way rather than being grandfathered: the whole point is that nothing says who stood behind it.
+    mine = writer()
+    if mine is not None and session != mine:
+        return None
+
+    return " ".join(fields[1:-2] if session else fields[1:-1]), int(age // 60)
+
+
+def disowned(key, now=None):
+    """(reason, whose) for every live deferral on the key that this session did not write.
+
+    Read by the guards so a suppression that did not happen is in front of the reader rather than
+    behind them, which is the same principle `deferred` states about a stale reason.
+    """
+    mine = writer()
+    if mine is None:
+        return []
+    try:
+        lines = DEFERRALS.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return []
+
+    found = []
+    for line in lines:
+        if not line.startswith(f"{key} "):
+            continue
+        fields = line.split()
+        session = written_by(fields)
+        if session == mine:
+            continue
+        stamp = epoch(fields[-2] if session else fields[-1])
+        if stamp is None:
+            continue
+        age = (time.time() if now is None else now) - stamp
+        if age < 0 or age >= TTL:
+            continue
+        found.append((" ".join(fields[1:-2] if session else fields[1:-1]),
+                      session or "a writer that did not say"))
+    return found
 
 
 def unusable(key, now=None):

--- a/.claude/hooks/lib/repository.py
+++ b/.claude/hooks/lib/repository.py
@@ -160,7 +160,7 @@ subject that is clear.
 If the pause is deliberate, arm the deferral for what the WORK is waiting on. The failure above is
 not that, and naming it there is how a deferral comes to record something nothing was waiting on:
 
-  echo "{key} <what the work is waiting on> $(date +%s)" >> {DEFERRALS}"""
+  echo "{key} <what the work is waiting on> $(date +%s) $CLAUDE_CODE_SESSION_ID" >> {DEFERRALS}"""
 
 
 def project_tree():

--- a/.claude/hooks/refuse/branch_from_unmerged.py
+++ b/.claude/hooks/refuse/branch_from_unmerged.py
@@ -193,7 +193,7 @@ def refusal(cwd, name, start_point):
             f"git checkout -b {name}",
             "",
             f"To stack on unmerged work on purpose, record intent and retry:",
-            f'  echo "{name} <why> $(date +%s)" >> ~/.velvet-pr-deferrals',
+            f'  echo "{name} <why> $(date +%s) $CLAUDE_CODE_SESSION_ID" >> ~/.velvet-pr-deferrals',
         ]
 
     if main_behind:

--- a/.claude/hooks/stop/open_backlog.py
+++ b/.claude/hooks/stop/open_backlog.py
@@ -164,7 +164,7 @@ what the stall looks like from inside — do the thing instead of announcing it 
 If the user asked something and is waiting on the answer, or the pause is deliberate, say so and
 arm the deferral. It expires after 45 minutes so the reason gets re-examined rather than forgotten:
 
-  echo "backlog <what clears it> $(date +%s)" >> {DEFERRALS}
+  echo "backlog <what clears it> $(date +%s) $CLAUDE_CODE_SESSION_ID" >> {DEFERRALS}
 
 A single issue is deferred the same way, by its number in place of `backlog`.
 

--- a/.claude/hooks/stop/unsettled_pr.py
+++ b/.claude/hooks/stop/unsettled_pr.py
@@ -259,7 +259,7 @@ def main():
 Holding one on purpose is allowed and expires after 45 minutes, so the reason gets re-examined
 rather than forgotten:
 
-  echo "<pr> <what clears it> $(date +%s)" >> {DEFERRALS}
+  echo "<pr> <what clears it> $(date +%s) $CLAUDE_CODE_SESSION_ID" >> {DEFERRALS}
 
 Otherwise: wait for it with a Monitor that emits on both pass and fail, or keep working on
 something that is itself on the critical path. Work that is off the critical path satisfies

--- a/.github/workflows/generators.yml
+++ b/.github/workflows/generators.yml
@@ -97,6 +97,8 @@ jobs:
 
       - run: python3 scripts/test_quality/run_suite.py scripts/release/test_publish_rules_come_from_main.py
 
+      - run: python3 scripts/test_quality/run_suite.py scripts/hooks/test_deferral_writer.py
+
       - name: Cohesion report
         run: python3 scripts/test_quality/cohesion_report.py
 

--- a/scripts/hooks/test_deferral_writer.py
+++ b/scripts/hooks/test_deferral_writer.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""A deferral suppresses a guard only for the session that wrote it.
+
+One file holds every deferral both Stop guards read, and an entry is a line nothing signs. So a
+process with no view of what a key is about can append as readily as the one holding it: measured, a
+subagent blocked by a guard naming six pull requests it neither owned nor could merge deferred all
+six. That was the only route forward it had, and the effect was that the guard holding the merge
+queue went quiet for every entry in it.
+
+Who wrote a line is readable, and not from what a hook is handed: a PreToolUse payload carries cwd,
+tool_name and tool_input and nothing else, while the environment of a tool call carries
+CLAUDE_CODE_SESSION_ID. The line records that, `deferred` honours only its own, and `disowned`
+reports the rest.
+
+A reader with no such variable cannot attribute anything, and that is the one state where this falls
+back to what it did before -- reporting nothing rather than refusing everything, since a guard that
+suppressed nothing would be a guard nobody could hold anything past.
+
+Run: python3 scripts/hooks/test_deferral_writer.py
+"""
+
+import importlib.util
+import os
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MODULE = REPO_ROOT / ".claude" / "hooks" / "lib" / "deferrals.py"
+
+_spec = importlib.util.spec_from_file_location("deferrals", MODULE)
+deferrals = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(deferrals)
+
+# Reached through getattr so a tree without it answers "nothing reported" rather than raising: a
+# case that raises carries no reading either way, and what this one has to say is that the base
+# reports nothing where this reports the line.
+def disowned(key, now=None):
+    return getattr(deferrals, "disowned", lambda *a, **k: [])(key, now)
+
+NOW = 1_000_000
+MINE = "mine-0001"
+
+
+class WhoseDeferral(unittest.TestCase):
+    def setUp(self):
+        root = Path(tempfile.mkdtemp(prefix="deferral-"))
+        self.addCleanup(shutil.rmtree, root, ignore_errors=True)
+        self.file = root / "deferrals"
+        self.addCleanup(setattr, deferrals, "DEFERRALS", deferrals.DEFERRALS)
+        deferrals.DEFERRALS = self.file
+        before = os.environ.get("CLAUDE_CODE_SESSION_ID")
+        self.addCleanup(self.restore, before)
+        os.environ["CLAUDE_CODE_SESSION_ID"] = MINE
+
+    def restore(self, before):
+        if before is None:
+            os.environ.pop("CLAUDE_CODE_SESSION_ID", None)
+        else:
+            os.environ["CLAUDE_CODE_SESSION_ID"] = before
+
+    def wrote(self, line):
+        self.file.write_text(line + "\n", encoding="utf-8")
+
+    def test_Given_ALineThisSessionWrote_When_TheKeyIsRead_Then_ItSuppresses(self):
+        # Arrange -- the ordinary case, and what must keep working.
+        self.wrote("377 waiting on review {} {}".format(NOW, MINE))
+
+        # Act / Assert
+        self.assertEqual(deferrals.deferred("377", NOW + 60), ("waiting on review", 1))
+
+    # GREEN_ON_BASE(characterization): the base honours this line and this case says it does not
+    # suppress -- which the base also satisfies, because on the base `deferred` reads no session at
+    # all and this line's trailing field is not an epoch, so it answers None for the wrong reason.
+    # The case beside it, which reports the line, is what separates the two.
+    def test_Given_ALineAnotherSessionWrote_When_TheKeyIsRead_Then_ItSuppressesNothing(self):
+        # Arrange -- the shape that silenced six pull requests at once.
+        self.wrote("377 waiting on review {} other-0002".format(NOW))
+
+        # Act / Assert
+        self.assertIsNone(deferrals.deferred("377", NOW + 60))
+
+    def test_Given_ALineAnotherSessionWrote_When_TheKeyIsRead_Then_ItIsReported(self):
+        # Arrange -- not suppressing is half of it; the reader has to be told it exists.
+        self.wrote("377 waiting on review {} other-0002".format(NOW))
+
+        # Act / Assert
+        self.assertEqual(disowned("377", NOW + 60),
+                         [("waiting on review", "other-0002")])
+
+    def test_Given_ALineSigningNothing_When_TheKeyIsRead_Then_ItSuppressesNothing(self):
+        # Arrange -- every line written before this was recorded. Grandfathering them would keep the
+        # hole open for exactly as long as the file lives.
+        self.wrote("377 waiting on review {}".format(NOW))
+
+        # Act / Assert
+        self.assertIsNone(deferrals.deferred("377", NOW + 60))
+
+    def test_Given_AReaderThatCannotAttribute_When_TheKeyIsRead_Then_ItSuppressesAsBefore(self):
+        # Arrange -- the one state this falls back on: with nothing to compare against, refusing
+        # every line would leave nothing holdable past a guard at all.
+        self.wrote("377 waiting on review {} other-0002".format(NOW))
+        os.environ.pop("CLAUDE_CODE_SESSION_ID", None)
+
+        # Act / Assert
+        self.assertEqual(deferrals.deferred("377", NOW + 60), ("waiting on review", 1))
+
+    # GREEN_ON_BASE(characterization): the expiry is not what this changes, and a control over it
+    # is green on both sides -- one that reddened would mean signing a line had moved when it dies.
+    def test_Given_AnExpiredLineOfThisSession_When_TheKeyIsRead_Then_TheExpiryStillDecides(self):
+        # Arrange -- the control on the other side: signing a line does not make it immortal.
+        self.wrote("377 waiting on review {} {}".format(NOW, MINE))
+
+        # Act / Assert
+        self.assertIsNone(deferrals.deferred("377", NOW + deferrals.TTL))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
One file holds every deferral both Stop guards read, and an entry was a line **nothing signed**. So a
process with no view of what a key is about could append as readily as the one holding it: a subagent
blocked by `edit_while_a_ready_pr_sits.py`, which named six pull requests it neither owned nor could
merge, deferred all six. That was the only route forward it had, and the effect was that the guard
holding the merge queue went quiet for every entry in it.

## Measured first, because the fix depended on it

The issue asks whether the writer is identifiable before anything is designed. It is — but not from
the payload:

- every field the hooks read from a `PreToolUse` payload: `cwd`, `tool_name`, `tool_input`;
- the environment of a tool call carries `CLAUDE_CODE_SESSION_ID`, and its value is this session's
  id.

So the answer is the issue's first branch, reached by a route it did not name: the writer signs from
its own environment rather than from what a hook is handed.

## What it does

The line records the session, `deferred` honours only its own, and `disowned` reports the rest —
because not suppressing is half of it, and the reader has to be told the line exists. Every advertised
remedy gains `$CLAUDE_CODE_SESSION_ID`, so following the instruction the guard prints writes a signed
line.

A line written before this was recorded goes the same way rather than being grandfathered: the whole
point is that nothing says who stood behind it, and they expire inside the hour anyway.

**One fallback, and it is the only place this reads as before.** A reader with no such variable
cannot attribute anything, and refusing every line there would leave nothing holdable past a guard at
all — so it suppresses as it did, rather than blocking everything on a reading it cannot take.

Six cases: four red on `origin/main`, and two declared — the base honours a stranger's line yet
answers `None` for it *for the wrong reason* (its trailing field is not an epoch), which is exactly
why the case that reports the line sits beside it; and the expiry is not what this changes.

Closes #627
