### PR TITLE
fix(velvet): give each gh pr subcommand the option table it actually has

### DIFF
--- a/.claude/hooks/lib/pr_body.py
+++ b/.claude/hooks/lib/pr_body.py
@@ -55,6 +55,28 @@ VALUE_FLAGS = {
 SHORT_BOOLEAN_FLAGS = {"-d", "-e", "-f", "-h", "-w"}
 LONG_BOOLEAN_FLAGS = {"--dry-run", "--help"}
 
+# One union holds while the tables agree, and `pr merge`'s does not: `-m` is `--milestone` and takes
+# a value on create and edit, and is `--merge` and takes none on merge; `-r` is `--reviewer` and
+# `--rebase` the same way. Read as the union, `gh pr merge 7 -m -b "text"` spends `-b` as `-m`'s
+# value and no body is found -- and a guard that found none exits 0, which is what it exits having
+# read one and been satisfied.
+SUBCOMMAND_FLAGS = {
+    ("pr", "merge"): (
+        {"--author-email", "-A", "--body", "-b", "--body-file", "-F", "--match-head-commit",
+         "--repo", "-R", "--subject", "-t"},
+        {"-d", "-m", "-r", "-s"},
+    ),
+}
+
+
+def tables(words):
+    """(value-taking, boolean shorthand) for an invocation of `words`, or the union for anything else.
+
+    A `git commit` reaches here too, and its `-m` and `-F` are the union's.
+    """
+    return SUBCOMMAND_FLAGS.get(tuple(words) if words else (),
+                                (VALUE_FLAGS, SHORT_BOOLEAN_FLAGS))
+
 # Why a body could not be read, decided in this order.
 UNEXPANDED_PATH = "unexpanded-path"
 STDIN = "stdin"
@@ -65,7 +87,7 @@ UNREADABLE = "unreadable"
 MOVERS = {"cd", "pushd", "popd"}
 
 
-def options(operands):
+def options(operands, words=None):
     """Every parsed (option, value), preserving order and excluding positional operands.
 
     gh takes a value in more spellings than the obvious one: after the flag, after an `=`, attached
@@ -74,6 +96,7 @@ def options(operands):
     this: the invocation was claimed, no body was found, and the command took the exemption for
     carrying no body operand at all. That is the accident these guards exist for, one letter apart.
     """
+    value_flags, boolean_shorthand = tables(words)
     found = []
     index = 0
     while index < len(operands):
@@ -85,7 +108,7 @@ def options(operands):
             found.append((name, inline if separator else None))
             index += 1
             continue
-        if name in VALUE_FLAGS:
+        if name in value_flags:
             if separator:
                 found.append((name, inline))
                 index += 1
@@ -102,14 +125,14 @@ def options(operands):
             cluster = token[1:]
             for offset, shorthand in enumerate(cluster):
                 flag = "-" + shorthand
-                if flag in SHORT_BOOLEAN_FLAGS:
+                if flag in boolean_shorthand:
                     attached = cluster[offset + 1:]
                     if attached.startswith("="):
                         found.append((flag, attached[1:]))
                         break
                     found.append((flag, None))
                     continue
-                if flag in VALUE_FLAGS:
+                if flag in value_flags:
                     attached = cluster[offset + 1:]
                     if attached.startswith("="):
                         attached = attached[1:]
@@ -125,13 +148,13 @@ def options(operands):
     return found
 
 
-def valued(operands, flags):
+def valued(operands, flags, words=None):
     """The last value given to one of `flags`, or None.
 
     Repeated scalar options use their last value. Options are parsed before names are matched so a
     value belonging to another option is not treated as a body flag.
     """
-    values = [value for name, value in options(operands) if name in flags]
+    values = [value for name, value in options(operands, words) if name in flags]
     return values[-1] if values else None
 
 
@@ -146,7 +169,7 @@ def exempted(operands, words=None):
     applies, which is what a caller reading one subcommand already knows.
     """
     last = {}
-    for name, value in options(operands):
+    for name, value in options(operands, words):
         if name not in EXEMPT_FLAGS:
             continue
         resolved = EXEMPT_FLAGS[name]
@@ -161,11 +184,11 @@ def effective_body(operands, cwd, after_a_move, words=None):
     """(text, obstruction, file path) for a `--body-file`'s body, or else the inline one."""
     if exempted(operands, words):
         return None, None, None
-    path = valued(operands, BODY_FILE_FLAGS)
+    path = valued(operands, BODY_FILE_FLAGS, words)
     if path is not None:
         text, obstruction = read_body_file(path, cwd, after_a_move)
         return text, obstruction, path
-    return valued(operands, BODY_FLAGS), None, None
+    return valued(operands, BODY_FLAGS, words), None, None
 
 
 def moves_directory(segment):

--- a/.claude/hooks/lib/pr_body.py
+++ b/.claude/hooks/lib/pr_body.py
@@ -55,16 +55,29 @@ VALUE_FLAGS = {
 SHORT_BOOLEAN_FLAGS = {"-d", "-e", "-f", "-h", "-w"}
 LONG_BOOLEAN_FLAGS = {"--dry-run", "--help"}
 
-# One union holds while the tables agree, and `pr merge`'s does not: `-m` is `--milestone` and takes
-# a value on create and edit, and is `--merge` and takes none on merge; `-r` is `--reviewer` and
-# `--rebase` the same way. Read as the union, `gh pr merge 7 -m -b "text"` spends `-b` as `-m`'s
-# value and no body is found -- and a guard that found none exits 0, which is what it exits having
-# read one and been satisfied.
+# Where a subcommand's table disagrees with the union above. `scripts/hooks/test_pr_body_flags.py`
+# holds each of these against gh's, per subcommand and in both directions, which is what stops them
+# drifting; the shape of the cost is the same in both: a flag wrongly value-taking spends the body
+# flag behind it, and one wrongly boolean lets its own value be read as one. Read as the union,
+# `gh pr merge 7 -m -b "text"` finds no body, and a guard that found none exits 0 -- which is what it
+# exits having read one and been satisfied.
 SUBCOMMAND_FLAGS = {
     ("pr", "merge"): (
-        {"--author-email", "-A", "--body", "-b", "--body-file", "-F", "--match-head-commit",
-         "--repo", "-R", "--subject", "-t"},
+        {"--author-email", "--body", "--body-file", "--match-head-commit", "--repo", "--subject",
+         "-A", "-F", "-R", "-b", "-t"},
         {"-d", "-m", "-r", "-s"},
+    ),
+    ("pr", "review"): (
+        {"--body", "--body-file", "--repo", "-F", "-R", "-b"},
+        {"-a", "-c", "-r"},
+    ),
+    ("pr", "close"): (
+        {"--comment", "--repo", "-R", "-c"},
+        {"-d"},
+    ),
+    ("pr", "reopen"): (
+        {"--comment", "--repo", "-R", "-c"},
+        set(),
     ),
 }
 
@@ -72,7 +85,9 @@ SUBCOMMAND_FLAGS = {
 def tables(words):
     """(value-taking, boolean shorthand) for an invocation of `words`, or the union for anything else.
 
-    A `git commit` reaches here too, and its `-m` and `-F` are the union's.
+    The union answers for `pr create`, `pr new`, `pr edit` and `pr comment`, whose tables agree with it
+    and with each other. It is not a safe default for a subcommand nobody checked: a claim over one
+    takes a row above before it takes this.
     """
     return SUBCOMMAND_FLAGS.get(tuple(words) if words else (),
                                 (VALUE_FLAGS, SHORT_BOOLEAN_FLAGS))

--- a/.claude/hooks/refuse/pr_body_of_another_branch.py
+++ b/.claude/hooks/refuse/pr_body_of_another_branch.py
@@ -175,7 +175,7 @@ def check(operands, cwd, after_a_move, command="gh pr create", words=None):
         return 0
     if path is None:
         return judge_inline(text, command)
-    inline = valued(operands, BODY_FLAGS)
+    inline = valued(operands, BODY_FLAGS, words)
     if inline is not None and answered(inline) != answered(text):
         return refuse_command(command, TWO_BODIES)
     return 0 if answered(text) else refuse_command(command, NO_ANSWER)

--- a/scripts/hooks/test_pr_body_flags.py
+++ b/scripts/hooks/test_pr_body_flags.py
@@ -166,6 +166,50 @@ class ValueFlagMirrorTests(unittest.TestCase):
                          "gh prints a boolean shorthand SHORT_BOOLEAN_FLAGS does not carry")
 
 
+class SubcommandTableTests(unittest.TestCase):
+    """The subcommands whose own table the parse carries, against gh's.
+
+    Held apart from the union above because the union covers the ones that agree, and this covers the
+    one that does not: read as the union, `gh pr merge 7 -m -b "text"` spends `-b` as `-m`'s value,
+    finds no body, and a guard that found none exits 0 — which is what it exits having read one and
+    been satisfied.
+    """
+
+    def test_Given_ghsOwnOptionTables_When_EachCarriedSubcommandIsRead_Then_ItsTableSpellsThemExactly(self):
+        # Arrange — both directions and both kinds, per subcommand rather than unioned: a flag
+        # wrongly value-taking swallows the body flag behind it, and one wrongly boolean lets its own
+        # value be read as one.
+        disagreement = []
+        for words, (value_taking, boolean) in sorted(pr_body.SUBCOMMAND_FLAGS.items()):
+            printed_value, printed_boolean = option_table(words[1])
+            printed_boolean = {flag for flag in printed_boolean if not flag.startswith("--")}
+            disagreement += [f"{' '.join(words)}: {kind} {sorted(missing)}"
+                             for kind, missing in (("value-taking, unmirrored",
+                                                    printed_value - value_taking),
+                                                   ("value-taking, not gh's",
+                                                    value_taking - printed_value),
+                                                   ("boolean shorthand, unmirrored",
+                                                    printed_boolean - boolean),
+                                                   ("boolean shorthand, not gh's",
+                                                    boolean - printed_boolean))
+                             if missing]
+
+        # Act / Assert — how many subcommands were read rides along, since an empty table disagrees
+        # with nothing.
+        self.assertEqual((len(pr_body.SUBCOMMAND_FLAGS), disagreement), (1, []))
+
+    def test_Given_AMergeBodyBehindAValuelessShorthand_When_TheOperandsAreParsed_Then_TheBodyIsFound(self):
+        # Arrange — `-m` is `--merge` here and carries no value, so the token after it is the next
+        # option rather than its operand.
+        operands = ["736", "-m", "-b", "the body"]
+
+        # Act
+        found = pr_body.valued(operands, pr_body.BODY_FLAGS, ("pr", "merge"))
+
+        # Assert
+        self.assertEqual(found, "the body")
+
+
 class ExemptionScopeTests(unittest.TestCase):
     """Where an exemption is real, against gh's own tables.
 

--- a/scripts/hooks/test_pr_body_flags.py
+++ b/scripts/hooks/test_pr_body_flags.py
@@ -48,7 +48,10 @@ SUBCOMMANDS = ("create", "edit")
 def load_pr_body():
     """Imports .claude/hooks/lib/pr_body.py by path, since .claude holds no packages."""
     path = REPO_ROOT / ".claude/hooks/lib/pr_body.py"
-    spec = importlib.util.spec_from_file_location("pr_body_lib", path)
+    # Named for the file, the way every sibling suite here names one: `base_red_check.py` relates a
+    # missing attribute to the file that adds it through the module name, and under an alias it
+    # cannot -- a case red on the base for a name the branch adds read as one that raised.
+    spec = importlib.util.spec_from_file_location("pr_body", path)
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
@@ -57,8 +60,22 @@ def load_pr_body():
 pr_body = load_pr_body()
 
 
-def option_table(subcommand):
-    """(value-taking, boolean) flag names gh prints for `gh pr <subcommand>`, both spellings of each.
+# Both reached the way `test_deferral_writer.py` reaches `disowned`, so a tree without them answers
+# with the union rather than raising: a case that dies before comparing carries no reading either way,
+# and what these have to say is that the union is the wrong table.
+def subcommand_flags():
+    return getattr(pr_body, "SUBCOMMAND_FLAGS", {})
+
+
+def valued(operands, flags, words):
+    try:
+        return pr_body.valued(operands, flags, words)
+    except TypeError:
+        return pr_body.valued(operands, flags)
+
+
+def option_table(*words):
+    """(value-taking, boolean) flag names gh prints for `gh <words>`, both spellings of each.
 
     Raised rather than returned empty: a table that parsed to nothing agrees with any mirror at all
     in the covering direction, which is the reading this exists to refuse.
@@ -68,11 +85,12 @@ def option_table(subcommand):
             "gh is not on PATH, so the option table these guards parse against cannot be read. "
             "The guards gate gh commands, so a checkout without gh cannot show that their parse "
             "is still right.")
-    printed = subprocess.run(["gh", "pr", subcommand, "--help"],
+    printed = subprocess.run(["gh", *words, "--help"],
                              capture_output=True, text=True, check=True).stdout
     blocks = BLOCK.findall(printed)
     if not blocks:
-        raise RuntimeError(f"gh pr {subcommand} --help printed no FLAGS block this can read.")
+        raise RuntimeError("gh {} --help printed no FLAGS block this can read.".format(
+            " ".join(words)))
     value_taking, boolean = set(), set()
     for block in blocks:
         for line in block.splitlines():
@@ -89,7 +107,7 @@ def option_table(subcommand):
 def across_subcommands(index):
     found = set()
     for subcommand in SUBCOMMANDS:
-        found |= option_table(subcommand)[index]
+        found |= option_table("pr", subcommand)[index]
     return found
 
 
@@ -169,10 +187,8 @@ class ValueFlagMirrorTests(unittest.TestCase):
 class SubcommandTableTests(unittest.TestCase):
     """The subcommands whose own table the parse carries, against gh's.
 
-    Held apart from the union above because the union covers the ones that agree, and this covers the
-    one that does not: read as the union, `gh pr merge 7 -m -b "text"` spends `-b` as `-m`'s value,
-    finds no body, and a guard that found none exits 0 — which is what it exits having read one and
-    been satisfied.
+    Held apart from the union above because the union covers the ones that agree. The module owns why
+    each of these does not.
     """
 
     def test_Given_ghsOwnOptionTables_When_EachCarriedSubcommandIsRead_Then_ItsTableSpellsThemExactly(self):
@@ -180,8 +196,8 @@ class SubcommandTableTests(unittest.TestCase):
         # wrongly value-taking swallows the body flag behind it, and one wrongly boolean lets its own
         # value be read as one.
         disagreement = []
-        for words, (value_taking, boolean) in sorted(pr_body.SUBCOMMAND_FLAGS.items()):
-            printed_value, printed_boolean = option_table(words[1])
+        for words, (value_taking, boolean) in sorted(subcommand_flags().items()):
+            printed_value, printed_boolean = option_table(*words)
             printed_boolean = {flag for flag in printed_boolean if not flag.startswith("--")}
             disagreement += [f"{' '.join(words)}: {kind} {sorted(missing)}"
                              for kind, missing in (("value-taking, unmirrored",
@@ -194,9 +210,9 @@ class SubcommandTableTests(unittest.TestCase):
                                                     boolean - printed_boolean))
                              if missing]
 
-        # Act / Assert — how many subcommands were read rides along, since an empty table disagrees
-        # with nothing.
-        self.assertEqual((len(pr_body.SUBCOMMAND_FLAGS), disagreement), (1, []))
+        # Act / Assert — that any subcommand was read rides along, since an empty table disagrees
+        # with nothing. Not the count: a second correct entry is not a regression.
+        self.assertEqual((bool(subcommand_flags()), disagreement), (True, []))
 
     def test_Given_AMergeBodyBehindAValuelessShorthand_When_TheOperandsAreParsed_Then_TheBodyIsFound(self):
         # Arrange — `-m` is `--merge` here and carries no value, so the token after it is the next
@@ -204,7 +220,7 @@ class SubcommandTableTests(unittest.TestCase):
         operands = ["736", "-m", "-b", "the body"]
 
         # Act
-        found = pr_body.valued(operands, pr_body.BODY_FLAGS, ("pr", "merge"))
+        found = valued(operands, pr_body.BODY_FLAGS, ("pr", "merge"))
 
         # Assert
         self.assertEqual(found, "the body")
@@ -218,12 +234,14 @@ class ExemptionScopeTests(unittest.TestCase):
     what a reader has to trust when they see one.
     """
 
+    # GREEN_ON_BASE(refactor): the exemption table is unchanged; what moved is how this case spells the
+    # lookup, now that `option_table` takes the whole command rather than a `gh pr` subcommand.
     def test_Given_ghsOwnOptionTables_When_TheDryRunExemptionIsRead_Then_ItNamesTheSubcommandsThatTakeIt(self):
         # Arrange — `pr new` is `pr create`'s alias and prints the same table, so it rides with it.
         # `merge` is read here though the body guard does not claim it: the exemption table is what
         # says where a flag exists, and that answer does not depend on who is asking.
         taking = {("pr", subcommand) for subcommand in SUBCOMMANDS + ("merge",)
-                  if "--dry-run" in option_table(subcommand)[1]}
+                  if "--dry-run" in option_table("pr", subcommand)[1]}
         if ("pr", "create") in taking:
             taking.add(("pr", "new"))
 


### PR DESCRIPTION
Closes #847.

`pr_body`'s parse consulted one flat `VALUE_FLAGS` for every `gh pr` subcommand a guard claims. That
holds while the tables agree, and three of them do not. Read off `gh pr <subcommand> --help` and
measured through the parse:

    gh pr merge  736 -m -b "the body"   body not found       -m is --merge, boolean
    gh pr merge  736 -sF b.md           body file not found  -s stops the cluster walk
    gh pr review 7   -a -b "text"       body not found       -a is --approve, boolean
    gh pr review 7   -aF b.md           body file not found  -a stops the cluster walk
    gh pr close  7   -c -F b.md         body file "found"    -c is --comment, so gh never opens it

The first four are a body a guard exists to refuse walking past — and a guard that found no body exits
0, which is what it exits having read one and been satisfied. The last is the other direction: a guard
answering about a file the command does not post.

`SUBCOMMAND_FLAGS` carries `merge`, `review`, `close` and `reopen`, each held against gh's own table
per subcommand and in both directions and both kinds — where the union it replaces agrees with
anything. `pr comment` was read too and agrees, so it stays on the union, and `tables()` says the
union is not a safe default for a subcommand nobody checked.

The two new cases reach the branch's surface through `getattr` and a signature fallback, the way
`test_deferral_writer.py` reaches `disowned`, so the base answers with the union and they fail on the
comparison: red on the base for the parse rather than for a missing name. `option_table` takes a whole
command now rather than a `gh pr` subcommand, and pins non-emptiness rather than a fixed count, which
is what both sibling cases do for the same anti-vacuity purpose.

The module is loaded under its own file's name, as every sibling suite here does. `base_red_check`
relates a missing attribute to the file that adds it through the module name, and under an alias it
could not: both cases read as raising rather than as red.

No guard reaches this parse for `pr merge` today — the four guards that claim `gh pr merge` use
`merges_nothing` and `program_invocations` — so no verdict changes here. This is what #692's `pr merge`
half was waiting on.

EditMode's two guard fixtures 11 passed / 0 failed; the suite 8 passed; base-red red on both new cases.
