### PR TITLE
fix(velvet): refuse the scope delimiter in every VNode key

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -92,22 +92,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   value naming no member of the enum, where they returned `0f` and `false`. Both have done so since
   2.0.1.
 
+- A key holding a NUL (U+0000) is refused wherever one reaches a VNode, where `V.Fragment` and the
+  two `V.ListFragment` overloads were the only factories refusing one. NUL is the delimiter the
+  reconciler's scope chains are composed from, so a key carrying it split into more segments than
+  one and let two different tree positions compose to the same scope string — where they then
+  reconciled as one identity. Measured on a `V.Label` keyed `"a\0b"` sitting beside a `V.Fragment`
+  keyed `"a"` that holds a `V.Label` keyed `"b"`, both under one keyed Fragment: the two labels
+  compose the same scope, and a re-render left the second label's element in the first label's
+  slot, a fresh element in the second's, and the first label's own element nowhere in the tree.
+  `V.Provider`, `V.Suspense`, `V.AnimatePresence`, `V.Component`, `V.MemoizedWithKey`,
+  `V.DragOverlay`, every element factory's `key:`, a `V.List` selector's key and a `V.VirtualList`
+  selector's key all reached that delimiter and none of them refused it. The refusal now sits on
+  `VNode.Key`, which each of them assigns through, so a call passing such a key throws
+  `ArgumentException` naming `key` where it used to build a node. A factory that takes from a pool
+  before building its node refuses ahead of that rent, so a refusal strands nothing that factory
+  rented; `V.List`, whose selector key is not known until an item is mapped, gives the child array
+  it rented back instead. A `V.VirtualList` `keySelector` returning such a key is answered without
+  a throw: that item is left out of the rendered range and a warning names the key, the selector
+  being read from a range update rather than from the `V.VirtualList(...)` call.
+
 ### Fixed
 
-- A key holding a NUL (U+0000) is refused wherever one reaches a VNode, and not at `V.Fragment` alone.
-  NUL is the delimiter the reconciler's scope chains are composed from, and `V.Fragment` was the only
-  factory refusing one, so a key carrying it contributed two segments instead of one and let two
-  different tree positions compose to the same scope string — where they then reconciled as one
-  identity. Measured on a `V.Label` whose key holds the delimiter, sitting beside a `V.Fragment` keyed
-  `"a"` that holds a `V.Label` keyed `"b"`, both under one keyed Fragment: a re-render left the second
-  label's element in the first label's slot and built a fresh one for the second, so the element the
-  first label had — with the fiber state, refs and focus riding on it — was gone, and the second
-  label's had moved to the wrong row. `V.Provider`, `V.Suspense`, `V.AnimatePresence`, `V.Component`,
-  `V.MemoizedWithKey`, `V.DragOverlay`, every element factory's `key:` and a `V.List` selector's key
-  all reached that delimiter and none of them refused it. The refusal now sits on `VNode.Key`, which
-  each of them assigns through. A factory that takes from a pool before building its node refuses
-  ahead of that rent, so a refusal strands nothing that factory rented; `V.List`, whose selector key
-  is not known until an item is mapped, gives the child array it rented back instead.
+- A renderer throwing inside `V.List` no longer strands the node array it rented. `V.List` takes that
+  array from `VNodePool` and fills it by calling the caller's `renderer` for each item, and a throw out
+  of the mapping left it out on loan with nothing able to give it back, so `RentNodeArray` found the
+  pool that much emptier on every pass — unbounded across a session, since an enclosing error boundary
+  re-renders and the renderer throws again. The array is now given back and the throw continues: it is
+  the one object the call can prove it owns, having just been popped from the pool with the local as its
+  only reference. The props bags of nodes the renderer already built are not given back, and cannot be —
+  the renderer is the caller's and may have returned a node the application still holds, which returning
+  would clear and alias into the shared pool.
 
 - `V.ListFragment` refuses a `key` holding a NUL (U+0000) before it maps the list rather than after.
   NUL is the delimiter the reconciler composes Fragment scope chains from, and both `V.ListFragment`

--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -94,10 +94,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A key holding a NUL (U+0000) is refused wherever one reaches a VNode, and not at `V.Fragment` alone.
+  NUL is the delimiter the reconciler's scope chains are composed from, and `V.Fragment` was the only
+  factory refusing one, so a key carrying it contributed two segments instead of one and let two
+  different tree positions compose to the same scope string — where they then reconciled as one
+  identity. Measured on a `V.Label` whose key holds the delimiter, sitting beside a `V.Fragment` keyed
+  `"a"` that holds a `V.Label` keyed `"b"`, both under one keyed Fragment: a re-render left the second
+  label's element in the first label's slot and built a fresh one for the second, so the element the
+  first label had — with the fiber state, refs and focus riding on it — was gone, and the second
+  label's had moved to the wrong row. `V.Provider`, `V.Suspense`, `V.AnimatePresence`, `V.Component`,
+  `V.MemoizedWithKey`, `V.DragOverlay`, every element factory's `key:` and a `V.List` selector's key
+  all reached that delimiter and none of them refused it. The refusal now sits on `VNode.Key`, which
+  each of them assigns through. A factory that takes from a pool before building its node refuses
+  ahead of that rent, so a refusal strands nothing that factory rented; `V.List`, whose selector key
+  is not known until an item is mapped, gives the child array it rented back instead.
+
 - `V.ListFragment` refuses a `key` holding a NUL (U+0000) before it maps the list rather than after.
-  The refusal is `V.Fragment`'s — NUL is the delimiter the reconciler composes Fragment scope chains
-  from — and both `V.ListFragment` overloads reached it by handing `V.List(...)` to `V.Fragment`, an
-  argument C# evaluates before the call. So a refused call had already run the renderer for every item,
+  NUL is the delimiter the reconciler composes Fragment scope chains from, and both `V.ListFragment`
+  overloads reached the refusal of it by handing `V.List(...)` to `V.Fragment`, an argument C#
+  evaluates before the call. So a refused call had already run the renderer for every item,
   and the pooled child array `V.List` took for the result, together with whatever the mapped nodes
   took, was out on loan when the refusal fired. A refused call builds no Fragment, so no later
   retirement could carry those back, and nothing else gives a pooled object back. Both overloads refuse

--- a/Packages/com.velvet.core/Runtime/Component/Experimental/VBuilders.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Experimental/VBuilders.cs
@@ -79,8 +79,16 @@ namespace Velvet.Experimental
         /// <see cref="VNodePool"/>, so the reconciler reclaims it on the next diff exactly as it does for
         /// <c>V.List</c> output — keeping the builder's only irreducible per-build cost the builder object itself.
         /// </summary>
+        /// <exception cref="ArgumentException">
+        /// Thrown when <see cref="Key"/> holds a NUL character, before this call takes anything from the pool.
+        /// </exception>
         protected VNode?[] BuildChildren()
         {
+            // Above the rent below: a Build() passes this call to its V.* factory as an argument, so the
+            // factory's own refusal of the same key comes too late. Same ordering rule as
+            // V.ListFragment's refusal above the mapping it feeds V.Fragment.
+            VNode.RequireKey(Key);
+
             if (_children == null)
             {
                 return Array.Empty<VNode>();
@@ -106,6 +114,10 @@ namespace Velvet.Experimental
         }
 
         /// <summary>Converts this builder into a concrete <see cref="VNode"/> by delegating to the matching <c>V.*</c> factory.</summary>
+        /// <exception cref="ArgumentException">
+        /// Thrown when <see cref="Key"/> holds a NUL character, under <see cref="VNode.Key"/>'s rule on what
+        /// a key may contain.
+        /// </exception>
         public abstract VNode Build();
 
         /// <summary>

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/VFactoryRefusalRentalTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/VFactoryRefusalRentalTests.cs
@@ -1,15 +1,19 @@
 using System;
+using System.Collections.Generic;
 using System.Reflection;
 using NUnit.Framework;
+using UnityEngine.UIElements;
 
 namespace Velvet.Tests
 {
     /// <summary>
-    /// Pins each <c>V.ListFragment</c> overload's NUL-key refusal to renting nothing. C# evaluates
-    /// <c>V.List(...)</c> before the <c>V.Fragment</c> call it feeds, so a refusal left to that call
-    /// runs after the list has rented its child array and after whatever the renderer's nodes rented
-    /// — and a refused call builds no Fragment, so nothing is left to carry those to a later
-    /// retirement and no later call can reach them to return them.
+    /// Pins a NUL-key refusal to renting nothing, at the <c>V.*</c> calls that take from a pool before
+    /// the node carrying the key exists. A refused call builds no node, so nothing is left to
+    /// carry what it rented to a later retirement and no later call can reach it to return it. Three
+    /// shapes reach that: each <c>V.ListFragment</c> overload, where C# evaluates <c>V.List(...)</c>
+    /// before the <c>V.Fragment</c> call it feeds; the factories that rent a props bag or an event array
+    /// ahead of building the node their key goes on; and each <c>V.List</c> overload, whose selector key
+    /// is not known until an item is mapped, so the array it rented is given back instead.
     /// </summary>
     /// <remarks>
     /// What these calls MAP to stays <c>VListTests</c>'s; only what they take from the pools is read
@@ -21,6 +25,7 @@ namespace Velvet.Tests
     internal sealed class VFactoryRefusalRentalTests
     {
         private const string OwnedPropsFieldName = "s_ownedProps";
+        private const string OwnedEventArraysFieldName = "s_ownedSingleEventArrays";
         private const string OwnedNodeArraysFieldName = "s_ownedNodeArrays";
         private const string CountPropertyName = "Count";
 
@@ -29,23 +34,43 @@ namespace Velvet.Tests
 
         private static readonly int[] TwoItems = { 1, 2 };
 
-        // The accepted-key case builds a Fragment no reconcile will ever retire, so its rentals would
+        // The accepted-key cases build nodes no reconcile will ever retire, so their rentals would
         // stay in the rented-out sets for the rest of the run. VFactoryEnumArgumentAllocTests states
         // what that costs a later fixture: a set that resizes between two allocation measurements
         // charges one side and not the other.
-        private FragmentNode? _unretired;
+        private readonly List<VNode?> _unretired = new();
+        private readonly List<VNode?[]> _unretiredArrays = new();
 
         [TearDown]
-        public void ReturnWhatTheAcceptedCallBuilt()
+        public void ReturnWhatTheAcceptedCallsBuilt()
         {
-            if (_unretired == null) return;
-            var children = _unretired.Children;
-            for (var i = 0; i < children.Length; i++)
+            foreach (var node in _unretired) Retire(node);
+            foreach (var array in _unretiredArrays) RetireArray(array);
+            _unretired.Clear();
+            _unretiredArrays.Clear();
+        }
+
+        private static void Retire(VNode? node)
+        {
+            switch (node)
             {
-                VNodePool.ReturnProps((children[i] as ElementNode)?.Props);
+                case FragmentNode fragment:
+                    RetireArray(fragment.Children);
+                    break;
+                case PortalNode portal:
+                    for (var i = 0; i < portal.Children.Length; i++) Retire(portal.Children[i]);
+                    break;
+                case BaseElementNode element:
+                    VNodePool.ReturnProps(element.Props);
+                    VNodePool.ReturnEventArray(element.Events);
+                    break;
             }
-            VNodePool.ReturnNodeArray(children);
-            _unretired = null;
+        }
+
+        private static void RetireArray(VNode?[] nodes)
+        {
+            for (var i = 0; i < nodes.Length; i++) Retire(nodes[i]);
+            VNodePool.ReturnNodeArray(nodes);
         }
 
         private static int RentedCount(string fieldName)
@@ -67,9 +92,10 @@ namespace Velvet.Tests
         // The refused parameter travels with the growth so one comparison covers both: a refusal
         // swapped for a silently empty Fragment rents nothing either, and the growth alone reads
         // that as the fix.
-        private static (string? RefusedParam, int Props, int NodeArrays) Measure(Action call)
+        private static (string? RefusedParam, int Props, int EventArrays, int NodeArrays) Measure(Action call)
         {
             var props = RentedCount(OwnedPropsFieldName);
+            var eventArrays = RentedCount(OwnedEventArraysFieldName);
             var nodeArrays = RentedCount(OwnedNodeArraysFieldName);
             string? refusedParam = null;
             try
@@ -82,6 +108,7 @@ namespace Velvet.Tests
             }
             return (refusedParam,
                 RentedCount(OwnedPropsFieldName) - props,
+                RentedCount(OwnedEventArraysFieldName) - eventArrays,
                 RentedCount(OwnedNodeArraysFieldName) - nodeArrays);
         }
 
@@ -90,6 +117,8 @@ namespace Velvet.Tests
 
         private static VNode RenderByIndex(int item, int index) => V.Draggable("row" + item + index);
 
+        // GREEN_ON_BASE(refactor): the base refuses this key ahead of the mapping already; what changed
+        // here is the event-array term the measurement gained, which reads zero on both sides.
         [Test]
         public void Given_AKeyedListFragmentWithANulKey_When_TheKeyIsRefused_Then_TheCallRentsNothing()
         {
@@ -98,9 +127,10 @@ namespace Velvet.Tests
             var refusal = Measure(() => V.ListFragment(TwoItems, item => item.ToString(), RenderByItem, NulKey));
 
             // Assert
-            Assert.That(refusal, Is.EqualTo(("key", 0, 0)));
+            Assert.That(refusal, Is.EqualTo(("key", 0, 0, 0)));
         }
 
+        // GREEN_ON_BASE(refactor): the overload above's reason, on the overload taking the index.
         [Test]
         public void Given_AnIndexedListFragmentWithANulKey_When_TheKeyIsRefused_Then_TheCallRentsNothing()
         {
@@ -109,22 +139,123 @@ namespace Velvet.Tests
                 V.ListFragment(TwoItems, (item, index) => item + "-" + index, RenderByIndex, NulKey));
 
             // Assert
-            Assert.That(refusal, Is.EqualTo(("key", 0, 0)));
+            Assert.That(refusal, Is.EqualTo(("key", 0, 0, 0)));
         }
 
-        // GREEN_ON_BASE(characterization): the base accepts this key and rents the same three objects.
-        // It is the control for the two refusal cases above, which assert absences: a probe over a set
-        // that never moved would satisfy their zeroes, and this is their call with the NUL taken out of
-        // the key.
+        // GREEN_ON_BASE(characterization): the base accepts this key and rents the same three objects,
+        // the event-array term this measurement gained reading zero there too. It is the control for the
+        // two refusal cases above, which assert absences: a probe over a set that never moved would
+        // satisfy their zeroes, and this is their call with the NUL taken out of the key.
         [Test]
         public void Given_AKeyedListFragmentWithAnAcceptedKey_When_ItBuildsTheFragment_Then_ItRentsWhatItBuiltFrom()
         {
             // Arrange + Act — the refusal cases' arrangement, minus the NUL.
             var accepted = Measure(() =>
-                _unretired = V.ListFragment(TwoItems, item => item.ToString(), RenderByItem, AcceptedKey));
+                _unretired.Add(V.ListFragment(TwoItems, item => item.ToString(), RenderByItem, AcceptedKey)));
 
             // Assert
-            Assert.That(accepted, Is.EqualTo(((string?)null, 2, 1)));
+            Assert.That(accepted, Is.EqualTo(((string?)null, 2, 0, 1)));
+        }
+
+        // One call per factory that takes from a pool before the node carrying its key exists, supplying
+        // whatever argument makes it rent where the rent is conditional. The accepted-key case below is
+        // what says a row rents at all; the key travels as an argument so both cases read the same call.
+        private static readonly (string Name, Func<string?, VNode> Build)[] FactoriesRentingBeforeTheirNode =
+        {
+            ("ScrollView", k => V.ScrollView(key: k, verticalScrollerVisibility: ScrollerVisibility.Auto)),
+            ("Button", k => V.Button(key: k, onClick: () => { })),
+            ("Label", k => V.Label(key: k, text: "x")),
+            ("Slider", k => V.Slider(key: k, onValueChanged: value => { })),
+            ("Toggle", k => V.Toggle(key: k, onValueChanged: value => { })),
+            ("TextField", k => V.TextField(key: k, onValueChanged: value => { })),
+            ("SceneView", k => V.SceneView(camera: null, key: k)),
+            ("Particles", k => V.Particles(effect: null, key: k)),
+            ("DropdownField", k => V.DropdownField(key: k, onValueChanged: value => { })),
+            ("ListView", k => V.ListView(key: k, enabled: true)),
+            ("RadioButton", k => V.RadioButton(key: k, onValueChanged: value => { })),
+            ("RadioButtonGroup", k => V.RadioButtonGroup(key: k, onValueChanged: value => { })),
+            ("IntegerField", k => V.IntegerField(key: k, onValueChanged: value => { })),
+            ("Anchored", k => V.Anchored(target: null, key: k)),
+            ("FocusScope", k => V.FocusScope(key: k)),
+            ("DndContext", k => V.DndContext(key: k)),
+            ("Draggable", k => V.Draggable("row", key: k)),
+            ("Droppable", k => V.Droppable("row", key: k)),
+            ("DragOverlay", k => V.DragOverlay(key: k)),
+        };
+
+        private static string Report(IEnumerable<string> rows) => string.Join(" ", rows);
+
+        [Test]
+        public void Given_EveryFactoryRentingBeforeItsNode_When_ANulKeyIsRefused_Then_TheCallRentsNothing()
+        {
+            // Arrange + Act — one report rather than one case each, so a failure names the factory
+            var measured = Report(Array.ConvertAll(FactoriesRentingBeforeTheirNode, factory =>
+            {
+                var refusal = Measure(() => factory.Build(NulKey));
+                return $"{factory.Name}={refusal.RefusedParam}/{refusal.Props}/{refusal.EventArrays}/{refusal.NodeArrays}";
+            }));
+
+            // Assert
+            Assert.That(measured, Is.EqualTo(Report(Array.ConvertAll(
+                FactoriesRentingBeforeTheirNode, factory => $"{factory.Name}=key/0/0/0"))));
+        }
+
+        // GREEN_ON_BASE(characterization): every row rents on the base too, its key being accepted there.
+        // It is the control for the row report above, which asserts absences: a row whose call happens to
+        // rent nothing satisfies that report's zeroes without the refusal having done anything.
+        [Test]
+        public void Given_EveryFactoryRentingBeforeItsNode_When_ItsKeyIsAccepted_Then_ItTakesFromAPool()
+        {
+            // Arrange + Act — the row report's calls, with the delimiter taken out of the key
+            var measured = Report(Array.ConvertAll(FactoriesRentingBeforeTheirNode, factory =>
+            {
+                var accepted = Measure(() => _unretired.Add(factory.Build(AcceptedKey)));
+                var took = accepted.Props + accepted.EventArrays + accepted.NodeArrays;
+                return $"{factory.Name}={accepted.RefusedParam}/{took > 0}";
+            }));
+
+            // Assert
+            Assert.That(measured, Is.EqualTo(Report(Array.ConvertAll(
+                FactoriesRentingBeforeTheirNode, factory => $"{factory.Name}=/True"))));
+        }
+
+        [Test]
+        public void Given_AKeyedListSelectorReturningANulKey_When_TheKeyIsRefused_Then_TheChildArrayIsGivenBack()
+        {
+            // Arrange + Act — the first item is mapped before its key is asked for, so its bag is out on
+            // loan when the refusal fires; what the pool's rented-out set says about a renderer's node
+            // leaves that where it is, and the array V.List itself took is the one that comes back.
+            var refusal = Measure(() => V.List(TwoItems, item => NulKey, RenderByItem));
+
+            // Assert
+            Assert.That(refusal, Is.EqualTo(("key", 1, 0, 0)));
+        }
+
+        [Test]
+        public void Given_AnIndexedListSelectorReturningANulKey_When_TheKeyIsRefused_Then_TheChildArrayIsGivenBack()
+        {
+            // Arrange + Act — the same, on the overload whose selector and renderer take the index.
+            var refusal = Measure(() => V.List(TwoItems, (item, index) => NulKey, RenderByIndex));
+
+            // Assert
+            Assert.That(refusal, Is.EqualTo(("key", 1, 0, 0)));
+        }
+
+        // GREEN_ON_BASE(characterization): the base accepts these keys and keeps the array out on loan.
+        // It is the control for the two cases above: an array the call never rented would satisfy their
+        // zero without the refusal having given anything back.
+        [Test]
+        public void Given_AKeyedListWithAcceptedKeys_When_ItMapsTheItems_Then_TheChildArrayStaysOnLoan()
+        {
+            // Arrange + Act — the refusal cases' arrangement, minus the NUL.
+            var accepted = Measure(() =>
+            {
+                var mapped = V.List(TwoItems, item => item.ToString(), RenderByItem);
+                _unretiredArrays.Add(mapped);
+            });
+
+            // Assert
+            Assert.That(accepted, Is.EqualTo(((string?)null, 2, 0, 1)));
         }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/VFactoryRefusalRentalTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/VFactoryRefusalRentalTests.cs
@@ -3,23 +3,29 @@ using System.Collections.Generic;
 using System.Reflection;
 using NUnit.Framework;
 using UnityEngine.UIElements;
+using Velvet.Experimental;
 
 namespace Velvet.Tests
 {
     /// <summary>
-    /// Pins a NUL-key refusal to renting nothing, at the <c>V.*</c> calls that take from a pool before
-    /// the node carrying the key exists. A refused call builds no node, so nothing is left to
-    /// carry what it rented to a later retirement and no later call can reach it to return it. Three
+    /// Pins a NUL-key refusal to renting nothing, at the calls that take from a pool on the way to the
+    /// node the key goes on. A refused call builds no node, so nothing is left to
+    /// carry what it rented to a later retirement and no later call can reach it to return it. Five
     /// shapes reach that: each <c>V.ListFragment</c> overload, where C# evaluates <c>V.List(...)</c>
     /// before the <c>V.Fragment</c> call it feeds; the factories that rent a props bag or an event array
-    /// ahead of building the node their key goes on; and each <c>V.List</c> overload, whose selector key
-    /// is not known until an item is mapped, so the array it rented is given back instead.
+    /// ahead of building the node their key goes on; the factories whose object initializer writes the
+    /// key above the member that rents; the <c>Velvet.Experimental</c> builders, whose <c>Build()</c>
+    /// hands a rented child array to a factory as an argument; and each <c>V.List</c> overload, whose
+    /// selector key is not known until an item is mapped, so the array it rented is given back instead.
     /// </summary>
     /// <remarks>
     /// What these calls MAP to stays <c>VListTests</c>'s; only what they take from the pools is read
-    /// here. An argument the CALLER built is a different question again and is not pinned here either:
-    /// a refusing factory has that node in hand and returns none of what it rented, and
-    /// <see cref="VNodePool"/>'s rented-out identity set states why.
+    /// here. What an APPLICATION's own argument expression rented is a different question and is not
+    /// pinned here: <c>V.Div(key: k, children: V.List(...))</c> evaluates that argument before the call,
+    /// so no ordering inside <c>V.Div</c> reaches it. The builders are pinned because that rent is the
+    /// package's own — <c>VBuilder.BuildChildren()</c> can refuse above it. What the builders keep in
+    /// their own scratch-list pool is outside this too: that pool holds no rented-out set, so a list a
+    /// refused <c>Build()</c> does not hand back is collected rather than held.
     /// </remarks>
     [TestFixture]
     internal sealed class VFactoryRefusalRentalTests
@@ -217,6 +223,107 @@ namespace Velvet.Tests
             // Assert
             Assert.That(measured, Is.EqualTo(Report(Array.ConvertAll(
                 FactoriesRentingBeforeTheirNode, factory => $"{factory.Name}=/True"))));
+        }
+
+        private static readonly IReadOnlyDictionary<string, string> OneDataAttribute =
+            new Dictionary<string, string> { ["state"] = "open" };
+
+        // One call per factory whose key is written by its object initializer above the member of that
+        // same initializer which rents, so member order is what keeps a refusal from stranding. Supplying
+        // data: is what makes that member rent.
+        private static readonly (string Name, Func<string?, VNode> Build)[] FactoriesRentingInsideTheirInitializer =
+        {
+            ("Div", k => V.Div(className: "row", key: k, data: OneDataAttribute)),
+            ("Custom", k => V.Custom<Label>(className: "row", key: k, data: OneDataAttribute)),
+            ("Image", k => V.Image(className: "row", key: k, data: OneDataAttribute)),
+        };
+
+        [Test]
+        public void Given_EveryFactoryRentingInsideItsInitializer_When_ANulKeyIsRefused_Then_TheCallRentsNothing()
+        {
+            // Arrange + Act — one report rather than one case each, so a failure names the factory
+            var measured = Report(Array.ConvertAll(FactoriesRentingInsideTheirInitializer, factory =>
+            {
+                var refusal = Measure(() => factory.Build(NulKey));
+                return $"{factory.Name}={refusal.RefusedParam}/{refusal.Props}/{refusal.EventArrays}/{refusal.NodeArrays}";
+            }));
+
+            // Assert
+            Assert.That(measured, Is.EqualTo(Report(Array.ConvertAll(
+                FactoriesRentingInsideTheirInitializer, factory => $"{factory.Name}=key/0/0/0"))));
+        }
+
+        // GREEN_ON_BASE(characterization): all three rows rent on the base as well, their keys accepted
+        // there. It is the control for the row report above, which asserts absences: a row whose call
+        // happens to rent nothing satisfies that report's zeroes without the member order having done
+        // anything.
+        [Test]
+        public void Given_EveryFactoryRentingInsideItsInitializer_When_ItsKeyIsAccepted_Then_ItTakesFromAPool()
+        {
+            // Arrange + Act — the row report's calls, with the delimiter taken out of the key
+            var measured = Report(Array.ConvertAll(FactoriesRentingInsideTheirInitializer, factory =>
+            {
+                var accepted = Measure(() => _unretired.Add(factory.Build(AcceptedKey)));
+                var took = accepted.Props + accepted.EventArrays + accepted.NodeArrays;
+                return $"{factory.Name}={accepted.RefusedParam}/{took > 0}";
+            }));
+
+            // Assert
+            Assert.That(measured, Is.EqualTo(Report(Array.ConvertAll(
+                FactoriesRentingInsideTheirInitializer, factory => $"{factory.Name}=/True"))));
+        }
+
+        // One builder per Build() that hands VBuilder.BuildChildren() to a V.* factory as an argument,
+        // which is a rent C# performs before that factory is entered at all.
+        private static readonly (string Name, Func<VNode, VBuilder> Author)[] BuildersRentingForTheirChildren =
+        {
+            ("VDiv", child => new VDiv("row") { child }),
+            ("VButton", child => new VButton("row") { child }),
+            ("VScrollView", child => new VScrollView("row") { child }),
+            ("VCustom", child => new VCustom<Label>("row") { child }),
+        };
+
+        [Test]
+        public void Given_EveryBuilderRentingForItsChildren_When_ANulKeyIsRefused_Then_TheBuildRentsNothing()
+        {
+            // Arrange + Act — the child is authored outside the measurement, so the report reads what
+            // Build() itself took and not what the collection initializer took before it.
+            var measured = Report(Array.ConvertAll(BuildersRentingForTheirChildren, builder =>
+            {
+                var child = V.Label(text: "x");
+                _unretired.Add(child);
+                var authored = builder.Author(child);
+                authored.Key = NulKey;
+                var refusal = Measure(() => authored.Build());
+                return $"{builder.Name}={refusal.RefusedParam}/{refusal.Props}/{refusal.EventArrays}/{refusal.NodeArrays}";
+            }));
+
+            // Assert
+            Assert.That(measured, Is.EqualTo(Report(Array.ConvertAll(
+                BuildersRentingForTheirChildren, builder => $"{builder.Name}=key/0/0/0"))));
+        }
+
+        // GREEN_ON_BASE(characterization): every builder takes a child array on the base too. Its key
+        // is accepted there, and it is the control for the report above, which asserts absences: a
+        // builder whose Build() happens to rent nothing satisfies those zeroes without the refusal
+        // having done anything.
+        [Test]
+        public void Given_EveryBuilderRentingForItsChildren_When_ItsKeyIsAccepted_Then_ItTakesFromAPool()
+        {
+            // Arrange + Act — the report above's builders, with the delimiter taken out of the key
+            var measured = Report(Array.ConvertAll(BuildersRentingForTheirChildren, builder =>
+            {
+                var authored = builder.Author(V.Label(text: "x"));
+                authored.Key = AcceptedKey;
+                VNode built = null;
+                var accepted = Measure(() => built = authored.Build());
+                _unretiredArrays.Add(((BaseElementNode)built).Children);
+                return $"{builder.Name}={accepted.RefusedParam}/{accepted.Props}/{accepted.EventArrays}/{accepted.NodeArrays}";
+            }));
+
+            // Assert
+            Assert.That(measured, Is.EqualTo(Report(Array.ConvertAll(
+                BuildersRentingForTheirChildren, builder => $"{builder.Name}=/0/0/1"))));
         }
 
         [Test]

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/VNodeKeyDelimiterRefusalTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/VNodeKeyDelimiterRefusalTests.cs
@@ -1,0 +1,145 @@
+using System;
+using NUnit.Framework;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Pins the refusal of a key holding the reconciler's scope delimiter at each construct whose key
+    /// reaches a different consumer of it: <c>V.Provider</c>'s reaches the Provider child scope,
+    /// <c>V.Suspense</c>'s the boundary key, <c>V.AnimatePresence</c>'s the presence key, a keyed leaf's
+    /// the scoped-key override its siblings are matched under (which is also what a presence child
+    /// contributes), <c>V.Component</c>'s the Component child scope and <c>V.MemoizedWithKey</c>'s the
+    /// dep-cache key. A <c>V.List</c> selector reaches the same override without passing through any
+    /// <c>key:</c> parameter.
+    /// </summary>
+    /// <remarks>
+    /// What a refusal takes from the pools is <see cref="VFactoryRefusalRentalTests"/>'s question.
+    /// </remarks>
+    [TestFixture]
+    internal sealed class VNodeKeyDelimiterRefusalTests
+    {
+        private const string NulKey = "a\0b";
+
+        // "accepted" rather than a null ParamName, so a call that stops throwing is told apart from one
+        // throwing an ArgumentException that names some other argument.
+        private static string Refusal(Action call)
+        {
+            try
+            {
+                call();
+                return "accepted";
+            }
+            catch (ArgumentException ex)
+            {
+                return ex.ParamName ?? "unnamed";
+            }
+        }
+
+        [Test]
+        public void Given_AProviderKeyHoldingTheDelimiter_When_TheProviderIsBuilt_Then_TheKeyIsRefused()
+        {
+            // Arrange + Act
+            var refusal = Refusal(() =>
+                V.Provider(ComponentContext<string>.Create("d"), "v", Array.Empty<VNode?>(), NulKey));
+
+            // Assert
+            Assert.That(refusal, Is.EqualTo("key"));
+        }
+
+        [Test]
+        public void Given_ASuspenseKeyHoldingTheDelimiter_When_TheBoundaryIsBuilt_Then_TheKeyIsRefused()
+        {
+            // Arrange + Act
+            var refusal = Refusal(() =>
+                V.Suspense(V.Div("fallback"), Array.Empty<VNode?>(), NulKey));
+
+            // Assert
+            Assert.That(refusal, Is.EqualTo("key"));
+        }
+
+        [Test]
+        public void Given_APresenceKeyHoldingTheDelimiter_When_ThePresenceIsBuilt_Then_TheKeyIsRefused()
+        {
+            // Arrange + Act
+            var refusal = Refusal(() => V.AnimatePresence(Array.Empty<VNode?>(), NulKey));
+
+            // Assert
+            Assert.That(refusal, Is.EqualTo("key"));
+        }
+
+        [Test]
+        public void Given_ALeafKeyHoldingTheDelimiter_When_TheLeafIsBuilt_Then_TheKeyIsRefused()
+        {
+            // Arrange + Act — a keyed leaf under an enclosing scope, which is what a presence child is
+            var refusal = Refusal(() => V.Div(className: "leaf", key: NulKey));
+
+            // Assert
+            Assert.That(refusal, Is.EqualTo("key"));
+        }
+
+        [Test]
+        public void Given_AComponentKeyHoldingTheDelimiter_When_TheComponentIsBuilt_Then_TheKeyIsRefused()
+        {
+            // Arrange + Act
+            var refusal = Refusal(() => V.Component(() => V.Div("body"), NulKey));
+
+            // Assert
+            Assert.That(refusal, Is.EqualTo("key"));
+        }
+
+        [Test]
+        public void Given_AMemoKeyHoldingTheDelimiter_When_TheMemoIsBuilt_Then_TheKeyIsRefused()
+        {
+            // Arrange + Act
+            var refusal = Refusal(() => V.MemoizedWithKey(NulKey, () => V.Div("inner")));
+
+            // Assert
+            Assert.That(refusal, Is.EqualTo("key"));
+        }
+
+        [Test]
+        public void Given_AListSelectorReturningTheDelimiter_When_TheListIsMapped_Then_TheKeyIsRefused()
+        {
+            // Arrange + Act — no key: parameter carries this one; the selector writes it onto the node
+            var refusal = Refusal(() => V.List(new[] { 1 }, _ => NulKey, _ => V.Div("row")));
+
+            // Assert
+            Assert.That(refusal, Is.EqualTo("key"));
+        }
+
+        [Test]
+        public void Given_AnIndexedListSelectorReturningTheDelimiter_When_TheListIsMapped_Then_TheKeyIsRefused()
+        {
+            // Arrange + Act
+            var refusal = Refusal(() =>
+                V.List(new[] { 1 }, (item, index) => NulKey, (item, index) => V.Div("row")));
+
+            // Assert
+            Assert.That(refusal, Is.EqualTo("key"));
+        }
+
+        [Test]
+        public void Given_AKeyOpeningOnTheDelimiter_When_TheNodeIsBuilt_Then_TheKeyIsRefused()
+        {
+            // Arrange + Act — the delimiter at index 0, which a search reporting where it sits reads
+            // differently from one further in
+            var refusal = Refusal(() => V.Div(className: "leaf", key: "\0b"));
+
+            // Assert
+            Assert.That(refusal, Is.EqualTo("key"));
+        }
+
+        // GREEN_ON_BASE(characterization): the base keeps an accepted key on the node too. The cases
+        // above assert a throw, and this is their key with the delimiter taken out: what they read as
+        // the refusal of a delimiter would read the same for a key refused on some other ground.
+        [Test]
+        public void Given_AKeyWithoutTheDelimiter_When_TheNodeIsBuilt_Then_TheKeyIsKept()
+        {
+            // Arrange + Act
+            var node = V.Div(className: "leaf", key: "ab");
+
+            // Assert
+            Assert.That(node.Key, Is.EqualTo("ab"));
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/VNodeKeyDelimiterRefusalTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/VNodeKeyDelimiterRefusalTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ad986afae5e2f412f8e494e71c335d6e

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/VirtualListTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/VirtualListTests.cs
@@ -20,6 +20,9 @@ namespace Velvet.Tests
     /// <item>The visible range is firstVisible..lastVisible derived from scroll offset, viewport height, and
     /// itemHeight, widened by overscan on both sides and clamped to the collection bounds.</item>
     /// <item>An empty collection renders no visible items and tolerates range updates without throwing.</item>
+    /// <item>An item whose <c>keySelector</c> returns a key holding the reconciler's scope delimiter is left
+    /// out of the rendered range under a warning naming it, the rest of the range rendering as it would
+    /// without it, and a key the renderer set on its own node does not put that item back in.</item>
     /// <item>An item's <c>refCallback</c> has run by the time a range update returns, though the update is
     /// driven from a scroll rather than from a reconcile pass.</item>
     /// <item>The DSL rejects a null items / keySelector / renderer with <see cref="ArgumentNullException"/>, and a
@@ -183,6 +186,103 @@ namespace Velvet.Tests
 
             // Assert — the last item the window rendered is the one the shared capture holds.
             Assert.That(captured, Is.SameAs(visibleContainer.ElementAt(visibleContainer.childCount - 1)));
+        }
+
+        [Test]
+        public void Given_AKeySelectorReturningTheDelimiter_When_TheRangeIsRendered_Then_TheOtherItemsStillRender()
+        {
+            // Arrange — item 1's key holds the delimiter; the renderer sets no key of its own, so the
+            // selector's is the one that would go on the node.
+            var node = V.VirtualList(
+                items: CreateItems(3),
+                keySelector: item => item.Id == "item-1" ? "a\0b" : item.Id,
+                itemHeight: 50f,
+                renderer: item => V.Label(text: item.Name),
+                overscan: 0);
+            var scrollView = new ScrollView(ScrollViewMode.Vertical);
+            using var controller = new FiberVirtualListController(scrollView, node, Reconciler);
+            var visibleContainer = scrollView.contentContainer.ElementAt(1);
+
+            // Act
+            controller.UpdateVisibleRange(scrollY: 0f, viewportHeight: 200f);
+
+            // Assert
+            Assert.That(
+                string.Join(",", visibleContainer.Children().Cast<Label>().Select(label => label.text)),
+                Is.EqualTo("Item 0,Item 2"));
+        }
+
+        [Test]
+        public void Given_ARendererKeyingItsOwnNode_When_TheSelectorReturnsTheDelimiter_Then_TheItemIsStillLeftOut()
+        {
+            // Arrange — the same, with the renderer keying its own node, which is what decides whether the
+            // selector's key would ever reach VNode.Key.
+            var node = V.VirtualList(
+                items: CreateItems(3),
+                keySelector: item => item.Id == "item-1" ? "a\0b" : item.Id,
+                itemHeight: 50f,
+                renderer: item => V.Label(text: item.Name, key: item.Id),
+                overscan: 0);
+            var scrollView = new ScrollView(ScrollViewMode.Vertical);
+            using var controller = new FiberVirtualListController(scrollView, node, Reconciler);
+            var visibleContainer = scrollView.contentContainer.ElementAt(1);
+
+            // Act
+            controller.UpdateVisibleRange(scrollY: 0f, viewportHeight: 200f);
+
+            // Assert
+            Assert.That(
+                string.Join(",", visibleContainer.Children().Cast<Label>().Select(label => label.text)),
+                Is.EqualTo("Item 0,Item 2"));
+        }
+
+        [Test]
+        public void Given_AKeySelectorReturningTheDelimiter_When_TheRangeIsRendered_Then_TheSkippedItemIsReported()
+        {
+            // Arrange
+            var node = V.VirtualList(
+                items: CreateItems(3),
+                keySelector: item => item.Id == "item-1" ? "a\0b" : item.Id,
+                itemHeight: 50f,
+                renderer: item => V.Label(text: item.Name),
+                overscan: 0);
+            var scrollView = new ScrollView(ScrollViewMode.Vertical);
+            using var controller = new FiberVirtualListController(scrollView, node, Reconciler);
+            UnityEngine.TestTools.LogAssert.Expect(UnityEngine.LogType.Warning,
+                new System.Text.RegularExpressions.Regex("FiberVirtualListController.*NUL"));
+
+            // Act
+            controller.UpdateVisibleRange(scrollY: 0f, viewportHeight: 200f);
+
+            // Assert — LogAssert.Expect verifies the item that left the range is named rather than
+            // dropped in silence
+        }
+
+        // GREEN_ON_BASE(characterization): the base renders all three of these items. No key of
+        // theirs holds a delimiter, and it is the control for the cases above that read an item's
+        // absence from the range: a range rendering two items whatever their keys would satisfy
+        // them, and this is their arrangement with the delimiter taken out of the one key holding it.
+        [Test]
+        public void Given_NoKeyHoldingTheDelimiter_When_TheRangeIsRendered_Then_EveryItemRenders()
+        {
+            // Arrange — the two cases above, minus the delimiter.
+            var node = V.VirtualList(
+                items: CreateItems(3),
+                keySelector: item => item.Id,
+                itemHeight: 50f,
+                renderer: item => V.Label(text: item.Name),
+                overscan: 0);
+            var scrollView = new ScrollView(ScrollViewMode.Vertical);
+            using var controller = new FiberVirtualListController(scrollView, node, Reconciler);
+            var visibleContainer = scrollView.contentContainer.ElementAt(1);
+
+            // Act
+            controller.UpdateVisibleRange(scrollY: 0f, viewportHeight: 200f);
+
+            // Assert
+            Assert.That(
+                string.Join(",", visibleContainer.Children().Cast<Label>().Select(label => label.text)),
+                Is.EqualTo("Item 0,Item 1,Item 2"));
         }
 
         [Test]

--- a/Packages/com.velvet.core/Runtime/Component/V.cs
+++ b/Packages/com.velvet.core/Runtime/Component/V.cs
@@ -220,6 +220,7 @@ namespace Velvet
             IReadOnlyDictionary<string, string>? data = null,
             IReadOnlyDictionary<string, string>? aria = null)
         {
+            VNode.RequireKey(key);
             FiberElementProps? props = null;
             if (verticalScrollerVisibility.HasValue || horizontalScrollerVisibility.HasValue || touchScrollBehavior.HasValue)
             {
@@ -305,6 +306,7 @@ namespace Velvet
             IReadOnlyDictionary<string, string>? data = null,
             IReadOnlyDictionary<string, string>? aria = null)
         {
+            VNode.RequireKey(key);
             var events = SingleEvent(onClick != null ? new ClickedBinding { Handler = onClick } : null);
 
             FiberElementProps? props = null;
@@ -379,6 +381,7 @@ namespace Velvet
             IReadOnlyDictionary<string, string>? data = null,
             IReadOnlyDictionary<string, string>? aria = null)
         {
+            VNode.RequireKey(key);
             FiberElementProps? props = null;
             if (text != null)
             {
@@ -439,6 +442,7 @@ namespace Velvet
             IReadOnlyDictionary<string, string>? data = null,
             IReadOnlyDictionary<string, string>? aria = null)
         {
+            VNode.RequireKey(key);
             var events = SingleEvent(onValueChanged != null ? new ChangeEventBinding<float> { Handler = onValueChanged } : null);
 
             FiberElementProps? props = null;
@@ -502,6 +506,7 @@ namespace Velvet
             IReadOnlyDictionary<string, string>? data = null,
             IReadOnlyDictionary<string, string>? aria = null)
         {
+            VNode.RequireKey(key);
             var events = SingleEvent(onValueChanged != null ? new ChangeEventBinding<bool> { Handler = onValueChanged } : null);
 
             FiberElementProps? props = null;
@@ -580,6 +585,7 @@ namespace Velvet
             bool? isReadOnly = null,
             bool? isDelayed = null)
         {
+            VNode.RequireKey(key);
             var events = SingleEvent(onValueChanged != null ? new ChangeEventBinding<string> { Handler = onValueChanged } : null);
 
             var declaresTextField = isPasswordField.HasValue || placeholder != null || maxLength.HasValue
@@ -697,6 +703,7 @@ namespace Velvet
             IReadOnlyDictionary<string, string>? data = null,
             IReadOnlyDictionary<string, string>? aria = null)
         {
+            VNode.RequireKey(key);
             // Validated BEFORE renting pooled props so a throwing call leaks nothing (the settings
             // constructor fail-fasts on an invalid scale for every construction path, this factory
             // included). Always carried (even with a null camera): the patcher needs the settings on
@@ -762,6 +769,7 @@ namespace Velvet
             IReadOnlyDictionary<string, string>? data = null,
             IReadOnlyDictionary<string, string>? aria = null)
         {
+            VNode.RequireKey(key);
             if (playOn is not (PlayTrigger.Mount or PlayTrigger.Manual))
             {
                 throw new ArgumentOutOfRangeException(nameof(playOn), playOn,
@@ -826,6 +834,7 @@ namespace Velvet
             IReadOnlyDictionary<string, string>? data = null,
             IReadOnlyDictionary<string, string>? aria = null)
         {
+            VNode.RequireKey(key);
             var events = SingleEvent(onValueChanged != null ? new ChangeEventBinding<string> { Handler = onValueChanged } : null);
 
             FiberElementProps? props = null;
@@ -883,6 +892,7 @@ namespace Velvet
             IReadOnlyDictionary<string, string>? data = null,
             IReadOnlyDictionary<string, string>? aria = null)
         {
+            VNode.RequireKey(key);
             FiberElementProps? props = null;
             if (enabled.HasValue)
             {
@@ -940,6 +950,7 @@ namespace Velvet
             IReadOnlyDictionary<string, string>? data = null,
             IReadOnlyDictionary<string, string>? aria = null)
         {
+            VNode.RequireKey(key);
             var events = SingleEvent(onValueChanged != null ? new ChangeEventBinding<bool> { Handler = onValueChanged } : null);
 
             FiberElementProps? props = null;
@@ -1002,6 +1013,7 @@ namespace Velvet
             IReadOnlyDictionary<string, string>? data = null,
             IReadOnlyDictionary<string, string>? aria = null)
         {
+            VNode.RequireKey(key);
             var events = SingleEvent(onValueChanged != null ? new ChangeEventBinding<int> { Handler = onValueChanged } : null);
 
             FiberElementProps? props = null;
@@ -1063,6 +1075,7 @@ namespace Velvet
             IReadOnlyDictionary<string, string>? data = null,
             IReadOnlyDictionary<string, string>? aria = null)
         {
+            VNode.RequireKey(key);
             var events = SingleEvent(onValueChanged != null ? new ChangeEventBinding<int> { Handler = onValueChanged } : null);
 
             FiberElementProps? props = null;
@@ -1124,16 +1137,27 @@ namespace Velvet
             }
 
             var result = VNodePool.RentNodeArray(items.Count);
-            for (var i = 0; i < items.Count; i++)
+            // The selector's key is not known until its item is mapped, so the refusal of one cannot be
+            // hoisted above this rent the way a key: parameter's is. Any throw out of the mapping gives
+            // the array back instead: a call that throws returns none, so nothing later can retire it.
+            try
             {
-                var node = renderer(items[i]);
-                if (node != null)
+                for (var i = 0; i < items.Count; i++)
                 {
-                    // The selector key is authoritative: it overrides any key the renderer set on the
-                    // node, so the list-mapping site owns the identity used for reconciliation.
-                    node.Key = keySelector(items[i]);
+                    var node = renderer(items[i]);
+                    if (node != null)
+                    {
+                        // The selector key is authoritative: it overrides any key the renderer set on the
+                        // node, so the list-mapping site owns the identity used for reconciliation.
+                        node.Key = keySelector(items[i]);
+                    }
+                    result[i] = node;
                 }
-                result[i] = node;
+            }
+            catch
+            {
+                VNodePool.ReturnNodeArray(result);
+                throw;
             }
 
             return result;
@@ -1159,16 +1183,25 @@ namespace Velvet
             }
 
             var result = VNodePool.RentNodeArray(items.Count);
-            for (var i = 0; i < items.Count; i++)
+            // Same ordering constraint as the overload above.
+            try
             {
-                var node = renderer(items[i], i);
-                if (node != null)
+                for (var i = 0; i < items.Count; i++)
                 {
-                    // The selector key is authoritative: it overrides any key the renderer set on the
-                    // node, so the list-mapping site owns the identity used for reconciliation.
-                    node.Key = keySelector(items[i], i);
+                    var node = renderer(items[i], i);
+                    if (node != null)
+                    {
+                        // The selector key is authoritative: it overrides any key the renderer set on the
+                        // node, so the list-mapping site owns the identity used for reconciliation.
+                        node.Key = keySelector(items[i], i);
+                    }
+                    result[i] = node;
                 }
-                result[i] = node;
+            }
+            catch
+            {
+                VNodePool.ReturnNodeArray(result);
+                throw;
             }
 
             return result;
@@ -1198,7 +1231,7 @@ namespace Velvet
             // refusal to the V.Fragment call below strands the child array List rented and whatever
             // the renderer's nodes rented, with no Fragment built to carry them to a later
             // retirement. Same ordering rule as V.Draggable's refusal above its own rent.
-            RequireFragmentKey(key);
+            VNode.RequireKey(key);
             return Fragment(List(items, keySelector, renderer), key);
         }
 
@@ -1222,7 +1255,7 @@ namespace Velvet
             string? key = null)
         {
             // Same ordering constraint as the overload above.
-            RequireFragmentKey(key);
+            VNode.RequireKey(key);
             return Fragment(List(items, keySelector, renderer), key);
         }
 
@@ -1752,6 +1785,7 @@ namespace Velvet
             IReadOnlyDictionary<string, string>? data = null,
             IReadOnlyDictionary<string, string>? aria = null)
         {
+            VNode.RequireKey(key);
             // Validated BEFORE renting pooled props so a throwing call leaks nothing (mirrors V.SceneView):
             // the settings constructor fail-fasts on an invalid distanceFactor for every construction path,
             // this factory included.
@@ -1813,6 +1847,7 @@ namespace Velvet
             IReadOnlyDictionary<string, string>? data = null,
             IReadOnlyDictionary<string, string>? aria = null)
         {
+            VNode.RequireKey(key);
             var mergedProps = WithAttributes(props, data, aria) ?? VNodePool.RentProps();
             mergedProps.FocusScope = new FocusScopeSettings(contain, restoreFocus, autoFocus, singleTabStop);
 
@@ -1870,6 +1905,7 @@ namespace Velvet
             IReadOnlyDictionary<string, string>? data = null,
             IReadOnlyDictionary<string, string>? aria = null)
         {
+            VNode.RequireKey(key);
             var mergedProps = WithAttributes(props, data, aria) ?? VNodePool.RentProps();
             mergedProps.DndContext = new DndContextSettings(
                 onDragStart, onDragOver, onDragEnd, onDragCancel, collisionDetection, activation);
@@ -1928,6 +1964,7 @@ namespace Velvet
             IReadOnlyDictionary<string, string>? data = null,
             IReadOnlyDictionary<string, string>? aria = null)
         {
+            VNode.RequireKey(key);
             // Above the rent below, so a refusal here strands no bag this factory rented.
             if (movement is not (DragMovement.Translate or DragMovement.None))
             {
@@ -1985,6 +2022,7 @@ namespace Velvet
             IReadOnlyDictionary<string, string>? data = null,
             IReadOnlyDictionary<string, string>? aria = null)
         {
+            VNode.RequireKey(key);
             var mergedProps = WithAttributes(props, data, aria) ?? VNodePool.RentProps();
             mergedProps.Droppable = new DroppableSettings(
                 id, dropData, disabled, whileOverClass, whileDragActiveClass);
@@ -2019,6 +2057,7 @@ namespace Velvet
         /// <returns>The created <see cref="PortalNode"/>.</returns>
         public static PortalNode DragOverlay(VNode?[]? children = null, string? key = null)
         {
+            VNode.RequireKey(key);
             var positionerProps = VNodePool.RentProps();
             positionerProps.DragOverlay = new DragOverlaySettings();
             return Portal(UILayer.Overlay, key: key, children: new VNode?[]
@@ -2057,30 +2096,18 @@ namespace Velvet
         /// </summary>
         /// <param name="children">Child VNodes returned as a flat sibling list.</param>
         /// <param name="key">
-        /// Optional key used to disambiguate the Fragment from siblings at the same position. Must
-        /// not contain a NUL (U+0000) character; NUL is reserved as the internal scope delimiter
-        /// used by the reconciler to compose Fragment scope chains.
+        /// Optional key used to disambiguate the Fragment from siblings at the same position, held to
+        /// <see cref="VNode.Key"/>'s rule on what a key may contain.
         /// </param>
         /// <exception cref="ArgumentException">Thrown when <paramref name="key"/> contains a NUL character.</exception>
         /// <returns>The created <see cref="FragmentNode"/>.</returns>
         public static FragmentNode Fragment(VNode?[] children, string? key = null)
         {
-            RequireFragmentKey(key);
             return new FragmentNode
             {
                 Key = key,
                 Children = children ?? EmptyChildren,
             };
-        }
-
-        private static void RequireFragmentKey(string? key)
-        {
-            if (key != null && key.IndexOf('\0') >= 0)
-            {
-                throw new ArgumentException(
-                    "Fragment key must not contain a NUL (U+0000) character; NUL is reserved as the internal scope delimiter.",
-                    nameof(key));
-            }
         }
 
         #endregion

--- a/Packages/com.velvet.core/Runtime/Component/V.cs
+++ b/Packages/com.velvet.core/Runtime/Component/V.cs
@@ -1125,6 +1125,9 @@ namespace Velvet
         /// <param name="items">Source collection. When null or empty, returns an empty VNode array.</param>
         /// <param name="keySelector">Selector that derives a stable per-item key.</param>
         /// <param name="renderer">Function that produces a VNode for each item.</param>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="keySelector"/> returns a key
+        /// containing a NUL character, after <paramref name="renderer"/> has run for that item and every
+        /// item before it.</exception>
         /// <returns>Array of rendered VNodes (each carrying the selected key).</returns>
         public static VNode?[] List<T>(
             IReadOnlyList<T> items,
@@ -1171,6 +1174,9 @@ namespace Velvet
         /// <param name="items">Source collection. When null or empty, returns an empty VNode array.</param>
         /// <param name="keySelector">Selector that derives a stable per-item key from the item and its index.</param>
         /// <param name="renderer">Function that produces a VNode from the item and its index.</param>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="keySelector"/> returns a key
+        /// containing a NUL character, after <paramref name="renderer"/> has run for that item and every
+        /// item before it.</exception>
         /// <returns>Array of rendered VNodes (each carrying the selected key).</returns>
         public static VNode?[] List<T>(
             IReadOnlyList<T> items,
@@ -1218,8 +1224,9 @@ namespace Velvet
         /// <param name="keySelector">Selector that derives a stable per-item key.</param>
         /// <param name="renderer">Function that produces a VNode for each item.</param>
         /// <param name="key">Optional key disambiguating this Fragment from siblings at the same position.</param>
-        /// <exception cref="ArgumentException">Thrown, before <paramref name="renderer"/> is invoked for
-        /// any item, when <paramref name="key"/> contains a NUL character.</exception>
+        /// <exception cref="ArgumentException">Thrown before <paramref name="renderer"/> is invoked for any
+        /// item when <paramref name="key"/> contains a NUL character; thrown after it has run for that item
+        /// and every item before it when <paramref name="keySelector"/> returns a key containing one.</exception>
         /// <returns>A <see cref="FragmentNode"/> wrapping the rendered VNodes.</returns>
         public static FragmentNode ListFragment<T>(
             IReadOnlyList<T> items,
@@ -1245,8 +1252,9 @@ namespace Velvet
         /// <param name="keySelector">Selector that derives a stable per-item key from the item and its index.</param>
         /// <param name="renderer">Function that produces a VNode from the item and its index.</param>
         /// <param name="key">Optional key disambiguating this Fragment from siblings at the same position.</param>
-        /// <exception cref="ArgumentException">Thrown, before <paramref name="renderer"/> is invoked for
-        /// any item, when <paramref name="key"/> contains a NUL character.</exception>
+        /// <exception cref="ArgumentException">Thrown before <paramref name="renderer"/> is invoked for any
+        /// item when <paramref name="key"/> contains a NUL character; thrown after it has run for that item
+        /// and every item before it when <paramref name="keySelector"/> returns a key containing one.</exception>
         /// <returns>A <see cref="FragmentNode"/> wrapping the rendered VNodes.</returns>
         public static FragmentNode ListFragment<T>(
             IReadOnlyList<T> items,
@@ -2326,13 +2334,17 @@ namespace Velvet
         /// </summary>
         /// <typeparam name="T">Element type of the source collection.</typeparam>
         /// <param name="items">Source collection. Must not be null.</param>
-        /// <param name="keySelector">Selector that derives a stable per-item key. Must not be null.</param>
+        /// <param name="keySelector">Selector that derives a stable per-item key, held to
+        /// <see cref="VNode.Key"/>'s rule on what a key may contain. Must not be null. An item whose key
+        /// breaks that rule is left out of the rendered range with a warning; the selector runs from a
+        /// range update rather than from this call, which has no item's key to refuse yet.</param>
         /// <param name="itemHeight">Fixed height (pixels) used for layout and visible-range calculation.</param>
         /// <param name="renderer">Function that produces a VNode for each visible item. Must not be null.</param>
         /// <param name="overscan">Extra items rendered above/below the visible window to smooth scroll-in.</param>
         /// <param name="key">Key used to disambiguate siblings at the same position.</param>
         /// <param name="className">CSS-like utility class string. Multiple classes separated by spaces.</param>
         /// <param name="name">Element name assigned to <see cref="VisualElement.name"/> for query/debug.</param>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="key"/> contains a NUL character.</exception>
         /// <returns>The created <see cref="VirtualListNode"/>.</returns>
         public static VirtualListNode VirtualList<T>(
             IReadOnlyList<T> items,

--- a/Packages/com.velvet.core/Runtime/Component/VNodeTypes.cs
+++ b/Packages/com.velvet.core/Runtime/Component/VNodeTypes.cs
@@ -11,10 +11,37 @@ namespace Velvet
     /// </summary>
     public abstract class VNode
     {
+        private string? _key;
+
         /// <summary>
         /// Key used by the Reconciler to track node identity across renders. Null when omitted at the call site.
+        /// Must not contain a NUL (U+0000) character: NUL is the delimiter the reconciler's scope chains are
+        /// composed from, so a key holding one lets two distinct tree positions compose to the same scope
+        /// string and reconcile as one identity.
         /// </summary>
-        public string? Key { get; internal set; }
+        /// <exception cref="ArgumentException">Thrown when the key contains a NUL (U+0000) character.</exception>
+        public string? Key
+        {
+            get => _key;
+            internal set
+            {
+                RequireKey(value);
+                _key = value;
+            }
+        }
+
+        // A factory that takes from a pool before it builds its node calls this above that rent, under the
+        // ordering rule V.Draggable's own refusal states. The setter above refuses the same key, but only
+        // once the node's initializer runs, which is after such a factory's rent.
+        internal static void RequireKey(string? key)
+        {
+            if (key != null && key.IndexOf('\0') >= 0)
+            {
+                throw new ArgumentException(
+                    "A VNode key must not contain a NUL (U+0000) character; NUL is reserved as the internal scope delimiter.",
+                    nameof(key));
+            }
+        }
     }
 
     /// <summary>

--- a/Packages/com.velvet.core/Runtime/Component/VNodeTypes.cs
+++ b/Packages/com.velvet.core/Runtime/Component/VNodeTypes.cs
@@ -35,13 +35,15 @@ namespace Velvet
         // once the node's initializer runs, which is after such a factory's rent.
         internal static void RequireKey(string? key)
         {
-            if (key != null && key.IndexOf('\0') >= 0)
+            if (KeyHoldsDelimiter(key))
             {
                 throw new ArgumentException(
                     "A VNode key must not contain a NUL (U+0000) character; NUL is reserved as the internal scope delimiter.",
                     nameof(key));
             }
         }
+
+        internal static bool KeyHoldsDelimiter(string? key) => key != null && key.IndexOf('\0') >= 0;
     }
 
     /// <summary>

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberKeying.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberKeying.cs
@@ -251,7 +251,7 @@ namespace Velvet
         // Composes a new scope by extending parentScope with
         // contribution. The NUL byte (U+0000) delimits scope segments;
         // VNode.Key refuses a key holding one, so a user-supplied key contributes a whole segment
-        // instead of splitting into two. A null parentScope means the outermost
+        // instead of splitting into more than one. A null parentScope means the outermost
         // keyed boundary — the contribution becomes the entire scope.
         internal static string ComposeFragmentScope(string? parentScope, string contribution)
             => parentScope == null ? contribution : parentScope + "\0" + contribution;

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberKeying.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberKeying.cs
@@ -250,8 +250,8 @@ namespace Velvet
 
         // Composes a new scope by extending parentScope with
         // contribution. The NUL byte (U+0000) delimits scope segments;
-        // V.Fragment rejects keys containing NUL at the factory so scope segments cannot collide
-        // with user-supplied key contents. A null parentScope means the outermost
+        // VNode.Key refuses a key holding one, so a user-supplied key contributes a whole segment
+        // instead of splitting into two. A null parentScope means the outermost
         // keyed boundary — the contribution becomes the entire scope.
         internal static string ComposeFragmentScope(string? parentScope, string contribution)
             => parentScope == null ? contribution : parentScope + "\0" + contribution;

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberVirtualListController.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberVirtualListController.cs
@@ -251,6 +251,16 @@ namespace Velvet
                     var item = _node.Items[itemIndex];
                     var key = _node.KeySelector(item);
 
+                    // Taken out of the range here rather than left to VNode.Key's refusal below:
+                    // RenderRange has no unwind, so a throw from inside this loop leaves the buffers it
+                    // cleared half-filled, the visible container never rebuilt, and the tracked range
+                    // still naming the one before it.
+                    if (VNode.KeyHoldsDelimiter(key))
+                    {
+                        FiberLogger.LogWarning("FiberVirtualListController", $"Key holding a NUL (U+0000) detected: \"{key}\". Skipping the item; NUL is reserved as the internal scope delimiter.");
+                        continue;
+                    }
+
                     if (!_reusedKeys.Add(key))
                     {
                         FiberLogger.LogWarning("FiberVirtualListController", $"Duplicate key detected: \"{key}\". Skipping duplicate item to prevent tracking inconsistency.");


### PR DESCRIPTION
NUL (U+0000) is the delimiter the reconciler composes its scope chains from. `V.Fragment` and the two
`V.ListFragment` overloads refused a key holding one; no other factory did. So a key carrying a NUL
split into more segments than one, and two different tree positions composed to the same scope string,
where they then reconciled as one identity.

Measured on a `V.Label` keyed `"a\0b"` sitting beside a `V.Fragment` keyed `"a"` that holds a `V.Label`
keyed `"b"`, both under one keyed Fragment — the two labels compose the same scope. One re-render left
the second label's element in the first label's slot, a fresh element in the second's, and the first
label's own element nowhere in the tree.

The refusal now sits on `VNode.Key`'s internal setter, the one place a user key becomes identity.
`V.Provider`, `V.Suspense`, `V.AnimatePresence`, `V.Component`, `V.MemoizedWithKey`, `V.DragOverlay`,
every element factory's `key:`, a `V.List` selector's key and a `V.VirtualList` selector's key all
assign through it.

Refusing per factory was rejected: 46 public `V.*` methods declare a `string? key`, 33 write
`Key = key` in their own initializer and the other 13 delegate to one that does, and a factory added
later reopens it silently. Refusing at the composer was rejected on a measurement — with the check
there, a re-render that reaches it drops the whole render and a first mount produces nothing, because
by then the tree is already being walked.

A factory that takes from a pool before the node carrying the key exists calls `VNode.RequireKey(key)`
above that rent, so a refusal strands nothing it rented. Three factories reach the same guarantee by
object-initializer member order instead, and a case pins that order. `V.List` cannot hoist anything —
its key is not known until an item is mapped — so it gives the child array it rented back.

`V.VirtualList` is answered without a throw. Its `keySelector` is read from a range update rather than
from the `V.VirtualList(...)` call, so throwing there unwinds the reconciler rather than the call the
application wrote: measured, a three-item list whose second key held the delimiter rendered none of
its three, and the next scroll threw again from a range index the failed pass never updated. That item
is now left out of the range and a warning names the key.

`V.List`'s return covers a second case the same code reaches. A renderer throwing for its own reasons
also left that array on loan, with nothing able to give it back and an enclosing error boundary
re-rendering into the same throw. The array goes back; the props bags of nodes the renderer already
built do not, and cannot — the renderer is the caller's and may have returned a node the application
still holds.

`Documentation~` needs no update: no guide states what a key may contain, and `react-migration.md`'s
treatment of key semantics stays true. The constraint lives once, on `VNode.Key`'s XML doc, which
DocFX publishes; `V.Fragment`'s `<param>` points there rather than restating it.

Closes #987
Closes #988
