### PR TITLE
fix(velvet): ask the guard operator what a deletion would strand

### DIFF
--- a/scripts/test_quality/mutation_check.py
+++ b/scripts/test_quality/mutation_check.py
@@ -629,6 +629,10 @@ def closes_a_do_block(text, mask, spans, number):
     return False
 
 
+# A control header whose body is the next line: deleting that line leaves the header with none.
+AWAITING_A_BODY = re.compile(r"(?:^|[;{}])\s*(?:if|for|foreach|while|else\s+if)\s*\(.*\)$|(?:^|[;{}])\s*else$")
+
+
 def deletable_line(text, mask, spans, number):
     """Whether removing line `number`'s code leaves what surrounds it standing.
 
@@ -835,8 +839,17 @@ def mutations_for(path, text, target_lines):
             if DECLARES_A_NAME.search(code_only(text, mask, start + column, start + column + len(cut))):
                 continue
             found.append(Mutant(path, number, column, cut, "", "clause removed"))
+        # This operator deletes a whole line too, so it owes the same two questions the removal
+        # operator asks -- but not the third. `deletable_line` also requires the code above to have
+        # ended a statement, which is about a declaration's tail and rejects a fragment that starts
+        # on the line under test; a guard is a whole statement by the pattern that matched it.
+        # What it does owe: the line above must not be a control header still waiting for its body,
+        # and the line below must not be an `else`. Neither is in the package today -- 396 mutants
+        # either way -- so what moves is that the next one cannot be emitted unread.
         if (GUARD_STATEMENT.match(stripped) and all(mask[start:start + limit])
-                and not DECLARES_A_NAME.search(code_only(text, mask, start, start + limit))):
+                and not DECLARES_A_NAME.search(code_only(text, mask, start, start + limit))
+                and not AWAITING_A_BODY.search(code_above(text, mask, spans, number))
+                and not code_below(text, mask, spans, number).startswith("else")):
             found.append(Mutant(path, number, line.index(stripped), stripped, "", "guard removed"))
     return found
 

--- a/scripts/test_quality/test_mutation_check.py
+++ b/scripts/test_quality/test_mutation_check.py
@@ -154,6 +154,71 @@ class NeighbouringCampaignTests(unittest.TestCase):
         self.assertIsNone(mutation_check.CAMPAIGN_RUNNING.match(line))
 
 
+class GuardRemovalReadsTheStatement(unittest.TestCase):
+    """The guard operator deletes a whole line, so it takes the reading the removal operator does.
+
+    Emitted without it, a guard nested under another `if` leaves that `if` with no body, and one
+    whose next line is an `else` strands the `else` -- the two shapes `deletable_line` was written
+    for. No such line is in this package today: the operator emits 396 mutants with the reading and
+    396 without, so this is a ratchet against the next one rather than a count that moved.
+    """
+
+    NESTED = """class C
+{
+    void M(bool outer, bool inner)
+    {
+        if (outer)
+            if (inner) return;
+        Body();
+    }
+    void Body() { }
+}
+"""
+
+    ELSE_BELOW = """class C
+{
+    void M(bool guard)
+    {
+        if (guard) return;
+        else Body();
+    }
+    void Body() { }
+}
+"""
+
+    PLAIN = """class C
+{
+    void M(bool guard)
+    {
+        if (guard) return;
+        Body();
+    }
+    void Body() { }
+}
+"""
+
+    def guards(self, source):
+        lines = set(range(1, source.count("\n") + 2))
+        return [mutant for mutant in mutation_check.mutations_for("C.cs", source, lines)
+                if mutant.operator == "guard removed"]
+
+    def test_Given_AGuardNestedUnderAnotherIf_When_TheMutantsAreRead_Then_ItIsNotEmitted(self):
+        # Arrange -- deleting it leaves `if (outer)` with no body.
+        # Act / Assert
+        self.assertEqual(self.guards(self.NESTED), [])
+
+    def test_Given_AGuardWhoseNextLineIsAnElse_When_TheMutantsAreRead_Then_ItIsNotEmitted(self):
+        # Arrange -- deleting it takes the `if` and strands the `else`.
+        # Act / Assert
+        self.assertEqual(self.guards(self.ELSE_BELOW), [])
+
+    def test_Given_AnOrdinaryGuard_When_TheMutantsAreRead_Then_ItIsStillEmitted(self):
+        # Arrange -- the control: a reading that emitted nothing would satisfy both cases above and
+        # take the operator with it.
+        # Act / Assert
+        self.assertEqual(len(self.guards(self.PLAIN)), 1)
+
+
 class CodeMaskTests(unittest.TestCase):
     """Which offsets count as code. Everything downstream of the mask reads only what it leaves.
 

--- a/scripts/test_quality/test_mutation_check.py
+++ b/scripts/test_quality/test_mutation_check.py
@@ -212,6 +212,9 @@ class GuardRemovalReadsTheStatement(unittest.TestCase):
         # Act / Assert
         self.assertEqual(self.guards(self.ELSE_BELOW), [])
 
+    # GREEN_ON_BASE(characterization): the control, and the base emits this one too -- that is the
+    # operator working, which this narrows rather than replaces. One that reddened would mean the
+    # narrowing had taken the operator with it.
     def test_Given_AnOrdinaryGuard_When_TheMutantsAreRead_Then_ItIsStillEmitted(self):
         # Arrange -- the control: a reading that emitted nothing would satisfy both cases above and
         # take the operator with it.


### PR DESCRIPTION
`guard removed` emits its mutant without any of the reading `line removed` takes, though it deletes a
whole line the same way. Two shapes it would strand:

```csharp
if (outer)
    if (inner) return;          // deleting the inner guard leaves `if (outer)` with no body

if (guard) return;
else Something();               // deleting the guard leaves a bare `else`
```

## Not `deletable_line` itself

That predicate also requires the code above to have **ended a statement** — a reading about a
declaration's tail (`=> Fragment(...)`, `= new(...)`), which was 77 mutants when #653 added it. A
guard is a whole statement by the pattern that matched it, and the condition rejects a fragment that
starts on the line under test, which is what the fixtures beside it are.

Routing the guard operator through it wholesale broke `GuardRemovalTests` and
`DeclarationRemovalTests`. Widening `deletable_line` so an empty line above counts as a boundary —
which is true, nothing up there to leave half-written — broke four more that depend on the opposite.
**The reading is load-bearing for the declaration operator on a fragment**, so the guard gets its own.

What it does owe is the other two questions: the line above must not be a control header still
waiting for its body, and the line below must not be an `else`.

## Measured

Neither shape is in the package today. **396** guard mutants with the reading and 396 without;
`line removed` unchanged at **13920**. So this is a ratchet against the next one rather than a count
that moved — which is why the issue filed it instead of folding it into #653, where a count that
moved had to stay attributable to one cause.

Three cases: the nested guard and the `else` below are red on `origin/main`; the ordinary guard still
emitting is the control, since a reading that emitted nothing would satisfy both and take the
operator with it.

Closes #709
