### PR TITLE
fix(velvet): read the Providers of the container an instance sits in

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -67,10 +67,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- An error boundary catching in a pass that is also re-rendering a sibling component no longer logs a
-  `NullReferenceException` from the reconciler. The sibling's inline re-render runs inside the host's
-  pass, and the catch disposes fibers — which clears the `Reconciler` that re-render is still holding,
-  so the three steps after it dereferenced a field the disposal had already nulled. The same field is
+- An error boundary whose child throws during a subsumed re-render no longer logs a
+  `NullReferenceException` from the reconciler. The boundary's inline re-render runs inside its host's
+  pass, and the catch disposes that child — which clears the `Reconciler` the re-render is still
+  holding, so the three steps after it dereferenced a field the disposal had already nulled. The same field is
   read for the same reason a few lines further on, where it was checked. The render now returns at that
   point instead: a disposed fiber has no pass left to be subsumed into, so its layout effect and its
   paint-tick effect are not queued and its lanes are not re-enrolled.
@@ -85,10 +85,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ones, which is an instance losing the Provider it is written inside. A `V.Motion`'s active label
   reaches a descendant through the same walk, so a descendant of the second of two sibling Motions read
   the first one's label. A candidate is now matched against the node the instance last rendered from as
-  well as against its key, and two occurrences of `V.Component` are two nodes. Unchanged, and reading
-  as they did before: one `V.Component` node instance written into both containers is one node; and a
-  consumer inside a `V.Portal` or a `V.VirtualList` item, which is matched by key alone because the
-  walk there searches the children captured when that consumer mounted.
+  well as against its key, and two occurrences of `V.Component` are two nodes — but only where the node
+  it holds came from the tree being walked, which a render the reconciler discarded and a time-sliced
+  pass that parked before reaching that component both leave untrue. Shapes that excludes read as they
+  did before, among them: one `V.Component` node instance written into both containers is one node; a
+  consumer inside a `V.Portal` or a `V.VirtualList` item, whose walk searches the children captured when
+  that consumer mounted; and a row a `StartTransition` list left past its park point, which is matched
+  by key alone until the resume commits it.
 
 - An `IRouteScopeFactory.CreateScope` that throws no longer takes the reconcile with it. The scope's
   *disposal* was already contained; its creation was not, at any of the three sites that ask for one —

--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -67,6 +67,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- An error boundary catching in a pass that is also re-rendering a sibling component no longer logs a
+  `NullReferenceException` from the reconciler. The sibling's inline re-render runs inside the host's
+  pass, and the catch disposes fibers — which clears the `Reconciler` that re-render is still holding,
+  so the three steps after it dereferenced a field the disposal had already nulled. The same field is
+  read for the same reason a few lines further on, where it was checked. The render now returns at that
+  point instead: a disposed fiber has no pass left to be subsumed into, so its layout effect and its
+  paint-tick effect are not queued and its lanes are not re-enrolled.
+
 - A component's own re-render now reads the Providers of the container it is written into, where the
   declaring body writes the component into each container as its own occurrence. Two sibling containers
   each holding the same component at the same position already mounted two instances, but the walk that

--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -67,17 +67,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- A component's own re-render now reads the Providers of the container it is written into. Two sibling
-  containers each holding the same component at the same position already mounted two instances, but
-  the walk that rebuilds a consumer's enclosing Providers for a re-render the consumer scheduled itself
-  looked every candidate up under that consumer's own container — so each container holding the
-  position answered, and the walk took the first. The instance in the second container read the first
-  container's value where the two Providers carried one context, and the context default where they
-  carried different ones, which is an instance losing the Provider it is written inside. A `V.Motion`'s
-  active label reaches a descendant through the same walk, so a descendant of the second of two sibling
-  Motions read the first one's label. A candidate is now matched against the node the instance
-  last rendered from as well as against its key; a declaring body that writes the component into each
-  container gives the two positions separate nodes, which is what tells them apart.
+- A component's own re-render now reads the Providers of the container it is written into, where the
+  declaring body writes the component into each container as its own occurrence. Two sibling containers
+  each holding the same component at the same position already mounted two instances, but the walk that
+  rebuilds a consumer's enclosing Providers for a re-render the consumer scheduled itself looked every
+  candidate up under that consumer's own container — so each container holding the position answered,
+  and the walk took the first. The instance in the second container read the first container's value
+  where the two Providers carried one context, and the context default where they carried different
+  ones, which is an instance losing the Provider it is written inside. A `V.Motion`'s active label
+  reaches a descendant through the same walk, so a descendant of the second of two sibling Motions read
+  the first one's label. A candidate is now matched against the node the instance last rendered from as
+  well as against its key, and two occurrences of `V.Component` are two nodes. Unchanged, and reading
+  as they did before: one `V.Component` node instance written into both containers is one node; and a
+  consumer inside a `V.Portal` or a `V.VirtualList` item, which is matched by key alone because the
+  walk there searches the children captured when that consumer mounted.
 
 - An `IRouteScopeFactory.CreateScope` that throws no longer takes the reconcile with it. The scope's
   *disposal* was already contained; its creation was not, at any of the three sites that ask for one —

--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -73,7 +73,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   holding, so the three steps after it dereferenced a field the disposal had already nulled. The same field is
   read for the same reason a few lines further on, where it was checked. The render now returns at that
   point instead: a disposed fiber has no pass left to be subsumed into, so its layout effect and its
-  paint-tick effect are not queued and its lanes are not re-enrolled.
+  paint-tick effect are not queued.
 
 - A component's own re-render now reads the Providers of the container it is written into, where the
   declaring body writes the component into each container as its own occurrence. Two sibling containers

--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -67,6 +67,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A component's own re-render now reads the Providers of the container it is written into. Two sibling
+  containers each holding the same component at the same position already mounted two instances, but
+  the walk that rebuilds a consumer's enclosing Providers for a re-render the consumer scheduled itself
+  looked every candidate up under that consumer's own container — so each container holding the
+  position answered, and the walk took the first. The instance in the second container read the first
+  container's value where the two Providers carried one context, and the context default where they
+  carried different ones, which is an instance losing the Provider it is written inside. A `V.Motion`'s
+  active label reaches a descendant through the same walk, so a descendant of the second of two sibling
+  Motions read the first one's label. A candidate is now matched against the node the instance
+  last rendered from as well as against its key; a declaring body that writes the component into each
+  container gives the two positions separate nodes, which is what tells them apart.
+
 - An `IRouteScopeFactory.CreateScope` that throws no longer takes the reconcile with it. The scope's
   *disposal* was already contained; its creation was not, at any of the three sites that ask for one —
   so an application whose factory failed on a route change lost the render as well as the scope. The

--- a/Packages/com.velvet.core/Runtime/Component/ComponentFiber.cs
+++ b/Packages/com.velvet.core/Runtime/Component/ComponentFiber.cs
@@ -678,6 +678,16 @@ namespace Velvet
         internal VNode?[]? PreviousTree { get; set; }
 
         /// <summary>
+        /// The <see cref="ComponentNode"/> occurrence in the parent's committed tree this fiber currently
+        /// answers for. Written on every <c>ComponentRegistry.GetOrCreate</c> that reaches the fiber, beside
+        /// <see cref="Body"/>, so it names an occurrence of the same render that fixed the parent's
+        /// <see cref="PreviousTree"/>. <see cref="FiberContextSpine"/> reads it while descending that tree to
+        /// tell apart two positions whose registry keys differ only in the container, which the descent has
+        /// no reading of.
+        /// </summary>
+        internal ComponentNode? SourceNode { get; set; }
+
+        /// <summary>
         /// Set where <c>FiberErrorBoundary.TryShowFallback</c> writes the fallback over
         /// <see cref="PreviousTree"/>, cleared at the top of every <c>FiberRenderer.RenderAndReconcile</c>
         /// for this fiber. What it answers that the reconciler's own abort flag cannot is which fiber the

--- a/Packages/com.velvet.core/Runtime/Component/ComponentFiber.cs
+++ b/Packages/com.velvet.core/Runtime/Component/ComponentFiber.cs
@@ -680,13 +680,31 @@ namespace Velvet
         /// <summary>
         /// The <see cref="ComponentNode"/> occurrence this fiber currently answers for: written on every
         /// <c>ComponentRegistry.GetOrCreate</c> that reaches the fiber, beside <see cref="Body"/>, so it
-        /// names an occurrence of the most recent render to reach it. That is what makes it comparable
-        /// against an ancestor's <see cref="PreviousTree"/>, which the same render fixed, and NOT against an
-        /// array captured at an earlier render and not rewritten since. <see cref="FiberContextSpine"/>
-        /// compares it on the first of those to tell apart two positions whose registry keys differ only in
-        /// the container; its <c>SpineWalk</c> owns which descent is which.
+        /// names an occurrence of the most recent render to reach it — which is not always the render that
+        /// fixed the ancestor's <see cref="PreviousTree"/>, because a render whose output is discarded has
+        /// already written its nodes onto the children it reached. <see cref="TreeEpoch"/> is what pairs the
+        /// two, and <see cref="FiberContextSpine"/> compares nodes only where they pair and only while
+        /// descending a committed tree; its <c>SpineWalk</c> owns the second of those conditions.
         /// </summary>
         internal ComponentNode? SourceNode { get; set; }
+
+        /// <summary>
+        /// Moves whenever a render of this fiber is discarded after its children were reconciled — an
+        /// error boundary catching in the pass, or a throw out of the reconcile — leaving
+        /// <see cref="PreviousTree"/> at the previous render's tree while those children carry the
+        /// discarded one's nodes. A child records the value it saw in <see cref="SourceNodeEpoch"/>, so
+        /// the two agree only where the child's <see cref="SourceNode"/> came from the render that fixed
+        /// this <see cref="PreviousTree"/>. <see cref="FiberContextSpine"/> compares nodes only then, and a
+        /// child the discarded render never reached keeps an older value and is compared no further.
+        /// </summary>
+        internal int TreeEpoch { get; set; }
+
+        /// <summary>
+        /// The parent's <see cref="TreeEpoch"/> when <see cref="SourceNode"/> was last written. Paired with
+        /// it and read only by <see cref="FiberContextSpine"/>; <see cref="TreeEpoch"/> owns what the
+        /// pairing means.
+        /// </summary>
+        internal int SourceNodeEpoch { get; set; }
 
         /// <summary>
         /// Set where <c>FiberErrorBoundary.TryShowFallback</c> writes the fallback over

--- a/Packages/com.velvet.core/Runtime/Component/ComponentFiber.cs
+++ b/Packages/com.velvet.core/Runtime/Component/ComponentFiber.cs
@@ -682,29 +682,21 @@ namespace Velvet
         /// <c>ComponentRegistry.GetOrCreate</c> that reaches the fiber, beside <see cref="Body"/>, so it
         /// names an occurrence of the most recent render to reach it — which is not always the render that
         /// fixed the ancestor's <see cref="PreviousTree"/>, because a render whose output is discarded has
-        /// already written its nodes onto the children it reached. <see cref="TreeEpoch"/> is what pairs the
+        /// already written its nodes onto the children it reached. <see cref="SourceTree"/> is what pairs the
         /// two, and <see cref="FiberContextSpine"/> compares nodes only where they pair and only while
         /// descending a committed tree; its <c>SpineWalk</c> owns the second of those conditions.
         /// </summary>
         internal ComponentNode? SourceNode { get; set; }
 
         /// <summary>
-        /// Moves whenever a render of this fiber is discarded after its children were reconciled — an
-        /// error boundary catching in the pass, or a throw out of the reconcile — leaving
-        /// <see cref="PreviousTree"/> at the previous render's tree while those children carry the
-        /// discarded one's nodes. A child records the value it saw in <see cref="SourceNodeEpoch"/>, so
-        /// the two agree only where the child's <see cref="SourceNode"/> came from the render that fixed
-        /// this <see cref="PreviousTree"/>. <see cref="FiberContextSpine"/> compares nodes only then, and a
-        /// child the discarded render never reached keeps an older value and is compared no further.
+        /// The node array <see cref="SourceNode"/> was read from — the output of the render that was expanding
+        /// when this fiber was last reached. It is <see cref="PreviousTree"/> of the fiber above only where
+        /// that render's output was committed AND reached this fiber, which is what
+        /// <see cref="FiberContextSpine"/> tests before comparing nodes: a render whose output was discarded
+        /// leaves the tree above at the array it kept while this names the discarded one, and a time-sliced
+        /// pass that parked before reaching this fiber leaves this naming the array the one above moved off.
         /// </summary>
-        internal int TreeEpoch { get; set; }
-
-        /// <summary>
-        /// The parent's <see cref="TreeEpoch"/> when <see cref="SourceNode"/> was last written. Paired with
-        /// it and read only by <see cref="FiberContextSpine"/>; <see cref="TreeEpoch"/> owns what the
-        /// pairing means.
-        /// </summary>
-        internal int SourceNodeEpoch { get; set; }
+        internal VNode?[]? SourceTree { get; set; }
 
         /// <summary>
         /// Set where <c>FiberErrorBoundary.TryShowFallback</c> writes the fallback over

--- a/Packages/com.velvet.core/Runtime/Component/ComponentFiber.cs
+++ b/Packages/com.velvet.core/Runtime/Component/ComponentFiber.cs
@@ -678,12 +678,13 @@ namespace Velvet
         internal VNode?[]? PreviousTree { get; set; }
 
         /// <summary>
-        /// The <see cref="ComponentNode"/> occurrence in the parent's committed tree this fiber currently
-        /// answers for. Written on every <c>ComponentRegistry.GetOrCreate</c> that reaches the fiber, beside
-        /// <see cref="Body"/>, so it names an occurrence of the same render that fixed the parent's
-        /// <see cref="PreviousTree"/>. <see cref="FiberContextSpine"/> reads it while descending that tree to
-        /// tell apart two positions whose registry keys differ only in the container, which the descent has
-        /// no reading of.
+        /// The <see cref="ComponentNode"/> occurrence this fiber currently answers for: written on every
+        /// <c>ComponentRegistry.GetOrCreate</c> that reaches the fiber, beside <see cref="Body"/>, so it
+        /// names an occurrence of the most recent render to reach it. That is what makes it comparable
+        /// against an ancestor's <see cref="PreviousTree"/>, which the same render fixed, and NOT against an
+        /// array captured at an earlier render and not rewritten since. <see cref="FiberContextSpine"/>
+        /// compares it on the first of those to tell apart two positions whose registry keys differ only in
+        /// the container; its <c>SpineWalk</c> owns which descent is which.
         /// </summary>
         internal ComponentNode? SourceNode { get; set; }
 

--- a/Packages/com.velvet.core/Runtime/Component/ComponentRegistry.cs
+++ b/Packages/com.velvet.core/Runtime/Component/ComponentRegistry.cs
@@ -157,7 +157,7 @@ namespace Velvet
             // the latest props; sync Body so the next render sees the current values.
             existingFiber.Body = node.Body;
             existingFiber.SourceNode = node;
-            existingFiber.SourceNodeEpoch = (site.Anchor as ComponentFiber)?.TreeEpoch ?? 0;
+            existingFiber.SourceTree = _ctx.CurrentFiberTree;
             // Only a memoized component bails a parent-driven re-render on
             // shallow-equal props. A plain component re-renders whenever its parent does, so the
             // props-equality bail is gated on opt-in memoization. Memoization is opted into either by
@@ -223,7 +223,7 @@ namespace Velvet
             // Written before the mount: the FiberSuspendSignal arm below registers the fiber and
             // rethrows, so a write placed after the try would not run for it.
             fiber.SourceNode = node;
-            fiber.SourceNodeEpoch = (site.Anchor as ComponentFiber)?.TreeEpoch ?? 0;
+            fiber.SourceTree = _ctx.CurrentFiberTree;
 
             try
             {

--- a/Packages/com.velvet.core/Runtime/Component/ComponentRegistry.cs
+++ b/Packages/com.velvet.core/Runtime/Component/ComponentRegistry.cs
@@ -156,6 +156,7 @@ namespace Velvet
             // V.Component<TProps> overload allocates a fresh closure each render that captures
             // the latest props; sync Body so the next render sees the current values.
             existingFiber.Body = node.Body;
+            existingFiber.SourceNode = node;
             // Only a memoized component bails a parent-driven re-render on
             // shallow-equal props. A plain component re-renders whenever its parent does, so the
             // props-equality bail is gated on opt-in memoization. Memoization is opted into either by
@@ -218,6 +219,9 @@ namespace Velvet
             _ctx.FiberStack.Current?.AppendChild(fiber);
             fiber.ExternalRef = node.ExternalRef;
             fiber.Props = node.Props;
+            // Written before the mount: the FiberSuspendSignal arm below registers the fiber and
+            // rethrows, so a write placed after the try would not run for it.
+            fiber.SourceNode = node;
 
             try
             {

--- a/Packages/com.velvet.core/Runtime/Component/ComponentRegistry.cs
+++ b/Packages/com.velvet.core/Runtime/Component/ComponentRegistry.cs
@@ -157,6 +157,7 @@ namespace Velvet
             // the latest props; sync Body so the next render sees the current values.
             existingFiber.Body = node.Body;
             existingFiber.SourceNode = node;
+            existingFiber.SourceNodeEpoch = (site.Anchor as ComponentFiber)?.TreeEpoch ?? 0;
             // Only a memoized component bails a parent-driven re-render on
             // shallow-equal props. A plain component re-renders whenever its parent does, so the
             // props-equality bail is gated on opt-in memoization. Memoization is opted into either by
@@ -222,6 +223,7 @@ namespace Velvet
             // Written before the mount: the FiberSuspendSignal arm below registers the fiber and
             // rethrows, so a write placed after the try would not run for it.
             fiber.SourceNode = node;
+            fiber.SourceNodeEpoch = (site.Anchor as ComponentFiber)?.TreeEpoch ?? 0;
 
             try
             {

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/ContextReRenderTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/ContextReRenderTests.cs
@@ -22,6 +22,8 @@ namespace Velvet.Tests
     /// default rather than throwing or reading a stale value.</item>
     /// <item>When a Provider value changes, a consumer that reads it via UseContext re-renders and observes
     /// the new value — including when the consumer sits behind a memoized subtree.</item>
+    /// <item>A consumer that re-renders on its own setState AFTER such a change reads the value the
+    /// Provider holds then, not the one it held when the consumer mounted.</item>
     /// <item>A plain (non-memoized) sibling re-renders because its parent re-rendered, since the
     /// props-equality bail is an opt-in gate a plain sibling does not have; a memoized sibling that does not
     /// read the context with unchanged props is neither re-rendered by the props bail nor spuriously
@@ -32,7 +34,7 @@ namespace Velvet.Tests
     /// Uses the <c>[Component] static VNode</c> + <c>V.Mount</c> + static-field exposure pattern. Each
     /// isolated-re-render consumer exposes a local-state bumper that triggers an isolated re-render and
     /// records the value it last read from context. The live-tracking parents each expose a setter over the
-    /// Provider value itself; four parent variants exist and each test mounts exactly one, so sharing the
+    /// Provider value itself; five parent variants exist and each test mounts exactly one, so sharing the
     /// <c>Action&lt;string&gt;</c> setter across parents is safe. Static fields are reset in <see cref="SetUp"/>.
     /// </remarks>
     [TestFixture]
@@ -290,6 +292,48 @@ namespace Velvet.Tests
             // Assert
             Assert.That(s_nonConsumerRenderCount, Is.EqualTo(nonConsumerRenderCountAtStart + 1),
                 "A plain sibling re-renders because its parent re-rendered, lacking the opt-in props bail");
+        }
+
+        // The consumer's own setState is taken AFTER the Provider's value has moved, so the spine rebuilds
+        // the enclosing Providers once more with nothing having changed since. A rebuild that read a copy
+        // of the enclosing values taken when the consumer mounted would answer with the mount-time value
+        // here; reading the ancestor's committed tree answers with the value it holds now.
+        // GREEN_ON_BASE(characterization): the base reads that committed tree already and answers
+        // "changed". What the case pins is what a mount-time snapshot of the enclosing Providers would
+        // cost, which the change keeps by going on reading the tree.
+        [Test]
+        public void Given_AProviderValueChangedAfterMount_When_TheConsumerReRendersOnItsOwnSetState_Then_ItReadsTheChangedValue()
+        {
+            // Arrange
+            using var mounted = V.Mount(_root, V.Component(SettableProviderSelfBumpingHostRender, key: "host"));
+            var atMount = s_consumerLastSeen;
+            s_parentSetValue.Invoke("changed");
+            mounted.FlushStateForTest();
+            var afterChange = s_consumerLastSeen;
+            var rendersBeforeBump = s_consumerRenderCount;
+
+            // Act
+            s_consumerBump.Invoke(1);
+            mounted.FlushStateForTest();
+
+            // Assert — the two earlier readings are folded in because "changed" below is vacuous without
+            // them: it is also what a Provider that never moved off that value would report. The render
+            // count is folded in on the other side, because a consumer that did not re-render on its own
+            // setState would still be holding the value its last render read.
+            Assert.That(
+                (atMount, afterChange, s_consumerLastSeen, s_consumerRenderCount > rendersBeforeBump),
+                Is.EqualTo(("initial", "changed", "changed", true)));
+        }
+
+        [Component]
+        private static VNode SettableProviderSelfBumpingHostRender()
+        {
+            var (value, setValue) = Hooks.UseState("initial");
+            s_parentSetValue = setValue;
+            return V.Provider(ThemeContext, value, new VNode[]
+            {
+                V.Component(SelfBumpingConsumerRender, key: "consumer"),
+            });
         }
 
         [Test]

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/FunctionalComponentErrorTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/FunctionalComponentErrorTests.cs
@@ -24,6 +24,8 @@ namespace Velvet.Tests
     /// <item>A fallback factory receives the original exception thrown by the child, and when it also takes an
     /// <see cref="ErrorInfo"/> it sees a component stack that lists the throwing fiber first and walks up
     /// through ancestors to the catching boundary.</item>
+    /// <item>A boundary catching in a pass that is re-rendering a sibling component in the same host does not
+    /// leave that sibling's re-render dereferencing the reconciler its own disposal cleared.</item>
     /// </list>
     /// </summary>
     /// <remarks>
@@ -225,6 +227,67 @@ namespace Velvet.Tests
             s_errorInfoLastException = null;
             s_errorInfoLastInfo = null;
         }
+
+        #region Sibling re-render across a caught pass
+
+        private static bool s_siblingCascadeThrows;
+        private static StateUpdater<int> s_setCascadeTick;
+
+        [Component]
+        private static VNode CascadeSiblingRender()
+        {
+            var (n, _) = Hooks.UseState(0);
+            return V.Label(name: "cascade-sibling", text: n.ToString());
+        }
+
+        [Component]
+        private static VNode CascadeThrowerRender()
+        {
+            if (s_siblingCascadeThrows) throw new InvalidOperationException("cascade");
+            return V.Label(name: "cascade-ok", text: "ok");
+        }
+
+        [Component(IsErrorBoundary = true)]
+        private static VNode CascadeBoundaryRender()
+        {
+            Hooks.UseFallback(ex => V.Label(name: "cascade-fallback", text: "fallback"));
+            return V.Component(CascadeThrowerRender, key: "cascade-thrower");
+        }
+
+        // The sibling is re-rendered inline by the host's pass — a plain component re-renders whenever its
+        // parent does — and the boundary catches later in that same pass. The catch disposes fibers, which
+        // clears the reconciler the sibling's in-flight inline render is still holding.
+        [Component]
+        private static VNode CascadeHostRender()
+        {
+            var (tick, setTick) = Hooks.UseState(0);
+            s_setCascadeTick = setTick;
+            return V.Div(name: "cascade-shell", children: new VNode?[]
+            {
+                V.Label(name: "cascade-tick", text: tick.ToString()),
+                V.Component(CascadeSiblingRender, key: "cascade-sibling"),
+                V.Component(CascadeBoundaryRender, key: "cascade-boundary"),
+            });
+        }
+
+        [Test]
+        public void Given_ASiblingReRenderingInThePassABoundaryCatchesIn_When_TheHostReRenders_Then_TheFallbackRendersWithoutADereferenceOfTheClearedReconciler()
+        {
+            // Arrange
+            s_siblingCascadeThrows = false;
+            using var mounted = V.Mount(_root, V.Component(CascadeHostRender, key: "cascade-host"));
+
+            // Act
+            s_siblingCascadeThrows = true;
+            s_setCascadeTick.Invoke(1);
+            mounted.FlushStateForTest();
+
+            // Assert — the fallback element is what says the pass completed; an unhandled NullReferenceException
+            // log fails the case on its own, which is the reading this exists for.
+            Assert.That(_root.Q<Label>("cascade-fallback"), Is.Not.Null);
+        }
+
+        #endregion
 
         [Component(IsErrorBoundary = true)]
         private static VNode ErrorInfoCaptureEbRender()

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/FunctionalComponentErrorTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/FunctionalComponentErrorTests.cs
@@ -24,8 +24,6 @@ namespace Velvet.Tests
     /// <item>A fallback factory receives the original exception thrown by the child, and when it also takes an
     /// <see cref="ErrorInfo"/> it sees a component stack that lists the throwing fiber first and walks up
     /// through ancestors to the catching boundary.</item>
-    /// <item>A boundary catching in a pass that is re-rendering a sibling component in the same host does not
-    /// leave that sibling's re-render dereferencing the reconciler its own disposal cleared.</item>
     /// </list>
     /// </summary>
     /// <remarks>
@@ -227,67 +225,6 @@ namespace Velvet.Tests
             s_errorInfoLastException = null;
             s_errorInfoLastInfo = null;
         }
-
-        #region Sibling re-render across a caught pass
-
-        private static bool s_siblingCascadeThrows;
-        private static StateUpdater<int> s_setCascadeTick;
-
-        [Component]
-        private static VNode CascadeSiblingRender()
-        {
-            var (n, _) = Hooks.UseState(0);
-            return V.Label(name: "cascade-sibling", text: n.ToString());
-        }
-
-        [Component]
-        private static VNode CascadeThrowerRender()
-        {
-            if (s_siblingCascadeThrows) throw new InvalidOperationException("cascade");
-            return V.Label(name: "cascade-ok", text: "ok");
-        }
-
-        [Component(IsErrorBoundary = true)]
-        private static VNode CascadeBoundaryRender()
-        {
-            Hooks.UseFallback(ex => V.Label(name: "cascade-fallback", text: "fallback"));
-            return V.Component(CascadeThrowerRender, key: "cascade-thrower");
-        }
-
-        // The sibling is re-rendered inline by the host's pass — a plain component re-renders whenever its
-        // parent does — and the boundary catches later in that same pass. The catch disposes fibers, which
-        // clears the reconciler the sibling's in-flight inline render is still holding.
-        [Component]
-        private static VNode CascadeHostRender()
-        {
-            var (tick, setTick) = Hooks.UseState(0);
-            s_setCascadeTick = setTick;
-            return V.Div(name: "cascade-shell", children: new VNode?[]
-            {
-                V.Label(name: "cascade-tick", text: tick.ToString()),
-                V.Component(CascadeSiblingRender, key: "cascade-sibling"),
-                V.Component(CascadeBoundaryRender, key: "cascade-boundary"),
-            });
-        }
-
-        [Test]
-        public void Given_ASiblingReRenderingInThePassABoundaryCatchesIn_When_TheHostReRenders_Then_TheFallbackRendersWithoutADereferenceOfTheClearedReconciler()
-        {
-            // Arrange
-            s_siblingCascadeThrows = false;
-            using var mounted = V.Mount(_root, V.Component(CascadeHostRender, key: "cascade-host"));
-
-            // Act
-            s_siblingCascadeThrows = true;
-            s_setCascadeTick.Invoke(1);
-            mounted.FlushStateForTest();
-
-            // Assert — the fallback element is what says the pass completed; an unhandled NullReferenceException
-            // log fails the case on its own, which is the reading this exists for.
-            Assert.That(_root.Q<Label>("cascade-fallback"), Is.Not.Null);
-        }
-
-        #endregion
 
         [Component(IsErrorBoundary = true)]
         private static VNode ErrorInfoCaptureEbRender()

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/PortalContextInheritanceTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/PortalContextInheritanceTests.cs
@@ -42,6 +42,7 @@ namespace Velvet.Tests
 
         private static string s_lastSeen;
         private static StateUpdater<int> s_setCount;
+        private static StateUpdater<int> s_setHostTick;
 
         [Test]
         public void Given_ProviderAbovePortal_When_ChildMounts_Then_ReadsProvidedValue()
@@ -80,6 +81,39 @@ namespace Velvet.Tests
             // Assert: the spine rebuilds the enclosing Provider for the isolated re-render.
             Assert.That(s_lastSeen, Is.EqualTo("provided"),
                 "An isolated re-render of a portal child reconstructs the context enclosing the Portal's tree position");
+        }
+
+        // The Provider sits INSIDE the Portal's children, which is the layer the enclosing snapshot does
+        // not carry — FiberContextSpine recovers it by walking DetachedMountContext.DescendantNodes. The
+        // host re-renders between the mount and the child's own setState: a drain stamps only the fibers
+        // it newly created, so a child that survives that re-render keeps the DescendantNodes captured at
+        // its mount while the declaring body's next render builds fresh nodes for the same positions.
+        // GREEN_ON_BASE(characterization): the base reads the in-portal Provider here and this must keep
+        // it. The node comparison this change adds is what an ungated form breaks: it would weigh a node
+        // the drain stamped once against a record every patch rewrites, and read the context default
+        // from the declaring component's second render onward.
+        [Test]
+        public void Given_AProviderInsideThePortal_When_TheHostReRendersAndThenTheChildReRendersAlone_Then_ItStillReadsTheInPortalValue()
+        {
+            // Arrange
+            using var mounted = V.Mount(_root, V.Component(InPortalProviderHostRender, key: "host"));
+            var atMount = s_lastSeen;
+            s_setHostTick.Invoke(1);
+            mounted.FlushStateForTest();
+            var afterHostRender = s_lastSeen;
+
+            // Act
+            s_lastSeen = null;
+            s_setCount.Invoke(1);
+            mounted.FlushStateForTest();
+
+            // Assert — the two earlier readings are folded in because they are what put a wrong value
+            // below on the isolated re-render rather than on the mount or on the host's own pass; and the
+            // field is cleared first so a consumer that did not re-render at all reads as null rather
+            // than as the value its previous render left.
+            Assert.That(
+                (atMount, afterHostRender, s_lastSeen),
+                Is.EqualTo(("inside", "inside", "inside")));
         }
 
         [Test]
@@ -153,6 +187,26 @@ namespace Velvet.Tests
                     V.Component(RerenderConsumerRender, key: "consumer"),
                 }),
             });
+
+        // A tick the host renders is what makes its re-render build a fresh tree rather than bail, so the
+        // portal's children on the second pass are new node instances at the same positions.
+        [Component]
+        private static VNode InPortalProviderHostRender()
+        {
+            var (tick, setTick) = Hooks.UseState(0);
+            s_setHostTick = setTick;
+            return V.Div(name: "shell", children: new VNode?[]
+            {
+                V.Label(name: "tick", text: tick.ToString()),
+                V.Portal("ctx-portal-target", children: new VNode?[]
+                {
+                    V.Provider(ThemeContext, "inside", new VNode[]
+                    {
+                        V.Component(RerenderConsumerRender, key: "consumer"),
+                    }),
+                }),
+            });
+        }
 
         [Component]
         private static VNode RerenderMotionConsumerRender()

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/ProviderErrorBoundaryNestedConsumerTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/ProviderErrorBoundaryNestedConsumerTests.cs
@@ -17,6 +17,9 @@ namespace Velvet.Tests
     /// inner Provider value is the one the consumer reads.</item>
     /// <item>Because the value resolves, the consumer does not throw, so the boundary's fallback never fires
     /// and the consumer's own label renders.</item>
+    /// <item>A consumer that is a SIBLING of the boundary rather than inside it keeps its Provider across a
+    /// render the boundary caught in: the host's render is discarded, so the consumer's own re-render after
+    /// it rebuilds its context from the tree the host committed before the throw.</item>
     /// </list>
     /// </summary>
     /// <remarks>
@@ -146,6 +149,90 @@ namespace Velvet.Tests
             }
             return V.Label(name: "inner-value-label", text: value);
         }
+
+        #region Consumer as a sibling of the boundary, across a caught render
+
+        private static readonly ComponentContext<string> SiblingContext =
+            ComponentContext<string>.Create("DEFAULT");
+        private static string s_siblingSeen;
+        private static int s_siblingCount;
+        private static bool s_siblingThrows;
+        private static StateUpdater<int> s_setSiblingTick;
+        private static StateUpdater<int> s_setSiblingCount;
+
+        [Component]
+        private static VNode SiblingConsumerRender()
+        {
+            var (n, setN) = Hooks.UseState(0);
+            s_setSiblingCount = setN;
+            s_siblingCount = n;
+            s_siblingSeen = Hooks.UseContext(SiblingContext);
+            return V.Label(name: "sibling-value", text: $"{s_siblingSeen}:{n}");
+        }
+
+        [Component(IsErrorBoundary = true)]
+        private static VNode SiblingBoundaryRender()
+        {
+            Hooks.UseFallback(ex =>
+            {
+                s_fallbackInvoked = true;
+                return V.Label(name: "sibling-fallback", text: "fallback");
+            });
+            return V.Component(SiblingThrowerRender, key: "sibling-thrower");
+        }
+
+        [Component]
+        private static VNode SiblingThrowerRender()
+        {
+            if (s_siblingThrows) throw new InvalidOperationException("thrower");
+            return V.Label(name: "thrower", text: "ok");
+        }
+
+        // The consumer and the boundary are siblings under one host, so the host's render reaches the
+        // consumer BEFORE the boundary catches. The host's output for that render is discarded, and what
+        // the consumer's own re-render afterwards has to rebuild its context from is the tree the host
+        // committed before the throw.
+        [Component]
+        private static VNode SiblingBoundaryHostRender()
+        {
+            var (tick, setTick) = Hooks.UseState(0);
+            s_setSiblingTick = setTick;
+            return V.Div(name: "sibling-shell", children: new VNode?[]
+            {
+                V.Label(name: "tick", text: tick.ToString()),
+                V.Provider(SiblingContext, "v" + tick, new VNode[]
+                {
+                    V.Component(SiblingConsumerRender, key: "sibling-consumer"),
+                }),
+                V.Component(SiblingBoundaryRender, key: "sibling-boundary"),
+            });
+        }
+
+        [Test]
+        public void Given_AConsumerBesideAnErrorBoundary_When_TheHostsRenderIsCaughtAndTheConsumerThenReRendersAlone_Then_ItStillReadsItsProvider()
+        {
+            // Arrange
+            s_siblingThrows = false;
+            using var mounted = V.Mount(_root, V.Component(SiblingBoundaryHostRender, key: "sibling-host"));
+            var atMount = s_siblingSeen;
+
+            // Act — the host re-renders, the boundary catches inside that pass, and the consumer then
+            // re-renders on its own setState.
+            s_siblingThrows = true;
+            s_setSiblingTick.Invoke(1);
+            mounted.FlushStateForTest();
+            s_setSiblingCount.Invoke(1);
+            mounted.FlushStateForTest();
+
+            // Assert — the consumer's own state is folded in because it is what separates a failed context
+            // rebuild from a remount that would have reset it, and the mount reading because the value
+            // below is not a Provider this position never had.
+            Assert.That(
+                (atMount, s_siblingSeen, s_siblingCount),
+                Is.EqualTo(("v0", "v0", 1)));
+        }
+
+        #endregion
 
         private static VNode BuildFallback(Exception ex)
         {

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/ProviderErrorBoundaryNestedConsumerTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/ProviderErrorBoundaryNestedConsumerTests.cs
@@ -191,7 +191,9 @@ namespace Velvet.Tests
         // The consumer and the boundary are siblings under one host, so the host's render reaches the
         // consumer BEFORE the boundary catches. The host's output for that render is discarded, and what
         // the consumer's own re-render afterwards has to rebuild its context from is the tree the host
-        // committed before the throw.
+        // committed before the throw. This arrangement also drives the boundary through the subsumed
+        // render whose disposal clears the reconciler, so an unhandled NullReferenceException from that
+        // path fails this case as well.
         [Component]
         private static VNode SiblingBoundaryHostRender()
         {

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberCommitWork.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberCommitWork.cs
@@ -133,6 +133,12 @@ namespace Velvet
             ComponentFiber fiber, VNode?[] oldTree, VNode?[] newTree, double frameBudgetMs, bool deferReconcile)
         {
             var slotStart = fiber.IsInlineMounted ? fiber.MountSlotStart : 0;
+            // The array this reconcile is expanding, for the children it stamps on the way through.
+            var treeContext = fiber.Reconciler?.Context;
+            var enclosingFiberTree = treeContext?.CurrentFiberTree;
+            if (treeContext != null) treeContext.CurrentFiberTree = newTree;
+            try
+            {
             if (!deferReconcile)
             {
                 // For inline-mounted fibers, the slot footprint is the *expanded* DOM count —
@@ -157,6 +163,11 @@ namespace Velvet
                 {
                     fiber.Reconciler!.Reconcile(fiber.MountPoint, oldTree, newTree, frameBudgetMs, slotStart);
                 }
+            }
+            }
+            finally
+            {
+                if (treeContext != null) treeContext.CurrentFiberTree = enclosingFiberTree;
             }
         }
 

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberContextSpine.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberContextSpine.cs
@@ -59,9 +59,17 @@ namespace Velvet
             // Both are therefore constants of one edge rather than readings of where the descent has
             // got to, so the key resolves SpineChild at every container holding the same position and
             // cannot say which of them the walk is in. MatchesInlineSpineChild separates them by the
-            // node instead.
+            // node instead, where WalksCommittedTree says that node can be compared. Two occurrences a
+            // declaring body builds from one shared node instance are one node, so those stay
+            // unseparated and the walk still takes the first.
             internal VisualElement? PortalScope { get; init; }
             internal VisualElement? Container { get; init; }
+
+            // Whether the nodes being walked are Ancestor's current PreviousTree. False for a detached
+            // mount's captured DescendantNodes, which is stamped onto a fiber only on the drain that
+            // created it — so after the declaring body renders again that array still holds the nodes
+            // of the render that captured it, which ComponentFiber.SourceNode no longer names.
+            internal bool WalksCommittedTree { get; init; }
         }
 
         // Pushes the Provider values that enclose target onto the live cursor and
@@ -142,6 +150,7 @@ namespace Velvet
                             IsInlineSpineChild = true,
                             PortalScope = detachedScope,
                             Container = detachedContainer,
+                            WalksCommittedTree = false,
                         };
                         PushEnclosingProviders(
                             detached.DescendantNodes, FiberKeying.WalkRoot, in detachedWalk);
@@ -166,6 +175,7 @@ namespace Velvet
                     IsInlineSpineChild = isInline,
                     PortalScope = childScope,
                     Container = childContainer,
+                    WalksCommittedTree = true,
                 };
                 PushEnclosingProviders(tree, FiberKeying.WalkRoot, in walk);
             }
@@ -347,7 +357,7 @@ namespace Velvet
             int nodeIndex,
             in SpineWalk walk)
         {
-            if (!ReferenceEquals(component, walk.SpineChild.SourceNode)) return false;
+            if (walk.WalksCommittedTree && !ReferenceEquals(component, walk.SpineChild.SourceNode)) return false;
             var registry = walk.Registry;
             var identity = component.ResolvedIdentity;
             var slotKey = component.Key ?? FiberKeying.ResolveInlinePositionKey(

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberContextSpine.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberContextSpine.cs
@@ -57,18 +57,9 @@ namespace Velvet
             // The Portal scope and container members of SpineChild's own registration key, read back
             // from the registry rather than derived here — ComponentRegistry.TryGetInlineKey owns why.
             // Both are therefore constants of one edge rather than readings of where the descent has
-            // got to, and Container being one is a known hole rather than a closed question: two
-            // containers holding the same position resolve the same fiber, so the match below fires at
-            // whichever the committed tree reaches first and the Providers pushed are that one's — a
-            // stranger's value where that container carries one, and none at all where it does not, so
-            // an instance can equally lose the Provider it is written inside. MotionContext.ActiveLabel
-            // is pushed through the same mechanism by PushMotionSubtree, so a descendant of the second
-            // of two sibling Motions animates to the first one's label. All three readings are pinned
-            // in ComponentContainerIdentityTests. Closing it by making this a reading of the descent needs
-            // the container it is currently inside, which means resolving each element node to the
-            // element it committed — the emitted-leaf coordinate GeneralPathReconciler.CommitLeaf owns,
-            // reproduced in a second walker that FiberKeying's header requires to stay in lockstep with
-            // the first.
+            // got to, so the key resolves SpineChild at every container holding the same position and
+            // cannot say which of them the walk is in. MatchesInlineSpineChild separates them by the
+            // node instead.
             internal VisualElement? PortalScope { get; init; }
             internal VisualElement? Container { get; init; }
         }
@@ -356,6 +347,7 @@ namespace Velvet
             int nodeIndex,
             in SpineWalk walk)
         {
+            if (!ReferenceEquals(component, walk.SpineChild.SourceNode)) return false;
             var registry = walk.Registry;
             var identity = component.ResolvedIdentity;
             var slotKey = component.Key ?? FiberKeying.ResolveInlinePositionKey(

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberContextSpine.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberContextSpine.cs
@@ -21,9 +21,10 @@ namespace Velvet
     // ComponentNode's position key is its slot in the child array it sits in under that array's
     // WalkPosition, Fragment/Provider extend the current position, an element node opens a fresh walk
     // for its children, and a Memo resolves to its committed inner.
-    // The match against the registry's key is what lets the reconstruction recognize the spine
-    // child without re-rendering. Both walkers derive every key
-    // through FiberKeying so the two stay in lockstep by construction.
+    // The registry's key narrows the reconstruction to the positions this fiber could occupy; it does
+    // not on its own name which one, since it answers at every container holding that position.
+    // MatchesInlineSpineChild owns what separates them. Both walkers derive every key through
+    // FiberKeying so the two stay in lockstep by construction.
     internal readonly struct FiberContextSpine
     {
         private readonly ComponentContextStack _stack;
@@ -357,7 +358,12 @@ namespace Velvet
             int nodeIndex,
             in SpineWalk walk)
         {
-            if (walk.WalksCommittedTree && !ReferenceEquals(component, walk.SpineChild.SourceNode)) return false;
+            if (walk.WalksCommittedTree
+                && walk.SpineChild.SourceNodeEpoch == walk.Ancestor.TreeEpoch
+                && !ReferenceEquals(component, walk.SpineChild.SourceNode))
+            {
+                return false;
+            }
             var registry = walk.Registry;
             var identity = component.ResolvedIdentity;
             var slotKey = component.Key ?? FiberKeying.ResolveInlinePositionKey(

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberContextSpine.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberContextSpine.cs
@@ -359,7 +359,7 @@ namespace Velvet
             in SpineWalk walk)
         {
             if (walk.WalksCommittedTree
-                && walk.SpineChild.SourceNodeEpoch == walk.Ancestor.TreeEpoch
+                && ReferenceEquals(walk.SpineChild.SourceTree, walk.Ancestor.PreviousTree)
                 && !ReferenceEquals(component, walk.SpineChild.SourceNode))
             {
                 return false;

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberRenderer.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberRenderer.cs
@@ -122,9 +122,8 @@ namespace Velvet
             RenderAndReconcile(fiber, deferReconcile: true);
             // The render above can dispose this fiber, which nulls Reconciler — RenderAndReconcile's own
             // post-render arm reads the field for that same reason and names the cascade that does it.
-            // There is then no pass left to subsume into: the three steps below would queue a layout
-            // effect and a paint-tick effect against a disposed fiber and re-enrol lanes the unmount
-            // has already cleared, along with the batch-scheduler entry it already dropped.
+            // There is then no pass left to subsume into: the two effect queues below would stage a layout
+            // effect and a paint-tick effect against a disposed fiber.
             var subsumedReconciler = fiber.Reconciler;
             if (subsumedReconciler == null) return;
             // Update commit: drain side runs prior cleanup + new setup (deps-comparing) without

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberRenderer.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberRenderer.cs
@@ -352,6 +352,7 @@ namespace Velvet
             fiber.DetachedMountContext = null;
 
             fiber.PreviousTree = null;
+            fiber.SourceNode = null;
             fiber.Reconciler?.Context.ParkedBaselineFibers.Remove(fiber);
             // Detach the parked baseline BEFORE the sweep — the mark treats owner.PendingOldTree as
             // live, and a still-attached reference would spare this very sweep's target.

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberRenderer.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberRenderer.cs
@@ -477,6 +477,11 @@ namespace Velvet
 
                 if (fiber.Reconciler?.HasPendingWork == true)
                 {
+                    // This resume runs outside the bracket FiberWorkLoop.ContinueReconcile puts around its
+                    // own, so it stamps the children it reaches against whatever array the caller left
+                    // current rather than against this fiber's. The ReconcileIntoSlotRange below supersedes
+                    // those stamps for every child its own diff reaches, and the two must stay in this
+                    // order — ComponentFiber.SourceTree owns what a stamp left from the wrong pass costs.
                     FiberCommitWork.DrainPendingWork(fiber);
                 }
 

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberRenderer.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberRenderer.cs
@@ -360,7 +360,7 @@ namespace Velvet
 
             fiber.PreviousTree = null;
             fiber.SourceNode = null;
-            fiber.SourceNodeEpoch = 0;
+            fiber.SourceTree = null;
             fiber.Reconciler?.Context.ParkedBaselineFibers.Remove(fiber);
             // Detach the parked baseline BEFORE the sweep — the mark treats owner.PendingOldTree as
             // live, and a still-attached reference would spare this very sweep's target.
@@ -509,11 +509,6 @@ namespace Velvet
                     // retained PreviousTree baseline and must keep its pooled parts.
                     FiberTreeReturn.ReturnRetiredTree(newTree, fiber);
                     FiberCommitWork.ReturnSupersededParkedBaseline(fiber, prevPendingOldTree, oldTree);
-                    // ReconcileIntoSlotRange above already wrote this render's nodes onto the child fibers
-                    // it reached, and PreviousTree is about to stay at the previous render's tree. Moving
-                    // the epoch is what stops those children being compared against a tree that never
-                    // held them — ComponentFiber.TreeEpoch owns the pairing.
-                    fiber.TreeEpoch++;
                 }
                 else
                 {
@@ -536,9 +531,6 @@ namespace Velvet
             }
             catch (Exception ex)
             {
-                // Same pairing as the discard arm above: a throw out of ReconcileIntoSlotRange leaves
-                // children carrying this render's nodes while PreviousTree keeps the previous render's.
-                fiber.TreeEpoch++;
                 FiberCommitWork.ReturnSupersededParkedBaseline(fiber, prevPendingOldTree, oldTree);
                 if (fiber.PendingOldTree != null)
                 {

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberRenderer.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberRenderer.cs
@@ -120,10 +120,17 @@ namespace Velvet
             }
             fiber.OpenSubsumedRenderWindow();
             RenderAndReconcile(fiber, deferReconcile: true);
+            // The render above can dispose this fiber, which nulls Reconciler — RenderAndReconcile's own
+            // post-render arm reads the field for that same reason and names the cascade that does it.
+            // There is then no pass left to subsume into: the three steps below would queue a layout
+            // effect and a paint-tick effect against a disposed fiber and re-enrol lanes the unmount
+            // has already cleared, along with the batch-scheduler entry it already dropped.
+            var subsumedReconciler = fiber.Reconciler;
+            if (subsumedReconciler == null) return;
             // Update commit: drain side runs prior cleanup + new setup (deps-comparing) without
             // the Editor-only mount double-invoke. ScheduleRunEffects forwards the same flag so the
             // passive (UseEffect) cleanup+setup pair fires at the next paint-tick.
-            fiber.Reconciler!.Context.DeferredInlineLayoutEffectFibers.Push((fiber, IsMount: false));
+            subsumedReconciler.Context.DeferredInlineLayoutEffectFibers.Push((fiber, IsMount: false));
             FiberEffects.ScheduleRunEffects(fiber, mountDoubleInvoke: false);
             SettleSubsumedFiber(fiber);
         }
@@ -353,6 +360,7 @@ namespace Velvet
 
             fiber.PreviousTree = null;
             fiber.SourceNode = null;
+            fiber.SourceNodeEpoch = 0;
             fiber.Reconciler?.Context.ParkedBaselineFibers.Remove(fiber);
             // Detach the parked baseline BEFORE the sweep — the mark treats owner.PendingOldTree as
             // live, and a still-attached reference would spare this very sweep's target.
@@ -501,6 +509,11 @@ namespace Velvet
                     // retained PreviousTree baseline and must keep its pooled parts.
                     FiberTreeReturn.ReturnRetiredTree(newTree, fiber);
                     FiberCommitWork.ReturnSupersededParkedBaseline(fiber, prevPendingOldTree, oldTree);
+                    // ReconcileIntoSlotRange above already wrote this render's nodes onto the child fibers
+                    // it reached, and PreviousTree is about to stay at the previous render's tree. Moving
+                    // the epoch is what stops those children being compared against a tree that never
+                    // held them — ComponentFiber.TreeEpoch owns the pairing.
+                    fiber.TreeEpoch++;
                 }
                 else
                 {
@@ -523,6 +536,9 @@ namespace Velvet
             }
             catch (Exception ex)
             {
+                // Same pairing as the discard arm above: a throw out of ReconcileIntoSlotRange leaves
+                // children carrying this render's nodes while PreviousTree keeps the previous render's.
+                fiber.TreeEpoch++;
                 FiberCommitWork.ReturnSupersededParkedBaseline(fiber, prevPendingOldTree, oldTree);
                 if (fiber.PendingOldTree != null)
                 {

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberWorkLoop.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberWorkLoop.cs
@@ -422,6 +422,13 @@ namespace Velvet
                 // the same way the pass that parked it did — see PendingReconcileDrainsTransitionWork.
                 var wasRenderingTransitionLane = IsRenderingTransitionLane;
                 IsRenderingTransitionLane = fiber.PendingReconcileDrainsTransitionWork;
+                // A resume continues the pass whose output is already this fiber's PreviousTree, so the
+                // children it reaches are stamped against that array exactly as the slice that parked
+                // stamped the ones it reached. Without it they are stamped against nothing, and
+                // ComponentFiber.SourceTree owns what that costs them.
+                var resumeContext = fiber.Reconciler.Context;
+                var enclosingFiberTree = resumeContext.CurrentFiberTree;
+                resumeContext.CurrentFiberTree = fiber.PreviousTree;
                 try
                 {
                     if (fiber.IsInlineMounted)
@@ -444,6 +451,7 @@ namespace Velvet
                 }
                 finally
                 {
+                    resumeContext.CurrentFiberTree = enclosingFiberTree;
                     IsRenderingTransitionLane = wasRenderingTransitionLane;
                 }
 

--- a/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/GeneralPathReconciler.cs
@@ -838,6 +838,10 @@ namespace Velvet
             if (fiber.PreviousTree == null || fiber.PreviousTree.Length == 0) return;
 
             _ctx.FiberStack.Push(fiber);
+            // Moved with the FiberStack push, for the same reason: what this descent stamps onto its children
+            // belongs to THIS fiber's output, not the outer caller's.
+            var enclosingFiberTree = _ctx.CurrentFiberTree;
+            _ctx.CurrentFiberTree = fiber.PreviousTree;
             try
             {
                 var componentPosition = FiberKeying.ComponentChild(position, component.Key, nodeIndex);
@@ -845,6 +849,7 @@ namespace Velvet
             }
             finally
             {
+                _ctx.CurrentFiberTree = enclosingFiberTree;
                 _ctx.FiberStack.Pop();
             }
         }

--- a/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/ReconcilerContext.cs
@@ -1008,6 +1008,13 @@ namespace Velvet
         // styling toggling the class via className props.
         public HashSet<VisualElement> OutletContainers { get; } = new();
 
+        // The node array being expanded for the fiber on top of FiberStack, which is the array whose nodes a
+        // GetOrCreate reached from here is stamping onto its children. Set where a fiber's own output enters
+        // the reconcile and where a nested fiber's committed output is descended, and restored after both, so
+        // an expansion nested inside either reads the array of the fiber it belongs to rather than the outer
+        // one. ComponentFiber.SourceTree owns what reads it.
+        internal VNode?[]? CurrentFiberTree { get; set; }
+
         // Effective key override published by the expansion pass for VNodes whose identity is gated
         // by an enclosing keyed FragmentNode. The keyed reconciler reads this map (via
         // ChildReconciler.EffectiveKey) instead of VNode.Key when looking up

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ComponentContainerIdentityTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ComponentContainerIdentityTests.cs
@@ -27,12 +27,15 @@ namespace Velvet.Tests
     /// fresh instance behind there and runs the departing instance's cleanup.</item>
     /// <item>A container returned to the primitive-element pool and rented again carries no registry entry
     /// into its next use.</item>
-    /// <item>Where two instances also share a position key, an instance's own isolated re-render reads
-    /// the Providers of the container it is written into rather than of whichever the committed tree
-    /// reaches first — both where the two containers' Providers carry one context, and where they
-    /// carry different ones, which is an instance keeping the Provider it is inside rather than
-    /// acquiring a stranger's. A <c>V.Motion</c>'s active label travels the same path and reads the
-    /// same way. All three are pinned here.</item>
+    /// <item>Where two instances also share a position key, and the declaring body writes each into its
+    /// container as its own occurrence, an instance's own isolated re-render reads the Providers of the
+    /// container it is written into rather than of whichever the committed tree reaches first — both
+    /// where the two containers' Providers carry one context, and where they carry different ones, which
+    /// is an instance keeping the Provider it is inside rather than acquiring a stranger's. A
+    /// <c>V.Motion</c>'s active label travels the same path and reads the same way. All three are pinned
+    /// here. Shapes the qualifier excludes read as they did before it, among them: one node instance
+    /// written into both containers, a consumer inside a <c>V.Portal</c> or a <c>V.VirtualList</c> item,
+    /// a wrapper-mounted Outlet child, and a row a time-sliced pass parked before reaching.</item>
     /// </list>
     /// <see cref="PortalChildFiberContinuityTests"/> owns the portal-scope member of the same key, and
     /// holds the shape where a shared container leaves that member the only thing separating two

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ComponentContainerIdentityTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/ComponentContainerIdentityTests.cs
@@ -27,13 +27,12 @@ namespace Velvet.Tests
     /// fresh instance behind there and runs the departing instance's cleanup.</item>
     /// <item>A container returned to the primitive-element pool and rented again carries no registry entry
     /// into its next use.</item>
-    /// <item>What the separation does NOT reach: where two instances also share a position key, an
-    /// instance's own isolated re-render reads the Providers of whichever container the committed tree
-    /// reaches first, because the spine that rebuilds its context cannot tell the containers apart. That
-    /// is a value from elsewhere where the two Providers carry the same context, and the context default
-    /// where the other container's carries a different one — so an instance can lose the Provider it is
-    /// written inside. A <c>V.Motion</c>'s active label travels the same path and reads the same way. All
-    /// three are pinned here.</item>
+    /// <item>Where two instances also share a position key, an instance's own isolated re-render reads
+    /// the Providers of the container it is written into rather than of whichever the committed tree
+    /// reaches first — both where the two containers' Providers carry one context, and where they
+    /// carry different ones, which is an instance keeping the Provider it is inside rather than
+    /// acquiring a stranger's. A <c>V.Motion</c>'s active label travels the same path and reads the
+    /// same way. All three are pinned here.</item>
     /// </list>
     /// <see cref="PortalChildFiberContinuityTests"/> owns the portal-scope member of the same key, and
     /// holds the shape where a shared container leaves that member the only thing separating two
@@ -314,15 +313,13 @@ namespace Velvet.Tests
                 }),
             });
 
-        // The separation this fixture pins reaches the reconcile and not the context spine, and the "L" in
-        // the expectation below is that gap rather than the value this position should read. The spine
-        // searches an ancestor's committed tree for the fiber it is re-rendering and resolves each
-        // candidate under that fiber's own container, so both containers answer and it stops at the first
-        // — FiberContextSpine's SpineWalk owns what closing it would cost. Whichever container the
-        // committed tree reaches first is the one whose Providers every instance of that position then
-        // reads; the instances are still separate, which is what the left container's own value says.
+        // The separation reaches the context spine as well as the reconcile: the spine searches an
+        // ancestor's committed tree for the fiber it is re-rendering and resolves each candidate under
+        // that fiber's own container, so both containers answer the key — and the node each instance
+        // answers for is what tells the two apart. Without that the walk stops at the first container
+        // and every instance of this position reads its Providers.
         [Test]
-        public void Given_TwoContainersEachWithItsOwnProvider_When_TheSecondInstanceReRendersAlone_Then_ItReadsTheFirstContainersProvider()
+        public void Given_TwoContainersEachWithItsOwnProvider_When_TheSecondInstanceReRendersAlone_Then_ItReadsItsOwnContainersProvider()
         {
             // Arrange
             var container = new VisualElement();
@@ -338,21 +335,21 @@ namespace Velvet.Tests
             s_setters[0].Invoke(5);
             _mounted.FlushStateForTest();
 
-            // Assert — the mount reading is folded in rather than assumed, because it is what says the
-            // wrong value below belongs to the spine rather than to the walk that commits these two; and
-            // the first container's own re-render, because it reads correctly either way and a single
-            // shared instance would leave it at its mount text instead of carrying 5.
+            // Assert — the mount reading is folded in rather than assumed, because it is what puts the
+            // value below on the spine rather than on the walk that commits these two; and the first
+            // container's own value, because a single instance answering for both would leave one of the
+            // two at its mount text.
             Assert.That(
                 (atMount.Item1, atMount.Item2, TextIn(left), TextIn(right)),
-                Is.EqualTo(("L:0", "R:0", "L:5", "L:7")));
+                Is.EqualTo(("L:0", "R:0", "L:5", "R:7")));
         }
 
         // The mirror of the case above: the two Providers carry DIFFERENT contexts, so the first
-        // container's supplies nothing the second container's instance reads. That instance is inside the
-        // Theme Provider and reads it at mount, and reads the context default once it re-renders alone.
-        // Both Providers sit at one position, which is what leaves the first container's instance
-        // answering to the second's key; a Provider only one of them carried would put the two instances
-        // at positions that no longer collide, and the spine would reach the right one.
+        // container's supplies nothing the second container's instance reads, and reaching the first
+        // container costs that instance the Provider it is written inside rather than handing it a
+        // stranger's value. Both Providers sit at one position, which is what makes the first
+        // container's instance answer to the second's key; a Provider only one of them carried would
+        // put the two instances at positions that no longer collide.
         [Component]
         private static VNode ProvidersOfTwoContextsPerContainerHost()
             => V.Div(name: "shell", children: new VNode?[]
@@ -367,11 +364,8 @@ namespace Velvet.Tests
                 }),
             });
 
-        // GREEN_ON_BASE(characterization): the base reads the same here, since its position key collides
-        // for two components at one index of two containers whether or not a Provider encloses them. This
-        // shape is what keeps the reading once the key stops colliding on the Provider level alone.
         [Test]
-        public void Given_TwoContainersWhoseProvidersCarryDifferentContexts_When_TheSecondInstanceReRendersAlone_Then_ItReadsTheContextDefault()
+        public void Given_TwoContainersWhoseProvidersCarryDifferentContexts_When_TheSecondInstanceReRendersAlone_Then_ItKeepsTheProviderItIsInside()
         {
             // Arrange
             var container = new VisualElement();
@@ -388,17 +382,17 @@ namespace Velvet.Tests
             _mounted.FlushStateForTest();
 
             // Assert — the mount reading is folded in because reading "R" there is what makes the value
-            // below a loss rather than a position that never had a Provider, and the first container's own
-            // value because a single instance answering for both would leave it at its mount text.
+            // below a Provider kept rather than a position that never had one, and the first container's
+            // own value because a single instance answering for both would leave one of the two at its
+            // mount text.
             Assert.That(
                 (atMount.Item1, atMount.Item2, TextIn(left), TextIn(right)),
-                Is.EqualTo(("default:0", "R:0", "default:5", "default:6")));
+                Is.EqualTo(("default:0", "R:0", "default:5", "R:6")));
         }
 
         // MotionContext.ActiveLabel reaches a descendant as a Provider does — FiberContextSpine's
         // PushMotionSubtree re-pushes it for an isolated re-render — so a Motion container is the same
-        // shape as the two above with the label in place of the context value, and the consequence is
-        // visible rather than only readable: the descendant animates to the wrong label.
+        // shape as the two above with the label in place of the context value.
         [Component]
         private static VNode LabelReader()
         {
@@ -417,7 +411,7 @@ namespace Velvet.Tests
             });
 
         [Test]
-        public void Given_TwoSiblingMotionContainersWithDifferentLabels_When_TheSecondsDescendantReRendersAlone_Then_ItReadsTheFirstsLabel()
+        public void Given_TwoSiblingMotionContainersWithDifferentLabels_When_TheSecondsDescendantReRendersAlone_Then_ItReadsItsOwnMotionsLabel()
         {
             // Arrange
             var container = new VisualElement();
@@ -434,11 +428,12 @@ namespace Velvet.Tests
             _mounted.FlushStateForTest();
 
             // Assert — the mount reading is folded in because reading "beta" there is what makes the value
-            // below the wrong label rather than one this position never had, and the first container's own
-            // value because a single instance answering for both would leave it at its mount text.
+            // below a label kept rather than one this position never had, and the first container's own
+            // value because a single instance answering for both would leave one of the two at its mount
+            // text.
             Assert.That(
                 (atMount.Item1, atMount.Item2, TextIn(left), TextIn(right)),
-                Is.EqualTo(("alpha:0", "beta:0", "alpha:5", "alpha:7")));
+                Is.EqualTo(("alpha:0", "beta:0", "alpha:5", "beta:7")));
         }
 
         // The occupant emits no poolable primitive of its own, so the only element this shape returns to

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/TimeSlicedFiberTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/TimeSlicedFiberTests.cs
@@ -28,6 +28,10 @@ namespace Velvet.Tests
     /// sibling that is itself time-sliced (its delta committed across slices), and a nested growth absorbed by a
     /// wrapper (which must NOT shift the following sibling, since propagation is scoped to the shared mount
     /// point).</item>
+    /// <item>The resume re-records every row it commits, so a row that re-renders on its own after the drain
+    /// reads its own row's Provider. Before the resume it does not: the host's output is committed while the
+    /// slice is still parked, so a row the pass never reached is looked up by key alone and answers to
+    /// whichever container the committed tree reaches first — the reading recorded here.</item>
     /// </list>
     /// </summary>
     /// <remarks>
@@ -837,6 +841,113 @@ namespace Velvet.Tests
             // A top-level Fragment of pure leaves is unwrapped to the flat array by NormalizeToArray, so the
             // fiber's own reconcile takes the time-sliceable fast path (no Component / Provider / Fragment leaf).
             return V.Fragment(children: children);
+        }
+
+        #endregion
+
+        #region Parked keyed list whose rows carry their own Provider
+
+        private static readonly ComponentContext<string> RowCtx = ComponentContext<string>.Create("DEFAULT");
+        private const int ParkRowCount = 8;
+        private static ComponentFiber s_parkListFiber;
+        private static StateUpdater<int> s_parkSetGen;
+        private static TransitionStarter s_parkStart;
+        private static readonly System.Collections.Generic.Dictionary<int, StateUpdater<int>> s_parkBumps = new();
+        private static readonly System.Collections.Generic.Dictionary<int, string> s_parkSeen = new();
+        private static readonly System.Collections.Generic.Dictionary<int, int> s_parkCount = new();
+
+        private static void ResetParkList()
+        {
+            s_parkBumps.Clear();
+            s_parkSeen.Clear();
+            s_parkCount.Clear();
+        }
+
+        private static VNode ParkRowBody(int index)
+        {
+            var (n, bump) = Hooks.UseState(0);
+            s_parkBumps[index] = bump;
+            s_parkCount[index] = n;
+            s_parkSeen[index] = Hooks.UseContext(RowCtx);
+            return V.Label(name: "park-row-" + index, text: s_parkSeen[index]);
+        }
+
+        // Each row is a keyed Div wrapping its own Provider, so the top level is plain keyed elements and the
+        // fiber's own reconcile takes the time-sliceable keyed path; the Provider and the Component sit one
+        // level down, where the Div's own ReconcileChildren reaches them only once that row is committed.
+        [Component]
+        private static VNode ParkListHost()
+        {
+            var (gen, setGen) = Hooks.UseState(0);
+            var (_, start) = Hooks.UseTransition();
+            s_parkSetGen = setGen;
+            s_parkStart = start;
+            s_parkListFiber = FiberAmbientStack.Current;
+            var children = new VNode[ParkRowCount];
+            for (var i = 0; i < ParkRowCount; i++)
+            {
+                children[i] = V.Div(key: "pk" + i, name: "park-cell-" + i, children: new VNode?[]
+                {
+                    V.Provider(RowCtx, $"g{gen}-{i}", new VNode[] { V.Component(ParkRowBody, i, key: "row") }),
+                });
+            }
+            return V.Fragment(children: children);
+        }
+
+        // GREEN_ON_BASE(characterization): the base reads the first row's value here too. The node comparison
+        // is off in this window because the row's recorded array is the one the host has moved off, so what is
+        // left is the key, which answers at every container holding this position — the hole issue #630 names,
+        // reached through a park rather than through two sibling containers.
+        [Test]
+        public void Given_AParkedKeyedListWhoseRowsCarryProviders_When_ARowPastTheParkPointReRendersAlone_Then_ItReadsTheFirstRowsProvider()
+        {
+            // Arrange
+            ResetParkList();
+            using var mounted = V.Mount(_root, V.Component(ParkListHost, key: "park-list"));
+            const int target = ParkRowCount - 1;
+            var atMount = s_parkSeen[target];
+
+            // Act — a transition-lane flush under a budget too small for one node parks after the first row,
+            // then the last row re-renders on its own before the resume.
+            s_parkStart.Invoke(() => s_parkSetGen.Invoke(1));
+            s_parkListFiber.FlushStateWithTinyBudgetForTest();
+            var parked = s_parkListFiber.HasPendingReconcileWorkForTest();
+            var beforeBump = s_parkSeen[target];
+            s_parkBumps[target].Invoke(1);
+            mounted.FlushStateForTest();
+
+            // Assert — the parked state and the pre-bump reading are folded in because they are what put the
+            // value below on the park rather than on the mount, and the row's own count because a row that did
+            // not re-render would still be holding whatever its last render read.
+            Assert.That(
+                (parked, atMount, beforeBump, s_parkSeen[target], s_parkCount[target]),
+                Is.EqualTo((true, "g0-7", "g0-7", "g1-0", 1)));
+        }
+
+        // The resume commits the rows the park left, so every row's own node is re-recorded there. A row that
+        // re-renders alone afterwards must read the Provider of its own row rather than of whichever row the
+        // committed tree reaches first.
+        [Test]
+        public void Given_AParkedKeyedListDrainedToCompletion_When_ARowReRendersAlone_Then_ItReadsItsOwnRowsProvider()
+        {
+            // Arrange
+            ResetParkList();
+            using var mounted = V.Mount(_root, V.Component(ParkListHost, key: "park-list"));
+            const int target = ParkRowCount - 1;
+            s_parkStart.Invoke(() => s_parkSetGen.Invoke(1));
+            s_parkListFiber.FlushStateWithTinyBudgetForTest();
+            s_parkListFiber.DrainTimeSlicedReconcileForTest();
+            var afterDrain = s_parkSeen[target];
+
+            // Act
+            s_parkBumps[target].Invoke(1);
+            mounted.FlushStateForTest();
+
+            // Assert — the post-drain reading is folded in because the value below is what a row that never
+            // re-rendered would still be holding, and the row's own count because that is what says it did.
+            Assert.That(
+                (afterDrain, s_parkSeen[target], s_parkCount[target]),
+                Is.EqualTo(("g1-7", "g1-7", 1)));
         }
 
         #endregion

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/TimeSlicedFiberTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/TimeSlicedFiberTests.cs
@@ -28,10 +28,12 @@ namespace Velvet.Tests
     /// sibling that is itself time-sliced (its delta committed across slices), and a nested growth absorbed by a
     /// wrapper (which must NOT shift the following sibling, since propagation is scoped to the shared mount
     /// point).</item>
-    /// <item>The resume re-records every row it commits, so a row that re-renders on its own after the drain
-    /// reads its own row's Provider. Before the resume it does not: the host's output is committed while the
-    /// slice is still parked, so a row the pass never reached is looked up by key alone and answers to
-    /// whichever container the committed tree reaches first — the reading recorded here.</item>
+    /// <item>A row the resume commits reads its own row's Provider when it re-renders on its own, whether
+    /// the transition was declared by the list's own host or by a sibling — the second is what asks the
+    /// resume itself, since the first is re-recorded by the settle's own re-render of the host. Before the
+    /// resume neither holds: the host's output is committed while the slice is still parked, so a row the
+    /// pass never reached is looked up by key alone and answers to whichever container the committed tree
+    /// reaches first — the reading recorded here.</item>
     /// </list>
     /// </summary>
     /// <remarks>
@@ -924,9 +926,10 @@ namespace Velvet.Tests
                 Is.EqualTo((true, "g0-7", "g0-7", "g1-0", 1)));
         }
 
-        // The resume commits the rows the park left, so every row's own node is re-recorded there. A row that
-        // re-renders alone afterwards must read the Provider of its own row rather than of whichever row the
-        // committed tree reaches first.
+        // A row the drain committed reads its own row's Provider afterwards rather than whichever row the
+        // committed tree reaches first. The host declares the transition here, so the settle after the
+        // terminal chunk schedules the host itself and every row is recorded again by that render — which
+        // is why this case does not isolate the resume. The sibling-declared case below does.
         [Test]
         public void Given_AParkedKeyedListDrainedToCompletion_When_ARowReRendersAlone_Then_ItReadsItsOwnRowsProvider()
         {
@@ -940,6 +943,70 @@ namespace Velvet.Tests
             var afterDrain = s_parkSeen[target];
 
             // Act
+            s_parkBumps[target].Invoke(1);
+            mounted.FlushStateForTest();
+
+            // Assert — the post-drain reading is folded in because the value below is what a row that never
+            // re-rendered would still be holding, and the row's own count because that is what says it did.
+            Assert.That(
+                (afterDrain, s_parkSeen[target], s_parkCount[target]),
+                Is.EqualTo(("g1-7", "g1-7", 1)));
+        }
+
+
+        private static ComponentFiber s_sibListFiber;
+        private static StateUpdater<int> s_sibSetGen;
+        private static TransitionStarter s_sibStart;
+
+        // The transition is declared by a SIBLING of the list, so the settle after the drain schedules the
+        // toolbar rather than the list: the list itself never re-renders, and the rows the resume committed
+        // are left with whatever the resume recorded on them.
+        [Component]
+        private static VNode SiblingToolbarRender()
+        {
+            var (_, start) = Hooks.UseTransition();
+            s_sibStart = start;
+            return V.Label(name: "sib-toolbar", text: "toolbar");
+        }
+
+        [Component]
+        private static VNode SiblingListRender()
+        {
+            var (gen, setGen) = Hooks.UseState(0);
+            s_sibSetGen = setGen;
+            s_sibListFiber = FiberAmbientStack.Current;
+            var children = new VNode[ParkRowCount];
+            for (var i = 0; i < ParkRowCount; i++)
+            {
+                children[i] = V.Div(key: "sk" + i, name: "sib-cell-" + i, children: new VNode?[]
+                {
+                    V.Provider(RowCtx, $"g{gen}-{i}", new VNode[] { V.Component(ParkRowBody, i, key: "row") }),
+                });
+            }
+            return V.Fragment(children: children);
+        }
+
+        [Component]
+        private static VNode SiblingTransitionHostRender()
+            => V.Div(name: "sib-shell", children: new VNode?[]
+            {
+                V.Component(SiblingToolbarRender, key: "toolbar"),
+                V.Component(SiblingListRender, key: "list"),
+            });
+
+        [Test]
+        public void Given_AListWhoseTransitionASiblingDeclares_When_ARowReRendersAloneAfterTheDrain_Then_ItReadsItsOwnRowsProvider()
+        {
+            // Arrange
+            ResetParkList();
+            using var mounted = V.Mount(_root, V.Component(SiblingTransitionHostRender, key: "sib-host"));
+            const int target = ParkRowCount - 1;
+
+            // Act — the sibling's starter moves the list's state, the list parks, and the drain completes it.
+            s_sibStart.Invoke(() => s_sibSetGen.Invoke(1));
+            s_sibListFiber.FlushStateWithTinyBudgetForTest();
+            s_sibListFiber.DrainTimeSlicedReconcileForTest();
+            var afterDrain = s_parkSeen[target];
             s_parkBumps[target].Invoke(1);
             mounted.FlushStateForTest();
 

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/TimeSlicedFiberTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/TimeSlicedFiberTests.cs
@@ -898,8 +898,9 @@ namespace Velvet.Tests
 
         // GREEN_ON_BASE(characterization): the base reads the first row's value here too. The node comparison
         // is off in this window because the row's recorded array is the one the host has moved off, so what is
-        // left is the key, which answers at every container holding this position — the hole issue #630 names,
-        // reached through a park rather than through two sibling containers.
+        // left is the key, which answers at every container holding this position, so a row reads whichever
+        // container the committed tree reaches first — reached through a park rather than through two
+        // sibling containers.
         [Test]
         public void Given_AParkedKeyedListWhoseRowsCarryProviders_When_ARowPastTheParkPointReRendersAlone_Then_ItReadsTheFirstRowsProvider()
         {


### PR DESCRIPTION
Closes #630.

`FiberContextSpine`'s inline arm looked every candidate up under the spine child's own container, so
two containers holding one position both answered the registry key and the walk took the first. An
instance in the second container read the first container's Provider where the two Providers carried
one context, and the context default where they carried different ones — an instance losing the
Provider it is written inside rather than acquiring a stranger's value. A `V.Motion`'s active label
reaches a descendant through the same walk, so a descendant of the second of two sibling Motions
animated to the first one's label.

The full walk from the root gets it right, so what a consumer read depended on whether its render was
reached from the root or scheduled on its own — a distinction a user can neither see nor control.

Each fiber now records the `ComponentNode` occurrence it last rendered from and the tree array that
render fixed, written wherever the registry reaches the fiber, and `MatchesInlineSpineChild` asks the
node as well as the key — but only where the walk is over that same array. A declaring body that
writes the component into each container gives the two positions separate nodes, which is what tells
them apart. Both are cleared in `FiberRenderer.Unmount` beside `PreviousTree` and the detached-mount
marker, which is where the pooled-remount scrub already lives.

**Why the comparison is asked against the array rather than unconditionally.** A stamp and a committed
tree come apart in both directions. A render discarded after its children were reconciled leaves each
child's `SourceNode` in a tree `PreviousTree` never takes — an error boundary catching a host's render
puts a consumer beside it into that state, and it stays there on every isolated re-render until the
declaring component next renders. A render *committed* while its reconcile is still parked leaves the
children past the park holding the previous render's nodes against the new tree. Asking whether the
stamp's array is the one being walked answers both, and is the whole of the mechanism: no counter, no
bump site, nothing to keep in step.

Where the arrays disagree the walk matches by key alone, as it did before this change. That is also
what a detached mount gets — a portal drain or a `V.VirtualList` item renderer walks
`DetachedMountContext.DescendantNodes`, stamped on the drain that created the fiber and not refreshed
for a survivor — so the containers those hold stay unseparated.

Re-running the walk with the comparison off after a miss also passes, and was rejected: it infers the
state from a failed search, so it fires where the child is genuinely absent too, and pays a second
full walk per spine edge on a state that repeats until the next successful render.

**What is not closed.** Two occurrences a declaring body builds from one shared node instance are one
node, so they stay unseparated; the separator is the occurrence, not the position. A row past a parked
reconcile reads a neighbour's Provider — wrong before this change and wrong after, characterized here
rather than claimed fixed, since closing it wants the container the descent is actually in. A
wrapper-mounted Outlet child never reaches the comparison at all.

**A crash on the same path, older than this change.** `FiberRenderer.SubsumeFiberIntoThisPass`
dereferenced `fiber.Reconciler!` where the arm below it reads the same field into a local and
null-checks it, under a comment naming the ErrorBoundary cascade that nulls it. A boundary catching in
a host's render disposes its own child as an orphan and returns into that child's subsume, raising
`NullReferenceException` from `ComponentRegistry.ReconcileExistingFiber` on `main`. It is guarded here
because the fixture that measures the Provider reading cannot be written without meeting it.

The alternative of capturing the enclosing Providers at mount — the mechanism
`DetachedMountContext.EnclosingSnapshot` already uses for portals — was measured rather than argued.
With the capture in place a consumer whose Provider value moved after mount reads the mount-time value
on its next own re-render, a case that passes today. It is pinned in `ContextReRenderTests` and is what
rejects the snapshot. Resolving each element node's committed `VisualElement` during the descent was
the other route named; it needs a second walker `FiberKeying`'s header requires to stay in lockstep
with the first, and reading the node the descent is already at needs no walker.

Three cases in `ComponentContainerIdentityTests` characterized the old readings, one under a
`GREEN_ON_BASE(characterization)` declaration; they now assert the corrected values.
`PortalContextInheritanceTests` pins the detached carve-out, `ProviderErrorBoundaryNestedConsumerTests`
the abort state, `TimeSlicedFiberTests` the parked characterization and both resume shapes, and
`ContextReRenderTests` the snapshot rejection.

`Documentation~` needs no change: the guides describe the behaviour this restores, and neither the
deviation nor the shapes named above was written down.

