### PR TITLE
fix(velvet): stop a fixture that reads this tree's text from counting as a kill

### DIFF
--- a/scripts/test_quality/mutation_check.py
+++ b/scripts/test_quality/mutation_check.py
@@ -1126,6 +1126,47 @@ def build_error(log):
     return found.group(1).replace("\\", "/") if found else None
 
 
+# What a fixture reads when it walks this repository's own text rather than running its code. A
+# mutation edits a source file, so such a fixture reddens on the edit itself -- measured on the
+# campaign for Hooks.cs:1603, where a clause-removal mutant was recorded killed by three cases and
+# one of them was DocumentationDriftTests walking an identifier allowlist against the sources.
+TEXT_CORPUS = ("DocumentationCorpus", "TrackedFiles")
+
+FIXTURE_CLASS = re.compile(r"\bclass\s+([A-Z][A-Za-z0-9_]*)")
+
+
+def text_reading_fixtures(project):
+    """Fixture names whose own source reads the repository's text.
+
+    Derived rather than listed: the set is what references the corpus, so a fixture added to it
+    later is covered by having been written that way. A list would be the mirror shape this
+    repository pins against, and it is the shape that goes stale silently.
+    """
+    found = set()
+    for path in Path(project).rglob("*Tests.cs"):
+        if "Library" in path.parts or "obj" in path.parts:
+            continue
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        if any(name in text for name in TEXT_CORPUS):
+            found.update(FIXTURE_CLASS.findall(text))
+    return found
+
+
+def killed_by_behaviour(names, text_readers):
+    """The failing cases that are not a text-reading fixture's.
+
+    A mutant killed only by those was not killed by anything a user could notice: the fixture
+    reddened because the mutation edited a source file, not because a behaviour changed. Counting it
+    as a kill hides exactly what a campaign exists to find, and hides it on the lines most worth
+    mutating -- an identifier the documentation names is one that is public.
+    """
+    return [name for name in names
+            if not any(part in text_readers for part in name.split("."))]
+
+
 def failing_names(results):
     root = ET.parse(str(results)).getroot()
     return [
@@ -1643,6 +1684,8 @@ def main():
     baseline_hashes = {path.name: sha(path) for path in assemblies_dir.glob("*.dll")}
 
     originals = {path: path.read_text() for path in targets}
+    # Derived once: which fixtures redden on the edit rather than on what it does.
+    text_readers = text_reading_fixtures(project)
     started = time.time()
     try:
         for index, mutant in enumerate(mutants, start=1):
@@ -1701,9 +1744,16 @@ def main():
                 # Naming the killers, because a mutant killed only by a test that also fails on an
                 # unmutated tree was not killed by anything.
                 names = failing_names(results)
-                mutant.verdict = KILLED
-                mutant.detail = "{} failed: {}".format(
-                    counts["failed"], ", ".join(name.split(".")[-1] for name in names[:3]))
+                behavioural = killed_by_behaviour(names, text_readers)
+                if behavioural:
+                    mutant.verdict = KILLED
+                    mutant.detail = "{} failed: {}".format(
+                        len(behavioural),
+                        ", ".join(name.split(".")[-1] for name in behavioural[:3]))
+                else:
+                    mutant.verdict = SURVIVED
+                    mutant.detail = "{} failed, every one a fixture reading this tree's text: {}".format(
+                        counts["failed"], ", ".join(name.split(".")[-1] for name in names[:3]))
             elif counts["inconclusive"]:
                 mutant.verdict = INCONCLUSIVE
                 mutant.detail = "{} inconclusive, 0 failed".format(counts["inconclusive"])

--- a/scripts/test_quality/test_mutation_check.py
+++ b/scripts/test_quality/test_mutation_check.py
@@ -116,6 +116,44 @@ def declaration(line, category="equivalent", reason="a reason of four words", wr
         return mutation_check.Declaration(category, reason, line, written_here=written_here)
 
 
+class TextReadingKillerTests(unittest.TestCase):
+    """A mutant killed only by a fixture that walks this tree's text was killed by nothing.
+
+    A mutation edits a source file, so such a fixture reddens on the edit itself. Measured on the
+    campaign for `Hooks.cs:1603`: the clause-removal mutant was recorded killed by three cases, and
+    the first of them walks an identifier allowlist against the sources. Where a mutated line carries
+    an identifier the allowlist names, that fixture kills every mutant on it -- and those are the
+    lines most worth mutating, since an identifier the documentation names is one that is public.
+    """
+
+    READERS = {"DocumentationDriftTests", "CrefTargetTests"}
+
+    def test_Given_ATextReaderBesideABehaviourCase_When_TheKillersAreRead_Then_TheBehaviourOneStands(self):
+        # Arrange -- the ordinary kill, which must keep counting.
+        names = ["Velvet.Tests.DocumentationDriftTests.Given_X", "Velvet.Tests.HookTests.Given_Y"]
+
+        # Act / Assert
+        self.assertEqual(mutation_check.killed_by_behaviour(names, self.READERS),
+                         ["Velvet.Tests.HookTests.Given_Y"])
+
+    def test_Given_OnlyTextReaders_When_TheKillersAreRead_Then_NothingKilledIt(self):
+        # Arrange -- the shape the campaign reported as covered.
+        names = ["Velvet.Tests.DocumentationDriftTests.Given_X",
+                 "Velvet.Tests.CrefTargetTests.Given_Z"]
+
+        # Act / Assert
+        self.assertEqual(mutation_check.killed_by_behaviour(names, self.READERS), [])
+
+    def test_Given_TheFixturesOfThisPackage_When_TheyAreDerived_Then_TheDriftOneIsAmongThem(self):
+        # Arrange -- derived from what references the corpus rather than listed, so a fixture written
+        # that way later is covered by having been written that way.
+        found = mutation_check.text_reading_fixtures(REPO_ROOT / "Packages/com.velvet.core")
+
+        # Act / Assert
+        self.assertEqual(("DocumentationDriftTests" in found, "HookBailoutEqualityTests" in found),
+                         (True, False))
+
+
 class NeighbouringCampaignTests(unittest.TestCase):
     """A receipt says whether the verdict was reached with the machine to itself.
 


### PR DESCRIPTION
A mutation edits a source file, so a fixture that walks the repository's **own text** reddens on the
edit rather than on what it does — and a campaign's verdict is `killed` as soon as one case reddens.

Measured on the campaign for `Hooks.cs:1603`. The clause-removal mutant was recorded killed by three
cases:

```
Given_TheIdentifierAllowlist_When_EachEntryIsSoughtInTheSpansAndTheSources_Then_EveryEntrySuppressesAReport
Given_ChangedResourceKey_When_ReRendered_Then_ReplacesResourceInstance
Given_NoResourceKey_When_InlineLambdaFactoryReRenders_Then_WarnsOnSecondRender
```

The second and third exercise the mutated code. The first walks an identifier allowlist against the
sources and reddened because the mutation removed an identifier from a file.

**The reach is not one line.** Where a mutated line carries an identifier the allowlist names, that
fixture kills every mutant on it — and those are the lines most worth mutating, since an identifier
the documentation names is one that is public.

## What this changes

The killers a verdict counts are the ones that are not such a fixture's. A mutant left with none
reads `survived`, with its would-be killers named in the detail so the reader can see what did
redden.

**The set is derived, not listed.** It is the fixtures whose own source references the text corpus —
today `DocumentationDriftTests`, `CrefTargetTests`, `CorrectedSentenceTests`, `AssemblyGraphTests`,
`WorkflowTriggerCoverageTests`, `DocumentationSampleCompileTests`. A fixture written that way later is
covered by having been written that way; a hand list is the mirror shape this repository pins against
and the one that goes stale in silence.

## What it does not change

Scope. `mutation_check`'s default is deliberately the whole platform suite *"so that nothing is
reported as surviving merely because the fixture that would have killed it was out of scope"*, and
narrowing it to fix this would run against that reasoning — which is why the issue names the discount
as the reading to price first.

Three cases, all red on `origin/main` for want of the reading: a text reader beside a behaviour case
leaves the behaviour one standing, text readers alone leave nothing, and the derivation finds
`DocumentationDriftTests` while leaving an ordinary fixture out.

Closes #750
