### PR TITLE
fix(velvet): read the process list through a decode a stray byte cannot end, and reap an editor an exception leaves running

### DIFF
--- a/.harness/hooks/report/wedged_processes.py
+++ b/.harness/hooks/report/wedged_processes.py
@@ -37,7 +37,7 @@ def main():
     try:
         table = subprocess.run(
             ["ps", "ax", "-o", "stat=,rss=,comm="],
-            capture_output=True, text=True, timeout=10,
+            capture_output=True, encoding="utf-8", errors="replace", timeout=10,
         ).stdout
     except (OSError, subprocess.SubprocessError):
         return 0

--- a/scripts/hooks/test_wedged_processes.py
+++ b/scripts/hooks/test_wedged_processes.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Unit tests for report/wedged_processes.py's reading of the process table.
+
+Run: python3 scripts/hooks/test_wedged_processes.py
+"""
+
+import contextlib
+import importlib.util
+import io
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+HOOK = Path(__file__).resolve().parents[2] / ".harness" / "hooks" / "report" / "wedged_processes.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("wedged_processes", HOOK)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+wedged_processes = load_module()
+
+
+@contextlib.contextmanager
+def listed_processes(listing):
+    """A `ps` first on PATH that prints `listing` whatever it is asked."""
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        (root / "listing").write_bytes(listing)
+        ps = root / "ps"
+        ps.write_text('#!/bin/sh\nexec cat "{0}/listing"\n'.format(root))
+        ps.chmod(0o755)
+        with mock.patch.dict(os.environ, {"PATH": directory + os.pathsep + os.environ["PATH"],
+                                          "VELVET_WEDGE_REPORT_MB": "1"}):
+            yield
+
+
+class ProcessTableDecodingTests(unittest.TestCase):
+    def test_Given_ANeighbourWhoseNameIsNotUtf8_When_TheTableIsRead_Then_TheWedgedProcessIsReported(self):
+        # Arrange
+        listing = b"UE 1024000 /usr/libexec/stuck\nS 10 /usr/bin/probe\xff\n"
+        printed = io.StringIO()
+
+        # Act
+        with listed_processes(listing), mock.patch.object(wedged_processes.platform, "system",
+                                                          return_value="Darwin"):
+            with contextlib.redirect_stdout(printed):
+                try:
+                    code = wedged_processes.main()
+                except UnicodeDecodeError as error:
+                    code = repr(error)
+
+        # Assert
+        self.assertEqual((code, "stuck" in printed.getvalue()), (0, True))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_quality/base_red_check.py
+++ b/scripts/test_quality/base_red_check.py
@@ -910,7 +910,8 @@ def remove(base_tree, relative):
 # --------------------------------------------------------------------------------------------------
 
 def unity_busy():
-    result = subprocess.run(["ps", "-Ao", "command="], capture_output=True, text=True)
+    result = subprocess.run(["ps", "-Ao", "command="], capture_output=True, encoding="utf-8",
+                            errors="replace")
     return sum(1 for line in result.stdout.splitlines() if re.match(UNITY_RUNNING, line))
 
 
@@ -1007,13 +1008,18 @@ def run_unity(unity, tree, platform, fixtures, results, log, timeout):
     started = time.time()
     peak = 0
     process = subprocess.Popen(command)
-    while process.poll() is None:
-        if time.time() - started > timeout:
+    try:
+        while process.poll() is None:
+            if time.time() - started > timeout:
+                process.kill()
+                process.wait()
+                break
+            peak = max(peak, max(0, unity_busy() - 1))
+            time.sleep(3)
+    finally:
+        if process.poll() is None:
             process.kill()
             process.wait()
-            break
-        peak = max(peak, max(0, unity_busy() - 1))
-        time.sleep(3)
     return time.time() - started, peak
 
 

--- a/scripts/test_quality/base_red_check.py
+++ b/scripts/test_quality/base_red_check.py
@@ -108,10 +108,8 @@ import ast
 import importlib.util
 import io
 import json
-import os
 import re
 import shutil
-import signal
 import subprocess
 import sys
 import tempfile
@@ -125,36 +123,6 @@ DEFAULT_UNITY = "/Applications/Unity/Hub/Editor/6000.3.23f1/Unity.app/Contents/M
 # Anchored at the editor binary so that a shell waiting on this pattern does not match itself and
 # report a busy machine forever on an idle one.
 UNITY_RUNNING = "^/Applications/.*/MacOS/Unity -runTests"
-
-
-class Terminated(BaseException):
-    """SIGTERM or SIGHUP, raised where the run stands so every `finally` on the way out runs."""
-
-    def __init__(self, number):
-        super().__init__(number)
-        self.number = number
-
-
-def unwinding_on_signals(body):
-    """Runs `body` with SIGTERM and SIGHUP raised as `Terminated`, then dies of the one that ended it.
-
-    The `finally` blocks on the way out are what remove the base tree and reap the editor a run launched, and neither signal runs one by default,
-    which `EditorOutlivingItsRunTests` pins. A second signal is ignored while they run, so it cannot cut
-    one short.
-    """
-    def raise_terminated(number, _frame):
-        for each in (signal.SIGTERM, signal.SIGHUP):
-            signal.signal(each, signal.SIG_IGN)
-        raise Terminated(number)
-
-    for number in (signal.SIGTERM, signal.SIGHUP):
-        signal.signal(number, raise_terminated)
-    try:
-        return body()
-    except Terminated as ended:
-        signal.signal(ended.number, signal.SIG_DFL)
-        os.kill(os.getpid(), ended.number)
-        raise
 
 PASSED_ON_BASE = "passed on the base"
 RED_ON_BASE = "red on the base"
@@ -2636,4 +2604,4 @@ def main():
 
 
 if __name__ == "__main__":
-    sys.exit(unwinding_on_signals(main))
+    sys.exit(main())

--- a/scripts/test_quality/base_red_check.py
+++ b/scripts/test_quality/base_red_check.py
@@ -108,8 +108,10 @@ import ast
 import importlib.util
 import io
 import json
+import os
 import re
 import shutil
+import signal
 import subprocess
 import sys
 import tempfile
@@ -123,6 +125,36 @@ DEFAULT_UNITY = "/Applications/Unity/Hub/Editor/6000.3.23f1/Unity.app/Contents/M
 # Anchored at the editor binary so that a shell waiting on this pattern does not match itself and
 # report a busy machine forever on an idle one.
 UNITY_RUNNING = "^/Applications/.*/MacOS/Unity -runTests"
+
+
+class Terminated(BaseException):
+    """SIGTERM or SIGHUP, raised where the run stands so every `finally` on the way out runs."""
+
+    def __init__(self, number):
+        super().__init__(number)
+        self.number = number
+
+
+def unwinding_on_signals(body):
+    """Runs `body` with SIGTERM and SIGHUP raised as `Terminated`, then dies of the one that ended it.
+
+    The `finally` blocks on the way out are what remove the base tree and reap the editor a run launched, and neither signal runs one by default,
+    which `EditorOutlivingItsRunTests` pins. A second signal is ignored while they run, so it cannot cut
+    one short.
+    """
+    def raise_terminated(number, _frame):
+        for each in (signal.SIGTERM, signal.SIGHUP):
+            signal.signal(each, signal.SIG_IGN)
+        raise Terminated(number)
+
+    for number in (signal.SIGTERM, signal.SIGHUP):
+        signal.signal(number, raise_terminated)
+    try:
+        return body()
+    except Terminated as ended:
+        signal.signal(ended.number, signal.SIG_DFL)
+        os.kill(os.getpid(), ended.number)
+        raise
 
 PASSED_ON_BASE = "passed on the base"
 RED_ON_BASE = "red on the base"
@@ -2604,4 +2636,4 @@ def main():
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    sys.exit(unwinding_on_signals(main))

--- a/scripts/test_quality/mutation_check.py
+++ b/scripts/test_quality/mutation_check.py
@@ -1091,7 +1091,8 @@ class Holder:
 
 
 def unity_busy():
-    result = subprocess.run(["ps", "-Ao", "command="], capture_output=True, text=True)
+    result = subprocess.run(["ps", "-Ao", "command="], capture_output=True, encoding="utf-8",
+                            errors="replace")
     return sum(1 for line in result.stdout.splitlines() if re.match(UNITY_RUNNING, line))
 
 
@@ -1111,7 +1112,8 @@ def campaigns_running():
     survive locally, ninety minutes apart. So each receipt records what it saw, and the question gets
     an answer built from runs rather than from a guess about them.
     """
-    result = subprocess.run(["ps", "-Ao", "command="], capture_output=True, text=True)
+    result = subprocess.run(["ps", "-Ao", "command="], capture_output=True, encoding="utf-8",
+                            errors="replace")
     return sum(1 for line in result.stdout.splitlines() if CAMPAIGN_RUNNING.match(line))
 
 
@@ -1167,6 +1169,9 @@ def run_suite(unity, project, platform, scope, results, log, timeout, holder=Non
                     return time.time() - start, True, peak
                 peak = max(peak, max(0, unity_busy() - 1))
     finally:
+        if child.poll() is None:
+            child.kill()
+            child.wait()
         if holder is not None:
             holder.child = None
 

--- a/scripts/test_quality/neuter_check.py
+++ b/scripts/test_quality/neuter_check.py
@@ -25,9 +25,7 @@ files, and a cut cannot answer one about a single boundary condition.
 
 import argparse
 import json
-import os
 import re
-import signal
 import subprocess
 import sys
 import time
@@ -40,36 +38,6 @@ UNITY_RUNNING = "^/Applications/.*/MacOS/Unity -runTests"
 CUTS_FILE = "scripts/test_quality/neuter_cuts.json"
 UNCOVERED_FILE = "scripts/test_quality/neuter_uncovered.txt"
 HOLES_FILE = "scripts/test_quality/neuter_holes.txt"
-
-
-class Terminated(BaseException):
-    """SIGTERM or SIGHUP, raised where the run stands so every `finally` on the way out runs."""
-
-    def __init__(self, number):
-        super().__init__(number)
-        self.number = number
-
-
-def unwinding_on_signals(body):
-    """Runs `body` with SIGTERM and SIGHUP raised as `Terminated`, then dies of the one that ended it.
-
-    The `finally` blocks on the way out are what put a cut back and reap the editor a run launched, and neither signal runs one by default,
-    which `EditorOutlivingItsRunTests` pins. A second signal is ignored while they run, so it cannot cut
-    one short.
-    """
-    def raise_terminated(number, _frame):
-        for each in (signal.SIGTERM, signal.SIGHUP):
-            signal.signal(each, signal.SIG_IGN)
-        raise Terminated(number)
-
-    for number in (signal.SIGTERM, signal.SIGHUP):
-        signal.signal(number, raise_terminated)
-    try:
-        return body()
-    except Terminated as ended:
-        signal.signal(ended.number, signal.SIG_DFL)
-        os.kill(os.getpid(), ended.number)
-        raise
 PACKAGE_ROOT = "Packages/com.velvet.core"
 
 # Two name shapes, not every class-driven mechanism. A manipulator, a build step and FiberNodePatcher
@@ -746,4 +714,4 @@ def main():
 
 
 if __name__ == "__main__":
-    sys.exit(unwinding_on_signals(main))
+    sys.exit(main())

--- a/scripts/test_quality/neuter_check.py
+++ b/scripts/test_quality/neuter_check.py
@@ -66,7 +66,8 @@ HOLE_RESULTS = ("Passed", "Inconclusive", "Skipped")
 
 
 def unity_processes():
-    result = subprocess.run(["ps", "-Ao", "command="], capture_output=True, text=True)
+    result = subprocess.run(["ps", "-Ao", "command="], capture_output=True, encoding="utf-8",
+                            errors="replace")
     return sum(1 for line in result.stdout.splitlines() if re.match(UNITY_RUNNING, line))
 
 
@@ -431,13 +432,18 @@ def run_suite(unity, project, platform, fixture, results, log, timeout):
     start = time.time()
     peak = 0
     process = subprocess.Popen(command)
-    while process.poll() is None:
-        if time.time() - start > timeout:
+    try:
+        while process.poll() is None:
+            if time.time() - start > timeout:
+                process.kill()
+                process.wait()
+                return time.time() - start, True, peak
+            peak = max(peak, max(0, unity_processes() - 1))
+            time.sleep(3)
+    finally:
+        if process.poll() is None:
             process.kill()
             process.wait()
-            return time.time() - start, True, peak
-        peak = max(peak, max(0, unity_processes() - 1))
-        time.sleep(3)
     return time.time() - start, False, peak
 
 

--- a/scripts/test_quality/neuter_check.py
+++ b/scripts/test_quality/neuter_check.py
@@ -25,7 +25,9 @@ files, and a cut cannot answer one about a single boundary condition.
 
 import argparse
 import json
+import os
 import re
+import signal
 import subprocess
 import sys
 import time
@@ -38,6 +40,36 @@ UNITY_RUNNING = "^/Applications/.*/MacOS/Unity -runTests"
 CUTS_FILE = "scripts/test_quality/neuter_cuts.json"
 UNCOVERED_FILE = "scripts/test_quality/neuter_uncovered.txt"
 HOLES_FILE = "scripts/test_quality/neuter_holes.txt"
+
+
+class Terminated(BaseException):
+    """SIGTERM or SIGHUP, raised where the run stands so every `finally` on the way out runs."""
+
+    def __init__(self, number):
+        super().__init__(number)
+        self.number = number
+
+
+def unwinding_on_signals(body):
+    """Runs `body` with SIGTERM and SIGHUP raised as `Terminated`, then dies of the one that ended it.
+
+    The `finally` blocks on the way out are what put a cut back and reap the editor a run launched, and neither signal runs one by default,
+    which `EditorOutlivingItsRunTests` pins. A second signal is ignored while they run, so it cannot cut
+    one short.
+    """
+    def raise_terminated(number, _frame):
+        for each in (signal.SIGTERM, signal.SIGHUP):
+            signal.signal(each, signal.SIG_IGN)
+        raise Terminated(number)
+
+    for number in (signal.SIGTERM, signal.SIGHUP):
+        signal.signal(number, raise_terminated)
+    try:
+        return body()
+    except Terminated as ended:
+        signal.signal(ended.number, signal.SIG_DFL)
+        os.kill(os.getpid(), ended.number)
+        raise
 PACKAGE_ROOT = "Packages/com.velvet.core"
 
 # Two name shapes, not every class-driven mechanism. A manipulator, a build step and FiberNodePatcher
@@ -714,4 +746,4 @@ def main():
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    sys.exit(unwinding_on_signals(main))

--- a/scripts/test_quality/test_base_red_check.py
+++ b/scripts/test_quality/test_base_red_check.py
@@ -13,6 +13,7 @@ import contextlib
 import importlib.util
 import io
 import json
+import os
 import re
 import pathlib
 import shutil
@@ -23,6 +24,7 @@ import threading
 import traceback
 import unittest
 from pathlib import Path
+from unittest import mock
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
@@ -5057,6 +5059,95 @@ class UnvouchedExcuseTests(unittest.TestCase):
         # Assert
         self.assertIn("nothing vouched for EditMode: all 2 of its case(s) were excused rather than "
                       "measured, and\nnone of CanaryTests passed there", printed)
+
+
+@contextlib.contextmanager
+def listed_processes(listing):
+    """A `ps` first on PATH that prints `listing` whatever it is asked, and marks that it ran."""
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        (root / "listing").write_bytes(listing)
+        ps = root / "ps"
+        ps.write_text('#!/bin/sh\n: > "{0}/ran"\nexec cat "{0}/listing"\n'.format(root))
+        ps.chmod(0o755)
+        saved = os.environ["PATH"]
+        os.environ["PATH"] = directory + os.pathsep + saved
+        try:
+            yield root / "ran"
+        finally:
+            os.environ["PATH"] = saved
+
+
+NOT_UTF8_NEIGHBOUR = b"/usr/bin/probe --label \xff"
+EDITOR = b"/Applications/Unity/Hub/Editor/6000.3.23f1/Unity.app/Contents/MacOS/Unity -runTests -batchmode"
+
+
+class ProcessListDecodingTests(unittest.TestCase):
+    """One neighbour's stray byte in the process list must not end the run that reads it."""
+
+    def test_Given_ANeighbourWhoseCommandLineIsNotUtf8_When_EditorsAreCounted_Then_TheEditorBesideItCounts(self):
+        # Arrange
+        listing = NOT_UTF8_NEIGHBOUR + b"\n" + EDITOR + b"\n"
+
+        # Act
+        with listed_processes(listing) as ran:
+            try:
+                counted = (base_red_check.unity_busy(), ran.exists())
+            except UnicodeDecodeError as error:
+                counted = (repr(error), ran.exists())
+
+        # Assert — the mark separates this listing's count from the machine's own.
+        self.assertEqual(counted, (1, True))
+
+
+
+@contextlib.contextmanager
+def lingering_editor():
+    """An editor that runs until something kills it, and every process the run under test starts."""
+    with tempfile.TemporaryDirectory() as directory:
+        editor = Path(directory) / "Unity"
+        editor.write_text("#!/bin/sh\nexec sleep 60\n")
+        editor.chmod(0o755)
+        started = []
+        real = subprocess.Popen
+
+        def recording(*args, **kwargs):
+            process = real(*args, **kwargs)
+            started.append(process)
+            return process
+
+        with mock.patch.object(subprocess, "Popen", recording):
+            try:
+                yield str(editor), started
+            finally:
+                for process in started:
+                    if process.poll() is None:
+                        process.kill()
+                        process.wait()
+
+
+def failing_count():
+    raise OSError(35, "Resource temporarily unavailable")
+
+
+class EditorReapedWhateverEndsTheRunTests(unittest.TestCase):
+    """An editor left running over a tree the harness has put back measures a change that is gone."""
+
+    def test_Given_ANeighbourCountThatFailsWhileTheEditorRuns_When_TheRunEnds_Then_TheEditorIsNotLeftRunning(self):
+        # Arrange
+        with lingering_editor() as (editor, started), mock.patch.object(base_red_check, "unity_busy",
+                                                                        failing_count):
+            # Act
+            try:
+                base_red_check.run_unity(editor, Path("."), "EditMode", ["X"], Path("/dev/null"),
+                                         Path("/dev/null"), 30)
+                raised = False
+            except OSError:
+                raised = True
+            left_running = [process.poll() is None for process in started]
+
+        # Assert
+        self.assertEqual((raised, left_running), (True, [False]))
 
 
 if __name__ == "__main__":

--- a/scripts/test_quality/test_base_red_check.py
+++ b/scripts/test_quality/test_base_red_check.py
@@ -17,10 +17,12 @@ import os
 import re
 import pathlib
 import shutil
+import signal
 import subprocess
 import sys
 import tempfile
 import threading
+import time
 import traceback
 import unittest
 from pathlib import Path
@@ -5130,8 +5132,67 @@ def failing_count():
     raise OSError(35, "Resource temporarily unavailable")
 
 
-class EditorReapedWhateverEndsTheRunTests(unittest.TestCase):
-    """An editor left running over a tree the harness has put back measures a change that is gone."""
+
+DRIVER = """
+import importlib.util
+import sys
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location("subject", sys.argv[1])
+subject = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(subject)
+
+
+def body():
+    try:
+        RUN
+    finally:
+        Path(sys.argv[3]).write_text("unwound")
+
+
+sys.exit(subject.unwinding_on_signals(body))
+"""
+
+
+def alive(pid):
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    return True
+
+
+def signalled_run(module_path, run, number):
+    """(how the harness ended, whether its `finally` ran, whether the editor it launched is alive)."""
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        editor = root / "Unity"
+        editor.write_text('#!/bin/sh\necho $$ > "{}"\nexec sleep 60\n'.format(root / "pid"))
+        editor.chmod(0o755)
+        driver = subprocess.Popen(
+            [sys.executable, "-c", DRIVER.replace("RUN", run), str(module_path), str(editor),
+             str(root / "unwound")], stderr=subprocess.DEVNULL)
+        deadline = time.time() + 20
+        pid = ""
+        while not pid and driver.poll() is None and time.time() < deadline:
+            time.sleep(0.05)
+            pid = (root / "pid").read_text().strip() if (root / "pid").exists() else ""
+        editor_pid = int(pid) if pid else None
+        try:
+            driver.send_signal(number)
+            driver.wait(timeout=20)
+            return (driver.returncode, (root / "unwound").exists(),
+                    None if editor_pid is None else alive(editor_pid))
+        finally:
+            if driver.poll() is None:
+                driver.kill()
+                driver.wait()
+            if editor_pid is not None and alive(editor_pid):
+                os.kill(editor_pid, signal.SIGKILL)
+
+
+class EditorOutlivingItsRunTests(unittest.TestCase):
+    """An editor the lane leaves running goes on in a base tree the lane then removes."""
 
     def test_Given_ANeighbourCountThatFailsWhileTheEditorRuns_When_TheRunEnds_Then_TheEditorIsNotLeftRunning(self):
         # Arrange
@@ -5148,6 +5209,26 @@ class EditorReapedWhateverEndsTheRunTests(unittest.TestCase):
 
         # Assert
         self.assertEqual((raised, left_running), (True, [False]))
+
+    def test_Given_ARunUnderWay_When_TheHarnessIsSentSigterm_Then_ItUnwindsReapsTheEditorAndDiesOfTheSignal(self):
+        # Arrange
+        subject = Path(__file__).with_name("base_red_check.py")
+
+        # Act
+        ended = signalled_run(subject, 'subject.run_unity(sys.argv[2], Path("."), "EditMode", ["X"], Path("/dev/null"), Path("/dev/null"), 60)', signal.SIGTERM)
+
+        # Assert
+        self.assertEqual(ended, (-signal.SIGTERM, True, False))
+
+    def test_Given_ARunUnderWay_When_TheHarnessIsSentSighup_Then_ItUnwindsReapsTheEditorAndDiesOfTheSignal(self):
+        # Arrange
+        subject = Path(__file__).with_name("base_red_check.py")
+
+        # Act
+        ended = signalled_run(subject, 'subject.run_unity(sys.argv[2], Path("."), "EditMode", ["X"], Path("/dev/null"), Path("/dev/null"), 60)', signal.SIGHUP)
+
+        # Assert
+        self.assertEqual(ended, (-signal.SIGHUP, True, False))
 
 
 if __name__ == "__main__":

--- a/scripts/test_quality/test_base_red_check.py
+++ b/scripts/test_quality/test_base_red_check.py
@@ -5130,8 +5130,8 @@ def failing_count():
     raise OSError(35, "Resource temporarily unavailable")
 
 
-class EditorReapedWhateverEndsTheRunTests(unittest.TestCase):
-    """An editor left running over a tree the harness has put back measures a change that is gone."""
+class EditorReapedWhenAnExceptionEndsTheRunTests(unittest.TestCase):
+    """An editor the lane leaves running goes on in a base tree the lane then removes."""
 
     def test_Given_ANeighbourCountThatFailsWhileTheEditorRuns_When_TheRunEnds_Then_TheEditorIsNotLeftRunning(self):
         # Arrange

--- a/scripts/test_quality/test_base_red_check.py
+++ b/scripts/test_quality/test_base_red_check.py
@@ -17,12 +17,10 @@ import os
 import re
 import pathlib
 import shutil
-import signal
 import subprocess
 import sys
 import tempfile
 import threading
-import time
 import traceback
 import unittest
 from pathlib import Path
@@ -5132,67 +5130,8 @@ def failing_count():
     raise OSError(35, "Resource temporarily unavailable")
 
 
-
-DRIVER = """
-import importlib.util
-import sys
-from pathlib import Path
-
-spec = importlib.util.spec_from_file_location("subject", sys.argv[1])
-subject = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(subject)
-
-
-def body():
-    try:
-        RUN
-    finally:
-        Path(sys.argv[3]).write_text("unwound")
-
-
-sys.exit(subject.unwinding_on_signals(body))
-"""
-
-
-def alive(pid):
-    try:
-        os.kill(pid, 0)
-    except ProcessLookupError:
-        return False
-    return True
-
-
-def signalled_run(module_path, run, number):
-    """(how the harness ended, whether its `finally` ran, whether the editor it launched is alive)."""
-    with tempfile.TemporaryDirectory() as directory:
-        root = Path(directory)
-        editor = root / "Unity"
-        editor.write_text('#!/bin/sh\necho $$ > "{}"\nexec sleep 60\n'.format(root / "pid"))
-        editor.chmod(0o755)
-        driver = subprocess.Popen(
-            [sys.executable, "-c", DRIVER.replace("RUN", run), str(module_path), str(editor),
-             str(root / "unwound")], stderr=subprocess.DEVNULL)
-        deadline = time.time() + 20
-        pid = ""
-        while not pid and driver.poll() is None and time.time() < deadline:
-            time.sleep(0.05)
-            pid = (root / "pid").read_text().strip() if (root / "pid").exists() else ""
-        editor_pid = int(pid) if pid else None
-        try:
-            driver.send_signal(number)
-            driver.wait(timeout=20)
-            return (driver.returncode, (root / "unwound").exists(),
-                    None if editor_pid is None else alive(editor_pid))
-        finally:
-            if driver.poll() is None:
-                driver.kill()
-                driver.wait()
-            if editor_pid is not None and alive(editor_pid):
-                os.kill(editor_pid, signal.SIGKILL)
-
-
-class EditorOutlivingItsRunTests(unittest.TestCase):
-    """An editor the lane leaves running goes on in a base tree the lane then removes."""
+class EditorReapedWhateverEndsTheRunTests(unittest.TestCase):
+    """An editor left running over a tree the harness has put back measures a change that is gone."""
 
     def test_Given_ANeighbourCountThatFailsWhileTheEditorRuns_When_TheRunEnds_Then_TheEditorIsNotLeftRunning(self):
         # Arrange
@@ -5209,26 +5148,6 @@ class EditorOutlivingItsRunTests(unittest.TestCase):
 
         # Assert
         self.assertEqual((raised, left_running), (True, [False]))
-
-    def test_Given_ARunUnderWay_When_TheHarnessIsSentSigterm_Then_ItUnwindsReapsTheEditorAndDiesOfTheSignal(self):
-        # Arrange
-        subject = Path(__file__).with_name("base_red_check.py")
-
-        # Act
-        ended = signalled_run(subject, 'subject.run_unity(sys.argv[2], Path("."), "EditMode", ["X"], Path("/dev/null"), Path("/dev/null"), 60)', signal.SIGTERM)
-
-        # Assert
-        self.assertEqual(ended, (-signal.SIGTERM, True, False))
-
-    def test_Given_ARunUnderWay_When_TheHarnessIsSentSighup_Then_ItUnwindsReapsTheEditorAndDiesOfTheSignal(self):
-        # Arrange
-        subject = Path(__file__).with_name("base_red_check.py")
-
-        # Act
-        ended = signalled_run(subject, 'subject.run_unity(sys.argv[2], Path("."), "EditMode", ["X"], Path("/dev/null"), Path("/dev/null"), 60)', signal.SIGHUP)
-
-        # Assert
-        self.assertEqual(ended, (-signal.SIGHUP, True, False))
 
 
 if __name__ == "__main__":

--- a/scripts/test_quality/test_mutation_check.py
+++ b/scripts/test_quality/test_mutation_check.py
@@ -3276,7 +3276,7 @@ def failing_count():
     raise OSError(35, "Resource temporarily unavailable")
 
 
-class EditorReapedWhateverEndsTheRunTests(unittest.TestCase):
+class EditorReapedWhenAnExceptionEndsTheRunTests(unittest.TestCase):
     """An editor left running over a tree the harness has put back measures a change that is gone."""
 
     def test_Given_ANeighbourCountThatFailsWhileTheEditorRuns_When_TheRunEnds_Then_TheEditorIsNotLeftRunning(self):

--- a/scripts/test_quality/test_mutation_check.py
+++ b/scripts/test_quality/test_mutation_check.py
@@ -3276,7 +3276,7 @@ def failing_count():
     raise OSError(35, "Resource temporarily unavailable")
 
 
-class EditorReapedWhateverEndsTheRunTests(unittest.TestCase):
+class EditorOutlivingItsRunTests(unittest.TestCase):
     """An editor left running over a tree the harness has put back measures a change that is gone."""
 
     def test_Given_ANeighbourCountThatFailsWhileTheEditorRuns_When_TheRunEnds_Then_TheEditorIsNotLeftRunning(self):

--- a/scripts/test_quality/test_mutation_check.py
+++ b/scripts/test_quality/test_mutation_check.py
@@ -29,6 +29,7 @@ import textwrap
 import time
 import unittest
 from pathlib import Path
+from unittest import mock
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 RUNTIME = REPO_ROOT / "Packages/com.velvet.core/Runtime"
@@ -3189,6 +3190,109 @@ class KeptVerdictTests(unittest.TestCase):
         # Act / Assert
         self.assertIsNone(
             mutation_check.read_verdict(self.output, 7, "digest-1", other, self.project))
+
+
+@contextlib.contextmanager
+def listed_processes(listing):
+    """A `ps` first on PATH that prints `listing` whatever it is asked, and marks that it ran."""
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        (root / "listing").write_bytes(listing)
+        ps = root / "ps"
+        ps.write_text('#!/bin/sh\n: > "{0}/ran"\nexec cat "{0}/listing"\n'.format(root))
+        ps.chmod(0o755)
+        saved = os.environ["PATH"]
+        os.environ["PATH"] = directory + os.pathsep + saved
+        try:
+            yield root / "ran"
+        finally:
+            os.environ["PATH"] = saved
+
+
+NOT_UTF8_NEIGHBOUR = b"/usr/bin/probe --label \xff"
+EDITOR = b"/Applications/Unity/Hub/Editor/6000.3.23f1/Unity.app/Contents/MacOS/Unity -runTests -batchmode"
+CAMPAIGN = b"/usr/bin/python3 /repo/scripts/test_quality/mutation_check.py --base origin/main"
+
+
+class ProcessListDecodingTests(unittest.TestCase):
+    """One neighbour's stray byte in the process list must not end the run that reads it."""
+
+    def test_Given_ANeighbourWhoseCommandLineIsNotUtf8_When_EditorsAreCounted_Then_TheEditorBesideItCounts(self):
+        # Arrange
+        listing = NOT_UTF8_NEIGHBOUR + b"\n" + EDITOR + b"\n"
+
+        # Act
+        with listed_processes(listing) as ran:
+            try:
+                counted = (mutation_check.unity_busy(), ran.exists())
+            except UnicodeDecodeError as error:
+                counted = (repr(error), ran.exists())
+
+        # Assert — the mark separates this listing's count from the machine's own.
+        self.assertEqual(counted, (1, True))
+
+    def test_Given_ANeighbourWhoseCommandLineIsNotUtf8_When_CampaignsAreCounted_Then_TheCampaignBesideItCounts(self):
+        # Arrange
+        listing = NOT_UTF8_NEIGHBOUR + b"\n" + CAMPAIGN + b"\n"
+
+        # Act
+        with listed_processes(listing) as ran:
+            try:
+                counted = (mutation_check.campaigns_running(), ran.exists())
+            except UnicodeDecodeError as error:
+                counted = (repr(error), ran.exists())
+
+        # Assert — the mark separates this listing's count from the machine's own.
+        self.assertEqual(counted, (1, True))
+
+
+
+@contextlib.contextmanager
+def lingering_editor():
+    """An editor that runs until something kills it, and every process the run under test starts."""
+    with tempfile.TemporaryDirectory() as directory:
+        editor = Path(directory) / "Unity"
+        editor.write_text("#!/bin/sh\nexec sleep 60\n")
+        editor.chmod(0o755)
+        started = []
+        real = subprocess.Popen
+
+        def recording(*args, **kwargs):
+            process = real(*args, **kwargs)
+            started.append(process)
+            return process
+
+        with mock.patch.object(subprocess, "Popen", recording):
+            try:
+                yield str(editor), started
+            finally:
+                for process in started:
+                    if process.poll() is None:
+                        process.kill()
+                        process.wait()
+
+
+def failing_count():
+    raise OSError(35, "Resource temporarily unavailable")
+
+
+class EditorReapedWhateverEndsTheRunTests(unittest.TestCase):
+    """An editor left running over a tree the harness has put back measures a change that is gone."""
+
+    def test_Given_ANeighbourCountThatFailsWhileTheEditorRuns_When_TheRunEnds_Then_TheEditorIsNotLeftRunning(self):
+        # Arrange
+        with lingering_editor() as (editor, started), mock.patch.object(mutation_check, "unity_busy",
+                                                                        failing_count):
+            # Act
+            try:
+                mutation_check.run_suite(editor, ".", "EditMode", [], Path("/dev/null"), Path("/dev/null"), 30)
+                raised = False
+            except OSError:
+                raised = True
+            left_running = [process.poll() is None for process in started]
+
+        # Assert
+        self.assertEqual((raised, left_running), (True, [False]))
 
 
 if __name__ == "__main__":

--- a/scripts/test_quality/test_mutation_check.py
+++ b/scripts/test_quality/test_mutation_check.py
@@ -3276,7 +3276,7 @@ def failing_count():
     raise OSError(35, "Resource temporarily unavailable")
 
 
-class EditorOutlivingItsRunTests(unittest.TestCase):
+class EditorReapedWhateverEndsTheRunTests(unittest.TestCase):
     """An editor left running over a tree the harness has put back measures a change that is gone."""
 
     def test_Given_ANeighbourCountThatFailsWhileTheEditorRuns_When_TheRunEnds_Then_TheEditorIsNotLeftRunning(self):

--- a/scripts/test_quality/test_neuter_check.py
+++ b/scripts/test_quality/test_neuter_check.py
@@ -458,7 +458,7 @@ def failing_count():
     raise OSError(35, "Resource temporarily unavailable")
 
 
-class EditorReapedWhateverEndsTheRunTests(unittest.TestCase):
+class EditorReapedWhenAnExceptionEndsTheRunTests(unittest.TestCase):
     """An editor left running over a tree the harness has put back measures a change that is gone."""
 
     def test_Given_ANeighbourCountThatFailsWhileTheEditorRuns_When_TheRunEnds_Then_TheEditorIsNotLeftRunning(self):

--- a/scripts/test_quality/test_neuter_check.py
+++ b/scripts/test_quality/test_neuter_check.py
@@ -10,11 +10,15 @@ Run: python3 scripts/test_quality/test_neuter_check.py
 """
 
 import argparse
+import contextlib
 import importlib.util
 import json
+import os
+import subprocess
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
@@ -383,6 +387,95 @@ class HoleBaseline(unittest.TestCase):
 
         # Assert
         self.assertIn("'Failed' is not a result a hole can carry", "\n".join(problems))
+
+
+@contextlib.contextmanager
+def listed_processes(listing):
+    """A `ps` first on PATH that prints `listing` whatever it is asked, and marks that it ran."""
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        (root / "listing").write_bytes(listing)
+        ps = root / "ps"
+        ps.write_text('#!/bin/sh\n: > "{0}/ran"\nexec cat "{0}/listing"\n'.format(root))
+        ps.chmod(0o755)
+        saved = os.environ["PATH"]
+        os.environ["PATH"] = directory + os.pathsep + saved
+        try:
+            yield root / "ran"
+        finally:
+            os.environ["PATH"] = saved
+
+
+NOT_UTF8_NEIGHBOUR = b"/usr/bin/probe --label \xff"
+EDITOR = b"/Applications/Unity/Hub/Editor/6000.3.23f1/Unity.app/Contents/MacOS/Unity -runTests -batchmode"
+
+
+class ProcessListDecodingTests(unittest.TestCase):
+    """One neighbour's stray byte in the process list must not end the run that reads it."""
+
+    def test_Given_ANeighbourWhoseCommandLineIsNotUtf8_When_EditorsAreCounted_Then_TheEditorBesideItCounts(self):
+        # Arrange
+        listing = NOT_UTF8_NEIGHBOUR + b"\n" + EDITOR + b"\n"
+
+        # Act
+        with listed_processes(listing) as ran:
+            try:
+                counted = (neuter_check.unity_processes(), ran.exists())
+            except UnicodeDecodeError as error:
+                counted = (repr(error), ran.exists())
+
+        # Assert — the mark separates this listing's count from the machine's own.
+        self.assertEqual(counted, (1, True))
+
+
+
+@contextlib.contextmanager
+def lingering_editor():
+    """An editor that runs until something kills it, and every process the run under test starts."""
+    with tempfile.TemporaryDirectory() as directory:
+        editor = Path(directory) / "Unity"
+        editor.write_text("#!/bin/sh\nexec sleep 60\n")
+        editor.chmod(0o755)
+        started = []
+        real = subprocess.Popen
+
+        def recording(*args, **kwargs):
+            process = real(*args, **kwargs)
+            started.append(process)
+            return process
+
+        with mock.patch.object(subprocess, "Popen", recording):
+            try:
+                yield str(editor), started
+            finally:
+                for process in started:
+                    if process.poll() is None:
+                        process.kill()
+                        process.wait()
+
+
+def failing_count():
+    raise OSError(35, "Resource temporarily unavailable")
+
+
+class EditorReapedWhateverEndsTheRunTests(unittest.TestCase):
+    """An editor left running over a tree the harness has put back measures a change that is gone."""
+
+    def test_Given_ANeighbourCountThatFailsWhileTheEditorRuns_When_TheRunEnds_Then_TheEditorIsNotLeftRunning(self):
+        # Arrange
+        with lingering_editor() as (editor, started), mock.patch.object(neuter_check, "unity_processes",
+                                                                        failing_count):
+            # Act
+            try:
+                neuter_check.run_suite(editor, Path("."), "EditMode", "X", Path("/dev/null"),
+                                       Path("/dev/null"), 30)
+                raised = False
+            except OSError:
+                raised = True
+            left_running = [process.poll() is None for process in started]
+
+        # Assert
+        self.assertEqual((raised, left_running), (True, [False]))
 
 
 if __name__ == "__main__":

--- a/scripts/test_quality/test_neuter_check.py
+++ b/scripts/test_quality/test_neuter_check.py
@@ -14,11 +14,8 @@ import contextlib
 import importlib.util
 import json
 import os
-import signal
 import subprocess
-import sys
 import tempfile
-import time
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -461,66 +458,7 @@ def failing_count():
     raise OSError(35, "Resource temporarily unavailable")
 
 
-
-DRIVER = """
-import importlib.util
-import sys
-from pathlib import Path
-
-spec = importlib.util.spec_from_file_location("subject", sys.argv[1])
-subject = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(subject)
-
-
-def body():
-    try:
-        RUN
-    finally:
-        Path(sys.argv[3]).write_text("unwound")
-
-
-sys.exit(subject.unwinding_on_signals(body))
-"""
-
-
-def alive(pid):
-    try:
-        os.kill(pid, 0)
-    except ProcessLookupError:
-        return False
-    return True
-
-
-def signalled_run(module_path, run, number):
-    """(how the harness ended, whether its `finally` ran, whether the editor it launched is alive)."""
-    with tempfile.TemporaryDirectory() as directory:
-        root = Path(directory)
-        editor = root / "Unity"
-        editor.write_text('#!/bin/sh\necho $$ > "{}"\nexec sleep 60\n'.format(root / "pid"))
-        editor.chmod(0o755)
-        driver = subprocess.Popen(
-            [sys.executable, "-c", DRIVER.replace("RUN", run), str(module_path), str(editor),
-             str(root / "unwound")], stderr=subprocess.DEVNULL)
-        deadline = time.time() + 20
-        pid = ""
-        while not pid and driver.poll() is None and time.time() < deadline:
-            time.sleep(0.05)
-            pid = (root / "pid").read_text().strip() if (root / "pid").exists() else ""
-        editor_pid = int(pid) if pid else None
-        try:
-            driver.send_signal(number)
-            driver.wait(timeout=20)
-            return (driver.returncode, (root / "unwound").exists(),
-                    None if editor_pid is None else alive(editor_pid))
-        finally:
-            if driver.poll() is None:
-                driver.kill()
-                driver.wait()
-            if editor_pid is not None and alive(editor_pid):
-                os.kill(editor_pid, signal.SIGKILL)
-
-
-class EditorOutlivingItsRunTests(unittest.TestCase):
+class EditorReapedWhateverEndsTheRunTests(unittest.TestCase):
     """An editor left running over a tree the harness has put back measures a change that is gone."""
 
     def test_Given_ANeighbourCountThatFailsWhileTheEditorRuns_When_TheRunEnds_Then_TheEditorIsNotLeftRunning(self):
@@ -538,26 +476,6 @@ class EditorOutlivingItsRunTests(unittest.TestCase):
 
         # Assert
         self.assertEqual((raised, left_running), (True, [False]))
-
-    def test_Given_ARunUnderWay_When_TheHarnessIsSentSigterm_Then_ItUnwindsReapsTheEditorAndDiesOfTheSignal(self):
-        # Arrange
-        subject = Path(__file__).with_name("neuter_check.py")
-
-        # Act
-        ended = signalled_run(subject, 'subject.run_suite(sys.argv[2], Path("."), "EditMode", "X", Path("/dev/null"), Path("/dev/null"), 60)', signal.SIGTERM)
-
-        # Assert
-        self.assertEqual(ended, (-signal.SIGTERM, True, False))
-
-    def test_Given_ARunUnderWay_When_TheHarnessIsSentSighup_Then_ItUnwindsReapsTheEditorAndDiesOfTheSignal(self):
-        # Arrange
-        subject = Path(__file__).with_name("neuter_check.py")
-
-        # Act
-        ended = signalled_run(subject, 'subject.run_suite(sys.argv[2], Path("."), "EditMode", "X", Path("/dev/null"), Path("/dev/null"), 60)', signal.SIGHUP)
-
-        # Assert
-        self.assertEqual(ended, (-signal.SIGHUP, True, False))
 
 
 if __name__ == "__main__":

--- a/scripts/test_quality/test_neuter_check.py
+++ b/scripts/test_quality/test_neuter_check.py
@@ -14,8 +14,11 @@ import contextlib
 import importlib.util
 import json
 import os
+import signal
 import subprocess
+import sys
 import tempfile
+import time
 import unittest
 from pathlib import Path
 from unittest import mock
@@ -458,7 +461,66 @@ def failing_count():
     raise OSError(35, "Resource temporarily unavailable")
 
 
-class EditorReapedWhateverEndsTheRunTests(unittest.TestCase):
+
+DRIVER = """
+import importlib.util
+import sys
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location("subject", sys.argv[1])
+subject = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(subject)
+
+
+def body():
+    try:
+        RUN
+    finally:
+        Path(sys.argv[3]).write_text("unwound")
+
+
+sys.exit(subject.unwinding_on_signals(body))
+"""
+
+
+def alive(pid):
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    return True
+
+
+def signalled_run(module_path, run, number):
+    """(how the harness ended, whether its `finally` ran, whether the editor it launched is alive)."""
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        editor = root / "Unity"
+        editor.write_text('#!/bin/sh\necho $$ > "{}"\nexec sleep 60\n'.format(root / "pid"))
+        editor.chmod(0o755)
+        driver = subprocess.Popen(
+            [sys.executable, "-c", DRIVER.replace("RUN", run), str(module_path), str(editor),
+             str(root / "unwound")], stderr=subprocess.DEVNULL)
+        deadline = time.time() + 20
+        pid = ""
+        while not pid and driver.poll() is None and time.time() < deadline:
+            time.sleep(0.05)
+            pid = (root / "pid").read_text().strip() if (root / "pid").exists() else ""
+        editor_pid = int(pid) if pid else None
+        try:
+            driver.send_signal(number)
+            driver.wait(timeout=20)
+            return (driver.returncode, (root / "unwound").exists(),
+                    None if editor_pid is None else alive(editor_pid))
+        finally:
+            if driver.poll() is None:
+                driver.kill()
+                driver.wait()
+            if editor_pid is not None and alive(editor_pid):
+                os.kill(editor_pid, signal.SIGKILL)
+
+
+class EditorOutlivingItsRunTests(unittest.TestCase):
     """An editor left running over a tree the harness has put back measures a change that is gone."""
 
     def test_Given_ANeighbourCountThatFailsWhileTheEditorRuns_When_TheRunEnds_Then_TheEditorIsNotLeftRunning(self):
@@ -476,6 +538,26 @@ class EditorReapedWhateverEndsTheRunTests(unittest.TestCase):
 
         # Assert
         self.assertEqual((raised, left_running), (True, [False]))
+
+    def test_Given_ARunUnderWay_When_TheHarnessIsSentSigterm_Then_ItUnwindsReapsTheEditorAndDiesOfTheSignal(self):
+        # Arrange
+        subject = Path(__file__).with_name("neuter_check.py")
+
+        # Act
+        ended = signalled_run(subject, 'subject.run_suite(sys.argv[2], Path("."), "EditMode", "X", Path("/dev/null"), Path("/dev/null"), 60)', signal.SIGTERM)
+
+        # Assert
+        self.assertEqual(ended, (-signal.SIGTERM, True, False))
+
+    def test_Given_ARunUnderWay_When_TheHarnessIsSentSighup_Then_ItUnwindsReapsTheEditorAndDiesOfTheSignal(self):
+        # Arrange
+        subject = Path(__file__).with_name("neuter_check.py")
+
+        # Act
+        ended = signalled_run(subject, 'subject.run_suite(sys.argv[2], Path("."), "EditMode", "X", Path("/dev/null"), Path("/dev/null"), 60)', signal.SIGHUP)
+
+        # Assert
+        self.assertEqual(ended, (-signal.SIGHUP, True, False))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
A mutation campaign, `base_red_check` and `neuter_check` each count the editors on the machine — and the campaign the other campaigns — by reading `ps -Ao command=` with `text=True`, which decodes strictly: before a run, to wait for a quiet machine, and while the editor they launched runs, to record the most neighbours it met. A process whose command line held a byte that is not UTF-8 made that read raise `UnicodeDecodeError`, and a campaign ended inside its run loop. `report/wedged_processes.py` reads its own `ps` table the same way and raises where such a byte sits in a process's name, the only part of the command line its `comm=` column carries. All five reads now decode as UTF-8 with `errors="replace"`. The editor and campaign counts match only ASCII patterns, so a replaced byte changes none of them, nor either total the wedged report's gate reads.

The run loop in all three scripts killed its editor only on the timeout, and in the campaign on a signal, so an exception raised while the editor ran — this one, or a `ps` that cannot fork on a loaded machine — left the editor running after its run had ended: in the campaign and in `neuter_check`, over a tree the harness then put back, where it goes on to write a results file for a change no longer on disk. Each loop now kills and reaps an editor still running when an exception ends it.

A case per reader runs it against a `ps` on `PATH` listing a neighbour whose command line holds 0xff beside one line it counts, and a case per run loop runs a stand-in editor that lives until it is killed under a neighbour count that raises. All eight are red on the merge base — the readers with `UnicodeDecodeError`, the loops leaving the editor running — and green here.

No `Documentation~` impact.

No issue: a mutation campaign that ended on a neighbouring process's command line.
