### PR TITLE
fix(velvet): check the index git builds for a commit, not two readings beside it

### DIFF
--- a/.harness/hooks/lib/shell_commands.py
+++ b/.harness/hooks/lib/shell_commands.py
@@ -39,8 +39,10 @@ GIT_DIRECTORY_FLAG = "--git-dir"
 GIT_DIRECTORY_VARIABLE = "GIT_DIR"
 WORK_TREE_FLAG = "--work-tree"
 WORK_TREE_VARIABLE = "GIT_WORK_TREE"
+INDEX_FILE_VARIABLE = "GIT_INDEX_FILE"
 
-GitContext = collections.namedtuple("GitContext", "working_directory git_directory work_tree")
+GitContext = collections.namedtuple("GitContext",
+                                    "working_directory git_directory work_tree index_file")
 
 # `git commit` options that swallow the token after them. Which flags a guard cares about stays its
 # own, per the note above; this is the one reading they share, and two guards taking it two ways
@@ -299,6 +301,7 @@ def git_invocation(tokens, git_directory=False):
     index = 0
     named = None
     tree = None
+    index_file = None
     while index < len(tokens) and (
         ENV_ASSIGNMENT.match(tokens[index]) or tokens[index] in LEADING_WORDS
     ):
@@ -307,6 +310,8 @@ def git_invocation(tokens, git_directory=False):
             named = value
         if git_directory and variable == WORK_TREE_VARIABLE:
             tree = value
+        if git_directory and variable == INDEX_FILE_VARIABLE:
+            index_file = value
         index += 1
     if index >= len(tokens) or os.path.basename(tokens[index]) != "git":
         return None
@@ -333,7 +338,7 @@ def git_invocation(tokens, git_directory=False):
 
     if index >= len(tokens):
         return None
-    context = GitContext(directory, named, tree) if git_directory else directory
+    context = GitContext(directory, named, tree, index_file) if git_directory else directory
     return context, tokens[index], tokens[index + 1:]
 
 

--- a/.harness/hooks/lib/shell_commands.py
+++ b/.harness/hooks/lib/shell_commands.py
@@ -37,8 +37,10 @@ GLOBAL_VALUE_FLAGS = {"-C", "-c", "--git-dir", "--work-tree", "--namespace", "--
 # hand it back to git may.
 GIT_DIRECTORY_FLAG = "--git-dir"
 GIT_DIRECTORY_VARIABLE = "GIT_DIR"
+WORK_TREE_FLAG = "--work-tree"
+WORK_TREE_VARIABLE = "GIT_WORK_TREE"
 
-GitContext = collections.namedtuple("GitContext", "working_directory git_directory")
+GitContext = collections.namedtuple("GitContext", "working_directory git_directory work_tree")
 
 # `git commit` options that swallow the token after them. Which flags a guard cares about stays its
 # own, per the note above; this is the one reading they share, and two guards taking it two ways
@@ -291,17 +293,20 @@ def git_invocation(tokens, git_directory=False):
     """(directory, subcommand, operands) when the segment runs git, else None.
 
     The directory is what the `-C` operands compose to. With `git_directory`, the first value is a
-    `GitContext` that keeps it alongside either spelling of the git directory. A caller needs both
-    to replay the repository selectors rather than replace one with the other.
+    `GitContext` that keeps it alongside either spelling of the git directory and of the working
+    tree, so that a caller can replay the repository selectors rather than replace one with another.
     """
     index = 0
     named = None
+    tree = None
     while index < len(tokens) and (
         ENV_ASSIGNMENT.match(tokens[index]) or tokens[index] in LEADING_WORDS
     ):
         variable, _, value = tokens[index].partition("=")
         if git_directory and variable == GIT_DIRECTORY_VARIABLE:
             named = value
+        if git_directory and variable == WORK_TREE_VARIABLE:
+            tree = value
         index += 1
     if index >= len(tokens) or os.path.basename(tokens[index]) != "git":
         return None
@@ -321,12 +326,14 @@ def git_invocation(tokens, git_directory=False):
                 directory = composed_directory(directory, value)
             elif git_directory and flag == GIT_DIRECTORY_FLAG:
                 named = value
+            elif git_directory and flag == WORK_TREE_FLAG:
+                tree = value
             continue
         index += 1
 
     if index >= len(tokens):
         return None
-    context = GitContext(directory, named) if git_directory else directory
+    context = GitContext(directory, named, tree) if git_directory else directory
     return context, tokens[index], tokens[index + 1:]
 
 

--- a/.harness/hooks/refuse/commit_failing_fast_checks.py
+++ b/.harness/hooks/refuse/commit_failing_fast_checks.py
@@ -34,6 +34,9 @@ NEUTER_CUTS = "scripts/test_quality/neuter_cuts.json"
 ALL = "--all"
 INCLUDE = "--include"
 SHORTEST_INCLUDE = "--inc"
+PATHSPEC_FROM_FILE = "--pathspec-from-file"
+SHORTEST_PATHSPEC_FROM_FILE = "--pathspec-fr"
+FROM_FILE = object()
 
 
 # A pathspec the shell has not expanded names no file, so every check runs over nothing and the
@@ -53,7 +56,7 @@ Unreadable = collections.namedtuple("Unreadable", "subject remedy")
 GitRead = collections.namedtuple("GitRead", "stdout said code asked")
 
 
-def git(cwd, *args, index=None):
+def git(cwd, *args, index=None, stdin=None):
     """git's stdout as the bytes it wrote, alongside what was asked and how it ended.
 
     Same reason `lib/repository.py` answers rather than raising: a hook that raises exits 1, and 1
@@ -61,7 +64,8 @@ def git(cwd, *args, index=None):
     """
     asked = displayed("git " + " ".join(args))
     try:
-        done = subprocess.run(["git", "-C", cwd, *args], capture_output=True, timeout=30,
+        done = subprocess.run(["git", "-C", cwd, *args], input=stdin, capture_output=True,
+                              timeout=30,
                               env=None if index is None else dict(os.environ, GIT_INDEX_FILE=index))
     except (OSError, subprocess.SubprocessError) as failure:
         return GitRead(b"", str(failure), None, asked)
@@ -96,10 +100,11 @@ def repo_root(cwd, selectors):
 
 
 def commit_invocations(command):
-    """(directory, onto the index, pathspecs) for each `git commit` in the command."""
+    """(directory, onto the index, pathspecs or `FROM_FILE`) per `git commit` in the command."""
     found = []
     for directory, _, operands in git_invocations(command, {"commit"}):
         onto_index = False
+        from_file = False
         pathspecs = []
         index = 0
         after_separator = False
@@ -113,6 +118,9 @@ def commit_invocations(command):
                 flag = token.partition("=")[0]
                 if flag == ALL or (flag.startswith(SHORTEST_INCLUDE) and INCLUDE.startswith(flag)):
                     onto_index = True
+                if (flag.startswith(SHORTEST_PATHSPEC_FROM_FILE)
+                        and PATHSPEC_FROM_FILE.startswith(flag)):
+                    from_file = True
                 if flag in COMMIT_VALUE_FLAGS and "=" not in token:
                     index += 2
                     continue
@@ -133,61 +141,104 @@ def commit_invocations(command):
                 continue
             pathspecs.append(token)
             index += 1
-        found.append((directory, onto_index, pathspecs))
+        found.append((directory, onto_index, FROM_FILE if from_file else pathspecs))
     return found
 
 
 BLOB_MODES = {b"100644", b"100755", b"120000"}
+SKIP_WORKTREE = b"S "
 
 
-def committed_content(cwd, selectors, onto_index, pathspecs):
-    """The blobs the commit would record where it changes HEAD, by path, or an `Unreadable`.
+def recorded_blobs(cwd, selectors, root, onto_index, pathspecs):
+    """path -> blob id for each blob `git diff-index` reports between the index built here and HEAD,
+    or an `Unreadable`.
 
     Built by git, in an index of this reading's own, rather than read off the working tree:
     `Given_ACarriageReturnGitNormalises_When_Judged_Then_TheNormalisedBytesAreChecked` is what fails
     when the bytes on disk stand in for the recorded ones.
     """
-    def ask(*args, index=None):
-        return git(cwd, *selectors, *args, index=index)
+    def ask(*args, index=None, stdin=None):
+        return git(cwd, *selectors, *args, index=index, stdin=stdin)
 
     head = ask("rev-parse", "--verify", "--quiet", "HEAD^{tree}")
     if head.code == 1:
         head = ask("hash-object", "-t", "tree", os.devnull)
     if head.code != 0:
         return unread(head)
-    located = ask("rev-parse", "--path-format=absolute", "--git-path", "index")
-    if located.code != 0:
-        return unread(located)
+    tree = head.stdout.decode().strip()
     with tempfile.TemporaryDirectory() as scratch:
         index = os.path.join(scratch, "index")
-        try:
-            shutil.copy2(located.stdout.decode(**repository.DECODING).removesuffix("\n"), index)
-        except FileNotFoundError:
-            pass
-        except OSError as error:
-            return Unreadable("the index could not be copied.\n\n  " + displayed(str(error)),
-                              "Correct what that names and retry.")
-        if onto_index or pathspecs:
-            added = ask("-c", "core.hooksPath=" + os.devnull, "add", "-u", "--", *pathspecs,
-                        index=index)
-            if added.code != 0:
-                return unread(added)
-        changed = ask("diff-index", "--cached", "--raw", "-z", "--no-renames",
-                      head.stdout.decode().strip(), "--", *([] if onto_index else pathspecs),
-                      index=index)
-        if changed.code != 0:
-            return unread(changed)
-        content = {}
-        fields = changed.stdout.split(b"\0")
-        for meta, path in zip(fields[::2], fields[1::2]):
-            _, mode, _, blob, _ = meta.split(b" ")
-            if mode not in BLOB_MODES:
-                continue
-            data = ask("cat-file", "blob", blob.decode())
-            if data.code != 0:
-                return unread(data)
-            content[path.decode(**repository.DECODING)] = data.stdout
-    return content
+
+        def write(*args, stdin=None):
+            return ask("-c", "core.hooksPath=" + os.devnull, "-c", "core.splitIndex=false", *args,
+                       index=index, stdin=stdin)
+
+        if pathspecs and not onto_index:
+            # Not `add -u` over a copy of the index:
+            # `Given_ADirectoryRemovedFromTheIndex_When_CommittedByPathspec_Then_TheCommitIsAllowed`
+            # and `Given_AnAssumeUnchangedFileBrokenOnDisk_When_CommittedByPathspec_Then_ItIsChecked`
+            # fail under it.
+            listed = ask("ls-files", "-z", "-t", "--full-name", "--error-unmatch",
+                         "--with-tree=" + tree, "--", *pathspecs)
+            if listed.code != 0:
+                return unread(listed)
+            top = root.encode(**repository.DECODING) + b"/"
+            taken = dict.fromkeys(top + record[2:] for record in listed.stdout.split(b"\0")
+                                  if record and not record.startswith(SKIP_WORKTREE))
+            built = write("read-tree", tree)
+            if built.code == 0:
+                built = write("update-index", "--add", "--remove", "-z", "--stdin",
+                              stdin=b"".join(path + b"\0" for path in taken))
+        else:
+            located = ask("rev-parse", "--path-format=absolute", "--git-path", "index")
+            if located.code != 0:
+                return unread(located)
+            try:
+                shutil.copy2(located.stdout.decode(**repository.DECODING).removesuffix("\n"), index)
+            except FileNotFoundError:
+                pass
+            except OSError as error:
+                return Unreadable("the index could not be copied.\n\n  " + displayed(str(error)),
+                                  "Correct what that names and retry.")
+            built = write("add", "-u", "--", *pathspecs) if onto_index else None
+        if built is not None and built.code != 0:
+            return unread(built)
+        changed = ask("diff-index", "--cached", "--ita-invisible-in-index", "--raw", "-z",
+                      "--no-renames", tree, index=index)
+    if changed.code != 0:
+        return unread(changed)
+    recorded = {}
+    fields = changed.stdout.split(b"\0")
+    for meta, path in zip(fields[::2], fields[1::2]):
+        _, mode, _, blob, _ = meta.split(b" ")
+        if mode in BLOB_MODES:
+            recorded[path.decode(**repository.DECODING)] = blob.decode()
+    return recorded
+
+
+def blob_contents(cwd, selectors, blobs):
+    """path -> the bytes of the blob `blobs` names for it, read by one git, or an `Unreadable`."""
+    wanted = list(dict.fromkeys(blobs.values()))
+    if not wanted:
+        return {}
+    answer = git(cwd, *selectors, "cat-file", "--batch",
+                 stdin="".join(blob + "\n" for blob in wanted).encode())
+    if answer.code != 0:
+        return unread(answer)
+    read, out, at = {}, answer.stdout, 0
+    for blob in wanted:
+        end = out.find(b"\n", at)
+        line = out[at:] if end < 0 else out[at:end]
+        header = line.split(b" ")
+        if end < 0 or len(header) != 3 or header[1] != b"blob":
+            return unread(answer._replace(said=line.decode(**repository.DECODING)))
+        at = end + 1 + int(header[2])
+        read[blob] = out[end + 1:at]
+        at += 1
+    return {path: read[blob] for path, blob in blobs.items()}
+
+
+Cut = collections.namedtuple("Cut", "file anchor neuter")
 
 
 def cut_targets(root):
@@ -199,10 +250,11 @@ def cut_targets(root):
     try:
         with open(cuts_path, encoding="utf-8") as cuts_file:
             raw = json.load(cuts_file)
-    except (OSError, ValueError):
+        edits = [Cut(edit["file"], edit["anchor"], edit["neuter"])
+                 for cut in raw.get("cuts", []) for edit in cut.get("edits", [])]
+        return {edit.file for edit in edits}, edits
+    except (OSError, ValueError, AttributeError, KeyError, TypeError):
         return set(), []
-    edits = [edit for cut in raw.get("cuts", []) for edit in cut.get("edits", [])]
-    return {edit["file"] for edit in edits}, edits
 
 
 def refuse(display, output, reproduce):
@@ -215,10 +267,24 @@ def refuse(display, output, reproduce):
 
 
 def run_tool(argv, display, reproduce):
-    proc = subprocess.run(argv, capture_output=True, timeout=30, **repository.DECODING)
+    try:
+        proc = subprocess.run(argv, capture_output=True, timeout=30, **repository.DECODING)
+    except (OSError, subprocess.SubprocessError) as failure:
+        return refuse_unreadable(Unreadable(
+            "the fast check of {} could not be run.\n\n  {}".format(displayed(display),
+                                                                  displayed(str(failure))),
+            "Reproduce: " + reproduce))
     if proc.returncode != 0:
         return refuse(display, proc.stderr or proc.stdout, reproduce)
     return 0
+
+
+JSON_SUFFIX = ".json"
+YAML_SUFFIXES = (".yml", ".yaml")
+FILE_SUFFIXES = (".py", ".sh")
+# No blob at another suffix is fetched unless a cut names its path, so a check for another suffix
+# joins this set.
+READ_SUFFIXES = {JSON_SUFFIX, *YAML_SUFFIXES, *FILE_SUFFIXES}
 
 
 def check_content(display, data):
@@ -229,14 +295,14 @@ def check_content(display, data):
     # a Python string literal, which is quoted whatever the name holds.
     shown = displayed(display)
     literal = json.dumps(display)
-    if suffix == ".json":
+    if suffix == JSON_SUFFIX:
         try:
             json.loads(data.decode("utf-8"))
         except (ValueError, UnicodeDecodeError) as err:
             return refuse(display, str(err), f"python3 -c 'import json; json.load(open({literal}))'")
         return 0
 
-    if suffix in (".yml", ".yaml"):
+    if suffix in YAML_SUFFIXES:
         try:
             import yaml
         except ImportError:
@@ -248,7 +314,7 @@ def check_content(display, data):
                           f"python3 -c 'import yaml; yaml.safe_load(open({literal}))'")
         return 0
 
-    if suffix not in (".py", ".sh"):
+    if suffix not in FILE_SUFFIXES:
         return 0
 
     # py_compile and shellcheck both want a file, and the content under test is the index's rather
@@ -302,8 +368,13 @@ def check_carried_mutation(root, paths):
     if not os.path.exists(script):
         return 0
     try:
+        # Its refusal prints back the path it matched, as the bytes git wrote:
+        # `Given_ACampaignHoldingANameOutsideTheEncoding_When_Judged_Then_TheRefusalSaysSo` fails
+        # when either end of the pipe takes them strictly.
         proc = subprocess.run(["python3", "-B", script, "--project", root, "--carried", *paths],
-                              capture_output=True, text=True, timeout=CARRIED_TIMEOUT, cwd=root)
+                              capture_output=True, timeout=CARRIED_TIMEOUT, cwd=root,
+                              env=dict(os.environ, PYTHONIOENCODING="utf-8:surrogateescape"),
+                              **repository.DECODING)
     except (OSError, subprocess.SubprocessError) as failure:
         # Raising here exits 1, which lets the tool through — and it would take every check
         # below out with it.
@@ -331,8 +402,13 @@ def check_neuter(root):
     script = os.path.join(root, "scripts", "test_quality", "neuter_check.py")
     if not os.path.exists(script):
         return 0
-    proc = subprocess.run(["python3", "-B", script, "--validate", "--project", root],
-                          capture_output=True, text=True, timeout=30, cwd=root)
+    try:
+        proc = subprocess.run(["python3", "-B", script, "--validate", "--project", root],
+                              capture_output=True, timeout=30, cwd=root, **repository.DECODING)
+    except (OSError, subprocess.SubprocessError) as failure:
+        return refuse_unreadable(Unreadable(
+            "the cut map could not be validated.\n\n  " + displayed("{}: {}".format(script, failure)),
+            "Reproduce: python3 scripts/test_quality/neuter_check.py --validate"))
     if proc.returncode != 0:
         return refuse(NEUTER_CUTS, proc.stderr or proc.stdout,
                       "python3 scripts/test_quality/neuter_check.py --validate")
@@ -349,7 +425,7 @@ def carried_neuters(content, edits):
     """
     found = []
     for edit in edits:
-        data = content.get(edit["file"])
+        data = content.get(edit.file)
         if data is None:
             continue
         try:
@@ -357,13 +433,13 @@ def carried_neuters(content, edits):
         except UnicodeDecodeError:
             continue
         for index, line in enumerate(lines):
-            if line.strip() != edit["anchor"]:
+            if line.strip() != edit.anchor:
                 continue
             body = next((i for i in range(index + 1, len(lines)) if lines[i].strip()), None)
             after = next((lines[i].strip() for i in range(body + 1, len(lines))
                           if lines[i].strip()), "") if body is not None else ""
-            if after == edit["neuter"]:
-                found.append(f"{edit['file']}: {edit['anchor']}")
+            if after == edit.neuter:
+                found.append(f"{edit.file}: {edit.anchor}")
     return found
 
 
@@ -376,13 +452,18 @@ def audit(cwd, selectors, onto_index, pathspecs):
     root = repo_root(cwd, selectors)
     if isinstance(root, Unreadable):
         return refuse_unreadable(root)
-    content = committed_content(cwd, selectors, onto_index, pathspecs)
-    if isinstance(content, Unreadable):
-        return refuse_unreadable(content)
-    if not content:
+    recorded = recorded_blobs(cwd, selectors, root, onto_index, pathspecs)
+    if isinstance(recorded, Unreadable):
+        return refuse_unreadable(recorded)
+    if not recorded:
         return 0
 
     targets, edits = cut_targets(root)
+    content = blob_contents(cwd, selectors, {
+        path: blob for path, blob in recorded.items()
+        if os.path.splitext(path)[1] in READ_SUFFIXES or path in targets})
+    if isinstance(content, Unreadable):
+        return refuse_unreadable(content)
     neutered = carried_neuters(content, edits)
     if neutered:
         sys.stderr.write(
@@ -402,11 +483,11 @@ def audit(cwd, selectors, onto_index, pathspecs):
 
     # After the content checks rather than before them: this one runs the working tree's copy of a
     # script, so a mid-edit one refusing here would hide the py_compile failure that explains it.
-    code = check_carried_mutation(root, sorted(content))
+    code = check_carried_mutation(root, sorted(recorded))
     if code:
         return code
 
-    if NEUTER_CUTS in content or any(path in targets for path in content):
+    if NEUTER_CUTS in recorded or any(path in targets for path in recorded):
         return check_neuter(root)
     return 0
 
@@ -452,6 +533,10 @@ def main():
                   "at all, rather than reading\nthe wrong one.\n\n"
                   "Spell the directory out.\n")
             return 2
+        if pathspecs is FROM_FILE:
+            sys.stderr.write(f"Refusing `git commit`: its paths come from `{PATHSPEC_FROM_FILE}`, "
+                             "which this check does not read.\n\nName them on the command line.\n")
+            return 2
         unresolved = [token for token in pathspecs if unexpanded(token)]
         if unresolved:
             sys.stderr.write(
@@ -461,6 +546,10 @@ def main():
                   "is still a variable names no file — so they would all run over nothing and pass, "
                   "and the commit would record content none of them saw.\n\n"
                   "Name the paths, or commit the index and let the checks read that.\n")
+            return 2
+        if context.index_file is not None:
+            sys.stderr.write("Refusing `git commit`: it records the index `GIT_INDEX_FILE` names, "
+                             "which this check does not read.\n\nCommit without the assignment.\n")
             return 2
         code = audit(cwd, [part for flag, value in selectors
                            for part in (flag, os.path.expanduser(value))],

--- a/.harness/hooks/refuse/commit_failing_fast_checks.py
+++ b/.harness/hooks/refuse/commit_failing_fast_checks.py
@@ -9,6 +9,11 @@ What is checked is what the commit records, not what the working tree happens to
 different files: a broken blob whose working copy was fixed afterwards passed every check, and a
 file staged and then deleted was refused with a `FileNotFoundError` for a commit git would accept.
 `git commit -a` and `git commit <pathspec>` record the working tree, so for those it is read too.
+
+Not replayed from the command: the global pathspec options `--glob-pathspecs`,
+`--noglob-pathspecs`, `--icase-pathspecs` and `--literal-pathspecs`, and a `GIT_*_PATHSPECS`
+variable the command sets itself, since the git this runs takes those variables from this hook's
+environment. Under any of them, the paths checked can differ from the paths the commit records.
 """
 
 import collections
@@ -150,18 +155,29 @@ BLOB_MODES = {b"100644", b"100755", b"120000"}
 SKIP_WORKTREE = b"S "
 WHOLE_TREE = ":/"
 LITERAL_PATHSPECS = "GIT_LITERAL_PATHSPECS"
+LITERAL_PROBE = "velvet.literalpathspecs"
 LONG_MAGIC = re.compile(r":\(([^)]*)\)")
 MAGIC_WORD = re.compile(r"(?:\\.|[^\\,])+")
 SHORT_EXCLUSION = re.compile(r":/*[!^]")
 
 
 def excludes(spec):
-    if os.environ.get(LITERAL_PATHSPECS, "").lower() in ("1", "true", "yes", "on"):
-        return False
     long_form = LONG_MAGIC.match(spec)
     if long_form:
         return "exclude" in MAGIC_WORD.findall(long_form.group(1))
     return SHORT_EXCLUSION.match(spec) is not None
+
+
+def reads_literally(ask):
+    """Whether `GIT_LITERAL_PATHSPECS` has the git this runs read every pathspec as a name.
+
+    git is asked for its reading of the variable rather than having its grammar restated:
+    `Given_PathspecsReadLiterally_When_AFileNamedAsAnExclusionIsCommitted_Then_ItIsAllowed` fails
+    where a restatement reads one of the spellings of true it holds as false.
+    """
+    value = os.environ.get(LITERAL_PATHSPECS)
+    return value is not None and ask("-c", LITERAL_PROBE + "=" + value, "config", "--type=bool",
+                                     LITERAL_PROBE).stdout == b"true\n"
 
 
 def recorded_blobs(cwd, selectors, onto_index, pathspecs):
@@ -195,7 +211,8 @@ def recorded_blobs(cwd, selectors, onto_index, pathspecs):
             # fail under it. Nor the pathspecs alone where they only exclude:
             # `Given_PathspecsThatOnlyExcludeFromASubdirectory_When_Judged_Then_AFileOutsideItIsChecked`
             # fails without the whole tree beside them.
-            whole = [WHOLE_TREE] if all(map(excludes, pathspecs)) else []
+            whole = ([WHOLE_TREE] if all(map(excludes, pathspecs)) and not reads_literally(ask)
+                     else [])
             listed = ask("ls-files", "-z", "-t", "--error-unmatch", "--with-tree=" + tree, "--",
                          *pathspecs, *whole)
             if listed.code != 0:
@@ -206,6 +223,8 @@ def recorded_blobs(cwd, selectors, onto_index, pathspecs):
             if built.code == 0:
                 built = write("update-index", "--add", "--remove", "--replace", "-z", "--stdin",
                               stdin=b"".join(path + b"\0" for path in taken))
+            if built.code != 0:
+                return unread(built)
         else:
             located = ask("rev-parse", "--path-format=absolute", "--git-path", "index")
             if located.code != 0:
@@ -217,9 +236,21 @@ def recorded_blobs(cwd, selectors, onto_index, pathspecs):
             except OSError as error:
                 return Unreadable("the index could not be copied.\n\n  " + displayed(str(error)),
                                   "Correct what that names and retry.")
-            built = write("add", "-u", "--", *pathspecs) if onto_index else None
-        if built is not None and built.code != 0:
-            return unread(built)
+            if onto_index:
+                # `git add` exits 1 when a pathspec matches only entries marked skip-worktree or
+                # outside the sparse-checkout definition, having updated the rest, where
+                # `git commit -i` goes on:
+                # `Given_ASkipWorktreeEntryNamedWithInclude_When_Judged_Then_TheCommitIsAllowed`
+                # fails when that exit is read as a refusal. Not `--sparse`, which updates entries
+                # outside the cone that `git commit` leaves:
+                # `Given_AFileOutsideTheSparseConeNamedWithInclude_When_Judged_Then_TheCommitIsAllowed`
+                # fails under it. `add.ignoreErrors`, which `git commit` does not read, gives a file
+                # git cannot read that exit too:
+                # `Given_AnUnreadableFileWhereAddIgnoresErrors_When_Judged_Then_TheRefusalIsGitsAccountOfIt`
+                # fails when it is read.
+                added = write("-c", "add.ignoreErrors=false", "add", "-u", "--", *pathspecs)
+                if added.code not in (0, 1):
+                    return unread(added)
         changed = ask("diff-index", "--cached", "--ita-invisible-in-index", "--raw", "-z",
                       "--no-renames", tree, index=index)
     if changed.code != 0:

--- a/.harness/hooks/refuse/commit_failing_fast_checks.py
+++ b/.harness/hooks/refuse/commit_failing_fast_checks.py
@@ -14,6 +14,7 @@ file staged and then deleted was refused with a `FileNotFoundError` for a commit
 import collections
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -147,9 +148,23 @@ def commit_invocations(command):
 
 BLOB_MODES = {b"100644", b"100755", b"120000"}
 SKIP_WORKTREE = b"S "
+WHOLE_TREE = ":/"
+LITERAL_PATHSPECS = "GIT_LITERAL_PATHSPECS"
+LONG_MAGIC = re.compile(r":\(([^)]*)\)")
+MAGIC_WORD = re.compile(r"(?:\\.|[^\\,])+")
+SHORT_EXCLUSION = re.compile(r":/*[!^]")
 
 
-def recorded_blobs(cwd, selectors, root, onto_index, pathspecs):
+def excludes(spec):
+    if os.environ.get(LITERAL_PATHSPECS, "").lower() in ("1", "true", "yes", "on"):
+        return False
+    long_form = LONG_MAGIC.match(spec)
+    if long_form:
+        return "exclude" in MAGIC_WORD.findall(long_form.group(1))
+    return SHORT_EXCLUSION.match(spec) is not None
+
+
+def recorded_blobs(cwd, selectors, onto_index, pathspecs):
     """path -> blob id for each blob `git diff-index` reports between the index built here and HEAD,
     or an `Unreadable`.
 
@@ -177,17 +192,19 @@ def recorded_blobs(cwd, selectors, root, onto_index, pathspecs):
             # Not `add -u` over a copy of the index:
             # `Given_ADirectoryRemovedFromTheIndex_When_CommittedByPathspec_Then_TheCommitIsAllowed`
             # and `Given_AnAssumeUnchangedFileBrokenOnDisk_When_CommittedByPathspec_Then_ItIsChecked`
-            # fail under it.
-            listed = ask("ls-files", "-z", "-t", "--full-name", "--error-unmatch",
-                         "--with-tree=" + tree, "--", *pathspecs)
+            # fail under it. Nor the pathspecs alone where they only exclude:
+            # `Given_PathspecsThatOnlyExcludeFromASubdirectory_When_Judged_Then_AFileOutsideItIsChecked`
+            # fails without the whole tree beside them.
+            whole = [WHOLE_TREE] if all(map(excludes, pathspecs)) else []
+            listed = ask("ls-files", "-z", "-t", "--error-unmatch", "--with-tree=" + tree, "--",
+                         *pathspecs, *whole)
             if listed.code != 0:
                 return unread(listed)
-            top = root.encode(**repository.DECODING) + b"/"
-            taken = dict.fromkeys(top + record[2:] for record in listed.stdout.split(b"\0")
+            taken = dict.fromkeys(record[2:] for record in listed.stdout.split(b"\0")
                                   if record and not record.startswith(SKIP_WORKTREE))
             built = write("read-tree", tree)
             if built.code == 0:
-                built = write("update-index", "--add", "--remove", "-z", "--stdin",
+                built = write("update-index", "--add", "--remove", "--replace", "-z", "--stdin",
                               stdin=b"".join(path + b"\0" for path in taken))
         else:
             located = ask("rev-parse", "--path-format=absolute", "--git-path", "index")
@@ -452,7 +469,7 @@ def audit(cwd, selectors, onto_index, pathspecs):
     root = repo_root(cwd, selectors)
     if isinstance(root, Unreadable):
         return refuse_unreadable(root)
-    recorded = recorded_blobs(cwd, selectors, root, onto_index, pathspecs)
+    recorded = recorded_blobs(cwd, selectors, onto_index, pathspecs)
     if isinstance(recorded, Unreadable):
         return refuse_unreadable(recorded)
     if not recorded:

--- a/.harness/hooks/refuse/commit_failing_fast_checks.py
+++ b/.harness/hooks/refuse/commit_failing_fast_checks.py
@@ -14,6 +14,7 @@ file staged and then deleted was refused with a `FileNotFoundError` for a commit
 import collections
 import json
 import os
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -30,7 +31,9 @@ HOOK_TOOLS = {"Bash"}
 
 NEUTER_CUTS = "scripts/test_quality/neuter_cuts.json"
 
-COMMIT_ALL_FLAGS = {"-a", "--all"}
+ALL = "--all"
+INCLUDE = "--include"
+SHORTEST_INCLUDE = "--inc"
 
 
 # A pathspec the shell has not expanded names no file, so every check runs over nothing and the
@@ -43,14 +46,14 @@ UNREADABLE_POLICY = "refuse"
 UNREADABLE_PROBE = {"command": "git commit -m probe"}
 
 
-# An empty listing says this commit records nothing a check could fail, and an empty index says
-# nothing in it is a submodule, so a reading that did not answer must not resolve to either.
+# An empty listing says this commit records nothing a check could fail, so a reading that did not
+# answer must not resolve to one.
 Unreadable = collections.namedtuple("Unreadable", "subject remedy")
 
 GitRead = collections.namedtuple("GitRead", "stdout said code asked")
 
 
-def git(cwd, *args):
+def git(cwd, *args, index=None):
     """git's stdout as the bytes it wrote, alongside what was asked and how it ended.
 
     Same reason `lib/repository.py` answers rather than raising: a hook that raises exits 1, and 1
@@ -58,7 +61,8 @@ def git(cwd, *args):
     """
     asked = displayed("git " + " ".join(args))
     try:
-        done = subprocess.run(["git", "-C", cwd, *args], capture_output=True, timeout=30)
+        done = subprocess.run(["git", "-C", cwd, *args], capture_output=True, timeout=30,
+                              env=None if index is None else dict(os.environ, GIT_INDEX_FILE=index))
     except (OSError, subprocess.SubprocessError) as failure:
         return GitRead(b"", str(failure), None, asked)
     return GitRead(done.stdout, done.stderr.decode(**repository.DECODING).strip(),
@@ -80,23 +84,22 @@ def unread(answer):
                       "Correct what git named and retry.")
 
 
-def repo_root(cwd):
+def repo_root(cwd, selectors):
     """The tree the checks run in, or an `Unreadable` when the reading did not answer.
 
-    Falling back to `cwd` was rejected: it drops this reading's account of what went wrong and
-    sends every reading below into a directory nothing has established is a tree.
+    Falling back to `cwd` was rejected: it drops this reading's account of what went wrong.
     """
-    answer = git(cwd, "rev-parse", "--show-toplevel")
+    answer = git(cwd, *selectors, "rev-parse", "--show-toplevel")
     # Same terminator-only reading as `repository.toplevel`, and for the reason given there.
     root = answer.stdout.decode(**repository.DECODING).removesuffix("\n")
     return root if answer.code == 0 and root else unread(answer)
 
 
 def commit_invocations(command):
-    """(directory, commits all, pathspecs) for each `git commit` in the command."""
+    """(directory, onto the index, pathspecs) for each `git commit` in the command."""
     found = []
     for directory, _, operands in git_invocations(command, {"commit"}):
-        commits_all = False
+        onto_index = False
         pathspecs = []
         index = 0
         after_separator = False
@@ -108,8 +111,8 @@ def commit_invocations(command):
                 continue
             if not after_separator and token.startswith("--"):
                 flag = token.partition("=")[0]
-                if flag in COMMIT_ALL_FLAGS:
-                    commits_all = True
+                if flag == ALL or (flag.startswith(SHORTEST_INCLUDE) and INCLUDE.startswith(flag)):
+                    onto_index = True
                 if flag in COMMIT_VALUE_FLAGS and "=" not in token:
                     index += 2
                     continue
@@ -121,8 +124,8 @@ def commit_invocations(command):
                 # one ends the group, taking either the rest of the token or the next one.
                 takes_next = False
                 for position, letter in enumerate(token[1:]):
-                    if letter == "a":
-                        commits_all = True
+                    if letter in "ai":
+                        onto_index = True
                     if "-" + letter in COMMIT_VALUE_FLAGS:
                         takes_next = position + 2 == len(token)
                         break
@@ -130,100 +133,60 @@ def commit_invocations(command):
                 continue
             pathspecs.append(token)
             index += 1
-        found.append((directory, commits_all, pathspecs))
+        found.append((directory, onto_index, pathspecs))
     return found
 
 
-def records(listing):
-    """The paths a NUL-delimited listing named."""
-    return [record.decode(**repository.DECODING)
-            for record in listing.split(b"\0") if record.strip()]
+BLOB_MODES = {b"100644", b"100755", b"120000"}
 
 
-def staged_paths(cwd):
-    # R is included: a rename reports it, and dropping it left a file renamed and broken in one
-    # staged change checked by nothing.
-    answer = git(cwd, "diff", "--cached", "-z", "--name-only", "--diff-filter=ACMR")
-    return records(answer.stdout) if answer.code == 0 else unread(answer)
+def committed_content(cwd, selectors, onto_index, pathspecs):
+    """The blobs the commit would record where it changes HEAD, by path, or an `Unreadable`.
 
-
-# The mode an index entry carries for a submodule.
-# `Given_ASubmoduleWhoseCommitIsStaged_When_Judged_Then_TheCommitIsAllowed` pins what a commit
-# records there, and fails when this stops being read.
-GITLINK = "160000"
-
-
-def index_modes(cwd):
-    """path -> the mode the index holds it at, or an `Unreadable` when the reading did not answer."""
-    answer = git(cwd, "ls-files", "-s", "-z")
-    if answer.code != 0:
-        return unread(answer)
-    modes = {}
-    for record in records(answer.stdout):
-        meta, _, path = record.partition("\t")
-        modes[path] = meta.partition(" ")[0]
-    return modes
-
-
-def worktree_paths(cwd, pathspecs):
-    """The paths a commit would take from the worktree, narrowed by `pathspecs`.
-
-    `~` is expanded before git sees it. The shell expands one and git does not, so a pathspec spelled
-    that way reached git literally, matched nothing, and left the checks below reading no content at
-    all -- measured, `git commit -m x -- ~/velvet/a.cs` passed every one of them. Expanded, it is an
-    absolute path outside the repository and git refuses it, which reaches the refusal above rather
-    than the silence.
+    Built by git, in an index of this reading's own, rather than read off the working tree:
+    `Given_ACarriageReturnGitNormalises_When_Judged_Then_TheNormalisedBytesAreChecked` is what fails
+    when the bytes on disk stand in for the recorded ones.
     """
-    args = ["diff", "-z", "--name-only", "--diff-filter=ACMR"]
-    if pathspecs:
-        args += ["--", *(os.path.expanduser(spec) for spec in pathspecs)]
-    answer = git(cwd, *args)
-    return records(answer.stdout) if answer.code == 0 else unread(answer)
+    def ask(*args, index=None):
+        return git(cwd, *selectors, *args, index=index)
 
-
-def recorded(full):
-    """The bytes at a worktree path, or None where a commit records no blob there at all."""
-    if os.path.islink(full):
-        return os.readlink(full).encode(**repository.DECODING)
-    if os.path.isdir(full):
-        return None
-    with open(full, "rb") as handle:
-        return handle.read()
-
-
-def committed_content(cwd, commits_all, pathspecs):
-    """path -> bytes the commit would record, or an `Unreadable` when part of it did not read."""
-    staged = staged_paths(cwd)
-    if isinstance(staged, Unreadable):
-        return staged
-    modes = index_modes(cwd) if staged else {}
-    if isinstance(modes, Unreadable):
-        return modes
-    content = {}
-    for path in staged:
-        if modes.get(path) == GITLINK:
-            continue
-        blob = git(cwd, "show", ":" + path)
-        if blob.code != 0:
-            return unread(blob)
-        content[path] = blob.stdout
-    if commits_all or pathspecs:
-        worktree = worktree_paths(cwd, pathspecs)
-        if isinstance(worktree, Unreadable):
-            return worktree
-        for path in worktree:
-            try:
-                data = recorded(os.path.join(cwd, path))
-            except OSError as error:
-                # Answered rather than skipped, so that the two halves of this function agree about
-                # a path that would not read. A skip left the refusal over the files that did read
-                # looking like a verdict over the whole commit.
-                return Unreadable(
-                    "a file this commit records could not be opened.\n\n  {}: {}".format(
-                        displayed(path), displayed(str(error))),
-                    "Make it readable, or commit without it.")
-            if data is not None:
-                content[path] = data
+    head = ask("rev-parse", "--verify", "--quiet", "HEAD^{tree}")
+    if head.code == 1:
+        head = ask("hash-object", "-t", "tree", os.devnull)
+    if head.code != 0:
+        return unread(head)
+    located = ask("rev-parse", "--path-format=absolute", "--git-path", "index")
+    if located.code != 0:
+        return unread(located)
+    with tempfile.TemporaryDirectory() as scratch:
+        index = os.path.join(scratch, "index")
+        try:
+            shutil.copy2(located.stdout.decode(**repository.DECODING).removesuffix("\n"), index)
+        except FileNotFoundError:
+            pass
+        except OSError as error:
+            return Unreadable("the index could not be copied.\n\n  " + displayed(str(error)),
+                              "Correct what that names and retry.")
+        if onto_index or pathspecs:
+            added = ask("-c", "core.hooksPath=" + os.devnull, "add", "-u", "--", *pathspecs,
+                        index=index)
+            if added.code != 0:
+                return unread(added)
+        changed = ask("diff-index", "--cached", "--raw", "-z", "--no-renames",
+                      head.stdout.decode().strip(), "--", *([] if onto_index else pathspecs),
+                      index=index)
+        if changed.code != 0:
+            return unread(changed)
+        content = {}
+        fields = changed.stdout.split(b"\0")
+        for meta, path in zip(fields[::2], fields[1::2]):
+            _, mode, _, blob, _ = meta.split(b" ")
+            if mode not in BLOB_MODES:
+                continue
+            data = ask("cat-file", "blob", blob.decode())
+            if data.code != 0:
+                return unread(data)
+            content[path.decode(**repository.DECODING)] = data.stdout
     return content
 
 
@@ -252,7 +215,7 @@ def refuse(display, output, reproduce):
 
 
 def run_tool(argv, display, reproduce):
-    proc = subprocess.run(argv, capture_output=True, text=True, timeout=30)
+    proc = subprocess.run(argv, capture_output=True, timeout=30, **repository.DECODING)
     if proc.returncode != 0:
         return refuse(display, proc.stderr or proc.stdout, reproduce)
     return 0
@@ -300,7 +263,7 @@ def check_content(display, data):
         code = run_tool(["bash", "-n", scratch], display, f"bash -n {shown}")
         if code:
             return code
-        shellcheck = __import__("shutil").which("shellcheck")
+        shellcheck = shutil.which("shellcheck")
         if not shellcheck:
             return 0
         # Warning and above. shellcheck exits non-zero on info-level notes too, and three hooks in
@@ -409,11 +372,11 @@ def refuse_unreadable(state):
     return 2
 
 
-def audit(cwd, commits_all, pathspecs):
-    root = repo_root(cwd)
+def audit(cwd, selectors, onto_index, pathspecs):
+    root = repo_root(cwd, selectors)
     if isinstance(root, Unreadable):
         return refuse_unreadable(root)
-    content = committed_content(root, commits_all, pathspecs)
+    content = committed_content(cwd, selectors, onto_index, pathspecs)
     if isinstance(content, Unreadable):
         return refuse_unreadable(content)
     if not content:
@@ -469,19 +432,25 @@ def main():
                          "tree holds that\ncontent is what the move decides.\n\n"
                          f"{NAME_THE_TREE}\n")
         return 2
-    for directory, commits_all, pathspecs in commits:
+    contexts = [context for context, _, _ in
+                git_invocations(command, {"commit"}, git_directory=True)]
+    for (directory, onto_index, pathspecs), context in zip(commits, contexts):
+        selectors = [(flag, value) for flag, value in (
+            ("-C", directory), ("--git-dir", context.git_directory),
+            ("--work-tree", context.work_tree)) if value]
         # The two operand kinds are refused apart, because the remedy for one does not reach the
         # other: naming the paths leaves a `-C` unresolved, and the reader told to do it tries
         # something that cannot help. Measured on an agent's own `git -C "$SP" commit`.
-        if directory and unexpanded(directory):
+        unresolved = [value for _, value in selectors if unexpanded(value)]
+        if unresolved:
             sys.stderr.write(
                 "Refusing `git commit`: the tree it runs in is named by an operand the shell has "
                 "not\nexpanded yet.\n\n"
-                f"  -C {directory}\n\n"
-                "Every check below reads the content the commit would record, and which repository "
-                "holds\nthat content is what `-C` decides — so this cannot read the tree at all, "
-                "rather than reading\nthe wrong one.\n\n"
-                "Spell the directory out.\n")
+                + "\n".join("  " + value for value in unresolved)
+                + "\n\nEvery check below reads the content the commit would record, and the "
+                  "repository holding\nthat content is named there — so this cannot read the tree "
+                  "at all, rather than reading\nthe wrong one.\n\n"
+                  "Spell the directory out.\n")
             return 2
         unresolved = [token for token in pathspecs if unexpanded(token)]
         if unresolved:
@@ -493,7 +462,9 @@ def main():
                   "and the commit would record content none of them saw.\n\n"
                   "Name the paths, or commit the index and let the checks read that.\n")
             return 2
-        code = audit(directory or cwd, commits_all, pathspecs)
+        code = audit(cwd, [part for flag, value in selectors
+                           for part in (flag, os.path.expanduser(value))],
+                     onto_index, [os.path.expanduser(spec) for spec in pathspecs])
         if code:
             return code
     return 0

--- a/.harness/hooks/refuse/commit_failing_fast_checks.py
+++ b/.harness/hooks/refuse/commit_failing_fast_checks.py
@@ -5,15 +5,25 @@ Every check this repository owns runs either at CI, twenty minutes away, or neve
 at what is about to be committed until integration. These checks finish in well under a second and
 would have caught defects that instead reached a commit or CI.
 
-What is checked is what the commit records, not what the working tree happens to hold. Those are
-different files: a broken blob whose working copy was fixed afterwards passed every check, and a
-file staged and then deleted was refused with a `FileNotFoundError` for a commit git would accept.
-`git commit -a` and `git commit <pathspec>` record the working tree, so for those it is read too.
+What is checked is what the commit records, not what the working tree happens to hold, outside the
+limits below. Those are different files: a broken blob whose working copy was fixed afterwards
+passed every check, and a file staged and then deleted was refused with a `FileNotFoundError` for
+a commit git would accept. `git commit -a` and `git commit <pathspec>` record the working tree,
+so for those it is read too.
 
 Not replayed from the command: the global pathspec options `--glob-pathspecs`,
-`--noglob-pathspecs`, `--icase-pathspecs` and `--literal-pathspecs`, and a `GIT_*_PATHSPECS`
+`--noglob-pathspecs`, `--icase-pathspecs` and `--literal-pathspecs`, a `GIT_*_PATHSPECS`
 variable the command sets itself, since the git this runs takes those variables from this hook's
-environment. Under any of them, the paths checked can differ from the paths the commit records.
+environment, and configuration the command sets itself with `-c`, `--config-env` or a
+`GIT_CONFIG_*` assignment. Under any of them, the paths or bytes checked can differ from those
+the commit records: `git -c core.sparseCheckout=false commit -i` records a file outside the
+sparse cone this did not check, and `git -c core.autocrlf=false commit -a` a carriage return
+this read normalised away. A `GIT_CONFIG` in this hook's environment stops `git config` reading
+the probe `reads_literally` asks, so a literal pathspec is read as magic.
+
+Refused though git records the commit: one run from inside an unpopulated submodule's
+directory, and one naming a path beyond a symbolic link, where this reading's own `git add` or
+`update-index` dies and `git commit` goes on.
 """
 
 import collections

--- a/scripts/hooks/test_commit_failing_fast_checks.py
+++ b/scripts/hooks/test_commit_failing_fast_checks.py
@@ -55,6 +55,8 @@ RAW_TARGET = b'{"a": "\xff"}'
 # A tracked file at a mode that lets nobody read it.
 CLOSED = "closed.py"
 
+STAGED = "staged.py"
+
 # Two submodule paths. Their index entries are written directly rather than cloned: what the guard
 # reads is the mode and the listing, and `git submodule add` adds a working tree and a `.gitmodules`
 # that neither reading looks at. The second ends in a suffix a fast check knows, which is what
@@ -68,14 +70,12 @@ BROKEN = "broken = (\n"
 
 # What a refusal says of a file a fast check rejected, against the sentences it carries for a path
 # that did not read at all. All are exit 2, so the code alone separates none of them, and the
-# remedy is the half that must not be shared: a reader sent back to git over a file at mode 000 has
-# been told a thing about git that refusal did not establish, and one told to correct what git
-# named where git never ran has been sent to look for a name nothing wrote.
+# remedy is the half that must not be shared: one told to correct what git named where git never
+# ran has been sent to look for a name nothing wrote.
 FAILED_A_CHECK = " failed a fast check"
-NOT_OPENED = "a file this commit records could not be opened."
-MAKE_IT_READABLE = "Make it readable, or commit without it."
 RETRY_WHEN_GIT_ANSWERS = "Retry when git answers."
 CORRECT_WHAT_GIT_NAMED = "Correct what git named and retry."
+NOT_COPIED = "the index could not be copied."
 
 # What git says of a directory with no repository at or above it.
 NOT_A_REPOSITORY = "not a git repository"
@@ -182,6 +182,15 @@ class UnexpandedOperands(GuardTestCase):
         self.assertEqual((code, RETRY_WHEN_GIT_ANSWERS in said, CORRECT_WHAT_GIT_NAMED in said),
                          (2, False, True))
 
+    def test_Given_ATildeSpelledDirectory_When_Judged_Then_TheRefusalNamesTheDirectoryGitWasGiven(self):
+        # Arrange / Act — a directory that is not there, so git's refusal quotes the one it was
+        # handed.
+        code, said = self.judge("git -C ~/velvet-no-such-tree commit -m x")
+
+        # Assert
+        missing = os.path.expanduser("~/velvet-no-such-tree")
+        self.assertEqual((code, missing in said, os.path.exists(missing)), (2, True, False))
+
     def test_Given_AnUnexpandedPathspec_When_Refused_Then_ItKeepsItsOwnRemedy(self):
         # Arrange — the reading the sentence was written for, which this must leave where it is.
         code, said = self.judge('git commit -m "x" -- "$FILES"')
@@ -191,8 +200,7 @@ class UnexpandedOperands(GuardTestCase):
 
 
 class IndexedContent(GuardTestCase):
-    # GREEN_ON_BASE(refactor): the index read this guard's collapse onto a shared reader preserves.
-    # Reading the working tree's copy where `git show :<path>` is asked is what reddens it.
+    # GREEN_ON_BASE(characterization): the base judges a commit of the index on the index too.
     def test_Given_ABlobBrokenInTheIndexAndWholeInTheTree_When_Judged_Then_TheRefusalQuotesTheIndex(self):
         # Arrange — the two halves carry different text, so the quoted line says which was read. A
         # refusal alone would not: the working tree's copy is what a commit of the index must not be
@@ -226,6 +234,17 @@ class IndexedContent(GuardTestCase):
         self.assertEqual((code, script + FAILED_A_CHECK in said, self.judge("git commit -m x")),
                          (2, True, (0, "")))
 
+    def test_Given_AStagedScriptWhoseBrokenLineHoldsAByteOutsideTheEncoding_When_Judged_Then_TheRefusalNamesIt(self):
+        # Arrange — the line `bash -n` rejects holds a byte UTF-8 does not map.
+        (self.root / "raw.sh").write_bytes(b"#!/bin/bash\nif then \xff\n")
+        self.git("add", "raw.sh")
+
+        # Act
+        code, said = self.judge("git commit -m x")
+
+        # Assert
+        self.assertEqual((code, "raw.sh" + FAILED_A_CHECK in said), (2, True))
+
     def test_Given_ANameGitQuotes_When_BrokenInTheIndex_Then_TheRefusalNamesIt(self):
         # Arrange — staged and never committed, so everything this commit records is the index's.
         (self.root / QUOTED).write_text(BROKEN, encoding="utf-8")
@@ -234,14 +253,11 @@ class IndexedContent(GuardTestCase):
         # Act
         code, said = self.judge("git commit -m x")
 
-        # Assert — the name, not merely the refusal: the base refuses this too, for having handed
-        # `git show` a spelling no path answers to, and tells the reader to retry when git answers.
+        # Assert — the name, not merely the refusal.
         self.assertEqual((code, QUOTED + FAILED_A_CHECK in said), (2, True))
 
     def test_Given_ANameHoldingAByteOutsideTheEncoding_When_BrokenInTheIndex_Then_TheRefusalNamesIt(self):
-        # Arrange — the index alone, since the byte cannot be written into a name here. A decoding
-        # that replaces the byte rather than escaping it hands `git show` a path no entry answers
-        # to, so the blob is never reached and the refusal is about the reading instead.
+        # Arrange — the index alone, since the byte cannot be written into a name here.
         self.index(b"100644 " + self.blob(BROKEN.encode("utf-8")) + b"\t" + RAW_BYTE_NAME + b"\x00")
 
         # Act
@@ -251,9 +267,9 @@ class IndexedContent(GuardTestCase):
         self.assertEqual((code, RAW_BYTE_SHOWN + FAILED_A_CHECK in said), (2, True))
 
     def test_Given_ASubmoduleWhoseCommitIsStaged_When_Judged_Then_TheCommitIsAllowed(self):
-        # Arrange — the staged listing names it and there is no blob behind it, which is the state
-        # the base refuses in. That the index really holds a gitlink is compared beside the verdict,
-        # since an entry at any other mode poses nothing.
+        # Arrange — the staged listing names it and there is no blob behind it. That the index
+        # really holds a gitlink is compared beside the verdict, since an entry at any other mode
+        # poses nothing.
         self.index(("160000 " + self.submodule() + "\t" + SUB + "\x00").encode("utf-8"))
         listed = self.git("ls-files", "-s", "--", SUB).split()[0]
 
@@ -283,8 +299,7 @@ class WorktreeContent(GuardTestCase):
 
     # GREEN_ON_BASE(characterization): a name needing no quoting is refused on the base too.
     # That is what makes the awkward names below about which spellings reach the checks, rather
-    # than about whether the working tree is read at all. Answering `[]` from `worktree_paths`
-    # reddens it.
+    # than about whether the working tree is read at all.
     def test_Given_APlainName_When_BrokenInTheWorktree_Then_TheRefusalNamesIt(self):
         # Arrange
         staged = self.broken_only_in_the_worktree(PLAIN)
@@ -302,8 +317,7 @@ class WorktreeContent(GuardTestCase):
         # Act
         code, said = self.judge("git commit -a -m x")
 
-        # Assert — on the base the listing spells this name back quoted, `open` raises for it, and
-        # the commit is allowed with nothing said.
+        # Assert
         self.assertEqual((code, QUOTED + FAILED_A_CHECK in said, staged), (2, True, ""))
 
     def test_Given_ANameHoldingACarriageReturn_When_BrokenInTheWorktree_Then_ItsContentIsChecked(self):
@@ -313,9 +327,7 @@ class WorktreeContent(GuardTestCase):
         # Act
         code, said = self.judge("git commit -a -m x")
 
-        # Assert — that a check ran and rejected the content, rather than which name it named: the
-        # return has to survive the read, and taking the same NUL-delimited listing through a text
-        # pipe leaves this naming a file nothing can open, which is a different refusal.
+        # Assert — that a check ran and rejected the content, rather than which name it named.
         self.assertEqual((code, FAILED_A_CHECK in said, staged), (2, True, ""))
 
     def test_Given_ANameHoldingALineBreak_When_Refused_Then_TheRefusalLineIsWhole(self):
@@ -410,9 +422,7 @@ class WorktreeContent(GuardTestCase):
                           self.git("show", "HEAD:" + RAW_LINK)),
                          (2, True, "", os.fsdecode(RAW_TARGET)))
 
-    # GREEN_ON_BASE(characterization): the base allows this too, by dropping every path it could
-    # not open and going on. Opening the path rather than reading what kind of entry it is reddens
-    # it, and the refusal that follows is the one neither of its halves can be acted on.
+    # GREEN_ON_BASE(characterization): the base allows this too.
     def test_Given_ASubmoduleWhoseCommitMoved_When_Judged_Then_TheCommitIsAllowed(self):
         # Arrange — committed at the first commit and moved on afterwards, so the worktree listing
         # names it and the staged one does not. Both listings are compared beside the verdict.
@@ -430,9 +440,7 @@ class WorktreeContent(GuardTestCase):
         self.assertEqual((code, said, listings, self.git("ls-tree", "HEAD", "--", SUB).split()[:2]),
                          (0, "", ("", SUB + "\n"), [GITLINK_MODE, "commit"]))
 
-    # GREEN_ON_BASE(characterization): the base allows this too, by dropping every path it could
-    # not open and going on. Carrying the answer for a path that records no blob into the checks
-    # reddens it, and what fails then is the hook itself, at the exit that lets a commit through.
+    # GREEN_ON_BASE(characterization): the base allows this too.
     def test_Given_ASubmoduleAtAPathAFastCheckKnows_When_Judged_Then_TheCommitIsAllowed(self):
         # Arrange — the case above with the suffix changed, which is the whole of what separates
         # them: a path whose suffix no fast check knows is returned on before its content is read.
@@ -454,7 +462,7 @@ class WorktreeContent(GuardTestCase):
                          (0, "", ("", SUB_CHECKED + "\n"), os.path.splitext(PROBE)[1],
                           [GITLINK_MODE, "commit"]))
 
-    def test_Given_APathTheListingNamesThatWillNotOpen_When_Judged_Then_TheRemedyIsAboutTheFile(self):
+    def test_Given_ATrackedFileThatWillNotOpen_When_Judged_Then_TheRefusalIsGitsAccountOfIt(self):
         # Arrange — a tracked file whose mode lets nobody read it.
         staged = self.broken_only_in_the_worktree(CLOSED)
         os.chmod(self.root / CLOSED, 0o000)
@@ -463,25 +471,140 @@ class WorktreeContent(GuardTestCase):
         # Act
         code, said = self.judge("git commit -a -m x")
 
-        # Assert — the name under the subject rather than anywhere in the refusal: the error this
-        # quotes carries the path itself, and that copy satisfies a bare containment on its own.
-        self.assertEqual((code, NOT_OPENED in said, "\n  " + CLOSED + ":" in said,
-                          MAKE_IT_READABLE in said, self.opens(CLOSED), staged),
-                         (2, True, True, True, False, ""))
+        # Assert
+        self.assertEqual((code, CLOSED in said, CORRECT_WHAT_GIT_NAMED in said, self.opens(CLOSED),
+                          staged), (2, True, True, False, ""))
 
-    def test_Given_ANameHoldingALineBreak_When_ItWillNotOpen_Then_TheRefusalLineIsWhole(self):
-        # Arrange — the same mode, under a name that divides the line it is printed in. This
-        # refusal spells the path in a sentence of its own, which the case above cannot reach.
-        staged = self.broken_only_in_the_worktree(BREAKING)
-        os.chmod(self.root / BREAKING, 0o000)
-        self.addCleanup(os.chmod, self.root / BREAKING, 0o644)
+    # GREEN_ON_BASE(characterization): the base runs no hook in this state either.
+    def test_Given_AHookOnEveryIndexWrite_When_Judged_Then_ItDoesNotRun(self):
+        # Arrange
+        staged = self.broken_only_in_the_worktree(PLAIN)
+        hook = self.root / ".git" / "hooks" / "post-index-change"
+        hook.write_text("#!/bin/sh\ntouch ran\n", encoding="utf-8")
+        os.chmod(hook, 0o755)
 
         # Act
         code, said = self.judge("git commit -a -m x")
 
-        # Assert — the escaped name where the sentence puts it.
-        self.assertEqual((code, json.dumps(BREAKING) + ":" in said, self.opens(BREAKING), staged),
-                         (2, True, False, ""))
+        # Assert — beside the refusal, so a guard that never reached the working tree cannot pass.
+        self.assertEqual((code, PLAIN + FAILED_A_CHECK in said, (self.root / "ran").exists(),
+                          staged), (2, True, False, ""))
+
+    def test_Given_ARelativePathspecFromASubdirectory_When_Judged_Then_TheFileItNamesIsChecked(self):
+        # Arrange
+        (self.root / "sub").mkdir()
+        staged = self.broken_only_in_the_worktree("sub/" + PLAIN)
+
+        # Act
+        code, said = self.judge("git commit -m x -- " + PLAIN, cwd=self.root / "sub")
+
+        # Assert
+        self.assertEqual((code, "sub/" + PLAIN + FAILED_A_CHECK in said, staged), (2, True, ""))
+
+    def test_Given_ASymlinkReplacedByABrokenFile_When_Judged_Then_TheFileIsChecked(self):
+        # Arrange
+        (self.root / FIRST_TARGET).write_text(WHOLE, encoding="utf-8")
+        os.symlink(FIRST_TARGET, self.root / LINK)
+        self.git("add", FIRST_TARGET, LINK)
+        self.git("commit", "-q", "-m", "arranged")
+        os.unlink(self.root / LINK)
+        (self.root / LINK).write_text(BROKEN, encoding="utf-8")
+
+        # Act
+        code, said = self.judge("git commit -a -m x")
+
+        # Assert — what the commit then wrote sits in the comparison, because this is a file's
+        # content to check only for as long as git records a file there.
+        self.git("commit", "-a", "-q", "-m", "recorded")
+        self.assertEqual((code, LINK + FAILED_A_CHECK in said,
+                          self.git("ls-tree", "HEAD", "--", LINK).split()[:2]),
+                         (2, True, ["100644", "blob"]))
+
+    def test_Given_ACarriageReturnGitNormalises_When_Judged_Then_TheNormalisedBytesAreChecked(self):
+        # Arrange — the working copy holds CRLF, which `.gitattributes` asks git to record as LF.
+        script = "normalised.sh"
+        (self.root / ".gitattributes").write_text("*.sh text eol=lf\n", encoding="utf-8")
+        (self.root / script).write_bytes(b"#!/bin/bash\necho first\n")
+        self.git("add", ".gitattributes", script)
+        self.git("commit", "-q", "-m", "arranged")
+        (self.root / script).write_bytes(b"#!/bin/bash\r\nif true; then\r\necho hi\r\nfi\r\n")
+
+        # Act
+        code, said = self.judge("git commit -a -m x")
+
+        # Assert — what the commit then wrote sits in the comparison, because checking git's copy
+        # rather than the working one is right only for as long as git's copy is the blob.
+        self.git("commit", "-a", "-q", "-m", "recorded")
+        self.assertEqual((code, said, self.git("show", "HEAD:" + script)),
+                         (0, "", "#!/bin/bash\nif true; then\necho hi\nfi\n"))
+
+    # GREEN_ON_BASE(characterization): the base checks a working copy's own bytes too.
+    def test_Given_AWorkingCopyBrokenByBareReturns_When_Judged_Then_ItsRecordedBytesAreChecked(self):
+        # Arrange — committed as another script, so its line-feed copy below is a change too.
+        script, content = "returns.sh", b"#!/bin/bash\nif true; then\recho hi\rfi\n"
+        (self.root / script).write_bytes(b"#!/bin/bash\necho first\n")
+        self.git("add", script)
+        self.git("commit", "-q", "-m", "arranged")
+        (self.root / script).write_bytes(content)
+
+        # Act
+        code, said = self.judge("git commit -a -m x")
+
+        # Assert — beside the verdict on the same script with its returns read as line feeds.
+        (self.root / script).write_bytes(content.replace(b"\r", b"\n"))
+        self.assertEqual((code, script + FAILED_A_CHECK in said, self.judge("git commit -a -m x")),
+                         (2, True, (0, "")))
+
+
+class PathspecCommits(GuardTestCase):
+    def staged_beside(self, named):
+        """`STAGED` staged broken, beside `named` changed whole in its working copy alone."""
+        for name in (named, STAGED):
+            (self.root / name).write_text(WHOLE, encoding="utf-8")
+        self.git("add", named, STAGED)
+        self.git("commit", "-q", "-m", "arranged")
+        (self.root / named).write_text(TREE_AND_WHOLE, encoding="utf-8")
+        (self.root / STAGED).write_text(BROKEN, encoding="utf-8")
+        self.git("add", STAGED)
+
+    def test_Given_AnotherFileStagedBroken_When_APathspecAloneIsCommitted_Then_ItIsNotChecked(self):
+        # Arrange
+        self.staged_beside(PLAIN)
+
+        # Act
+        code, said = self.judge("git commit -m x -- " + PLAIN)
+
+        # Assert — what the commit then wrote sits in the comparison, because leaving the staged
+        # file unchecked is right only for as long as the commit leaves it out.
+        self.git("commit", "-q", "-m", "recorded", "--", PLAIN)
+        self.assertEqual((code, said, self.git("show", "HEAD:" + STAGED)), (0, "", WHOLE))
+
+    # GREEN_ON_BASE(characterization): the base checks what is staged beside a pathspec too.
+    def test_Given_AnotherFileStagedBroken_When_CommittedWithInclude_Then_ItIsChecked(self):
+        # Arrange
+        self.staged_beside(PLAIN)
+
+        # Act
+        code, said = self.judge("git commit -m x -i -- " + PLAIN)
+
+        # Assert — what the commit then wrote sits in the comparison, because `-i` is what takes
+        # the staged file into it.
+        self.git("commit", "-q", "-m", "recorded", "-i", "--", PLAIN)
+        self.assertEqual((code, STAGED + FAILED_A_CHECK in said,
+                          self.git("show", "HEAD:" + STAGED)), (2, True, BROKEN))
+
+    # GREEN_ON_BASE(characterization): the base checks what is staged beside a pathspec too.
+    def test_Given_AnotherFileStagedBroken_When_CommittedWithIncludeAbbreviated_Then_ItIsChecked(self):
+        # Arrange
+        self.staged_beside(PLAIN)
+
+        # Act
+        code, said = self.judge("git commit -m x --inc -- " + PLAIN)
+
+        # Assert — what the commit then wrote sits in the comparison, as above.
+        self.git("commit", "-q", "-m", "recorded", "--inc", "--", PLAIN)
+        self.assertEqual((code, STAGED + FAILED_A_CHECK in said,
+                          self.git("show", "HEAD:" + STAGED)), (2, True, BROKEN))
 
 
 class TreeTheChecksRunIn(GuardTestCase):
@@ -513,6 +636,61 @@ class TreeTheChecksRunIn(GuardTestCase):
 
         # Assert
         self.assertEqual((code, NOT_A_REPOSITORY in said), (2, True))
+
+    def elsewhere(self):
+        """A second repository, holding `PLAIN` committed whole and broken in its working copy."""
+        other = self.repository(Path(tempfile.mkdtemp(prefix="fast-checks-other-")).resolve())
+        (other / PLAIN).write_text(WHOLE, encoding="utf-8")
+        self.git("add", PLAIN, root=other)
+        self.git("commit", "-q", "-m", "arranged", root=other)
+        (other / PLAIN).write_text(BROKEN, encoding="utf-8")
+        return other
+
+    def test_Given_ACommitAimedByGitDirAndWorkTreeFlags_When_Judged_Then_ThatTreeIsChecked(self):
+        # Arrange — started in a repository holding nothing to check.
+        other = self.elsewhere()
+
+        # Act
+        code, said = self.judge(f"git --git-dir={other}/.git --work-tree={other} commit -a -m x")
+
+        # Assert
+        self.assertEqual((code, PLAIN + FAILED_A_CHECK in said), (2, True))
+
+    def test_Given_ACommitAimedByGitDirAndWorkTreeVariables_When_Judged_Then_ThatTreeIsChecked(self):
+        # Arrange — started in a directory in no repository.
+        other = self.elsewhere()
+        plain = Path(tempfile.mkdtemp(prefix="fast-checks-none-")).resolve()
+        self.addCleanup(shutil.rmtree, plain, ignore_errors=True)
+
+        # Act
+        code, said = self.judge(f"GIT_DIR={other}/.git GIT_WORK_TREE={other} git commit -a -m x",
+                                cwd=plain)
+
+        # Assert
+        self.assertEqual((code, PLAIN + FAILED_A_CHECK in said), (2, True))
+
+    def test_Given_ARelativeDirectory_When_Judged_Then_ItIsReadFromWhereTheCommandRuns(self):
+        # Arrange
+        other = self.elsewhere()
+
+        # Act
+        code, said = self.judge(f"git -C {os.path.relpath(other, self.root)} commit -a -m x")
+
+        # Assert
+        self.assertEqual((code, PLAIN + FAILED_A_CHECK in said), (2, True))
+
+    def test_Given_AnIndexThatWillNotOpen_When_Judged_Then_TheRefusalSaysSo(self):
+        # Arrange
+        (self.root / PLAIN).write_text(WHOLE, encoding="utf-8")
+        self.git("add", PLAIN)
+        os.chmod(self.root / ".git" / "index", 0o000)
+        self.addCleanup(os.chmod, self.root / ".git" / "index", 0o644)
+
+        # Act
+        code, said = self.judge("git commit -m x")
+
+        # Assert
+        self.assertEqual((code, NOT_COPIED in said, self.opens(".git/index")), (2, True, False))
 
     # GREEN_ON_BASE(characterization): the base answers a git that never ran with this remedy too.
     def test_Given_NoGitOnThePath_When_Judged_Then_TheRemedyIsToRetry(self):

--- a/scripts/hooks/test_commit_failing_fast_checks.py
+++ b/scripts/hooks/test_commit_failing_fast_checks.py
@@ -15,6 +15,10 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 GUARD = REPO_ROOT / ".claude/hooks/refuse/commit_failing_fast_checks.py"
+CAMPAIGN = REPO_ROOT / "scripts/test_quality/mutation_check.py"
+
+sys.path.insert(0, str(CAMPAIGN.parent))
+from mutation_check import SENTINEL, Holder  # noqa: E402
 
 # A file whose two versions are both distinctive, so that a refusal quoting one of them says which
 # half the guard read. The staged half is what a fast check has to reject.
@@ -24,8 +28,7 @@ TREE_AND_WHOLE = "tree_is_fine = 1\n"
 
 # One name needing no quoting, one git quotes under the default `core.quotePath`, one holding a
 # character universal newlines rewrite, one holding a line break that survives that rewriting, and
-# one `str.splitlines()` reads as a single line. A refusal spells the last three quoted and
-# escaped, and the first two as they stand.
+# one `str.splitlines()` reads as a single line.
 PLAIN = "plain.py"
 QUOTED = "café.py"
 RETURNING = "with-return\r.py"
@@ -57,6 +60,10 @@ CLOSED = "closed.py"
 
 STAGED = "staged.py"
 
+# Where the guard reads the cuts a neuter sweep may be holding, and what validates them.
+CUT_MAP = "scripts/test_quality/neuter_cuts.json"
+CUT_VALIDATOR = "scripts/test_quality/neuter_check.py"
+
 # Two submodule paths. Their index entries are written directly rather than cloned: what the guard
 # reads is the mode and the listing, and `git submodule add` adds a working tree and a `.gitmodules`
 # that neither reading looks at. The second ends in a suffix a fast check knows, which is what
@@ -76,6 +83,12 @@ FAILED_A_CHECK = " failed a fast check"
 RETRY_WHEN_GIT_ANSWERS = "Retry when git answers."
 CORRECT_WHAT_GIT_NAMED = "Correct what git named and retry."
 NOT_COPIED = "the index could not be copied."
+NOT_RUN = " could not be run."
+NOT_VALIDATED = "the cut map could not be validated."
+HOLDING = "a mutation campaign is holding one of these files."
+NEUTER_CARRIED = "carries a neuter from a sweep."
+PATHS_FROM_A_FILE = "its paths come from `--pathspec-from-file`"
+NAMED_INDEX = "the index `GIT_INDEX_FILE` names"
 
 # What git says of a directory with no repository at or above it.
 NOT_A_REPOSITORY = "not a git repository"
@@ -93,14 +106,42 @@ class GuardTestCase(unittest.TestCase):
                        capture_output=True, timeout=60)
         return root
 
-    def judge(self, command, cwd=None, path=None):
+    def judge(self, command, cwd=None, path=None, env=None):
         """The guard's verdict, as (exit code, stderr)."""
         event = {"tool_name": "Bash", "cwd": str(cwd or self.root),
                  "tool_input": {"command": command}}
+        environment = dict(os.environ, **(env or {}))
+        if path is not None:
+            environment["PATH"] = path
         done = subprocess.run([sys.executable, str(GUARD)], input=json.dumps(event).encode("utf-8"),
-                              capture_output=True, timeout=60,
-                              env=None if path is None else dict(os.environ, PATH=path))
+                              capture_output=True, timeout=60, env=environment)
         return done.returncode, done.stderr.decode("utf-8", "surrogateescape")
+
+    def scratch(self, prefix):
+        """A directory outside the repository, removed with the case."""
+        made = Path(tempfile.mkdtemp(prefix=prefix)).resolve()
+        self.addCleanup(shutil.rmtree, made, ignore_errors=True)
+        return made
+
+    def only_git(self):
+        """A PATH holding git and nothing else."""
+        path = self.scratch("fast-checks-path-")
+        os.symlink(shutil.which("git"), path / "git")
+        return str(path)
+
+    def logged_git(self):
+        """A directory whose `git` writes each command it runs to `started`, and what `cat-file` is
+        handed to `asked`, before running git."""
+        log = self.scratch("fast-checks-git-")
+        (log / "git").write_text(
+            "#!/bin/sh\n"
+            f'printf "%s\\n" "$*" >> "{log}/started"\n'
+            'case " $* " in\n'
+            f'  *" cat-file "*) tee -a "{log}/asked" | "{shutil.which("git")}" "$@" ;;\n'
+            f'  *) exec "{shutil.which("git")}" "$@" ;;\n'
+            "esac\n", encoding="utf-8")
+        os.chmod(log / "git", 0o755)
+        return log
 
     def git(self, *args, root=None):
         done = subprocess.run(["git", "-C", str(root or self.root), "-c", "user.email=t@velvet",
@@ -142,6 +183,14 @@ class GuardTestCase(unittest.TestCase):
                 return True
         except OSError:
             return False
+
+    def committed(self, *names):
+        """Each of `names` committed whole."""
+        for name in names:
+            (self.root / name).parent.mkdir(parents=True, exist_ok=True)
+            (self.root / name).write_text(WHOLE, encoding="utf-8")
+        self.git("add", *names)
+        self.git("commit", "-q", "-m", "arranged")
 
 
 class UnexpandedOperands(GuardTestCase):
@@ -281,6 +330,35 @@ class IndexedContent(GuardTestCase):
         self.git("commit", "-q", "-m", "recorded")
         self.assertEqual((code, said, listed, self.git("ls-tree", "HEAD", "--", SUB).split()[:2]),
                          (0, "", GITLINK_MODE, [GITLINK_MODE, "commit"]))
+
+    # GREEN_ON_BASE(characterization): the base's staged listing leaves an intent-to-add entry out.
+    def test_Given_AnIntentToAddEntry_When_TheIndexIsCommitted_Then_ItIsNotChecked(self):
+        # Arrange — broken JSON behind `add -N`, and a staged file so that the commit records one.
+        (self.root / "new.json").write_text('{"a": [1\n', encoding="utf-8")
+        self.git("add", "-N", "new.json")
+        (self.root / PLAIN).write_text(WHOLE, encoding="utf-8")
+        self.git("add", PLAIN)
+        listed = self.git("ls-files", "--", "new.json")
+
+        # Act
+        code, said = self.judge("git commit -m x")
+
+        # Assert — what the commit then wrote sits in the comparison, because leaving the entry
+        # unchecked is right only for as long as git records nothing there.
+        self.git("commit", "-q", "-m", "recorded")
+        self.assertEqual((code, said, listed, self.git("ls-tree", "--name-only", "HEAD")),
+                         (0, "", "new.json\n", PLAIN + "\n"))
+
+    def test_Given_NoPythonToCompileWith_When_AScriptIsCommitted_Then_TheRefusalSaysTheCheckDidNotRun(self):
+        # Arrange
+        (self.root / PLAIN).write_text(WHOLE, encoding="utf-8")
+        self.git("add", PLAIN)
+
+        # Act
+        code, said = self.judge("git commit -m x", path=self.only_git())
+
+        # Assert — beside the sentence a check that ran and failed writes, which is not this one's.
+        self.assertEqual((code, PLAIN + NOT_RUN in said, FAILED_A_CHECK in said), (2, True, False))
 
 
 class WorktreeContent(GuardTestCase):
@@ -486,9 +564,46 @@ class WorktreeContent(GuardTestCase):
         # Act
         code, said = self.judge("git commit -a -m x")
 
-        # Assert — beside the refusal, so a guard that never reached the working tree cannot pass.
-        self.assertEqual((code, PLAIN + FAILED_A_CHECK in said, (self.root / "ran").exists(),
-                          staged), (2, True, False, ""))
+        # Assert — beside the refusal, so a guard that never reached the working tree cannot pass,
+        # and beside an index write of git's own afterwards, which does run the hook.
+        ran = (self.root / "ran").exists()
+        self.git("add", PLAIN)
+        self.assertEqual((code, PLAIN + FAILED_A_CHECK in said, ran, (self.root / "ran").exists(),
+                          staged), (2, True, False, True, ""))
+
+    # GREEN_ON_BASE(characterization): the base runs no hook in this state either.
+    def test_Given_AHookOnEveryIndexWrite_When_CommittedByPathspec_Then_ItDoesNotRun(self):
+        # Arrange
+        staged = self.broken_only_in_the_worktree(PLAIN)
+        hook = self.root / ".git" / "hooks" / "post-index-change"
+        hook.write_text("#!/bin/sh\ntouch ran\n", encoding="utf-8")
+        os.chmod(hook, 0o755)
+
+        # Act
+        code, said = self.judge("git commit -m x -- " + PLAIN)
+
+        # Assert — as in the case above.
+        ran = (self.root / "ran").exists()
+        self.git("add", PLAIN)
+        self.assertEqual((code, PLAIN + FAILED_A_CHECK in said, ran, (self.root / "ran").exists(),
+                          staged), (2, True, False, True, ""))
+
+    # GREEN_ON_BASE(characterization): the base writes no shared index in this state either.
+    def test_Given_AnIndexSplitOnEveryWrite_When_Judged_Then_NoSharedIndexIsLeftBehind(self):
+        # Arrange
+        self.git("config", "core.splitIndex", "true")
+        self.git("config", "splitIndex.maxPercentChange", "0")
+        staged = self.broken_only_in_the_worktree(PLAIN)
+        before = sorted(path.name for path in (self.root / ".git").glob("sharedindex.*"))
+
+        # Act
+        code, said = self.judge("git commit -a -m x")
+
+        # Assert — beside the shared indexes the repository already held, so a repository that
+        # never split cannot pass.
+        after = sorted(path.name for path in (self.root / ".git").glob("sharedindex.*"))
+        self.assertEqual((code, PLAIN + FAILED_A_CHECK in said, bool(before), after, staged),
+                         (2, True, True, before, ""))
 
     def test_Given_ARelativePathspecFromASubdirectory_When_Judged_Then_TheFileItNamesIsChecked(self):
         # Arrange
@@ -606,6 +721,216 @@ class PathspecCommits(GuardTestCase):
         self.assertEqual((code, STAGED + FAILED_A_CHECK in said,
                           self.git("show", "HEAD:" + STAGED)), (2, True, BROKEN))
 
+    # GREEN_ON_BASE(characterization): the base's listings name nothing under a removed directory.
+    def test_Given_ADirectoryRemovedFromTheIndex_When_CommittedByPathspec_Then_TheCommitIsAllowed(self):
+        # Arrange — so the pathspec matches nothing but what HEAD holds.
+        self.committed("old/" + PLAIN)
+        self.git("rm", "-q", "-r", "old")
+
+        # Act
+        code, said = self.judge("git commit -m x -- old")
+
+        # Assert — what the commit then wrote sits in the comparison, because allowing it is right
+        # only for as long as git records the removal.
+        self.git("commit", "-q", "-m", "recorded", "--", "old")
+        self.assertEqual((code, said, self.git("ls-tree", "--name-only", "HEAD")), (0, "", ""))
+
+    def test_Given_AFileRemovedFromTheIndexAlone_When_ItsDirectoryIsCommitted_Then_ItIsChecked(self):
+        # Arrange — broken in the working copy, and in HEAD but not in the index. The file beside
+        # it keeps the pathspec matching something the index holds.
+        self.committed("sub/" + PLAIN, "sub/" + STAGED)
+        self.git("rm", "-q", "--cached", "sub/" + PLAIN)
+        (self.root / "sub" / PLAIN).write_text(BROKEN, encoding="utf-8")
+        listed = self.git("ls-files", "--", "sub/" + PLAIN)
+
+        # Act
+        code, said = self.judge("git commit -m x -- sub")
+
+        # Assert — what the commit then wrote sits in the comparison, because checking the file is
+        # right only for as long as git takes it back from the working tree.
+        self.git("commit", "-q", "-m", "recorded", "--", "sub")
+        self.assertEqual((code, "sub/" + PLAIN + FAILED_A_CHECK in said, listed,
+                          self.git("show", "HEAD:sub/" + PLAIN)), (2, True, "", BROKEN))
+
+    def test_Given_AnAssumeUnchangedFileBrokenOnDisk_When_CommittedByPathspec_Then_ItIsChecked(self):
+        # Arrange
+        self.committed(PLAIN)
+        self.git("update-index", "--assume-unchanged", PLAIN)
+        (self.root / PLAIN).write_text(BROKEN, encoding="utf-8")
+        listed = self.git("ls-files", "-v", "--", PLAIN)
+
+        # Act
+        code, said = self.judge("git commit -m x -- " + PLAIN)
+
+        # Assert — what the commit then wrote sits in the comparison, as above.
+        self.git("commit", "-q", "-m", "recorded", "--", PLAIN)
+        self.assertEqual((code, PLAIN + FAILED_A_CHECK in said, listed,
+                          self.git("show", "HEAD:" + PLAIN)), (2, True, "h " + PLAIN + "\n", BROKEN))
+
+    # GREEN_ON_BASE(characterization): the base's working-tree listing leaves a skip-worktree entry out.
+    def test_Given_ASkipWorktreeEntryBrokenOnDisk_When_CommittedByPathspec_Then_ItIsNotChecked(self):
+        # Arrange — beside a file changed whole, so that the commit records one.
+        self.committed(PLAIN, STAGED)
+        self.git("update-index", "--skip-worktree", PLAIN)
+        (self.root / PLAIN).write_text(BROKEN, encoding="utf-8")
+        (self.root / STAGED).write_text(TREE_AND_WHOLE, encoding="utf-8")
+
+        # Act
+        code, said = self.judge(f"git commit -m x -- {PLAIN} {STAGED}")
+
+        # Assert — what the commit then wrote sits in the comparison, because leaving the file
+        # unchecked is right only for as long as git keeps HEAD's copy of it.
+        self.git("commit", "-q", "-m", "recorded", "--", PLAIN, STAGED)
+        self.assertEqual((code, said, self.git("show", "HEAD:" + PLAIN)), (0, "", WHOLE))
+
+    def test_Given_PathsReadFromAFile_When_Judged_Then_TheCommitIsRefused(self):
+        # Arrange — the file names a path broken in its working copy alone, which git records. The
+        # flag spelled out, and abbreviated as far as git reads it as this flag alone.
+        self.committed(PLAIN)
+        (self.root / PLAIN).write_text(BROKEN, encoding="utf-8")
+        (self.root / "paths").write_text(PLAIN + "\n", encoding="utf-8")
+
+        # Act
+        verdicts = [self.judge("git commit -m x " + flag)
+                    for flag in ("--pathspec-from-file=paths", "--pathspec-fr paths")]
+
+        # Assert
+        self.assertEqual([(code, PATHS_FROM_A_FILE in said) for code, said in verdicts],
+                         [(2, True)] * 2)
+
+
+class GitProcesses(GuardTestCase):
+    def judge_logging(self, command):
+        """The guard's verdict under a `git` that logs, beside the directory holding the log."""
+        log = self.logged_git()
+        return self.judge(command, path=str(log) + os.pathsep + os.environ["PATH"]), log
+
+    # GREEN_ON_BASE(characterization): the base opens the working tree's files itself under `-a`.
+    def test_Given_MoreChangedFiles_When_Judged_Then_NoMoreGitProcessesStart(self):
+        # Arrange — twelve files committed whole, and the verdict over one of them changed. Each
+        # changes to text of its own, since files changed alike record one blob between them.
+        names = [f"file{number}.py" for number in range(12)]
+        self.committed(*names)
+        (self.root / names[0]).write_text("changed = 0\n", encoding="utf-8")
+        one, one_log = self.judge_logging("git commit -a -m x")
+        for number, name in enumerate(names[1:], 1):
+            (self.root / name).write_text(f"changed = {number}\n", encoding="utf-8")
+        changed = self.git("diff", "--name-only").splitlines()
+
+        # Act
+        many, many_log = self.judge_logging("git commit -a -m x")
+
+        # Assert
+        started = [len((log / "started").read_text(encoding="utf-8").splitlines())
+                   for log in (one_log, many_log)]
+        self.assertEqual((one, many, len(changed), started[1]),
+                         ((0, ""), (0, ""), len(names), started[0]))
+
+    def test_Given_AChangedFileNoCheckReads_When_Judged_Then_ItsBlobIsNotRead(self):
+        # Arrange — one suffix a fast check reads and one none does.
+        self.committed(PLAIN, "Unread.cs")
+        (self.root / PLAIN).write_text(TREE_AND_WHOLE, encoding="utf-8")
+        (self.root / "Unread.cs").write_text("class Unread {}\n", encoding="utf-8")
+        changed = self.git("diff", "--name-only")
+        blobs = [self.git("hash-object", name).strip() for name in ("Unread.cs", PLAIN)]
+
+        # Act
+        (code, said), log = self.judge_logging("git commit -a -m x")
+
+        # Assert — beside the blob a check does read, so a git nobody asked cannot pass.
+        asked = "".join(each.read_text(encoding="utf-8")
+                        for each in (log / "started", log / "asked") if each.exists())
+        self.assertEqual((code, said, changed, [blob in asked for blob in blobs]),
+                         (0, "", "Unread.cs\n" + PLAIN + "\n", [False, True]))
+
+
+class CampaignsAndCuts(GuardTestCase):
+    def campaign_holding(self, name):
+        """A campaign's record holding `name`, beside the script that reads it."""
+        script = self.root / CAMPAIGN.relative_to(REPO_ROOT)
+        script.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy(CAMPAIGN, script)
+        Holder(self.root / SENTINEL).hold(self.root / name, WHOLE, BROKEN, "probe")
+
+    # GREEN_ON_BASE(characterization): the base reads every file it lists, whatever its suffix.
+    def test_Given_ACutsSourceCarryingItsNeuter_When_Committed_Then_ItIsRefused(self):
+        # Arrange — a suffix no fast check reads, so the cut is all that asks for this blob.
+        (self.root / CUT_MAP).parent.mkdir(parents=True)
+        (self.root / CUT_MAP).write_text(json.dumps({"cuts": [{"edits": [
+            {"file": "Cut.cs", "anchor": "void Run()", "neuter": "return;"}]}]}), encoding="utf-8")
+        (self.root / "Cut.cs").write_text(
+            "class Cut\n{\n    void Run()\n    {\n        return;\n    }\n}\n", encoding="utf-8")
+        self.git("add", "Cut.cs")
+
+        # Act
+        code, said = self.judge("git commit -m x")
+
+        # Assert
+        self.assertEqual((code, NEUTER_CARRIED in said), (2, True))
+
+    def test_Given_ACampaignHoldingANameOutsideTheEncoding_When_Judged_Then_TheRefusalSaysSo(self):
+        # Arrange — the name in the index alone, as for the index cases above, and a caller whose
+        # Python writes its streams strictly.
+        self.index(b"100644 " + self.blob(WHOLE.encode("utf-8")) + b"\t" + RAW_BYTE_NAME + b"\x00")
+        self.campaign_holding(os.fsdecode(RAW_BYTE_NAME))
+        strict = {"PYTHONIOENCODING": "utf-8:strict"}
+
+        # Act
+        code, said = self.judge("git commit -m x", env=strict)
+
+        # Assert — the name too, as the refusal spells it, since a name in UTF-8 is refused alike;
+        # and that this caller's Python cannot write the name, since one that can poses nothing.
+        writes = subprocess.run([sys.executable, "-c", "print('\\udcff')"], capture_output=True,
+                                timeout=60, env=dict(os.environ, **strict)).returncode
+        self.assertEqual((code, HOLDING in said, RAW_BYTE_SHOWN.strip('"') in said, writes),
+                         (2, True, True, 1))
+
+    # GREEN_ON_BASE(characterization): the base asks the campaign about every file it reads.
+    def test_Given_ACampaignHoldingASourceNoCheckReads_When_ItIsCommitted_Then_TheRefusalSaysSo(self):
+        # Arrange
+        self.committed("Held.cs")
+        (self.root / "Held.cs").write_text("class Held {}\n", encoding="utf-8")
+        self.campaign_holding("Held.cs")
+
+        # Act
+        code, said = self.judge("git commit -a -m x")
+
+        # Assert
+        self.assertEqual((code, HOLDING in said), (2, True))
+
+    def test_Given_NoPythonToValidateTheCutMap_When_TheMapIsCommitted_Then_TheRefusalSaysSo(self):
+        # Arrange — the validator is there to run, and the map is what the commit records.
+        (self.root / CUT_VALIDATOR).parent.mkdir(parents=True)
+        (self.root / CUT_VALIDATOR).write_text("", encoding="utf-8")
+        (self.root / CUT_MAP).write_text(json.dumps({"cuts": [], "fixtures": []}), encoding="utf-8")
+        self.git("add", CUT_MAP)
+
+        # Act
+        code, said = self.judge("git commit -m x", path=self.only_git())
+
+        # Assert
+        self.assertEqual((code, NOT_VALIDATED in said), (2, True))
+
+    def verdict_beside_cut_map(self, shape):
+        """The verdict on the commit arranged below, with the working tree's cut map as `shape`."""
+        (self.root / CUT_MAP).write_text(json.dumps(shape), encoding="utf-8")
+        code, said = self.judge("git commit -m x")
+        return code, PLAIN + FAILED_A_CHECK in said
+
+    def test_Given_ACutMapOfAnotherShape_When_ABrokenFileIsCommitted_Then_ItIsStillChecked(self):
+        # Arrange — JSON each time, and none of it the map's shape: a list, an edit with no file,
+        # and cuts that are not a list.
+        (self.root / CUT_MAP).parent.mkdir(parents=True)
+        (self.root / PLAIN).write_text(BROKEN, encoding="utf-8")
+        self.git("add", PLAIN)
+
+        # Act
+        verdicts = [self.verdict_beside_cut_map(shape)
+                    for shape in ([], {"cuts": [{"edits": [{}]}]}, {"cuts": 1})]
+
+        # Assert
+        self.assertEqual(verdicts, [(2, True)] * 3)
+
 
 class TreeTheChecksRunIn(GuardTestCase):
     def test_Given_ARootWhoseNameEndsInASpace_When_Judged_Then_TheChecksReachIt(self):
@@ -668,6 +993,22 @@ class TreeTheChecksRunIn(GuardTestCase):
 
         # Assert
         self.assertEqual((code, PLAIN + FAILED_A_CHECK in said), (2, True))
+
+    def test_Given_AnIndexNamedByAnAssignment_When_Judged_Then_TheCommitIsRefused(self):
+        # Arrange — that index holds a broken blob, and the repository's own stages nothing.
+        self.committed(PLAIN)
+        other = self.scratch("fast-checks-index-") / "index"
+        shutil.copy(self.root / ".git" / "index", other)
+        (self.root / PLAIN).write_text(BROKEN, encoding="utf-8")
+        subprocess.run(["git", "-C", str(self.root), "add", PLAIN], check=True, capture_output=True,
+                       timeout=60, env=dict(os.environ, GIT_INDEX_FILE=str(other)))
+        (self.root / PLAIN).write_text(WHOLE, encoding="utf-8")
+
+        # Act
+        code, said = self.judge(f"GIT_INDEX_FILE={other} git commit -m x")
+
+        # Assert
+        self.assertEqual((code, NAMED_INDEX in said), (2, True))
 
     def test_Given_ARelativeDirectory_When_Judged_Then_ItIsReadFromWhereTheCommandRuns(self):
         # Arrange

--- a/scripts/hooks/test_commit_failing_fast_checks.py
+++ b/scripts/hooks/test_commit_failing_fast_checks.py
@@ -59,6 +59,8 @@ RAW_TARGET = b'{"a": "\xff"}'
 CLOSED = "closed.py"
 
 STAGED = "staged.py"
+EXCLUDED = "excluded.json"
+TOP = "top.py"
 
 # Where the guard reads the cuts a neuter sweep may be holding, and what validates them.
 CUT_MAP = "scripts/test_quality/neuter_cuts.json"
@@ -130,14 +132,15 @@ class GuardTestCase(unittest.TestCase):
         return str(path)
 
     def logged_git(self):
-        """A directory whose `git` writes each command it runs to `started`, and what `cat-file` is
-        handed to `asked`, before running git."""
+        """A directory whose `git` writes each command it runs to `started`, and what `cat-file`
+        and `update-index` are handed to `asked` and `indexed`, before running git."""
         log = self.scratch("fast-checks-git-")
         (log / "git").write_text(
             "#!/bin/sh\n"
             f'printf "%s\\n" "$*" >> "{log}/started"\n'
             'case " $* " in\n'
             f'  *" cat-file "*) tee -a "{log}/asked" | "{shutil.which("git")}" "$@" ;;\n'
+            f'  *" update-index "*) tee -a "{log}/indexed" | "{shutil.which("git")}" "$@" ;;\n'
             f'  *) exec "{shutil.which("git")}" "$@" ;;\n'
             "esac\n", encoding="utf-8")
         os.chmod(log / "git", 0o755)
@@ -798,6 +801,105 @@ class PathspecCommits(GuardTestCase):
         self.assertEqual([(code, PATHS_FROM_A_FILE in said) for code, said in verdicts],
                          [(2, True)] * 2)
 
+    # GREEN_ON_BASE(characterization): the base checks the staged file in this state too.
+    def test_Given_AFileReplacedByADirectory_When_ItsFileIsCommittedByPathspec_Then_ItIsChecked(self):
+        # Arrange — a name that is a file in HEAD and a directory in the index.
+        self.committed("tool")
+        self.git("rm", "-q", "tool")
+        (self.root / "tool").mkdir()
+        (self.root / "tool" / PLAIN).write_text(BROKEN, encoding="utf-8")
+        self.git("add", "tool/" + PLAIN)
+
+        # Act
+        code, said = self.judge("git commit -m x -- tool/" + PLAIN)
+
+        # Assert — what the commit then wrote sits in the comparison, because checking the file is
+        # right only for as long as git records it.
+        self.git("commit", "-q", "-m", "recorded", "--", "tool/" + PLAIN)
+        self.assertEqual((code, "tool/" + PLAIN + FAILED_A_CHECK in said,
+                          self.git("show", "HEAD:tool/" + PLAIN)), (2, True, BROKEN))
+
+    # GREEN_ON_BASE(characterization): the base checks the staged file in this state too.
+    def test_Given_ADirectoryReplacedByAFile_When_TheFileIsCommittedByPathspec_Then_ItIsChecked(self):
+        # Arrange — a name that is a directory in HEAD and a file in the index.
+        self.committed("settings.json/" + PLAIN)
+        self.git("rm", "-q", "-r", "settings.json")
+        (self.root / "settings.json").write_text(BROKEN, encoding="utf-8")
+        self.git("add", "settings.json")
+
+        # Act
+        code, said = self.judge("git commit -m x -- settings.json")
+
+        # Assert — what the commit then wrote sits in the comparison, as above.
+        self.git("commit", "-q", "-m", "recorded", "--", "settings.json")
+        self.assertEqual((code, "settings.json" + FAILED_A_CHECK in said,
+                          self.git("show", "HEAD:settings.json")), (2, True, BROKEN))
+
+    def below_a_broken_file(self):
+        """`sub`, holding a file changed whole and one broken, below a file broken in its working
+        copy alone whose name sorts after both, so that a check reaching the broken one in `sub`
+        refuses over that first."""
+        self.committed(TOP, "sub/" + STAGED, "sub/" + EXCLUDED)
+        (self.root / TOP).write_text(BROKEN, encoding="utf-8")
+        (self.root / "sub" / STAGED).write_text(TREE_AND_WHOLE, encoding="utf-8")
+        (self.root / "sub" / EXCLUDED).write_text(BROKEN, encoding="utf-8")
+        return self.root / "sub"
+
+    def test_Given_PathspecsThatOnlyExcludeFromASubdirectory_When_Judged_Then_AFileOutsideItIsChecked(self):
+        # Arrange — the exclusion spelled five ways.
+        sub = self.below_a_broken_file()
+        spellings = [":(exclude)" + EXCLUDED, ":!" + EXCLUDED, ":^" + EXCLUDED,
+                     ":(icase,exclude)" + EXCLUDED, ":/!sub/" + EXCLUDED]
+
+        # Act
+        verdicts = [self.judge(f"git commit -m x -- '{spelling}'", cwd=sub)
+                    for spelling in spellings]
+
+        # Assert — what the commit then wrote sits in the comparison, because checking the file
+        # above is right only for as long as git takes it into the commit.
+        self.git("commit", "-q", "-m", "recorded", "--", spellings[0], root=sub)
+        self.assertEqual(([(code, TOP + FAILED_A_CHECK in said) for code, said in verdicts],
+                          self.git("show", "HEAD:" + TOP)),
+                         ([(2, True)] * len(spellings), BROKEN))
+
+    # GREEN_ON_BASE(characterization): the base leaves the file above unchecked here too.
+    def test_Given_PathspecsThatDoNotOnlyExcludeFromASubdirectory_When_Judged_Then_AFileOutsideItIsNotChecked(self):
+        # Arrange — an exclusion beside a path, magic that is not an exclusion, and an exclusion's
+        # name in an attribute's value behind an escaped comma.
+        sub = self.below_a_broken_file()
+        (sub / ".gitattributes").write_text(STAGED + " x=a,exclude\n", encoding="utf-8")
+        operands = [f"{STAGED} ':!{EXCLUDED}'", f"':/sub/{STAGED}'", f"':(top)sub/{STAGED}'",
+                    f"':(attr:x=a\\,exclude){STAGED}'"]
+
+        # Act
+        verdicts = [self.judge("git commit -m x -- " + each, cwd=sub) for each in operands]
+
+        # Assert — what the commit then wrote sits in the comparison, because leaving the file
+        # above unchecked is right only for as long as the commit leaves it out.
+        self.git("commit", "-q", "-m", "recorded", "--", STAGED, ":!" + EXCLUDED, root=sub)
+        self.assertEqual((verdicts, self.git("show", "HEAD:" + TOP)),
+                         ([(0, "")] * len(operands), WHOLE))
+
+    # GREEN_ON_BASE(characterization): the base lists this file alone here too.
+    def test_Given_PathspecsReadLiterally_When_AFileNamedAsAnExclusionIsCommitted_Then_ItIsAllowed(self):
+        # Arrange — git's documented literals for true, one of them in capitals.
+        named = ":!" + PLAIN
+        (self.root / named).write_text(WHOLE, encoding="utf-8")
+        self.git("--literal-pathspecs", "add", named)
+        self.git("commit", "-q", "-m", "arranged")
+        (self.root / named).write_text(TREE_AND_WHOLE, encoding="utf-8")
+
+        # Act
+        verdicts = [self.judge(f"git commit -m x -- '{named}'",
+                               env={"GIT_LITERAL_PATHSPECS": value})
+                    for value in ("1", "TRUE", "yes", "on")]
+
+        # Assert — what the commit then wrote sits in the comparison, because reading the pathspec as
+        # a name is right only for as long as git reads it as one.
+        self.git("--literal-pathspecs", "commit", "-q", "-m", "recorded", "--", named)
+        self.assertEqual((verdicts, self.git("show", "HEAD:" + named)),
+                         ([(0, "")] * 4, TREE_AND_WHOLE))
+
 
 class GitProcesses(GuardTestCase):
     def judge_logging(self, command):
@@ -842,6 +944,21 @@ class GitProcesses(GuardTestCase):
                         for each in (log / "started", log / "asked") if each.exists())
         self.assertEqual((code, said, changed, [blob in asked for blob in blobs]),
                          (0, "", "Unread.cs\n" + PLAIN + "\n", [False, True]))
+
+    def test_Given_APathspecCommit_When_Judged_Then_TheIndexIsHandedNoAbsolutePath(self):
+        # Arrange
+        self.committed(PLAIN)
+        (self.root / PLAIN).write_text(BROKEN, encoding="utf-8")
+
+        # Act
+        (code, said), log = self.judge_logging("git commit -m x -- " + PLAIN)
+
+        # Assert — beside the refusal, so a guard that never reached the file cannot pass.
+        indexed = log / "indexed"
+        handed = indexed.read_bytes().split(b"\0")[:-1] if indexed.exists() else []
+        self.assertEqual(
+            (code, PLAIN + FAILED_A_CHECK in said, [os.path.isabs(path) for path in handed]),
+            (2, True, [False]))
 
 
 class CampaignsAndCuts(GuardTestCase):

--- a/scripts/hooks/test_commit_failing_fast_checks.py
+++ b/scripts/hooks/test_commit_failing_fast_checks.py
@@ -62,6 +62,8 @@ STAGED = "staged.py"
 EXCLUDED = "excluded.json"
 TOP = "top.py"
 
+LITERAL_PATHSPECS = "GIT_LITERAL_PATHSPECS"
+
 # Where the guard reads the cuts a neuter sweep may be holding, and what validates them.
 CUT_MAP = "scripts/test_quality/neuter_cuts.json"
 CUT_VALIDATOR = "scripts/test_quality/neuter_check.py"
@@ -146,11 +148,18 @@ class GuardTestCase(unittest.TestCase):
         os.chmod(log / "git", 0o755)
         return log
 
-    def git(self, *args, root=None):
+    def git(self, *args, root=None, env=None):
         done = subprocess.run(["git", "-C", str(root or self.root), "-c", "user.email=t@velvet",
                                "-c", "user.name=t", *args],
-                              check=True, capture_output=True, timeout=60)
+                              check=True, capture_output=True, timeout=60,
+                              env=None if env is None else dict(os.environ, **env))
         return done.stdout.decode("utf-8", "surrogateescape")
+
+    def exits(self, *args):
+        """What git exits with, for a command that is expected to refuse."""
+        return subprocess.run(["git", "-C", str(self.root), "-c", "user.email=t@velvet",
+                               "-c", "user.name=t", *args],
+                              capture_output=True, timeout=60).returncode
 
     def index(self, record):
         """`record` written into the index, as the raw bytes of one `--index-info` line."""
@@ -556,6 +565,23 @@ class WorktreeContent(GuardTestCase):
         self.assertEqual((code, CLOSED in said, CORRECT_WHAT_GIT_NAMED in said, self.opens(CLOSED),
                           staged), (2, True, True, False, ""))
 
+    def test_Given_AnUnreadableFileWhereAddIgnoresErrors_When_Judged_Then_TheRefusalIsGitsAccountOfIt(self):
+        # Arrange — the case above, in a repository whose `git add` passes over a file it cannot
+        # read.
+        self.git("config", "add.ignoreErrors", "true")
+        staged = self.broken_only_in_the_worktree(CLOSED)
+        os.chmod(self.root / CLOSED, 0o000)
+        self.addCleanup(os.chmod, self.root / CLOSED, 0o644)
+
+        # Act
+        code, said = self.judge("git commit -a -m x")
+
+        # Assert — beside what `git add -u` and then the commit exit with here: the setting is live
+        # for the one, and refusing is right only for as long as the other refuses.
+        self.assertEqual((code, CLOSED in said, CORRECT_WHAT_GIT_NAMED in said, self.opens(CLOSED),
+                          staged, self.exits("add", "-u"), self.exits("commit", "-a", "-m", "x")),
+                         (2, True, True, False, "", 1, 128))
+
     # GREEN_ON_BASE(characterization): the base runs no hook in this state either.
     def test_Given_AHookOnEveryIndexWrite_When_Judged_Then_ItDoesNotRun(self):
         # Arrange
@@ -712,6 +738,22 @@ class PathspecCommits(GuardTestCase):
                           self.git("show", "HEAD:" + STAGED)), (2, True, BROKEN))
 
     # GREEN_ON_BASE(characterization): the base checks what is staged beside a pathspec too.
+    def test_Given_AnotherFileStagedBroken_When_ASkipWorktreeEntryIsCommittedWithInclude_Then_ItIsChecked(self):
+        # Arrange — the case above with the named file marked skip-worktree.
+        self.staged_beside(PLAIN)
+        self.git("update-index", "--skip-worktree", PLAIN)
+        listed = self.git("ls-files", "-t", "--", PLAIN)
+
+        # Act
+        code, said = self.judge("git commit -m x -i -- " + PLAIN)
+
+        # Assert — what the commit then wrote sits in the comparison, as above; and the listing,
+        # since without its bit `git add` does not exit 1 here and this is the case above.
+        self.git("commit", "-q", "-m", "recorded", "-i", "--", PLAIN)
+        self.assertEqual((code, STAGED + FAILED_A_CHECK in said, listed,
+                          self.git("show", "HEAD:" + STAGED)), (2, True, "S " + PLAIN + "\n", BROKEN))
+
+    # GREEN_ON_BASE(characterization): the base checks what is staged beside a pathspec too.
     def test_Given_AnotherFileStagedBroken_When_CommittedWithIncludeAbbreviated_Then_ItIsChecked(self):
         # Arrange
         self.staged_beside(PLAIN)
@@ -785,6 +827,105 @@ class PathspecCommits(GuardTestCase):
         # unchecked is right only for as long as git keeps HEAD's copy of it.
         self.git("commit", "-q", "-m", "recorded", "--", PLAIN, STAGED)
         self.assertEqual((code, said, self.git("show", "HEAD:" + PLAIN)), (0, "", WHOLE))
+
+    # GREEN_ON_BASE(characterization): the base leaves this entry unchecked under `-i` too.
+    def test_Given_ASkipWorktreeEntryNamedWithInclude_When_Judged_Then_TheCommitIsAllowed(self):
+        # Arrange — broken in its working copy, beside a file staged whole so that the commit
+        # records one.
+        self.committed(PLAIN, STAGED)
+        self.git("update-index", "--skip-worktree", PLAIN)
+        (self.root / PLAIN).write_text(BROKEN, encoding="utf-8")
+        (self.root / STAGED).write_text(TREE_AND_WHOLE, encoding="utf-8")
+        self.git("add", STAGED)
+
+        # Act
+        code, said = self.judge("git commit -m x -i -- " + PLAIN)
+
+        # Assert — what the commit then wrote sits in the comparison, because leaving the entry
+        # unchecked is right only for as long as git keeps the index's copy of it; and the working
+        # copy beside it, since a whole one leaves this passing whichever copy was read.
+        self.git("commit", "-q", "-m", "recorded", "-i", "--", PLAIN)
+        self.assertEqual((code, said, (self.root / PLAIN).read_text(encoding="utf-8"),
+                          self.git("show", "HEAD:" + PLAIN)), (0, "", BROKEN, WHOLE))
+
+    # GREEN_ON_BASE(characterization): the base checks a staged blob under `-i` whatever its bit.
+    def test_Given_ASkipWorktreeEntryStagedBroken_When_NamedWithInclude_Then_ItsStagedCopyIsChecked(self):
+        # Arrange — staged broken before it was marked, and whole in its working copy.
+        self.committed(PLAIN)
+        (self.root / PLAIN).write_text(BROKEN, encoding="utf-8")
+        self.git("add", PLAIN)
+        self.git("update-index", "--skip-worktree", PLAIN)
+        (self.root / PLAIN).write_text(WHOLE, encoding="utf-8")
+
+        # Act
+        code, said = self.judge("git commit -m x -i -- " + PLAIN)
+
+        # Assert — what the commit then wrote sits in the comparison, because checking the staged
+        # copy is right only for as long as git records it; and the working copy, since a broken
+        # one leaves this refusing whether the staged copy or the working one was read.
+        self.git("commit", "-q", "-m", "recorded", "-i", "--", PLAIN)
+        self.assertEqual((code, PLAIN + FAILED_A_CHECK in said,
+                          (self.root / PLAIN).read_text(encoding="utf-8"),
+                          self.git("show", "HEAD:" + PLAIN)), (2, True, WHOLE, BROKEN))
+
+    # GREEN_ON_BASE(characterization): the base checks a named file's working copy under `-i` too.
+    def test_Given_ASkipWorktreeEntryNamedWithIncludeBesideABrokenFile_When_Judged_Then_TheBrokenFileIsChecked(self):
+        # Arrange — one pathspec for each, the file broken in its working copy alone.
+        self.committed(PLAIN, STAGED)
+        self.git("update-index", "--skip-worktree", PLAIN)
+        (self.root / STAGED).write_text(BROKEN, encoding="utf-8")
+        listed = self.git("ls-files", "-t", "--", PLAIN)
+
+        # Act
+        code, said = self.judge(f"git commit -m x -i -- {PLAIN} {STAGED}")
+
+        # Assert — what the commit then wrote sits in the comparison, because checking the file is
+        # right only for as long as git takes it from the working tree; and the entry's listing,
+        # since without its bit `git add` does not exit 1 here.
+        self.git("commit", "-q", "-m", "recorded", "-i", "--", PLAIN, STAGED)
+        self.assertEqual((code, STAGED + FAILED_A_CHECK in said, listed,
+                          self.git("show", "HEAD:" + STAGED)), (2, True, "S " + PLAIN + "\n", BROKEN))
+
+    def outside_the_cone(self):
+        """A sparse checkout of `in`, with `out/PLAIN` tracked, broken in its working copy and not
+        marked skip-worktree, beside `in/STAGED` staged whole; as that entry's listing."""
+        self.committed("in/" + STAGED, "out/" + PLAIN)
+        self.git("sparse-checkout", "set", "in")
+        (self.root / "out").mkdir(exist_ok=True)
+        (self.root / "out" / PLAIN).write_text(BROKEN, encoding="utf-8")
+        (self.root / "in" / STAGED).write_text(TREE_AND_WHOLE, encoding="utf-8")
+        self.git("add", "in/" + STAGED)
+        return self.git("ls-files", "-t", "--", "out/" + PLAIN)
+
+    def test_Given_AFileOutsideTheSparseConeNamedWithInclude_When_Judged_Then_TheCommitIsAllowed(self):
+        # Arrange
+        listed = self.outside_the_cone()
+
+        # Act
+        code, said = self.judge("git commit -m x -i -- out/" + PLAIN)
+
+        # Assert — what the commit then wrote sits in the comparison, because leaving the file
+        # unchecked is right only for as long as git keeps the index's copy of it; the listing,
+        # since an entry marked skip-worktree is what
+        # `test_Given_ASkipWorktreeEntryNamedWithInclude_When_Judged_Then_TheCommitIsAllowed`
+        # arranges; and the working copy, for the reason given there.
+        self.git("commit", "-q", "-m", "recorded", "-i", "--", "out/" + PLAIN)
+        self.assertEqual((code, said, listed, (self.root / "out" / PLAIN).read_text(encoding="utf-8"),
+                          self.git("show", "HEAD:out/" + PLAIN)),
+                         (0, "", "H out/" + PLAIN + "\n", BROKEN, WHOLE))
+
+    def test_Given_AFileOutsideTheSparseCone_When_CommittedWithAll_Then_TheCommitIsAllowed(self):
+        # Arrange
+        listed = self.outside_the_cone()
+
+        # Act
+        code, said = self.judge("git commit -a -m x")
+
+        # Assert — as in the case above.
+        self.git("commit", "-a", "-q", "-m", "recorded")
+        self.assertEqual((code, said, listed, (self.root / "out" / PLAIN).read_text(encoding="utf-8"),
+                          self.git("show", "HEAD:out/" + PLAIN)),
+                         (0, "", "H out/" + PLAIN + "\n", BROKEN, WHOLE))
 
     def test_Given_PathsReadFromAFile_When_Judged_Then_TheCommitIsRefused(self):
         # Arrange — the file names a path broken in its working copy alone, which git records. The
@@ -882,23 +1023,50 @@ class PathspecCommits(GuardTestCase):
 
     # GREEN_ON_BASE(characterization): the base lists this file alone here too.
     def test_Given_PathspecsReadLiterally_When_AFileNamedAsAnExclusionIsCommitted_Then_ItIsAllowed(self):
-        # Arrange — git's documented literals for true, one of them in capitals.
+        # Arrange — git's words for true, one of them in capitals, and non-zero integers signed, in
+        # octal and in hexadecimal, after whitespace and before a unit. The file beside it is one
+        # an exclusion would list too.
         named = ":!" + PLAIN
-        (self.root / named).write_text(WHOLE, encoding="utf-8")
-        self.git("--literal-pathspecs", "add", named)
+        for name in (named, STAGED):
+            (self.root / name).write_text(WHOLE, encoding="utf-8")
+        self.git("--literal-pathspecs", "add", named, STAGED)
         self.git("commit", "-q", "-m", "arranged")
         (self.root / named).write_text(TREE_AND_WHOLE, encoding="utf-8")
+        values = ("1", "TRUE", "yes", "on", "2", "-1", "010", "0x1", "\t1", "1k")
 
         # Act
-        verdicts = [self.judge(f"git commit -m x -- '{named}'",
-                               env={"GIT_LITERAL_PATHSPECS": value})
-                    for value in ("1", "TRUE", "yes", "on")]
+        verdicts = [self.judge(f"git commit -m x -- '{named}'", env={LITERAL_PATHSPECS: value})
+                    for value in values]
 
         # Assert — what the commit then wrote sits in the comparison, because reading the pathspec as
-        # a name is right only for as long as git reads it as one.
+        # a name is right only for as long as git reads it as one; and git's listing under each
+        # value, which names this file alone only while git reads the value as true.
+        listings = [self.git("ls-files", "--", named, env={LITERAL_PATHSPECS: value})
+                    for value in values]
         self.git("--literal-pathspecs", "commit", "-q", "-m", "recorded", "--", named)
-        self.assertEqual((verdicts, self.git("show", "HEAD:" + named)),
-                         ([(0, "")] * 4, TREE_AND_WHOLE))
+        self.assertEqual((verdicts, listings, self.git("show", "HEAD:" + named)),
+                         ([(0, "")] * len(values), [named + "\n"] * len(values), TREE_AND_WHOLE))
+
+    def test_Given_ALiteralSettingGitReadsAsFalse_When_PathspecsOnlyExcludeFromASubdirectory_Then_AFileOutsideItIsChecked(self):
+        # Arrange — git's words for false, one of them in capitals, the empty value, and zero in
+        # the forms of the case above.
+        sub = self.below_a_broken_file()
+        values = ("", "off", "NO", "0", "-0", "00", "0x0", "\t0", "0k")
+
+        # Act
+        verdicts = [self.judge(f"git commit -m x -- ':!{EXCLUDED}'", cwd=sub,
+                               env={LITERAL_PATHSPECS: value}) for value in values]
+
+        # Assert — what the commit then wrote sits in the comparison, because checking the file
+        # above is right only for as long as git takes it into the commit; and git's listing under
+        # each value, which reads the exclusion as one only while git reads the value as false.
+        listings = [self.git("ls-files", "--", ":!" + EXCLUDED, root=sub,
+                             env={LITERAL_PATHSPECS: value}) for value in values]
+        self.git("commit", "-q", "-m", "recorded", "--", ":!" + EXCLUDED, root=sub,
+                 env={LITERAL_PATHSPECS: values[-1]})
+        self.assertEqual(([(code, TOP + FAILED_A_CHECK in said) for code, said in verdicts],
+                          listings, self.git("show", "HEAD:" + TOP)),
+                         ([(2, True)] * len(values), [STAGED + "\n"] * len(values), BROKEN))
 
 
 class GitProcesses(GuardTestCase):


### PR DESCRIPTION
The fast-check guard assembled what a commit records from two readings of its own: the staged blobs, and the working-tree files a `git diff` listing named, opened from disk. Each stood in for the recorded bytes, and each parted from them somewhere:

- a pathspec relative to a subdirectory was handed to git at the repository root, matched nothing there, and no check read the file it named;
- `.gitattributes` normalisation was not applied, so a CRLF script git records as LF was refused;
- a typechange reports as `T`, which `--diff-filter=ACMR` dropped;
- `git commit -- <paths>` records only those paths, while the guard checked everything staged, and a path the index had dropped, or an assume-unchanged file, went unchecked though git records it from disk;
- `--git-dir`, `--work-tree`, `GIT_DIR` and `GIT_WORK_TREE` were not read, so a commit aimed at another repository was checked against the directory the command started in.

The guard now builds an index of its own and checks the blobs `git diff-index` reports between it and HEAD. For a commit of the index it is a copy of the index. Under `-a` or `-i` it is that copy after `git add -u`, with `add.ignoreErrors` off, since `git commit` does not read it, and read past the exit 1 `git add` gives a pathspec matching only entries marked skip-worktree or outside the sparse-checkout definition, where `git commit -i` goes on. For a pathspec alone it is HEAD's tree with each path the pathspecs match in the index or in HEAD taken from disk, or dropped where disk has none, and a skip-worktree entry left as HEAD has it. Pathspecs that only exclude are matched against the whole tree wherever the command runs, as `git commit` matches them, except where `GIT_LITERAL_PATHSPECS` has git read every pathspec as a name. Whether it does is asked of git rather than restated: git reads `2`, `-1`, `010`, `0x1`, a tab before `1` and `1k` as true too. An intent-to-add entry is read as absent. The readings replay `-C`, `--git-dir`, `--work-tree`, `GIT_DIR` and `GIT_WORK_TREE` from the directory the command runs in. The real index is not written, and the guard's writes to its own run with hooks and index splitting off.

Not replayed: the global pathspec options `--glob-pathspecs`, `--noglob-pathspecs`, `--icase-pathspecs` and `--literal-pathspecs`, a `GIT_*_PATHSPECS` variable the command sets itself, and configuration the command sets itself with `-c`, `--config-env` or a `GIT_CONFIG_*` assignment. Under any of them the paths or bytes checked can differ from those the commit records: beside a `d/x.py`, a broken top-level `x.py` that `git --glob-pathspecs commit -m x -- '**/x.py'` records passes unchecked, as it does on main; `GIT_ICASE_PATHSPECS=1 git commit -m x -- X.PY`, which git records `x.py` under, is refused as naming nothing; `git -c core.sparseCheckout=false commit -i` records a file outside the sparse cone the guard did not check; and `git -c core.autocrlf=false commit -a` records a carriage return the guard read normalised away. A `GIT_CONFIG` in the hook's environment stops the literal-pathspec probe answering, so a literal pathspec is read as magic. A commit run from inside an unpopulated submodule's directory, or naming a path beyond a symbolic link, is refused though git records it: the guard's own `git add` or `update-index` dies there and `git commit` goes on.

A commit of the index read each staged blob with its own `git show`: 800 staged `.cs` files, which no check reads, took 15.4 s here, past the 15 s timeout the hook is registered with. The blobs are now read by one `git cat-file --batch`, and only those whose suffix a fast check handles or whose path a neuter cut names; the same commit takes 0.3 s. The `.py` and `.sh` checks still start a process per file they check.

A commit whose paths come from `--pathspec-from-file`, or whose index a leading `GIT_INDEX_FILE=` names, is refused: the guard reads neither. A file git cannot read is refused in git's own words.

Five states exited 1, which lets the commit through unchecked: `bash -n` or the carried-mutation check printing back bytes UTF-8 does not map, the cut-map validator or a fast-check tool failing to start, and a working-tree cut map of the wrong shape. The first four are now refusals, and a cut map of the wrong shape no longer stops the commit being checked. The carried-mutation check is run with its output in UTF-8, so a strict locale no longer turns its refusal into a claim that it could not read the campaign's record.

`lib/shell_commands.py` returns the working tree and a leading `GIT_INDEX_FILE=` beside the git directory in `GitContext`.

No `Documentation~` or CHANGELOG impact: no guide describes this guard, and it is contributor tooling.

Closes #1006: the last three of its sites, in this guard. Closes #1023, closes #1024, closes #1029, closes #1030.
