### PR TITLE
fix(velvet): record whether a mutant's verdict had the machine to itself

### DIFF
--- a/scripts/test_quality/mutation_check.py
+++ b/scripts/test_quality/mutation_check.py
@@ -1044,6 +1044,26 @@ def unity_busy():
     return sum(1 for line in result.stdout.splitlines() if re.match(UNITY_RUNNING, line))
 
 
+# A campaign, seen from outside. `wait_for_quiet` counts editors, and a campaign holds none between
+# its mutants -- it applies the mutation, restores the previous one and writes its record -- so two
+# can sample zero in the same gap and launch together. A case reddened by that load reads KILLED in
+# both receipts, with nothing in either to tell it from a mutant a test really killed.
+CAMPAIGN_RUNNING = re.compile(
+    r"^[^ ]*[Pp]ython[^ ]* .*[ /]mutation_check\.py\b")
+
+
+def campaigns_running():
+    """How many mutation campaigns are on this machine, including this one.
+
+    Sampled rather than waited on. Whether a lock is worth its deadlock is a question about how often
+    two are live at once, and that is not answerable from what this repository keeps: two receipts
+    survive locally, ninety minutes apart. So each receipt records what it saw, and the question gets
+    an answer built from runs rather than from a guess about them.
+    """
+    result = subprocess.run(["ps", "-Ao", "command="], capture_output=True, text=True)
+    return sum(1 for line in result.stdout.splitlines() if CAMPAIGN_RUNNING.match(line))
+
+
 def wait_for_quiet(seconds):
     """Waits rather than sharing the machine: every failure in a mutant run has to be attributable
     to the mutation, and a second editor is a second explanation for all of them."""
@@ -1225,10 +1245,17 @@ PASSING_RECEIPTS = ("pass", "unreachable")
 def write_receipt(output, digest, base, verdict, detail):
     path = receipt_path(output, digest)
     path.parent.mkdir(parents=True, exist_ok=True)
+    alone = campaigns_running() <= 1
     path.write_text(json.dumps({
         "digest": digest, "base": base, "verdict": verdict, "detail": detail,
         "at": time.strftime("%Y-%m-%dT%H:%M:%S"),
+        # Whether this verdict was reached with the machine to itself. A neighbouring campaign is a
+        # second explanation for every failure in this one, and the editor count cannot see one
+        # between its mutants.
+        "alone": alone,
     }, indent=2))
+    if not alone:
+        print("    a second campaign was running when this verdict was written", flush=True)
     return path
 
 

--- a/scripts/test_quality/test_mutation_check.py
+++ b/scripts/test_quality/test_mutation_check.py
@@ -116,6 +116,44 @@ def declaration(line, category="equivalent", reason="a reason of four words", wr
         return mutation_check.Declaration(category, reason, line, written_here=written_here)
 
 
+class NeighbouringCampaignTests(unittest.TestCase):
+    """A receipt says whether the verdict was reached with the machine to itself.
+
+    wait_for_quiet counts editors, and a campaign holds none between its mutants -- it applies the
+    mutation, restores the previous one and writes its record. So two can sample zero in the same gap
+    and launch together, and a case reddened by that load reads KILLED in both receipts, with nothing
+    in either to tell it from a mutant a test really killed.
+
+    Recorded rather than gated: whether a lock is worth its deadlock is a question about how often
+    two are live at once, and that is not answerable from what this repository keeps -- two receipts
+    survive locally, ninety minutes apart.
+    """
+
+    def test_Given_ACampaignsOwnCommandLine_When_TheProcessListIsRead_Then_ItCounts(self):
+        # Arrange — what this campaign looks like from outside.
+        line = "/usr/bin/python3 /repo/scripts/test_quality/mutation_check.py --base origin/main"
+
+        # Act / Assert
+        self.assertIsNotNone(mutation_check.CAMPAIGN_RUNNING.match(line))
+
+    def test_Given_ASiblingHarness_When_TheProcessListIsRead_Then_ItDoesNotCount(self):
+        # Arrange — the control: base_red_check and neuter_check wait for a quiet machine
+        # themselves, and counting them here would make a campaign wait out something that is not a
+        # second explanation for its own failures.
+        line = "/usr/bin/python3 /repo/scripts/test_quality/base_red_check.py --lane csharp"
+
+        # Act / Assert
+        self.assertIsNone(mutation_check.CAMPAIGN_RUNNING.match(line))
+
+    def test_Given_AnEditorRunningTests_When_TheProcessListIsRead_Then_ItIsNotACampaign(self):
+        # Arrange — the other control: an editor is what the existing wait already counts, and
+        # counting it twice would report a neighbour where there is one explanation, not two.
+        line = "/Applications/Unity/Hub/Editor/6000.3.11f1/Unity.app/Contents/MacOS/Unity -runTests"
+
+        # Act / Assert
+        self.assertIsNone(mutation_check.CAMPAIGN_RUNNING.match(line))
+
+
 class CodeMaskTests(unittest.TestCase):
     """Which offsets count as code. Everything downstream of the mask reads only what it leaves.
 


### PR DESCRIPTION
`wait_for_quiet` counts **editors**, and a campaign holds none between its mutants — it applies the
mutation, restores the previous one and writes its record. So two campaigns can both sample zero in
the same gap and launch together, and a case reddened by that load reads `KILLED` in **both**
receipts, with nothing in either to tell it from a mutant a test really killed.

That is the failure the wait's own docstring exists to prevent — *"a second editor is a second
explanation for all of them"* — and it prevents it against an ordinary suite run, not against another
campaign.

## Recorded rather than gated, and why

The issue asks for the frequency before either fix is built, because a lock is the more expensive
answer and this repository has withdrawn guards after measuring their yield. **That frequency is not
readable from what survives.** Receipts under every session tree on this machine: **2**, ninety
minutes apart, both from one session. Under the repository: **0**. Two points cannot say how often
two campaigns are live at once.

So each receipt carries what it saw — `"alone": true|false` — and a verdict reached beside a
neighbour prints so as it is written. The next decision about a lock is then made from runs rather
than from a guess about them, which is the measurement the issue asks for and could not have.

## What the sampler counts

Campaigns, and nothing else. `base_red_check` and `neuter_check` wait for a quiet machine themselves,
and an editor is what the existing wait already counts — either would report a second explanation
where there is one. Three cases pin that: a campaign's own command line matches, a sibling harness's
does not, and an editor running tests does not.

All three are red on `origin/main` for want of the reading.

This does not stop two campaigns colliding. It stops a collision being invisible in the receipt that
came out of it.

Closes #712
