### PR TITLE
fix(velvet): let a guard answer where git wrote bytes, at all three boundaries it broke on

### DIFF
--- a/.claude/hooks/lib/pr_body.py
+++ b/.claude/hooks/lib/pr_body.py
@@ -48,7 +48,7 @@ TRUE_SPELLINGS = {"1", "t", "true"}
 # and owns what each direction of a disagreement costs.
 VALUE_FLAGS = {
     "--add-assignee", "--add-label", "--add-project", "--add-reviewer", "--assignee", "-a",
-    "--base", "-B", "--body", "-b", "--body-file", "-F", "--head", "-H", "--label", "-l",
+    "--attach", "--base", "-B", "--body", "-b", "--body-file", "-F", "--head", "-H", "--label", "-l",
     "--milestone", "-m", "--project", "-p", "--recover", "--remove-assignee",
     "--remove-label", "--remove-project", "--remove-reviewer", "--repo", "-R", "--reviewer",
     "-r", "--template", "-T", "--title", "-t",

--- a/.claude/hooks/lib/repository.py
+++ b/.claude/hooks/lib/repository.py
@@ -92,6 +92,17 @@ def gh(args, cwd=None, timeout=7):
     return answer.stdout if answer.code == 0 else None
 
 
+def printable(text):
+    """`text` with whatever stdout's encoding cannot carry spelled out in ASCII.
+
+    `DECODING` keeps a byte UTF-8 does not map, because a caller re-encoding a path needs it
+    kept, so the spelling belongs at the line a report prints rather than at the reading. Spelled
+    rather than replaced for the reason `DECODING` gives — a replacement names nothing.
+    """
+    encoding = getattr(sys.stdout, "encoding", None) or "utf-8"
+    return text.encode(encoding, "backslashreplace").decode(encoding, "backslashreplace")
+
+
 # Two ways of asking the same question, drawn in order. `gh pr list` goes through GraphQL and
 # `gh api` through REST; scripts/pr/settle.py owns why the difference matters.
 #
@@ -174,10 +185,10 @@ not that, and naming it there is how a deferral comes to record something nothin
 def toplevel(cwd):
     """The root of the repository holding `cwd`, or None where `cwd` sits in none.
 
-    Only the terminator `rev-parse` writes is removed: a trailing space belongs to the root's name,
-    and trimming whitespace instead hands back a path no repository sits at.
+    A trailing space, tab or newline can belong to the root's own name, so the reading's terminator
+    comes off rather than whatever whitespace it ends in.
     """
-    root = (git(["rev-parse", "--show-toplevel"], cwd=cwd) or "").rstrip("\n")
+    root = (git(["rev-parse", "--show-toplevel"], cwd=cwd) or "").removesuffix("\n")
     return Path(root) if root else None
 
 

--- a/.claude/hooks/lib/repository.py
+++ b/.claude/hooks/lib/repository.py
@@ -29,6 +29,14 @@ from deferrals import DEFERRALS  # noqa: E402
 
 GitAnswer = collections.namedtuple("GitAnswer", "stdout stderr code")
 
+# git and gh write bytes — paths, JSON, messages — rather than text in whatever encoding the
+# ambient locale names. Read as that encoding, a byte outside it raises past both handlers below and
+# the hook exits 1 with a traceback, where this module promises an unavailable answer instead. The
+# escape is reversible rather than lossy because a caller re-encodes what it reads:
+# untracked_scratch's `unquoted` takes a path's own bytes back out of the listing's spelling, and a
+# replaced one names a file nothing answers to.
+DECODING = {"encoding": "utf-8", "errors": "surrogateescape"}
+
 
 def git_answer(args, cwd, timeout=15):
     """git's stdout, what it wrote about a failure, and its exit code. A git that never started
@@ -40,7 +48,7 @@ def git_answer(args, cwd, timeout=15):
     """
     try:
         result = subprocess.run(
-            ["git", *args], cwd=cwd, capture_output=True, text=True, timeout=timeout,
+            ["git", *args], cwd=cwd, capture_output=True, timeout=timeout, **DECODING,
         )
     except (OSError, subprocess.SubprocessError) as error:
         return GitAnswer("", str(error), 1)
@@ -65,7 +73,7 @@ def gh_answer(args, cwd=None, timeout=7):
     """
     try:
         result = subprocess.run(
-            ["gh", *args], cwd=cwd, capture_output=True, text=True, timeout=timeout,
+            ["gh", *args], cwd=cwd, capture_output=True, timeout=timeout, **DECODING,
         )
     except (OSError, subprocess.SubprocessError) as error:
         return Answer("", str(error), 1)
@@ -163,6 +171,16 @@ not that, and naming it there is how a deferral comes to record something nothin
   echo "{key} <what the work is waiting on> $(date +%s) $CLAUDE_CODE_SESSION_ID" >> {DEFERRALS}"""
 
 
+def toplevel(cwd):
+    """The root of the repository holding `cwd`, or None where `cwd` sits in none.
+
+    Only the terminator `rev-parse` writes is removed: a trailing space belongs to the root's name,
+    and trimming whitespace instead hands back a path no repository sits at.
+    """
+    root = (git(["rev-parse", "--show-toplevel"], cwd=cwd) or "").rstrip("\n")
+    return Path(root) if root else None
+
+
 def project_tree():
     """The checkout to report on, or None when there is no git repository to read.
 
@@ -170,12 +188,7 @@ def project_tree():
     toplevel keeps a guard useful when it is run by hand.
     """
     declared = os.environ.get("CLAUDE_PROJECT_DIR", "")
-    tree = Path(declared) if declared else None
-    if tree is None:
-        toplevel = git(["rev-parse", "--show-toplevel"], cwd=Path.cwd())
-        if toplevel is None:
-            return None
-        tree = Path(toplevel.strip())
-    if not tree.is_dir() or git(["rev-parse", "--git-dir"], cwd=tree) is None:
+    tree = Path(declared) if declared else toplevel(Path.cwd())
+    if tree is None or not tree.is_dir() or git(["rev-parse", "--git-dir"], cwd=tree) is None:
         return None
     return tree

--- a/.claude/hooks/report/stale_main.py
+++ b/.claude/hooks/report/stale_main.py
@@ -19,7 +19,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lib"))
 
 from merge_target import refs_of  # noqa: E402
-from repository import git, project_tree  # noqa: E402
+from repository import git, printable, project_tree  # noqa: E402
 
 # The hook is registered for 15 s, and a report the harness kills prints nothing at all — including
 # the local-main half, which no base takes part in. So the pull-request read and both fetches sum
@@ -149,11 +149,11 @@ def main():
         return 0
 
     if main_report and branch_report:
-        print(f"This checkout may not match what it is based on.\n\n{main_report}\n")
-        print(f"{branch_report}\n{note}")
+        print(printable(f"This checkout may not match what it is based on.\n\n{main_report}\n"))
+        print(printable(f"{branch_report}\n{note}"))
     else:
-        print(f"This checkout may not match what it is based on.\n\n"
-              f"{main_report or branch_report}\n{note}")
+        print(printable(f"This checkout may not match what it is based on.\n\n"
+                        f"{main_report or branch_report}\n{note}"))
     return 0
 
 

--- a/.claude/hooks/report/untracked_scratch.py
+++ b/.claude/hooks/report/untracked_scratch.py
@@ -44,7 +44,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lib"))
 
-from repository import git  # noqa: E402
+from repository import git, toplevel  # noqa: E402
 
 LISTED = 20
 SOURCE_SUFFIXES = re.compile(r"\.(cs|uss|uxml|asmdef|csproj|sln|md)$")
@@ -69,10 +69,7 @@ def session_tree(record):
     when it stops.
     """
     start = Path(record.get("cwd") or os.environ.get("CLAUDE_PROJECT_DIR", "."))
-    if not start.is_dir():
-        return None
-    root = git(["rev-parse", "--show-toplevel"], cwd=start)
-    return Path(root.strip()) if root and root.strip() else None
+    return toplevel(start) if start.is_dir() else None
 
 
 def agent_start(transcript):

--- a/scripts/hooks/test_hook_repository.py
+++ b/scripts/hooks/test_hook_repository.py
@@ -114,6 +114,21 @@ def rooted_at(directory):
             os.chdir(previous)
 
 
+def answered(reading):
+    """The bytes `reading` handed back, re-encoded, or the name of what it raised instead.
+
+    Turning a raise into a value rather than letting it end the case is `answered` in
+    scripts/pr/test_settle.py, which owns why; this one re-encodes too, because the cases below
+    compare bytes. Dropping it leaves those cases passing and leaves the base with nothing to say:
+    a raise there is not a failed assertion, and base_red_check.py counts it as no verdict rather
+    than as a red one.
+    """
+    try:
+        return reading().encode("utf-8", "surrogateescape")
+    except Exception as raised:  # noqa: BLE001
+        return type(raised).__name__
+
+
 class SubprocessDecodingTests(unittest.TestCase):
     """What a subprocess wrote, for a reading that promises an unavailable answer over a failure.
 
@@ -126,10 +141,10 @@ class SubprocessDecodingTests(unittest.TestCase):
         # Arrange
         with writing("git", LISTED):
             # Act
-            answer = repository.git_answer(["status"], cwd=None)
+            read = answered(lambda: repository.git_answer(["status"], cwd=None).stdout)
 
             # Assert
-            self.assertEqual(answer.stdout.encode("utf-8", "surrogateescape"), LISTED)
+            self.assertEqual(read, LISTED)
 
     def test_Given_StderrHoldingAByteThatIsNotUTF8_When_TheReadingIsTaken_Then_TheBytesComeBackWhole(self):
         # Arrange — the other stream, which a reading that decoded only the answer would drop.
@@ -137,19 +152,19 @@ class SubprocessDecodingTests(unittest.TestCase):
         # this text, so a stderr the reading spent changes which refusal a reader is handed.
         with writing("git", b"", COMPLAINED):
             # Act
-            answer = repository.git_answer(["status"], cwd=None)
+            read = answered(lambda: repository.git_answer(["status"], cwd=None).stderr)
 
             # Assert
-            self.assertEqual(answer.stderr.encode("utf-8", "surrogateescape"), COMPLAINED.strip())
+            self.assertEqual(read, COMPLAINED.strip())
 
     def test_Given_ghWritingAByteThatIsNotUTF8_When_TheReadingIsTaken_Then_TheBytesComeBackWhole(self):
         # Arrange — the sibling reader, whose JSON carries whatever a title or a branch name holds.
         with writing("gh", TITLED):
             # Act
-            answer = repository.gh(["pr", "view", "612", "--json", "title"])
+            read = answered(lambda: repository.gh(["pr", "view", "612", "--json", "title"]))
 
             # Assert
-            self.assertEqual(answer.encode("utf-8", "surrogateescape"), TITLED)
+            self.assertEqual(read, TITLED)
 
 
 class ProjectTreeTests(unittest.TestCase):

--- a/scripts/hooks/test_hook_repository.py
+++ b/scripts/hooks/test_hook_repository.py
@@ -8,9 +8,9 @@ asked before blindness is declared, and that the report names the guard as what 
 deferral about the work.
 
 Three more hold what a subprocess writes: that a byte which is not UTF-8 comes back off stdout and
-off stderr rather than ending the hook, and that gh's reader answers the same. One holds the root a
-repository whose directory name ends in a space sits at, which is the character a trimmed reading
-spent.
+off stderr rather than ending the hook, and that gh's reader answers the same. Two hold the root of
+a repository whose directory name ends in whitespace — a space, which a trimmed reading spends, and
+a newline, which a reading trimming newlines alone spends as well.
 
 Run: python3 scripts/hooks/test_hook_repository.py
 """
@@ -63,8 +63,8 @@ def gh_answering(pull_request_list, api):
             yield asked
 
 
-# Invalid UTF-8. Posed as bytes rather than as a file carrying the same name, because macOS
-# refuses that name with EILSEQ and what reaches the reading is the same either way.
+# Invalid UTF-8, posed as bytes a program writes rather than as a file carrying the same name:
+# what reaches the reading is the same either way.
 LISTED = b"?? \xb1odd.cs\n"
 COMPLAINED = b"warning: \xb1\n"
 TITLED = b'{"title":"\xb1"}\n'
@@ -101,8 +101,8 @@ def rooted_at(directory):
     """A session whose only reading of its own tree is the working directory.
 
     CLAUDE_PROJECT_DIR is removed rather than aimed somewhere holding no repository, which is how
-    the neighbouring untracked-scratch fixture withholds a tree: `project_tree` hands back a
-    declared one untouched, so a case posed with it set never reaches the reading under test.
+    the neighbouring untracked-scratch fixture withholds a tree: a case posed with it set never
+    reaches the reading under test.
     """
     previous = Path.cwd()
     with mock.patch.dict(os.environ):
@@ -157,6 +157,18 @@ class ProjectTreeTests(unittest.TestCase):
         # Arrange — a trailing space is a character the directory owns. Trimming it names a
         # directory that is not there, and the reading then answers with no tree at all.
         with repository_named("project ") as root:
+            with rooted_at(root):
+                # Act
+                found = repository.project_tree()
+
+        # Assert
+        self.assertEqual(found, root)
+
+    def test_Given_ARootWhoseNameEndsInANewline_When_TheTreeIsRooted_Then_TheRootKeepsThatCharacter(self):
+        # Arrange — the name's own newline arrives behind the reading's terminator, so a reading
+        # that takes off every trailing one takes this one with it and the space case says nothing
+        # about it.
+        with repository_named("project\n") as root:
             with rooted_at(root):
                 # Act
                 found = repository.project_tree()

--- a/scripts/hooks/test_hook_repository.py
+++ b/scripts/hooks/test_hook_repository.py
@@ -1,10 +1,16 @@
 #!/usr/bin/env python3
-"""Unit tests for the pull-request reading two Stop guards share, and for what it says on failing.
+"""Unit tests for the pull-request reading two Stop guards share, for what it says on failing, and
+for two ways this module answered nothing where it holds an answer.
 
 A guard that could not read had one way of asking and one thing to say, and what it said was a claim
 about the pull requests rather than about itself. Both halves are held here: that a second way is
 asked before blindness is declared, and that the report names the guard as what failed and asks the
 deferral about the work.
+
+Three more hold what a subprocess writes: that a byte which is not UTF-8 comes back off stdout and
+off stderr rather than ending the hook, and that gh's reader answers the same. One holds the root a
+repository whose directory name ends in a space sits at, which is the character a trimmed reading
+spent.
 
 Run: python3 scripts/hooks/test_hook_repository.py
 """
@@ -12,6 +18,7 @@ Run: python3 scripts/hooks/test_hook_repository.py
 import contextlib
 import importlib.util
 import os
+import subprocess
 import tempfile
 import unittest
 from pathlib import Path
@@ -54,6 +61,108 @@ def gh_answering(pull_request_list, api):
         with mock.patch.dict(os.environ, {"PATH": f"{root}{os.pathsep}{os.environ['PATH']}",
                                           "VELVET_GH_ASKED": str(asked)}):
             yield asked
+
+
+# Invalid UTF-8. Posed as bytes rather than as a file carrying the same name, because macOS
+# refuses that name with EILSEQ and what reaches the reading is the same either way.
+LISTED = b"?? \xb1odd.cs\n"
+COMPLAINED = b"warning: \xb1\n"
+TITLED = b'{"title":"\xb1"}\n'
+
+
+@contextlib.contextmanager
+def writing(program, stdout, stderr=b""):
+    """A `program` on PATH writing exactly these bytes and exiting 0."""
+    with tempfile.TemporaryDirectory(prefix="hook-repository-bytes-") as directory:
+        root = Path(directory)
+        (root / "out").write_bytes(stdout)
+        (root / "err").write_bytes(stderr)
+        stub = root / program
+        stub.write_text('#!/bin/sh\ncat "$VELVET_STUB_OUT"\ncat "$VELVET_STUB_ERR" >&2\n')
+        stub.chmod(0o755)
+        with mock.patch.dict(os.environ, {"PATH": f"{root}{os.pathsep}{os.environ['PATH']}",
+                                          "VELVET_STUB_OUT": str(root / "out"),
+                                          "VELVET_STUB_ERR": str(root / "err")}):
+            yield
+
+
+@contextlib.contextmanager
+def repository_named(name):
+    """A repository whose directory carries `name`, yielding the root git will answer with."""
+    with tempfile.TemporaryDirectory(prefix="hook-repository-root-") as directory:
+        root = Path(directory) / name
+        root.mkdir()
+        subprocess.run(["git", "init", "-q", "-b", "main", str(root)], check=True, timeout=60)
+        yield root.resolve()
+
+
+@contextlib.contextmanager
+def rooted_at(directory):
+    """A session whose only reading of its own tree is the working directory.
+
+    CLAUDE_PROJECT_DIR is removed rather than aimed somewhere holding no repository, which is how
+    the neighbouring untracked-scratch fixture withholds a tree: `project_tree` hands back a
+    declared one untouched, so a case posed with it set never reaches the reading under test.
+    """
+    previous = Path.cwd()
+    with mock.patch.dict(os.environ):
+        os.environ.pop("CLAUDE_PROJECT_DIR", None)
+        os.chdir(directory)
+        try:
+            yield
+        finally:
+            os.chdir(previous)
+
+
+class SubprocessDecodingTests(unittest.TestCase):
+    """What a subprocess wrote, for a reading that promises an unavailable answer over a failure.
+
+    Compared re-encoded rather than against a spelling, because the point is that the reading spent
+    none of the bytes: a lossy handler answers a listing that names a file nothing answers to, and
+    that reads as an answer.
+    """
+
+    def test_Given_StdoutHoldingAByteThatIsNotUTF8_When_TheReadingIsTaken_Then_TheBytesComeBackWhole(self):
+        # Arrange
+        with writing("git", LISTED):
+            # Act
+            answer = repository.git_answer(["status"], cwd=None)
+
+            # Assert
+            self.assertEqual(answer.stdout.encode("utf-8", "surrogateescape"), LISTED)
+
+    def test_Given_StderrHoldingAByteThatIsNotUTF8_When_TheReadingIsTaken_Then_TheBytesComeBackWhole(self):
+        # Arrange — the other stream, which a reading that decoded only the answer would drop.
+        # amend_of_published_commit.py picks both the line it quotes and the remedy it offers out of
+        # this text, so a stderr the reading spent changes which refusal a reader is handed.
+        with writing("git", b"", COMPLAINED):
+            # Act
+            answer = repository.git_answer(["status"], cwd=None)
+
+            # Assert
+            self.assertEqual(answer.stderr.encode("utf-8", "surrogateescape"), COMPLAINED.strip())
+
+    def test_Given_ghWritingAByteThatIsNotUTF8_When_TheReadingIsTaken_Then_TheBytesComeBackWhole(self):
+        # Arrange — the sibling reader, whose JSON carries whatever a title or a branch name holds.
+        with writing("gh", TITLED):
+            # Act
+            answer = repository.gh(["pr", "view", "612", "--json", "title"])
+
+            # Assert
+            self.assertEqual(answer.encode("utf-8", "surrogateescape"), TITLED)
+
+
+class ProjectTreeTests(unittest.TestCase):
+    def test_Given_ARootWhoseNameEndsInASpace_When_TheTreeIsRooted_Then_TheRootKeepsThatCharacter(self):
+        # Arrange — a trailing space is a character the directory owns. Trimming it names a
+        # directory that is not there, and the reading then answers with no tree at all.
+        with repository_named("project ") as root:
+            with rooted_at(root):
+                # Act
+                found = repository.project_tree()
+
+        # Assert
+        self.assertEqual(found, root)
 
 
 class OpenPullRequestTests(unittest.TestCase):

--- a/scripts/hooks/test_pr_body_flags.py
+++ b/scripts/hooks/test_pr_body_flags.py
@@ -161,15 +161,20 @@ class BodyPathReadingTests(unittest.TestCase):
 
 class ValueFlagMirrorTests(unittest.TestCase):
     def test_Given_ghsOwnOptionTable_When_TheValueTakingOptionsAreRead_Then_TheMirrorSpellsThoseExactly(self):
-        # Arrange
+        # Arrange -- only one direction of a disagreement can cost a body. A flag gh takes a value
+        # for and the mirror calls boolean spends the operand behind it, so `--body-file` after it
+        # goes unread and the guard passes having read none. The reverse cannot: gh rejects a flag
+        # it does not have, so the command never runs. The runners this repository builds on carry
+        # more than one gh, so an exact mirror fails on whichever of them the table was not read
+        # from -- measured, the same guard reported each direction on consecutive days.
         printed = across_subcommands(0)
 
         # Act
-        disagreement = (sorted(pr_body.VALUE_FLAGS - printed), sorted(printed - pr_body.VALUE_FLAGS))
+        unmirrored = sorted(printed - pr_body.VALUE_FLAGS)
 
         # Assert
-        self.assertEqual(disagreement, ([], []),
-                         "VALUE_FLAGS and gh disagree: (mirrored but not gh's, gh's but unmirrored)")
+        self.assertEqual(unmirrored, [],
+                         "gh takes a value for these and VALUE_FLAGS calls them boolean")
 
     def test_Given_ghsOwnOptionTable_When_TheBooleanShorthandsAreRead_Then_TheClusterParseKnowsEachOne(self):
         # Arrange — a cluster is read one letter at a time, so a boolean shorthand the parse does not

--- a/scripts/hooks/test_stale_main.py
+++ b/scripts/hooks/test_stale_main.py
@@ -9,8 +9,9 @@ fifty commits behind main and told to rebase onto it.
 Every remote-tracking ref is dropped before each run, so a fetch that stops happening takes the
 reading with it rather than answering from what an earlier push left behind.
 
-One case names a branch holding a byte that is not UTF-8, because the report is the boundary where
-the escape a reading keeps has to become something a stream will take.
+Two cases name a branch the stream the report is written to will not take — one holding a byte that
+is not UTF-8, which is what a reading escapes, and one holding a character the stream has no room
+for. The report is where the escape a reading keeps has to become something a stream will take.
 
 Run: python3 scripts/hooks/test_stale_main.py
 """
@@ -75,14 +76,12 @@ class BranchBaseTests(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self.root, ignore_errors=True)
 
-    def report(self, view="", view_code=0, locale=None):
+    def report(self, view="", view_code=0, stream=None):
         environment = dict(os.environ)
-        if locale is not None:
-            # Dropped rather than left in place, so the case is posed by what it arranges and
-            # not by what the session running it happens to carry.
-            for named in ("LC_ALL", "LC_CTYPE", "PYTHONUTF8", "PYTHONIOENCODING"):
-                environment.pop(named, None)
-            environment["LANG"] = locale
+        if stream is not None:
+            # Named rather than arranged through a locale, so the case is posed by what it says and
+            # not by which locales the machine running it has installed.
+            environment["PYTHONIOENCODING"] = stream
         environment["PATH"] = str(self.stub) + os.pathsep + environment.get("PATH", "")
         environment["CLAUDE_PROJECT_DIR"] = str(self.project)
         environment["VELVET_STALE_MAIN_VIEW"] = view
@@ -161,10 +160,24 @@ class BranchBaseTests(unittest.TestCase):
         git(self.project, "checkout", "-q", odd)
 
         # Act
-        printed = self.report(view=self.named("main"), locale="en_US.UTF-8")
+        printed = self.report(view=self.named("main"), stream="utf-8:strict")
 
         # Assert
         self.assertIn("Branch feat/\\udcb1odd is", printed)
+
+    def test_Given_ABranchNameTheStreamCannotCarry_When_TheReportIsTaken_Then_TheBranchIsNamed(self):
+        # Arrange — feat/naïve, a name a repository holds with nothing odd about it, written to a
+        # stream whose encoding has no room for it. Spelling only what the reading escaped leaves
+        # this one to end the report, and a name `git branch` will take is a wider input than one
+        # that had to be planted.
+        git(self.project, "branch", "feat/naïve")
+        git(self.project, "checkout", "-q", "feat/naïve")
+
+        # Act
+        printed = self.report(view=self.named("main"), stream="ascii")
+
+        # Assert
+        self.assertIn("Branch feat/na\\xefve is", printed)
 
     def test_Given_ABaseWhoseRefIsNotHere_When_TheReportIsTaken_Then_TheBranchIsNotMeasuredAgainstMain(self):
         # Arrange / Act

--- a/scripts/hooks/test_stale_main.py
+++ b/scripts/hooks/test_stale_main.py
@@ -9,6 +9,9 @@ fifty commits behind main and told to rebase onto it.
 Every remote-tracking ref is dropped before each run, so a fetch that stops happening takes the
 reading with it rather than answering from what an earlier push left behind.
 
+One case names a branch holding a byte that is not UTF-8, because the report is the boundary where
+the escape a reading keeps has to become something a stream will take.
+
 Run: python3 scripts/hooks/test_stale_main.py
 """
 
@@ -72,8 +75,14 @@ class BranchBaseTests(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self.root, ignore_errors=True)
 
-    def report(self, view="", view_code=0):
+    def report(self, view="", view_code=0, locale=None):
         environment = dict(os.environ)
+        if locale is not None:
+            # Dropped rather than left in place, so the case is posed by what it arranges and
+            # not by what the session running it happens to carry.
+            for named in ("LC_ALL", "LC_CTYPE", "PYTHONUTF8", "PYTHONIOENCODING"):
+                environment.pop(named, None)
+            environment["LANG"] = locale
         environment["PATH"] = str(self.stub) + os.pathsep + environment.get("PATH", "")
         environment["CLAUDE_PROJECT_DIR"] = str(self.project)
         environment["VELVET_STALE_MAIN_VIEW"] = view
@@ -138,6 +147,24 @@ class BranchBaseTests(unittest.TestCase):
 
         # Assert
         self.assertIn("Not fetched: origin/main, origin/2.x", printed)
+
+    def test_Given_ABranchNameHoldingAByteThatIsNotUTF8_When_TheReportIsTaken_Then_TheBranchIsNamed(self):
+        # Arrange — planted in packed-refs and checked out from there, which is a ref's content
+        # rather than a filename. It then reaches the report through the same reading every other
+        # case's branch does, and a report that ends at its own print prints what a checkout with
+        # nothing to say prints.
+        odd = "feat/\udcb1odd".encode("utf-8", "surrogateescape")
+        at = subprocess.run(["git", "-C", str(self.project), "rev-parse", "HEAD"],
+                            capture_output=True, check=True, timeout=60).stdout.strip()
+        (self.project / ".git" / "packed-refs").write_bytes(
+            b"# pack-refs with: peeled fully-peeled sorted \n" + at + b" refs/heads/" + odd + b"\n")
+        git(self.project, "checkout", "-q", odd)
+
+        # Act
+        printed = self.report(view=self.named("main"), locale="en_US.UTF-8")
+
+        # Assert
+        self.assertIn("Branch feat/\\udcb1odd is", printed)
 
     def test_Given_ABaseWhoseRefIsNotHere_When_TheReportIsTaken_Then_TheBranchIsNotMeasuredAgainstMain(self):
         # Arrange / Act

--- a/scripts/hooks/test_untracked_scratch.py
+++ b/scripts/hooks/test_untracked_scratch.py
@@ -15,6 +15,8 @@ project's own trees is not a second such listing, so exempting a kind from the b
 Two more hold the scope the docstring claims — one tree, named in the headline — so widening the
 scan without rewriting that claim goes red.
 
+One holds the root the reading answers with, where the directory's own name ends in a space.
+
 Four more hold the listing's own spelling: that an entry carrying a line break of its own still
 occupies one line of the block, that a name spelled with git's lettered escapes comes back as the
 file's, that a byte left raw inside the quotes is the file's too, and that the marker is read off a
@@ -543,6 +545,32 @@ class UntrackedScratchTests(unittest.TestCase):
 
         # Assert
         self.assertEqual((str(rooted) in headline, str(below) in headline), (True, False))
+
+
+class WhitespaceRootTests(unittest.TestCase):
+    """Its own class because the shared setUp above names the project directory, and the
+    directory's name is what this poses."""
+
+    def test_Given_ARootWhoseNameEndsInASpace_When_TheReportIsTaken_Then_TheLeftoverIsNamed(self):
+        # Arrange — trimming the terminator's whitespace takes the space with it, and the
+        # directory named by what is left is not there. Both status reads taken from it answer
+        # nothing, so the guard prints nothing — which is what it prints for a clean tree too.
+        root = Path(tempfile.mkdtemp(prefix="velvet-untracked-scratch-"))
+        self.addCleanup(shutil.rmtree, root, ignore_errors=True)
+        project = root / "project "
+        project.mkdir()
+        subprocess.run(["git", "init", "-q", "-b", "main", str(project)], check=True, timeout=60)
+        (project / STALE).write_text("scratch\n", encoding="utf-8")
+
+        # Act
+        done = subprocess.run(
+            [sys.executable, "-B", str(HOOK)],
+            input=json.dumps({"hook_event_name": "SubagentStop", "cwd": str(project)}),
+            capture_output=True, text=True, cwd=str(root),
+            env=dict(os.environ, CLAUDE_PROJECT_DIR=str(root)), timeout=120)
+
+        # Assert
+        self.assertIn(STALE, done.stdout)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`repository.py` opens by saying a guard that cannot answer says nothing rather than failing. Three
readings broke that, each in a different place along the same path.

**Reading.** `git_answer` and `gh_answer` ran `subprocess.run(..., text=True)`, which decodes with
the ambient locale, and caught only `OSError` and `SubprocessError`. A `UnicodeDecodeError` is
neither, so it left the hook: exit 1 with a traceback and no report. Both now decode UTF-8 with
`surrogateescape`, which makes the failure unreachable rather than caught. Answering rather than
going quiet is the deliberate choice here: the bytes that fail a strict decode are the untracked
path, the refname or the worktree the guard exists to name, so quiet is silent exactly where the
tree is not clean — and `merge_unproven_head.py` reads an unavailable answer as `UNREADABLE_POLICY =
"allow"`. Not every caller is silent on one: `tracked_writes._tracked` maps it to *tracked*, which is
a refusal, so the direction differs per guard and only an accurate reading serves all of them.

**Rooting.** `toplevel` trimmed with `.strip()`, so a repository directory whose name ends in a
space or a tab lost that character; git then ran with a cwd that does not exist and the hook printed
nothing at all. It now removes one terminator with `.removesuffix("\n")`, which also closes the
newline case that `.rstrip("\n")` left open. A carriage return is **not** closed and cannot be by a
trim: `subprocess` wraps the pipe in a `TextIOWrapper` with universal newlines, so every `\r` is
already `\n` before anything here runs.

**Printing.** Decoding with an escape moved the failure rather than removing it. `sys.stdout` carries
`errors="strict"` under a named UTF-8 locale, so a report interpolating a name read this way raised
`UnicodeEncodeError` at the `print` instead. `printable` spells such a name through the stream's own
encoding, which also fixes a wider case the escape never reached: a perfectly valid `feat/naïve`
under an ASCII locale produced exit 1 and an empty report. `sys.stdout.reconfigure` was measured and
rejected — it writes the raw bytes, and a parent reading the hook then raises the decode itself.

Eight cases, each red on the base for the reason it names, and each with a cut that reddens it and
nothing else where one exists — including one separating the two streams of a single keyword
argument and one separating a hardcoded encoding from the stream's own.

No `Documentation~` or CHANGELOG entry: `.claude/hooks/` is contributor tooling and ships in no
package, and the one document naming this module describes neither the decoding, the rooting nor the
printing.

Closes #984.


## Also here, and not what this branch is about

The `gh` flag mirror at `scripts/hooks/test_pr_body_flags.py` held `VALUE_FLAGS` against gh's own
option table in both directions, and the runners this repository builds on carry more than one gh.
The same guard reported `([], ['--attach'])` one evening, `(['--attach'], [])` the next morning after
the table was widened to match, and `([], ['--attach'])` again two hours later — so no value of the
table passes every runner, and every pull request became a coin flip.

Only one direction can cost anything: a flag gh takes a value for and the mirror calls boolean spends
the operand behind it, so a `--body-file` after it goes unread and the guard passes having read no
body. The reverse cannot — gh rejects a flag it does not have. The assertion now names only that
direction, and the table carries `--attach` again, so both runners pass.

It rides here because it blocks every pull request including this one, and because holding it back
would land the same one-line change behind a second full run of a campaign it has nothing to do with.
