### PR TITLE
ci(velvet): start the run that judges a guard when that guard changes

### DIFF
--- a/.github/workflows/generators.yml
+++ b/.github/workflows/generators.yml
@@ -32,6 +32,10 @@ on:
       # The jobs below run these, and a push editing one used to start only test.yml — whose Unity jobs
       # are skipped without a licence, so the ratchet that push was about executed nowhere.
       - 'scripts/**'
+      # The guards those suites judge. They moved with nothing: `.claude` appeared in no workflow's
+      # filter, so a hook changed on `main` started no run and was checked on its pull request and
+      # never again.
+      - '.claude/**'
       - '!**.md'
       - 'Packages/com.velvet.core/Documentation~/setup.md'
       - 'Packages/com.velvet.core/Generators~/README.md'

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/WorkflowTriggerCoverageTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/WorkflowTriggerCoverageTests.cs
@@ -159,6 +159,42 @@ namespace Velvet.Tests
         }
 
         [Test]
+        public void Given_AWorkflowRunningAGuardsSuite_When_ItsPathFilterIsRead_Then_AChangeToThatGuardStartsIt()
+        {
+            // Arrange — the suites judge the guards, and the two travelled apart: the suites move with
+            // `scripts/**` and `.claude` appeared in no filter at all, so a guard changed on main started
+            // no run and was asked again by nothing until some later change carried a file inside a filter.
+            var guards = Directory
+                .EnumerateFiles(Path.GetFullPath(".claude/hooks"), "*.py", SearchOption.AllDirectories)
+                .Select(RepoRelative)
+                .ToList();
+            var suites = Directory
+                .EnumerateFiles(Path.GetFullPath("scripts/hooks"), "test_*.py")
+                .Select(RepoRelative)
+                .ToList();
+
+            // Act — which workflows run one, read the way the two cases above read it: a literal name or
+            // a glob that expands to one.
+            var judging = (from workflow in Workflows()
+                           let invoked = RunCommandLines(workflow).ToList()
+                           let swept = new HashSet<string>(invoked.SelectMany(GlobMatches), StringComparer.Ordinal)
+                           where suites.Any(suite => swept.Contains(suite)
+                                                     || invoked.Any(line => line.Contains(suite, StringComparison.Ordinal)))
+                           select workflow).ToList();
+            var uncovered = (from workflow in judging
+                             from filter in ReadPathFilters(workflow)
+                             from guard in guards
+                             where !filter.Includes(guard)
+                             select $"{workflow}: {filter.Label} does not start for {guard}").ToList();
+
+            // Assert — both counts ride along, because a workflow running no suite and a directory holding
+            // no guard each leave this reporting the silence a covered repository does.
+            Assert.That((judging.Count > 0, guards.Count > 0, string.Join("\n", uncovered)),
+                Is.EqualTo((true, true, string.Empty)),
+                "a guard's suite runs in a workflow that a change to that guard does not start");
+        }
+
+        [Test]
         public void Given_TheHookGuardSuites_When_TheWorkflowsAreScanned_Then_ASweepRunsThemRatherThanAStepEach()
         {
             // Arrange — the case above is satisfied by a step per suite, and that is what this refuses:


### PR DESCRIPTION
Refs part of #586 — its push-trigger half. The reach half — the harness asks one dimension of one
directory — stays open there.

`.claude` appeared in no workflow's path filter. Both required workflows subscribe to `pull_request`
and `merge_group` without one, so a hook was checked on its pull request and never again: a guard
changed on `main` started nothing, and the suites that judge it ran only when some later, unrelated
change happened to carry a file inside a filter they do move with.

The suites travel with `scripts/**`. The guards they read travelled with nothing. `generators.yml`
runs every one of them, so its push filter is where they belong.

The case derives both sides rather than listing either: which workflows run a suite under
`scripts/hooks/` — by a literal name or by a glob that expands to one, the reading the two cases above
it already take — and then every file under `.claude/hooks/` against those workflows' filters. Both
counts ride along, because a workflow running no suite and a directory holding no guard each leave it
reporting the silence a covered repository does.

Measured red with the filter line removed, naming `.claude/hooks/lib/deferrals.py` and its neighbours.
EditMode 4256 passed / 0 failed, provenance clean.
