### PR TITLE
fix(velvet): stop a loop that is standing still from spending its budget

### DIFF
--- a/scripts/test_quality/base_red_check.py
+++ b/scripts/test_quality/base_red_check.py
@@ -1993,6 +1993,20 @@ def shapes_remedy(carried):
             "land is yours to decide, and this has nothing further to say about it.".format(carried))
 
 
+# How many rounds of no progress are a fixed point rather than a slow one. Two says nothing -- a
+# withdrawal can take a file with no cases and the next round is the one that moves -- and three is
+# where the loop has asked the same question three times running.
+STILL_ROUNDS = 3
+
+
+def standing_still_reason(platform, attempt, fixtures):
+    """What to print where the loop has stopped moving rather than run out of budget."""
+    return ("\n{} asked the same {} fixture(s) {} rounds running and measured nothing each time.\n"
+            "Withdrawing is taking files that hold no case, so the next round is the one before it:\n"
+            "this is a fixed point rather than a budget. Spending the rest of --max-rounds would\n"
+            "report the cap instead of this.".format(platform, fixtures, STILL_ROUNDS))
+
+
 def exhausted_reason(spent, withdrawn, carried):
     """What a loop that ran out of rounds without ever compiling the base has to say for itself.
 
@@ -2274,6 +2288,12 @@ def main():
                 args.max_rounds)
             if note:
                 print(note, flush=True)
+            # A round that measures nothing and leaves the fixture count where it was is the loop
+            # standing still: it withdrew a file with no cases in it, so the next round asks exactly
+            # what this one did. Measured on the branch replacing UniTask: EditMode stopped
+            # withdrawing after round 1 and repeated the same round seven more times, four seconds
+            # each, and the run then reported the round cap rather than the fixed point.
+            standing_still, last_count = 0, None
             for attempt in range(1, args.max_rounds + 1):
                 rounds_spent = max(rounds_spent, attempt)
                 put_back |= withdrawn
@@ -2298,6 +2318,12 @@ def main():
                 # tree holds did not build, never which file, so withdrawing every silent one at
                 # once would take out the files that were merely standing next to the offender and
                 # leave their cases unmeasured behind somebody else's error.
+                standing_still = standing_still + 1 if not seen and len(fixtures) == last_count else 0
+                last_count = len(fixtures)
+                if standing_still >= STILL_ROUNDS:
+                    print(standing_still_reason(platform, attempt, len(fixtures)), flush=True)
+                    break
+
                 ran = fixtures_that_ran(seen)
                 silent = sorted({case.path for case in live if case.fixture not in ran})
                 if not silent:

--- a/scripts/test_quality/test_base_red_check.py
+++ b/scripts/test_quality/test_base_red_check.py
@@ -714,6 +714,36 @@ class DeclarationTests(unittest.TestCase):
             "characterization", "the ordering the base already commits to").complaint)
 
 
+class StandingStillTests(unittest.TestCase):
+    """A loop that asks the same question three rounds running has stopped, not slowed.
+
+    Measured on the branch replacing UniTask: EditMode stopped withdrawing after round 1 and repeated
+    the same round seven more times at four seconds each -- the compile abort rather than a run --
+    and the verdict then named the round cap. The cap is a budget finding; this is not one.
+    """
+
+    def test_Given_TheFixedPoint_When_ItIsReported_Then_ItSaysTheRoundsAskedTheSameThing(self):
+        # Arrange
+        said = base_red_check.standing_still_reason("EditMode", 8, 23)
+
+        # Act / Assert
+        self.assertIn("same 23 fixture(s) 3 rounds running", said)
+
+    def test_Given_TheFixedPoint_When_ItIsReported_Then_ItSaysItIsNotABudget(self):
+        # Arrange -- the remedy for a budget is a bigger one, and giving it here spends the rest of
+        # --max-rounds to reach the same place.
+        said = base_red_check.standing_still_reason("PlayMode", 4, 9)
+
+        # Act / Assert
+        self.assertIn("fixed point rather than a budget", said)
+
+    def test_Given_TheThreshold_When_ItIsRead_Then_TwoRoundsAreNotEnough(self):
+        # Arrange -- a withdrawal can take a file holding no case, and the round after it is the one
+        # that moves. Two says nothing; three is the same question asked three times.
+        # Act / Assert
+        self.assertEqual(base_red_check.STILL_ROUNDS, 3)
+
+
 class BudgetShortfallTests(unittest.TestCase):
     """What the loop can say before spending a round, rather than after spending all of them.
 


### PR DESCRIPTION
A round that measures nothing and leaves the fixture count where it was is the loop **standing
still**: the withdrawal took a file holding no case, so the next round asks exactly what this one
did.

Measured on the branch replacing UniTask, which is what this issue is written from:

```
EditMode attempt 1..8:  0 case(s) over 24, 23, 23, 23, 23, 23, 23, 23 fixture(s), 4s each
```

Four seconds is the compile abort rather than a run. EditMode stopped withdrawing after round 1 and
repeated the same round seven more times — and the verdict then named the **round cap**.

## Why naming the cap there is wrong

The cap is a budget finding, and the remedy for a budget is a bigger one. Given it, the loop spends
the rest of `--max-rounds` to arrive in the same place — which is what #901 corrected a sentence for
claiming otherwise about. Three rounds of the same question is a fixed point, and it says so:

```
EditMode asked the same 23 fixture(s) 3 rounds running and measured nothing each time.
Withdrawing is taking files that hold no case, so the next round is the one before it:
this is a fixed point rather than a budget. Spending the rest of --max-rounds would
report the cap instead of this.
```

Three rather than two, because a withdrawal can legitimately take a file with no case in it and the
round after that one is the one that moves. Two would call a slow loop a stopped one.

## What this is not

The first of the two halves the issue separates. The second — what category a change the base cannot
compile at all should carry, and what evidence its reason has to hold when the base run structurally
cannot supply any — is a design question and is untouched here.

Three cases, all red on `origin/main` for want of the reading, including the threshold itself so that
lowering it to two is a decision somebody takes against a case rather than an edit.

Closes #865
