### PR TITLE
fix(velvet): stop the router disposing a token source that code it handed the token to can still read

### DIFF
--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -183,21 +183,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `Debug.LogException` at the two fiber sites and through `StoreLogger.LogError` at the store — and
   the teardown runs to its end.
 
-- A Loader or a Blocker still holding the `CancellationToken` the router handed it reads the cancellation
-  off it, rather than finding the source behind it gone. The router used to dispose a loader round's
-  source when the round ended, and a navigation's source when the navigation ended and at
-  `Router.Dispose` — while the Loaders below one that navigated, an `Await` loader a newer navigation
-  superseded, a `Suspend` loader streaming into the route on screen, or a Blocker awaiting the navigation
-  could still be reading it. `CancellationToken.WaitHandle` then raised `ObjectDisposedException`, which
-  code written to catch `OperationCanceledException` does not catch. The router now cancels those
-  sources and never disposes them. What it lets go of instead is each one's link to the token it was
-  made from, so a navigation or a loader round that never finishes is no longer kept reachable through
-  the token passed to `NavigateAsync` once it has been cancelled. A navigation started while the router
-  is being disposed — from a cancellation callback the disposal runs — returns
-  `NavigationResult.Cancelled`, as one started on a disposed router now does, where it used to run on
-  and could commit after the disposal. A navigation a cancellation callback starts while another is
-  taking over now supersedes it, where the one taking over used to overwrite it and leave it running, so
-  that both could commit.
+- A Loader or a Blocker still holding the `CancellationToken` the router handed it can go on reading it,
+  rather than finding the source behind it gone. The router used to dispose a loader round's source when
+  the round ended, and a navigation's source when the navigation ended and at `Router.Dispose` — while
+  the Loaders below one that navigated, an `Await` loader a newer navigation superseded, a `Suspend`
+  loader streaming into the route on screen, or a Blocker awaiting the navigation could still be reading
+  it. `CancellationToken.WaitHandle` then raised `ObjectDisposedException`, which code written to catch
+  `OperationCanceledException` does not catch. The router no longer disposes those sources. What it lets
+  go of instead is each one's link to the token it was made from, so a navigation or a loader round that
+  never finishes is no longer kept reachable through the token passed to `NavigateAsync` once it has been
+  cancelled. A navigation started while the router is being disposed — from a cancellation callback the
+  disposal runs — returns `NavigationResult.Cancelled`, as one started on a disposed router now does,
+  where it used to run on and could commit after the disposal. A navigation a cancellation callback
+  starts while another is taking over now supersedes it, where the one taking over used to overwrite it
+  and leave it running, so that both could commit.
 
 - A `V.VirtualList` whose item renderer returns a `V.Component` or a `V.Provider` stacks its visible
   items instead of starting every one of them at the same place. Velvet anchors such an item's fiber on

--- a/Packages/com.velvet.core/CHANGELOG.md
+++ b/Packages/com.velvet.core/CHANGELOG.md
@@ -183,15 +183,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `Debug.LogException` at the two fiber sites and through `StoreLogger.LogError` at the store — and
   the teardown runs to its end.
 
-- A Loader that still holds its round's `CancellationToken` when the round ends reads the cancellation
-  off it, rather than finding the source behind it gone. The round's source used to be disposed at the
-  moment the round ended, which lands before the run that launched the Loaders has handed that token to
-  the matches below the one that ended it, before an `Await` loader a newer navigation superseded has
-  unwound, and before a `Suspend` loader streaming into the route on screen has finished.
-  `CancellationToken.WaitHandle` read from any of those three then raised `ObjectDisposedException`,
-  which a Loader written to catch `OperationCanceledException` does not catch. The source is now not
-  released until the round has ended, the run that launched it has returned, and every `Suspend` loader
-  it started has finished.
+- A Loader or a Blocker still holding the `CancellationToken` the router handed it reads the cancellation
+  off it, rather than finding the source behind it gone. The router used to dispose a loader round's
+  source when the round ended, and a navigation's source when the navigation ended and at
+  `Router.Dispose` — while the Loaders below one that navigated, an `Await` loader a newer navigation
+  superseded, a `Suspend` loader streaming into the route on screen, or a Blocker awaiting the navigation
+  could still be reading it. `CancellationToken.WaitHandle` then raised `ObjectDisposedException`, which
+  code written to catch `OperationCanceledException` does not catch. The router now cancels those
+  sources and never disposes them. What it lets go of instead is each one's link to the token it was
+  made from, so a navigation or a loader round that never finishes is no longer kept reachable through
+  the token passed to `NavigateAsync` once it has been cancelled. A navigation started while the router
+  is being disposed — from a cancellation callback the disposal runs — returns
+  `NavigationResult.Cancelled`, as one started on a disposed router now does, where it used to run on
+  and could commit after the disposal. A navigation a cancellation callback starts while another is
+  taking over now supersedes it, where the one taking over used to overwrite it and leave it running, so
+  that both could commit.
 
 - A `V.VirtualList` whose item renderer returns a `V.Component` or a `V.Provider` stacks its visible
   items instead of starting every one of them at the same place. Velvet anchors such an item's fiber on

--- a/Packages/com.velvet.core/Documentation~/routing.md
+++ b/Packages/com.velvet.core/Documentation~/routing.md
@@ -83,8 +83,8 @@ belongs to is still the one on screen: it keeps its cancellation token and its r
 `Hooks.UseLoaderData`. The commit that leaves the route is what cancels it.
 
 A loader still running when its round is cancelled can go on reading its token, and so can a Blocker
-still awaiting when its navigation is cancelled: the router cancels the source behind a token it hands
-out and never disposes it, so the token reads as cancelled for as long as anything holds it.
+still awaiting when its navigation is cancelled: the router never disposes the source behind a token it
+hands out, so a cancelled token reads as cancelled for as long as anything holds it.
 
 A cancellation callback a loader registers on its token runs when that cancellation happens. One that
 throws is reported through `Debug.LogException` rather than raised at the navigation or the disposal

--- a/Packages/com.velvet.core/Documentation~/routing.md
+++ b/Packages/com.velvet.core/Documentation~/routing.md
@@ -82,10 +82,9 @@ A `Suspend` loader keeps running while an `Await` loader holds the next commit, 
 belongs to is still the one on screen: it keeps its cancellation token and its result still reaches
 `Hooks.UseLoaderData`. The commit that leaves the route is what cancels it.
 
-A loader still running when its round is cancelled can go on reading its token. The source behind the
-token is not released until the round has ended, the run that launched the loaders has returned, and
-every `Suspend` loader it started has finished — so a loader unwinding on the cancellation reads its
-token as cancelled.
+A loader still running when its round is cancelled can go on reading its token, and so can a Blocker
+still awaiting when its navigation is cancelled: the router cancels the source behind a token it hands
+out and never disposes it, so the token reads as cancelled for as long as anything holds it.
 
 A cancellation callback a loader registers on its token runs when that cancellation happens. One that
 throws is reported through `Debug.LogException` rather than raised at the navigation or the disposal

--- a/Packages/com.velvet.core/Runtime/Hooks/Hooks.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Hooks.cs
@@ -504,8 +504,7 @@ namespace Velvet
         /// </remarks>
         /// <param name="shouldBlock">
         /// Async predicate; returning true blocks the departure. The token is the navigation's, which unmounting
-        /// the component does not cancel. <c>Documentation~/routing-blockers.md</c> owns what unmounting does to a
-        /// Blocker.
+        /// the component does not cancel.
         /// </param>
         /// <returns>The shared <see cref="RouteBlockerState"/> handle for inspecting / resolving the pending departure.</returns>
         public static RouteBlockerState UseBlocker(Func<NavigationAttempt, CancellationToken, VelvetTask<bool>> shouldBlock)
@@ -523,8 +522,7 @@ namespace Velvet
         /// </summary>
         /// <param name="shouldBlock">
         /// Async predicate; returning true blocks the departure. The token is the navigation's, which unmounting
-        /// the component does not cancel. <c>Documentation~/routing-blockers.md</c> owns what unmounting does to a
-        /// Blocker.
+        /// the component does not cancel.
         /// </param>
         /// <param name="deps">Dependency array. When null, re-registers on every render.</param>
         /// <returns>The shared <see cref="RouteBlockerState"/> handle for inspecting / resolving the pending departure.</returns>

--- a/Packages/com.velvet.core/Runtime/Hooks/Hooks.cs
+++ b/Packages/com.velvet.core/Runtime/Hooks/Hooks.cs
@@ -502,7 +502,11 @@ namespace Velvet
         /// The single-argument overload exists so that omitting deps is unambiguous — see
         /// <see cref="UseCallback{T}(T)"/> for the hazard it avoids.
         /// </remarks>
-        /// <param name="shouldBlock">Async predicate; returning true blocks the departure. The CancellationToken is cancelled on unmount.</param>
+        /// <param name="shouldBlock">
+        /// Async predicate; returning true blocks the departure. The token is the navigation's, which unmounting
+        /// the component does not cancel. <c>Documentation~/routing-blockers.md</c> owns what unmounting does to a
+        /// Blocker.
+        /// </param>
         /// <returns>The shared <see cref="RouteBlockerState"/> handle for inspecting / resolving the pending departure.</returns>
         public static RouteBlockerState UseBlocker(Func<NavigationAttempt, CancellationToken, VelvetTask<bool>> shouldBlock)
         {
@@ -517,7 +521,11 @@ namespace Velvet
         /// only when a dependency changes. Use when integrating with asynchronous UI such as confirmation
         /// dialogs.
         /// </summary>
-        /// <param name="shouldBlock">Async predicate; returning true blocks the departure. The CancellationToken is cancelled on unmount.</param>
+        /// <param name="shouldBlock">
+        /// Async predicate; returning true blocks the departure. The token is the navigation's, which unmounting
+        /// the component does not cancel. <c>Documentation~/routing-blockers.md</c> owns what unmounting does to a
+        /// Blocker.
+        /// </param>
         /// <param name="deps">Dependency array. When null, re-registers on every render.</param>
         /// <returns>The shared <see cref="RouteBlockerState"/> handle for inspecting / resolving the pending departure.</returns>
         public static RouteBlockerState UseBlocker(Func<NavigationAttempt, CancellationToken, VelvetTask<bool>> shouldBlock, params object?[]? deps)

--- a/Packages/com.velvet.core/Runtime/Routing/RouteCancellationSource.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/RouteCancellationSource.cs
@@ -15,9 +15,9 @@ namespace Velvet
         private readonly CancellationTokenSource _source = new();
         private CancellationTokenRegistration _link;
 
-        // The link is registered with execution-context flow suppressed: capturing the context costs four
-        // allocation blocks a navigation, which RouterNavigationAllocationEditorTests pins. SuppressFlow throws
-        // where flow is suppressed already, which RouterTests pins for a caller that suppressed it.
+        // The link is registered with execution-context flow suppressed, which RouterNavigationAllocationEditorTests
+        // pins. SuppressFlow throws where flow is suppressed already, which RouterTests pins for a caller that
+        // suppressed it.
         internal RouteCancellationSource(CancellationToken linkedTo)
         {
             if (ExecutionContext.IsFlowSuppressed())
@@ -33,8 +33,8 @@ namespace Velvet
 
         internal CancellationToken Token => _source.Token;
 
-        // Unlinked first: the cancellation runs callbacks that can throw, and a link left behind lets the token
-        // this source was linked to keep it alive.
+        // Unlinked first, which RouteLoaderRunnerTests pins: the cancellation runs callbacks that can throw, and a
+        // link left behind lets the token this source was linked to keep it alive.
         internal void Cancel()
         {
             _link.Dispose();

--- a/Packages/com.velvet.core/Runtime/Routing/RouteCancellationSource.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/RouteCancellationSource.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Threading;
+
+namespace Velvet
+{
+    // The source behind a token the router hands to a Loader or a Blocker. Either can go on reading the token
+    // after the source is cancelled, and nothing the router holds says when the last such read has happened,
+    // so the source is never disposed: disposing it is what makes a read of the token's wait handle throw,
+    // which CancellationTokenReleaseTests pins. It is linked by a registration rather than created as a linked
+    // source because only a registration can be dropped without disposing the source.
+    internal sealed class RouteCancellationSource
+    {
+        private static readonly Action<object?> CancelLinked = source => ((CancellationTokenSource)source!).Cancel();
+
+        private readonly CancellationTokenSource _source = new();
+        private CancellationTokenRegistration _link;
+
+        // The link is registered with execution-context flow suppressed: capturing the context costs four
+        // allocation blocks a navigation, which RouterNavigationAllocationEditorTests pins. SuppressFlow throws
+        // where flow is suppressed already, which RouterTests pins for a caller that suppressed it.
+        internal RouteCancellationSource(CancellationToken linkedTo)
+        {
+            if (ExecutionContext.IsFlowSuppressed())
+            {
+                _link = linkedTo.Register(CancelLinked, _source);
+                return;
+            }
+            using (ExecutionContext.SuppressFlow())
+            {
+                _link = linkedTo.Register(CancelLinked, _source);
+            }
+        }
+
+        internal CancellationToken Token => _source.Token;
+
+        // Unlinked first: the cancellation runs callbacks that can throw, and a link left behind lets the token
+        // this source was linked to keep it alive.
+        internal void Cancel()
+        {
+            _link.Dispose();
+            _source.Cancel();
+        }
+
+        internal void Unlink() => _link.Dispose();
+    }
+}

--- a/Packages/com.velvet.core/Runtime/Routing/RouteCancellationSource.cs.meta
+++ b/Packages/com.velvet.core/Runtime/Routing/RouteCancellationSource.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9e116168ab7a4f779f22d96d111fca6d

--- a/Packages/com.velvet.core/Runtime/Routing/RouteLoaderRunner.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/RouteLoaderRunner.cs
@@ -27,18 +27,9 @@ namespace Velvet
 
             internal int Pending;
 
-            // The source every loader of this round was launched under. Cancelling it is what ends the round,
-            // and nulling it at the release is what keeps a second path reaching that release from
-            // disposing it again.
-            internal CancellationTokenSource? Cts;
+            internal readonly RouteCancellationSource? Cancellation;
 
-            internal bool Retired;
-
-            internal bool Cancelling;
-
-            internal bool RunReturned;
-
-            internal LoaderRound(CancellationTokenSource? cts) => Cts = cts;
+            internal LoaderRound(RouteCancellationSource? cancellation) => Cancellation = cancellation;
 
             internal bool Settled => Pending == 0;
         }
@@ -47,6 +38,8 @@ namespace Velvet
 
         // The round whose Suspend loaders may announce. Null until the caller promotes one.
         private LoaderRound? _liveRound;
+
+        private bool _disposed;
 
         public RouteLoaderRunner() => _currentRound = new LoaderRound(null);
 
@@ -65,82 +58,74 @@ namespace Velvet
             IReadOnlyList<RouteMatch> matches,
             CancellationToken externalToken)
         {
-            var cts = CancellationTokenSource.CreateLinkedTokenSource(externalToken);
+            var cancellation = new RouteCancellationSource(externalToken);
             // Captured once for the round, and before the round is installed: retiring the outgoing round
             // can run application code — a cancellation callback one of its Loaders registered — and a
             // round that code starts retires the round BeginRound has just installed. A nested navigation
             // retires this round too, and its remaining Loaders must still launch under the token they
             // belong to rather than the nested round's.
-            var roundToken = cts.Token;
-            var round = BeginRound(cts);
+            var roundToken = cancellation.Token;
+            var round = BeginRound(cancellation);
 
             var awaitTasks = new List<(string? routeId, VelvetTask<object> task)>();
 
-            try
+            foreach (var match in matches)
             {
-                foreach (var match in matches)
+                if (match.Route?.Loader == null)
                 {
-                    if (match.Route?.Loader == null)
-                    {
-                        continue;
-                    }
-
-                    var route = match.Route;
-
-                    var loaderContext = new RouteLoaderContext
-                    {
-                        Params = match.Params,
-                        Path = match.MatchedPath,
-                    };
-
-                    var key = match.RouteId;
-
-                    VelvetTask<object> task;
-                    try
-                    {
-                        task = route.Loader(loaderContext, roundToken);
-                    }
-                    catch (Exception ex)
-                    {
-                        round.Errors[key] = ex;
-                        continue;
-                    }
-
-                    if (route.LoaderMode == LoaderMode.Await)
-                    {
-                        awaitTasks.Add((key, task));
-                    }
-                    else
-                    {
-                        round.Pending++;
-                        RunSuspendLoader(key, task, round).Forget();
-                    }
+                    continue;
                 }
 
-                foreach (var (routeId, task) in awaitTasks)
+                var route = match.Route;
+
+                var loaderContext = new RouteLoaderContext
                 {
-                    try
-                    {
-                        round.Results[routeId] = await task;
-                    }
-                    catch (OperationCanceledException)
-                    {
-                        // A cancellation is not this route's load failure. What this loop leaves in
-                        // Errors is what Router.RunLoaderPhase hands to UseRouteError.
-                    }
-                    catch (Exception ex)
-                    {
-                        round.Errors[routeId] = ex;
-                    }
+                    Params = match.Params,
+                    Path = match.MatchedPath,
+                };
+
+                var key = match.RouteId;
+
+                VelvetTask<object> task;
+                try
+                {
+                    task = route.Loader(loaderContext, roundToken);
+                }
+                catch (Exception ex)
+                {
+                    round.Errors[key] = ex;
+                    continue;
                 }
 
-                return round;
+                if (route.LoaderMode == LoaderMode.Await)
+                {
+                    awaitTasks.Add((key, task));
+                }
+                else
+                {
+                    round.Pending++;
+                    RunSuspendLoader(key, task, round).Forget();
+                }
             }
-            finally
+
+            foreach (var (routeId, task) in awaitTasks)
             {
-                round.RunReturned = true;
-                ReleaseIfUnheld(round);
+                try
+                {
+                    round.Results[routeId] = await task;
+                }
+                catch (OperationCanceledException)
+                {
+                    // A cancellation is not this route's load failure. What this loop leaves in
+                    // Errors is what Router.RunLoaderPhase hands to UseRouteError.
+                }
+                catch (Exception ex)
+                {
+                    round.Errors[routeId] = ex;
+                }
             }
+
+            return round;
         }
 
         /// <summary>
@@ -154,10 +139,18 @@ namespace Velvet
         // The outgoing round is retired here unless it is the live one: the live round belongs to the
         // location on screen, and Promote — called by the commit that leaves that location — is what ends it.
         // Anything else current has not reached a commit.
-        private LoaderRound BeginRound(CancellationTokenSource? cts)
+        private LoaderRound BeginRound(RouteCancellationSource? cancellation)
         {
+            var round = new LoaderRound(cancellation);
+            // Dispose ends the rounds it finds, and a cancellation callback it runs can begin another: one
+            // begun on a disposed runner is ended here, before any of its loaders launch, and never becomes
+            // current.
+            if (_disposed)
+            {
+                Retire(round);
+                return round;
+            }
             var outgoing = _currentRound;
-            var round = new LoaderRound(cts);
             _currentRound = round;
             if (!ReferenceEquals(outgoing, _liveRound))
             {
@@ -168,10 +161,14 @@ namespace Velvet
 
         /// <summary>
         /// Makes <paramref name="round"/> the one whose Suspend loaders announce, and ends the round that
-        /// held that place.
+        /// held that place. A disposed runner makes none live: it announces nothing.
         /// </summary>
         public void Promote(LoaderRound round)
         {
+            if (_disposed)
+            {
+                return;
+            }
             var departing = _liveRound;
             // Assigned before the Retire below, not after: a loader continuation that resumes synchronously
             // inside Cancel() and completes successfully would otherwise still read the departing round as
@@ -185,47 +182,17 @@ namespace Velvet
 
         private static void Retire(LoaderRound round)
         {
-            var cts = round.Cts;
-            if (cts == null || round.Retired)
-            {
-                return;
-            }
-            round.Retired = true;
-            round.Cancelling = true;
             // A callback the application registered on this round's token must not decide the outcome of
             // the operation ending the round: the caller is installing a different round or disposing the
-            // runner, and the callback belongs to neither. Reported on Announce's terms, and the flag's
-            // clear and the release below both sit under the catch: a throwing callback that left the
-            // flag set would decline every release after it.
+            // runner, and the callback belongs to neither. Reported on Announce's terms.
             try
             {
-                cts.Cancel();
+                round.Cancellation?.Cancel();
             }
             catch (Exception cancellationFailure)
             {
                 FiberLogger.LogException(nameof(RouteLoaderRunner), cancellationFailure);
             }
-            round.Cancelling = false;
-            ReleaseIfUnheld(round);
-        }
-
-        // Separate from the cancellation above because a retired round's token can still be in use. The
-        // launch loop goes on handing it to the matches below a loader that retired the round, the await
-        // loop holds it for the Await-mode loaders it launched, a Suspend-mode loader launched under it
-        // runs until its own task completes, and Retire holds it across the Cancel() it issues itself, so
-        // a holder unwinding from inside that call does not take the release out from under it. A
-        // cancellation this round's source receives from anywhere else is outside what that flag spans.
-        // Releasing it earlier is what left a read of the token answering that the source is gone rather
-        // than that the round was cancelled; CancellationTokenReleaseTests holds which read that is.
-        private static void ReleaseIfUnheld(LoaderRound round)
-        {
-            var cts = round.Cts;
-            if (cts == null || !round.Retired || round.Cancelling || !round.RunReturned || round.Pending > 0)
-            {
-                return;
-            }
-            round.Cts = null;
-            cts.Dispose();
         }
 
         private async VelvetTask RunSuspendLoader(string? routeId, VelvetTask<object> task, LoaderRound round)
@@ -267,7 +234,6 @@ namespace Velvet
             finally
             {
                 _activeSuspendTaskCount--;
-                ReleaseIfUnheld(round);
             }
         }
 
@@ -286,7 +252,8 @@ namespace Velvet
 
         public void Dispose()
         {
-            // Cleared before either Retire, on the ordering Promote states.
+            // Both set before either Retire, on the orderings BeginRound and Promote state.
+            _disposed = true;
             var live = _liveRound;
             _liveRound = null;
             Retire(_currentRound);

--- a/Packages/com.velvet.core/Runtime/Routing/Router.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/Router.cs
@@ -144,7 +144,7 @@ namespace Velvet
         /// <see cref="NavigationResult.NotFound"/> when no route matches,
         /// <see cref="NavigationResult.Blocked"/> when a Blocker rejects the attempt,
         /// <see cref="NavigationResult.Cancelled"/> when concurrent navigation or the cancellation token aborts it,
-        /// when the router has been disposed,
+        /// when it is asked of a router already disposed,
         /// or when <paramref name="mode"/> is <see cref="NavigationMode.Back"/> / <see cref="NavigationMode.Forward"/>
         /// and the history has no entry to step onto,
         /// or <see cref="NavigationResult.Error"/> on redirect overflow.

--- a/Packages/com.velvet.core/Runtime/Routing/Router.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/Router.cs
@@ -353,6 +353,11 @@ namespace Velvet
             PendingNavigation? initiator,
             RouteCancellationSource? takeover)
         {
+            if (_disposed)
+            {
+                return NavigationResult.Cancelled;
+            }
+
             if (redirectCount >= MaxRedirects)
             {
                 WithdrawInitiatorsDestination(initiator);
@@ -395,12 +400,9 @@ namespace Velvet
                 {
                     // Installed before the predecessor is cancelled, as RouteLoaderRunner.BeginRound installs a
                     // round: a navigation that a cancellation callback starts inside that cancel displaces this
-                    // one, and this one ends there. A disposed router installs nothing.
+                    // one, and this one ends there.
                     var displaced = _activeNavigation;
-                    if (!_disposed)
-                    {
-                        _activeNavigation = takeover;
-                    }
+                    _activeNavigation = takeover;
                     // Contained on RouteLoaderRunner.Retire's terms: a predecessor parked on an Await loader
                     // runs its round under a token linked to the one cancelled here, so that round's Loaders
                     // have their cancellation callbacks run from here.

--- a/Packages/com.velvet.core/Runtime/Routing/Router.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/Router.cs
@@ -20,11 +20,12 @@ namespace Velvet
         private Dictionary<string?, Exception> _loaderErrors = new();
         private const int MaxRedirects = 5;
         private const int MaxHistoryEntries = 50;
-        // Cancellation token for the currently in-flight navigation (null when idle). A newer navigation
+        // Cancellation for the currently in-flight navigation (null when idle). A newer navigation
         // that matches cancels it on its way past the match, so the prior attempt unwinds
         // (NavigationResult.Cancelled) wherever it is parked and concurrent navigations resolve to the most
         // recent one that had somewhere to go.
-        private CancellationTokenSource? _activeNavigationCts;
+        private RouteCancellationSource? _activeNavigation;
+        private bool _disposed;
         // Identifies whoever currently owns Status. An attempt that has lost the claim must not put Status
         // back: cancelling its token does not force it to resume at that moment, so it can reach its rollback
         // after a newer navigation has established its own Status, and by then the value it would write
@@ -143,6 +144,7 @@ namespace Velvet
         /// <see cref="NavigationResult.NotFound"/> when no route matches,
         /// <see cref="NavigationResult.Blocked"/> when a Blocker rejects the attempt,
         /// <see cref="NavigationResult.Cancelled"/> when concurrent navigation or the cancellation token aborts it,
+        /// when the router has been disposed,
         /// or when <paramref name="mode"/> is <see cref="NavigationMode.Back"/> / <see cref="NavigationMode.Forward"/>
         /// and the history has no entry to step onto,
         /// or <see cref="NavigationResult.Error"/> on redirect overflow.
@@ -303,26 +305,26 @@ namespace Velvet
             int redirectCount,
             PendingNavigation? initiator)
         {
-            // Redirect recursion shares the initiating CTS and claim without cancelling or dispossessing the
-            // navigation it belongs to.
-            CancellationTokenSource? myCts = null;
+            // Redirect recursion shares the initiating cancellation and claim without cancelling or
+            // dispossessing the navigation it belongs to.
+            RouteCancellationSource? myCancellation = null;
             CancellationToken navToken = cancellationToken;
             if (redirectCount == 0)
             {
                 // Built here so the phases run under it, but not installed here: taking over from the
                 // in-flight navigation is NavigateCore's, on the far side of the match.
-                myCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-                navToken = myCts.Token;
+                myCancellation = new RouteCancellationSource(cancellationToken);
+                navToken = myCancellation.Token;
             }
 
             try
             {
-                return await NavigateCore(path, mode, navToken, redirectCount, initiator, myCts);
+                return await NavigateCore(path, mode, navToken, redirectCount, initiator, myCancellation);
             }
-            catch (OperationCanceledException) when (myCts != null && myCts.IsCancellationRequested)
+            catch (OperationCanceledException) when (myCancellation != null && navToken.IsCancellationRequested)
             {
-                // Cancellation came either from a newer navigation taking over OR from the caller's
-                // own token (both flow through `myCts` because we linked it to the caller). Map both
+                // Cancellation came from a newer navigation taking over, from the router's disposal, or from
+                // the caller's own token, which `myCancellation` is linked to. Map each of them
                 // to NavigationResult.Cancelled to match the loader-phase behavior in NavigateCore
                 // (the early `if (cancellationToken.IsCancellationRequested) return Cancelled` check)
                 // — callers branch on `nav != Success` and don't catch OCE.
@@ -330,13 +332,15 @@ namespace Velvet
             }
             finally
             {
-                if (myCts != null)
+                if (myCancellation != null)
                 {
-                    // Only clear the active-CTS field if this navigation is the one holding it: an attempt
-                    // that matched nothing never took the field, and one a newer navigation took over from
-                    // has already had the field replaced with that navigation's own CTS.
-                    if (ReferenceEquals(_activeNavigationCts, myCts)) _activeNavigationCts = null;
-                    myCts.Dispose();
+                    // Only clear the active field if this navigation is the one holding it: an attempt that
+                    // matched nothing never took the field, and one a newer navigation took over from has
+                    // already had the field replaced with that navigation's own.
+                    if (ReferenceEquals(_activeNavigation, myCancellation)) _activeNavigation = null;
+                    // Unlinked rather than cancelled: the round this navigation committed runs on under a
+                    // token linked to this one.
+                    myCancellation.Unlink();
                 }
             }
         }
@@ -347,7 +351,7 @@ namespace Velvet
             CancellationToken cancellationToken,
             int redirectCount,
             PendingNavigation? initiator,
-            CancellationTokenSource? takeover)
+            RouteCancellationSource? takeover)
         {
             if (redirectCount >= MaxRedirects)
             {
@@ -389,21 +393,29 @@ namespace Velvet
                 // one able to put Status back and the only one its destination and its token belong to.
                 if (takeover != null)
                 {
-                    // Dispose of the prior CTS is left to the prior navigation's own finally — disposing
-                    // here would double-dispose and confuse ownership, and the synchronous Cancel chain may
-                    // already run the prior finally before we proceed.
+                    // Installed before the predecessor is cancelled, as RouteLoaderRunner.BeginRound installs a
+                    // round: a navigation that a cancellation callback starts inside that cancel displaces this
+                    // one, and this one ends there. A disposed router installs nothing.
+                    var displaced = _activeNavigation;
+                    if (!_disposed)
+                    {
+                        _activeNavigation = takeover;
+                    }
                     // Contained on RouteLoaderRunner.Retire's terms: a predecessor parked on an Await loader
-                    // runs its round under a token linked to this source, so that round's Loaders have their
-                    // cancellation callbacks run from here, above the install that takes the field.
+                    // runs its round under a token linked to the one cancelled here, so that round's Loaders
+                    // have their cancellation callbacks run from here.
                     try
                     {
-                        _activeNavigationCts?.Cancel();
+                        displaced?.Cancel();
                     }
                     catch (Exception cancellationFailure)
                     {
                         FiberLogger.LogException(nameof(Router), cancellationFailure);
                     }
-                    _activeNavigationCts = takeover;
+                    if (!ReferenceEquals(_activeNavigation, takeover))
+                    {
+                        return NavigationResult.Cancelled;
+                    }
                 }
                 pending = new PendingNavigation(++_navigationSequence, CommitIndexFor(mode), path, mode);
             }
@@ -965,6 +977,8 @@ namespace Velvet
 
         public void Dispose()
         {
+            // Before the Cancel: a callback it runs can start a navigation, which NavigateCore then refuses.
+            _disposed = true;
             // Retire the outstanding claim BEFORE the Cancel, which inverts the ordering a navigation uses.
             // A navigation takes its claim afterwards so that a prior attempt unwinding synchronously inside
             // the Cancel still restores its own state; here there is no such attempt worth restoring, and
@@ -974,21 +988,19 @@ namespace Velvet
             // Retiring the claim above is what stops the unwinding attempt from clearing this itself, and a
             // destination left published would outlive the navigation that was heading for it.
             PendingLocation = null;
-            // Cancel and dispose any in-flight navigation CTS so a pending Blocker await unwinds
-            // cleanly during shutdown. Contained on RouteLoaderRunner.Retire's terms: a navigation parked
-            // on an Await loader runs its round under a token linked to this source, so that round's
-            // Loaders have their cancellation callbacks run from here. The releases below it are this
-            // source, the runner's rounds and the static Current.
+            // Cancel any in-flight navigation so a pending Blocker await unwinds cleanly during shutdown.
+            // Contained on RouteLoaderRunner.Retire's terms: a navigation parked on an Await loader runs its
+            // round under a token linked to this source, so that round's Loaders have their cancellation
+            // callbacks run from here.
             try
             {
-                _activeNavigationCts?.Cancel();
+                _activeNavigation?.Cancel();
             }
             catch (Exception cancellationFailure)
             {
                 FiberLogger.LogException(nameof(Router), cancellationFailure);
             }
-            _activeNavigationCts?.Dispose();
-            _activeNavigationCts = null;
+            _activeNavigation = null;
             _loaderRunner.Dispose();
             if (Current == this)
             {

--- a/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouteLoaderRunnerTests.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouteLoaderRunnerTests.cs
@@ -888,9 +888,33 @@ namespace Velvet.Tests
                 "A retired round is kept alive by whatever still holds its token, not by the token it was linked to");
         }
 
+        [Test]
+        public void Given_RoundsWhoseLoadersRegisterACancellationCallbackThatThrows_When_EachHasBeenRetired_Then_TheTokenTheyWereLinkedToKeepsNoneOfThemAlive()
+        {
+            // Arrange
+            var runner = new RouteLoaderRunner();
+            using var navigation = new CancellationTokenSource();
+            const int rounds = 32;
+            for (var i = 0; i < rounds; i++)
+            {
+                ContainedFailureLog.Expect<InvalidOperationException>(nameof(RouteLoaderRunner), "callback-threw");
+            }
+            var waitHandles = RetireRoundsWhoseLoadersNeverFinish(runner, navigation.Token, rounds,
+                registerThrowingCallback: true);
+
+            // Act
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+
+            // Assert
+            Assert.That(waitHandles.Count(handle => handle.IsAlive), Is.LessThan(waitHandles.Count / 2),
+                "A retirement whose cancellation throws still drops the link to the token the round was made from");
+        }
+
         [MethodImpl(MethodImplOptions.NoInlining)]
         private static List<WeakReference> RetireRoundsWhoseLoadersNeverFinish(
-            RouteLoaderRunner runner, CancellationToken linkedTo, int count)
+            RouteLoaderRunner runner, CancellationToken linkedTo, int count, bool registerThrowingCallback = false)
         {
             var waitHandles = new List<WeakReference>();
             for (var i = 0; i < count; i++)
@@ -899,6 +923,10 @@ namespace Velvet.Tests
                     MakeMatch("stuck", loaderMode: LoaderMode.Suspend, loader: (ctx, ct) =>
                     {
                         waitHandles.Add(new WeakReference(ct.WaitHandle));
+                        if (registerThrowingCallback)
+                        {
+                            ct.Register(() => throw new InvalidOperationException("callback-threw"));
+                        }
                         return new VelvetTaskCompletionSource<object>().Task;
                     }),
                     linkedTo);

--- a/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouteLoaderRunnerTests.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouteLoaderRunnerTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using NUnit.Framework;
 using UnityEngine;
@@ -605,13 +606,11 @@ namespace Velvet.Tests
                 "A loader handed a retired round's token reads the round's cancellation off it");
         }
 
-        // GREEN_ON_BASE(characterization): the base releases a superseded round's source at the retirement.
-        // This branch defers that release to here, and the release itself has to survive the move.
         [Test]
-        public void Given_ALoaderThatStartsAnotherRound_When_TheRunThatItRetiredHasReturned_Then_TheSourceBehindItsTokenIsReleased()
+        public void Given_ALoaderThatStartsAnotherRound_When_TheRunThatItRetiredHasReturned_Then_ItsTokenStillReadsCancelled()
         {
-            // The other half of the rule the sibling above states. This round starts no Suspend loader, so
-            // the run returning is the last thing holding the token and the source goes there.
+            // This round starts no Suspend loader, so the run returning is the last holder of the token the
+            // runner can see. The sibling below asks the same of a Suspend loader finishing.
             // Arrange
             var runner = new RouteLoaderRunner();
             CancellationToken nextLoadersToken = default;
@@ -631,18 +630,14 @@ namespace Velvet.Tests
             runner.RunLoadersSync(matches, CancellationToken.None);
 
             // Assert
-            Assert.That(() => nextLoadersToken.WaitHandle, Throws.TypeOf<ObjectDisposedException>(),
-                "A retired round's source is released, not left open behind the token its loaders held");
+            Assert.That(ReadTokenState(nextLoadersToken), Is.EqualTo("cancelled"),
+                "Whatever still holds a retired round's token can read it, whoever the runner last saw holding it");
         }
 
-        // GREEN_ON_BASE(characterization): the base releases a superseded round's source at the retirement.
-        // This branch defers that release to here, and the release itself has to survive the move.
         [UnityTest]
-        public IEnumerator Given_ARetiredRoundsSuspendLoader_When_ItsTaskCompletes_Then_TheSourceBehindItsTokenIsReleased()
+        public IEnumerator Given_ARetiredRoundsSuspendLoader_When_ItsTaskCompletes_Then_ItsTokenStillReadsCancelled()
             => VelvetTask.ToCoroutine(async () =>
         {
-            // The release a Suspend loader's own completion reaches: its round was retired while it was
-            // still running, so the loader is what the release waits for.
             // Arrange
             var runner = new RouteLoaderRunner();
             var streaming = new VelvetTaskCompletionSource<object>();
@@ -661,18 +656,17 @@ namespace Velvet.Tests
             await VelvetTask.Yield();
 
             // Assert
-            Assert.That(() => streamingLoadersToken.WaitHandle, Throws.TypeOf<ObjectDisposedException>(),
-                "A round retired while a Suspend loader ran releases its source once that loader is done");
+            Assert.That(ReadTokenState(streamingLoadersToken), Is.EqualTo("cancelled"),
+                "A Suspend loader finishing is not the end of every read of the token it was handed");
         });
 
-        // GREEN_ON_BASE(characterization): the base releases only once Cancel() has returned.
-        // Nothing there reaches the release from inside the cancellation. This branch moves the release
-        // onto the holders of the token, where a holder that unwinds inside the cancellation does.
+        // GREEN_ON_BASE(characterization): the base holds its release across the Cancel() that Retire
+        // issues, so the loader finishing inside this callback does not release the source under it.
         [Test]
         public void Given_ASuspendLoaderCancelledByItsOwnCallback_When_ThatCallbackThenReadsTheToken_Then_ItIsCancelledRatherThanReleased()
         {
-            // Completing the loader's task from the callback resumes that loader on this thread, so the
-            // release its finally reaches would land before the callback running it is done with the token.
+            // Completing the loader's task from the callback resumes that loader on this thread, so a release
+            // keyed to the loader finishing would land before the callback running it is done with the token.
             // Arrange
             var runner = new RouteLoaderRunner();
             var streaming = new VelvetTaskCompletionSource<object>();
@@ -701,9 +695,8 @@ namespace Velvet.Tests
         [Test]
         public void Given_AnAwaitLoaderCancelledByItsOwnCallback_When_ThatCallbackThenReadsTheToken_Then_ItIsCancelledRatherThanReleased()
         {
-            // Where the sibling above defers the release onto a Suspend loader, this case defers it onto
-            // the run: nothing here is pending, so the run is what the release waits on, and the callback
-            // completing the task is what returns it.
+            // Where the sibling above has a Suspend loader finish inside the callback, this case has the run
+            // return there: nothing here is pending, and the callback completing the task is what returns it.
             // Arrange
             var runner = new RouteLoaderRunner();
             var parked = new VelvetTaskCompletionSource<object>();
@@ -726,30 +719,6 @@ namespace Velvet.Tests
             // Assert
             Assert.That(callbackSaw, Is.EqualTo("cancelled"),
                 "An Await loader unwinding inside the cancellation leaves the token answering for the round");
-        }
-
-        [Test]
-        public void Given_ACancellationCallbackThatThrows_When_TheRoundItRegisteredOnIsRetired_Then_TheSourceBehindItsTokenIsStillReleased()
-        {
-            // Arrange
-            var runner = new RouteLoaderRunner();
-            CancellationToken registeringRoundsToken = default;
-            runner.RunLoadersSync(
-                MakeMatch("registering", loader: (ctx, ct) =>
-                {
-                    registeringRoundsToken = ct;
-                    ct.Register(() => throw new InvalidOperationException("callback-threw"));
-                    return VelvetTask.FromResult<object>("registering-data");
-                }),
-                CancellationToken.None);
-            ContainedFailureLog.Expect<InvalidOperationException>(nameof(RouteLoaderRunner), "callback-threw");
-
-            // Act
-            runner.RunLoadersSync(MakeMatch("second"), CancellationToken.None);
-
-            // Assert
-            Assert.That(() => registeringRoundsToken.WaitHandle, Throws.TypeOf<ObjectDisposedException>(),
-                "A callback that throws must not leave the source behind the token it ran under open");
         }
 
         [Test]
@@ -780,15 +749,11 @@ namespace Velvet.Tests
                 "A round retired mid-installation still reaches its Loaders, under the token its own source issued");
         }
 
-        // GREEN_ON_BASE(characterization): the base nulls the round's source before it cancels.
-        // That is what turns a re-entrant Retire there into a no-op. This branch nulls it at the release
-        // instead, so the retirement flag is what has to do that work.
+        // GREEN_ON_BASE(characterization): the base's retirement flag turns the Retire this callback reaches
+        // for the round already being retired into a no-op.
         [Test]
         public void Given_ACancellationCallbackThatStartsARound_When_ItThenReadsTheRetiringRoundsToken_Then_ItIsCancelledRatherThanReleased()
         {
-            // Installing a round from the callback reaches Retire for the round already being retired. That
-            // second entry has to stop at the door: a release taken there lands inside the cancellation that
-            // is still running this callback.
             // Arrange
             var runner = new RouteLoaderRunner();
             string callbackSaw = null;
@@ -810,6 +775,136 @@ namespace Velvet.Tests
             // Assert
             Assert.That(callbackSaw, Is.EqualTo("cancelled"),
                 "A round already being retired is not retired again from inside its own cancellation");
+        }
+
+        [Test]
+        public void Given_ARoundCancelledThroughTheTokenItIsLinkedTo_When_ACallbackOnItStartsARoundAndThenReadsItsToken_Then_ItIsCancelledRatherThanReleased()
+        {
+            // Arrange
+            var runner = new RouteLoaderRunner();
+            using var navigation = new CancellationTokenSource();
+            string callbackSaw = null;
+            runner.RunLoadersSync(
+                MakeMatch("registering", loader: (ctx, ct) =>
+                {
+                    ct.Register(() =>
+                    {
+                        runner.RunLoadersSync(MakeMatch("from-callback"), CancellationToken.None);
+                        callbackSaw = ReadTokenState(ct);
+                    });
+                    return VelvetTask.FromResult<object>("registering-data");
+                }),
+                navigation.Token);
+
+            // Act
+            navigation.Cancel();
+
+            // Assert
+            Assert.That(callbackSaw, Is.EqualTo("cancelled"),
+                "A cancellation arriving through the link holds the token for as long as it runs the callback");
+        }
+
+        [Test]
+        public void Given_ACancellationCallbackThatStartsARound_When_TheRunnerIsDisposed_Then_ThatRoundsLoaderRunsUnderACancelledToken()
+        {
+            // Arrange
+            var runner = new RouteLoaderRunner();
+            CancellationToken fromCallbacksToken = default;
+            runner.RunLoadersSync(
+                MakeMatch("registering", loader: (ctx, ct) =>
+                {
+                    ct.Register(() => runner.RunLoadersSync(
+                        MakeMatch("from-callback", loader: (innerCtx, innerCt) =>
+                        {
+                            fromCallbacksToken = innerCt;
+                            return VelvetTask.FromResult<object>("from-callback-data");
+                        }),
+                        CancellationToken.None));
+                    return VelvetTask.FromResult<object>("registering-data");
+                }),
+                CancellationToken.None);
+
+            // Act
+            runner.Dispose();
+
+            // Assert
+            Assert.That(fromCallbacksToken.IsCancellationRequested, Is.True,
+                "A round started from inside the disposal is one the disposal ends too");
+        }
+
+        [UnityTest]
+        public IEnumerator Given_ACancellationCallbackThatStartsAndPromotesARound_When_TheRunnerIsDisposed_Then_ThatRoundsSuspendLoaderAnnouncesNothing()
+            => VelvetTask.ToCoroutine(async () =>
+        {
+            // The launch is folded in because a loader that never ran announces nothing either.
+            // Arrange
+            var runner = new RouteLoaderRunner();
+            var streaming = new VelvetTaskCompletionSource<object>();
+            var launched = false;
+            var announced = 0;
+            runner.OnSuspendLoaderCompleted += (_, __) => announced++;
+            runner.RunLoadersSync(
+                MakeMatch("registering", loader: (ctx, ct) =>
+                {
+                    ct.Register(() => runner.Promote(runner.RunLoadersSync(
+                        MakeMatch("from-callback", loaderMode: LoaderMode.Suspend, loader: (innerCtx, innerCt) =>
+                        {
+                            launched = true;
+                            return streaming.Task;
+                        }),
+                        CancellationToken.None)));
+                    return VelvetTask.FromResult<object>("registering-data");
+                }),
+                CancellationToken.None);
+            runner.Dispose();
+
+            // Act
+            streaming.TrySetResult("from-callback-data");
+            await VelvetTask.Yield();
+
+            // Assert
+            Assert.That($"launched={launched} announced={announced}", Is.EqualTo("launched=True announced=0"),
+                "A disposed runner has no live round for a late result to be announced from");
+        });
+
+        [Test]
+        public void Given_RoundsWhoseSuspendLoadersNeverFinish_When_EachHasBeenRetired_Then_TheTokenTheyWereLinkedToKeepsNoneOfThemAlive()
+        {
+            // A round's source is reached here only through its wait handle, which the source alone refers to,
+            // and each loader's task is dropped with its round. Half is the midpoint between a link keeping
+            // every source alive and none being kept.
+            // Arrange
+            var runner = new RouteLoaderRunner();
+            using var navigation = new CancellationTokenSource();
+            var waitHandles = RetireRoundsWhoseLoadersNeverFinish(runner, navigation.Token, 32);
+
+            // Act
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+
+            // Assert
+            Assert.That(waitHandles.Count(handle => handle.IsAlive), Is.LessThan(waitHandles.Count / 2),
+                "A retired round is kept alive by whatever still holds its token, not by the token it was linked to");
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static List<WeakReference> RetireRoundsWhoseLoadersNeverFinish(
+            RouteLoaderRunner runner, CancellationToken linkedTo, int count)
+        {
+            var waitHandles = new List<WeakReference>();
+            for (var i = 0; i < count; i++)
+            {
+                runner.RunLoadersSync(
+                    MakeMatch("stuck", loaderMode: LoaderMode.Suspend, loader: (ctx, ct) =>
+                    {
+                        waitHandles.Add(new WeakReference(ct.WaitHandle));
+                        return new VelvetTaskCompletionSource<object>().Task;
+                    }),
+                    linkedTo);
+            }
+            runner.RunLoadersSync(MakeMatch("last"), linkedTo);
+            return waitHandles;
         }
 
         #endregion

--- a/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouterCancellationUnwindTests.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouterCancellationUnwindTests.cs
@@ -441,5 +441,56 @@ namespace Velvet.Tests
                 Is.EqualTo("result=Cancelled history=/home"),
                 "A navigation started from inside the teardown is one the teardown ends too");
         }
+
+        [Test]
+        public void Given_ABlockersCancellationCallbackThatNavigatesToAnUnmatchedPath_When_TheRouterIsDisposed_Then_ThatNavigationRaisesNoStatus()
+        {
+            // Arrange
+            var router = BuildRouter("/home", _routes);
+            var parked = new VelvetTaskCompletionSource<bool>();
+            NavigationResult? fromCallback = null;
+            using var registration = router.RouteBlockerManager.Register((attempt, ct) =>
+            {
+                ct.Register(() => fromCallback = router.NavigateSync("/nonexistent"));
+                return parked.Task;
+            }, new RouteBlockerState());
+            router.NavigateAsync("/about").Forget();
+            var statusEvents = new List<RouterStatus>();
+            router.OnStatusChanged += status => statusEvents.Add(status);
+
+            // Act
+            router.Dispose();
+
+            // Assert
+            Assert.That($"result={fromCallback} events={string.Join(",", statusEvents)}",
+                Is.EqualTo("result=Cancelled events="),
+                "A navigation started from inside the teardown raises no status on the router being torn down");
+        }
+
+        [Test]
+        public void Given_AGuardThatDisposesTheRouter_When_ItRedirects_Then_TheRedirectPublishesNoDestination()
+        {
+            // Arrange
+            Router router = null;
+            router = BuildRouter("/home",
+                Route("/", children: new[]
+                {
+                    Route("home"),
+                    Route("guarded", guard: _ =>
+                    {
+                        router.Dispose();
+                        return "/target";
+                    }),
+                    Route("target"),
+                }));
+
+            // Act
+            var result = router.NavigateSync("/guarded");
+
+            // Assert
+            Assert.That($"result={result} pending={router.PendingLocation?.Path ?? "none"}",
+                Is.EqualTo("result=Cancelled pending=none"),
+                "A redirect taken on a disposed router publishes no destination");
+        }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouterCancellationUnwindTests.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouterCancellationUnwindTests.cs
@@ -360,5 +360,86 @@ namespace Velvet.Tests
             Assert.That(statusEvents, Is.EqualTo(0),
                 "Teardown leaves nothing for a resuming blocker to restore, so it must raise no transition");
         });
+
+        [Test]
+        public void Given_ABlockerParkedAcrossDisposal_When_ItReadsItsTokenAfterward_Then_ItIsCancelledRatherThanReleased()
+        {
+            // Arrange
+            var router = BuildRouter("/home", _routes);
+            var parked = new VelvetTaskCompletionSource<bool>();
+            CancellationToken blockersToken = default;
+            using var registration = router.RouteBlockerManager.Register((_, ct) =>
+            {
+                blockersToken = ct;
+                return parked.Task;
+            }, new RouteBlockerState());
+            router.NavigateAsync("/about").Forget();
+
+            // Act
+            router.Dispose();
+
+            // Assert
+            Assert.That(ReadTokenState(blockersToken), Is.EqualTo("cancelled"),
+                "A Blocker the teardown cancelled is still able to ask its token what happened");
+        }
+
+        [Test]
+        public void Given_ABlockerWhoseCancellationCallbackEndsItsWait_When_ThatCallbackThenReadsTheToken_Then_ItIsCancelledRatherThanReleased()
+        {
+            // Ending the wait resumes the superseded navigation through to its own unwind before the
+            // callback's next line runs.
+            // Arrange
+            var router = BuildRouter("/home", _routes);
+            var parked = new VelvetTaskCompletionSource<bool>();
+            string callbackSaw = null;
+            using var registration = router.RouteBlockerManager.Register((attempt, ct) =>
+            {
+                if (attempt.NextPath != "/about")
+                {
+                    return VelvetTask.FromResult(false);
+                }
+                ct.Register(() =>
+                {
+                    parked.TrySetResult(false);
+                    callbackSaw = ReadTokenState(ct);
+                });
+                return parked.Task;
+            }, new RouteBlockerState());
+            router.NavigateAsync("/about").Forget();
+
+            // Act
+            router.NavigateSync("/home");
+
+            // Assert
+            Assert.That(callbackSaw, Is.EqualTo("cancelled"),
+                "A Blocker's callback holds the token for as long as the cancellation running it does");
+        }
+
+        [Test]
+        public void Given_ABlockersCancellationCallbackThatNavigates_When_TheRouterIsDisposed_Then_ThatNavigationCommitsNothing()
+        {
+            // Arrange
+            var router = BuildRouter("/home", _routes);
+            var parked = new VelvetTaskCompletionSource<bool>();
+            NavigationResult? fromCallback = null;
+            using var registration = router.RouteBlockerManager.Register((attempt, ct) =>
+            {
+                if (attempt.NextPath != "/about")
+                {
+                    return VelvetTask.FromResult(false);
+                }
+                ct.Register(() => fromCallback = router.NavigateSync("/home"));
+                return parked.Task;
+            }, new RouteBlockerState());
+            router.NavigateAsync("/about").Forget();
+
+            // Act
+            router.Dispose();
+
+            // Assert
+            Assert.That($"result={fromCallback} history={RouterHistoryProbe.PathsOf(router)}",
+                Is.EqualTo("result=Cancelled history=/home"),
+                "A navigation started from inside the teardown is one the teardown ends too");
+        }
     }
 }

--- a/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouterTests.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouterTests.cs
@@ -1233,6 +1233,88 @@ namespace Velvet.Tests
                 "A cancelled cached Back does not commit the previous entry");
         });
 
+        [UnityTest]
+        public IEnumerator Given_ACancellationCallbackThatNavigatesDuringATakeover_When_BothNavigationsFinish_Then_OnlyTheOneStartedLastCommits()
+            => VelvetTask.ToCoroutine(async () =>
+        {
+            // The status is read while the later navigation is still loading, the window the one taking over
+            // would otherwise report into.
+            // Arrange
+            var lastLoader = new VelvetTaskCompletionSource<object>();
+            var router = BuildRouter("/home",
+                Route("home"),
+                Route("away"),
+                Route("takeover"),
+                Route("last", loader: (ctx, ct) => lastLoader.Task));
+            var parked = new VelvetTaskCompletionSource<bool>();
+            using var registration = router.RouteBlockerManager.Register((attempt, ct) =>
+            {
+                if (attempt.NextPath != "/away")
+                {
+                    return VelvetTask.FromResult(false);
+                }
+                ct.Register(() => router.NavigateAsync("/last").Forget());
+                return parked.Task;
+            }, new RouteBlockerState());
+            router.NavigateAsync("/away").Forget();
+
+            // Act
+            var takeover = await router.NavigateAsync("/takeover");
+            var whileLastLoads = $"{router.Status} {router.PendingLocation?.Path ?? "none"}";
+            lastLoader.TrySetResult("last-data");
+            await VelvetTask.Yield();
+
+            // Assert
+            Assert.That($"takeover={takeover} while={whileLastLoads} history={RouterHistoryProbe.PathsOf(router)}",
+                Is.EqualTo("takeover=Cancelled while=Loading /last history=/home,/last"),
+                "A navigation started from inside a takeover supersedes the navigation taking over");
+        });
+
+        // GREEN_ON_BASE(characterization): the base suppresses no execution-context flow, so a caller's own
+        // suppression has nothing to collide with there.
+        [Test]
+        public void Given_ACallerThatHasSuppressedExecutionContextFlow_When_ItNavigates_Then_TheNavigationCommits()
+        {
+            // Arrange
+            var router = BuildRouter("/home", _routes);
+            NavigationResult result;
+
+            // Act
+            using (ExecutionContext.SuppressFlow())
+            {
+                result = router.NavigateSync("/about");
+            }
+
+            // Assert
+            Assert.That(result, Is.EqualTo(NavigationResult.Success));
+        }
+
+        // GREEN_ON_BASE(characterization): the base unlinks a finished navigation by disposing its source.
+        [UnityTest]
+        public IEnumerator Given_ACommittedRoutesSuspendLoader_When_TheTokenItsNavigationWasGivenIsCancelled_Then_TheLoadersTokenIsNot()
+            => VelvetTask.ToCoroutine(async () =>
+        {
+            // CanBeCanceled is folded in because a loader that never ran leaves a token reading not-cancelled too.
+            // Arrange
+            using var caller = new CancellationTokenSource();
+            CancellationToken loadersToken = default;
+            var router = BuildRouter("/home",
+                Route("home"),
+                Route("feed", loaderMode: LoaderMode.Suspend, loader: (ctx, ct) =>
+                {
+                    loadersToken = ct;
+                    return new VelvetTaskCompletionSource<object>().Task;
+                }));
+            await router.NavigateAsync("/feed", cancellationToken: caller.Token);
+
+            // Act
+            caller.Cancel();
+
+            // Assert
+            Assert.That($"{loadersToken.CanBeCanceled} {ReadTokenState(loadersToken)}", Is.EqualTo("True not-cancelled"),
+                "A navigation's caller token stops reaching it once the navigation has ended");
+        });
+
         #endregion
     }
 }

--- a/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouterTests.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouterTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Reflection;
 using System.Threading;
 using NUnit.Framework;
@@ -138,6 +139,40 @@ namespace Velvet.Tests
             // Assert
             Assert.That(
                 $"result={result} status={router.Status}", Is.EqualTo("result=NotFound status=NotFound"));
+        }
+
+        [Test]
+        public void Given_ADisposedRouter_When_NavigatingToAnUnmatchedPath_Then_ItIsCancelledWithoutAStatusChange()
+        {
+            // Arrange
+            var router = BuildRouter("/home", _routes);
+            router.Dispose();
+            var statusEvents = new List<RouterStatus>();
+            router.OnStatusChanged += status => statusEvents.Add(status);
+
+            // Act
+            var result = router.NavigateSync("/nonexistent");
+
+            // Assert
+            Assert.That($"result={result} events={string.Join(",", statusEvents)}", Is.EqualTo("result=Cancelled events="),
+                "A disposed router refuses the navigation rather than reporting that no route matched");
+        }
+
+        [Test]
+        public void Given_ADisposedRouter_When_NavigatingToAPathThatResolvesToNothing_Then_ItIsCancelledWithoutAStatusChange()
+        {
+            // Arrange
+            var router = BuildRouter("/home", _routes);
+            router.Dispose();
+            var statusEvents = new List<RouterStatus>();
+            router.OnStatusChanged += status => statusEvents.Add(status);
+
+            // Act
+            var result = router.NavigateSync(null);
+
+            // Assert
+            Assert.That($"result={result} events={string.Join(",", statusEvents)}", Is.EqualTo("result=Cancelled events="),
+                "A disposed router refuses the navigation rather than reporting that the path resolved to nothing");
         }
 
         #endregion

--- a/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouterUnfinishedNavigationTests.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouterUnfinishedNavigationTests.cs
@@ -152,6 +152,37 @@ namespace Velvet.Tests
                 "A navigation that died on an exception reports the failure and stops reporting itself as in flight");
         });
 
+        // GREEN_ON_BASE(characterization): the base maps an OperationCanceledException to Cancelled only when
+        // the navigation's own token is the cancelled one.
+        [UnityTest]
+        public IEnumerator Given_AGuardThatThrowsACancellationOfItsOwn_When_TheNavigationIsNotCancelled_Then_TheExceptionReachesTheCaller()
+            => VelvetTask.ToCoroutine(async () =>
+        {
+            // Arrange
+            var router = BuildRouter("/home",
+                Route("/", children: new[]
+                {
+                    Route("home"),
+                    Route("guarded", guard: _ => throw new OperationCanceledException("guard-cancelled")),
+                }));
+            NavigationResult? result = null;
+            Exception caught = null;
+
+            // Act
+            try
+            {
+                result = await router.NavigateAsync("/guarded");
+            }
+            catch (OperationCanceledException ex)
+            {
+                caught = ex;
+            }
+
+            // Assert
+            Assert.That($"threw={caught != null} result={result?.ToString() ?? "none"}", Is.EqualTo("threw=True result=none"),
+                "A Guard's own cancellation is its failure, not a cancellation of the navigation");
+        });
+
         [UnityTest]
         public IEnumerator Given_ARedirectTargetDeclaringBothRedirectToAndGuard_When_ItThrows_Then_TheOriginatingPathIsNotRecorded()
             => VelvetTask.ToCoroutine(async () =>

--- a/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouterUnfinishedNavigationTests.cs
+++ b/Packages/com.velvet.core/Runtime/Routing/Tests/Editor/RouterUnfinishedNavigationTests.cs
@@ -312,9 +312,9 @@ namespace Velvet.Tests
         [Test]
         public void Given_AParkedLoadersCancellationCallbackThatThrows_When_TheRouterIsDisposed_Then_TheTeardownStillCompletes()
         {
-            // Disposal cancels the parked navigation's source above its own releases, and the parked round
-            // runs under a token linked to it, so that round's Loaders have their cancellation callbacks run
-            // from there rather than from the runner's retire below it.
+            // Disposal cancels the parked navigation's source, and the parked round runs under a token linked
+            // to it, so that round's Loaders have their cancellation callbacks run from there rather than from
+            // the runner's retire below it.
             // Arrange
             var parking = new VelvetTaskCompletionSource<object>();
             var router = BuildRouter("/home",


### PR DESCRIPTION
The router disposed the source behind a token it had handed to a Loader or a Blocker while that code could still read it, and a read of the token's wait handle then threw `ObjectDisposedException`, which code written to catch `OperationCanceledException` does not catch. The deferred release a loader round carried covered only the holders the runner counts. A cancellation reaching a round through its link runs callbacks the `Cancelling` flag does not span, so a round started from one of them released the source under the rest; a loader that never finishes held the release off for good, while the link kept the source reachable from the token it was linked to; and a navigation's own source has Blockers reading it, which the router cannot count at all, so `Router.Dispose` and the navigation's own unwinding disposed it under them.

No count of holders can be made complete, so the router no longer disposes these sources. `RouteCancellationSource` owns one: it links to its parent through a registration instead of being a linked source, so it can be cancelled and unlinked without being disposed. A navigation holds one, and so does each round `RunLoadersAsync` begins; `LoaderRound` loses `Cts`, `Retired`, `Cancelling` and `RunReturned`, and `ReleaseIfUnheld` is removed. A retired round is cancelled, while a navigation that ends on its own is only unlinked, so a Blocker that keeps the token of a navigation that committed reads it as not cancelled. The link is registered with execution-context flow suppressed, which `RouterNavigationAllocationEditorTests` pins.

`RouteLoaderRunner.Dispose` read the rounds it ends once, so a round a cancellation callback began during the disposal was never retired and, promoted, went on announcing. A round begun on a disposed runner is now retired before its loaders launch and never becomes current, and `Promote` on a disposed runner makes nothing live. `Router.Dispose` had the same shape one level up: a navigation a callback started inside its cancel installed itself in the field that `Dispose` then disposed without cancelling, and committed during the disposal. A navigation started on a disposed router — from inside `Router.Dispose` too, and a redirect a Guard issues after disposing it — now returns `NavigationResult.Cancelled` before it matches, so it commits nothing, raises no status and publishes no destination there.

The takeover cancelled the in-flight navigation before installing its own source, the opposite order to `BeginRound`, so a navigation a cancellation callback started inside that cancel was overwritten in the field and never cancelled, and both committed. The takeover now installs first, and a navigation displaced during its own takeover ends there, leaving the status to the one that displaced it.

Fifteen cases are red on the merge base and green here. On the runner: a round a cancellation callback starts during `RouteLoaderRunner.Dispose` runs its loader under a token that is not cancelled (`Expected: True But was: False`), and one started and promoted there announces its late result (`launched=True announced=1`); a retired round's token reads `released` to a loader that started another round, to a retired round's Suspend loader finishing, and to a callback on a round cancelled through its link; and 32 of 32 retired rounds whose loaders never finish are kept alive by the token they were linked to, with or without a cancellation callback that throws (fewer than 16 allowed). On the router: a Blocker parked across disposal, and one whose callback ends its own wait, read `released`; a navigation a Blocker's cancellation callback starts during `Router.Dispose` commits (`result=Success history=/home,/home`), and one to an unmatched path raises a status there (`result=NotFound events=NotFound`), as a disposed router asked for an unmatched or a null path does; a Guard that disposes the router and redirects leaves its destination published (`pending=/target`); and the takeover lets both navigations commit (`takeover=Success while=Ready none history=/home,/takeover,/last`). Three characterization cases, green on the base as declared, pin that a caller's token stops reaching a navigation once it has ended, that a caller who suppressed execution-context flow can still navigate, and that a Guard's own `OperationCanceledException` reaches the caller rather than reading as the navigation's cancellation. The case that pinned a released source after a throwing callback is removed, since nothing is released now; the throwing-callback case above fails when `RouteCancellationSource.Cancel` unlinks after cancelling.

`Documentation~/routing.md` states the token rule for Blockers as well as Loaders, and the unreleased CHANGELOG entry that described the deferred release is rewritten to the rule that replaces it. `Hooks.UseBlocker`'s async overloads no longer say their token is cancelled on unmount: it is the navigation's, and unmounting does not cancel it.

Closes #981, closes #991, closes #992, closes #995.
