### PR TITLE
fix(velvet): judge a commit message against the tree the commit is made in

### DIFF
--- a/.harness/hooks/lib/shell_commands.py
+++ b/.harness/hooks/lib/shell_commands.py
@@ -342,6 +342,14 @@ def git_invocation(tokens, git_directory=False):
     return context, tokens[index], tokens[index + 1:]
 
 
+def tree_selectors(context):
+    """(option, value) for each selector in `context` that decides which tree git acts on, with an
+    assignment spelled as the option it stands for."""
+    return [(flag, value) for flag, value in (
+        ("-C", context.working_directory), (GIT_DIRECTORY_FLAG, context.git_directory),
+        (WORK_TREE_FLAG, context.work_tree)) if value]
+
+
 # Where a move left the shell when nothing here places it.
 UNRESOLVED_CD = object()
 

--- a/.harness/hooks/refuse/commit_failing_fast_checks.py
+++ b/.harness/hooks/refuse/commit_failing_fast_checks.py
@@ -39,7 +39,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lib"))
 from display import displayed
 from shell_commands import (COMMIT_VALUE_FLAGS, NAME_THE_TREE, UNPLACEABLE_MOVE, UNRESOLVED_CD,
-                            command_directory, git_invocations, unexpanded)
+                            command_directory, git_invocations, tree_selectors, unexpanded)
 import repository
 
 
@@ -116,9 +116,9 @@ def repo_root(cwd, selectors):
 
 
 def commit_invocations(command):
-    """(directory, onto the index, pathspecs or `FROM_FILE`) per `git commit` in the command."""
+    """(`GitContext`, onto the index, pathspecs or `FROM_FILE`) per `git commit` in the command."""
     found = []
-    for directory, _, operands in git_invocations(command, {"commit"}):
+    for context, _, operands in git_invocations(command, {"commit"}, git_directory=True):
         onto_index = False
         from_file = False
         pathspecs = []
@@ -157,7 +157,7 @@ def commit_invocations(command):
                 continue
             pathspecs.append(token)
             index += 1
-        found.append((directory, onto_index, FROM_FILE if from_file else pathspecs))
+        found.append((context, onto_index, FROM_FILE if from_file else pathspecs))
     return found
 
 
@@ -571,12 +571,8 @@ def main():
                          "tree holds that\ncontent is what the move decides.\n\n"
                          f"{NAME_THE_TREE}\n")
         return 2
-    contexts = [context for context, _, _ in
-                git_invocations(command, {"commit"}, git_directory=True)]
-    for (directory, onto_index, pathspecs), context in zip(commits, contexts):
-        selectors = [(flag, value) for flag, value in (
-            ("-C", directory), ("--git-dir", context.git_directory),
-            ("--work-tree", context.work_tree)) if value]
+    for context, onto_index, pathspecs in commits:
+        selectors = tree_selectors(context)
         # The two operand kinds are refused apart, because the remedy for one does not reach the
         # other: naming the paths leaves a `-C` unresolved, and the reader told to do it tries
         # something that cannot help. Measured on an agent's own `git -C "$SP" commit`.

--- a/.harness/hooks/refuse/commit_failing_fast_checks.py
+++ b/.harness/hooks/refuse/commit_failing_fast_checks.py
@@ -116,9 +116,9 @@ def repo_root(cwd, selectors):
 
 
 def commit_invocations(command):
-    """(`GitContext`, onto the index, pathspecs or `FROM_FILE`) per `git commit` in the command."""
+    """(directory, onto the index, pathspecs or `FROM_FILE`) per `git commit` in the command."""
     found = []
-    for context, _, operands in git_invocations(command, {"commit"}, git_directory=True):
+    for directory, _, operands in git_invocations(command, {"commit"}):
         onto_index = False
         from_file = False
         pathspecs = []
@@ -157,7 +157,7 @@ def commit_invocations(command):
                 continue
             pathspecs.append(token)
             index += 1
-        found.append((context, onto_index, FROM_FILE if from_file else pathspecs))
+        found.append((directory, onto_index, FROM_FILE if from_file else pathspecs))
     return found
 
 
@@ -571,7 +571,9 @@ def main():
                          "tree holds that\ncontent is what the move decides.\n\n"
                          f"{NAME_THE_TREE}\n")
         return 2
-    for context, onto_index, pathspecs in commits:
+    contexts = [context for context, _, _ in
+                git_invocations(command, {"commit"}, git_directory=True)]
+    for (_, onto_index, pathspecs), context in zip(commits, contexts):
         selectors = tree_selectors(context)
         # The two operand kinds are refused apart, because the remedy for one does not reach the
         # other: naming the paths leaves a `-C` unresolved, and the reader told to do it tries

--- a/.harness/hooks/refuse/message_outside_its_worktree.py
+++ b/.harness/hooks/refuse/message_outside_its_worktree.py
@@ -26,6 +26,10 @@ commit made in a worktree from the primary checkout was refused over a message i
 worktree, and a commit aimed at a second worktree passed with a message from the one it was run in.
 `gh` takes no option naming a tree, so for it the worktree is the one the command runs in.
 
+Not replayed: a selector the shell rewrites before git sees it — a glob, `~+`, `~-` — which this
+stands down over and `commit_failing_fast_checks.py` refuses; and one a command sets with `export`
+or `env`, which neither guard reads.
+
 `pr_body_of_another_branch.py` asks whether the body says anything; this asks where it lives. Kept
 apart because the remedies differ and a guard that refuses two things names one of them first.
 
@@ -62,9 +66,8 @@ UNEXPANDED_POLICY = "refuse"
 UNEXPANDED_PROBE = 'git commit -F "$MSG"'
 
 # A git that will not name a worktree leaves this with no question to ask rather than an unanswered
-# one, and it costs nothing: `git commit` and `gh pr create` both need a repository themselves, so a
-# command this stands down over fails on its own a moment later. The unexpanded case above is the
-# opposite, and refuses, because there the command is fine and only the reading is blind.
+# one. The unexpanded case above is the opposite, and refuses, because there the command is fine and
+# only the reading is blind.
 UNREADABLE_POLICY = "allow"
 UNREADABLE_PROBE = {"command": "git commit -F /tmp/velvet-message-probe.txt"}
 
@@ -138,7 +141,7 @@ def placed(here, selectors):
 
 
 def inside(path, root, base):
-    """Whether `path` resolves under `root`. A relative path is read from `base`."""
+    """Whether `path` resolves under `root`."""
     try:
         resolved = (Path(base) / path).resolve() if not os.path.isabs(path) else Path(path).resolve()
     except OSError:

--- a/.harness/hooks/refuse/message_outside_its_worktree.py
+++ b/.harness/hooks/refuse/message_outside_its_worktree.py
@@ -19,6 +19,13 @@ one agent, so a fixed name even there can be another agent's; AGENTS.md's Conven
 rest of the way, into a directory of the author's own. Every one of the 163 reaches both by changing
 a path.
 
+For `git commit` that worktree is the one git makes the commit in, asked of git with the command's
+own `-C`, `--git-dir`, `--work-tree`, `GIT_DIR=` and `GIT_WORK_TREE=` replayed, as
+`commit_failing_fast_checks.py` asks it. Read off the directory the command runs in instead, a
+commit made in a worktree from the primary checkout was refused over a message inside that
+worktree, and a commit aimed at a second worktree passed with a message from the one it was run in.
+`gh` takes no option naming a tree, so for it the worktree is the one the command runs in.
+
 `pr_body_of_another_branch.py` asks whether the body says anything; this asks where it lives. Kept
 apart because the remedies differ and a guard that refuses two things names one of them first.
 
@@ -33,10 +40,10 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "lib"))
 
 from pr_body import valued as gh_valued  # noqa: E402
-from repository import toplevel  # noqa: E402
+from repository import DECODING, git_bytes  # noqa: E402
 from shell_commands import (  # noqa: E402
     NAME_THE_TREE, UNPLACEABLE_MOVE, UNRESOLVED_CD, command_directory, git_invocations,
-    program_invocations, unexpanded)
+    program_invocations, tree_selectors, unexpanded)
 
 HOOK_TOOLS = {"Bash"}
 
@@ -108,16 +115,32 @@ def valued(operands, flags):
     return found
 
 
-def worktree_of(directory):
-    """The top of the worktree `directory` sits in, or None when git will not say."""
-    top = toplevel(directory, timeout=10)
-    return top.resolve() if top else None
+def rev_parse(here, selectors, flag):
+    """None when git did not answer, which an empty prefix is not. Only the terminator comes off,
+    for the reason `repository.toplevel` gives."""
+    answer = git_bytes([*selectors, "rev-parse", flag], cwd=here, timeout=10)
+    return None if answer is None else answer.removesuffix(b"\n").decode(**DECODING)
 
 
-def inside(path, root, cwd):
-    """Whether `path` resolves under `root`. A relative path is read from `cwd`, as the shell will."""
+def placed(here, selectors):
+    """(the top of the worktree git acts on, the directory it reads a relative path from), or None
+    when git will not name a worktree.
+
+    The second is git's answer too. Derived here instead, as `here` joined to a `-C` or as the top
+    of the tree, it fails a case in scripts/hooks/test_message_outside_its_worktree.py's
+    `TreeTheCommitIsMadeIn` that commits a relative message and reads back which file git took.
+    """
+    top = rev_parse(here, selectors, "--show-toplevel")
+    prefix = rev_parse(here, selectors, "--show-prefix") if top else None
+    if prefix is None:
+        return None
+    return Path(top).resolve(), Path(top, prefix)
+
+
+def inside(path, root, base):
+    """Whether `path` resolves under `root`. A relative path is read from `base`."""
     try:
-        resolved = (Path(cwd) / path).resolve() if not os.path.isabs(path) else Path(path).resolve()
+        resolved = (Path(base) / path).resolve() if not os.path.isabs(path) else Path(path).resolve()
     except OSError:
         return False
     return resolved == root or root in resolved.parents
@@ -129,28 +152,29 @@ def refuse(what, path, root):
         "A path several agents share is one another agent can overwrite between the write and the "
         "read,\nand the failure is silent — the command succeeds, the tree is right, and only the "
         "prose is\nanother change's.\n\n"
-        f"Write it under {root}, in a directory of your own as AGENTS.md's Conventions say,\n"
-        "and pass that path.\n")
+        f"Write it in a directory of your own under {root / 'Logs'},\n"
+        "as AGENTS.md's Conventions say, and pass that path.\n")
     return 2
 
 
 def judge(command, cwd):
     """0, or 2 with the reason written to stderr."""
-    asked = [("git commit", operands, MESSAGE_FLAGS, None)
-             for _, _, operands in git_invocations(command, ("commit",))]
+    asked = [("git commit", operands, MESSAGE_FLAGS, None, tree_selectors(context))
+             for context, _, operands in git_invocations(command, ("commit",), git_directory=True)]
     for words in GH_WORDS:
         for operands in program_invocations(command, "gh", words):
-            asked.append(("gh " + " ".join(words), operands, BODY_FILE_FLAGS, words))
+            asked.append(("gh " + " ".join(words), operands, BODY_FILE_FLAGS, words, []))
 
-    named = [(what, valued(operands, flags) if words is None else gh_valued(operands, flags, words))
-             for what, operands, flags, words in asked]
-    named = [(what, path) for what, path in named if path is not None]
+    named = [(what, valued(operands, flags) if words is None else gh_valued(operands, flags, words),
+              selectors)
+             for what, operands, flags, words, selectors in asked]
+    named = [(what, path, selectors) for what, path, selectors in named if path is not None]
     if not named:
         return 0
 
     # Asked before the worktree, because a path the shell has not expanded is unreadable in any tree
     # and the worktree reading stands down where git will not answer.
-    for what, path in named:
+    for what, path, _ in named:
         if unexpanded(path):
             sys.stderr.write(
                 f"Refusing `{what}`: the message path is still unexpanded, so which worktree it\n"
@@ -160,16 +184,28 @@ def judge(command, cwd):
 
     here = command_directory(command, cwd)
     if here is UNRESOLVED_CD:
-        # The tree the command runs in cannot be read, so neither can the question.
+        # Every reading below is taken from the directory the command runs in.
         sys.stderr.write("Refusing this command: which worktree the message belongs to could not "
                          f"be read.\n\n{UNPLACEABLE_MOVE}\n\n{NAME_THE_TREE}\n")
         return 2
 
-    root = worktree_of(here)
-    if root is None:
-        return 0
-    for what, path in named:
-        if not inside(path, root, here):
+    for what, path, selectors in named:
+        # Asked before the reading, as the path is: whatever git makes of the literal, it is not the
+        # tree the command names.
+        unresolved = [value for _, value in selectors if unexpanded(value)]
+        if unresolved:
+            sys.stderr.write(
+                f"Refusing `{what}`: the tree it is made in is named by an operand the shell has not\n"
+                "expanded yet, so which worktree the message belongs to cannot be read here.\n\n"
+                + "\n".join("  " + value for value in unresolved)
+                + "\n\nSpell the directory out.\n")
+            return 2
+        tree = placed(here, [part for flag, value in selectors
+                             for part in (flag, os.path.expanduser(value))])
+        if tree is None:
+            continue
+        root, base = tree
+        if not inside(path, root, base):
             return refuse(what, path, root)
     return 0
 

--- a/scripts/hooks/test_message_outside_its_worktree.py
+++ b/scripts/hooks/test_message_outside_its_worktree.py
@@ -160,6 +160,188 @@ class Verdicts(unittest.TestCase):
         self.assertEqual((code, said), (0, ""))
 
 
+class TreeTheCommitIsMadeIn(unittest.TestCase):
+    def setUp(self):
+        self.checkouts = Path(tempfile.mkdtemp(prefix="message-commit-tree-")).resolve()
+        self.addCleanup(shutil.rmtree, self.checkouts, ignore_errors=True)
+        self.primary = self.checkouts / "primary"
+        self.worktree = self.checkouts / "worktree"
+        for args in (["init", "--quiet", "-b", "main", str(self.primary)],
+                     ["-C", str(self.primary), "config", "user.email", "t@velvet"],
+                     ["-C", str(self.primary), "config", "user.name", "t"],
+                     ["-C", str(self.primary), "commit", "--quiet", "--allow-empty", "-m", "root"],
+                     ["-C", str(self.primary), "worktree", "add", "--quiet", "-b", "work",
+                      str(self.worktree)]):
+            subprocess.run(["git", *args], check=True, capture_output=True, timeout=30)
+        self.outside = Path(tempfile.mkdtemp(prefix="message-no-repository-")).resolve()
+        self.addCleanup(shutil.rmtree, self.outside, ignore_errors=True)
+
+    @staticmethod
+    def judge(command, cwd, home=None):
+        """The guard's verdict, as (exit code, stderr)."""
+        event = {"tool_name": "Bash", "cwd": str(cwd), "tool_input": {"command": command}}
+        environment = dict(os.environ, **({} if home is None else {"HOME": str(home)}))
+        done = subprocess.run(["python3", str(GUARD)], input=json.dumps(event),
+                              capture_output=True, text=True, timeout=30, env=environment)
+        return done.returncode, done.stderr
+
+    def committed(self, command):
+        """The subject at the head of the worktree's branch once `command` has run from the primary
+        checkout, run by a shell so that the text the guard was handed is what runs."""
+        subprocess.run(command, shell=True, cwd=self.primary, capture_output=True, timeout=30)
+        return subprocess.run(["git", "-C", str(self.worktree), "log", "-1", "--format=%s"],
+                              check=True, capture_output=True, text=True, timeout=30).stdout.strip()
+
+    def test_Given_ACommitMadeInAWorktreeFromThePrimary_When_ItsMessageIsInsideThatWorktree_Then_ItIsLetThrough(self):
+        # Arrange — under the Logs of the worktree the change is in, where AGENTS.md sends it.
+        command = f"git -C {self.worktree} commit -F {self.worktree}/Logs/run/msg.txt"
+
+        # Act
+        code, said = self.judge(command, self.primary)
+
+        # Assert
+        self.assertEqual((code, said), (0, ""))
+
+    def test_Given_ACommitMadeInAWorktreeFromThePrimary_When_ItsMessageIsInsideThePrimary_Then_ItIsRefusedNamingTheWorktree(self):
+        # Arrange — inside the tree the command starts in, and outside the one the commit is made in.
+        command = f"git -C {self.worktree} commit -F {self.primary}/Logs/run/msg.txt"
+
+        # Act
+        code, said = self.judge(command, self.primary)
+
+        # Assert — the tree named, since the refusal sends the message there.
+        self.assertEqual((code, f"is outside {self.worktree}, the worktree it describes" in said),
+                         (2, True))
+
+    def test_Given_ACommitAimedByGitDirAndWorkTreeFlags_When_ItsMessageIsInsideThatTree_Then_ItIsLetThrough(self):
+        # Arrange
+        command = (f"git --git-dir={self.worktree}/.git --work-tree={self.worktree} commit "
+                   f"-F {self.worktree}/Logs/run/msg.txt")
+
+        # Act
+        code, said = self.judge(command, self.primary)
+
+        # Assert
+        self.assertEqual((code, said), (0, ""))
+
+    def test_Given_ACommitAimedByGitDirAndWorkTreeFlagsFromNoRepository_When_ItsMessageIsOutsideThatTree_Then_ItIsRefused(self):
+        # Arrange — started in no repository, so without the git directory the flags name git finds
+        # none and the guard stands down; and the message outside that directory as well as the
+        # worktree, so the work tree they name is not what this turns on.
+        command = (f"git --git-dir={self.worktree}/.git --work-tree={self.worktree} commit "
+                   f"-F {self.checkouts}/msg.txt")
+
+        # Act
+        code, said = self.judge(command, self.outside)
+
+        # Assert
+        self.assertEqual((code, "the worktree it describes" in said), (2, True))
+
+    def test_Given_ACommitAimedByGitDirAndWorkTreeVariables_When_ItsMessageIsInsideThatTree_Then_ItIsLetThrough(self):
+        # Arrange
+        command = (f"GIT_DIR={self.worktree}/.git GIT_WORK_TREE={self.worktree} git commit "
+                   f"-F {self.worktree}/Logs/run/msg.txt")
+
+        # Act
+        code, said = self.judge(command, self.primary)
+
+        # Assert
+        self.assertEqual((code, said), (0, ""))
+
+    def test_Given_ACommitAimedByGitDirAndWorkTreeVariablesFromNoRepository_When_ItsMessageIsOutsideThatTree_Then_ItIsRefused(self):
+        # Arrange — as with the flags above.
+        command = (f"GIT_DIR={self.worktree}/.git GIT_WORK_TREE={self.worktree} git commit "
+                   f"-F {self.checkouts}/msg.txt")
+
+        # Act
+        code, said = self.judge(command, self.outside)
+
+        # Assert
+        self.assertEqual((code, "the worktree it describes" in said), (2, True))
+
+    def test_Given_ACommitMadeInASubdirectoryOfAWorktree_When_ARelativeMessageIsCommitted_Then_ItIsReadFromThatSubdirectory(self):
+        # Arrange — `../msg.txt` is the worktree's own file from its `sub`, and the one beside the
+        # checkouts from the primary; git is what says which it reads.
+        (self.worktree / "sub").mkdir()
+        (self.worktree / "msg.txt").write_text("the worktree's message\n", encoding="utf-8")
+        (self.checkouts / "msg.txt").write_text("a message beside the checkouts\n", encoding="utf-8")
+        command = f"git -C {self.worktree}/sub commit --quiet --allow-empty -F ../msg.txt"
+
+        # Act
+        code, said = self.judge(command, self.primary)
+        recorded = self.committed(command)
+
+        # Assert — what git recorded rides along, so the verdict is about the file git read.
+        self.assertEqual((code, said, recorded), (0, "", "the worktree's message"))
+
+    # GREEN_ON_BASE(characterization): the base lets this through as well, having judged the primary's file.
+    # What reddens it is reading a relative path from the directory the command starts in, or from
+    # that directory joined to a `-C`, while judging it against the tree the commit is made in.
+    def test_Given_AWorkTreeTheCommandStartsOutside_When_ARelativeMessageIsCommitted_Then_ItIsReadFromThatTree(self):
+        # Arrange — `msg.txt` sits in both trees, and the one git reads is the worktree's.
+        (self.worktree / "msg.txt").write_text("the worktree's message\n", encoding="utf-8")
+        (self.primary / "msg.txt").write_text("the primary's message\n", encoding="utf-8")
+        command = (f"git --git-dir={self.worktree}/.git --work-tree={self.worktree} commit "
+                   "--quiet --allow-empty -F msg.txt")
+
+        # Act
+        code, said = self.judge(command, self.primary)
+        recorded = self.committed(command)
+
+        # Assert — as in the case above.
+        self.assertEqual((code, said, recorded), (0, "", "the worktree's message"))
+
+    def test_Given_ACommitAimedByAnUnexpandedDirectory_When_ItsMessageIsSpelledOut_Then_ItIsRefused(self):
+        # Arrange — the message sits in the tree the command starts in, so the tree the commit is
+        # made in is the only thing left to refuse over.
+        command = f'git -C "$WORKTREE" commit -F {self.primary}/Logs/run/msg.txt'
+
+        # Act
+        code, said = self.judge(command, self.primary)
+
+        # Assert
+        self.assertEqual((code, "Spell the directory out" in said), (2, True))
+
+    def test_Given_ACommitAimedByATildeSpelledDirectory_When_ItsMessageIsOutsideThatTree_Then_ItIsRefused(self):
+        # Arrange — HOME is where the checkouts sit, so once the shell has expanded it `~/worktree`
+        # is the worktree.
+        command = f"git -C ~/{self.worktree.name} commit -F {self.primary}/Logs/run/msg.txt"
+
+        # Act
+        code, said = self.judge(command, self.primary, home=self.checkouts)
+
+        # Assert
+        self.assertEqual((code, f"is outside {self.worktree}, the worktree it describes" in said),
+                         (2, True))
+
+    # GREEN_ON_BASE(characterization): the base reads one tree for every invocation and refuses this message too.
+    # What reddens it is standing the whole command down when git names no tree for one of them.
+    def test_Given_ACommitWhoseTreeGitWillNotName_When_ACommitAfterItCarriesAMessageFromOutside_Then_ThatOneIsRefused(self):
+        # Arrange
+        command = (f"git -C {self.checkouts}/missing commit -F {self.primary}/msg.txt; "
+                   f"git commit -F {self.checkouts}/msg.txt")
+
+        # Act
+        code, said = self.judge(command, self.primary)
+
+        # Assert
+        self.assertEqual((code, f"{self.checkouts}/msg.txt\nis outside {self.primary}," in said),
+                         (2, True))
+
+    # GREEN_ON_BASE(characterization): the base judges the body against the tree the command runs in.
+    # What reddens it is judging gh against a tree read off the `git -C` beside it.
+    def test_Given_AGitDashCBesideAPullRequestBody_When_TheBodyIsInsideTheTreeTheCommandRunsIn_Then_ItIsLetThrough(self):
+        # Arrange — gh takes no `-C`, so the one beside it moves nothing gh reads.
+        command = (f"git -C {self.worktree} commit -m x && "
+                   f"gh pr create --title t --body-file {self.primary}/Logs/run/body.md")
+
+        # Act
+        code, said = self.judge(command, self.primary)
+
+        # Assert
+        self.assertEqual((code, said), (0, ""))
+
+
 class ToplevelReadingTests(unittest.TestCase):
     def setUp(self):
         self.root = Path(tempfile.mkdtemp(prefix="message-worktree-toplevel-")).resolve()


### PR DESCRIPTION
`refuse/message_outside_its_worktree.py` judged a `git commit -F`/`--file` message file against the worktree of the directory the command ran in, and took no account of `-C`, `--git-dir`, `--work-tree`, `GIT_DIR=` or `GIT_WORK_TREE=`. Both directions went wrong:

- from the primary checkout, `git -C <worktree> commit -F <worktree>/Logs/<dir>/msg.txt` was refused as outside the primary, though the message sits in the tree the commit is made in, where AGENTS.md sends it;
- `git -C <second worktree> commit -F <a file in the first>` went through, though the message is outside the tree the commit is made in.

## What changes

- The guard asks git for the tree each commit is made in, replaying the command's own selectors from the directory the command runs in, which is the reading `refuse/commit_failing_fast_checks.py` takes. The selector list moves into `lib/shell_commands.py` as `tree_selectors`, and both guards build it there.
- A relative message path is read from where git reads it, and git is asked for that too: `--show-toplevel` joined to `--show-prefix`, which is the directory git starts in or, when that is outside the work tree, the work tree's top. Judged against the commit's tree but resolved from the command's directory, `git -C <worktree> commit -F Logs/<dir>/msg.txt` from the primary is refused over a file git never reads.
- A selector the shell has not expanded (`git -C "$WT" commit -F …`) is refused, as the fast-check guard refuses it.
- Each invocation git names a tree for is judged against that tree. One it names none for is skipped, and the rest of the command is still judged.
- Not replayed: a selector the shell rewrites before git sees it — a glob, `~+`, `~-` — which this guard stands down over and the fast-check guard refuses; and one set with `export` or `env`, which neither guard reads.
- `gh`, which takes no option naming a tree, is judged as before.
- The refusal sends the message to a directory under the tree's `Logs`, as AGENTS.md's Conventions do.

From a primary checkout P with a linked worktree W, base → this branch:

| command | base | branch |
|---|---|---|
| `git -C W commit -F W/Logs/m/msg.txt` | refused | allowed |
| `git -C W commit -F P/Logs/m/msg.txt` | allowed | refused |
| `git --git-dir=W/.git --work-tree=W commit -F W/…`, and as `GIT_DIR=`/`GIT_WORK_TREE=` | refused | allowed |
| the same with the message in P | allowed | refused |
| `--work-tree=W` or `GIT_WORK_TREE=W` alone, message in W | refused | allowed |
| `--git-dir=W/.git` or `GIT_DIR=` alone, which git gives the directory the command runs in as its work tree | judged against that directory's worktree, P | judged against that directory: P from P's top, the subdirectory from inside one |
| `git -C "$WT" commit -F P/…` | allowed | refused |
| `gh pr create --body-file …` in P, in W, and after `cd W` | allowed, refused, allowed | unchanged |

## Evidence

- `scripts/hooks/test_message_outside_its_worktree.py` gains `TreeTheCommitIsMadeIn`, 12 cases. `base_red_check.py --lane python` against `7d372e9`: exit 0, 9 red on the base, 3 declared `characterization` and green as declared. On the base the false refusal fails with ``Tuples differ: (2, "Refusing `git commit`: /private/var/f[632 chars].\n") != (0, '')`` and the miss with `Tuples differ: (0, False) != (2, True)`.
- The two relative-path cases run the commit and read back what git recorded, so each verdict is about the file git took.
- Each new case reddens under at least one of these cuts, and no case outside the new class reddens under any of them:
  - dropping the `-C`, `--git-dir` or `--work-tree` replay;
  - `lib/shell_commands.py` ignoring `GIT_DIR=`, `GIT_WORK_TREE=`, `--git-dir` or `--work-tree`, each of which reddens one case alone;
  - reading a relative path from the command's directory, from that directory joined to a `-C`, or from the tree's top;
  - not refusing an unexpanded selector;
  - stopping at the first invocation whose tree git will not name, so later ones go unjudged;
  - judging `gh` against a `git -C` beside it;
  - dropping the `~` expansion;
  - taking the union or the intersection of the two trees.
- Cutting each term of `tree_selectors` also reddens `test_commit_failing_fast_checks.py`'s own cases.
- Hook suites through CI's loop: 35 suites, 698 cases, 0 failed. `cwd_resolution_check.py`, `unreadable_state_check.py`, `harness/sync.py --check`, `pull_request_base_check.py`, `assume_gate_check.py` and `stranded_name_check.py --base 7d372e9` exit 0.
- No CHANGELOG entry: contributor tooling. No `Documentation~` impact.

No issue: found by agents whose commits from the primary checkout into a worktree were refused.
