### PR TITLE
fix(velvet): put the overlaid release rules back before the split reads the tree

### DIFF
--- a/.github/workflows/upm.yml
+++ b/.github/workflows/upm.yml
@@ -60,6 +60,16 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
         run: python3 scripts/test_quality/run_suite.py scripts/release/test_release_notes.py
 
+      # The overlay leaves main's bytes in the working tree and this line's in the index, which is a
+      # modified tracked file. `git subtree split` below checks out a package-at-root commit whose tree
+      # holds none of `scripts/`, and a checkout refuses to remove a modified file -- measured, `Entry
+      # 'scripts/release/…' not uptodate. Cannot merge.`, exit 128, after the note is built and before
+      # any tag is pushed. Put back rather than forced away at the split, so the split keeps refusing a
+      # modification nobody here made.
+      - name: Put the release rules back
+        if: github.event_name == 'workflow_dispatch'
+        run: git checkout --quiet -- scripts/release scripts/test_quality/run_suite.py
+
       - name: Verify version matches package.json (release only)
         if: github.event_name == 'workflow_dispatch'
         env:

--- a/.github/workflows/upm.yml
+++ b/.github/workflows/upm.yml
@@ -68,7 +68,15 @@ jobs:
       # modification nobody here made.
       - name: Put the release rules back
         if: github.event_name == 'workflow_dispatch'
-        run: git checkout --quiet -- scripts/release scripts/test_quality/run_suite.py
+        # One pathspec at a time. git validates every pathspec before it touches the working tree, so
+        # naming both in one command aborts the whole restore where the dispatched line does not track
+        # one of them -- measured on `2.x`, which has no `run_suite.py`: exit 1, nothing restored, and
+        # the modification this step exists to clear still there. Where the line has not got the file,
+        # the overlay created it and removing it is the restore.
+        run: |
+          git checkout --quiet -- scripts/release
+          git checkout --quiet -- scripts/test_quality/run_suite.py \
+            || git clean --quiet --force -- scripts/test_quality/run_suite.py
 
       - name: Verify version matches package.json (release only)
         if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/upm.yml
+++ b/.github/workflows/upm.yml
@@ -75,8 +75,14 @@ jobs:
         # the overlay created it and removing it is the restore.
         run: |
           git checkout --quiet -- scripts/release
-          git checkout --quiet -- scripts/test_quality/run_suite.py \
-            || git clean --quiet --force -- scripts/test_quality/run_suite.py
+          # The `||` reaches every failure, not only the pathspec mismatch it is for. Narrowed by
+          # asking first: where the line tracks the file, the checkout is the restore and a failure
+          # from it is one this should not swallow.
+          if git ls-files --error-unmatch scripts/test_quality/run_suite.py >/dev/null 2>&1; then
+            git checkout --quiet -- scripts/test_quality/run_suite.py
+          else
+            git clean --quiet --force -- scripts/test_quality/run_suite.py
+          fi
 
       - name: Verify version matches package.json (release only)
         if: github.event_name == 'workflow_dispatch'

--- a/scripts/release/test_publish_rules_come_from_main.py
+++ b/scripts/release/test_publish_rules_come_from_main.py
@@ -58,12 +58,19 @@ class PublishRulesTests(unittest.TestCase):
         overlay = index_of(lambda run: "origin main" in run and "scripts/release" in run)
         restore = index_of(lambda run: "checkout --quiet --" in run and "scripts/release" in run)
         split = index_of(lambda run: "subtree split" in run)
+        # Every path the overlay writes, against the ones the restore names. Ordering alone left the
+        # restore free to name fewer, and a path it misses is one still holding main's bytes.
+        overlaid = {word for word in (steps()[overlay].get("run") or "").split()
+                    if word.startswith("scripts/")} if overlay is not None else set()
+        putback = {word for word in (steps()[restore].get("run") or "").split()
+                   if word.startswith("scripts/")} if restore is not None else set()
 
         # Act / Assert
         self.assertEqual(
             (overlay is not None, split is not None,
-             restore is not None and overlay < restore < split),
-            (True, True, True))
+             restore is not None and overlay < restore < split,
+             sorted(overlaid - putback)),
+            (True, True, True, []))
 
     def test_Given_TheOverlayAndTheRules_When_TheEventIsAPush_Then_NeitherRuns(self):
         # Arrange -- a push to main is the mirror split, not a release, and has no version to check.

--- a/scripts/release/test_publish_rules_come_from_main.py
+++ b/scripts/release/test_publish_rules_come_from_main.py
@@ -13,6 +13,7 @@ and a 4.x are cut the same way and inherit the same staleness the day they are c
 Run: python3 scripts/release/test_publish_rules_come_from_main.py
 """
 
+import shlex
 import unittest
 from pathlib import Path
 
@@ -26,6 +27,17 @@ RULES = "scripts/release/test_release_notes.py"
 def steps():
     job = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))["jobs"]
     return next(iter(job.values()))["steps"]
+
+
+def pathspecs(step):
+    """The repository paths a step's `run:` hands git, however they are quoted.
+
+    Split on whitespace alone, a quoted pathspec is a token starting with a quote and the comparison
+    below stops seeing it — measured, quoting the overlay's two leaves the case green with the restore
+    naming nothing.
+    """
+    return {word.strip("'\"") for word in shlex.split(step.get("run") or "", comments=True)
+            if word.strip("'\"").startswith("scripts/")}
 
 
 def index_of(predicate):
@@ -60,10 +72,8 @@ class PublishRulesTests(unittest.TestCase):
         split = index_of(lambda run: "subtree split" in run)
         # Every path the overlay writes, against the ones the restore names. Ordering alone left the
         # restore free to name fewer, and a path it misses is one still holding main's bytes.
-        overlaid = {word for word in (steps()[overlay].get("run") or "").split()
-                    if word.startswith("scripts/")} if overlay is not None else set()
-        putback = {word for word in (steps()[restore].get("run") or "").split()
-                   if word.startswith("scripts/")} if restore is not None else set()
+        overlaid = pathspecs(steps()[overlay]) if overlay is not None else set()
+        putback = pathspecs(steps()[restore]) if restore is not None else set()
 
         # Act / Assert
         self.assertEqual(

--- a/scripts/release/test_publish_rules_come_from_main.py
+++ b/scripts/release/test_publish_rules_come_from_main.py
@@ -49,6 +49,22 @@ class PublishRulesTests(unittest.TestCase):
         # Act / Assert
         self.assertEqual((rules is not None, overlay is not None and rules > overlay), (True, True))
 
+    def test_Given_TheOverlay_When_TheSplitRuns_Then_TheTreeIsCleanAgain(self):
+        # Arrange -- the overlay leaves main's bytes in the working tree and this line's in the index,
+        # which is a modified tracked file. The split checks out a package-at-root commit holding none
+        # of `scripts/`, and a checkout refuses to remove a modified file: measured, `Entry
+        # 'scripts/release/...' not uptodate. Cannot merge.`, exit 128, after the note is built and
+        # before any tag is pushed.
+        overlay = index_of(lambda run: "origin main" in run and "scripts/release" in run)
+        restore = index_of(lambda run: "checkout --quiet --" in run and "scripts/release" in run)
+        split = index_of(lambda run: "subtree split" in run)
+
+        # Act / Assert
+        self.assertEqual(
+            (overlay is not None, split is not None,
+             restore is not None and overlay < restore < split),
+            (True, True, True))
+
     def test_Given_TheOverlayAndTheRules_When_TheEventIsAPush_Then_NeitherRuns(self):
         # Arrange -- a push to main is the mirror split, not a release, and has no version to check.
         guarded = [step.get("if") for step in steps()


### PR DESCRIPTION
No issue: found by a review of #921, which widened the overlay this breaks.

The dispatch overlays main's `scripts/release` and its runner over whatever the dispatched line holds,
then `git reset` the index for those paths. A pathspec reset is index-only, so main's bytes stay in the
working tree and the line's stay in the index — those files are modified. `git subtree split` then
checks out a package-at-root commit whose tree holds none of `scripts/`, and a checkout refuses to
remove a modified tracked file.

Measured on a scratch repository reproducing the end state:

    without the restore   exit=128   error: Entry 'scripts/release/rules.py' not uptodate. Cannot merge.
    with the restore      exit=0     and the tracked side clean

The failure lands after the release note is built and before any tag is pushed, so a maintenance line
whose rules main has moved since could not publish at all.

It has never fired, and not for the reason a first reading suggests: the overlay itself has never run.
It landed on main at 2026-08-30T13:00:53Z, and the newest dispatch was 2026-08-30T01:38Z on `2.x`,
whose own `upm.yml` carries neither step. So the arming condition is the next release cut from a line
after this, and that is why the fix goes in before one.

Three things a review found and this now answers:

- **One pathspec at a time.** git validates every pathspec before touching the working tree, so naming
  both in one command aborts the whole restore where the line does not track one — measured on `2.x`,
  which has no `run_suite.py`: `exit=1`, nothing restored, and the modification still there.
- **Asked rather than swallowed.** `git ls-files --error-unmatch` decides which of the two the file
  needs: where the line tracks it the checkout is the restore and a failure from it is one nothing
  should swallow; where it does not, the overlay created it and removing it is the restore.
- **The case reads pathspecs, not whitespace-separated words.** It compares the paths the overlay names
  against the ones the restore names, through `shlex`, because quoting the overlay's two left the case
  green with the restore naming nothing.

Put back rather than forced away at the split. `git checkout --force "$SPLIT"` would clear it too, and
would also remove a modification nobody here made; the split refusing one is worth keeping.

Untracked files are left alone by the split checkout, so the restore is about the tracked side; on a
real line other untracked paths may remain and none of them blocks it.
