### PR TITLE
fix(velvet): let the selector's key decide a VirtualList row's identity

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -113,6 +113,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A `V.VirtualList` row whose renderer keys its own node is reused across a scroll rather than rebuilt.
+  The controller tracks a row by the key `keySelector` returns, but indexed the previous range's rows by
+  whatever key had ended up on the node — and it wrote that key with `??=`, so a node the renderer had
+  already keyed kept the renderer's. Where those two strings differ the reuse lookup missed, the row read
+  as scrolled out of the range it was leaving, and it was disposed and rebuilt on every range change. The
+  list still rendered the right content, which is why this was silent; what it cost was identity. A rebuilt
+  row renders from a fresh fiber, so its `Hooks.UseState` values return to their initial ones on every
+  range change. The selector's key is now what lands on the node, as `V.List` does at its own mapping
+  site, so a row still inside the range is patched in place. A renderer that leaves the key
+  alone, or that sets the same string the selector returns, is unaffected — but keying inside a renderer
+  is not exotic: one returning a shared component, or building its child through a helper that keys for
+  its own reasons, reaches it without the author thinking about the list's key at all.
+
 - A renderer throwing inside `V.List` no longer strands the node array it rented. `V.List` takes that
   array from `VNodePool` and fills it by calling the caller's `renderer` for each item, and a throw out
   of the mapping left it out on loan with nothing able to give it back, so `RentNodeArray` found the

--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -119,12 +119,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   already keyed kept the renderer's. Where those two strings differ the reuse lookup missed, the row read
   as scrolled out of the range it was leaving, and it was disposed and rebuilt on every range change. The
   list still rendered the right content, which is why this was silent; what it cost was identity. A rebuilt
-  row renders from a fresh fiber, so its `Hooks.UseState` values return to their initial ones on every
-  range change. The selector's key is now what lands on the node, as `V.List` does at its own mapping
-  site, so a row still inside the range is patched in place. A renderer that leaves the key
-  alone, or that sets the same string the selector returns, is unaffected — but keying inside a renderer
-  is not exotic: one returning a shared component, or building its child through a helper that keys for
-  its own reasons, reaches it without the author thinking about the list's key at all.
+  row renders from a fresh fiber, so its `Hooks.UseState` values return to their initial ones and the
+  per-mount work its body does — a lazy fetch, an impression ping, a subscription a `Hooks.UseEffect`
+  takes under an empty dependency array — runs again. Measured on a ten-item list with a five-row window
+  scrolled by one row: all five rows ran their `refCallback` cleanup and a fresh setup, where the same
+  scroll now runs one of each. The selector's key is now the one that lands on the node — the same
+  overwrite `V.List` makes at its own mapping site — so a row still inside the range is patched in place.
+  A renderer that returns a freshly built node and leaves its key alone, or that sets the same string the
+  selector returns, is unaffected; a renderer whose node arrives already keyed is not exotic, though — a
+  shared row component that keys itself, or a child built through a helper that keys for its own reasons,
+  reaches this without the author thinking about the list's key at all.
 
 - A renderer throwing inside `V.List` no longer strands the node array it rented. `V.List` takes that
   array from `VNodePool` and fills it by calling the caller's `renderer` for each item, and a throw out

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/VirtualListTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/VirtualListTests.cs
@@ -23,6 +23,9 @@ namespace Velvet.Tests
     /// <item>An item whose <c>keySelector</c> returns a key holding the reconciler's scope delimiter is left
     /// out of the rendered range under a warning naming it, the rest of the range rendering as it would
     /// without it, and a key the renderer set on its own node does not put that item back in.</item>
+    /// <item>A row still inside the range after a range change keeps the state on its fiber, and a key
+    /// the renderer set on that row's own node does not change that: the selector's key is the identity
+    /// the range diff runs on.</item>
     /// <item>An item's <c>refCallback</c> has run by the time a range update returns, though the update is
     /// driven from a scroll rather than from a reconcile pass.</item>
     /// <item>The DSL rejects a null items / keySelector / renderer with <see cref="ArgumentNullException"/>, and a
@@ -357,6 +360,96 @@ namespace Velvet.Tests
 
             // Assert: item 0 is a fresh VisualElement, not the old Label patched in place.
             Assert.That(visibleContainer.ElementAt(0).GetType(), Is.EqualTo(typeof(VisualElement)));
+        }
+
+        #endregion
+
+        #region Row identity across a range change
+
+        private static StateUpdater<string> s_keptRowMark;
+
+        // The mark a row shows is that row's own hook state, which is what separates a row whose fiber
+        // survived a range change from one rebuilt in its place: a rebuild runs UseState again and shows
+        // the initial value, whichever element instance the pool hands the replacement.
+        [Component]
+        private static VNode MarkedRowRender(string id)
+        {
+            var (mark, setMark) = Hooks.UseState("a");
+            if (id == "item-2")
+            {
+                s_keptRowMark = setMark;
+            }
+            return V.Label(name: "row-" + id, text: mark);
+        }
+
+        [Component]
+        private static VNode RendererKeyedRowsHostRender()
+            => V.VirtualList(
+                items: CreateItems(10),
+                keySelector: item => "sel-" + item.Id,
+                itemHeight: 50f,
+                renderer: item => V.Component(MarkedRowRender, item.Id, key: "ren-" + item.Id),
+                overscan: 0);
+
+        [Component]
+        private static VNode UnkeyedRowsHostRender()
+            => V.VirtualList(
+                items: CreateItems(10),
+                keySelector: item => "sel-" + item.Id,
+                itemHeight: 50f,
+                renderer: item => V.Component(MarkedRowRender, item.Id),
+                overscan: 0);
+
+        [Test]
+        public void Given_ARendererKeyingItsOwnNode_When_ARangeChangeKeepsTheRowInRange_Then_TheRowKeepsItsState()
+        {
+            // Arrange — the renderer's key and the selector's are different strings, which is the whole
+            // arrangement. Items 0..4 render, and item-2 is inside the window the Act moves to as well.
+            s_keptRowMark = default;
+            var root = new VisualElement();
+            using var mounted = V.Mount(root, V.Component(RendererKeyedRowsHostRender, key: "host"));
+            var scrollView = root.Q<ScrollView>();
+            var visibleContainer = scrollView.contentContainer.ElementAt(1);
+            var controller = mounted.Root.Reconciler.Context.VirtualListControllers[scrollView];
+            controller.UpdateVisibleRange(scrollY: 0f, viewportHeight: 200f);
+            s_keptRowMark.Invoke("b");
+            mounted.FlushStateForTest();
+
+            // Act — the window becomes items 1..5.
+            controller.UpdateVisibleRange(scrollY: 50f, viewportHeight: 200f);
+
+            // Assert — the name of the row now at the head of the window travels with the mark, because a
+            // range update that returned before rendering leaves the mark reading as it was written.
+            Assert.That(
+                scrollView.Q<Label>("row-item-2")?.text + " under " + visibleContainer.Q<Label>()?.name,
+                Is.EqualTo("b under row-item-1"));
+        }
+
+        // GREEN_ON_BASE(characterization): the base reuses a row whose node the renderer left unkeyed.
+        // The selector's key is the only one there is to index such a row under, so this is what says
+        // the mark-writing arrangement answers on the base at all — and that the sibling case's red
+        // there is the renderer's key rather than a mount that marked nothing.
+        [Test]
+        public void Given_ARendererLeavingTheKeyAlone_When_ARangeChangeKeepsTheRowInRange_Then_TheRowKeepsItsState()
+        {
+            // Arrange — the case above, with the renderer's key taken off.
+            s_keptRowMark = default;
+            var root = new VisualElement();
+            using var mounted = V.Mount(root, V.Component(UnkeyedRowsHostRender, key: "host"));
+            var scrollView = root.Q<ScrollView>();
+            var visibleContainer = scrollView.contentContainer.ElementAt(1);
+            var controller = mounted.Root.Reconciler.Context.VirtualListControllers[scrollView];
+            controller.UpdateVisibleRange(scrollY: 0f, viewportHeight: 200f);
+            s_keptRowMark.Invoke("b");
+            mounted.FlushStateForTest();
+
+            // Act — the window becomes items 1..5.
+            controller.UpdateVisibleRange(scrollY: 50f, viewportHeight: 200f);
+
+            // Assert — the head-of-window name travels with the mark for the reason the case above gives.
+            Assert.That(
+                scrollView.Q<Label>("row-item-2")?.text + " under " + visibleContainer.Q<Label>()?.name,
+                Is.EqualTo("b under row-item-1"));
         }
 
         #endregion

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/VirtualListTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/VirtualListTests.cs
@@ -412,17 +412,23 @@ namespace Velvet.Tests
             var visibleContainer = scrollView.contentContainer.ElementAt(1);
             var controller = mounted.Root.Reconciler.Context.VirtualListControllers[scrollView];
             controller.UpdateVisibleRange(scrollY: 0f, viewportHeight: 200f);
+            var markSetterCaptured = !s_keptRowMark.Equals(default(StateUpdater<string>));
             s_keptRowMark.Invoke("b");
             mounted.FlushStateForTest();
 
             // Act — the window becomes items 1..5.
             controller.UpdateVisibleRange(scrollY: 50f, viewportHeight: 200f);
 
-            // Assert — the name of the row now at the head of the window travels with the mark, because a
-            // range update that returned before rendering leaves the mark reading as it was written.
+            // Assert — the name of the row now at the head of the window and the capture of the setter
+            // travel with the mark, and they answer opposite failures. A range update that returned before
+            // rendering leaves the mark reading as it was written, which would pass; a first window that
+            // never rendered item-2 leaves the setter default, whose Invoke is a silent no-op, which would
+            // fail in the words a lost row reuse fails in.
             Assert.That(
-                scrollView.Q<Label>("row-item-2")?.text + " under " + visibleContainer.Q<Label>()?.name,
-                Is.EqualTo("b under row-item-1"));
+                scrollView.Q<Label>("row-item-2")?.text
+                    + " under " + visibleContainer.Q<Label>()?.name
+                    + " via a " + (markSetterCaptured ? "captured" : "default") + " setter",
+                Is.EqualTo("b under row-item-1 via a captured setter"));
         }
 
         // GREEN_ON_BASE(characterization): the base reuses a row whose node the renderer left unkeyed.
@@ -440,16 +446,20 @@ namespace Velvet.Tests
             var visibleContainer = scrollView.contentContainer.ElementAt(1);
             var controller = mounted.Root.Reconciler.Context.VirtualListControllers[scrollView];
             controller.UpdateVisibleRange(scrollY: 0f, viewportHeight: 200f);
+            var markSetterCaptured = !s_keptRowMark.Equals(default(StateUpdater<string>));
             s_keptRowMark.Invoke("b");
             mounted.FlushStateForTest();
 
             // Act — the window becomes items 1..5.
             controller.UpdateVisibleRange(scrollY: 50f, viewportHeight: 200f);
 
-            // Assert — the head-of-window name travels with the mark for the reason the case above gives.
+            // Assert — the head-of-window name and the setter's capture travel with the mark for the
+            // reason the case above gives.
             Assert.That(
-                scrollView.Q<Label>("row-item-2")?.text + " under " + visibleContainer.Q<Label>()?.name,
-                Is.EqualTo("b under row-item-1"));
+                scrollView.Q<Label>("row-item-2")?.text
+                    + " under " + visibleContainer.Q<Label>()?.name
+                    + " via a " + (markSetterCaptured ? "captured" : "default") + " setter",
+                Is.EqualTo("b under row-item-1 via a captured setter"));
         }
 
         #endregion

--- a/Packages/com.velvet.core/Runtime/Component/V.cs
+++ b/Packages/com.velvet.core/Runtime/Component/V.cs
@@ -2339,7 +2339,9 @@ namespace Velvet
         /// breaks that rule is left out of the rendered range with a warning; the selector runs from a
         /// range update rather than from this call, which has no item's key to refuse yet.</param>
         /// <param name="itemHeight">Fixed height (pixels) used for layout and visible-range calculation.</param>
-        /// <param name="renderer">Function that produces a VNode for each visible item. Must not be null.</param>
+        /// <param name="renderer">Function that produces a VNode for each visible item. Must not be null.
+        /// A key it sets on the node it returns is overwritten by <paramref name="keySelector"/>'s, which is
+        /// the identity a range change reuses a row by.</param>
         /// <param name="overscan">Extra items rendered above/below the visible window to smooth scroll-in.</param>
         /// <param name="key">Key used to disambiguate siblings at the same position.</param>
         /// <param name="className">CSS-like utility class string. Multiple classes separated by spaces.</param>

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberVirtualListController.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberVirtualListController.cs
@@ -273,7 +273,11 @@ namespace Velvet
                         _reusedKeys.Remove(key);
                         continue;
                     }
-                    vnode.Key ??= key;
+                    // IndexOldRenderedItems keys the next pass's reuse table off VNode.Key, and that table
+                    // is read back by the selector's key, so the two sides answer each other only while
+                    // the selector's key is the one that lands on the node — the authority V.List's
+                    // mapping states.
+                    vnode.Key = key;
                     newNodes[i] = vnode;
 
                     // Not routed through ChildReconciler.PatchOrReplaceAtSlot despite the same CanPatch

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberVirtualListController.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberVirtualListController.cs
@@ -275,8 +275,8 @@ namespace Velvet
                     }
                     // IndexOldRenderedItems keys the next pass's reuse table off VNode.Key, and that table
                     // is read back by the selector's key, so the two sides answer each other only while
-                    // the selector's key is the one that lands on the node — the authority V.List's
-                    // mapping states.
+                    // the selector's key is the one that lands on the node — the same overwrite V.List
+                    // makes at its own mapping site.
                     vnode.Key = key;
                     newNodes[i] = vnode;
 


### PR DESCRIPTION
`FiberVirtualListController` tracked a row by the key `keySelector` returns but indexed the previous
range's rows by whatever key ended up on the node, and it wrote that key with `??=`, so a node the
renderer had already keyed kept the renderer's. Where those two strings differ the reuse lookup
missed, the row also read as scrolled out of the range it was leaving, and it was disposed and
rebuilt on every range change. The content stayed right; the row's identity did not.

Measured over a one-row scroll of a five-row window: **ten elements created and five cleaned up**,
where a list whose renderer leaves the key alone creates one and cleans one. So a row's
`Hooks.UseState` returned to its initial value on every range change — and, more expensively, its
mount and unmount ran on every range change, so per-mount work fired each time: a lazy fetch, an
impression ping, a `UseEffect(..., [])` subscription.

The selector's key now lands on the node — the same overwrite `V.List` makes at its own mapping
site, where a comment states the selector is authoritative. That one write fixes both readers: the
reuse lookup and the sweep that decides which rows scrolled out were reading the same disagreement
from opposite ends.

A renderer that returns a freshly built node and leaves its key alone is unaffected, measured
identical before and after.

Filed under `### Fixed` rather than as breaking: on the base a renderer-keyed row was **never**
reused, so nothing could rely on reuse. What a working application could have relied on is the
remount on every range change, which is the base being wrong about what a key means.

`Documentation~` needs no update: `react-migration.md` is the only guide naming `V.VirtualList` and
marks it as not yet documented separately, so no guide describes the behaviour this changes. The
`renderer` parameter's own XML doc now states that a key it sets is overwritten by the selector's.

The two constructs still disagree about what a **null** key means — `V.List` accepts one and
reconciles positionally, `V.VirtualList` throws out of the range update. That divergence is filed
separately and is untouched here.

Closes #1011
