### PR TITLE
fix(velvet): select a fixture whose table moved, where nothing else selected it

### DIFF
--- a/scripts/test_quality/base_red_check.py
+++ b/scripts/test_quality/base_red_check.py
@@ -674,6 +674,29 @@ def spanned_code(lines, case):
                      if line.strip())
 
 
+def shared_material_differs(relative, before, after):
+    """Whether what the cases share -- everything outside every case body -- is not the base's.
+
+    A line reading is not enough on its own: git describes a reorder as one block deleted and
+    re-added, so the lines between two swapped cases read as changed while every one of them is the
+    base's own text. Compared as a multiset, a reorder is no difference and an added row is.
+    """
+    if before is None:
+        return True
+
+    def shared(text):
+        if not text:
+            return []
+        found = cases_in(relative, text)
+        inside = set()
+        for case in found:
+            inside |= set(range(case.first_line, case.last_line + 1))
+        return sorted(line.strip() for number, line in enumerate(text.splitlines(), 1)
+                      if number not in inside and line.strip())
+
+    return shared(before) != shared(after)
+
+
 def authored(relative, cases, before, after):
     """(the cases whose code this branch changed, the ones it left standing while editing their text).
 
@@ -2064,6 +2087,19 @@ def collect(project, base, lane):
                 case.declaration.written_here = case.declaration.written_in(lines)
         wanted = {case.name for case in authored(relative, touched(cases, lines),
                                                  held_at(project, since, relative), text)[0]}
+        # A change wholly outside every case body, in a file that has cases: a static readonly table
+        # the cases drive, a SetUp, a helper. `authored` keeps such a case out, correctly -- the
+        # branch did not write it -- and with nothing else selected the lane exits 0 having measured
+        # a genuinely base-red change as nothing at all. Measured on a branch adding rows to a table
+        # in CommitGuardParsingTests, and 88 of this repository's 276 C# fixtures declare such data
+        # outside every case body.
+        #
+        # Only where nothing was selected. Widening it to every file with a shared line was tried
+        # and puts every case a fixture has on trial for a line added to SetUp; `outside` reports
+        # that instead. What is left here is the state where reporting it is all that happens.
+        if (cases and lines is not None and not wanted and outside(cases, lines)
+                and shared_material_differs(relative, held_at(project, since, relative), text)):
+            wanted = {case.name for case in cases}
         changed.extend(as_the_runner_names_them(
             [case for case in cases if case.name in wanted], heirs))
         loose = outside(cases, lines)

--- a/scripts/test_quality/test_base_red_check.py
+++ b/scripts/test_quality/test_base_red_check.py
@@ -3642,6 +3642,43 @@ class BranchReadingTests(unittest.TestCase):
         run("commit", "-qm", "branch")
         return root
 
+    def test_Given_ABranchThatChangedOnlyATable_When_ItIsRead_Then_TheFixturesCasesAreSelected(self):
+        # Arrange -- a static readonly the cases drive, changed outside every case body. Nothing was
+        # selected before this and the lane exited 0 having measured a genuinely base-red change as
+        # nothing at all. Measured on a branch adding rows to a table in CommitGuardParsingTests,
+        # and 88 of this repository's 276 C# fixtures declare such data outside every case body.
+        table = '        static readonly string[] Rows = { "one" };\n'
+        root = self.repository(self.source().replace("        [SetUp]", table + "        [SetUp]"),
+                               self.source().replace("        [SetUp]",
+                                                     table.replace('"one"', '"one", "two"')
+                                                     + "        [SetUp]"))
+
+        # Act
+        _, cases, _, _, _ = base_red_check.collect(root, "HEAD~1", "csharp")
+
+        # Assert
+        self.assertEqual(sorted(case.name for case in cases),
+                         ["N.ProbeTests.Given_A_When_B_Then_C", "N.ProbeTests.Given_D_When_E_Then_F"])
+
+    # GREEN_ON_BASE(characterization): the control for the reading beside it. The base selects the
+    # one case whose body moved and nothing else, which is what this narrows rather than replaces --
+    # a control that reddened would mean the widening had taken every fixture with a shared line.
+    def test_Given_ABranchThatChangedOneCaseAndATable_When_ItIsRead_Then_OnlyThatCaseIsSelected(self):
+        # Arrange -- the control, and the reading this must not widen into: selecting the file whole
+        # whenever a shared line moved puts every case a fixture has on trial for a line in SetUp,
+        # which `outside` reports instead. Only where nothing at all was selected does this apply.
+        table = '        static readonly string[] Rows = { "one" };\n'
+        root = self.repository(self.source().replace("        [SetUp]", table + "        [SetUp]"),
+                               self.source(first="Assert.Fail()").replace(
+                                   "        [SetUp]", table.replace('"one"', '"one", "two"')
+                                   + "        [SetUp]"))
+
+        # Act
+        _, cases, _, _, _ = base_red_check.collect(root, "HEAD~1", "csharp")
+
+        # Assert
+        self.assertEqual([case.name for case in cases], ["N.ProbeTests.Given_A_When_B_Then_C"])
+
     def test_Given_ABranchThatChangedASetUp_When_ItIsRead_Then_ItsOtherCasesAreNotControls(self):
         # Arrange -- the untouched case is not the base's own text any more: what it shares with the
         # case beside it moved. Reading the tree by it converts the sharpest red-on-base evidence


### PR DESCRIPTION
Cases are selected by changed lines falling **inside a case body**, so a change to a static readonly
table the cases drive is selected by nothing: the lane reports "no changed test case in scope" and
exits **0**, having measured a genuinely base-red change as nothing at all. That message is a correct
description of a docs-only or tooling-only branch, which is what makes a table-driven fixture
indistinguishable from one at the point of the decision.

Measured on `tooling/refuse-amend-and-first-line`, whose rows sit at lines 32–38 of a static field
while the fixture's one case spans 63–84 — and **88 of this repository's 276** C# fixtures declare
such data outside every case body.

## Where the widening sits, and why there

`authored` keeps those cases out and is right to: the branch did not write them. So the widening is
after it, and only where it selected nothing at all.

Widening to *every* file with a shared changed line was tried before this and rejected — it puts
every case a fixture has on trial for a line added to `SetUp`, and `outside` reports that instead.
What is left is the state where reporting it is all that happens, and exit 0 is the whole verdict.

## What the first attempt got wrong

A line reading alone cannot say the shared material moved. git describes a reorder as one block
deleted and re-added, so the lines between two swapped cases read as changed while every one of them
is the base's own text — which is exactly what `AuthorshipTests` holds, and it went red on the first
attempt. `shared_material_differs` compares the text outside every case body as a multiset: a reorder
is no difference, an added row is.

Two cases: the table-only branch selecting both of a fixture's cases is red on `origin/main`; the
control — one case rewritten *and* the table changed, selecting only that case — is declared, since
the base already does that and it is what this narrows rather than replaces.

Closes #674
