### PR TITLE
fix(velvet): read the untracked listing by record, and spell the tree it names

### DIFF
--- a/.claude/hooks/lib/repository.py
+++ b/.claude/hooks/lib/repository.py
@@ -33,8 +33,8 @@ GitAnswer = collections.namedtuple("GitAnswer", "stdout stderr code")
 # ambient locale names. Read as that encoding, a byte outside it raises past both handlers below and
 # the hook exits 1 with a traceback, where this module promises an unavailable answer instead. The
 # escape is reversible rather than lossy because a caller re-encodes what it reads:
-# untracked_scratch's `unquoted` takes a path's own bytes back out of the listing's spelling, and a
-# replaced one names a file nothing answers to.
+# untracked_scratch ages a file by the name a listing gave it, and a replaced byte gives a name
+# that is no longer that file's.
 DECODING = {"encoding": "utf-8", "errors": "surrogateescape"}
 
 
@@ -59,6 +59,22 @@ def git(args, cwd, timeout=15):
     """Run git and return its stdout, or None when it could not answer."""
     answer = git_answer(args, cwd, timeout)
     return answer.stdout if answer.code == 0 else None
+
+
+def git_bytes(args, cwd, timeout=15):
+    """git's stdout as the bytes it wrote, or None when it could not answer.
+
+    A second reader rather than a flag on `git` above, since a caller reading paths that carry no
+    quoting of their own needs them byte for byte.
+    scripts/hooks/test_untracked_scratch.py's
+    `Given_ANameHoldingACarriageReturn_When_TheReportIsTaken_Then_TheBoundReachesTheFile` is what
+    fails when such a caller takes the other one.
+    """
+    try:
+        result = subprocess.run(["git", *args], cwd=cwd, capture_output=True, timeout=timeout)
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return result.stdout if result.returncode == 0 else None
 
 
 Answer = collections.namedtuple("Answer", "stdout combined code")

--- a/.claude/hooks/lib/repository.py
+++ b/.claude/hooks/lib/repository.py
@@ -30,11 +30,11 @@ from deferrals import DEFERRALS  # noqa: E402
 GitAnswer = collections.namedtuple("GitAnswer", "stdout stderr code")
 
 # git and gh write bytes — paths, JSON, messages — rather than text in whatever encoding the
-# ambient locale names. Read as that encoding, a byte outside it raises past both handlers below and
-# the hook exits 1 with a traceback, where this module promises an unavailable answer instead. The
-# escape is reversible rather than lossy because a caller re-encodes what it reads:
-# untracked_scratch ages a file by the name a listing gave it, and a replaced byte gives a name
-# that is no longer that file's.
+# ambient locale names. Read as that encoding, a byte outside it raises past the handler of each
+# reader that decodes and the hook exits 1 with a traceback, where this module promises an
+# unavailable answer instead. The escape is reversible rather than lossy because a caller re-encodes
+# what it reads: untracked_scratch ages a file by the name a listing gave it, and a replaced byte
+# gives a name that is no longer that file's.
 DECODING = {"encoding": "utf-8", "errors": "surrogateescape"}
 
 
@@ -64,11 +64,11 @@ def git(args, cwd, timeout=15):
 def git_bytes(args, cwd, timeout=15):
     """git's stdout as the bytes it wrote, or None when it could not answer.
 
-    A second reader rather than a flag on `git` above, since a caller reading paths that carry no
-    quoting of their own needs them byte for byte.
+    A second reader rather than a flag on `git` above: a flag would make the return type depend on
+    an argument, where every reader in this module answers at one type or with None.
     scripts/hooks/test_untracked_scratch.py's
     `Given_ANameHoldingACarriageReturn_When_TheReportIsTaken_Then_TheBoundReachesTheFile` is what
-    fails when such a caller takes the other one.
+    fails when a caller that needs the bytes takes the decoding reader instead.
     """
     try:
         result = subprocess.run(["git", *args], cwd=cwd, capture_output=True, timeout=timeout)

--- a/.claude/hooks/refuse/commit_failing_fast_checks.py
+++ b/.claude/hooks/refuse/commit_failing_fast_checks.py
@@ -21,6 +21,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lib"))
 from shell_commands import (COMMIT_VALUE_FLAGS, NAME_THE_TREE, UNPLACEABLE_MOVE, UNRESOLVED_CD,
                             command_directory, git_invocations, unexpanded)
+import repository
 
 
 HOOK_TOOLS = {"Bash"}
@@ -55,14 +56,6 @@ def git(cwd, *args):
         return subprocess.run(["git", "-C", cwd, *args], capture_output=True, text=True, timeout=30)
     except (OSError, subprocess.SubprocessError):
         return None
-
-
-def git_bytes(cwd, *args):
-    try:
-        result = subprocess.run(["git", "-C", cwd, *args], capture_output=True, timeout=30)
-    except (OSError, subprocess.SubprocessError):
-        return None
-    return result.stdout if result.returncode == 0 else None
 
 
 def repo_root(cwd):
@@ -146,7 +139,7 @@ def committed_content(cwd, commits_all, pathspecs):
         return UNREADABLE
     content = {}
     for path in staged:
-        blob = git_bytes(cwd, "show", ":" + path)
+        blob = repository.git_bytes(["show", ":" + path], cwd)
         if blob is None:
             return UNREADABLE
         content[path] = blob

--- a/.claude/hooks/report/untracked_scratch.py
+++ b/.claude/hooks/report/untracked_scratch.py
@@ -107,15 +107,19 @@ def entries(status, marker):
 
     Read as NUL-delimited records rather than as lines, so that no character a name may hold can
     divide one. `Given_ANameGitLeavesRaw_When_TheReportIsTaken_Then_TheBoundReachesTheFile` is what
-    fails when the split is a line break instead.
+    fails when the split is a line break instead, and
+    `Given_ARenameWhoseOldNameHoldsAByteOutsideTheEncoding_When_TheReportIsTaken_Then_NoPhantomIsNamed`
+    when the decode below stops escaping.
 
-    A rename's or a copy's origin path follows its record as a field of its own, carrying no
-    marker, so it is stepped over rather than read. Both status columns are asked, since porcelain
-    pairs a record with an origin from either, and a field left unread there is taken for a record
-    of its own — which drops the record after it as that one's origin.
+    A rename's or a copy's origin path follows its record as a field of its own, carrying no status
+    pair, so it is stepped over rather than read. Both status columns are asked, since porcelain
+    pairs a record with an origin from either, and a field left unread there is read as a record of
+    its own — so an origin whose path opens with the marker becomes an entry the listing never
+    marked.
     `Given_ARenameWhoseOldNameOpensWithTheMarker_When_TheReportIsTaken_Then_NoPhantomIsNamed`,
-    `Given_AWorktreeRenameBeforeAnUntrackedFile_When_TheReportIsTaken_Then_TheUntrackedFileIsNamed`
-    and `Given_AWorktreeCopyBeforeAnUntrackedFile_When_TheReportIsTaken_Then_TheUntrackedFileIsNamed`
+    `Given_AWorktreeRenameWhoseOldNameOpensWithTheMarker_When_TheListingIsRead_Then_ItHoldsTheUntrackedFileAlone`
+    and
+    `Given_AWorktreeCopyWhoseSourceNameOpensWithTheMarker_When_TheListingIsRead_Then_ItHoldsTheUntrackedFileAlone`
     are what fail when any of that stops.
     """
     fields = (status or b"").decode(**DECODING).split("\0")

--- a/.claude/hooks/report/untracked_scratch.py
+++ b/.claude/hooks/report/untracked_scratch.py
@@ -44,14 +44,11 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lib"))
 
-from repository import git, toplevel  # noqa: E402
+from repository import DECODING, git_bytes, toplevel  # noqa: E402
 
 LISTED = 20
 SOURCE_SUFFIXES = re.compile(r"\.(cs|uss|uxml|asmdef|csproj|sln|md)$")
 BUILD_DIRECTORIES = re.compile(r"^(Library|Temp|obj|Logs)/")
-ESCAPE = re.compile(rb"\\([abfnrtv\"\\]|[0-7]{3})")
-CONTROLS = {b"a": b"\a", b"b": b"\b", b"f": b"\f", b"n": b"\n", b"r": b"\r", b"t": b"\t",
-            b"v": b"\v"}
 
 
 def payload():
@@ -64,9 +61,11 @@ def payload():
 def session_tree(record):
     """The repository root holding the session's cwd, or None where that is not a repository.
 
-    Rooted rather than taken as handed, so the age bound below reaches the files the listing names.
-    `Given_ACwdBelowTheRepositoryRoot_When_TheReportIsTaken_Then_TheBoundStillApplies` is what fails
-    when it stops.
+    Rooted rather than taken as handed: the listing spells its paths from the root, which is where
+    the age bound joins them, and the report names the tree it read rather than the directory it
+    was handed. `Given_ACwdBelowTheRepositoryRoot_When_TheReportIsTaken_Then_TheBoundStillApplies`
+    and `Given_AReportWithSomethingToName_When_TheHeadlineIsRead_Then_ItNamesTheTreeItRead` are what
+    fail when it stops.
     """
     start = Path(record.get("cwd") or os.environ.get("CLAUDE_PROJECT_DIR", "."))
     return toplevel(start) if start.is_dir() else None
@@ -103,45 +102,39 @@ def written_since(path, moment):
         return True
 
 
-def unquoted(listed):
-    """The file a porcelain listing's spelling names.
-
-    Porcelain answers a path holding a space, a quote, a backslash or a control character with a
-    C-quoted spelling, and that spelling is not the path's own: an age taken from it is not the
-    file's, and a suffix read off its end is the closing quote. A non-ASCII byte is escaped into
-    that spelling too, unless `core.quotePath` is off — then it arrives as itself, inside whatever
-    quoting the rest of the name forced. So the unescaping runs over the encoded bytes rather than
-    over the decoded characters;
-    `Given_ARawNonASCIIByteInsideTheQuotes_When_TheReportIsTaken_Then_TheBoundReachesTheFile` is
-    what fails when it stops.
-
-    Asking git for `-z` output instead was rejected: it answers in NUL-separated fields rather than
-    lines, and a rename's second field is a bare path a marker filter would take for an entry of its
-    own. `Given_ARenameWhoseOldNameOpensWithTheMarker_When_TheReportIsTaken_Then_NoPhantomIsNamed`
-    is what fails when the form changes.
-    """
-    if not (listed.startswith('"') and listed.endswith('"') and len(listed) > 1):
-        return listed
-
-    def byte(hit):
-        found = hit.group(1)
-        return bytes([int(found, 8)]) if len(found) == 3 else CONTROLS.get(found, found)
-
-    return ESCAPE.sub(byte, listed[1:-1].encode("utf-8", "surrogateescape")).decode(
-        "utf-8", "surrogateescape")
-
-
 def entries(status, marker):
-    """The files a porcelain status marked, with the marker dropped and the spelling read back."""
-    return [unquoted(line[3:]) for line in (status or "").splitlines()
-            if line.startswith(marker)]
+    """The files a porcelain status marked, with the marker dropped.
+
+    Read as NUL-delimited records rather than as lines, so that no character a name may hold can
+    divide one. `Given_ANameGitLeavesRaw_When_TheReportIsTaken_Then_TheBoundReachesTheFile` is what
+    fails when the split is a line break instead.
+
+    A rename's or a copy's origin path follows its record as a field of its own, carrying no
+    marker, so it is stepped over rather than read. Both status columns are asked, since porcelain
+    pairs a record with an origin from either, and a field left unread there is taken for a record
+    of its own — which drops the record after it as that one's origin.
+    `Given_ARenameWhoseOldNameOpensWithTheMarker_When_TheReportIsTaken_Then_NoPhantomIsNamed`,
+    `Given_AWorktreeRenameBeforeAnUntrackedFile_When_TheReportIsTaken_Then_TheUntrackedFileIsNamed`
+    and `Given_AWorktreeCopyBeforeAnUntrackedFile_When_TheReportIsTaken_Then_TheUntrackedFileIsNamed`
+    are what fail when any of that stops.
+    """
+    fields = (status or b"").decode(**DECODING).split("\0")
+    found, index = [], 0
+    while index < len(fields):
+        record, index = fields[index], index + 1
+        if len(record) < 3:
+            continue
+        if record[0] in "RC" or record[1] in "RC":
+            index += 1
+        if record.startswith(marker):
+            found.append(record[3:])
+    return found
 
 
 def displayed(path):
-    """How a path is spelled inside the block, whose entries a reader separates by line.
-
-    A path carrying a line break of its own does not survive that separation, so it is spelled
-    quoted and escaped instead.
+    """Every line of this report is read whole — an entry, the headline, the sentence a listing
+    hangs under — and a path carrying a line break of its own divides the line it lands in. Such
+    a path is spelled quoted and escaped instead.
     """
     return path if path.splitlines() == [path] else json.dumps(path)
 
@@ -162,13 +155,14 @@ def main():
     # Counted before the truncation, not after: the headline read "20 untracked" for a tree holding
     # thirty-seven, and a reader who clears the twenty believes they are done.
     untracked = [path for path in
-                 entries(git(["status", "--porcelain", "--untracked-files=all"], tree), "??")
+                 entries(git_bytes(["status", "--porcelain", "-z", "--untracked-files=all"], tree),
+                         "??")
                  if not path.startswith("Library/") and written_since(tree / path, started)]
 
     # An ignored source file is the dangerous case; build output is ignored on purpose.
     ignored = [path for path in
-               entries(git(["status", "--porcelain", "--ignored=matching",
-                            "--untracked-files=all"], tree), "!!")
+               entries(git_bytes(["status", "--porcelain", "-z", "--ignored=matching",
+                                  "--untracked-files=all"], tree), "!!")
                if SOURCE_SUFFIXES.search(path) and not BUILD_DIRECTORIES.match(path)]
 
     if not untracked and not ignored:
@@ -178,11 +172,13 @@ def main():
     scope = "" if started is None else (
         " The listing is bounded by when this subagent started; the tree may hold more.")
 
+    named = displayed(str(tree))
+
     headline, parts = [], []
     if untracked:
         headline.append(f"{len(untracked)} untracked{since}")
         parts.append(
-            f"Untracked files remain in {tree}.{scope} Read each before deciding it is harmless — a "
+            f"Untracked files remain in {named}.{scope} Read each before deciding it is harmless — a "
             "probe fixture left behind reads as production code to the next session, and an agent's "
             "own report that it cleaned up has been wrong before. What stays is for whoever owns "
             "this tree to decide; nothing here asks for a deletion:\n"
@@ -200,7 +196,7 @@ def main():
         # A reader in another worktree of this repository has to be able to tell at a glance
         # whether the report is about the tree they are working in, so the headline names the one
         # read.
-        "systemMessage": f"files remain in {tree} — " + ", ".join(headline),
+        "systemMessage": f"files remain in {named} — " + ", ".join(headline),
         "hookSpecificOutput": {
             "hookEventName": "SubagentStop",
             "additionalContext": "\n\n".join(parts),

--- a/scripts/hooks/test_commit_failing_fast_checks.py
+++ b/scripts/hooks/test_commit_failing_fast_checks.py
@@ -1,10 +1,13 @@
 #!/usr/bin/env python3
-"""Unit tests for the unexpanded-operand readings in .claude/hooks/refuse/commit_failing_fast_checks.py.
+"""Unit tests for .claude/hooks/refuse/commit_failing_fast_checks.py.
 
-The two operand kinds are refused apart because the remedy for one does not reach the other. They were
-folded into one list under a sentence written for a pathspec, and an agent's own `git -C "$SP" commit`
-was refused with `$SP` printed under advice to name the paths or commit the index — two things that
-cannot resolve a `-C`.
+Four hold the unexpanded-operand readings. The two operand kinds are refused apart because the remedy
+for one does not reach the other. They were folded into one list under a sentence written for a
+pathspec, and an agent's own `git -C "$SP" commit` was refused with `$SP` printed under advice to name
+the paths or commit the index — two things that cannot resolve a `-C`.
+
+One holds which content the checks run over, the index's rather than the working tree's, by giving the
+two different text and reading which of them the refusal quotes back.
 
 Run: python3 scripts/hooks/test_commit_failing_fast_checks.py
 """
@@ -19,8 +22,14 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 GUARD = REPO_ROOT / ".claude/hooks/refuse/commit_failing_fast_checks.py"
 
+# A file whose two versions are both distinctive, so that a refusal quoting one of them says which
+# half the guard read. The staged half is what a fast check has to reject.
+PROBE = "probe.py"
+STAGED_AND_BROKEN = "indexed_and_broken = (\n"
+TREE_AND_WHOLE = "tree_is_fine = 1\n"
 
-class UnexpandedOperands(unittest.TestCase):
+
+class GuardTestCase(unittest.TestCase):
     def setUp(self):
         self.root = Path(tempfile.mkdtemp(prefix="fast-checks-")).resolve()
         self.addCleanup(shutil.rmtree, self.root, ignore_errors=True)
@@ -35,6 +44,8 @@ class UnexpandedOperands(unittest.TestCase):
                               capture_output=True, text=True, timeout=60)
         return done.returncode, done.stderr
 
+
+class UnexpandedOperands(GuardTestCase):
     def test_Given_AnUnexpandedDirectory_When_Refused_Then_TheRemedyIsToSpellItOut(self):
         # Arrange — naming the paths leaves the `-C` unresolved, and so does committing the index.
         code, said = self.judge('git -C "$SP" commit -m "x"')
@@ -69,6 +80,30 @@ class UnexpandedOperands(unittest.TestCase):
 
         # Act / Assert
         self.assertEqual((code, "Name the paths" in said), (2, True))
+
+
+class IndexedContent(GuardTestCase):
+    # GREEN_ON_BASE(refactor): the index read this guard's collapse onto a shared reader preserves.
+    # `repository.git_bytes` takes its arguments the other way round from the reader removed here,
+    # so passing `cwd` where the paths go is what reddens this — measured, on a TypeError no handler
+    # catches, which exits 1 and lets the commit through rather than refusing it.
+    def test_Given_ABlobBrokenInTheIndexAndWholeInTheTree_When_Judged_Then_TheRefusalQuotesTheIndex(self):
+        # Arrange — the two halves carry different text, so the quoted line says which was read. A
+        # refusal alone would not: the working tree's copy is what a commit of the index must not be
+        # judged on, and both halves failing would be a case that passes either way — so what the
+        # tree held while the guard ran is compared beside the refusal.
+        (self.root / PROBE).write_text(STAGED_AND_BROKEN, encoding="utf-8")
+        subprocess.run(["git", "-C", str(self.root), "add", PROBE], check=True,
+                       capture_output=True, timeout=60)
+        (self.root / PROBE).write_text(TREE_AND_WHOLE, encoding="utf-8")
+
+        # Act
+        code, said = self.judge("git commit -m x")
+
+        # Assert
+        self.assertEqual((code, STAGED_AND_BROKEN.strip() in said,
+                          (self.root / PROBE).read_text(encoding="utf-8")),
+                         (2, True, TREE_AND_WHOLE))
 
 
 if __name__ == "__main__":

--- a/scripts/hooks/test_untracked_scratch.py
+++ b/scripts/hooks/test_untracked_scratch.py
@@ -6,22 +6,25 @@ before the agent started is not one the agent can make — it was handed the sam
 stop. The cases below hold the narrowing that ends that: which of the payload's two transcripts the
 bound comes from and which record of it, that a leftover written during the run survives it, and
 that a reading which fails widens the report rather than silencing it or answering with the other
-transcript the payload carries. Three hold the names porcelain quotes, whose listed spelling is not
-the path's own: an old one the bound reaches, a fresh one named as the file is spelled, and an
-excluded source the quoting had been hiding from the suffix match. Two hold what the report says
-its count is of, in the arm where a bound was taken and in the arm where none was. One holds the
-listing the bound is kept away from, the gitignored sources; one holds that a source under the
-project's own trees is not a second such listing, so exempting a kind from the bound goes red there.
+transcript the payload carries. Three hold names a line-based listing would have spelled back
+quoted, that spelling not being the path's own: an old one the bound reaches, a fresh one named as
+the file is, and an excluded source whose spelling had been hiding it from the suffix match. Two
+hold what the report says its count is of, in the arm where a bound was taken and in the arm where
+none was. One holds the listing the bound is kept away from, the gitignored sources; one holds that
+a source under the project's own trees is not a second such listing, so exempting a kind from the
+bound goes red there.
 Two more hold the scope the docstring claims — one tree, named in the headline — so widening the
 scan without rewriting that claim goes red.
 
 One holds the root the reading answers with, where the directory's own name ends in a space.
 
-Four more hold the listing's own spelling: that an entry carrying a line break of its own still
-occupies one line of the block, that a name spelled with git's lettered escapes comes back as the
-file's, that a byte left raw inside the quotes is the file's too, and that the marker is read off a
-record rather than off a field. One holds the side a path whose age will not read falls on, asked of
-the reading directly rather than through a report.
+Nine more hold what the report reads and what it writes. Two hold that an entry carrying a line
+break of its own still occupies one line of the block, one for each half of the listing. One holds
+that a name git leaves as itself is not divided into two, and one that a name holding a return is
+aged by the file's. Three hold that a record's marker is read off a record: one where a rename's
+origin would be taken for an entry, and two where an origin left unread swallows the record behind
+it. Two hold a root whose own name holds a line break, one per channel. One holds the side a path
+whose age will not read falls on, asked of the reading directly rather than through a report.
 
 Run: python3 scripts/hooks/test_untracked_scratch.py
 """
@@ -66,12 +69,10 @@ NESTED = "sub/deeper/nested-scratch.txt"
 LINK = "link-to-elsewhere.txt"
 SIBLING_PROBE = "SiblingProbeFixture.cs"
 
-# Three names the listing quotes: one whose quoting adds no escape, one carrying both an escaped
-# quote and a byte spelled in octal, and one for the ignored half. `AS_LISTED` is what porcelain
-# answers for the second, and it is not the name the file was placed under.
+# Three names a line-based listing would have had to quote: one whose quoting would add no escape,
+# one carrying both a quote and a byte over 0x80, and one for the ignored half.
 SPACED = "with space.txt"
 AWKWARD = 'a"b ß.txt'
-AS_LISTED = '"a\\"b \\303\\237.txt"'
 EXCLUDED_SPACED = "Runtime/Excluded source.cs"
 
 # A name whose own line break would divide it across the block, and what the block spells it as
@@ -80,18 +81,38 @@ ORDINARY = "ordinary.cs"
 BROKEN = "probe\nfixture.cs"
 BROKEN_AS_SHOWN = '"probe\\nfixture.cs"'
 
-# Three of the escapes git spells with a letter rather than in octal, none of them a line break.
-CONTROLLED = "bell\a-back\b-tab\t.txt"
+# A name holding a carriage return, for the half of the reading that is about bytes rather than
+# about records.
+RETURNING = "with-return\r.txt"
 
-# A name the quoting reaches for its space, while `core.quotePath` off leaves its ï raw inside
-# those quotes.
-RAW_BYTE = "sp ïce.cs"
+# Three of the eleven boundaries `splitlines()` documents, chosen because git leaves them as
+# themselves once `core.quotePath` is off. All three in one name, so that a reading which handled
+# two of them would still fail.
+RAW_SEPARATORS = "mid\u0085a\u2028b\u2029c.txt"
+
+# A gitignored source whose own name holds a line break, and what the block spells it as instead.
+EXCLUDED_BROKEN = "Runtime/broken\nsource.cs"
+EXCLUDED_BROKEN_AS_SHOWN = '"Runtime/broken\\nsource.cs"'
+EXCLUDING = "Excluded.cs\nExcluded source.cs\nbroken*.cs\n"
+
+# A checkout whose own directory name holds a line break, which both channels have to spell
+# rather than write as it is.
+BROKEN_ROOT = "pro\nject"
 
 # A committed name opening with the untracked marker, and the substring that says the report took a
 # rename's old path for an entry of its own.
 MARKED = "?? phantom.cs"
 PHANTOM = "phantom.cs"
 RENAMED = "renamed.cs"
+
+# A pairing whose origin path opens with one of the two letters a record's status columns spell a
+# pairing with, and an untracked name sorting after the record that carries it. Content enough for
+# git to pair the two on.
+PAIRED_SOURCE = "Runtime/aaa-original.cs"
+PAIRED_RENAME = "Runtime/mmm-moved.cs"
+PAIRED_COPY = "Runtime/mmm-copy.cs"
+PAIRED_BODY = "".join("line {}\n".format(number) for number in range(40))
+BEHIND_THE_PAIRING = "Runtime/zzz-scratch.txt"
 
 
 def stamp(moment):
@@ -124,6 +145,16 @@ class UntrackedScratchTests(unittest.TestCase):
         path = self.root / name
         path.write_text("".join(json.dumps({"type": "user", "timestamp": stamp(at)}) + "\n"
                                 for at in moments), encoding="utf-8")
+        return path
+
+    def commit(self, relative, body):
+        """A tracked file with `body` in it, so that git has something to pair a later path with."""
+        path = self.project / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(body, encoding="utf-8")
+        for command in (["add", relative], ["commit", "-q", "-m", "commit " + relative]):
+            subprocess.run(["git", "-C", str(self.project), "-c", "user.email=t@velvet",
+                            "-c", "user.name=t", *command], check=True, timeout=60)
         return path
 
     def place(self, relative, moment):
@@ -340,11 +371,13 @@ class UntrackedScratchTests(unittest.TestCase):
         # Assert
         self.assertIs(kept, True)
 
-    def test_Given_AnOldPathTheListingQuotes_When_TheReportIsTaken_Then_TheBoundWithholdsIt(self):
-        # Arrange — the shape four of this repository's own tracked paths carry. The listing spells
-        # it back quoted, and that spelling is not the file's own, which is where the bound stopped
-        # reaching it. The written one is beside it because a report that named neither would
-        # satisfy the half about the quoted path on its own.
+    # GREEN_ON_BASE(characterization): the bound reaching a name a line-based listing would spell
+    # back quoted, which the base gets by decoding that spelling and this branch gets from a listing
+    # that has no spelling of its own. Dropping `-z` from the two status reads is what reddens it.
+    def test_Given_AnOldPathHoldingASpace_When_TheReportIsTaken_Then_TheBoundWithholdsIt(self):
+        # Arrange — the shape four of this repository's own tracked paths carry. The written one is
+        # beside it because a report that named neither would satisfy the half about the spaced path
+        # on its own.
         self.place(SPACED, BEFORE_BOTH)
         self.place(WRITTEN, AFTER_AGENT)
 
@@ -354,21 +387,22 @@ class UntrackedScratchTests(unittest.TestCase):
         # Assert
         self.assertEqual((SPACED in context, WRITTEN in context), (False, True))
 
-    def test_Given_AFreshPathTheListingQuotes_When_TheReportIsTaken_Then_ItIsNamedAsTheFileIs(self):
-        # Arrange — a name whose listed spelling carries both escape families, asked of both
-        # spellings at once because a report naming neither would satisfy the half about the
-        # listed one.
+    # GREEN_ON_BASE(characterization): a name holding a quote and a byte over 0x80 named as the file
+    # is, which the base gets by decoding a quoted spelling and this branch gets from a listing that
+    # has none. Dropping `-z` from the two status reads is what reddens it.
+    def test_Given_AFreshPathHoldingAQuoteAndAHighByte_When_TheReportIsTaken_Then_ItIsNamedAsTheFileIs(self):
+        # Arrange
         self.place(AWKWARD, AFTER_AGENT)
 
         # Act
         context = json.loads(self.report(self.agent))["hookSpecificOutput"]["additionalContext"]
 
         # Assert
-        self.assertEqual((AWKWARD in context, AS_LISTED in context), (True, False))
+        self.assertIn(AWKWARD, context)
 
-    # GREEN_ON_BASE(characterization): one line per entry is what the base already gives.
-    # It gives it by printing the listed spelling and reading nothing back out of it, which is what
-    # this branch changed, so the block is where that change has to be held to the same shape.
+    # GREEN_ON_BASE(characterization): one line per entry in the untracked half, which the base
+    # already gives. Replacing `shown(untracked[:LISTED], len(untracked))` with a join over the
+    # paths themselves is what reddens it.
     def test_Given_ANameHoldingALineBreak_When_TheListingIsRead_Then_EachEntryIsOneLine(self):
         # Arrange
         self.place(ORDINARY, AFTER_AGENT)
@@ -380,24 +414,30 @@ class UntrackedScratchTests(unittest.TestCase):
         # Assert
         self.assertEqual(listing.splitlines(), [ORDINARY, BROKEN_AS_SHOWN])
 
-    def test_Given_ANameSpelledWithGitsControlEscapes_When_TheReportIsTaken_Then_ItIsNamedAsTheFileIs(self):
-        # Arrange — a name the listing spells with three lettered escapes at once, so a reading
-        # that took each escape for its own letter would name a file nothing answers to.
-        self.place(CONTROLLED, AFTER_AGENT)
+    # GREEN_ON_BASE(characterization): the same one line per entry in the gitignored half, which
+    # the base already gives and no case reached, so that half was free to join its paths as they
+    # are. Replacing `shown(ignored[:LISTED], len(ignored))` with such a join is what reddens it.
+    def test_Given_AGitignoredSourceHoldingALineBreak_When_TheListingIsRead_Then_ItsEntryIsOneLine(self):
+        # Arrange — the pattern is written here rather than into the shared setUp, since no other
+        # case wants a name shaped like this excluded. Nothing untracked is placed beside it, so
+        # the block holds the gitignored listing alone.
+        (self.project / ".gitignore").write_text(EXCLUDING, encoding="utf-8")
+        self.place(EXCLUDED_BROKEN, BEFORE_BOTH)
 
         # Act
-        context = json.loads(self.report(self.agent))["hookSpecificOutput"]["additionalContext"]
+        listing = self.block(self.report(self.agent))
 
         # Assert
-        self.assertIn(CONTROLLED, context)
+        self.assertEqual(listing.splitlines(), [EXCLUDED_BROKEN_AS_SHOWN])
 
-    def test_Given_ARawNonASCIIByteInsideTheQuotes_When_TheReportIsTaken_Then_TheBoundReachesTheFile(self):
-        # Arrange — `core.quotePath` off, which quotes this name for its space and leaves the byte
-        # inside those quotes as itself. The written file keeps the report from being empty, so
-        # what is compared is a listing rather than the absence of one.
-        subprocess.run(["git", "-C", str(self.project), "config", "core.quotePath", "false"],
-                       check=True, timeout=60)
-        self.place(RAW_BYTE, BEFORE_BOTH)
+    # GREEN_ON_BASE(characterization): the bound reaching a name holding a carriage return, which
+    # the base gets by decoding git's quoted spelling and this branch has to get from git's own
+    # bytes. Reading the listing through the text pipe `git` uses is what reddens it.
+    def test_Given_ANameHoldingACarriageReturn_When_TheReportIsTaken_Then_TheBoundReachesTheFile(self):
+        # Arrange — asked of the bound rather than of the block's spelling, so that how the block
+        # spells such a name is left to the case that poses it. The written file keeps the report
+        # from being empty, so what is compared is a listing rather than the absence of one.
+        self.place(RETURNING, BEFORE_BOTH)
         self.place(WRITTEN, AFTER_AGENT)
 
         # Act
@@ -406,9 +446,25 @@ class UntrackedScratchTests(unittest.TestCase):
         # Assert
         self.assertEqual(listing.splitlines(), [WRITTEN])
 
-    # GREEN_ON_BASE(characterization): both trees read the porcelain by lines, not by fields.
-    # Asking git for `-z` instead and splitting the answer on NUL is what reddens this: a rename's
-    # old path arrives there as a bare field, and this one opens with the marker.
+    def test_Given_ANameGitLeavesRaw_When_TheReportIsTaken_Then_TheBoundReachesTheFile(self):
+        # Arrange — `core.quotePath` off makes no difference to this reading and decides a
+        # line-based one, which is the arrangement this is written against. The written file keeps
+        # the report from being empty, so what is compared is a listing rather than the absence of
+        # one.
+        subprocess.run(["git", "-C", str(self.project), "config", "core.quotePath", "false"],
+                       check=True, timeout=60)
+        self.place(RAW_SEPARATORS, BEFORE_BOTH)
+        self.place(WRITTEN, AFTER_AGENT)
+
+        # Act
+        listing = self.block(self.report(self.agent))
+
+        # Assert
+        self.assertEqual(listing.splitlines(), [WRITTEN])
+
+    # GREEN_ON_BASE(characterization): no phantom, which the base gets from reading the porcelain
+    # by lines and this branch has to get from stepping over a rename's origin field, that field
+    # carrying no marker of its own. Stepping over no origin field at all is what reddens it.
     def test_Given_ARenameWhoseOldNameOpensWithTheMarker_When_TheReportIsTaken_Then_NoPhantomIsNamed(self):
         # Arrange — the rename is staged, so the old name reaches the listing only as the far half
         # of one record. That git paired the two rather than reporting a delete and an add is what
@@ -431,9 +487,58 @@ class UntrackedScratchTests(unittest.TestCase):
         self.assertEqual((PHANTOM in printed, WRITTEN in printed, paired.startswith("R ")),
                          (False, True, True))
 
-    def test_Given_AnExcludedSourceTheListingQuotes_When_TheReportIsTaken_Then_ItIsNamed(self):
-        # Arrange — the other half of the same listing, where the spelling costs a source file its
-        # suffix rather than its age.
+    # GREEN_ON_BASE(characterization): an untracked file behind a worktree rename is named, which
+    # the base gets from reading the porcelain by lines and this branch has to get from asking the
+    # worktree column too. Dropping `record[1] in "RC"` is what reddens it: the origin is then a
+    # record of its own, and its own first letter takes the entry behind it for its origin.
+    def test_Given_AWorktreeRenameBeforeAnUntrackedFile_When_TheReportIsTaken_Then_TheUntrackedFileIsNamed(self):
+        # Arrange — intent-to-add is what puts the new path where git can pair it with the old one
+        # without the rename being staged. That git paired them, and in the worktree column, is
+        # compared beside the report, since an unpaired tree poses nothing.
+        self.commit(PAIRED_SOURCE, PAIRED_BODY)
+        os.rename(self.project / PAIRED_SOURCE, self.project / PAIRED_RENAME)
+        subprocess.run(["git", "-C", str(self.project), "add", "-N", PAIRED_RENAME],
+                       check=True, timeout=60)
+        self.place(BEHIND_THE_PAIRING, AFTER_AGENT)
+        paired = subprocess.run(["git", "-C", str(self.project), "status", "--porcelain"],
+                                capture_output=True, text=True, check=True, timeout=60).stdout
+
+        # Act
+        printed = self.report(self.agent)
+
+        # Assert
+        self.assertEqual((BEHIND_THE_PAIRING in printed, paired.startswith(" R ")), (True, True))
+
+    # GREEN_ON_BASE(characterization): the same file behind the other letter, which the base gets
+    # the same way. Dropping the `C` from `record[0] in "RC" or record[1] in "RC"` is what reddens
+    # it, and nothing else here poses a copy.
+    def test_Given_AWorktreeCopyBeforeAnUntrackedFile_When_TheReportIsTaken_Then_TheUntrackedFileIsNamed(self):
+        # Arrange — copy detection is off unless `status.renames` asks for it, and it pairs a new
+        # path with a source the same change modifies. That git paired them is compared beside the
+        # report, since a tree where it paired nothing poses nothing.
+        subprocess.run(["git", "-C", str(self.project), "config", "status.renames", "copies"],
+                       check=True, timeout=60)
+        self.commit(PAIRED_SOURCE, PAIRED_BODY)
+        (self.project / PAIRED_SOURCE).write_text(PAIRED_BODY + "one more\n", encoding="utf-8")
+        (self.project / PAIRED_COPY).write_text(PAIRED_BODY, encoding="utf-8")
+        subprocess.run(["git", "-C", str(self.project), "add", "-N", PAIRED_COPY],
+                       check=True, timeout=60)
+        self.place(BEHIND_THE_PAIRING, AFTER_AGENT)
+        paired = subprocess.run(["git", "-C", str(self.project), "status", "--porcelain"],
+                                capture_output=True, text=True, check=True, timeout=60).stdout
+
+        # Act
+        printed = self.report(self.agent)
+
+        # Assert
+        self.assertEqual((BEHIND_THE_PAIRING in printed, " C " in paired), (True, True))
+
+    # GREEN_ON_BASE(characterization): the suffix match reaching a name a line-based listing would
+    # spell back quoted, which the base gets by decoding that spelling and this branch gets from a
+    # listing that has none. Dropping `-z` from the two status reads is what reddens it.
+    def test_Given_AnExcludedSourceHoldingASpace_When_TheReportIsTaken_Then_ItIsNamed(self):
+        # Arrange — the other half of the same listing, where a spelling that is not the file's own
+        # costs a source file its suffix rather than its age.
         self.place(EXCLUDED_SPACED, BEFORE_BOTH)
 
         # Act
@@ -571,6 +676,53 @@ class WhitespaceRootTests(unittest.TestCase):
 
         # Assert
         self.assertIn(STALE, done.stdout)
+
+
+class LineBrokenRootTests(unittest.TestCase):
+    """Its own class for the reason `WhitespaceRootTests` gives, posing a root whose name divides
+    the line it is written into rather than one whose name ends in whitespace."""
+
+    def rooted(self):
+        """A checkout whose own directory name holds a line break, with one leftover in it."""
+        root = Path(tempfile.mkdtemp(prefix="velvet-untracked-scratch-"))
+        self.addCleanup(shutil.rmtree, root, ignore_errors=True)
+        project = root / BROKEN_ROOT
+        project.mkdir()
+        subprocess.run(["git", "init", "-q", "-b", "main", str(project)], check=True, timeout=60)
+        (project / STALE).write_text("scratch\n", encoding="utf-8")
+        return project
+
+    def report(self, project):
+        done = subprocess.run(
+            [sys.executable, "-B", str(HOOK)],
+            input=json.dumps({"hook_event_name": "SubagentStop", "cwd": str(project)}),
+            capture_output=True, text=True, cwd=str(project.parent),
+            env=dict(os.environ, CLAUDE_PROJECT_DIR=str(project.parent)), timeout=120)
+        return json.loads(done.stdout)
+
+    def test_Given_ARootHoldingALineBreak_When_TheHeadlineIsRead_Then_ItIsOneLineNamingTheTree(self):
+        # Arrange — asked of the line count and of the name at once, since a headline that stopped
+        # naming the tree at all would occupy one line as well.
+        project = self.rooted()
+
+        # Act
+        headline = self.report(project)["systemMessage"]
+
+        # Assert
+        self.assertEqual((headline.splitlines(), json.dumps(str(project.resolve())) in headline),
+                         ([headline], True))
+
+    def test_Given_ARootHoldingALineBreak_When_TheBlockIsRead_Then_ItsOpeningSentenceIsOneLine(self):
+        # Arrange — asked of that sentence and of what hangs under it at once, since the entries a
+        # reader takes off the block are whatever the first line does not cover.
+        project = self.rooted()
+
+        # Act
+        context = self.report(project)["hookSpecificOutput"]["additionalContext"]
+
+        # Assert
+        self.assertEqual((json.dumps(str(project.resolve())) in context.split("\n", 1)[0],
+                          context.split("\n", 1)[1].splitlines()), (True, [STALE]))
 
 
 if __name__ == "__main__":

--- a/scripts/hooks/test_untracked_scratch.py
+++ b/scripts/hooks/test_untracked_scratch.py
@@ -18,13 +18,15 @@ scan without rewriting that claim goes red.
 
 One holds the root the reading answers with, where the directory's own name ends in a space.
 
-Nine more hold what the report reads and what it writes. Two hold that an entry carrying a line
+Eleven more hold what the report reads and what it writes. Two hold that an entry carrying a line
 break of its own still occupies one line of the block, one for each half of the listing. One holds
 that a name git leaves as itself is not divided into two, and one that a name holding a return is
-aged by the file's. Three hold that a record's marker is read off a record: one where a rename's
-origin would be taken for an entry, and two where an origin left unread swallows the record behind
-it. Two hold a root whose own name holds a line break, one per channel. One holds the side a path
-whose age will not read falls on, asked of the reading directly rather than through a report.
+aged by the file's. Four hold that a record's marker is read off a record and never off an origin
+field, each posing an origin path that opens with the marker: one per pairing letter in the worktree
+column, and two in the index column, the second of those holding a byte the encoding does not map
+and written straight into the index, this filesystem not carrying it. Two hold a root whose own
+name holds a line break, one per channel. One holds the side a path whose age will not read falls
+on, asked of the reading directly rather than through a report.
 
 Run: python3 scripts/hooks/test_untracked_scratch.py
 """
@@ -105,14 +107,27 @@ MARKED = "?? phantom.cs"
 PHANTOM = "phantom.cs"
 RENAMED = "renamed.cs"
 
-# A pairing whose origin path opens with one of the two letters a record's status columns spell a
-# pairing with, and an untracked name sorting after the record that carries it. Content enough for
-# git to pair the two on.
-PAIRED_SOURCE = "Runtime/aaa-original.cs"
-PAIRED_RENAME = "Runtime/mmm-moved.cs"
-PAIRED_COPY = "Runtime/mmm-copy.cs"
+# The same name with a byte UTF-8 does not map added to it, and the spelling a printed report
+# carries it as: the escape leaves a surrogate in the path and `json.dumps` writes that surrogate
+# out as text, so a search for the path itself finds nothing in the report and pins nothing. The
+# name is written into the index rather than onto disk — a file carrying the byte was the first
+# arrangement tried and this filesystem refused to make one, with `Illegal byte sequence`.
+RAW_BYTE_MARKED = b"?? lat\xedn1.cs"
+RAW_BYTE_PHANTOM = "lat\\udcedn1.cs"
+
+UNTRACKED_MARKER = "?? "
+
+# A pairing whose origin path opens with that marker, so that a reading which does not step over
+# the origin names it as an entry of its own. What the origin is called is what makes that visible:
+# measured, for an origin opening with neither the marker nor a pairing letter, a reading that
+# misses the worktree column answers with the same listing as this one — which is why both cases
+# below compare the marker as a term of their own. Beside it an untracked file, so the report holds
+# a listing rather than nothing, and content enough for git to pair on.
+PAIRED_SOURCE = "?? original.cs"
+PAIRED_RENAME = "moved.cs"
+PAIRED_COPY = "copy.cs"
 PAIRED_BODY = "".join("line {}\n".format(number) for number in range(40))
-BEHIND_THE_PAIRING = "Runtime/zzz-scratch.txt"
+BESIDE_THE_PAIRING = "Runtime/scratch.txt"
 
 
 def stamp(moment):
@@ -156,6 +171,23 @@ class UntrackedScratchTests(unittest.TestCase):
             subprocess.run(["git", "-C", str(self.project), "-c", "user.email=t@velvet",
                             "-c", "user.name=t", *command], check=True, timeout=60)
         return path
+
+    def listed(self):
+        """The bytes git's own untracked listing holds.
+
+        A name git never listed and a name the report withheld are the same absence, so a case
+        posing a name the filesystem might mangle and asserting the report does not carry it
+        compares this beside that absence. Without it, a `place` whose file the listing never
+        reached passes having measured no withholding at all.
+        """
+        return subprocess.run(["git", "-C", str(self.project), "status", "--porcelain", "-z",
+                               "--untracked-files=all"], capture_output=True, check=True,
+                              timeout=60).stdout
+
+    def index(self, records):
+        """Index records written straight in, for a path this filesystem will not hold."""
+        subprocess.run(["git", "-C", str(self.project), "update-index", "-z", "--index-info"],
+                       input=records, check=True, timeout=60)
 
     def place(self, relative, moment):
         path = self.project / relative
@@ -380,12 +412,14 @@ class UntrackedScratchTests(unittest.TestCase):
         # on its own.
         self.place(SPACED, BEFORE_BOTH)
         self.place(WRITTEN, AFTER_AGENT)
+        listed = self.listed()
 
         # Act
         context = json.loads(self.report(self.agent))["hookSpecificOutput"]["additionalContext"]
 
         # Assert
-        self.assertEqual((SPACED in context, WRITTEN in context), (False, True))
+        self.assertEqual((SPACED in context, WRITTEN in context,
+                          SPACED.encode("utf-8") in listed), (False, True, True))
 
     # GREEN_ON_BASE(characterization): a name holding a quote and a byte over 0x80 named as the file
     # is, which the base gets by decoding a quoted spelling and this branch gets from a listing that
@@ -439,12 +473,14 @@ class UntrackedScratchTests(unittest.TestCase):
         # from being empty, so what is compared is a listing rather than the absence of one.
         self.place(RETURNING, BEFORE_BOTH)
         self.place(WRITTEN, AFTER_AGENT)
+        listed = self.listed()
 
         # Act
         listing = self.block(self.report(self.agent))
 
         # Assert
-        self.assertEqual(listing.splitlines(), [WRITTEN])
+        self.assertEqual((listing.splitlines(), RETURNING.encode("utf-8") in listed),
+                         ([WRITTEN], True))
 
     def test_Given_ANameGitLeavesRaw_When_TheReportIsTaken_Then_TheBoundReachesTheFile(self):
         # Arrange — `core.quotePath` off makes no difference to this reading and decides a
@@ -455,12 +491,14 @@ class UntrackedScratchTests(unittest.TestCase):
                        check=True, timeout=60)
         self.place(RAW_SEPARATORS, BEFORE_BOTH)
         self.place(WRITTEN, AFTER_AGENT)
+        listed = self.listed()
 
         # Act
         listing = self.block(self.report(self.agent))
 
         # Assert
-        self.assertEqual(listing.splitlines(), [WRITTEN])
+        self.assertEqual((listing.splitlines(), RAW_SEPARATORS.encode("utf-8") in listed),
+                         ([WRITTEN], True))
 
     # GREEN_ON_BASE(characterization): no phantom, which the base gets from reading the porcelain
     # by lines and this branch has to get from stepping over a rename's origin field, that field
@@ -487,35 +525,69 @@ class UntrackedScratchTests(unittest.TestCase):
         self.assertEqual((PHANTOM in printed, WRITTEN in printed, paired.startswith("R ")),
                          (False, True, True))
 
-    # GREEN_ON_BASE(characterization): an untracked file behind a worktree rename is named, which
-    # the base gets from reading the porcelain by lines and this branch has to get from asking the
-    # worktree column too. Dropping `record[1] in "RC"` is what reddens it: the origin is then a
-    # record of its own, and its own first letter takes the entry behind it for its origin.
-    def test_Given_AWorktreeRenameBeforeAnUntrackedFile_When_TheReportIsTaken_Then_TheUntrackedFileIsNamed(self):
-        # Arrange — intent-to-add is what puts the new path where git can pair it with the old one
-        # without the rename being staged. That git paired them, and in the worktree column, is
-        # compared beside the report, since an unpaired tree poses nothing.
-        self.commit(PAIRED_SOURCE, PAIRED_BODY)
-        os.rename(self.project / PAIRED_SOURCE, self.project / PAIRED_RENAME)
-        subprocess.run(["git", "-C", str(self.project), "add", "-N", PAIRED_RENAME],
+    # GREEN_ON_BASE(characterization): no phantom where the origin holds a byte the encoding does
+    # not map, which the base gets from the same escape this branch reads the records through.
+    # Decoding the listing as strict UTF-8 rather than through `DECODING` is what reddens it, and
+    # no other case here poses a byte outside the encoding.
+    def test_Given_ARenameWhoseOldNameHoldsAByteOutsideTheEncoding_When_TheReportIsTaken_Then_NoPhantomIsNamed(self):
+        # Arrange — the sibling above renames a file to put its old name in a pairing; here the
+        # index is written directly, since no file on this filesystem can carry the byte. The
+        # written file keeps the report from being empty, so what is compared is a listing rather
+        # than the absence of one, and that git paired the two is compared beside it.
+        blob = subprocess.run(["git", "-C", str(self.project), "hash-object", "-w", "--stdin"],
+                              input=b"tracked\n", capture_output=True, check=True,
+                              timeout=60).stdout.strip()
+        self.index(b"100644 " + blob + b"\t" + RAW_BYTE_MARKED + b"\x00")
+        subprocess.run(["git", "-C", str(self.project), "-c", "user.email=t@velvet",
+                        "-c", "user.name=t", "commit", "-q", "-m", "commit the raw name"],
                        check=True, timeout=60)
-        self.place(BEHIND_THE_PAIRING, AFTER_AGENT)
+        self.index(b"0 " + b"0" * 40 + b"\t" + RAW_BYTE_MARKED + b"\x00"
+                   + b"100644 " + blob + b"\t" + RENAMED.encode("utf-8") + b"\x00")
+        (self.project / RENAMED).write_bytes(b"tracked\n")
         paired = subprocess.run(["git", "-C", str(self.project), "status", "--porcelain"],
                                 capture_output=True, text=True, check=True, timeout=60).stdout
+        self.place(WRITTEN, AFTER_AGENT)
 
         # Act
         printed = self.report(self.agent)
 
         # Assert
-        self.assertEqual((BEHIND_THE_PAIRING in printed, paired.startswith(" R ")), (True, True))
+        self.assertEqual((RAW_BYTE_PHANTOM in printed, WRITTEN in printed,
+                          paired.startswith("R ")), (False, True, True))
 
-    # GREEN_ON_BASE(characterization): the same file behind the other letter, which the base gets
-    # the same way. Dropping the `C` from `record[0] in "RC" or record[1] in "RC"` is what reddens
-    # it, and nothing else here poses a copy.
-    def test_Given_AWorktreeCopyBeforeAnUntrackedFile_When_TheReportIsTaken_Then_TheUntrackedFileIsNamed(self):
+    # GREEN_ON_BASE(characterization): a worktree rename's origin is no entry, which the base gets
+    # from reading the porcelain by lines — where an origin sits inside a line the status pair
+    # starts — and this branch has to get from stepping over a field. Narrowing `record[1] in "RC"`
+    # to `record[1] in "C"` is what reddens it, and nothing else here poses a worktree rename.
+    def test_Given_AWorktreeRenameWhoseOldNameOpensWithTheMarker_When_TheListingIsRead_Then_ItHoldsTheUntrackedFileAlone(self):
+        # Arrange — intent-to-add is what puts the new path where git can pair it with the old one
+        # without the rename being staged. Two controls sit in the comparison: that git paired the
+        # two in the worktree column, since an unpaired tree poses nothing, and that the source is
+        # still spelled with the marker, since a source renamed past that poses nothing either.
+        self.commit(PAIRED_SOURCE, PAIRED_BODY)
+        os.rename(self.project / PAIRED_SOURCE, self.project / PAIRED_RENAME)
+        subprocess.run(["git", "-C", str(self.project), "add", "-N", PAIRED_RENAME],
+                       check=True, timeout=60)
+        self.place(BESIDE_THE_PAIRING, AFTER_AGENT)
+        paired = subprocess.run(["git", "-C", str(self.project), "status", "--porcelain"],
+                                capture_output=True, text=True, check=True, timeout=60).stdout
+
+        # Act
+        listing = self.block(self.report(self.agent))
+
+        # Assert
+        self.assertEqual((listing, " R " in paired,
+                          PAIRED_SOURCE.startswith(UNTRACKED_MARKER)),
+                         (BESIDE_THE_PAIRING, True, True))
+
+    # GREEN_ON_BASE(characterization): the same origin behind the other letter, which the base gets
+    # the same way. Narrowing `record[1] in "RC"` to `record[1] in "R"` is what reddens it, and
+    # nothing else here poses a copy.
+    def test_Given_AWorktreeCopyWhoseSourceNameOpensWithTheMarker_When_TheListingIsRead_Then_ItHoldsTheUntrackedFileAlone(self):
         # Arrange — copy detection is off unless `status.renames` asks for it, and it pairs a new
-        # path with a source the same change modifies. That git paired them is compared beside the
-        # report, since a tree where it paired nothing poses nothing.
+        # path with a source the same change modifies, so here the source stays in the tree and
+        # reports a modification of its own beside the pairing. The two controls are the ones the
+        # rename case states.
         subprocess.run(["git", "-C", str(self.project), "config", "status.renames", "copies"],
                        check=True, timeout=60)
         self.commit(PAIRED_SOURCE, PAIRED_BODY)
@@ -523,15 +595,17 @@ class UntrackedScratchTests(unittest.TestCase):
         (self.project / PAIRED_COPY).write_text(PAIRED_BODY, encoding="utf-8")
         subprocess.run(["git", "-C", str(self.project), "add", "-N", PAIRED_COPY],
                        check=True, timeout=60)
-        self.place(BEHIND_THE_PAIRING, AFTER_AGENT)
+        self.place(BESIDE_THE_PAIRING, AFTER_AGENT)
         paired = subprocess.run(["git", "-C", str(self.project), "status", "--porcelain"],
                                 capture_output=True, text=True, check=True, timeout=60).stdout
 
         # Act
-        printed = self.report(self.agent)
+        listing = self.block(self.report(self.agent))
 
         # Assert
-        self.assertEqual((BEHIND_THE_PAIRING in printed, " C " in paired), (True, True))
+        self.assertEqual((listing, " C " in paired,
+                          PAIRED_SOURCE.startswith(UNTRACKED_MARKER)),
+                         (BESIDE_THE_PAIRING, True, True))
 
     # GREEN_ON_BASE(characterization): the suffix match reaching a name a line-based listing would
     # spell back quoted, which the base gets by decoding that spelling and this branch gets from a


### PR DESCRIPTION
`entries()` split `git status --porcelain` with `splitlines()`, which divides a record on eleven
documented boundaries. Git C-quotes a control byte under either `core.quotePath`, so eight of those
rows arrived quoted and survived; U+0085, U+2028 and U+2029 are over 0x80, so with `core.quotePath`
off nothing forced quoting and they arrived as themselves. The record was two lines before the
unquoting ran, and the agent was handed a name no file answers to, at every stop.

The listing is now read NUL-delimited, which no character a name may hold can divide, so the C-quote
decoder goes away rather than being repaired: `unquoted`, `ESCAPE` and `CONTROLS` are gone. Two
things that reading owes. A path arrives with no quoting of its own, so it has to arrive byte for
byte — `repository.git_bytes` reads the pipe without the text wrapper, a second reader rather than a
flag on `git`, which would make a return type depend on an argument where every reader in that
module answers at one type or with None. And a rename's or a copy's origin path follows its record
as a field carrying no status pair, so it is stepped over. Both status columns are asked: git pairs
a record with an origin from either, and measured on git 2.50.1 each of `R `, ` R`, `C ` and ` C`
occurs and each carries one — a worktree rename needs only `git add -N`.

Both channels interpolated `git rev-parse --show-toplevel`'s answer as it came. Measured with a root
named `pro<LF>ject`, the headline split in two, the first line naming a directory that is not there,
and the block's opening sentence split as well, putting prose where a reader takes entries. The tree
is now spelled the way an entry is, by the one function that owns that spelling.

`refuse/commit_failing_fast_checks.py` carried a second `git_bytes`: the same read and the same
handler, scoped with `-C` rather than a working directory, under a 30-second bound its own
15-second hook registration puts out of reach, and taking `(cwd, *args)` where the shared one takes
`(args, cwd)`. It reads the index blob two of the four fast checks run over, and no case pinned that read:
measured, handing the shared reader the arguments the removed one took raises a `TypeError` past the
handler, the hook exits 1, and `git commit` is allowed with nothing having looked at what it
records. One reader now, and a case that compares which half of a file the refusal quotes back, its
index copy broken and its working copy whole. The `git` beside it is left alone: its callers read a `CompletedProcess` rather than an answer, and it
decodes strictly — measured, a path git writes as raw bytes takes that reader past its handler and
the guard exits 1 there too, which is a second defect rather than a second spelling.

Three cases arranged an awkward name and then asserted only that the report did not carry it, so a
`place` that succeeded while git listed nothing would have passed having measured no withholding:
measured, removing the arranged name from any of the three left the suite green. Each compares git's
own listing beside the report now, and removing the name reddens its own case.

Twelve cases in scope. `base_red_check.py --lane python` reports three red on the base — the three
raw separators in one name, and the root's line break at each channel — and nine declared green
there and green as declared, eight characterizations and one refactor.

Narrowing the worktree column to
`C` reddens the worktree rename alone and to `R` the worktree copy alone; dropping the index column
reddens the two index-column cases; stepping over no origin at all reddens all four. Reading the
listing back through the text pipe reddens the carriage-return case alone, and decoding `entries()`'
own read as strict UTF-8 rather than through the escape reddens the raw-byte case alone. That read
had been under no case of its own: the byte belongs to a name this filesystem refuses to create, so
the record goes into the index rather than onto disk.

No `Documentation~` or CHANGELOG entry: `.claude/hooks/` is contributor tooling and ships in no
package, and the one document naming `repository.py` describes the Stop guards' blindness report,
which this does not touch.

Closes #983.
