### PR TITLE
ci(velvet): let docs/build.py own the staging and the site it produces

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -122,6 +122,7 @@ jobs:
           echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
 
       - name: Build docs
+        id: site
         env:
           # Linux editor image: engine managed assemblies live under <Editor>/Data.
           UnityEditorContents: /opt/unity/Editor/Data
@@ -130,18 +131,12 @@ jobs:
             echo "::error::Compiled assemblies were not restored — the compile job did not produce Library/ScriptAssemblies."
             exit 1
           }
-          cd docs
-          # Stage a disposable copy of the Documentation~ guides so DocFX's TOC/xref resolution
-          # can see them (see docs/build.py for why this can't reference Documentation~ in place).
-          rm -rf guides
-          mkdir -p guides
-          cp ../Packages/com.velvet.core/Documentation~/*.md guides/
-          docfx metadata docfx.json
-          docfx build docfx.json
+          python3 docs/build.py
+          echo "path=$(python3 docs/build.py --site-path)" >> "$GITHUB_OUTPUT"
 
       - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
-          path: docs/_site
+          path: ${{ steps.site.outputs.path }}
 
   deploy:
     name: Deploy to GitHub Pages

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,6 +39,12 @@ concurrency:
   group: docs
   cancel-in-progress: true
 
+# Carried at job level for the reason test_workflow_bytecode_env.py states, and required by it.
+# Named without its path: a workflow that names a repo file is one this repository's push filter has
+# to start for, and a pointer in prose is not a reason to run the docs build.
+env:
+  PYTHONDONTWRITEBYTECODE: "1"
+
 jobs:
   license-check:
     name: Check Unity license secret

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,9 +39,10 @@ concurrency:
   group: docs
   cancel-in-progress: true
 
-# Carried at job level for the reason test_workflow_bytecode_env.py states, and required by it.
-# Named without its path: a workflow that names a repo file is one this repository's push filter has
-# to start for, and a pointer in prose is not a reason to run the docs build.
+# Required by test_workflow_bytecode_env.py, for the reason it states. At the root rather than under
+# a job, because the root mapping is what that guard reads. Its module is named without a path: a repo
+# file this workflow names is one its own push filter has to start for, and this filter covers no
+# suite.
 env:
   PYTHONDONTWRITEBYTECODE: "1"
 
@@ -138,7 +139,10 @@ jobs:
             exit 1
           }
           python3 docs/build.py
-          echo "path=$(python3 docs/build.py --site-path)" >> "$GITHUB_OUTPUT"
+          # Assigned before it is echoed: a substitution inside `echo` fails into an empty output
+          # while the step reports success, and the upload then dies naming itself rather than this.
+          site=$(python3 docs/build.py --site-path)
+          echo "path=$site" >> "$GITHUB_OUTPUT"
 
       - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/DocumentationDriftTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/DocumentationDriftTests.cs
@@ -1520,25 +1520,28 @@ namespace Velvet.Tests
         [Test]
         public void Given_TheDocfxGeneratedDirectories_When_TheWorkflowsAreScanned_Then_NoneIsWrittenOutAgain()
         {
-            // Arrange - the Pages upload used to carry docs/_site as a literal beside the docfx.json that
-            // declares it. Renaming the key there moves what docfx writes and leaves the upload pointed at
-            // a directory that is now empty, which publishes an empty site with the workflow green.
+            // Arrange - the Pages upload carried docs/_site as a literal beside the docfx.json that
+            // declares it, and a rename of that key moves what docfx writes while the upload stays where
+            // it was. Which of the two then reports it is the action's to decide and is not stated here.
             var generated = DocfxGeneratedDirectories();
+            var workflows = Directory
+                .EnumerateFiles(Path.GetFullPath(".github/workflows"), "*.yml")
+                .Concat(Directory.EnumerateFiles(Path.GetFullPath(".github/workflows"), "*.yaml"))
+                .ToList();
 
             // Act
-            var restated = (from workflow in Directory
-                                .EnumerateFiles(Path.GetFullPath(".github/workflows"), "*.yml")
-                                .Concat(Directory.EnumerateFiles(Path.GetFullPath(".github/workflows"), "*.yaml"))
+            var restated = (from workflow in workflows
                             let text = File.ReadAllText(workflow)
                             from directory in generated
                             where text.Contains(directory, StringComparison.Ordinal)
                             select $"{Path.GetFileName(workflow)} names {directory}")
                 .ToList();
 
-            // Assert - how many directories were derived rides along, because a derivation finding none
-            // leaves this reporting the same silence a workflow that restates none does.
-            Assert.That((generated.Count, string.Join("\n", restated)), Is.EqualTo((2, string.Empty)),
-                "docs/docfx.json owns where DocFX writes; a workflow repeating it drifts in silence");
+            // Assert - both counts ride along, because a derivation finding none and a directory holding
+            // no workflow each leave this reporting the silence a repository restating none does.
+            Assert.That((generated.Count, workflows.Count > 1, string.Join("\n", restated)),
+                Is.EqualTo((2, true, string.Empty)),
+                "docs/docfx.json owns where DocFX writes; a workflow repeating it is a second place to change");
         }
 
         // GREEN_ON_BASE(characterization): the exclusion this pins lives in DocumentationCorpus.

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/DocumentationDriftTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/DocumentationDriftTests.cs
@@ -1517,6 +1517,30 @@ namespace Velvet.Tests
         private static readonly Regex DocfxOutputPattern =
             new(@"""(?:dest|output)""\s*:\s*""([^""]+)""", RegexOptions.Compiled);
 
+        [Test]
+        public void Given_TheDocfxGeneratedDirectories_When_TheWorkflowsAreScanned_Then_NoneIsWrittenOutAgain()
+        {
+            // Arrange - the Pages upload used to carry docs/_site as a literal beside the docfx.json that
+            // declares it. Renaming the key there moves what docfx writes and leaves the upload pointed at
+            // a directory that is now empty, which publishes an empty site with the workflow green.
+            var generated = DocfxGeneratedDirectories();
+
+            // Act
+            var restated = (from workflow in Directory
+                                .EnumerateFiles(Path.GetFullPath(".github/workflows"), "*.yml")
+                                .Concat(Directory.EnumerateFiles(Path.GetFullPath(".github/workflows"), "*.yaml"))
+                            let text = File.ReadAllText(workflow)
+                            from directory in generated
+                            where text.Contains(directory, StringComparison.Ordinal)
+                            select $"{Path.GetFileName(workflow)} names {directory}")
+                .ToList();
+
+            // Assert - how many directories were derived rides along, because a derivation finding none
+            // leaves this reporting the same silence a workflow that restates none does.
+            Assert.That((generated.Count, string.Join("\n", restated)), Is.EqualTo((2, string.Empty)),
+                "docs/docfx.json owns where DocFX writes; a workflow repeating it drifts in silence");
+        }
+
         // GREEN_ON_BASE(characterization): the exclusion this pins lives in DocumentationCorpus.
         // That is a test-assembly file the base run carries from the branch along with the case, so the
         // base answers over the branch's own list. What stands in for the base run is the entry removed

--- a/docs/build.py
+++ b/docs/build.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Generate the Velvet API reference site into docs/_site.
+"""Generate the Velvet API reference site into the directory docs/docfx.json names.
 
 Prerequisites:
   1. A prior Unity compile so Library/ScriptAssemblies/{UniTask,Unity.Addressables,
@@ -37,7 +37,7 @@ def run(command):
 
 def main():
     # The caller that publishes the site asks for the path rather than repeating it, so a rename in
-    # docfx.json moves the upload with it instead of leaving it pointed at an empty directory.
+    # docfx.json moves the upload with it.
     if "--site-path" in sys.argv[1:]:
         print(site().relative_to(HERE.parent).as_posix())
         return 0
@@ -49,8 +49,15 @@ def main():
     # rather than referencing Documentation~ in place — nothing under docs/guides/ is ever committed.
     shutil.rmtree(GUIDES, ignore_errors=True)
     GUIDES.mkdir(parents=True)
+    staged = 0
     for guide in DOCUMENTATION.glob("*.md"):
         shutil.copyfile(guide, GUIDES / guide.name)
+        staged += 1
+    # `glob` over a directory that is not there yields nothing and raises nothing, so a move or a
+    # rename of the guides leaves DocFX building the API pages alone and the site publishing without
+    # them. The shell this replaced could not reach that state: its `cp` had no files to name.
+    if not staged:
+        raise SystemExit(f"error: no guides staged from {DOCUMENTATION}")
 
     run(["docfx", "metadata", "docfx.json"])
     run(["docfx", "build", "docfx.json"])

--- a/docs/build.py
+++ b/docs/build.py
@@ -12,14 +12,21 @@ For a non-default Unity install, point at its managed-assemblies parent:
 MSBuild reads UnityEditorContents from the environment automatically.
 """
 
+import json
 import shutil
 import subprocess
 import sys
 from pathlib import Path
 
 HERE = Path(__file__).resolve().parent
+DOCFX = HERE / "docfx.json"
 GUIDES = HERE / "guides"
 DOCUMENTATION = HERE.parent / "Packages" / "com.velvet.core" / "Documentation~"
+
+
+def site():
+    """Where DocFX writes the built site, which docfx.json owns."""
+    return HERE / json.loads(DOCFX.read_text(encoding="utf-8"))["build"]["output"]
 
 
 def run(command):
@@ -29,6 +36,12 @@ def run(command):
 
 
 def main():
+    # The caller that publishes the site asks for the path rather than repeating it, so a rename in
+    # docfx.json moves the upload with it instead of leaving it pointed at an empty directory.
+    if "--site-path" in sys.argv[1:]:
+        print(site().relative_to(HERE.parent).as_posix())
+        return 0
+
     # The hand-authored guides under Packages/com.velvet.core/Documentation~ are the single source
     # of truth (that directory is also the standard Unity Package Manager offline-docs location, so
     # it must stay put). DocFX's TOC/xref resolution only matches conceptual pages that live under
@@ -42,7 +55,7 @@ def main():
     run(["docfx", "metadata", "docfx.json"])
     run(["docfx", "build", "docfx.json"])
 
-    print(f"Velvet API site generated at: {HERE / '_site' / 'index.html'}")
+    print(f"Velvet API site generated at: {site() / 'index.html'}")
     return 0
 
 


### PR DESCRIPTION
Closes #686.

`docs.yml`'s Build docs step re-implemented `docs/build.py`'s guide staging inline — `rm -rf guides`,
`mkdir`, `cp ../Packages/com.velvet.core/Documentation~/*.md guides/` — beside a script that does the
same thing for a local build. Two stagers in one job with nothing holding them to each other: a change
to which files are staged, or to where, lands in one and the site published differs from the site
built. The workflow calls the script now.

The Pages upload carried `docs/_site` as a literal while `docs/docfx.json` declares `"output"`.
`build.py` reads the key, `--site-path` prints it, and the upload step reads that. A new case in
`DocumentationDriftTests` refuses any workflow that names a directory `docfx.json` declares, so the
literal cannot come back; it gates both the derived count and the workflow count, because a derivation
finding none and a directory holding no workflow each leave it reporting the same silence.

Three things the move needed that the inline shell had for free:

- `PYTHONDONTWRITEBYTECODE` at the root, which every workflow running Python carries and this one now
  does — without it `test_workflow_bytecode_env.py` reddens `Required checks (generators)`, measured on
  the branch and green on the base.
- `Path.glob` over a directory that is not there yields nothing and raises nothing, where the `cp` it
  replaced had no files to name and `set -e` stopped the job. `build.py` refuses a staging that staged
  nothing.
- `echo "path=$(…)" >> "$GITHUB_OUTPUT"` discards the substitution's exit code, so a `--site-path`
  that raised would leave an empty output and the job would die inside the upload action naming
  itself. Assigned on its own line, `bash -e` stops at the build.

No claim is made about which of the upload action and the build would report a renamed `"output"`,
because that was not measured. What the change does is leave the path written in one place.

EditMode 4255 passed / 0 failed, provenance and inconclusive checks clean.
