### PR TITLE
fix(velvet): refuse a NUL Fragment key before V.ListFragment maps the list

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -94,6 +94,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `V.ListFragment` refuses a `key` holding a NUL (U+0000) before it maps the list rather than after.
+  The refusal is `V.Fragment`'s — NUL is the delimiter the reconciler composes Fragment scope chains
+  from — and both `V.ListFragment` overloads reached it by handing `V.List(...)` to `V.Fragment`, an
+  argument C# evaluates before the call. So a refused call had already run the renderer for every item,
+  and the pooled child array `V.List` took for the result, together with whatever the mapped nodes
+  took, was out on loan when the refusal fired. A refused call builds no Fragment, so no later
+  retirement could carry those back, and nothing else gives a pooled object back. Both overloads refuse
+  ahead of the mapping now: a refused call runs no renderer and takes nothing from a pool.
+
 - A navigation to a path that matches no route no longer cancels the navigation already in flight, nor
   takes `Router.Status` away from it. It used to cancel and to write its status before matching, so a
   stale deep link or a renamed `redirectTo` target made a navigation the user had actually asked for

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/VFactoryRefusalRentalTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/VFactoryRefusalRentalTests.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Reflection;
+using NUnit.Framework;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins each <c>V.ListFragment</c> overload's NUL-key refusal to renting nothing. C# evaluates
+    /// <c>V.List(...)</c> before the <c>V.Fragment</c> call it feeds, so a refusal left to that call
+    /// runs after the list has rented its child array and after whatever the renderer's nodes rented
+    /// — and a refused call builds no Fragment, so nothing is left to carry those to a later
+    /// retirement and no later call can reach them to return them.
+    /// </summary>
+    /// <remarks>
+    /// What these calls MAP to stays <c>VListTests</c>'s; only what they take from the pools is read
+    /// here. An argument the CALLER built is a different question again and is not pinned here either:
+    /// a refusing factory has that node in hand and returns none of what it rented, and
+    /// <see cref="VNodePool"/>'s rented-out identity set states why.
+    /// </remarks>
+    [TestFixture]
+    internal sealed class VFactoryRefusalRentalTests
+    {
+        private const string OwnedPropsFieldName = "s_ownedProps";
+        private const string OwnedNodeArraysFieldName = "s_ownedNodeArrays";
+        private const string CountPropertyName = "Count";
+
+        private const string NulKey = "a\0b";
+        private const string AcceptedKey = "ab";
+
+        private static readonly int[] TwoItems = { 1, 2 };
+
+        // The accepted-key case builds a Fragment no reconcile will ever retire, so its rentals would
+        // stay in the rented-out sets for the rest of the run. VFactoryEnumArgumentAllocTests states
+        // what that costs a later fixture: a set that resizes between two allocation measurements
+        // charges one side and not the other.
+        private FragmentNode? _unretired;
+
+        [TearDown]
+        public void ReturnWhatTheAcceptedCallBuilt()
+        {
+            if (_unretired == null) return;
+            var children = _unretired.Children;
+            for (var i = 0; i < children.Length; i++)
+            {
+                VNodePool.ReturnProps((children[i] as ElementNode)?.Props);
+            }
+            VNodePool.ReturnNodeArray(children);
+            _unretired = null;
+        }
+
+        private static int RentedCount(string fieldName)
+        {
+            var field = typeof(VNodePool).GetField(fieldName, BindingFlags.Static | BindingFlags.NonPublic);
+            if (field == null)
+            {
+                throw new MissingFieldException(typeof(VNodePool).FullName, fieldName);
+            }
+            var set = field.GetValue(null)!;
+            var count = set.GetType().GetProperty(CountPropertyName, BindingFlags.Instance | BindingFlags.Public);
+            if (count == null)
+            {
+                throw new MissingMemberException(set.GetType().FullName, CountPropertyName);
+            }
+            return (int)count.GetValue(set)!;
+        }
+
+        // The refused parameter travels with the growth so one comparison covers both: a refusal
+        // swapped for a silently empty Fragment rents nothing either, and the growth alone reads
+        // that as the fix.
+        private static (string? RefusedParam, int Props, int NodeArrays) Measure(Action call)
+        {
+            var props = RentedCount(OwnedPropsFieldName);
+            var nodeArrays = RentedCount(OwnedNodeArraysFieldName);
+            string? refusedParam = null;
+            try
+            {
+                call();
+            }
+            catch (ArgumentException ex)
+            {
+                refusedParam = ex.ParamName;
+            }
+            return (refusedParam,
+                RentedCount(OwnedPropsFieldName) - props,
+                RentedCount(OwnedNodeArraysFieldName) - nodeArrays);
+        }
+
+        // Neither renderer passes a props: bag of its own, so V.Draggable rents one per item.
+        private static VNode RenderByItem(int item) => V.Draggable("row" + item);
+
+        private static VNode RenderByIndex(int item, int index) => V.Draggable("row" + item + index);
+
+        [Test]
+        public void Given_AKeyedListFragmentWithANulKey_When_TheKeyIsRefused_Then_TheCallRentsNothing()
+        {
+            // Arrange + Act — two items, so a refusal after the list ran would strand both their
+            // bags and the child array V.List rented for them.
+            var refusal = Measure(() => V.ListFragment(TwoItems, item => item.ToString(), RenderByItem, NulKey));
+
+            // Assert
+            Assert.That(refusal, Is.EqualTo(("key", 0, 0)));
+        }
+
+        [Test]
+        public void Given_AnIndexedListFragmentWithANulKey_When_TheKeyIsRefused_Then_TheCallRentsNothing()
+        {
+            // Arrange + Act — the same, on the overload whose selector and renderer take the index.
+            var refusal = Measure(() =>
+                V.ListFragment(TwoItems, (item, index) => item + "-" + index, RenderByIndex, NulKey));
+
+            // Assert
+            Assert.That(refusal, Is.EqualTo(("key", 0, 0)));
+        }
+
+        // GREEN_ON_BASE(characterization): the base accepts this key and rents the same three objects.
+        // It is the control for the two refusal cases above, which assert absences: a probe over a set
+        // that never moved would satisfy their zeroes, and this is their call with the NUL taken out of
+        // the key.
+        [Test]
+        public void Given_AKeyedListFragmentWithAnAcceptedKey_When_ItBuildsTheFragment_Then_ItRentsWhatItBuiltFrom()
+        {
+            // Arrange + Act — the refusal cases' arrangement, minus the NUL.
+            var accepted = Measure(() =>
+                _unretired = V.ListFragment(TwoItems, item => item.ToString(), RenderByItem, AcceptedKey));
+
+            // Assert
+            Assert.That(accepted, Is.EqualTo(((string?)null, 2, 1)));
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/VFactoryRefusalRentalTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/VFactoryRefusalRentalTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3b1efece1be84a13b7315b670786670b

--- a/Packages/com.velvet.core/Runtime/Component/V.cs
+++ b/Packages/com.velvet.core/Runtime/Component/V.cs
@@ -1185,13 +1185,22 @@ namespace Velvet
         /// <param name="keySelector">Selector that derives a stable per-item key.</param>
         /// <param name="renderer">Function that produces a VNode for each item.</param>
         /// <param name="key">Optional key disambiguating this Fragment from siblings at the same position.</param>
+        /// <exception cref="ArgumentException">Thrown, before <paramref name="renderer"/> is invoked for
+        /// any item, when <paramref name="key"/> contains a NUL character.</exception>
         /// <returns>A <see cref="FragmentNode"/> wrapping the rendered VNodes.</returns>
         public static FragmentNode ListFragment<T>(
             IReadOnlyList<T> items,
             Func<T, string> keySelector,
             Func<T, VNode> renderer,
-            string? key = null) =>
-            Fragment(List(items, keySelector, renderer), key);
+            string? key = null)
+        {
+            // Refuses the key BEFORE List runs: C# evaluates that argument first, so leaving the
+            // refusal to the V.Fragment call below strands the child array List rented and whatever
+            // the renderer's nodes rented, with no Fragment built to carry them to a later
+            // retirement. Same ordering rule as V.Draggable's refusal above its own rent.
+            RequireFragmentKey(key);
+            return Fragment(List(items, keySelector, renderer), key);
+        }
 
         /// <summary>
         /// Sibling-friendly variant of <see cref="List{T}(IReadOnlyList{T}, Func{T, int, string}, Func{T, int, VNode})"/>
@@ -1203,13 +1212,19 @@ namespace Velvet
         /// <param name="keySelector">Selector that derives a stable per-item key from the item and its index.</param>
         /// <param name="renderer">Function that produces a VNode from the item and its index.</param>
         /// <param name="key">Optional key disambiguating this Fragment from siblings at the same position.</param>
+        /// <exception cref="ArgumentException">Thrown, before <paramref name="renderer"/> is invoked for
+        /// any item, when <paramref name="key"/> contains a NUL character.</exception>
         /// <returns>A <see cref="FragmentNode"/> wrapping the rendered VNodes.</returns>
         public static FragmentNode ListFragment<T>(
             IReadOnlyList<T> items,
             Func<T, int, string> keySelector,
             Func<T, int, VNode> renderer,
-            string? key = null) =>
-            Fragment(List(items, keySelector, renderer), key);
+            string? key = null)
+        {
+            // Same ordering constraint as the overload above.
+            RequireFragmentKey(key);
+            return Fragment(List(items, keySelector, renderer), key);
+        }
 
         #endregion
 
@@ -2048,17 +2063,22 @@ namespace Velvet
         /// <returns>The created <see cref="FragmentNode"/>.</returns>
         public static FragmentNode Fragment(VNode?[] children, string? key = null)
         {
+            RequireFragmentKey(key);
+            return new FragmentNode
+            {
+                Key = key,
+                Children = children ?? EmptyChildren,
+            };
+        }
+
+        private static void RequireFragmentKey(string? key)
+        {
             if (key != null && key.IndexOf('\0') >= 0)
             {
                 throw new ArgumentException(
                     "Fragment key must not contain a NUL (U+0000) character; NUL is reserved as the internal scope delimiter.",
                     nameof(key));
             }
-            return new FragmentNode
-            {
-                Key = key,
-                Children = children ?? EmptyChildren,
-            };
         }
 
         #endregion

--- a/Packages/com.velvet.core/Runtime/Component/VNodePool.cs
+++ b/Packages/com.velvet.core/Runtime/Component/VNodePool.cs
@@ -68,6 +68,12 @@ namespace Velvet
         // Rent, removed on Return) rather than created-scoped, so the return is idempotent: the recycle
         // sweep can encounter one bag through several retired trees (a baseline retired by its owner and
         // again by a parent expansion) and only the first return recycles it. Mirrors s_ownedNodeArrays.
+        //
+        // A V.* factory that refuses AFTER its arguments were evaluated returns none of what they
+        // rented, for the reason above: the node an argument built may be one the caller still holds.
+        // What returns a bag is FiberTreeReturn's sweep over a retired tree, whose live marks say
+        // which nodes committed state still reaches; a factory has no such marks, and may run with no
+        // fiber on the stack at all.
         private static readonly HashSet<FiberElementProps> s_ownedProps = new();
 
         public static FiberElementProps RentProps()


### PR DESCRIPTION
`V.ListFragment` refused a NUL key from inside `V.Fragment`, which sits below `V.List` — so by the
time the refusal fired, `V.List` had already rented a child array and the renderer had already run
and rented a props bag per item. The exception left every one of those on loan: `VNodePool` records
what it handed out, nothing gives an abandoned rental back, and the pool is empty by that much on
the next call. Measured on a two-item list, one refused call strands two props bags and one node
array. The refusal now fires above the mapping, in `RequireFragmentKey` — the guard moved verbatim
out of `V.Fragment`, same exception, same message, same `ParamName` — called by both
`V.ListFragment` overloads before `V.List` runs.

A refused call also runs no renderer now, where before it ran the renderer for every item and then
threw. That is the behaviour a caller can see change; the refusal itself is spelled exactly as it
was, so a `catch` that names the parameter still names it.

**What this does not close.** A factory that refuses after its arguments were evaluated strands
whatever those arguments rented, because the rental belongs to the caller's expression rather than
to the call — ten public entry points measure that way, and `V.Fragment(V.List(items, selector,
renderer), key)`, the longhand of the sugar fixed here, is one of them. Returning those is not
available: `VNodePool` recycles only what it rented and never a caller-supplied instance, and
returning an argument's rental reproduces exactly the harm that rule exists to prevent — measured,
it takes a settings object off a node the caller still holds. What could be reordered instead has
been.

Three cases pin it: each overload's refusal, and an accepted-key control that separates a refusal
from an empty result. The list carries two items because an empty one rents nothing at all, so a
case posed that way would pass on the broken behaviour too.

No `Documentation~` impact: no guide, no index row and no README names `V.ListFragment` or the pool.

Closes #955.
