### PR TITLE
fix(velvet): read what the cases share with its comments blanked, as a case is read

### DIFF
--- a/scripts/test_quality/base_red_check.py
+++ b/scripts/test_quality/base_red_check.py
@@ -680,6 +680,9 @@ def shared_material_differs(relative, before, after):
     A line reading is not enough on its own: git describes a reorder as one block deleted and
     re-added, so the lines between two swapped cases read as changed while every one of them is the
     base's own text. Compared as a multiset, a reorder is no difference and an added row is.
+
+    Read with the comments blanked, as `authored` reads a case: a remark rewritten above a helper is
+    not what any case's run decides on, and counting it put every case in the file on trial for it.
     """
     if before is None:
         return True
@@ -691,7 +694,7 @@ def shared_material_differs(relative, before, after):
         inside = set()
         for case in found:
             inside |= set(range(case.first_line, case.last_line + 1))
-        return sorted(line.strip() for number, line in enumerate(text.splitlines(), 1)
+        return sorted(line.strip() for number, line in enumerate(outside_comments(relative, text), 1)
                       if number not in inside and line.strip())
 
     return shared(before) != shared(after)

--- a/scripts/test_quality/base_red_check.py
+++ b/scripts/test_quality/base_red_check.py
@@ -2155,8 +2155,8 @@ def collect(project, base, lane):
         for case in cases:
             if case.declaration is not None and lines is not None:
                 case.declaration.written_here = case.declaration.written_in(lines)
-        wanted = {case.name for case in authored(relative, touched(cases, lines),
-                                                 held_at(project, since, relative), text)[0]}
+        before = held_at(project, since, relative)
+        wanted = {case.name for case in authored(relative, touched(cases, lines), before, text)[0]}
         # A change wholly outside every case body, in a file that has cases: a static readonly table
         # the cases drive, a SetUp, a helper. `authored` keeps such a case out, correctly -- the
         # branch did not write it -- and with nothing else selected the lane exits 0 having measured
@@ -2168,11 +2168,15 @@ def collect(project, base, lane):
         # and puts every case a fixture has on trial for a line added to SetUp; `outside` reports
         # that instead. What is left here is the state where reporting it is all that happens.
         if (cases and lines is not None and not wanted and outside(cases, lines)
-                and shared_material_differs(relative, held_at(project, since, relative), text)):
+                and shared_material_differs(relative, before, text)):
             wanted = {case.name for case in cases}
         changed.extend(as_the_runner_names_them(
             [case for case in cases if case.name in wanted], heirs))
+        # Read as the promotion above reads it: a changed line outside every case that is only a
+        # comment leaves the cases beside it the base's text, controls included.
         loose = outside(cases, lines)
+        if loose and not shared_material_differs(relative, before, text):
+            loose = set()
         if not loose and not shared_helper:
             control.extend(as_the_runner_names_them(
                 [case for case in cases if case.name not in wanted], heirs))

--- a/scripts/test_quality/test_base_red_check.py
+++ b/scripts/test_quality/test_base_red_check.py
@@ -4131,6 +4131,8 @@ class SharedMaterialTests(unittest.TestCase):
         self.assertFalse(base_red_check.shared_material_differs(
             self.FIXTURE, self.text("what it was", "1"), self.text("what it is", "1")))
 
+    # GREEN_ON_BASE(characterization): a helper's code changed already reads as the branch's, and the
+    # comment reading beside it must not lose that direction.
     def test_Given_AHelpersCodeChanged_When_TheSharedMaterialIsRead_Then_ItIsTheBranchs(self):
         # Act / Assert
         self.assertTrue(base_red_check.shared_material_differs(

--- a/scripts/test_quality/test_base_red_check.py
+++ b/scripts/test_quality/test_base_red_check.py
@@ -4158,21 +4158,27 @@ class SharedMaterialTests(unittest.TestCase):
     def test_Given_ARemarkRewrittenAboveAHelper_When_ThePlanIsTaken_Then_TheFilesCasesAreNotInIt(self):
         # Arrange -- the whole reading, since a plan that holds every case of a fixture for a
         # remark is what put twenty-seven cases on trial on the branch that measured this. The exit
-        # status rides along: an absence over a plan that crashed is an absence over nothing.
+        # status and the other file's case ride along: an absence over a plan that crashed, or that
+        # moved its listing elsewhere, is an absence over nothing.
         # Act
         status, printed = self.planned()
 
         # Assert
-        self.assertEqual((status, "N.ProbeTests.Given_A_When_B_Then_C" in printed), (0, False))
+        self.assertEqual((status, "N.OtherTests.Given_A_When_B_Then_C" in printed,
+                          "N.ProbeTests.Given_A_When_B_Then_C" in printed), (0, True, False))
 
     def test_Given_ARemarkRewrittenAboveAHelper_When_ThePlanIsTaken_Then_TheFilesCasesStayControls(self):
         # Arrange -- the other reading of the same lines: a remark that put no case on trial must not
         # take the file's controls away either, or the report says the cases are the branch's text.
+        # The control's presence rides along with the report's absence, since the report is only
+        # printed where the controls went, and a gate that dropped them without saying so would pass
+        # the absence alone.
         # Act
         status, printed = self.planned()
 
         # Assert
-        self.assertEqual((status, "no control:" in printed), (0, False))
+        self.assertEqual((status, "(1 control case(s) alongside)" in printed, "no control:" in printed),
+                         (0, True, False))
 
 
 if __name__ == "__main__":

--- a/scripts/test_quality/test_base_red_check.py
+++ b/scripts/test_quality/test_base_red_check.py
@@ -4113,5 +4113,45 @@ class RepositoryTests(unittest.TestCase):
         self.assertEqual([name for name, (wrote, carries) in uneven if wrote != carries], [])
 
 
+class SharedMaterialTests(unittest.TestCase):
+    """What the cases share -- everything outside every case body -- read the way a case is read."""
+
+    FIXTURE = "Packages/p/Runtime/A/Tests/Editor/ProbeTests.cs"
+
+    def text(self, remark, helper):
+        return ("namespace N\n{\n    class ProbeTests\n    {\n"
+                "        /// <summary>" + remark + "</summary>\n"
+                "        static int Helper() => " + helper + ";\n\n"
+                "        [Test]\n        public void Given_A_When_B_Then_C() => Assert.That(Helper(), Is.EqualTo(1));\n"
+                "    }\n}\n")
+
+    def test_Given_ARemarkRewrittenAboveAHelper_When_TheSharedMaterialIsRead_Then_ItIsTheBases(self):
+        # Arrange -- a comment is not what any case's run decides on, outside a case as inside one.
+        # Act / Assert
+        self.assertFalse(base_red_check.shared_material_differs(
+            self.FIXTURE, self.text("what it was", "1"), self.text("what it is", "1")))
+
+    def test_Given_AHelpersCodeChanged_When_TheSharedMaterialIsRead_Then_ItIsTheBranchs(self):
+        # Act / Assert
+        self.assertTrue(base_red_check.shared_material_differs(
+            self.FIXTURE, self.text("the same", "1"), self.text("the same", "2")))
+
+    def test_Given_ARemarkRewrittenAboveAHelper_When_ThePlanIsTaken_Then_TheFilesCasesAreNotInIt(self):
+        # Arrange -- the whole reading, since a plan that holds every case of a fixture for a
+        # remark is what put twenty-six cases on trial on the branch that measured this.
+        root, since = two_commit_repo(
+            self, {self.FIXTURE: self.text("what it was", "1")},
+            {self.FIXTURE: self.text("what it is", "1")})
+
+        # Act
+        printed = subprocess.run(
+            [sys.executable, str(REPO_ROOT / "scripts/test_quality/base_red_check.py"),
+             "--project", str(root), "--base", since, "--lane", "csharp", "--plan"],
+            capture_output=True, text=True).stdout
+
+        # Assert
+        self.assertNotIn("N.ProbeTests.Given_A_When_B_Then_C", printed)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/scripts/test_quality/test_base_red_check.py
+++ b/scripts/test_quality/test_base_red_check.py
@@ -4118,41 +4118,61 @@ class SharedMaterialTests(unittest.TestCase):
 
     FIXTURE = "Packages/p/Runtime/A/Tests/Editor/ProbeTests.cs"
 
-    def text(self, remark, helper):
-        return ("namespace N\n{\n    class ProbeTests\n    {\n"
+    OTHER = "Packages/p/Runtime/A/Tests/Editor/OtherTests.cs"
+
+    def text(self, remark, helper, name="ProbeTests", expected="a"):
+        return ("namespace N\n{\n    class " + name + "\n    {\n"
                 "        /// <summary>" + remark + "</summary>\n"
-                "        static int Helper() => " + helper + ";\n\n"
-                "        [Test]\n        public void Given_A_When_B_Then_C() => Assert.That(Helper(), Is.EqualTo(1));\n"
+                "        static string Helper() => \"" + helper + "\";\n\n"
+                "        [Test]\n        public void Given_A_When_B_Then_C() => Assert.That(Helper(), "
+                "Is.EqualTo(\"" + expected + "\"));\n"
                 "    }\n}\n")
+
+    def planned(self):
+        """(exit status, what `--plan` printed) over a branch that rewrote the remark above
+        ProbeTests' helper and changed a case body in OtherTests, so the plan is not empty."""
+        root, since = two_commit_repo(
+            self, {self.FIXTURE: self.text("what it was", "a"),
+                   self.OTHER: self.text("the same", "a", "OtherTests")},
+            {self.FIXTURE: self.text("what it is", "a"),
+             self.OTHER: self.text("the same", "a", "OtherTests", expected="b")})
+        printed = subprocess.run(
+            [sys.executable, str(REPO_ROOT / "scripts/test_quality/base_red_check.py"),
+             "--project", str(root), "--base", since, "--lane", "csharp", "--plan"],
+            capture_output=True, text=True)
+        return printed.returncode, printed.stdout
 
     def test_Given_ARemarkRewrittenAboveAHelper_When_TheSharedMaterialIsRead_Then_ItIsTheBases(self):
         # Arrange -- a comment is not what any case's run decides on, outside a case as inside one.
         # Act / Assert
         self.assertFalse(base_red_check.shared_material_differs(
-            self.FIXTURE, self.text("what it was", "1"), self.text("what it is", "1")))
+            self.FIXTURE, self.text("what it was", "a"), self.text("what it is", "a")))
 
-    # GREEN_ON_BASE(characterization): a helper's code changed already reads as the branch's, and the
-    # comment reading beside it must not lose that direction.
-    def test_Given_AHelpersCodeChanged_When_TheSharedMaterialIsRead_Then_ItIsTheBranchs(self):
+    # GREEN_ON_BASE(characterization): a helper's literal changed already reads as the branch's, and
+    # a reading that blanked literals with the comments would lose it.
+    def test_Given_AHelpersLiteralChanged_When_TheSharedMaterialIsRead_Then_ItIsTheBranchs(self):
         # Act / Assert
         self.assertTrue(base_red_check.shared_material_differs(
-            self.FIXTURE, self.text("the same", "1"), self.text("the same", "2")))
+            self.FIXTURE, self.text("the same", "a"), self.text("the same", "b")))
 
     def test_Given_ARemarkRewrittenAboveAHelper_When_ThePlanIsTaken_Then_TheFilesCasesAreNotInIt(self):
         # Arrange -- the whole reading, since a plan that holds every case of a fixture for a
-        # remark is what put twenty-six cases on trial on the branch that measured this.
-        root, since = two_commit_repo(
-            self, {self.FIXTURE: self.text("what it was", "1")},
-            {self.FIXTURE: self.text("what it is", "1")})
-
+        # remark is what put twenty-seven cases on trial on the branch that measured this. The exit
+        # status rides along: an absence over a plan that crashed is an absence over nothing.
         # Act
-        printed = subprocess.run(
-            [sys.executable, str(REPO_ROOT / "scripts/test_quality/base_red_check.py"),
-             "--project", str(root), "--base", since, "--lane", "csharp", "--plan"],
-            capture_output=True, text=True).stdout
+        status, printed = self.planned()
 
         # Assert
-        self.assertNotIn("N.ProbeTests.Given_A_When_B_Then_C", printed)
+        self.assertEqual((status, "N.ProbeTests.Given_A_When_B_Then_C" in printed), (0, False))
+
+    def test_Given_ARemarkRewrittenAboveAHelper_When_ThePlanIsTaken_Then_TheFilesCasesStayControls(self):
+        # Arrange -- the other reading of the same lines: a remark that put no case on trial must not
+        # take the file's controls away either, or the report says the cases are the branch's text.
+        # Act
+        status, printed = self.planned()
+
+        # Assert
+        self.assertEqual((status, "no control:" in printed), (0, False))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #940.

`shared_material_differs` compared everything outside every case body as a multiset of stripped lines,
comments included, while `authored` reads a case with its comments blanked. So a remark rewritten
above a helper made every case in the file the branch's text, where the same remark rewritten inside
a case made nothing the branch's.

The shared reading now blanks comments the way the case reading does, through `outside_comments`,
and both readers of it in `collect` decide off that: the one that puts a file's cases on trial when
nothing else in it was selected, and the one that takes the file's other cases out of the controls.
The multiset comparison stays, for the reorder its docstring gives. What is blanked is what
`comment_spans_of` yields for the file's extension — `//`, `///` and block comments in C#, `#`
comments in Python. A string literal stays code in both, and so does a Python docstring, which is
where the case reading has it too; `#region`, `#if` and `#pragma` lines stay code as well.

Measured on the branch replacing UniTask: `DocumentationDriftTests.cs` differed from `origin/main` in
one `//` comment inside a case and three lines of a `///` remark on a member outside every case, and
the plan held the fixture's 27 cases. With this it holds none of them, and the branch's own text of
the remark stays.

Four cases: a remark rewritten above a helper reads as the base's; the helper's literal changed reads
as the branch's, which the base already does, so a reading that blanked literals with the comments
would lose it; and the plan taken over a repository whose only changes are such a remark and one
case in another file holds none of the file's cases and takes none of its controls away, the exit
status folded into each so an absence over a plan that crashed is not a pass.

No `Documentation~` guide changes. CONTRIBUTING.md describes the case reading's blanked comments and
the control gate, and neither sentence changes.
