### PR TITLE
fix(velvet): give a VirtualList's null key, throwing range update and empty update V.List's answers

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -113,6 +113,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A `V.VirtualList` whose `keySelector` returns null for one item renders that row instead of throwing
+  out of the scroll that reached it. A null key is no key, which is the answer `V.List` gives the same
+  selector: the row renders and reconciles by position, which for a virtualized list is its item index,
+  so a range change that keeps it in view patches it in place and its `Hooks.UseState` values and effects
+  survive. The controller looked a row up in a `Dictionary` keyed by string, whose lookup refuses a null
+  key even against an empty dictionary, so the range update threw from inside the item loop — and the
+  buffers it abandoned there were the live ones, since a window whose size has not changed reuses them in
+  place. Measured on a five-row window: after the throw the container still showed five rows while the
+  controller's element buffer named two of them, and disposing the controller then ran two of the five
+  rows' `refCallback` cleanups. The tracked range still named the old window, so a further scroll threw
+  from the same item and stranded another set. A selector returning a key holding a NUL is unchanged:
+  that item is still left out of the range under a warning.
+
+- A `V.VirtualList` item renderer that throws no longer leaves the list showing rows the controller has
+  stopped naming. The throw still reaches the caller — a renderer is application code and a failure in it
+  is not the framework's to swallow — but the range update that ends releases the rows it had placed and
+  the prior rows it had not reached, empties the visible container and leaves the tracked range naming
+  nothing, so the next range update rebuilds from a state it can use. It previously ran to the throw and
+  stopped: rows already rendered for the new range were orphaned with their fibers, the visible container
+  still showed the previous range, and the tracked range still named it, so a further scroll threw from
+  the same item and stranded another set. Measured on a five-row window scrolled by one row, the renderer
+  refusing the row scrolling in: the container still showed the five rows of the window before it, the
+  tracked range still named that window, and disposing the list afterwards ran two of the five rows'
+  `refCallback` cleanups. The list going blank is the visible change to weigh — a working program does
+  not reach this, since reaching it means the renderer threw.
+
 - A `V.VirtualList` row whose renderer keys its own node is reused across a scroll rather than rebuilt.
   The controller tracks a row by the key `keySelector` returns, but indexed the previous range's rows by
   whatever key had ended up on the node — and it wrote that key with `??=`, so a node the renderer had

--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -114,30 +114,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - A `V.VirtualList` whose `keySelector` returns null for one item renders that row instead of throwing
-  out of the scroll that reached it. A null key is no key, which is the answer `V.List` gives the same
-  selector: the row renders and reconciles by position, which for a virtualized list is its item index,
-  so a range change that keeps it in view patches it in place and its `Hooks.UseState` values and effects
-  survive. The controller looked a row up in a `Dictionary` keyed by string, whose lookup refuses a null
-  key even against an empty dictionary, so the range update threw from inside the item loop — and the
-  buffers it abandoned there were the live ones, since a window whose size has not changed reuses them in
-  place. Measured on a five-row window: after the throw the container still showed five rows while the
-  controller's element buffer named two of them, and disposing the controller then ran two of the five
-  rows' `refCallback` cleanups. The tracked range still named the old window, so a further scroll threw
-  from the same item and stranded another set. A selector returning a key holding a NUL is unchanged:
-  that item is still left out of the range under a warning.
+  out of the range update that reached it. A null key is no key, which is the answer `V.List` gives the
+  same selector: the row renders and reconciles by position, which for a virtualized list is its item
+  index, so a range change that keeps it in view patches it in place and its `Hooks.UseState` values and
+  effects survive. The controller looked a row up in a `Dictionary` keyed by string, whose lookup refuses
+  a null key even against an empty dictionary, so the range update threw from inside the item loop — and
+  the buffers it abandoned there were the live ones, since a window whose size has not changed reuses
+  them in place. Measured on a five-row window scrolled by one row, the third row of the new window
+  keyed null: after the throw the container still showed five rows while the controller's element buffer
+  named two of them, and three of the five rows had their `refCallback` cleanup run by nothing,
+  disposing the controller included. The tracked range still named the old window, so a further scroll
+  threw from the same item and stranded another set. A selector returning a key holding a NUL is
+  unchanged: that item is still left out of the range under a warning.
 
-- A `V.VirtualList` item renderer that throws no longer leaves the list showing rows the controller has
-  stopped naming. The throw still reaches the caller — a renderer is application code and a failure in it
-  is not the framework's to swallow — but the range update that ends releases the rows it had placed and
-  the prior rows it had not reached, empties the visible container and leaves the tracked range naming
-  nothing, so the next range update rebuilds from a state it can use. It previously ran to the throw and
-  stopped: rows already rendered for the new range were orphaned with their fibers, the visible container
-  still showed the previous range, and the tracked range still named it, so a further scroll threw from
-  the same item and stranded another set. Measured on a five-row window scrolled by one row, the renderer
-  refusing the row scrolling in: the container still showed the five rows of the window before it, the
-  tracked range still named that window, and disposing the list afterwards ran two of the five rows'
-  `refCallback` cleanups. The list going blank is the visible change to weigh — a working program does
-  not reach this, since reaching it means the renderer threw.
+- A `V.VirtualList` range update that throws — from the item renderer, or from creating or patching the
+  row it describes, as a `V.Custom<T>` element whose constructor throws does — no longer leaves the list
+  showing rows the controller has stopped naming. The throw still reaches the caller — a renderer is
+  application code and a failure in it is not the framework's to swallow — but the range update that
+  ends releases the rows it had placed and the prior rows it had not, the one whose create or patch threw
+  among them, empties the visible container and leaves the tracked range naming nothing, so the next
+  range update rebuilds from a state it can use. It previously ran to the throw and stopped: rows already
+  rendered for the new range were orphaned with their fibers, the visible container still showed the
+  previous range, and the tracked range still named it, so a further scroll threw from the same item and
+  stranded another set. Measured on a five-row window scrolled by one row, the renderer refusing the row
+  scrolling in: the container still showed the five rows of the window before it, the tracked range
+  still named that window, and the row that window was leaving had its `refCallback` cleanup run by
+  nothing, disposing the list included. The list going blank is the visible change to weigh — a working
+  program does not reach this, since reaching it means something the range update ran threw.
 
 - A `V.VirtualList` row whose renderer keys its own node is reused across a scroll rather than rebuilt.
   The controller tracks a row by the key `keySelector` returns, but indexed the previous range's rows by
@@ -815,6 +818,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   shape.
 
 ### Fixed
+
+- A `V.VirtualList` updated to an empty item list releases the rows it was showing. The controller drops
+  its tracked range before it renders an updated list, and the branch for an empty list released rows
+  only while that range named some, so every row of the previous range stayed in the visible container
+  over a spacer now zero high, released by nothing until the list itself unmounted — their `refCallback`
+  and `Hooks.UseEffect` cleanups with them. Rendering items again then reused those rows, and that is what a working
+  application notices changing: a list that passes through empty on its way to new items — cleared while
+  a reload is in flight, say — now shows no rows while it is empty, and its rows mount afresh afterwards,
+  their hook state back at its initial values and their mount effects run again, as React unmounts and
+  remounts them. State to keep across the empty render is lifted above the list, into a `Store` or a
+  `Hooks.UseState` in the component that renders it. A list the node holds, cleared in place and later
+  refilled, no longer brings a released row back either: the range update over the emptied list released
+  the rows but left the render buffers naming them, so the one after the refill patched a released
+  `V.TextField` back in with what had been typed into it.
 
 - A slot whose component changes builds the arriving component's element rather than patching the
   departing one's into it. A component's subtree is expanded away before the host leaves are matched,

--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -120,12 +120,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   effects survive. The controller looked a row up in a `Dictionary` keyed by string, whose lookup refuses
   a null key even against an empty dictionary, so the range update threw from inside the item loop — and
   the buffers it abandoned there were the live ones, since a window whose size has not changed reuses
-  them in place. Measured on a five-row window scrolled by one row, the third row of the new window
-  keyed null: after the throw the container still showed five rows while the controller's element buffer
-  named two of them, and three of the five rows had their `refCallback` cleanup run by nothing,
-  disposing the controller included. The tracked range still named the old window, so a further scroll
-  threw from the same item and stranded another set. A selector returning a key holding a NUL is
-  unchanged: that item is still left out of the range under a warning.
+  them in place. A selector returning a key holding a NUL is unchanged: that item is still left out of the
+  range under a warning.
 
 - A `V.VirtualList` range update that throws — from the item renderer, or from creating or patching the
   row it describes, as a `V.Custom<T>` element whose constructor throws does — no longer leaves the list
@@ -822,7 +818,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A `V.VirtualList` updated to an empty item list releases the rows it was showing. The controller drops
   its tracked range before it renders an updated list, and the branch for an empty list released rows
   only while that range named some, so every row of the previous range stayed in the visible container
-  over a spacer now zero high, released by nothing until the list itself unmounted — their `refCallback`
+  over a spacer now zero high, released by nothing while the list stayed empty — their `refCallback`
   and `Hooks.UseEffect` cleanups with them. Rendering items again then reused those rows, and that is what a working
   application notices changing: a list that passes through empty on its way to new items — cleared while
   a reload is in flight, say — now shows no rows while it is empty, and its rows mount afresh afterwards,

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/VirtualListTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/VirtualListTests.cs
@@ -38,9 +38,13 @@ namespace Velvet.Tests
     /// cleanup, and one scrolled away and back returns as a remount rather than as the element that was
     /// disposed.</item>
     /// <item>Of two items sharing a key, the second renders when the first renders nothing.</item>
-    /// <item>An item renderer's throw reaches the caller, and the range update it ends releases the rows
-    /// it had placed and, separately, the prior rows it had not reached, empties the visible container and
-    /// leaves the tracked range naming nothing.</item>
+    /// <item>A throw from the item renderer, or from creating or patching the row it describes, reaches
+    /// the caller, and the range update it ends releases the rows it had placed and, separately, the prior
+    /// rows it had not — the one whose create or patch threw among them — empties the visible container
+    /// and leaves the tracked range naming nothing.</item>
+    /// <item>An update to no items releases the rows the list showed and empties the visible container,
+    /// and a row that comes back after the list went empty — by an update or in place — renders
+    /// afresh.</item>
     /// </list>
     /// </summary>
     [TestFixture]
@@ -517,11 +521,11 @@ namespace Velvet.Tests
             // Arrange — the row-identity cases above, with item-2's selector key taken to null; it is
             // their mark-writing component that answers, for the reason stated above it. Two things
             // diverge from them. Where they pin which of two keys wins, this pins that a row with no key
-            // is reused at all, and by which position: an index one row out reuses item-1's fiber, whose
-            // mark was never written. And where the renderer-keying one of the two arranges a renderer's
-            // key against a selector's string, this arranges it against the selector's null — which has
-            // to land on the node and displace it, or the next range indexes the row under the renderer's
-            // string and no item index finds it.
+            // is reused at all, and by which position: an index one row out finds no row, item-2 being
+            // the only unkeyed one, and remounts it with its mark unwritten. And where the renderer-keying
+            // one of the two arranges a renderer's key against a selector's string, this arranges it
+            // against the selector's null — which has to land on the node and displace it, or the next
+            // range indexes the row under the renderer's string and no item index finds it.
             s_keptRowMark = default;
             var root = new VisualElement();
             using var mounted = V.Mount(root, V.Component(NullKeyedRowsHostRender, key: "host"));
@@ -576,15 +580,13 @@ namespace Velvet.Tests
         [Test]
         public void Given_EveryRowUnkeyed_When_ARangeChangeScrollsThemAllOutOfRange_Then_EachOnesCleanupRuns()
         {
-            // Arrange — the instrument is a refCallback's returned action rather than the element
-            // instance, which a Label being one of the two primitives FiberPrimitiveElementPool pools
-            // would not settle: a released row's element can be handed straight back to the row after it.
+            // Arrange
             var cleaned = new List<string>();
             var node = V.VirtualList(
                 items: CreateItems(20),
                 keySelector: item => (string)null,
                 itemHeight: 50f,
-                renderer: CleanupRecordingRenderer(cleaned, _ => false),
+                renderer: CleanupRecordingRenderer(cleaned, RecordedLabel),
                 overscan: 0);
             var scrollView = new ScrollView(ScrollViewMode.Vertical);
             using var controller = new FiberVirtualListController(scrollView, node, Reconciler);
@@ -624,9 +626,11 @@ namespace Velvet.Tests
             controller.UpdateVisibleRange(scrollY: 0f, viewportHeight: 200f);
 
             // Assert — what the first field took rides along: text that never landed in it would leave the
-            // returning field empty whether or not it is the same one.
+            // returning field empty whether or not it is the same one. A field that did not return at all
+            // reads as absent rather than as empty.
             Assert.That(
-                "[" + typed + "] typed, [" + scrollView.Q<TextField>("field-item-2")?.value + "] shown on return",
+                "[" + typed + "] typed, ["
+                    + (scrollView.Q<TextField>("field-item-2")?.value ?? "no field") + "] shown on return",
                 Is.EqualTo("[typed] typed, [] shown on return"));
         }
 
@@ -663,16 +667,11 @@ namespace Velvet.Tests
         // that would install the replacement, so the release that followed would then record nothing and
         // the two errors would cancel.
         private static Func<TestItem, VNode> CleanupRecordingRenderer(
-            List<string> cleaned, Func<TestItem, bool> poisoned)
+            List<string> cleaned, Func<TestItem, Func<VisualElement, Action>, VNode> row)
         {
             var attaches = new Dictionary<string, Func<VisualElement, Action>>();
             return item =>
             {
-                if (poisoned(item))
-                {
-                    throw new InvalidOperationException("item renderer refused " + item.Id);
-                }
-
                 if (!attaches.TryGetValue(item.Id, out var attach))
                 {
                     var id = item.Id;
@@ -680,9 +679,12 @@ namespace Velvet.Tests
                     attaches[id] = attach;
                 }
 
-                return V.Label(text: item.Name, refCallback: attach);
+                return row(item, attach);
             };
         }
+
+        private static VNode RecordedLabel(TestItem item, Func<VisualElement, Action> attach)
+            => V.Label(text: item.Name, refCallback: attach);
 
         #endregion
 
@@ -693,8 +695,35 @@ namespace Velvet.Tests
                 items: CreateItems(20),
                 keySelector: item => item.Id,
                 itemHeight: 50f,
-                renderer: CleanupRecordingRenderer(cleaned, poisoned),
+                renderer: CleanupRecordingRenderer(cleaned, (item, attach) => poisoned(item)
+                    ? throw new InvalidOperationException("item renderer refused " + item.Id)
+                    : RecordedLabel(item, attach)),
                 overscan: 0);
+
+        // Div rows, so what a poisoned item returns can be an element that refuses construction or a Div
+        // handed a child that does. refusingRow is given the item's own delegate so that a patch can find
+        // it unchanged, for the reason CleanupRecordingRenderer gives.
+        private static VirtualListNode RowRefusingList(
+            Func<TestItem, string> keySelector,
+            Func<TestItem, bool> poisoned,
+            List<string> cleaned,
+            Func<Func<VisualElement, Action>, VNode> refusingRow)
+            => V.VirtualList(
+                items: CreateItems(20),
+                keySelector: keySelector,
+                itemHeight: 50f,
+                renderer: CleanupRecordingRenderer(cleaned, (item, attach) => poisoned(item)
+                    ? refusingRow(attach)
+                    : V.Div(refCallback: attach)),
+                overscan: 0);
+
+        private sealed class ConstructionRefusingElement : VisualElement
+        {
+            public ConstructionRefusingElement()
+            {
+                throw new InvalidOperationException("constructor refused");
+            }
+        }
 
         // GREEN_ON_BASE(characterization): the base already lets an item renderer's throw out of the update.
         // The unwind the cases below pin must not turn it into a silent skip, and the last two of them
@@ -774,6 +803,104 @@ namespace Velvet.Tests
         }
 
         [Test]
+        public void Given_ARowWhoseReplacementRefusesConstruction_When_ThatRangeUpdateFails_Then_ThePriorRowIsReleased()
+        {
+            // Arrange — item-2's row turns from a Div into an element whose constructor throws, a type
+            // flip, so the pass has looked up item-2's prior row and is creating its replacement when the
+            // throw comes. The window becomes items 1..5, whose second row that is.
+            var poisoned = false;
+            var cleaned = new List<string>();
+            var node = RowRefusingList(item => item.Id, item => poisoned && item.Id == "item-2", cleaned,
+                _ => V.Custom<ConstructionRefusingElement>());
+            var scrollView = new ScrollView(ScrollViewMode.Vertical);
+            using var controller = new FiberVirtualListController(scrollView, node, Reconciler);
+            controller.UpdateVisibleRange(scrollY: 0f, viewportHeight: 200f);
+            poisoned = true;
+            var thrown = "nothing";
+
+            // Act
+            try
+            {
+                controller.UpdateVisibleRange(scrollY: 50f, viewportHeight: 200f);
+            }
+            catch (Exception exception)
+            {
+                thrown = exception.GetBaseException().Message;
+            }
+
+            // Assert — what reached the caller rides along: a replacement that constructs completes the
+            // flip, and a completed flip releases the prior row by itself.
+            Assert.That(
+                "[" + thrown + "] thrown, item-2 released " + cleaned.Count(id => id == "item-2") + " time(s)",
+                Is.EqualTo("[constructor refused] thrown, item-2 released 1 time(s)"));
+        }
+
+        [Test]
+        public void Given_AReusedRowWhosePatchThrows_When_ThatRangeUpdateFails_Then_ThatRowIsReleased()
+        {
+            // Arrange — the case above, with item-2 kept a Div, so the pass reuses its prior row and
+            // patches it: the patch hands it a child whose constructor throws.
+            var poisoned = false;
+            var cleaned = new List<string>();
+            var node = RowRefusingList(item => item.Id, item => poisoned && item.Id == "item-2", cleaned,
+                attach => V.Div(
+                    refCallback: attach, children: new VNode[] { V.Custom<ConstructionRefusingElement>() }));
+            var scrollView = new ScrollView(ScrollViewMode.Vertical);
+            using var controller = new FiberVirtualListController(scrollView, node, Reconciler);
+            controller.UpdateVisibleRange(scrollY: 0f, viewportHeight: 200f);
+            poisoned = true;
+            var thrown = "nothing";
+
+            // Act
+            try
+            {
+                controller.UpdateVisibleRange(scrollY: 50f, viewportHeight: 200f);
+            }
+            catch (Exception exception)
+            {
+                thrown = exception.GetBaseException().Message;
+            }
+
+            // Assert — what reached the caller rides along: a child that constructs completes the patch,
+            // and a completed patch keeps the row.
+            Assert.That(
+                "[" + thrown + "] thrown, item-2 released " + cleaned.Count(id => id == "item-2") + " time(s)",
+                Is.EqualTo("[constructor refused] thrown, item-2 released 1 time(s)"));
+        }
+
+        [Test]
+        public void Given_AnUnkeyedReusedRowWhosePatchThrows_When_ThatRangeUpdateFails_Then_ThatRowIsReleased()
+        {
+            // Arrange — the case above with every row unkeyed, so the prior row whose patch fails is one
+            // the pass found by its item index rather than by a key.
+            var poisoned = false;
+            var cleaned = new List<string>();
+            var node = RowRefusingList(item => (string)null, item => poisoned && item.Id == "item-2", cleaned,
+                attach => V.Div(
+                    refCallback: attach, children: new VNode[] { V.Custom<ConstructionRefusingElement>() }));
+            var scrollView = new ScrollView(ScrollViewMode.Vertical);
+            using var controller = new FiberVirtualListController(scrollView, node, Reconciler);
+            controller.UpdateVisibleRange(scrollY: 0f, viewportHeight: 200f);
+            poisoned = true;
+            var thrown = "nothing";
+
+            // Act
+            try
+            {
+                controller.UpdateVisibleRange(scrollY: 50f, viewportHeight: 200f);
+            }
+            catch (Exception exception)
+            {
+                thrown = exception.GetBaseException().Message;
+            }
+
+            // Assert — both terms for the reason the case above gives.
+            Assert.That(
+                "[" + thrown + "] thrown, item-2 released " + cleaned.Count(id => id == "item-2") + " time(s)",
+                Is.EqualTo("[constructor refused] thrown, item-2 released 1 time(s)"));
+        }
+
+        [Test]
         public void Given_ARendererThrowingOnOneItem_When_ThatRangeUpdateFails_Then_TheControllerNamesNoRenderedRange()
         {
             // Arrange
@@ -830,6 +957,125 @@ namespace Velvet.Tests
             => (int)typeof(FiberVirtualListController)
                 .GetField(field, BindingFlags.NonPublic | BindingFlags.Instance)
                 .GetValue(controller);
+
+        #endregion
+
+        #region A list that goes empty
+
+        private static VirtualListNode LabelRowsList(int count, Func<TestItem, VNode> renderer)
+            => V.VirtualList(
+                items: CreateItems(count),
+                keySelector: item => item.Id,
+                itemHeight: 50f,
+                renderer: renderer,
+                overscan: 0);
+
+        private static VirtualListNode TextFieldRowsList(int count)
+            => V.VirtualList(
+                items: CreateItems(count),
+                keySelector: item => item.Id,
+                itemHeight: 50f,
+                renderer: item => V.TextField(name: "field-" + item.Id),
+                overscan: 0);
+
+        [Test]
+        public void Given_ARenderedRange_When_TheListIsUpdatedToNoItems_Then_EachRowsCleanupRuns()
+        {
+            // Arrange — one renderer for both nodes: a second one's delegates are new to the rows, so a
+            // patch would run their cleanups by itself, and an update that kept the rows would read here
+            // as one that released them.
+            var cleaned = new List<string>();
+            var renderer = CleanupRecordingRenderer(cleaned, RecordedLabel);
+            var scrollView = new ScrollView(ScrollViewMode.Vertical);
+            using var controller = new FiberVirtualListController(scrollView, LabelRowsList(10, renderer), Reconciler);
+            controller.UpdateVisibleRange(scrollY: 0f, viewportHeight: 200f);
+
+            // Act — Update renders nothing while no viewport height is known, so the range is re-supplied
+            // as the type-flip case in the visible-range region does.
+            controller.Update(LabelRowsList(0, renderer));
+            controller.UpdateVisibleRange(scrollY: 0f, viewportHeight: 200f);
+
+            // Assert
+            Assert.That(string.Join(",", cleaned.OrderBy(id => id, StringComparer.Ordinal)),
+                Is.EqualTo("item-0,item-1,item-2,item-3,item-4"));
+        }
+
+        [Test]
+        public void Given_ARenderedRange_When_TheListIsUpdatedToNoItems_Then_TheVisibleContainerShowsNoRows()
+        {
+            // Arrange
+            var renderer = CleanupRecordingRenderer(new List<string>(), RecordedLabel);
+            var scrollView = new ScrollView(ScrollViewMode.Vertical);
+            using var controller = new FiberVirtualListController(scrollView, LabelRowsList(10, renderer), Reconciler);
+            var visibleContainer = scrollView.contentContainer.ElementAt(1);
+            controller.UpdateVisibleRange(scrollY: 0f, viewportHeight: 200f);
+
+            // Act — the range re-supplied for the reason the case above gives.
+            controller.Update(LabelRowsList(0, renderer));
+            controller.UpdateVisibleRange(scrollY: 0f, viewportHeight: 200f);
+
+            // Assert
+            Assert.That(visibleContainer.childCount, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void Given_AListUpdatedToNoItemsAndBack_When_ARowReturns_Then_WhatWasTypedIntoItIsGone()
+        {
+            // Arrange — keyed rows, so a prior row left indexed would be found again by its key; the field
+            // is uncontrolled for the reason the unkeyed scrolled-away-and-back case gives.
+            var scrollView = new ScrollView(ScrollViewMode.Vertical);
+            using var controller = new FiberVirtualListController(scrollView, TextFieldRowsList(10), Reconciler);
+            controller.UpdateVisibleRange(scrollY: 0f, viewportHeight: 200f);
+            var typedInto = scrollView.Q<TextField>("field-item-2");
+            typedInto.value = "typed";
+            var typed = typedInto.value;
+            controller.Update(TextFieldRowsList(0));
+            controller.UpdateVisibleRange(scrollY: 0f, viewportHeight: 200f);
+
+            // Act — the items come back, the range re-supplied as above.
+            controller.Update(TextFieldRowsList(10));
+            controller.UpdateVisibleRange(scrollY: 0f, viewportHeight: 200f);
+
+            // Assert — what the first field took rides along, and an absent field reads as absent, for the
+            // reasons that case gives.
+            Assert.That(
+                "[" + typed + "] typed, ["
+                    + (scrollView.Q<TextField>("field-item-2")?.value ?? "no field") + "] shown on return",
+                Is.EqualTo("[typed] typed, [] shown on return"));
+        }
+
+        [Test]
+        public void Given_TheItemListEmptiedInPlace_When_ItIsRefilled_Then_WhatWasTypedIntoARowIsGone()
+        {
+            // Arrange — the case above through the other way into an empty list: the list the node holds is
+            // cleared in place and the range re-supplied, which reaches the same branch with the tracked
+            // range still naming the rows rather than dropped by an Update.
+            var items = new List<TestItem>(CreateItems(10));
+            var node = V.VirtualList(
+                items: items,
+                keySelector: item => item.Id,
+                itemHeight: 50f,
+                renderer: item => V.TextField(name: "field-" + item.Id),
+                overscan: 0);
+            var scrollView = new ScrollView(ScrollViewMode.Vertical);
+            using var controller = new FiberVirtualListController(scrollView, node, Reconciler);
+            controller.UpdateVisibleRange(scrollY: 0f, viewportHeight: 200f);
+            var typedInto = scrollView.Q<TextField>("field-item-2");
+            typedInto.value = "typed";
+            var typed = typedInto.value;
+            items.Clear();
+            controller.UpdateVisibleRange(scrollY: 0f, viewportHeight: 200f);
+
+            // Act
+            items.AddRange(CreateItems(10));
+            controller.UpdateVisibleRange(scrollY: 0f, viewportHeight: 200f);
+
+            // Assert — both terms for the reasons the unkeyed scrolled-away-and-back case gives.
+            Assert.That(
+                "[" + typed + "] typed, ["
+                    + (scrollView.Q<TextField>("field-item-2")?.value ?? "no field") + "] shown on return",
+                Is.EqualTo("[typed] typed, [] shown on return"));
+        }
 
         #endregion
 

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/VirtualListTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/VirtualListTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using NUnit.Framework;
 using Velvet;
 using UnityEngine.UIElements;
@@ -31,6 +32,15 @@ namespace Velvet.Tests
     /// <item>The DSL rejects a null items / keySelector / renderer with <see cref="ArgumentNullException"/>, and a
     /// non-positive itemHeight with <see cref="ArgumentOutOfRangeException"/>.</item>
     /// <item>The type-erased item list admits a null element, since the source element type may itself.</item>
+    /// <item>A null key is no key, as it is for <see cref="V.List{T}(IReadOnlyList{T}, Func{T, string},
+    /// Func{T, VNode})"/>: the row renders alongside the rest, a range change or an update that keeps it
+    /// in range reuses it by its item index so its fiber survives, one that scrolls it out runs its
+    /// cleanup, and one scrolled away and back returns as a remount rather than as the element that was
+    /// disposed.</item>
+    /// <item>Of two items sharing a key, the second renders when the first renders nothing.</item>
+    /// <item>An item renderer's throw reaches the caller, and the range update it ends releases the rows
+    /// it had placed and, separately, the prior rows it had not reached, empties the visible container and
+    /// leaves the tracked range naming nothing.</item>
     /// </list>
     /// </summary>
     [TestFixture]
@@ -461,6 +471,365 @@ namespace Velvet.Tests
                     + " via a " + (markSetterCaptured ? "captured" : "default") + " setter",
                 Is.EqualTo("b under row-item-1 via a captured setter"));
         }
+
+        #endregion
+
+        #region A key the selector left null
+
+        [Component]
+        private static VNode NullKeyedRowsHostRender() => NullKeyedRowsList();
+
+        private static VirtualListNode NullKeyedRowsList()
+            => V.VirtualList(
+                items: CreateItems(10),
+                keySelector: item => item.Id == "item-2" ? null : "sel-" + item.Id,
+                itemHeight: 50f,
+                renderer: item => V.Component(MarkedRowRender, item.Id, key: "ren-" + item.Id),
+                overscan: 0);
+
+        [Test]
+        public void Given_AKeySelectorReturningNullForOneItem_When_TheRangeIsRendered_Then_ThatRowRendersWithTheRest()
+        {
+            // Arrange
+            var node = V.VirtualList(
+                items: CreateItems(10),
+                keySelector: item => item.Id == "item-3" ? null : item.Id,
+                itemHeight: 50f,
+                renderer: item => V.Label(text: item.Name),
+                overscan: 0);
+            var scrollView = new ScrollView(ScrollViewMode.Vertical);
+            using var controller = new FiberVirtualListController(scrollView, node, Reconciler);
+            var visibleContainer = scrollView.contentContainer.ElementAt(1);
+
+            // Act
+            controller.UpdateVisibleRange(scrollY: 0f, viewportHeight: 200f);
+
+            // Assert — the texts in window order rather than a count, so a row dropped the way the NUL
+            // path drops one names itself.
+            Assert.That(
+                string.Join(",", visibleContainer.Children().Cast<Label>().Select(label => label.text)),
+                Is.EqualTo("Item 0,Item 1,Item 2,Item 3,Item 4"));
+        }
+
+        [Test]
+        public void Given_AKeySelectorReturningNullForOneItem_When_ARangeChangeKeepsThatRowInRange_Then_TheRowKeepsItsState()
+        {
+            // Arrange — the row-identity cases above, with item-2's selector key taken to null; it is
+            // their mark-writing component that answers, for the reason stated above it. Two things
+            // diverge from them. Where they pin which of two keys wins, this pins that a row with no key
+            // is reused at all, and by which position: an index one row out reuses item-1's fiber, whose
+            // mark was never written. And where the renderer-keying one of the two arranges a renderer's
+            // key against a selector's string, this arranges it against the selector's null — which has
+            // to land on the node and displace it, or the next range indexes the row under the renderer's
+            // string and no item index finds it.
+            s_keptRowMark = default;
+            var root = new VisualElement();
+            using var mounted = V.Mount(root, V.Component(NullKeyedRowsHostRender, key: "host"));
+            var scrollView = root.Q<ScrollView>();
+            var visibleContainer = scrollView.contentContainer.ElementAt(1);
+            var controller = mounted.Root.Reconciler.Context.VirtualListControllers[scrollView];
+            controller.UpdateVisibleRange(scrollY: 0f, viewportHeight: 200f);
+            var markSetterCaptured = !s_keptRowMark.Equals(default(StateUpdater<string>));
+            s_keptRowMark.Invoke("b");
+            mounted.FlushStateForTest();
+
+            // Act — the window becomes items 1..5.
+            controller.UpdateVisibleRange(scrollY: 50f, viewportHeight: 200f);
+
+            // Assert — the three terms for the reason the cases above give.
+            Assert.That(
+                scrollView.Q<Label>("row-item-2")?.text
+                    + " under " + visibleContainer.Q<Label>()?.name
+                    + " via a " + (markSetterCaptured ? "captured" : "default") + " setter",
+                Is.EqualTo("b under row-item-1 via a captured setter"));
+        }
+
+        [Test]
+        public void Given_AKeySelectorReturningNullForOneItem_When_TheListIsUpdatedOverTheSameWindow_Then_TheRowKeepsItsState()
+        {
+            // Arrange — the scrolling case above, with the range left where it is. What differs is the
+            // pass that follows Update: Update drops the tracked range to force a render while the render
+            // buffers still hold every row, so this pass is where an unkeyed row's item index is read from
+            // somewhere other than the tracked range.
+            s_keptRowMark = default;
+            var root = new VisualElement();
+            using var mounted = V.Mount(root, V.Component(NullKeyedRowsHostRender, key: "host"));
+            var scrollView = root.Q<ScrollView>();
+            var controller = mounted.Root.Reconciler.Context.VirtualListControllers[scrollView];
+            controller.UpdateVisibleRange(scrollY: 0f, viewportHeight: 200f);
+            var markSetterCaptured = !s_keptRowMark.Equals(default(StateUpdater<string>));
+            s_keptRowMark.Invoke("b");
+            mounted.FlushStateForTest();
+
+            // Act — Update renders nothing while no viewport height is known, so the range is re-supplied
+            // as the type-flip case in the visible-range region does.
+            controller.Update(NullKeyedRowsList());
+            controller.UpdateVisibleRange(scrollY: 0f, viewportHeight: 200f);
+
+            // Assert — the setter's capture rides along for the reason the scrolling case gives.
+            Assert.That(
+                scrollView.Q<Label>("row-item-2")?.text
+                    + " via a " + (markSetterCaptured ? "captured" : "default") + " setter",
+                Is.EqualTo("b via a captured setter"));
+        }
+
+        [Test]
+        public void Given_EveryRowUnkeyed_When_ARangeChangeScrollsThemAllOutOfRange_Then_EachOnesCleanupRuns()
+        {
+            // Arrange — the instrument is a refCallback's returned action rather than the element
+            // instance, which a Label being one of the two primitives FiberPrimitiveElementPool pools
+            // would not settle: a released row's element can be handed straight back to the row after it.
+            var cleaned = new List<string>();
+            var node = V.VirtualList(
+                items: CreateItems(20),
+                keySelector: item => (string)null,
+                itemHeight: 50f,
+                renderer: CleanupRecordingRenderer(cleaned, _ => false),
+                overscan: 0);
+            var scrollView = new ScrollView(ScrollViewMode.Vertical);
+            using var controller = new FiberVirtualListController(scrollView, node, Reconciler);
+            controller.UpdateVisibleRange(scrollY: 0f, viewportHeight: 200f);
+
+            // Act — the window becomes items 10..14, sharing no item index with items 0..4.
+            controller.UpdateVisibleRange(scrollY: 500f, viewportHeight: 200f);
+
+            // Assert
+            Assert.That(string.Join(",", cleaned.OrderBy(id => id, StringComparer.Ordinal)),
+                Is.EqualTo("item-0,item-1,item-2,item-3,item-4"));
+        }
+
+        [Test]
+        public void Given_AnUnkeyedRowScrolledAwayAndBack_When_ItReturns_Then_WhatWasTypedIntoItIsGone()
+        {
+            // Arrange — items 0..4, then 10..14, then 0..4 again. The sweep that takes item-2 out of range
+            // disposes its row, so the one that comes back is a remount and starts from what its node
+            // declares. The field is uncontrolled so that nothing but the element itself carries what was
+            // typed: a disposed field put back on screen shows it, and a freshly created one — or one the
+            // pool resets on its way back — does not.
+            var node = V.VirtualList(
+                items: CreateItems(20),
+                keySelector: item => (string)null,
+                itemHeight: 50f,
+                renderer: item => V.TextField(name: "field-" + item.Id),
+                overscan: 0);
+            var scrollView = new ScrollView(ScrollViewMode.Vertical);
+            using var controller = new FiberVirtualListController(scrollView, node, Reconciler);
+            controller.UpdateVisibleRange(scrollY: 0f, viewportHeight: 200f);
+            var typedInto = scrollView.Q<TextField>("field-item-2");
+            typedInto.value = "typed";
+            var typed = typedInto.value;
+            controller.UpdateVisibleRange(scrollY: 500f, viewportHeight: 200f);
+
+            // Act
+            controller.UpdateVisibleRange(scrollY: 0f, viewportHeight: 200f);
+
+            // Assert — what the first field took rides along: text that never landed in it would leave the
+            // returning field empty whether or not it is the same one.
+            Assert.That(
+                "[" + typed + "] typed, [" + scrollView.Q<TextField>("field-item-2")?.value + "] shown on return",
+                Is.EqualTo("[typed] typed, [] shown on return"));
+        }
+
+        // GREEN_ON_BASE(characterization): a key whose first item renders nothing is free for the next.
+        // The pass claims a key before the renderer runs and gives it back when the renderer returns
+        // null, and this is the one thing that giving-back still decides now that the scrolled-out sweep
+        // no longer reads the claim.
+        [Test]
+        public void Given_TwoItemsSharingAKeyWhoseFirstRendersNothing_When_TheRangeIsRendered_Then_TheSecondRenders()
+        {
+            // Arrange — item-2 takes item-1's key, and item-1's renderer returns null.
+            var node = V.VirtualList(
+                items: CreateItems(5),
+                keySelector: item => item.Id == "item-2" ? "item-1" : item.Id,
+                itemHeight: 50f,
+                renderer: item => item.Id == "item-1" ? null : V.Label(text: item.Name),
+                overscan: 0);
+            var scrollView = new ScrollView(ScrollViewMode.Vertical);
+            using var controller = new FiberVirtualListController(scrollView, node, Reconciler);
+            var visibleContainer = scrollView.contentContainer.ElementAt(1);
+
+            // Act
+            controller.UpdateVisibleRange(scrollY: 0f, viewportHeight: 200f);
+
+            // Assert
+            Assert.That(
+                string.Join(",", visibleContainer.Children().Cast<Label>().Select(label => label.text)),
+                Is.EqualTo("Item 0,Item 2,Item 3,Item 4"));
+        }
+
+        // The refCallback delegate is held per item across renders rather than rebuilt inside the
+        // renderer. A patch handed a fresh delegate runs the cleanup the previous one returned, which would
+        // put a row on the list with nothing having released it — and a failed pass never reaches the drain
+        // that would install the replacement, so the release that followed would then record nothing and
+        // the two errors would cancel.
+        private static Func<TestItem, VNode> CleanupRecordingRenderer(
+            List<string> cleaned, Func<TestItem, bool> poisoned)
+        {
+            var attaches = new Dictionary<string, Func<VisualElement, Action>>();
+            return item =>
+            {
+                if (poisoned(item))
+                {
+                    throw new InvalidOperationException("item renderer refused " + item.Id);
+                }
+
+                if (!attaches.TryGetValue(item.Id, out var attach))
+                {
+                    var id = item.Id;
+                    attach = _ => () => cleaned.Add(id);
+                    attaches[id] = attach;
+                }
+
+                return V.Label(text: item.Name, refCallback: attach);
+            };
+        }
+
+        #endregion
+
+        #region A range update that throws
+
+        private static VirtualListNode ThrowingRendererList(Func<TestItem, bool> poisoned, List<string> cleaned)
+            => V.VirtualList(
+                items: CreateItems(20),
+                keySelector: item => item.Id,
+                itemHeight: 50f,
+                renderer: CleanupRecordingRenderer(cleaned, poisoned),
+                overscan: 0);
+
+        // GREEN_ON_BASE(characterization): the base already lets an item renderer's throw out of the update.
+        // The unwind the cases below pin must not turn it into a silent skip, and the last two of them
+        // share this arrangement exactly, so it is also what says their Act reached the renderer at all.
+        [Test]
+        public void Given_ARendererThrowingOnOneItem_When_ARangeChangeReachesIt_Then_TheThrowReachesTheCaller()
+        {
+            // Arrange
+            var poisoned = false;
+            var node = ThrowingRendererList(item => poisoned && item.Id == "item-5", new List<string>());
+            var scrollView = new ScrollView(ScrollViewMode.Vertical);
+            using var controller = new FiberVirtualListController(scrollView, node, Reconciler);
+            controller.UpdateVisibleRange(scrollY: 0f, viewportHeight: 200f);
+            poisoned = true;
+
+            // Act + Assert — the window becomes items 1..5, whose last item the renderer refuses.
+            Assert.Throws<InvalidOperationException>(
+                () => controller.UpdateVisibleRange(scrollY: 50f, viewportHeight: 200f));
+        }
+
+        [Test]
+        public void Given_ARendererThrowingOnTheRowScrollingIn_When_ThatRangeUpdateFails_Then_TheRowsThePassHadPlacedAreReleased()
+        {
+            // Arrange — the window grows from items 0..4 to items 0..5, so the failed pass has taken every
+            // prior row into a slot of its own and left none behind: what it holds when the renderer
+            // refuses item-5 is the five it placed, and nothing else. A window that changes size is also
+            // the arm of the buffer allocation that does not alias, which the case below takes the other of.
+            var poisoned = false;
+            var cleaned = new List<string>();
+            var node = ThrowingRendererList(item => poisoned && item.Id == "item-5", cleaned);
+            var scrollView = new ScrollView(ScrollViewMode.Vertical);
+            using var controller = new FiberVirtualListController(scrollView, node, Reconciler);
+            controller.UpdateVisibleRange(scrollY: 0f, viewportHeight: 200f);
+            poisoned = true;
+
+            // Act — the throw is the characterization case's to pin; here it is only how the pass ends.
+            try
+            {
+                controller.UpdateVisibleRange(scrollY: 0f, viewportHeight: 250f);
+            }
+            catch (InvalidOperationException)
+            {
+            }
+
+            // Assert
+            Assert.That(string.Join(",", cleaned.OrderBy(id => id, StringComparer.Ordinal)),
+                Is.EqualTo("item-0,item-1,item-2,item-3,item-4"));
+        }
+
+        [Test]
+        public void Given_ARendererThrowingOnTheFirstRowOfTheNewRange_When_ThatRangeUpdateFails_Then_TheRowsThePassNeverReachedAreReleased()
+        {
+            // Arrange — the renderer refuses the first item of the new window, so the pass fills no slot at
+            // all and everything it holds is the five prior rows it had not got to. That splits this from
+            // the case above, whose five are the placed ones: between them the two halves of the unwind
+            // are asked for separately rather than in a sum either half alone could satisfy.
+            var poisoned = false;
+            var cleaned = new List<string>();
+            var node = ThrowingRendererList(item => poisoned && item.Id == "item-1", cleaned);
+            var scrollView = new ScrollView(ScrollViewMode.Vertical);
+            using var controller = new FiberVirtualListController(scrollView, node, Reconciler);
+            controller.UpdateVisibleRange(scrollY: 0f, viewportHeight: 200f);
+            poisoned = true;
+
+            // Act — the window becomes items 1..5, whose first item the renderer refuses.
+            try
+            {
+                controller.UpdateVisibleRange(scrollY: 50f, viewportHeight: 200f);
+            }
+            catch (InvalidOperationException)
+            {
+            }
+
+            // Assert
+            Assert.That(string.Join(",", cleaned.OrderBy(id => id, StringComparer.Ordinal)),
+                Is.EqualTo("item-0,item-1,item-2,item-3,item-4"));
+        }
+
+        [Test]
+        public void Given_ARendererThrowingOnOneItem_When_ThatRangeUpdateFails_Then_TheControllerNamesNoRenderedRange()
+        {
+            // Arrange
+            var poisoned = false;
+            var node = ThrowingRendererList(item => poisoned && item.Id == "item-5", new List<string>());
+            var scrollView = new ScrollView(ScrollViewMode.Vertical);
+            using var controller = new FiberVirtualListController(scrollView, node, Reconciler);
+            controller.UpdateVisibleRange(scrollY: 0f, viewportHeight: 200f);
+            poisoned = true;
+
+            // Act — the throw is the characterization case's to pin; here it is only how the pass ends.
+            try
+            {
+                controller.UpdateVisibleRange(scrollY: 50f, viewportHeight: 200f);
+            }
+            catch (InvalidOperationException)
+            {
+            }
+
+            // Assert
+            Assert.That(
+                RenderedIndexForTest(controller, "_firstRenderedIndex")
+                    + ".." + RenderedIndexForTest(controller, "_lastRenderedIndex"),
+                Is.EqualTo("-1..-1"));
+        }
+
+        [Test]
+        public void Given_ARendererThrowingOnOneItem_When_ThatRangeUpdateFails_Then_TheVisibleContainerShowsNoRows()
+        {
+            // Arrange
+            var poisoned = false;
+            var node = ThrowingRendererList(item => poisoned && item.Id == "item-5", new List<string>());
+            var scrollView = new ScrollView(ScrollViewMode.Vertical);
+            using var controller = new FiberVirtualListController(scrollView, node, Reconciler);
+            var visibleContainer = scrollView.contentContainer.ElementAt(1);
+            controller.UpdateVisibleRange(scrollY: 0f, viewportHeight: 200f);
+            poisoned = true;
+
+            // Act — the throw is the characterization case's to pin; here it is only how the pass ends.
+            try
+            {
+                controller.UpdateVisibleRange(scrollY: 50f, viewportHeight: 200f);
+            }
+            catch (InvalidOperationException)
+            {
+            }
+
+            // Assert — the rows are gone from the DOM, not merely released: a disposed element left in the
+            // container is what the user goes on scrolling past.
+            Assert.That(visibleContainer.childCount, Is.EqualTo(0));
+        }
+
+        private static int RenderedIndexForTest(FiberVirtualListController controller, string field)
+            => (int)typeof(FiberVirtualListController)
+                .GetField(field, BindingFlags.NonPublic | BindingFlags.Instance)
+                .GetValue(controller);
 
         #endregion
 

--- a/Packages/com.velvet.core/Runtime/Component/Tests/Editor/VirtualListTests.cs
+++ b/Packages/com.velvet.core/Runtime/Component/Tests/Editor/VirtualListTests.cs
@@ -38,10 +38,10 @@ namespace Velvet.Tests
     /// cleanup, and one scrolled away and back returns as a remount rather than as the element that was
     /// disposed.</item>
     /// <item>Of two items sharing a key, the second renders when the first renders nothing.</item>
-    /// <item>A throw from the item renderer, or from creating or patching the row it describes, reaches
-    /// the caller, and the range update it ends releases the rows it had placed and, separately, the prior
-    /// rows it had not — the one whose create or patch threw among them — empties the visible container
-    /// and leaves the tracked range naming nothing.</item>
+    /// <item>A throw from the item renderer, or from an element's constructor while its row is created or
+    /// patched, reaches the caller, and the range update it ends releases the rows it had placed and,
+    /// separately, the prior rows it had not — the one whose create or patch threw among them — empties
+    /// the visible container and leaves the tracked range naming nothing.</item>
     /// <item>An update to no items releases the rows the list showed and empties the visible container,
     /// and a row that comes back after the list went empty — by an update or in place — renders
     /// afresh.</item>
@@ -981,9 +981,7 @@ namespace Velvet.Tests
         [Test]
         public void Given_ARenderedRange_When_TheListIsUpdatedToNoItems_Then_EachRowsCleanupRuns()
         {
-            // Arrange — one renderer for both nodes: a second one's delegates are new to the rows, so a
-            // patch would run their cleanups by itself, and an update that kept the rows would read here
-            // as one that released them.
+            // Arrange
             var cleaned = new List<string>();
             var renderer = CleanupRecordingRenderer(cleaned, RecordedLabel);
             var scrollView = new ScrollView(ScrollViewMode.Vertical);

--- a/Packages/com.velvet.core/Runtime/Component/V.cs
+++ b/Packages/com.velvet.core/Runtime/Component/V.cs
@@ -2343,8 +2343,9 @@ namespace Velvet
         /// <param name="itemHeight">Fixed height (pixels) used for layout and visible-range calculation.</param>
         /// <param name="renderer">Function that produces a VNode for each visible item. Must not be null.
         /// A key it sets on the node it returns is overwritten by <paramref name="keySelector"/>'s, which is
-        /// the identity a range change reuses a row by. A throw of its own is not contained — it reaches
-        /// the caller, and the range update it ends leaves the list showing no rows.</param>
+        /// the identity a range change reuses a row by. A throw of its own, or one from creating or
+        /// patching the row its node describes, is not contained — it reaches the caller, and the range
+        /// update it ends leaves the list showing no rows.</param>
         /// <param name="overscan">Extra items rendered above/below the visible window to smooth scroll-in.</param>
         /// <param name="key">Key used to disambiguate siblings at the same position.</param>
         /// <param name="className">CSS-like utility class string. Multiple classes separated by spaces.</param>

--- a/Packages/com.velvet.core/Runtime/Component/V.cs
+++ b/Packages/com.velvet.core/Runtime/Component/V.cs
@@ -2337,11 +2337,14 @@ namespace Velvet
         /// <param name="keySelector">Selector that derives a stable per-item key, held to
         /// <see cref="VNode.Key"/>'s rule on what a key may contain. Must not be null. An item whose key
         /// breaks that rule is left out of the rendered range with a warning; the selector runs from a
-        /// range update rather than from this call, which has no item's key to refuse yet.</param>
+        /// range update rather than from this call, which has no item's key to refuse yet. A null key is
+        /// no key, the answer <see cref="List{T}(IReadOnlyList{T}, Func{T, string}, Func{T, VNode})"/>
+        /// gives the same selector: the row renders, and a range change reuses it by its item index.</param>
         /// <param name="itemHeight">Fixed height (pixels) used for layout and visible-range calculation.</param>
         /// <param name="renderer">Function that produces a VNode for each visible item. Must not be null.
         /// A key it sets on the node it returns is overwritten by <paramref name="keySelector"/>'s, which is
-        /// the identity a range change reuses a row by.</param>
+        /// the identity a range change reuses a row by. A throw of its own is not contained — it reaches
+        /// the caller, and the range update it ends leaves the list showing no rows.</param>
         /// <param name="overscan">Extra items rendered above/below the visible window to smooth scroll-in.</param>
         /// <param name="key">Key used to disambiguate siblings at the same position.</param>
         /// <param name="className">CSS-like utility class string. Multiple classes separated by spaces.</param>

--- a/Packages/com.velvet.core/Runtime/Component/V.cs
+++ b/Packages/com.velvet.core/Runtime/Component/V.cs
@@ -2343,9 +2343,8 @@ namespace Velvet
         /// <param name="itemHeight">Fixed height (pixels) used for layout and visible-range calculation.</param>
         /// <param name="renderer">Function that produces a VNode for each visible item. Must not be null.
         /// A key it sets on the node it returns is overwritten by <paramref name="keySelector"/>'s, which is
-        /// the identity a range change reuses a row by. A throw of its own, or one from creating or
-        /// patching the row its node describes, is not contained — it reaches the caller, and the range
-        /// update it ends leaves the list showing no rows.</param>
+        /// the identity a range change reuses a row by. A throw of its own is not contained — it reaches
+        /// the caller, and the range update it ends leaves the list showing no rows.</param>
         /// <param name="overscan">Extra items rendered above/below the visible window to smooth scroll-in.</param>
         /// <param name="key">Key used to disambiguate siblings at the same position.</param>
         /// <param name="className">CSS-like utility class string. Multiple classes separated by spaces.</param>

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberVirtualListController.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberVirtualListController.cs
@@ -26,12 +26,20 @@ namespace Velvet
         private VirtualListNode _node;
         private VNode[] _renderedNodes;
         private VisualElement[] _renderedElements;
+        // _firstRenderedIndex cannot stand in for this: ForceRefresh drops it to -1 while the buffers
+        // above still hold the rows it named.
+        private int _bufferFirstItemIndex = -1;
         private int _firstRenderedIndex = -1;
         private int _lastRenderedIndex = -1;
         private float _viewportHeight;
         private bool _isDisposed;
 
+        // The prior pass's rows, split by what the next pass may find them under: a keyed row by its key,
+        // an unkeyed one by the item index it was rendered for. A row is REMOVED from its table as the
+        // pass takes it, so what is left over is what the pass did not take — which is what the
+        // scrolled-out sweep and the failed-pass unwind dispose.
         private readonly Dictionary<string, (VNode node, VisualElement element)> _oldNodesByKey = new();
+        private readonly Dictionary<int, (VNode node, VisualElement element)> _oldNodesByItemIndex = new();
         private readonly HashSet<string> _reusedKeys = new();
 
         public FiberVirtualListController(
@@ -177,7 +185,21 @@ namespace Velvet
 
             AllocateRenderBuffers(newCount, out var newNodes, out var newElements);
 
-            PatchOrReplaceVisibleItems(newFirst, newCount, newNodes, newElements);
+            // The loop below runs the application's keySelector and renderer, so it can throw for the
+            // reasons application code throws, and it must not escape half-done: AllocateRenderBuffers may
+            // have aliased the live buffers, leaving the controller pointing at a part-filled array while
+            // the container still shows the rows it no longer names. Containing the item instead was
+            // rejected — V.List, the mapping site this construct follows, releases what its pass took and
+            // rethrows.
+            try
+            {
+                PatchOrReplaceVisibleItems(newFirst, newCount, newNodes, newElements);
+            }
+            catch
+            {
+                DiscardFailedPass(newElements);
+                throw;
+            }
 
             DisposeScrolledOutItems();
 
@@ -185,6 +207,7 @@ namespace Velvet
 
             _renderedNodes = newNodes;
             _renderedElements = newElements;
+            _bufferFirstItemIndex = newFirst;
             _firstRenderedIndex = newFirst;
             _lastRenderedIndex = newLast;
 
@@ -194,17 +217,18 @@ namespace Velvet
             _reconciler.DrainRefAttachesForController();
         }
 
-        // Indexes the still-rendered items by key into _oldNodesByKey, for RenderRange's reuse/patch
+        // Indexes the still-rendered items into the two old-row tables, for RenderRange's reuse/patch
         // lookup and recycle-cleanup pass.
         private void IndexOldRenderedItems()
         {
-            // Index the still-rendered items by key BEFORE allocating the new buffers: when the window size is
+            // Index the still-rendered items BEFORE allocating the new buffers: when the window size is
             // unchanged the new buffers ALIAS _renderedNodes/_renderedElements (a zero-allocation reuse), so the
-            // Array.Clear below would wipe the very entries this index reads. Building it first keeps the per-key
+            // Array.Clear below would wipe the very entries this index reads. Building it first keeps the per-row
             // (node, element) references — the reuse/patch lookup and, critically, the recycle-cleanup pass that
             // disposes scrolled-out items. Skipping it (the aliased-and-cleared path) silently leaked every item's
             // fiber (effects, store subscriptions, nested inline children) on uniform same-size scrolling.
             _oldNodesByKey.Clear();
+            _oldNodesByItemIndex.Clear();
             for (var i = 0; i < _renderedNodes.Length; i++)
             {
                 if (_renderedNodes[i] != null)
@@ -218,13 +242,17 @@ namespace Velvet
                             _oldNodesByKey[key] = (_renderedNodes[i], _renderedElements[i]);
                         }
                     }
+                    else
+                    {
+                        _oldNodesByItemIndex[_bufferFirstItemIndex + i] = (_renderedNodes[i], _renderedElements[i]);
+                    }
                 }
             }
         }
 
         // Aliases the existing _renderedNodes/_renderedElements buffers when the window size is unchanged
         // (zero-allocation reuse), else allocates fresh ones sized to newCount, and clears both plus the
-        // per-render _reusedKeys set for the patch-or-replace pass that follows.
+        // per-render set the patch-or-replace pass detects a repeated key with.
         private void AllocateRenderBuffers(int newCount, out VNode[] newNodes, out VisualElement[] newElements)
         {
             newNodes = _renderedNodes.Length == newCount ? _renderedNodes : new VNode[newCount];
@@ -251,17 +279,19 @@ namespace Velvet
                     var item = _node.Items[itemIndex];
                     var key = _node.KeySelector(item);
 
-                    // Taken out of the range here rather than left to VNode.Key's refusal below:
-                    // RenderRange has no unwind, so a throw from inside this loop leaves the buffers it
-                    // cleared half-filled, the visible container never rebuilt, and the tracked range
-                    // still naming the one before it.
+                    // Taken out of the range here rather than left to VNode.Key's refusal below, which
+                    // would end the pass and blank the list over one item's key.
                     if (VNode.KeyHoldsDelimiter(key))
                     {
                         FiberLogger.LogWarning("FiberVirtualListController", $"Key holding a NUL (U+0000) detected: \"{key}\". Skipping the item; NUL is reserved as the internal scope delimiter.");
                         continue;
                     }
 
-                    if (!_reusedKeys.Add(key))
+                    // A null key is no key, the answer V.List gives the same selector: the row renders and
+                    // reconciles by position, which here is its item index, and never through the two
+                    // string-keyed collections below. VirtualListKeyCollectionContractTests holds those
+                    // two to what each does with one.
+                    if (key != null && !_reusedKeys.Add(key))
                     {
                         FiberLogger.LogWarning("FiberVirtualListController", $"Duplicate key detected: \"{key}\". Skipping duplicate item to prevent tracking inconsistency.");
                         continue;
@@ -270,7 +300,10 @@ namespace Velvet
                     var vnode = _node.Renderer(item);
                     if (vnode == null)
                     {
-                        _reusedKeys.Remove(key);
+                        if (key != null)
+                        {
+                            _reusedKeys.Remove(key);
+                        }
                         continue;
                     }
                     // IndexOldRenderedItems keys the next pass's reuse table off VNode.Key, and that table
@@ -288,7 +321,9 @@ namespace Velvet
                     // element AFTER creating the replacement (create-before-dispose, see below) rather
                     // than before, so it could not reuse that helper's eager remove-then-create order
                     // even if the class boundary were bridged.
-                    var hasExisting = _oldNodesByKey.TryGetValue(key, out var existing);
+                    var hasExisting = key != null
+                        ? _oldNodesByKey.Remove(key, out var existing)
+                        : _oldNodesByItemIndex.Remove(itemIndex, out existing);
                     if (hasExisting && ReconcileKeying.CanPatch(existing.node, vnode))
                     {
                         // Store the patch's RETURN: a class-driven wrap/unwrap (shadow-*/clip-path-*)
@@ -321,17 +356,44 @@ namespace Velvet
             }
         }
 
-        // Disposes every item still held from the prior render whose key was not reused in this render
-        // pass (scrolled out of the visible range).
+        // Disposes what the pass left in the two tables above: the prior render's rows it did not take,
+        // which is what scrolled out of the visible range.
         private void DisposeScrolledOutItems()
         {
             foreach (var kvp in _oldNodesByKey)
             {
-                if (!_reusedKeys.Contains(kvp.Key))
+                _reconciler.CleanupElementForController(kvp.Value.element);
+            }
+
+            foreach (var kvp in _oldNodesByItemIndex)
+            {
+                _reconciler.CleanupElementForController(kvp.Value.element);
+            }
+        }
+
+        // Releases what a pass that threw was holding, so that what the controller names is what it
+        // holds: the rows the pass had placed, plus the prior rows it had not reached. A row already
+        // taken out of a table is in a slot or was cleaned up as it was replaced, so nothing here is
+        // disposed twice. The prior range is not recoverable — a reused row has been patched in place
+        // toward its new node, and a same-key type flip has already disposed the element it replaced —
+        // so the range is left naming nothing and the next update rebuilds it.
+        private void DiscardFailedPass(VisualElement[] newElements)
+        {
+            for (var i = 0; i < newElements.Length; i++)
+            {
+                if (newElements[i] != null)
                 {
-                    _reconciler.CleanupElementForController(kvp.Value.element);
+                    _reconciler.CleanupElementForController(newElements[i]);
                 }
             }
+
+            DisposeScrolledOutItems();
+
+            _visibleContainer.Clear();
+            _renderedNodes = Array.Empty<VNode>();
+            _renderedElements = Array.Empty<VisualElement>();
+            _firstRenderedIndex = -1;
+            _lastRenderedIndex = -1;
         }
 
         // Repopulates _visibleContainer from newElements at its new scroll offset.

--- a/Packages/com.velvet.core/Runtime/Reconciler/FiberVirtualListController.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/FiberVirtualListController.cs
@@ -35,9 +35,8 @@ namespace Velvet
         private bool _isDisposed;
 
         // The prior pass's rows, split by what the next pass may find them under: a keyed row by its key,
-        // an unkeyed one by the item index it was rendered for. A row is REMOVED from its table as the
-        // pass takes it, so what is left over is what the pass did not take — which is what the
-        // scrolled-out sweep and the failed-pass unwind dispose.
+        // an unkeyed one by the item index it was rendered for. What a pass leaves in them, whether it
+        // finishes or throws, is what DisposeUntakenRows releases.
         private readonly Dictionary<string, (VNode node, VisualElement element)> _oldNodesByKey = new();
         private readonly Dictionary<int, (VNode node, VisualElement element)> _oldNodesByItemIndex = new();
         private readonly HashSet<string> _reusedKeys = new();
@@ -126,8 +125,6 @@ namespace Velvet
             _scrollView.verticalScroller.valueChanged -= OnScrollValueChanged;
 
             ClearRenderedItems();
-            _renderedNodes = Array.Empty<VNode>();
-            _renderedElements = Array.Empty<VisualElement>();
         }
 
         private void OnGeometryChanged(GeometryChangedEvent evt)
@@ -151,12 +148,11 @@ namespace Velvet
         {
             if (_isDisposed || _node.Items.Count == 0)
             {
-                if (_firstRenderedIndex != -1)
-                {
-                    ClearRenderedItems();
-                    _firstRenderedIndex = -1;
-                    _lastRenderedIndex = -1;
-                }
+                // Not gated on the tracked range, which cannot say whether rows are held — the reason
+                // _bufferFirstItemIndex exists.
+                ClearRenderedItems();
+                _firstRenderedIndex = -1;
+                _lastRenderedIndex = -1;
                 return;
             }
 
@@ -185,12 +181,12 @@ namespace Velvet
 
             AllocateRenderBuffers(newCount, out var newNodes, out var newElements);
 
-            // The loop below runs the application's keySelector and renderer, so it can throw for the
-            // reasons application code throws, and it must not escape half-done: AllocateRenderBuffers may
-            // have aliased the live buffers, leaving the controller pointing at a part-filled array while
-            // the container still shows the rows it no longer names. Containing the item instead was
-            // rejected — V.List, the mapping site this construct follows, releases what its pass took and
-            // rethrows.
+            // The loop below can throw — from the application's keySelector and renderer, and from
+            // creating or patching the row the renderer describes — and it must not escape half-done:
+            // AllocateRenderBuffers may have aliased the live buffers, leaving the controller pointing at a
+            // part-filled array while the container still shows the rows it no longer names. Containing
+            // the item instead was rejected — V.List, the mapping site this construct follows, releases
+            // what its pass took and rethrows.
             try
             {
                 PatchOrReplaceVisibleItems(newFirst, newCount, newNodes, newElements);
@@ -201,7 +197,7 @@ namespace Velvet
                 throw;
             }
 
-            DisposeScrolledOutItems();
+            DisposeUntakenRows();
 
             RebuildVisibleContainer(newFirst, newCount, newElements);
 
@@ -211,7 +207,7 @@ namespace Velvet
             _firstRenderedIndex = newFirst;
             _lastRenderedIndex = newLast;
 
-            // After DisposeScrolledOutItems, so a recycled item's ref cleanup runs before the setup of
+            // After DisposeUntakenRows, so a recycled item's ref cleanup runs before the setup of
             // whatever took its place, and after the container rebuild, so a setup reads an item that is
             // already in the list.
             _reconciler.DrainRefAttachesForController();
@@ -322,8 +318,8 @@ namespace Velvet
                     // than before, so it could not reuse that helper's eager remove-then-create order
                     // even if the class boundary were bridged.
                     var hasExisting = key != null
-                        ? _oldNodesByKey.Remove(key, out var existing)
-                        : _oldNodesByItemIndex.Remove(itemIndex, out existing);
+                        ? _oldNodesByKey.TryGetValue(key, out var existing)
+                        : _oldNodesByItemIndex.TryGetValue(itemIndex, out existing);
                     if (hasExisting && ReconcileKeying.CanPatch(existing.node, vnode))
                     {
                         // Store the patch's RETURN: a class-driven wrap/unwrap (shadow-*/clip-path-*)
@@ -334,15 +330,25 @@ namespace Velvet
                     else
                     {
                         // A same-key type flip (CanPatch=false) is a replacement, not a patch — mirroring
-                        // the general keyed diff path's create-before-dispose ordering: a throw while
-                        // constructing the replacement element leaves the old one intact instead of the
-                        // slot holding nothing recoverable.
+                        // the general keyed diff path's create-before-dispose ordering.
                         var replacement = _reconciler.CreateElementForController(vnode);
                         if (hasExisting)
                         {
                             _reconciler.CleanupElementForController(existing.element);
                         }
                         newElements[i] = replacement;
+                    }
+
+                    // The prior row leaves its table only once the slot holds an element, the order
+                    // GeneralPathReconciler.CommitLeaf keeps for a key it marks used: a throw from the create
+                    // or the patch above leaves it there for DiscardFailedPass to release.
+                    if (key != null)
+                    {
+                        _oldNodesByKey.Remove(key);
+                    }
+                    else
+                    {
+                        _oldNodesByItemIndex.Remove(itemIndex);
                     }
 
                     // Stamp this item's newly created fibers with its own vnode so an isolated re-render can
@@ -356,9 +362,7 @@ namespace Velvet
             }
         }
 
-        // Disposes what the pass left in the two tables above: the prior render's rows it did not take,
-        // which is what scrolled out of the visible range.
-        private void DisposeScrolledOutItems()
+        private void DisposeUntakenRows()
         {
             foreach (var kvp in _oldNodesByKey)
             {
@@ -371,12 +375,11 @@ namespace Velvet
             }
         }
 
-        // Releases what a pass that threw was holding, so that what the controller names is what it
-        // holds: the rows the pass had placed, plus the prior rows it had not reached. A row already
-        // taken out of a table is in a slot or was cleaned up as it was replaced, so nothing here is
-        // disposed twice. The prior range is not recoverable — a reused row has been patched in place
-        // toward its new node, and a same-key type flip has already disposed the element it replaced —
-        // so the range is left naming nothing and the next update rebuilds it.
+        // Releases what a pass that threw was holding — the elements in its slots, and the prior rows
+        // left in the tables — and leaves the range naming nothing, so the next range update renders it
+        // from nothing. Putting the previous range back was rejected: a same-key type flip the pass
+        // completed has already disposed the element that range showed, so what came back would not
+        // always be that range.
         private void DiscardFailedPass(VisualElement[] newElements)
         {
             for (var i = 0; i < newElements.Length; i++)
@@ -387,7 +390,7 @@ namespace Velvet
                 }
             }
 
-            DisposeScrolledOutItems();
+            DisposeUntakenRows();
 
             _visibleContainer.Clear();
             _renderedNodes = Array.Empty<VNode>();
@@ -412,6 +415,8 @@ namespace Velvet
             }
         }
 
+        // The buffers go with the rows they held: IndexOldRenderedItems offers whatever they still name
+        // for reuse, so a released row left there can be patched back in by the next pass.
         private void ClearRenderedItems()
         {
             for (var i = 0; i < _renderedElements.Length; i++)
@@ -422,6 +427,8 @@ namespace Velvet
                 }
             }
             _visibleContainer.Clear();
+            _renderedNodes = Array.Empty<VNode>();
+            _renderedElements = Array.Empty<VisualElement>();
         }
 
         private void ForceRefresh()

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/VirtualListKeyCollectionContractTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/VirtualListKeyCollectionContractTests.cs
@@ -1,0 +1,51 @@
+// annotations only: incremental nullable hygiene. See the leading comment in Velvet core Hooks.cs for details.
+#nullable enable annotations
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace Velvet.Tests
+{
+    /// <summary>
+    /// Holds the two BCL collections a <see cref="V.VirtualList{T}"/> range update tracks item keys in to
+    /// what each does with a null key, which is why the controller keeps one out of both.
+    /// <list type="bullet">
+    /// <item>A <c>Dictionary&lt;string, …&gt;</c> lookup by a null key throws, against an empty dictionary
+    /// as much as a populated one.</item>
+    /// <item>A <c>HashSet&lt;string&gt;</c> takes a null as a member, so it reports the first null it is
+    /// handed as newly added rather than refusing it.</item>
+    /// </list>
+    /// </summary>
+    [TestFixture]
+    internal sealed class VirtualListKeyCollectionContractTests
+    {
+        // GREEN_ON_BASE(characterization): the throw the null-key guard exists for.
+        // Nothing of this repository's is on either side, so no change here could redden it; what it
+        // exists to catch is the day the framework stops throwing and the guard reads as dead weight.
+        [Test]
+        public void Given_AnEmptyStringKeyedDictionary_When_LookedUpByNull_Then_ItThrows()
+        {
+            // Arrange
+            var byKey = new Dictionary<string, int>();
+
+            // Act + Assert
+            Assert.Throws<ArgumentNullException>(() => byKey.TryGetValue(null, out _));
+        }
+
+        // GREEN_ON_BASE(characterization): the set takes what the dictionary refuses.
+        // The asymmetry is why a null key handed to both would surface at the dictionary rather than at
+        // the set, which is the throw the controller's guard is placed ahead of.
+        [Test]
+        public void Given_AnEmptyStringKeyedSet_When_ANullIsAdded_Then_ItIsTakenAsANewMember()
+        {
+            // Arrange
+            var claimed = new HashSet<string>();
+
+            // Act
+            var added = claimed.Add(null);
+
+            // Assert
+            Assert.That(added, Is.True);
+        }
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/VirtualListKeyCollectionContractTests.cs
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/VirtualListKeyCollectionContractTests.cs
@@ -10,8 +10,8 @@ namespace Velvet.Tests
     /// Holds the two BCL collections a <see cref="V.VirtualList{T}"/> range update tracks item keys in to
     /// what each does with a null key, which is why the controller keeps one out of both.
     /// <list type="bullet">
-    /// <item>A <c>Dictionary&lt;string, …&gt;</c> lookup by a null key throws, against an empty dictionary
-    /// as much as a populated one.</item>
+    /// <item>A <c>Dictionary&lt;string, …&gt;</c> lookup or removal by a null key throws, against an empty
+    /// dictionary as much as a populated one.</item>
     /// <item>A <c>HashSet&lt;string&gt;</c> takes a null as a member, so it reports the first null it is
     /// handed as newly added rather than refusing it.</item>
     /// </list>
@@ -30,6 +30,19 @@ namespace Velvet.Tests
 
             // Act + Assert
             Assert.Throws<ArgumentNullException>(() => byKey.TryGetValue(null, out _));
+        }
+
+        // GREEN_ON_BASE(characterization): removing by a null key throws as the lookup does.
+        // A range update makes this call with the key it looked a row up with, once the row's slot holds
+        // an element.
+        [Test]
+        public void Given_AnEmptyStringKeyedDictionary_When_RemovedFromByNull_Then_ItThrows()
+        {
+            // Arrange
+            var byKey = new Dictionary<string, int>();
+
+            // Act + Assert
+            Assert.Throws<ArgumentNullException>(() => byKey.Remove(null));
         }
 
         // GREEN_ON_BASE(characterization): the set takes what the dictionary refuses.

--- a/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/VirtualListKeyCollectionContractTests.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Reconciler/Tests/Editor/VirtualListKeyCollectionContractTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8bf6f956967eb4c79a43ec0f8d518b1d


### PR DESCRIPTION
A `V.VirtualList` whose `keySelector` returned null for one item threw `ArgumentNullException` out of the range update that reached it: a null passes the delimiter check and the claimed-key set takes it, but the `Dictionary` lookup refuses it even when empty. A throwing item renderer left the same wreckage by the same path. The pass stopped half-done, and when the window size is unchanged the new buffers alias the live ones, so the controller was left naming a part-filled array while the container still showed the previous rows; some rows' `refCallback` cleanups then never ran, and a further scroll reaching the same item threw again.

Both now get the answer `V.List` gives. A null key is no key: the row renders and reconciles by position, which for a virtualized list is its item index, so an unkeyed prior row is indexed by item index beside the keyed table. A throw from the item loop — from the renderer, or from an element's constructor while its row is created or patched — unwinds the pass and is rethrown: the unwind releases the rows the pass had placed and the prior rows it had not reached, empties the visible container and leaves the tracked range naming nothing, so the next range update rebuilds from a state it can use. A prior row now leaves its table only once its slot holds an element, the order `GeneralPathReconciler.CommitLeaf` keeps for a key it marks used, so a row whose create or patch threw is released with the rest instead of being left in no table and no slot. Skipping the item was rejected because rows sit at fixed offsets and a skipped row misaligns every row after it; refusing at the `V.VirtualList` call would mean running the selector over the whole collection, which virtualization exists to avoid.

Updating a `V.VirtualList` to an empty item list released none of the rows it showed. The controller drops its tracked range before it renders an updated list, and the empty-list branch released rows only while that range named some, so the rows stayed in the container over a zero-height spacer with their effects live, and an update back to items reused them. The branch now releases whatever the buffers hold and empties the buffers with the rows. A list that passes through empty now shows no rows while it is empty and remounts its rows afterwards, their hook state back at its initial values, as React unmounts and remounts them — which is why that entry sits in the CHANGELOG's breaking section.

A component row's own render throw is unchanged: it is caught as any component's is, and reaches an error boundary or the log rather than the caller. `DisposeScrolledOutItems` becomes `DisposeUntakenRows`, since the unwind disposes rows through it that never scrolled out, and `VirtualListKeyCollectionContractTests` pins the dictionary removal the controller calls beside its lookup. No `Documentation~` guide describes `V.VirtualList`; its XmlDoc carries the key and throw rules.

Closes #1018. Closes #1012.
