### PR TITLE
fix(velvet): read a mutant under the configurations that light its line

### DIFF
--- a/Packages/com.velvet.core/Generators~/tests/Velvet.SourceGenerators.Tests/MutantDeclarationRemovalTests.cs
+++ b/Packages/com.velvet.core/Generators~/tests/Velvet.SourceGenerators.Tests/MutantDeclarationRemovalTests.cs
@@ -51,7 +51,12 @@ namespace Velvet.SourceGenerators.Tests
             foreach (var byFile in mutants.GroupBy(mutant => mutant.Path, StringComparer.Ordinal))
             {
                 var lines = File.ReadAllLines(Path.Combine(repository, byFile.Key));
-                var original = CSharpSyntaxTree.ParseText(string.Join("\n", lines));
+                var text = string.Join("\n", lines);
+                // Read under the configuration that lights the most of the file. Under the default
+                // one a line inside an `#if` region nothing defines is trivia: there is no
+                // designation on it to lose, so a mutant there was examined by nothing.
+                var reading = MutantParseReadings.Widest(text);
+                var original = CSharpSyntaxTree.ParseText(text, reading);
                 var declared = DesignationsByLine(original);
                 foreach (var mutant in byFile)
                 {
@@ -63,7 +68,7 @@ namespace Velvet.SourceGenerators.Tests
                     examined++;
                     var swapped = (string[])lines.Clone();
                     swapped[mutant.Line - 1] = mutant.Text;
-                    var mutated = CSharpSyntaxTree.ParseText(string.Join("\n", swapped));
+                    var mutated = CSharpSyntaxTree.ParseText(string.Join("\n", swapped), reading);
                     var survivors = DesignationsByLine(mutated).TryGetValue(mutant.Line, out var after)
                         ? after.Select(designation => designation.Identifier.ValueText).ToHashSet(StringComparer.Ordinal)
                         : new HashSet<string>(StringComparer.Ordinal);
@@ -127,7 +132,10 @@ namespace Velvet.SourceGenerators.Tests
             foreach (var byFile in mutants.GroupBy(mutant => mutant.Path, StringComparer.Ordinal))
             {
                 var lines = File.ReadAllLines(Path.Combine(repository, byFile.Key));
-                var original = CSharpSyntaxTree.ParseText(string.Join("\n", lines));
+                var text = string.Join("\n", lines);
+                // Same reading as the case above, for the reason stated there.
+                var reading = MutantParseReadings.Widest(text);
+                var original = CSharpSyntaxTree.ParseText(text, reading);
                 var assigned = AssignedOutArgumentsByLine(original);
                 foreach (var mutant in byFile)
                 {
@@ -139,7 +147,7 @@ namespace Velvet.SourceGenerators.Tests
                     examined++;
                     var swapped = (string[])lines.Clone();
                     swapped[mutant.Line - 1] = mutant.Text;
-                    var mutated = CSharpSyntaxTree.ParseText(string.Join("\n", swapped));
+                    var mutated = CSharpSyntaxTree.ParseText(string.Join("\n", swapped), reading);
                     var survivors = AssignedOutArgumentsByLine(mutated).TryGetValue(mutant.Line, out var after)
                         ? new List<string>(after)
                         : new List<string>();

--- a/Packages/com.velvet.core/Generators~/tests/Velvet.SourceGenerators.Tests/MutantLineRemovalTests.cs
+++ b/Packages/com.velvet.core/Generators~/tests/Velvet.SourceGenerators.Tests/MutantLineRemovalTests.cs
@@ -37,9 +37,6 @@ namespace Velvet.SourceGenerators.Tests
     {
         private const string Operator = "line removed";
 
-        private static readonly Regex ConditionalSymbol = new(
-            @"^\s*#\s*(?:if|elif)\s+(.*)$", RegexOptions.Multiline);
-
         [Fact]
         public void Given_EveryLineRemovalThisPackageGenerates_When_ItIsApplied_Then_NothingExecutableIsLeftOnTheLine()
         {
@@ -57,7 +54,7 @@ namespace Velvet.SourceGenerators.Tests
             {
                 var lines = File.ReadAllLines(Path.Combine(repository, byFile.Key));
                 var source = string.Join("\n", lines);
-                var readings = Readings(source).Select(options =>
+                var readings = MutantParseReadings.For(source).Select(options =>
                     (Options: options, Original: CSharpSyntaxTree.ParseText(source, options))).ToList();
                 foreach (var mutant in byFile)
                 {
@@ -111,42 +108,6 @@ namespace Velvet.SourceGenerators.Tests
                 (examined > 1000, mutants.Count - examined, surviving.Count));
         }
 
-        /// <summary>The configurations a file is read under: nothing defined, everything it tests,
-        /// and everything it never negates.</summary>
-        /// <remarks>
-        /// The third because a region nested inside one the second lights can turn on the absence of a
-        /// symbol that one defines, which leaves it dark under both of the others.
-        /// </remarks>
-        private static IEnumerable<CSharpParseOptions> Readings(string source)
-        {
-            var conditions = ConditionalSymbol.Matches(source)
-                .Select(match => match.Groups[1].Value)
-                .ToList();
-            var symbols = conditions
-                .SelectMany(condition => Names(condition))
-                .Distinct(StringComparer.Ordinal)
-                .ToList();
-            var negated = conditions
-                .SelectMany(condition => Regex.Matches(condition, @"!\s*([A-Za-z_][A-Za-z0-9_]*)")
-                    .Select(match => match.Groups[1].Value))
-                .ToHashSet(StringComparer.Ordinal);
-            var sets = new List<List<string>>
-            {
-                new(),
-                symbols,
-                symbols.Where(name => !negated.Contains(name)).ToList(),
-            };
-            var seen = new HashSet<string>(StringComparer.Ordinal);
-            foreach (var set in sets.Where(set => seen.Add(string.Join(",", set.OrderBy(n => n, StringComparer.Ordinal)))))
-            {
-                yield return CSharpParseOptions.Default.WithPreprocessorSymbols(set);
-            }
-        }
-
-        private static IEnumerable<string> Names(string condition) =>
-            Regex.Matches(condition, @"[A-Za-z_][A-Za-z0-9_]*")
-                .Select(match => match.Value)
-                .Where(name => name != "true" && name != "false");
 
         /// <summary>Every token starting on a one-based line, comments and whitespace aside.</summary>
         private static List<SyntaxToken> LeftOnLine(SyntaxTree tree, int line) =>

--- a/Packages/com.velvet.core/Generators~/tests/Velvet.SourceGenerators.Tests/MutantParseReadings.cs
+++ b/Packages/com.velvet.core/Generators~/tests/Velvet.SourceGenerators.Tests/MutantParseReadings.cs
@@ -1,0 +1,72 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace Velvet.SourceGenerators.Tests
+{
+    /// <summary>
+    /// The configurations a source is read under when a guard has to see every line of it.
+    /// </summary>
+    /// <remarks>
+    /// A line inside an <c>#if</c> region no symbol lights is trivia: a guard parsing with
+    /// <c>CSharpParseOptions.Default</c> sees no tokens there and has nothing to check. Measured on
+    /// this package, 124 of 3255 line-removal mutants sit on such lines.
+    /// <para>
+    /// Which symbols the second and third light is derived from the source rather than listed. The
+    /// regions here are not limited to <c>UNITY_EDITOR</c>, and a hand list is the mirror shape this
+    /// repository pins against elsewhere.
+    /// </para>
+    /// </remarks>
+    internal static class MutantParseReadings
+    {
+        private static readonly Regex ConditionalSymbol = new(
+            @"^\s*#\s*(?:if|elif)\s+(.*)$", RegexOptions.Multiline);
+
+        /// <summary>Nothing defined, everything the source tests, and everything it never negates.</summary>
+        /// <remarks>
+        /// The third because a region nested inside one the second lights can turn on the absence of
+        /// a symbol that one defines, which leaves it dark under both of the others.
+        /// </remarks>
+        internal static IEnumerable<CSharpParseOptions> For(string source)
+        {
+            var conditions = ConditionalSymbol.Matches(source)
+                .Select(match => match.Groups[1].Value)
+                .ToList();
+            var symbols = conditions
+                .SelectMany(Names)
+                .Distinct(System.StringComparer.Ordinal)
+                .ToList();
+            var negated = conditions
+                .SelectMany(condition => Regex.Matches(condition, @"!\s*([A-Za-z_][A-Za-z0-9_]*)")
+                    .Select(match => match.Groups[1].Value))
+                .ToHashSet(System.StringComparer.Ordinal);
+            var sets = new List<List<string>>
+            {
+                new(),
+                symbols,
+                symbols.Where(name => !negated.Contains(name)).ToList(),
+            };
+            var seen = new HashSet<string>(System.StringComparer.Ordinal);
+            foreach (var set in sets.Where(set => seen.Add(
+                         string.Join(",", set.OrderBy(name => name, System.StringComparer.Ordinal)))))
+            {
+                yield return CSharpParseOptions.Default.WithPreprocessorSymbols(set);
+            }
+        }
+
+        /// <summary>The one of them that leaves the least of a source unread.</summary>
+        /// <remarks>
+        /// A guard comparing one parse against another needs a single reading, not three: the same
+        /// line has to be a designation in both. The widest is the one that lights the most, and a
+        /// region dark under it is one no configuration derived from the source lights.
+        /// </remarks>
+        internal static CSharpParseOptions Widest(string source) =>
+            For(source).OrderByDescending(options => options.PreprocessorSymbolNames.Count()).First();
+
+        private static IEnumerable<string> Names(string condition) =>
+            Regex.Matches(condition, @"[A-Za-z_][A-Za-z0-9_]*")
+                .Select(match => match.Value)
+                .Where(name => name != "true" && name != "false");
+    }
+}

--- a/Packages/com.velvet.core/Generators~/tests/Velvet.SourceGenerators.Tests/MutantParseabilityTests.cs
+++ b/Packages/com.velvet.core/Generators~/tests/Velvet.SourceGenerators.Tests/MutantParseabilityTests.cs
@@ -82,9 +82,13 @@ namespace Velvet.SourceGenerators.Tests
                 (mutants.Count > 1000, rejected.Count));
         }
 
+        // Read under every configuration MutantParseReadings names, because a line inside an `#if`
+        // region nothing lights is trivia to the default one -- there are no tokens there to be
+        // unparseable, and a mutant on such a line passed this guard unread.
         private static int ErrorCount(string source) =>
-            CSharpSyntaxTree.ParseText(source)
-                .GetDiagnostics()
-                .Count(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
+            MutantParseReadings.For(source)
+                .Sum(options => CSharpSyntaxTree.ParseText(source, options)
+                    .GetDiagnostics()
+                    .Count(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error));
     }
 }


### PR DESCRIPTION
`MutantParseabilityTests` and `MutantDeclarationRemovalTests` parsed with `CSharpParseOptions.Default`,
so a line inside an `#if` region no symbol lights is **trivia** to them: no tokens there to be
unparseable, and no designation there to lose. **124 of this package's 3255** line-removal mutants sit
on such lines and passed both guards unread.

## Shared rather than copied a third time

`MutantLineRemovalTests` already derived three configurations from the source for exactly this reason
— nothing defined, everything the source tests, and everything it never negates, the third because a
region nested inside one the second lights can turn on the *absence* of a symbol it defines. That
reading moves to `MutantParseReadings` and all three fixtures use it. The two older ones ask a
different question of the same tree, so what they want is the parse, not a copy of the case.

Which symbols each configuration lights stays derived from the source. The `#if` regions here are not
limited to `UNITY_EDITOR`, and a hand list is the mirror shape this repository pins against.

## The two guards want it differently

Parseability **sums** the diagnostics across all three: a mutant unparseable under any configuration
is one the campaign cannot compile.

The declaration guard takes the **widest single** one. It compares one parse against another, and the
same line has to be a designation in both — three readings would compare a designation seen under one
against its absence under another and report every `#if` line as stranded.

## The measurement the issue asks for first

With the guards able to read those 124: **nothing fails**. 426 generator tests pass.

So this is a ratchet against a future generator defect on those lines rather than one it found today
— which is the answer the issue names as one of the two possible ones, and it is the cheaper one to
have been wrong about.

Closes #708
