### PR TITLE
fix(velvet): sample for a run's whole life, not once before it

### DIFF
--- a/scripts/test_quality/base_red_check.py
+++ b/scripts/test_quality/base_red_check.py
@@ -979,17 +979,34 @@ def next_to_withdraw(log_text, carry, withdrawn, silent):
 
 
 def run_unity(unity, tree, platform, fixtures, results, log, timeout):
+    """(wall clock, the most other editors seen at once) for one base run.
+
+    Sampled for the run's whole life rather than once before it. The wait at the top of the lane
+    covers the instant it happens in, and a neighbour arriving after it is invisible for every round
+    that follows -- where it can redden a timing-sensitive case on the base tree, and `red on the
+    base` is exactly the evidence this harness is asked for. Contention there does not produce a
+    confusing verdict; it produces a confident wrong one.
+
+    `neuter_check.run_suite` already samples this way and prints what it saw. Recorded rather than
+    refused: what a non-zero peak should cost a verdict wants measuring against how often a
+    neighbour actually appears, and silence is the one answer that cannot be re-examined later.
+    """
     command = [
         unity, "-runTests", "-batchmode", "-projectPath", str(tree),
         "-testPlatform", platform, "-testResults", str(results), "-logFile", str(log),
         "-testFilter", ";".join(sorted(fixtures)),
     ]
     started = time.time()
-    try:
-        subprocess.run(command, timeout=timeout)
-    except subprocess.TimeoutExpired:
-        pass
-    return time.time() - started
+    peak = 0
+    process = subprocess.Popen(command)
+    while process.poll() is None:
+        if time.time() - started > timeout:
+            process.kill()
+            process.wait()
+            break
+        peak = max(peak, max(0, unity_busy() - 1))
+        time.sleep(3)
+    return time.time() - started, peak
 
 
 # The source a stack-trace frame names, matched under the two roots a Unity project's own code sits
@@ -2248,6 +2265,7 @@ def main():
     transcript = []
     canaries = {}
     last_log = None
+    met_a_neighbour = False
     ever_wrote = not any(kind_of(case.path) == "csharp" for case in cases)
     rounds_spent = 0
     put_back = set()
@@ -2306,13 +2324,17 @@ def main():
                 for stale in (results, log):
                     if stale.exists():
                         stale.unlink()
-                wall = run_unity(args.unity, base_tree, platform, fixtures, results, log, args.timeout)
+                wall, neighbours = run_unity(
+                    args.unity, base_tree, platform, fixtures, results, log, args.timeout)
+                met_a_neighbour = met_a_neighbour or neighbours > 0
                 last_log = log
                 seen, wrote = results_from(results)
                 ever_wrote = ever_wrote or wrote
                 reported.update(seen)
-                print("{} attempt {}: {} case(s) over {} fixture(s) in {:.0f}s".format(
-                    platform, attempt, len(seen), len(fixtures), wall), flush=True)
+                print("{} attempt {}: {} case(s) over {} fixture(s) in {:.0f}s{}".format(
+                    platform, attempt, len(seen), len(fixtures), wall,
+                    "" if not neighbours else
+                    "; {} other editor(s) were up".format(neighbours)), flush=True)
 
                 # One file per attempt. A round that reports nothing says only that something the
                 # tree holds did not build, never which file, so withdrawing every silent one at
@@ -2352,6 +2374,10 @@ def main():
             print(shapes_remedy(len(carry)), flush=True)
         elif rounds_spent >= args.max_rounds:
             print(exhausted_reason(rounds_spent, put_back, len(carry)), flush=True)
+    if met_a_neighbour:
+        print("\nA second editor was up during at least one of these runs, so a failure here has a\n"
+              "second explanation. Nothing below distinguishes one it caused from one the branch did.",
+              flush=True)
     offenders = report(cases, control, reported, canaries, ever_wrote)
     print("\nlogs: {}".format(output), flush=True)
     return 1 if offenders else 0

--- a/scripts/test_quality/mutation_check.py
+++ b/scripts/test_quality/mutation_check.py
@@ -1080,7 +1080,8 @@ def wait_for_quiet(seconds):
 
 
 def run_suite(unity, project, platform, scope, results, log, timeout, holder=None):
-    """Returns the wall clock and whether the editor had to be killed.
+    """Returns the wall clock, whether the editor had to be killed, and the most other
+    editors seen at once.
 
     A mutation can turn a loop bound into one that never terminates, and the run would otherwise
     wait on it for as long as the machine is left alone.
@@ -1098,13 +1099,22 @@ def run_suite(unity, project, platform, scope, results, log, timeout, holder=Non
     child = subprocess.Popen(command)
     if holder is not None:
         holder.child = child
+    # Sampled for the run's whole life, not once before it. The campaign waits before every mutant,
+    # and a neighbour arriving ten seconds in is invisible for the rest of that mutant -- where it
+    # can redden a timing-sensitive case, and the mutant is then recorded killed. A mutant that
+    # actually survived, which is a hole in the tests, reported as covered.
+    peak = 0
     try:
-        child.wait(timeout=timeout)
-        return time.time() - start, False
-    except subprocess.TimeoutExpired:
-        child.kill()
-        child.wait()
-        return time.time() - start, True
+        while True:
+            try:
+                child.wait(timeout=3)
+                return time.time() - start, False, peak
+            except subprocess.TimeoutExpired:
+                if time.time() - start > timeout:
+                    child.kill()
+                    child.wait()
+                    return time.time() - start, True, peak
+                peak = max(peak, max(0, unity_busy() - 1))
     finally:
         if holder is not None:
             holder.child = None
@@ -1659,7 +1669,7 @@ def main():
     # the baseline's editor outliving a killed campaign holds the project lock against the next one.
     holder.guard()
     baseline_results = output / "baseline.xml"
-    baseline_wall, baseline_timed_out = run_suite(args.unity, project, args.platform, scope,
+    baseline_wall, baseline_timed_out, _ = run_suite(args.unity, project, args.platform, scope,
                                                   baseline_results, output / "baseline.log",
                                                   args.timeout, holder)
     if baseline_timed_out:
@@ -1702,7 +1712,7 @@ def main():
             mutated = apply_mutation(originals[mutant.path], mutant)
             holder.hold(mutant.path, originals[mutant.path], mutated, mutant.describe(project))
             mutant.path.write_text(mutated)
-            wall, timed_out = run_suite(args.unity, project, args.platform, scope, results, log,
+            wall, timed_out, neighbours = run_suite(args.unity, project, args.platform, scope, results, log,
                                         args.timeout, holder)
             if holder.release() is None:
                 # The record is still there naming a file still mutated. Going on would apply the
@@ -1759,6 +1769,9 @@ def main():
                 mutant.detail = "{} inconclusive, 0 failed".format(counts["inconclusive"])
             else:
                 mutant.verdict = SURVIVED
+            if neighbours:
+                mutant.detail = "{}; {} other editor(s) were up".format(
+                    mutant.detail or "-", neighbours)
             average = (time.time() - started) / index
             print("      {} ({}) in {:.0f}s; {:.0f}s left at {:.0f}s each".format(
                 mutant.verdict, mutant.detail or "-", wall, average * (len(mutants) - index), average))

--- a/scripts/test_quality/test_base_red_check.py
+++ b/scripts/test_quality/test_base_red_check.py
@@ -714,6 +714,38 @@ class DeclarationTests(unittest.TestCase):
             "characterization", "the ordering the base already commits to").complaint)
 
 
+class NeighbourDuringTheRunTests(unittest.TestCase):
+    """A second editor arriving after the one quiet check is recorded rather than missed.
+
+    The wait at the top of the lane covers the instant it happens in, and the lane then runs
+    platforms x rounds without looking again. A neighbour arriving after it can redden a
+    timing-sensitive case on the base tree, and `red on the base` is exactly the evidence this
+    harness is asked for -- so contention there produces a confident wrong verdict rather than a
+    confusing one. `neuter_check.run_suite` already samples for its run's whole life.
+    """
+
+    @staticmethod
+    def reading():
+        """What one run reports, as a flat tuple -- a bare float is a run that reported one thing."""
+        result = base_red_check.run_unity(
+            sys.executable, ".", "EditMode", ["X"], Path("/dev/null"), Path("/dev/null"), 30)
+        return tuple(result) if isinstance(result, tuple) else (result,)
+
+    def test_Given_ARunThatMetNoNeighbour_When_ItIsRead_Then_ThePeakIsZero(self):
+        # Arrange -- a command that exits at once, so the loop samples and finds only this run.
+        reading = self.reading()
+
+        # Act / Assert -- the wall clock rides along, since a peak of zero from a run that never
+        # started says nothing.
+        self.assertEqual((len(reading), reading[-1], reading[0] >= 0), (2, 0, True))
+
+    def test_Given_TheRunner_When_ItReturns_Then_ItCarriesBothReadings(self):
+        # Arrange -- read as a shape rather than unpacked, so a tree reporting one thing fails here
+        # instead of raising: a case that raises carries no reading either way.
+        # Act / Assert
+        self.assertEqual(len(self.reading()), 2)
+
+
 class StandingStillTests(unittest.TestCase):
     """A loop that asks the same question three rounds running has stopped, not slowed.
 

--- a/scripts/test_quality/test_mutation_check.py
+++ b/scripts/test_quality/test_mutation_check.py
@@ -116,6 +116,38 @@ def declaration(line, category="equivalent", reason="a reason of four words", wr
         return mutation_check.Declaration(category, reason, line, written_here=written_here)
 
 
+class NeighbourDuringAMutantTests(unittest.TestCase):
+    """A second editor arriving after the wait is recorded rather than missed.
+
+    The campaign waits before every mutant, and then waits on the child without sampling. A
+    neighbour arriving ten seconds in can redden a timing-sensitive case, `counts["failed"]` is
+    non-zero, and the mutant is recorded killed -- a mutant that actually survived, which is a hole
+    in the tests, reported as covered. `wait_for_quiet`'s own docstring states the invariant this
+    breaks, and enforces it at one instant.
+    """
+
+    @staticmethod
+    def reading():
+        """What one run reports, as a tuple, so a shorter one fails rather than raises."""
+        return tuple(mutation_check.run_suite(
+            sys.executable, ".", "EditMode", ["-c", "pass"],
+            Path("/dev/null"), Path("/dev/null"), 30))
+
+    def test_Given_ARunThatMetNoNeighbour_When_ItIsRead_Then_ThePeakIsZero(self):
+        # Arrange -- a command that exits at once, so the loop samples and finds only this run.
+        reading = self.reading()
+
+        # Act / Assert -- the other two readings ride along, since a peak of zero from a run that
+        # never started says nothing.
+        self.assertEqual((len(reading), reading[-1], reading[1], reading[0] >= 0),
+                         (3, 0, False, True))
+
+    def test_Given_TheRunner_When_ItReturns_Then_ItCarriesAllThreeReadings(self):
+        # Arrange -- read as a shape, so a tree reporting a pair fails here rather than raising.
+        # Act / Assert
+        self.assertEqual(len(self.reading()), 3)
+
+
 class TextReadingKillerTests(unittest.TestCase):
     """A mutant killed only by a fixture that walks this tree's text was killed by nothing.
 
@@ -1815,16 +1847,16 @@ class StubbedCampaign:
         wall = 0.0 if mutant else self.baseline_seconds
         if mutant and self.no_results:
             Path(log).write_text("")
-            return wall, False
+            return wall, False, 0
         if self.not_rebuilt:
             (self.project / "Library" / "ScriptAssemblies" / "None.dll").write_bytes(b"same")
         if mutant and self.times_out:
-            return wall, True
+            return wall, True, 0
         Path(results).write_text(FAILING_RESULTS if (mutant and self.kills) else GREEN_RESULTS)
         Path(log).write_text(
             "Packages/com.velvet.core/Runtime/Probe.cs(5,9): error VEL501: too many branches\n"
             if (mutant and self.build_error) else "")
-        return wall, False
+        return wall, False, 0
 
     def unity_busy(self):
         self.seen.append(self.source.read_text())


### PR DESCRIPTION
Both harnesses check for a neighbouring editor **only before starting**, and neither looks again
while its own editor is up. A neighbour arriving after the check is invisible for the rest of the
work, and in both cases its effect is indistinguishable from the answer the harness exists to
produce.

**`base_red_check`** waits once and then runs `platforms × max_rounds` through `run_unity`, which was
a bare `subprocess.run` with no sampling. A neighbour reddening a timing-sensitive case on the base
tree reads as `red on the base` — exactly the evidence the lane is asked for. So contention there does
not produce a confusing verdict; it produces a **confident wrong one**, and signs off a case that is
green on the base.

**`mutation_check`** waits before every mutant and then waits on the child without sampling. A
neighbour reddening a case ten seconds in makes `counts["failed"]` non-zero and the mutant reads
`killed` — a mutant that actually **survived**, which is a hole in the tests, recorded as covered.
`wait_for_quiet`'s own docstring states the invariant this breaks: *"a second editor is a second
explanation for all of them."*

## The pattern was already here

`neuter_check.run_suite` samples for its run's whole life and prints `peak other runs {peak}`. Copied
rather than invented: `run_unity` returns `(wall, peak)`, `run_suite` returns `(wall, killed, peak)`,
the lane prints `N other editor(s) were up` beside the round that met one, a mutant's detail carries
it, and the verdict is preceded by a line saying a failure below has a second explanation.

## Recorded, not refused

The issue separates the two levels. What a non-zero peak should *cost* a verdict — a withheld reading,
a re-run mutant — wants measuring against how often a neighbour actually appears, and this repository
has withdrawn guards after measuring their yield. Silence is the one answer that cannot be
re-examined afterwards, so it goes first.

Four cases, all red on `origin/main`. They read the returned **shape** rather than unpacking it: a
tree that reports one reading fails them instead of raising, and a case that raises carries no reading
either way — which is what the first attempt did.

Closes #658
