### PR TITLE
feat(velvet): refuse a value naming no member of its enum at six more V.* factory arguments

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -497,6 +497,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   catch it, and the message names the unmatched number rather than the argument it came from. A silent
   `Overlay` was how such a cast survived to put a portal on a layer nobody asked for.
 
+- Six more `V.*` factory arguments are refused when they name no member of their enum, as
+  `V.Portal(layer:)`'s already is: `focusOrder:` on `V.Portal` and on `V.WorldSpace`, `playOn:` on
+  `V.Particles`, `movement:` on `V.Draggable`, `mode:` on `V.AnimatePresence` and `loaderMode:` on
+  `V.Route`. Each throws `ArgumentOutOfRangeException` from the call itself, naming the parameter and
+  carrying the value; every named member is accepted as it was, and only a value naming none of them
+  reaches this. Such a value used to behave as `Isolated` for `focusOrder:`, `Manual` for `playOn:`,
+  `None` for `movement:`, `Sync` for `mode:` and `Suspend` for `loaderMode:`, without a word — which is
+  how a cast could put a route's loader on the background path nobody asked for. A caller wanting one
+  of those behaviours names its member.
+
 - A `[Component(Memoize = true)]` component's props bail decides a props value whole, the way React's
   shallow-equal comparison decides each key of a props object with `Object.is`. The member walk runs on
   the props bag and on nothing it finds: a props value that is not a bag — a value type, a string, a

--- a/Packages/com.velvet.core/Documentation~/drag-and-drop.md
+++ b/Packages/com.velvet.core/Documentation~/drag-and-drop.md
@@ -18,7 +18,8 @@ pooled element leaves with everything the session ever wrote restored.
   whether the element itself follows the pointer (`Translate`, the default — an inline
   `translate` written every move and restored afterward) or stays put (`None` — the
   `V.DragOverlay` ghost pattern); `whileDraggingClass:` is the zero-re-render styling channel for
-  the dragging state.
+  the dragging state. A `movement:` naming no `DragMovement` member is refused at construction:
+  the factory throws `ArgumentOutOfRangeException`, naming the parameter.
 - **`V.Droppable(id:)`** — a drop target, dnd-kit's `useDroppable`. `whileOverClass:` applies
   while it is the winning collision; `whileDragActiveClass:` applies to every enabled candidate
   while any drag is live in the scope (dnd-kit's droppable `active` cue). `dropData:` rides into

--- a/Packages/com.velvet.core/Documentation~/focus.md
+++ b/Packages/com.velvet.core/Documentation~/focus.md
@@ -83,6 +83,9 @@ cross-panel focus handoff from inside another panel's event dispatch does not st
 empirically — the still-focused source panel wins the reconciliation), so the source element is
 blurred synchronously and the target focused on its own panel's next tick.
 
+A `focusOrder:` naming no `PanelFocusOrder` member is refused at construction: `V.Portal` and
+`V.WorldSpace` each throw `ArgumentOutOfRangeException` from the call itself, naming the parameter.
+
 ## Scope cuts
 
 - No imperative focus-manager handle.

--- a/Packages/com.velvet.core/Documentation~/motion.md
+++ b/Packages/com.velvet.core/Documentation~/motion.md
@@ -75,6 +75,8 @@ V.Div(name: "row", className: "flex flex-row gap-x-2", children: new VNode[]
   for out of the class strings; *Driven channels* below is the single list of what that covers and
   what it deliberately leaves out. A `skew-*` exit never animates under any driver, because skew
   is a silhouette paint rather than a transform.
+- A `mode:` naming no `AnimatePresenceMode` member is refused at construction: `V.AnimatePresence`
+  throws `ArgumentOutOfRangeException`, naming the parameter.
 
 ### `PopLayout` mode
 

--- a/Packages/com.velvet.core/Documentation~/particles.md
+++ b/Packages/com.velvet.core/Documentation~/particles.md
@@ -19,7 +19,8 @@ rest:
 - `playOn: PlayTrigger.Mount` (default) starts the clone on mount; `PlayTrigger.Manual`
   instantiates it stopped for imperative control — call `Play()` / `Stop()` on the mounted
   `ParticlesElement` (reach it via `refCallback` or a query). Flipping `playOn` on a later
-  render applies to the live host.
+  render applies to the live host. A `playOn:` naming no `PlayTrigger` member is refused at
+  construction: the factory throws `ArgumentOutOfRangeException`, naming the parameter.
 - Swapping the `effect:` prop destroys the old host and clones the new effect; `null`
   destroys the host and leaves an inert box. Unmounting (conditional removal, type swaps,
   tree disposal included) destroys the host.

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/VFactoryEnumArgumentAllocTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/VFactoryEnumArgumentAllocTests.cs
@@ -1,0 +1,80 @@
+using System;
+using NUnit.Framework;
+using Velvet.TestUtilities;
+
+namespace Velvet.Tests.Performance
+{
+    /// <summary>
+    /// Pins the enum-argument refusals on the <c>V.*</c> factories to no allocation of their own.
+    /// <see cref="VNodePoolZeroAllocTests"/> names an accidental boxing as what it exists to catch, but it
+    /// measures <see cref="VNodePool"/>; a factory allocates its node by design, so a bare zero-allocation
+    /// assertion cannot be made about one. Each case here measures the factory against constructing the
+    /// same node directly and pins the difference at zero, which is the refusal's own cost and nothing else.
+    /// </summary>
+    /// <remarks>
+    /// <c>Enum.IsDefined(Type, object)</c> boxes its argument, and netstandard 2.1 — this project's API
+    /// level — declares no generic overload that would not. Velvet rebuilds the VNode tree per render, so
+    /// a factory in a render body runs on each of them and the boxing was a per-render heap allocation.
+    /// </remarks>
+    [TestFixture]
+    [Category("Performance")]
+    internal sealed class VFactoryEnumArgumentAllocTests
+    {
+        // Static, so the measured delegates capture nothing and allocate no closure of their own.
+        private static readonly VNode[] NoChildren = new VNode[0];
+
+        private static readonly Action PortalViaFactory = () => GC.KeepAlive(
+            V.Portal(UILayer.Overlay, children: NoChildren, focusOrder: PanelFocusOrder.Isolated));
+
+        private static readonly Action PortalViaInit = () => GC.KeepAlive(new PortalNode
+        {
+            Layer = UILayer.Overlay, Children = NoChildren, FocusOrder = PanelFocusOrder.Isolated,
+        });
+
+        private static readonly Action PresenceViaFactory = () => GC.KeepAlive(
+            V.AnimatePresence(children: NoChildren, mode: AnimatePresenceMode.Sync));
+
+        private static readonly Action PresenceViaInit = () => GC.KeepAlive(new AnimatePresenceNode
+        {
+            Children = NoChildren, Mode = AnimatePresenceMode.Sync,
+        });
+
+        // The difference is what the refusal costs; the second term is what a probe stuck at zero fails,
+        // since two zeroed counts would satisfy the difference vacuously.
+        private static (int Difference, bool Measured) RefusalCost(Action viaFactory, Action viaInit)
+        {
+            // The first execution of a path charges one-time runtime work to whatever scope runs it, so
+            // both delegates run once outside the measured window.
+            viaFactory();
+            viaInit();
+            var factoryBlocks = GCAllocationProbe.SampleBlocksDuring(viaFactory);
+            var initBlocks = GCAllocationProbe.SampleBlocksDuring(viaInit);
+            return (factoryBlocks - initBlocks, initBlocks > 0);
+        }
+
+        [Test]
+        public void Given_ANamedLayerAndFocusOrder_When_VPortalIsCalled_Then_ItsTwoRefusalsAllocateNothing()
+        {
+            // Arrange + Act
+            var cost = RefusalCost(PortalViaFactory, PortalViaInit);
+
+            // Assert
+            Assert.That(cost, Is.EqualTo((0, true)));
+        }
+
+        // GREEN_ON_BASE(characterization): the base's V.AnimatePresence allocates its node and no more.
+        // It carries no refusal there at all, so the difference is zero for a different reason than it
+        // is here. What this pins is that adding one costs nothing: spell the check `Enum.IsDefined`
+        // and the difference measures two blocks. The V.Portal case above needs no declaration -- the
+        // base already refuses `layer:` and pays a block pair for it, so it is red there.
+        [Test]
+        public void Given_ANamedMode_When_VAnimatePresenceIsCalled_Then_ItsRefusalAllocatesNothing()
+        {
+            // Arrange + Act
+            var cost = RefusalCost(PresenceViaFactory, PresenceViaInit);
+
+            // Assert
+            Assert.That(cost, Is.EqualTo((0, true)));
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/VFactoryEnumArgumentAllocTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/VFactoryEnumArgumentAllocTests.cs
@@ -1,15 +1,21 @@
 using System;
 using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.UIElements;
 using Velvet.TestUtilities;
 
 namespace Velvet.Tests.Performance
 {
     /// <summary>
-    /// Pins the enum-argument refusals on the <c>V.*</c> factories to no allocation of their own.
-    /// <see cref="VNodePoolZeroAllocTests"/> names an accidental boxing as what it exists to catch, but it
-    /// measures <see cref="VNodePool"/>; a factory allocates its node by design, so a bare zero-allocation
-    /// assertion cannot be made about one. Each case here measures the factory against constructing the
-    /// same node directly and pins the difference at zero, which is the refusal's own cost and nothing else.
+    /// Pins each of the seven enum-argument refusals on the <c>V.*</c> factories to no allocation of its
+    /// own: <c>layer:</c> and <c>focusOrder:</c> on <c>V.Portal</c>, <c>focusOrder:</c> on
+    /// <c>V.WorldSpace</c>, <c>playOn:</c> on <c>V.Particles</c>, <c>movement:</c> on
+    /// <c>V.Draggable</c>, <c>mode:</c> on <c>V.AnimatePresence</c> and <c>loaderMode:</c> on
+    /// <c>V.Route</c>. <see cref="VNodePoolZeroAllocTests"/> names an accidental boxing as what it
+    /// exists to catch, but it measures <see cref="VNodePool"/>; a factory allocates its node by design,
+    /// so a bare zero-allocation assertion cannot be made about one. Each case here measures the factory
+    /// against building the same node directly and pins the difference at zero, which is the refusal's
+    /// own cost and nothing else.
     /// </summary>
     /// <remarks>
     /// <c>Enum.IsDefined(Type, object)</c> boxes its argument, and netstandard 2.1 — this project's API
@@ -21,7 +27,14 @@ namespace Velvet.Tests.Performance
     internal sealed class VFactoryEnumArgumentAllocTests
     {
         // Static, so the measured delegates capture nothing and allocate no closure of their own.
-        private static readonly VNode[] NoChildren = new VNode[0];
+        private static readonly VNode[] NoChildren = Array.Empty<VNode>();
+
+        [Component]
+        private static VNode RouteElementRender() => V.Div();
+
+        private static readonly ComponentNode RouteElement = V.Component(RouteElementRender);
+
+        #region delegates that allocate only their node
 
         private static readonly Action PortalViaFactory = () => GC.KeepAlive(
             V.Portal(UILayer.Overlay, children: NoChildren, focusOrder: PanelFocusOrder.Isolated));
@@ -29,6 +42,18 @@ namespace Velvet.Tests.Performance
         private static readonly Action PortalViaInit = () => GC.KeepAlive(new PortalNode
         {
             Layer = UILayer.Overlay, Children = NoChildren, FocusOrder = PanelFocusOrder.Isolated,
+        });
+
+        private static readonly Action WorldSpaceViaFactory = () => GC.KeepAlive(
+            V.WorldSpace(Vector3.zero, children: NoChildren, focusOrder: PanelFocusOrder.Isolated));
+
+        private static readonly Action WorldSpaceViaInit = () => GC.KeepAlive(new WorldSpaceNode
+        {
+            Position = Vector3.zero,
+            Rotation = Quaternion.identity,
+            PanelSize = new Vector2(1920f, 1080f),
+            FocusOrder = PanelFocusOrder.Isolated,
+            Children = NoChildren,
         });
 
         private static readonly Action PresenceViaFactory = () => GC.KeepAlive(
@@ -39,12 +64,65 @@ namespace Velvet.Tests.Performance
             Children = NoChildren, Mode = AnimatePresenceMode.Sync,
         });
 
+        private static readonly Action RouteViaFactory = () => GC.KeepAlive(
+            V.Route("reports", element: RouteElement, loaderMode: LoaderMode.Await));
+
+        private static readonly Action RouteViaInit = () => GC.KeepAlive(new RouteDefinition
+        {
+            Path = "reports", Element = RouteElement, LoaderMode = LoaderMode.Await,
+        });
+
+        #endregion
+
+        #region delegates that also rent a props bag
+
+        // V.Particles and V.Draggable rent from VNodePool, so both sides of their pairs return the bag.
+        // Renting without returning would leave the pool empty at every call and grow the rented set
+        // across the two measurements, and a set that resizes between them charges one side and not
+        // the other.
+        private static readonly Action ParticlesViaFactory = () =>
+            VNodePool.ReturnProps(V.Particles(effect: null, playOn: PlayTrigger.Mount).Props);
+
+        private static readonly Action ParticlesViaInit = () =>
+        {
+            var props = VNodePool.RentProps();
+            props.Particles = new ParticlesSettings(null, PlayTrigger.Mount, 100f);
+            GC.KeepAlive(new ElementNode
+            {
+                ElementType = typeof(ParticlesElement),
+                ClassNames = Array.Empty<string>(),
+                Props = props,
+                Children = NoChildren,
+                Events = Array.Empty<FiberEventBinding>(),
+            });
+            VNodePool.ReturnProps(props);
+        };
+
+        private static readonly Action DraggableViaFactory = () =>
+            VNodePool.ReturnProps(V.Draggable("row", movement: DragMovement.Translate).Props);
+
+        private static readonly Action DraggableViaInit = () =>
+        {
+            var props = VNodePool.RentProps();
+            props.Draggable = new DraggableSettings("row");
+            GC.KeepAlive(new ElementNode
+            {
+                ElementType = typeof(VisualElement),
+                ClassNames = Array.Empty<string>(),
+                Props = props,
+                Children = NoChildren,
+                Events = Array.Empty<FiberEventBinding>(),
+            });
+            VNodePool.ReturnProps(props);
+        };
+
+        #endregion
+
         // The difference is what the refusal costs; the second term is what a probe stuck at zero fails,
-        // since two zeroed counts would satisfy the difference vacuously.
+        // since two zeroed counts would satisfy the difference vacuously. Both delegates run once first,
+        // for the warming reason VNodePoolZeroAllocTests states.
         private static (int Difference, bool Measured) RefusalCost(Action viaFactory, Action viaInit)
         {
-            // The first execution of a path charges one-time runtime work to whatever scope runs it, so
-            // both delegates run once outside the measured window.
             viaFactory();
             viaInit();
             var factoryBlocks = GCAllocationProbe.SampleBlocksDuring(viaFactory);
@@ -62,16 +140,72 @@ namespace Velvet.Tests.Performance
             Assert.That(cost, Is.EqualTo((0, true)));
         }
 
+        // GREEN_ON_BASE(characterization): the base's V.WorldSpace allocates its node and no more.
+        // It carries no refusal there at all, so the difference is zero for a different reason than it is
+        // here. What this pins for the branch is that adding one costs nothing: spell the check
+        // `Enum.IsDefined` and the difference measures two blocks.
+        [Test]
+        public void Given_ANamedFocusOrder_When_VWorldSpaceIsCalled_Then_ItsRefusalAllocatesNothing()
+        {
+            // Arrange + Act
+            var cost = RefusalCost(WorldSpaceViaFactory, WorldSpaceViaInit);
+
+            // Assert
+            Assert.That(cost, Is.EqualTo((0, true)));
+        }
+
+        // GREEN_ON_BASE(characterization): the base's V.Particles allocates its node and its settings and
+        // no more. It carries no refusal there at all, so the difference is zero for a different reason
+        // than it is here. What this pins for the branch is that adding one costs nothing: spell the
+        // check `Enum.IsDefined` and the difference measures two blocks.
+        [Test]
+        public void Given_ANamedPlayOn_When_VParticlesIsCalled_Then_ItsRefusalAllocatesNothing()
+        {
+            // Arrange + Act
+            var cost = RefusalCost(ParticlesViaFactory, ParticlesViaInit);
+
+            // Assert
+            Assert.That(cost, Is.EqualTo((0, true)));
+        }
+
+        // GREEN_ON_BASE(characterization): the base's V.Draggable allocates its node and its settings and
+        // no more. It carries no refusal there at all, so the difference is zero for a different reason
+        // than it is here. What this pins for the branch is that adding one costs nothing: spell the
+        // check `Enum.IsDefined` and the difference measures two blocks.
+        [Test]
+        public void Given_ANamedMovement_When_VDraggableIsCalled_Then_ItsRefusalAllocatesNothing()
+        {
+            // Arrange + Act
+            var cost = RefusalCost(DraggableViaFactory, DraggableViaInit);
+
+            // Assert
+            Assert.That(cost, Is.EqualTo((0, true)));
+        }
+
         // GREEN_ON_BASE(characterization): the base's V.AnimatePresence allocates its node and no more.
-        // It carries no refusal there at all, so the difference is zero for a different reason than it
-        // is here. What this pins is that adding one costs nothing: spell the check `Enum.IsDefined`
-        // and the difference measures two blocks. The V.Portal case above needs no declaration -- the
-        // base already refuses `layer:` and pays a block pair for it, so it is red there.
+        // It carries no refusal there at all, so the difference is zero for a different reason than it is
+        // here. What this pins for the branch is that adding one costs nothing: spell the check
+        // `Enum.IsDefined` and the difference measures two blocks. The V.Portal case above needs no
+        // declaration -- the base already refuses `layer:` and pays a block pair for it, so it is red there.
         [Test]
         public void Given_ANamedMode_When_VAnimatePresenceIsCalled_Then_ItsRefusalAllocatesNothing()
         {
             // Arrange + Act
             var cost = RefusalCost(PresenceViaFactory, PresenceViaInit);
+
+            // Assert
+            Assert.That(cost, Is.EqualTo((0, true)));
+        }
+
+        // GREEN_ON_BASE(characterization): the base's V.Route allocates its definition and no more.
+        // It carries no refusal there at all, so the difference is zero for a different reason than it is
+        // here. What this pins for the branch is that adding one costs nothing: spell the check
+        // `Enum.IsDefined` and the difference measures two blocks.
+        [Test]
+        public void Given_ANamedLoaderMode_When_VRouteIsCalled_Then_ItsRefusalAllocatesNothing()
+        {
+            // Arrange + Act
+            var cost = RefusalCost(RouteViaFactory, RouteViaInit);
 
             // Assert
             Assert.That(cost, Is.EqualTo((0, true)));

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/VFactoryEnumArgumentAllocTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/VFactoryEnumArgumentAllocTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b3168f756c9847d19299111c80c3b436

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/VFactoryEnumArgumentTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/VFactoryEnumArgumentTests.cs
@@ -1,0 +1,428 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Specifies what <c>V.Portal(focusOrder:)</c>, <c>V.WorldSpace(focusOrder:)</c>,
+    /// <c>V.Particles(playOn:)</c>, <c>V.Draggable(movement:)</c>, <c>V.AnimatePresence(mode:)</c> and
+    /// <c>V.Route(loaderMode:)</c> do with their enum argument:
+    /// <list type="bullet">
+    /// <item>A value naming no member of the enum is refused synchronously with an
+    /// <see cref="ArgumentOutOfRangeException"/> that names the parameter, carries the value, and names
+    /// the API and the enum in its message.</item>
+    /// <item>Every member still reaches what the factory builds.</item>
+    /// </list>
+    /// <see cref="VPortalFactoryTests"/> specifies the same of <c>V.Portal(layer:)</c>, whose check
+    /// these follow.
+    /// </summary>
+    [TestFixture]
+    internal sealed class VFactoryEnumArgumentTests
+    {
+        private const PanelFocusOrder UnnamedFocusOrder = (PanelFocusOrder)99;
+        private const PlayTrigger UnnamedPlayTrigger = (PlayTrigger)99;
+        private const DragMovement UnnamedMovement = (DragMovement)99;
+        private const AnimatePresenceMode UnnamedMode = (AnimatePresenceMode)99;
+        private const LoaderMode UnnamedLoaderMode = (LoaderMode)99;
+
+        [Component]
+        private static VNode RouteElementRender() => V.Div();
+
+        #region V.Portal(focusOrder:)
+
+        [Test]
+        public void Given_AFocusOrderNamingNoMember_When_VPortalIsCalled_Then_ItThrowsArgumentOutOfRange()
+        {
+            // Act + Assert
+            Assert.That(() => V.Portal(UILayer.Overlay, focusOrder: UnnamedFocusOrder),
+                Throws.TypeOf<ArgumentOutOfRangeException>());
+        }
+
+        [Test]
+        public void Given_AFocusOrderNamingNoMember_When_VPortalThrows_Then_TheParamNameIsFocusOrder()
+        {
+            // Act
+            var ex = Assert.Throws<ArgumentOutOfRangeException>(
+                () => V.Portal(UILayer.Overlay, focusOrder: UnnamedFocusOrder));
+
+            // Assert
+            Assert.That(ex.ParamName, Is.EqualTo("focusOrder"));
+        }
+
+        [Test]
+        public void Given_AFocusOrderNamingNoMember_When_VPortalThrows_Then_TheMessageNamesTheApiAndTheEnum()
+        {
+            // Act
+            var ex = Assert.Throws<ArgumentOutOfRangeException>(
+                () => V.Portal(UILayer.Overlay, focusOrder: UnnamedFocusOrder));
+
+            // Assert
+            Assert.That((ex.Message.Contains("V.Portal"), ex.Message.Contains("PanelFocusOrder")),
+                Is.EqualTo((true, true)));
+        }
+
+        [Test]
+        public void Given_AFocusOrderNamingNoMember_When_VPortalThrows_Then_TheActualValueIsTheCast()
+        {
+            // Act
+            var ex = Assert.Throws<ArgumentOutOfRangeException>(
+                () => V.Portal(UILayer.Overlay, focusOrder: UnnamedFocusOrder));
+
+            // Assert
+            Assert.That(ex.ActualValue, Is.EqualTo(UnnamedFocusOrder));
+        }
+
+        // GREEN_ON_BASE(characterization): every PanelFocusOrder member reaches the portal node on the base.
+        // What it answers for is the refusal this branch adds: narrow that check to one member
+        // and this case goes red.
+        [Test]
+        public void Given_EveryMemberOfPanelFocusOrder_When_VPortalIsCalled_Then_EachBuildsANodeCarryingIt()
+        {
+            // Arrange
+            var members = (PanelFocusOrder[])Enum.GetValues(typeof(PanelFocusOrder));
+
+            // Act
+            var carried = new List<string>();
+            foreach (var member in members)
+            {
+                carried.Add(V.Portal(UILayer.Overlay, focusOrder: member).FocusOrder.ToString());
+            }
+
+            // Assert
+            Assert.That(string.Join(",", carried), Is.EqualTo(string.Join(",", members.Select(m => m.ToString()))));
+        }
+
+        #endregion
+
+        #region V.WorldSpace(focusOrder:)
+
+        [Test]
+        public void Given_AFocusOrderNamingNoMember_When_VWorldSpaceIsCalled_Then_ItThrowsArgumentOutOfRange()
+        {
+            // Act + Assert
+            Assert.That(() => V.WorldSpace(Vector3.zero, focusOrder: UnnamedFocusOrder),
+                Throws.TypeOf<ArgumentOutOfRangeException>());
+        }
+
+        [Test]
+        public void Given_AFocusOrderNamingNoMember_When_VWorldSpaceThrows_Then_TheParamNameIsFocusOrder()
+        {
+            // Act
+            var ex = Assert.Throws<ArgumentOutOfRangeException>(
+                () => V.WorldSpace(Vector3.zero, focusOrder: UnnamedFocusOrder));
+
+            // Assert
+            Assert.That(ex.ParamName, Is.EqualTo("focusOrder"));
+        }
+
+        [Test]
+        public void Given_AFocusOrderNamingNoMember_When_VWorldSpaceThrows_Then_TheMessageNamesTheApiAndTheEnum()
+        {
+            // Act
+            var ex = Assert.Throws<ArgumentOutOfRangeException>(
+                () => V.WorldSpace(Vector3.zero, focusOrder: UnnamedFocusOrder));
+
+            // Assert
+            Assert.That((ex.Message.Contains("V.WorldSpace"), ex.Message.Contains("PanelFocusOrder")),
+                Is.EqualTo((true, true)));
+        }
+
+        [Test]
+        public void Given_AFocusOrderNamingNoMember_When_VWorldSpaceThrows_Then_TheActualValueIsTheCast()
+        {
+            // Act
+            var ex = Assert.Throws<ArgumentOutOfRangeException>(
+                () => V.WorldSpace(Vector3.zero, focusOrder: UnnamedFocusOrder));
+
+            // Assert
+            Assert.That(ex.ActualValue, Is.EqualTo(UnnamedFocusOrder));
+        }
+
+        // GREEN_ON_BASE(characterization): every PanelFocusOrder member reaches the world-space node on the base.
+        // What it answers for is the refusal this branch adds: narrow that check to one member
+        // and this case goes red.
+        [Test]
+        public void Given_EveryMemberOfPanelFocusOrder_When_VWorldSpaceIsCalled_Then_EachBuildsANodeCarryingIt()
+        {
+            // Arrange
+            var members = (PanelFocusOrder[])Enum.GetValues(typeof(PanelFocusOrder));
+
+            // Act
+            var carried = new List<string>();
+            foreach (var member in members)
+            {
+                carried.Add(V.WorldSpace(Vector3.zero, focusOrder: member).FocusOrder.ToString());
+            }
+
+            // Assert
+            Assert.That(string.Join(",", carried), Is.EqualTo(string.Join(",", members.Select(m => m.ToString()))));
+        }
+
+        #endregion
+
+        #region V.Particles(playOn:)
+
+        [Test]
+        public void Given_APlayOnNamingNoMember_When_VParticlesIsCalled_Then_ItThrowsArgumentOutOfRange()
+        {
+            // Act + Assert
+            Assert.That(() => V.Particles(effect: null, playOn: UnnamedPlayTrigger),
+                Throws.TypeOf<ArgumentOutOfRangeException>());
+        }
+
+        [Test]
+        public void Given_APlayOnNamingNoMember_When_VParticlesThrows_Then_TheParamNameIsPlayOn()
+        {
+            // Act
+            var ex = Assert.Throws<ArgumentOutOfRangeException>(
+                () => V.Particles(effect: null, playOn: UnnamedPlayTrigger));
+
+            // Assert
+            Assert.That(ex.ParamName, Is.EqualTo("playOn"));
+        }
+
+        [Test]
+        public void Given_APlayOnNamingNoMember_When_VParticlesThrows_Then_TheMessageNamesTheApiAndTheEnum()
+        {
+            // Act
+            var ex = Assert.Throws<ArgumentOutOfRangeException>(
+                () => V.Particles(effect: null, playOn: UnnamedPlayTrigger));
+
+            // Assert
+            Assert.That((ex.Message.Contains("V.Particles"), ex.Message.Contains("PlayTrigger")),
+                Is.EqualTo((true, true)));
+        }
+
+        [Test]
+        public void Given_APlayOnNamingNoMember_When_VParticlesThrows_Then_TheActualValueIsTheCast()
+        {
+            // Act
+            var ex = Assert.Throws<ArgumentOutOfRangeException>(
+                () => V.Particles(effect: null, playOn: UnnamedPlayTrigger));
+
+            // Assert
+            Assert.That(ex.ActualValue, Is.EqualTo(UnnamedPlayTrigger));
+        }
+
+        // GREEN_ON_BASE(characterization): every PlayTrigger member reaches the particles settings on the base.
+        // What it answers for is the refusal this branch adds: narrow that check to one member
+        // and this case goes red.
+        [Test]
+        public void Given_EveryMemberOfPlayTrigger_When_VParticlesIsCalled_Then_EachBuildsANodeCarryingIt()
+        {
+            // Arrange
+            var members = (PlayTrigger[])Enum.GetValues(typeof(PlayTrigger));
+
+            // Act
+            var carried = new List<string>();
+            foreach (var member in members)
+            {
+                carried.Add(V.Particles(effect: null, playOn: member).Props?.Particles?.PlayOn.ToString() ?? "null");
+            }
+
+            // Assert
+            Assert.That(string.Join(",", carried), Is.EqualTo(string.Join(",", members.Select(m => m.ToString()))));
+        }
+
+        #endregion
+
+        #region V.Draggable(movement:)
+
+        [Test]
+        public void Given_AMovementNamingNoMember_When_VDraggableIsCalled_Then_ItThrowsArgumentOutOfRange()
+        {
+            // Act + Assert
+            Assert.That(() => V.Draggable("source", movement: UnnamedMovement),
+                Throws.TypeOf<ArgumentOutOfRangeException>());
+        }
+
+        [Test]
+        public void Given_AMovementNamingNoMember_When_VDraggableThrows_Then_TheParamNameIsMovement()
+        {
+            // Act
+            var ex = Assert.Throws<ArgumentOutOfRangeException>(
+                () => V.Draggable("source", movement: UnnamedMovement));
+
+            // Assert
+            Assert.That(ex.ParamName, Is.EqualTo("movement"));
+        }
+
+        [Test]
+        public void Given_AMovementNamingNoMember_When_VDraggableThrows_Then_TheMessageNamesTheApiAndTheEnum()
+        {
+            // Act
+            var ex = Assert.Throws<ArgumentOutOfRangeException>(
+                () => V.Draggable("source", movement: UnnamedMovement));
+
+            // Assert
+            Assert.That((ex.Message.Contains("V.Draggable"), ex.Message.Contains("DragMovement")),
+                Is.EqualTo((true, true)));
+        }
+
+        [Test]
+        public void Given_AMovementNamingNoMember_When_VDraggableThrows_Then_TheActualValueIsTheCast()
+        {
+            // Act
+            var ex = Assert.Throws<ArgumentOutOfRangeException>(
+                () => V.Draggable("source", movement: UnnamedMovement));
+
+            // Assert
+            Assert.That(ex.ActualValue, Is.EqualTo(UnnamedMovement));
+        }
+
+        // GREEN_ON_BASE(characterization): every DragMovement member reaches the draggable settings on the base.
+        // What it answers for is the refusal this branch adds: narrow that check to one member
+        // and this case goes red.
+        [Test]
+        public void Given_EveryMemberOfDragMovement_When_VDraggableIsCalled_Then_EachBuildsANodeCarryingIt()
+        {
+            // Arrange
+            var members = (DragMovement[])Enum.GetValues(typeof(DragMovement));
+
+            // Act
+            var carried = new List<string>();
+            foreach (var member in members)
+            {
+                carried.Add(V.Draggable("source", movement: member).Props?.Draggable?.Movement.ToString() ?? "null");
+            }
+
+            // Assert
+            Assert.That(string.Join(",", carried), Is.EqualTo(string.Join(",", members.Select(m => m.ToString()))));
+        }
+
+        #endregion
+
+        #region V.AnimatePresence(mode:)
+
+        [Test]
+        public void Given_AModeNamingNoMember_When_VAnimatePresenceIsCalled_Then_ItThrowsArgumentOutOfRange()
+        {
+            // Act + Assert
+            Assert.That(() => V.AnimatePresence(mode: UnnamedMode),
+                Throws.TypeOf<ArgumentOutOfRangeException>());
+        }
+
+        [Test]
+        public void Given_AModeNamingNoMember_When_VAnimatePresenceThrows_Then_TheParamNameIsMode()
+        {
+            // Act
+            var ex = Assert.Throws<ArgumentOutOfRangeException>(() => V.AnimatePresence(mode: UnnamedMode));
+
+            // Assert
+            Assert.That(ex.ParamName, Is.EqualTo("mode"));
+        }
+
+        [Test]
+        public void Given_AModeNamingNoMember_When_VAnimatePresenceThrows_Then_TheMessageNamesTheApiAndTheEnum()
+        {
+            // Act
+            var ex = Assert.Throws<ArgumentOutOfRangeException>(() => V.AnimatePresence(mode: UnnamedMode));
+
+            // Assert
+            Assert.That((ex.Message.Contains("V.AnimatePresence"), ex.Message.Contains("AnimatePresenceMode")),
+                Is.EqualTo((true, true)));
+        }
+
+        [Test]
+        public void Given_AModeNamingNoMember_When_VAnimatePresenceThrows_Then_TheActualValueIsTheCast()
+        {
+            // Act
+            var ex = Assert.Throws<ArgumentOutOfRangeException>(() => V.AnimatePresence(mode: UnnamedMode));
+
+            // Assert
+            Assert.That(ex.ActualValue, Is.EqualTo(UnnamedMode));
+        }
+
+        // GREEN_ON_BASE(characterization): every AnimatePresenceMode member reaches the presence node on the base.
+        // What it answers for is the refusal this branch adds: narrow that check to one member
+        // and this case goes red.
+        [Test]
+        public void Given_EveryMemberOfAnimatePresenceMode_When_VAnimatePresenceIsCalled_Then_EachBuildsANodeCarryingIt()
+        {
+            // Arrange
+            var members = (AnimatePresenceMode[])Enum.GetValues(typeof(AnimatePresenceMode));
+
+            // Act
+            var carried = new List<string>();
+            foreach (var member in members)
+            {
+                carried.Add(V.AnimatePresence(mode: member).Mode.ToString());
+            }
+
+            // Assert
+            Assert.That(string.Join(",", carried), Is.EqualTo(string.Join(",", members.Select(m => m.ToString()))));
+        }
+
+        #endregion
+
+        #region V.Route(loaderMode:)
+
+        [Test]
+        public void Given_ALoaderModeNamingNoMember_When_VRouteIsCalled_Then_ItThrowsArgumentOutOfRange()
+        {
+            // Act + Assert
+            Assert.That(
+                () => V.Route("reports", element: V.Component(RouteElementRender), loaderMode: UnnamedLoaderMode),
+                Throws.TypeOf<ArgumentOutOfRangeException>());
+        }
+
+        [Test]
+        public void Given_ALoaderModeNamingNoMember_When_VRouteThrows_Then_TheParamNameIsLoaderMode()
+        {
+            // Act
+            var ex = Assert.Throws<ArgumentOutOfRangeException>(
+                () => V.Route("reports", element: V.Component(RouteElementRender), loaderMode: UnnamedLoaderMode));
+
+            // Assert
+            Assert.That(ex.ParamName, Is.EqualTo("loaderMode"));
+        }
+
+        [Test]
+        public void Given_ALoaderModeNamingNoMember_When_VRouteThrows_Then_TheMessageNamesTheApiAndTheEnum()
+        {
+            // Act
+            var ex = Assert.Throws<ArgumentOutOfRangeException>(
+                () => V.Route("reports", element: V.Component(RouteElementRender), loaderMode: UnnamedLoaderMode));
+
+            // Assert
+            Assert.That((ex.Message.Contains("V.Route"), ex.Message.Contains("LoaderMode")),
+                Is.EqualTo((true, true)));
+        }
+
+        [Test]
+        public void Given_ALoaderModeNamingNoMember_When_VRouteThrows_Then_TheActualValueIsTheCast()
+        {
+            // Act
+            var ex = Assert.Throws<ArgumentOutOfRangeException>(
+                () => V.Route("reports", element: V.Component(RouteElementRender), loaderMode: UnnamedLoaderMode));
+
+            // Assert
+            Assert.That(ex.ActualValue, Is.EqualTo(UnnamedLoaderMode));
+        }
+        // GREEN_ON_BASE(characterization): every LoaderMode member reaches the route definition on the base.
+        // What it answers for is the refusal this branch adds: narrow that check to one member
+        // and this case goes red.
+        [Test]
+        public void Given_EveryMemberOfLoaderMode_When_VRouteIsCalled_Then_EachBuildsADefinitionCarryingIt()
+        {
+            // Arrange
+            var members = (LoaderMode[])Enum.GetValues(typeof(LoaderMode));
+
+            // Act
+            var carried = new List<string>();
+            foreach (var member in members)
+            {
+                carried.Add(V.Route("reports", element: V.Component(RouteElementRender), loaderMode: member)
+                    .LoaderMode.ToString());
+            }
+
+            // Assert
+            Assert.That(string.Join(",", carried), Is.EqualTo(string.Join(",", members.Select(m => m.ToString()))));
+        }
+
+        #endregion
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/VFactoryEnumArgumentTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/VFactoryEnumArgumentTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 56582b2a57244b9ebc8709a9e46e6750

--- a/Packages/com.velvet.core/Runtime/Component/V.cs
+++ b/Packages/com.velvet.core/Runtime/Component/V.cs
@@ -763,7 +763,7 @@ namespace Velvet
             IReadOnlyDictionary<string, string>? data = null,
             IReadOnlyDictionary<string, string>? aria = null)
         {
-            if (!Enum.IsDefined(typeof(PlayTrigger), playOn))
+            if (playOn is not (PlayTrigger.Mount or PlayTrigger.Manual))
             {
                 throw new ArgumentOutOfRangeException(nameof(playOn), playOn,
                     "V.Particles takes a member of PlayTrigger as its playOn.");
@@ -1618,12 +1618,12 @@ namespace Velvet
         public static PortalNode Portal(UILayer layer, VNode?[]? children = null, string? key = null,
             PanelFocusOrder focusOrder = PanelFocusOrder.Isolated)
         {
-            if (!Enum.IsDefined(typeof(UILayer), layer))
+            if (layer is not (UILayer.Background or UILayer.Overlay or UILayer.Topmost))
             {
                 throw new ArgumentOutOfRangeException(nameof(layer), layer,
                     "V.Portal takes a member of UILayer as its layer.");
             }
-            if (!Enum.IsDefined(typeof(PanelFocusOrder), focusOrder))
+            if (focusOrder is not (PanelFocusOrder.Isolated or PanelFocusOrder.Chained))
             {
                 throw new ArgumentOutOfRangeException(nameof(focusOrder), focusOrder,
                     "V.Portal takes a member of PanelFocusOrder as its focusOrder.");
@@ -1668,7 +1668,7 @@ namespace Velvet
             string? key = null,
             PanelFocusOrder focusOrder = PanelFocusOrder.Isolated)
         {
-            if (!Enum.IsDefined(typeof(PanelFocusOrder), focusOrder))
+            if (focusOrder is not (PanelFocusOrder.Isolated or PanelFocusOrder.Chained))
             {
                 throw new ArgumentOutOfRangeException(nameof(focusOrder), focusOrder,
                     "V.WorldSpace takes a member of PanelFocusOrder as its focusOrder.");
@@ -1914,8 +1914,8 @@ namespace Velvet
             IReadOnlyDictionary<string, string>? data = null,
             IReadOnlyDictionary<string, string>? aria = null)
         {
-            // Refused before the props bag is rented, so a throwing call strands none in the pool's rented set.
-            if (!Enum.IsDefined(typeof(DragMovement), movement))
+            // Above the rent below, so a refusal here strands no bag this factory rented.
+            if (movement is not (DragMovement.Translate or DragMovement.None))
             {
                 throw new ArgumentOutOfRangeException(nameof(movement), movement,
                     "V.Draggable takes a member of DragMovement as its movement.");
@@ -2097,7 +2097,7 @@ namespace Velvet
             AnimatePresenceMode mode = AnimatePresenceMode.Sync,
             Action? onExitComplete = null)
         {
-            if (!Enum.IsDefined(typeof(AnimatePresenceMode), mode))
+            if (mode is not (AnimatePresenceMode.Sync or AnimatePresenceMode.Wait or AnimatePresenceMode.PopLayout))
             {
                 throw new ArgumentOutOfRangeException(nameof(mode), mode,
                     "V.AnimatePresence takes a member of AnimatePresenceMode as its mode.");
@@ -2376,7 +2376,7 @@ namespace Velvet
                     "redirectTo and guard cannot be specified together. Use redirectTo for redirect-only routes and guard for pass-through routes.");
             }
 
-            if (!Enum.IsDefined(typeof(LoaderMode), loaderMode))
+            if (loaderMode is not (LoaderMode.Await or LoaderMode.Suspend))
             {
                 throw new ArgumentOutOfRangeException(nameof(loaderMode), loaderMode,
                     "V.Route takes a member of LoaderMode as its loaderMode.");

--- a/Packages/com.velvet.core/Runtime/Component/V.cs
+++ b/Packages/com.velvet.core/Runtime/Component/V.cs
@@ -746,7 +746,8 @@ namespace Velvet
         /// <param name="data">data-* attribute map matched by <c>data-[...]</c> variants.</param>
         /// <param name="aria">aria-* attribute map matched by <c>aria-[...]</c> variants.</param>
         /// <returns>The created <see cref="ElementNode"/> representing this particles element.</returns>
-        /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="pixelsPerUnit"/> is not positive.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="pixelsPerUnit"/> is not positive,
+        /// or when <paramref name="playOn"/> names no member of <see cref="PlayTrigger"/>.</exception>
         public static ElementNode Particles(
             ParticleSystem? effect,
             string? className = null,
@@ -762,6 +763,11 @@ namespace Velvet
             IReadOnlyDictionary<string, string>? data = null,
             IReadOnlyDictionary<string, string>? aria = null)
         {
+            if (!Enum.IsDefined(typeof(PlayTrigger), playOn))
+            {
+                throw new ArgumentOutOfRangeException(nameof(playOn), playOn,
+                    "V.Particles takes a member of PlayTrigger as its playOn.");
+            }
             // Validated BEFORE renting pooled props so a throwing call leaks nothing (the settings
             // constructor fail-fasts on an invalid mapping for every construction path, this factory
             // included). Always carried (even with a null effect): the patcher needs the settings on
@@ -1606,7 +1612,8 @@ namespace Velvet
         /// <param name="layer">The framework-managed layer panel to attach the children to.</param>
         /// <param name="children">Descendant VNodes mounted into the layer panel.</param>
         /// <param name="key">Key used to disambiguate siblings at the same position.</param>
-        /// <exception cref="ArgumentOutOfRangeException"><paramref name="layer"/> names no member of <see cref="UILayer"/>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="layer"/> names no member of <see cref="UILayer"/>,
+        /// or <paramref name="focusOrder"/> names no member of <see cref="PanelFocusOrder"/>.</exception>
         /// <returns>The created <see cref="PortalNode"/>.</returns>
         public static PortalNode Portal(UILayer layer, VNode?[]? children = null, string? key = null,
             PanelFocusOrder focusOrder = PanelFocusOrder.Isolated)
@@ -1615,6 +1622,11 @@ namespace Velvet
             {
                 throw new ArgumentOutOfRangeException(nameof(layer), layer,
                     "V.Portal takes a member of UILayer as its layer.");
+            }
+            if (!Enum.IsDefined(typeof(PanelFocusOrder), focusOrder))
+            {
+                throw new ArgumentOutOfRangeException(nameof(focusOrder), focusOrder,
+                    "V.Portal takes a member of PanelFocusOrder as its focusOrder.");
             }
             return new PortalNode
             {
@@ -1645,6 +1657,8 @@ namespace Velvet
         /// <param name="panelSize">Virtual panel resolution in pixels (fixed world-space size mode).</param>
         /// <param name="children">Descendant VNodes rendered inside the world-space panel.</param>
         /// <param name="key">Key used to disambiguate siblings at the same position.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="focusOrder"/> names no member of
+        /// <see cref="PanelFocusOrder"/>.</exception>
         /// <returns>The created <see cref="WorldSpaceNode"/>.</returns>
         public static WorldSpaceNode WorldSpace(
             Vector3 position,
@@ -1654,6 +1668,11 @@ namespace Velvet
             string? key = null,
             PanelFocusOrder focusOrder = PanelFocusOrder.Isolated)
         {
+            if (!Enum.IsDefined(typeof(PanelFocusOrder), focusOrder))
+            {
+                throw new ArgumentOutOfRangeException(nameof(focusOrder), focusOrder,
+                    "V.WorldSpace takes a member of PanelFocusOrder as its focusOrder.");
+            }
             return new WorldSpaceNode
             {
                 Key = key,
@@ -1872,6 +1891,8 @@ namespace Velvet
         /// <param name="activation">Per-draggable activation constraint; wins over the scope's.</param>
         /// <param name="whileDraggingClass">Classes applied while this element's drag is active — the
         /// zero-re-render isDragging channel.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="movement"/> names no member of
+        /// <see cref="DragMovement"/>.</exception>
         /// <returns>The created <see cref="ElementNode"/>.</returns>
         public static ElementNode Draggable(
             string id,
@@ -1893,6 +1914,12 @@ namespace Velvet
             IReadOnlyDictionary<string, string>? data = null,
             IReadOnlyDictionary<string, string>? aria = null)
         {
+            // Refused before the props bag is rented, so a throwing call strands none in the pool's rented set.
+            if (!Enum.IsDefined(typeof(DragMovement), movement))
+            {
+                throw new ArgumentOutOfRangeException(nameof(movement), movement,
+                    "V.Draggable takes a member of DragMovement as its movement.");
+            }
             var mergedProps = WithAttributes(props, data, aria) ?? VNodePool.RentProps();
             mergedProps.Draggable = new DraggableSettings(
                 id, dragData, disabled, movement, activation, whileDraggingClass);
@@ -2053,6 +2080,8 @@ namespace Velvet
         /// pulls an exiting child out of layout flow so still-present siblings reflow immediately.</param>
         /// <param name="onExitComplete">Invoked once when every in-flight exit animation has finished;
         /// not fired for cancelled exits or animation-less removals.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="mode"/> names no member of
+        /// <see cref="AnimatePresenceMode"/>.</exception>
         /// <returns>The created <see cref="AnimatePresenceNode"/>.</returns>
         /// <remarks>
         /// AnimatePresence emits no element of its own — its keyed children expand directly into the parent.
@@ -2068,6 +2097,11 @@ namespace Velvet
             AnimatePresenceMode mode = AnimatePresenceMode.Sync,
             Action? onExitComplete = null)
         {
+            if (!Enum.IsDefined(typeof(AnimatePresenceMode), mode))
+            {
+                throw new ArgumentOutOfRangeException(nameof(mode), mode,
+                    "V.AnimatePresence takes a member of AnimatePresenceMode as its mode.");
+            }
             return new AnimatePresenceNode
             {
                 Key = key,
@@ -2304,6 +2338,8 @@ namespace Velvet
         /// <param name="redirectTo">Path to redirect to. Mutually exclusive with <paramref name="element"/> and <paramref name="guard"/>.</param>
         /// <param name="guard">Pass-through guard returning a redirect path or null. Cannot be combined with <paramref name="redirectTo"/>.</param>
         /// <param name="caseSensitive">When true, literal path segments match case-sensitively. Defaults to false (case-insensitive).</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="loaderMode"/> names no member of
+        /// <see cref="LoaderMode"/>.</exception>
         /// <returns>The created <see cref="RouteDefinition"/>.</returns>
         public static RouteDefinition Route(
             string? path,
@@ -2338,6 +2374,12 @@ namespace Velvet
             {
                 throw new ArgumentException(
                     "redirectTo and guard cannot be specified together. Use redirectTo for redirect-only routes and guard for pass-through routes.");
+            }
+
+            if (!Enum.IsDefined(typeof(LoaderMode), loaderMode))
+            {
+                throw new ArgumentOutOfRangeException(nameof(loaderMode), loaderMode,
+                    "V.Route takes a member of LoaderMode as its loaderMode.");
             }
 
             return new RouteDefinition


### PR DESCRIPTION
Closes #941.

`V.Portal(layer:)` already refused a `UILayer` naming no member. Five other Velvet enums reach a public
factory the same way and are read downstream by an equality against one member, so a value naming none
of them fell to the other side and behaved as the member sitting there, with nothing raised and nothing
logged:

| argument | behaved as | because |
|---|---|---|
| `focusOrder:` on `V.Portal` and `V.WorldSpace` | `Isolated` | `ChildReconciler` and `FiberNodePatcher` ask `== Chained` |
| `playOn:` on `V.Particles` | `Manual` | `ParticlesDriver` asks `== Mount` and stops the host otherwise |
| `movement:` on `V.Draggable` | `None` | `DndActiveDrag` asks `== Translate` at its per-move write and at the restore that undoes it |
| `mode:` on `V.AnimatePresence` | `Sync` | `GeneralPathReconciler` asks `!= Wait` once and `== PopLayout` three times, and such a value answers yes to the first and no to the second |
| `loaderMode:` on `V.Route` | `Suspend` | `RouteLoaderRunner` asks `== Await` and runs the loader in the background otherwise |

That last one is the one of the five where a cast changes when a navigation commits.

Six arguments rather than five factories: `focusOrder:` appears on two.

Each now throws `ArgumentOutOfRangeException` from the call itself, carrying the parameter's name, the
value, and a message naming the API and the enum — the same exception `V.Portal(layer:)` already threw.

**The check is a member comparison, not `Enum.IsDefined`.** That API's only overload on netstandard 2.1
takes `object`, so every call boxed its argument, and three of these factories are called on every render.
`V.Portal(layer:)`'s existing check is converted here for the same reason, so the assembly now carries no
`Enum.IsDefined` call and nine boxes rather than sixteen, the nine being the seven throw paths and two
in `PanelHostFactory` that predate this. `VFactoryEnumArgumentAllocTests` measures the cost of a refusal
on the accept path at all seven arguments, in six cases since `V.Portal`'s covers its two. The
throw path still boxes, deliberately: `ArgumentOutOfRangeException` takes its value as `object`.

A member comparison is a mirror of its enum, and CS8509 cannot pin it — that warning fires on a switch
*expression*, and a switch shape that would fire it throws `SwitchExpressionException` rather than the
`ArgumentOutOfRangeException` these owe. Each check is pinned instead by a case walking
`Enum.GetValues`, which reddens on a member no arm names: six here and, for `UILayer`, the one
`VPortalFactoryTests` already had.

The refusal is at the factory, so a node assembled by hand still carries such a value: `PortalNode`,
`WorldSpaceNode`, `AnimatePresenceNode`, `RouteDefinition`, `ParticlesSettings` and `DraggableSettings`
are public and take theirs through `init` or a constructor. That is the boundary `V.Portal(layer:)`
already draws, and it is what lets the routing fixtures keep building a `RouteDefinition` directly.

A refusal strands no props bag **this factory** rented: on `V.Draggable` the check sits above the rent,
and `V.Particles` validates ahead of its own. It cannot reach a bag an *argument* rented — C# evaluates
arguments first, so `V.Portal(…, children: new[] { V.Draggable("row") }, focusOrder: (PanelFocusOrder)99)`
abandons the child's rental in `VNodePool.s_ownedProps`. That is #955, older than these refusals and not
their doing, though a cast is a new way to reach it.

Breaking for a caller passing such a cast, which today works by falling to one side, so the entry goes in
`## [Unreleased — breaking]`. A caller wanting one of those behaviours names its member.

`Documentation~/drag-and-drop.md`, `focus.md`, `motion.md` and `particles.md` state the refusal where they
document each parameter. Nothing documents `loaderMode:`, so nothing there is falsified.

