### PR TITLE
fix(velvet): read gh's operands through the table that knows them

### DIFF
--- a/.claude/hooks/refuse/message_outside_its_worktree.py
+++ b/.claude/hooks/refuse/message_outside_its_worktree.py
@@ -64,8 +64,15 @@ def valued(operands, flags):
 
     `git commit`'s reading, and only its. gh's goes through `pr_body`, which knows which options carry
     a value -- this one does not, and measured, `gh pr create -dF /tmp/x.md` reads no body file here
-    while gh posts one. The union `pr_body` falls back to is the wrong table for `git commit`: under
-    it `git commit -am "..."` parses as `[('-a', 'm')]` and the message goes unfound.
+    while gh posts one. The union `pr_body` falls back to is gh's table, not git's, and measured over
+    the flags this looks for it loses every one of them:
+
+        --file <path>       here /tmp/m.txt      under the union None
+        --file=<path>       here /tmp/m.txt      under the union None
+        -a -F <path>        here /tmp/m.txt      under the union None
+
+    `--file` is not one of gh's options at all, and `-a` is `--assignee` there and takes the `-F`
+    behind it. Each is a path this refuses today and would stop seeing.
     """
     found = None
     index = 0

--- a/.claude/hooks/refuse/message_outside_its_worktree.py
+++ b/.claude/hooks/refuse/message_outside_its_worktree.py
@@ -60,22 +60,31 @@ UNREADABLE_PROBE = {"command": "git commit -F /tmp/velvet-message-probe.txt"}
 
 
 def valued(operands, flags):
-    """The last value given to any of `flags`, or None. `--flag=value` counts.
+    """The last value given to any of `flags`, or None. `--flag=value` and `-Fvalue` count.
 
     `git commit`'s reading, and only its. gh's goes through `pr_body`, which knows which options carry
     a value -- this one does not, and measured, `gh pr create -dF /tmp/x.md` reads no body file here
-    while gh posts one. The union `pr_body` falls back to is gh's table, not git's, and measured over
-    the flags this looks for it loses every one of them:
+    while gh posts one.
+
+    The union `pr_body` falls back to is gh's table rather than git's, and neither reading covers the
+    other. Measured over the flags this looks for:
 
         --file <path>       here /tmp/m.txt      under the union None
-        --file=<path>       here /tmp/m.txt      under the union None
-        -a -F <path>        here /tmp/m.txt      under the union None
+        -F <path>           here /tmp/m.txt      under the union /tmp/m.txt
+        -F<path>            here /tmp/m.txt      under the union /tmp/m.txt
 
-    `--file` is not one of gh's options at all, and `-a` is `--assignee` there and takes the `-F`
-    behind it. Each is a path this refuses today and would stop seeing.
+    `--file` is not one of gh's options at all, which is why the two stay apart. The attached form was
+    read by neither until now: measured, `git commit -F/tmp/m.txt` reads that file and this guard let
+    it through.
+
+    A cluster -- `-aF <path>` -- is still not read, and closing it would take git's own table of which
+    short options carry a value. That is the parse this repository has reduced twice, so what is done
+    instead is the unambiguous half: `-F` at the head of the token, where no other letter can have
+    claimed the tail.
     """
     found = None
     index = 0
+    short = tuple(flag for flag in flags if len(flag) == 2 and flag.startswith("-"))
     while index < len(operands):
         token = operands[index]
         flag, separator, attached = token.partition("=")
@@ -86,6 +95,11 @@ def valued(operands, flags):
             else:
                 found = operands[index + 1] if index + 1 < len(operands) else None
                 index += 2
+            continue
+        head = next((flag for flag in short if token.startswith(flag) and len(token) > 2), None)
+        if head is not None:
+            found = token[len(head):]
+            index += 1
             continue
         index += 1
     return found

--- a/.claude/hooks/refuse/message_outside_its_worktree.py
+++ b/.claude/hooks/refuse/message_outside_its_worktree.py
@@ -31,6 +31,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "lib"))
 
+from pr_body import valued as gh_valued  # noqa: E402
 from shell_commands import (  # noqa: E402
     UNRESOLVED_CD, git_invocations, leading_cd, program_invocations, unexpanded)
 
@@ -59,7 +60,13 @@ UNREADABLE_PROBE = {"command": "git commit -F /tmp/velvet-message-probe.txt"}
 
 
 def valued(operands, flags):
-    """The last value given to any of `flags`, or None. `--flag=value` counts."""
+    """The last value given to any of `flags`, or None. `--flag=value` counts.
+
+    `git commit`'s reading, and only its. gh's goes through `pr_body`, which knows which options carry
+    a value -- this one does not, and measured, `gh pr create -dF /tmp/x.md` reads no body file here
+    while gh posts one. The union `pr_body` falls back to is the wrong table for `git commit`: under
+    it `git commit -am "..."` parses as `[('-a', 'm')]` and the message goes unfound.
+    """
     found = None
     index = 0
     while index < len(operands):
@@ -122,13 +129,14 @@ def judge(command, cwd):
         return 2
     here = os.path.join(cwd, moved) if moved else cwd
 
-    asked = [("git commit", operands, MESSAGE_FLAGS)
+    asked = [("git commit", operands, MESSAGE_FLAGS, None)
              for _, _, operands in git_invocations(command, ("commit",))]
     for words in GH_WORDS:
         for operands in program_invocations(command, "gh", words):
-            asked.append(("gh " + " ".join(words), operands, BODY_FILE_FLAGS))
+            asked.append(("gh " + " ".join(words), operands, BODY_FILE_FLAGS, words))
 
-    named = [(what, valued(operands, flags)) for what, operands, flags in asked]
+    named = [(what, valued(operands, flags) if words is None else gh_valued(operands, flags, words))
+             for what, operands, flags, words in asked]
     named = [(what, path) for what, path in named if path is not None]
     if not named:
         return 0

--- a/scripts/hooks/test_message_outside_its_worktree.py
+++ b/scripts/hooks/test_message_outside_its_worktree.py
@@ -41,6 +41,22 @@ class Verdicts(unittest.TestCase):
                               capture_output=True, text=True, timeout=30)
         return done.returncode, done.stderr
 
+    def test_Given_ABodyFileBehindABooleanShorthand_When_Judged_Then_ItIsStillRefused(self):
+        # Arrange — one character, and the guard saw no body file at all: a cluster is read a letter
+        # at a time, so `-d` has to be known before `-F` behind it is. gh posts the file either way.
+        code, said = self.judge(f"gh pr create --title x -dF {self.elsewhere}/body.md")
+
+        # Act / Assert
+        self.assertEqual((code, "the worktree it describes" in said), (2, True))
+
+    def test_Given_APathStandingWhereAnotherOptionsValueGoes_When_Judged_Then_ItIsNotRefused(self):
+        # Arrange — the other direction. `--title` takes a value, so gh reads `-F` as that value and
+        # posts nothing from a file; refusing here is a refusal over a path the command never opens.
+        code, said = self.judge(f"gh pr create --title -F {self.elsewhere}/body.md")
+
+        # Act / Assert
+        self.assertEqual((code, said), (0, ""))
+
     def test_Given_ACommitMessageAtASharedPath_When_Judged_Then_ItIsRefused(self):
         # Arrange — the shape that landed one change's message on another: a generic path outside
         # every worktree, written by whichever agent wrote it last.

--- a/scripts/hooks/test_message_outside_its_worktree.py
+++ b/scripts/hooks/test_message_outside_its_worktree.py
@@ -41,6 +41,18 @@ class Verdicts(unittest.TestCase):
                               capture_output=True, text=True, timeout=30)
         return done.returncode, done.stderr
 
+    # GREEN_ON_BASE(characterization): the base refuses this because it reads every command with one
+    # table, and this branch keeps refusing it because it reads git's with git's. What the case holds is
+    # that routing gh through `pr_body` did not take `--file` with it — measured by posing git's operands
+    # to `pr_body` too, which answers None and lets the path through.
+    def test_Given_AGitCommitFileInGhsSpelling_When_Judged_Then_ItIsStillRefused(self):
+        # Arrange — `--file` is not one of gh's options at all, so reading git's operands through gh's
+        # table would lose this path. The two readings are kept apart for that, and this is what says so.
+        code, said = self.judge(f"git commit --file {self.elsewhere}/msg.txt")
+
+        # Act / Assert
+        self.assertEqual((code, "the worktree it describes" in said), (2, True))
+
     def test_Given_ABodyFileBehindABooleanShorthand_When_Judged_Then_ItIsStillRefused(self):
         # Arrange — one character, and the guard saw no body file at all: a cluster is read a letter
         # at a time, so `-d` has to be known before `-F` behind it is. gh posts the file either way.

--- a/scripts/hooks/test_message_outside_its_worktree.py
+++ b/scripts/hooks/test_message_outside_its_worktree.py
@@ -41,6 +41,15 @@ class Verdicts(unittest.TestCase):
                               capture_output=True, text=True, timeout=30)
         return done.returncode, done.stderr
 
+    def test_Given_AMessageAttachedToItsShortFlag_When_Judged_Then_ItIsRefused(self):
+        # Arrange — git reads `-F/path` as readily as `-F /path`, and this guard read neither the
+        # attached form nor a cluster. The attached one is unambiguous: no other letter can have
+        # claimed the tail.
+        code, said = self.judge(f"git commit -F{self.elsewhere}/msg.txt")
+
+        # Act / Assert
+        self.assertEqual((code, "the worktree it describes" in said), (2, True))
+
     # GREEN_ON_BASE(characterization): the base refuses this because it reads every command with one
     # table, and this branch keeps refusing it because it reads git's with git's. What the case holds is
     # that routing gh through `pr_body` did not take `--file` with it — measured by posing git's operands


### PR DESCRIPTION
Closes #919.

`refuse/message_outside_its_worktree.py` walked gh's tokens looking for its own flags and consulted no
option table, so it disagreed with gh in both directions. Measured, over the same operands:

    gh pr create --title x -dF /tmp/x.md            guard found nothing   gh posts the file
    gh pr create --title -F /tmp/x.md               guard found the path  gh posts nothing
    gh pr create --title x --assignee -F /tmp/x.md  guard found the path  gh posts nothing

The first is the one that costs something. A body file at a path this guard exists to refuse goes
through unrefused when it is written as `-dF`, because a cluster is read a letter at a time and a
boolean the walk does not know stops it — and an unrefused command is indistinguishable from one
nobody needed to refuse. That is the accident `pr_body.options` names in its own docstring, closed
there and open here.

The other two are the opposite: a refusal over a path gh never opens, with a message about a file the
command does not post.

`pr_body.valued(operands, flags, words)` answers all three and already takes the subcommand, which
#847 gave it. gh's invocations go through it now, and the option table it consults is held against
gh's own by `scripts/hooks/test_pr_body_flags.py`.

**`git commit` keeps its own reading, and a review found a hole in it while checking why.** Measured
over the flags this looks for:

    --file <path>       here /tmp/m.txt      under gh's table None
    -F <path>           here /tmp/m.txt      under gh's table /tmp/m.txt
    -F<path>            here /tmp/m.txt      under gh's table /tmp/m.txt   ← and here, None, until now

`git commit -F/tmp/msg.txt` reads that file, and this guard let it through: exit 0 against a shared
path it exists to refuse. The attached short form is read now. A cluster, `-aF <path>`, still is not —
closing that takes git's own table of which short options carry a value, which is the parse this
repository has reduced twice, so what is done is the unambiguous half where no other letter can have
claimed the tail. The docstring says so rather than implying coverage.

What keeps the two readings apart is `--file`, which git has and gh has not.

Four cases: the clustered body file is refused, the one standing where another option's value goes is
not, a message attached to its short flag is refused, and — declared `GREEN_ON_BASE(characterization)`
— `git commit --file` stays refused, which is what says the gh routing did not take it along.
