### PR TITLE
fix(velvet): stop emitting two rewrites that cannot compile

### DIFF
--- a/scripts/test_quality/mutation_check.py
+++ b/scripts/test_quality/mutation_check.py
@@ -392,6 +392,17 @@ OPERATORS = [
 
 WORD_OPERATORS = [("true", "false", "literal"), ("false", "true", "literal")]
 
+def joins_a_string(line, index):
+    """Whether the ` + ` at `index` has a string literal for one of its operands.
+
+    Read on either side of that one operator rather than over the line, which holds both kinds at
+    once: `Log("x" + name)` beside `total = a + b` is one line and one of the two is arithmetic.
+    """
+    return line[:index].rstrip().endswith('"') or line[index + 3:].lstrip().startswith('"')
+
+# `while (true)`, which is how a method with no other returning path returns at all.
+FOREVER_LOOP = re.compile(r"\bwhile\s*\(\s*true\s*$")
+
 # An identifier, an optional type argument list, a parenthesised head, a semicolon-terminated tail.
 # The word in front of the parenthesis is no part of that, so what the removal takes is everything the
 # line runs rather than one call -- which is what its verdict is named for.
@@ -809,13 +820,23 @@ def mutations_for(path, text, target_lines):
                 continue
             index = line.find(before)
             while index >= 0:
-                if all(mask[start + index:start + index + len(before)]):
+                # `"a" - "b"` is not an expression: `-` has no string overload, so a `+` with a
+                # literal on either side rewrites into CS0019 rather than into behaviour a test
+                # could notice. Read per occurrence -- a line can hold one of each, and skipping
+                # the line took 650 arithmetic mutants where the mechanism is 93.
+                if (all(mask[start + index:start + index + len(before)])
+                        and not (before == " + " and joins_a_string(line, index))):
                     found.append(Mutant(path, number, index, before.strip(), after.strip(), operator))
                 index = line.find(before, index + 1)
         for before, after, operator in WORD_OPERATORS:
             for match in re.finditer(r"\b{}\b".format(before), line):
-                if all(mask[start + match.start():start + match.end()]):
-                    found.append(Mutant(path, number, match.start(), before, after, operator))
+                if not all(mask[start + match.start():start + match.end()]):
+                    continue
+                # `while (true)` is how a method's only returning path is reached; `while (false)`
+                # leaves it with none and the file stops compiling -- CS0161 rather than a verdict.
+                if before == "true" and FOREVER_LOOP.search(line[:match.end()]):
+                    continue
+                found.append(Mutant(path, number, match.start(), before, after, operator))
         stripped = line.strip()
         limit = len(line.rstrip())
         # The masked code rather than the raw line: `;$` fails wherever anything follows the

--- a/scripts/test_quality/test_mutation_check.py
+++ b/scripts/test_quality/test_mutation_check.py
@@ -192,6 +192,54 @@ class NeighbouringCampaignTests(unittest.TestCase):
         self.assertIsNone(mutation_check.CAMPAIGN_RUNNING.match(line))
 
 
+class RewritesThatCannotCompile(unittest.TestCase):
+    """Two of the three mechanisms behind a mutant that cannot compile from a rewrite.
+
+    `-` has no string overload, so a `+` joining a literal rewrites into CS0019; and `while (true)`
+    is how a method with no other returning path returns at all, so `while (false)` leaves it with
+    none and the file stops compiling with CS0161. Neither is behaviour a test could notice.
+
+    Measured over this package's production sources: arithmetic 807 to 743, literal 1709 to 1707 --
+    66 of the 208 the issue counts. The third mechanism, a flip leaving a pattern variable
+    unassigned, is 113 of them and is not a line reading.
+    """
+
+    def operators(self, line, wanted):
+        lines = set(range(1, line.count("\n") + 2))
+        return [m for m in mutation_check.mutations_for("C.cs", line, lines)
+                if m.operator == wanted]
+
+    def test_Given_APlusJoiningALiteral_When_TheMutantsAreRead_Then_ItIsNotOffered(self):
+        # Arrange -- `"a" - name` is not an expression.
+        # Act / Assert
+        self.assertEqual(self.operators('Log("a" + name);\n', "arithmetic"), [])
+
+    # GREEN_ON_BASE(characterization): the control, and the base offers this one too -- that is the
+    # operator working, which this narrows rather than replaces.
+    def test_Given_APlusBetweenNumbers_When_TheMutantsAreRead_Then_ItIsStillOffered(self):
+        # Arrange -- the control: a reading that skipped every `+` would satisfy the case above and
+        # take the operator with it.
+        # Act / Assert
+        self.assertEqual(len(self.operators("total = a + b;\n", "arithmetic")), 1)
+
+    def test_Given_BothOnOneLine_When_TheMutantsAreRead_Then_OnlyTheArithmeticOneIsOffered(self):
+        # Arrange -- read per occurrence rather than per line: skipping the line took 650 where the
+        # mechanism is 64.
+        # Act / Assert
+        self.assertEqual(len(self.operators('Log("a" + name, x + y);\n', "arithmetic")), 1)
+
+    def test_Given_AForeverLoop_When_TheMutantsAreRead_Then_ItsTrueIsNotFlipped(self):
+        # Arrange -- `while (false)` leaves a method with no returning path.
+        # Act / Assert
+        self.assertEqual(self.operators("while (true)\n", "literal"), [])
+
+    # GREEN_ON_BASE(characterization): as above, on the other operator.
+    def test_Given_AnOrdinaryTrue_When_TheMutantsAreRead_Then_ItIsStillFlipped(self):
+        # Arrange -- the control on the other side.
+        # Act / Assert
+        self.assertEqual(len(self.operators("var ready = true;\n", "literal")), 1)
+
+
 class GuardRemovalReadsTheStatement(unittest.TestCase):
     """The guard operator deletes a whole line, so it takes the reading the removal operator does.
 


### PR DESCRIPTION
Two of the three mechanisms the issue separates, both decidable from the line.

`-` has no string overload, so a `+` joining a literal rewrites into **CS0019**. And `while (true)` is
how a method with no other returning path returns at all, so `while (false)` leaves it with none and
the file stops compiling with **CS0161**. Neither is behaviour a test could notice, and a mutant that
cannot compile is reported as surviving or as a build failure rather than as what it is.

## Measured

Over this package's production sources:

| operator | before | after |
|---|---|---|
| `arithmetic` | 807 | **743** |
| `literal` | 1709 | **1707** |

66 of the 208 the issue counts.

## Per occurrence, not per line

A line holds both kinds at once — `Log("a" + name, x + y)` — and the first attempt skipped the whole
line, which took **650** arithmetic mutants where the mechanism is 64. The reading is now on either
side of the one operator.

It also reads the raw line rather than the masked code: `code_only` blanks a literal's text along
with the comments, so the quotes it looks for are not there to find. The mask still decides whether
the operator itself is code, so a `+` inside a string or a comment was never a candidate.

## What is left

The third mechanism — a flip leaving a pattern variable unassigned (`CS0165`, `CS0170`, `CS0177`,
`CS0269`) — is **113 of the 208** and is not a line reading: it needs to know that a designation the
left operand declares is read by the right. Untouched here.

Five cases: the three narrowings are red on `origin/main`, and the two controls — an ordinary `+`
between numbers, an ordinary `true` — are declared, since a reading that emitted nothing would satisfy
the others and take both operators with it.

Refs #662
