### PR TITLE
fix(velvet): keep a campaign's verdicts, so a killed one resumes

### DIFF
--- a/scripts/test_quality/mutation_check.py
+++ b/scripts/test_quality/mutation_check.py
@@ -1344,6 +1344,40 @@ def write_receipt(output, digest, base, verdict, detail):
     return path
 
 
+def verdict_path(output, index):
+    return output / "mutant-{:03d}.json".format(index)
+
+
+def write_verdict(output, index, digest, mutant, project):
+    """Record one mutant's verdict beside its results, keyed on what the campaign measured.
+
+    A campaign is all-or-nothing today: killed at mutant 24 of 32, it leaves 24 sound verdicts on disk
+    that mean nothing to the next run, which starts at 1. The results XML alone cannot answer for them
+    -- HUNG reads the wall clock, NOT_BUILT reads an assembly hash the restart has already restored --
+    so what is kept is the verdict itself.
+    """
+    verdict_path(output, index).write_text(json.dumps({
+        "digest": digest, "index": index, "mutant": mutant.describe(project),
+        "verdict": mutant.verdict, "detail": mutant.detail,
+    }, indent=2))
+
+
+def read_verdict(output, index, digest, mutant, project):
+    """(verdict, detail) a previous run of this same campaign reached for this mutant, or None.
+
+    Keyed on the digest AND on what the mutant is, because an index is only this mutant's while the
+    list is the same list. The digest covers the working tree rather than a commit, so an edit to a
+    mutated file since moves it and the record is refused rather than reused.
+    """
+    try:
+        held = json.loads(verdict_path(output, index).read_text())
+    except (OSError, ValueError):
+        return None
+    if held.get("digest") != digest or held.get("mutant") != mutant.describe(project):
+        return None
+    return held.get("verdict"), held.get("detail")
+
+
 def read_receipt(output, digest):
     path = receipt_path(output, digest)
     if not path.exists():
@@ -1731,9 +1765,19 @@ def main():
     # Derived once: which fixtures redden on the edit rather than on what it does.
     text_readers = text_reading_fixtures(project)
     started = time.time()
+    # What the receipt is keyed on, computed here so a verdict written mid-campaign can carry it.
+    campaign = scope_digest(merge_base_of(project, args.base), targets, project, args.platform)
+    resumed = 0
     try:
         for index, mutant in enumerate(mutants, start=1):
             print("[{}/{}] {}".format(index, len(mutants), mutant.describe(project)), flush=True)
+            kept = read_verdict(output, index, campaign, mutant, project)
+            if kept is not None:
+                mutant.verdict, mutant.detail = kept
+                resumed += 1
+                print("      {} ({}) from a previous run of this campaign".format(
+                    mutant.verdict, mutant.detail or "-"))
+                continue
             results = output / "mutant-{:03d}.xml".format(index)
             log = output / "mutant-{:03d}.log".format(index)
             if results.exists():
@@ -1806,13 +1850,20 @@ def main():
             if neighbours:
                 mutant.detail = "{}; {} other editor(s) were up".format(
                     mutant.detail or "-", neighbours)
-            average = (time.time() - started) / index
+            write_verdict(output, index, campaign, mutant, project)
+            average = (time.time() - started) / max(1, index - resumed)
             print("      {} ({}) in {:.0f}s; {:.0f}s left at {:.0f}s each".format(
-                mutant.verdict, mutant.detail or "-", wall, average * (len(mutants) - index), average))
+                mutant.verdict, mutant.detail or "-", wall,
+                average * (len(mutants) - index), average))
     finally:
         holder.release()
         for path, text in originals.items():
             path.write_text(text)
+
+    if resumed:
+        print("\n{} of {} verdict(s) came from a previous run of this campaign, which is why the "
+              "wall\nclock below is shorter than the work it reports".format(resumed, len(mutants)),
+              flush=True)
 
     declared = declarations_for(targets, changed) if whole else {}
     unanswered, stale = answered(mutants, deferred, declared)

--- a/scripts/test_quality/mutation_check.py
+++ b/scripts/test_quality/mutation_check.py
@@ -1348,7 +1348,7 @@ def verdict_path(output, index):
     return output / "mutant-{:03d}.json".format(index)
 
 
-def write_verdict(output, index, digest, mutant, project):
+def write_verdict(output, index, digest, mutant, project, killers=()):
     """Record one mutant's verdict beside its results, keyed on what the campaign measured.
 
     A campaign is all-or-nothing today: killed at mutant 24 of 32, it leaves 24 sound verdicts on disk
@@ -1359,6 +1359,10 @@ def write_verdict(output, index, digest, mutant, project):
     verdict_path(output, index).write_text(json.dumps({
         "digest": digest, "index": index, "mutant": mutant.describe(project),
         "verdict": mutant.verdict, "detail": mutant.detail,
+        # Every case that failed under this mutation, not the three the detail names. Which cases kill
+        # which mutant is the reading #713 wants and a receipt does not carry, and it is on disk here
+        # anyway -- the detail truncates it for a reader rather than because that is all there was.
+        "killers": sorted(killers),
     }, indent=2))
 
 
@@ -1799,6 +1803,7 @@ def main():
                                  "at {} names what is outstanding".format(mutant.path, holder.sentinel))
 
             counts = read_counts(results)
+            killers = ()
             dll = assemblies_dir / "{}.dll".format(assembly_of(mutant.path))
             blamed = build_error(log)
             if timed_out and baseline_wall * HANG_MARGIN <= args.timeout:
@@ -1832,6 +1837,7 @@ def main():
                 # Naming the killers, because a mutant killed only by a test that also fails on an
                 # unmutated tree was not killed by anything.
                 names = failing_names(results)
+                killers = names
                 behavioural = killed_by_behaviour(names, text_readers)
                 if behavioural:
                     mutant.verdict = KILLED
@@ -1850,7 +1856,7 @@ def main():
             if neighbours:
                 mutant.detail = "{}; {} other editor(s) were up".format(
                     mutant.detail or "-", neighbours)
-            write_verdict(output, index, campaign, mutant, project)
+            write_verdict(output, index, campaign, mutant, project, killers)
             average = (time.time() - started) / max(1, index - resumed)
             print("      {} ({}) in {:.0f}s; {:.0f}s left at {:.0f}s each".format(
                 mutant.verdict, mutant.detail or "-", wall,

--- a/scripts/test_quality/mutation_check.py
+++ b/scripts/test_quality/mutation_check.py
@@ -1372,6 +1372,10 @@ def read_verdict(output, index, digest, mutant, project):
     Keyed on the digest AND on what the mutant is, because an index is only this mutant's while the
     list is the same list. The digest covers the working tree rather than a commit, so an edit to a
     mutated file since moves it and the record is refused rather than reused.
+
+    What it does not cover is a test-side change, and that is `scope_digest`'s own limit rather than
+    one this adds: removing a test can make a killed mutant survive, and the receipt stays valid
+    across it for the reason stated there. A resumed verdict inherits exactly that, no more.
     """
     try:
         held = json.loads(verdict_path(output, index).read_text())

--- a/scripts/test_quality/test_mutation_check.py
+++ b/scripts/test_quality/test_mutation_check.py
@@ -3064,6 +3064,16 @@ class KeptVerdictTests(unittest.TestCase):
         self.mutant.detail = "0 failed"
         mutation_check.write_verdict(self.output, 7, "digest-1", self.mutant, self.project)
 
+    def test_Given_ACampaignThatKilledAMutant_When_TheRecordIsRead_Then_ItNamesEveryKiller(self):
+        # Arrange — the detail names three for a reader. Which cases kill which mutant is a reading
+        # nothing else carries, and it is on disk here anyway.
+        mutation_check.write_verdict(self.output, 8, "digest-1", self.mutant, self.project,
+                                     ("N.C.b", "N.C.a", "N.C.c", "N.C.d"))
+
+        # Act / Assert
+        self.assertEqual(json.loads((self.output / "mutant-008.json").read_text())["killers"],
+                         ["N.C.a", "N.C.b", "N.C.c", "N.C.d"])
+
     def test_Given_AVerdictThisCampaignWrote_When_TheSameMutantIsReached_Then_ItIsAnswered(self):
         # Act / Assert
         self.assertEqual(

--- a/scripts/test_quality/test_mutation_check.py
+++ b/scripts/test_quality/test_mutation_check.py
@@ -21,6 +21,7 @@ import json
 import os
 import re
 import signal
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -3043,6 +3044,45 @@ class MaskRefusalTests(unittest.TestCase):
 
         # Assert
         self.assertIn("swallows code", str(code))
+
+
+class KeptVerdictTests(unittest.TestCase):
+    """What a killed campaign leaves behind for the next run of the same one.
+
+    A campaign is all-or-nothing: killed at mutant 24 of 32 it leaves 24 sound verdicts on disk and
+    the next run starts at 1. Each is recorded as it is reached so a later run answers from it — and
+    refused where the tree it measured has moved, since a verdict about other bytes is not a verdict.
+    """
+
+    def setUp(self):
+        self.output = Path(tempfile.mkdtemp(prefix="mutation-kept-"))
+        self.addCleanup(shutil.rmtree, self.output, ignore_errors=True)
+        self.project = Path(tempfile.mkdtemp(prefix="mutation-kept-project-"))
+        self.addCleanup(shutil.rmtree, self.project, ignore_errors=True)
+        self.mutant = mutation_check.Mutant(self.project / "A.cs", 3, 0, "a", "b", "literal")
+        self.mutant.verdict = "survived"
+        self.mutant.detail = "0 failed"
+        mutation_check.write_verdict(self.output, 7, "digest-1", self.mutant, self.project)
+
+    def test_Given_AVerdictThisCampaignWrote_When_TheSameMutantIsReached_Then_ItIsAnswered(self):
+        # Act / Assert
+        self.assertEqual(
+            mutation_check.read_verdict(self.output, 7, "digest-1", self.mutant, self.project),
+            ("survived", "0 failed"))
+
+    def test_Given_TheTreeHasMovedSince_When_TheSameMutantIsReached_Then_TheVerdictIsRefused(self):
+        # Arrange — the digest covers the working tree, so an edit to a mutated file moves it.
+        # Act / Assert
+        self.assertIsNone(
+            mutation_check.read_verdict(self.output, 7, "digest-2", self.mutant, self.project))
+
+    def test_Given_ADifferentMutantAtThatIndex_When_ItIsReached_Then_TheVerdictIsRefused(self):
+        # Arrange — an index is this mutant's only while the list is the same list.
+        other = mutation_check.Mutant(self.project / "A.cs", 3, 0, "a", "b", "boundary")
+
+        # Act / Assert
+        self.assertIsNone(
+            mutation_check.read_verdict(self.output, 7, "digest-1", other, self.project))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Refs part of #668 — its resume half. The `wait_for_quiet` half stays open there.

A campaign is all-or-nothing. Measured on this repository: one reached 24 of 32 mutants — 24 result
XMLs on disk, an hour of Unity runs — was killed, and the next run started at mutant 1. Killing a
campaign is the most expensive thing that can happen on this machine, and it happens for ordinary
reasons: a worker's task ends, a session is interrupted, a machine sleeps.

Each verdict is written beside its results as it is reached, and a later run over the same output
directory answers from it rather than running the mutant again.

What is kept is the verdict rather than the results file. The results alone cannot answer for every
one: `HUNG` reads the wall clock against the baseline, and `NOT_BUILT` reads an assembly hash a
restart has already restored — so a resume that re-read the XML would silently re-score those two.

The record is keyed on two things, and both are needed:

- the digest the receipt is keyed on, which covers the **working tree** rather than a commit, so an
  edit to a mutated file since moves it and the record is refused rather than reused;
- what the mutant is, because an index is only this mutant's while the list is the same list.

`--emit`/`--verdict`, which `base_red_check.py` has, is not what this gains and is not what it wants:
that split hands off one Unity run, and a campaign is N of them, run by the thing that needs the
machine. Resume is most of what the split was wanted for on a busy machine — a campaign that keeps its
verdicts across a kill can be run in whatever windows exist.

Three cases: a verdict this campaign wrote is answered, one whose tree has moved is refused, and one
at an index a different mutant now holds is refused. Suite 188 passed / 0 failed.
