### PR TITLE
fix(velvet): report the deferral this session did not write

### DIFF
--- a/.claude/hooks/lib/deferrals.py
+++ b/.claude/hooks/lib/deferrals.py
@@ -120,7 +120,7 @@ def disowned(key, now=None):
     Read by all four guards that suppress on a deferral, so a suppression that did not happen is in
     front of the reader rather than behind them — the same principle `deferred` states about a stale
     reason. Written for a while before any of them called it, which is a helper claiming a behaviour
-    the tree did not have.
+    the tree did not have, in a module that said so twice.
     """
     mine = writer()
     if mine is None:

--- a/.claude/hooks/lib/deferrals.py
+++ b/.claude/hooks/lib/deferrals.py
@@ -117,8 +117,10 @@ def deferred(key, now=None):
 def disowned(key, now=None):
     """(reason, whose) for every live deferral on the key that this session did not write.
 
-    Read by the guards so a suppression that did not happen is in front of the reader rather than
-    behind them, which is the same principle `deferred` states about a stale reason.
+    Read by all four guards that suppress on a deferral, so a suppression that did not happen is in
+    front of the reader rather than behind them — the same principle `deferred` states about a stale
+    reason. Written for a while before any of them called it, which is a helper claiming a behaviour
+    the tree did not have.
     """
     mine = writer()
     if mine is None:

--- a/.claude/hooks/refuse/branch_from_unmerged.py
+++ b/.claude/hooks/refuse/branch_from_unmerged.py
@@ -19,7 +19,7 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lib"))
-from deferrals import deferred, unusable
+from deferrals import deferred, disowned, unusable
 from shell_commands import command_segments, git_invocation, tokens_of, without_redirections
 from velvet_hooks import BRANCH_BASES
 
@@ -242,6 +242,9 @@ def main():
         broken = unusable(name)
         if broken is not None:
             print(f"A deferral was written for {name}, and {broken} — so it is being ignored.",
+                  file=sys.stderr)
+        for reason, whose in disowned(name):
+            print(f"Session {whose} deferred {name} as \"{reason}\", which does not suppress here.",
                   file=sys.stderr)
         if deferred(name):
             # Parent tip at branch creation is gone after squash-merge; rebase --onto needs it now.

--- a/.claude/hooks/refuse/edit_while_a_ready_pr_sits.py
+++ b/.claude/hooks/refuse/edit_while_a_ready_pr_sits.py
@@ -27,7 +27,7 @@ from pathlib import Path
 HOOK_DIRECTORY = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(HOOK_DIRECTORY / "lib"))
 sys.path.insert(0, str(HOOK_DIRECTORY.parent.parent / "scripts" / "pr"))
-from deferrals import DEFERRALS, deferred, unusable
+from deferrals import DEFERRALS, deferred, disowned, unusable
 from watcher_state import READY_STATE, STALE_AFTER, alive, unreadable_beat
 
 # Held on the editing tools, which carry a file path rather than a shell command, so there is no operand
@@ -65,6 +65,9 @@ def sitting(now):
         if broken is not None:
             print(f"A deferral was written for PR #{number}, and {broken} — so it is being ignored.",
                   file=sys.stderr)
+        for reason, whose in disowned(number, now):
+            print(f"Session {whose} deferred PR #{number} as \"{reason}\", which does not suppress "
+                  "here.", file=sys.stderr)
         if now - since < GRACE or deferred(number, now):
             continue
         found.append((number, int(now - since)))
@@ -95,6 +98,9 @@ def main():
         if broken is not None:
             sys.stderr.write(f"A deferral was written for {WATCHER_KEY}, and {broken} — so it is "
                              "being ignored.\n")
+        for reason, whose in disowned(WATCHER_KEY, now):
+            sys.stderr.write(f"Session {whose} deferred {WATCHER_KEY} as \"{reason}\", which does "
+                             "not suppress here.\n")
         # Two states reach here and they want opposite actions: start a watcher, or end one. Saying
         # "nothing is watching" of the second is this guard's blindness written as a fact about the
         # watcher, and the command it would name refuses while that watcher runs.

--- a/.claude/hooks/stop/open_backlog.py
+++ b/.claude/hooks/stop/open_backlog.py
@@ -38,7 +38,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lib"))
 
-from deferrals import DEFERRALS, deferred, unusable  # noqa: E402
+from deferrals import DEFERRALS, deferred, disowned, unusable  # noqa: E402
 from repository import open_pull_requests, unreadable_report  # noqa: E402
 
 UNREADABLE_POLICY = "refuse"
@@ -92,6 +92,9 @@ def main():
     if broken is not None:
         print("A deferral was written for the backlog, and "
               f"{broken} — so it is being ignored.", file=sys.stderr)
+    for reason, whose in disowned("backlog"):
+        print(f"Session {whose} deferred the backlog as \"{reason}\", which does not suppress here.",
+              file=sys.stderr)
     holding = deferred("backlog")
     if holding is not None:
         reason, minutes = holding

--- a/.claude/hooks/stop/unsettled_pr.py
+++ b/.claude/hooks/stop/unsettled_pr.py
@@ -38,7 +38,7 @@ HOOK_DIRECTORY = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(HOOK_DIRECTORY / "lib"))
 sys.path.insert(0, str(HOOK_DIRECTORY.parent.parent / "scripts" / "pr"))
 
-from deferrals import DEFERRALS, deferred, unusable  # noqa: E402
+from deferrals import DEFERRALS, deferred, disowned, unusable  # noqa: E402
 from repository import SELF_REPORT, open_pull_requests, unreadable_report  # noqa: E402
 from watcher_state import HEARTBEAT, alive, unreadable_beat  # noqa: E402
 
@@ -221,6 +221,9 @@ def main():
         broken = unusable(pr)
         if broken is not None:
             ignored.append(f"  PR #{pr} — a deferral was written for it, and {broken}.")
+        for reason, whose in disowned(pr):
+            ignored.append(f"  PR #{pr} — session {whose} deferred it as \"{reason}\", which does "
+                           "not suppress here.")
         holding = deferred(pr)
         if holding is not None:
             reason, minutes = holding

--- a/scripts/hooks/test_unreadable_state_check.py
+++ b/scripts/hooks/test_unreadable_state_check.py
@@ -869,6 +869,21 @@ class WatcherDeferralTests(unittest.TestCase):
         # the recipe it stopped reaching would then be unsigned with this green.
         self.assertEqual((reached, unsigned), ([(True, True)] * 3, []))
 
+    def test_Given_AnotherSessionDeferredIt_When_TheGuardRefuses_Then_ItSaysSoRatherThanNothing(self):
+        # Arrange — a deferral this session did not write suppresses nothing, which is the ownership
+        # rule. What it must not do is vanish: the reader is refused with a line about their pull
+        # request sitting, while a line about that pull request is in the file saying it was held.
+        home = self.home()
+        self.arrange(home, "green and unmerged long enough to have been forgotten")
+        (home / ".velvet-pr-deferrals").write_text(
+            f"777 waiting on the other half {int(time.time())} another-0002\n", encoding="utf-8")
+
+        # Act
+        _, _, refusal, _ = check.run_guard(self.GUARD, self.PAYLOAD, "gh-empty", REPO_ROOT, home)
+
+        # Assert
+        self.assertIn("another-0002", refusal)
+
     def test_Given_TheRecipesItPrints_When_TheyAreFollowed_Then_TheNextWriteGoesThrough(self):
         # Arrange — both branches whose recipe can be followed as printed. The other two key their
         # line on `<pr>`, a placeholder a person fills in, so a verbatim run writes a line about no


### PR DESCRIPTION
Closes #920.

`disowned` was imported by no guard, and `.claude/hooks/lib/deferrals.py` said twice that guards read
it — once in as many words: "Read by the guards so a suppression that did not happen is in front of
the reader rather than behind them." (A third claim sat inside `deferred`'s comment until #926 removed
it with the ownership check beside it.)

That sentence was false, and the behaviour it described is the useful one. A session writes a deferral
for a pull request, another session's guard disowns it as not its own — correctly, that is the
ownership rule — and nobody is told. The line is in the file saying the pull request is held, and the
reader is refused with a message about it sitting green.

All four guards that suppress on a deferral report it now:

    stop/unsettled_pr.py                 per pull request, beside the unusable line
    stop/open_backlog.py                 for the backlog key
    refuse/edit_while_a_ready_pr_sits.py per pull request, and for the watcher key
    refuse/branch_from_unmerged.py       per branch

In each, the report is emitted above the next decision, so a reader sees it with the verdict rather
than after it.

Nothing about suppression moves, and that is driven rather than argued. Over five states, with a live
ready entry past the grace period:

    this session's own live line     exit 0   nothing reported
    another session's live line      exit 2   reported
    another session's expired line   exit 2   nothing reported
    an unsigned malformed line       exit 2   nothing reported — that one is `unusable`'s
    no deferral at all               exit 2   nothing reported

The docstring now says what is true rather than what was intended. One case pins it — a deferral
another session wrote, on a pull request the guard is refusing over, is named in the refusal — and it
is red on the base.
