### PR TITLE
fix(velvet): give unusable the reading deferred already has

### DIFF
--- a/.claude/hooks/lib/deferrals.py
+++ b/.claude/hooks/lib/deferrals.py
@@ -162,7 +162,10 @@ def unusable(key, now=None):
         return None
 
     fields = matching[-1].split()
-    stamp = epoch(fields[-1])
+    # The same reading `deferred` takes, because the two run over one line: updated there and not
+    # here, a signed line was honoured and reported unusable in the same breath.
+    session = written_by(fields)
+    stamp = epoch(fields[-2] if session else fields[-1])
     if stamp is None:
         return f"its last field is {fields[-1]!r}, not the epoch second it was written"
     if (time.time() if now is None else now) - stamp < 0:

--- a/scripts/hooks/test_deferral_writer.py
+++ b/scripts/hooks/test_deferral_writer.py
@@ -142,6 +142,9 @@ class SignedLineIsNotUnusable(unittest.TestCase):
         # Act / Assert
         self.assertIsNone(deferrals.unusable("377", NOW + 60))
 
+    # GREEN_ON_BASE(characterization): the control, and the base names a malformed line too -- that
+    # reading is what this widens rather than replaces. One that reddened would mean the widening had
+    # taken the rejection with it.
     def test_Given_ALineWhoseStampIsMissing_When_ItIsReadForRejection_Then_ItIsStillNamed(self):
         # Arrange -- the control: the reading that catches a malformed line has to keep catching it.
         self.file.write_text("377 waiting on review later {}\n".format(MINE), encoding="utf-8")

--- a/scripts/hooks/test_deferral_writer.py
+++ b/scripts/hooks/test_deferral_writer.py
@@ -116,5 +116,39 @@ class WhoseDeferral(unittest.TestCase):
         self.assertIsNone(deferrals.deferred("377", NOW + deferrals.TTL))
 
 
+class SignedLineIsNotUnusable(unittest.TestCase):
+    """`deferred` and `unusable` read one line, so they read it the same way.
+
+    Updated in one and not the other, a signed line was honoured and reported unusable in the same
+    breath -- the guard printed it under "Held on purpose" and under "Deferrals that were ignored".
+    """
+
+    def setUp(self):
+        root = Path(tempfile.mkdtemp(prefix="deferral-"))
+        self.addCleanup(shutil.rmtree, root, ignore_errors=True)
+        self.file = root / "deferrals"
+        self.addCleanup(setattr, deferrals, "DEFERRALS", deferrals.DEFERRALS)
+        deferrals.DEFERRALS = self.file
+        before = os.environ.get("CLAUDE_CODE_SESSION_ID")
+        self.addCleanup(
+            lambda: os.environ.__setitem__("CLAUDE_CODE_SESSION_ID", before) if before
+            else os.environ.pop("CLAUDE_CODE_SESSION_ID", None))
+        os.environ["CLAUDE_CODE_SESSION_ID"] = MINE
+
+    def test_Given_ALineThisSessionSigned_When_ItIsReadForRejection_Then_NothingIsWrongWithIt(self):
+        # Arrange
+        self.file.write_text("377 waiting on review {} {}\n".format(NOW, MINE), encoding="utf-8")
+
+        # Act / Assert
+        self.assertIsNone(deferrals.unusable("377", NOW + 60))
+
+    def test_Given_ALineWhoseStampIsMissing_When_ItIsReadForRejection_Then_ItIsStillNamed(self):
+        # Arrange -- the control: the reading that catches a malformed line has to keep catching it.
+        self.file.write_text("377 waiting on review later {}\n".format(MINE), encoding="utf-8")
+
+        # Act / Assert
+        self.assertIsNotNone(deferrals.unusable("377", NOW + 60))
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
`deferred` and `unusable` read the same line. #908 taught the first that the trailing field may be
the session that wrote the entry, and left the second parsing the epoch from the end — so a signed
line was honoured and reported unusable **in the same breath**:

```
Held on purpose, and worth re-reading:
  PR #377 — held 0m ago because: blocked on the admin call; …

Deferrals that were ignored:
  PR #377 — a deferral was written for it, and its last field is 'd901fcd6-…',
            not the epoch second it was written.
```

One run, one line, both readings. The remedy the second prints then tells the writer to do what they
already did.

`unusable` takes the same reading now. The control comes with it: a line whose stamp really is
missing is still named, so this is the format widening rather than the rejection going quiet.

No issue: it repairs a reader this repository shipped today, found by the guard reporting a pull
request twice in one message.
