### PR TITLE
fix(velvet): read git's answers in four guards through the one decode

### DIFF
--- a/.harness/hooks/lib/repository.py
+++ b/.harness/hooks/lib/repository.py
@@ -77,6 +77,44 @@ def git_bytes(args, cwd, timeout=15):
     return result.stdout if result.returncode == 0 else None
 
 
+def status_entries(cwd, marker, options=(), timeout=15):
+    """The files `git status --porcelain` marked with `marker`, with the marker dropped, or None
+    when git did not answer.
+
+    Read as NUL-delimited records rather than as lines, so that no character a name may hold can
+    divide one. scripts/hooks/test_untracked_scratch.py's
+    `Given_ANameGitLeavesRaw_When_TheReportIsTaken_Then_TheBoundReachesTheFile` is what fails when
+    the split is a line break instead, and
+    `Given_ARenameWhoseOldNameHoldsAByteOutsideTheEncoding_When_TheReportIsTaken_Then_NoPhantomIsNamed`
+    when the decode below stops escaping.
+
+    A rename's or a copy's origin path follows its record as a field of its own, carrying no status
+    pair, so it is stepped over rather than read. Both status columns are asked, since porcelain
+    pairs a record with an origin from either, and a field left unread there is read as a record of
+    its own — so an origin whose path opens with the marker becomes an entry the listing never
+    marked.
+    `Given_ARenameWhoseOldNameOpensWithTheMarker_When_TheReportIsTaken_Then_NoPhantomIsNamed`,
+    `Given_AWorktreeRenameWhoseOldNameOpensWithTheMarker_When_TheListingIsRead_Then_ItHoldsTheUntrackedFileAlone`
+    and
+    `Given_AWorktreeCopyWhoseSourceNameOpensWithTheMarker_When_TheListingIsRead_Then_ItHoldsTheUntrackedFileAlone`
+    are what fail when any of that stops.
+    """
+    status = git_bytes(["status", "--porcelain", "-z", *options], cwd=cwd, timeout=timeout)
+    if status is None:
+        return None
+    fields = status.decode(**DECODING).split("\0")
+    found, index = [], 0
+    while index < len(fields):
+        record, index = fields[index], index + 1
+        if len(record) < 3:
+            continue
+        if record[0] in "RC" or record[1] in "RC":
+            index += 1
+        if record.startswith(marker):
+            found.append(record[3:])
+    return found
+
+
 Worktree = collections.namedtuple("Worktree", "path branch primary")
 
 
@@ -255,13 +293,14 @@ not that, and naming it there is how a deferral comes to record something nothin
   echo "{key} <what the work is waiting on> $(date +%s) $CLAUDE_CODE_SESSION_ID" >> {DEFERRALS}"""
 
 
-def toplevel(cwd):
+def toplevel(cwd, timeout=15):
     """The root of the repository holding `cwd`, or None where `cwd` sits in none.
 
     A trailing space, tab or newline can belong to the root's own name, so the reading's terminator
     comes off rather than whatever whitespace it ends in.
     """
-    root = (git(["rev-parse", "--show-toplevel"], cwd=cwd) or "").removesuffix("\n")
+    listed = git(["rev-parse", "--show-toplevel"], cwd=cwd, timeout=timeout)
+    root = (listed or "").removesuffix("\n")
     return Path(root) if root else None
 
 

--- a/.harness/hooks/lib/repository.py
+++ b/.harness/hooks/lib/repository.py
@@ -127,18 +127,20 @@ def worktrees(cwd, timeout=20):
     that marks it.
 
     Read here rather than in each caller because a second spelling of how git's bytes are decoded
-    drifts from `git` above in silence, and a guard that mis-reads this list exits 0.
+    drifts from `DECODING` in silence, and a guard that mis-reads this list exits 0.
 
     Read under `-z` so a record ends on a byte a path cannot hold, and the path is taken whole rather
     than stripped, because it is printed back as a command to run and one that lost a character at
     either end is not the path git listed. scripts/hooks/test_hook_repository.py holds a path with a
-    newline in it.
+    newline in it, and
+    `Given_AWorktreeAtAPathHoldingACarriageReturn_When_TheListIsRead_Then_ThePathComesBackWhole` is
+    what fails when this takes `git` rather than `git_bytes`.
     """
-    listing = git(["worktree", "list", "--porcelain", "-z"], cwd=cwd, timeout=timeout)
+    listing = git_bytes(["worktree", "list", "--porcelain", "-z"], cwd=cwd, timeout=timeout)
     if listing is None:
         return None
     found = []
-    for record in listing.split("\0"):
+    for record in listing.decode(**DECODING).split("\0"):
         if record.startswith("worktree "):
             found.append([record[len("worktree "):], None])
         elif record.startswith("branch ") and found:
@@ -297,10 +299,12 @@ def toplevel(cwd, timeout=15):
     """The root of the repository holding `cwd`, or None where `cwd` sits in none.
 
     A trailing space, tab or newline can belong to the root's own name, so the reading's terminator
-    comes off rather than whatever whitespace it ends in.
+    comes off rather than whatever whitespace it ends in. scripts/hooks/test_hook_repository.py's
+    `Given_ARootWhoseNameEndsInACarriageReturn_When_TheTreeIsRooted_Then_TheRootKeepsThatCharacter`
+    is what fails when this takes `git` rather than `git_bytes`.
     """
-    listed = git(["rev-parse", "--show-toplevel"], cwd=cwd, timeout=timeout)
-    root = (listed or "").removesuffix("\n")
+    listed = git_bytes(["rev-parse", "--show-toplevel"], cwd=cwd, timeout=timeout)
+    root = (listed or b"").removesuffix(b"\n").decode(**DECODING)
     return Path(root) if root else None
 
 

--- a/.harness/hooks/refuse/blind_git_add.py
+++ b/.harness/hooks/refuse/blind_git_add.py
@@ -12,11 +12,12 @@ paths are to hand rather than something to go and look up.
 """
 
 import json
-import subprocess
 import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lib"))
+from display import displayed
+from repository import status_entries
 from shell_commands import UNPLACEABLE_MOVE, UNRESOLVED_CD, command_directory, git_invocations
 
 
@@ -61,15 +62,7 @@ def untracked_in(cwd):
     reading that failed puts "Nothing is untracked right now" in a refusal as a fact about a tree
     nothing read.
     """
-    try:
-        listing = subprocess.run(
-            ["git", "-C", cwd, "status", "--porcelain", "--untracked-files=all"],
-            capture_output=True, text=True, timeout=8)
-    except (OSError, subprocess.SubprocessError):
-        return None
-    if listing.returncode != 0:
-        return None
-    return [line[3:] for line in listing.stdout.splitlines() if line.startswith("??")]
+    return status_entries(cwd, "??", ["--untracked-files=all"], timeout=8)
 
 
 def main():
@@ -104,7 +97,7 @@ def main():
                    UNPLACEABLE_MOVE if where is UNRESOLVED_CD else "git did not answer."]
     elif untracked:
         reason += ["", f"Untracked right now ({len(untracked)}):"]
-        reason += [f"  {path}" for path in untracked[:20]]
+        reason += [f"  {displayed(path)}" for path in untracked[:20]]
         if len(untracked) > 20:
             reason.append(f"  … and {len(untracked) - 20} more")
     else:

--- a/.harness/hooks/refuse/branch_from_unmerged.py
+++ b/.harness/hooks/refuse/branch_from_unmerged.py
@@ -16,12 +16,12 @@ start point is a positional beside the path rather than the token after the flag
 """
 
 import json
-import subprocess
 import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lib"))
 from deferrals import deferred, disowned, unusable
+from repository import git_answer
 from shell_commands import (NAME_THE_TREE, UNPLACEABLE_MOVE, UNRESOLVED_CD, command_directory,
                             command_segments, git_invocation, tokens_of, without_redirections)
 from velvet_hooks import BRANCH_BASES
@@ -157,8 +157,7 @@ def creations(command):
 
 
 # Resolving an unexpanded operand fails, and this already refuses on that failure — the right
-# direction for a guard over branch creation. What it used to print was the failure itself, as a
-# detached HEAD at an empty SHA, so the refusal named a repository state that was never true.
+# direction for a guard over branch creation.
 UNEXPANDED_POLICY = "refuse"
 UNEXPANDED_PROBE = 'git -C "$D" branch feat/x'
 
@@ -167,10 +166,7 @@ UNREADABLE_PROBE = {"command": "git branch tooling/probe"}
 
 
 def git(cwd, *args):
-    return subprocess.run(
-        ["git", "-C", cwd, *args],
-        capture_output=True, text=True, timeout=30,
-    )
+    return git_answer(list(args), cwd, timeout=30)
 
 
 def head_description(cwd):
@@ -223,12 +219,12 @@ def refusal(cwd, name, start_point):
         head_ref = git(cwd, "rev-parse", "--abbrev-ref", "HEAD").stdout.strip()
         if head_ref != "main":
             on_main = git(cwd, "merge-base", "--is-ancestor", "HEAD", "main")
-            if on_main.returncode != 0:
+            if on_main.code != 0:
                 head_not_main = True
 
     behind_count = None
     origin_main = git(cwd, "rev-parse", "--verify", "origin/main")
-    origin_missing = origin_main.returncode != 0
+    origin_missing = origin_main.code != 0
     main_behind = False
     if not origin_missing:
         count = git(cwd, "rev-list", "--count", "main..origin/main")

--- a/.harness/hooks/refuse/branch_from_unmerged.py
+++ b/.harness/hooks/refuse/branch_from_unmerged.py
@@ -178,6 +178,10 @@ def head_description(cwd):
     return f"detached at {sha.stdout.strip()}"
 
 
+def what_git_said(asked, answer):
+    return "\n".join("  " + line for line in [f"git {asked}"] + answer.stderr.splitlines())
+
+
 def record_branch_base(name, sha):
     try:
         with open(BRANCH_BASES, "a", encoding="utf-8") as bases:
@@ -216,7 +220,11 @@ def refusal(cwd, name, start_point):
 
     head_not_main = False
     if start_point is None:
-        head_ref = git(cwd, "rev-parse", "--abbrev-ref", "HEAD").stdout.strip()
+        head = git(cwd, "rev-parse", "--abbrev-ref", "HEAD")
+        if head.code != 0:
+            return (f"Refusing to create `{name}`: git could not read HEAD.\n\n"
+                    + what_git_said("rev-parse --abbrev-ref HEAD", head))
+        head_ref = head.stdout.strip()
         if head_ref != "main":
             on_main = git(cwd, "merge-base", "--is-ancestor", "HEAD", "main")
             if on_main.code != 0:
@@ -309,7 +317,12 @@ def main():
                   file=sys.stderr)
         if deferred(name):
             # Parent tip at branch creation is gone after squash-merge; rebase --onto needs it now.
-            head_sha = git(target, "rev-parse", "HEAD").stdout.strip()
+            head = git(target, "rev-parse", "HEAD")
+            if head.code != 0:
+                sys.stderr.write(f"No base was recorded for `{name}`: git could not read HEAD.\n\n"
+                                 + what_git_said("rev-parse HEAD", head) + "\n")
+                continue
+            head_sha = head.stdout.strip()
             record_branch_base(name, head_sha)
             sys.stderr.write(
                 f"Recorded base {head_sha} for `{name}`. "

--- a/.harness/hooks/refuse/changelog_into_closed_version.py
+++ b/.harness/hooks/refuse/changelog_into_closed_version.py
@@ -120,7 +120,7 @@ def published_copies(path, versions):
     tracked = prefix.strip() + Path(path).name
     try:
         tagged = published_check.remote_tag_shas(where)
-    except (OSError, subprocess.SubprocessError):
+    except (OSError, subprocess.SubprocessError, ValueError):
         return {}, tracked
     copies = {}
     for version in versions:
@@ -128,7 +128,7 @@ def published_copies(path, versions):
             found = drain.published_copy(
                 version, tagged,
                 lambda revision: drain.run(["git", "show", f"{revision}:{tracked}"], cwd=where))
-        except drain.UnreadableRelease:
+        except (drain.UnreadableRelease, ValueError):
             continue
         if found is not None:
             copies[version] = (found[0], tagged[found[0]], found[1])

--- a/.harness/hooks/refuse/changelog_into_closed_version.py
+++ b/.harness/hooks/refuse/changelog_into_closed_version.py
@@ -229,7 +229,7 @@ def main():
     if not in_scope(path, event.get("cwd")):
         return 0
     try:
-        text = Path(path).read_text()
+        text = Path(path).read_text(**repository.DECODING)
     except OSError:
         return 0
 

--- a/.harness/hooks/refuse/message_outside_its_worktree.py
+++ b/.harness/hooks/refuse/message_outside_its_worktree.py
@@ -25,13 +25,13 @@ Exit 2 refuses; exit 1 lets the tool through, so nothing here may raise.
 
 import json
 import os
-import subprocess
 import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "lib"))
 
 from pr_body import valued as gh_valued  # noqa: E402
+from repository import toplevel  # noqa: E402
 from shell_commands import (  # noqa: E402
     NAME_THE_TREE, UNPLACEABLE_MOVE, UNRESOLVED_CD, command_directory, git_invocations,
     program_invocations, unexpanded)
@@ -108,15 +108,8 @@ def valued(operands, flags):
 
 def worktree_of(directory):
     """The top of the worktree `directory` sits in, or None when git will not say."""
-    try:
-        done = subprocess.run(["git", "-C", str(directory), "rev-parse", "--show-toplevel"],
-                              capture_output=True, text=True, timeout=10)
-    except (OSError, subprocess.SubprocessError):
-        return None
-    if done.returncode != 0:
-        return None
-    top = done.stdout.strip()
-    return Path(top).resolve() if top else None
+    top = toplevel(directory, timeout=10)
+    return top.resolve() if top else None
 
 
 def inside(path, root, cwd):

--- a/.harness/hooks/refuse/pr_without_mutation_receipt.py
+++ b/.harness/hooks/refuse/pr_without_mutation_receipt.py
@@ -41,6 +41,7 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lib"))
+from repository import DECODING, toplevel  # noqa: E402
 from shell_commands import (  # noqa: E402
     NAME_THE_TREE, UNPLACEABLE_MOVE, UNRESOLVED_CD, command_directory, program_invocations,
     unexpanded)
@@ -65,8 +66,8 @@ SCRIPT = os.path.join("scripts", "test_quality", "mutation_check.py")
 # status, which means it could not take the reading at all. ReceiptRefusalStatusTests pins the pair.
 RECEIPT_REFUSAL = 3
 
-# The whole hook, against the 25 s it is registered with: this budget and `repo_root`'s own have to
-# fit inside that together, or the harness kills the hook and the refusal goes with it.
+# The whole hook, against the 25 s it is registered with: this budget and the root reading's own
+# have to fit inside that together, or the harness kills the hook and the refusal goes with it.
 ROOT_TIMEOUT = 5
 TIMEOUT = 15
 
@@ -77,15 +78,6 @@ SHORT_ELSEWHERE = ("-R", "-H")
 
 OWED = "no mutation campaign covers this branch's change."
 UNREAD = "this guard could not read the state it decides from."
-
-
-def repo_root(cwd):
-    try:
-        found = subprocess.run(["git", "-C", cwd, "rev-parse", "--show-toplevel"],
-                               capture_output=True, text=True, timeout=ROOT_TIMEOUT)
-    except (OSError, subprocess.SubprocessError):
-        return None
-    return found.stdout.strip() if found.returncode == 0 else None
 
 
 def elsewhere(operands):
@@ -150,7 +142,7 @@ def main():
     cwd = command_directory(command, event.get("cwd") or ".")
     if cwd is UNRESOLVED_CD:
         return refuse(UNREAD, UNPLACEABLE_MOVE + "\n\n" + NAME_THE_TREE)
-    root = repo_root(cwd)
+    root = toplevel(cwd, timeout=ROOT_TIMEOUT)
     if root is None:
         return refuse(UNREAD,
                       "git could not say which checkout {} is in, so nothing here read a "
@@ -164,7 +156,7 @@ def main():
 
     try:
         proc = subprocess.run(["python3", "-B", script, "--project", root, "--receipt"],
-                              capture_output=True, text=True, timeout=TIMEOUT, cwd=root)
+                              capture_output=True, timeout=TIMEOUT, cwd=root, **DECODING)
     except (OSError, subprocess.SubprocessError) as failure:
         return refuse(UNREAD,
                       "{} could not be run, so nothing read the receipt: {}".format(script, failure))

--- a/.harness/hooks/refuse/pr_without_mutation_receipt.py
+++ b/.harness/hooks/refuse/pr_without_mutation_receipt.py
@@ -148,6 +148,10 @@ def main():
                       "git could not say which checkout {} is in, so nothing here read a "
                       "receipt at all.\nA reading that did not happen is not a reading that "
                       "found nothing owed.".format(cwd))
+    if not os.path.isdir(root):
+        return refuse(UNREAD,
+                      "git names {} as the checkout {} is in, and no directory is found there, "
+                      "so nothing here\nread a receipt at all.".format(root, cwd))
     # A repository that carries no campaign harness is a definite reading rather than a failed one:
     # there is no receipt to owe.
     script = os.path.join(root, SCRIPT)

--- a/.harness/hooks/report/untracked_scratch.py
+++ b/.harness/hooks/report/untracked_scratch.py
@@ -45,7 +45,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lib"))
 
 from display import displayed  # noqa: E402
-from repository import DECODING, git_bytes, toplevel  # noqa: E402
+from repository import status_entries, toplevel  # noqa: E402
 
 LISTED = 20
 SOURCE_SUFFIXES = re.compile(r"\.(cs|uss|uxml|asmdef|csproj|sln|md)$")
@@ -103,39 +103,6 @@ def written_since(path, moment):
         return True
 
 
-def entries(status, marker):
-    """The files a porcelain status marked, with the marker dropped.
-
-    Read as NUL-delimited records rather than as lines, so that no character a name may hold can
-    divide one. `Given_ANameGitLeavesRaw_When_TheReportIsTaken_Then_TheBoundReachesTheFile` is what
-    fails when the split is a line break instead, and
-    `Given_ARenameWhoseOldNameHoldsAByteOutsideTheEncoding_When_TheReportIsTaken_Then_NoPhantomIsNamed`
-    when the decode below stops escaping.
-
-    A rename's or a copy's origin path follows its record as a field of its own, carrying no status
-    pair, so it is stepped over rather than read. Both status columns are asked, since porcelain
-    pairs a record with an origin from either, and a field left unread there is read as a record of
-    its own — so an origin whose path opens with the marker becomes an entry the listing never
-    marked.
-    `Given_ARenameWhoseOldNameOpensWithTheMarker_When_TheReportIsTaken_Then_NoPhantomIsNamed`,
-    `Given_AWorktreeRenameWhoseOldNameOpensWithTheMarker_When_TheListingIsRead_Then_ItHoldsTheUntrackedFileAlone`
-    and
-    `Given_AWorktreeCopyWhoseSourceNameOpensWithTheMarker_When_TheListingIsRead_Then_ItHoldsTheUntrackedFileAlone`
-    are what fail when any of that stops.
-    """
-    fields = (status or b"").decode(**DECODING).split("\0")
-    found, index = [], 0
-    while index < len(fields):
-        record, index = fields[index], index + 1
-        if len(record) < 3:
-            continue
-        if record[0] in "RC" or record[1] in "RC":
-            index += 1
-        if record.startswith(marker):
-            found.append(record[3:])
-    return found
-
-
 def shown(listing, total):
     """The truncated listing, told how much it is hiding."""
     text = "\n".join(displayed(path) for path in listing)
@@ -151,15 +118,12 @@ def main():
 
     # Counted before the truncation, not after: the headline read "20 untracked" for a tree holding
     # thirty-seven, and a reader who clears the twenty believes they are done.
-    untracked = [path for path in
-                 entries(git_bytes(["status", "--porcelain", "-z", "--untracked-files=all"], tree),
-                         "??")
+    untracked = [path for path in status_entries(tree, "??", ["--untracked-files=all"]) or []
                  if not path.startswith("Library/") and written_since(tree / path, started)]
 
     # An ignored source file is the dangerous case; build output is ignored on purpose.
     ignored = [path for path in
-               entries(git_bytes(["status", "--porcelain", "-z", "--ignored=matching",
-                                  "--untracked-files=all"], tree), "!!")
+               status_entries(tree, "!!", ["--ignored=matching", "--untracked-files=all"]) or []
                if SOURCE_SUFFIXES.search(path) and not BUILD_DIRECTORIES.match(path)]
 
     if not untracked and not ignored:

--- a/scripts/hooks/test_blind_git_add.py
+++ b/scripts/hooks/test_blind_git_add.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Unit tests for .claude/hooks/refuse/blind_git_add.py.
+
+The refusal is a deny decision on stdout, and the untracked names under it are the remedy it offers.
+One case holds a listing carrying a byte UTF-8 does not map: a strict decode raised on it, the hook
+exited 1 with no decision printed, and the staging went ahead. Two hold a name a line-based reading
+listed as something no file is called: one git leaves raw, which `splitlines()` divided, and one git
+escapes, which nothing read back.
+
+Run: python3 scripts/hooks/test_blind_git_add.py
+"""
+
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HOOK = REPO_ROOT / ".claude/hooks/refuse/blind_git_add.py"
+
+SWEEP = "git add -A"
+HEADER = "Untracked right now"
+
+# A tracked name holding a byte UTF-8 does not map, written into the index rather than onto disk,
+# where APFS refuses such a name with `Illegal byte sequence`.
+UNDECODABLE = b"lat\xedn1.txt"
+ORDINARY = "ordinary.txt"
+
+# Three of the boundaries `splitlines()` documents that git leaves raw once `core.quotePath` is off,
+# all in one name so that a reading handling two of them still fails, and how the refusal spells it.
+RAW_SEPARATORS = "mid\u0085a\u2028b\u2029c.txt"
+RAW_SEPARATORS_AS_SHOWN = '"mid\\u0085a\\u2028b\\u2029c.txt"'
+
+# A name git's porcelain escapes with `core.quotePath` on, for its byte over 0x80.
+ESCAPED = "lat\u00edn.txt"
+
+
+def git(cwd, *args, stdin=None):
+    """A failed arrangement is not a verdict, so one must not reach the assertion as an answer."""
+    return subprocess.run(["git", "-C", str(cwd), *args], input=stdin, check=True,
+                          capture_output=True, timeout=60)
+
+
+class StagingRefusalTests(unittest.TestCase):
+    def setUp(self):
+        self.root = Path(tempfile.mkdtemp(prefix="velvet-blind-add-"))
+        self.addCleanup(shutil.rmtree, self.root, ignore_errors=True)
+        git(self.root, "init", "-q", "-b", "main")
+
+    def place(self, name):
+        (self.root / name).write_text("untracked\n", encoding="utf-8")
+
+    def index(self, name):
+        """A tracked path written straight into the index, for a name this filesystem will not hold."""
+        blob = git(self.root, "hash-object", "-w", "--stdin", stdin=b"tracked\n").stdout.strip()
+        git(self.root, "update-index", "-z", "--index-info",
+            stdin=b"100644 " + blob + b"\t" + name + b"\x00")
+
+    def listing_is_undecodable(self):
+        """Whether the arrangement reached the guard's own input, read as bytes rather than through
+        the decode under test."""
+        raw = git(self.root, "status", "--porcelain", "-z", "--untracked-files=all").stdout
+        try:
+            raw.decode("utf-8")
+        except UnicodeDecodeError:
+            return True
+        return False
+
+    def ask(self):
+        event = {"tool_name": "Bash", "cwd": str(self.root), "tool_input": {"command": SWEEP}}
+        return subprocess.run([sys.executable, "-B", str(HOOK)], input=json.dumps(event),
+                              capture_output=True, text=True, timeout=60)
+
+    @staticmethod
+    def refusal(result):
+        """(the decision printed, the untracked block from its header on), each None where absent."""
+        try:
+            output = json.loads(result.stdout)["hookSpecificOutput"]
+        except (ValueError, KeyError, TypeError):
+            return None, None
+        _, header, block = output.get("permissionDecisionReason", "").partition(HEADER)
+        return output.get("permissionDecision"), (header + block).splitlines() if header else None
+
+    def test_Given_ATrackedNameThatIsNotUTF8_When_EverythingIsStaged_Then_TheRefusalListsWhatIsUntracked(self):
+        # Arrange — quoting off, since with it on a line-based listing carries the byte as an escape
+        # and a strict decode of it never meets one. The gate rides in the comparison because a
+        # listing that decoded would leave nothing to fail on, and this case green having posed
+        # nothing.
+        git(self.root, "config", "core.quotePath", "false")
+        self.index(UNDECODABLE)
+        self.place(ORDINARY)
+        arranged = self.listing_is_undecodable()
+
+        # Act
+        result = self.ask()
+
+        # Assert
+        self.assertEqual((arranged, result.returncode, *self.refusal(result)),
+                         (True, 0, "deny", [f"{HEADER} (1):", f"  {ORDINARY}"]))
+
+    def test_Given_ANameGitLeavesRaw_When_EverythingIsStaged_Then_TheRefusalListsItWhole(self):
+        # Arrange — `core.quotePath` off makes no difference to a record-based reading and decides a
+        # line-based one, which is the arrangement this is written against.
+        git(self.root, "config", "core.quotePath", "false")
+        self.place(RAW_SEPARATORS)
+
+        # Act
+        result = self.ask()
+
+        # Assert
+        self.assertEqual(self.refusal(result),
+                         ("deny", [f"{HEADER} (1):", f"  {RAW_SEPARATORS_AS_SHOWN}"]))
+
+    def test_Given_ANameGitEscapes_When_EverythingIsStaged_Then_TheRefusalListsItAsTheFileIs(self):
+        # Arrange — set rather than inherited: with quoting off git leaves this name as it is, and
+        # the case poses nothing.
+        git(self.root, "config", "core.quotePath", "true")
+        self.place(ESCAPED)
+
+        # Act
+        result = self.ask()
+
+        # Assert
+        self.assertEqual(self.refusal(result), ("deny", [f"{HEADER} (1):", f"  {ESCAPED}"]))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/hooks/test_branch_from_unmerged.py
+++ b/scripts/hooks/test_branch_from_unmerged.py
@@ -15,6 +15,9 @@ asks the whole guard, since a reading nothing acts on refuses nothing.
 `UndecodableHeadTests` holds the guard over a HEAD git names with a byte UTF-8 does not map. A strict
 decode raised there, and the hook exited 1, which lets the creation through.
 
+`UnreadHeadTests` holds it where git reads no HEAD at all: the refusal named a detached HEAD at an
+empty SHA there, and a deferred creation recorded a base with no commit in it.
+
 Run: python3 scripts/hooks/test_branch_from_unmerged.py
 """
 
@@ -25,6 +28,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import time
 import unittest
 from pathlib import Path
 
@@ -232,6 +236,48 @@ class UndecodableHeadTests(unittest.TestCase):
 
         # Assert
         self.assertEqual((arranged, result.returncode), (True, ALLOWED))
+
+
+UNREAD_BRANCH = "tooling/unread-head-probe"
+SESSION = "probe-0001"
+
+
+class UnreadHeadTests(unittest.TestCase):
+    """A directory that is not a repository, so git reads no HEAD in it."""
+
+    def setUp(self):
+        self.home = Path(tempfile.mkdtemp(prefix="velvet-branch-unread-"))
+        self.addCleanup(shutil.rmtree, self.home, ignore_errors=True)
+        self.tree = self.home / "tree"
+        self.tree.mkdir()
+
+    def ask(self, command):
+        event = {"tool_name": "Bash", "cwd": str(self.tree), "tool_input": {"command": command}}
+        environment = dict(os.environ, HOME=str(self.home), CLAUDE_CODE_SESSION_ID=SESSION)
+        return subprocess.run([sys.executable, "-B", str(HOOK)], input=json.dumps(event),
+                              capture_output=True, text=True, env=environment, timeout=120)
+
+    def test_Given_NoHeadGitCanRead_When_ABranchIsCreated_Then_TheRefusalNamesTheReadingRatherThanAHead(self):
+        # Arrange / Act
+        result = self.ask(f"git branch {UNREAD_BRANCH}")
+
+        # Assert
+        self.assertEqual((result.returncode, "detached at" in result.stderr,
+                          "git rev-parse --abbrev-ref HEAD" in result.stderr),
+                         (REFUSED, False, True))
+
+    def test_Given_NoHeadGitCanRead_When_ADeferredBranchIsCreated_Then_NoBaseIsRecorded(self):
+        # Arrange
+        (self.home / ".velvet-pr-deferrals").write_text(
+            f"{UNREAD_BRANCH} stacking on purpose {int(time.time())} {SESSION}\n", encoding="utf-8")
+        bases = self.home / ".velvet-branch-bases"
+
+        # Act
+        result = self.ask(f"git branch {UNREAD_BRANCH}")
+
+        # Assert
+        self.assertEqual((result.returncode, bases.read_text() if bases.exists() else None),
+                         (ALLOWED, None))
 
 
 if __name__ == "__main__":

--- a/scripts/hooks/test_branch_from_unmerged.py
+++ b/scripts/hooks/test_branch_from_unmerged.py
@@ -12,6 +12,9 @@ The guard's failure mode is silence: a spelling it does not recognise exits 0 wi
 is what a guard with nothing to say also does. So the table asserts the reading, and a case beside it
 asks the whole guard, since a reading nothing acts on refuses nothing.
 
+`UndecodableHeadTests` holds the guard over a HEAD git names with a byte UTF-8 does not map. A strict
+decode raised there, and the hook exited 1, which lets the creation through.
+
 Run: python3 scripts/hooks/test_branch_from_unmerged.py
 """
 
@@ -30,6 +33,9 @@ HOOK = REPO_ROOT / ".claude/hooks/refuse/branch_from_unmerged.py"
 
 REFUSED = 2
 ALLOWED = 0
+
+UNDECODABLE_BRANCH = b"bad\xffbranch"
+PROBE_BRANCH = "tooling/undecodable-head-probe"
 
 # What a reading that named no creation at all answers with, so a table row records that rather than
 # a case dying on an empty list — an exception is not a disagreement, here or to base_red_check.py.
@@ -157,6 +163,75 @@ class WorktreeCreationTests(unittest.TestCase):
 
         # Assert
         self.assertEqual(result.returncode, ALLOWED)
+
+
+class UndecodableHeadTests(unittest.TestCase):
+    """HEAD on a branch whose name holds a byte UTF-8 does not map. `git check-ref-format` accepts
+    the name, and a packed ref carries it where APFS refuses a loose ref's file, with `Illegal byte
+    sequence`."""
+
+    def setUp(self):
+        self.root = Path(tempfile.mkdtemp(prefix="velvet-branch-bytes-"))
+        self.addCleanup(shutil.rmtree, self.root, ignore_errors=True)
+        self.project = self.root / "project"
+        subprocess.run(["git", "init", "-q", "-b", "main", str(self.project)], check=True,
+                       timeout=60)
+        commit(self.project, "on main")
+        self.on_main = git(self.project, "rev-parse", "HEAD").stdout.strip()
+        commit(self.project, "work main does not contain")
+        self.unmerged = git(self.project, "rev-parse", "HEAD").stdout.strip()
+        git(self.project, "reset", "-q", "--hard", self.on_main)
+
+    def check_out_undecodable(self, commit_id):
+        refs = self.project / ".git"
+        with open(refs / "packed-refs", "ab") as packed:
+            packed.write(commit_id.encode("ascii") + b" refs/heads/" + UNDECODABLE_BRANCH + b"\n")
+        (refs / "HEAD").write_bytes(b"ref: refs/heads/" + UNDECODABLE_BRANCH + b"\n")
+
+    def head_is_undecodable(self):
+        """Whether git names HEAD with the byte, read as bytes rather than through the decode under
+        test."""
+        raw = subprocess.run(["git", "-C", str(self.project), "rev-parse", "--abbrev-ref", "HEAD"],
+                             capture_output=True, check=True, timeout=60).stdout
+        try:
+            raw.decode("utf-8")
+        except UnicodeDecodeError:
+            return True
+        return False
+
+    def ask(self, command):
+        """What the guard does with `command`, under a HOME holding no deferral that could decide it
+        instead."""
+        event = {"tool_name": "Bash", "cwd": str(self.project), "tool_input": {"command": command}}
+        environment = dict(os.environ, HOME=str(self.root))
+        return subprocess.run([sys.executable, "-B", str(HOOK)], input=json.dumps(event),
+                              capture_output=True, text=True, env=environment, timeout=120)
+
+    def test_Given_AHeadNamedWithAByteThatIsNotUTF8_When_ABranchIsCutFromUnmergedWork_Then_ItIsRefused(self):
+        # Arrange — the gate rides in the comparison because a name that decoded would leave
+        # nothing to fail on, and this case green having posed nothing.
+        self.check_out_undecodable(self.unmerged)
+        arranged = self.head_is_undecodable()
+
+        # Act
+        result = self.ask(f"git branch {PROBE_BRANCH}")
+
+        # Assert
+        self.assertEqual((arranged, result.returncode,
+                          "not main and not a commit main contains" in result.stderr),
+                         (True, REFUSED, True))
+
+    def test_Given_AHeadNamedWithAByteThatIsNotUTF8_When_ABranchIsCutFromMainsCommit_Then_ItIsAllowed(self):
+        # Arrange — the other side of the same name, so a reading that survives the byte by
+        # refusing whatever it is asked is not what makes the case above pass.
+        self.check_out_undecodable(self.on_main)
+        arranged = self.head_is_undecodable()
+
+        # Act
+        result = self.ask(f"git branch {PROBE_BRANCH}")
+
+        # Assert
+        self.assertEqual((arranged, result.returncode), (True, ALLOWED))
 
 
 if __name__ == "__main__":

--- a/scripts/hooks/test_changelog_into_closed_version.py
+++ b/scripts/hooks/test_changelog_into_closed_version.py
@@ -547,5 +547,40 @@ class AgainstTheTag(unittest.TestCase):
         self.assertEqual((code, "v2.0.0-main" in said), (2, True))
 
 
+# RELEASED with a byte UTF-8 does not map, on a line neither case below edits.
+UNDECODABLE = RELEASED.encode("utf-8").replace(b"edit around.", b"edit around \xff.")
+
+
+class UndecodableChangelogTests(unittest.TestCase):
+    """A CHANGELOG holding a byte UTF-8 does not map. A strict decode of it raised, and the hook
+    exited 1, which lets the edit through unread."""
+
+    def setUp(self):
+        self.root = Path(tempfile.mkdtemp(prefix="closed-version-bytes-"))
+        self.addCleanup(shutil.rmtree, self.root, ignore_errors=True)
+        subprocess.run(["git", "-C", str(self.root), "init", "--quiet"],
+                       check=True, capture_output=True)
+        self.changelog = self.root / CHANGELOG_REL
+        self.changelog.parent.mkdir(parents=True)
+        self.changelog.write_bytes(UNDECODABLE)
+
+    def test_Given_AChangelogHoldingAByteThatIsNotUTF8_When_AnEntryIsFiledIntoAReleasedSection_Then_ItIsRefused(self):
+        # Arrange / Act
+        code, said = judged(self.root, self.changelog, "- A thing that shipped.\n",
+                            "- A thing that shipped.\n- A thing that did not.\n")
+
+        # Assert
+        self.assertEqual((code, "2.0.0" in said), (2, True))
+
+    def test_Given_AChangelogHoldingAByteThatIsNotUTF8_When_AnEntryIsFiledUnderUnreleased_Then_ItIsLetThrough(self):
+        # Arrange / Act — the other side of the same file, so a reading that survives the byte by
+        # refusing whatever it is asked is not what makes the case above pass.
+        code, said = judged(self.root, self.changelog, "- Something not yet shipped.\n",
+                            "- Something not yet shipped.\n- And another.\n")
+
+        # Assert
+        self.assertEqual((code, said), (0, ""))
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/scripts/hooks/test_changelog_into_closed_version.py
+++ b/scripts/hooks/test_changelog_into_closed_version.py
@@ -547,7 +547,7 @@ class AgainstTheTag(unittest.TestCase):
         self.assertEqual((code, "v2.0.0-main" in said), (2, True))
 
 
-# RELEASED with a byte UTF-8 does not map, on a line neither case below edits.
+# RELEASED with a byte UTF-8 does not map, on a line no case below edits.
 UNDECODABLE = RELEASED.encode("utf-8").replace(b"edit around.", b"edit around \xff.")
 
 
@@ -577,6 +577,67 @@ class UndecodableChangelogTests(unittest.TestCase):
         # refusing whatever it is asked is not what makes the case above pass.
         code, said = judged(self.root, self.changelog, "- Something not yet shipped.\n",
                             "- Something not yet shipped.\n- And another.\n")
+
+        # Assert
+        self.assertEqual((code, said), (0, ""))
+
+
+class UndecodablePublicationTests(unittest.TestCase):
+    """A published release whose tag's copy, or whose tag's own name, holds a byte UTF-8 does not
+    map. Neither may end the hook: exiting 1 lets the edit through unread."""
+
+    def shipped_the_byte(self):
+        root, changelog = published(self, RELEASED, "closed-version-shipped-bytes-")
+        changelog.write_bytes(UNDECODABLE)
+        git(root, "commit", "--quiet", "-am", "a release that shipped the byte")
+        git(root, "tag", "--force", "v2.0.0-main")
+        return root, changelog
+
+    def tagged_with_the_byte(self):
+        root, changelog = published(self, RELEASED, "closed-version-tag-name-bytes-")
+        with open(root / ".git" / "packed-refs", "ab") as packed:
+            packed.write(git(root, "rev-parse", "HEAD").encode("ascii") + b" refs/tags/v\xff\n")
+        return root, changelog
+
+    def test_Given_ATagWhoseCopyHoldsAByteThatIsNotUTF8_When_AnEntryIsFiledIntoItsSection_Then_ItIsRefused(self):
+        # Arrange
+        root, changelog = self.shipped_the_byte()
+
+        # Act
+        code, said = judged(root, changelog, "- A thing that shipped.\n",
+                            "- A thing that shipped.\n- A thing that did not.\n")
+
+        # Assert
+        self.assertEqual((code, "2.0.0" in said), (2, True))
+
+    def test_Given_ATagWhoseCopyHoldsAByteThatIsNotUTF8_When_ItsSectionLosesALine_Then_TheOneStepReadingLetsItThrough(self):
+        # Arrange — the other direction of the reading a copy that cannot be read falls back to, so
+        # a guard that refuses every edit to the section is not what makes the case above pass.
+        root, changelog = self.shipped_the_byte()
+
+        # Act
+        code, said = judged(root, changelog, "- A thing that shipped.\n", "")
+
+        # Assert
+        self.assertEqual((code, said), (0, ""))
+
+    def test_Given_ARemoteTagNamedWithAByteThatIsNotUTF8_When_AnEntryIsFiledIntoAReleasedSection_Then_ItIsRefused(self):
+        # Arrange
+        root, changelog = self.tagged_with_the_byte()
+
+        # Act
+        code, said = judged(root, changelog, "- A thing that shipped.\n",
+                            "- A thing that shipped.\n- A thing that did not.\n")
+
+        # Assert
+        self.assertEqual((code, "2.0.0" in said), (2, True))
+
+    def test_Given_ARemoteTagNamedWithAByteThatIsNotUTF8_When_AReleasedSectionLosesALine_Then_TheOneStepReadingLetsItThrough(self):
+        # Arrange
+        root, changelog = self.tagged_with_the_byte()
+
+        # Act
+        code, said = judged(root, changelog, "- A thing that shipped.\n", "")
 
         # Assert
         self.assertEqual((code, said), (0, ""))

--- a/scripts/hooks/test_hook_repository.py
+++ b/scripts/hooks/test_hook_repository.py
@@ -8,9 +8,9 @@ asked before blindness is declared, and that the report names the guard as what 
 deferral about the work.
 
 Three more hold what a subprocess writes: that a byte which is not UTF-8 comes back off stdout and
-off stderr rather than ending the hook, and that gh's reader answers the same. Two hold the root of
-a repository whose directory name ends in whitespace — a space, which a trimmed reading spends, and
-a newline, which a reading trimming newlines alone spends as well.
+off stderr rather than ending the hook, and that gh's reader answers the same. Three hold the root of
+a repository whose directory name ends in whitespace — a space, which a trimmed reading spends, a
+newline, which a reading trimming newlines alone spends as well, and a carriage return.
 
 Run: python3 scripts/hooks/test_hook_repository.py
 """
@@ -192,6 +192,17 @@ class ProjectTreeTests(unittest.TestCase):
         # Assert
         self.assertEqual(found, root)
 
+    def test_Given_ARootWhoseNameEndsInACarriageReturn_When_TheTreeIsRooted_Then_TheRootKeepsThatCharacter(self):
+        # Arrange — the two cases above pass when the root is read through `git` rather than
+        # `git_bytes`, and this one does not.
+        with repository_named("project\r") as root:
+            with rooted_at(root):
+                # Act
+                found = repository.project_tree()
+
+        # Assert
+        self.assertEqual(found, root)
+
 
 class WorktreeListingTests(unittest.TestCase):
     """What separates the worktree a guard can offer to remove from the one no removal reaches.
@@ -240,6 +251,20 @@ class WorktreeListingTests(unittest.TestCase):
 
         # Assert
         self.assertEqual((found, "\n" in str(named)), (os.path.realpath(named), True))
+
+    def test_Given_AWorktreeAtAPathHoldingACarriageReturn_When_TheListIsRead_Then_ThePathComesBackWhole(self):
+        # Arrange — the case above passes when the listing is read through `git` rather than
+        # `git_bytes`, and this one does not.
+        named = self.root / "lin\rked"
+        subprocess.run(["git", "-C", str(self.project), "worktree", "add", "-q", "-b", "split",
+                        str(named)], check=True, timeout=60)
+
+        # Act
+        read = repository.worktrees(str(self.project))
+
+        # Assert
+        self.assertEqual(next((tree.path for tree in read or [] if tree.branch == "split"), None),
+                         os.path.realpath(named))
 
     def test_Given_AGitThatCannotRun_When_TheListIsRead_Then_ThereIsNoAnswerAtAll(self):
         # Arrange — the reading failure every caller's fail-closed branch is written against. An

--- a/scripts/hooks/test_message_outside_its_worktree.py
+++ b/scripts/hooks/test_message_outside_its_worktree.py
@@ -5,9 +5,10 @@ The defect is silent: `-F` succeeds, the tree is right, the diff is right, and o
 another change's — so the cases hold the refusals and, just as much, the shapes that must still go
 through, because a guard that refuses too much is one somebody turns off.
 
-`ToplevelReadingTests` holds two roots git names that a reading of its answer has to take as written:
-one holding a byte UTF-8 does not map, which a strict decode raised on so the hook exited 1 and let
-the command through, and one whose name ends in a space, which a trimmed reading spent.
+`ToplevelReadingTests` holds three roots git names that a reading of its answer has to take as
+written: one holding a byte UTF-8 does not map, which a strict decode raised on so the hook exited 1
+and let the command through, and two whose names end in a space or in a carriage return, each of
+which a reading of the root has spent.
 
 Run: python3 scripts/hooks/test_message_outside_its_worktree.py
 """
@@ -227,6 +228,16 @@ class ToplevelReadingTests(unittest.TestCase):
     def test_Given_AWorktreeWhoseNameEndsInASpace_When_AMessageInsideItIsCommitted_Then_ItIsLetThrough(self):
         # Arrange — relative, so the path is read from inside the name the space belongs to.
         repository = self.repository("checkout ")
+
+        # Act
+        code, said = self.judge("git commit -F msg.txt", repository)
+
+        # Assert
+        self.assertEqual((code, said), (0, ""))
+
+    def test_Given_AWorktreeWhoseNameEndsInACarriageReturn_When_AMessageInsideItIsCommitted_Then_ItIsLetThrough(self):
+        # Arrange
+        repository = self.repository("checkout\r")
 
         # Act
         code, said = self.judge("git commit -F msg.txt", repository)

--- a/scripts/hooks/test_message_outside_its_worktree.py
+++ b/scripts/hooks/test_message_outside_its_worktree.py
@@ -5,10 +5,15 @@ The defect is silent: `-F` succeeds, the tree is right, the diff is right, and o
 another change's — so the cases hold the refusals and, just as much, the shapes that must still go
 through, because a guard that refuses too much is one somebody turns off.
 
+`ToplevelReadingTests` holds two roots git names that a reading of its answer has to take as written:
+one holding a byte UTF-8 does not map, which a strict decode raised on so the hook exited 1 and let
+the command through, and one whose name ends in a space, which a trimmed reading spent.
+
 Run: python3 scripts/hooks/test_message_outside_its_worktree.py
 """
 
 import json
+import os
 import shutil
 import subprocess
 import tempfile
@@ -17,6 +22,10 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 GUARD = REPO_ROOT / ".claude/hooks/refuse/message_outside_its_worktree.py"
+
+# A worktree name holding a byte UTF-8 does not map, recorded as `core.worktree`: git names it as the
+# toplevel with no directory behind it, and APFS refuses to make one, with `Illegal byte sequence`.
+UNDECODABLE_TREE = b"tree\xff"
 
 
 class Verdicts(unittest.TestCase):
@@ -147,6 +156,82 @@ class Verdicts(unittest.TestCase):
         code, said = self.judge(f"git commit -F {self.elsewhere}/msg.txt", cwd=self.elsewhere)
 
         # Act / Assert
+        self.assertEqual((code, said), (0, ""))
+
+
+class ToplevelReadingTests(unittest.TestCase):
+    def setUp(self):
+        self.root = Path(tempfile.mkdtemp(prefix="message-worktree-toplevel-")).resolve()
+        self.addCleanup(shutil.rmtree, self.root, ignore_errors=True)
+        self.elsewhere = Path(tempfile.mkdtemp(prefix="message-shared-")).resolve()
+        self.addCleanup(shutil.rmtree, self.elsewhere, ignore_errors=True)
+
+    def repository(self, name):
+        made = self.root / name
+        subprocess.run(["git", "init", "--quiet", str(made)], check=True, capture_output=True)
+        return made
+
+    def undecodable_worktree(self):
+        """A repository whose worktree git names with the byte, and that name as the guard's reading
+        spells it."""
+        made = self.repository("repository")
+        tree = bytes(made) + b"/" + UNDECODABLE_TREE
+        subprocess.run([b"git", b"-C", bytes(made), b"config", b"core.worktree", tree],
+                       check=True, capture_output=True)
+        return made, os.fsdecode(tree)
+
+    @staticmethod
+    def toplevel_is_undecodable(repository):
+        """Whether git names the toplevel with the byte, read as bytes rather than through the
+        decode under test."""
+        raw = subprocess.run(["git", "-C", str(repository), "rev-parse", "--show-toplevel"],
+                             capture_output=True, check=True).stdout
+        try:
+            raw.decode("utf-8")
+        except UnicodeDecodeError:
+            return True
+        return False
+
+    @staticmethod
+    def judge(command, cwd):
+        """The guard's verdict, as (exit code, stderr)."""
+        event = {"tool_name": "Bash", "cwd": str(cwd), "tool_input": {"command": command}}
+        done = subprocess.run(["python3", str(GUARD)], input=json.dumps(event),
+                              capture_output=True, text=True, timeout=30)
+        return done.returncode, done.stderr
+
+    def test_Given_AWorktreeGitNamesWithAByteThatIsNotUTF8_When_AMessageOutsideItIsCommitted_Then_ItIsRefused(self):
+        # Arrange — the gate rides in the comparison because a toplevel that decoded would leave
+        # nothing to fail on, and this case green having posed nothing.
+        repository, _ = self.undecodable_worktree()
+        arranged = self.toplevel_is_undecodable(repository)
+
+        # Act
+        code, said = self.judge(f"git commit -F {self.elsewhere}/msg.txt", repository)
+
+        # Assert
+        self.assertEqual((arranged, code, "the worktree it describes" in said), (True, 2, True))
+
+    def test_Given_AWorktreeGitNamesWithAByteThatIsNotUTF8_When_AMessageInsideItIsCommitted_Then_ItIsLetThrough(self):
+        # Arrange — the other side of the same worktree, so a reading that survives the byte by
+        # refusing whatever it is asked is not what makes the case above pass.
+        repository, tree = self.undecodable_worktree()
+        arranged = self.toplevel_is_undecodable(repository)
+
+        # Act
+        code, said = self.judge(f"git commit -F {tree}/msg.txt", repository)
+
+        # Assert
+        self.assertEqual((arranged, code, said), (True, 0, ""))
+
+    def test_Given_AWorktreeWhoseNameEndsInASpace_When_AMessageInsideItIsCommitted_Then_ItIsLetThrough(self):
+        # Arrange — relative, so the path is read from inside the name the space belongs to.
+        repository = self.repository("checkout ")
+
+        # Act
+        code, said = self.judge("git commit -F msg.txt", repository)
+
+        # Assert
         self.assertEqual((code, said), (0, ""))
 
 

--- a/scripts/hooks/test_pr_without_mutation_receipt.py
+++ b/scripts/hooks/test_pr_without_mutation_receipt.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Unit tests for how .claude/hooks/refuse/pr_without_mutation_receipt.py reads its two answers.
+
+The verdict is decided from git's name for the checkout and from what the checkout's campaign
+harness answers. A strict decode of either raised where a byte was not UTF-8, and the hook exited 1,
+which opens the pull request unasked. Two cases hold the harness's answer, one on each side of the
+verdict; one holds git's name; one holds a checkout whose name ends in a space, which a trimmed
+reading spent — and with it the harness, so nothing was owed.
+
+Run: python3 scripts/hooks/test_pr_without_mutation_receipt.py
+"""
+
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HOOK = REPO_ROOT / ".claude/hooks/refuse/pr_without_mutation_receipt.py"
+
+OPEN = "gh pr create --fill"
+REFUSED = 2
+ALLOWED = 0
+
+# What mutation_check.py exits when a receipt is owed and absent. The guard's verdict is decided by
+# this number, so a stub exiting it is a checkout that owes one.
+RECEIPT_REFUSAL = 3
+OWED = "no mutation campaign covers this branch's change."
+
+# A harness naming a file whose name holds a byte UTF-8 does not map, then exiting as told.
+STRAY_BYTE_HARNESS = "import sys\nsys.stdout.buffer.write(b'lat\\xedn1.cs\\n')\nsys.exit({})\n"
+
+# A checkout name holding the same kind of byte, recorded as `core.worktree`: git names it as the
+# toplevel with no directory behind it, and APFS refuses to make one, with `Illegal byte sequence`.
+UNDECODABLE_TREE = b"tree\xff"
+
+
+class ReadingTests(unittest.TestCase):
+    def setUp(self):
+        self.root = Path(tempfile.mkdtemp(prefix="velvet-receipt-reading-"))
+        self.addCleanup(shutil.rmtree, self.root, ignore_errors=True)
+
+    def checkout(self, name, harness):
+        """A repository named `name` whose campaign harness is `harness`, and nothing else."""
+        made = self.root / name
+        subprocess.run(["git", "init", "-q", str(made)], check=True, capture_output=True,
+                       timeout=60)
+        script = made / "scripts" / "test_quality" / "mutation_check.py"
+        script.parent.mkdir(parents=True)
+        script.write_text(harness, encoding="utf-8")
+        return made
+
+    @staticmethod
+    def judge(cwd):
+        event = {"tool_name": "Bash", "cwd": str(cwd), "tool_input": {"command": OPEN}}
+        return subprocess.run([sys.executable, "-B", str(HOOK)], input=json.dumps(event),
+                              capture_output=True, text=True, timeout=90)
+
+    def test_Given_AHarnessWritingAByteThatIsNotUTF8_When_ItFindsAReceiptOwed_Then_TheOpeningIsRefused(self):
+        # Arrange
+        made = self.checkout("checkout", STRAY_BYTE_HARNESS.format(RECEIPT_REFUSAL))
+
+        # Act
+        result = self.judge(made)
+
+        # Assert
+        self.assertEqual((result.returncode, OWED in result.stderr), (REFUSED, True))
+
+    def test_Given_AHarnessWritingAByteThatIsNotUTF8_When_ItFindsNothingOwed_Then_TheOpeningGoesThrough(self):
+        # Arrange — the other side of the same answer, so a reading that survives the byte by
+        # refusing whatever the harness says is not what makes the case above pass. The line the
+        # guard says it read the receipt with is compared too, since a guard that never ran the
+        # harness exits 0 as well.
+        made = self.checkout("checkout", STRAY_BYTE_HARNESS.format(0))
+
+        # Act
+        result = self.judge(made)
+
+        # Assert
+        self.assertEqual((result.returncode, "Mutation receipt: " in result.stderr),
+                         (ALLOWED, True))
+
+    def test_Given_ACheckoutGitNamesWithAByteThatIsNotUTF8_When_APullRequestIsOpened_Then_ItIsReadAsHoldingNoHarness(self):
+        # Arrange — the harness stays under the directory that does exist, so a guard that found
+        # it there would be reading some checkout other than the one git named. The gate rides in
+        # the comparison because a name that decoded would leave nothing to fail on, and this case
+        # green having posed nothing.
+        made = self.checkout("checkout", STRAY_BYTE_HARNESS.format(RECEIPT_REFUSAL))
+        subprocess.run([b"git", b"-C", bytes(made), b"config", b"core.worktree",
+                        bytes(made) + b"/" + UNDECODABLE_TREE], check=True, capture_output=True)
+        named = subprocess.run(["git", "-C", str(made), "rev-parse", "--show-toplevel"],
+                               capture_output=True, check=True, timeout=60).stdout
+        arranged = UNDECODABLE_TREE in named
+
+        # Act
+        result = self.judge(made)
+
+        # Assert
+        self.assertEqual((arranged, result.returncode, result.stderr), (True, ALLOWED, ""))
+
+    def test_Given_ACheckoutWhoseNameEndsInASpace_When_ItOwesAReceipt_Then_TheOpeningIsRefused(self):
+        # Arrange
+        made = self.checkout("checkout ", f"import sys\nsys.exit({RECEIPT_REFUSAL})\n")
+
+        # Act
+        result = self.judge(made)
+
+        # Assert
+        self.assertEqual((result.returncode, OWED in result.stderr), (REFUSED, True))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/hooks/test_pr_without_mutation_receipt.py
+++ b/scripts/hooks/test_pr_without_mutation_receipt.py
@@ -4,8 +4,9 @@
 The verdict is decided from git's name for the checkout and from what the checkout's campaign
 harness answers. A strict decode of either raised where a byte was not UTF-8, and the hook exited 1,
 which opens the pull request unasked. Two cases hold the harness's answer, one on each side of the
-verdict; one holds git's name; one holds a checkout whose name ends in a space, which a trimmed
-reading spent — and with it the harness, so nothing was owed.
+verdict; one holds a name git gives with no directory behind it, which is refused as unread; two
+hold a checkout whose name ends in a space or in a carriage return, each of which a reading of the
+root has spent — and with it the harness, so nothing was owed.
 
 Run: python3 scripts/hooks/test_pr_without_mutation_receipt.py
 """
@@ -29,6 +30,7 @@ ALLOWED = 0
 # this number, so a stub exiting it is a checkout that owes one.
 RECEIPT_REFUSAL = 3
 OWED = "no mutation campaign covers this branch's change."
+UNREAD = "this guard could not read the state it decides from."
 
 # A harness naming a file whose name holds a byte UTF-8 does not map, then exiting as told.
 STRAY_BYTE_HARNESS = "import sys\nsys.stdout.buffer.write(b'lat\\xedn1.cs\\n')\nsys.exit({})\n"
@@ -83,7 +85,7 @@ class ReadingTests(unittest.TestCase):
         self.assertEqual((result.returncode, "Mutation receipt: " in result.stderr),
                          (ALLOWED, True))
 
-    def test_Given_ACheckoutGitNamesWithAByteThatIsNotUTF8_When_APullRequestIsOpened_Then_ItIsReadAsHoldingNoHarness(self):
+    def test_Given_ACheckoutGitNamesWithAByteThatIsNotUTF8_When_APullRequestIsOpened_Then_TheOpeningIsRefusedAsUnread(self):
         # Arrange — the harness stays under the directory that does exist, so a guard that found
         # it there would be reading some checkout other than the one git named. The gate rides in
         # the comparison because a name that decoded would leave nothing to fail on, and this case
@@ -99,11 +101,22 @@ class ReadingTests(unittest.TestCase):
         result = self.judge(made)
 
         # Assert
-        self.assertEqual((arranged, result.returncode, result.stderr), (True, ALLOWED, ""))
+        self.assertEqual((arranged, result.returncode, UNREAD in result.stderr),
+                         (True, REFUSED, True))
 
     def test_Given_ACheckoutWhoseNameEndsInASpace_When_ItOwesAReceipt_Then_TheOpeningIsRefused(self):
         # Arrange
         made = self.checkout("checkout ", f"import sys\nsys.exit({RECEIPT_REFUSAL})\n")
+
+        # Act
+        result = self.judge(made)
+
+        # Assert
+        self.assertEqual((result.returncode, OWED in result.stderr), (REFUSED, True))
+
+    def test_Given_ACheckoutWhoseNameEndsInACarriageReturn_When_ItOwesAReceipt_Then_TheOpeningIsRefused(self):
+        # Arrange
+        made = self.checkout("checkout\r", f"import sys\nsys.exit({RECEIPT_REFUSAL})\n")
 
         # Act
         result = self.judge(made)


### PR DESCRIPTION
Four refusing guards read git's output with `text=True` inside `subprocess.run`, beneath a handler that catches `OSError` and `SubprocessError` — and a `UnicodeDecodeError` is a `ValueError`, which escapes both. So a byte UTF-8 does not map made the hook exit 1, and exit 1 is not a refusal: the tool went through in exactly the state the guard exists to stop. `blind_git_add.py`, `branch_from_unmerged.py`, `message_outside_its_worktree.py` and `pr_without_mutation_receipt.py` now read through `lib/repository.py`, which decodes with `surrogateescape` and answers None rather than raising. `changelog_into_closed_version.py` reads its file the same way.

`blind_git_add.py` also printed names no file answers to. It split `git status --porcelain` on line breaks — which git leaves raw for U+0085, U+2028 and U+2029 under `core.quotePath false` — and never unquoted the names git did quote, so its refusal listed `mid` for `mid<U+0085>name.txt` and `"with space.txt"` with the quotes in. It now reads the listing NUL-delimited through a reader moved into `lib/repository.py` from the untracked report, and spells each name through `lib/display.py`.

Reading the root through `repository.toplevel` stopped two guards trimming it. The receipt guard found no harness in a checkout whose name ends in whitespace and let `gh pr create` through; the message guard refused a message inside such a worktree. A carriage return needed more: `toplevel` and `worktrees` read git through a text pipe, which translates `\r` to `\n`, so a root or worktree path holding one was read as a different path. Both now read the bytes and decode once.

The receipt guard used to read a root git names but no directory holds as a checkout with no harness, and let the pull request open where nothing had been read. It now refuses it as unread.

`changelog_into_closed_version.py` raised where the remote's tag list, or a tag's copy of the CHANGELOG, held such a byte, so an entry filed into a published section went through. Both now take the fallback `published_copies` already gives an unreadable remote or copy.

`branch_from_unmerged.py`, where git could not read HEAD, refused naming a detached HEAD at an empty SHA, and a deferred creation there recorded a base with no commit in it. It now names the reading that failed, and records nothing.

Non-UTF-8 names are arranged through the index, `core.worktree` and packed refs rather than on disk, since APFS refuses such a filename outright.

No `Documentation~` guide describes these guards.

Closes #1008
Refs #1006
