### PR TITLE
fix(velvet): shift only the siblings a growth can reach

### DIFF
--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberCommitWork.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberCommitWork.cs
@@ -67,6 +67,15 @@ namespace Velvet
                     continue;
                 }
 
+                // The chain is creation order, and NextInlineSiblingSlotStart says a keyed reorder
+                // does not resync it -- so a following sibling can hold rows that sit BEFORE this
+                // growth, and shifting one moves its next write off the rows it owns. Growth at an
+                // index cannot move what starts before it.
+                if (sibling.MountSlotStart < fiber.MountSlotStart)
+                {
+                    continue;
+                }
+
                 sibling.MountSlotStart += actualDelta;
                 // A following sibling whose own time-sliced reconcile is parked captured its slotStart as an
                 // absolute offset into the shared parent. This shift moved its already-committed rows within

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/InlineSlotShiftOrderTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/InlineSlotShiftOrderTests.cs
@@ -1,0 +1,86 @@
+using NUnit.Framework;
+using UnityEngine.UIElements;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Holds the slot shift to siblings the growth can actually move.
+    /// <para>
+    /// The shift walks the fiber tree's sibling chain, which is creation order —
+    /// <c>NextInlineSiblingSlotStart</c> states that a keyed reorder does not resync it. So a
+    /// following sibling can hold rows that sit before the growth, and shifting one moves its next
+    /// write off the rows it owns. Growth at an index cannot move what starts before it.
+    /// </para>
+    /// </summary>
+    [TestFixture]
+    internal sealed class InlineSlotShiftOrderTests
+    {
+        private static ComponentFiber Mounted(VisualElement target, int slotStart)
+        {
+            var fiber = new ComponentFiber { MountPoint = target, MountSlotStart = slotStart };
+            return fiber;
+        }
+
+        [Test]
+        public void Given_AFollowingSiblingThatStartsBeforeTheGrowth_When_TheShiftRuns_Then_ItIsLeftAlone()
+        {
+            // Arrange — the chain is A then B, and B's rows sit first. A keyed reorder leaves exactly
+            // this: the order the fibers were created in is not the order their rows sit in.
+            var target = new VisualElement();
+            var parent = new ComponentFiber();
+            var growing = Mounted(target, 5);
+            var earlier = Mounted(target, 0);
+            parent.AppendChild(growing);
+            parent.AppendChild(earlier);
+
+            // Act
+            FiberCommitWork.PropagateInlineSlotShift(growing, 2);
+
+            // Assert
+            Assert.That(earlier.MountSlotStart, Is.EqualTo(0));
+        }
+
+        // GREEN_ON_BASE(characterization): the control, and a control is green on both sides by
+        // construction -- one that reddened would mean the narrowing had stopped the propagation
+        // rather than bounding it.
+        [Test]
+        public void Given_AFollowingSiblingThatStartsAfterTheGrowth_When_TheShiftRuns_Then_ItMoves()
+        {
+            // Arrange — the control: a shift that moved nothing would satisfy the case above while
+            // losing what the propagation is for.
+            var target = new VisualElement();
+            var parent = new ComponentFiber();
+            var growing = Mounted(target, 5);
+            var later = Mounted(target, 9);
+            parent.AppendChild(growing);
+            parent.AppendChild(later);
+
+            // Act
+            FiberCommitWork.PropagateInlineSlotShift(growing, 2);
+
+            // Assert
+            Assert.That(later.MountSlotStart, Is.EqualTo(11));
+        }
+
+        // GREEN_ON_BASE(characterization): the reading this narrows rather than replaces, and the
+        // base already takes it. It sits here so a later edit cannot lose one bound while adding
+        // the other.
+        [Test]
+        public void Given_AFollowingSiblingOnAnotherTarget_When_TheShiftRuns_Then_ItIsLeftAlone()
+        {
+            // Arrange — the other control, and the reading this narrows rather than replaces: a
+            // delta measured on one target says nothing about a coordinate into another.
+            var parent = new ComponentFiber();
+            var growing = Mounted(new VisualElement(), 5);
+            var elsewhere = Mounted(new VisualElement(), 9);
+            parent.AppendChild(growing);
+            parent.AppendChild(elsewhere);
+
+            // Act
+            FiberCommitWork.PropagateInlineSlotShift(growing, 2);
+
+            // Assert
+            Assert.That(elsewhere.MountSlotStart, Is.EqualTo(9));
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/InlineSlotShiftOrderTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/InlineSlotShiftOrderTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a7a62a1fa8fd14318b895511ac1b7363


### PR DESCRIPTION
`PropagateInlineSlotShift` walks the fiber tree's **sibling chain**, and that chain is *creation*
order — `NextInlineSiblingSlotStart` says in as many words that a keyed reorder does not resync it.
So a following sibling can hold rows that sit **before** the growth, and shifting one moves its next
write off the rows it owns. Growth at an index cannot move what starts before it.

## Established, which is what the issue asks for first

#599 records this as *"a reading, not a measurement, and establishing it is the first work here."*

It is measured now. With the chain out of slot order — the state a keyed reorder leaves — the base
shifts a sibling whose rows sit ahead of the growth, and the case naming it is **red on
`origin/main`**.

And the narrowing moves nothing else: **4251 passed** over EditMode before it, **4254** after, the
three being the cases added here. So every chain the suite reaches is already in slot order, and the
disagreement is exactly the state nothing exercised.

Three cases, two of them declared: a following sibling that starts after the growth still moves —
otherwise a narrowing that shifted nothing would satisfy the first — and one on another target is
still left alone, which is the bound this narrows rather than replaces.

## What it does not do

It does not close #599. The wrong-element patch that issue opens with is a stale `MountSlotStart` on
a portal's component child, and the issue is explicit that maintaining it is not safe to write blind:
the drain-anchor interaction has to be measured first, because at a portal drain two portals'
top-level children can share one sibling chain. That is untouched here.

This is the second defect the issue records in the same function, and it is the half that could be
established without that measurement.

Refs #599
