### PR TITLE
fix(velvet): read the canaries where excuses covered every case

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -316,7 +316,9 @@ Either reading is only believed on a tree the run proved can build and answer at
 prove it. Cases of the base's own that the branch did not carry run alongside — C# fixtures for a
 platform, Python cases for that lane — and at least one has to pass. A lane with no eligible canary fails closed, as does a run
 that wrote no results file at all, rather than reading either as a base that built none of the branch's
-tests.
+tests. A withdrawal decides a case before this reading is reached, so a platform where withdrawals
+covered every case would leave it unread; there it is read anyway, and a platform nothing vouched
+for fails rather than passing on excuses.
 
 Which cases are the branch's own is decided by comparing each case's code — its own text with the
 comments blanked out — against the base's, since a diff over a large rewrite describes untouched text

--- a/scripts/test_quality/base_red_check.py
+++ b/scripts/test_quality/base_red_check.py
@@ -1784,6 +1784,24 @@ def unsound_platforms(canaries, reported):
     return broken
 
 
+def unvouched_excuses(cases, withdrawn):
+    """(platform, its cases, why) where an excuse decided every one of them and no canary vouched.
+
+    `report` decides a withdrawn file's cases above the reading that says whether the platform
+    answered at all, so a platform excuses covered entirely never reaches that reading. Here it
+    stands anyway: nothing there was measured, and nothing said it could be.
+    """
+    found = []
+    for platform, reason in sorted(withdrawn.items()):
+        theirs = [case for case in cases if measured_by(case.path) == platform]
+        # COULD_NOT_LOAD is not in this comparison because no case here can hold it: `decide` is the
+        # only place that hands it out, and `report` reaches `decide` only where the platform is not
+        # withdrawn. Moving that reading above the withdrawal reopens what this closes.
+        if theirs and all(case.verdict == COULD_NOT_COMPILE for case in theirs):
+            found.append((platform, theirs, reason))
+    return found
+
+
 def unsound_fixtures(control, reported):
     """Fixture -> the control case that says the base tree is answering about itself.
 
@@ -2059,6 +2077,9 @@ def report(cases, control, reported, canaries=None, wrote=True, unbuildable=None
     `blamed` is what `replan` withdrew on the editor's own error list between rounds, each with the
     detail it was withdrawn under, and it is read where `unbuildable` is: a compiler's reading of the
     same question the static one approximates, and outranked by `wrote` for the same reason.
+
+    A platform they covered every case of leaves the canary reading unread, and
+    `unvouched_excuses` is where it stands instead.
     """
     unsound = unsound_fixtures(control, reported)
     withdrawn = unsound_platforms(canaries or {}, reported)
@@ -2085,6 +2106,10 @@ def report(cases, control, reported, canaries=None, wrote=True, unbuildable=None
         else:
             case.verdict, case.detail = decide(case, outcome_for(case.key, reported),
                                                case.fixture in ran)
+    unvouched = unvouched_excuses(cases, withdrawn)
+    for _, excused, reason in unvouched:
+        for case in excused:
+            case.verdict, case.detail = BASE_UNSOUND, "{}, and {}".format(case.detail, reason)
     print("\n--- what the base said ---", flush=True)
     for case in cases:
         print("{:<32} {}  ({})".format(case.verdict, case.name, case.detail), flush=True)
@@ -2105,6 +2130,10 @@ def report(cases, control, reported, canaries=None, wrote=True, unbuildable=None
     if unbuilt:
         print("\n{} of {} case(s) sit in a fixture the base built none of, so the reading is that "
               "fixture's rather than each case's".format(len(unbuilt), len(cases)), flush=True)
+    for platform, excused, reason in unvouched:
+        print("\nnothing vouched for {}: all {} of its case(s) were excused rather than measured, "
+              "and\n{} -- so the excuses are this platform's whole reading and nothing there stands "
+              "behind them".format(platform, len(excused), reason), flush=True)
     offenders = [case for case in cases if case.verdict in FAILING_VERDICTS]
     # Split by whether a behavioural verdict exists, because one remedy does not cover both. Offering
     # a declaration where the run produced none sends the author to sharpen a case that may be perfectly

--- a/scripts/test_quality/test_base_red_check.py
+++ b/scripts/test_quality/test_base_red_check.py
@@ -3777,13 +3777,16 @@ class WithdrawnFileVerdictTests(unittest.TestCase):
         self.assertEqual((verdicts[self.UNBUILDABLE], verdicts[self.BESIDE]),
                          (base_red_check.BASE_UNSOUND, base_red_check.BASE_UNSOUND))
 
+    # GREEN_ON_BASE(characterization): the excuse a plan carries still names what proved it.
+    # This read the exit code before, on a canary that failed -- which is the state the refusal
+    # this branch adds exists to catch, so the reading had to move off it.
     def test_Given_AWithdrawalTheReadingTook_When_ADifferentProcessDecides_Then_ItStillReadsIt(self):
         # Arrange -- the two halves are separate invocations with a JSON file between them, and a
         # field the emitting half writes that the deciding half never asks for is a silent fail-closed
         # on exactly the branches this exists to let through. Built by `as_plan` for the reason its
         # own round trip is: a literal here would go on carrying what the emitter had stopped writing.
-        # The canary reports and fails, so the platform is withdrawn and only the plan's own field
-        # can leave the case anything but a failing verdict.
+        # The canary passes, so the fixture's own silence excuses the case whether or not the field
+        # arrives and the verdict separates nothing -- the detail is what only the field can name.
         holder = tempfile.mkdtemp(prefix="base-red-roundtrip-")
         self.addCleanup(shutil.rmtree, holder, ignore_errors=True)
         case = base_red_check.Case("N.NewTests.Given_A_When_B_Then_C", self.UNBUILDABLE, 1, 2)
@@ -3792,17 +3795,17 @@ class WithdrawnFileVerdictTests(unittest.TestCase):
             withdrawn={self.UNBUILDABLE: "Proceeding"})))
         Path(holder, "results").mkdir()
         Path(holder, "results", "r.xml").write_text(
-            '<test-run><test-case fullname="N.CanaryTests.Given_X_When_Y_Then_Z" result="Failed" />'
+            '<test-run><test-case fullname="N.CanaryTests.Given_X_When_Y_Then_Z" result="Passed" />'
             '</test-run>')
 
         # Act
-        status = subprocess.run(
+        printed = subprocess.run(
             [sys.executable, str(REPO_ROOT / "scripts/test_quality/base_red_check.py"),
              "--verdict", str(Path(holder, "plan.json")),
-             "--results", str(Path(holder, "results"))], capture_output=True, text=True).returncode
+             "--results", str(Path(holder, "results"))], capture_output=True, text=True).stdout
 
         # Assert
-        self.assertEqual(status, 0)
+        self.assertIn("the base has no Proceeding", printed)
 
 
 class RemedyTests(unittest.TestCase):
@@ -4935,11 +4938,14 @@ class BlamedFileVerdictTests(unittest.TestCase):
         # Assert
         self.assertEqual(case.verdict, base_red_check.BASE_UNSOUND)
 
+    # GREEN_ON_BASE(characterization): the code a round blamed still reaches the detail.
+    # This read the exit code before, on a canary that failed -- which is the state the refusal
+    # this branch adds exists to catch, so the reading had to move off it.
     def test_Given_ABlamedFileInTheReading_When_ADifferentProcessDecides_Then_ItStillReadsIt(self):
         # Arrange -- the field `--replan` writes is one `--verdict` has to ask for. The canary
-        # reports and fails, so the platform is withdrawn and only that field can leave the case
-        # anything but a failing verdict; beside a passing canary the fixture's silence alone
-        # would excuse it, and the field could go unread without this noticing.
+        # passes, so the fixture's own silence excuses the case whether or not the field arrives and
+        # the verdict separates nothing; the code the compiler gave is what only the field carries,
+        # and a lane that never asked for it would print the silence instead.
         holder = tempfile.mkdtemp(prefix="base-red-blamed-")
         self.addCleanup(shutil.rmtree, holder, ignore_errors=True)
         case = base_red_check.Case("N.NewTests.Given_A_When_B_Then_C", self.BLAMED, 1, 2)
@@ -4948,17 +4954,84 @@ class BlamedFileVerdictTests(unittest.TestCase):
         Path(holder, "plan.json").write_text(json.dumps(plan))
         Path(holder, "results").mkdir()
         Path(holder, "results", "r.xml").write_text(
-            '<test-run><test-case fullname="N.CanaryTests.Given_X_When_Y_Then_Z" result="Failed" />'
+            '<test-run><test-case fullname="N.CanaryTests.Given_X_When_Y_Then_Z" result="Passed" />'
             '</test-run>')
 
         # Act
-        status = subprocess.run(
+        printed = subprocess.run(
             [sys.executable, str(REPO_ROOT / "scripts/test_quality/base_red_check.py"),
              "--verdict", str(Path(holder, "plan.json")),
-             "--results", str(Path(holder, "results"))], capture_output=True, text=True).returncode
+             "--results", str(Path(holder, "results"))], capture_output=True, text=True).stdout
 
         # Assert
-        self.assertEqual(status, 0)
+        self.assertIn("the compiler blamed it (CS0012) in round 1", printed)
+
+
+class UnvouchedExcuseTests(unittest.TestCase):
+    """What the deciding half does where an excuse covered every case a platform had.
+
+    Both excuses are read above the canaries, so a platform they cover entirely decides every case
+    before that reading is reached -- and the reading has to stand there anyway.
+    """
+
+    UNBUILDABLE = "Packages/p/Runtime/A/Tests/Editor/NewTests.cs"
+    BLAMED = "Packages/p/Runtime/A/Tests/Editor/OldTests.cs"
+
+    BLAME = "the compiler blamed it (CS0246) in round 2"
+
+    def excused(self, canary):
+        """The cases, the offenders and the output, where each excuse covered one of two cases."""
+        cases = [base_red_check.Case("N.NewTests.Given_A_When_B_Then_C", self.UNBUILDABLE, 1, 2),
+                 base_red_check.Case("N.OldTests.Given_D_When_E_Then_F", self.BLAMED, 1, 2)]
+        printed = io.StringIO()
+        with contextlib.redirect_stdout(printed):
+            offenders = base_red_check.report(
+                cases, [], {"N.CanaryTests.Given_X_When_Y_Then_Z": canary},
+                {"EditMode": ["N.CanaryTests"]}, True, {self.UNBUILDABLE: "Proceeding"},
+                blamed={self.BLAMED: self.BLAME})
+        return cases, offenders, printed.getvalue()
+
+    def test_Given_EveryCaseExcusedAndNoCanaryPassing_When_TheVerdictsAreTaken_Then_TheRunFails(self):
+        # Arrange -- what the rounds can grow into: every carried file put back, a last round asking
+        # only the canaries, and what it wrote vouching for nothing. Both excuses in one comparison,
+        # because either alone leaves the other a way through the same run, and each detail beside
+        # its verdict, because the excuse is what an author has to be told was overruled.
+        # Act
+        _, offenders, _ = self.excused("Failed")
+
+        # Assert
+        self.assertEqual(
+            [(case.verdict, case.detail) for case in offenders],
+            [(base_red_check.BASE_UNSOUND,
+              "the base has no Proceeding, and none of CanaryTests passed there"),
+             (base_red_check.BASE_UNSOUND, self.BLAME + ", and none of CanaryTests passed there")])
+
+    # GREEN_ON_BASE(characterization): a platform its canaries vouched for still passes here.
+    # It is the half the refusal beside it must not take with it, and no base run can show that.
+    def test_Given_EveryCaseExcusedAndACanaryPassing_When_TheVerdictsAreTaken_Then_TheRunPasses(self):
+        # Arrange -- the shape a branch whose every changed test names a symbol the base has not got
+        # leaves, and the one the refusal above must not take with it: the excuses are the whole
+        # reading here too, and a tree that answered is the whole difference. The details are folded
+        # in because a fixture nobody built is excused without either of them, so an empty offender
+        # list alone holds whether or not this run read them.
+        # Act
+        cases, offenders, _ = self.excused("Passed")
+
+        # Assert
+        self.assertEqual(([case.verdict for case in offenders], [case.detail for case in cases]),
+                         ([], ["the base has no Proceeding", self.BLAME]))
+
+    def test_Given_APlatformNothingVouchedFor_When_TheRefusalIsPrinted_Then_ItSaysWhatWasMissing(self):
+        # Arrange -- a verdict line carries its own case's reason and names neither the platform nor
+        # how much of it the excuses covered, which is the difference between a list and a refusal.
+        # An author whose run was green until now has to be told which platform stopped counting,
+        # how far the excuses reached there, and what did not pass.
+        # Act
+        _, _, printed = self.excused("Failed")
+
+        # Assert
+        self.assertIn("nothing vouched for EditMode: all 2 of its case(s) were excused rather than "
+                      "measured, and\nnone of CanaryTests passed there", printed)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #948.

`report` decides a case the static reading withdrew, or a round's compiler blamed, above the reading
that says whether the platform answered at all. Both excuses are tolerated, so a platform where they
covered every case exits zero with the canary reading reached by nothing — and over the rounds
`--replan` runs, every carried file can end up blamed and put back, which is that state at full size.
On the branch replacing UniTask, round 1 blamed 19 of 19 carried files.

`unvouched_excuses` is the floor: where excuses decided every case a platform had and no canary passed
there, the canary reading stands anyway, each case keeps what excused it beside the reason the excuse
does not stand, and the run refuses. A platform whose canaries did pass is untouched — that is the
ordinary shape of a branch every changed test of which names a symbol the base has not got, and a case
pins it.

`COULD_NOT_LOAD` is deliberately outside the comparison: `decide` is the only place that hands it out,
and `report` reaches `decide` only where the platform is not withdrawn, so no case the floor reads can
carry it. Moving that reading above the withdrawal reopens what this closes.

The two round-trip cases over the plan's `withdrawn` and `blamed` fields read the exit code in exactly
the state this refuses, so both now read the detail instead, which the field is still the only thing
that can name.

**What the corpus says, and what it does not.** Over 46 `Base-red check (*)` jobs from 16 runs, 23
carried a case and this moves none of them — but 13 of those are the Python lane, which has no canaries
and so can never be in the set the floor reads. The jobs that could have moved and did not are the 10
EditMode ones. No PlayMode job in the corpus carried a case at all, so the floor's reading there is
unexercised rather than measured.

The issue offered moving the canary reading above `unbuildable` and `blamed` outright. That changes
verdicts on trees that pass today, and the corpus holds no job in the state it would fix: a floor
leaves every tolerated verdict where it is and refuses only where nothing vouched.

`CONTRIBUTING.md` gains the floor beside the verdicts it already describes. No `Documentation~` change:
this is contributor tooling.
