### PR TITLE
fix(velvet): place a module a suite loads by path

### DIFF
--- a/scripts/test_quality/base_red_check.py
+++ b/scripts/test_quality/base_red_check.py
@@ -1291,8 +1291,44 @@ def import_directories(case, tree):
     return found
 
 
+def loaded_by_path(case, tree):
+    """module name -> the repository file a `spec_from_file_location` in the case binds it to.
+
+    A suite here loads its subject by explicit path more often than by import: 18 of the 22 that do
+    also put nothing on `sys.path`, so `import_directories` has only the case's own directory to
+    offer and the join below misses. The verdict then falls through to `could not answer there`,
+    which fails the run — for a case that is red on the base for exactly the reason the tolerated
+    verdict records.
+
+    The path expression is folded the way an insert's is, so a call this cannot read contributes
+    nothing rather than a guess.
+    """
+    home = Path(case.path)
+    source = tree / case.path
+    try:
+        parsed = ast.parse(source.read_text(encoding="utf-8", errors="replace")
+                           if source.is_file() else "")
+    except SyntaxError:
+        return {}
+    bound = path_bindings(parsed)
+    found = {}
+    for node in ast.walk(parsed):
+        if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "spec_from_file_location" and len(node.args) >= 2):
+            continue
+        named = node.args[0]
+        if not (isinstance(named, ast.Constant) and isinstance(named.value, str)):
+            continue
+        for relative in sorted(folded_path(node.args[1], home, bound)):
+            found.setdefault(named.value, relative)
+    return found
+
+
 def module_relatives(case, module, tree):
     """The files the module named in a traceback could be, one per directory the run searches."""
+    bound = loaded_by_path(case, tree).get(module)
+    if bound is not None:
+        return [Path(bound)]
     parts = module.split(".")
     return [directory.joinpath(*parts).with_suffix(".py")
             for directory in import_directories(case, tree)]

--- a/scripts/test_quality/base_red_check.py
+++ b/scripts/test_quality/base_red_check.py
@@ -1294,11 +1294,11 @@ def import_directories(case, tree):
 def loaded_by_path(case, tree):
     """module name -> the repository file a `spec_from_file_location` in the case binds it to.
 
-    A suite here loads its subject by explicit path more often than by import: 18 of the 22 that do
-    also put nothing on `sys.path`, so `import_directories` has only the case's own directory to
-    offer and the join below misses. The verdict then falls through to `could not answer there`,
-    which fails the run — for a case that is red on the base for exactly the reason the tolerated
-    verdict records.
+    A suite here loads its subject by explicit path more often than by import, and the join below has
+    nowhere to look unless the module's name happens to be a sibling of the case's own file. Measured
+    over this repository: a binding is read in 10 suites, the join already resolves 2 of them, and the
+    other 8 were reaching `could not answer there` — a verdict that fails the run, for a case that is
+    red on the base for exactly the reason the tolerated one records.
 
     The path expression is folded the way an insert's is, so a call this cannot read contributes
     nothing rather than a guess.

--- a/scripts/test_quality/test_base_red_check.py
+++ b/scripts/test_quality/test_base_red_check.py
@@ -1549,6 +1549,26 @@ class PythonNamedSurfaceTests(unittest.TestCase):
             output, root / "base", root / "branch",
             base_red_check.Case("T.test_a", case_path, 1, 2))
 
+    def test_Given_ASuiteLoadingItsSubjectByPath_When_ItReachesAnAddedName_Then_TheReachIsPlaced(self):
+        # Arrange -- the shape 18 of this repository's 22 such suites take: the module is loaded through
+        # `spec_from_file_location` under a name of its own and nothing is put on `sys.path`, so the
+        # directory join has only the case's own folder to offer and the file is never found.
+        preamble = ("import importlib.util\n"
+                    "from pathlib import Path\n"
+                    "_spec = importlib.util.spec_from_file_location(\n"
+                    "    'subject', Path(__file__).resolve().parents[1] / 'lib' / 'subject.py')\n"
+                    "subject = importlib.util.module_from_spec(_spec)\n"
+                    "_spec.loader.exec_module(subject)\n")
+        base = {"lib/subject.py": "OLD = 1\n"}
+        branch = {"lib/subject.py": "OLD = 1\nADDED = 2\n"}
+
+        # Act
+        placed = self.read("AttributeError: module 'subject' has no attribute 'ADDED'",
+                           "suite/test_subject.py", base, branch, "subject.ADDED", preamble)
+
+        # Assert
+        self.assertTrue(placed)
+
     def raised_importing(self, module, files):
         """The exception line a real import leaves, rather than one transcribed into this file.
 


### PR DESCRIPTION
Closes #927.

`added_python_surface` relates the module a traceback names to a file by joining that name onto the
directories `import_directories` found, and those come from `sys.path` inserts in the case's own file.
A suite that loads its subject by explicit path inserts nothing, so unless the module's name happens
to be a sibling of the case's own file the join has nowhere to look, and the verdict falls through to
`could not answer there` — a failing verdict, for a case that is red on the base for exactly the
reason the tolerated one records.

Measured over this repository with the reading in place:

    suites where a binding is read              10
    of those, the join already resolves          2
    of those, it did not                         8

`test_pr_body_flags.py` is where it was found, landing #847: two cases reaching
`pr_body.SUBCOMMAND_FLAGS`, a name that branch adds, read as raising rather than as depending on the
change — the module is loaded as `pr_body`, so the only candidate became `scripts/hooks/pr_body.py`,
and its subject is `.claude/hooks/lib/pr_body.py`. The workaround there was to reach the new surface
through `getattr`, which an author has to know about and nothing tells them: the message says the base
raised, not that the reading could not find the file.

`spec_from_file_location(name, path)` states both halves in one call, and `folded_path` already
resolves such an expression against the case's own file — it is what the `sys.path` arm uses. So the
binding is read off the call rather than searched for, and a call this cannot fold contributes nothing
rather than a guess.

One case, red on the base: a suite loading its subject by path, reaching a name only the branch
provides. Suite 252 passed / 0 failed.
